### PR TITLE
Fix issue #20076 createdump faults.

### DIFF
--- a/src/debug/daccess/stack.cpp
+++ b/src/debug/daccess/stack.cpp
@@ -1257,7 +1257,7 @@ ClrDataFrame::GetLocalSig(MetaSig** sig,
         {
             *sig = NULL;
             *count = 0;
-            return S_FALSE;
+            return E_FAIL;
         }
 
         COR_ILMETHOD_DECODER methodDecoder(m_methodDesc->GetILHeader());
@@ -1267,7 +1267,7 @@ ClrDataFrame::GetLocalSig(MetaSig** sig,
         {
             *sig = NULL;
             *count = 0;
-            return S_FALSE;
+            return E_FAIL;
         }
 
         ULONG tokenSigLen;


### PR DESCRIPTION
Return E_FAIL instead of S_FALSE from ClrDataFrame::GetLocalSig().

Also issue https://github.com/dotnet/diagnostics/issues/61