### PR TITLE
Adding a perf test for Double.ToString("R") and Single.ToString("R")

### DIFF
--- a/tests/src/JIT/Performance/CodeQuality/Numerics/Double/ToString_R.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Numerics/Double/ToString_R.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.Xunit.Performance;
+
+namespace Numerics
+{
+    public static partial class DoubleTests
+    {
+        // Tests Double.ToString("R") over 5000 iterations for -1.0 to +1.0
+
+        private const double ToString_RDelta = 0.0004;
+
+        [Benchmark(InnerIterationCount = ToString_RIterations)]
+        public static void ToString_RBenchmark()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        ToString_RTest();
+                    }
+                }
+            }
+        }
+
+        public static void ToString_RTest()
+        {
+            double value = -1.0;
+
+            for (int i = 0; i < ToString_RIterations; i++)
+            {
+                value += ToString_RDelta;
+                value.ToString("R");
+            }
+        }
+    }
+}

--- a/tests/src/JIT/Performance/CodeQuality/Numerics/DoubleTests.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Numerics/DoubleTests.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Numerics
+{
+    public static partial class DoubleTests
+    {
+        private const int ToString_RIterations = 5000;
+    }
+}

--- a/tests/src/JIT/Performance/CodeQuality/Numerics/Numerics.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/Numerics/Numerics.csproj
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{C949CB07-60B2-420A-B3CA-59847ED4700B}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetTargetMoniker>.NETCoreApp,Version=v3.0</NuGetTargetMoniker>
+    <NuGetTargetMonikerShort>netcoreapp3.0</NuGetTargetMonikerShort>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="DoubleTests.cs" />
+    <Compile Include="Double\ToString_R.cs" />
+    <Compile Include="SingleTests.cs" />
+    <Compile Include="Single\ToString_R.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/Performance/CodeQuality/Numerics/Program.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Numerics/Program.cs
@@ -1,0 +1,139 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.Xunit.Performance;
+
+[assembly: OptimizeForBenchmarks]
+
+namespace Numerics
+{
+    public static class Program
+    {
+#if DEBUG
+        private const int defaultIterations = 1;
+#else
+        private const int defaultIterations = 1000;
+#endif
+
+        private static readonly IDictionary<string, Action> TestList = new Dictionary<string, Action>() {
+            ["double.tostring_r"] = DoubleTests.ToString_RTest,
+            ["single.tostring_r"] = SingleTests.ToString_RTest,
+        };
+
+        private static int Main(string[] args)
+        {
+            var isPassing = true; var iterations = defaultIterations;
+            ICollection<string> testsToRun = new HashSet<string>();
+
+            try
+            {
+                for (int index = 0; index < args.Length; index++)
+                {
+                    if (args[index].ToLowerInvariant() == "-bench")
+                    {
+                        index++;
+
+                        if ((index >= args.Length) || !int.TryParse(args[index], out iterations))
+                        {
+                            iterations = defaultIterations;
+                        }
+                    }
+                    else if (args[index].ToLowerInvariant() == "all")
+                    {
+                        testsToRun = TestList.Keys;
+                        break;
+                    }
+                    else
+                    {
+                        var testName = args[index].ToLowerInvariant();
+
+                        if (!TestList.ContainsKey(testName))
+                        {
+                            PrintUsage();
+                            break;
+                        }
+
+                        testsToRun.Add(testName);
+                    }
+                }
+
+                if (testsToRun.Count == 0)
+                {
+                    testsToRun = TestList.Keys;
+                }
+
+                foreach (var testToRun in testsToRun)
+                {
+                    Console.WriteLine($"Running {testToRun} test...");
+                    Test(iterations, TestList[testToRun]);
+                }
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine($"    Error: {exception.Message}");
+                isPassing = false;
+            }
+
+            return isPassing ? 100 : -1;
+        }
+
+        private static void PrintUsage()
+        {
+            Console.WriteLine(@"Usage:
+Functions [name] [-bench #]
+
+  [name]: The name of the function to test. Defaults to 'all'.
+    all");
+
+            foreach (var testName in TestList.Keys)
+            {
+                Console.WriteLine($"  {testName}");
+            }
+
+            Console.WriteLine($@"
+  [-bench #]: The number of iterations. Defaults to {defaultIterations}");
+        }
+
+        private static void Test(int iterations, Action action)
+        {
+            // ****************************************************************
+
+            Console.WriteLine("  Warming up...");
+
+            var startTimestamp = Stopwatch.GetTimestamp();
+
+            action();
+
+            var totalElapsedTime = (Stopwatch.GetTimestamp() - startTimestamp);
+            var totalElapsedTimeInSeconds = (totalElapsedTime / (double)(Stopwatch.Frequency));
+
+            Console.WriteLine($"    Total Time: {totalElapsedTimeInSeconds}");
+
+            // ****************************************************************
+
+            Console.WriteLine($"  Executing {iterations} iterations...");
+
+            totalElapsedTime = 0L;
+
+            for (var iteration = 0; iteration < iterations; iteration++)
+            {
+                startTimestamp = Stopwatch.GetTimestamp();
+
+                action();
+
+                totalElapsedTime += (Stopwatch.GetTimestamp() - startTimestamp);
+            }
+
+            totalElapsedTimeInSeconds = (totalElapsedTime / (double)(Stopwatch.Frequency));
+
+            Console.WriteLine($"    Total Time: {totalElapsedTimeInSeconds} seconds");
+            Console.WriteLine($"    Average Time: {totalElapsedTimeInSeconds / iterations} seconds");
+
+            // ****************************************************************
+        }
+    }
+}

--- a/tests/src/JIT/Performance/CodeQuality/Numerics/Single/ToString_R.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Numerics/Single/ToString_R.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.Xunit.Performance;
+
+namespace Numerics
+{
+    public static partial class SingleTests
+    {
+        // Tests Single.ToString("R") over 5000 iterations for -1.0 to +1.0
+
+        private const float ToString_RDelta = 0.0004f;
+
+        [Benchmark(InnerIterationCount = ToString_RIterations)]
+        public static void ToString_RBenchmark()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        ToString_RTest();
+                    }
+                }
+            }
+        }
+
+        public static void ToString_RTest()
+        {
+            float value = -1.0f;
+
+            for (int i = 0; i < ToString_RIterations; i++)
+            {
+                value += ToString_RDelta;
+                value.ToString("R");
+            }
+        }
+    }
+}

--- a/tests/src/JIT/Performance/CodeQuality/Numerics/SingleTests.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Numerics/SingleTests.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Numerics
+{
+    public static partial class SingleTests
+    {
+        private const int ToString_RIterations = 5000;
+    }
+}


### PR DESCRIPTION
This adds a basic perf test for `Double.ToString("R")` and `Single.ToString("R")`.

Testing locally, for x64 Windows I see:
```
Running double.tostring_r test...
  Warming up...
    Total Time: 0.0016542
  Executing 1000 iterations...
    Total Time: 1.5293879 seconds
    Average Time: 0.0015293879 seconds
Running single.tostring_r test...
  Warming up...
    Total Time: 0.0011746
  Executing 1000 iterations...
    Total Time: 1.0363284 seconds
    Average Time: 0.0010363284 seconds
```

For x86 Windows I see:
```
Running double.tostring_r test...
  Warming up...
    Total Time: 0.0023679
  Executing 1000 iterations...
    Total Time: 2.2525623 seconds
    Average Time: 0.0022525623 seconds
Running single.tostring_r test...
  Warming up...
    Total Time: 0.001681
  Executing 1000 iterations...
    Total Time: 1.5032813 seconds
    Average Time: 0.0015032813 seconds
```