### PR TITLE
[Reflection] Make TypeInfo constructor internal

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Reflection/TypeInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/TypeInfo.cs
@@ -8,7 +8,7 @@ namespace System.Reflection
 {
     public abstract partial class TypeInfo : Type, IReflectableType
     {
-        protected TypeInfo() { }
+        internal TypeInfo() { }
 
         TypeInfo IReflectableType.GetTypeInfo() => this;
         public virtual Type AsType() => this;


### PR DESCRIPTION
It looks like that TypeInfo ctor needs to have `internal` access modifier according this reference source: https://referencesource.microsoft.com/#mscorlib/system/reflection/typeinfo.cs,32.
 
This PR is instead of https://github.com/dotnet/corefx/pull/32557