### PR TITLE
Move Assert class from Interop into the CoreCLRTestLibrary

### DIFF
--- a/tests/src/Common/CoreCLRTestLibrary/Assertion.cs
+++ b/tests/src/Common/CoreCLRTestLibrary/Assertion.cs
@@ -8,14 +8,14 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace CoreFXTestLibrary
+namespace TestLibrary
 {
     /// <summary>
     ///    A collection of helper classes to test various conditions within
     /// unit tests. If the condition being tested is not met, an exception
     /// is thrown.
     /// </summary>
-    internal static class Assert
+    public static class Assert
     {
         /// <summary>
         ///     Asserts that the given delegate throws an <see cref="ArgumentNullException"/> with the given parameter name.
@@ -771,7 +771,7 @@ namespace CoreFXTestLibrary
     /// <summary>
     /// Exception raised by the Assert on Fail
     /// </summary>
-    internal class AssertTestException : Exception
+    public class AssertTestException : Exception
     {
         public AssertTestException(string message)
             : base(message)
@@ -784,7 +784,7 @@ namespace CoreFXTestLibrary
         }
     }
 
-    internal static class ExceptionAssert
+    public static class ExceptionAssert
     {
         public static void Throws<T>(String message, Action a) where T : Exception
         {
@@ -796,7 +796,7 @@ namespace CoreFXTestLibrary
     ///     Specifies whether <see cref="Assert.Throws{T}"/> should require an exact type match when comparing the expected exception type with the thrown exception.
     /// </summary>
     [Flags]
-    internal enum AssertThrowsOptions
+    public enum AssertThrowsOptions
     {
         /// <summary>
         ///     Specifies that <see cref="Assert.Throws{T}"/> should require an exact type 

--- a/tests/src/Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj
+++ b/tests/src/Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj
@@ -26,6 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Assertion.cs" />
     <Compile Include="Generator.cs" />
     <Compile Include="Logging.cs" />
     <Compile Include="TestFramework.cs" />

--- a/tests/src/Interop/ArrayMarshalling/ByValArray/MarshalArrayByValTest.cs
+++ b/tests/src/Interop/ArrayMarshalling/ByValArray/MarshalArrayByValTest.cs
@@ -9,7 +9,7 @@ class TestHelper
 {
     public static void Assert(bool exp,string msg="")
     {
-        CoreFXTestLibrary.Assert.IsTrue(exp, msg);
+        TestLibrary.Assert.IsTrue(exp, msg);
     }
 }
 

--- a/tests/src/Interop/ArrayMarshalling/ByValArray/MarshalArrayByValTest.csproj
+++ b/tests/src/Interop/ArrayMarshalling/ByValArray/MarshalArrayByValTest.csproj
@@ -25,7 +25,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MarshalArrayByValTest.cs" />
-    <Compile Include="..\..\common\Assertion.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/Interop/BestFitMapping/BestFitMapping.csproj
+++ b/tests/src/Interop/BestFitMapping/BestFitMapping.csproj
@@ -24,7 +24,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="*.cs" />
-    <Compile Include="..\common\Assertion.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/Interop/COM/Activator/Program.cs
+++ b/tests/src/Interop/COM/Activator/Program.cs
@@ -7,7 +7,7 @@ namespace Activator
     using System;
     using System.Runtime.InteropServices;
 
-    using CoreFXTestLibrary;
+    using TestLibrary;
 
     using Console = Internal.Console;
 

--- a/tests/src/Interop/COM/NETClients/Primitives/ArrayTests.cs
+++ b/tests/src/Interop/COM/NETClients/Primitives/ArrayTests.cs
@@ -4,10 +4,10 @@
 
 namespace NetClient
 {
-    using CoreFXTestLibrary;
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using TestLibrary;
 
     class ArrayTests
     {

--- a/tests/src/Interop/COM/NETClients/Primitives/ErrorTests.cs
+++ b/tests/src/Interop/COM/NETClients/Primitives/ErrorTests.cs
@@ -4,9 +4,9 @@
 
 namespace NetClient
 {
-    using CoreFXTestLibrary;
     using System;
     using System.Runtime.InteropServices;
+    using TestLibrary;
 
     class ErrorTests
     {

--- a/tests/src/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
+++ b/tests/src/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
@@ -29,10 +29,10 @@
     <Compile Include="../../ServerContracts/Primitives.cs" />
     <Compile Include="../../ServerContracts/PrimitivesNativeServer.cs" />
     <Compile Include="../../ServerContracts/ServerGuids.cs" />
-    <Compile Include="../../../common/Assertion.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
+    <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/tests/src/Interop/COM/NETClients/Primitives/NumericTests.cs
+++ b/tests/src/Interop/COM/NETClients/Primitives/NumericTests.cs
@@ -4,8 +4,8 @@
 
 namespace NetClient
 {
-    using CoreFXTestLibrary;
     using System;
+    using TestLibrary;
 
     class NumericTests
     {

--- a/tests/src/Interop/COM/NETClients/Primitives/StringTests.cs
+++ b/tests/src/Interop/COM/NETClients/Primitives/StringTests.cs
@@ -4,12 +4,12 @@
 
 namespace NetClient
 {
-    using CoreFXTestLibrary;
     using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Text;
     using System.Runtime.InteropServices;
+    using TestLibrary;
 
     class StringTests
     {

--- a/tests/src/Interop/COM/NativeClients/Primitives.csproj
+++ b/tests/src/Interop/COM/NativeClients/Primitives.csproj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Interop.settings.targets))\Interop.settings.targets" />
   <PropertyGroup>
-    <IgnoreInteropAssertionFile>true</IgnoreInteropAssertionFile>
+    <IgnoreCoreCLRTestLibraryDependency>true</IgnoreCoreCLRTestLibraryDependency>
     <CLRTestScriptLocalCoreShim>true</CLRTestScriptLocalCoreShim>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/Interop/DllImportAttribute/FileExtensionProbe.csproj
+++ b/tests/src/Interop/DllImportAttribute/FileExtensionProbe.csproj
@@ -24,7 +24,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="*.cs" />
-    <Compile Include="..\common\Assertion.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/Interop/FuncPtrAsDelegateParam/FuncPtrAsDelegateParam.csproj
+++ b/tests/src/Interop/FuncPtrAsDelegateParam/FuncPtrAsDelegateParam.csproj
@@ -24,7 +24,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="*.cs" />
-    <Compile Include="..\common\Assertion.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/Interop/Interop.settings.targets
+++ b/tests/src/Interop/Interop.settings.targets
@@ -10,6 +10,11 @@
 
   <!-- Required source files -->
   <ItemGroup>
-    <Compile Condition="'$(IgnoreInteropAssertionFile)' != 'true'" Include="$(InteropCommonDir)Assertion.cs"/>
+    <ProjectReference 
+      Condition="('$(IgnoreCoreCLRTestLibraryDependency)' != 'true') And ('$(ReferenceSystemPrivateCoreLib)' != 'true')" 
+      Include="$(MSBuildThisFileDirectory)\..\Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj" />
+    <Compile
+      Condition="('$(IgnoreCoreCLRTestLibraryDependency)' != 'true') And ('$(ReferenceSystemPrivateCoreLib)' == 'true')"
+      Include="$(MSBuildThisFileDirectory)\..\Common\CoreCLRTestLibrary\Assertion.cs" />
   </ItemGroup>
 </Project>

--- a/tests/src/Interop/MarshalAPI/FunctionPointer/FunctionPtrTest.csproj
+++ b/tests/src/Interop/MarshalAPI/FunctionPointer/FunctionPtrTest.csproj
@@ -25,7 +25,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="*.cs" />
-    <Compile Include="..\..\common\Assertion.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/Interop/MarshalAPI/IUnknown/IUnknownTest.cs
+++ b/tests/src/Interop/MarshalAPI/IUnknown/IUnknownTest.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 using System.Security;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
-using CoreFXTestLibrary;
+using TestLibrary;
 
 #pragma warning disable 618
 

--- a/tests/src/Interop/MarshalAPI/IUnknown/IUnknownTest.csproj
+++ b/tests/src/Interop/MarshalAPI/IUnknown/IUnknownTest.csproj
@@ -29,7 +29,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="*.cs" />
-    <Compile Include="..\..\common\Assertion.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/Interop/NativeCallable/NativeCallableTest.csproj
+++ b/tests/src/Interop/NativeCallable/NativeCallableTest.csproj
@@ -27,11 +27,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="NativeCallableTest.cs" />
-    <Compile Include="..\common\Assertion.cs" />
   </ItemGroup>
   <ItemGroup>
     <!-- This is needed to make sure native binary gets installed in the right location -->
     <ProjectReference Include="CMakeLists.txt" />
+    <ProjectReference Include="..\..\..\Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/tests/src/Interop/PrimitiveMarshalling/Bool/BoolTest.csproj
+++ b/tests/src/Interop/PrimitiveMarshalling/Bool/BoolTest.csproj
@@ -24,7 +24,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="*.cs" />
-    <Compile Include="..\..\common\Assertion.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/Interop/PrimitiveMarshalling/EnumMarshalling/EnumTest.csproj
+++ b/tests/src/Interop/PrimitiveMarshalling/EnumMarshalling/EnumTest.csproj
@@ -24,7 +24,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="*.cs" />
-    <Compile Include="..\..\common\Assertion.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/Interop/PrimitiveMarshalling/UIntPtr/PInvokeUIntPtrTest.csproj
+++ b/tests/src/Interop/PrimitiveMarshalling/UIntPtr/PInvokeUIntPtrTest.csproj
@@ -24,7 +24,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="PInvokeUIntPtrTest.cs" />
-    <Compile Include="..\..\common\Assertion.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/Interop/ReadMe.md
+++ b/tests/src/Interop/ReadMe.md
@@ -10,7 +10,7 @@ There should be no more than **1** project type per folder (i.e. a folder can co
 
 Ancillary source assets for all tests should be located in `Interop/common` and can be easily added to all managed tests via the `Interop.settings.targets` file or native tests via `Interop.cmake`.
 
-A common pattern for testing is using the `Assert` utilities found in the `CoreFX` repo. A copy of some of these utilities can be found at `Interop/common/Assertion.cs` and is included in all test projects by the `Interop.settings.targets` import. In order to use, add the following `using CoreFXTestLibrary;` in the relevant test file.
+A common pattern for testing is using the `Assert` utilities found in the `CoreFX` repo. This class is part of the `CoreCLRTestLibrary` which is included in all test projects by the `Interop.settings.targets` import. In order to use, add the following `using TestLibrary;` in the relevant test file.
 
 ### Managed
 

--- a/tests/src/Interop/RefCharArray/RefCharArrayTest.csproj
+++ b/tests/src/Interop/RefCharArray/RefCharArrayTest.csproj
@@ -24,7 +24,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="*.cs" />
-    <Compile Include="..\common\Assertion.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/Interop/RefInt/RefIntTest.csproj
+++ b/tests/src/Interop/RefInt/RefIntTest.csproj
@@ -24,7 +24,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="*.cs" />
-    <Compile Include="..\common\Assertion.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/Interop/SimpleStruct/SimpleStruct.csproj
+++ b/tests/src/Interop/SimpleStruct/SimpleStruct.csproj
@@ -24,7 +24,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="*.cs" />
-    <Compile Include="..\common\Assertion.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/Interop/SizeConst/SizeConstTest.csproj
+++ b/tests/src/Interop/SizeConst/SizeConstTest.csproj
@@ -27,7 +27,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="SizeConstTest.cs" />
-    <Compile Include="..\common\Assertion.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/Interop/StringMarshalling/LPSTR/LPSTRTest.csproj
+++ b/tests/src/Interop/StringMarshalling/LPSTR/LPSTRTest.csproj
@@ -25,7 +25,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="*.cs" />    
-    <Compile Include="..\..\common\Assertion.cs" />    
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/Interop/StringMarshalling/LPTSTR/LPTSTRTest.csproj
+++ b/tests/src/Interop/StringMarshalling/LPTSTR/LPTSTRTest.csproj
@@ -24,7 +24,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="*.cs" />
-    <Compile Include="..\..\common\Assertion.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/Interop/StringMarshalling/UTF8/UTF8Test.csproj
+++ b/tests/src/Interop/StringMarshalling/UTF8/UTF8Test.csproj
@@ -24,7 +24,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="*.cs" />
-    <Compile Include="..\..\common\Assertion.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />


### PR DESCRIPTION
Moving the Assert class to the common library so that it can be used
by tests outside of the Interop tree.