### PR TITLE
Fix test for GT_INDEX_ADDR to forcibly compile with minopts

### DIFF
--- a/tests/src/JIT/Regression/JitBlue/GitHub_20040/GitHub_20040.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_20040/GitHub_20040.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 
 // GitHub 20040: operand ordering bug with GT_INDEX_ADDR
 // Requires minopts/tier0 to repro
@@ -48,6 +49,7 @@ namespace GitHub_20040
             return currentBuffer;
         }
 
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         public byte ReadByte()
         {
             int offset;


### PR DESCRIPTION
Update test introduced in #20047 so that the key method `ReadByte` is compiled
with minopts by default.