### PR TITLE
Throw an exception when we try to marshal a non-blittable fixed buffer.

### DIFF
--- a/src/vm/classnames.h
+++ b/src/vm/classnames.h
@@ -157,6 +157,7 @@
 #define g_UnmanagedFunctionPointerAttribute "System.Runtime.InteropServices.UnmanagedFunctionPointerAttribute"
 #define g_DefaultDllImportSearchPathsAttribute "System.Runtime.InteropServices.DefaultDllImportSearchPathsAttribute"
 #define g_NativeCallableAttribute "System.Runtime.InteropServices.NativeCallableAttribute"
+#define g_FixedBufferAttribute "System.Runtime.CompilerServices.FixedBufferAttribute"
 
 #define g_CompilerServicesTypeDependencyAttribute "System.Runtime.CompilerServices.TypeDependencyAttribute"
 

--- a/src/vm/fieldmarshaler.cpp
+++ b/src/vm/fieldmarshaler.cpp
@@ -34,7 +34,8 @@
 // forward declaration
 BOOL CheckForPrimitiveType(CorElementType elemType, CQuickArray<WCHAR> *pStrPrimitiveType);
 TypeHandle ArraySubTypeLoadWorker(const SString &strUserDefTypeName, Assembly* pAssembly);
-TypeHandle GetFieldTypeHandleWorker(MetaSig *pFieldSig);  
+TypeHandle GetFieldTypeHandleWorker(MetaSig *pFieldSig);
+BOOL IsFixedBuffer(mdFieldDef field, IMDInternalImport *pInternalImport);
 
 
 //=======================================================================

--- a/src/vm/fieldmarshaler.cpp
+++ b/src/vm/fieldmarshaler.cpp
@@ -659,7 +659,14 @@ do                                                      \
                 {
                     if (IsStructMarshalable(thNestedType))
                     {
-                        INITFIELDMARSHALER(NFT_NESTEDVALUECLASS, FieldMarshaler_NestedValueClass, (thNestedType.GetMethodTable()));
+                        if (IsFixedBuffer(pfwalk->m_MD, pInternalImport) && !thNestedType.GetMethodTable()->IsBlittable())
+                        {
+                            INITFIELDMARSHALER(NFT_ILLEGAL, FieldMarshaler_Illegal, (IDS_EE_BADMARSHAL_NOTMARSHALABLE));
+                        }
+                        else
+                        {
+                            INITFIELDMARSHALER(NFT_NESTEDVALUECLASS, FieldMarshaler_NestedValueClass, (thNestedType.GetMethodTable()));
+                        }
                     }
                     else
                     {
@@ -1226,6 +1233,13 @@ BOOL IsStructMarshalable(TypeHandle th)
     }
 
     return TRUE;
+}
+
+BOOL IsFixedBuffer(mdFieldDef field, IMDInternalImport *pInternalImport)
+{
+    HRESULT hr = pInternalImport->GetCustomAttributeByName(field, g_FixedBufferAttribute, NULL, NULL);
+
+    return hr == S_OK ? TRUE : FALSE;
 }
 
 

--- a/src/vm/fieldmarshaler.h
+++ b/src/vm/fieldmarshaler.h
@@ -116,8 +116,6 @@ BOOL HasLayoutMetadata(Assembly* pAssembly, IMDInternalImport *pInternalImport, 
 //=======================================================================
 BOOL IsStructMarshalable(TypeHandle th);
 
-BOOL IsFixedBuffer(mdFieldDef field, IMDInternalImport *pInternalImport);
-
 //=======================================================================
 // The classloader stores an intermediate representation of the layout
 // metadata in an array of these structures. The dual-pass nature

--- a/src/vm/fieldmarshaler.h
+++ b/src/vm/fieldmarshaler.h
@@ -116,6 +116,8 @@ BOOL HasLayoutMetadata(Assembly* pAssembly, IMDInternalImport *pInternalImport, 
 //=======================================================================
 BOOL IsStructMarshalable(TypeHandle th);
 
+BOOL IsFixedBuffer(mdFieldDef field, IMDInternalImport *pInternalImport);
+
 //=======================================================================
 // The classloader stores an intermediate representation of the layout
 // metadata in an array of these structures. The dual-pass nature


### PR DESCRIPTION
@luqunl and I were talking yesterday and we felt that since we are not supporting correctly marshaling fixed buffers of non-blittable types, we should throw an exception when trying to marshal them instead of having buggy behavior for any non-blittable fixed buffer with more than one element.

Without throwing this exception, we incorrectly lay out the native fields, which can lead to crashes where the native code reads past the (too small) native object and crashes due to an AV or just reads random memory.

For example:

If the native structure is:

```cpp
struct TestStruct {
    BOOL buffer[4];
    INT value;
};
```

and the managed is:

```csharp
struct TestStruct {
    fixed bool buffer[4];
    int value;
}
```

Any native code expecting to receive a `TestStruct` by value will read past the end of the structure if it tries to access the `value` field, possibly causing an AV.


So, we felt that it would be better for the user if we were to throw while marshaling instead of either crashing or causing unexpected behavior (either the issues mentioned above or issues like #20521).
