### PR TITLE
Disable Interop/DllImportAttribute/FileExtensionProbe on Unix

### DIFF
--- a/tests/src/Interop/DllImportAttribute/FileExtensionProbe.csproj
+++ b/tests/src/Interop/DllImportAttribute/FileExtensionProbe.csproj
@@ -13,6 +13,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
     <CLRTestPriority>1</CLRTestPriority>
+    <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'"></PropertyGroup>


### PR DESCRIPTION
Temporary disable building Interop/DllImportAttribute/FileExtensionProbe on Unix to unblock CI (#20174)