### PR TITLE
Remove mention of rotor from comments

### DIFF
--- a/Documentation/botr/exceptions.md
+++ b/Documentation/botr/exceptions.md
@@ -13,7 +13,7 @@ Exceptions matter almost everywhere. They matter the most in functions that thro
 Why are CLR internal exceptions different?
 ==========================================
 
-The CLR's internal exceptions are much like C++ exceptions, but not exactly. Rotor can be built for Mac OSX, for BSD, and for Windows. The OS and compiler differences dictate that we can't just use standard C++ try/catch. In addition, the CLR internal exceptions provide features similar to the managed "finally" and "fault".
+The CLR's internal exceptions are much like C++ exceptions, but not exactly. CoreCLR can be built for Mac OSX, for Linux, for BSD, and for Windows. The OS and compiler differences dictate that we can't just use standard C++ try/catch. In addition, the CLR internal exceptions provide features similar to the managed "finally" and "fault".
 
 With the help of some macros, it is possible to write exception handling code that is almost as easy to write and to read as standard C++.
 

--- a/src/System.Private.CoreLib/src/Microsoft/Win32/Win32Native.cs
+++ b/src/System.Private.CoreLib/src/Microsoft/Win32/Win32Native.cs
@@ -6,8 +6,8 @@
 **
 **
 **
-** Purpose: The CLR wrapper for all Win32 as well as 
-**          ROTOR-style Unix PAL, etc. native operations
+** Purpose: CoreCLR wrapper for Win32, either the native
+**          operations or the Unix PAL implemtation of them.
 **
 **
 ===========================================================*/
@@ -105,11 +105,8 @@ namespace Microsoft.Win32
     using ULONG = System.UInt32;
 
     /**
-     * Win32 encapsulation for MSCORLIB.
+     * Win32 encapsulation for System.Private.CoreLib.
      */
-    // Remove the default demands for all P/Invoke methods with this
-    // global declaration on the class.
-
     internal static class Win32Native
     {
         internal const int LMEM_FIXED = 0x0000;

--- a/src/ToolBox/SOS/DacTableGen/main.cs
+++ b/src/ToolBox/SOS/DacTableGen/main.cs
@@ -296,7 +296,7 @@ Required:
         if (pdbFile != null)
         {
 #if FEATURE_PAL     
-            throw new InvalidOperationException("Not supported in Rotor.");
+            throw new InvalidOperationException("PDBs are only supported on Windows.");
 #else
             PdbSymbolProvider pdbSymProvider = new PdbSymbolProvider(pdbFile, dllFile);
 
@@ -337,7 +337,7 @@ Required:
                 List<UInt32> mapRvaArray = new List<UInt32>();
                 UInt32 mapNumGlobals;
 
-                // check that both map file and pdb file produce same output to avoid breakages on Rotor
+                // check that both map file and pdb file produce same output to avoid breakages
                 ScanDacFile(dacFile, 
                     new MapSymbolProvider(mapFile),
                     mapRvaArray, 

--- a/src/binder/utils.cpp
+++ b/src/binder/utils.cpp
@@ -148,7 +148,6 @@ namespace BINDER_SPACE
 
     BOOL IsURL(SString &urlOrPath)
     {
-        // This is also in defined rotor pal
         return PathIsURLW(urlOrPath);
     }
 

--- a/src/debug/daccess/enummem.cpp
+++ b/src/debug/daccess/enummem.cpp
@@ -218,7 +218,6 @@ HRESULT ClrDataAccess::EnumMemCLRStatic(IN CLRDataEnumMemoryFlags flags)
     }
     EX_END_CATCH(RethrowCancelExceptions)
 
-    // StressLog is not defined on Rotor build for DAC
     CATCH_ALL_EXCEPT_RETHROW_COR_E_OPERATIONCANCELLED ( ReportMem(m_globalBase + g_dacGlobals.dac__g_pStressLog, sizeof(StressLog *)); )
 
     EX_TRY

--- a/src/debug/di/nativepipeline.h
+++ b/src/debug/di/nativepipeline.h
@@ -19,8 +19,9 @@
 // that is being debugged.
 //
 // On windows, this is a wrapper around the win32 debugging API 
-// (eg, kernel32!WaitForDebugEvent). On rotor, it has an alternative implementation.
-// .  See code:IEventChannel for more information.
+// (eg, kernel32!WaitForDebugEvent). On most Unix-like platforms,
+// it has an alternative implementation. See code:IEventChannel and
+// platformspecific.cpp for more information.
 // @dbgtodo : All of the APIs that return BOOL should probably be changed to
 // return HRESULTS so we don't have to rely on some implicit GetLastError protocol.
 //-----------------------------------------------------------------------------

--- a/src/debug/di/rsthread.cpp
+++ b/src/debug/di/rsthread.cpp
@@ -2140,7 +2140,7 @@ HRESULT CordbThread::InterceptCurrentException(ICorDebugFrame * pFrame)
     ATT_REQUIRE_STOPPED_MAY_FAIL(GetProcess());
     
 #if defined(FEATURE_DBGIPC_TRANSPORT_DI)
-    // Continuable exceptions are not implemented on rotor and Mac.
+    // Continuable exceptions are not implemented on Unix-like platforms.
     return E_NOTIMPL;
 
 #else  // !FEATURE_DBGIPC_TRANSPORT_DI

--- a/src/debug/di/shimprocess.cpp
+++ b/src/debug/di/shimprocess.cpp
@@ -814,7 +814,7 @@ HRESULT ShimProcess::HandleWin32DebugEvent(const DEBUG_EVENT * pEvent)
                 // Call back into that. This will handle Continuing the debug event.
                 m_pProcess->HandleDebugEventForInteropDebugging(pEvent); 
 #else
-                _ASSERTE(!"Interop debugging not supported on Rotor");
+                _ASSERTE(!"Interop debugging not supported");
 #endif
             }
             else

--- a/src/debug/ildbsymlib/symwrite.cpp
+++ b/src/debug/ildbsymlib/symwrite.cpp
@@ -127,7 +127,7 @@ COM_METHOD SymWriter::Initialize
 {    
     HRESULT hr = S_OK;
     
-    // Incremental compile not implemented in Rotor
+    // Incremental compile not implemented
     _ASSERTE(fFullBuild);
     
     if (emitter == NULL)
@@ -1072,8 +1072,6 @@ COM_METHOD SymWriter::SetSymAttribute(
     BYTE data[])
 {
     // Setting attributes on the symbol isn't supported
-
-    // ROTORTODO: #156785 in PS
     return S_OK;
 }
 

--- a/src/debug/inc/dbgtargetcontext.h
+++ b/src/debug/inc/dbgtargetcontext.h
@@ -10,9 +10,9 @@
 #include "crosscomp.h"
 
 //
-// The right side of the debugger can now be built to target multiple platforms. This means it is no longer
+// The right side of the debugger can be built to target multiple platforms. This means it is not
 // safe to use the CONTEXT structure directly: the context of the platform we're building for might not match
-// that of the one the debugger is targetting. So now all right side code will use the DT_CONTEXT abstraction
+// that of the one the debugger is targetting. So all right side code will use the DT_CONTEXT abstraction
 // instead. When the debugger target is the local platform this will just resolve back into CONTEXT, but cross
 // platform we'll provide a hand-rolled version.
 //
@@ -26,11 +26,8 @@
 // ByteSwapContext.
 //
 
-// For now, the only cross-platform CONTEXTs we support are x86/PAL and ARM/Win. Look in
-// rotor/pal/inc/rotor_pal.h for the original PAL definitions.
-
 //
-// **** NOTE: Keep these in sync with rotor/pal/inc/rotor_pal.h ****
+// **** NOTE: Keep these in sync with pal/inc/pal.h ****
 //
 
 // This odd define pattern is needed because in DBI we set _TARGET_ to match the host and

--- a/src/dlls/mscordbi/mscordbi.cpp
+++ b/src/dlls/mscordbi/mscordbi.cpp
@@ -21,9 +21,6 @@ extern BOOL WINAPI DbgDllMain(HINSTANCE hInstance, DWORD dwReason,
 extern "C"
 BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
 {
-	//<TODO> Shoud we call DisableThreadLibraryCalls?  Or does this code
-	//	need native thread attatch/detatch notifications? </TODO>
-
 	// Defer to the main debugging code.
     return DbgDllMain(hInstance, dwReason, lpReserved);
 }

--- a/src/inc/corhdr.h
+++ b/src/inc/corhdr.h
@@ -198,8 +198,8 @@ typedef enum ReplacesCorHdrNumericDefines
 // The most important of these is the MetaData tables.   The easiest way of looking at meta-data is using
 // the IlDasm.exe tool.   
 // 
-// MetaData holds most of the information in the IL image.  THe exceptions are resource blobs and the IL
-// instructions streams for individual methods.  Intstead the Meta-data for a method holds an RVA to a 
+// MetaData holds most of the information in the IL image.  The exceptions are resource blobs and the IL
+// instructions streams for individual methods.  Instead the Meta-data for a method holds an RVA to a
 // code:IMAGE_COR_ILMETHOD which holds all the IL stream (and exception handling information).  
 // 
 // Precompiled (NGEN) images use the same IMAGE_COR20_HEADER but also use the ManagedNativeHeader field to

--- a/src/inc/daccess.h
+++ b/src/inc/daccess.h
@@ -1889,10 +1889,6 @@ public: name(TADDR addr, TADDR vtAddr);
 
 #define GFN_TADDR(name) (DacGlobalBase() + g_dacGlobals.fn__ ## name)
 
-// ROTORTODO - g++ 3 doesn't like the use of the operator& in __GlobalVal
-// here. Putting GVAL_ADDR in to get things to compile while I discuss
-// this matter with the g++ authors.
-
 #define GVAL_ADDR(g) \
     ((g).operator&())
 

--- a/src/inc/ex.h
+++ b/src/inc/ex.h
@@ -720,10 +720,6 @@ private:
 // backout code following the END_CATCH that has to be executed. The solution is
 // to replace that backout code with holder objects.
 
-
-// This is a rotten way to define an enum but as long as we're treating
-// "if (optimizabletoconstant)" warnings as fatal errors, we have little choice.
-
 //-----------------------------------------------------------------------
 
 #define RethrowTransientExceptions                                      \
@@ -926,7 +922,8 @@ Exception *ExThrowWithInnerHelper(Exception *inner);
                 INDEBUG(static bool __alwayszero;)                                      \
                 INDEBUG(VolatileLoad(&__alwayszero);)                                   \
                 {                                                                       \
-                    /* this is necessary for Rotor exception handling to work */        \
+                    /* Disallow returns to make exception handling work. */             \
+                    /* Some work is done after the catch, see EX_ENDTRY. */             \
                     DEBUG_ASSURE_NO_RETURN_BEGIN(EX_TRY)                                \
                     EX_TRY_HOLDER                                                       \
 
@@ -977,7 +974,8 @@ Exception *ExThrowWithInnerHelper(Exception *inner);
             INDEBUG(static bool __alwayszero;)                                      \
             INDEBUG(VolatileLoad(&__alwayszero);)                                   \
             {                                                                       \
-                /* this is necessary for Rotor exception handling to work */        \
+                /* Disallow returns to make exception handling work. */             \
+                /* Some work is done after the catch, see EX_ENDTRY. */             \
                 DEBUG_ASSURE_NO_RETURN_BEGIN(EX_TRY)                                \
 
 #define EX_CATCH_IMPL_CPP_ONLY                                                      \

--- a/src/inc/palclr.h
+++ b/src/inc/palclr.h
@@ -185,7 +185,7 @@
 // integer constants. 64-bit integer constants should be wrapped in the
 // declarations listed here.
 //
-// Each of the #defines here is wrapped to avoid conflicts with rotor_pal.h.
+// Each of the #defines here is wrapped to avoid conflicts with pal.h.
 
 #if defined(_MSC_VER)
 

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -10,9 +10,9 @@ Module Name:
 
 Abstract:
 
-    Rotor Platform Adaptation Layer (PAL) header file.  This file
-    defines all types and API calls required by the Rotor port of
-    the Microsoft Common Language Runtime.
+    CoreCLR Platform Adaptation Layer (PAL) header file.  This file
+    defines all types and API calls required by the CoreCLR when
+    compiled for Unix-like systems.
 
     Defines which control the behavior of this include file:
       UNICODE - define it to set the Ansi/Unicode neutral names to

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -5043,9 +5043,7 @@ public:
 };
 
 //
-// NOTE: Catching hardware exceptions are only enabled in the DAC and SOS 
-// builds. A hardware exception in coreclr code will fail fast/terminate
-// the process.
+// NOTE: This is only defined in one PAL test.
 //
 #ifdef FEATURE_ENABLE_HARDWARE_EXCEPTIONS
 #define HardwareExceptionHolder CatchHardwareExceptionHolder __catchHardwareException;

--- a/src/pal/inc/rt/palrt.h
+++ b/src/pal/inc/rt/palrt.h
@@ -14,9 +14,9 @@
 
 Abstract:
 
-    Rotor runtime functions.  These are functions which are ordinarily
-    implemented as part of the Win32 API set, but for Rotor, are
-    implemented as a runtime library on top of the PAL.
+    PAL runtime functions.  These are functions which are ordinarily
+    implemented as part of the Win32 API set, but when compiling CoreCLR for
+    Unix-like systems, are implemented as a runtime library on top of the PAL.
 
 Author:
 

--- a/src/pal/inc/rt/sal.h
+++ b/src/pal/inc/rt/sal.h
@@ -2951,7 +2951,3 @@ __PRIMOP(int, _In_function_class_(__In_impl_ char*);)
 #ifdef  __cplusplus // [
 }
 #endif // ]
-
-// Rotor doesn't need concurrency sal.
-// #include <ConcurrencySal.h>
-

--- a/src/pal/inc/rt/specstrings.h
+++ b/src/pal/inc/rt/specstrings.h
@@ -515,9 +515,6 @@ void __pfx_assume(int, const char *);
 #define __PRIMOP(type, fun)
 #endif /* !defined(_Outptr_) || _MSC_VER <= 1600 */
 
-// ROTOR doesn't need driverspecs.h
-// #include <driverspecs.h>
-
 /*
  If no SAL 2 appears to have been defined (_Outptr_ is a representative choice)
  then we must be operating in a downlevel build environment (such as VS10).

--- a/src/pal/src/examples/example1.cpp
+++ b/src/pal/src/examples/example1.cpp
@@ -9,13 +9,10 @@
  *
  * Run it using:
  *   export PAL_DBG_CHANNELS="+all.all"
- *   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:..
  *   ./example1
  *
  * With the PAL_DEBUG_CHANNELS environment variable set as above you
- * should see a trace output when the program runs. Setting
- * LD_LIBRARY_PATH is necessary unless you have installed librotor_pal.so in
- * a standard location.
+ * should see a trace output when the program runs.
  *
  * Build notes :
  * Since the PAL uses pthreads, some options must be passed to gcc to tell it

--- a/src/pal/src/file/file.cpp
+++ b/src/pal/src/file/file.cpp
@@ -1433,7 +1433,7 @@ Function:
   GetFileAttributesA
 
 Note:
-  Checking for directory and read-only file, according to Rotor spec.
+  Checking for directory and read-only file.
 
 Caveats:
   There are some important things to note about this implementation, which

--- a/src/pal/src/file/find.cpp
+++ b/src/pal/src/file/find.cpp
@@ -857,7 +857,7 @@ finding no matches but without any error occurring) or FALSE if any error
 occurs.  It calls SetLastError() if it returns FALSE.
 
 Sorting doesn't seem to be consistent on all Windows platform, and it's
-not required for Rotor to have the same sorting algorithm than Windows 2000.
+not required for CoreCLR to have the same sorting algorithm as Windows 2000.
 This implementation will give slightly different result for the sort list 
 than Windows 2000.
 

--- a/src/pal/src/include/pal/palinternal.h
+++ b/src/pal/src/include/pal/palinternal.h
@@ -12,9 +12,9 @@ Module Name:
 
 Abstract:
 
-    Rotor Platform Adaptation Layer (PAL) header file used by source
+    CoreCLR Platform Adaptation Layer (PAL) header file used by source
     file part of the PAL implementation. This is a wrapper over 
-    unix/inc/pal.h. It allows avoiding name collisions when including 
+    pal/inc/pal.h. It allows avoiding name collisions when including
     system header files, and it allows redirecting calls to 'standard' functions
     to their PAL counterpart
 

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -1026,7 +1026,7 @@ PALCommonCleanup()
 
 BOOL PALIsShuttingDown()
 {
-    /* ROTORTODO: This function may be used to provide a reader/writer-like
+    /* TODO: This function may be used to provide a reader/writer-like
        mechanism (or a ref counting one) to prevent PAL APIs that need to access 
        PAL runtime data, from working when PAL is shutting down. Each of those API 
        should acquire a read access while executing. The shutting down code would
@@ -1038,7 +1038,7 @@ BOOL PALIsShuttingDown()
 
 void PALSetShutdownIntent()
 {
-    /* ROTORTODO: See comment in PALIsShuttingDown */
+    /* TODO: See comment in PALIsShuttingDown */
     shutdown_intent = TRUE;
 }
 

--- a/src/pal/src/loader/modulename.cpp
+++ b/src/pal/src/loader/modulename.cpp
@@ -40,11 +40,11 @@ SET_DEFAULT_DEBUG_CHANNEL(LOADER);
     Internal wrapper for dladder used only to get module name
 
 Parameters:
-    None
+    LPVOID ProcAddress: a pointer to a function in a shared library
 
 Return value:
-    Pointer to string with the fullpath to the librotor_pal.so being
-    used.
+    Pointer to string with the fullpath to the shared library containing
+    ProcAddress.
 
     NULL if error occurred.
 

--- a/src/pal/src/locale/unicode.cpp
+++ b/src/pal/src/locale/unicode.cpp
@@ -314,7 +314,7 @@ Notes :
 "pseudo code pages", like CP_ACP, aren't considered 'valid' in this context.
 CP_UTF7 and CP_UTF8, however, *are* considered valid code pages, even though
 MSDN fails to mention them in the IsValidCodePage entry.
-Note : CP_UTF7 support isn't required for Rotor
+Note : CP_UTF7 support isn't required for CoreCLR
 --*/
 BOOL
 PALAPI
@@ -336,7 +336,7 @@ IsValidCodePage(
         retval = FALSE;
         break;
     case CP_UTF7:
-        /* valid in Win32, but not supported in Rotor */
+        /* valid in Win32, but not supported in the PAL */
         retval = FALSE;
         break;
     case CP_UTF8:

--- a/src/pal/src/misc/miscpalapi.cpp
+++ b/src/pal/src/misc/miscpalapi.cpp
@@ -154,8 +154,6 @@ Function :
     
     On failure it returns FALSE and sets the 
     proper LastError code.
-    
-See rotor_pal.doc for more details.
 
 --*/
 PALIMPORT

--- a/src/pal/src/misc/time.cpp
+++ b/src/pal/src/misc/time.cpp
@@ -170,7 +170,7 @@ Return Values
 The return value is the number of milliseconds that have elapsed since
 the system was started.
 
-In the ROTOR implementation the return value is the elapsed time since
+In the PAL implementation the return value is the elapsed time since
 the start of the epoch.
 
 --*/

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -7603,8 +7603,7 @@ LONG WINAPI CLRVectoredExceptionHandlerPhase2(PEXCEPTION_POINTERS pExceptionInfo
             return EXCEPTION_CONTINUE_SEARCH;
         }
 
-        // The breakpoint was from managed or the runtime.  Handle it.  Or,
-        //  this may be a Rotor build.
+        // The breakpoint was from managed or the runtime.  Handle it.
         return UserBreakpointFilter(pExceptionInfo);
     }
 

--- a/src/vm/i386/asmconstants.h
+++ b/src/vm/i386/asmconstants.h
@@ -40,7 +40,7 @@
 #define DynamicHelperFrameFlags_ObjectArg2  2
 
 
-// CONTEXT from rotor_pal.h
+// CONTEXT from pal.h
 #define CONTEXT_Edi 0x9c
 ASMCONSTANTS_C_ASSERT(CONTEXT_Edi == offsetof(CONTEXT,Edi))
 

--- a/src/vm/jitinterfacegen.cpp
+++ b/src/vm/jitinterfacegen.cpp
@@ -1,17 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
 // ===========================================================================
 // File: JITinterfaceGen.CPP
 //
-
+// This contains the AMD64 version of InitJITHelpers1().
+//
 // ===========================================================================
-
-// This contains generic C versions of some of the routines
-// required by JITinterface.cpp. They are modeled after
-// X86 specific routines found in JIThelp.asm or JITinterfaceX86.cpp
-// More and more we're making AMD64 and IA64 specific versions of
-// the helpers as well, JitInterfaceGen.cpp sticks around for rotor...
 
 
 #include "common.h"

--- a/src/vm/pendingload.h
+++ b/src/vm/pendingload.h
@@ -217,7 +217,7 @@ public:
 };
 
 // Hash table used to hold pending type loads
-// @todo : use shash.h when Rotor build problems are fixed and it supports LoaderHeap/Alloc\MemTracker
+// @todo : use shash.h when it supports LoaderHeap/Alloc\MemTracker
 class PendingTypeLoadTable
 {
 protected:

--- a/src/vm/profattachclient.cpp
+++ b/src/vm/profattachclient.cpp
@@ -673,8 +673,8 @@ HRESULT ProfilingAPIAttachClient::SignalAttachEvent(LPCWSTR wszEventName)
     }
 
     // Dealing directly with Windows event objects, not CLR event cookies, so
-    // using Win32 API directly.  Note that none of this code executes on rotor
-    // or if we're memory / sync-hosted, so the CLR wrapper is of no use to us anyway.
+    // using Win32 API directly.  Note that none of this code executes on Unix,
+    // so the CLR wrapper is of no use to us anyway.
 #pragma push_macro("SetEvent")
 #undef SetEvent
     if (!SetEvent(hAttachEvent))

--- a/src/vm/proftoeeinterfaceimpl.cpp
+++ b/src/vm/proftoeeinterfaceimpl.cpp
@@ -7749,7 +7749,7 @@ HRESULT ProfToEEInterfaceImpl::DoStackSnapshot(ThreadID thread,
         contextSize));
    
     HRESULT hr = E_UNEXPECTED;
-    // (hr assignment is to appease the rotor compiler; we won't actually return without explicitly setting hr again)
+    // (hr assignment is to appease the compiler; we won't actually return without explicitly setting hr again)
     
     Thread *pThreadToSnapshot = NULL;
     Thread * pCurrentThread = GetThreadNULLOk();


### PR DESCRIPTION
Related to #9872.

I've removed mentions of rotor in comments and documention, either by adding a more useful comment or removing an outdated comment.

I did not touch the non-compiling PAL tests, in case the comments would help in cleaning those up.
This commit does not remove references from code, that will be a followup PR.