### PR TITLE
Loop-free GC rounding helpers with _BitScanReverse

### DIFF
--- a/src/gc/env/gcenv.base.h
+++ b/src/gc/env/gcenv.base.h
@@ -220,8 +220,10 @@ typedef DWORD (WINAPI *PTHREAD_START_ROUTINE)(void* lpThreadParameter);
 
 #ifdef _MSC_VER
 #pragma intrinsic(_BitScanForward)
+#pragma intrinsic(_BitScanReverse)
 #if _WIN64
  #pragma intrinsic(_BitScanForward64)
+ #pragma intrinsic(_BitScanReverse64)
 #endif
 #endif // _MSC_VER
 
@@ -277,6 +279,56 @@ inline uint8_t BitScanForward64(uint32_t *bitIndex, uint64_t mask)
     *bitIndex = static_cast<uint32_t>(iIndex - 1);
     // Both GCC and Clang generate better, smaller code if we check whether the
     // mask was/is zero rather than the equivalent check that iIndex is zero.
+    return mask != 0 ? TRUE : FALSE;
+#endif // _MSC_VER
+}
+
+// Cross-platform wrapper for the _BitScanReverse compiler intrinsic.
+inline uint8_t BitScanReverse(uint32_t *bitIndex, uint32_t mask)
+{
+#ifdef _MSC_VER
+    return _BitScanReverse((unsigned long*)bitIndex, mask);
+#else // _MSC_VER
+    // The result of __builtin_clzl is undefined when mask is zero,
+    // but it's still OK to call the intrinsic in that case (just don't use the output).
+    // Unconditionally calling the intrinsic in this way allows the compiler to
+    // emit branchless code for this function when possible (depending on how the
+    // intrinsic is implemented for the target platform).
+    int lzcount = __builtin_clzl(mask);
+    *bitIndex = static_cast<uint32_t>(31 - lzcount);
+    return mask != 0 ? TRUE : FALSE;
+#endif // _MSC_VER
+}
+
+// Cross-platform wrapper for the _BitScanReverse64 compiler intrinsic.
+inline uint8_t BitScanReverse64(uint32_t *bitIndex, uint64_t mask)
+{
+#ifdef _MSC_VER
+ #if _WIN64
+    return _BitScanReverse64((unsigned long*)bitIndex, mask);
+ #else
+    // MSVC targeting a 32-bit target does not support this intrinsic.
+    // We can fake it checking whether the upper 32 bits are zeros (or not)
+    // then calling _BitScanReverse() on either the upper or lower 32 bits.
+    uint32_t upper = static_cast<uint32_t>(mask >> 32);
+
+    if (upper != 0)
+    {
+        uint8_t result = _BitScanReverse((unsigned long*)bitIndex, upper);
+        *bitIndex += 32;
+        return result;
+    }
+
+    return _BitScanReverse((unsigned long*)bitIndex, static_cast<uint32_t>(mask));
+ #endif // _WIN64
+#else
+    // The result of __builtin_clzll is undefined when mask is zero,
+    // but it's still OK to call the intrinsic in that case (just don't use the output).
+    // Unconditionally calling the intrinsic in this way allows the compiler to
+    // emit branchless code for this function when possible (depending on how the
+    // intrinsic is implemented for the target platform).
+    int lzcount = __builtin_clzll(mask);
+    *bitIndex = static_cast<uint32_t>(63 - lzcount);
     return mask != 0 ? TRUE : FALSE;
 #endif // _MSC_VER
 }

--- a/src/gc/gcrecord.h
+++ b/src/gc/gcrecord.h
@@ -311,7 +311,9 @@ static gc_mechanism_descr gc_mechanisms_descr[max_mechanism_per_heap] =
 };
 #endif //DT_LOG
 
-int index_of_set_bit (size_t power2);
+// Get the 0-based index of the most-significant bit in the value.
+// Returns -1 if the input value is zero (i.e. has no set bits).
+int index_of_highest_set_bit (size_t value);
 
 #define mechanism_mask (1 << (sizeof (uint32_t) * 8 - 1))
 // interesting per heap data we want to record for each GC.
@@ -372,7 +374,7 @@ public:
 
         if (mechanism & mechanism_mask)
         {
-            int index = index_of_set_bit ((size_t)(mechanism & (~mechanism_mask)));
+            int index = index_of_highest_set_bit ((size_t)(mechanism & (~mechanism_mask)));
             assert (index != -1);
             return index;
         }

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -3295,6 +3295,55 @@ BitScanForward64(
     return qwMask != 0 ? TRUE : FALSE;
 }
 
+// Define BitScanReverse64 and BitScanReverse
+// Per MSDN, BitScanReverse64 will search the mask data from MSB to LSB for a set bit.
+// If one is found, its bit position is stored in the out PDWORD argument and 1 is returned.
+// Otherwise, an undefined value is stored in the out PDWORD argument and 0 is returned.
+//
+// GCC/clang don't have a directly equivalent intrinsic; they do provide the __builtin_clzll
+// intrinsic, which returns the number of leading 0-bits in x starting at the most significant
+// bit position (the result is undefined when x = 0).
+//
+// The same is true for BitScanReverse, except that the GCC function is __builtin_clzl.
+
+EXTERN_C
+PALIMPORT
+inline
+unsigned char
+PALAPI
+BitScanReverse(
+    IN OUT PDWORD Index,
+    IN UINT qwMask)
+{
+    // The result of __builtin_clzl is undefined when qwMask is zero,
+    // but it's still OK to call the intrinsic in that case (just don't use the output).
+    // Unconditionally calling the intrinsic in this way allows the compiler to
+    // emit branchless code for this function when possible (depending on how the
+    // intrinsic is implemented for the target platform).
+    int lzcount = __builtin_clzl(qwMask);
+    *Index = (DWORD)(31 - lzcount);
+    return qwMask != 0;
+}
+
+EXTERN_C
+PALIMPORT
+inline
+unsigned char
+PALAPI
+BitScanReverse64(
+    IN OUT PDWORD Index,
+    IN UINT64 qwMask)
+{
+    // The result of __builtin_clzll is undefined when qwMask is zero,
+    // but it's still OK to call the intrinsic in that case (just don't use the output).
+    // Unconditionally calling the intrinsic in this way allows the compiler to
+    // emit branchless code for this function when possible (depending on how the
+    // intrinsic is implemented for the target platform).
+    int lzcount = __builtin_clzll(qwMask);
+    *Index = (DWORD)(63 - lzcount);
+    return qwMask != 0;
+}
+
 FORCEINLINE void PAL_ArmInterlockedOperationBarrier()
 {
 #ifdef _ARM64_

--- a/src/pal/src/include/pal/palinternal.h
+++ b/src/pal/src/include/pal/palinternal.h
@@ -342,6 +342,7 @@ function_name() to call the system's implementation
 
 #if !defined(_MSC_VER) && defined(_WIN64)
 #undef _BitScanForward64
+#undef _BitScanReverse64
 #endif 
 
 /* pal.h defines alloca(3) as a compiler builtin.


### PR DESCRIPTION
I noticed some helper functions used within the GC were looping to calculate (effectively) integer log2 along with round-up/down-to-nearest-power-of-2. Those operations can be implemented more efficiently by utilizing the ``bsr`` or ``lzcnt`` instructions (x86).

I’ve modified the implementations to use compiler intrinsics, and now they’re loop-free and require only one branch (which could possibly be eliminated too, at least if using ``lzcnt``).

I was able to compile and run the test suite against a Debug build. I got one test failure (due to timeout); are there any additional tests I should be running for these changes? Or should Inrun the test suite again with different settings (e.g. with GCStress enabled)?