### PR TITLE
Added generic GetValues, GetName and GetNames method

### DIFF
--- a/src/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/System.Private.CoreLib/src/System/Enum.cs
@@ -556,6 +556,11 @@ namespace System
             return enumType.GetEnumValues();
         }
 
+        public static TEnum[] GetValues<TEnum>() where TEnum : Enum
+        {
+            return (TEnum[])typeof(TEnum).GetEnumValues();
+        }
+
         internal static ulong[] InternalGetValues(RuntimeType enumType)
         {
             // Get all of the values
@@ -570,12 +575,22 @@ namespace System
             return enumType.GetEnumName(value);
         }
 
+        public static string GetName<TEnum>(object value) where TEnum : Enum
+        {
+            return typeof(TEnum).GetEnumName(value);
+        }
+
         public static string[] GetNames(Type enumType)
         {
             if (enumType == null)
                 throw new ArgumentNullException(nameof(enumType));
 
             return enumType.GetEnumNames();
+        }
+
+        public static string[] GetNames<TEnum>() where TEnum : Enum
+        {
+            return typeof(TEnum).GetEnumNames();
         }
 
         internal static string[] InternalGetNames(RuntimeType enumType)


### PR DESCRIPTION
I would love to have this API proposal revisited. I've stumbled upon developers asking about a generic `Enum.GetValues` and `Enum.GetNames` for years now. This would be an easy win to add to the amazing API - I look forward to this ask getting some attention soon, thank you.

```csharp
// Instead of saying:
var x = (DayOfWeek[])Enum.GetValues(typeof(DayOfWeek));

// We would be able to say:
var y = Enum.GetValues<DayOfWeek>();
```

Fixes: https://github.com/dotnet/corefx/issues/27453