### PR TITLE
Fast-path ExecutionContext for ThreadPool items

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
@@ -149,7 +149,7 @@ namespace System.Threading
             ExecutionContext previousExecutionCtx = previousExecutionCtx0;
             SynchronizationContext previousSyncCtx = currentThread0.SynchronizationContext;
 
-            if (executionContext?.m_isDefault ?? false)
+            if (executionContext != null && executionContext.m_isDefault)
             {
                 // Default is a null ExecutionContext internally
                 executionContext = null;
@@ -220,7 +220,7 @@ namespace System.Threading
             Thread currentThread0 = Thread.CurrentThread;
             Thread currentThread = currentThread0;
             ExecutionContext previousExecutionCtx0 = currentThread0.ExecutionContext;
-            if (previousExecutionCtx0?.m_isDefault ?? false)
+            if (previousExecutionCtx0 != null && previousExecutionCtx0.m_isDefault)
             {
                 // Default is a null ExecutionContext internally
                 previousExecutionCtx0 = null;
@@ -233,7 +233,7 @@ namespace System.Threading
             ExecutionContext previousExecutionCtx = previousExecutionCtx0;
             SynchronizationContext previousSyncCtx = currentThread0.SynchronizationContext;
 
-            if (executionContext?.m_isDefault ?? false)
+            if (executionContext != null && executionContext.m_isDefault)
             {
                 // Default is a null ExecutionContext internally
                 executionContext = null;
@@ -302,7 +302,7 @@ namespace System.Threading
 
             Thread currentThread = Thread.CurrentThread;
 
-            if (executionContext?.m_isDefault ?? false)
+            if (executionContext != null && executionContext.m_isDefault)
             {
                 // Default is a null ExecutionContext internally
                 executionContext = null;
@@ -381,12 +381,15 @@ namespace System.Threading
             callback.Invoke(state);
 
             ExecutionContext currentExecutionCtx = currentThread.ExecutionContext;
-            if (currentExecutionCtx?.HasChangeNotifications ?? false)
+            if (currentExecutionCtx != null)
             {
                 // Reset ExecutionContext to null (Default) prior to calling OnValuesChanged callback
                 currentThread.ExecutionContext = null;
-                // There are change notifications; trigger any affected
-                OnValuesChanged(currentExecutionCtx, nextExecutionCtx: null);
+                if (currentExecutionCtx.HasChangeNotifications)
+                {
+                    // There are change notifications; trigger any affected
+                    OnValuesChanged(currentExecutionCtx, nextExecutionCtx: null);
+                }
             }
 
             // For QUWICallbacks there are no extra steps and ThreadPoolWorkQueue.Dispatch 
@@ -407,12 +410,15 @@ namespace System.Threading
             // Capture current thread to local rather than looking it up multiple times
             Thread currentThread = Thread.CurrentThread;
             ExecutionContext currentExecutionCtx = currentThread.ExecutionContext;
-            if (currentExecutionCtx?.HasChangeNotifications ?? false)
+            if (currentExecutionCtx != null)
             {
                 // Reset ExecutionContext to null (Default) prior to calling OnValuesChanged callback
                 currentThread.ExecutionContext = null;
-                // There are change notifications; trigger any affected
-                OnValuesChanged(currentExecutionCtx, nextExecutionCtx: null);
+                if (currentExecutionCtx.HasChangeNotifications)
+                {
+                    // There are change notifications; trigger any affected
+                    OnValuesChanged(currentExecutionCtx, nextExecutionCtx: null);
+                }
             }
 
             // For QUWICallbacks there are no extra steps and ThreadPoolWorkQueue.Dispatch 

--- a/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
@@ -336,7 +336,10 @@ namespace System.Threading
             ExecutionContext currentExecutionCtx = currentThread1.ExecutionContext;
             if (currentExecutionCtx != null)
             {
-                // Restore to Default before Notifications
+                // The EC always needs to be reset for this overload, as it will flow back to the caller if it performs 
+                // extra work prior to returning to the Dispatch loop. For example for Task-likes it will flow out of await points
+
+                // Restore to Default before Notifications, as the change can be observed in the handler.
                 currentThread1.ExecutionContext = null;
                 if (currentExecutionCtx.HasChangeNotifications)
                 {
@@ -371,7 +374,7 @@ namespace System.Threading
             ExecutionContext currentExecutionCtx = currentThread.ExecutionContext;
             if (currentExecutionCtx.HasChangeNotifications)
             {
-                // Restore to Default before Notifications
+                // Restore to Default before Notifications, as the change can be observed in the handler
                 currentThread.ExecutionContext = null;
                 OnValuesChanged(currentExecutionCtx, nextExecutionCtx: null);
             }
@@ -389,7 +392,7 @@ namespace System.Threading
             ExecutionContext currentExecutionCtx = currentThread.ExecutionContext;
             if (currentExecutionCtx != null && currentExecutionCtx.HasChangeNotifications)
             {
-                // Restore to Default before Notifications
+                // Restore to Default before Notifications, as the change can be observed in the handler
                 currentThread.ExecutionContext = null;
                 OnValuesChanged(currentExecutionCtx, nextExecutionCtx: null);
             }

--- a/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
@@ -136,7 +136,7 @@ namespace System.Threading
             Thread currentThread0 = Thread.CurrentThread;
             Thread currentThread = currentThread0;
             ExecutionContext previousExecutionCtx0 = currentThread0.ExecutionContext;
-            if (previousExecutionCtx0?.m_isDefault ?? false)
+            if (previousExecutionCtx0 != null && previousExecutionCtx0.m_isDefault)
             {
                 // Default is a null ExecutionContext internally
                 previousExecutionCtx0 = null;

--- a/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
@@ -295,6 +295,7 @@ namespace System.Threading
 
         internal static void RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, object state)
         {
+            Debug.Assert(threadPoolThread == Thread.CurrentThread);
             CheckThreadPoolAndContextsAreDefault();
             // ThreadPool starts on Default Context so we don't need to save the "previous" state as we know it is Default (null)
 

--- a/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
@@ -12,6 +12,7 @@
 ===========================================================*/
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Runtime.Serialization;
 
@@ -374,6 +375,8 @@ namespace System.Threading
             // ThreadPoolWorkQueue.Dispatch will handle notifications and reset EC and SyncCtx back to default
         }
 
+        // Inline as only called in one place and always called
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void ResetThreadPoolThread(Thread currentThread)
         {
             ExecutionContext currentExecutionCtx = currentThread.ExecutionContext;

--- a/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
@@ -396,7 +396,7 @@ namespace System.Threading
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
-        private static void CheckThreadPoolAndContextsAreDefault()
+        internal static void CheckThreadPoolAndContextsAreDefault()
         {
             Debug.Assert(Thread.CurrentThread.IsThreadPoolThread);
             Debug.Assert(Thread.CurrentThread.ExecutionContext == null, "ThreadPool thread not on Default ExecutionContext.");

--- a/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
@@ -386,17 +386,19 @@ namespace System.Threading
         internal static void ResetThreadPoolThread(Thread currentThread)
         {
             ExecutionContext currentExecutionCtx = currentThread.ExecutionContext;
+
+            // Reset to defaults
+            currentThread.SynchronizationContext = null;
+            currentThread.ExecutionContext = null;
+
             if (currentExecutionCtx != null && currentExecutionCtx.HasChangeNotifications)
             {
-                // Restore to Default before Notifications, as the change can be observed in the handler
+                OnValuesChanged(currentExecutionCtx, nextExecutionCtx: null);
+
+                // Reset to defaults again without change notifications in case the Change handler changed the contexts
                 currentThread.SynchronizationContext = null;
                 currentThread.ExecutionContext = null;
-                OnValuesChanged(currentExecutionCtx, nextExecutionCtx: null);
             }
-
-            // Reset back to defaults in case the Change handler changed the contexts
-            currentThread.ExecutionContext = null;
-            currentThread.SynchronizationContext = null;
         }
 
         [System.Diagnostics.Conditional("DEBUG")]

--- a/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
@@ -292,7 +292,7 @@ namespace System.Threading
             edi?.Throw();
         }
 
-        internal static void RunFromThreadPool(ExecutionContext executionContext, ContextCallback callback, object state)
+        internal static void RunFromThreadPoolDispatchLoop(ExecutionContext executionContext, ContextCallback callback, object state)
         {
             // ThreadPool starts on Default Context so we don't need to save the "previous" state as we know it is Default (null)
 
@@ -341,7 +341,7 @@ namespace System.Threading
             }
 
             ExecutionContext currentExecutionCtx = currentThread1.ExecutionContext;
-            if (currentExecutionCtx != null && !currentExecutionCtx.m_isDefault)
+            if (currentExecutionCtx != null)
             {
                 // Restore changed ExecutionContext back to Default (null)
                 currentThread1.ExecutionContext = null;
@@ -356,7 +356,7 @@ namespace System.Threading
             edi?.Throw();
         }
 
-        internal static void RunUserWorkItem<TState>(ExecutionContext executionContext, Action<TState> callback, in TState state)
+        internal static void RunForThreadPoolUserWorkItem<TState>(ExecutionContext executionContext, Action<TState> callback, in TState state)
         {
             Debug.Assert(Thread.CurrentThread.IsThreadPoolThread);
             Debug.Assert(Thread.CurrentThread.ExecutionContext == null, "ThreadPool thread not on Default ExecutionContext.");
@@ -393,7 +393,7 @@ namespace System.Threading
             // will reset EC and SyncCtx back to defaults, so it doesn't need to be done here.
         }
 
-        internal static void RunUserWorkItemWithDefaultContext<TState>(Action<TState> callback, in TState state)
+        internal static void RunForThreadPoolUserWorkItemWithDefaultContext<TState>(Action<TState> callback, in TState state)
         {
             Debug.Assert(Thread.CurrentThread.IsThreadPoolThread);
             Debug.Assert(Thread.CurrentThread.ExecutionContext == null, "ThreadPool thread not on Default ExecutionContext.");

--- a/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
@@ -374,15 +374,6 @@ namespace System.Threading
             // ThreadPoolWorkQueue.Dispatch will handle notifications and reset EC and SyncCtx back to default
         }
 
-        internal static void RunForThreadPoolUserWorkItemWithDefaultContext<TState>(Action<TState> callback, in TState state)
-        {
-            CheckThreadPoolAndContextsAreDefault();
-
-            callback.Invoke(state);
-
-            // ThreadPoolWorkQueue.Dispatch will handle notifications and reset EC and SyncCtx back to default
-        }
-
         internal static void ResetThreadPoolThread(Thread currentThread)
         {
             ExecutionContext currentExecutionCtx = currentThread.ExecutionContext;

--- a/src/System.Private.CoreLib/shared/System/Threading/SemaphoreSlim.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/SemaphoreSlim.cs
@@ -80,7 +80,7 @@ namespace System.Threading
             internal TaskNode Prev, Next;
             internal TaskNode() : base() { }
 
-            internal override void ExecuteFromThreadPool()
+            internal override void ExecuteFromThreadPool(Thread threadPoolThread)
             {
                 bool setSuccessfully = TrySetResult(true);
                 Debug.Assert(setSuccessfully, "Should have been able to complete task");

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -543,9 +543,9 @@ namespace System.Runtime.CompilerServices
             internal sealed override void ExecuteFromThreadPool() => MoveNext(isThreadPool: true);
 
             /// <summary>Calls MoveNext on <see cref="StateMachine"/></summary>
-            public void MoveNext() => MoveNext();
+            public void MoveNext() => MoveNext(isThreadPool: false);
 
-            private void MoveNext(bool isThreadPool = false)
+            private void MoveNext(bool isThreadPool)
             {
                 Debug.Assert(!IsCompleted);
 

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -540,10 +540,12 @@ namespace System.Runtime.CompilerServices
             /// <summary>A delegate to the <see cref="MoveNext"/> method.</summary>
             public Action MoveNextAction => _moveNextAction ?? (_moveNextAction = new Action(MoveNext));
 
-            internal sealed override void ExecuteFromThreadPool() => MoveNext();
+            internal sealed override void ExecuteFromThreadPool() => MoveNext(isThreadPool: true);
 
             /// <summary>Calls MoveNext on <see cref="StateMachine"/></summary>
-            public void MoveNext()
+            public void MoveNext() => MoveNext();
+
+            private void MoveNext(bool isThreadPool = false)
             {
                 Debug.Assert(!IsCompleted);
 
@@ -560,7 +562,14 @@ namespace System.Runtime.CompilerServices
                 }
                 else
                 {
-                    ExecutionContext.RunInternal(context, s_callback, this);
+                    if (isThreadPool)
+                    {
+                        ExecutionContext.RunFromThreadPool(context, s_callback, this);
+                    }
+                    else
+                    {
+                        ExecutionContext.RunInternal(context, s_callback, this);
+                    }
                 }
 
                 if (IsCompleted)

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -540,12 +540,12 @@ namespace System.Runtime.CompilerServices
             /// <summary>A delegate to the <see cref="MoveNext"/> method.</summary>
             public Action MoveNextAction => _moveNextAction ?? (_moveNextAction = new Action(MoveNext));
 
-            internal sealed override void ExecuteFromThreadPool() => MoveNext(isThreadPool: true);
+            internal sealed override void ExecuteFromThreadPool(Thread threadPoolThread) => MoveNext(threadPoolThread);
 
             /// <summary>Calls MoveNext on <see cref="StateMachine"/></summary>
-            public void MoveNext() => MoveNext(isThreadPool: false);
+            public void MoveNext() => MoveNext(threadPoolThread: null);
 
-            private void MoveNext(bool isThreadPool)
+            private void MoveNext(Thread threadPoolThread)
             {
                 Debug.Assert(!IsCompleted);
 
@@ -562,13 +562,13 @@ namespace System.Runtime.CompilerServices
                 }
                 else
                 {
-                    if (isThreadPool)
+                    if (threadPoolThread is null)
                     {
-                        ExecutionContext.RunFromThreadPoolDispatchLoop(context, s_callback, this);
+                        ExecutionContext.RunInternal(context, s_callback, this);
                     }
                     else
                     {
-                        ExecutionContext.RunInternal(context, s_callback, this);
+                        ExecutionContext.RunFromThreadPoolDispatchLoop(threadPoolThread, context, s_callback, this);
                     }
                 }
 

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -564,7 +564,7 @@ namespace System.Runtime.CompilerServices
                 {
                     if (isThreadPool)
                     {
-                        ExecutionContext.RunFromThreadPool(context, s_callback, this);
+                        ExecutionContext.RunFromThreadPoolDispatchLoop(context, s_callback, this);
                     }
                     else
                     {

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -2440,7 +2440,7 @@ namespace System.Threading.Tasks
                         // Invoke it under the captured ExecutionContext
                         if (isThreadPool)
                         {
-                            ExecutionContext.RunFromThreadPool(ec, s_ecCallback, this);
+                            ExecutionContext.RunFromThreadPoolDispatchLoop(ec, s_ecCallback, this);
                         }
                         else
                         {

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -2367,16 +2367,16 @@ namespace System.Threading.Tasks
         /// can override to customize their behavior, which is usually done by promises
         /// that want to reuse the same object as a queued work item.
         /// </summary>
-        internal virtual void ExecuteFromThreadPool() => ExecuteEntryUnsafe();
+        internal virtual void ExecuteFromThreadPool() => ExecuteEntryUnsafe(isThreadPool: true);
 
-        internal void ExecuteEntryUnsafe() // used instead of ExecuteEntry() when we don't have to worry about double-execution prevent
+        internal void ExecuteEntryUnsafe(bool isThreadPool = false) // used instead of ExecuteEntry() when we don't have to worry about double-execution prevent
         {
             // Remember that we started running the task delegate.
             m_stateFlags |= TASK_STATE_DELEGATE_INVOKED;
 
             if (!IsCancellationRequested & !IsCanceled)
             {
-                ExecuteWithThreadLocal(ref t_currentTask);
+                ExecuteWithThreadLocal(ref t_currentTask, isThreadPool);
             }
             else
             {
@@ -2397,7 +2397,7 @@ namespace System.Threading.Tasks
         }
 
         // A trick so we can refer to the TLS slot with a byref.
-        private void ExecuteWithThreadLocal(ref Task currentTaskSlot)
+        private void ExecuteWithThreadLocal(ref Task currentTaskSlot, bool isThreadPool = false)
         {
             // Remember the current task so we can restore it after running, and then
             Task previousTask = currentTaskSlot;
@@ -2438,7 +2438,14 @@ namespace System.Threading.Tasks
                     else
                     {
                         // Invoke it under the captured ExecutionContext
-                        ExecutionContext.RunInternal(ec, s_ecCallback, this);
+                        if (isThreadPool)
+                        {
+                            ExecutionContext.RunFromThreadPool(ec, s_ecCallback, this);
+                        }
+                        else
+                        {
+                            ExecutionContext.RunInternal(ec, s_ecCallback, this);
+                        }
                     }
                 }
                 catch (Exception exn)

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
@@ -650,6 +650,7 @@ namespace System.Threading.Tasks
                 // We don't have to use ExecutionContext.Run for the Default context here as there is no extra processing after the delegate
                 if (context == null || context.IsDefault)
                 {
+                    ExecutionContext.CheckThreadPoolAndContextsAreDefault();
                     m_action();
                     // ThreadPoolWorkQueue.Dispatch handles notifications and reset context back to default
                 }

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
@@ -654,7 +654,7 @@ namespace System.Threading.Tasks
                 // If there is an execution context, get the cached delegate and run the action under the context.
                 else
                 {
-                    ExecutionContext.RunInternal(context, GetInvokeActionCallback(), m_action);
+                    ExecutionContext.RunFromThreadPool(context, GetInvokeActionCallback(), m_action);
                 }
             }
             finally

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
@@ -654,7 +654,7 @@ namespace System.Threading.Tasks
                 // If there is an execution context, get the cached delegate and run the action under the context.
                 else
                 {
-                    ExecutionContext.RunFromThreadPool(context, GetInvokeActionCallback(), m_action);
+                    ExecutionContext.RunFromThreadPoolDispatchLoop(context, GetInvokeActionCallback(), m_action);
                 }
             }
             finally

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
@@ -33,7 +33,7 @@ namespace System.Threading.Tasks
         }
 
         // static delegate for threads allocated to handle LongRunning tasks.
-        private static readonly ParameterizedThreadStart s_longRunningThreadWork = s => ((Task)s).ExecuteEntryUnsafe();
+        private static readonly ParameterizedThreadStart s_longRunningThreadWork = s => ((Task)s).ExecuteEntryUnsafe(threadPoolThread: null);
 
         /// <summary>
         /// Schedules a task to the ThreadPool.
@@ -73,7 +73,7 @@ namespace System.Threading.Tasks
 
             try
             {
-                task.ExecuteEntryUnsafe(); // handles switching Task.Current etc.
+                task.ExecuteEntryUnsafe(threadPoolThread: null); // handles switching Task.Current etc.
             }
             finally
             {

--- a/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
@@ -567,6 +567,17 @@ namespace System.Threading
                     //
                     workQueue.EnsureThreadRequested();
 
+                    // Start on clean ExecutionContext and SynchronizationContext
+                    if (currentThread.ExecutionContext != null)
+                    {
+                        currentThread.ExecutionContext = null;
+                    }
+
+                    if (currentThread.SynchronizationContext != null)
+                    {
+                        currentThread.SynchronizationContext = null;
+                    }
+
                     //
                     // Execute the workitem outside of any finally blocks, so that it can be aborted if needed.
                     //
@@ -607,18 +618,6 @@ namespace System.Threading
                         Unsafe.As<IThreadPoolWorkItem>(workItem).Execute();
                     }
                     workItem = null;
-
-                    if (currentThread.ExecutionContext != null)
-                    {
-                        // Reset ThreadPool thread's EC back to Default (null) if changed by Execute and not restored
-                        currentThread.ExecutionContext = null;
-                    }
-
-                    if (currentThread.SynchronizationContext != null)
-                    {
-                        // Reset ThreadPool thread's SyncCtx back to Default (null) if changed by Execute and not restored
-                        currentThread.SynchronizationContext = null;
-                    }
 
                     // 
                     // Notify the VM that we executed this workitem.  This is also our opportunity to ask whether Hill Climbing wants

--- a/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
@@ -571,15 +571,8 @@ namespace System.Threading
                     workQueue.EnsureThreadRequested();
 
                     // Start on clean ExecutionContext and SynchronizationContext
-                    if (currentThread.ExecutionContext != null)
-                    {
-                        currentThread.ExecutionContext = null;
-                    }
-
-                    if (currentThread.SynchronizationContext != null)
-                    {
-                        currentThread.SynchronizationContext = null;
-                    }
+                    currentThread.ExecutionContext = null;
+                    currentThread.SynchronizationContext = null;
 
                     //
                     // Execute the workitem outside of any finally blocks, so that it can be aborted if needed.

--- a/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
@@ -1018,6 +1018,7 @@ namespace System.Threading
 
         public override void Execute()
         {
+            ExecutionContext.CheckThreadPoolAndContextsAreDefault();
             base.Execute();
 
             WaitCallback callback = _callback;
@@ -1044,6 +1045,7 @@ namespace System.Threading
 
         public override void Execute()
         {
+            ExecutionContext.CheckThreadPoolAndContextsAreDefault();
             base.Execute();
 
             Action<TState> callback = _callback;

--- a/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
@@ -586,7 +586,7 @@ namespace System.Threading
                             reportedStatus = true;
                             if (workItem is Task task)
                             {
-                                task.ExecuteFromThreadPool();
+                                task.ExecuteFromThreadPool(currentThread);
                             }
                             else
                             {
@@ -606,7 +606,7 @@ namespace System.Threading
                         // for Task and then Unsafe.As for the interface, rather than
                         // vice versa, in particular when the object implements a bunch
                         // of interfaces.
-                        task.ExecuteFromThreadPool();
+                        task.ExecuteFromThreadPool(currentThread);
                     }
                     else
                     {

--- a/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
@@ -980,7 +980,7 @@ namespace System.Threading
             }
             else
             {
-                ExecutionContext.RunFromThreadPool(context, s_executionContextShim, this);
+                ExecutionContext.RunUserWorkItem(context, s_executionContextShim, this);
             }
         }
     }
@@ -1014,7 +1014,7 @@ namespace System.Threading
                 Debug.Assert(callback != null);
                 _callback = null;
 
-                ExecutionContext.RunFromThreadPool(context, callback, in _state);
+                ExecutionContext.RunUserWorkItem(context, callback, in _state);
             }
         }
     }
@@ -1042,7 +1042,7 @@ namespace System.Threading
         public override void Execute()
         {
             base.Execute();
-            ExecutionContext.RunDefaultFromThreadPool(s_executionContextShim, this);
+            ExecutionContext.RunUserWorkItemWithDefaultContext(s_executionContextShim, this);
         }
     }
 
@@ -1064,7 +1064,7 @@ namespace System.Threading
             Debug.Assert(callback != null);
             _callback = null;
 
-            ExecutionContext.RunDefaultFromThreadPool(callback, in _state);
+            ExecutionContext.RunUserWorkItemWithDefaultContext(callback, in _state);
         }
     }
 

--- a/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
@@ -984,7 +984,7 @@ namespace System.Threading
             }
             else
             {
-                ExecutionContext.RunUserWorkItem(context, s_executionContextShim, this);
+                ExecutionContext.RunForThreadPoolUserWorkItem(context, s_executionContextShim, this);
             }
         }
     }
@@ -1018,7 +1018,7 @@ namespace System.Threading
                 Debug.Assert(callback != null);
                 _callback = null;
 
-                ExecutionContext.RunUserWorkItem(context, callback, in _state);
+                ExecutionContext.RunForThreadPoolUserWorkItem(context, callback, in _state);
             }
         }
     }
@@ -1046,7 +1046,7 @@ namespace System.Threading
         public override void Execute()
         {
             base.Execute();
-            ExecutionContext.RunUserWorkItemWithDefaultContext(s_executionContextShim, this);
+            ExecutionContext.RunForThreadPoolUserWorkItemWithDefaultContext(s_executionContextShim, this);
         }
     }
 
@@ -1068,7 +1068,7 @@ namespace System.Threading
             Debug.Assert(callback != null);
             _callback = null;
 
-            ExecutionContext.RunUserWorkItemWithDefaultContext(callback, in _state);
+            ExecutionContext.RunForThreadPoolUserWorkItemWithDefaultContext(callback, in _state);
         }
     }
 

--- a/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
@@ -614,10 +614,11 @@ namespace System.Threading
                         Unsafe.As<IThreadPoolWorkItem>(workItem).Execute();
                     }
 
-                    // Release refs and return to clean ExecutionContext and SynchronizationContext
+                    // Release refs
                     outerWorkItem = workItem = null;
-                    currentThread.ExecutionContext = null;
-                    currentThread.SynchronizationContext = null;
+
+                    // Return to clean ExecutionContext and SynchronizationContext
+                    ExecutionContext.ResetThreadPoolThread(currentThread);
 
                     // 
                     // Notify the VM that we executed this workitem.  This is also our opportunity to ask whether Hill Climbing wants

--- a/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
@@ -532,7 +532,7 @@ namespace System.Threading
                 // Set up our thread-local data
                 //
                 ThreadPoolWorkQueueThreadLocals tl = workQueue.EnsureCurrentThreadHasQueue();
-                Thread currentThread = Thread.CurrentThread;
+                Thread currentThread = tl.currentThread;
 
                 //
                 // Loop until our quantum expires.
@@ -698,6 +698,7 @@ namespace System.Threading
 
         public readonly ThreadPoolWorkQueue workQueue;
         public readonly ThreadPoolWorkQueue.WorkStealingQueue workStealingQueue;
+        public readonly Thread currentThread;
         public FastRandom random = new FastRandom(Thread.CurrentThread.ManagedThreadId); // mutable struct, do not copy or make readonly
 
         public ThreadPoolWorkQueueThreadLocals(ThreadPoolWorkQueue tpq)
@@ -705,6 +706,7 @@ namespace System.Threading
             workQueue = tpq;
             workStealingQueue = new ThreadPoolWorkQueue.WorkStealingQueue();
             ThreadPoolWorkQueue.WorkStealingQueueList.Add(workStealingQueue);
+            currentThread = Thread.CurrentThread;
         }
 
         private void CleanUp()

--- a/src/System.Private.CoreLib/src/System/Threading/Timer.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Timer.cs
@@ -734,7 +734,7 @@ namespace System.Threading
             {
                 if (isThreadPool)
                 {
-                    ExecutionContext.RunFromThreadPoolDispatchLoop(context, s_callCallbackInContext, this);
+                    ExecutionContext.RunFromThreadPoolDispatchLoop(Thread.CurrentThread, context, s_callCallbackInContext, this);
                 }
                 else
                 {

--- a/src/System.Private.CoreLib/src/System/Threading/Timer.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Timer.cs
@@ -734,7 +734,7 @@ namespace System.Threading
             {
                 if (isThreadPool)
                 {
-                    ExecutionContext.RunFromThreadPool(context, s_callCallbackInContext, this);
+                    ExecutionContext.RunFromThreadPoolDispatchLoop(context, s_callCallbackInContext, this);
                 }
                 else
                 {

--- a/src/System.Private.CoreLib/src/System/Threading/Timer.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Timer.cs
@@ -674,9 +674,9 @@ namespace System.Threading
             }
         }
 
-        void IThreadPoolWorkItem.Execute() => Fire();
+        void IThreadPoolWorkItem.Execute() => Fire(isThreadPool: true);
 
-        internal void Fire()
+        internal void Fire(bool isThreadPool = false)
         {
             bool canceled = false;
 
@@ -690,7 +690,7 @@ namespace System.Threading
             if (canceled)
                 return;
 
-            CallCallback();
+            CallCallback(isThreadPool);
 
             bool shouldSignal = false;
             lock (m_associatedTimerQueue)
@@ -719,7 +719,7 @@ namespace System.Threading
             }
         }
 
-        internal void CallCallback()
+        internal void CallCallback(bool isThreadPool)
         {
             if (FrameworkEventSource.IsInitialized && FrameworkEventSource.Log.IsEnabled(EventLevel.Informational, FrameworkEventSource.Keywords.ThreadTransfer))
                 FrameworkEventSource.Log.ThreadTransferReceiveObj(this, 1, string.Empty);
@@ -732,7 +732,14 @@ namespace System.Threading
             }
             else
             {
-                ExecutionContext.RunInternal(context, s_callCallbackInContext, this);
+                if (isThreadPool)
+                {
+                    ExecutionContext.RunFromThreadPool(context, s_callCallbackInContext, this);
+                }
+                else
+                {
+                    ExecutionContext.RunInternal(context, s_callCallbackInContext, this);
+                }
             }
         }
 


### PR DESCRIPTION
`ExecutionContext.Run` has logic for saving and restoring the current contexts and extra logic to optimise the enregistering around exception handling.

When items are run on the ThreadPool we can fast-path for the threads starting on the Default context and avoid stashing the current context to restore later (as it is Default). 

For CallbackDefaultContext items we can further fast-path by not restoring the new context (as it is still the Default) and only need to return back to the Default context after the callback is run (in case it moves off the Defaults in the callback).

Additionally; if a naked exception is thrown on the ThreadPool it will crash the process; so the additional exception handling logic can be avoided.

The `ThreadPool.Dispatch` loop resets `ExecutionContext` and `SynchronizationContext` after the workitems to move the ThreadPool thread back onto the Default context from any `AsyncLocal<T>` leakage from Unsafe work items, CustomWorkItems or AsyncLocals being set in AsyncLocals `OnValuesChanged` handler to guarantee the ThreadPool threads are on the Default contexts when a workitem starts. * 

In addition to the standard `ExecutionContext.RunInternal` (328 bytes asm) this introduces 3 fast-path overloads for running via `ExecutionContext` from the ThreadPool using the above preconditions.

`ExecutionContext:RunFromThreadPoolDispatchLoop` (230 bytes asm), for 
`Task`/`AsyncStateMachineBox`/`AwaitTaskContinuation`/`Timer` using the `Task.ExecuteFromThreadPool` overload; where any exception must be captured and propagated after the Default context has been restored.

`ExecutionContext:RunForThreadPoolUserWorkItem` (108 bytes asm), for QueueUserWorkItems that aren't on the default context.

`ExecutionContext:RunForThreadPoolUserWorkItemWithDefaultContext` (71 bytes asm), for QueueUserWorkItems that are on the default context.

Also drops an additional delegate invocation for work items queued using the  `QueueUserWorkItem<TState>(Action<TState>, TState, Boolean)` overload by accepting the `Action<TState>` directly rather than requiring a wrapper to convert it to a `ContextCallback` delegate.

Resolves:  dotnet/corefx#32695

*In `Dispatch` the currentThread is stored and used from the same lookup as the work queue to avoid calling `Thread.CurrentThread`  VM call https://github.com/dotnet/coreclr/pull/20308#issuecomment-435769584; and added some tweaks to the loop to enregister the locals https://github.com/dotnet/coreclr/pull/20308/commits/5db2e9f94ac3d32f1aad9957486b7893dc426bb8 to make up the difference.

/cc @stephentoub @kouvel 