### PR TITLE
delete superpmi-shared/compileresult.cpp  assert on x86.

### DIFF
--- a/src/ToolBox/superpmi/superpmi-shared/compileresult.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/compileresult.cpp
@@ -672,14 +672,6 @@ void CompileResult::repRecordRelocation(void* location, void* target, WORD fRelo
     value.slotNum    = (DWORD)slotNum;
     value.addlDelta  = (DWORD)addlDelta;
 
-#ifdef _TARGET_X86_
-    if (value.fRelocType == IMAGE_REL_BASED_HIGHLOW)
-    {
-        Assert(value.addlDelta == 0);
-        Assert(value.slotNum == 0);
-    }
-#endif // _TARGET_X86_
-
     RecordRelocation->Append(value);
 }
 

--- a/src/ToolBox/superpmi/superpmi-shared/compileresult.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/compileresult.cpp
@@ -731,8 +731,6 @@ void CompileResult::applyRelocs(unsigned char* block1, ULONG blocksize1, void* o
                              (DWORD)tmp.target);
                     *(DWORD*)address = (DWORD)tmp.target;
                 }
-                if (tmp.addlDelta != 0)
-                    __debugbreak();
                 if (tmp.slotNum != 0)
                     __debugbreak();
             }

--- a/src/ToolBox/superpmi/superpmi-shared/compileresult.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/compileresult.cpp
@@ -672,6 +672,14 @@ void CompileResult::repRecordRelocation(void* location, void* target, WORD fRelo
     value.slotNum    = (DWORD)slotNum;
     value.addlDelta  = (DWORD)addlDelta;
 
+#ifdef _TARGET_X86_
+    if (value.fRelocType == IMAGE_REL_BASED_HIGHLOW)
+    {
+        Assert(value.addlDelta == 0);
+        Assert(value.slotNum == 0);
+    }
+#endif // _TARGET_X86_
+
     RecordRelocation->Append(value);
 }
 

--- a/src/ToolBox/superpmi/superpmi-shared/compileresult.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/compileresult.cpp
@@ -672,6 +672,8 @@ void CompileResult::repRecordRelocation(void* location, void* target, WORD fRelo
     value.slotNum    = (DWORD)slotNum;
     value.addlDelta  = (DWORD)addlDelta;
 
+    Assert(value.slotNum == 0);
+
     RecordRelocation->Append(value);
 }
 
@@ -731,8 +733,6 @@ void CompileResult::applyRelocs(unsigned char* block1, ULONG blocksize1, void* o
                              (DWORD)tmp.target);
                     *(DWORD*)address = (DWORD)tmp.target;
                 }
-                if (tmp.slotNum != 0)
-                    __debugbreak();
             }
             break;
 #endif // _TARGET_X86_

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -7143,6 +7143,8 @@ void emitter::emitRecordRelocation(void* location,            /* IN */
                                    WORD  slotNum /* = 0 */,   /* IN */
                                    INT32 addlDelta /* = 0 */) /* IN */
 {
+    assert(slotNum == 0); // It is unused on all supported platforms.
+
     // If we're an unmatched altjit, don't tell the VM anything. We still record the relocation for
     // late disassembly; maybe we'll need it?
     if (emitComp->info.compMatchedVM)

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -9450,19 +9450,15 @@ GOT_DSP:
 
                     if (addc)
                     {
-                        // It is of the form "ins [disp], immed"
-                        // For emitting relocation, we also need to take into account of the
-                        // additional bytes of code emitted for immed val.
-
                         ssize_t cval = addc->cnsVal;
 
 #ifdef _TARGET_AMD64_
                         // all these opcodes only take a sign-extended 4-byte immediate
                         noway_assert(opsz < 8 || ((int)cval == cval && !addc->cnsReloc));
-#else
-                        noway_assert(opsz <= 4);
-#endif
 
+                        // It is of the form "ins [disp], immed"
+                        // For emitting relocation, we also need to take into account of the
+                        // additional bytes of code emitted for immed val on amd64.
                         switch (opsz)
                         {
                             case 0:
@@ -9481,14 +9477,19 @@ GOT_DSP:
                                 assert(!"unexpected operand size");
                                 unreached();
                         }
+#else // _TARGET_X86_
+                        noway_assert(opsz <= 4);
+#endif // _TARGET_X86_
                     }
 
 #ifdef _TARGET_AMD64_
                     // We emit zero on Amd64, to avoid the assert in emitOutputLong()
                     dst += emitOutputLong(dst, 0);
-#else
+#else  // _TARGET_X86_
                     dst += emitOutputLong(dst, dsp);
-#endif
+                    // x86 uses an absiolute 32-bit address, it doesn't need addlDelta.
+                    assert(addlDelta == 0);
+#endif // _TARGET_X86_
                     emitRecordRelocation((void*)(dst - sizeof(INT32)), (void*)dsp, IMAGE_REL_BASED_DISP32, 0,
                                          addlDelta);
                 }

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -9459,9 +9459,9 @@ GOT_DSP:
 #ifdef _TARGET_AMD64_
                         // all these opcodes only take a sign-extended 4-byte immediate
                         noway_assert(opsz < 8 || ((int)cval == cval && !addc->cnsReloc));
-#else
+#else  //_TARGET_X86_
                         noway_assert(opsz <= 4);
-#endif
+#endif //_TARGET_X86_
 
                         switch (opsz)
                         {
@@ -10695,9 +10695,9 @@ BYTE* emitter::emitOutputCV(BYTE* dst, instrDesc* id, code_t code, CnsVal* addc)
 #ifdef _TARGET_AMD64_
             // all these opcodes only take a sign-extended 4-byte immediate
             noway_assert(opsz < 8 || ((int)cval == cval && !addc->cnsReloc));
-#else
+#else  //_TARGET_X86_
             noway_assert(opsz <= 4);
-#endif
+#endif //_TARGET_X86_
 
             switch (opsz)
             {

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -9450,15 +9450,19 @@ GOT_DSP:
 
                     if (addc)
                     {
+                        // It is of the form "ins [disp], immed"
+                        // For emitting relocation, we also need to take into account of the
+                        // additional bytes of code emitted for immed val.
+
                         ssize_t cval = addc->cnsVal;
 
 #ifdef _TARGET_AMD64_
                         // all these opcodes only take a sign-extended 4-byte immediate
                         noway_assert(opsz < 8 || ((int)cval == cval && !addc->cnsReloc));
+#else
+                        noway_assert(opsz <= 4);
+#endif
 
-                        // It is of the form "ins [disp], immed"
-                        // For emitting relocation, we also need to take into account of the
-                        // additional bytes of code emitted for immed val on amd64.
                         switch (opsz)
                         {
                             case 0:
@@ -9477,19 +9481,14 @@ GOT_DSP:
                                 assert(!"unexpected operand size");
                                 unreached();
                         }
-#else // _TARGET_X86_
-                        noway_assert(opsz <= 4);
-#endif // _TARGET_X86_
                     }
 
 #ifdef _TARGET_AMD64_
                     // We emit zero on Amd64, to avoid the assert in emitOutputLong()
                     dst += emitOutputLong(dst, 0);
-#else  // _TARGET_X86_
+#else
                     dst += emitOutputLong(dst, dsp);
-                    // x86 uses an absiolute 32-bit address, it doesn't need addlDelta.
-                    assert(addlDelta == 0);
-#endif // _TARGET_X86_
+#endif
                     emitRecordRelocation((void*)(dst - sizeof(INT32)), (void*)dsp, IMAGE_REL_BASED_DISP32, 0,
                                          addlDelta);
                 }


### PR DESCRIPTION
Spmi diffs failed on this x86 IMAGE_REL_BASED_HIGHLOW assert:
https://github.com/dotnet/coreclr/blob/e6ae9d6460fb8366134d4026b46bb1611045d416/src/ToolBox/superpmi/superpmi-shared/compileresult.cpp#L734-L739 

We have checked that x86 does not use `addlDelta` field for this case so that assert is valid.

The fix it to propagate this check to `repRecordRelocation` that it checks not only diffs, but replays and collections as well;
and fix `emitter::emitOutputAM` that it doesn't set an unused value on x86.