### PR TITLE
Specify configuration to runtest.sh

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -2385,7 +2385,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
 
                             buildCommands += "./build.sh ${lowerConfiguration} ${architecture} skiptests"
                             buildCommands += "./build-test.sh ${lowerConfiguration} ${architecture} generatetesthostonly"
-                            buildCommands += "./tests/runtest.sh --corefxtestsall --testHostDir=\${WORKSPACE}/bin/tests/${osGroup}.${architecture}.${configuration}/testhost/ --coreclr-src=\${WORKSPACE}"
+                            buildCommands += "./tests/runtest.sh ${lowerConfiguration} --corefxtestsall --testHostDir=\${WORKSPACE}/bin/tests/${osGroup}.${architecture}.${configuration}/testhost/ --coreclr-src=\${WORKSPACE}"
                             
                             break
                             // Archive and process (only) the test results
@@ -3468,6 +3468,7 @@ def static CreateOtherTestJob(def dslFactory, def project, def branch, def archi
 
                 shell("""\
 ${runScript} \\
+    ${lowerConfiguration} \\
     --testRootDir=\"\${WORKSPACE}/bin/tests/${osGroup}.${architecture}.${configuration}\" \\
     --coreOverlayDir=\"\${WORKSPACE}/bin/tests/${osGroup}.${architecture}.${configuration}/Tests/Core_Root\" \\
     --testNativeBinDir=\"\${WORKSPACE}/bin/obj/${osGroup}.${architecture}.${configuration}/tests\" \\


### PR DESCRIPTION
All jobs using runtest.sh wrapper script run `runtest.py` with `-build_type Debug` arguments

```
:~/echesako/git/coreclr$ ./tests/runtest.sh --testRootDir=$(pwd)/bin/tests/Linux.arm64.Checked --coreOverlayDir=$(pwd)/bin/tests/Linux.arm64.Checked/Tests/Core_Root --testNativeBinDir=$(pwd)/bin/obj/Linux.arm64.Checked/tests --copyNativeTestBin --limitedDumpGeneration --crossgen --runcrossgentests --jitstress=2
Running on  CPU- arm64
Build Architecture            : arm64
Build Configuration           : Debug
Test Location                 : /home/robox/echesako/git/coreclr/bin/tests/Linux.arm64.Checked
Core Root Location            : /home/robox/echesako/git/coreclr/bin/tests/Linux.arm64.Checked/Tests/Core_Root
Test Native Bin Location      : /home/robox/echesako/git/coreclr/bin/obj/Linux.arm64.Checked/tests

Skipping xunit wrapper build. If build-test was called on a different
host_os or arch the test run will most likely have failures.
python /home/robox/echesako/git/coreclr/tests/runtest.py -arch arm64 -build_type Debug -test_location /home/robox/echesako/git/coreclr/bin/tests/Linux.arm64.Checked -core_root /home/robox/echesako/git/coreclr/bin/tests/Linux.arm64.Checked/Tests/Core_Root -test_native_bin_location /home/robox/echesako/git/coreclr/bin/obj/Linux.arm64.Checked/tests --run_crossgen_tests --precompile_core_root
Using default test location.
TestLocation: /home/robox/echesako/git/coreclr/bin/tests/Linux.arm64.Checked

Core_Root: /home/robox/echesako/git/coreclr/bin/tests/Linux.arm64.Checked/Tests/Core_Root
Found COMPlus variables in the current environment

Unset COMPlus_gcServer
Unset COMPlus_JitStress
Unset COMPlus_EnableEventLog

TestEnv: /tmp/tmpaQFhuN
```
Specify `${lowerConfiguration}` to the wrapper to make runtest.py use the correct `build_type` value.