### PR TITLE
Revert "Move smoketests to use Helix queue"

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -39,12 +39,7 @@ def static getOSGroup(def os) {
 
                         def newJob = job(Utilities.getFullJobName(project, jobName, isPR)) {
                             // Set the label.
-                            if (isSmoketest) {
-                                label('Windows.Amd64.ClientRS4.DevEx.15.8.Perf')
-                            }
-                            else {
-                                label('windows_server_2016_clr_perf')
-                            }
+                            label('windows_server_2016_clr_perf')
                             wrappers {
                                 credentialsBinding {
                                     string('BV_UPLOAD_SAS_TOKEN', 'CoreCLR Perf BenchView Sas')
@@ -107,6 +102,9 @@ def static getOSGroup(def os) {
                             }
                         }
 
+                        if (isSmoketest) {
+                            Utilities.setMachineAffinity(newJob, "Windows_NT", '20170427-elevated')
+                        }
                         def archiveSettings = new ArchivalSettings()
                         archiveSettings.addFiles('bin/sandbox_logs/**/*_log.txt')
                         archiveSettings.addFiles('bin/sandbox_logs/**/*.csv')


### PR DESCRIPTION
Reverts dotnet/coreclr#20017

Moving to the helix queue removed the direct path to python via py.exe, so we need to rework this so that the smoketests can find py