### PR TITLE
Implement LeadingSignCount and LeadingZeroCount ARM64 Base Intrinsics

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Base.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Base.cs
@@ -12,7 +12,7 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
     [CLSCompliant(false)]
     public static class Base
     {
-        public static bool IsSupported { get { return false; }}
+        public static bool IsSupported { get { return IsSupported; }}
 
         /// <summary>
         /// Vector LeadingSignCount

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -5033,7 +5033,7 @@ void CodeGen::genHWIntrinsicUnaryOp(GenTreeHWIntrinsic* node)
 {
     GenTree*  op1       = node->gtGetOp1();
     regNumber targetReg = node->gtRegNum;
-    emitAttr  attr      = emitActualTypeSize(node);
+    emitAttr  attr      = emitActualTypeSize(op1->TypeGet());
 
     assert(targetReg != REG_NA);
     var_types targetType = node->TypeGet();

--- a/src/jit/hwintrinsicArm64.cpp
+++ b/src/jit/hwintrinsicArm64.cpp
@@ -254,6 +254,11 @@ GenTree* Compiler::impHWIntrinsic(NamedIntrinsic        intrinsic,
         case HWIntrinsicInfo::Unsupported:
             return impUnsupportedHWIntrinsic(CORINFO_HELP_THROW_PLATFORM_NOT_SUPPORTED, method, sig, mustExpand);
 
+        case HWIntrinsicInfo::UnaryOp:
+            op1 = impPopStack().val;
+
+            return gtNewScalarHWIntrinsicNode(JITtype2varType(sig->retType), op1, intrinsic);
+
         case HWIntrinsicInfo::SimdBinaryOp:
         case HWIntrinsicInfo::SimdBinaryRMWOp:
             // op1 is the first operand

--- a/tests/src/JIT/HardwareIntrinsics/Arm64/Base.cs
+++ b/tests/src/JIT/HardwareIntrinsics/Arm64/Base.cs
@@ -99,7 +99,6 @@ namespace Arm64intrisicsTest
 
         static void TestLeadingSignCount()
         {
-#if COREFX_HAS_ARM64_BASE
             String name = "LeadingSignCount";
 
             if (Base.IsSupported)
@@ -120,12 +119,10 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // COREFX_HAS_ARM64_BASE
         }
 
         static void TestLeadingZeroCount()
         {
-#if COREFX_HAS_ARM64_BASE
             String name = "LeadingZeroCount";
 
             if (Base.IsSupported)
@@ -152,7 +149,6 @@ namespace Arm64intrisicsTest
             }
 
             Console.WriteLine($"Test{name} passed");
-#endif // COREFX_HAS_ARM64_BASE
         }
 
         static void ExecuteAllTests()
@@ -163,7 +159,6 @@ namespace Arm64intrisicsTest
 
         static int Main(string[] args)
         {
-#if COREFX_HAS_ARM64_BASE
             Console.WriteLine($"System.Runtime.Intrinsics.Arm.Arm64.Base.IsSupported = {Base.IsSupported}");
 
             // Reflection call
@@ -171,7 +166,6 @@ namespace Arm64intrisicsTest
             bool reflectedIsSupported = Convert.ToBoolean(typeof(Base).GetMethod(issupported).Invoke(null, null));
 
             Debug.Assert(reflectedIsSupported == Base.IsSupported, "Reflection result does not match");
-#endif // COREFX_HAS_ARM64_BASE
 
             ExecuteAllTests();
 

--- a/tests/src/JIT/HardwareIntrinsics/Arm64/Base.cs
+++ b/tests/src/JIT/HardwareIntrinsics/Arm64/Base.cs
@@ -52,48 +52,6 @@ namespace Arm64intrisicsTest
             }
         }
 
-        static ulong bitsToUint64<T>(T x)
-        {
-            return Unsafe.As<T, ulong>(ref x) & ~(~0UL << 8*Unsafe.SizeOf<T>());
-        }
-
-        static int leadingZero<T>(T x)
-            where T : IConvertible
-        {
-            ulong compare = 0x1UL << (8*Unsafe.SizeOf<T>() - 1);
-            int result = 0;
-            ulong value = bitsToUint64(x);
-
-            while(value < compare)
-            {
-                result++;
-                compare >>= 1;
-            }
-
-            return result;
-
-            throw new Exception("Unexpected Type");
-        }
-
-        static int leadingSign<T>(T x)
-            where T : IConvertible
-        {
-            ulong value = bitsToUint64(x);
-            ulong signBit = value & (0x1UL << (8*Unsafe.SizeOf<T>() - 1));
-            int result = 0;
-
-            if (signBit == 0)
-            {
-                result = leadingZero(x);
-            }
-            else
-            {
-                result = leadingZero((T) Convert.ChangeType(value ^ (signBit + (signBit - 1)),  typeof(T)));
-            }
-
-            return result - 1;
-        }
-
         static int s_SignBit32 = 1 << 31;
         static long s_SignBit64 = 1L << 63;
 


### PR DESCRIPTION
This enables `LeadingSignCount` and `LeadingZeroCount` ARM64 Base (scalar) Intrinsics.

**JitDisasm for LeadingSignCount:**
```
; Assembly listing for method System.Runtime.Intrinsics.Arm.Arm64.Base:LeadingSignCount(int):int
; Emitting BLENDED_CODE for
; optimized code
; fp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T00] (  3,  3   )     int  ->   x0
;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [sp+0x00]
;
; Lcl frame size = 0

G_M27166_IG01:
        A9BF7BFD          stp     fp, lr, [sp,#-16]!
        910003FD          mov     fp, sp

G_M27166_IG02:
        5AC01400          cls     w0, w0

G_M27166_IG03:
        A8C17BFD          ldp     fp, lr, [sp],#16
        D65F03C0          ret     lr

; Total bytes of code 20, prolog size 8 for method System.Runtime.Intrinsics.Arm.Arm64.Base:LeadingSignCount(int):int
; ============================================================
```
```
; Assembly listing for method System.Runtime.Intrinsics.Arm.Arm64.Base:LeadingSignCount(long):int
; Emitting BLENDED_CODE for
; optimized code
; fp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T00] (  3,  3   )    long  ->   x0
;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [sp+0x00]
;
; Lcl frame size = 0

G_M27166_IG01:
        A9BF7BFD          stp     fp, lr, [sp,#-16]!
        910003FD          mov     fp, sp

G_M27166_IG02:
        DAC01400          cls     x0, x0

G_M27166_IG03:
        A8C17BFD          ldp     fp, lr, [sp],#16
        D65F03C0          ret     lr

; Total bytes of code 20, prolog size 8 for method System.Runtime.Intrinsics.Arm.Arm64.Base:LeadingSignCount(long):int
; ============================================================
```

**JitDisasm for LeadingZeroCount:**
```
; Assembly listing for method System.Runtime.Intrinsics.Arm.Arm64.Base:LeadingZeroCount(int):int
; Emitting BLENDED_CODE for
; optimized code
; fp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T00] (  3,  3   )     int  ->   x0
;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [sp+0x00]
;
; Lcl frame size = 0

G_M35375_IG01:
        A9BF7BFD          stp     fp, lr, [sp,#-16]!
        910003FD          mov     fp, sp

G_M35375_IG02:
        5AC01000          clz     w0, w0

G_M35375_IG03:
        A8C17BFD          ldp     fp, lr, [sp],#16
        D65F03C0          ret     lr

; Total bytes of code 20, prolog size 8 for method System.Runtime.Intrinsics.Arm.Arm64.Base:LeadingZeroCount(int):int
; ============================================================
```
```
; Assembly listing for method System.Runtime.Intrinsics.Arm.Arm64.Base:LeadingZeroCount(int):int
; Emitting BLENDED_CODE for
; optimized code
; fp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T00] (  3,  3   )     int  ->   x0
;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [sp+0x00]
;
; Lcl frame size = 0

G_M35375_IG01:
        A9BF7BFD          stp     fp, lr, [sp,#-16]!
        910003FD          mov     fp, sp

G_M35375_IG02:
        5AC01000          clz     w0, w0

G_M35375_IG03:
        A8C17BFD          ldp     fp, lr, [sp],#16
        D65F03C0          ret     lr

; Total bytes of code 20, prolog size 8 for method System.Runtime.Intrinsics.Arm.Arm64.Base:LeadingZeroCount(int):int
; ============================================================
```
```
; Assembly listing for method System.Runtime.Intrinsics.Arm.Arm64.Base:LeadingZeroCount(long):int
; Emitting BLENDED_CODE for
; optimized code
; fp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T00] (  3,  3   )    long  ->   x0
;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [sp+0x00]
;
; Lcl frame size = 0

G_M35375_IG01:
        A9BF7BFD          stp     fp, lr, [sp,#-16]!
        910003FD          mov     fp, sp

G_M35375_IG02:
        DAC01000          clz     x0, x0

G_M35375_IG03:
        A8C17BFD          ldp     fp, lr, [sp],#16
        D65F03C0          ret     lr

; Total bytes of code 20, prolog size 8 for method System.Runtime.Intrinsics.Arm.Arm64.Base:LeadingZeroCount(long):int
; ============================================================
```