### PR TITLE
Expose 64-bit only hardware intrinsic in nested classes

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Bmi1.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Bmi1.PlatformNotSupported.cs
@@ -17,6 +17,62 @@ namespace System.Runtime.Intrinsics.X86
 
         public static bool IsSupported { get { return false; } }
 
+        public abstract class X64
+        {
+            internal X64() { }
+
+            public static bool IsSupported { get { return false; } }
+
+            /// <summary>
+            /// unsigned __int64 _andn_u64 (unsigned __int64 a, unsigned __int64 b)
+            ///   ANDN r64a, r64b, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong AndNot(ulong left, ulong right) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// unsigned __int64 _bextr_u64 (unsigned __int64 a, unsigned int start, unsigned int len)
+            ///   BEXTR r64a, reg/m64, r64b
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong BitFieldExtract(ulong value, byte start, byte length) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// unsigned __int64 _bextr2_u64 (unsigned __int64 a, unsigned __int64 control)
+            ///   BEXTR r64a, reg/m64, r64b
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong BitFieldExtract(ulong value, ushort control) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// unsigned __int64 _blsi_u64 (unsigned __int64 a)
+            ///   BLSI reg, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong ExtractLowestSetBit(ulong value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// unsigned __int64 _blsmsk_u64 (unsigned __int64 a)
+            ///   BLSMSK reg, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong GetMaskUpToLowestSetBit(ulong value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// unsigned __int64 _blsr_u64 (unsigned __int64 a)
+            ///   BLSR reg, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong ResetLowestSetBit(ulong value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// __int64 _mm_tzcnt_64 (unsigned __int64 a)
+            ///   TZCNT reg, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong TrailingZeroCount(ulong value) { throw new PlatformNotSupportedException(); }
+        }
+
         /// <summary>
         /// unsigned int _andn_u32 (unsigned int a, unsigned int b)
         ///   ANDN r32a, r32b, reg/m32

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Bmi1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Bmi1.cs
@@ -17,6 +17,62 @@ namespace System.Runtime.Intrinsics.X86
 
         public static bool IsSupported { get => IsSupported; }
 
+        public abstract class X64
+        {
+            internal X64() { }
+
+            public static bool IsSupported { get => IsSupported; }
+
+            /// <summary>
+            /// unsigned __int64 _andn_u64 (unsigned __int64 a, unsigned __int64 b)
+            ///   ANDN r64a, r64b, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong AndNot(ulong left, ulong right) => AndNot(left, right);
+
+            /// <summary>
+            /// unsigned __int64 _bextr_u64 (unsigned __int64 a, unsigned int start, unsigned int len)
+            ///   BEXTR r64a, reg/m64, r64b
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong BitFieldExtract(ulong value, byte start, byte length) => BitFieldExtract(value, start, length);
+
+            /// <summary>
+            /// unsigned __int64 _bextr2_u64 (unsigned __int64 a, unsigned __int64 control)
+            ///   BEXTR r64a, reg/m64, r64b
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong BitFieldExtract(ulong value, ushort control) => BitFieldExtract(value, control);
+
+            /// <summary>
+            /// unsigned __int64 _blsi_u64 (unsigned __int64 a)
+            ///   BLSI reg, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong ExtractLowestSetBit(ulong value) => ExtractLowestSetBit(value);
+
+            /// <summary>
+            /// unsigned __int64 _blsmsk_u64 (unsigned __int64 a)
+            ///   BLSMSK reg, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong GetMaskUpToLowestSetBit(ulong value) => GetMaskUpToLowestSetBit(value);
+
+            /// <summary>
+            /// unsigned __int64 _blsr_u64 (unsigned __int64 a)
+            ///   BLSR reg, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong ResetLowestSetBit(ulong value) => ResetLowestSetBit(value);
+
+            /// <summary>
+            /// __int64 _mm_tzcnt_64 (unsigned __int64 a)
+            ///   TZCNT reg, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong TrailingZeroCount(ulong value) => TrailingZeroCount(value);
+        }
+
         /// <summary>
         /// unsigned int _andn_u32 (unsigned int a, unsigned int b)
         ///   ANDN r32a, r32b, reg/m32

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Bmi2.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Bmi2.PlatformNotSupported.cs
@@ -17,6 +17,41 @@ namespace System.Runtime.Intrinsics.X86
 
         public static bool IsSupported { get { return false; } }
 
+        public abstract class X64
+        {
+            internal X64() { }
+
+            public static bool IsSupported { get { return false; } }
+
+            /// <summary>
+            /// unsigned __int64 _bzhi_u64 (unsigned __int64 a, unsigned int index)
+            ///   BZHI r64a, reg/m32, r64b
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong ZeroHighBits(ulong value, ulong index) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// unsigned __int64 _mulx_u64 (unsigned __int64 a, unsigned __int64 b, unsigned __int64* hi)
+            ///   MULX r64a, r64b, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static unsafe ulong MultiplyNoFlags(ulong left, ulong right, ulong* high) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// unsigned __int64 _pdep_u64 (unsigned __int64 a, unsigned __int64 mask)
+            ///   PDEP r64a, r64b, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong ParallelBitDeposit(ulong value, ulong mask) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// unsigned __int64 _pext_u64 (unsigned __int64 a, unsigned __int64 mask)
+            ///   PEXT r64a, r64b, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong ParallelBitExtract(ulong value, ulong mask) { throw new PlatformNotSupportedException(); }
+        }
+
         /// <summary>
         /// unsigned int _bzhi_u32 (unsigned int a, unsigned int index)
         ///   BZHI r32a, reg/m32, r32b

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Bmi2.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Bmi2.cs
@@ -17,6 +17,41 @@ namespace System.Runtime.Intrinsics.X86
 
         public static bool IsSupported { get => IsSupported; }
 
+        public abstract class X64
+        {
+            internal X64() { }
+
+            public static bool IsSupported { get => IsSupported; }
+
+            /// <summary>
+            /// unsigned __int64 _bzhi_u64 (unsigned __int64 a, unsigned int index)
+            ///   BZHI r64a, reg/m32, r64b
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong ZeroHighBits(ulong value, ulong index) => ZeroHighBits(value, index);
+
+            /// <summary>
+            /// unsigned __int64 _mulx_u64 (unsigned __int64 a, unsigned __int64 b, unsigned __int64* hi)
+            ///   MULX r64a, r64b, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static unsafe ulong MultiplyNoFlags(ulong left, ulong right, ulong* high) => MultiplyNoFlags(left, right, high);
+
+            /// <summary>
+            /// unsigned __int64 _pdep_u64 (unsigned __int64 a, unsigned __int64 mask)
+            ///   PDEP r64a, r64b, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong ParallelBitDeposit(ulong value, ulong mask) => ParallelBitDeposit(value, mask);
+
+            /// <summary>
+            /// unsigned __int64 _pext_u64 (unsigned __int64 a, unsigned __int64 mask)
+            ///   PEXT r64a, r64b, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong ParallelBitExtract(ulong value, ulong mask) => ParallelBitExtract(value, mask);
+        }
+
         /// <summary>
         /// unsigned int _bzhi_u32 (unsigned int a, unsigned int index)
         ///   BZHI r32a, reg/m32, r32b

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Lzcnt.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Lzcnt.PlatformNotSupported.cs
@@ -16,6 +16,20 @@ namespace System.Runtime.Intrinsics.X86
 
         public static bool IsSupported { get { return false; } }
 
+        public abstract class X64
+        {
+            internal X64() { }
+
+            public static bool IsSupported { get { return false; } }
+
+            /// <summary>
+            /// unsigned __int64 _lzcnt_u64 (unsigned __int64 a)
+            ///   LZCNT reg, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong LeadingZeroCount(ulong value) { throw new PlatformNotSupportedException(); }
+        }
+
         /// <summary>
         /// unsigned int _lzcnt_u32 (unsigned int a)
         ///   LZCNT reg, reg/m32

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Lzcnt.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Lzcnt.cs
@@ -17,6 +17,20 @@ namespace System.Runtime.Intrinsics.X86
 
         public static bool IsSupported { get => IsSupported; }
 
+        public abstract class X64
+        {
+            internal X64() { }
+
+            public static bool IsSupported { get => IsSupported; }
+
+            /// <summary>
+            /// unsigned __int64 _lzcnt_u64 (unsigned __int64 a)
+            ///   LZCNT reg, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong LeadingZeroCount(ulong value) => LeadingZeroCount(value);
+        }
+
         /// <summary>
         /// unsigned int _lzcnt_u32 (unsigned int a)
         ///   LZCNT reg, reg/m32

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Popcnt.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Popcnt.PlatformNotSupported.cs
@@ -16,6 +16,18 @@ namespace System.Runtime.Intrinsics.X86
 
         public new static bool IsSupported { get { return false; } }
 
+        public new abstract class X64 : Sse41.X64
+        {
+            internal X64() { }
+            public new static bool IsSupported { get => IsSupported; }
+            /// <summary>
+            /// __int64 _mm_popcnt_u64 (unsigned __int64 a)
+            ///   POPCNT reg64, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong PopCount(ulong value) => PopCount(value);
+        }
+
         /// <summary>
         /// int _mm_popcnt_u32 (unsigned int a)
         ///   POPCNT reg, reg/m32

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Popcnt.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Popcnt.cs
@@ -17,6 +17,18 @@ namespace System.Runtime.Intrinsics.X86
 
         public new static bool IsSupported { get => IsSupported; }
 
+        public new abstract class X64 : Sse41.X64
+        {
+            internal X64() { }
+            public new static bool IsSupported { get => IsSupported; }
+            /// <summary>
+            /// __int64 _mm_popcnt_u64 (unsigned __int64 a)
+            ///   POPCNT reg64, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong PopCount(ulong value) => PopCount(value);
+        }
+
         /// <summary>
         /// int _mm_popcnt_u32 (unsigned int a)
         ///   POPCNT reg, reg/m32

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse.PlatformNotSupported.cs
@@ -17,6 +17,34 @@ namespace System.Runtime.Intrinsics.X86
 
         public static bool IsSupported { get { return false; } }
 
+        public abstract class X64
+        {
+            internal X64() { }
+
+            public static bool IsSupported { get { return false; } }
+
+            /// <summary>
+            /// __int64 _mm_cvtss_si64 (__m128 a)
+            ///   CVTSS2SI r64, xmm/m32
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static long ConvertToInt64(Vector128<float> value) { throw new PlatformNotSupportedException(); }
+            /// <summary>
+            /// __m128 _mm_cvtsi64_ss (__m128 a, __int64 b)
+            ///   CVTSI2SS xmm, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static Vector128<float> ConvertScalarToVector128Single(Vector128<float> upper, long value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// __int64 _mm_cvttss_si64 (__m128 a)
+            ///   CVTTSS2SI r64, xmm/m32
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static long ConvertToInt64WithTruncation(Vector128<float> value) { throw new PlatformNotSupportedException(); }
+
+        }
+
         /// <summary>
         /// __m128 _mm_add_ps (__m128 a,  __m128 b)
         ///   ADDPS xmm, xmm/m128

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse.cs
@@ -18,6 +18,34 @@ namespace System.Runtime.Intrinsics.X86
 
         public static bool IsSupported { get => IsSupported; }
 
+        public abstract class X64
+        {
+            internal X64() { }
+
+            public static bool IsSupported { get => IsSupported; }
+
+            /// <summary>
+            /// __int64 _mm_cvtss_si64 (__m128 a)
+            ///   CVTSS2SI r64, xmm/m32
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static long ConvertToInt64(Vector128<float> value) => ConvertToInt64(value);
+            /// <summary>
+            /// __m128 _mm_cvtsi64_ss (__m128 a, __int64 b)
+            ///   CVTSI2SS xmm, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static Vector128<float> ConvertScalarToVector128Single(Vector128<float> upper, long value) => ConvertScalarToVector128Single(upper, value);
+
+            /// <summary>
+            /// __int64 _mm_cvttss_si64 (__m128 a)
+            ///   CVTTSS2SI r64, xmm/m32
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static long ConvertToInt64WithTruncation(Vector128<float> value) => ConvertToInt64WithTruncation(value);
+
+        }
+
         /// <summary>
         /// __m128 _mm_add_ps (__m128 a,  __m128 b)
         ///   ADDPS xmm, xmm/m128

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse2.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse2.PlatformNotSupported.cs
@@ -17,7 +17,75 @@ namespace System.Runtime.Intrinsics.X86
 
         public new static bool IsSupported { get { return false; } }
 
-                /// <summary>
+        public new abstract class X64 : Sse.X64
+        {
+            internal X64() { }
+
+            public new static bool IsSupported { get { return false; } }
+
+            /// <summary>
+            /// __int64 _mm_cvtsd_si64 (__m128d a)
+            ///   CVTSD2SI r64, xmm/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static long ConvertToInt64(Vector128<double> value) { throw new PlatformNotSupportedException(); }
+            /// <summary>
+            /// __int64 _mm_cvtsi128_si64 (__m128i a)
+            ///   MOVQ reg/m64, xmm
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static long ConvertToInt64(Vector128<long> value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// __int64 _mm_cvtsi128_si64 (__m128i a)
+            ///   MOVQ reg/m64, xmm
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong ConvertToUInt64(Vector128<ulong> value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// __m128d _mm_cvtsi64_sd (__m128d a, __int64 b)
+            ///   CVTSI2SD xmm, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static Vector128<double> ConvertScalarToVector128Double(Vector128<double> upper, long value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// __m128i _mm_cvtsi64_si128 (__int64 a)
+            ///   MOVQ xmm, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static Vector128<long> ConvertScalarToVector128Int64(long value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// __m128i _mm_cvtsi64_si128 (__int64 a)
+            ///   MOVQ xmm, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static Vector128<ulong> ConvertScalarToVector128UInt64(ulong value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// __int64 _mm_cvttsd_si64 (__m128d a)
+            ///   CVTTSD2SI reg, xmm/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static long ConvertToInt64WithTruncation(Vector128<double> value) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// void _mm_stream_si64(__int64 *p, __int64 a)
+            ///   MOVNTI m64, r64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static unsafe void StoreNonTemporal(long* address, long value) { throw new PlatformNotSupportedException(); }
+            /// <summary>
+            /// void _mm_stream_si64(__int64 *p, __int64 a)
+            ///   MOVNTI m64, r64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static unsafe void StoreNonTemporal(ulong* address, ulong value) { throw new PlatformNotSupportedException(); }
+        }
+
+        /// <summary>
         /// __m128i _mm_add_epi8 (__m128i a,  __m128i b)
         ///   PADDB xmm, xmm/m128
         /// </summary>

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse2.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse2.cs
@@ -18,6 +18,74 @@ namespace System.Runtime.Intrinsics.X86
 
         public new static bool IsSupported { get => IsSupported; }
 
+        public new abstract class X64 : Sse.X64
+        {
+            internal X64() { }
+
+            public new static bool IsSupported { get => IsSupported; }
+
+            /// <summary>
+            /// __int64 _mm_cvtsd_si64 (__m128d a)
+            ///   CVTSD2SI r64, xmm/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static long ConvertToInt64(Vector128<double> value) => ConvertToInt64(value);
+            /// <summary>
+            /// __int64 _mm_cvtsi128_si64 (__m128i a)
+            ///   MOVQ reg/m64, xmm
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static long ConvertToInt64(Vector128<long> value) => ConvertToInt64(value);
+
+            /// <summary>
+            /// __int64 _mm_cvtsi128_si64 (__m128i a)
+            ///   MOVQ reg/m64, xmm
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong ConvertToUInt64(Vector128<ulong> value) => ConvertToUInt64(value);
+
+            /// <summary>
+            /// __m128d _mm_cvtsi64_sd (__m128d a, __int64 b)
+            ///   CVTSI2SD xmm, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static Vector128<double> ConvertScalarToVector128Double(Vector128<double> upper, long value) => ConvertScalarToVector128Double(upper, value);
+
+            /// <summary>
+            /// __m128i _mm_cvtsi64_si128 (__int64 a)
+            ///   MOVQ xmm, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static Vector128<long> ConvertScalarToVector128Int64(long value) => ConvertScalarToVector128Int64(value);
+
+            /// <summary>
+            /// __m128i _mm_cvtsi64_si128 (__int64 a)
+            ///   MOVQ xmm, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static Vector128<ulong> ConvertScalarToVector128UInt64(ulong value) => ConvertScalarToVector128UInt64(value);
+
+            /// <summary>
+            /// __int64 _mm_cvttsd_si64 (__m128d a)
+            ///   CVTTSD2SI reg, xmm/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static long ConvertToInt64WithTruncation(Vector128<double> value) => ConvertToInt64WithTruncation(value);
+
+            /// <summary>
+            /// void _mm_stream_si64(__int64 *p, __int64 a)
+            ///   MOVNTI m64, r64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static unsafe void StoreNonTemporal(long* address, long value) => StoreNonTemporal(address, value);
+            /// <summary>
+            /// void _mm_stream_si64(__int64 *p, __int64 a)
+            ///   MOVNTI m64, r64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static unsafe void StoreNonTemporal(ulong* address, ulong value) => StoreNonTemporal(address, value);
+        }
+
         /// <summary>
         /// __m128i _mm_add_epi8 (__m128i a,  __m128i b)
         ///   PADDB xmm, xmm/m128
@@ -543,7 +611,7 @@ namespace System.Runtime.Intrinsics.X86
         /// </summary>
         public static Vector128<double> ConvertScalarToVector128Double(Vector128<double> upper, int value) => ConvertScalarToVector128Double(upper, value);
         /// <summary>
-        /// __m128d _mm_cvtsi64_sd (__m128d a, int b)
+        /// __m128d _mm_cvtsi64_sd (__m128d a, __int64 b)
         ///   CVTSI2SD xmm, reg/m64
         /// </summary>
         public static Vector128<double> ConvertScalarToVector128Double(Vector128<double> upper, long value) => ConvertScalarToVector128Double(upper, value);

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse41.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse41.PlatformNotSupported.cs
@@ -17,6 +17,39 @@ namespace System.Runtime.Intrinsics.X86
 
         public new static bool IsSupported { get { return false; } }
 
+        public new abstract class X64 : Sse2.X64
+        {
+            internal X64() { }
+
+            public new static bool IsSupported { get { return false; } }
+
+            /// <summary>
+            /// __int64 _mm_extract_epi64 (__m128i a, const int imm8)
+            ///   PEXTRQ reg/m64, xmm, imm8
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static long Extract(Vector128<long> value, byte index) { throw new PlatformNotSupportedException(); }
+            /// <summary>
+            /// __int64 _mm_extract_epi64 (__m128i a, const int imm8)
+            ///   PEXTRQ reg/m64, xmm, imm8
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong Extract(Vector128<ulong> value, byte index) { throw new PlatformNotSupportedException(); }
+
+            /// <summary>
+            /// __m128i _mm_insert_epi64 (__m128i a, __int64 i, const int imm8)
+            ///   PINSRQ xmm, reg/m64, imm8
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static Vector128<long> Insert(Vector128<long> value, long data, byte index) { throw new PlatformNotSupportedException(); }
+            /// <summary>
+            /// __m128i _mm_insert_epi64 (__m128i a, __int64 i, const int imm8)
+            ///   PINSRQ xmm, reg/m64, imm8
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static Vector128<ulong> Insert(Vector128<ulong> value, ulong data, byte index) { throw new PlatformNotSupportedException(); }
+        }
+
         /// <summary>
         /// __m128i _mm_blend_epi16 (__m128i a, __m128i b, const int imm8)
         ///   PBLENDW xmm, xmm/m128 imm8

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse41.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse41.cs
@@ -17,6 +17,39 @@ namespace System.Runtime.Intrinsics.X86
 
         public new static bool IsSupported { get => IsSupported; }
 
+        public new abstract class X64 : Sse2.X64
+        {
+            internal X64() { }
+
+            public new static bool IsSupported { get => IsSupported; }
+
+            /// <summary>
+            /// __int64 _mm_extract_epi64 (__m128i a, const int imm8)
+            ///   PEXTRQ reg/m64, xmm, imm8
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static long Extract(Vector128<long> value, byte index) => Extract(value, index);
+            /// <summary>
+            /// __int64 _mm_extract_epi64 (__m128i a, const int imm8)
+            ///   PEXTRQ reg/m64, xmm, imm8
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong Extract(Vector128<ulong> value, byte index) => Extract(value, index);
+
+            /// <summary>
+            /// __m128i _mm_insert_epi64 (__m128i a, __int64 i, const int imm8)
+            ///   PINSRQ xmm, reg/m64, imm8
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static Vector128<long> Insert(Vector128<long> value, long data, byte index) => Insert(value, data, index);
+            /// <summary>
+            /// __m128i _mm_insert_epi64 (__m128i a, __int64 i, const int imm8)
+            ///   PINSRQ xmm, reg/m64, imm8
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static Vector128<ulong> Insert(Vector128<ulong> value, ulong data, byte index) => Insert(value, data, index);
+        }
+
         /// <summary>
         /// __m128i _mm_blend_epi16 (__m128i a, __m128i b, const int imm8)
         ///   PBLENDW xmm, xmm/m128 imm8

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse42.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse42.PlatformNotSupported.cs
@@ -17,6 +17,20 @@ namespace System.Runtime.Intrinsics.X86
 
         public new static bool IsSupported { get { return false; } }
 
+        public new abstract class X64 : Sse41.X64
+        {
+            internal X64() { }
+
+            public new static bool IsSupported { get { return false; } }
+
+            /// <summary>
+            /// unsigned __int64 _mm_crc32_u64 (unsigned __int64 crc, unsigned __int64 v)
+            ///   CRC32 reg, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong Crc32(ulong crc, ulong data) { throw new PlatformNotSupportedException(); }
+        }
+
         /// <summary>
         /// int _mm_cmpistra (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse42.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse42.cs
@@ -17,6 +17,20 @@ namespace System.Runtime.Intrinsics.X86
 
         public new static bool IsSupported { get => IsSupported; }
 
+        public new abstract class X64 : Sse41.X64
+        {
+            internal X64() { }
+
+            public new static bool IsSupported { get => IsSupported; }
+
+            /// <summary>
+            /// unsigned __int64 _mm_crc32_u64 (unsigned __int64 crc, unsigned __int64 v)
+            ///   CRC32 reg, reg/m64
+            /// This intrinisc is only available on 64-bit processes
+            /// </summary>
+            public static ulong Crc32(ulong crc, ulong data) => Crc32(crc, data);
+        }
+
         /// <summary>
         /// int _mm_cmpistra (__m128i a, __m128i b, const int imm8)
         ///   PCMPISTRI xmm, xmm/m128, imm8


### PR DESCRIPTION
This PR contribute to https://github.com/dotnet/coreclr/issues/20062

1. Each ISA class may have a nested class named `X64` to contain 64-bit only hardware intrinsic. .
2. This PR only moves "intrinsic" into the nested classes, and helper intrinsic will support 32-bit platforms by fallback or JIT in the next steps.