### PR TITLE
Add back ExeFile directory for non-Windows

### DIFF
--- a/tests/src/Interop/CMakeLists.txt
+++ b/tests/src/Interop/CMakeLists.txt
@@ -29,13 +29,13 @@ add_subdirectory(StringMarshalling/UTF8)
 add_subdirectory(MarshalAPI/FunctionPointer)
 add_subdirectory(MarshalAPI/IUnknown)
 add_subdirectory(SizeConst)
+add_subdirectory(DllImportAttribute/ExeFile)
 add_subdirectory(DllImportAttribute/FileNameContainDot)
 add_subdirectory(DllImportAttribute/Simple)
 
 if(WIN32)
     add_subdirectory(COM/NativeServer)
     add_subdirectory(COM/NativeClients/Primitives)
-    add_subdirectory(DllImportAttribute/ExeFile)
     add_subdirectory(IJW/FakeMscoree)
 
     # IJW isn't supported on ARM64


### PR DESCRIPTION
Fix for https://github.com/dotnet/coreclr/issues/20174
My previous PR exclude ExeFile directory for non-Windows which break Priority1 build