### PR TITLE
convert HandleStore::_underlyingBucket to a pointer

### DIFF
--- a/src/gc/gchandletable.cpp
+++ b/src/gc/gchandletable.cpp
@@ -18,35 +18,35 @@ IGCHandleManager* CreateGCHandleManager()
 
 void GCHandleStore::Uproot()
 {
-    Ref_RemoveHandleTableBucket(_underlyingBucket);
+    Ref_RemoveHandleTableBucket(&_underlyingBucket);
 }
 
 bool GCHandleStore::ContainsHandle(OBJECTHANDLE handle)
 {
-    return _underlyingBucket->Contains(handle);
+    return _underlyingBucket.Contains(handle);
 }
 
 OBJECTHANDLE GCHandleStore::CreateHandleOfType(Object* object, HandleType type)
 {
-    HHANDLETABLE handletable = _underlyingBucket->pTable[GetCurrentThreadHomeHeapNumber()];
+    HHANDLETABLE handletable = _underlyingBucket.pTable[GetCurrentThreadHomeHeapNumber()];
     return ::HndCreateHandle(handletable, type, ObjectToOBJECTREF(object));
 }
 
 OBJECTHANDLE GCHandleStore::CreateHandleOfType(Object* object, HandleType type, int heapToAffinitizeTo)
 {
-    HHANDLETABLE handletable = _underlyingBucket->pTable[heapToAffinitizeTo];
+    HHANDLETABLE handletable = _underlyingBucket.pTable[heapToAffinitizeTo];
     return ::HndCreateHandle(handletable, type, ObjectToOBJECTREF(object));
 }
 
 OBJECTHANDLE GCHandleStore::CreateHandleWithExtraInfo(Object* object, HandleType type, void* pExtraInfo)
 {
-    HHANDLETABLE handletable = _underlyingBucket->pTable[GetCurrentThreadHomeHeapNumber()];
+    HHANDLETABLE handletable = _underlyingBucket.pTable[GetCurrentThreadHomeHeapNumber()];
     return ::HndCreateHandle(handletable, type, ObjectToOBJECTREF(object), reinterpret_cast<uintptr_t>(pExtraInfo));
 }
 
 OBJECTHANDLE GCHandleStore::CreateDependentHandle(Object* primary, Object* secondary)
 {
-    HHANDLETABLE handletable = _underlyingBucket->pTable[GetCurrentThreadHomeHeapNumber()];
+    HHANDLETABLE handletable = _underlyingBucket.pTable[GetCurrentThreadHomeHeapNumber()];
     OBJECTHANDLE handle = ::HndCreateHandle(handletable, HNDTYPE_DEPENDENT, ObjectToOBJECTREF(primary));
     if (!handle)
     {
@@ -61,7 +61,7 @@ void GCHandleStore::RelocateAsyncPinnedHandles(IGCHandleStore* pTarget, void (*c
 {
     // assumption - the IGCHandleStore is an instance of GCHandleStore
     GCHandleStore* other = static_cast<GCHandleStore*>(pTarget);
-    ::Ref_RelocateAsyncPinHandles(_underlyingBucket, other->_underlyingBucket, clearIfComplete, setHandle);
+    ::Ref_RelocateAsyncPinHandles(&_underlyingBucket, &other->_underlyingBucket, clearIfComplete, setHandle);
 }
 
 bool GCHandleStore::EnumerateAsyncPinnedHandles(async_pin_enum_fn callback, void* context)
@@ -71,7 +71,7 @@ bool GCHandleStore::EnumerateAsyncPinnedHandles(async_pin_enum_fn callback, void
 
 GCHandleStore::~GCHandleStore()
 {
-    ::Ref_DestroyHandleTableBucket(_underlyingBucket);
+    ::Ref_DestroyHandleTableBucket(&_underlyingBucket);
 }
 
 bool GCHandleManager::Initialize()
@@ -103,14 +103,7 @@ IGCHandleStore* GCHandleManager::CreateHandleStore(void* context)
         return nullptr;
     }
 
-    store->_underlyingBucket = new (nothrow) HandleTableBucket();
-    if (store->_underlyingBucket == nullptr)
-    {
-        delete store;
-        return nullptr;
-    }
-
-    bool success = ::Ref_InitializeHandleTableBucket(store->_underlyingBucket, context);
+    bool success = ::Ref_InitializeHandleTableBucket(&store->_underlyingBucket, context);
     if (!success)
     {
         delete store;

--- a/src/gc/gchandletableimpl.h
+++ b/src/gc/gchandletableimpl.h
@@ -29,7 +29,7 @@ public:
 
     virtual ~GCHandleStore();
 
-    PTR_HandleTableBucket _underlyingBucket;
+    HandleTableBucket _underlyingBucket;
 };
 
 extern GCHandleStore* g_gcGlobalHandleStore;

--- a/src/gc/gchandletableimpl.h
+++ b/src/gc/gchandletableimpl.h
@@ -29,7 +29,7 @@ public:
 
     virtual ~GCHandleStore();
 
-    HandleTableBucket _underlyingBucket;
+    PTR_HandleTableBucket _underlyingBucket;
 };
 
 extern GCHandleStore* g_gcGlobalHandleStore;

--- a/src/gc/objecthandle.cpp
+++ b/src/gc/objecthandle.cpp
@@ -606,17 +606,8 @@ bool Ref_Initialize()
         return false;
     }
 
-    g_gcGlobalHandleStore->_underlyingBucket = new (nothrow) HandleTableBucket();
-    if (g_gcGlobalHandleStore->_underlyingBucket == NULL)
-    {
-        delete[] pBuckets;
-        delete g_gcGlobalHandleStore;
-        g_gcGlobalHandleStore = NULL;
-        return false;
-    }
-
     // Initialize the bucket in the global handle store
-    HandleTableBucket* pBucket = g_gcGlobalHandleStore->_underlyingBucket;
+    HandleTableBucket* pBucket = &g_gcGlobalHandleStore->_underlyingBucket;
 
     pBucket->HandleTableIndex = 0;
 
@@ -698,21 +689,6 @@ void Ref_Shutdown()
 }
 
 #ifndef FEATURE_REDHAWK
-HandleTableBucket* Ref_CreateHandleTableBucket(void* context)
-{
-    HandleTableBucket* result = new (nothrow) HandleTableBucket();
-    if (result == nullptr)
-        return nullptr;
-
-    if (!Ref_InitializeHandleTableBucket(result, context))
-    {
-        delete result;
-        return nullptr;
-    }
-
-    return result;
-}
-
 bool Ref_InitializeHandleTableBucket(HandleTableBucket* bucket, void* context)
 {
     CONTRACTL
@@ -845,7 +821,6 @@ void Ref_DestroyHandleTableBucket(HandleTableBucket *pBucket)
         HndDestroyHandleTable(pBucket->pTable[uCPUindex]);
     }
     delete [] pBucket->pTable;
-    delete pBucket;
 }
 
 int getSlotNumber(ScanContext* sc)

--- a/src/gc/objecthandle.cpp
+++ b/src/gc/objecthandle.cpp
@@ -606,8 +606,17 @@ bool Ref_Initialize()
         return false;
     }
 
+    g_gcGlobalHandleStore->_underlyingBucket = new (nothrow) HandleTableBucket();
+    if (g_gcGlobalHandleStore->_underlyingBucket == NULL)
+    {
+        delete[] pBuckets;
+        delete g_gcGlobalHandleStore;
+        g_gcGlobalHandleStore = NULL;
+        return false;
+    }
+
     // Initialize the bucket in the global handle store
-    HandleTableBucket* pBucket = &g_gcGlobalHandleStore->_underlyingBucket;
+    HandleTableBucket* pBucket = g_gcGlobalHandleStore->_underlyingBucket;
 
     pBucket->HandleTableIndex = 0;
 

--- a/src/gc/objecthandle.h
+++ b/src/gc/objecthandle.h
@@ -78,7 +78,6 @@ int GetCurrentThreadHomeHeapNumber();
  */
 bool Ref_Initialize();
 void Ref_Shutdown();
-HandleTableBucket* Ref_CreateHandleTableBucket(void* context);
 bool Ref_InitializeHandleTableBucket(HandleTableBucket* bucket, void* context);
 BOOL Ref_HandleAsyncPinHandles(async_pin_enum_fn callback, void* context);
 void Ref_RelocateAsyncPinHandles(HandleTableBucket *pSource, HandleTableBucket *pTarget, void (*clearIfComplete)(Object*), void (*setHandle)(Object*, OBJECTHANDLE));

--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -4137,7 +4137,7 @@ void AppDomain::Init()
 
 #ifdef FEATURE_APPDOMAIN_RESOURCE_MONITORING
     // NOTE: it's important that we initialize ARM data structures before calling
-    // Ref_CreateHandleTableBucket, this is because AD::Init() can race with GC
+    // IGCHandleManager::CreateHandleStore, this is because AD::Init() can race with GC
     // and once we add ourselves to the handle table map the GC can start walking
     // our handles and calling AD::RecordSurvivedBytes() which touches ARM data.
     if (GCHeapUtilities::IsServerHeap())


### PR DESCRIPTION
Currently in `~GCHandleStore` we call `Ref_DestroyHandleTableBucket` on `_underlyingBucket`
https://github.com/dotnet/coreclr/blob/030a3ea9b8dbeae89c90d34441d4d9a1cf4a7de6/src/gc/gchandletable.cpp#L72-L75

`Ref_DestroyHandleTableBucket` deletes the bucket at the end, but `_underlyingBucket` is not a pointer.
https://github.com/dotnet/coreclr/blob/00ab7387d849da889ebf6aac432ec989091bacec/src/gc/objecthandle.cpp#L826-L840