### PR TITLE
MemoryExtensions.Contains

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Guid.cs
+++ b/src/System.Private.CoreLib/shared/System/Guid.cs
@@ -427,7 +427,7 @@ namespace System
             }
 
             // Check for dashes
-            bool dashesExistInString = guidString.IndexOf('-') >= 0;
+            bool dashesExistInString = guidString.Contains('-');
 
             if (dashesExistInString)
             {

--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
@@ -83,19 +83,12 @@ namespace System
             return CompareInfo.EqualsOrdinalIgnoreCase(ref MemoryMarshal.GetReference(span), ref MemoryMarshal.GetReference(value), span.Length);
         }
 
-        // TODO https://github.com/dotnet/corefx/issues/27526
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool Contains(this ReadOnlySpan<char> source, char value)
-        {
-            for (int i = 0; i < source.Length; i++)
-            {
-                if (source[i] == value)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
+            => SpanHelpers.Contains(
+                ref MemoryMarshal.GetReference(source),
+                value,
+                source.Length);
 
         /// <summary>
         /// Compares the specified <paramref name="span"/> and <paramref name="other"/> using the specified <paramref name="comparisonType"/>,

--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.cs
@@ -183,6 +183,55 @@ namespace System
         }
 
         /// <summary>
+        /// Searches for the specified value and returns true if found. If not found, returns false. Values are compared using IEquatable{T}.Equals(T).
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value">The value to search for.</param>
+        public static bool Contains<T>(this Span<T> span, T value)
+            where T : IEquatable<T>
+        {
+            if (typeof(T) == typeof(byte))
+                return SpanHelpers.Contains(
+                    ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
+                    Unsafe.As<T, byte>(ref value),
+                    span.Length);
+
+            if (typeof(T) == typeof(char))
+                return SpanHelpers.Contains(
+                    ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
+                    Unsafe.As<T, char>(ref value),
+                    span.Length);
+
+            return SpanHelpers.Contains(ref MemoryMarshal.GetReference(span), value, span.Length);
+        }
+
+        /// <summary>
+        /// Searches for the specified value and returns true if found. If not found, returns false. Values are compared using IEquatable{T}.Equals(T).
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="span">The span to search.</param>
+        /// <param name="value">The value to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool Contains<T>(this ReadOnlySpan<T> span, T value)
+            where T : IEquatable<T>
+        {
+            if (typeof(T) == typeof(byte))
+                return SpanHelpers.Contains(
+                    ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
+                    Unsafe.As<T, byte>(ref value),
+                    span.Length);
+
+            if (typeof(T) == typeof(char))
+                return SpanHelpers.Contains(
+                    ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
+                    Unsafe.As<T, char>(ref value),
+                    span.Length);
+
+            return SpanHelpers.Contains(ref MemoryMarshal.GetReference(span), value, span.Length);
+        }
+
+        /// <summary>
         /// Searches for the specified value and returns the index of its first occurrence. If not found, returns -1. Values are compared using IEquatable{T}.Equals(T). 
         /// </summary>
         /// <param name="span">The span to search.</param>
@@ -196,6 +245,7 @@ namespace System
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                     Unsafe.As<T, byte>(ref value),
                     span.Length);
+
             if (typeof(T) == typeof(char))
                 return SpanHelpers.IndexOf(
                     ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
@@ -238,6 +288,7 @@ namespace System
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                     Unsafe.As<T, byte>(ref value),
                     span.Length);
+
             if (typeof(T) == typeof(char))
                 return SpanHelpers.LastIndexOf(
                     ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
@@ -322,6 +373,7 @@ namespace System
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                     Unsafe.As<T, byte>(ref value),
                     span.Length);
+
             if (typeof(T) == typeof(char))
                 return SpanHelpers.IndexOf(
                     ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
@@ -364,6 +416,7 @@ namespace System
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                     Unsafe.As<T, byte>(ref value),
                     span.Length);
+
             if (typeof(T) == typeof(char))
                 return SpanHelpers.LastIndexOf(
                     ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
@@ -16,7 +16,7 @@ using nuint = System.UInt32;
 
 namespace System
 {
-    internal static partial class SpanHelpers
+    internal static partial class SpanHelpers // .Byte
     {
         public static int IndexOf(ref byte searchSpace, int searchSpaceLength, ref byte value, int valueLength)
         {
@@ -94,6 +94,97 @@ namespace System
                     index = tempIndex;
             }
             return index;
+        }
+
+        // Adapted from IndexOf(...)
+        public static unsafe bool Contains(ref byte searchSpace, byte value, int length)
+        {
+            Debug.Assert(length >= 0);
+
+            if (length == 0) return false;
+
+            uint uValue = value; // Use uint for comparisons to avoid unnecessary 8->32 extensions
+            IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr nLength = (IntPtr)length;
+
+            if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
+            {
+                int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+                nLength = (IntPtr)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
+            }
+
+            SequentialScan:
+            while ((byte*)nLength >= (byte*)8)
+            {
+                nLength -= 8;
+
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 0) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 1) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 2) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 3) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 4) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 5) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 6) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 7))
+                {
+                    return true;
+                }
+
+                index += 8;
+            }
+
+            if ((byte*)nLength >= (byte*)4)
+            {
+                nLength -= 4;
+
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 0) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 1) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 2) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 3))
+                {
+                    return true;
+                }
+
+                index += 4;
+            }
+
+            while ((byte*)nLength > (byte*)0)
+            {
+                nLength -= 1;
+
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index))
+                    return true;
+
+                index += 1;
+            }
+
+            if (Vector.IsHardwareAccelerated && ((int)(byte*)index < length))
+            {
+                nLength = (IntPtr)((length - (int)(byte*)index) & ~(Vector<byte>.Count - 1));
+
+                // Get comparison Vector
+                Vector<byte> vComparison = new Vector<byte>(value);
+
+                while ((byte*)nLength > (byte*)index)
+                {
+                    var vMatches = Vector.Equals(vComparison, Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index)));
+                    if (Vector<byte>.Zero.Equals(vMatches))
+                    {
+                        index += Vector<byte>.Count;
+                        continue;
+                    }
+
+                    return true;
+                }
+
+                if ((int)(byte*)index < length)
+                {
+                    nLength = (IntPtr)(length - (int)(byte*)index);
+                    goto SequentialScan;
+                }
+            }
+
+            return false;
         }
 
         public static unsafe int IndexOf(ref byte searchSpace, byte value, int length)

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
@@ -15,7 +15,7 @@ using System.Numerics;
 
 namespace System
 {
-    internal static partial class SpanHelpers
+    internal static partial class SpanHelpers // .Char
     {
         public static unsafe int SequenceCompareTo(ref char first, int firstLength, ref char second, int secondLength)
         {
@@ -79,6 +79,96 @@ namespace System
 
         Equal:
             return lengthDelta;
+        }
+
+        // Adapted from IndexOf(...)
+        public static unsafe bool Contains(ref char searchSpace, char value, int length)
+        {
+            Debug.Assert(length >= 0);
+
+            if (length == 0) return false;
+
+            fixed (char* pChars = &searchSpace)
+            {
+                char* pCh = pChars;
+                char* pEndCh = pCh + length;
+
+#if !netstandard11
+                if (Vector.IsHardwareAccelerated && length >= Vector<ushort>.Count * 2)
+                {
+                    // Figure out how many characters to read sequentially until we are vector aligned
+                    // This is equivalent to:
+                    //         unaligned = ((int)pCh % Unsafe.SizeOf<Vector<ushort>>()) / elementsPerByte
+                    //         length = (Vector<ushort>.Count - unaligned) % Vector<ushort>.Count
+                    const int elementsPerByte = sizeof(ushort) / sizeof(byte);
+                    int unaligned = ((int)pCh & (Unsafe.SizeOf<Vector<ushort>>() - 1)) / elementsPerByte;
+                    length = (Vector<ushort>.Count - unaligned) & (Vector<ushort>.Count - 1);
+                }
+
+                SequentialScan:
+#endif
+                while (length >= 4)
+                {
+                    length -= 4;
+
+                    if (value == *pCh ||
+                        value == *(pCh + 1) ||
+                        value == *(pCh + 2) ||
+                        value == *(pCh + 3))
+                    {
+                        return true;
+                    }
+
+                    pCh += 4;
+                }
+
+                while (length > 0)
+                {
+                    length -= 1;
+
+                    if (value == *pCh)
+                        return true;
+
+                    pCh += 1;
+                }
+
+#if !netstandard11
+                // We get past SequentialScan only if IsHardwareAccelerated is true. However, we still have the redundant check to allow
+                // the JIT to see that the code is unreachable and eliminate it when the platform does not have hardware accelerated.
+                if (Vector.IsHardwareAccelerated && pCh < pEndCh)
+                {
+                    // Get the highest multiple of Vector<ushort>.Count that is within the search space.
+                    // That will be how many times we iterate in the loop below.
+                    // This is equivalent to: length = Vector<ushort>.Count * ((int)(pEndCh - pCh) / Vector<ushort>.Count)
+                    length = (int)((pEndCh - pCh) & ~(Vector<ushort>.Count - 1));
+
+                    // Get comparison Vector
+                    Vector<ushort> vComparison = new Vector<ushort>(value);
+
+                    while (length > 0)
+                    {
+                        // Using Unsafe.Read instead of ReadUnaligned since the search space is pinned and pCh is always vector aligned
+                        Debug.Assert(((int)pCh & (Unsafe.SizeOf<Vector<ushort>>() - 1)) == 0);
+                        Vector<ushort> vMatches = Vector.Equals(vComparison, Unsafe.Read<Vector<ushort>>(pCh));
+                        if (Vector<ushort>.Zero.Equals(vMatches))
+                        {
+                            pCh += Vector<ushort>.Count;
+                            length -= Vector<ushort>.Count;
+                            continue;
+                        }
+
+                        return true;
+                    }
+
+                    if (pCh < pEndCh)
+                    {
+                        length = (int)(pEndCh - pCh);
+                        goto SequentialScan;
+                    }
+                }
+#endif
+                return false;
+            }
         }
 
         public static unsafe int IndexOf(ref char searchSpace, char value, int length)

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.T.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.T.cs
@@ -15,7 +15,7 @@ using System.Numerics;
 
 namespace System
 {
-    internal static partial class SpanHelpers
+    internal static partial class SpanHelpers // .T
     {
         public static int IndexOf<T>(ref T searchSpace, int searchSpaceLength, ref T value, int valueLength)
             where T : IEquatable<T>
@@ -51,6 +51,62 @@ namespace System
                 index++;
             }
             return -1;
+        }
+
+        // Adapted from IndexOf(...)
+        public static unsafe bool Contains<T>(ref T searchSpace, T value, int length)
+               where T : IEquatable<T>
+        {
+            Debug.Assert(length >= 0);
+
+            if (length == 0) return false;
+
+            IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            while (length >= 8)
+            {
+                length -= 8;
+
+                if (value.Equals(Unsafe.Add(ref searchSpace, index + 0)) ||
+                    value.Equals(Unsafe.Add(ref searchSpace, index + 1)) ||
+                    value.Equals(Unsafe.Add(ref searchSpace, index + 2)) ||
+                    value.Equals(Unsafe.Add(ref searchSpace, index + 3)) ||
+                    value.Equals(Unsafe.Add(ref searchSpace, index + 4)) ||
+                    value.Equals(Unsafe.Add(ref searchSpace, index + 5)) ||
+                    value.Equals(Unsafe.Add(ref searchSpace, index + 6)) ||
+                    value.Equals(Unsafe.Add(ref searchSpace, index + 7)))
+                {
+                    return true;
+                }
+
+                index += 8;
+            }
+
+            if (length >= 4)
+            {
+                length -= 4;
+
+                if (value.Equals(Unsafe.Add(ref searchSpace, index + 0)) ||
+                    value.Equals(Unsafe.Add(ref searchSpace, index + 1)) ||
+                    value.Equals(Unsafe.Add(ref searchSpace, index + 2)) ||
+                    value.Equals(Unsafe.Add(ref searchSpace, index + 3)))
+                {
+                    return true;
+                }
+
+                index += 4;
+            }
+
+            while (length > 0)
+            {
+                length -= 1;
+
+                if (value.Equals(Unsafe.Add(ref searchSpace, index)))
+                    return true;
+
+                index += 1;
+            }
+
+            return false;
         }
 
         public static unsafe int IndexOf<T>(ref T searchSpace, T value, int length)

--- a/src/System.Private.CoreLib/shared/System/Version.cs
+++ b/src/System.Private.CoreLib/shared/System/Version.cs
@@ -341,7 +341,7 @@ namespace System
                 if (buildEnd != -1)
                 {
                     buildEnd += (minorEnd + 1);
-                    if (input.Slice(buildEnd + 1).IndexOf('.') != -1)
+                    if (input.Slice(buildEnd + 1).Contains('.'))
                     {
                         if (throwOnFailure) throw new ArgumentException(SR.Arg_VersionString, nameof(input));
                         return null;


### PR DESCRIPTION
- Added extensions for Span<T>.Contains(...)
- Partial fix for [27526](https://github.com/dotnet/corefx/issues/27526) (`IEqualityComparer<T>` methods will be in a separate PR)
- Adapted existing `IndexOf<T>` code to return `true`/`false` instead of the index location
- Provide specific overloads for `<byte>` and `<char>`
- Update known call-sites to use `Contains(…)` instead of `IndexOf(…) > -1`