### PR TITLE
Fix up the majority of IEEE compliance bugs for Double/Single ToString and Parse

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Double.cs
+++ b/src/System.Private.CoreLib/shared/System/Double.cs
@@ -345,15 +345,15 @@ namespace System
             if (!success)
             {
                 ReadOnlySpan<char> sTrim = s.Trim();
-                if (sTrim.EqualsOrdinal(info.PositiveInfinitySymbol))
+                if (sTrim.EqualsOrdinalIgnoreCase(info.PositiveInfinitySymbol))
                 {
                     result = PositiveInfinity;
                 }
-                else if (sTrim.EqualsOrdinal(info.NegativeInfinitySymbol))
+                else if (sTrim.EqualsOrdinalIgnoreCase(info.NegativeInfinitySymbol))
                 {
                     result = NegativeInfinity;
                 }
-                else if (sTrim.EqualsOrdinal(info.NaNSymbol))
+                else if (sTrim.EqualsOrdinalIgnoreCase(info.NaNSymbol))
                 {
                     result = NaN;
                 }

--- a/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
@@ -402,21 +402,27 @@ namespace System
             NumberBuffer number = default;
             number.kind = NumberBufferKind.Double;
 
+            int precision;
+
             if ((fmt == 'R') || (fmt == 'r'))
             {
-                // IEEE Roundtripping requires us to include at least `17` digits
                 fmt = 'G';
-                digits = DefaultDoublePrecision;
+                precision = DefaultDoublePrecision;
+
+                // IEEE Roundtripping requires us to include at least `17` digits
+                digits = precision;
             }
             else if (digits <= 0)
             {
                 // This ensures that, for the default case, we return a string containing the old
                 // number of digits (15), which results in "prettier" numbers for most cases.
-                digits = DefaultDoubleDigits;
+                precision = DefaultDoubleDigits;
             }
-
-            // IEEE requires we correctly round to the requested number of digits
-            int precision = digits;
+            else
+            {
+                // IEEE requires we correctly round to the requested number of digits
+                precision = digits;
+            }
 
             DoubleToNumber(value, precision, ref number);
 
@@ -470,21 +476,27 @@ namespace System
             NumberBuffer number = default;
             number.kind = NumberBufferKind.Double;
 
+            int precision;
+
             if ((fmt == 'R') || (fmt == 'r'))
             {
-                // IEEE Roundtripping requires us to include at least `9` digits
                 fmt = 'G';
-                digits = DefaultSinglePrecision;
+                precision = DefaultSinglePrecision;
+
+                // IEEE Roundtripping requires us to include at least `9` digits
+                digits = digits;
             }
             else if (digits <= 0)
             {
                 // This ensures that, for the default case, we return a string containing the old
                 // number of digits (7), which results in "prettier" numbers for most cases.
-                digits = DefaultSingleDigits;
+                precision = DefaultSingleDigits;
             }
-
-            // IEEE requires we correctly round to the requested number of digits
-            int precision = digits;
+            else
+            {
+                // IEEE requires we correctly round to the requested number of digits
+                precision = digits;
+            }
 
             DoubleToNumber(value, precision, ref number);
 

--- a/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
@@ -243,8 +243,8 @@ namespace System
     internal static partial class Number
     {
         internal const int DecimalPrecision = 29; // Decimal.DecCalc also uses this value
-        private const int FloatPrecision = 7;
-        private const int DoublePrecision = 15;
+        private const int SinglePrecision = 9;
+        private const int DoublePrecision = 17;
         private const int ScaleNAN = unchecked((int)0x80000000);
         private const int ScaleINF = 0x7FFFFFFF;
         private const int MaxUInt32DecDigits = 10;
@@ -391,57 +391,18 @@ namespace System
             NumberBuffer number = default;
             number.kind = NumberBufferKind.Double;
 
-            switch (fmt)
+            if ((fmt == 'R') || (fmt == 'r'))
             {
-                case 'R':
-                case 'r':
-                    {
-                        // In order to give numbers that are both friendly to display and round-trippable, we parse the
-                        // number using 15 digits and then determine if it round trips to the same value. If it does, we
-                        // convert that NUMBER to a string, otherwise we reparse using 17 digits and display that.
-                        DoubleToNumber(value, DoublePrecision, ref number);
-                        if (number.scale == ScaleNAN)
-                        {
-                            return info.NaNSymbol;
-                        }
-                        else if (number.scale == ScaleINF)
-                        {
-                            return number.sign ? info.NegativeInfinitySymbol : info.PositiveInfinitySymbol;
-                        }
-
-                        if (NumberToDouble(ref number) == value)
-                        {
-                            NumberToString(ref sb, ref number, 'G', DoublePrecision, info);
-                        }
-                        else
-                        {
-                            DoubleToNumber(value, 17, ref number);
-                            NumberToString(ref sb, ref number, 'G', 17, info);
-                        }
-
-                        return null;
-                    }
-
-                case 'E':
-                case 'e':
-                    // Round values less than E14 to 15 digits
-                    if (digits > 14)
-                    {
-                        precision = 17;
-                    }
-                    break;
-
-                case 'G':
-                case 'g':
-                    // Round values less than G15 to 15 digits. G16 and G17 will not be touched.
-                    if (digits > 15)
-                    {
-                        precision = 17;
-                    }
-                    break;
+                fmt = 'G';
+                digits = DoublePrecision;
+            }
+            else if (digits > 0)
+            {
+                precision = digits;
             }
 
             DoubleToNumber(value, precision, ref number);
+
             if (number.scale == ScaleNAN)
             {
                 return info.NaNSymbol;
@@ -488,60 +449,22 @@ namespace System
         private static string FormatSingle(ref ValueStringBuilder sb, float value, ReadOnlySpan<char> format, NumberFormatInfo info)
         {
             char fmt = ParseFormatSpecifier(format, out int digits);
-            int precision = FloatPrecision;
+            int precision = SinglePrecision;
             NumberBuffer number = default;
             number.kind = NumberBufferKind.Double;
 
-            switch (fmt)
+            if ((fmt == 'R') || (fmt == 'r'))
             {
-                case 'R':
-                case 'r':
-                    {
-                        // In order to give numbers that are both friendly to display and round-trippable, we parse the
-                        // number using 7 digits and then determine if it round trips to the same value. If it does, we
-                        // convert that NUMBER to a string, otherwise we reparse using 9 digits and display that.
-                        DoubleToNumber(value, FloatPrecision, ref number);
-                        if (number.scale == ScaleNAN)
-                        {
-                            return info.NaNSymbol;
-                        }
-                        else if (number.scale == ScaleINF)
-                        {
-                            return number.sign ? info.NegativeInfinitySymbol : info.PositiveInfinitySymbol;
-                        }
-
-                        if ((float)NumberToDouble(ref number) == value)
-                        {
-                            NumberToString(ref sb, ref number, 'G', FloatPrecision, info);
-                        }
-                        else
-                        {
-                            DoubleToNumber(value, 9, ref number);
-                            NumberToString(ref sb, ref number, 'G', 9, info);
-                        }
-                        return null;
-                    }
-
-                case 'E':
-                case 'e':
-                    // Round values less than E14 to 15 digits.
-                    if (digits > 6)
-                    {
-                        precision = 9;
-                    }
-                    break;
-
-                case 'G':
-                case 'g':
-                    // Round values less than G15 to 15 digits. G16 and G17 will not be touched.
-                    if (digits > 7)
-                    {
-                        precision = 9;
-                    }
-                    break;
+                fmt = 'G';
+                digits = SinglePrecision;
+            }
+            else if (digits > 0)
+            {
+                precision = digits;
             }
 
             DoubleToNumber(value, precision, ref number);
+
             if (number.scale == ScaleNAN)
             {
                 return info.NaNSymbol;
@@ -559,6 +482,7 @@ namespace System
             {
                 NumberToStringFormat(ref sb, ref number, format, info);
             }
+
             return null;
         }
 

--- a/src/System.Private.CoreLib/shared/System/Number.NumberBuffer.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.NumberBuffer.cs
@@ -10,7 +10,9 @@ namespace System
 {
     internal static partial class Number
     {
-        private const int NumberMaxDigits = 50; // needs to == NUMBER_MAXDIGITS in coreclr's src/classlibnative/bcltype/number.h.
+        // needs to == NUMBER_MAXDIGITS in coreclr's src/classlibnative/bcltype/number.h.
+        // We currently set this to 99, as that is the maximum precision allowed for the standard format strings
+        private const int NumberMaxDigits = 99;
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
         internal unsafe ref struct NumberBuffer // needs to match layout of NUMBER in coreclr's src/classlibnative/bcltype/number.h

--- a/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
@@ -534,7 +534,7 @@ namespace System
                         {
                             number.scale = 0;
                         }
-                        if ((state & StateDecimal) == 0)
+                        if ((number.kind == NumberBufferKind.Integer) && ((state & StateDecimal) == 0))
                         {
                             number.sign = false;
                         }

--- a/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
@@ -1589,15 +1589,15 @@ namespace System
                 //Check the three with which we're concerned and rethrow if it's not one of
                 //those strings.
                 ReadOnlySpan<char> sTrim = value.Trim();
-                if (sTrim.EqualsOrdinal(info.PositiveInfinitySymbol))
+                if (sTrim.EqualsOrdinalIgnoreCase(info.PositiveInfinitySymbol))
                 {
                     return double.PositiveInfinity;
                 }
-                if (sTrim.EqualsOrdinal(info.NegativeInfinitySymbol))
+                if (sTrim.EqualsOrdinalIgnoreCase(info.NegativeInfinitySymbol))
                 {
                     return double.NegativeInfinity;
                 }
-                if (sTrim.EqualsOrdinal(info.NaNSymbol))
+                if (sTrim.EqualsOrdinalIgnoreCase(info.NaNSymbol))
                 {
                     return double.NaN;
                 }
@@ -1624,15 +1624,15 @@ namespace System
                 //Check the three with which we're concerned and rethrow if it's not one of
                 //those strings.
                 ReadOnlySpan<char> sTrim = value.Trim();
-                if (sTrim.EqualsOrdinal(info.PositiveInfinitySymbol))
+                if (sTrim.EqualsOrdinalIgnoreCase(info.PositiveInfinitySymbol))
                 {
                     return float.PositiveInfinity;
                 }
-                if (sTrim.EqualsOrdinal(info.NegativeInfinitySymbol))
+                if (sTrim.EqualsOrdinalIgnoreCase(info.NegativeInfinitySymbol))
                 {
                     return float.NegativeInfinity;
                 }
-                if (sTrim.EqualsOrdinal(info.NaNSymbol))
+                if (sTrim.EqualsOrdinalIgnoreCase(info.NaNSymbol))
                 {
                     return float.NaN;
                 }

--- a/src/System.Private.CoreLib/shared/System/Single.cs
+++ b/src/System.Private.CoreLib/shared/System/Single.cs
@@ -334,15 +334,15 @@ namespace System
             if (!success)
             {
                 ReadOnlySpan<char> sTrim = s.Trim();
-                if (sTrim.EqualsOrdinal(info.PositiveInfinitySymbol))
+                if (sTrim.EqualsOrdinalIgnoreCase(info.PositiveInfinitySymbol))
                 {
                     result = PositiveInfinity;
                 }
-                else if (sTrim.EqualsOrdinal(info.NegativeInfinitySymbol))
+                else if (sTrim.EqualsOrdinalIgnoreCase(info.NegativeInfinitySymbol))
                 {
                     result = NegativeInfinity;
                 }
-                else if (sTrim.EqualsOrdinal(info.NaNSymbol))
+                else if (sTrim.EqualsOrdinalIgnoreCase(info.NaNSymbol))
                 {
                     result = NaN;
                 }

--- a/src/classlibnative/bcltype/number.cpp
+++ b/src/classlibnative/bcltype/number.cpp
@@ -304,13 +304,20 @@ void DoubleToNumber(double value, int precision, NUMBER* number)
     WRAPPER_NO_CONTRACT
     _ASSERTE(number != NULL);
 
+    if (precision > NUMBER_MAXDIGITS)
+    {
+        precision = NUMBER_MAXDIGITS;
+    }
     number->precision = precision;
-    if (((FPDOUBLE*)&value)->exp == 0x7FF) {
+
+    if (((FPDOUBLE*)&value)->exp == 0x7FF)
+    {
         number->scale = (((FPDOUBLE*)&value)->mantLo || ((FPDOUBLE*)&value)->mantHi) ? SCALE_NAN: SCALE_INF;
         number->sign = ((FPDOUBLE*)&value)->sign;
         number->digits[0] = 0;
     }
-    else {
+    else
+    {
         DoubleToNumberWorker(value, precision, &number->scale, &number->sign, number->digits);
     }
 }

--- a/src/classlibnative/bcltype/number.h
+++ b/src/classlibnative/bcltype/number.h
@@ -12,7 +12,7 @@
 
 #include <pshpack1.h>
 
-#define NUMBER_MAXDIGITS 50
+#define NUMBER_MAXDIGITS 99
 
 static const double LOG10V2 = 0.30102999566398119521373889472449;
 

--- a/tests/CoreFX/CoreFX.issues.json
+++ b/tests/CoreFX/CoreFX.issues.json
@@ -117,6 +117,14 @@
                 {
                     "name": "System.ComponentModel.Tests.EnumConverterTests.ConvertTo_ULongFlagsEnum_EnumArray",
                     "reason": "System.OverflowException : Value was either too large or too small for an Int64."
+                },
+                {
+                    "name": "System.ComponentModel.Tests.DoubleConverterTests.ConvertTo_WithContext",
+                    "reason": "https://github.com/dotnet/coreclr/pull/19905"
+                },
+                {
+                    "name": "System.ComponentModel.Tests.SingleConverterTests.ConvertTo_WithContext",
+                    "reason": "https://github.com/dotnet/coreclr/pull/19905"
                 }
             ]
         }
@@ -285,6 +293,18 @@
                { 
                 "name": "System.Buffers.Text.Tests.FormatterTests.TestFormatterDecimal",
                 "reason": "https://github.com/dotnet/coreclr/pull/19775"
+               },
+               {
+                "name": "System.Buffers.Text.Tests.ParserTests.TestParserSingle",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               {
+                "name": "System.Buffers.Text.Tests.ParserTests.TestParserDouble",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               {
+                "name": "System.Buffers.Text.Tests.ParserTests.TestParserDecimal",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
                }
             ]
         }
@@ -299,6 +319,344 @@
                { 
                 "name": "System.Tests.ConvertToStringTests.FromBoxedObject",
                 "reason": "https://github.com/dotnet/coreclr/pull/19775"
+               }
+            ]
+        }
+    },
+    {
+        "name": "System.Runtime.Serialization.Xml.Tests",
+        "enabled": true,
+        "exclusions": {
+            "namespaces": null,
+            "classes": null,
+            "methods": [
+               { 
+                "name": "DataContractSerializerTests.DCS_ArrayOfDouble",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractSerializerTests.DCS_ArrayOfSingle",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractSerializerTests.DCS_BasicRoundTripResolvePrimitiveTypes",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractSerializerTests.DCS_BasicPerSerializerRoundTripAndCompare_EnumStruct",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractSerializerTests.DCS_DoubleAsRoot",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractSerializerTests.DCS_FloatAsRoot",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractSerializerTests.DCS_GenericICollectionOfDouble",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractSerializerTests.DCS_GenericICollectionOfSingle",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractSerializerTests.DCS_GenericTypeWithNestedGenerics",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractSerializerTests.DCS_TypeWithAllPrimitiveProperties",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractSerializerTests.DCS_TypeWithPrimitiveKnownTypes",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               }
+            ]
+        }
+    },
+    {
+        "name": "System.Runtime.Serialization.Xml.ReflectionOnly.Tests",
+        "enabled": true,
+        "exclusions": {
+            "namespaces": null,
+            "classes": null,
+            "methods": [
+               { 
+                "name": "DataContractSerializerTests.DCS_ArrayOfDouble",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractSerializerTests.DCS_ArrayOfSingle",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractSerializerTests.DCS_BasicRoundTripResolvePrimitiveTypes",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractSerializerTests.DCS_BasicPerSerializerRoundTripAndCompare_EnumStruct",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractSerializerTests.DCS_DoubleAsRoot",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractSerializerTests.DCS_FloatAsRoot",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractSerializerTests.DCS_GenericICollectionOfDouble",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractSerializerTests.DCS_GenericICollectionOfSingle",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractSerializerTests.DCS_GenericTypeWithNestedGenerics",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractSerializerTests.DCS_TypeWithAllPrimitiveProperties",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractSerializerTests.DCS_TypeWithPrimitiveKnownTypes",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               }
+            ]
+        }
+    },
+    {
+        "name": "System.Runtime.Serialization.Json.Tests",
+        "enabled": true,
+        "exclusions": {
+            "namespaces": null,
+            "classes": null,
+            "methods": [
+               { 
+                "name": "DataContractJsonSerializerTests.DCJS_ArrayOfDouble",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractJsonSerializerTests.DCJS_ArrayOfSingle",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractJsonSerializerTests.DCJS_DoubleAsRoot",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractJsonSerializerTests.DCJS_FloatAsRoot",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractJsonSerializerTests.DCJS_GenericICollectionOfDouble",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractJsonSerializerTests.DCJS_GenericICollectionOfSingle",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractJsonSerializerTests.DCJS_GenericTypeWithNestedGenerics",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractJsonSerializerTests.DCJS_TypeWithAllPrimitiveProperties",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractJsonSerializerTests.DCJS_VerifyIndentation",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               }
+            ]
+        }
+    },
+    {
+        "name": "System.Runtime.Serialization.Json.ReflectionOnly.Tests",
+        "enabled": true,
+        "exclusions": {
+            "namespaces": null,
+            "classes": null,
+            "methods": [
+               { 
+                "name": "DataContractJsonSerializerTests.DCJS_ArrayOfDouble",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractJsonSerializerTests.DCJS_ArrayOfSingle",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractJsonSerializerTests.DCJS_DoubleAsRoot",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractJsonSerializerTests.DCJS_FloatAsRoot",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractJsonSerializerTests.DCJS_GenericICollectionOfDouble",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractJsonSerializerTests.DCJS_GenericICollectionOfSingle",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractJsonSerializerTests.DCJS_GenericTypeWithNestedGenerics",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractJsonSerializerTests.DCJS_TypeWithAllPrimitiveProperties",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "DataContractJsonSerializerTests.DCJS_VerifyIndentation",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               }
+            ]
+        }
+    },
+    {
+        "name": "System.Drawing.Primitives.Tests",
+        "enabled": true,
+        "exclusions": {
+            "namespaces": null,
+            "classes": null,
+            "methods": [
+               { 
+                "name": "System.Drawing.Primitives.Tests.DataContractSerializerTests.DCS_RectangleF",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               }
+            ]
+        }
+    },
+    {
+        "name": "System.Json.Tests",
+        "enabled": true,
+        "exclusions": {
+            "namespaces": null,
+            "classes": null,
+            "methods": [
+               { 
+                "name": "System.Json.Tests.JsonPrimitiveTests.ToString_Double",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "System.Json.Tests.JsonPrimitiveTests.ToString_Float",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "System.Json.Tests.JsonValueTests.JsonValue_Parse_MinMax_Integers_ViaJsonPrimitive",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               }
+            ]
+        }
+    },
+    {
+        "name": "System.Xml.Xsl.XslTransformApi.Tests",
+        "enabled": true,
+        "exclusions": {
+            "namespaces": null,
+            "classes": null,
+            "methods": [
+               { 
+                "name": "System.Xml.Tests.CArgAddExtObj.AddExtObject22",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               }
+            ]
+        }
+    },
+    {
+        "name": "System.Xml.RW.XmlWriterApi.Tests",
+        "enabled": true,
+        "exclusions": {
+            "namespaces": null,
+            "classes": null,
+            "methods": [
+               { 
+                "name": "System.Xml.Tests.TCFullEndElement+TCWriteValue.writeValue_1",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "System.Xml.Tests.TCFullEndElement+TCWriteValue.writeValue_2",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "System.Xml.Tests.TCFullEndElement+TCWriteValue.writeValue_3",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "System.Xml.Tests.TCFullEndElement+TCWriteValue.writeValue_4",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "System.Xml.Tests.TCFullEndElement+TCWriteValue.writeValue_5",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "System.Xml.Tests.TCFullEndElement+TCWriteValue.writeValue_6",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "System.Xml.Tests.TCFullEndElement+TCWriteValue.writeValue_27",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               }
+            ]
+        }
+    },
+    {
+        "name": "System.Xml.RW.XmlConvert.Tests",
+        "enabled": true,
+        "exclusions": {
+            "namespaces": null,
+            "classes": null,
+            "methods": [
+               { 
+                "name": "System.Xml.Tests.XmlConvertTests.RunTests",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               }
+            ]
+        }
+    },
+    {
+        "name": "System.Xml.XmlSerializer.Tests",
+        "enabled": true,
+        "exclusions": {
+            "namespaces": null,
+            "classes": null,
+            "methods": [
+               { 
+                "name": "XmlSerializerTests.Xml_FloatAsRoot",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "XmlSerializerTests.Xml_DoubleAsRoot",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               }
+            ]
+        }
+    },
+    {
+        "name": "System.Xml.XmlSerializer.ReflectionOnly.Tests",
+        "enabled": true,
+        "exclusions": {
+            "namespaces": null,
+            "classes": null,
+            "methods": [
+               { 
+                "name": "XmlSerializerTests.Xml_FloatAsRoot",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
+               },
+               { 
+                "name": "XmlSerializerTests.Xml_DoubleAsRoot",
+                "reason": "https://github.com/dotnet/coreclr/pull/19905"
                }
             ]
         }


### PR DESCRIPTION
This resolves the majority of the issues covered by https://github.com/dotnet/coreclr/issues/19802:
* Ensures that double.Parse for `-0` works correctly
* Ensures that recovering `NaN`, `PositiveInfinity`, and `NegativeInfinity` is done case insensitively
* Ensures that "R" always roundtrips to the required number of digits
* Ensures that the "precision" specifier works up to `50` digits
  * `50` is the current internal limit for `DoubleToNumber`
  * IEEE requires at least `20` for Double and `12` for Single

This should resolve (validated locally, can close after CoreFX tests are added):
* https://github.com/dotnet/coreclr/issues/16783

This should partially resolve, both of which deal with `ToString("R")`, but which also involves parsing the result back as well:
* https://github.com/dotnet/coreclr/issues/3313
* https://github.com/dotnet/coreclr/issues/13106

Not Resolved:
* https://github.com/dotnet/coreclr/issues/1316
* https://github.com/dotnet/coreclr/issues/13615
  * `double.MinValue` and `double.MaxValue` require 17 digits to roundtrip, otherwise an overflow occurs. The current default number of digits is 15, for any format that isn't "R"
* https://github.com/dotnet/coreclr/issues/17467

This does not handle:
* `-nan` and `+nan`, which IEEE requires we support parsing, but which we can parse to "Regular" `NaN`
* `snan`, which IEEE requires we support parsing; but which we can parse to "regular" `NaN`
  * support for preceding `-` and `+` is also required for `snan`
  * IEEE does not require us to support formatting `snan`, we are free to format to "regular" `NaN`.
* `NaN` and `SNaN` payloads, which are optional
* `+Infinity` (case insensitive), which IEEE requires we support parsing