### PR TITLE
JIT: make sure to use normalized type when retyping box temp

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -12876,17 +12876,18 @@ GenTree* Compiler::gtTryRemoveBoxUpstreamEffects(GenTree* op, BoxRemovalOptions 
         lvaTable[boxTempLcl].lvType   = TYP_UNDEF;
         const bool isUnsafeValueClass = false;
         lvaSetStruct(boxTempLcl, boxClass, isUnsafeValueClass);
+        var_types boxTempType = lvaTable[boxTempLcl].lvType;
 
         // Remove the newobj and assigment to box temp
         JITDUMP("Bashing NEWOBJ [%06u] to NOP\n", dspTreeID(asg));
         asg->gtBashToNOP();
 
         // Update the copy from the value to be boxed to the box temp
-        GenTree* newDst     = gtNewOperNode(GT_ADDR, TYP_BYREF, gtNewLclvNode(boxTempLcl, TYP_STRUCT));
+        GenTree* newDst     = gtNewOperNode(GT_ADDR, TYP_BYREF, gtNewLclvNode(boxTempLcl, boxTempType));
         copyDst->gtOp.gtOp1 = newDst;
 
         // Return the address of the now-struct typed box temp
-        GenTree* retValue = gtNewOperNode(GT_ADDR, TYP_BYREF, gtNewLclvNode(boxTempLcl, TYP_STRUCT));
+        GenTree* retValue = gtNewOperNode(GT_ADDR, TYP_BYREF, gtNewLclvNode(boxTempLcl, boxTempType));
 
         return retValue;
     }

--- a/tests/src/JIT/Regression/JitBlue/GitHub_20260/GitHub_20260.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_20260/GitHub_20260.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Globalization;
+using System.Numerics;
+
+namespace GitHub_20260
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {         
+            Vector<double> x = new Vector<double>();
+            string s = ((IFormattable)x).ToString("G", CultureInfo.InvariantCulture);
+            string e = "<0, 0, 0, 0>";
+
+            if (s != e)
+            {
+                Console.WriteLine($"FAIL: Expected {e}, got {s}");
+                return -1;
+            }
+
+            return 100;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_20260/GitHub_20260.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_20260/GitHub_20260.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Globalization;
 using System.Numerics;
@@ -8,9 +12,28 @@ namespace GitHub_20260
     {
         static int Main(string[] args)
         {         
+            // The jit will devirtualize the call to ToString and then undo the box.
+            // Make sure that happens properly for vectors.
+
             Vector<double> x = new Vector<double>();
             string s = ((IFormattable)x).ToString("G", CultureInfo.InvariantCulture);
-            string e = "<0, 0, 0, 0>";
+            string e = null;
+
+            switch (Vector<double>.Count)
+            {
+                case 2:
+                    e = "<0, 0>";
+                    break;
+                case 4:
+                    e = "<0, 0, 0, 0>";
+                    break;
+                case 8:
+                    e = "<0, 0, 0, 0, 0, 0, 0, 0>";
+                    break;
+                default:
+                    e = "unexpected vector length";
+                    break;
+            }
 
             if (s != e)
             {
@@ -18,6 +41,7 @@ namespace GitHub_20260
                 return -1;
             }
 
+            Console.WriteLine($"PASS: {s}");
             return 100;
         }
     }

--- a/tests/src/JIT/Regression/JitBlue/GitHub_20260/GitHub_20260.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_20260/GitHub_20260.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Take advantage of the fact that `lvaSetStruct` figures out the right
type to use in the IR.

Fixes first part of #20260.