### PR TITLE
Fix xplat debugging perf problem.

### DIFF
--- a/src/debug/ee/debugger.h
+++ b/src/debug/ee/debugger.h
@@ -2679,6 +2679,7 @@ private:
         ipce->hr = S_OK;
 
         ipce->processId = m_processId;
+        ipce->threadId = 0;
         // AppDomain, Thread, are already initialized
     }
 
@@ -2709,6 +2710,7 @@ private:
         ipce->type = type;
         ipce->hr = S_OK;
         ipce->processId = m_processId;
+        ipce->threadId = pThread ? pThread->GetOSThreadId() : 0;
         ipce->vmAppDomain = vmAppDomain;
         ipce->vmThread.SetRawPtr(pThread);
     }

--- a/src/debug/inc/dbgipcevents.h
+++ b/src/debug/inc/dbgipcevents.h
@@ -180,15 +180,14 @@ struct MSLAYOUT DebuggerIPCRuntimeOffsets
 
 #if defined(DBG_TARGET_X86) || defined(DBG_TARGET_ARM)
 #ifdef _WIN64
-#define CorDBIPC_BUFFER_SIZE (2096)
+#define CorDBIPC_BUFFER_SIZE 2104
 #else
-#define CorDBIPC_BUFFER_SIZE (2088) // hand tuned to ensure that ipc block in IPCHeader.h fits in 1 page.
+#define CorDBIPC_BUFFER_SIZE 2092
 #endif
 #else  // !_TARGET_X86_ && !_TARGET_ARM_
-// This is the size of a DebuggerIPCEvent.  You will hit an assert in Cordb::Initialize() (DI\process.cpp)
+// This is the size of a DebuggerIPCEvent.  You will hit an assert in Cordb::Initialize() (di\rsmain.cpp)
 // if this is not defined correctly.  AMD64 actually has a page size of 0x1000, not 0x2000.
-#define CorDBIPC_BUFFER_SIZE 4016 // (4016 + 6) * 2 + 148 = 8192 (two (DebuggerIPCEvent + alignment padding) +
-                                  //                              other fields = page size)
+#define CorDBIPC_BUFFER_SIZE 4016 // (4016 + 6) * 2 + 148 = 8192 (two (DebuggerIPCEvent + alignment padding) + other fields = page size)
 #endif // DBG_TARGET_X86 || DBG_TARGET_ARM
 
 //
@@ -1911,6 +1910,7 @@ struct MSLAYOUT DebuggerIPCEvent
     DebuggerIPCEvent*       next;
     DebuggerIPCEventType    type;
     DWORD             processId;
+    DWORD             threadId;
     VMPTR_AppDomain   vmAppDomain;
     VMPTR_Thread      vmThread;
 


### PR DESCRIPTION
Issue #18705

Add threadId to DebuggerIPCEvent so we don't need to use the
slow DAC functions (because of extra memory reads) to get it.