### PR TITLE
add SysStringByteLen for x-plat BSTR Marshalling

### DIFF
--- a/src/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/dlls/mscoree/mscorwks_unixexports.src
@@ -63,6 +63,7 @@ SetEnvironmentVariableW
 SetEvent
 SysAllocStringLen
 SysFreeString
+SysStringByteLen
 SysStringLen
 VirtualAlloc
 VirtualFree


### PR DESCRIPTION
When try to enable x-plat BSTR marshaling, it need SysStringByteLen support from native side.