### PR TITLE
Expand CrossGen Comparison script to able to run on DotNetSdk archive

### DIFF
--- a/tests/scripts/crossgen_comparison.py
+++ b/tests/scripts/crossgen_comparison.py
@@ -287,7 +287,7 @@ class CrossGenRunner:
     def __init__(self, crossgen_executable_filename, no_logo=True):
         self.crossgen_executable_filename = crossgen_executable_filename
         self.no_logo = no_logo
-        self.platform_assemblies_paths_sep = ";"
+        self.platform_assemblies_paths_sep = ';' if sys.platform == 'win32' else ':'
 
     """
         Creates a subprocess running crossgen with specified set of arguments, 

--- a/tests/scripts/crossgen_comparison.py
+++ b/tests/scripts/crossgen_comparison.py
@@ -116,7 +116,7 @@ def build_argument_parser():
     frameworks_parser.add_argument('--result_dir', dest='result_dirname', required=True)
     frameworks_parser.set_defaults(func=crossgen_framework)
 
-    dotnet_sdk_parser_description = """Unpack .NET Core SDK archive file and runs crossgen on each assembly."""
+    dotnet_sdk_parser_description = "Unpack .NET Core SDK archive file and runs crossgen on each assembly."
     dotnet_sdk_parser = subparsers.add_parser('crossgen_dotnet_sdk', description=dotnet_sdk_parser_description)
     dotnet_sdk_parser.add_argument('--crossgen', dest='crossgen_executable_filename', required=True)
     dotnet_sdk_parser.add_argument('--il_corelib', dest='il_corelib_filename', required=True)

--- a/tests/scripts/crossgen_comparison.py
+++ b/tests/scripts/crossgen_comparison.py
@@ -27,7 +27,7 @@
 #  --il_corelib bin/Product/Linux.arm.Checked/IL/System.Private.CoreLib.dll
 #  --result_dir Linux.arm_arm.Checked
 #
-# runs arm_arm crossgen on System.Private.CoreLib.dll and puts all the
+# runs Hostarm/arm crossgen on System.Private.CoreLib.dll and puts all the
 # information in file Linux.arm_arm.Checked/System.Private.CoreLib.dll.json
 #
 #  ~/git/coreclr$ cat Linux.arm_arm.Checked/System.Private.CoreLib.dll.json
@@ -40,6 +40,31 @@
 #       "Native image /tmp/System.Private.CoreLib.dll generated successfully."
 #     ]
 #   }
+#
+# The following command
+#
+#  ~/git/coreclr$ python tests/scripts/crossgen_comparison.py crossgen_dotnet_sdk
+#  --crossgen bin/Product/Linux.arm.Checked/x64/crossgen
+#  --il_corelib bin/Product/Linux.arm.Checked/IL/System.Private.CoreLib.dll
+#  --dotnet_sdk dotnet-sdk-latest-linux-arm.tar.gz
+#  --result_dir Linux.x64_arm.Checked
+#
+#  runs Hostx64/arm crossgen on System.Private.CoreLib.dll in bin/Product and on
+#  all the assemblies inside dotnet-sdk-latest-linux-arm.tar.gz and stores the
+#  collected information in directory Linux.x64_arm.Checked
+#
+#  ~/git/coreclr$ ls Linux.x64_arm.Checked | head
+#   Microsoft.AI.DependencyCollector.dll.json
+#   Microsoft.ApplicationInsights.AspNetCore.dll.json
+#   Microsoft.ApplicationInsights.dll.json
+#   Microsoft.AspNetCore.Antiforgery.dll.json
+#   Microsoft.AspNetCore.ApplicationInsights.HostingStartup.dll.json
+#   Microsoft.AspNetCore.Authentication.Abstractions.dll.json
+#   Microsoft.AspNetCore.Authentication.Cookies.dll.json
+#   Microsoft.AspNetCore.Authentication.Core.dll.json
+#   Microsoft.AspNetCore.Authentication.dll.json
+#   Microsoft.AspNetCore.Authentication.Facebook.dll.json
+#
 ################################################################################
 ################################################################################
 


### PR DESCRIPTION
The example of `crossgen_dotnet_sdk` command
```
~/git/coreclr$ python tests/scripts/crossgen_comparison.py crossgen_dotnet_sdk 
--crossgen bin/Product/Linux.arm.Checked/x64/crossgen 
--il_corelib bin/Product/Linux.arm.Checked/IL/System.Private.CoreLib.dll 
--dotnet_sdk dotnet-sdk-latest-linux-arm.tar.gz 
--result_dir Linux.x64_arm.Checked 
```
which unpacks dotnet_sdk tarball and runs crossgen on 345 assemblies in it.

This PR also improve reporting format for 'compare' command