### PR TITLE
Fix spmi environment reset.

### DIFF
--- a/src/ToolBox/superpmi/superpmi-shared/lwmlist.h
+++ b/src/ToolBox/superpmi/superpmi-shared/lwmlist.h
@@ -42,7 +42,6 @@ LWM(EmbedGenericHandle, Agnostic_EmbedGenericHandle, Agnostic_CORINFO_GENERICHAN
 LWM(EmbedMethodHandle, DWORDLONG, DLDL)
 LWM(EmbedModuleHandle, DWORDLONG, DLDL)
 DENSELWM(EmptyStringLiteral, DLD)
-DENSELWM(Environment, Agnostic_Environment)
 DENSELWM(ErrorList, DWORD)
 LWM(FilterException, DWORD, DWORD)
 LWM(FindCallSiteSig, Agnostic_FindCallSiteSig, Agnostic_CORINFO_SIG_INFO)

--- a/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -17,26 +17,6 @@
 #include "spmirecordhelper.h"
 #include "spmidumphelper.h"
 
-struct
-{
-    int         packetID;
-    const char* message;
-} retiredPackets[] = {
-    {6, "CanEmbedModuleHandleForHelper id 6 superseded by GetLazyStringLiteralHelper id 147 on 12/20/2013"},
-    {13, "CheckMethodModifier id 13 superseded by id 142 on 2013/07/04. Re-record input with newer shim."},
-    {14, "CompileMethod id 14 superseded by id 141 on 2013/07/03. Re-record input with newer shim."},
-    {24, "FindNameOfToken id 24 superseded by id 145 on 2013/07/19. Re-record input with newer shim. Adjusted members "
-         "to be proper."},
-    {28, "GetArgClass id 28 superseded by id 139 on 2013/07/03. Re-record input with newer shim."},
-    {30, "GetArgType id 30 superseded by id 140 on 2013/07/03. Re-record input with newer shim."},
-    {93, "GetUnBoxHelper2 id 93 unused. 2016/02/19. Re-record input with newer shim."},
-    {104, "IsValidToken id 104 superseded by id 144 on 2013/07/19. Re-record input with newer shim. Adjusted members "
-          "to be proper."},
-    {141, "CompileMethod id 141 superseded by id 142 on 2013/07/09. Re-record input with newer shim. We basically "
-          "reset lots of other stuff too. :-)"},
-};
-int retiredPacketCount = 7;
-
 #define sparseMC // Support filling in details where guesses are okay and will still generate good code. (i.e. helper
                  // function addresses)
 
@@ -306,7 +286,7 @@ void MethodContext::MethodInitHelper(unsigned char* buff2, unsigned int totalLen
 
     while (buffIndex < totalLen)
     {
-        unsigned char packetType = buff2[buffIndex++];
+        mcPackets packetType = (mcPackets)buff2[buffIndex++];
         memcpy(&localsize, &buff2[buffIndex], sizeof(unsigned int));
         buffIndex += 4;
 
@@ -321,11 +301,6 @@ void MethodContext::MethodInitHelper(unsigned char* buff2, unsigned int totalLen
 #include "crlwmlist.h"
 
             default:
-                for (int i = 0; i < retiredPacketCount; i++)
-                {
-                    AssertCodeMsg(retiredPackets[i].packetID != packetType, EXCEPTIONCODE_MC,
-                                  "Ran into retired packet %u '%s'", packetType, retiredPackets[i].message);
-                }
                 LogException(EXCEPTIONCODE_MC, "Read ran into unknown packet type %u. Are you using a newer recorder?",
                              packetType);
                 // break;

--- a/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -496,10 +496,6 @@ void MethodContext::recGlobalContext(const MethodContext& other)
     }
 }
 
-void MethodContext::dmpEnvironment(DWORD key, const Agnostic_Environment& value)
-{
-}
-
 void MethodContext::dumpToConsole(int mcNumber)
 {
     printf("*****************************************");
@@ -6290,52 +6286,157 @@ OnError:
 #endif // !FEATURE_PAL
 }
 
-DenseLightWeightMap<MethodContext::Agnostic_Environment>* MethodContext::prevEnviroment = nullptr;
-
-bool MethodContext::wasEnviromentChanged()
+MethodContext::Environment MethodContext::cloneEnvironment()
 {
-    bool changed = false;
-    if (prevEnviroment == nullptr)
+    MethodContext::Environment env;
+    if (GetIntConfigValue != nullptr)
     {
-        changed = true;
+        env.getIntConfigValue = new LightWeightMap<MethodContext::Agnostic_ConfigIntInfo, DWORD>(*GetIntConfigValue);
     }
-    else if (Environment->GetCount() != prevEnviroment->GetCount())
+    if (GetStringConfigValue != nullptr)
     {
-        changed = true;
+        env.getStingConfigValue = new LightWeightMap<DWORD, DWORD>(*GetStringConfigValue);
     }
-    else
-    {
-        for (unsigned int i = 0; i < Environment->GetCount(); i++)
-        {
-            Agnostic_Environment currEnvValue = Environment->Get(i);
-            LPCSTR               currKey      = (LPCSTR)Environment->GetBuffer(currEnvValue.name_index);
-            LPCSTR               currVal      = (LPCSTR)Environment->GetBuffer(currEnvValue.val_index);
+    return env;
+}
 
-            Agnostic_Environment prevEnvValue = prevEnviroment->Get(i);
-            LPCSTR               prevKey      = (LPCSTR)prevEnviroment->GetBuffer(prevEnvValue.name_index);
-            LPCSTR               prevVal      = (LPCSTR)prevEnviroment->GetBuffer(prevEnvValue.val_index);
-            if (strcmp(currKey, prevKey) != 0 || strcmp(currVal, prevVal) != 0)
-            {
-                changed = true;
-                break;
-            }
-        }
-    }
-    if (changed)
+// Check that there is a difference between the current enviroment variables maps and the prevEnv.
+bool MethodContext::WasEnvironmentChanged(const Environment& prevEnv)
+{
+    if (!IsEnvironmentHeaderEqual(prevEnv))
     {
-        if (prevEnviroment != nullptr)
-        {
-            delete prevEnviroment;
-        }
-        if (Environment != nullptr)
-        {
-            prevEnviroment = new DenseLightWeightMap<Agnostic_Environment>(*Environment);
-        }
-        else
-        {
-            prevEnviroment = nullptr;
-        }
+        return true;
+    }
+    if (!IsEnvironmentContentEqual(prevEnv))
+    {
         return true;
     }
     return false;
+}
+
+// Check that environment maps headers are equal to the prevEnv maps headers.
+bool MethodContext::IsEnvironmentHeaderEqual(const Environment& prevEnv)
+{
+    if (!AreLWMHeadersEqual(prevEnv.getIntConfigValue, GetIntConfigValue))
+    {
+        return false;
+    }
+    if (!AreLWMHeadersEqual(prevEnv.getStingConfigValue, GetStringConfigValue))
+    {
+        return false;
+    }
+    return true;
+}
+
+// Check that environment maps content is equal to the prevEnv content.
+bool MethodContext::IsEnvironmentContentEqual(const Environment& prevEnv)
+{
+    if (!IsIntConfigContentEqual(prevEnv.getIntConfigValue, GetIntConfigValue))
+    {
+        return false;
+    }
+    if (!IsStringContentEqual(prevEnv.getStingConfigValue, GetStringConfigValue))
+    {
+        return false;
+    }
+    return true;
+}
+
+// Check pointers to be both initizlized or null and number of keys to be equal.
+template <typename key, typename value>
+bool MethodContext::AreLWMHeadersEqual(LightWeightMap<key, value>* prev, LightWeightMap<key, value>* curr)
+{
+    if (prev == nullptr && curr == nullptr)
+    {
+        return true;
+    }
+    if (prev != nullptr && curr != nullptr)
+    {
+        if (prev->GetCount() == curr->GetCount())
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool MethodContext::IsIntConfigContentEqual(LightWeightMap<Agnostic_ConfigIntInfo, DWORD>* prev,
+                                            LightWeightMap<Agnostic_ConfigIntInfo, DWORD>* curr)
+{
+    if (prev != nullptr && curr != nullptr)
+    {
+        if (prev->GetCount() != curr->GetCount())
+        {
+            return false;
+        }
+
+        for (unsigned i = 0; i < prev->GetCount(); ++i)
+        {
+            DWORD currValue = curr->GetItem(i);
+            DWORD prevValue = prev->GetItem(i);
+            if (currValue != prevValue)
+            {
+                return false;
+            }
+
+            Agnostic_ConfigIntInfo currKey = curr->GetKey(i);
+            Agnostic_ConfigIntInfo prevKey = prev->GetKey(i);
+
+            if (currKey.defaultValue != prevKey.defaultValue)
+            {
+                return false;
+            }
+
+            DWORD  currNameIndex = currKey.nameIndex;
+            LPCSTR currName      = (LPCSTR)curr->GetBuffer(currNameIndex);
+            DWORD  prevNameIndex = prevKey.nameIndex;
+            LPCSTR prevName      = (LPCSTR)prev->GetBuffer(currNameIndex);
+            if (strcmp(currName, prevName) != 0)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+    else
+    {
+        return (prev == curr);
+    }
+}
+
+bool MethodContext::IsStringContentEqual(LightWeightMap<DWORD, DWORD>* prev, LightWeightMap<DWORD, DWORD>* curr)
+{
+    if (prev != nullptr && curr != nullptr)
+    {
+        if (prev->GetCount() != curr->GetCount())
+        {
+            return false;
+        }
+
+        for (unsigned i = 0; i < curr->GetCount(); ++i)
+        {
+            DWORD  currKeyIndex = curr->GetKey(i);
+            LPCSTR currKey      = (LPCSTR)curr->GetBuffer(currKeyIndex);
+            DWORD  prevKeyIndex = prev->GetKey(i);
+            LPCSTR prevKey      = (LPCSTR)prev->GetBuffer(prevKeyIndex);
+            if (strcmp(currKey, prevKey) != 0)
+            {
+                return false;
+            }
+
+            DWORD  currValueIndex = curr->GetItem(i);
+            LPCSTR currValue      = (LPCSTR)curr->GetBuffer(currValueIndex);
+            DWORD  prevValueIndex = prev->GetItem(i);
+            LPCSTR prevValue      = (LPCSTR)prev->GetBuffer(prevValueIndex);
+            if (strcmp(currValue, prevValue) != 0)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+    else
+    {
+        return (prev == curr);
+    }
 }

--- a/src/ToolBox/superpmi/superpmi-shared/methodcontext.h
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontext.h
@@ -1342,7 +1342,7 @@ enum mcPackets
     Packet_EmbedMethodHandle                             = 19,
     Packet_EmbedModuleHandle                             = 20,
     Packet_EmptyStringLiteral                            = 21,
-    Packet_Environment                                   = 136, // Deprecated 7/29/2017
+    Retired9                                             = 136,
     Packet_ErrorList                                     = 22,
     Packet_FilterException                               = 134,
     Packet_FindCallSiteSig                               = 23,

--- a/src/ToolBox/superpmi/superpmi-shared/methodcontext.h
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontext.h
@@ -1275,14 +1275,34 @@ public:
     void dmpGetStringConfigValue(DWORD nameIndex, DWORD result);
     const wchar_t* repGetStringConfigValue(const wchar_t* name);
 
-    bool                                              wasEnviromentChanged();
-    static DenseLightWeightMap<Agnostic_Environment>* prevEnviroment;
+    struct Environment
+    {
+        Environment() : getIntConfigValue(nullptr), getStingConfigValue(nullptr)
+        {
+        }
+
+        LightWeightMap<MethodContext::Agnostic_ConfigIntInfo, DWORD>* getIntConfigValue;
+        LightWeightMap<DWORD, DWORD>*                                 getStingConfigValue;
+    };
+
+    Environment cloneEnvironment();
+
+    bool WasEnvironmentChanged(const Environment& prevEnv);
 
     CompileResult* cr;
     CompileResult* originalCR;
     int            index;
 
 private:
+    bool IsEnvironmentHeaderEqual(const Environment& prevEnv);
+    bool IsEnvironmentContentEqual(const Environment& prevEnv);
+
+    template <typename key, typename value>
+    static bool AreLWMHeadersEqual(LightWeightMap<key, value>* prev, LightWeightMap<key, value>* curr);
+    static bool IsIntConfigContentEqual(LightWeightMap<Agnostic_ConfigIntInfo, DWORD>* prev,
+                                        LightWeightMap<Agnostic_ConfigIntInfo, DWORD>* curr);
+    static bool IsStringContentEqual(LightWeightMap<DWORD, DWORD>* prev, LightWeightMap<DWORD, DWORD>* curr);
+
 #define LWM(map, key, value) LightWeightMap<key, value>* map;
 #define DENSELWM(map, value) DenseLightWeightMap<value>* map;
 #include "lwmlist.h"

--- a/src/ToolBox/superpmi/superpmi-shared/methodcontextreader.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontextreader.cpp
@@ -122,10 +122,6 @@ MethodContextReader::MethodContextReader(
 
 MethodContextReader::~MethodContextReader()
 {
-    if (MethodContext::prevEnviroment != nullptr)
-    {
-        delete MethodContext::prevEnviroment;
-    }
     if (fileHandle != INVALID_HANDLE_VALUE)
     {
         CloseHandle(this->fileHandle);

--- a/src/ToolBox/superpmi/superpmi/commandline.cpp
+++ b/src/ToolBox/superpmi/superpmi/commandline.cpp
@@ -120,14 +120,14 @@ void CommandLine::DumpHelp(const char* program)
 #endif // USE_COREDISTOOLS
     printf("\n");
     printf(" -jitoption [force] key=value\n");
-    printf("     Set the JIT option named \"key\" to \"value\" for JIT 1 if the option was not set.");
-    printf("     With optional force flag overwrites the existing value if it was already set. NOTE: do not use a "
-           "\"COMPlus_\" prefix!\n");
+    printf("     Set the JIT option named \"key\" to \"value\" for JIT 1 if the option was not set.\n");
+    printf("     With optional force flag overwrites the existing value if it was already set.\n");
+    printf("     NOTE: do not use a \"COMPlus_\" prefix, \"key\" and \"value\" are case sensitive!\n");
     printf("\n");
     printf(" -jit2option [force] key=value\n");
-    printf("     Set the JIT option named \"key\" to \"value\" for JIT 2 if the option was not set.");
-    printf("     With optional force flag overwrites the existing value if it was already set. NOTE: do not use a "
-           "\"COMPlus_\" prefix!\n");
+    printf("     Set the JIT option named \"key\" to \"value\" for JIT 2 if the option was not set.\n");
+    printf("     With optional force flag overwrites the existing value if it was already set.\n");
+    printf("     NOTE: do not use a \"COMPlus_\" prefix, \"key\" and \"value\" are case sensitive!\n");
     printf("\n");
     printf("Inputs are case sensitive.\n");
     printf("\n");

--- a/src/ToolBox/superpmi/superpmi/jithost.h
+++ b/src/ToolBox/superpmi/superpmi/jithost.h
@@ -14,6 +14,8 @@ public:
 #include "icorjithostimpl.h"
 
 private:
+    bool convertStringValueToInt(const wchar_t* key, const wchar_t* stringValue, int& result);
+
     JitInstance& jitInstance;
 };
 

--- a/src/ToolBox/superpmi/superpmi/jitinstance.cpp
+++ b/src/ToolBox/superpmi/superpmi/jitinstance.cpp
@@ -30,6 +30,9 @@ JitInstance* JitInstance::InitJit(char*          nameOfJit,
 
     jit->options = options;
 
+    jit->environment.getIntConfigValue   = nullptr;
+    jit->environment.getStingConfigValue = nullptr;
+
     if (st1 != nullptr)
         st1->Start();
     HRESULT hr = jit->StartUp(nameOfJit, false, breakOnAssert, firstContext);
@@ -500,6 +503,9 @@ bool JitInstance::callJitStartup(ICorJitHost* jithost)
     }
     PAL_ENDTRY
 
+    Assert(environment.getIntConfigValue == nullptr && environment.getStingConfigValue == nullptr);
+    environment = mc->cloneEnvironment();
+
     return param.result;
 }
 
@@ -509,6 +515,18 @@ bool JitInstance::resetConfig(MethodContext* firstContext)
     if (pnjitStartup == nullptr)
     {
         return false;
+    }
+
+    if (environment.getIntConfigValue != nullptr)
+    {
+        delete environment.getIntConfigValue;
+        environment.getIntConfigValue = nullptr;
+    }
+
+    if (environment.getStingConfigValue != nullptr)
+    {
+        delete environment.getStingConfigValue;
+        environment.getStingConfigValue = nullptr;
     }
 
     mc                   = firstContext;
@@ -522,4 +540,9 @@ bool JitInstance::resetConfig(MethodContext* firstContext)
     delete static_cast<JitHost*>(jitHost);
     jitHost = newHost;
     return true;
+}
+
+const MethodContext::Environment& JitInstance::getEnvironment()
+{
+    return environment;
 }

--- a/src/ToolBox/superpmi/superpmi/jitinstance.h
+++ b/src/ToolBox/superpmi/superpmi/jitinstance.h
@@ -28,6 +28,8 @@ private:
     LightWeightMap<DWORD, DWORD>* forceOptions;
     LightWeightMap<DWORD, DWORD>* options;
 
+    MethodContext::Environment environment;
+
     JitInstance(){};
     void timeResult(CORINFO_METHOD_INFO info, unsigned flags);
 
@@ -63,6 +65,8 @@ public:
     const wchar_t* getForceOption(const wchar_t* key);
     const wchar_t* getOption(const wchar_t* key);
     const wchar_t* getOption(const wchar_t* key, LightWeightMap<DWORD, DWORD>* options);
+
+    const MethodContext::Environment& getEnvironment();
 
     void* allocateArray(ULONG size);
     void* allocateLongLivedArray(ULONG size);

--- a/src/ToolBox/superpmi/superpmi/superpmi.cpp
+++ b/src/ToolBox/superpmi/superpmi/superpmi.cpp
@@ -329,7 +329,7 @@ int __cdecl main(int argc, char* argv[])
         mc->cr         = new CompileResult();
         mc->originalCR = crl;
 
-        if (mc->wasEnviromentChanged())
+        if (mc->WasEnvironmentChanged(jit->getEnvironment()))
         {
             if (!jit->resetConfig(mc))
             {


### PR DESCRIPTION
e8678de2f1: Dump spmi string environment variables with -d key.

Sometimes it is not clear which environment variables are set during a replay. Add a possibility to dump all active string environment variables with "-v d" key.

It is especially useful when you debug one method and can't get output that you want (for example JitDump) because, for example, altJit was set during the collection.

500af80c33: Dump int spmi environment variables with -d key.

The same change but for int variables that need an additional parsing.

81f803d9db: Fix environment reset in spmi.

The previous changes revealed that we have a problem with environment reset. The reset was added in #13596 to support a correct replay of mch files with mc that had different env variables during the collection.

It was based on `Environment` LWM that was later deprecated by #13110.

That caused the environment to be reset for each mc. The fix updates env only when it is necessary and decreases the replay time of an mch file with 200000 methods from 500s to 370s.

7c5a3e7038: Fix dumpHelp.

Fix formating and adds note that all keys and values are case sensetive.

ba832bebe0: Delete retired packages logic.

These packages were retired a long time ago and there is no value to have a special logic for them.