### PR TITLE
Change cse vars dump from cse0 to CSE #1.

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -10051,8 +10051,8 @@ void Compiler::gtGetLclVarNameInfo(unsigned lclNum, const char** ilKindOut, cons
 #if FEATURE_ANYCSE
         if (lclNumIsTrueCSE(lclNum))
         {
-            ilKind = "cse";
-            ilNum  = lclNum - optCSEstart;
+            ilKind = "CSE #";
+            ilNum  = lclNum - optCSEstart + 1;
         }
         else if (lclNum >= optCSEstart)
         {


### PR DESCRIPTION
`gtDispNode` prints them as https://github.com/dotnet/coreclr/blob/030e0af89bb897554acef575075c69aaf5176268/src/jit/gentree.cpp#L9542
where `GET_CSE_INDEX(tree->gtCSEnum)` starts from 1,
but `gtGetLclVarNameInfo` printed them as `cse` + `Number` where `Number` started from 0.

Maybe we can unify them and always show as `CSE #1basedNumber`?