### PR TITLE
Fix perf scenarios in the min_opt config

### DIFF
--- a/tests/scripts/run-xunit-perf.py
+++ b/tests/scripts/run-xunit-perf.py
@@ -455,7 +455,7 @@ def main(args):
     build_perfharness(coreclrRepo, sandboxDir, extension, myEnv)
 
     # Set up environment for running tests
-    if optLevel == 'min_opts':
+    if optLevel == 'min_opt':
         myEnv['COMPlus_JITMinOpts'] = '1'
         myEnv['COMPlus_TieredCompilation'] = '0'
     elif optLevel == 'full_opt':


### PR DESCRIPTION
- The appropriate environment variables were not being set due to a config name mismatch