### PR TITLE
Clear unnecessary state from completed Tasks

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -2178,9 +2178,15 @@ namespace System.Threading.Tasks
             // continuations hold onto the task, and therefore are keeping it alive.
             m_action = null;
 
-            // Notify parent if this was an attached task
-            if (m_contingentProperties != null)
+            ContingentProperties cp = m_contingentProperties;
+            if (cp != null)
             {
+                // Similarly, null out any ExecutionContext we may have captured,
+                // to avoid keeping state like async locals alive unnecessarily
+                // when the Task is kept alive.
+                cp.m_capturedContext = null;
+
+                // Notify parent if this was an attached task
                 NotifyParentIfPotentiallyAttachedTask();
             }
 


### PR DESCRIPTION
When Tasks backed by delegates are created, an ExecutionContext is captured.  When the task completes, its delegate is being cleared, but its ExecutionContext is not, which means if the Task is subsequently kept alive (e.g. stored in a cache), so too is its ExecutionContext, which can capture an arbitrary amount of ambient state via async locals.  This commit augments the clearing of the delegate to similarly clear the ExecutionContext.

Related, async methods can also capture ExecutionContext when awaits yield, so this clears out that context as well.  And as long as we're doing that, we may as well also clear the state machine state, so that any hoisted locals in the state machine aren't kept alive if the resulting task is kept alive.  Not doing so previously was a conscious choice, in order to aid in debugging, but as we've heard of at least a couple of cases where it unexpectedly caused a leak, I'm going ahead and changing it.

Fixes https://github.com/dotnet/coreclr/issues/20273
Fixes https://github.com/dotnet/coreclr/issues/20244
cc: @kouvel, @tarekgh, @davidfowl, @benaadams 