### PR TITLE
Porting fix on Desktop for VirtualUnlock perf issue on WKS GC 

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -30668,7 +30668,15 @@ void reset_memory (uint8_t* o, size_t sizeo)
         // on write watched memory.
         if (reset_mm_p)
         {
-            reset_mm_p = GCToOSInterface::VirtualReset((void*)page_start, size, true /* unlock */);
+#ifdef MULTIPLE_HEAPS
+            bool unlock_p = true;
+#else
+            // We don't do unlock because there could be many processes using workstation GC and it's
+            // bad perf to have many threads doing unlock at the same time.
+            bool unlock_p = false;
+#endif // MULTIPLE_HEAPS
+
+            reset_mm_p = GCToOSInterface::VirtualReset((void*)page_start, size, unlock_p);
         }
     }
 }


### PR DESCRIPTION
This is a port for CoreCLR on a Desktop fix that was made:
http://codeflow/extensions/launcher.html?server=https:%2f%2fdevdiv.visualstudio.com%2f&projectId=0bdbc590-a062-4c3f-b0f6-9383f67865ee&reviewId=147349&projectshortname=DevDiv (Microsoft only link) 

This fixes a perf issue with memory manager lock becoming very hot when we call VirtualUnlock() in reset_memory() with WKS GC mode with too many processes. 