### PR TITLE
Performance fix for R2R: vtable calls

### DIFF
--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -717,8 +717,10 @@ static bool CallerAndCalleeInSystemVersionBubble(MethodDesc* pCaller, MethodDesc
 {
     LIMITED_METHOD_CONTRACT;
 
+#ifdef FEATURE_READYTORUN_COMPILER
     if (IsReadyToRunCompilation())
         return pCallee->GetModule()->IsSystem() && IsInSameVersionBubble(pCaller, pCallee);
+#endif
 
     return false;
 }

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -2203,7 +2203,8 @@ void ZapInfo::getCallInfo(CORINFO_RESOLVED_TOKEN * pResolvedToken,
         break;
 
     case CORINFO_VIRTUALCALL_VTABLE:
-        _ASSERTE(!IsReadyToRunCompilation());
+        // READYTORUN: FUTURE: support for vtable-based calls (currently, only calls within the CoreLib version bubble is supported, and the codegen we generate
+        // is the same as the fragile NI (because CoreLib and the runtime will always be updated together anyways - this is a special case)
         break;
 
     case CORINFO_VIRTUALCALL_LDVIRTFTN:


### PR DESCRIPTION
Use vtable-based codegen for virtual calls within the System.Private.CoreLib version bubble, avoiding the use of the VSD, or in the generics case, a dictionary lookup.

The CoreLib assembly will always be serviced along side the coreclr runtime, so special casing CoreLib to using vtable-based calls like the fragile NI case is ok.

Using the CscBench c# benchmark, here are the results...
1) For fragile S.P.CoreLib NI:
 CscBench.exe         | Metric   | Unit | Iterations | Average | STDEV.S |     Min |     Max
:-------------------- |:-------- |:----:|:----------:| -------:| -------:| -------:| -------:
 CscBench.CompileTest | Duration | msec |     21     | 320.526 |  14.378 | 301.041 | 355.959
 CscBench.DatflowTest | Duration | msec |     21     | 432.629 |   8.515 | 420.860 | 449.777

2) For R2R S.P.CoreLib image without the fix:
 CscBench.exe         | Metric   | Unit | Iterations | Average | STDEV.S |     Min |     Max
:-------------------- |:-------- |:----:|:----------:| -------:| -------:| -------:| -------:
 CscBench.CompileTest | Duration | msec |     21     | 339.125 |  10.665 | 321.584 | 364.844
 CscBench.DatflowTest | Duration | msec |     21     | 436.541 |   8.735 | 426.044 | 458.947

3) For R2R S.P.CoreLib image with the fix:
 CscBench.exe         | Metric   | Unit | Iterations | Average | STDEV.S |     Min |     Max
:-------------------- |:-------- |:----:|:----------:| -------:| -------:| -------:| -------:
 CscBench.CompileTest | Duration | msec |     21     | 327.147 |   8.348 | 315.935 | 347.631
 CscBench.DatflowTest | Duration | msec |     21     | 438.999 |  13.856 | 425.804 | 484.654