### PR TITLE
Introduce a fourth type of LazyThreadSafetyMode: ThreadSafeValueOnly

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/LazyThreadSafetyMode.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/LazyThreadSafetyMode.cs
@@ -17,7 +17,7 @@ namespace System.Threading
     {
         /// <summary>
         /// This mode makes no guarantees around the thread-safety of the <see cref="T:System.Threading.Lazy{T}"/> instance.  If used from multiple threads, the behavior of the <see cref="T:System.Threading.Lazy{T}"/> is undefined.
-        /// This mode should be used when a <see cref="T:System.Threading.Lazy{T}"/> is guaranteed to never be initialized from more than one thread simultaneously and high performance is crucial. 
+        /// This mode should be used when a <see cref="T:System.Threading.Lazy{T}"/> is guaranteed to never be initialized from more than one thread simultaneously and high performance is crucial.
         /// If valueFactory throws an exception when the <see cref="T:System.Threading.Lazy{T}"/> is initialized, the exception will be cached and returned on subsequent accesses to Value. Also, if valueFactory recursively
         /// accesses Value on this <see cref="T:System.Threading.Lazy{T}"/> instance, a <see cref="T:System.InvalidOperationException"/> will be thrown.
         /// </summary>
@@ -39,6 +39,14 @@ namespace System.Threading
         /// handled carefully.  If valueFactory throws an exception when the<see cref="T:System.Threading.Lazy{T}"/> is initialized, the exception will be cached and returned on
         /// subsequent accesses to Value. Also, if valueFactory recursively accesses Value on this <see cref="T:System.Threading.Lazy{T}"/> instance, a  <see cref="T:System.InvalidOperationException"/> will be thrown.
         /// </summary>
-        ExecutionAndPublication
+        ExecutionAndPublication,
+
+        /// <summary>
+        /// This mode uses locks to ensure that only a single thread can initialize a <see cref="T:System.Threading.Lazy{T}"/> instance in a thread-safe manner.  In general,
+        /// taken if this mode is used in conjunction with a <see cref="T:System.Threading.Lazy{T}"/> valueFactory delegate that uses locks internally, a deadlock can occur if not
+        /// handled carefully.  If valueFactory throws an exception on any thread, that exception will be
+        /// propagated out of Value. Also, if valueFactory recursively accesses Value on this <see cref="T:System.Threading.Lazy{T}"/> instance, a  <see cref="T:System.InvalidOperationException"/> will be thrown.
+        /// </summary>
+        ThreadSafeValueOnly
     }
 }


### PR DESCRIPTION
This is a missing case that is commonly asked for, see for example https://stackoverflow.com/questions/34393352/lazyt-without-exception-caching

This mode is similar to ExecutionAndPublication in that it uses locks so only a single thread can run the factory at a time. It will cache the value returned by the factory, but it does not cache exceptions thrown by the factory. Subsequent calls will have to try again, and will continue to do so until a value is returned, similar to how PublicationOnly works.

This is very useful when Lazy is used for values that are expected to fail intermittently but recover quickly.

BTW, the name ThreadSafeValueOnly is very much bikeshedable, so if you have a suggestion for another name of this mode I am very much up for changing it.