### PR TITLE
Remove some dead remoting and context static things

### DIFF
--- a/src/debug/daccess/dacdbiimpl.cpp
+++ b/src/debug/daccess/dacdbiimpl.cpp
@@ -3226,7 +3226,7 @@ TypeHandle DacDbiInterfaceImpl::ExpandedTypeInfoToTypeHandle(DebuggerIPCE_Expand
 // This can commonly fail, in which case, it will return NULL.
 // ----------------------------------------------------------------------------
 CORDB_ADDRESS DacDbiInterfaceImpl::GetThreadStaticAddress(VMPTR_FieldDesc vmField,
-                                                                    VMPTR_Thread    vmRuntimeThread)
+                                                          VMPTR_Thread    vmRuntimeThread)
 {
     DD_ENTER_MAY_THROW;
 

--- a/src/debug/daccess/dacdbiimpl.cpp
+++ b/src/debug/daccess/dacdbiimpl.cpp
@@ -3217,20 +3217,15 @@ TypeHandle DacDbiInterfaceImpl::ExpandedTypeInfoToTypeHandle(DebuggerIPCE_Expand
 } // DacDbiInterfaceImpl::ExpandedTypeInfoToTypeHandle
 
 // ----------------------------------------------------------------------------
-// DacDbi API: GetThreadOrContextStaticAddress
-// Get the target field address of a context or thread local static. 
+// DacDbi API: GetThreadStaticAddress
+// Get the target field address of a thread local static.
 // 
 // Notes: 
-// The address is  constant and could be cached.
-// 
-// If this is a context-static, the function uses the thread's current context.  
-// [This is important because it means that you can't lookup a context static 
-// unless you have a thread in that context. If anybody actually cared about contexts, 
-// we might have to revise this in the future] 
+// The address is constant and could be cached.
 // 
 // This can commonly fail, in which case, it will return NULL.
 // ----------------------------------------------------------------------------
-CORDB_ADDRESS DacDbiInterfaceImpl::GetThreadOrContextStaticAddress(VMPTR_FieldDesc vmField,
+CORDB_ADDRESS DacDbiInterfaceImpl::GetThreadStaticAddress(VMPTR_FieldDesc vmField,
                                                                     VMPTR_Thread    vmRuntimeThread)
 {
     DD_ENTER_MAY_THROW;
@@ -3241,8 +3236,7 @@ CORDB_ADDRESS DacDbiInterfaceImpl::GetThreadOrContextStaticAddress(VMPTR_FieldDe
 
     _ASSERTE(pRuntimeThread != NULL);
 
-    // Find out whether the field is thread local or context local and get its
-    // address. 
+    // Find out whether the field is thread local and get its address.
     if (pFieldDesc->IsThreadStatic())
     {
         fieldAddress = pRuntimeThread->GetStaticFieldAddrNoCreate(pFieldDesc, NULL);
@@ -3255,7 +3249,7 @@ CORDB_ADDRESS DacDbiInterfaceImpl::GetThreadOrContextStaticAddress(VMPTR_FieldDe
     }
     return fieldAddress;
 
-} // DacDbiInterfaceImpl::GetThreadOrContextStaticAddress
+} // DacDbiInterfaceImpl::GetThreadStaticAddress
 
     // Get the target field address of a collectible types static. 
 CORDB_ADDRESS DacDbiInterfaceImpl::GetCollectibleTypeStaticAddress(VMPTR_FieldDesc vmField,

--- a/src/debug/daccess/dacdbiimpl.h
+++ b/src/debug/daccess/dacdbiimpl.h
@@ -304,7 +304,7 @@ public:
                              TypeParamsList *    pGenericTypeParams);
 
     // Get the target field address of a context or thread local static. 
-    CORDB_ADDRESS GetThreadOrContextStaticAddress(VMPTR_FieldDesc vmField,
+    CORDB_ADDRESS GetThreadStaticAddress(VMPTR_FieldDesc vmField,
                                                   VMPTR_Thread    vmRuntimeThread);
 
     // Get the target field address of a collectible types static. 

--- a/src/debug/daccess/dacdbiimpl.h
+++ b/src/debug/daccess/dacdbiimpl.h
@@ -305,7 +305,7 @@ public:
 
     // Get the target field address of a context or thread local static. 
     CORDB_ADDRESS GetThreadStaticAddress(VMPTR_FieldDesc vmField,
-                                                  VMPTR_Thread    vmRuntimeThread);
+                                         VMPTR_Thread    vmRuntimeThread);
 
     // Get the target field address of a collectible types static. 
     CORDB_ADDRESS GetCollectibleTypeStaticAddress(VMPTR_FieldDesc vmField,

--- a/src/debug/daccess/nidump.cpp
+++ b/src/debug/daccess/nidump.cpp
@@ -5523,7 +5523,6 @@ NativeImageDumper::EnumMnemonics s_MTFlagsLow[] =
     MTFLAG_ENTRY(GenericsMask_GenericInst),
     MTFLAG_ENTRY(GenericsMask_SharedInst),
     MTFLAG_ENTRY(GenericsMask_TypicalInst),
-    MTFLAG_ENTRY(HasRemotingVtsInfo),
     MTFLAG_ENTRY(HasVariance),
     MTFLAG_ENTRY(HasDefaultCtor),
     MTFLAG_ENTRY(HasPreciseInitCctors),

--- a/src/debug/daccess/nidump.h
+++ b/src/debug/daccess/nidump.h
@@ -29,7 +29,6 @@ typedef DPTR(ArrayClass) PTR_ArrayClass;
 typedef DPTR(DelegateEEClass) PTR_DelegateEEClass;
 typedef DPTR(UMThunkMarshInfo) PTR_UMThunkMarshInfo;
 typedef DPTR(CORCOMPILE_DEPENDENCY) PTR_CORCOMPILE_DEPENDENCY;
-typedef DPTR(struct RemotableMethodInfo) PTR_RemotableMethodInfo;
 typedef DPTR(struct ModuleCtorInfo) PTR_ModuleCtorInfo;
 typedef DPTR(class EEImplMethodDesc) PTR_EEImplMethodDesc;
 typedef DPTR(class EEClassLayoutInfo) PTR_EEClassLayoutInfo;

--- a/src/debug/di/rsclass.cpp
+++ b/src/debug/di/rsclass.cpp
@@ -261,13 +261,13 @@ HRESULT CordbClass::GetStaticFieldValue2(CordbModule * pModule,
     }
     else
     {
-        // We've got a thread or context local static
+        // We've got a thread local static
 
         if( fEnCHangingField )
         {
             // fEnCHangingField is set for fields added with EnC which hang off the FieldDesc.
-            // Thread-local and context-local statics cannot be added with EnC, so we shouldn't be here
-            // if this is an EnC field is thread- or context-local.
+            // Thread-local statics cannot be added with EnC, so we shouldn't be here
+            // if this is an EnC field is thread-local.
             _ASSERTE(!pFieldData->m_fFldIsTLS );
         }
         else
@@ -285,8 +285,8 @@ HRESULT CordbClass::GetStaticFieldValue2(CordbModule * pModule,
 
             EX_TRY
             {
-                pRmtStaticValue = pProcess->GetDAC()->GetThreadOrContextStaticAddress(pFieldData->m_vmFieldDesc, 
-                                                                                      pThread->m_vmThreadToken);
+                pRmtStaticValue = pProcess->GetDAC()->GetThreadStaticAddress(pFieldData->m_vmFieldDesc,
+                                                                             pThread->m_vmThreadToken);
             }
             EX_CATCH_HRESULT(hr);
             if(FAILED(hr)) 

--- a/src/debug/inc/dacdbiinterface.h
+++ b/src/debug/inc/dacdbiinterface.h
@@ -1923,7 +1923,7 @@ public:
                              OUT UINT32 *            pcGenericClassTypeParams,
                              OUT TypeParamsList *    pGenericTypeParams) = 0;
 
-    // Get the target field address of a context or thread local static. 
+    // Get the target field address of a thread local static.
     // Arguments: 
     //     input: vmField         - pointer to the field descriptor for the static field
     //            vmRuntimeThread - thread to which the static field belongs. This must 
@@ -1937,7 +1937,7 @@ public:
     //  Field storage is constant once allocated, so this value can be cached. 
 
     virtual
-    CORDB_ADDRESS GetThreadOrContextStaticAddress(VMPTR_FieldDesc vmField,
+    CORDB_ADDRESS GetThreadStaticAddress(VMPTR_FieldDesc vmField,
                                                    VMPTR_Thread    vmRuntimeThread) = 0;
 
     // Get the target field address of a collectible types static. 

--- a/src/debug/inc/dacdbiinterface.h
+++ b/src/debug/inc/dacdbiinterface.h
@@ -1938,7 +1938,7 @@ public:
 
     virtual
     CORDB_ADDRESS GetThreadStaticAddress(VMPTR_FieldDesc vmField,
-                                                   VMPTR_Thread    vmRuntimeThread) = 0;
+                                         VMPTR_Thread    vmRuntimeThread) = 0;
 
     // Get the target field address of a collectible types static. 
     // Arguments: 

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -1431,15 +1431,13 @@ protected:
     PTR_CLRPrivBinderWinRT m_pWinRtBinder;
 #endif // FEATURE_COMINTEROP
 
-    // Protects allocation of slot IDs for thread and context statics
+    // Protects allocation of slot IDs for thread statics
     static CrstStatic   m_SpecialStaticsCrst;
 
 public:
     // Only call this routine when you can guarantee there are no
     // loads in progress.
     void ClearFusionContext();
-
-public:
 
     //****************************************************************************************
     // Synchronization holders.

--- a/src/vm/array.cpp
+++ b/src/vm/array.cpp
@@ -342,12 +342,10 @@ MethodTable* Module::CreateArrayMethodTable(TypeHandle elemTypeHnd, CorElementTy
     // Allocate space for optional members
     // We always have a non-virtual slot array, see assert at end
     cbMT += MethodTable::GetOptionalMembersAllocationSize(dwMultipurposeSlotsMask,
-                                                          FALSE,                           // RemotableMethodInfo
                                                           FALSE,                           // GenericsStaticsInfo
                                                           FALSE,                           // GuidInfo
                                                           FALSE,                           // CCWTemplate
                                                           FALSE,                           // RCWPerTypeData
-                                                          FALSE,                           // RemotingVtsInfo
                                                           FALSE);                          // TokenOverflow
 
     // This is the offset of the beginning of the interface map

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -2067,7 +2067,7 @@ void Module::BuildStaticsOffsets(AllocMemTracker *pamTracker)
                     continue;
 
                 // We account for "regular statics" and "thread statics" separately. 
-                // Currently we are lumping RVA and context statics into "regular statics",
+                // Currently we are lumping RVA into "regular statics",
                 // but we probably shouldn't.
                 switch (ElementType)
                 {

--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -1314,27 +1314,6 @@ BOOL CEEPreloader::CanEmbedFunctionEntryPoint(
     STANDARD_VM_CONTRACT;
 
     MethodDesc * pMethod = GetMethod(methodHandle);
-    MethodDesc * pContext = GetMethod(contextHandle);
-
-    // IsRemotingInterceptedViaVirtualDispatch is a rather special case.
-    //
-    // Other remoting intercepts are implemented by one of:
-    //  (1) in DoPrestub (for non-virtual calls)
-    //  (2) by transparent proxy vtables, where all the entries in the vtable
-    //      go to the same code.
-    //
-    // However when calling virtual functions non-virtually the JIT interface
-    // pointer to the code for the function in a stub 
-    // (see GetNonVirtualEntryPointForVirtualMethod).  
-    // Thus we cannot embed non-virtual calls to these functions because we 
-    // don't save these stubs.  Unlike most other remoting stubs these ones 
-    // are NOT inserted by DoPrestub.
-    //
-    if (((accessFlags & CORINFO_ACCESS_THIS) == 0) &&
-        (pMethod->IsRemotingInterceptedViaVirtualDispatch()))
-    {
-        return FALSE;
-    }
 
     // Methods with native callable attribute are special , since 
     // they are used as LDFTN targets.Native Callable methods

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -1552,7 +1552,7 @@ void BulkStaticsLogger::LogAllStatics()
                     ApproxFieldDescIterator fieldIter(mt, ApproxFieldDescIterator::STATIC_FIELDS);
                     for (FieldDesc *field = fieldIter.Next(); field != NULL; field = fieldIter.Next())
                     {
-                        // Don't want thread local or context local
+                        // Don't want thread local
                         _ASSERTE(field->IsStatic());
                         if (field->IsSpecialStatic() || field->IsEnCNew())
                             continue;

--- a/src/vm/fptrstubs.cpp
+++ b/src/vm/fptrstubs.cpp
@@ -52,13 +52,6 @@ PrecodeType FuncPtrStubs::GetDefaultType(MethodDesc* pMD)
     type = PRECODE_FIXUP;
 #endif // HAS_FIXUP_PRECODE
 
-#ifdef HAS_REMOTING_PRECODE
-    if (pMD->IsRemotingInterceptedViaVirtualDispatch())
-    {
-        type = PRECODE_REMOTING;
-    }
-#endif // HAS_REMOTING_PRECODE
-
     return type;
 }
 

--- a/src/vm/generics.cpp
+++ b/src/vm/generics.cpp
@@ -224,7 +224,6 @@ ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation(
 
     // These are all copied across from the old MT, i.e. don't depend on the
     // instantiation.
-    BOOL fHasRemotingVtsInfo = FALSE;
     BOOL fHasGenericsStaticsInfo = pOldMT->HasGenericsStaticsInfo();
 
 #ifdef FEATURE_COMINTEROP
@@ -278,12 +277,10 @@ ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation(
 
     // We need space for the optional members.
     DWORD cbOptional = MethodTable::GetOptionalMembersAllocationSize(dwMultipurposeSlotsMask,
-                                                      FALSE, // fHasRemotableMethodInfo
                                                       fHasGenericsStaticsInfo,
                                                       fHasGuidInfo,
                                                       fHasCCWTemplate,
                                                       fHasRCWPerTypeData,
-                                                      fHasRemotingVtsInfo,
                                                       pOldMT->HasTokenOverflow());
 
     // We need space for the PerInstInfo, i.e. the generic dictionary pointers...

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -5373,23 +5373,14 @@ void CEEInfo::getCallInfo(
 
         if (devirt)
         {
-            // We can't allow generic remotable methods to be considered resolved, it leads to a non-instantiating method desc being
-            // passed to the remoting stub. The easiest way to deal with these is to force them through the virtual code path.
-            // It is actually good to do this deoptimization for all remotable methods since remoting interception via vtable dispatch 
-            // is faster then remoting interception via thunk
-            if (!pTargetMD->IsRemotingInterceptedViaVirtualDispatch() /* || !pTargetMD->HasMethodInstantiation() */)
-            {
-                resolvedCallVirt = true;
-                directCall = true;
-            }
+            resolvedCallVirt = true;
+            directCall = true;
         }
     }
 
     if (directCall)
     {
-        bool allowInstParam = (flags & CORINFO_CALLINFO_ALLOWINSTPARAM)
-            // See code:IsRemotingInterceptedViaPrestub on why we need need to disallow inst param for remoting.
-            && !( pTargetMD->MayBeRemotingIntercepted() && !pTargetMD->IsVtableMethod() );
+        bool allowInstParam = (flags & CORINFO_CALLINFO_ALLOWINSTPARAM);
 
         // Create instantiating stub if necesary
         if (!allowInstParam && pTargetMD->RequiresInstArg())
@@ -7873,12 +7864,6 @@ CorInfoInline CEEInfo::canInline (CORINFO_METHOD_HANDLE hCaller,
         {
             dwRestrictions |= INLINE_NO_CALLEE_LDSTR;
         }
-
-        // The remoting interception can be skipped only if the call is on same this pointer
-        if (pCallee->MayBeRemotingIntercepted())
-        {
-            dwRestrictions |= INLINE_SAME_THIS;
-        }
     }
 
 #ifdef PROFILING_SUPPORTED
@@ -9163,8 +9148,6 @@ void CEEInfo::getFunctionEntryPoint(CORINFO_METHOD_HANDLE  ftnHnd,
     {
         // should never get here for EnC methods or if interception via remoting stub is required
         _ASSERTE(!ftn->IsEnCMethod());
-
-        _ASSERTE((accessFlags & CORINFO_ACCESS_THIS) || !ftn->IsRemotingInterceptedViaVirtualDispatch());
 
         ret = (void *)ftn->GetAddrOfSlot();
 

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -2157,8 +2157,7 @@ PCODE MethodDesc::TryGetMultiCallableAddrOfCode(CORINFO_ACCESS_FLAGS accessFlags
     if (IsFCall())
     {
         // Call FCalls directly when possible
-        if (((accessFlags & CORINFO_ACCESS_THIS) || !IsRemotingInterceptedViaPrestub()) 
-            && !IsInterface() && !GetMethodTable()->ContainsGenericVariables())
+        if (!IsInterface() && !GetMethodTable()->ContainsGenericVariables())
         {
             BOOL fSharedOrDynamicFCallImpl;
             PCODE pFCallImpl = ECall::GetFCallImpl(this, &fSharedOrDynamicFCallImpl);
@@ -2803,13 +2802,6 @@ bool MethodDesc::CanSkipDoPrestub (
 
     // @todo generics: Until we fix the RVA map in zapper.cpp to be instantiation-aware, this must remain
     CheckRestore();
-
-    // The remoting interception is not necessary if we are calling on the same thisptr
-    if (!(accessFlags & CORINFO_ACCESS_THIS) && IsRemotingInterceptedViaPrestub())
-    {
-        *pReason = CORINFO_INDIRECT_CALL_REMOTING;
-        return false;
-    }
 
     // The wrapper stubs cannot be called directly (like any other stubs)
     if (IsWrapperStub())
@@ -5488,7 +5480,7 @@ PrecodeType MethodDesc::GetPrecodeType()
     PrecodeType precodeType = PRECODE_INVALID;
 
 #ifdef HAS_REMOTING_PRECODE
-    if (IsRemotingInterceptedViaPrestub() || (IsComPlusCall() && !IsStatic()))
+    if (IsComPlusCall() && !IsStatic())
     {
         precodeType = PRECODE_REMOTING;
     }

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -285,7 +285,7 @@ public:
         }
         CONTRACTL_END
 
-        return !MayHaveNativeCode() || IsRemotingInterceptedViaPrestub() || IsVersionableWithPrecode();
+        return !MayHaveNativeCode() || IsVersionableWithPrecode();
     }
 
     void InterlockedUpdateFlags2(BYTE bMask, BOOL fSet);
@@ -709,51 +709,6 @@ public:
     VOID EnsureActive();
 #endif
     CHECK CheckActivated();
-
-
-    //================================================================
-    // REMOTING
-    //
-    // IsRemoting...: These predicates indicate how are remoting
-    // intercepts are implemented.
-    //
-    // Remoting intercepts are required for all invocations of  methods on
-    // MarshalByRef classes (including virtual calls on methods
-    // which end up invoking a method on the MarshalByRef class).
-    //
-    // Remoting intercepts are implemented by one of the following techniques:
-    //  (1) Non-virtual methods: inserting a stub in DoPrestub (for non-virtual calls)
-    //   See: IsRemotingInterceptedViaPrestub
-    //
-    //  (2) Virtual methods: by transparent proxy vtables, where all the entries in the vtable
-    //      are a special hook which traps into the remoting logic
-    //   See: IsRemotingInterceptedViaVirtualDispatch (context indicates
-    //        if it is a virtual call)
-    //
-    //  (3) Non-virtual-calls on virtual methods:
-    //      by forcing calls to be indirect and wrapping the
-    //      call with a stub returned by GetNonVirtualEntryPointForVirtualMethod.
-    //      (this is used when invoking virtual methods non-virtually using 'call')
-    //   See: IsRemotingInterceptedViaVirtualDispatch (context indicates
-    //        if it is a virtual call)
-    //
-    // Ultimately essentially all calls go through CTPMethodTable::OnCall in
-    // remoting.cpp.
-    //
-    // Check if this methoddesc needs to be intercepted
-    // by the context code, using a stub.
-    // Also see IsRemotingInterceptedViaVirtualDispatch()
-    BOOL IsRemotingInterceptedViaPrestub();
-
-    // Check if is intercepted by the context code, using the virtual table
-    // of TransparentProxy.
-    // If such a function is called non-virtually, it needs to be handled specially
-    BOOL IsRemotingInterceptedViaVirtualDispatch();
-
-    BOOL MayBeRemotingIntercepted();
-
-    //================================================================
-    // Does it represent a one way method call with no out/return parameters?
 
     //================================================================
     // FCalls.

--- a/src/vm/method.inl
+++ b/src/vm/method.inl
@@ -153,25 +153,6 @@ inline void MethodDesc::SetupGenericComPlusCall()
 #endif // FEATURE_COMINTEROP
 
 
-inline BOOL MethodDesc::MayBeRemotingIntercepted()
-{
-    LIMITED_METHOD_CONTRACT;
-    return FALSE;
-}
-
-inline BOOL MethodDesc::IsRemotingInterceptedViaPrestub()
-{
-    LIMITED_METHOD_CONTRACT;
-    return FALSE;
-}
-
-inline BOOL MethodDesc::IsRemotingInterceptedViaVirtualDispatch()
-{
-    LIMITED_METHOD_CONTRACT;
-    return FALSE;
-}
-
-
 #ifdef FEATURE_COMINTEROP
 
 // static

--- a/src/vm/methodtable.h
+++ b/src/vm/methodtable.h
@@ -4396,12 +4396,6 @@ private:
 
     void SetModule(Module * pModule);
 
-    /************************************
-    //
-    // CONTEXT STATIC
-    //
-    ************************************/
-
 public:
 
     BOOL Validate ();

--- a/src/vm/methodtable.h
+++ b/src/vm/methodtable.h
@@ -290,80 +290,6 @@ struct CrossModuleGenericsStaticsInfo
 };  // struct CrossModuleGenericsStaticsInfo
 typedef DPTR(CrossModuleGenericsStaticsInfo) PTR_CrossModuleGenericsStaticsInfo;
 
-// This structure records methods and fields which are interesting for VTS
-// (Version Tolerant Serialization). A pointer to it is optionally appended to
-// MethodTables with VTS event methods or NotSerialized or OptionallySerialized
-// fields. The structure is variable length to incorporate a packed array of
-// data describing the disposition of fields in the type.
-struct RemotingVtsInfo
-{
-    enum VtsCallbackType
-    {
-        VTS_CALLBACK_ON_SERIALIZING = 0,
-        VTS_CALLBACK_ON_SERIALIZED,
-        VTS_CALLBACK_ON_DESERIALIZING,
-        VTS_CALLBACK_ON_DESERIALIZED,
-        VTS_NUM_CALLBACK_TYPES
-    };
-
-    FixupPointer<PTR_MethodDesc> m_pCallbacks[VTS_NUM_CALLBACK_TYPES];
-#ifdef _DEBUG
-    DWORD               m_dwNumFields;
-#endif
-    DWORD               m_rFieldTypes[1];
-
-    static DWORD GetSize(DWORD dwNumFields)
-    {
-        LIMITED_METHOD_CONTRACT;
-        // Encode each field in two bits. Round up allocation to the nearest DWORD.
-        DWORD dwBitsRequired = dwNumFields * 2;
-        DWORD dwBytesRequired = (dwBitsRequired + 7) / 8;
-        return (DWORD)(offsetof(RemotingVtsInfo, m_rFieldTypes[0]) + ALIGN_UP(dwBytesRequired, sizeof(DWORD)));
-    }
-
-    void SetIsNotSerialized(DWORD dwFieldIndex)
-    {
-        LIMITED_METHOD_CONTRACT;
-        _ASSERTE(dwFieldIndex < m_dwNumFields);
-        DWORD dwRecordIndex = dwFieldIndex * 2;
-        DWORD dwOffset = dwRecordIndex / (sizeof(DWORD) * 8);
-        DWORD dwMask = 1 << (dwRecordIndex % (sizeof(DWORD) * 8));
-        m_rFieldTypes[dwOffset] |= dwMask;
-    }
-
-    BOOL IsNotSerialized(DWORD dwFieldIndex)
-    {
-        LIMITED_METHOD_CONTRACT;
-        _ASSERTE(dwFieldIndex < m_dwNumFields);
-        DWORD dwRecordIndex = dwFieldIndex * 2;
-        DWORD dwOffset = dwRecordIndex / (sizeof(DWORD) * 8);
-        DWORD dwMask = 1 << (dwRecordIndex % (sizeof(DWORD) * 8));
-        return m_rFieldTypes[dwOffset] & dwMask;
-    }
-
-    void SetIsOptionallySerialized(DWORD dwFieldIndex)
-    {
-        LIMITED_METHOD_CONTRACT;
-        _ASSERTE(dwFieldIndex < m_dwNumFields);
-        DWORD dwRecordIndex = dwFieldIndex * 2;
-        DWORD dwOffset = dwRecordIndex / (sizeof(DWORD) * 8);
-        DWORD dwMask = 2 << (dwRecordIndex % (sizeof(DWORD) * 8));
-        m_rFieldTypes[dwOffset] |= dwMask;
-    }
-
-    BOOL IsOptionallySerialized(DWORD dwFieldIndex)
-    {
-        LIMITED_METHOD_CONTRACT;
-        _ASSERTE(dwFieldIndex < m_dwNumFields);
-        DWORD dwRecordIndex = dwFieldIndex * 2;
-        DWORD dwOffset = dwRecordIndex / (sizeof(DWORD) * 8);
-        DWORD dwMask = 2 << (dwRecordIndex % (sizeof(DWORD) * 8));
-        return m_rFieldTypes[dwOffset] & dwMask;
-    }
-};  // struct RemotingVtsInfo
-typedef DPTR(RemotingVtsInfo) PTR_RemotingVtsInfo;
-
-
 #ifdef FEATURE_COMINTEROP
 struct RCWPerTypeData;
 #endif // FEATURE_COMINTEROP
@@ -3908,8 +3834,6 @@ private:
         enum_flag_GenericsMask_GenericInst  = 0x00000010,   // regular instantiation, e.g. List<String>
         enum_flag_GenericsMask_SharedInst   = 0x00000020,   // shared instantiation, e.g. List<__Canon> or List<MyValueType<__Canon>>
         enum_flag_GenericsMask_TypicalInst  = 0x00000030,   // the type instantiated at its formal parameters, e.g. List<T>
-
-        enum_flag_HasRemotingVtsInfo        = 0x00000080,   // Optional data present indicating VTS methods and optional fields
 
         enum_flag_HasVariance               = 0x00000100,   // This is an instantiated type some of whose type parameters are co or contra-variant
 

--- a/src/vm/methodtable.h
+++ b/src/vm/methodtable.h
@@ -4341,12 +4341,10 @@ private:
 
     inline static DWORD GetOptionalMembersAllocationSize(
                                                   DWORD dwMultipurposeSlotsMask,
-                                                  BOOL needsRemotableMethodInfo,
                                                   BOOL needsGenericsStaticsInfo,
                                                   BOOL needsGuidInfo,
                                                   BOOL needsCCWTemplate,
                                                   BOOL needsRCWPerTypeData,
-                                                  BOOL needsRemotingVtsInfo,
                                                   BOOL needsTokenOverflow);
     inline DWORD GetOptionalMembersSize();
 

--- a/src/vm/methodtable.inl
+++ b/src/vm/methodtable.inl
@@ -1388,26 +1388,17 @@ FORCEINLINE DWORD MethodTable::GetOffsetOfOptionalMember(OptionalMemberId id)
 }
 
 //==========================================================================================
-// this is not the pretties function however I got bitten pretty hard by the computation 
-// of the allocation size of a MethodTable done "by hand" in few places.
-// Essentially the idea is that this is going to centralize computation of size for optional
-// members so the next morons that need to add an optional member will look at this function
-// and hopefully be less exposed to code doing size computation behind their back
 inline DWORD MethodTable::GetOptionalMembersAllocationSize(DWORD dwMultipurposeSlotsMask,
-                                                           BOOL needsRemotableMethodInfo,
                                                            BOOL needsGenericsStaticsInfo,
                                                            BOOL needsGuidInfo,
                                                            BOOL needsCCWTemplate,
                                                            BOOL needsRCWPerTypeData,
-                                                           BOOL needsRemotingVtsInfo,
                                                            BOOL needsTokenOverflow)
 {
     LIMITED_METHOD_CONTRACT;
 
     DWORD size = c_OptionalMembersStartOffsets[dwMultipurposeSlotsMask] - sizeof(MethodTable);
 
-    if (needsRemotableMethodInfo)
-        size += sizeof(UINT_PTR);
     if (needsGenericsStaticsInfo)
         size += sizeof(GenericsStaticsInfo);
     if (needsGuidInfo)
@@ -1415,8 +1406,6 @@ inline DWORD MethodTable::GetOptionalMembersAllocationSize(DWORD dwMultipurposeS
     if (needsCCWTemplate)
         size += sizeof(UINT_PTR);
     if (needsRCWPerTypeData)
-        size += sizeof(UINT_PTR);
-    if (needsRemotingVtsInfo)
         size += sizeof(UINT_PTR);
     if (dwMultipurposeSlotsMask & enum_flag_HasInterfaceMap)
         size += sizeof(UINT_PTR);

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -5206,8 +5206,7 @@ MethodTableBuilder::PlaceNonVirtualMethods()
 #endif // _DEBUG
 
         if (!fCanHaveNonVtableSlots ||
-            it->GetMethodType() == METHOD_TYPE_INSTANTIATED ||
-            MayBeRemotingIntercepted(*it))
+            it->GetMethodType() == METHOD_TYPE_INSTANTIATED)
         {
             // We use slot during remoting and to map methods between generic instantiations
             // (see MethodTable::GetParallelMethodDesc). The current implementation
@@ -6961,15 +6960,6 @@ MethodTableBuilder::NeedsNativeCodeSlot(bmtMDMethod * pMDMethod)
 #endif
 
     return GetModule()->IsEditAndContinueEnabled();
-}
-
-//*******************************************************************************
-BOOL
-MethodTableBuilder::MayBeRemotingIntercepted(bmtMDMethod * pMDMethod)
-{
-    LIMITED_METHOD_CONTRACT;
-
-    return FALSE;
 }
 
 //*******************************************************************************

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -9779,9 +9779,7 @@ MethodTable * MethodTableBuilder::AllocateNewMT(Module *pLoaderModule,
                                          BOOL isInterface,
                                          BOOL fDynamicStatics,
                                          BOOL fHasGenericsStaticsInfo,
-                                         BOOL fNeedsRCWPerTypeData,
-                                         BOOL fNeedsRemotableMethodInfo,
-                                         BOOL fNeedsRemotingVtsInfo
+                                         BOOL fNeedsRCWPerTypeData
 #ifdef FEATURE_COMINTEROP
         , BOOL fHasDynamicInterfaceMap
 #endif
@@ -9826,12 +9824,10 @@ MethodTable * MethodTableBuilder::AllocateNewMT(Module *pLoaderModule,
 
     // Add space for optional members here. Same as GetOptionalMembersSize()
     cbTotalSize += MethodTable::GetOptionalMembersAllocationSize(dwMultipurposeSlotsMask,
-                                                      fNeedsRemotableMethodInfo,
                                                       fHasGenericsStaticsInfo,
                                                       FALSE, // no GuidInfo needed for canonical instantiations
                                                       FALSE, // no CCW template needed for canonical instantiations
                                                       fNeedsRCWPerTypeData,
-                                                      fNeedsRemotingVtsInfo,
                                                       RidFromToken(GetCl()) >= METHODTABLE_TOKEN_OVERFLOW);
 
     // Interface map starts here
@@ -10079,10 +10075,6 @@ MethodTableBuilder::SetupMethodTable2(
                           bmtGenerics->GetNumGenericArgs(), pClass->GetDictionaryLayout())
                    : 0;
 
-
-    BOOL fNeedsRemotableMethodInfo=FALSE;
-    BOOL fNeedsRemotingVtsInfo = FALSE;
-
 #ifdef FEATURE_COLLECTIBLE_TYPES
     BOOL fCollectible = pLoaderModule->IsCollectible();
 #endif // FEATURE_COLLECTIBLE_TYPES
@@ -10122,8 +10114,6 @@ MethodTableBuilder::SetupMethodTable2(
                                    bmtProp->fDynamicStatics,
                                    bmtProp->fGenericsStatics,
                                    fNeedsRCWPerTypeData,
-                                   fNeedsRemotableMethodInfo,
-                                   fNeedsRemotingVtsInfo,
 #ifdef FEATURE_COMINTEROP 
                                    fHasDynamicInterfaceMap,
 #endif

--- a/src/vm/methodtablebuilder.h
+++ b/src/vm/methodtablebuilder.h
@@ -1868,8 +1868,8 @@ private:
         // Counts instance fields
         DWORD dwNumInstanceFields;
 
-        // Counts both regular statics and thread statics. Currently RVA and
-        // context statics get lumped in with "regular statics".
+        // Counts both regular statics and thread statics. Currently RVA
+        // get lumped in with "regular statics".
         DWORD dwNumStaticFields;
         DWORD dwNumStaticObjRefFields;
         DWORD dwNumStaticBoxedFields;

--- a/src/vm/methodtablebuilder.h
+++ b/src/vm/methodtablebuilder.h
@@ -2935,9 +2935,7 @@ private:
                                 BOOL isIFace, 
                                 BOOL fDynamicStatics,
                                 BOOL fHasGenericsStaticsInfo,
-                                BOOL fNeedsRCWPerTypeData,
-                                BOOL fNeedsRemotableMethodInfo,
-                                BOOL fNeedsRemotingVtsInfo
+                                BOOL fNeedsRCWPerTypeData
 #ifdef FEATURE_COMINTEROP
                                 , BOOL bHasDynamicInterfaceMap
 #endif

--- a/src/vm/methodtablebuilder.h
+++ b/src/vm/methodtablebuilder.h
@@ -2801,11 +2801,6 @@ private:
     NeedsNativeCodeSlot(bmtMDMethod * pMDMethod);
 
     // --------------------------------------------------------------------------------------------
-    // MethodTableBuilder version of code:MethodDesc::MayBeRemotingIntercepted. Used for MethodDesc layout.
-    BOOL
-    MayBeRemotingIntercepted(bmtMDMethod * pMDMethod);
-
-    // --------------------------------------------------------------------------------------------
     // Used to allocate and initialize the dictionary used with generic types.
     VOID
     AllocAndInitDictionary();

--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -85,7 +85,6 @@ class Thread;
 class BaseDomain;
 class Assembly;
 class Context;
-class CtxStaticData;
 class DomainAssembly;
 class AssemblyNative;
 class WaitHandleNative;

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -1992,11 +1992,7 @@ static PCODE PatchNonVirtualExternalMethod(MethodDesc * pMD, PCODE pCode, PTR_CO
     //
 #ifdef HAS_FIXUP_PRECODE
     if (pMD->HasPrecode() && pMD->GetPrecode()->GetType() == PRECODE_FIXUP
-        && pMD->IsNativeCodeStableAfterInit()
-#ifndef HAS_REMOTING_PRECODE
-        && !pMD->IsRemotingInterceptedViaPrestub()
-#endif
-        )
+        && pMD->IsNativeCodeStableAfterInit())
     {
         PCODE pDirectTarget = pMD->IsFCall() ? ECall::GetFCallImpl(pMD) : pMD->GetNativeCode();
         if (pDirectTarget != NULL)

--- a/src/vm/proftoeeinterfaceimpl.cpp
+++ b/src/vm/proftoeeinterfaceimpl.cpp
@@ -3537,9 +3537,7 @@ HRESULT ProfToEEInterfaceImpl::GetThreadStaticAddress2(ClassID classId,
  *    pAddress - location for storing the resulting address location.
  *
  * Returns:
- *    S_OK on success,
- *    E_INVALIDARG if not a context static,
- *    CORPROF_E_DATAINCOMPLETE if not yet initialized.
+ *    E_NOTIMPL
  *
  */
 HRESULT ProfToEEInterfaceImpl::GetContextStaticAddress(ClassID classId,


### PR DESCRIPTION
Building on #20256, this further cleans up references to context statics. It also removes some adjacent remoting things.