### PR TITLE
CallSites for MemoryExtensions.Contains (CoreCLR)

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/TraceLogging/Statics.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/TraceLogging/Statics.cs
@@ -174,7 +174,7 @@ namespace System.Diagnostics.Tracing
 
         public static void CheckName(string name)
         {
-            if (name != null && 0 <= name.IndexOf('\0'))
+            if (name != null && name.Contains('\0'))
             {
                 throw new ArgumentOutOfRangeException(nameof(name));
             }

--- a/src/System.Private.CoreLib/shared/System/Globalization/CalendarData.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CalendarData.Unix.cs
@@ -311,7 +311,7 @@ namespace System.Globalization
                         break;
                     default:
                         const string unsupportedDateFieldSymbols = "YuUrQqwWDFg";
-                        Debug.Assert(unsupportedDateFieldSymbols.IndexOf(input[index]) == -1,
+                        Debug.Assert(!unsupportedDateFieldSymbols.Contains(input[index]),
                             string.Format(CultureInfo.InvariantCulture,
                                 "Encountered an unexpected date field symbol '{0}' from ICU which has no known corresponding .NET equivalent.", 
                                 input[index]));

--- a/src/System.Private.CoreLib/shared/System/Globalization/CultureData.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CultureData.cs
@@ -2268,7 +2268,7 @@ namespace System.Globalization
             for (int i = startIndex; i < format.Length; ++i)
             {
                 // See if we have a time Part
-                if (!inQuote && timeParts.IndexOf(format[i]) != -1)
+                if (!inQuote && timeParts.Contains(format[i]))
                 {
                     return i;
                 }

--- a/src/System.Private.CoreLib/shared/System/Guid.cs
+++ b/src/System.Private.CoreLib/shared/System/Guid.cs
@@ -449,7 +449,7 @@ namespace System
             }
 
             // Check for braces
-            bool bracesExistInString = (guidString.IndexOf('{') >= 0);
+            bool bracesExistInString = guidString.Contains('{');
 
             if (bracesExistInString)
             {
@@ -471,7 +471,7 @@ namespace System
             }
 
             // Check for parenthesis
-            bool parenthesisExistInString = (guidString.IndexOf('(') >= 0);
+            bool parenthesisExistInString = guidString.Contains('(');
 
             if (parenthesisExistInString)
             {

--- a/src/System.Private.CoreLib/shared/System/IO/Path.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/Path.Unix.cs
@@ -23,7 +23,7 @@ namespace System.IO
             if (path.Length == 0)
                 throw new ArgumentException(SR.Arg_PathEmpty, nameof(path));
 
-            if (path.IndexOf('\0') != -1)
+            if (path.Contains('\0'))
                 throw new ArgumentException(SR.Argument_InvalidPathChars, nameof(path)); 
             
             // Expand with current directory if necessary

--- a/src/System.Private.CoreLib/shared/System/IO/Path.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/Path.Windows.cs
@@ -47,7 +47,7 @@ namespace System.IO
             // Embedded null characters are the only invalid character case we trully care about.
             // This is because the nulls will signal the end of the string to Win32 and therefore have
             // unpredictable results.
-            if (path.IndexOf('\0') != -1)
+            if (path.Contains('\0'))
                 throw new ArgumentException(SR.Argument_InvalidPathChars, nameof(path));
 
             if (PathInternal.IsExtended(path.AsSpan()))

--- a/src/System.Private.CoreLib/shared/System/IO/PathHelper.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/PathHelper.Windows.cs
@@ -33,7 +33,7 @@ namespace System.IO
 
             // If we have the exact same string we were passed in, don't allocate another string.
             // TryExpandShortName does this input identity check.
-            string result = builder.AsSpan().IndexOf('~') >= 0
+            string result = builder.AsSpan().Contains('~')
                 ? TryExpandShortFileName(ref builder, originalPath: path)
                 : builder.AsSpan().Equals(path.AsSpan(), StringComparison.Ordinal) ? path : builder.ToString();
 
@@ -56,7 +56,7 @@ namespace System.IO
             // Get the full path
             GetFullPathName(path.AsSpan(terminate: true), ref builder);
 
-            string result = builder.AsSpan().IndexOf('~') >= 0
+            string result = builder.AsSpan().Contains('~')
                 ? TryExpandShortFileName(ref builder, originalPath: null)
                 : builder.ToString();
 

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.T.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.T.cs
@@ -51,7 +51,7 @@ namespace System
         }
 
         // Adapted from IndexOf(...)
-        public static unsafe bool Contains<T>(ref T searchSpace, T value, int length)
+        public static bool Contains<T>(ref T searchSpace, T value, int length)
                where T : IEquatable<T>
         {
             Debug.Assert(length >= 0);

--- a/src/System.Private.CoreLib/shared/System/String.Searching.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Searching.cs
@@ -22,10 +22,7 @@ namespace System
             return (IndexOf(value, comparisonType) >= 0);
         }
 
-        public bool Contains(char value)
-        {
-            return IndexOf(value) != -1;
-        }
+        public bool Contains(char value) => SpanHelpers.Contains(ref _firstChar, value, Length);
 
         public bool Contains(char value, StringComparison comparisonType)
         {

--- a/src/System.Private.CoreLib/src/Microsoft/Win32/RegistryKey.cs
+++ b/src/System.Private.CoreLib/src/Microsoft/Win32/RegistryKey.cs
@@ -1041,7 +1041,7 @@ namespace Microsoft.Win32
         internal static string FixupName(string name)
         {
             Debug.Assert(name != null, "[FixupName]name!=null");
-            if (name.IndexOf('\\') == -1)
+            if (!name.Contains('\\'))
                 return name;
 
             StringBuilder sb = new StringBuilder(name);

--- a/src/System.Private.CoreLib/src/System/Environment.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.cs
@@ -420,7 +420,7 @@ namespace System
             {
                 throw new ArgumentException(SR.Argument_StringFirstCharIsZero, nameof(variable));
             }
-            if (variable.IndexOf('=') != -1)
+            if (variable.Contains('='))
             {
                 throw new ArgumentException(SR.Argument_IllegalEnvVarName, nameof(variable));
             }

--- a/src/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
@@ -582,7 +582,7 @@ namespace System.Reflection
             {
                 return true;
             }
-            return (RFC3986ReservedMarks.IndexOf(c) >= 0);
+            return (RFC3986ReservedMarks.Contains(c));
         }
 
         internal static unsafe bool IsUnreserved(char c)
@@ -591,7 +591,7 @@ namespace System.Reflection
             {
                 return true;
             }
-            return (RFC3986UnreservedMarks.IndexOf(c) >= 0);
+            return (RFC3986UnreservedMarks.Contains(c));
         }
 
         //Only consider ASCII characters


### PR DESCRIPTION
- See https://github.com/dotnet/corefx/issues/27526 : `Contains` is optimized over `IndexOf`
- Found additional (~12) callsites that can take advantage of `Span<T>.Contains`
- Extension method does not need to be `unsafe`