### PR TITLE
Don't check for libintl.h on Darwin (OSX)

### DIFF
--- a/src/pal/src/configure.cmake
+++ b/src/pal/src/configure.cmake
@@ -37,7 +37,10 @@ check_include_files(sys/prctl.h HAVE_PRCTL_H)
 check_include_files(numa.h HAVE_NUMA_H)
 check_include_files(pthread_np.h HAVE_PTHREAD_NP_H)
 check_include_files("sys/auxv.h;asm/hwcap.h" HAVE_AUXV_HWCAP_H)
-check_include_files("libintl.h" HAVE_LIBINTL_H)
+
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  check_include_files("libintl.h" HAVE_LIBINTL_H)
+endif()
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD AND NOT CMAKE_SYSTEM_NAME STREQUAL NetBSD)
   set(CMAKE_REQUIRED_FLAGS "-ldl")


### PR DESCRIPTION
The build fails to link if `HAVE_LIBINTL_H` is set when building on a Mac. `libintl` is unexpected on OSX and isn't configured correctly. This change makes OSX builds always ignore `libintl`. The intent is to use native internationalization anyway, so not using this library is correct.

Addresses https://github.com/dotnet/coreclr/issues/20092, but this change is also needed in `release/2.1` and `release/2.2` to avoid adding patches in source-build.