### PR TITLE
Make Hostx64/arm crossgen /CreatePerfMap behave the same as Hostarm/arm crossgen

### DIFF
--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -4499,7 +4499,7 @@ HRESULT __stdcall CreatePdb(CORINFO_ASSEMBLY_HANDLE hAssembly, BSTR pNativeImage
     {
         pModule = moduleIterator.GetModule();
 
-        if (pModule->HasNativeImage() || pModule->IsReadyToRun())
+        if (pModule->HasNativeOrReadyToRunImage())
         {
 #if !defined(NO_NGENPDB)
             IfFailThrow(pdbWriter.WritePDBDataForModule(pModule));

--- a/src/vm/perfmap.cpp
+++ b/src/vm/perfmap.cpp
@@ -12,6 +12,16 @@
 #include "perfinfo.h"
 #include "pal.h"
 
+// The code addresses are actually native image offsets during crossgen. Print
+// them as 32-bit numbers for consistent output when cross-targeting and to
+// make the output more compact.
+
+#ifdef CROSSGEN_COMPILE
+#define FMT_CODE_ADDR "%08x"
+#else
+#define FMT_CODE_ADDR "%p"
+#endif
+
 PerfMap * PerfMap::s_Current = nullptr;
 
 // Initialize the map for the process - called from EEStartupHelper.
@@ -173,7 +183,7 @@ void PerfMap::LogMethod(MethodDesc * pMethod, PCODE pCode, size_t codeSize)
         // Build the map file line.
         StackScratchBuffer scratch;
         SString line;
-        line.Printf("%p %x %s\n", pCode, codeSize, fullMethodSignature.GetANSI(scratch));
+        line.Printf(FMT_CODE_ADDR " %x %s\n", pCode, codeSize, fullMethodSignature.GetANSI(scratch));
 
         // Write the line.
         WriteLine(line);
@@ -253,7 +263,7 @@ void PerfMap::LogStubs(const char* stubType, const char* stubOwner, PCODE pCode,
 
         // Build the map file line.
         SString line;
-        line.Printf("%p %x stub<%d> %s<%s>\n", pCode, codeSize, ++(s_Current->m_StubsMapped), stubType, stubOwner);
+        line.Printf(FMT_CODE_ADDR " %x stub<%d> %s<%s>\n", pCode, codeSize, ++(s_Current->m_StubsMapped), stubType, stubOwner);
 
         // Write the line.
         s_Current->WriteLine(line);

--- a/src/vm/readytoruninfo.cpp
+++ b/src/vm/readytoruninfo.cpp
@@ -433,7 +433,7 @@ static bool AcquireImage(Module * pModule, PEImageLayout * pLayout, READYTORUN_H
 
         // Found an eager fixup section. Check the signature of each fixup in this section.
         PVOID *pFixups = (PVOID *)((PBYTE)pLayout->GetBase() + pCurSection->Section.VirtualAddress);
-        DWORD nFixups = pCurSection->Section.Size / sizeof(PVOID);
+        DWORD nFixups = pCurSection->Section.Size / TARGET_POINTER_SIZE;
         DWORD *pSignatures = (DWORD *)((PBYTE)pLayout->GetBase() + pCurSection->Signatures);
         for (DWORD i = 0; i < nFixups; i++)
         {


### PR DESCRIPTION
This PR addresses couple issues with `/CreatePerfMap` with Hostx64/arm32 crossgen:
1. `line.Printf` uses host-specific "%p" -> change to target-specific format string `FMT_TARGET_ADDR` in src/vm/perfmap.cpp 
2. `AcquireImage` uses `sizeof(PVOID)` -> replace with `TARGET_POINTER_SIZE`  in src/vm/readytoruninfo.cpp
3. Nit: replace `pModule->HasNativeImage() || pModule->IsReadyToRun()` with `pModule->HasNativeOrReadyToRunImage()` in src/vm/compile.cpp 