### PR TITLE
Fix SegmentInitialize for OS_PAGE_SIZE > 4k

### DIFF
--- a/src/gc/handletablecore.cpp
+++ b/src/gc/handletablecore.cpp
@@ -508,10 +508,7 @@ BOOL SegmentInitialize(TableSegment *pSegment, HandleTable *pTable)
     */
     
     // we want to commit enough for the header PLUS some handles
-    uint32_t dwCommit = HANDLE_HEADER_SIZE;
-
-    // Round down to the dwPageSize
-    dwCommit &= ~(OS_PAGE_SIZE - 1);
+    size_t dwCommit = ALIGN_UP(HANDLE_HEADER_SIZE, OS_PAGE_SIZE);
 
     // commit the header
     if (!GCToOSInterface::VirtualCommit(pSegment, dwCommit))


### PR DESCRIPTION
The function was incorrectly rounding the dwCommit down instead of up
to OS_PAGE_SIZE. It accidentally works for OSes where page size is 4096
bytes, because the dwCommit is 4096. But for ARM64 Linux distros where
the page size is 64kB, this was committing zero bytes and so the runtime
initialization was crashing a bit later when it tried to access the
memory it was supposed to be commited.

This problem was introduced in #17769.