### PR TITLE
Fix incorrect CMPXCHG visiting order

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -9634,7 +9634,7 @@ public:
             {
                 GenTreeCmpXchg* const cmpXchg = node->AsCmpXchg();
 
-                result = WalkTree(&cmpXchg->gtOpComparand, cmpXchg);
+                result = WalkTree(&cmpXchg->gtOpLocation, cmpXchg);
                 if (result == fgWalkResult::WALK_ABORT)
                 {
                     return result;
@@ -9644,7 +9644,7 @@ public:
                 {
                     return result;
                 }
-                result = WalkTree(&cmpXchg->gtOpLocation, cmpXchg);
+                result = WalkTree(&cmpXchg->gtOpComparand, cmpXchg);
                 if (result == fgWalkResult::WALK_ABORT)
                 {
                     return result;


### PR DESCRIPTION
Somehow the 1st and 3rd operands of `GT_CMPXCHG` got swapped in `GenTreeVisitor`. The correct order is `gtOpLocation`, `gtOpValue`, `gtOpComparand`  as can be seen in the `GenTreeCmpXchg` class itself or in `fgSetTreeSeqHelper`

https://github.com/dotnet/coreclr/blob/380d347310c3ccbea12839186fec95c7da48df89/src/jit/gentree.h#L3828-L3833

https://github.com/dotnet/coreclr/blob/380d347310c3ccbea12839186fec95c7da48df89/src/jit/flowgraph.cpp#L18663-L18668

No diffs. As far as I can tell most current uses of `GenTreeVisitor` don't care much about ordering. `SideEffectExtractor` would care but since `GT_CMPXCHG` always has side effects it is extracted as is rather than having its children extracted in the wrong order.