### PR TITLE
Fix compat issue with Type.IsAssignableFrom

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Type.Helpers.cs
+++ b/src/System.Private.CoreLib/shared/System/Type.Helpers.cs
@@ -342,7 +342,7 @@ namespace System
             // For backward-compatibility, we need to special case for the types
             // whose UnderlyingSystemType are runtime implemented. 
             Type toType = this.UnderlyingSystemType;
-            if (toType.IsRuntimeImplemented())
+            if (toType?.IsRuntimeImplemented() == true)
                 return toType.IsAssignableFrom(c);
 
             // If c is a subclass of this class, then c can be cast to this type.


### PR DESCRIPTION
Fix issue where netcore implementation of Type.UnderlyingSystemType must be non-null while netfx supports null. Fix is to support null like netfx. This enables Type.IsAssignableFrom to be used without a null reference exception.

Fixes https://github.com/dotnet/coreclr/issues/20154

Tests will be added in corefx repro (see https://github.com/dotnet/corefx/pull/32601)