### PR TITLE
Run arm64 Linux corefx jobs daily, not weekly

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1586,10 +1586,8 @@ def static addNonPRTriggers(def job, def branch, def isPR, def architecture, def
                 break
             }
             if (jobRequiresLimitedHardware(architecture, os)) {
-                if ((architecture == 'arm64') && (os == 'Ubuntu16.04') && !isCoreFxScenario(scenario)) {
+                if ((architecture == 'arm64') && (os == 'Ubuntu16.04')) {
                     // These jobs are very fast on Linux/arm64 hardware, so run them daily.
-                    // TODO: When the corefx jobs are made to run in parallel, run those
-                    // jobs daily as well.
                     addPeriodicTriggerHelper(job, '@daily')
                 }
                 else {


### PR DESCRIPTION
With parallel run-corefx-tests.sh runs, these run very fast (<20 minutes).