### PR TITLE
Enable delegate marshalling for collectible types

### DIFF
--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -2887,9 +2887,6 @@
   <data name="NotSupported_CollectibleCOM" xml:space="preserve">
     <value>COM Interop is not supported for collectible types.</value>
   </data>
-  <data name="NotSupported_CollectibleDelegateMarshal" xml:space="preserve">
-    <value>Delegate marshaling for types within collectible assemblies is not supported.</value>
-  </data>
   <data name="NotSupported_CreateInstanceWithTypeBuilder" xml:space="preserve">
     <value>CreateInstance cannot be used with an object of type TypeBuilder.</value>
   </data>

--- a/src/vm/comdelegate.cpp
+++ b/src/vm/comdelegate.cpp
@@ -1145,9 +1145,6 @@ LPVOID COMDelegate::ConvertToCallback(OBJECTREF pDelegateObj)
     if (pMT->HasInstantiation())
         COMPlusThrowArgumentException(W("delegate"), W("Argument_NeedNonGenericType"));
 
-    if (pMT->Collectible())
-        COMPlusThrow(kNotSupportedException, W("NotSupported_CollectibleDelegateMarshal"));
-
     // If we are a delegate originally created from an unmanaged function pointer, we will simply return 
     // that function pointer.
     if (DELEGATE_MARKER_UNMANAGEDFPTR == pDelegate->GetInvocationCount())
@@ -1338,9 +1335,6 @@ OBJECTREF COMDelegate::ConvertToDelegate(LPVOID pCallback, MethodTable* pMT)
     DelegateEEClass*    pClass      = (DelegateEEClass*)pMT->GetClass();
     MethodDesc*         pMD         = FindDelegateInvokeMethod(pMT);
 
-    if (pMT->Collectible())
-        COMPlusThrow(kNotSupportedException, W("NotSupported_CollectibleDelegateMarshal"));
-
     PREFIX_ASSUME(pClass != NULL);
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1440,9 +1434,6 @@ OBJECTREF COMDelegate::ConvertWinRTInterfaceToDelegate(IUnknown *pIdentity, Meth
     CONTRACTL_END;
 
     MethodDesc*         pMD         = FindDelegateInvokeMethod(pMT);
-
-    if (pMT->Collectible())
-        COMPlusThrow(kNotSupportedException, W("NotSupported_CollectibleDelegateMarshal"));
 
     if (pMD->IsSharedByGenericInstantiations())
     {

--- a/tests/CoreFX/CoreFX.issues.json
+++ b/tests/CoreFX/CoreFX.issues.json
@@ -417,6 +417,28 @@
                 {
                     "name" : "System.Runtime.InteropServices.Tests.SafeBufferTests.Initialize_NumBytesTimesSizeOfEachElement_ThrowsOverflowException",
                     "reason" : "https://github.com/dotnet/coreclr/pull/20132"
+                },
+                {
+                    "name" : "System.Runtime.InteropServices.Tests.GetFunctionPointerForDelegateTests.GetFunctionPointerForDelegate_DelegateCollectible_ThrowsNotSupportedException",
+                    "reason" : "outdated"
+                }
+            ]
+        }
+    },
+    {
+        "name": "System.Runtime.Loader.Tests",
+        "enabled": true,
+        "exclusions": {
+            "namespaces": null,
+            "classes": null,
+            "methods": [
+                {
+                    "name" : "System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unsupported_DelegateMarshalling",
+                    "reason" : "outdated"
+                },
+                {
+                    "name" : "System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unsupported_ThreadStaticAndFixedAddressValueType",
+                    "reason" : "outdated"
                 }
             ]
         }


### PR DESCRIPTION
This change is trivial - it just removes checks preventing the delegate
marshalling for collectible types. The unmanaged to managed thunks are
allocated from a global LoaderAllocator and they are released when the
corresponding managed delegates are collected. So for unloadability, we
don't need to change this behavior in any way.