### PR TITLE
Fix the slashes when setting the ZapBBInstrDir

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -451,7 +451,7 @@ build_CoreLib()
 
     # Invoke MSBuild
     __ExtraBuildArgs=""
-    if [[ "$__IbcTuning" -eq "" ]]; then
+    if [[ "$__IbcTuning" == "" ]]; then
         __ExtraBuildArgs="$__ExtraBuildArgs -OptimizationDataDir=\"$__PackagesDir/optimization.$__BuildOS-$__BuildArch.IBC.CoreCLR/$__IbcOptDataVersion/data/\""
         __ExtraBuildArgs="$__ExtraBuildArgs -EnableProfileGuidedOptimization=true"
     fi

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -10962,14 +10962,22 @@ HANDLE Module::OpenMethodProfileDataLogFile(GUID mvid)
         path.Set(assemblyPath);                         // no, then put it beside the IL dll
     }
     else {
-        LPCWSTR assemblyFileName = wcsrchr(assemblyPath, '\\'); 
+#ifdef FEATURE_PAL
+        LPCWSTR assemblyFileName = wcsrchr(assemblyPath, '/'); 
+#else
+        LPCWSTR assemblyFileName = wcsrchr(assemblyPath, '\\');
+#endif 
         if (assemblyFileName)
             assemblyFileName++;                         // skip past the \ char
         else 
             assemblyFileName = assemblyPath;
 
         path.Set(ibcDir);                               // yes, put it in the directory, named with the assembly name.
+#ifdef FEATURE_PAL
+        path.Append('/');
+#else
         path.Append('\\');
+#endif
         path.Append(assemblyFileName);
     }
 

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -10962,22 +10962,14 @@ HANDLE Module::OpenMethodProfileDataLogFile(GUID mvid)
         path.Set(assemblyPath);                         // no, then put it beside the IL dll
     }
     else {
-#ifdef FEATURE_PAL
-        LPCWSTR assemblyFileName = wcsrchr(assemblyPath, '/'); 
-#else
-        LPCWSTR assemblyFileName = wcsrchr(assemblyPath, '\\');
-#endif 
+        LPCWSTR assemblyFileName = wcsrchr(assemblyPath, DIRECTORY_SEPARATOR_CHAR_W);
         if (assemblyFileName)
             assemblyFileName++;                         // skip past the \ char
         else 
             assemblyFileName = assemblyPath;
 
         path.Set(ibcDir);                               // yes, put it in the directory, named with the assembly name.
-#ifdef FEATURE_PAL
-        path.Append('/');
-#else
-        path.Append('\\');
-#endif
+        path.Append(DIRECTORY_SEPARATOR_CHAR_W);
         path.Append(assemblyFileName);
     }
 


### PR DESCRIPTION
In OpenMethodProfileDataLogFile, we try to set the directory and path for the .ibc files using windows slashes (\\). This causes this code to fail on Linux, which uses forward slashes. This is particularly a problem when setting COMPlus_ZapBBInstrDir, which takes that environment variable and attempts to find the name of the file using wcsrchr(assemblyPath, '\\'). This causes a crash on linux when collecting IBC counts. The fix is to ifdef it for linux to use the correct path separator.

This change also includes a fix to change the code for checking if IbcTuning is set to use == instead of -eq which was causing a failure in the build that was ignored.