### PR TITLE
Always define printf/fprintf in JIT

### DIFF
--- a/src/jit/host.h
+++ b/src/jit/host.h
@@ -5,13 +5,12 @@
 /*****************************************************************************/
 
 #ifdef DEBUG
-#ifndef printf
-#define printf logf
-#endif
 
-#ifndef fprintf
+#undef printf
+#define printf logf
+
+#undef fprintf
 #define fprintf flogf
-#endif
 
 class Compiler;
 class LogEnv


### PR DESCRIPTION
In PAL based builds the stdio printf is already a macro so JIT's host.h fails to replace it with logf/flogf.

Fixes #19710