### PR TITLE
Publish both Hostx86 and Hostx64 arm32 CrossGens on Linux

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -160,7 +160,10 @@
     <HasCrossTargetComponents Condition="'$(TargetsWindows)' == 'true' and ('$(PackagePlatform)' =='arm64' or '$(PackagePlatform)' =='arm')">true</HasCrossTargetComponents>
     <HasCrossTargetComponents Condition="'$(TargetsLinux)' == 'true' and ('$(PackagePlatform)' =='arm64' or '$(PackagePlatform)' =='arm') and '$(__DoCrossArchBuild)' == '1'">true</HasCrossTargetComponents>
     <CrossTargetComponentFolder Condition="'$(PackagePlatform)' == 'arm64'">x64</CrossTargetComponentFolder>
-    <CrossTargetComponentFolder Condition="'$(PackagePlatform)' == 'arm'">x86</CrossTargetComponentFolder>
+    <CrossTargetComponentFolder Condition="'$(PackagePlatform)' == 'arm' and '$(TargetsWindows)' == 'true'">x86</CrossTargetComponentFolder>
+    <CrossTargetComponentFolder Condition="'$(PackagePlatform)' == 'arm' and '$(TargetsLinux)' == 'true'">x64</CrossTargetComponentFolder>
+    <_HasObsoleteCrossTargetComponents Condition="'$(TargetsLinux)' == 'true' and '$(PackagePlatform)' =='arm' and '$(__DoCrossArchBuild)' == '1'">true</_HasObsoleteCrossTargetComponents>
+    <_ObsoleteCrossTargetComponentFolder Condition="'$(PackagePlatform)' == 'arm'">x86</_ObsoleteCrossTargetComponentFolder>
 
     <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(PackagesBinDir)/pkg/</PackageOutputPath>
     <SymbolPackageOutputPath Condition="'$(SymbolPackageOutputPath)' == ''">$(PackagesBinDir)/symbolpkg/</SymbolPackageOutputPath>

--- a/src/.nuget/Microsoft.NETCore.Jit/runtime.Linux.Microsoft.NETCore.Jit.props
+++ b/src/.nuget/Microsoft.NETCore.Jit/runtime.Linux.Microsoft.NETCore.Jit.props
@@ -3,5 +3,6 @@
   <ItemGroup>
     <NativeBinary Include="$(BinDir)libclrjit.so" />
     <CrossArchitectureSpecificNativeFileAndSymbol Condition="'$(HasCrossTargetComponents)' == 'true'" Include="$(BinDir)$(CrossTargetComponentFolder)\libclrjit.so" />
+    <_ObsoleteCrossArchitectureSpecificNativeFileAndSymbol Condition="'$(_HasObsoleteCrossTargetComponents)' == 'true'" Include="$(BinDir)$(_ObsoleteCrossTargetComponentFolder)\libclrjit.so" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -26,5 +26,6 @@
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
     <CrossArchitectureSpecificToolFile Condition="'$(HasCrossTargetComponents)' == 'true'" Include="$(BinDir)$(CrossTargetComponentFolder)\crossgen" />
+    <_ObsoleteCrossArchitectureSpecificToolFile Condition="'$(_HasObsoleteCrossTargetComponents)' == 'true'" Include="$(BinDir)$(_ObsoleteCrossTargetComponentFolder)\crossgen" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/dir.targets
+++ b/src/.nuget/dir.targets
@@ -39,6 +39,15 @@
       </NativeWithSymbolFile>
     </ItemGroup>
 
+    <ItemGroup Condition="'$(_HasObsoleteCrossTargetComponents)'=='true'">
+      <NativeWithSymbolFile Include="@(_ObsoleteCrossArchitectureSpecificNativeFileAndSymbol)">
+        <TargetPath>runtimes/$(_ObsoleteCrossTargetComponentFolder)_$(Platform)/native</TargetPath>
+      </NativeWithSymbolFile>
+      <NativeWithSymbolFile Include="@(_ObsoleteCrossArchitectureSpecificToolFile)">
+        <TargetPath>tools/$(_ObsoleteCrossTargetComponentFolder)_$(Platform)</TargetPath>
+      </NativeWithSymbolFile>
+   </ItemGroup>
+
     <ItemGroup>
       <!-- The symbols for these files are already in place together with respective *.ni.pdb -->
       <IlForCrossGenedFile Include="@(CrossGenBinary -> '%(RootDir)%(Directory)IL\%(Filename).dll')">


### PR DESCRIPTION
This PR enables publishing both Hostx86 and Hostx64 arm32 CrossGens and Jits on Linux so the corresponding transport NuGet packages would like these:
```
transport.runtime.linux-arm.microsoft.netcore.jit.3.0.0-preview1-26913-06>dir runtimes

09/13/2018  10:32 AM    <DIR>          .
09/13/2018  10:32 AM    <DIR>          ..
09/13/2018  10:32 AM    <DIR>          linux-arm
09/13/2018  10:32 AM    <DIR>          x64_arm
09/13/2018  10:32 AM    <DIR>          x86_arm
               0 File(s)              0 bytes
               5 Dir(s)  290,486,042,624 bytes free
```
```
transport.runtime.linux-arm.microsoft.netcore.runtime.coreclr.3.0.0-preview1-26913-06>dir tools

09/13/2018  10:32 AM    <DIR>          .
09/13/2018  10:32 AM    <DIR>          ..
09/13/2018  10:32 AM    <DIR>          x64_arm
09/13/2018  10:32 AM    <DIR>          x86_arm
09/13/2018  04:57 PM         4,393,179 crossgen
09/13/2018  04:57 PM        47,812,406 crossgen.dbg
               2 File(s)     52,205,585 bytes
               4 Dir(s)  290,483,445,760 bytes free
```

Hostx86/arm32 CrossGen and Jit are enabled as "ObsoleteCrossTargetComponents" - the corresponding changes in MSBuild files are added temporary and eventually will be removed.

Hostx64/arm32 CrossGen and Jit are enabled as *default* "CrossTargetComponents"