### PR TITLE
Replace assert in Precode::SetTargetInterlocked

### DIFF
--- a/src/vm/precode.cpp
+++ b/src/vm/precode.cpp
@@ -456,6 +456,7 @@ void Precode::ResetTargetInterlocked()
 BOOL Precode::SetTargetInterlocked(PCODE target, BOOL fOnlyRedirectFromPrestub)
 {
     WRAPPER_NO_CONTRACT;
+    _ASSERTE(!IsPointingToPrestub(target));
 
     PCODE expected = GetTarget();
     BOOL ret = FALSE;
@@ -498,7 +499,6 @@ BOOL Precode::SetTargetInterlocked(PCODE target, BOOL fOnlyRedirectFromPrestub)
     // Although executable code is modified on x86/x64, a FlushInstructionCache() is not necessary on those platforms due to the
     // interlocked operation above (see ClrFlushInstructionCache())
 
-    _ASSERTE(!IsPointingToPrestub());
     return ret;
 }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/19954
- `SetTargetInterlocked` can be soon followed by `ResetTargetInterlocked` since tiered compilation is now enabled by default, so the assert at the end of `SetTargetInterlocked` is invalid. `ResetTargetInterlocked` may be used in other scenarios in the future.
- Removed the assert and instead just verified that the specified target is not the default prestub target