### PR TITLE
Updating NumberToStringFormat to not print the sign if there are no digits being returned

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
@@ -1770,8 +1770,8 @@ SkipRounding:
                     }
                 }
             }
-            
-            if (number.sign && section == 0)
+
+            if (number.sign && (section == 0) && (number.scale != 0))
                 sb.Append(info.NegativeSign);
 
             bool decimalWritten = false;
@@ -1929,6 +1929,9 @@ SkipRounding:
                     }
                 }
             }
+
+            if (number.sign && (section == 0) && (number.scale == 0) && (sb.Length > 0))
+                sb.Insert(0, info.NegativeSign);
         }
 
         private static void FormatCurrency(ref ValueStringBuilder sb, ref NumberBuffer number, int nMaxDigits, NumberFormatInfo info)

--- a/src/System.Private.CoreLib/shared/System/Text/ValueStringBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/ValueStringBuilder.cs
@@ -139,6 +139,21 @@ namespace System.Text
             _pos += count;
         }
 
+        public void Insert(int index, string s)
+        {
+            int count = s.Length;
+
+            if (_pos > (_chars.Length - count))
+            {
+                Grow(count);
+            }
+
+            int remaining = _pos - index;
+            _chars.Slice(index, remaining).CopyTo(_chars.Slice(index + count));
+            s.AsSpan().CopyTo(_chars.Slice(index));
+            _pos += count;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(char c)
         {


### PR DESCRIPTION
This ensures that the sign is only printed if we are returning one or more digits.