### PR TITLE
[WIP] promoted structs cleaning.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2975,10 +2975,12 @@ public:
         bool               canPromote;
         bool               containsHoles;
         bool               customLayout;
+        bool               fieldsSorted;
         unsigned char      fieldCnt;
         lvaStructFieldInfo fields[MAX_NumOfFieldsInPromotableStruct];
 
-        lvaStructPromotionInfo() : canPromote(false), containsHoles(false), customLayout(false), fieldCnt(0)
+        lvaStructPromotionInfo()
+            : canPromote(false), containsHoles(false), customLayout(false), fieldsSorted(false), fieldCnt(0)
         {
             memset(fields, 0, sizeof(fields));
         }
@@ -2997,6 +2999,7 @@ public:
         bool CanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd);
         bool ShouldPromoteStructVar(unsigned lclNum, const lvaStructPromotionInfo* structPromotionInfo);
 
+        void SortStructFields(lvaStructPromotionInfo* structPromotionInfo);
         void PromoteStructVar(unsigned lclNum, const lvaStructPromotionInfo* structPromotionInfo);
 
         lvaStructPromotionInfo* GetStructPromotionInfo(CORINFO_CLASS_HANDLE typeHnd);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2985,7 +2985,6 @@ public:
     };
 
     static int __cdecl lvaFieldOffsetCmp(const void* field1, const void* field2);
-    bool lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPromotionInfo* structPromotionInfo);
     void lvaCanPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* structPromotionInfo);
 
     // This class is responsible for checking possibility and profitability of struct promotion.
@@ -2993,11 +2992,13 @@ public:
     class StructPromotionHelper
     {
     public:
-        StructPromotionHelper();
+        StructPromotionHelper(Compiler* compiler);
 
         bool CanPromoteStructVar(unsigned lclNum);
         bool CanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd);
         bool ShouldPromoteStructVar(unsigned lclNum);
+
+        lvaStructPromotionInfo GetStructPromotionInfo(CORINFO_CLASS_HANDLE typeHnd);
 
 #ifdef _TARGET_ARM_
         bool GetRequiresScratchVar();
@@ -3005,9 +3006,14 @@ public:
 #endif // _TARGET_ARM_
 
     private:
+        Compiler* compiler;
+
 #ifdef _TARGET_ARM_
         bool requiresScratchVar;
 #endif // _TARGET_ARM_
+        typedef JitHashTable<CORINFO_CLASS_HANDLE, JitPtrKeyFuncs<CORINFO_CLASS_STRUCT_>, lvaStructPromotionInfo>
+                                         StructPromotionInfoForTypeHndMap;
+        StructPromotionInfoForTypeHndMap promotionInfoMap;
     };
 
     StructPromotionHelper structPromotionHelper;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2974,14 +2974,12 @@ public:
     {
         CORINFO_CLASS_HANDLE typeHnd;
         bool                 canPromote;
-        bool                 requiresScratchVar;
         bool                 containsHoles;
         bool                 customLayout;
         unsigned char        fieldCnt;
         lvaStructFieldInfo   fields[MAX_NumOfFieldsInPromotableStruct];
 
-        lvaStructPromotionInfo()
-            : typeHnd(nullptr), canPromote(false), requiresScratchVar(false), containsHoles(false), customLayout(false)
+        lvaStructPromotionInfo() : typeHnd(nullptr), canPromote(false), containsHoles(false), customLayout(false)
         {
         }
     };
@@ -3001,7 +2999,15 @@ public:
         bool CanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd);
         bool ShouldPromoteStructVar(unsigned lclNum);
 
+#ifdef _TARGET_ARM_
+        bool GetRequiresScratchVar();
+        void SetRequiresScratchVar();
+#endif // _TARGET_ARM_
+
     private:
+#ifdef _TARGET_ARM_
+        bool requiresScratchVar;
+#endif // _TARGET_ARM_
     };
 
     StructPromotionHelper structPromotionHelper;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2985,7 +2985,7 @@ public:
     };
 
     static int __cdecl lvaFieldOffsetCmp(const void* field1, const void* field2);
-    void lvaCanPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* structPromotionInfo);
+    bool lvaCanPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* structPromotionInfo);
 
     // This class is responsible for checking possibility and profitability of struct promotion.
     // If it decide to do promotion than it initializes nessesary information for fgMorphStructField to use.

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2990,6 +2990,22 @@ public:
     void lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPromotionInfo* structPromotionInfo);
     void lvaCanPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* structPromotionInfo);
 
+    // This class is responsible for checking possibility and profitability of struct promotion.
+    // If it decide to do promotion than it initializes nessesary information for fgMorphStructField to use.
+    class StructPromotionHelper
+    {
+    public:
+        StructPromotionHelper();
+
+        bool CanPromoteStructVar(unsigned lclNum);
+        bool CanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd);
+        bool ShouldPromoteStructVar(unsigned lclNum);
+
+    private:
+    };
+
+    StructPromotionHelper structPromotionHelper;
+
     bool lvaShouldPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* structPromotionInfo);
     void lvaPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* structPromotionInfo);
 #if !defined(_TARGET_64BIT_)

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3028,7 +3028,7 @@ public:
 #if !defined(_TARGET_64BIT_)
     void lvaPromoteLongVars();
 #endif // !defined(_TARGET_64BIT_)
-    unsigned lvaGetFieldLocal(LclVarDsc* varDsc, unsigned int fldOffset);
+    unsigned lvaGetFieldLocal(const LclVarDsc* varDsc, unsigned int fldOffset);
     lvaPromotionType lvaGetPromotionType(const LclVarDsc* varDsc);
     lvaPromotionType lvaGetPromotionType(unsigned varNum);
     lvaPromotionType lvaGetParentPromotionType(const LclVarDsc* varDsc);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2972,15 +2972,13 @@ public:
     // Info about struct type to be promoted.
     struct lvaStructPromotionInfo
     {
-        CORINFO_CLASS_HANDLE typeHnd;
-        bool                 canPromote;
-        bool                 containsHoles;
-        bool                 customLayout;
-        unsigned char        fieldCnt;
-        lvaStructFieldInfo   fields[MAX_NumOfFieldsInPromotableStruct];
+        bool               canPromote;
+        bool               containsHoles;
+        bool               customLayout;
+        unsigned char      fieldCnt;
+        lvaStructFieldInfo fields[MAX_NumOfFieldsInPromotableStruct];
 
-        lvaStructPromotionInfo()
-            : typeHnd(nullptr), canPromote(false), containsHoles(false), customLayout(false), fieldCnt(0)
+        lvaStructPromotionInfo() : canPromote(false), containsHoles(false), customLayout(false), fieldCnt(0)
         {
             memset(fields, 0, sizeof(fields));
         }

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2999,8 +2999,8 @@ public:
         bool CanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd);
         bool ShouldPromoteStructVar(unsigned lclNum);
 
-        lvaStructPromotionInfo GetStructPromotionInfo(CORINFO_CLASS_HANDLE typeHnd);
-        lvaStructPromotionInfo GetStructPromotionInfo(unsigned lclNum);
+        lvaStructPromotionInfo* GetStructPromotionInfo(CORINFO_CLASS_HANDLE typeHnd);
+        lvaStructPromotionInfo* GetStructPromotionInfo(unsigned lclNum);
 
 #ifdef _TARGET_ARM_
         bool GetRequiresScratchVar();
@@ -3013,7 +3013,7 @@ public:
 #ifdef _TARGET_ARM_
         bool requiresScratchVar;
 #endif // _TARGET_ARM_
-        typedef JitHashTable<CORINFO_CLASS_HANDLE, JitPtrKeyFuncs<CORINFO_CLASS_STRUCT_>, lvaStructPromotionInfo>
+        typedef JitHashTable<CORINFO_CLASS_HANDLE, JitPtrKeyFuncs<CORINFO_CLASS_STRUCT_>, lvaStructPromotionInfo*>
                                          StructPromotionInfoForTypeHndMap;
         StructPromotionInfoForTypeHndMap promotionInfoMap;
     };

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2997,6 +2997,7 @@ public:
 
         bool CanPromoteStructVar(unsigned lclNum);
         bool CanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd);
+        bool CanPromoteStructField(lvaStructFieldInfo& outerFieldInfo);
         bool ShouldPromoteStructVar(unsigned lclNum, const lvaStructPromotionInfo* structPromotionInfo);
 
         void SortStructFields(lvaStructPromotionInfo* structPromotionInfo);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2979,8 +2979,10 @@ public:
         unsigned char        fieldCnt;
         lvaStructFieldInfo   fields[MAX_NumOfFieldsInPromotableStruct];
 
-        lvaStructPromotionInfo() : typeHnd(nullptr), canPromote(false), containsHoles(false), customLayout(false)
+        lvaStructPromotionInfo()
+            : typeHnd(nullptr), canPromote(false), containsHoles(false), customLayout(false), fieldCnt(0)
         {
+            memset(fields, 0, sizeof(fields));
         }
     };
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3023,7 +3023,7 @@ public:
         StructPromotionInfoForTypeHndMap promotionInfoMap;
     };
 
-    StructPromotionHelper structPromotionHelper;
+    StructPromotionHelper* structPromotionHelper;
 
 #if !defined(_TARGET_64BIT_)
     void lvaPromoteLongVars();

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3005,6 +3005,10 @@ public:
         lvaStructPromotionInfo* GetStructPromotionInfo(CORINFO_CLASS_HANDLE typeHnd);
         lvaStructPromotionInfo* GetStructPromotionInfo(unsigned lclNum);
 
+#ifdef DEBUG
+        void CheckFakedType(CORINFO_FIELD_HANDLE fieldHnd, var_types requestedType);
+#endif // DEBUG
+
 #ifdef _TARGET_ARM_
         bool GetRequiresScratchVar();
         void SetRequiresScratchVar();
@@ -3021,6 +3025,11 @@ public:
         typedef JitHashTable<CORINFO_CLASS_HANDLE, JitPtrKeyFuncs<CORINFO_CLASS_STRUCT_>, lvaStructPromotionInfo*>
                                          StructPromotionInfoForTypeHndMap;
         StructPromotionInfoForTypeHndMap promotionInfoMap;
+
+#ifdef DEBUG
+        typedef JitHashTable<CORINFO_FIELD_HANDLE, JitPtrKeyFuncs<CORINFO_FIELD_STRUCT_>, var_types> FakedFieldsMap;
+        FakedFieldsMap fakedFieldsMap;
+#endif // DEBUG
     };
 
     StructPromotionHelper* structPromotionHelper;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3009,6 +3009,8 @@ public:
         bool GetRequiresScratchVar();
         void SetRequiresScratchVar();
 #endif // _TARGET_ARM_
+    private:
+        lvaStructFieldInfo GetFieldInfo(CORINFO_FIELD_HANDLE fieldHnd, BYTE ordinal);
 
     private:
         Compiler* compiler;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2985,7 +2985,7 @@ public:
     };
 
     static int __cdecl lvaFieldOffsetCmp(const void* field1, const void* field2);
-    void lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPromotionInfo* structPromotionInfo);
+    bool lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPromotionInfo* structPromotionInfo);
     void lvaCanPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* structPromotionInfo);
 
     // This class is responsible for checking possibility and profitability of struct promotion.

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2997,7 +2997,7 @@ public:
 
         bool CanPromoteStructVar(unsigned lclNum);
         bool CanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd);
-        bool ShouldPromoteStructVar(unsigned lclNum);
+        bool ShouldPromoteStructVar(unsigned lclNum, const lvaStructPromotionInfo* structPromotionInfo);
 
         lvaStructPromotionInfo* GetStructPromotionInfo(CORINFO_CLASS_HANDLE typeHnd);
         lvaStructPromotionInfo* GetStructPromotionInfo(unsigned lclNum);
@@ -3020,7 +3020,6 @@ public:
 
     StructPromotionHelper structPromotionHelper;
 
-    bool lvaShouldPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* structPromotionInfo);
     void lvaPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* structPromotionInfo);
 #if !defined(_TARGET_64BIT_)
     void lvaPromoteLongVars();

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2999,6 +2999,8 @@ public:
         bool CanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd);
         bool ShouldPromoteStructVar(unsigned lclNum, const lvaStructPromotionInfo* structPromotionInfo);
 
+        void PromoteStructVar(unsigned lclNum, const lvaStructPromotionInfo* structPromotionInfo);
+
         lvaStructPromotionInfo* GetStructPromotionInfo(CORINFO_CLASS_HANDLE typeHnd);
         lvaStructPromotionInfo* GetStructPromotionInfo(unsigned lclNum);
 
@@ -3020,7 +3022,6 @@ public:
 
     StructPromotionHelper structPromotionHelper;
 
-    void lvaPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* structPromotionInfo);
 #if !defined(_TARGET_64BIT_)
     void lvaPromoteLongVars();
 #endif // !defined(_TARGET_64BIT_)

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2958,7 +2958,7 @@ public:
 
 #define MAX_NumOfFieldsInPromotableStruct 4 // Maximum number of fields in promotable struct
 
-    // Info about struct fields
+    // Info about struct type fields.
     struct lvaStructFieldInfo
     {
         CORINFO_FIELD_HANDLE fldHnd;
@@ -2969,7 +2969,7 @@ public:
         CORINFO_CLASS_HANDLE fldTypeHnd;
     };
 
-    // Info about struct to be promoted.
+    // Info about struct type to be promoted.
     struct lvaStructPromotionInfo
     {
         CORINFO_CLASS_HANDLE typeHnd;
@@ -2985,7 +2985,6 @@ public:
     };
 
     static int __cdecl lvaFieldOffsetCmp(const void* field1, const void* field2);
-    bool lvaCanPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* structPromotionInfo);
 
     // This class is responsible for checking possibility and profitability of struct promotion.
     // If it decide to do promotion than it initializes nessesary information for fgMorphStructField to use.
@@ -2999,6 +2998,7 @@ public:
         bool ShouldPromoteStructVar(unsigned lclNum);
 
         lvaStructPromotionInfo GetStructPromotionInfo(CORINFO_CLASS_HANDLE typeHnd);
+        lvaStructPromotionInfo GetStructPromotionInfo(unsigned lclNum);
 
 #ifdef _TARGET_ARM_
         bool GetRequiresScratchVar();

--- a/src/jit/compmemkind.h
+++ b/src/jit/compmemkind.h
@@ -54,6 +54,7 @@ CompMemKindMacro(Unknown)
 CompMemKindMacro(RangeCheck)
 CompMemKindMacro(CopyProp)
 CompMemKindMacro(SideEffects)
+CompMemKindMacro(StructPromotion)
 //clang-format on
 
 #undef CompMemKindMacro

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -17742,7 +17742,8 @@ void Compiler::impMakeDiscretionaryInlineObservations(InlineInfo* pInlineInfo, I
     // Note if the callee's class is a promotable struct
     if ((info.compClassAttr & CORINFO_FLG_VALUECLASS) != 0)
     {
-        if (structPromotionHelper.CanPromoteStructType(info.compClassHnd))
+        assert(structPromotionHelper != nullptr);
+        if (structPromotionHelper->CanPromoteStructType(info.compClassHnd))
         {
             inlineResult->Note(InlineObservation::CALLEE_CLASS_PROMOTABLE);
         }

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -17743,8 +17743,7 @@ void Compiler::impMakeDiscretionaryInlineObservations(InlineInfo* pInlineInfo, I
     if ((info.compClassAttr & CORINFO_FLG_VALUECLASS) != 0)
     {
         lvaStructPromotionInfo structPromotionInfo;
-        lvaCanPromoteStructType(info.compClassHnd, &structPromotionInfo);
-        if (structPromotionInfo.canPromote)
+        if (lvaCanPromoteStructType(info.compClassHnd, &structPromotionInfo))
         {
             inlineResult->Note(InlineObservation::CALLEE_CLASS_PROMOTABLE);
         }

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -17742,8 +17742,7 @@ void Compiler::impMakeDiscretionaryInlineObservations(InlineInfo* pInlineInfo, I
     // Note if the callee's class is a promotable struct
     if ((info.compClassAttr & CORINFO_FLG_VALUECLASS) != 0)
     {
-        lvaStructPromotionInfo structPromotionInfo;
-        if (lvaCanPromoteStructType(info.compClassHnd, &structPromotionInfo))
+        if (structPromotionHelper.CanPromoteStructType(info.compClassHnd))
         {
             inlineResult->Note(InlineObservation::CALLEE_CLASS_PROMOTABLE);
         }

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1621,12 +1621,8 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
             fieldInfo.fldHnd              = compHandle->getFieldInClass(typeHnd, ordinal);
             unsigned fldOffset            = compHandle->getFieldOffset(fieldInfo.fldHnd);
 
-            // The fldOffset value should never be larger than our structSize.
-            if (fldOffset >= structSize)
-            {
-                noway_assert(false);
-                return false;
-            }
+            // The fldOffset value should fit into structSize.
+            noway_assert(fldOffset < structSize);
 
             fieldInfo.fldOffset  = (BYTE)fldOffset;
             fieldInfo.fldOrdinal = ordinal;

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1503,7 +1503,7 @@ void Compiler::StructPromotionHelper::SetRequiresScratchVar()
 /*****************************************************************************
  * Is this type promotable? */
 
-void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPromotionInfo* structPromotionInfo)
+bool Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPromotionInfo* structPromotionInfo)
 {
     assert(eeIsValueClass(typeHnd));
 
@@ -1541,13 +1541,13 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPr
         unsigned structSize = compHandle->getClassSize(typeHnd);
         if (structSize > MaxOffset)
         {
-            return; // struct is too large
+            return false; // struct is too large
         }
 
         unsigned fieldCnt = compHandle->getClassNumInstanceFields(typeHnd);
         if (fieldCnt == 0 || fieldCnt > MAX_NumOfFieldsInPromotableStruct)
         {
-            return; // struct must have between 1 and MAX_NumOfFieldsInPromotableStruct fields
+            return false; // struct must have between 1 and MAX_NumOfFieldsInPromotableStruct fields
         }
 
         structPromotionInfo->fieldCnt = (BYTE)fieldCnt;
@@ -1556,13 +1556,13 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPr
         bool overlappingFields = StructHasOverlappingFields(typeFlags);
         if (overlappingFields)
         {
-            return;
+            return false;
         }
 
         // Don't struct promote if we have an CUSTOMLAYOUT flag on an HFA type
         if (StructHasCustomLayout(typeFlags) && IsHfa(typeHnd))
         {
-            return;
+            return false;
         }
 
 #ifdef _TARGET_ARM_
@@ -1588,7 +1588,7 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPr
             if (fldOffset >= structSize)
             {
                 noway_assert(false);
-                return;
+                return false;
             }
 
             pFieldInfo->fldOffset  = (BYTE)fldOffset;
@@ -1621,7 +1621,7 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPr
                 // fields of TYP_BLK, TYP_FUNC or TYP_VOID.
                 if (pFieldInfo->fldType != TYP_STRUCT)
                 {
-                    return;
+                    return false;
                 }
 
                 // Non-primitive struct field.
@@ -1631,7 +1631,7 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPr
                 // Do Not promote if the struct field in turn has more than one field.
                 if (compHandle->getClassNumInstanceFields(pFieldInfo->fldTypeHnd) != 1)
                 {
-                    return;
+                    return false;
                 }
 
                 // Do not promote if the single field is not aligned at its natural boundary within
@@ -1640,7 +1640,7 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPr
                 unsigned             fOffset = compHandle->getFieldOffset(fHnd);
                 if (fOffset != 0)
                 {
-                    return;
+                    return false;
                 }
 
                 CorInfoType fieldCorType = compHandle->getFieldType(fHnd);
@@ -1664,7 +1664,7 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPr
                 {
                     JITDUMP("Promotion blocked: struct contains struct field with one field,"
                             " but that field has invalid size or type");
-                    return;
+                    return false;
                 }
 
                 // Insist this wrapped field occupy all of its parent storage.
@@ -1674,7 +1674,7 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPr
                 {
                     JITDUMP("Promotion blocked: struct contains struct field with one field,"
                             " but that field is not the same size as its parent.");
-                    return;
+                    return false;
                 }
 
                 // Retype the field as the type of the single field of the struct
@@ -1687,7 +1687,7 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPr
                 // The code in Compiler::genPushArgList that reconstitutes
                 // struct values on the stack from promoted fields expects
                 // those fields to be at their natural alignment.
-                return;
+                return false;
             }
 
             if (varTypeIsGC(pFieldInfo->fldType))
@@ -1710,7 +1710,7 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPr
             if (pFieldInfo->fldSize > structAlignment)
             {
                 // Don't promote vars whose struct types violates the invariant.  (Alignment == size for primitives.)
-                return;
+                return false;
             }
             // If we have any small fields we will allocate a single PromotedStructScratch local var for the method.
             // This is a stack area that we use to assemble the small fields in order to place them in a register
@@ -1764,12 +1764,15 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPr
         // as a struct) in order.
         qsort(structPromotionInfo->fields, structPromotionInfo->fieldCnt, sizeof(*structPromotionInfo->fields),
               lvaFieldOffsetCmp);
+
+        return true;
     }
     else
     {
         // Asking for the same type of struct as the last time.
         // Nothing need to be done.
         // Fall through ...
+        return structPromotionInfo->canPromote;
     }
 }
 

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1831,12 +1831,12 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
 //
 bool Compiler::StructPromotionHelper::CanPromoteStructVar(unsigned lclNum)
 {
-    noway_assert(lclNum < compiler->lvaCount);
+    assert(lclNum < compiler->lvaCount);
 
     LclVarDsc* varDsc = &compiler->lvaTable[lclNum];
 
-    noway_assert(varTypeIsStruct(varDsc));
-    noway_assert(!varDsc->lvPromoted); // Don't ask again :)
+    assert(varTypeIsStruct(varDsc));
+    assert(!varDsc->lvPromoted); // Don't ask again :)
 
     // If this lclVar is used in a SIMD intrinsic, then we don't want to struct promote it.
     // Note, however, that SIMD lclVars that are NOT used in a SIMD intrinsic may be
@@ -2003,10 +2003,10 @@ void Compiler::StructPromotionHelper::PromoteStructVar(unsigned                 
     LclVarDsc* varDsc = &compiler->lvaTable[lclNum];
 
     // We should never see a reg-sized non-field-addressed struct here.
-    noway_assert(!varDsc->lvRegStruct);
+    assert(!varDsc->lvRegStruct);
 
-    noway_assert(structPromotionInfo->canPromote);
-    noway_assert(structPromotionInfo->typeHnd == varDsc->lvVerTypeInfo.GetClassHandle());
+    assert(structPromotionInfo->canPromote);
+    assert(structPromotionInfo->typeHnd == varDsc->lvVerTypeInfo.GetClassHandle());
 
     // structPromotionInfo is passed as arg to avoid this lookup in release.
     assert(GetStructPromotionInfo(lclNum) == structPromotionInfo);

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1727,7 +1727,9 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
                     return false;
                 }
 
-                // Retype the field as the type of the single field of the struct
+                // Retype the field as the type of the single field of the struct.
+                // This is a hack that allows us to promote such fields before we support recursive struct promotion
+                // (tracked by #10019).
                 fieldInfo.fldType = fieldVarType;
                 fieldInfo.fldSize = fieldSize;
             }

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1613,13 +1613,7 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
         unsigned structAlignment = roundUp(compHandle->getClassAlignmentRequirement(typeHnd), TARGET_POINTER_SIZE);
 #endif // _TARGET_ARM_
 
-        bool isHole[MaxOffset]; // isHole[] is initialized to true for every valid offset in the struct and false for
-                                // the rest
-        unsigned i;             // then as we process the fields we clear the isHole[] values that the field spans.
-        for (i = 0; i < MaxOffset; i++)
-        {
-            isHole[i] = (i < structSize) ? true : false;
-        }
+        unsigned fieldsSize = 0;
 
         for (BYTE ordinal = 0; ordinal < fieldCnt; ++ordinal)
         {
@@ -1742,10 +1736,7 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
             // The end offset for this field should never be larger than our structSize.
             noway_assert(fldOffset + pFieldInfo->fldSize <= structSize);
 
-            for (i = 0; i < pFieldInfo->fldSize; i++)
-            {
-                isHole[fldOffset + i] = false;
-            }
+            fieldsSize += pFieldInfo->fldSize;
 
 #ifdef _TARGET_ARM_
             // On ARM, for struct types that don't use explicit layout, the alignment of the struct is
@@ -1787,15 +1778,13 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
             structPromotionInfo->customLayout = true;
         }
 
-        // Check if this promoted struct contains any holes
-        //
-        for (i = 0; i < structSize; i++)
+        // Check if this promoted struct contains any holes.
+        assert(!overlappingFields);
+        if (fieldsSize != structSize)
         {
-            if (isHole[i])
-            {
-                structPromotionInfo->containsHoles = true;
-                break;
-            }
+            // If sizes do not match it means we have an overlapping fields or holes.
+            // Overlapping fields were rejected early, so here it can mean only holes.
+            structPromotionInfo->containsHoles = true;
         }
 
         // Cool, this struct is promotable.

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -2209,7 +2209,7 @@ void Compiler::lvaPromoteLongVars()
    that represents this field.
 */
 
-unsigned Compiler::lvaGetFieldLocal(LclVarDsc* varDsc, unsigned int fldOffset)
+unsigned Compiler::lvaGetFieldLocal(const LclVarDsc* varDsc, unsigned int fldOffset)
 {
     noway_assert(varTypeIsStruct(varDsc));
     noway_assert(varDsc->lvPromoted);

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -69,7 +69,7 @@ void Compiler::lvaInit()
     lvaArg0Var          = BAD_VAR_NUM;
     lvaMonAcquired      = BAD_VAR_NUM;
 
-    structPromotionHelper = StructPromotionHelper(this);
+    structPromotionHelper = new StructPromotionHelper(this);
 
     lvaInlineeReturnSpillTemp = BAD_VAR_NUM;
 

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1575,8 +1575,6 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
         assert((BYTE)MAX_NumOfFieldsInPromotableStruct ==
                MAX_NumOfFieldsInPromotableStruct); // because lvaStructFieldInfo.fieldCnt is byte-sized
 
-        bool containsHoles      = false;
-        bool customLayout       = false;
         bool containsGCpointers = false;
 
         structPromotionInfo->canPromote = false;
@@ -1786,7 +1784,7 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
         //
         if (StructHasCustomLayout(typeFlags) && ((typeFlags & CORINFO_FLG_CONTAINS_GC_PTR) == 0))
         {
-            customLayout = true;
+            structPromotionInfo->customLayout = true;
         }
 
         // Check if this promoted struct contains any holes
@@ -1795,15 +1793,13 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
         {
             if (isHole[i])
             {
-                containsHoles = true;
+                structPromotionInfo->containsHoles = true;
                 break;
             }
         }
 
         // Cool, this struct is promotable.
-        structPromotionInfo->canPromote    = true;
-        structPromotionInfo->containsHoles = containsHoles;
-        structPromotionInfo->customLayout  = customLayout;
+        structPromotionInfo->canPromote = true;
 
         // Sort the fields according to the increasing order of the field offset.
         // This is needed because the fields need to be pushed on stack (when referenced

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1671,76 +1671,10 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
 
             if (fieldInfo.fldSize == 0)
             {
-                // Size of TYP_BLK, TYP_FUNC, TYP_VOID and TYP_STRUCT is zero.
-                // Early out if field type is other than TYP_STRUCT.
-                // This is a defensive check as we don't expect a struct to have
-                // fields of TYP_BLK, TYP_FUNC or TYP_VOID.
-                if (fieldInfo.fldType != TYP_STRUCT)
+                if (!CanPromoteStructField(fieldInfo))
                 {
                     return false;
                 }
-
-                // Non-primitive struct field.
-                // Try to promote structs of single field of scalar types aligned at their
-                // natural boundary.
-
-                // Do Not promote if the struct field in turn has more than one field.
-                if (compHandle->getClassNumInstanceFields(fieldInfo.fldTypeHnd) != 1)
-                {
-                    return false;
-                }
-
-                // Do not promote if the single field is not aligned at its natural boundary within
-                // the struct field.
-                CORINFO_FIELD_HANDLE fHnd    = compHandle->getFieldInClass(fieldInfo.fldTypeHnd, 0);
-                unsigned             fOffset = compHandle->getFieldOffset(fHnd);
-                if (fOffset != 0)
-                {
-                    return false;
-                }
-
-                CorInfoType fieldCorType = compHandle->getFieldType(fHnd);
-                var_types   fieldVarType = JITtype2varType(fieldCorType);
-                unsigned    fieldSize    = genTypeSize(fieldVarType);
-
-                // Do not promote if either not a primitive type or size equal to ptr size on
-                // target or a struct containing a single floating-point field.
-                //
-                // TODO-PERF: Structs containing a single floating-point field on Amd64
-                // needs to be passed in integer registers. Right now LSRA doesn't support
-                // passing of floating-point LCL_VARS in integer registers.  Enabling promotion
-                // of such structs results in an assert in lsra right now.
-                //
-                // TODO-PERF: Right now promotion is confined to struct containing a ptr sized
-                // field (int/uint/ref/byref on 32-bits and long/ulong/ref/byref on 64-bits).
-                // Though this would serve the purpose of promoting Span<T> containing ByReference<T>,
-                // this can be extended to other primitive types as long as they are aligned at their
-                // natural boundary.
-                if (fieldSize == 0 || fieldSize != TARGET_POINTER_SIZE || varTypeIsFloating(fieldVarType))
-                {
-                    JITDUMP("Promotion blocked: struct contains struct field with one field,"
-                            " but that field has invalid size or type");
-                    return false;
-                }
-
-                // Insist this wrapped field occupy all of its parent storage.
-                unsigned innerStructSize = compHandle->getClassSize(fieldInfo.fldTypeHnd);
-
-                if (fieldSize != innerStructSize)
-                {
-                    JITDUMP("Promotion blocked: struct contains struct field with one field,"
-                            " but that field is not the same size as its parent.");
-                    return false;
-                }
-
-                // Retype the field as the type of the single field of the struct.
-                // This is a hack that allows us to promote such fields before we support recursive struct promotion
-                // (tracked by #10019).
-                fieldInfo.fldType = fieldVarType;
-                fieldInfo.fldSize = fieldSize;
-#ifdef DEBUG
-                fakedFieldsMap.Set(fieldInfo.fldHnd, fieldInfo.fldType);
-#endif // DEBUG
             }
 
             if ((fieldInfo.fldOffset % fieldInfo.fldSize) != 0)
@@ -1822,6 +1756,95 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
         // We have already analized this type, return the memorized answer.
         return promotionInfoMap[typeHnd]->canPromote;
     }
+}
+
+//--------------------------------------------------------------------------------------------
+// CanPromoteStructField - checks that this struct's field is a struct that can be promoted as scalar type
+//   aligned at its natural boundary.
+//
+// Arguments:
+//   outerFieldInfo - information about the field in the outer struct.
+//
+// Return value:
+//   true if the intrenal struct can be promoted.
+//
+// Notes:
+//   it retypes outer field type and size with promoted type if succeed.
+//
+bool Compiler::StructPromotionHelper::CanPromoteStructField(lvaStructFieldInfo& outerFieldInfo)
+{
+
+    // Size of TYP_BLK, TYP_FUNC, TYP_VOID and TYP_STRUCT is zero.
+    // Early out if field type is other than TYP_STRUCT.
+    // This is a defensive check as we don't expect a struct to have
+    // fields of TYP_BLK, TYP_FUNC or TYP_VOID.
+    if (outerFieldInfo.fldType != TYP_STRUCT)
+    {
+        return false;
+    }
+
+    COMP_HANDLE compHandle = compiler->info.compCompHnd;
+
+    // Do Not promote if the struct field in turn has more than one field.
+    if (compHandle->getClassNumInstanceFields(outerFieldInfo.fldTypeHnd) != 1)
+    {
+        return false;
+    }
+
+    COMP_HANDLE compHandl = compiler->info.compCompHnd;
+
+    // Do not promote if the single field is not aligned at its natural boundary within
+    // the struct field.
+    CORINFO_FIELD_HANDLE internalFieldHndl   = compHandle->getFieldInClass(outerFieldInfo.fldTypeHnd, 0);
+    unsigned             internalFieldOffset = compHandle->getFieldOffset(internalFieldHndl);
+    if (internalFieldOffset != 0)
+    {
+        return false;
+    }
+
+    CorInfoType fieldCorType = compHandle->getFieldType(internalFieldHndl);
+    var_types   fieldVarType = JITtype2varType(fieldCorType);
+    unsigned    fieldSize    = genTypeSize(fieldVarType);
+
+    // Do not promote if either not a primitive type or size equal to ptr size on
+    // target or a struct containing a single floating-point field.
+    //
+    // TODO-PERF: Structs containing a single floating-point field on Amd64
+    // needs to be passed in integer registers. Right now LSRA doesn't support
+    // passing of floating-point LCL_VARS in integer registers.  Enabling promotion
+    // of such structs results in an assert in lsra right now.
+    //
+    // TODO-PERF: Right now promotion is confined to struct containing a ptr sized
+    // field (int/uint/ref/byref on 32-bits and long/ulong/ref/byref on 64-bits).
+    // Though this would serve the purpose of promoting Span<T> containing ByReference<T>,
+    // this can be extended to other primitive types as long as they are aligned at their
+    // natural boundary.
+    if (fieldSize == 0 || fieldSize != TARGET_POINTER_SIZE || varTypeIsFloating(fieldVarType))
+    {
+        JITDUMP("Promotion blocked: struct contains struct field with one field,"
+                " but that field has invalid size or type");
+        return false;
+    }
+
+    // Insist this wrapped field occupy all of its parent storage.
+    unsigned innerStructSize = compHandle->getClassSize(outerFieldInfo.fldTypeHnd);
+
+    if (fieldSize != innerStructSize)
+    {
+        JITDUMP("Promotion blocked: struct contains struct field with one field,"
+                " but that field is not the same size as its parent.");
+        return false;
+    }
+
+    // Retype the field as the type of the single field of the struct.
+    // This is a hack that allows us to promote such fields before we support recursive struct promotion
+    // (tracked by #10019).
+    outerFieldInfo.fldType = fieldVarType;
+    outerFieldInfo.fldSize = fieldSize;
+#ifdef DEBUG
+    fakedFieldsMap.Set(outerFieldInfo.fldHnd, outerFieldInfo.fldType);
+#endif // DEBUG
+    return true;
 }
 
 //--------------------------------------------------------------------------------------------

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1536,20 +1536,22 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPr
         structPromotionInfo->typeHnd    = typeHnd;
         structPromotionInfo->canPromote = false;
 
-        unsigned structSize = info.compCompHnd->getClassSize(typeHnd);
+        COMP_HANDLE compHandle = info.compCompHnd;
+
+        unsigned structSize = compHandle->getClassSize(typeHnd);
         if (structSize > MaxOffset)
         {
             return; // struct is too large
         }
 
-        unsigned fieldCnt = info.compCompHnd->getClassNumInstanceFields(typeHnd);
+        unsigned fieldCnt = compHandle->getClassNumInstanceFields(typeHnd);
         if (fieldCnt == 0 || fieldCnt > MAX_NumOfFieldsInPromotableStruct)
         {
             return; // struct must have between 1 and MAX_NumOfFieldsInPromotableStruct fields
         }
 
         structPromotionInfo->fieldCnt = (BYTE)fieldCnt;
-        DWORD typeFlags               = info.compCompHnd->getClassAttribs(typeHnd);
+        DWORD typeFlags               = compHandle->getClassAttribs(typeHnd);
 
         bool overlappingFields = StructHasOverlappingFields(typeFlags);
         if (overlappingFields)
@@ -1565,8 +1567,7 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPr
 
 #ifdef _TARGET_ARM_
         // On ARM, we have a requirement on the struct alignment; see below.
-        unsigned structAlignment =
-            roundUp(info.compCompHnd->getClassAlignmentRequirement(typeHnd), TARGET_POINTER_SIZE);
+        unsigned structAlignment = roundUp(compHandle->getClassAlignmentRequirement(typeHnd), TARGET_POINTER_SIZE);
 #endif // _TARGET_ARM_
 
         bool isHole[MaxOffset]; // isHole[] is initialized to true for every valid offset in the struct and false for
@@ -1580,8 +1581,8 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPr
         for (BYTE ordinal = 0; ordinal < fieldCnt; ++ordinal)
         {
             lvaStructFieldInfo* pFieldInfo = &structPromotionInfo->fields[ordinal];
-            pFieldInfo->fldHnd             = info.compCompHnd->getFieldInClass(typeHnd, ordinal);
-            unsigned fldOffset             = info.compCompHnd->getFieldOffset(pFieldInfo->fldHnd);
+            pFieldInfo->fldHnd             = compHandle->getFieldInClass(typeHnd, ordinal);
+            unsigned fldOffset             = compHandle->getFieldOffset(pFieldInfo->fldHnd);
 
             // The fldOffset value should never be larger than our structSize.
             if (fldOffset >= structSize)
@@ -1592,7 +1593,7 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPr
 
             pFieldInfo->fldOffset  = (BYTE)fldOffset;
             pFieldInfo->fldOrdinal = ordinal;
-            CorInfoType corType    = info.compCompHnd->getFieldType(pFieldInfo->fldHnd, &pFieldInfo->fldTypeHnd);
+            CorInfoType corType    = compHandle->getFieldType(pFieldInfo->fldHnd, &pFieldInfo->fldTypeHnd);
             pFieldInfo->fldType    = JITtype2varType(corType);
             pFieldInfo->fldSize    = genTypeSize(pFieldInfo->fldType);
 
@@ -1628,21 +1629,21 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPr
                 // natural boundary.
 
                 // Do Not promote if the struct field in turn has more than one field.
-                if (info.compCompHnd->getClassNumInstanceFields(pFieldInfo->fldTypeHnd) != 1)
+                if (compHandle->getClassNumInstanceFields(pFieldInfo->fldTypeHnd) != 1)
                 {
                     return;
                 }
 
                 // Do not promote if the single field is not aligned at its natural boundary within
                 // the struct field.
-                CORINFO_FIELD_HANDLE fHnd    = info.compCompHnd->getFieldInClass(pFieldInfo->fldTypeHnd, 0);
-                unsigned             fOffset = info.compCompHnd->getFieldOffset(fHnd);
+                CORINFO_FIELD_HANDLE fHnd    = compHandle->getFieldInClass(pFieldInfo->fldTypeHnd, 0);
+                unsigned             fOffset = compHandle->getFieldOffset(fHnd);
                 if (fOffset != 0)
                 {
                     return;
                 }
 
-                CorInfoType fieldCorType = info.compCompHnd->getFieldType(fHnd);
+                CorInfoType fieldCorType = compHandle->getFieldType(fHnd);
                 var_types   fieldVarType = JITtype2varType(fieldCorType);
                 unsigned    fieldSize    = genTypeSize(fieldVarType);
 
@@ -1667,7 +1668,7 @@ void Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPr
                 }
 
                 // Insist this wrapped field occupy all of its parent storage.
-                unsigned innerStructSize = info.compCompHnd->getClassSize(pFieldInfo->fldTypeHnd);
+                unsigned innerStructSize = compHandle->getClassSize(pFieldInfo->fldTypeHnd);
 
                 if (fieldSize != innerStructSize)
                 {

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1579,7 +1579,6 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
         bool customLayout       = false;
         bool containsGCpointers = false;
 
-        structPromotionInfo->typeHnd    = typeHnd;
         structPromotionInfo->canPromote = false;
 
         COMP_HANDLE compHandle = compiler->info.compCompHnd;
@@ -2006,7 +2005,6 @@ void Compiler::StructPromotionHelper::PromoteStructVar(unsigned                 
     assert(!varDsc->lvRegStruct);
 
     assert(structPromotionInfo->canPromote);
-    assert(structPromotionInfo->typeHnd == varDsc->lvVerTypeInfo.GetClassHandle());
 
     // structPromotionInfo is passed as arg to avoid this lookup in release.
     assert(GetStructPromotionInfo(lclNum) == structPromotionInfo);
@@ -2025,7 +2023,8 @@ void Compiler::StructPromotionHelper::PromoteStructVar(unsigned                 
 #ifdef DEBUG
     if (compiler->verbose)
     {
-        printf("\nPromoting struct local V%02u (%s):", lclNum, compiler->eeGetClassName(structPromotionInfo->typeHnd));
+        printf("\nPromoting struct local V%02u (%s):", lclNum,
+               compiler->eeGetClassName(varDsc->lvVerTypeInfo.GetClassHandle()));
     }
 #endif
 

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1479,6 +1479,10 @@ int __cdecl Compiler::lvaFieldOffsetCmp(const void* field1, const void* field2)
     }
 }
 
+Compiler::StructPromotionHelper::StructPromotionHelper()
+{
+}
+
 /*****************************************************************************
  * Is this type promotable? */
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17064,10 +17064,11 @@ void Compiler::fgPromoteStructs()
         }
         else if (varTypeIsStruct(varDsc))
         {
-            if (structPromotionHelper.CanPromoteStructVar(lclNum))
+            assert(structPromotionHelper != nullptr);
+            if (structPromotionHelper->CanPromoteStructVar(lclNum))
             {
                 // Make one hashtable lookup here to use its result in several places below.
-                lvaStructPromotionInfo* structPromotionInfo = structPromotionHelper.GetStructPromotionInfo(lclNum);
+                lvaStructPromotionInfo* structPromotionInfo = structPromotionHelper->GetStructPromotionInfo(lclNum);
 
 #if 0
                 // Often-useful debugging code: if you've narrowed down a struct-promotion problem to a single
@@ -17076,15 +17077,15 @@ void Compiler::fgPromoteStructs()
                 structPromoVarNum++;
                 if (atoi(getenv("structpromovarnumlo")) <= structPromoVarNum && structPromoVarNum <= atoi(getenv("structpromovarnumhi")))
 #endif // 0
-                if (structPromotionHelper.ShouldPromoteStructVar(lclNum, structPromotionInfo))
+                if (structPromotionHelper->ShouldPromoteStructVar(lclNum, structPromotionInfo))
                 {
                     if (!structPromotionInfo->fieldsSorted)
                     {
-                        structPromotionHelper.SortStructFields(structPromotionInfo);
+                        structPromotionHelper->SortStructFields(structPromotionInfo);
                     }
 
                     // Promote the this struct local var.
-                    structPromotionHelper.PromoteStructVar(lclNum, structPromotionInfo);
+                    structPromotionHelper->PromoteStructVar(lclNum, structPromotionInfo);
                     promotedVar = true;
                 }
             }
@@ -17099,7 +17100,7 @@ void Compiler::fgPromoteStructs()
     }
 
 #ifdef _TARGET_ARM_
-    if (structPromotionHelper.GetRequiresScratchVar())
+    if (structPromotionHelper->GetRequiresScratchVar())
     {
         // Ensure that the scratch variable is allocated, in case we
         // pass a promoted struct as an argument.

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17039,7 +17039,7 @@ void Compiler::fgPromoteStructs()
     // Loop through the original lvaTable. Looking for struct locals to be promoted.
     //
     lvaStructPromotionInfo structPromotionInfo;
-    bool                   tooManyLocals = false;
+    bool                   tooManyLocalsReported = false;
 
     for (unsigned lclNum = 0; lclNum < startLvaCount; lclNum++)
     {
@@ -17057,11 +17057,11 @@ void Compiler::fgPromoteStructs()
         else if (lvaHaveManyLocals())
         {
             // Print the message first time when we detected this condition
-            if (!tooManyLocals)
+            if (!tooManyLocalsReported)
             {
                 JITDUMP("Stopped promoting struct fields, due to too many locals.\n");
             }
-            tooManyLocals = true;
+            tooManyLocalsReported = true;
         }
         else if (varTypeIsStruct(varDsc))
         {

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17067,10 +17067,10 @@ void Compiler::fgPromoteStructs()
         {
             bool shouldPromote;
 
-            lvaCanPromoteStructVar(lclNum, &structPromotionInfo);
-            if (structPromotionInfo.canPromote)
+            if (structPromotionHelper.CanPromoteStructVar(lclNum))
             {
-                shouldPromote = lvaShouldPromoteStructVar(lclNum, &structPromotionInfo);
+                structPromotionInfo = structPromotionHelper.GetStructPromotionInfo(lclNum);
+                shouldPromote       = lvaShouldPromoteStructVar(lclNum, &structPromotionInfo);
             }
             else
             {

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17078,7 +17078,7 @@ void Compiler::fgPromoteStructs()
                 if (structPromotionHelper.ShouldPromoteStructVar(lclNum, structPromotionInfo))
                 {
                     // Promote the this struct local var.
-                    lvaPromoteStructVar(lclNum, structPromotionInfo);
+                    structPromotionHelper.PromoteStructVar(lclNum, structPromotionInfo);
                     promotedVar = true;
                 }
             }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17090,20 +17090,6 @@ void Compiler::fgPromoteStructs()
                 // Promote the this struct local var.
                 lvaPromoteStructVar(lclNum, &structPromotionInfo);
                 promotedVar = true;
-
-#ifdef _TARGET_ARM_
-                if (structPromotionInfo.requiresScratchVar)
-                {
-                    // Ensure that the scratch variable is allocated, in case we
-                    // pass a promoted struct as an argument.
-                    if (lvaPromotedStructAssemblyScratchVar == BAD_VAR_NUM)
-                    {
-                        lvaPromotedStructAssemblyScratchVar =
-                            lvaGrabTempWithImplicitUse(false DEBUGARG("promoted struct assembly scratch var."));
-                        lvaTable[lvaPromotedStructAssemblyScratchVar].lvType = TYP_I_IMPL;
-                    }
-                }
-#endif // _TARGET_ARM_
             }
         }
 
@@ -17114,6 +17100,20 @@ void Compiler::fgPromoteStructs()
             varDsc->lvRegStruct = true;
         }
     }
+
+#ifdef _TARGET_ARM_
+    if (structPromotionHelper.GetRequiresScratchVar())
+    {
+        // Ensure that the scratch variable is allocated, in case we
+        // pass a promoted struct as an argument.
+        if (lvaPromotedStructAssemblyScratchVar == BAD_VAR_NUM)
+        {
+            lvaPromotedStructAssemblyScratchVar =
+                lvaGrabTempWithImplicitUse(false DEBUGARG("promoted struct assembly scratch var."));
+            lvaTable[lvaPromotedStructAssemblyScratchVar].lvType = TYP_I_IMPL;
+        }
+    }
+#endif // _TARGET_ARM_
 
 #ifdef DEBUG
     if (verbose)

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17066,7 +17066,7 @@ void Compiler::fgPromoteStructs()
         {
             if (structPromotionHelper.CanPromoteStructVar(lclNum))
             {
-                lvaStructPromotionInfo structPromotionInfo = structPromotionHelper.GetStructPromotionInfo(lclNum);
+                lvaStructPromotionInfo* structPromotionInfo = structPromotionHelper.GetStructPromotionInfo(lclNum);
 
 #if 0
                 // Often-useful debugging code: if you've narrowed down a struct-promotion problem to a single
@@ -17076,10 +17076,10 @@ void Compiler::fgPromoteStructs()
                 if (atoi(getenv("structpromovarnumlo")) <= structPromoVarNum && structPromoVarNum <= atoi(getenv("structpromovarnumhi")))
 #endif // 0
 
-                if (lvaShouldPromoteStructVar(lclNum, &structPromotionInfo))
+                if (lvaShouldPromoteStructVar(lclNum, structPromotionInfo))
                 {
                     // Promote the this struct local var.
-                    lvaPromoteStructVar(lclNum, &structPromotionInfo);
+                    lvaPromoteStructVar(lclNum, structPromotionInfo);
                     promotedVar = true;
                 }
             }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17038,8 +17038,7 @@ void Compiler::fgPromoteStructs()
     //
     // Loop through the original lvaTable. Looking for struct locals to be promoted.
     //
-    lvaStructPromotionInfo structPromotionInfo;
-    bool                   tooManyLocalsReported = false;
+    bool tooManyLocalsReported = false;
 
     for (unsigned lclNum = 0; lclNum < startLvaCount; lclNum++)
     {
@@ -17067,7 +17066,7 @@ void Compiler::fgPromoteStructs()
         {
             if (structPromotionHelper.CanPromoteStructVar(lclNum))
             {
-                structPromotionInfo = structPromotionHelper.GetStructPromotionInfo(lclNum);
+                lvaStructPromotionInfo structPromotionInfo = structPromotionHelper.GetStructPromotionInfo(lclNum);
 
 #if 0
                 // Often-useful debugging code: if you've narrowed down a struct-promotion problem to a single

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17078,6 +17078,11 @@ void Compiler::fgPromoteStructs()
 #endif // 0
                 if (structPromotionHelper.ShouldPromoteStructVar(lclNum, structPromotionInfo))
                 {
+                    if (!structPromotionInfo->fieldsSorted)
+                    {
+                        structPromotionHelper.SortStructFields(structPromotionInfo);
+                    }
+
                     // Promote the this struct local var.
                     structPromotionHelper.PromoteStructVar(lclNum, structPromotionInfo);
                     promotedVar = true;

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17171,7 +17171,7 @@ void Compiler::fgMorphStructField(GenTree* tree, GenTree* parent)
                     // constant, then it is interpreted as init-block incorrectly.
                     //
                     // TODO - This can also be avoided if we implement recursive struct
-                    // promotion.
+                    // promotion, tracked by #10019.
                     if (varTypeIsStruct(parent) && parent->gtOp.gtOp2 == tree && !varTypeIsStruct(tree))
                     {
                         tree->gtFlags |= GTF_DONT_CSE;

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17075,8 +17075,7 @@ void Compiler::fgPromoteStructs()
                 structPromoVarNum++;
                 if (atoi(getenv("structpromovarnumlo")) <= structPromoVarNum && structPromoVarNum <= atoi(getenv("structpromovarnumhi")))
 #endif // 0
-
-                if (lvaShouldPromoteStructVar(lclNum, structPromotionInfo))
+                if (structPromotionHelper.ShouldPromoteStructVar(lclNum, structPromotionInfo))
                 {
                     // Promote the this struct local var.
                     lvaPromoteStructVar(lclNum, structPromotionInfo);

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17134,8 +17134,8 @@ void Compiler::fgMorphStructField(GenTree* tree, GenTree* parent)
 
     if ((obj != nullptr) && (obj->gtOper == GT_LCL_VAR))
     {
-        unsigned   lclNum = obj->gtLclVarCommon.gtLclNum;
-        LclVarDsc* varDsc = &lvaTable[lclNum];
+        unsigned         lclNum = obj->gtLclVarCommon.gtLclNum;
+        const LclVarDsc* varDsc = &lvaTable[lclNum];
 
         if (varTypeIsStruct(obj))
         {

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17065,31 +17065,24 @@ void Compiler::fgPromoteStructs()
         }
         else if (varTypeIsStruct(varDsc))
         {
-            bool shouldPromote;
-
             if (structPromotionHelper.CanPromoteStructVar(lclNum))
             {
                 structPromotionInfo = structPromotionHelper.GetStructPromotionInfo(lclNum);
-                shouldPromote       = lvaShouldPromoteStructVar(lclNum, &structPromotionInfo);
-            }
-            else
-            {
-                shouldPromote = false;
-            }
 
 #if 0
-            // Often-useful debugging code: if you've narrowed down a struct-promotion problem to a single
-            // method, this allows you to select a subset of the vars to promote (by 1-based ordinal number).
-            static int structPromoVarNum = 0;
-            structPromoVarNum++;
-            if (atoi(getenv("structpromovarnumlo")) <= structPromoVarNum && structPromoVarNum <= atoi(getenv("structpromovarnumhi")))
+                // Often-useful debugging code: if you've narrowed down a struct-promotion problem to a single
+                // method, this allows you to select a subset of the vars to promote (by 1-based ordinal number).
+                static int structPromoVarNum = 0;
+                structPromoVarNum++;
+                if (atoi(getenv("structpromovarnumlo")) <= structPromoVarNum && structPromoVarNum <= atoi(getenv("structpromovarnumhi")))
 #endif // 0
 
-            if (shouldPromote)
-            {
-                // Promote the this struct local var.
-                lvaPromoteStructVar(lclNum, &structPromotionInfo);
-                promotedVar = true;
+                if (lvaShouldPromoteStructVar(lclNum, &structPromotionInfo))
+                {
+                    // Promote the this struct local var.
+                    lvaPromoteStructVar(lclNum, &structPromotionInfo);
+                    promotedVar = true;
+                }
             }
         }
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17066,6 +17066,7 @@ void Compiler::fgPromoteStructs()
         {
             if (structPromotionHelper.CanPromoteStructVar(lclNum))
             {
+                // Make one hashtable lookup here to use its result in several places below.
                 lvaStructPromotionInfo* structPromotionInfo = structPromotionHelper.GetStructPromotionInfo(lclNum);
 
 #if 0


### PR DESCRIPTION
b123a032d2: Create StructPromotionHelper.

it will replace lvaStructPromotionInfo and methods that use it.

a46fe02358: Move requiresScratchVar from individual lvaStructPromotionInfo to global StructPromotionHelper.

It allows to make lvaStructPromotionInfo smaller and extract the check from the loop.

2e39cb9d09: Create a local variable for `compHandle` in `lvaCanPromoteStructType`.

e67b50cb83: Return result from `lvaCanPromoteStructType` as bool return value.

f1ea38fa97: Replace `lvaCanPromoteStructType` with `structPromotionHelper.CanPromoteStructType`.

Makes `lvaStructPromotionInfo` available globally that will be used later.

Also, it allows to memorize all analyzed struct types and does not waste type analyzing them again. Before we memorized only one previous type.

69bb1587a1: Return result from `lvaCanPromoteStructVar` as bool return value.

7e06402f96: Replace `lvaCanPromoteStructVar` with `structPromotionHelper.CanPromoteStructVar`.

Note: this change makes `lvaStructPromotionInfo` type specific before it was used both for variables and types.

01d3612df6: Get rid of `bool shouldPromote;`  in `fgPromoteStructs`.

It makes codes straightforward and shows that we do not use `structPromotionInfo` before we initialize it.

595bf4be9d: Rename `tooManyLocals` to `tooManyLocalsReported`.

d4a108d971: Move `structPromotionInfo` declaration inside the loop.

We do not use it to memorize the previous iteration anymore, it was delegated to `structPromotionHelper`.

1c9eb325e5: Initialize all fields in `lvaStructPromotionInfo` constructor.

It makes debugging easier.

251788650c: change `StructPromotionInfoForTypeHndMap` to store pointers.

It works better when we need to sort fields.

023b16d1a5: Replace `lvaShouldPromoteStructVar` with `StructPromotionHelper::ShouldPromoteStructVar`.

47357c5cd2: Replace `lvaPromoteStructVar` with `StructPromotionHelper::PromoteStructVar`.

51c45a4bd5: Replace `noway_assert` with plain `assert` in StructPromotionHelper.

The checks are straightforward now, so we can relax these asserts.
For example, `PromoteStructVar` is called only in one place under `CanPromoteStructVar` and `ShouldPromoteStructVar` conditions.

7fdf513769: Delete `typeHnd` from `lvaStructPromotionInfo`.

This field is no longer needed. Save space.

2fb5ba9526: Add some comments.

d2f8abbf6e: Delete unused local vars in `StructPromotionHelper::CanPromoteStructType`.

645483ab0e: Extract `StructPromotionHelper::SortFields`.

We need fields to be sorted only when we actually promote struct, so do not waste time when we reject it because `ShouldPromoteStructVar` says `No` or when we ask for inlining.

6c14d1304e: Optimize setting of `structPromotionInfo->containsHoles`.

Use the fact that we have already rejected structs with overlapping fields and can just check sum of fields sizes match structSize.

15207ef326: Use reference instead of pointer for `lvaStructFieldInfo` in `CanPromoteStructType`.

51094b1614: Refactor one `noway_assert` in `CanPromoteStructType`.

2fee16b7fa: Extract `GetFieldInfo`.

90c25b0316: Keep `structPromotionHelper` as pointer in `Compiler`.

Allows us to move `StructPromotionHelper`, `lvaStructFieldInfo` and `lvaStructPromotionInfo` out of `compiler.h` once we create its own header for it.

50f1dc150b: Change `lvaGetFieldLocal` argument to be const.

1d7d11bf3a: Add an additional comments.

a31fdb44fd: Add the check for promoted fields with changed type.

`CanPromoteStructType` can fake a field type if the field type is "structs of a single field of scalar types aligned at their natural boundary.". Add a check in debug that when we morph struct field access we have an expected type in the field handle.

7ce8784448: Extract `CanPromoteStructField` from `CanPromoteStructType`.

