### PR TITLE
[arm64] Fix GitHub 20211 Issue

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -4601,8 +4601,28 @@ void CodeGen::genSIMDIntrinsicGetItem(GenTreeSIMD* simdNode)
                 assert(op1->isUsedFromReg());
                 regNumber srcReg = op1->gtRegNum;
 
-                // mov targetReg, srcReg[#index]
-                getEmitter()->emitIns_R_R_I(INS_mov, baseTypeSize, targetReg, srcReg, index);
+                instruction ins;
+                if (varTypeIsFloating(baseType))
+                {
+                    assert(genIsValidFloatReg(targetReg));
+                    // dup targetReg, srcReg[#index]
+                    ins = INS_dup;
+                }
+                else
+                {
+                    assert(genIsValidIntReg(targetReg));
+                    if (varTypeIsUnsigned(baseType) || (baseTypeSize == EA_8BYTE))
+                    {
+                        // umov targetReg, srcReg[#index]
+                        ins = INS_umov;
+                    }
+                    else
+                    {
+                        // smov targetReg, srcReg[#index]
+                        ins = INS_smov;
+                    }
+                }
+                getEmitter()->emitIns_R_R_I(ins, baseTypeSize, targetReg, srcReg, index);
             }
         }
     }

--- a/tests/src/JIT/Regression/JitBlue/GitHub_20211/GitHub_20211.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_20211/GitHub_20211.cs
@@ -1,0 +1,206 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace GitHub_20211
+{
+    class Program
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static unsafe sbyte SquareRootAt0(Vector<sbyte> arg)
+        {
+            return (sbyte)Math.Sqrt(arg[0]);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static unsafe byte SquareRootAt0(Vector<byte> arg)
+        {
+            return (byte)Math.Sqrt(arg[0]);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static unsafe short SquareRootAt0(Vector<short> arg)
+        {
+            return (short)Math.Sqrt(arg[0]);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static unsafe ushort SquareRootAt0(Vector<ushort> arg)
+        {
+            return (ushort)Math.Sqrt(arg[0]);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static unsafe int SquareRootAt0(Vector<int> arg)
+        {
+            return (int)Math.Sqrt(arg[0]);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static unsafe uint SquareRootAt0(Vector<uint> arg)
+        {
+            return (uint)Math.Sqrt(arg[0]);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static unsafe long SquareRootAt0(Vector<long> arg)
+        {
+            return (long)Math.Sqrt(arg[0]);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static unsafe ulong SquareRootAt0(Vector<ulong> arg)
+        {
+            return (ulong)Math.Sqrt(arg[0]);
+        }
+
+        enum Result { Pass, Fail }
+
+        struct TestRunner
+        {
+            void TestSquareRootAt0(sbyte arg0)
+            {
+                Vector<sbyte> arg = new Vector<sbyte>(arg0);
+                sbyte actual = SquareRootAt0(arg);
+                sbyte expected = (sbyte)Math.Sqrt(arg0);
+
+                if (actual != expected)
+                {
+                    Console.WriteLine($"Fail: sbyte (actual={actual}, expected={expected})");
+                    result = Result.Fail;
+                }
+            }
+
+            void TestSquareRootAt0(byte arg0)
+            {
+                Vector<byte> arg = new Vector<byte>(arg0);
+                byte actual = SquareRootAt0(arg);
+                byte expected = (byte)Math.Sqrt(arg0);
+
+                if (actual != expected)
+                {
+                    Console.WriteLine($"Fail: byte (actual={actual}, expected={expected})");
+                    result = Result.Fail;
+                }
+            }
+
+            void TestSquareRootAt0(short arg0)
+            {
+                Vector<short> arg = new Vector<short>(arg0);
+                short actual = SquareRootAt0(arg);
+                short expected = (short)Math.Sqrt(arg0);
+
+                if (actual != expected)
+                {
+                    Console.WriteLine($"Fail: short (actual={actual}, expected={expected})");
+                    result = Result.Fail;
+                }
+            }
+
+            void TestSquareRootAt0(ushort arg0)
+            {
+                Vector<ushort> arg = new Vector<ushort>(arg0);
+                ushort actual = SquareRootAt0(arg);
+                ushort expected = (ushort)Math.Sqrt(arg0);
+
+                if (actual != expected)
+                {
+                    Console.WriteLine($"Fail: ushort (actual={actual}, expected={expected})");
+                    result = Result.Fail;
+                }
+            }
+
+            void TestSquareRootAt0(int arg0)
+            {
+                Vector<int> arg = new Vector<int>(arg0);
+                int actual = SquareRootAt0(arg);
+                int expected = (int)Math.Sqrt(arg0);
+
+                if (actual != expected)
+                {
+                    Console.WriteLine($"Fail: int (actual={actual}, expected={expected})");
+                    result = Result.Fail;
+                }
+            }
+
+            void TestSquareRootAt0(uint arg0)
+            {
+                Vector<uint> arg = new Vector<uint>(arg0);
+                uint actual = SquareRootAt0(arg);
+                uint expected = (uint)Math.Sqrt(arg0);
+
+                if (actual != expected)
+                {
+                    Console.WriteLine($"Fail: uint (actual={actual}, expected={expected})");
+                    result = Result.Fail;
+                }
+            }
+
+            void TestSquareRootAt0(long arg0)
+            {
+                Vector<long> arg = new Vector<long>(arg0);
+                long actual = SquareRootAt0(arg);
+                long expected = (long)Math.Sqrt(arg0);
+
+                if (actual != expected)
+                {
+                    Console.WriteLine($"Fail: long (actual={actual}, expected={expected})");
+                    result = Result.Fail;
+                }
+            }
+
+            void TestSquareRootAt0(ulong arg0)
+            {
+                Vector<ulong> arg = new Vector<ulong>(arg0);
+                ulong actual = SquareRootAt0(arg);
+                ulong expected = (ulong)Math.Sqrt(arg0);
+
+                if (actual != expected)
+                {
+                    Console.WriteLine($"Fail: ulong (actual={actual}, expected={expected})");
+                    result = Result.Fail;
+                }
+            }
+
+            Result result;
+
+            public Result Run()
+            {
+                result = Result.Pass;
+
+                TestSquareRootAt0((sbyte)-1);
+                TestSquareRootAt0((short)-1);
+                TestSquareRootAt0((int)-1);
+                TestSquareRootAt0((long)-1);
+
+                TestSquareRootAt0((sbyte)1);
+                TestSquareRootAt0((byte)1);
+                TestSquareRootAt0((short)1);
+                TestSquareRootAt0((ushort)1);
+                TestSquareRootAt0((int)1);
+                TestSquareRootAt0((uint)1);
+                TestSquareRootAt0((long)1);
+                TestSquareRootAt0((ulong)1);
+
+                return result;
+            }
+        }
+
+        static int Main(string[] args)
+        {
+            if (new TestRunner().Run() == Result.Pass)
+            {
+                Console.WriteLine("Pass");
+                return 100;
+            }
+            else
+            {
+                return 0;
+            }
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_20211/GitHub_20211.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_20211/GitHub_20211.cs
@@ -58,6 +58,18 @@ namespace GitHub_20211
             return (ulong)Math.Sqrt(arg[0]);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static unsafe float SquareRootAt0(Vector<float> arg)
+        {
+            return (float)Math.Sqrt(arg[0]);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static unsafe double SquareRootAt0(Vector<double> arg)
+        {
+            return (double)Math.Sqrt(arg[0]);
+        }
+
         enum Result { Pass, Fail }
 
         struct TestRunner
@@ -166,6 +178,32 @@ namespace GitHub_20211
                 }
             }
 
+            void TestSquareRootAt0(float arg0)
+            {
+                Vector<float> arg = new Vector<float>(arg0);
+                float actual = SquareRootAt0(arg);
+                float expected = (float)Math.Sqrt(arg0);
+
+                if (actual != expected)
+                {
+                    Console.WriteLine($"Fail: float (actual={actual}, expected={expected})");
+                    result = Result.Fail;
+                }
+            }
+
+            void TestSquareRootAt0(double arg0)
+            {
+                Vector<double> arg = new Vector<double>(arg0);
+                double actual = SquareRootAt0(arg);
+                double expected = (double)Math.Sqrt(arg0);
+
+                if (actual != expected)
+                {
+                    Console.WriteLine($"Fail: double (actual={actual}, expected={expected})");
+                    result = Result.Fail;
+                }
+            }
+
             Result result;
 
             public Result Run()
@@ -185,6 +223,9 @@ namespace GitHub_20211
                 TestSquareRootAt0((uint)1);
                 TestSquareRootAt0((long)1);
                 TestSquareRootAt0((ulong)1);
+
+                TestSquareRootAt0((float)4);
+                TestSquareRootAt0((double)4);
 
                 return result;
             }

--- a/tests/src/JIT/Regression/JitBlue/GitHub_20211/GitHub_20211.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_20211/GitHub_20211.cs
@@ -6,6 +6,11 @@ using System;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 
+// GitHub 20211: bug with lowering SIMDIntrinsicGetItem on ARM64
+// when INS_mov (move w/o sign-extension) was used to copy signed value
+// from Vn.b[i] (or Vn.h[i]) to general register Wd (or Xd) instead of
+// INS_smov (move with sign-extension).
+
 namespace GitHub_20211
 {
     class Program

--- a/tests/src/JIT/Regression/JitBlue/GitHub_20211/GitHub_20211.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_20211/GitHub_20211.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_20211/GitHub_20211.tt
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_20211/GitHub_20211.tt
@@ -1,0 +1,90 @@
+<#@ template debug="false" hostspecific="true" language="C#" #>
+<#@ output extension=".cs" #>
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace GitHub_20211
+{
+    class Program
+    {
+<#
+        string[] typeNames = { "sbyte", "byte", "short", "ushort", "int", "uint", "long", "ulong" };
+        foreach (string typeName in typeNames)
+        {
+#>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static unsafe <#= typeName #> SquareRootAt0(Vector<<#= typeName #>> arg)
+        {
+            return (<#= typeName #>)Math.Sqrt(arg[0]);
+        }
+
+<#
+        }
+#>
+        enum Result { Pass, Fail }
+
+        struct TestRunner
+        {
+<#
+        foreach (string typeName in typeNames)
+        {
+#>
+            void TestSquareRootAt0(<#= typeName #> arg0)
+            {
+                Vector<<#= typeName #>> arg = new Vector<<#= typeName #>>(arg0);
+                <#= typeName #> actual = SquareRootAt0(arg);
+                <#= typeName #> expected = (<#= typeName #>)Math.Sqrt(arg0);
+
+                if (actual != expected)
+                {
+                    Console.WriteLine($"Fail: <#= typeName #> (actual={actual}, expected={expected})");
+                    result = Result.Fail;
+                }
+            }
+
+<#
+        }
+#>
+            Result result;
+
+            public Result Run()
+            {
+                result = Result.Pass;
+
+                TestSquareRootAt0((sbyte)-1);
+                TestSquareRootAt0((short)-1);
+                TestSquareRootAt0((int)-1);
+                TestSquareRootAt0((long)-1);
+
+                TestSquareRootAt0((sbyte)1);
+                TestSquareRootAt0((byte)1);
+                TestSquareRootAt0((short)1);
+                TestSquareRootAt0((ushort)1);
+                TestSquareRootAt0((int)1);
+                TestSquareRootAt0((uint)1);
+                TestSquareRootAt0((long)1);
+                TestSquareRootAt0((ulong)1);
+
+                return result;
+            }
+        }
+
+        static int Main(string[] args)
+        {
+            if (new TestRunner().Run() == Result.Pass)
+            {
+                Console.WriteLine("Pass");
+                return 100;
+            }
+            else
+            {
+                return 0;
+            }
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_20211/GitHub_20211.tt
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_20211/GitHub_20211.tt
@@ -13,7 +13,7 @@ namespace GitHub_20211
     class Program
     {
 <#
-        string[] typeNames = { "sbyte", "byte", "short", "ushort", "int", "uint", "long", "ulong" };
+        string[] typeNames = { "sbyte", "byte", "short", "ushort", "int", "uint", "long", "ulong", "float", "double" };
         foreach (string typeName in typeNames)
         {
 #>
@@ -69,6 +69,9 @@ namespace GitHub_20211
                 TestSquareRootAt0((uint)1);
                 TestSquareRootAt0((long)1);
                 TestSquareRootAt0((ulong)1);
+
+                TestSquareRootAt0((float)4);
+                TestSquareRootAt0((double)4);
 
                 return result;
             }

--- a/tests/src/JIT/Regression/JitBlue/GitHub_20211/GitHub_20211.tt
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_20211/GitHub_20211.tt
@@ -8,6 +8,11 @@ using System;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 
+// GitHub 20211: bug with lowering SIMDIntrinsicGetItem on ARM64
+// when INS_mov (move w/o sign-extension) was used to copy signed value
+// from Vn.b[i] (or Vn.h[i]) to general register Wd (or Xd) instead of
+// INS_smov (move with sign-extension).
+
 namespace GitHub_20211
 {
     class Program


### PR DESCRIPTION
Below is the description of the problem in #20211

**SIMDIntrinsicGetItem** in the tree node
```
               [000011] ------------              *  STMT      void  (IL 0x000...  ???)
               [000010] ------------              \--*  RETURN    int
               [000009] ------------                 \--*  CAST      int <- byte <- double
               [000008] ------------                    \--*  INTRINSIC double sqrt
               [000007] ------------                       \--*  CAST      double <- int
               [000003] ------------                          |  /--*  CNS_INT   int    0
               [000006] ------------                          \--*  SIMD      int    byte get[i]
               [000005] n-----------                             \--*  OBJ(16)   simd16
               [000004] L-----------                                \--*  ADDR      byref
               [000001] ------------                                   \--*  LCL_VAR   simd16 V00 arg0
```
is lowered into `mov     w0, v16.b[0]` as can be seen in the following JIT output
```
G_M60354_IG01:
            stp     fp, lr, [sp,#-16]!
            mov     fp, sp
            mov     v16.d[0], x0
            mov     v16.d[1], x1

G_M60354_IG02:
            mov     w0, v16.b[0]
            scvtf   d16, w0
            fsqrt   d16, d16
            fcvtzs  w0, d16
            sxtb    w0, w0

G_M60354_IG03:
            ldp     fp, lr, [sp],#16
            ret     lr

```
where instead it should have lowered into signed `smov`.

In #20211, the issue was reproducible only for `sbyte` GetItem, but in my regression test the issue also reproduces for `short` . 

For example, 
```
               [000011] ------------              *  STMT      void  (IL 0x000...  ???)
               [000010] ------------              \--*  RETURN    int
               [000009] ------------                 \--*  CAST      int <- short <- double
               [000008] ------------                    \--*  INTRINSIC double sqrt
               [000007] ------------                       \--*  CAST      double <- int
               [000003] ------------                          |  /--*  CNS_INT   int    0
               [000006] ------------                          \--*  SIMD      int    short get[i]
               [000005] n-----------                             \--*  OBJ(16)   simd16
               [000004] L-----------                                \--*  ADDR      byref
               [000001] ------------                                   \--*  LCL_VAR   simd16 V00 arg0
```
got compiled into
```
G_M60354_IG01:
            stp     fp, lr, [sp,#-16]!
            mov     fp, sp
            mov     v16.d[0], x0
            mov     v16.d[1], x1

G_M60354_IG02:
            mov     w0, v16.h[0]
            scvtf   d16, w0
            fsqrt   d16, d16
            fcvtzs  w0, d16
            sxth    w0, w0

G_M60354_IG03:
            ldp     fp, lr, [sp],#16
            ret     lr
```

Fixes #20211