### PR TITLE
Stop updating gtRsvdRegs before LSRA

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -9496,11 +9496,8 @@ void Compiler::fgSimpleLowering()
                     }
                     else
                     {
-                        con             = gtNewIconNode(arrLen->ArrLenOffset(), TYP_I_IMPL);
-                        con->gtRsvdRegs = RBM_NONE;
-
-                        add             = gtNewOperNode(GT_ADD, TYP_REF, arr, con);
-                        add->gtRsvdRegs = arr->gtRsvdRegs;
+                        con = gtNewIconNode(arrLen->ArrLenOffset(), TYP_I_IMPL);
+                        add = gtNewOperNode(GT_ADD, TYP_REF, arr, con);
 
                         range.InsertAfter(arr, con, add);
                     }

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -2067,16 +2067,6 @@ public:
     // Returns "true" iff "*this" is a statement containing an assignment that defines an SSA name (lcl = phi(...));
     bool IsPhiDefnStmt();
 
-    // Can't use an assignment operator, because we need the extra "comp" argument
-    // (to provide the allocator necessary for the VarSet assignment).
-    // TODO-Cleanup: Not really needed now, w/o liveset on tree nodes
-    void CopyTo(class Compiler* comp, const GenTree& gt);
-
-    // Like the above, excepts assumes copying from small node to small node.
-    // (Following the code it replaces, it does *not* copy the GenTree fields,
-    // which CopyTo does.)
-    void CopyToSmall(const GenTree& gt);
-
     // Because of the fact that we hid the assignment operator of "BitSet" (in DEBUG),
     // we can't synthesize an assignment operator.
     // TODO-Cleanup: Could change this w/o liveset on tree nodes

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -4368,7 +4368,6 @@ GenTree* Lowering::TryCreateAddrMode(LIR::Use&& use, bool isIndir)
     {
         index->ClearContained();
     }
-    addrMode->gtRsvdRegs = addr->gtRsvdRegs;
     addrMode->gtFlags |= (addr->gtFlags & GTF_IND_FLAGS);
     addrMode->gtFlags &= ~GTF_ALL_EFFECT; // LEAs are side-effect-free.
 


### PR DESCRIPTION
LSRA's `buildRefPositionsForNode` sets it to `RBM_NONE` so whatever it was there before is lost. There's no point in setting `gtRsvdRegs` in `gtSetEvalOrder` (which is pretty expensive as it is) or anywhere else before LSRA.

Also delete unused `GenTree::CopyTo(Small)` that copied `gtRsvdRegs` among other things. `gtCloneExpr` still copies `gtRsvdRegs` even though that's likely bogus, there's little chance to clone a node after LSRA and not mess up register allocation somehow.

No FX diffs. Small drop in instructions retired (~0.09%).