### PR TITLE
switch to netcoreapp2.0 in test builds.

### DIFF
--- a/tests/src/Common/external/external.depproj
+++ b/tests/src/Common/external/external.depproj
@@ -13,7 +13,7 @@
     <ContainsPackageReferences>true</ContainsPackageReferences>
     <OutputPath>$(TargetingPackPath)</OutputPath>
     <XUnitRunnerPackageId>xunit.runner.console</XUnitRunnerPackageId>
-    <XUnitRunnerTargetFramework>netcoreapp1.0</XUnitRunnerTargetFramework>
+    <XUnitRunnerTargetFramework>netcoreapp2.0</XUnitRunnerTargetFramework>
     <CLRTestKind>SharedLibrary</CLRTestKind>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>


### PR DESCRIPTION
Allows us to get rid of "CSC : warning CS1685: The predefined type 'MarshalByRefObject' is defined in multiple assemblies in the global alias;".

Fix #19924.