### PR TITLE
Refactoring of struct promotion code for the future fix.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2987,7 +2987,7 @@ public:
     };
 
     static int __cdecl lvaFieldOffsetCmp(const void* field1, const void* field2);
-    void lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPromotionInfo* structPromotionInfo);
+    bool lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPromotionInfo* structPromotionInfo);
     void lvaCanPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* structPromotionInfo);
 
     // This class is responsible for checking possibility and profitability of struct promotion.

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3016,6 +3016,9 @@ public:
         void PromoteStructVar(unsigned lclNum);
         void SortStructFields();
 
+        lvaStructFieldInfo GetFieldInfo(CORINFO_FIELD_HANDLE fieldHnd, BYTE ordinal);
+        bool TryPromoteStructField(lvaStructFieldInfo& outerFieldInfo);
+
     private:
         Compiler*              compiler;
         lvaStructPromotionInfo structPromotionInfo;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3007,6 +3007,7 @@ public:
     private:
         bool CanPromoteStructVar(unsigned lclNum);
         bool ShouldPromoteStructVar(unsigned lclNum);
+        void PromoteStructVar(unsigned lclNum);
 
     private:
         Compiler*              compiler;
@@ -3019,7 +3020,6 @@ public:
 
     StructPromotionHelper* structPromotionHelper;
 
-    void lvaPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* structPromotionInfo);
 #if !defined(_TARGET_64BIT_)
     void lvaPromoteLongVars();
 #endif // !defined(_TARGET_64BIT_)

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2974,7 +2974,7 @@ public:
         }
     };
 
-    // Info about struct type to be promoted.
+    // Info about a struct type, instances of which may be candidates for promotion.
     struct lvaStructPromotionInfo
     {
         CORINFO_CLASS_HANDLE typeHnd;
@@ -2998,9 +2998,9 @@ public:
 
     static int __cdecl lvaFieldOffsetCmp(const void* field1, const void* field2);
 
-    // This class is responsible for checking possibility and profitability of struct promotion.
-    // If the both checks pass than it promotes struct and initializes nessesary information for fgMorphStructField to
-    // use.
+    // This class is responsible for checking validity and profitability of struct promotion.
+    // If it is both legal and profitable, then TryPromoteStructVar promotes the struct and initializesinitializes
+    // nessesary information for fgMorphStructField to use.
     class StructPromotionHelper
     {
     public:

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2976,11 +2976,17 @@ public:
         bool                 canPromote;
         bool                 containsHoles;
         bool                 customLayout;
+        bool                 fieldsSorted;
         unsigned char        fieldCnt;
         lvaStructFieldInfo   fields[MAX_NumOfFieldsInPromotableStruct];
 
         lvaStructPromotionInfo(CORINFO_CLASS_HANDLE typeHnd = nullptr)
-            : typeHnd(typeHnd), canPromote(false), containsHoles(false), customLayout(false), fieldCnt(0)
+            : typeHnd(typeHnd)
+            , canPromote(false)
+            , containsHoles(false)
+            , customLayout(false)
+            , fieldsSorted(false)
+            , fieldCnt(0)
         {
             memset(fields, 0, sizeof(fields));
         }
@@ -3008,6 +3014,7 @@ public:
         bool CanPromoteStructVar(unsigned lclNum);
         bool ShouldPromoteStructVar(unsigned lclNum);
         void PromoteStructVar(unsigned lclNum);
+        void SortStructFields();
 
     private:
         Compiler*              compiler;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2999,7 +2999,7 @@ public:
     static int __cdecl lvaFieldOffsetCmp(const void* field1, const void* field2);
 
     // This class is responsible for checking validity and profitability of struct promotion.
-    // If it is both legal and profitable, then TryPromoteStructVar promotes the struct and initializesinitializes
+    // If it is both legal and profitable, then TryPromoteStructVar promotes the struct and initializes
     // nessesary information for fgMorphStructField to use.
     class StructPromotionHelper
     {

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3002,7 +3002,8 @@ public:
         bool TryPromoteStructVar(unsigned lclNum);
 
     private:
-        Compiler* compiler;
+        Compiler*              compiler;
+        lvaStructPromotionInfo structPromotionInfo;
     };
 
     StructPromotionHelper* structPromotionHelper;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2974,14 +2974,12 @@ public:
     {
         CORINFO_CLASS_HANDLE typeHnd;
         bool                 canPromote;
-        bool                 requiresScratchVar;
         bool                 containsHoles;
         bool                 customLayout;
         unsigned char        fieldCnt;
         lvaStructFieldInfo   fields[MAX_NumOfFieldsInPromotableStruct];
 
-        lvaStructPromotionInfo()
-            : typeHnd(nullptr), canPromote(false), requiresScratchVar(false), containsHoles(false), customLayout(false)
+        lvaStructPromotionInfo() : typeHnd(nullptr), canPromote(false), containsHoles(false), customLayout(false)
         {
         }
     };
@@ -3000,12 +2998,21 @@ public:
         bool CanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd);
         bool TryPromoteStructVar(unsigned lclNum);
 
+#ifdef _TARGET_ARM_
+        bool GetRequiresScratchVar();
+        void SetRequiresScratchVar();
+#endif // _TARGET_ARM_
+
     private:
         bool CanPromoteStructVar(unsigned lclNum);
 
     private:
         Compiler*              compiler;
         lvaStructPromotionInfo structPromotionInfo;
+
+#ifdef _TARGET_ARM_
+        bool requiresScratchVar;
+#endif // _TARGET_ARM_
     };
 
     StructPromotionHelper* structPromotionHelper;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3006,6 +3006,7 @@ public:
 
     private:
         bool CanPromoteStructVar(unsigned lclNum);
+        bool ShouldPromoteStructVar(unsigned lclNum);
 
     private:
         Compiler*              compiler;
@@ -3018,7 +3019,6 @@ public:
 
     StructPromotionHelper* structPromotionHelper;
 
-    bool lvaShouldPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* structPromotionInfo);
     void lvaPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* structPromotionInfo);
 #if !defined(_TARGET_64BIT_)
     void lvaPromoteLongVars();

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2990,6 +2990,23 @@ public:
     void lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPromotionInfo* structPromotionInfo);
     void lvaCanPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* structPromotionInfo);
 
+    // This class is responsible for checking possibility and profitability of struct promotion.
+    // If the both checks pass than it promotes struct and initializes nessesary information for fgMorphStructField to
+    // use.
+    class StructPromotionHelper
+    {
+    public:
+        StructPromotionHelper(Compiler* compiler);
+
+        bool CanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd);
+        bool TryPromoteStructVar(unsigned lclNum);
+
+    private:
+        Compiler* compiler;
+    };
+
+    StructPromotionHelper* structPromotionHelper;
+
     bool lvaShouldPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* structPromotionInfo);
     void lvaPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* structPromotionInfo);
 #if !defined(_TARGET_64BIT_)

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2958,7 +2958,7 @@ public:
 
 #define MAX_NumOfFieldsInPromotableStruct 4 // Maximum number of fields in promotable struct
 
-    // Info about struct fields
+    // Info about struct type fields.
     struct lvaStructFieldInfo
     {
         CORINFO_FIELD_HANDLE fldHnd;
@@ -2969,7 +2969,7 @@ public:
         CORINFO_CLASS_HANDLE fldTypeHnd;
     };
 
-    // Info about struct to be promoted.
+    // Info about struct type to be promoted.
     struct lvaStructPromotionInfo
     {
         CORINFO_CLASS_HANDLE typeHnd;
@@ -2988,7 +2988,6 @@ public:
 
     static int __cdecl lvaFieldOffsetCmp(const void* field1, const void* field2);
     bool lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPromotionInfo* structPromotionInfo);
-    bool lvaCanPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* structPromotionInfo);
 
     // This class is responsible for checking possibility and profitability of struct promotion.
     // If the both checks pass than it promotes struct and initializes nessesary information for fgMorphStructField to
@@ -3000,6 +2999,9 @@ public:
 
         bool CanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd);
         bool TryPromoteStructVar(unsigned lclNum);
+
+    private:
+        bool CanPromoteStructVar(unsigned lclNum);
 
     private:
         Compiler*              compiler;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2979,13 +2979,14 @@ public:
         unsigned char        fieldCnt;
         lvaStructFieldInfo   fields[MAX_NumOfFieldsInPromotableStruct];
 
-        lvaStructPromotionInfo() : typeHnd(nullptr), canPromote(false), containsHoles(false), customLayout(false)
+        lvaStructPromotionInfo(CORINFO_CLASS_HANDLE typeHnd = nullptr)
+            : typeHnd(typeHnd), canPromote(false), containsHoles(false), customLayout(false), fieldCnt(0)
         {
+            memset(fields, 0, sizeof(fields));
         }
     };
 
     static int __cdecl lvaFieldOffsetCmp(const void* field1, const void* field2);
-    bool lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPromotionInfo* structPromotionInfo);
 
     // This class is responsible for checking possibility and profitability of struct promotion.
     // If the both checks pass than it promotes struct and initializes nessesary information for fgMorphStructField to

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3010,7 +3010,7 @@ public:
         bool TryPromoteStructVar(unsigned lclNum);
 
 #ifdef DEBUG
-        void CheckFakedType(CORINFO_FIELD_HANDLE fieldHnd, var_types requestedType);
+        void CheckRetypedAsScalar(CORINFO_FIELD_HANDLE fieldHnd, var_types requestedType);
 #endif // DEBUG
 
 #ifdef _TARGET_ARM_
@@ -3035,8 +3035,9 @@ public:
 #endif // _TARGET_ARM_
 
 #ifdef DEBUG
-        typedef JitHashTable<CORINFO_FIELD_HANDLE, JitPtrKeyFuncs<CORINFO_FIELD_STRUCT_>, var_types> FakedFieldsMap;
-        FakedFieldsMap fakedFieldsMap;
+        typedef JitHashTable<CORINFO_FIELD_HANDLE, JitPtrKeyFuncs<CORINFO_FIELD_STRUCT_>, var_types>
+                                 RetypedAsScalarFieldsMap;
+        RetypedAsScalarFieldsMap retypedFieldsMap;
 #endif // DEBUG
     };
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3030,7 +3030,7 @@ public:
 #if !defined(_TARGET_64BIT_)
     void lvaPromoteLongVars();
 #endif // !defined(_TARGET_64BIT_)
-    unsigned lvaGetFieldLocal(LclVarDsc* varDsc, unsigned int fldOffset);
+    unsigned lvaGetFieldLocal(const LclVarDsc* varDsc, unsigned int fldOffset);
     lvaPromotionType lvaGetPromotionType(const LclVarDsc* varDsc);
     lvaPromotionType lvaGetPromotionType(unsigned varNum);
     lvaPromotionType lvaGetParentPromotionType(const LclVarDsc* varDsc);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2988,7 +2988,7 @@ public:
 
     static int __cdecl lvaFieldOffsetCmp(const void* field1, const void* field2);
     bool lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPromotionInfo* structPromotionInfo);
-    void lvaCanPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* structPromotionInfo);
+    bool lvaCanPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* structPromotionInfo);
 
     // This class is responsible for checking possibility and profitability of struct promotion.
     // If the both checks pass than it promotes struct and initializes nessesary information for fgMorphStructField to

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2967,6 +2967,11 @@ public:
         var_types            fldType;
         unsigned             fldSize;
         CORINFO_CLASS_HANDLE fldTypeHnd;
+
+        lvaStructFieldInfo()
+            : fldHnd(nullptr), fldOffset(0), fldOrdinal(0), fldType(TYP_UNDEF), fldSize(0), fldTypeHnd(nullptr)
+        {
+        }
     };
 
     // Info about struct type to be promoted.
@@ -2988,7 +2993,6 @@ public:
             , fieldsSorted(false)
             , fieldCnt(0)
         {
-            memset(fields, 0, sizeof(fields));
         }
     };
 
@@ -3011,7 +3015,6 @@ public:
 
 #ifdef _TARGET_ARM_
         bool GetRequiresScratchVar();
-        void SetRequiresScratchVar();
 #endif // _TARGET_ARM_
 
     private:

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3005,6 +3005,10 @@ public:
         bool CanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd);
         bool TryPromoteStructVar(unsigned lclNum);
 
+#ifdef DEBUG
+        void CheckFakedType(CORINFO_FIELD_HANDLE fieldHnd, var_types requestedType);
+#endif // DEBUG
+
 #ifdef _TARGET_ARM_
         bool GetRequiresScratchVar();
         void SetRequiresScratchVar();
@@ -3026,6 +3030,11 @@ public:
 #ifdef _TARGET_ARM_
         bool requiresScratchVar;
 #endif // _TARGET_ARM_
+
+#ifdef DEBUG
+        typedef JitHashTable<CORINFO_FIELD_HANDLE, JitPtrKeyFuncs<CORINFO_FIELD_STRUCT_>, var_types> FakedFieldsMap;
+        FakedFieldsMap fakedFieldsMap;
+#endif // DEBUG
     };
 
     StructPromotionHelper* structPromotionHelper;

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -17742,9 +17742,8 @@ void Compiler::impMakeDiscretionaryInlineObservations(InlineInfo* pInlineInfo, I
     // Note if the callee's class is a promotable struct
     if ((info.compClassAttr & CORINFO_FLG_VALUECLASS) != 0)
     {
-        lvaStructPromotionInfo structPromotionInfo;
-        lvaCanPromoteStructType(info.compClassHnd, &structPromotionInfo);
-        if (structPromotionInfo.canPromote)
+        assert(structPromotionHelper != nullptr);
+        if (structPromotionHelper->CanPromoteStructType(info.compClassHnd))
         {
             inlineResult->Note(InlineObservation::CALLEE_CLASS_PROMOTABLE);
         }

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1842,7 +1842,7 @@ bool Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd, lvaStructPr
 /*****************************************************************************
  * Is this struct type local variable promotable? */
 
-void Compiler::lvaCanPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* structPromotionInfo)
+bool Compiler::lvaCanPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* structPromotionInfo)
 {
     noway_assert(lclNum < lvaCount);
 
@@ -1858,7 +1858,7 @@ void Compiler::lvaCanPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* s
     {
         JITDUMP("  struct promotion of V%02u is disabled because lvIsUsedInSIMDIntrinsic()\n", lclNum);
         structPromotionInfo->canPromote = false;
-        return;
+        return false;
     }
 
     // Reject struct promotion of parameters when -GS stack reordering is enabled
@@ -1867,7 +1867,7 @@ void Compiler::lvaCanPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* s
     {
         JITDUMP("  struct promotion of V%02u is disabled because lvIsParam and compGSReorderStackLayout\n", lclNum);
         structPromotionInfo->canPromote = false;
-        return;
+        return false;
     }
 
     // Explicitly check for HFA reg args and reject them for promotion here.
@@ -1879,7 +1879,7 @@ void Compiler::lvaCanPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* s
     {
         JITDUMP("  struct promotion of V%02u is disabled because lvIsHfaRegArg()\n", lclNum);
         structPromotionInfo->canPromote = false;
-        return;
+        return false;
     }
 
 #if !FEATURE_MULTIREG_STRUCT_PROMOTE
@@ -1887,7 +1887,7 @@ void Compiler::lvaCanPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* s
     {
         JITDUMP("  struct promotion of V%02u is disabled because lvIsMultiRegArg\n", lclNum);
         structPromotionInfo->canPromote = false;
-        return;
+        return false;
     }
 #endif
 
@@ -1895,11 +1895,13 @@ void Compiler::lvaCanPromoteStructVar(unsigned lclNum, lvaStructPromotionInfo* s
     {
         JITDUMP("  struct promotion of V%02u is disabled because lvIsMultiRegRet\n", lclNum);
         structPromotionInfo->canPromote = false;
-        return;
+        return false;
     }
 
     CORINFO_CLASS_HANDLE typeHnd = varDsc->lvVerTypeInfo.GetClassHandle();
-    lvaCanPromoteStructType(typeHnd, structPromotionInfo);
+    bool                 result  = lvaCanPromoteStructType(typeHnd, structPromotionInfo);
+    assert(result == structPromotionInfo->canPromote);
+    return result;
 }
 
 //--------------------------------------------------------------------------------------------

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1577,8 +1577,6 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
         assert((BYTE)MAX_NumOfFieldsInPromotableStruct ==
                MAX_NumOfFieldsInPromotableStruct); // because lvaStructFieldInfo.fieldCnt is byte-sized
 
-        bool containsHoles      = false;
-        bool customLayout       = false;
         bool containsGCpointers = false;
 
         COMP_HANDLE compHandle = compiler->info.compCompHnd;
@@ -1781,7 +1779,7 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
         //
         if (StructHasCustomLayout(typeFlags) && ((typeFlags & CORINFO_FLG_CONTAINS_GC_PTR) == 0))
         {
-            customLayout = true;
+            structPromotionInfo.customLayout = true;
         }
 
         // Check if this promoted struct contains any holes
@@ -1790,15 +1788,13 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
         {
             if (isHole[i])
             {
-                containsHoles = true;
+                structPromotionInfo.containsHoles = true;
                 break;
             }
         }
 
         // Cool, this struct is promotable.
-        structPromotionInfo.canPromote    = true;
-        structPromotionInfo.containsHoles = containsHoles;
-        structPromotionInfo.customLayout  = customLayout;
+        structPromotionInfo.canPromote = true;
 
         // Sort the fields according to the increasing order of the field offset.
         // This is needed because the fields need to be pushed on stack (when referenced

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1488,7 +1488,7 @@ Compiler::StructPromotionHelper::StructPromotionHelper(Compiler* compiler)
     , requiresScratchVar(false)
 #endif // _TARGET_ARM_
 #ifdef DEBUG
-    , fakedFieldsMap(compiler->getAllocator(CMK_DebugOnly))
+    , retypedFieldsMap(compiler->getAllocator(CMK_DebugOnly))
 #endif // DEBUG
 {
 }
@@ -1538,7 +1538,7 @@ bool Compiler::StructPromotionHelper::TryPromoteStructVar(unsigned lclNum)
 
 #ifdef DEBUG
 //--------------------------------------------------------------------------------------------
-// CheckFakedType - check that the fldType for this fieldHnd was retyped as requested type.
+// CheckRetypedAsScalar - check that the fldType for this fieldHnd was retyped as requested type.
 //
 // Arguments:
 //   fieldHnd      - the field handler;
@@ -1550,10 +1550,10 @@ bool Compiler::StructPromotionHelper::TryPromoteStructVar(unsigned lclNum)
 //   "GT_FIELD struct A.B -> ADDR -> LCL_VAR A" can be promoted to "LCL_VAR long A.B" and then
 //   there is type mistmatch between "GT_FIELD struct B.c" and  "LCL_VAR long A.B".
 //
-void Compiler::StructPromotionHelper::CheckFakedType(CORINFO_FIELD_HANDLE fieldHnd, var_types requestedType)
+void Compiler::StructPromotionHelper::CheckRetypedAsScalar(CORINFO_FIELD_HANDLE fieldHnd, var_types requestedType)
 {
-    assert(fakedFieldsMap.Lookup(fieldHnd));
-    assert(fakedFieldsMap[fieldHnd] == requestedType);
+    assert(retypedFieldsMap.Lookup(fieldHnd));
+    assert(retypedFieldsMap[fieldHnd] == requestedType);
 }
 #endif // DEBUG
 
@@ -1946,7 +1946,7 @@ Compiler::lvaStructFieldInfo Compiler::StructPromotionHelper::GetFieldInfo(CORIN
             fieldInfo.fldType = compiler->getSIMDTypeForSize(simdSize);
             fieldInfo.fldSize = simdSize;
 #ifdef DEBUG
-            fakedFieldsMap.Set(fieldInfo.fldHnd, fieldInfo.fldType);
+            retypedFieldsMap.Set(fieldInfo.fldHnd, fieldInfo.fldType);
 #endif // DEBUG
         }
     }
@@ -2043,7 +2043,7 @@ bool Compiler::StructPromotionHelper::TryPromoteStructField(lvaStructFieldInfo& 
     fieldInfo.fldType = fieldVarType;
     fieldInfo.fldSize = fieldSize;
 #ifdef DEBUG
-    fakedFieldsMap.Set(fieldInfo.fldHnd, fieldInfo.fldType);
+    retypedFieldsMap.Set(fieldInfo.fldHnd, fieldInfo.fldType);
 #endif // DEBUG
     return true;
 }

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -79,6 +79,8 @@ void Compiler::lvaInit()
     lvaSIMDInitTempVarNum = BAD_VAR_NUM;
 #endif // FEATURE_SIMD
     lvaCurEpoch = 0;
+
+    structPromotionHelper = new (this, CMK_Unknown) StructPromotionHelper(this);
 }
 
 /*****************************************************************************/
@@ -1477,6 +1479,47 @@ int __cdecl Compiler::lvaFieldOffsetCmp(const void* field1, const void* field2)
     {
         return (pFieldInfo1->fldOffset > pFieldInfo2->fldOffset) ? +1 : -1;
     }
+}
+
+Compiler::StructPromotionHelper::StructPromotionHelper(Compiler* compiler) : compiler(compiler)
+{
+}
+
+//--------------------------------------------------------------------------------------------
+// CanPromoteStructType - checks if the struct type can be promoted.
+//
+// Arguments:
+//   typeHnd - struct handle to check.
+//
+// Return value:
+//   true if the struct type can be promoted.
+//
+// Notes:
+//   The last analyzed type is memorized to skip the check if we ask about the same time again next.
+//   However, it was not found profitable to memorize all analyzed types in a map.
+//
+//   The check initializes only nessasary fields in lvaStructPromotionInfo,
+//   so if the promotion is rejected early than the most fields will be uninitialized.
+//
+bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd)
+{
+    NYI("Will be implemented later.");
+    return false;
+}
+
+//--------------------------------------------------------------------------------------------
+// TryPromoteStructVar - promote struct var if it is possible and profitable.
+//
+// Arguments:
+//   lclNum - struct number to try.
+//
+// Return value:
+//   true if the struct var was promoted.
+//
+bool Compiler::StructPromotionHelper::TryPromoteStructVar(unsigned lclNum)
+{
+    NYI("Will be implemented later.");
+    return false;
 }
 
 /*****************************************************************************

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1629,12 +1629,7 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
             pFieldInfo->fldHnd             = compHandle->getFieldInClass(typeHnd, ordinal);
             unsigned fldOffset             = compHandle->getFieldOffset(pFieldInfo->fldHnd);
 
-            // The fldOffset value should never be larger than our structSize.
-            if (fldOffset >= structSize)
-            {
-                noway_assert(false);
-                return false;
-            }
+            noway_assert(fldOffset < structSize);
 
             pFieldInfo->fldOffset  = (BYTE)fldOffset;
             pFieldInfo->fldOrdinal = ordinal;

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -2184,7 +2184,7 @@ void Compiler::lvaPromoteLongVars()
    that represents this field.
 */
 
-unsigned Compiler::lvaGetFieldLocal(LclVarDsc* varDsc, unsigned int fldOffset)
+unsigned Compiler::lvaGetFieldLocal(const LclVarDsc* varDsc, unsigned int fldOffset)
 {
     noway_assert(varTypeIsStruct(varDsc));
     noway_assert(varDsc->lvPromoted);

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1515,30 +1515,21 @@ void Compiler::StructPromotionHelper::SetRequiresScratchVar()
 //
 bool Compiler::StructPromotionHelper::TryPromoteStructVar(unsigned lclNum)
 {
-    bool shouldPromote;
-
     if (CanPromoteStructVar(lclNum))
     {
-        shouldPromote = compiler->lvaShouldPromoteStructVar(lclNum, &structPromotionInfo);
-    }
-    else
-    {
-        shouldPromote = false;
-    }
-
 #if 0
-    // Often-useful debugging code: if you've narrowed down a struct-promotion problem to a single
-    // method, this allows you to select a subset of the vars to promote (by 1-based ordinal number).
-    static int structPromoVarNum = 0;
-    structPromoVarNum++;
-    if (atoi(getenv("structpromovarnumlo")) <= structPromoVarNum && structPromoVarNum <= atoi(getenv("structpromovarnumhi")))
+            // Often-useful debugging code: if you've narrowed down a struct-promotion problem to a single
+            // method, this allows you to select a subset of the vars to promote (by 1-based ordinal number).
+            static int structPromoVarNum = 0;
+            structPromoVarNum++;
+            if (atoi(getenv("structpromovarnumlo")) <= structPromoVarNum && structPromoVarNum <= atoi(getenv("structpromovarnumhi")))
 #endif // 0
-
-    if (shouldPromote)
-    {
-        // Promote the this struct local var.
-        compiler->lvaPromoteStructVar(lclNum, &structPromotionInfo);
-        return true;
+        if (compiler->lvaShouldPromoteStructVar(lclNum, &structPromotionInfo))
+        {
+            // Promote the this struct local var.
+            compiler->lvaPromoteStructVar(lclNum, &structPromotionInfo);
+            return true;
+        }
     }
     return false;
 }

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1460,12 +1460,17 @@ CORINFO_CLASS_HANDLE Compiler::lvaGetStruct(unsigned varNum)
     return varDsc->lvVerTypeInfo.GetClassHandleForValueClass();
 }
 
-/*****************************************************************************
- *
- *  Compare function passed to qsort() by Compiler::StructPromotionHelper.
- */
-
-/* static */
+//--------------------------------------------------------------------------------------------
+// lvaFieldOffsetCmp - a static compare function passed to qsort() by Compiler::StructPromotionHelper;
+//   compares fields' offsets.
+//
+// Arguments:
+//   field1 - pointer to the first field;
+//   field2 - pointer to the second field.
+//
+// Return value:
+//   0 if the fields' offsets are equal, 1 if the first field has bigger offset, -1 otherwise.
+//
 int __cdecl Compiler::lvaFieldOffsetCmp(const void* field1, const void* field2)
 {
     lvaStructFieldInfo* pFieldInfo1 = (lvaStructFieldInfo*)field1;
@@ -1498,7 +1503,7 @@ Compiler::StructPromotionHelper::StructPromotionHelper(Compiler* compiler)
 // GetRequiresScratchVar - do we need a stack area to assemble small fields in order to place them in a register.
 //
 // Return value:
-//   true if there was a small promoted variable and scratch var is requered.
+//   true if there was a small promoted variable and scratch var is required .
 //
 bool Compiler::StructPromotionHelper::GetRequiresScratchVar()
 {
@@ -1541,7 +1546,7 @@ bool Compiler::StructPromotionHelper::TryPromoteStructVar(unsigned lclNum)
 // CheckRetypedAsScalar - check that the fldType for this fieldHnd was retyped as requested type.
 //
 // Arguments:
-//   fieldHnd      - the field handler;
+//   fieldHnd      - the field handle;
 //   requestedType - as which type the field was accessed;
 //
 // Notes:
@@ -1571,7 +1576,7 @@ void Compiler::StructPromotionHelper::CheckRetypedAsScalar(CORINFO_FIELD_HANDLE 
 //   However, it was not found profitable to memorize all analyzed types in a map.
 //
 //   The check initializes only nessasary fields in lvaStructPromotionInfo,
-//   so if the promotion is rejected early than the most fields will be uninitialized.
+//   so if the promotion is rejected early than most fields will be uninitialized.
 //
 bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd)
 {
@@ -1912,6 +1917,7 @@ void Compiler::StructPromotionHelper::SortStructFields()
     structPromotionInfo.fieldsSorted = true;
 }
 
+//--------------------------------------------------------------------------------------------
 // GetFieldInfo - get struct field information.
 // Arguments:
 //   fieldHnd - field handle to get info for;
@@ -1962,13 +1968,13 @@ Compiler::lvaStructFieldInfo Compiler::StructPromotionHelper::GetFieldInfo(CORIN
 
 //--------------------------------------------------------------------------------------------
 // TryPromoteStructField - checks that this struct's field is a struct that can be promoted as scalar type
-//   aligned at its natural boundary. Promotes the field as a scalar if succeed.
+//   aligned at its natural boundary. Promotes the field as a scalar if the check succeeded.
 //
 // Arguments:
 //   fieldInfo - information about the field in the outer struct.
 //
 // Return value:
-//   true if the intrenal struct can be promoted.
+//   true if the internal struct was promoted.
 //
 bool Compiler::StructPromotionHelper::TryPromoteStructField(lvaStructFieldInfo& fieldInfo)
 {
@@ -1983,7 +1989,7 @@ bool Compiler::StructPromotionHelper::TryPromoteStructField(lvaStructFieldInfo& 
 
     COMP_HANDLE compHandle = compiler->info.compCompHnd;
 
-    // Do Not promote if the struct field in turn has more than one field.
+    // Do not promote if the struct field in turn has more than one field.
     if (compHandle->getClassNumInstanceFields(fieldInfo.fldTypeHnd) != 1)
     {
         return false;
@@ -2008,7 +2014,7 @@ bool Compiler::StructPromotionHelper::TryPromoteStructField(lvaStructFieldInfo& 
     // target or a struct containing a single floating-point field.
     //
     // TODO-PERF: Structs containing a single floating-point field on Amd64
-    // needs to be passed in integer registers. Right now LSRA doesn't support
+    // need to be passed in integer registers. Right now LSRA doesn't support
     // passing of floating-point LCL_VARS in integer registers.  Enabling promotion
     // of such structs results in an assert in lsra right now.
     //
@@ -2250,11 +2256,16 @@ void Compiler::lvaPromoteLongVars()
 }
 #endif // !defined(_TARGET_64BIT_)
 
-/*****************************************************************************
- * Given a fldOffset in a promoted struct var, return the index of the local
-   that represents this field.
-*/
-
+//--------------------------------------------------------------------------------------------
+// lvaGetFieldLocal - returns the local var index for a promoted field in a promoted struct var.
+//
+// Arguments:
+//   varDsc    - the promoted struct var descriptor;
+//   fldOffset - field offset in the struct.
+//
+// Return value:
+//   the index of the local that represents this field.
+//
 unsigned Compiler::lvaGetFieldLocal(const LclVarDsc* varDsc, unsigned int fldOffset)
 {
     noway_assert(varTypeIsStruct(varDsc));

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1486,6 +1486,12 @@ int __cdecl Compiler::lvaFieldOffsetCmp(const void* field1, const void* field2)
     }
 }
 
+//------------------------------------------------------------------------
+// StructPromotionHelper constructor.
+//
+// Arguments:
+//   compiler - pointer to a compiler to get access to an allocator, compHandle etc.
+//
 Compiler::StructPromotionHelper::StructPromotionHelper(Compiler* compiler)
     : compiler(compiler)
     , structPromotionInfo()

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1487,6 +1487,9 @@ Compiler::StructPromotionHelper::StructPromotionHelper(Compiler* compiler)
 #ifdef _TARGET_ARM_
     , requiresScratchVar(false)
 #endif // _TARGET_ARM_
+#ifdef DEBUG
+    , fakedFieldsMap(compiler->getAllocator(CMK_DebugOnly))
+#endif // DEBUG
 {
 }
 
@@ -1532,6 +1535,14 @@ bool Compiler::StructPromotionHelper::TryPromoteStructVar(unsigned lclNum)
     }
     return false;
 }
+
+#ifdef DEBUG
+void Compiler::StructPromotionHelper::CheckFakedType(CORINFO_FIELD_HANDLE fieldHnd, var_types requestedType)
+{
+    assert(fakedFieldsMap.Lookup(fieldHnd));
+    assert(fakedFieldsMap[fieldHnd] == requestedType);
+}
+#endif // DEBUG
 
 //--------------------------------------------------------------------------------------------
 // CanPromoteStructType - checks if the struct type can be promoted.
@@ -1923,6 +1934,9 @@ Compiler::lvaStructFieldInfo Compiler::StructPromotionHelper::GetFieldInfo(CORIN
         {
             fieldInfo.fldType = compiler->getSIMDTypeForSize(simdSize);
             fieldInfo.fldSize = simdSize;
+#ifdef DEBUG
+            fakedFieldsMap.Set(fieldInfo.fldHnd, fieldInfo.fldType);
+#endif // DEBUG
         }
     }
 #endif // FEATURE_SIMD
@@ -2014,6 +2028,9 @@ bool Compiler::StructPromotionHelper::TryPromoteStructField(lvaStructFieldInfo& 
     // (tracked by #10019).
     outerFieldInfo.fldType = fieldVarType;
     outerFieldInfo.fldSize = fieldSize;
+#ifdef DEBUG
+    fakedFieldsMap.Set(outerFieldInfo.fldHnd, outerFieldInfo.fldType);
+#endif // DEBUG
     return true;
 }
 

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1710,8 +1710,9 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
                     return false;
                 }
 
-                // Retype the field as the type of the single field of the struct
-                pFieldInfo->fldType = fieldVarType;
+                // Retype the field as the type of the single field of the struct.
+                // This is a hack that allows us to promote such fields before we support recursive struct promotion
+                // (tracked by #10019).                pFieldInfo->fldType = fieldVarType;
                 pFieldInfo->fldSize = fieldSize;
             }
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17039,7 +17039,7 @@ void Compiler::fgPromoteStructs()
     // Loop through the original lvaTable. Looking for struct locals to be promoted.
     //
     lvaStructPromotionInfo structPromotionInfo;
-    bool                   tooManyLocals = false;
+    bool                   tooManyLocalsReported = false;
 
     for (unsigned lclNum = 0; lclNum < startLvaCount; lclNum++)
     {
@@ -17057,11 +17057,11 @@ void Compiler::fgPromoteStructs()
         else if (lvaHaveManyLocals())
         {
             // Print the message first time when we detected this condition
-            if (!tooManyLocals)
+            if (!tooManyLocalsReported)
             {
                 JITDUMP("Stopped promoting struct fields, due to too many locals.\n");
             }
-            tooManyLocals = true;
+            tooManyLocalsReported = true;
         }
         else if (varTypeIsStruct(varDsc))
         {

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17149,7 +17149,7 @@ void Compiler::fgMorphStructField(GenTree* tree, GenTree* parent)
                     // constant, then it is interpreted as init-block incorrectly.
                     //
                     // TODO - This can also be avoided if we implement recursive struct
-                    // promotion.
+                    // promotion, tracked by #10019.
                     if (varTypeIsStruct(parent) && parent->gtOp.gtOp2 == tree && !varTypeIsStruct(tree))
                     {
                         tree->gtFlags |= GTF_DONT_CSE;

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17112,8 +17112,8 @@ void Compiler::fgMorphStructField(GenTree* tree, GenTree* parent)
 
     if ((obj != nullptr) && (obj->gtOper == GT_LCL_VAR))
     {
-        unsigned   lclNum = obj->gtLclVarCommon.gtLclNum;
-        LclVarDsc* varDsc = &lvaTable[lclNum];
+        unsigned         lclNum = obj->gtLclVarCommon.gtLclNum;
+        const LclVarDsc* varDsc = &lvaTable[lclNum];
 
         if (varTypeIsStruct(obj))
         {

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17145,7 +17145,7 @@ void Compiler::fgMorphStructField(GenTree* tree, GenTree* parent)
                         // says that it has another type. It can happen only if struct promotion faked
                         // field type for a struct of single field of scalar type aligned at their natural boundary.
                         assert(structPromotionHelper != nullptr);
-                        structPromotionHelper->CheckFakedType(field->gtFldHnd, fieldType);
+                        structPromotionHelper->CheckRetypedAsScalar(field->gtFldHnd, fieldType);
                     }
 #endif // DEBUG
                 }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17104,8 +17104,9 @@ void Compiler::fgMorphStructField(GenTree* tree, GenTree* parent)
 {
     noway_assert(tree->OperGet() == GT_FIELD);
 
-    GenTree* objRef = tree->gtField.gtFldObj;
-    GenTree* obj    = ((objRef != nullptr) && (objRef->gtOper == GT_ADDR)) ? objRef->gtOp.gtOp1 : nullptr;
+    GenTreeField* field  = tree->AsField();
+    GenTree*      objRef = field->gtFldObj;
+    GenTree*      obj    = ((objRef != nullptr) && (objRef->gtOper == GT_ADDR)) ? objRef->gtOp.gtOp1 : nullptr;
     noway_assert((tree->gtFlags & GTF_GLOB_REF) || ((obj != nullptr) && (obj->gtOper == GT_LCL_VAR)));
 
     /* Is this an instance data member? */
@@ -17120,13 +17121,38 @@ void Compiler::fgMorphStructField(GenTree* tree, GenTree* parent)
             if (varDsc->lvPromoted)
             {
                 // Promoted struct
-                unsigned fldOffset     = tree->gtField.gtFldOffset;
+                unsigned fldOffset     = field->gtFldOffset;
                 unsigned fieldLclIndex = lvaGetFieldLocal(varDsc, fldOffset);
                 noway_assert(fieldLclIndex != BAD_VAR_NUM);
 
+                const LclVarDsc* fieldDsc  = &lvaTable[fieldLclIndex];
+                var_types        fieldType = fieldDsc->TypeGet();
+
+                assert(fieldType != TYP_STRUCT); // promoted LCL_VAR can't have a struct type.
+                if (tree->TypeGet() != fieldType)
+                {
+                    if (tree->TypeGet() != TYP_STRUCT)
+                    {
+                        // This is going to be an incorrect instruction promotion.
+                        // For example when we try to read int as long.
+                        // Tolerate this case now to keep no asm difs in this PR.
+                        // TODO make a return.
+                    }
+#ifdef DEBUG
+                    if (tree->TypeGet() == TYP_STRUCT)
+                    {
+                        // The field tree accesses it as a struct, but the promoted lcl var for the field
+                        // says that it has another type. It can happen only if struct promotion faked
+                        // field type for a struct of single field of scalar type aligned at their natural boundary.
+                        assert(structPromotionHelper != nullptr);
+                        structPromotionHelper->CheckFakedType(field->gtFldHnd, fieldType);
+                    }
+#endif // DEBUG
+                }
+
                 tree->SetOper(GT_LCL_VAR);
                 tree->gtLclVarCommon.SetLclNum(fieldLclIndex);
-                tree->gtType = lvaTable[fieldLclIndex].TypeGet();
+                tree->gtType = fieldType;
                 tree->gtFlags &= GTF_NODE_MASK;
                 tree->gtFlags &= ~GTF_GLOB_REF;
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17077,6 +17077,20 @@ void Compiler::fgPromoteStructs()
         }
     }
 
+#ifdef _TARGET_ARM_
+    if (structPromotionHelper->GetRequiresScratchVar())
+    {
+        // Ensure that the scratch variable is allocated, in case we
+        // pass a promoted struct as an argument.
+        if (lvaPromotedStructAssemblyScratchVar == BAD_VAR_NUM)
+        {
+            lvaPromotedStructAssemblyScratchVar =
+                lvaGrabTempWithImplicitUse(false DEBUGARG("promoted struct assembly scratch var."));
+            lvaTable[lvaPromotedStructAssemblyScratchVar].lvType = TYP_I_IMPL;
+        }
+    }
+#endif // _TARGET_ARM_
+
 #ifdef DEBUG
     if (verbose)
     {

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17065,46 +17065,8 @@ void Compiler::fgPromoteStructs()
         }
         else if (varTypeIsStruct(varDsc))
         {
-            bool shouldPromote;
-
-            lvaCanPromoteStructVar(lclNum, &structPromotionInfo);
-            if (structPromotionInfo.canPromote)
-            {
-                shouldPromote = lvaShouldPromoteStructVar(lclNum, &structPromotionInfo);
-            }
-            else
-            {
-                shouldPromote = false;
-            }
-
-#if 0
-            // Often-useful debugging code: if you've narrowed down a struct-promotion problem to a single
-            // method, this allows you to select a subset of the vars to promote (by 1-based ordinal number).
-            static int structPromoVarNum = 0;
-            structPromoVarNum++;
-            if (atoi(getenv("structpromovarnumlo")) <= structPromoVarNum && structPromoVarNum <= atoi(getenv("structpromovarnumhi")))
-#endif // 0
-
-            if (shouldPromote)
-            {
-                // Promote the this struct local var.
-                lvaPromoteStructVar(lclNum, &structPromotionInfo);
-                promotedVar = true;
-
-#ifdef _TARGET_ARM_
-                if (structPromotionInfo.requiresScratchVar)
-                {
-                    // Ensure that the scratch variable is allocated, in case we
-                    // pass a promoted struct as an argument.
-                    if (lvaPromotedStructAssemblyScratchVar == BAD_VAR_NUM)
-                    {
-                        lvaPromotedStructAssemblyScratchVar =
-                            lvaGrabTempWithImplicitUse(false DEBUGARG("promoted struct assembly scratch var."));
-                        lvaTable[lvaPromotedStructAssemblyScratchVar].lvType = TYP_I_IMPL;
-                    }
-                }
-#endif // _TARGET_ARM_
-            }
+            assert(structPromotionHelper != nullptr);
+            promotedVar = structPromotionHelper->TryPromoteStructVar(lclNum);
         }
 
         if (!promotedVar && varDsc->lvIsSIMDType() && !varDsc->lvFieldAccessed)


### PR DESCRIPTION
This PR continues work started in #20141 for #18986.
No asm diffs (x86/x64).
There is a small drop in instructions retired (~0.06%).

The last commit contains code to fix #18986 but it is commented out to keep this PR diff free.
Without the additional analysis  that this PR adds the straightforward fix rejects all cases where we lie about struct types (when use `SIMD` or retype internal structs' fields as scalar types).

In addition to a cleaner code it also gives a better debug experience (for example because now we always initialize all fields in `structInfo`).


Note: now we can move this helper as well as `lvaStructFieldInfo` and `lvaStructPromotionInfo` out of `compiler.h`, but I have not found a better place for them yet.

**Please review per commit.**

b549918379: Create StructPromotionHelper.

It will replace lvaStructPromotionInfo and methods that use it.

c90f266cac: Move struct promotion logic from `fgPromoteStructs` to `TryPromoteStructVar`.

789e8ef859: Create a local variable for `compHandle` in `lvaCanPromoteStructType`.

6adadedebd: Return result from `lvaCanPromoteStructType` as bool return value.

176b013c10: Return result from `lvaCanPromoteStructVar` as bool return value.

5770867651: Replace `lvaCanPromoteStructVar` with `structPromotionHelper.CanPromoteStructVar`.

Note: this change makes `lvaStructPromotionInfo` type specific before it was used both for variables and types.

4765204ad6: Move requiresScratchVar from individual lvaStructPromotionInfo to global StructPromotionHelper.

It allows to make lvaStructPromotionInfo smaller and extract the check from the loop.

ba43c194b6: Replace `lvaCanPromoteStructType` with `structPromotionHelper.CanPromoteStructType`.

403a6380dc: Get rid of `bool shouldPromote;` in `fgPromoteStructs`.

12388d8374: Rename `tooManyLocals` to `tooManyLocalsReported`.

64ad4c7ff1: Replace `lvaShouldPromoteStructVar` with `StructPromotionHelper::ShouldPromoteStructVar`.

2af955c5f0: Replace `lvaPromoteStructVar` with `StructPromotionHelper::PromoteStructVar`.

cdc59b22e2: Refactor one `noway_assert` in `CanPromoteStructType`.

27557081d0: Delete unused local vars in `StructPromotionHelper::CanPromoteStructType`.

0d5fae40f4: Optimize setting of `structPromotionInfo->containsHoles`.

Use the fact that we have already rejected structs with overlapping fields and can just check sum of fields sizes match structSize.

b6f4a7d77b: Extract `StructPromotionHelper::SortFields`.

We need fields to be sorted only when we actually promote struct, so do not waste time when we reject it because `ShouldPromoteStructVar` says `No` or when we ask for inlining.

c78e29b74a: Change `lvaGetFieldLocal` argument to be const.

4213c4db6c: Add the link to the recursive promotion issue.

1cf30ef528: Extract `GetFieldInfo` and `TryPromoteStructField`.

e7ad751dff: Add the check for promoted fields with changed type.

`CanPromoteStructType` can fake a field type if the field type is "structs of a single field of scalar types aligned at their natural boundary.". Add a check in debug that when we morph struct field access we have an expected type in the field handle.


