### PR TITLE
Fix emitIns_S_S_R_R not to encode SP to ZR before an add may be emitted

### DIFF
--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -6783,7 +6783,6 @@ void emitter::emitIns_S_S_R_R(
 
     // TODO-ARM64-CQ: with compLocallocUsed, should we use REG_SAVED_LOCALLOC_SP instead?
     regNumber reg3 = FPbased ? REG_FPBASE : REG_SPBASE;
-    reg3           = encodingSPtoZR(reg3);
 
     bool    useRegForAdr = true;
     ssize_t imm          = disp;
@@ -6836,6 +6835,8 @@ void emitter::emitIns_S_S_R_R(
     {
         id->idGCrefReg2(GCT_NONE);
     }
+
+    reg3 = encodingSPtoZR(reg3);
 
     id->idReg1(reg1);
     id->idReg2(reg2);


### PR DESCRIPTION
There is a potential branch in `emitIns_S_S_R_R` below where we were calling `encodingSPtoZR`. That branch can lead us to call `emitIns_R_R_Imm` to emit an add instruction. If `reg3` has already been encoded as ZR by this point, `emitIns_R_R_I` throws an assert because it does not expect SP to have already been encoded as ZR (in fact, `emitIns_R_R_I` does the same encoding itself to the regs passed in).

This fix just moves the encoding of `reg3` in `emitIns_S_S_R_R` further down past where `reg3` might be involved in an add to prevent this from happening.

@BruceForstall @jashook 