### PR TITLE
Clean up output; fix return code

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -427,7 +427,7 @@ def create_and_use_test_env(_os, env, func):
 
     if len(list(complus_vars.keys())) > 0:
         print("Found COMPlus variables in the current environment")
-        print()
+        print("")
 
         file_header = None
 
@@ -470,13 +470,13 @@ REM Temporary test env for test run.
                 test_env.write(line)
                 contents += line
 
-            print()
+            print("")
             print("TestEnv: %s" % test_env.name)
-            print() 
+            print("")
             print("Contents:")
-            print()
+            print("")
             print(contents)
-            print()
+            print("")
 
             return func(test_env.name)
 
@@ -743,6 +743,7 @@ def run_tests(host_os,
         os.environ["__TestTimeout"] = str(120*60*1000) # 1,800,000 ms
 
     # Set Core_Root
+    printf("Setting CORE_ROOT=%s" % core_root)
     os.environ["CORE_ROOT"] = core_root
 
     # Set test env if exists
@@ -826,7 +827,7 @@ def setup_args(args):
 
             print("Using default test location.")
             print("TestLocation: %s" % default_test_location)
-            print()
+            print("")
 
         else:
             # The tests for the default location have not been built.
@@ -888,7 +889,7 @@ def setup_args(args):
 
             print("Using default test location.")
             print("TestLocation: %s" % default_test_location)
-            print()
+            print("")
 
     if core_root is None:
         default_core_root = os.path.join(test_location, "Tests", "Core_Root")
@@ -898,7 +899,7 @@ def setup_args(args):
 
             print("Using default location for core_root.")
             print("Core_Root: %s" % core_root)
-            print()
+            print("")
 
         elif args.generate_layout is False:
             # CORE_ROOT has not been setup correctly.
@@ -918,7 +919,7 @@ def setup_args(args):
             print("Using default location for test_native_bin_location.")
             test_native_bin_location = os.path.join(os.path.join(coreclr_repo_location, "bin", "obj", "%s.%s.%s" % (host_os, arch, build_type), "tests"))
             print("Native bin location: %s" % test_native_bin_location)
-            print()
+            print("")
             
         if not os.path.isdir(test_native_bin_location):
             print("Error, test_native_bin_location: %s, does not exist." % test_native_bin_location)
@@ -1109,7 +1110,7 @@ def precompile_core_root(test_location,
         return passed
 
     print("Precompiling all assemblies in %s" % core_root)
-    print()
+    print("")
 
     env = os.environ.copy()
 
@@ -1135,7 +1136,7 @@ def precompile_core_root(test_location,
     for dll in dlls:
         call_crossgen(dll, env)
 
-    print()
+    print("")
 
 def setup_core_root(host_os, 
                     arch, 
@@ -1327,12 +1328,12 @@ def setup_core_root(host_os,
                 shutil.copytree(item, new_dir)
 
     # Copy the product dir to the core_root directory
-    print()
+    print("")
     print("Copying Product Bin to Core_Root:")
     print("cp -r %s%s* %s" % (product_location, os.path.sep, core_root))
     copy_tree(product_location, core_root)
     print("---------------------------------------------------------------------")
-    print()
+    print("")
 
     if is_corefx:
         corefx_utility_setup = os.path.join(coreclr_repo_location,
@@ -1740,13 +1741,13 @@ def print_summary(tests):
         else:
             skipped_tests.append(test)
 
-    print()
+    print("")
     print("Total tests run: %d" % len(tests))
-    print()
+    print("")
     print("Total passing tests: %d" % len(passed_tests))
     print("Total failed tests: %d" % len(failed_tests))
     print("Total skipped tests: %d" % len(skipped_tests))
-    print()
+    print("")
 
     failed_tests.sort(key=lambda item: item["time"], reverse=True)
     passed_tests.sort(key=lambda item: item["time"], reverse=True)
@@ -1789,25 +1790,25 @@ def print_summary(tests):
 
     if len(failed_tests) > 0:
         print("Failed tests:")
-        print()
+        print("")
         print_tests_helper(failed_tests, None)
         
 
     if len(passed_tests) > 50:
-        print()
+        print("")
         print("50 slowest passing tests:")
-        print()
+        print("")
         print_tests_helper(passed_tests, 50)
 
     if len(failed_tests) > 0:
-        print()
+        print("")
         print("#################################################################")
         print("Output of failing tests:")
-        print()
+        print("")
 
         for item in failed_tests:
             print("[%s]: " % item["test_path"])
-            print()
+            print("")
             
             test_output = item["test_output"]
 
@@ -1816,13 +1817,13 @@ def print_summary(tests):
             test_output = test_output.replace("\\n", "\n")
 
             print(test_output)
-            print()
+            print("")
 
-        print()
+        print("")
         print("#################################################################")
         print("End of output of failing tests")
         print("#################################################################")
-        print()
+        print("")
 
 def create_repro(host_os, arch, build_type, env, core_root, coreclr_repo_location, tests):
     """ Go through the failing tests and create repros for them
@@ -1853,7 +1854,7 @@ def create_repro(host_os, arch, build_type, env, core_root, coreclr_repo_locatio
     print("mkdir %s" % repro_location)
     os.makedirs(repro_location)
 
-    print()
+    print("")
     print("Creating repo files, they can be found at: %s" % repro_location)
 
     assert os.path.isdir(repro_location)
@@ -1932,7 +1933,7 @@ def do_setup(host_os,
         else:
             build_test_wrappers(host_os, arch, build_type, coreclr_repo_location, test_location)
 
-    run_tests(host_os, 
+    return run_tests(host_os, 
               arch,
               build_type,
               core_root, 
@@ -1991,6 +1992,8 @@ def main(args):
     if tests is not None:
         print_summary(tests)
         create_repro(host_os, arch, build_type, env, core_root, coreclr_repo_location, tests)
+
+    return ret_code
 
 ################################################################################
 # __main__

--- a/tests/tests.targets
+++ b/tests/tests.targets
@@ -48,6 +48,9 @@
       <XunitArgs>$(XunitArgs) @(IncludeTraitsItems->'-trait %(Identity)', ' ')</XunitArgs>
       <XunitArgs>$(XunitArgs) @(ExcludeTraitsItems->'-notrait %(Identity)', ' ')</XunitArgs>
 
+      <!-- Color output doesn't work well when capturing the output in the CI system -->
+      <XunitArgs>$(XunitArgs) -nocolor</XunitArgs>
+
       <CorerunExecutable Condition="'$(RunningOnUnix)' == 'true'">$(CORE_ROOT)\corerun</CorerunExecutable>
       <CorerunExecutable Condition="'$(RunningOnUnix)' != 'true'">$(CORE_ROOT)\corerun.exe</CorerunExecutable>
     </PropertyGroup>


### PR DESCRIPTION
Clean up empty line output from runtest.py.

Use `-nocolor` for xunit to avoid garbage characters in log files.

Fix return code from runtest.py