### PR TITLE
Avoid allocation in Task.Yield() awaiter

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/YieldAwaitable.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/YieldAwaitable.cs
@@ -143,7 +143,7 @@ namespace System.Runtime.CompilerServices
                     TaskScheduler scheduler = TaskScheduler.Current;
                     if (scheduler == TaskScheduler.Default)
                     {
-                        ThreadPool.UnsafeQueueUserWorkItem(s => ((IAsyncStateMachineBox)s).MoveNext(), box);
+                        ThreadPool.UnsafeQueueCustomWorkItem(box, forceGlobal: true);
                     }
                     else
                     {


### PR DESCRIPTION
Now that IAsyncStateMachineBox is an IThreadPoolWorkItem, we can queue it directly in Task.Yield's awaiter.  This makes `await Task.Yield();` allocation-free when the default scheduler is used.

cc: @kouvel, @davidfowl 