### PR TITLE
Fix Interop/SizeConst/SizeConstTest to successfully run in all locales.

### DIFF
--- a/tests/src/Interop/SizeConst/SizeConstTest.cs
+++ b/tests/src/Interop/SizeConst/SizeConstTest.cs
@@ -26,7 +26,7 @@ class Test
     {
         // always marshal managedArray.Length
         S_CHARArray_ByValTStr s = new S_CHARArray_ByValTStr();
-        s.arr = "有个可爱";
+        s.arr = "abcd";
         TakeByValTStr(s, s.arr.Length);
 
         // off by one byte since  sizeconst == 4 and 


### PR DESCRIPTION
This test initially would fail when run on a multibyte character set with characters for the original value of `s.arr` such as zh-CH. We cannot change the marshaler since there is not a good way to determine how many bytes/character we need at type-load-time (when the size of the native type is determined).

This change allows us to accurately run this test on Windows machines with multi-byte character sets.

Fixes #7793.