### PR TITLE
Changes to use VNNormalValue in assertionProp

### DIFF
--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -856,8 +856,8 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
             GenTreeBoundsChk* arrBndsChk = op1->AsBoundsChk();
             assertion->assertionKind     = assertionKind;
             assertion->op1.kind          = O1K_ARR_BND;
-            assertion->op1.bnd.vnIdx     = vnStore->VNNormalValue(arrBndsChk->gtIndex->gtVNPair, VNK_Conservative);
-            assertion->op1.bnd.vnLen     = vnStore->VNNormalValue(arrBndsChk->gtArrLen->gtVNPair, VNK_Conservative);
+            assertion->op1.bnd.vnIdx     = vnStore->VNConservativeNormalValue(arrBndsChk->gtIndex->gtVNPair);
+            assertion->op1.bnd.vnLen     = vnStore->VNConservativeNormalValue(arrBndsChk->gtArrLen->gtVNPair);
             goto DONE_ASSERTION;
         }
     }
@@ -932,7 +932,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
                 goto DONE_ASSERTION; // Don't make an assertion
             }
 
-            vn = vnStore->VNNormalValue(op1->gtVNPair, VNK_Conservative);
+            vn = vnStore->VNConservativeNormalValue(op1->gtVNPair);
             VNFuncApp funcAttr;
 
             // Try to get value number corresponding to the GC ref of the indirection
@@ -975,7 +975,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
             assertion->op1.kind       = O1K_LCLVAR;
             assertion->op1.lcl.lclNum = lclNum;
             assertion->op1.lcl.ssaNum = op1->AsLclVarCommon()->GetSsaNum();
-            vn                        = vnStore->VNNormalValue(op1->gtVNPair, VNK_Conservative);
+            vn                        = vnStore->VNConservativeNormalValue(op1->gtVNPair);
         }
 
         assertion->op1.vn           = vn;
@@ -1036,10 +1036,10 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
             //
             assertion->op1.kind         = O1K_SUBTYPE;
             assertion->op1.lcl.lclNum   = lclNum;
-            assertion->op1.vn           = vnStore->VNNormalValue(op1->gtVNPair, VNK_Conservative);
+            assertion->op1.vn           = vnStore->VNConservativeNormalValue(op1->gtVNPair);
             assertion->op1.lcl.ssaNum   = op1->AsLclVarCommon()->GetSsaNum();
             assertion->op2.u1.iconVal   = op2->gtIntCon.gtIconVal;
-            assertion->op2.vn           = vnStore->VNNormalValue(op2->gtVNPair, VNK_Conservative);
+            assertion->op2.vn           = vnStore->VNConservativeNormalValue(op2->gtVNPair);
             assertion->op2.u1.iconFlags = op2->GetIconHandleFlag();
 
             //
@@ -1057,7 +1057,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
 
             assertion->op1.kind       = O1K_LCLVAR;
             assertion->op1.lcl.lclNum = lclNum;
-            assertion->op1.vn         = vnStore->VNNormalValue(op1->gtVNPair, VNK_Conservative);
+            assertion->op1.vn         = vnStore->VNConservativeNormalValue(op1->gtVNPair);
             assertion->op1.lcl.ssaNum = op1->AsLclVarCommon()->GetSsaNum();
 
             switch (op2->gtOper)
@@ -1104,7 +1104,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
 
                     assertion->op2.kind    = op2Kind;
                     assertion->op2.lconVal = 0;
-                    assertion->op2.vn      = vnStore->VNNormalValue(op2->gtVNPair, VNK_Conservative);
+                    assertion->op2.vn      = vnStore->VNConservativeNormalValue(op2->gtVNPair);
 
                     if (op2->gtOper == GT_CNS_INT)
                     {
@@ -1190,7 +1190,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
 
                     assertion->op2.kind       = O2K_LCLVAR_COPY;
                     assertion->op2.lcl.lclNum = lclNum2;
-                    assertion->op2.vn         = vnStore->VNNormalValue(op2->gtVNPair, VNK_Conservative);
+                    assertion->op2.vn         = vnStore->VNConservativeNormalValue(op2->gtVNPair);
                     assertion->op2.lcl.ssaNum = op2->AsLclVarCommon()->GetSsaNum();
 
                     //
@@ -1319,13 +1319,13 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
 
             assertion->op1.kind       = O1K_EXACT_TYPE;
             assertion->op1.lcl.lclNum = lclNum;
-            assertion->op1.vn         = vnStore->VNNormalValue(op1->gtVNPair, VNK_Conservative);
+            assertion->op1.vn         = vnStore->VNConservativeNormalValue(op1->gtVNPair);
             assertion->op1.lcl.ssaNum = op1->AsLclVarCommon()->GetSsaNum();
 
             assert(assertion->op1.lcl.ssaNum == SsaConfig::RESERVED_SSA_NUM ||
                    assertion->op1.vn ==
-                       vnStore->VNNormalValue(lvaTable[lclNum].GetPerSsaData(assertion->op1.lcl.ssaNum)->m_vnPair,
-                                              VNK_Conservative));
+                       vnStore->VNConservativeNormalValue(
+                           lvaTable[lclNum].GetPerSsaData(assertion->op1.lcl.ssaNum)->m_vnPair));
 
             ssize_t  cnsValue  = 0;
             unsigned iconFlags = 0;
@@ -1340,7 +1340,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
                 assertion->assertionKind  = assertionKind;
                 assertion->op2.kind       = O2K_IND_CNS_INT;
                 assertion->op2.u1.iconVal = cnsValue;
-                assertion->op2.vn         = vnStore->VNNormalValue(op2->gtOp.gtOp1->gtVNPair, VNK_Conservative);
+                assertion->op2.vn         = vnStore->VNConservativeNormalValue(op2->gtOp.gtOp1->gtVNPair);
 
                 /* iconFlags should only contain bits in GTF_ICON_HDL_MASK */
                 assert((iconFlags & ~GTF_ICON_HDL_MASK) == 0);
@@ -1358,7 +1358,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
                 assertion->assertionKind  = assertionKind;
                 assertion->op2.kind       = O2K_IND_CNS_INT;
                 assertion->op2.u1.iconVal = cnsValue;
-                assertion->op2.vn         = vnStore->VNNormalValue(op2->gtVNPair, VNK_Conservative);
+                assertion->op2.vn         = vnStore->VNConservativeNormalValue(op2->gtVNPair);
 
                 /* iconFlags should only contain bits in GTF_ICON_HDL_MASK */
                 assert((iconFlags & ~GTF_ICON_HDL_MASK) == 0);
@@ -1436,7 +1436,7 @@ bool Compiler::optIsTreeKnownIntValue(bool vnBased, GenTree* tree, ssize_t* pCon
     }
 
     // Global assertion prop
-    ValueNum vn = vnStore->VNNormalValue(tree->gtVNPair, VNK_Conservative);
+    ValueNum vn = vnStore->VNConservativeNormalValue(tree->gtVNPair);
     if (!vnStore->IsVNConstant(vn))
     {
         return false;
@@ -1768,9 +1768,9 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
     GenTree* op1 = relop->gtGetOp1();
     GenTree* op2 = relop->gtGetOp2();
 
-    ValueNum op1VN   = vnStore->VNNormalValue(op1->gtVNPair, VNK_Conservative);
-    ValueNum op2VN   = vnStore->VNNormalValue(op2->gtVNPair, VNK_Conservative);
-    ValueNum relopVN = vnStore->VNNormalValue(relop->gtVNPair, VNK_Conservative);
+    ValueNum op1VN   = vnStore->VNConservativeNormalValue(op1->gtVNPair);
+    ValueNum op2VN   = vnStore->VNConservativeNormalValue(op2->gtVNPair);
+    ValueNum relopVN = vnStore->VNConservativeNormalValue(relop->gtVNPair);
 
     bool hasTestAgainstZero =
         (relop->gtOper == GT_EQ || relop->gtOper == GT_NE) && (op2VN == vnStore->VNZeroForType(op2->TypeGet()));
@@ -2224,7 +2224,7 @@ AssertionIndex Compiler::optAssertionIsSubrange(GenTree* tree, var_types toType,
             // For local assertion prop use comparison on locals, and use comparison on vns for global prop.
             bool isEqual = optLocalAssertionProp
                                ? (curAssertion->op1.lcl.lclNum == tree->AsLclVarCommon()->GetLclNum())
-                               : (curAssertion->op1.vn == vnStore->VNNormalValue(tree->gtVNPair, VNK_Conservative));
+                               : (curAssertion->op1.vn == vnStore->VNConservativeNormalValue(tree->gtVNPair));
             if (!isEqual)
             {
                 continue;
@@ -2293,9 +2293,8 @@ AssertionIndex Compiler::optAssertionIsSubtype(GenTree* tree, GenTree* methodTab
         }
 
         // If local assertion prop use "lcl" based comparison, if global assertion prop use vn based comparison.
-        if ((optLocalAssertionProp)
-                ? (curAssertion->op1.lcl.lclNum != tree->AsLclVarCommon()->GetLclNum())
-                : (curAssertion->op1.vn != vnStore->VNNormalValue(tree->gtVNPair, VNK_Conservative)))
+        if ((optLocalAssertionProp) ? (curAssertion->op1.lcl.lclNum != tree->AsLclVarCommon()->GetLclNum())
+                                    : (curAssertion->op1.vn != vnStore->VNConservativeNormalValue(tree->gtVNPair)))
         {
             continue;
         }
@@ -2376,8 +2375,8 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* stmt, Gen
     }
 
     // We want to use the Normal ValueNumber when checking for constants.
-    ValueNum vnCns = vnStore->VNNormalValue(tree->gtVNPair, VNK_Conservative);
-    ValueNum vnLib = vnStore->VNNormalValue(tree->gtVNPair, VNK_Liberal);
+    ValueNum vnCns = vnStore->VNConservativeNormalValue(tree->gtVNPair);
+    ValueNum vnLib = vnStore->VNLiberalNormalValue(tree->gtVNPair);
 
     // Check if node evaluates to a constant.
     if (!vnStore->IsVNConstant(vnCns))
@@ -2897,7 +2896,7 @@ GenTree* Compiler::optAssertionProp_LclVar(ASSERT_VALARG_TP assertions, GenTree*
                 return optConstantAssertionProp(curAssertion, tree, stmt DEBUGARG(assertionIndex));
             }
             // If global assertion, perform constant propagation only if the VN's match and the lcl is non-CSE.
-            else if (curAssertion->op1.vn == vnStore->VNNormalValue(tree->gtVNPair, VNK_Conservative))
+            else if (curAssertion->op1.vn == vnStore->VNConservativeNormalValue(tree->gtVNPair))
             {
 #if FEATURE_ANYCSE
                 // Don't perform constant prop for CSE LclVars
@@ -2981,8 +2980,8 @@ AssertionIndex Compiler::optGlobalAssertionIsEqualOrNotEqual(ASSERT_VALARG_TP as
             continue;
         }
 
-        if ((curAssertion->op1.vn == vnStore->VNNormalValue(op1->gtVNPair, VNK_Conservative)) &&
-            (curAssertion->op2.vn == vnStore->VNNormalValue(op2->gtVNPair, VNK_Conservative)))
+        if ((curAssertion->op1.vn == vnStore->VNConservativeNormalValue(op1->gtVNPair)) &&
+            (curAssertion->op2.vn == vnStore->VNConservativeNormalValue(op2->gtVNPair)))
         {
             return assertionIndex;
         }
@@ -3054,7 +3053,7 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
     bool allowReverse = true;
 
     // If the assertion involves "op2" and it is a constant, then check if "op1" also has a constant value.
-    ValueNum vnCns = vnStore->VNNormalValue(op2->gtVNPair, VNK_Conservative);
+    ValueNum vnCns = vnStore->VNConservativeNormalValue(op2->gtVNPair);
     if (vnStore->IsVNConstant(vnCns))
     {
 #ifdef DEBUG
@@ -3717,9 +3716,9 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions, GenTree
 #endif
 
         // Do we have a previous range check involving the same 'vnLen' upper bound?
-        if (curAssertion->op1.bnd.vnLen == vnStore->VNNormalValue(arrBndsChk->gtArrLen->gtVNPair, VNK_Conservative))
+        if (curAssertion->op1.bnd.vnLen == vnStore->VNConservativeNormalValue(arrBndsChk->gtArrLen->gtVNPair))
         {
-            ValueNum vnCurIdx = vnStore->VNNormalValue(arrBndsChk->gtIndex->gtVNPair, VNK_Conservative);
+            ValueNum vnCurIdx = vnStore->VNConservativeNormalValue(arrBndsChk->gtIndex->gtVNPair);
 
             // Do we have the exact same lower bound 'vnIdx'?
             //       a[i] followed by a[i]
@@ -4613,7 +4612,7 @@ GenTree* Compiler::optPrepareTreeForReplacement(GenTree* oldTree, GenTree* newTr
             // (e.g. VN may evaluate a DIV/MOD node to a constant and the node may still
             // have GTF_EXCEPT set, even if it does not actually throw any exceptions).
             assert(!gtNodeHasSideEffects(oldTree, GTF_EXCEPT) ||
-                   vnStore->IsVNConstant(vnStore->VNNormalValue(oldTree->gtVNPair, VNK_Conservative)));
+                   vnStore->IsVNConstant(vnStore->VNConservativeNormalValue(oldTree->gtVNPair)));
 
             ignoreRoot = true;
         }

--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -856,8 +856,8 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
             GenTreeBoundsChk* arrBndsChk = op1->AsBoundsChk();
             assertion->assertionKind     = assertionKind;
             assertion->op1.kind          = O1K_ARR_BND;
-            assertion->op1.bnd.vnIdx     = arrBndsChk->gtIndex->gtVNPair.GetConservative();
-            assertion->op1.bnd.vnLen     = arrBndsChk->gtArrLen->gtVNPair.GetConservative();
+            assertion->op1.bnd.vnIdx     = vnStore->VNNormalValue(arrBndsChk->gtIndex->gtVNPair, VNK_Conservative);
+            assertion->op1.bnd.vnLen     = vnStore->VNNormalValue(arrBndsChk->gtArrLen->gtVNPair, VNK_Conservative);
             goto DONE_ASSERTION;
         }
     }
@@ -932,7 +932,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
                 goto DONE_ASSERTION; // Don't make an assertion
             }
 
-            vn = op1->gtVNPair.GetConservative();
+            vn = vnStore->VNNormalValue(op1->gtVNPair, VNK_Conservative);
             VNFuncApp funcAttr;
 
             // Try to get value number corresponding to the GC ref of the indirection
@@ -975,7 +975,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
             assertion->op1.kind       = O1K_LCLVAR;
             assertion->op1.lcl.lclNum = lclNum;
             assertion->op1.lcl.ssaNum = op1->AsLclVarCommon()->GetSsaNum();
-            vn                        = op1->gtVNPair.GetConservative();
+            vn                        = vnStore->VNNormalValue(op1->gtVNPair, VNK_Conservative);
         }
 
         assertion->op1.vn           = vn;
@@ -1036,10 +1036,10 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
             //
             assertion->op1.kind         = O1K_SUBTYPE;
             assertion->op1.lcl.lclNum   = lclNum;
-            assertion->op1.vn           = op1->gtVNPair.GetConservative();
+            assertion->op1.vn           = vnStore->VNNormalValue(op1->gtVNPair, VNK_Conservative);
             assertion->op1.lcl.ssaNum   = op1->AsLclVarCommon()->GetSsaNum();
             assertion->op2.u1.iconVal   = op2->gtIntCon.gtIconVal;
-            assertion->op2.vn           = op2->gtVNPair.GetConservative();
+            assertion->op2.vn           = vnStore->VNNormalValue(op2->gtVNPair, VNK_Conservative);
             assertion->op2.u1.iconFlags = op2->GetIconHandleFlag();
 
             //
@@ -1057,7 +1057,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
 
             assertion->op1.kind       = O1K_LCLVAR;
             assertion->op1.lcl.lclNum = lclNum;
-            assertion->op1.vn         = op1->gtVNPair.GetConservative();
+            assertion->op1.vn         = vnStore->VNNormalValue(op1->gtVNPair, VNK_Conservative);
             assertion->op1.lcl.ssaNum = op1->AsLclVarCommon()->GetSsaNum();
 
             switch (op2->gtOper)
@@ -1104,7 +1104,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
 
                     assertion->op2.kind    = op2Kind;
                     assertion->op2.lconVal = 0;
-                    assertion->op2.vn      = op2->gtVNPair.GetConservative();
+                    assertion->op2.vn      = vnStore->VNNormalValue(op2->gtVNPair, VNK_Conservative);
 
                     if (op2->gtOper == GT_CNS_INT)
                     {
@@ -1190,7 +1190,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
 
                     assertion->op2.kind       = O2K_LCLVAR_COPY;
                     assertion->op2.lcl.lclNum = lclNum2;
-                    assertion->op2.vn         = op2->gtVNPair.GetConservative();
+                    assertion->op2.vn         = vnStore->VNNormalValue(op2->gtVNPair, VNK_Conservative);
                     assertion->op2.lcl.ssaNum = op2->AsLclVarCommon()->GetSsaNum();
 
                     //
@@ -1319,11 +1319,13 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
 
             assertion->op1.kind       = O1K_EXACT_TYPE;
             assertion->op1.lcl.lclNum = lclNum;
-            assertion->op1.vn         = op1->gtVNPair.GetConservative();
+            assertion->op1.vn         = vnStore->VNNormalValue(op1->gtVNPair, VNK_Conservative);
             assertion->op1.lcl.ssaNum = op1->AsLclVarCommon()->GetSsaNum();
+
             assert(assertion->op1.lcl.ssaNum == SsaConfig::RESERVED_SSA_NUM ||
                    assertion->op1.vn ==
-                       lvaTable[lclNum].GetPerSsaData(assertion->op1.lcl.ssaNum)->m_vnPair.GetConservative());
+                       vnStore->VNNormalValue(lvaTable[lclNum].GetPerSsaData(assertion->op1.lcl.ssaNum)->m_vnPair,
+                                              VNK_Conservative));
 
             ssize_t  cnsValue  = 0;
             unsigned iconFlags = 0;
@@ -1338,7 +1340,8 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
                 assertion->assertionKind  = assertionKind;
                 assertion->op2.kind       = O2K_IND_CNS_INT;
                 assertion->op2.u1.iconVal = cnsValue;
-                assertion->op2.vn         = op2->gtOp.gtOp1->gtVNPair.GetConservative();
+                assertion->op2.vn         = vnStore->VNNormalValue(op2->gtOp.gtOp1->gtVNPair, VNK_Conservative);
+
                 /* iconFlags should only contain bits in GTF_ICON_HDL_MASK */
                 assert((iconFlags & ~GTF_ICON_HDL_MASK) == 0);
                 assertion->op2.u1.iconFlags = iconFlags;
@@ -1355,7 +1358,8 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
                 assertion->assertionKind  = assertionKind;
                 assertion->op2.kind       = O2K_IND_CNS_INT;
                 assertion->op2.u1.iconVal = cnsValue;
-                assertion->op2.vn         = op2->gtVNPair.GetConservative();
+                assertion->op2.vn         = vnStore->VNNormalValue(op2->gtVNPair, VNK_Conservative);
+
                 /* iconFlags should only contain bits in GTF_ICON_HDL_MASK */
                 assert((iconFlags & ~GTF_ICON_HDL_MASK) == 0);
                 assertion->op2.u1.iconFlags = iconFlags;
@@ -1432,12 +1436,14 @@ bool Compiler::optIsTreeKnownIntValue(bool vnBased, GenTree* tree, ssize_t* pCon
     }
 
     // Global assertion prop
-    if (!vnStore->IsVNConstant(tree->gtVNPair.GetConservative()))
+    ValueNum vn = vnStore->VNNormalValue(tree->gtVNPair, VNK_Conservative);
+    if (!vnStore->IsVNConstant(vn))
     {
         return false;
     }
 
-    ValueNum  vn     = tree->gtVNPair.GetConservative();
+    // ValueNumber 'vn' indicates that this node evaluates to a constant
+
     var_types vnType = vnStore->TypeOfVN(vn);
     if (vnType == TYP_INT)
     {
@@ -1762,20 +1768,23 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
     GenTree* op1 = relop->gtGetOp1();
     GenTree* op2 = relop->gtGetOp2();
 
-    ValueNum vn = op1->gtVNPair.GetConservative();
+    ValueNum op1VN   = vnStore->VNNormalValue(op1->gtVNPair, VNK_Conservative);
+    ValueNum op2VN   = vnStore->VNNormalValue(op2->gtVNPair, VNK_Conservative);
+    ValueNum relopVN = vnStore->VNNormalValue(relop->gtVNPair, VNK_Conservative);
+
+    bool hasTestAgainstZero =
+        (relop->gtOper == GT_EQ || relop->gtOper == GT_NE) && (op2VN == vnStore->VNZeroForType(op2->TypeGet()));
 
     ValueNumStore::UnsignedCompareCheckedBoundInfo unsignedCompareBnd;
     // Cases where op1 holds the upper bound arithmetic and op2 is 0.
     // Loop condition like: "i < bnd +/-k == 0"
     // Assertion: "i < bnd +/- k == 0"
-    if (vnStore->IsVNCompareCheckedBoundArith(vn) &&
-        op2->gtVNPair.GetConservative() == vnStore->VNZeroForType(op2->TypeGet()) &&
-        (relop->gtOper == GT_EQ || relop->gtOper == GT_NE))
+    if (hasTestAgainstZero && vnStore->IsVNCompareCheckedBoundArith(op1VN))
     {
         AssertionDsc dsc;
         dsc.assertionKind    = relop->gtOper == GT_EQ ? OAK_EQUAL : OAK_NOT_EQUAL;
         dsc.op1.kind         = O1K_BOUND_OPER_BND;
-        dsc.op1.vn           = vn;
+        dsc.op1.vn           = op1VN;
         dsc.op2.kind         = O2K_CONST_INT;
         dsc.op2.vn           = vnStore->VNZeroForType(op2->TypeGet());
         dsc.op2.u1.iconVal   = 0;
@@ -1787,14 +1796,12 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
     // Cases where op1 holds the upper bound and op2 is 0.
     // Loop condition like: "i < bnd == 0"
     // Assertion: "i < bnd == false"
-    else if (vnStore->IsVNCompareCheckedBound(vn) &&
-             (op2->gtVNPair.GetConservative() == vnStore->VNZeroForType(op2->TypeGet())) &&
-             (relop->gtOper == GT_EQ || relop->gtOper == GT_NE))
+    else if (hasTestAgainstZero && vnStore->IsVNCompareCheckedBound(op1VN))
     {
         AssertionDsc dsc;
         dsc.assertionKind    = relop->gtOper == GT_EQ ? OAK_EQUAL : OAK_NOT_EQUAL;
         dsc.op1.kind         = O1K_BOUND_LOOP_BND;
-        dsc.op1.vn           = vn;
+        dsc.op1.vn           = op1VN;
         dsc.op2.kind         = O2K_CONST_INT;
         dsc.op2.vn           = vnStore->VNZeroForType(op2->TypeGet());
         dsc.op2.u1.iconVal   = 0;
@@ -1806,12 +1813,12 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
     // Cases where op1 holds the lhs of the condition op2 holds the bound.
     // Loop condition like "i < bnd"
     // Assertion: "i < bnd != 0"
-    else if (vnStore->IsVNCompareCheckedBound(relop->gtVNPair.GetConservative()))
+    else if (vnStore->IsVNCompareCheckedBound(relopVN))
     {
         AssertionDsc dsc;
         dsc.assertionKind    = OAK_NOT_EQUAL;
         dsc.op1.kind         = O1K_BOUND_LOOP_BND;
-        dsc.op1.vn           = relop->gtVNPair.GetConservative();
+        dsc.op1.vn           = relopVN;
         dsc.op2.kind         = O2K_CONST_INT;
         dsc.op2.vn           = vnStore->VNZeroForType(TYP_INT);
         dsc.op2.u1.iconVal   = 0;
@@ -1822,7 +1829,7 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
     }
     // Loop condition like "(uint)i < (uint)bnd" or equivalent
     // Assertion: "no throw" since this condition guarantees that i is both >= 0 and < bnd (on the appropiate edge)
-    else if (vnStore->IsVNUnsignedCompareCheckedBound(relop->gtVNPair.GetConservative(), &unsignedCompareBnd))
+    else if (vnStore->IsVNUnsignedCompareCheckedBound(relopVN, &unsignedCompareBnd))
     {
         assert(unsignedCompareBnd.vnIdx != ValueNumStore::NoVN);
         assert((unsignedCompareBnd.cmpOper == VNF_LT_UN) || (unsignedCompareBnd.cmpOper == VNF_GE_UN));
@@ -1831,9 +1838,9 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
         AssertionDsc dsc;
         dsc.assertionKind = OAK_NO_THROW;
         dsc.op1.kind      = O1K_ARR_BND;
-        dsc.op1.vn        = relop->gtVNPair.GetConservative();
+        dsc.op1.vn        = relopVN;
         dsc.op1.bnd.vnIdx = unsignedCompareBnd.vnIdx;
-        dsc.op1.bnd.vnLen = unsignedCompareBnd.vnBound;
+        dsc.op1.bnd.vnLen = vnStore->VNNormalValue(unsignedCompareBnd.vnBound);
         dsc.op2.kind      = O2K_INVALID;
         dsc.op2.vn        = ValueNumStore::NoVN;
 
@@ -1849,14 +1856,12 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
     // Cases where op1 holds the condition bound check and op2 is 0.
     // Loop condition like: "i < 100 == 0"
     // Assertion: "i < 100 == false"
-    else if (vnStore->IsVNConstantBound(vn) &&
-             (op2->gtVNPair.GetConservative() == vnStore->VNZeroForType(op2->TypeGet())) &&
-             (relop->gtOper == GT_EQ || relop->gtOper == GT_NE))
+    else if (hasTestAgainstZero && vnStore->IsVNConstantBound(op1VN))
     {
         AssertionDsc dsc;
         dsc.assertionKind    = relop->gtOper == GT_EQ ? OAK_EQUAL : OAK_NOT_EQUAL;
         dsc.op1.kind         = O1K_CONSTANT_LOOP_BND;
-        dsc.op1.vn           = vn;
+        dsc.op1.vn           = op1VN;
         dsc.op2.kind         = O2K_CONST_INT;
         dsc.op2.vn           = vnStore->VNZeroForType(op2->TypeGet());
         dsc.op2.u1.iconVal   = 0;
@@ -1868,12 +1873,12 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
     // Cases where op1 holds the lhs of the condition op2 holds rhs.
     // Loop condition like "i < 100"
     // Assertion: "i < 100 != 0"
-    else if (vnStore->IsVNConstantBound(relop->gtVNPair.GetConservative()))
+    else if (vnStore->IsVNConstantBound(relopVN))
     {
         AssertionDsc dsc;
         dsc.assertionKind    = OAK_NOT_EQUAL;
         dsc.op1.kind         = O1K_CONSTANT_LOOP_BND;
-        dsc.op1.vn           = relop->gtVNPair.GetConservative();
+        dsc.op1.vn           = relopVN;
         dsc.op2.kind         = O2K_CONST_INT;
         dsc.op2.vn           = vnStore->VNZeroForType(TYP_INT);
         dsc.op2.u1.iconVal   = 0;
@@ -2217,8 +2222,9 @@ AssertionIndex Compiler::optAssertionIsSubrange(GenTree* tree, var_types toType,
             (curAssertion->op1.kind == O1K_LCLVAR))
         {
             // For local assertion prop use comparison on locals, and use comparison on vns for global prop.
-            bool isEqual = optLocalAssertionProp ? (curAssertion->op1.lcl.lclNum == tree->AsLclVarCommon()->GetLclNum())
-                                                 : (curAssertion->op1.vn == tree->gtVNPair.GetConservative());
+            bool isEqual = optLocalAssertionProp
+                               ? (curAssertion->op1.lcl.lclNum == tree->AsLclVarCommon()->GetLclNum())
+                               : (curAssertion->op1.vn == vnStore->VNNormalValue(tree->gtVNPair, VNK_Conservative));
             if (!isEqual)
             {
                 continue;
@@ -2287,8 +2293,9 @@ AssertionIndex Compiler::optAssertionIsSubtype(GenTree* tree, GenTree* methodTab
         }
 
         // If local assertion prop use "lcl" based comparison, if global assertion prop use vn based comparison.
-        if ((optLocalAssertionProp) ? (curAssertion->op1.lcl.lclNum != tree->AsLclVarCommon()->GetLclNum())
-                                    : (curAssertion->op1.vn != tree->gtVNPair.GetConservative()))
+        if ((optLocalAssertionProp)
+                ? (curAssertion->op1.lcl.lclNum != tree->AsLclVarCommon()->GetLclNum())
+                : (curAssertion->op1.vn != vnStore->VNNormalValue(tree->gtVNPair, VNK_Conservative)))
         {
             continue;
         }
@@ -2368,8 +2375,9 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* stmt, Gen
         return nullptr;
     }
 
-    ValueNum vnCns = tree->gtVNPair.GetConservative();
-    ValueNum vnLib = tree->gtVNPair.GetLiberal();
+    // We want to use the Normal ValueNumber when checking for constants.
+    ValueNum vnCns = vnStore->VNNormalValue(tree->gtVNPair, VNK_Conservative);
+    ValueNum vnLib = vnStore->VNNormalValue(tree->gtVNPair, VNK_Liberal);
 
     // Check if node evaluates to a constant.
     if (!vnStore->IsVNConstant(vnCns))
@@ -2889,7 +2897,7 @@ GenTree* Compiler::optAssertionProp_LclVar(ASSERT_VALARG_TP assertions, GenTree*
                 return optConstantAssertionProp(curAssertion, tree, stmt DEBUGARG(assertionIndex));
             }
             // If global assertion, perform constant propagation only if the VN's match and the lcl is non-CSE.
-            else if (curAssertion->op1.vn == tree->gtVNPair.GetConservative())
+            else if (curAssertion->op1.vn == vnStore->VNNormalValue(tree->gtVNPair, VNK_Conservative))
             {
 #if FEATURE_ANYCSE
                 // Don't perform constant prop for CSE LclVars
@@ -2973,8 +2981,8 @@ AssertionIndex Compiler::optGlobalAssertionIsEqualOrNotEqual(ASSERT_VALARG_TP as
             continue;
         }
 
-        if (curAssertion->op1.vn == op1->gtVNPair.GetConservative() &&
-            curAssertion->op2.vn == op2->gtVNPair.GetConservative())
+        if ((curAssertion->op1.vn == vnStore->VNNormalValue(op1->gtVNPair, VNK_Conservative)) &&
+            (curAssertion->op2.vn == vnStore->VNNormalValue(op2->gtVNPair, VNK_Conservative)))
         {
             return assertionIndex;
         }
@@ -3046,9 +3054,9 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
     bool allowReverse = true;
 
     // If the assertion involves "op2" and it is a constant, then check if "op1" also has a constant value.
-    if (vnStore->IsVNConstant(op2->gtVNPair.GetConservative()))
+    ValueNum vnCns = vnStore->VNNormalValue(op2->gtVNPair, VNK_Conservative);
+    if (vnStore->IsVNConstant(vnCns))
     {
-        ValueNum vnCns = op2->gtVNPair.GetConservative();
 #ifdef DEBUG
         if (verbose)
         {
@@ -3709,9 +3717,9 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions, GenTree
 #endif
 
         // Do we have a previous range check involving the same 'vnLen' upper bound?
-        if (curAssertion->op1.bnd.vnLen == arrBndsChk->gtArrLen->gtVNPair.GetConservative())
+        if (curAssertion->op1.bnd.vnLen == vnStore->VNNormalValue(arrBndsChk->gtArrLen->gtVNPair, VNK_Conservative))
         {
-            ValueNum vnCurIdx = arrBndsChk->gtIndex->gtVNPair.GetConservative();
+            ValueNum vnCurIdx = vnStore->VNNormalValue(arrBndsChk->gtIndex->gtVNPair, VNK_Conservative);
 
             // Do we have the exact same lower bound 'vnIdx'?
             //       a[i] followed by a[i]
@@ -4605,7 +4613,7 @@ GenTree* Compiler::optPrepareTreeForReplacement(GenTree* oldTree, GenTree* newTr
             // (e.g. VN may evaluate a DIV/MOD node to a constant and the node may still
             // have GTF_EXCEPT set, even if it does not actually throw any exceptions).
             assert(!gtNodeHasSideEffects(oldTree, GTF_EXCEPT) ||
-                   vnStore->IsVNConstant(oldTree->gtVNPair.GetConservative()));
+                   vnStore->IsVNConstant(vnStore->VNNormalValue(oldTree->gtVNPair, VNK_Conservative)));
 
             ignoreRoot = true;
         }
@@ -4678,7 +4686,9 @@ GenTree* Compiler::optVNConstantPropOnJTrue(BasicBlock* block, GenTree* stmt, Ge
     //
     assert((relop->gtFlags & GTF_RELOP_JMP_USED) != 0);
 
-    if (!vnStore->IsVNConstant(relop->gtVNPair.GetConservative()))
+    ValueNum vnCns = relop->gtVNPair.GetConservative();
+    ValueNum vnLib = relop->gtVNPair.GetLiberal();
+    if (!vnStore->IsVNConstant(vnCns))
     {
         return nullptr;
     }
@@ -4694,9 +4704,7 @@ GenTree* Compiler::optVNConstantPropOnJTrue(BasicBlock* block, GenTree* stmt, Ge
     relop->gtOp.gtOp2->gtVNPair = ValueNumPair(vnZero, vnZero);
 
     // Update the oper and restore the value numbers.
-    ValueNum vnCns       = relop->gtVNPair.GetConservative();
-    ValueNum vnLib       = relop->gtVNPair.GetLiberal();
-    bool     evalsToTrue = (vnStore->CoercedConstantValue<INT64>(vnCns) != 0);
+    bool evalsToTrue = (vnStore->CoercedConstantValue<INT64>(vnCns) != 0);
     relop->SetOper(evalsToTrue ? GT_EQ : GT_NE);
     relop->gtVNPair = ValueNumPair(vnLib, vnCns);
 

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -16966,7 +16966,7 @@ void GenTree::ParseArrayAddressWork(Compiler*       comp,
                 break;
         }
         // If we didn't return above, must be a contribution to the non-constant part of the index VN.
-        ValueNum vn = comp->GetValueNumStore()->VNNormalValue(gtVNPair, VNK_Liberal);
+        ValueNum vn = comp->GetValueNumStore()->VNLiberalNormalValue(gtVNPair);
         if (inputMul != 1)
         {
             ValueNum mulVN = comp->GetValueNumStore()->VNForLongCon(inputMul);

--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -75,7 +75,7 @@ bool RangeCheck::BetweenBounds(Range& range, int lower, GenTree* upper)
     ValueNumStore* vnStore = m_pCompiler->vnStore;
 
     // Get the VN for the upper limit.
-    ValueNum uLimitVN = vnStore->VNNormalValue(upper->gtVNPair, VNK_Conservative);
+    ValueNum uLimitVN = vnStore->VNConservativeNormalValue(upper->gtVNPair);
 
 #ifdef DEBUG
     JITDUMP(FMT_VN " upper bound is: ", uLimitVN);
@@ -208,8 +208,8 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, GenTree* stmt, GenTree* t
     GenTree* treeIndex        = bndsChk->gtIndex;
 
     // Take care of constant index first, like a[2], for example.
-    ValueNum idxVn    = m_pCompiler->vnStore->VNNormalValue(treeIndex->gtVNPair, VNK_Conservative);
-    ValueNum arrLenVn = m_pCompiler->vnStore->VNNormalValue(bndsChk->gtArrLen->gtVNPair, VNK_Conservative);
+    ValueNum idxVn    = m_pCompiler->vnStore->VNConservativeNormalValue(treeIndex->gtVNPair);
+    ValueNum arrLenVn = m_pCompiler->vnStore->VNConservativeNormalValue(bndsChk->gtArrLen->gtVNPair);
     int      arrSize  = 0;
 
     if (m_pCompiler->vnStore->IsVNConstant(arrLenVn))
@@ -541,7 +541,7 @@ void RangeCheck::MergeEdgeAssertions(GenTreeLclVarCommon* lcl, ASSERT_VALARG_TP 
         genTreeOps cmpOper = GT_NONE;
 
         LclSsaVarDsc* ssaData     = m_pCompiler->lvaTable[lcl->gtLclNum].GetPerSsaData(lcl->gtSsaNum);
-        ValueNum      normalLclVN = m_pCompiler->vnStore->VNNormalValue(ssaData->m_vnPair, VNK_Conservative);
+        ValueNum      normalLclVN = m_pCompiler->vnStore->VNConservativeNormalValue(ssaData->m_vnPair);
 
         // Current assertion is of the form (i < len - cns) != 0
         if (curAssertion->IsCheckedBoundArithBound())
@@ -626,7 +626,7 @@ void RangeCheck::MergeEdgeAssertions(GenTreeLclVarCommon* lcl, ASSERT_VALARG_TP 
         }
 #endif
 
-        ValueNum arrLenVN = m_pCompiler->vnStore->VNNormalValue(m_pCurBndsChk->gtArrLen->gtVNPair, VNK_Conservative);
+        ValueNum arrLenVN = m_pCompiler->vnStore->VNConservativeNormalValue(m_pCurBndsChk->gtArrLen->gtVNPair);
 
         if (m_pCompiler->vnStore->IsVNConstant(arrLenVN))
         {
@@ -744,7 +744,7 @@ void RangeCheck::MergeEdgeAssertions(GenTreeLclVarCommon* lcl, ASSERT_VALARG_TP 
 void RangeCheck::MergeAssertion(BasicBlock* block, GenTree* op, Range* pRange DEBUGARG(int indent))
 {
     JITDUMP("Merging assertions from pred edges of " FMT_BB " for op [%06d] " FMT_VN "\n", block->bbNum,
-            Compiler::dspTreeID(op), m_pCompiler->vnStore->VNNormalValue(op->gtVNPair, VNK_Conservative));
+            Compiler::dspTreeID(op), m_pCompiler->vnStore->VNConservativeNormalValue(op->gtVNPair));
     ASSERT_TP assertions = BitVecOps::UninitVal();
 
     // If we have a phi arg, we can get to the block from it and use its assertion out.
@@ -1059,7 +1059,7 @@ Range RangeCheck::ComputeRange(BasicBlock* block, GenTree* expr, bool monotonic 
     bool  newlyAdded = !m_pSearchPath->Set(expr, block);
     Range range      = Limit(Limit::keUndef);
 
-    ValueNum vn = m_pCompiler->vnStore->VNNormalValue(expr->gtVNPair, VNK_Conservative);
+    ValueNum vn = m_pCompiler->vnStore->VNConservativeNormalValue(expr->gtVNPair);
     // If newly added in the current search path, then reduce the budget.
     if (newlyAdded)
     {

--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -75,7 +75,7 @@ bool RangeCheck::BetweenBounds(Range& range, int lower, GenTree* upper)
     ValueNumStore* vnStore = m_pCompiler->vnStore;
 
     // Get the VN for the upper limit.
-    ValueNum uLimitVN = upper->gtVNPair.GetConservative();
+    ValueNum uLimitVN = vnStore->VNNormalValue(upper->gtVNPair, VNK_Conservative);
 
 #ifdef DEBUG
     JITDUMP(FMT_VN " upper bound is: ", uLimitVN);
@@ -208,8 +208,8 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, GenTree* stmt, GenTree* t
     GenTree* treeIndex        = bndsChk->gtIndex;
 
     // Take care of constant index first, like a[2], for example.
-    ValueNum idxVn    = treeIndex->gtVNPair.GetConservative();
-    ValueNum arrLenVn = bndsChk->gtArrLen->gtVNPair.GetConservative();
+    ValueNum idxVn    = m_pCompiler->vnStore->VNNormalValue(treeIndex->gtVNPair, VNK_Conservative);
+    ValueNum arrLenVn = m_pCompiler->vnStore->VNNormalValue(bndsChk->gtArrLen->gtVNPair, VNK_Conservative);
     int      arrSize  = 0;
 
     if (m_pCompiler->vnStore->IsVNConstant(arrLenVn))
@@ -540,6 +540,9 @@ void RangeCheck::MergeEdgeAssertions(GenTreeLclVarCommon* lcl, ASSERT_VALARG_TP 
         Limit      limit(Limit::keUndef);
         genTreeOps cmpOper = GT_NONE;
 
+        LclSsaVarDsc* ssaData     = m_pCompiler->lvaTable[lcl->gtLclNum].GetPerSsaData(lcl->gtSsaNum);
+        ValueNum      normalLclVN = m_pCompiler->vnStore->VNNormalValue(ssaData->m_vnPair, VNK_Conservative);
+
         // Current assertion is of the form (i < len - cns) != 0
         if (curAssertion->IsCheckedBoundArithBound())
         {
@@ -548,8 +551,8 @@ void RangeCheck::MergeEdgeAssertions(GenTreeLclVarCommon* lcl, ASSERT_VALARG_TP 
             // Get i, len, cns and < as "info."
             m_pCompiler->vnStore->GetCompareCheckedBoundArithInfo(curAssertion->op1.vn, &info);
 
-            if (m_pCompiler->lvaTable[lcl->gtLclNum].GetPerSsaData(lcl->gtSsaNum)->m_vnPair.GetConservative() !=
-                info.cmpOp)
+            // If we don't have the same variable we are comparing against, bail.
+            if (normalLclVN != info.cmpOp)
             {
                 continue;
             }
@@ -577,13 +580,12 @@ void RangeCheck::MergeEdgeAssertions(GenTreeLclVarCommon* lcl, ASSERT_VALARG_TP 
             // Get the info as "i", "<" and "len"
             m_pCompiler->vnStore->GetCompareCheckedBound(curAssertion->op1.vn, &info);
 
-            ValueNum lclVn =
-                m_pCompiler->lvaTable[lcl->gtLclNum].GetPerSsaData(lcl->gtSsaNum)->m_vnPair.GetConservative();
             // If we don't have the same variable we are comparing against, bail.
-            if (lclVn != info.cmpOp)
+            if (normalLclVN != info.cmpOp)
             {
                 continue;
             }
+
             limit   = Limit(Limit::keBinOpArray, info.vnBound, 0);
             cmpOper = (genTreeOps)info.cmpOper;
         }
@@ -595,11 +597,8 @@ void RangeCheck::MergeEdgeAssertions(GenTreeLclVarCommon* lcl, ASSERT_VALARG_TP 
             // Get the info as "i", "<" and "100"
             m_pCompiler->vnStore->GetConstantBoundInfo(curAssertion->op1.vn, &info);
 
-            ValueNum lclVn =
-                m_pCompiler->lvaTable[lcl->gtLclNum].GetPerSsaData(lcl->gtSsaNum)->m_vnPair.GetConservative();
-
             // If we don't have the same variable we are comparing against, bail.
-            if (lclVn != info.cmpOpVN)
+            if (normalLclVN != info.cmpOpVN)
             {
                 continue;
             }
@@ -627,7 +626,7 @@ void RangeCheck::MergeEdgeAssertions(GenTreeLclVarCommon* lcl, ASSERT_VALARG_TP 
         }
 #endif
 
-        ValueNum arrLenVN = m_pCurBndsChk->gtArrLen->gtVNPair.GetConservative();
+        ValueNum arrLenVN = m_pCompiler->vnStore->VNNormalValue(m_pCurBndsChk->gtArrLen->gtVNPair, VNK_Conservative);
 
         if (m_pCompiler->vnStore->IsVNConstant(arrLenVN))
         {
@@ -745,7 +744,7 @@ void RangeCheck::MergeEdgeAssertions(GenTreeLclVarCommon* lcl, ASSERT_VALARG_TP 
 void RangeCheck::MergeAssertion(BasicBlock* block, GenTree* op, Range* pRange DEBUGARG(int indent))
 {
     JITDUMP("Merging assertions from pred edges of " FMT_BB " for op [%06d] " FMT_VN "\n", block->bbNum,
-            Compiler::dspTreeID(op), op->gtVNPair.GetConservative());
+            Compiler::dspTreeID(op), m_pCompiler->vnStore->VNNormalValue(op->gtVNPair, VNK_Conservative));
     ASSERT_TP assertions = BitVecOps::UninitVal();
 
     // If we have a phi arg, we can get to the block from it and use its assertion out.
@@ -1060,7 +1059,7 @@ Range RangeCheck::ComputeRange(BasicBlock* block, GenTree* expr, bool monotonic 
     bool  newlyAdded = !m_pSearchPath->Set(expr, block);
     Range range      = Limit(Limit::keUndef);
 
-    ValueNum vn = expr->gtVNPair.GetConservative();
+    ValueNum vn = m_pCompiler->vnStore->VNNormalValue(expr->gtVNPair, VNK_Conservative);
     // If newly added in the current search path, then reduce the budget.
     if (newlyAdded)
     {

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -639,7 +639,7 @@ T ValueNumStore::EvalOpSpecialized(VNFunc vnf, T v0)
 //
 
 template <typename T>
-T ValueNumStore::EvalOp(VNFunc vnf, T v0, T v1, ValueNum* pExcSet)
+T ValueNumStore::EvalOp(VNFunc vnf, T v0, T v1)
 {
     // Here we handle the binary ops that are the same for all types.
 
@@ -2707,7 +2707,6 @@ ValueNum ValueNumStore::EvalFuncForConstantArgs(var_types typ, VNFunc func, Valu
     }
 
     ValueNum result; // left uninitialized, we are required to initialize it on all paths below.
-    ValueNum excSet = VNForEmptyExcSet();
 
     // Are both args of the same type?
     if (arg0VNtyp == arg1VNtyp)
@@ -2725,17 +2724,16 @@ ValueNum ValueNumStore::EvalFuncForConstantArgs(var_types typ, VNFunc func, Valu
             else
             {
                 assert(typ == TYP_INT);
-                int resultVal = EvalOp<int>(func, arg0Val, arg1Val, &excSet);
+                int resultVal = EvalOp<int>(func, arg0Val, arg1Val);
                 // Bin op on a handle results in a handle.
                 ValueNum handleVN = IsVNHandle(arg0VN) ? arg0VN : IsVNHandle(arg1VN) ? arg1VN : NoVN;
                 if (handleVN != NoVN)
                 {
-                    assert(excSet == VNForEmptyExcSet()); // Handles aren't allowed to generate exceptions
                     result = VNForHandle(ssize_t(resultVal), GetHandleFlags(handleVN)); // Use VN for Handle
                 }
                 else
                 {
-                    result = VNWithExc(VNForIntCon(resultVal), excSet);
+                    result = VNForIntCon(resultVal);
                 }
             }
         }
@@ -2752,12 +2750,17 @@ ValueNum ValueNumStore::EvalFuncForConstantArgs(var_types typ, VNFunc func, Valu
             else
             {
                 assert(typ == TYP_LONG);
-                INT64    resultVal = EvalOp<INT64>(func, arg0Val, arg1Val, &excSet);
+                INT64    resultVal = EvalOp<INT64>(func, arg0Val, arg1Val);
                 ValueNum handleVN  = IsVNHandle(arg0VN) ? arg0VN : IsVNHandle(arg1VN) ? arg1VN : NoVN;
-                ValueNum resultVN  = (handleVN != NoVN)
-                                        ? VNForHandle(ssize_t(resultVal), GetHandleFlags(handleVN)) // Use VN for Handle
-                                        : VNForLongCon(resultVal);
-                result = VNWithExc(resultVN, excSet);
+
+                if (handleVN != NoVN)
+                {
+                    result = VNForHandle(ssize_t(resultVal), GetHandleFlags(handleVN)); // Use VN for Handle
+                }
+                else
+                {
+                    result = VNForLongCon(resultVal);
+                }
             }
         }
         else // both args are TYP_REF or both args are TYP_BYREF
@@ -2772,14 +2775,14 @@ ValueNum ValueNumStore::EvalFuncForConstantArgs(var_types typ, VNFunc func, Valu
             }
             else if (typ == TYP_INT) // We could see GT_OR of a constant ByRef and Null
             {
-                int resultVal = (int)EvalOp<INT64>(func, arg0Val, arg1Val, &excSet);
-                result        = VNWithExc(VNForIntCon(resultVal), excSet);
+                int resultVal = (int)EvalOp<INT64>(func, arg0Val, arg1Val);
+                result        = VNForIntCon(resultVal);
             }
             else // We could see GT_OR of a constant ByRef and Null
             {
                 assert((typ == TYP_BYREF) || (typ == TYP_LONG));
-                INT64 resultVal = EvalOp<INT64>(func, arg0Val, arg1Val, &excSet);
-                result          = VNWithExc(VNForByrefCon(resultVal), excSet);
+                INT64 resultVal = EvalOp<INT64>(func, arg0Val, arg1Val);
+                result          = VNForByrefCon(resultVal);
             }
         }
     }
@@ -2798,37 +2801,28 @@ ValueNum ValueNumStore::EvalFuncForConstantArgs(var_types typ, VNFunc func, Valu
         }
         else if (typ == TYP_INT) // We could see GT_OR of an int and constant ByRef or Null
         {
-            int resultVal = (int)EvalOp<INT64>(func, arg0Val, arg1Val, &excSet);
-            result        = VNWithExc(VNForIntCon(resultVal), excSet);
+            int resultVal = (int)EvalOp<INT64>(func, arg0Val, arg1Val);
+            result        = VNForIntCon(resultVal);
         }
         else
         {
             assert(typ != TYP_INT);
-            ValueNum resultValx = VNForEmptyExcSet();
-            INT64    resultVal  = EvalOp<INT64>(func, arg0Val, arg1Val, &resultValx);
+            INT64 resultVal = EvalOp<INT64>(func, arg0Val, arg1Val);
 
-            // check for the Exception case
-            if (resultValx != VNForEmptyExcSet())
+            switch (typ)
             {
-                result = VNWithExc(VNForVoid(), resultValx);
-            }
-            else
-            {
-                switch (typ)
-                {
-                    case TYP_BYREF:
-                        result = VNForByrefCon(resultVal);
-                        break;
-                    case TYP_LONG:
-                        result = VNForLongCon(resultVal);
-                        break;
-                    case TYP_REF:
-                        assert(resultVal == 0); // Only valid REF constant
-                        result = VNForNull();
-                        break;
-                    default:
-                        unreached();
-                }
+                case TYP_BYREF:
+                    result = VNForByrefCon(resultVal);
+                    break;
+                case TYP_LONG:
+                    result = VNForLongCon(resultVal);
+                    break;
+                case TYP_REF:
+                    assert(resultVal == 0); // Only valid REF constant
+                    result = VNForNull();
+                    break;
+                default:
+                    unreached();
             }
         }
     }
@@ -2876,23 +2870,17 @@ ValueNum ValueNumStore::EvalFuncForConstantFPArgs(var_types typ, VNFunc func, Va
         assert(varTypeIsFloating(typ));
         assert(arg0VNtyp == typ);
 
-        ValueNum exception = VNForEmptyExcSet();
-
         if (typ == TYP_FLOAT)
         {
-            float floatResultVal =
-                EvalOp<float>(func, GetConstantSingle(arg0VN), GetConstantSingle(arg1VN), &exception);
-            assert(exception == VNForEmptyExcSet()); // Floating point ops don't throw.
-            result = VNForFloatCon(floatResultVal);
+            float floatResultVal = EvalOp<float>(func, GetConstantSingle(arg0VN), GetConstantSingle(arg1VN));
+            result               = VNForFloatCon(floatResultVal);
         }
         else
         {
             assert(typ == TYP_DOUBLE);
 
-            double doubleResultVal =
-                EvalOp<double>(func, GetConstantDouble(arg0VN), GetConstantDouble(arg1VN), &exception);
-            assert(exception == VNForEmptyExcSet()); // Floating point ops don't throw.
-            result = VNForDoubleCon(doubleResultVal);
+            double doubleResultVal = EvalOp<double>(func, GetConstantDouble(arg0VN), GetConstantDouble(arg1VN));
+            result                 = VNForDoubleCon(doubleResultVal);
         }
     }
 
@@ -8058,7 +8046,7 @@ ValueNumPair ValueNumStore::VNPairForCast(ValueNumPair srcVNPair,
     ValueNumPair castArgxVNP = ValueNumStore::VNPForEmptyExcSet();
     VNPUnpackExc(srcVNPair, &castArgVNP, &castArgxVNP);
 
-    // When we're considering actual value returned by a non-checking cast (or a checking cast that succeeds),
+    // When we're considering actual value returned by a non-checking cast, (hasOverflowCheck is false)
     // whether or not the source is unsigned does *not* matter for non-widening casts.
     // That is, if we cast an int or a uint to short, we just extract the first two bytes from the source
     // bit pattern, not worrying about the interpretation.  The same is true in casting between signed/unsigned
@@ -8068,26 +8056,25 @@ ValueNumPair ValueNumStore::VNPairForCast(ValueNumPair srcVNPair,
     // Important: Casts to floating point cannot be optimized in this fashion. (bug 946768)
     //
     bool srcIsUnsignedNorm = srcIsUnsigned;
-    if (genTypeSize(castToType) <= genTypeSize(castFromType) && !varTypeIsFloating(castToType))
+    if (!hasOverflowCheck && !varTypeIsFloating(castToType) && (genTypeSize(castToType) <= genTypeSize(castFromType)))
     {
         srcIsUnsignedNorm = false;
     }
 
+    VNFunc       vnFunc     = hasOverflowCheck ? VNF_CastOvf : VNF_Cast;
     ValueNum     castTypeVN = VNForCastOper(castToType, srcIsUnsignedNorm);
     ValueNumPair castTypeVNPair(castTypeVN, castTypeVN);
-    ValueNumPair castNormRes = VNPairForFunc(resultType, VNF_Cast, castArgVNP, castTypeVNPair);
+    ValueNumPair castNormRes = VNPairForFunc(resultType, vnFunc, castArgVNP, castTypeVNPair);
 
     ValueNumPair resultVNP = VNPWithExc(castNormRes, castArgxVNP);
 
     // If we have a check for overflow, add the exception information.
     if (hasOverflowCheck)
     {
-        // For overflow checking, we always need to know whether the source is unsigned.
-        castTypeVNPair.SetBoth(VNForCastOper(castToType, srcIsUnsigned));
-        ValueNumPair excSet =
-            VNPExcSetSingleton(VNPairForFunc(TYP_REF, VNF_ConvOverflowExc, castArgVNP, castTypeVNPair));
-        excSet    = VNPExcSetUnion(excSet, castArgxVNP);
-        resultVNP = VNPWithExc(castNormRes, excSet);
+        ValueNumPair ovfChk = VNPairForFunc(TYP_REF, VNF_ConvOverflowExc, castArgVNP, castTypeVNPair);
+        ValueNumPair excSet = VNPExcSetSingleton(ovfChk);
+        excSet              = VNPExcSetUnion(excSet, castArgxVNP);
+        resultVNP           = VNPWithExc(castNormRes, excSet);
     }
 
     return resultVNP;

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -3666,7 +3666,7 @@ ValueNum ValueNumStore::ExtendPtrVN(GenTree* opA, FieldSeqNode* fldSeq)
 #ifdef DEBUG
         // For PtrToLoc, lib == cons.
         VNFuncApp consFuncApp;
-        assert(GetVNFunc(VNNormalValue(opA->gtVNPair, VNK_Conservative), &consFuncApp) && consFuncApp.Equals(funcApp));
+        assert(GetVNFunc(VNConservativeNormalValue(opA->gtVNPair), &consFuncApp) && consFuncApp.Equals(funcApp));
 #endif
         ValueNum fldSeqVN = VNForFieldSeq(fldSeq);
         res = VNForFunc(TYP_BYREF, VNF_PtrToLoc, funcApp.m_args[0], FieldSeqVNAppend(funcApp.m_args[1], fldSeqVN));
@@ -6368,8 +6368,7 @@ void Compiler::fgValueNumberBlockAssignment(GenTree* tree)
                             rhsVNPair = vnStore->VNPairApplySelectors(rhsVNPair, rhsFldSeq, indType);
                         }
                     }
-                    else if (vnStore->GetVNFunc(vnStore->VNNormalValue(srcAddr->gtVNPair, VNK_Liberal),
-                                                &srcAddrFuncApp))
+                    else if (vnStore->GetVNFunc(vnStore->VNLiberalNormalValue(srcAddr->gtVNPair), &srcAddrFuncApp))
                     {
                         if (srcAddrFuncApp.m_func == VNF_PtrToStatic)
                         {
@@ -7232,14 +7231,14 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                                     if (obj != nullptr)
                                     {
                                         // construct the ValueNumber for 'fldMap at obj'
-                                        normVal = vnStore->VNNormalValue(obj->gtVNPair, VNK_Liberal);
+                                        normVal = vnStore->VNLiberalNormalValue(obj->gtVNPair);
                                         valAtAddr =
                                             vnStore->VNForMapSelect(VNK_Liberal, firstFieldType, fldMapVN, normVal);
                                     }
                                     else // (staticOffset != nullptr)
                                     {
                                         // construct the ValueNumber for 'fldMap at staticOffset'
-                                        normVal = vnStore->VNNormalValue(staticOffset->gtVNPair, VNK_Liberal);
+                                        normVal = vnStore->VNLiberalNormalValue(staticOffset->gtVNPair);
                                         valAtAddr =
                                             vnStore->VNForMapSelect(VNK_Liberal, firstFieldType, fldMapVN, normVal);
                                     }
@@ -7502,7 +7501,7 @@ void Compiler::fgValueNumberTree(GenTree* tree)
 
                 // We take the "VNNormalValue"s here, because if either has exceptional outcomes, they will be captured
                 // as part of the value of the composite "addr" operation...
-                ValueNum arrVN = vnStore->VNNormalValue(arr->gtVNPair, VNK_Liberal);
+                ValueNum arrVN = vnStore->VNLiberalNormalValue(arr->gtVNPair);
                 inxVN          = vnStore->VNNormalValue(inxVN);
 
                 // Additionally, relabel the address with a PtrToArrElem value number.
@@ -7636,13 +7635,13 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                         if (obj != nullptr)
                         {
                             // construct the ValueNumber for 'fldMap at obj'
-                            ValueNum objNormVal = vnStore->VNNormalValue(obj->gtVNPair, VNK_Liberal);
+                            ValueNum objNormVal = vnStore->VNLiberalNormalValue(obj->gtVNPair);
                             valAtAddr = vnStore->VNForMapSelect(VNK_Liberal, firstFieldType, fldMapVN, objNormVal);
                         }
                         else if (staticOffset != nullptr)
                         {
                             // construct the ValueNumber for 'fldMap at staticOffset'
-                            ValueNum offsetNormVal = vnStore->VNNormalValue(staticOffset->gtVNPair, VNK_Liberal);
+                            ValueNum offsetNormVal = vnStore->VNLiberalNormalValue(staticOffset->gtVNPair);
                             valAtAddr = vnStore->VNForMapSelect(VNK_Liberal, firstFieldType, fldMapVN, offsetNormVal);
                         }
 

--- a/src/jit/valuenum.h
+++ b/src/jit/valuenum.h
@@ -197,13 +197,12 @@ private:
     // returns vnf(v0)  for int/INT32
     int EvalOpInt(VNFunc vnf, int v0);
 
-    // If vnf(v0, v1) would raise an exception, sets *pExcSet to the singleton set containing the exception, and
-    // returns (T)0. Otherwise, returns vnf(v0, v1).
+    // returns vnf(v0, v1).
     template <typename T>
-    T EvalOp(VNFunc vnf, T v0, T v1, ValueNum* pExcSet);
+    T EvalOp(VNFunc vnf, T v0, T v1);
 
     // returns vnf(v0, v1)  for int/INT32
-    int EvalOpInt(VNFunc vnf, int v0, int v1, ValueNum* pExcSet);
+    int EvalOpInt(VNFunc vnf, int v0, int v1);
 
     // return vnf(v0) or vnf(v0, v1), respectively (must, of course be unary/binary ops, respectively.)
     template <typename T>

--- a/src/jit/valuenum.h
+++ b/src/jit/valuenum.h
@@ -421,6 +421,20 @@ public:
     // The Normal value is the value number of the expression when no exceptions occurred
     ValueNum VNNormalValue(ValueNumPair vnp, ValueNumKind vnk);
 
+    // Given a "vnp", get the NormalValuew for the VNK_Liberal part of that ValueNum
+    // The Normal value is the value number of the expression when no exceptions occurred
+    inline ValueNum VNLiberalNormalValue(ValueNumPair vnp)
+    {
+        return VNNormalValue(vnp, VNK_Liberal);
+    }
+
+    // Given a "vnp", get the NormalValuew for the VNK_Conservative part of that ValueNum
+    // The Normal value is the value number of the expression when no exceptions occurred
+    inline ValueNum VNConservativeNormalValue(ValueNumPair vnp)
+    {
+        return VNNormalValue(vnp, VNK_Conservative);
+    }
+
     // Given a "vnp", get the Normal values for both the liberal and conservative parts of "vnp"
     // The Normal value is the value number of the expression when no exceptions occurred
     ValueNumPair VNPNormalPair(ValueNumPair vnp);


### PR DESCRIPTION
Removed the excSet argument to the constant folding EvalOp methods.
We no longer will fold an expression when an exception must be generated.
Don't ignore the unsigned flag when trying to fold overflow checking casts.