### PR TITLE
Add EH info support to R2RDump

### DIFF
--- a/src/tools/r2rdump/EHInfo.cs
+++ b/src/tools/r2rdump/EHInfo.cs
@@ -1,0 +1,234 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection.PortableExecutable;
+using System.Text;
+
+namespace R2RDump
+{
+    /// <summary>
+    /// If COR_ILMETHOD_SECT_HEADER::Kind() = CorILMethod_Sect_EHTable then the attribute
+    /// is a list of exception handling clauses.  There are two formats, fat or small
+    /// </summary>
+    public enum CorExceptionFlag
+    {
+        COR_ILEXCEPTION_CLAUSE_NONE,                    // This is a typed handler
+        COR_ILEXCEPTION_CLAUSE_OFFSETLEN = 0x0000,      // Deprecated
+        COR_ILEXCEPTION_CLAUSE_DEPRECATED = 0x0000,     // Deprecated
+        COR_ILEXCEPTION_CLAUSE_FILTER = 0x0001,         // If this bit is on, then this EH entry is for a filter
+        COR_ILEXCEPTION_CLAUSE_FINALLY = 0x0002,        // This clause is a finally clause
+        COR_ILEXCEPTION_CLAUSE_FAULT = 0x0004,          // Fault clause (finally that is called on exception only)
+        COR_ILEXCEPTION_CLAUSE_DUPLICATED = 0x0008,     // duplicated clause. This clause was duplicated to a funclet which was pulled out of line
+    }
+
+    /// <summary>
+    /// This class represents a single exception handling clause. It basically corresponds
+    /// to IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT in
+    /// <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/cordebuginfo.h">src\inc\corhdr.h</a>.
+    /// </summary>
+    public class EHClause
+    {
+        /// <summary>
+        /// Length of the serialized EH clause in the PE image.
+        /// </summary>
+        public const int Length = 6 * sizeof(int);
+
+        /// <summary>
+        /// Flags describing the exception handler.
+        /// </summary>
+        CorExceptionFlag Flags;
+
+        /// <summary>
+        /// Starting offset of the try block
+        /// </summary>
+        public uint TryOffset;
+
+        /// <summary>
+        /// End offset of the try block
+        /// </summary>
+        public uint TryEnd;
+
+        /// <summary>
+        /// Offset of the exception handler for the try block
+        /// </summary>
+        public uint HandlerOffset;
+
+        /// <summary>
+        /// End offset of the exception handler
+        /// </summary>
+        public uint HandlerEnd;
+
+        /// <summary>
+        /// For type-based exception handlers, this is the type token.
+        /// For filter-based exception handlers, this is the filter offset.
+        /// </summary>
+        public uint ClassTokenOrFilterOffset;
+
+        /// <summary>
+        /// Read the EH clause from a given file offset in the PE image.
+        /// </summary>
+        /// <param name="image">R2R PE executable image</param>
+        /// <param name="offset">Offset of the EH clause in the image</param>
+        public EHClause(byte[] image, int offset)
+        {
+            Flags = (CorExceptionFlag)BitConverter.ToUInt32(image, offset + 0 * sizeof(uint));
+            TryOffset = BitConverter.ToUInt32(image, offset + 1 * sizeof(uint));
+            TryEnd = BitConverter.ToUInt32(image, offset + 2 * sizeof(uint));
+            HandlerOffset = BitConverter.ToUInt32(image, offset + 3 * sizeof(uint));
+            HandlerEnd = BitConverter.ToUInt32(image, offset + 4 * sizeof(uint));
+            ClassTokenOrFilterOffset = BitConverter.ToUInt32(image, offset + 5 * sizeof(uint));
+        }
+
+        /// <summary>
+        /// Emit a textual representation of the EH info to a given string builder.
+        /// </summary>
+        /// <param name="stringBuilder">Output builder for the textual representation</param>
+        /// <param name="methodRva">Starting RVA of the runtime function is used to display the try / handler info as RVA intervals</param>
+        public void WriteTo(StringBuilder stringBuilder, int methodRva)
+        {
+            stringBuilder.Append($@"Flags {(uint)Flags:X2} ");
+            stringBuilder.Append($@"TryOff {TryOffset:X4} (RVA {(TryOffset + methodRva):X4}) ");
+            stringBuilder.Append($@"TryEnd {TryEnd:X4} (RVA {(TryEnd + methodRva):X4}) ");
+            stringBuilder.Append($@"HndOff {HandlerOffset:X4} (RVA {(HandlerOffset + methodRva):X4}) ");
+            stringBuilder.Append($@"HndEnd {HandlerEnd:X4} (RVA {(HandlerEnd + methodRva):X4}) ");
+            stringBuilder.Append($@"ClsFlt {ClassTokenOrFilterOffset:X4}");
+
+            if ((Flags & CorExceptionFlag.COR_ILEXCEPTION_CLAUSE_FILTER) != CorExceptionFlag.COR_ILEXCEPTION_CLAUSE_NONE)
+            {
+                stringBuilder.Append($@" (RVA {(ClassTokenOrFilterOffset + methodRva):X4})");
+
+                stringBuilder.Append(" FILTER");
+            }
+            if ((Flags & CorExceptionFlag.COR_ILEXCEPTION_CLAUSE_FINALLY) != CorExceptionFlag.COR_ILEXCEPTION_CLAUSE_NONE)
+            {
+                stringBuilder.Append(" FINALLY");
+            }
+            if ((Flags & CorExceptionFlag.COR_ILEXCEPTION_CLAUSE_FAULT) != CorExceptionFlag.COR_ILEXCEPTION_CLAUSE_NONE)
+            {
+                stringBuilder.Append(" FAULT");
+            }
+            if ((Flags & CorExceptionFlag.COR_ILEXCEPTION_CLAUSE_DUPLICATED) != CorExceptionFlag.COR_ILEXCEPTION_CLAUSE_NONE)
+            {
+                stringBuilder.Append(" DUPLICATED");
+            }
+        }
+    }
+
+    /// <summary>
+    /// This class represents EH info for a single runtime function. EH info
+    /// is located using the map from runtime functions to EH clause lists in
+    /// the READYTORUN_SECTION_EXCEPTION_INFO header table.
+    /// </summary>
+    public class EHInfo
+    {
+        /// <summary>
+        /// RVA of the EH info in the PE image.
+        /// </summary>
+        public readonly int EHInfoRVA;
+
+        /// <summary>
+        /// Starting RVA of the corresponding runtime function.
+        /// </summary>
+        public readonly int MethodRVA;
+
+        /// <summary>
+        /// List of EH clauses for the runtime function.
+        /// </summary>
+        public readonly EHClause[] EHClauses;
+
+        /// <summary>
+        /// Construct the EH info for a given runtime method by reading it from a given offset
+        /// in the R2R PE executable. The offset is located by looking up the starting
+        /// IP address of the runtime function in the READYTORUN_SECTION_EXCEPTION_INFO table.
+        /// The length of the 
+        /// </summary>
+        /// <param name="image">R2R PE image</param>
+        /// <param name="ehInfoRva">RVA of the EH info</param>
+        /// <param name="methodRva">Starting RVA of the runtime function</param>
+        /// <param name="offset">File offset of the EH info</param>
+        /// <param name="clauseCount">Number of EH info clauses</param>
+        public EHInfo(byte[] image, int ehInfoRva, int methodRva, int offset, int clauseCount)
+        {
+            EHInfoRVA = ehInfoRva;
+            MethodRVA = methodRva;
+            EHClauses = new EHClause[clauseCount];
+            for (int clauseIndex = 0; clauseIndex < clauseCount; clauseIndex++)
+            {
+                EHClauses[clauseIndex] = new EHClause(image, offset + clauseIndex * EHClause.Length);
+            }
+        }
+
+        /// <summary>
+        /// Emit the textual representation of the EH info into a given writer.
+        /// </summary>
+        public void WriteTo(StringBuilder stringBuilder)
+        {
+            foreach (EHClause ehClause in EHClauses)
+            {
+                ehClause.WriteTo(stringBuilder, MethodRVA);
+                stringBuilder.AppendLine();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Location of the EH clauses for a single runtime function
+    /// </summary>
+    public class EHInfoLocation
+    {
+        /// <summary>
+        /// RVA of the EH clause list in the R2R PE image
+        /// </summary>
+        public readonly int EHInfoRVA;
+
+        /// <summary>
+        /// Number of EH clauses
+        /// </summary>
+        public readonly int ClauseCount;
+
+        public EHInfoLocation(int ehInfoRva, int clauseCount)
+        {
+            EHInfoRVA = ehInfoRva;
+            ClauseCount = clauseCount;
+        }
+    }
+
+    /// <summary>
+    /// Lookup table maps IP RVAs to EH info.
+    /// </summary>
+    public class EHLookupTable
+    {
+        /// <summary>
+        /// Map from runtime function RVA's to EH info location in the R2R PE file.
+        /// </summary>
+        public readonly Dictionary<int, EHInfoLocation> RuntimeFunctionToEHInfoMap;
+
+        /// <summary>
+        /// Reads the EH info lookup table from the PE image.
+        /// </summary>
+        /// <param name="image">R2R PE image</param>
+        /// <param name="offset">Starting offset of the EH info in the PE image</param>
+        /// <param name="length">Byte length of the EH info</param>
+        public EHLookupTable(byte[] image, int offset, int length)
+        {
+            RuntimeFunctionToEHInfoMap = new Dictionary<int, EHInfoLocation>();
+
+            int rva1 = BitConverter.ToInt32(image, offset);
+            int eh1 = BitConverter.ToInt32(image, offset + sizeof(uint));
+
+            while ((length -= 2 * sizeof(uint)) >= 8)
+            {
+                offset += 2 * sizeof(uint);
+                int rva2 = BitConverter.ToInt32(image, offset);
+                int eh2 = BitConverter.ToInt32(image, offset + sizeof(uint));
+
+                RuntimeFunctionToEHInfoMap.Add(rva1, new EHInfoLocation(eh1, (eh2 - eh1) / EHClause.Length));
+            }
+        }
+    }
+}

--- a/src/tools/r2rdump/EHInfo.cs
+++ b/src/tools/r2rdump/EHInfo.cs
@@ -124,11 +124,11 @@ namespace R2RDump
                     break;
 
                 case CorExceptionFlag.COR_ILEXCEPTION_CLAUSE_FINALLY:
-                    stringBuilder.AppendFormat(" FINALLY (RVA {0:X4})", ClassTokenOrFilterOffset + methodRva);
+                    stringBuilder.AppendFormat(" FINALLY");
                     break;
 
                 case CorExceptionFlag.COR_ILEXCEPTION_CLAUSE_FAULT:
-                    stringBuilder.AppendFormat(" FAULT (RVA {0:X4})", ClassTokenOrFilterOffset + methodRva);
+                    stringBuilder.AppendFormat(" FAULT");
                     break;
 
                 default:

--- a/src/tools/r2rdump/EHInfo.cs
+++ b/src/tools/r2rdump/EHInfo.cs
@@ -36,7 +36,7 @@ namespace R2RDump
         /// <summary>
         /// Length of the serialized EH clause in the PE image.
         /// </summary>
-        public const int Length = 6 * sizeof(int);
+        public const int Length = 6 * sizeof(uint);
 
         /// <summary>
         /// Flags describing the exception handler.
@@ -228,6 +228,9 @@ namespace R2RDump
                 int eh2 = BitConverter.ToInt32(image, offset + sizeof(uint));
 
                 RuntimeFunctionToEHInfoMap.Add(rva1, new EHInfoLocation(eh1, (eh2 - eh1) / EHClause.Length));
+
+                rva1 = rva2;
+                eh1 = eh2;
             }
         }
     }

--- a/src/tools/r2rdump/R2RMethod.cs
+++ b/src/tools/r2rdump/R2RMethod.cs
@@ -82,11 +82,23 @@ namespace R2RDump
 
         public BaseUnwindInfo UnwindInfo { get; }
 
+        public EHInfo EHInfo { get; }
+
         public DebugInfo DebugInfo { get; }
 
         public RuntimeFunction() { }
 
-        public RuntimeFunction(int id, int startRva, int endRva, int unwindRva, int codeOffset, R2RMethod method, BaseUnwindInfo unwindInfo, BaseGcInfo gcInfo, DebugInfo debugInfo)
+        public RuntimeFunction(
+            int id, 
+            int startRva, 
+            int endRva, 
+            int unwindRva, 
+            int codeOffset, 
+            R2RMethod method, 
+            BaseUnwindInfo unwindInfo, 
+            BaseGcInfo gcInfo, 
+            EHInfo ehInfo,
+            DebugInfo debugInfo)
         {
             Id = id;
             StartAddress = startRva;
@@ -121,6 +133,7 @@ namespace R2RDump
             }
             CodeOffset = codeOffset;
             method.GcInfo = gcInfo;
+            EHInfo = ehInfo;
         }
 
         public override string ToString()
@@ -177,6 +190,13 @@ namespace R2RDump
                 }
             }
             sb.AppendLine();
+
+            if (EHInfo != null)
+            {
+                sb.AppendLine($@"EH info @ {EHInfo.EHInfoRVA:X4}, #clauses = {EHInfo.EHClauses.Length}");
+                EHInfo.WriteTo(sb);
+                sb.AppendLine();
+            }
 
             if (DebugInfo != null)
             {

--- a/src/tools/r2rdump/R2RReader.cs
+++ b/src/tools/r2rdump/R2RReader.cs
@@ -393,7 +393,7 @@ namespace R2RDump
                     EHInfoLocation ehInfoLocation;
                     if (EHLookupTable.RuntimeFunctionToEHInfoMap.TryGetValue(startRva, out ehInfoLocation))
                     {
-                        ehInfo = new EHInfo(Image, ehInfoLocation.EHInfoRVA, startRva, GetOffset(ehInfoLocation.EHInfoRVA), ehInfoLocation.ClauseCount);
+                        ehInfo = new EHInfo(this, ehInfoLocation.EHInfoRVA, startRva, GetOffset(ehInfoLocation.EHInfoRVA), ehInfoLocation.ClauseCount);
                     }
 
                     RuntimeFunction rtf = new RuntimeFunction(

--- a/src/tools/r2rdump/R2RReader.cs
+++ b/src/tools/r2rdump/R2RReader.cs
@@ -118,6 +118,11 @@ namespace R2RDump
         public string CompilerIdentifier { get; }
 
         /// <summary>
+        /// Exception lookup table is used to map runtime function addresses to EH clauses.
+        /// </summary>
+        public EHLookupTable EHLookupTable { get; }
+
+        /// <summary>
         /// List of import sections present in the R2R executable.
         /// </summary>
         public IList<R2RImportSection> ImportSections { get; }
@@ -183,6 +188,9 @@ namespace R2RDump
                     MetadataReader = PEReader.GetMetadataReader();
 
                     ParseDebugInfo();
+
+                    R2RSection exceptionInfoSection = R2RHeader.Sections[R2RSection.SectionType.READYTORUN_SECTION_EXCEPTION_INFO];
+                    EHLookupTable = new EHLookupTable(Image, GetOffset(exceptionInfoSection.RelativeVirtualAddress), exceptionInfoSection.Size);
 
                     R2RMethods = new List<R2RMethod>();
                     if (R2RHeader.Sections.ContainsKey(R2RSection.SectionType.READYTORUN_SECTION_RUNTIME_FUNCTIONS))
@@ -380,7 +388,26 @@ namespace R2RDump
                         }
                     }
 
-                    RuntimeFunction rtf = new RuntimeFunction(runtimeFunctionId, startRva, endRva, unwindRva, codeOffset, method, unwindInfo, gcInfo, _runtimeFunctionToDebugInfo.GetValueOrDefault(runtimeFunctionId));
+                    EHInfo ehInfo = null;
+
+                    EHInfoLocation ehInfoLocation;
+                    if (EHLookupTable.RuntimeFunctionToEHInfoMap.TryGetValue(startRva, out ehInfoLocation))
+                    {
+                        ehInfo = new EHInfo(Image, ehInfoLocation.EHInfoRVA, startRva, GetOffset(ehInfoLocation.EHInfoRVA), ehInfoLocation.ClauseCount);
+                    }
+
+                    RuntimeFunction rtf = new RuntimeFunction(
+                        runtimeFunctionId,
+                        startRva,
+                        endRva,
+                        unwindRva,
+                        codeOffset,
+                        method,
+                        unwindInfo,
+                        gcInfo,
+                        ehInfo,
+                        _runtimeFunctionToDebugInfo.GetValueOrDefault(runtimeFunctionId));
+
                     method.RuntimeFunctions.Add(rtf);
                     runtimeFunctionId++;
                     codeOffset += rtf.Size;


### PR DESCRIPTION
This change expands runtime function dump to include the exception
handling info looked up via the EXCEPTION_INFO R2R header table.

Thanks

Tomas