### PR TITLE
Enable Ubuntu arm Cross Release crossgen_comparison scenario by default

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1961,7 +1961,7 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                             }
                             break
                          case 'crossgen_comparison':
-                            if (os == 'Ubuntu' && architecture == 'arm' && (configuration == 'Checked' || configuration == 'Release)) {
+                            if (os == 'Ubuntu' && architecture == 'arm' && (configuration == 'Checked' || configuration == 'Release')) {
                                 isDefaultTrigger = true
                             }
                             break

--- a/netci.groovy
+++ b/netci.groovy
@@ -1961,7 +1961,7 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                             }
                             break
                          case 'crossgen_comparison':
-                            if (os == 'Ubuntu' && architecture == 'arm' && configuration == 'Checked') {
+                            if (os == 'Ubuntu' && architecture == 'arm' && (configuration == 'Checked' || configuration == 'Release)) {
                                 isDefaultTrigger = true
                             }
                             break


### PR DESCRIPTION
Given that running the test on Linux/arm machine takes only 6 minutes (https://ci.dot.net/job/dotnet_coreclr/job/master/job/arm_cross_release_ubuntu_crossgen_comparison_flow_prtest/1/console)
```
20:49:05 Build dotnet_coreclr » master » arm_cross_release_ubuntu_crossgen_comparison_tst_prtest #1 started
20:55:11 dotnet_coreclr » master » arm_cross_release_ubuntu_crossgen_comparison_tst_prtest #1 completed 
```
it is worth having this check running in CI against each PR.