### PR TITLE
Make `structType` optional in jitEEInterface method `getFieldType`.

### DIFF
--- a/src/ToolBox/superpmi/superpmi-shared/icorjitinfoimpl.h
+++ b/src/ToolBox/superpmi/superpmi-shared/icorjitinfoimpl.h
@@ -508,7 +508,7 @@ CORINFO_CLASS_HANDLE getFieldClass(CORINFO_FIELD_HANDLE field);
 // 'memberParent' is typically only set when verifying.  It should be the
 // result of calling getMemberParent.
 CorInfoType getFieldType(CORINFO_FIELD_HANDLE  field,
-                         CORINFO_CLASS_HANDLE* structType,
+                         CORINFO_CLASS_HANDLE* structType = NULL,
                          CORINFO_CLASS_HANDLE  memberParent = NULL /* IN */
                          );
 

--- a/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -4245,7 +4245,14 @@ void MethodContext::recGetFieldType(CORINFO_FIELD_HANDLE  field,
     key.A = (DWORDLONG)field;
     key.B = (DWORDLONG)memberParent;
 
-    value.A = (DWORDLONG)*structType;
+    if (structType == nullptr)
+    {
+        value.A = 0;
+    }
+    else
+    {
+        value.A = (DWORDLONG)*structType;
+    }
     value.B = (DWORD)result;
 
     GetFieldType->Add(key, value);

--- a/src/inc/corinfo.h
+++ b/src/inc/corinfo.h
@@ -2640,7 +2640,7 @@ public:
     // result of calling getMemberParent.
     virtual CorInfoType getFieldType(
                         CORINFO_FIELD_HANDLE    field,
-                        CORINFO_CLASS_HANDLE   *structType,
+                        CORINFO_CLASS_HANDLE   *structType = NULL,
                         CORINFO_CLASS_HANDLE    memberParent = NULL /* IN */
                         ) = 0;
 

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -16399,9 +16399,8 @@ bool Compiler::gtIsStaticFieldPtrToBoxedStruct(var_types fieldNodeType, CORINFO_
     {
         return false;
     }
-    CORINFO_CLASS_HANDLE fldCls = nullptr;
     noway_assert(fldHnd != nullptr);
-    CorInfoType cit      = info.compCompHnd->getFieldType(fldHnd, &fldCls);
+    CorInfoType cit      = info.compCompHnd->getFieldType(fldHnd);
     var_types   fieldTyp = JITtype2varType(cit);
     return fieldTyp != TYP_REF;
 }

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -236,8 +236,7 @@ bool Compiler::impILConsumesAddr(const BYTE* codeAddr, CORINFO_METHOD_HANDLE fnc
             CORINFO_RESOLVED_TOKEN resolvedToken;
             impResolveToken(codeAddr + sizeof(__int8), &resolvedToken, CORINFO_TOKENKIND_Field);
 
-            CORINFO_CLASS_HANDLE clsHnd;
-            var_types lclTyp = JITtype2varType(info.compCompHnd->getFieldType(resolvedToken.hField, &clsHnd));
+            var_types lclTyp = JITtype2varType(info.compCompHnd->getFieldType(resolvedToken.hField));
 
             // Preserve 'small' int types
             if (!varTypeIsSmall(lclTyp))

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1622,10 +1622,9 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPr
                     return;
                 }
 
-                CORINFO_CLASS_HANDLE cHnd;
-                CorInfoType          fieldCorType = info.compCompHnd->getFieldType(fHnd, &cHnd);
-                var_types            fieldVarType = JITtype2varType(fieldCorType);
-                unsigned             fieldSize    = genTypeSize(fieldVarType);
+                CorInfoType fieldCorType = info.compCompHnd->getFieldType(fHnd);
+                var_types   fieldVarType = JITtype2varType(fieldCorType);
+                unsigned    fieldSize    = genTypeSize(fieldVarType);
 
                 // Do not promote if either not a primitive type or size equal to ptr size on
                 // target or a struct containing a single floating-point field.

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -3493,10 +3493,9 @@ ValueNum ValueNumStore::VNApplySelectorsAssign(
         }
 
         // Otherwise, fldHnd is a real field handle.
-        CORINFO_FIELD_HANDLE fldHnd     = fieldSeq->m_fieldHnd;
-        CORINFO_CLASS_HANDLE structType = nullptr;
+        CORINFO_FIELD_HANDLE fldHnd = fieldSeq->m_fieldHnd;
         noway_assert(fldHnd != nullptr);
-        CorInfoType fieldCit  = m_pComp->info.compCompHnd->getFieldType(fldHnd, &structType);
+        CorInfoType fieldCit  = m_pComp->info.compCompHnd->getFieldType(fldHnd);
         var_types   fieldType = JITtype2varType(fieldCit);
 
         ValueNum fieldHndVN = VNForHandle(ssize_t(fldHnd), GTF_ICON_FIELD_HDL);

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -9289,8 +9289,8 @@ CORINFO_CLASS_HANDLE CEEInfo::getFieldClass (CORINFO_FIELD_HANDLE fieldHnd)
 /*********************************************************************/
 // Returns the basic type of the field (not the the type that declares the field)
 //
-// pTypeHnd - On return, for reference and value types, *pTypeHnd will contain 
-//            the normalized type of the field.
+// pTypeHnd - Optional. If not null then on return, for reference and value types, 
+//            *pTypeHnd will contain the normalized type of the field.
 // owner - Optional. For resolving in a generic context
 
 CorInfoType CEEInfo::getFieldType (CORINFO_FIELD_HANDLE fieldHnd, 
@@ -9322,7 +9322,10 @@ CorInfoType CEEInfo::getFieldTypeInternal (CORINFO_FIELD_HANDLE fieldHnd,
 {
     STANDARD_VM_CONTRACT;
 
-    *pTypeHnd = 0;
+    if (pTypeHnd != nullptr)
+    {
+        *pTypeHnd = 0;
+    }
 
     TypeHandle clsHnd = TypeHandle();
     FieldDesc* field = (FieldDesc*) fieldHnd;

--- a/src/vm/jitinterface.h
+++ b/src/vm/jitinterface.h
@@ -834,9 +834,9 @@ public:
     CORINFO_CLASS_HANDLE getFieldClass (CORINFO_FIELD_HANDLE field);
 
     //@GENERICSVER: added owner parameter
-    CorInfoType getFieldType (CORINFO_FIELD_HANDLE field, CORINFO_CLASS_HANDLE* structType,CORINFO_CLASS_HANDLE owner = NULL);
+    CorInfoType getFieldType (CORINFO_FIELD_HANDLE field, CORINFO_CLASS_HANDLE* structType = NULL,CORINFO_CLASS_HANDLE owner = NULL);
     // Internal version without JIT-EE transition
-    CorInfoType getFieldTypeInternal (CORINFO_FIELD_HANDLE field, CORINFO_CLASS_HANDLE* structType,CORINFO_CLASS_HANDLE owner = NULL);
+    CorInfoType getFieldTypeInternal (CORINFO_FIELD_HANDLE field, CORINFO_CLASS_HANDLE* structType = NULL,CORINFO_CLASS_HANDLE owner = NULL);
 
     unsigned getFieldOffset (CORINFO_FIELD_HANDLE field);
 


### PR DESCRIPTION
a76496c0f6: Make `structType` optional in `getFieldType`.

The declaration in `corinfo.h` says: "if 'structType' == 0, then don't bother the structure info". However, `getFieldTypeInternal ` did not expect that case.

https://github.com/dotnet/coreclr/blob/49209e181103006603e2cf4e05dccb564bef537d/src/inc/corinfo.h#L2635-L2640

a8b1da0ae9: Do not bother the structure info when we do not need it from `getFieldType`.

Not a breaking change.