### PR TITLE
Streamline MemoryExtension Trim and Trim(char) by removing calls to TrimStart/End and avoiding unnecessary Slice.

### DIFF
--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.cs
@@ -26,13 +26,24 @@ namespace System
         /// </summary>
         public static ReadOnlySpan<char> Trim(this ReadOnlySpan<char> span)
         {
-            return span.TrimStart().TrimEnd();
+            int start = 0;
+            for (; start < span.Length; start++)
+            {
+                if (!char.IsWhiteSpace(span[start]))
+                    break;
+            }
+            int end = span.Length - 1;
+            for (; end >= start; end--)
+            {
+                if (!char.IsWhiteSpace(span[end]))
+                    break;
+            }
+            return span.Slice(start, end - start + 1);
         }
 
         /// <summary>
         /// Removes all leading white-space characters from the span.
         /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ReadOnlySpan<char> TrimStart(this ReadOnlySpan<char> span)
         {
             int start = 0;
@@ -47,7 +58,6 @@ namespace System
         /// <summary>
         /// Removes all trailing white-space characters from the span.
         /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ReadOnlySpan<char> TrimEnd(this ReadOnlySpan<char> span)
         {
             int end = span.Length - 1;
@@ -66,7 +76,19 @@ namespace System
         /// <param name="trimChar">The specified character to look for and remove.</param>
         public static ReadOnlySpan<char> Trim(this ReadOnlySpan<char> span, char trimChar)
         {
-            return span.TrimStart(trimChar).TrimEnd(trimChar);
+            int start = 0;
+            for (; start < span.Length; start++)
+            {
+                if (span[start] != trimChar)
+                    break;
+            }
+            int end = span.Length - 1;
+            for (; end >= start; end--)
+            {
+                if (span[end] != trimChar)
+                    break;
+            }
+            return span.Slice(start, end - start + 1);
         }
 
         /// <summary>
@@ -74,7 +96,6 @@ namespace System
         /// </summary>
         /// <param name="span">The source span from which the character is removed.</param>
         /// <param name="trimChar">The specified character to look for and remove.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ReadOnlySpan<char> TrimStart(this ReadOnlySpan<char> span, char trimChar)
         {
             int start = 0;
@@ -91,7 +112,6 @@ namespace System
         /// </summary>
         /// <param name="span">The source span from which the character is removed.</param>
         /// <param name="trimChar">The specified character to look for and remove.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ReadOnlySpan<char> TrimEnd(this ReadOnlySpan<char> span, char trimChar)
         {
             int end = span.Length - 1;

--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.cs
@@ -32,6 +32,7 @@ namespace System
         /// <summary>
         /// Removes all leading white-space characters from the span.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ReadOnlySpan<char> TrimStart(this ReadOnlySpan<char> span)
         {
             int start = 0;
@@ -46,6 +47,7 @@ namespace System
         /// <summary>
         /// Removes all trailing white-space characters from the span.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ReadOnlySpan<char> TrimEnd(this ReadOnlySpan<char> span)
         {
             int end = span.Length - 1;
@@ -72,6 +74,7 @@ namespace System
         /// </summary>
         /// <param name="span">The source span from which the character is removed.</param>
         /// <param name="trimChar">The specified character to look for and remove.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ReadOnlySpan<char> TrimStart(this ReadOnlySpan<char> span, char trimChar)
         {
             int start = 0;
@@ -88,6 +91,7 @@ namespace System
         /// </summary>
         /// <param name="span">The source span from which the character is removed.</param>
         /// <param name="trimChar">The specified character to look for and remove.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ReadOnlySpan<char> TrimEnd(this ReadOnlySpan<char> span, char trimChar)
         {
             int end = span.Length - 1;


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.11.1.739-nightly, OS=Windows 10.0.17744
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
  [Host] : .NET Core ? (CoreCLR 4.6.26913.07, CoreFX 4.6.26913.0), 64bit RyuJIT

Job=InProcess  Toolchain=InProcessToolchain  

```
**Before:**

|           Method |          Data |      Mean |     Error |    StdDev | Allocated |
|----------------- |-------------- |----------:|----------:|----------:|----------:|
|             **Trim** |              **""** | **13.138 ns** | **0.3064 ns** | **0.5904 ns** |       **0 B** |
|     TrimStartEnd |       ""        | 12.525 ns | 0.2815 ns | 0.3351 ns |       0 B |
|         TrimChar |        ""       | 10.401 ns | 0.2290 ns | 0.2638 ns |       0 B |
| TrimStartEndChar |      ""         |  9.809 ns | 0.2176 ns | 0.2138 ns |       0 B |
|             **Trim** | **"&nbsp;&nbsp;&nbsp;abcdefg&nbsp;&nbsp;&nbsp;"** | **22.113 ns** | **0.4640 ns** | **0.4340 ns** |       **0 B** |
|     TrimStartEnd | "&nbsp;&nbsp;&nbsp;abcdefg&nbsp;&nbsp;&nbsp;" | 21.659 ns | 0.3144 ns | 0.2626 ns |       0 B |
|         TrimChar | "&nbsp;&nbsp;&nbsp;abcdefg&nbsp;&nbsp;&nbsp;" | 15.874 ns | 0.1309 ns | 0.1160 ns |       0 B |
| TrimStartEndChar | "&nbsp;&nbsp;&nbsp;abcdefg&nbsp;&nbsp;&nbsp;" | 15.644 ns | 0.3407 ns | 0.2845 ns |       0 B |
|             **Trim** | **"&nbsp;&nbsp;abcdefg&nbsp;&nbsp;"** | **19.968 ns** | **0.0545 ns** | **0.0425 ns** |       **0 B** |
|     TrimStartEnd | "&nbsp;&nbsp;abcdefg&nbsp;&nbsp;" | 20.067 ns | 0.1905 ns | 0.1689 ns |       0 B |
|         TrimChar | "&nbsp;&nbsp;abcdefg&nbsp;&nbsp;" | 14.405 ns | 0.1835 ns | 0.1717 ns |       0 B |
| TrimStartEndChar | "&nbsp;&nbsp;abcdefg&nbsp;&nbsp;" | 14.458 ns | 0.1644 ns | 0.1457 ns |       0 B |
|             **Trim** | **"&nbsp;abcdefg&nbsp;"** | **18.606 ns** | **0.3105 ns** | **0.2752 ns** |       **0 B** |
|     TrimStartEnd | "&nbsp;abcdefg&nbsp;" | 18.802 ns | 0.2130 ns | 0.1888 ns |       0 B |
|         TrimChar | "&nbsp;abcdefg&nbsp;" | 12.374 ns | 0.1894 ns | 0.1772 ns |       0 B |
| TrimStartEndChar | "&nbsp;abcdefg&nbsp;" | 12.842 ns | 0.2829 ns | 0.3966 ns |       0 B |
|             **Trim** | **"abcdefg"** | **15.090 ns** | **0.3258 ns** | **0.3200 ns** |       **0 B** |
|     TrimStartEnd | "abcdefg" | 14.909 ns | 0.3049 ns | 0.2852 ns |       0 B |
|         TrimChar | "abcdefg" | 10.989 ns | 0.2348 ns | 0.2197 ns |       0 B |
| TrimStartEndChar | "abcdefg" | 11.225 ns | 0.1960 ns | 0.1834 ns |       0 B |

**After:**

|           Method |          Data |      Mean |     Error |    StdDev | Allocated |
|----------------- |-------------- |----------:|----------:|----------:|----------:|
|             **Trim** |              **** |  **1.592 ns** | **0.0404 ns** | **0.0337 ns** |       **0 B** |
|     TrimStartEnd |               |  1.642 ns | 0.0098 ns | 0.0082 ns |       0 B |
|         TrimChar |               |  1.120 ns | 0.0394 ns | 0.0308 ns |       0 B |
| TrimStartEndChar |               |  1.093 ns | 0.0511 ns | 0.0502 ns |       0 B |
|             **Trim** | **   abcdefg   ** | **11.772 ns** | **0.0684 ns** | **0.0639 ns** |       **0 B** |
|     TrimStartEnd |    abcdefg    | 12.366 ns | 0.3084 ns | 0.3428 ns |       0 B |
|         TrimChar |    abcdefg    |  5.810 ns | 0.0442 ns | 0.0413 ns |       0 B |
| TrimStartEndChar |    abcdefg    |  5.961 ns | 0.0849 ns | 0.0753 ns |       0 B |
|             **Trim** |   **  abcdefg  ** |  **9.552 ns** | **0.1697 ns** | **0.1417 ns** |       **0 B** |
|     TrimStartEnd |     abcdefg   | 10.650 ns | 0.1403 ns | 0.1312 ns |       0 B |
|         TrimChar |     abcdefg   |  4.984 ns | 0.0738 ns | 0.0654 ns |       0 B |
| TrimStartEndChar |     abcdefg   |  4.467 ns | 0.1236 ns | 0.1850 ns |       0 B |
|             **Trim** |     ** abcdefg ** |  **7.277 ns** | **0.0279 ns** | **0.0233 ns** |       **0 B** |
|     TrimStartEnd |      abcdefg  |  7.771 ns | 0.1833 ns | 0.1882 ns |       0 B |
|         TrimChar |      abcdefg  |  4.007 ns | 0.0726 ns | 0.0679 ns |       0 B |
| TrimStartEndChar |      abcdefg  |  3.283 ns | 0.0475 ns | 0.0421 ns |       0 B |
|             **Trim** |       **abcdefg** |  **4.133 ns** | **0.0746 ns** | **0.0661 ns** |       **0 B** |
|     TrimStartEnd |       abcdefg |  3.947 ns | 0.0812 ns | 0.0678 ns |       0 B |
|         TrimChar |       abcdefg |  1.896 ns | 0.0609 ns | 0.0570 ns |       0 B |
| TrimStartEndChar |       abcdefg |  1.649 ns | 0.0409 ns | 0.0341 ns |       0 B |

cc @jkotas, @AndyAyersMS 

@adamsitnik, can we do something about how string data shows up in the BDN output for GitHub so its clearly visible, especially if it contains white space? Surrounding it with quotes might help (I manually formatted the output in the "Before" case above).

```C#
[MemoryDiagnoser]
[InProcess]
public class Benchmark
{
    private static void Main(string[] args)
    {
        Summary summary = BenchmarkRunner.Run<Benchmark>();
    }

    [Params("", " abcdefg ", "  abcdefg  ", "   abcdefg   ", "abcdefg")]
    public string Data;

    [Benchmark]
    public int Trim() => Data.AsSpan().Trim().Length;

    [Benchmark]
    public int TrimStartEnd() => Data.AsSpan().TrimStart().TrimEnd().Length;

    [Benchmark]
    public int TrimChar() => Data.AsSpan().Trim(' ').Length;

    [Benchmark]
    public int TrimStartEndChar() => Data.AsSpan().TrimStart(' ').TrimEnd(' ').Length;
}
```