### PR TITLE
Avoid building DebugFinalizableAsyncStateMachineBox unless necessary

### DIFF
--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -485,13 +485,19 @@ namespace System.Runtime.CompilerServices
             // object's identity to track this specific builder/state machine.  As such, we proceed to
             // overwrite whatever's there anyway, even if it's non-null.
             var box = AsyncMethodBuilderCore.TrackAsyncMethodCompletion ?
-                new DebugFinalizableAsyncStateMachineBox<TStateMachine>() :
+                CreateDebugFinalizableAsyncStateMachineBox<TStateMachine>() :
                 new AsyncStateMachineBox<TStateMachine>();
             m_task = box; // important: this must be done before storing stateMachine into box.StateMachine!
             box.StateMachine = stateMachine;
             box.Context = currentContext;
             return box;
         }
+
+        // Avoid forcing the JIT to build DebugFinalizableAsyncStateMachineBox<TStateMachine> unless it's actually needed.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static AsyncStateMachineBox<TStateMachine> CreateDebugFinalizableAsyncStateMachineBox<TStateMachine>()
+            where TStateMachine : IAsyncStateMachine =>
+            new DebugFinalizableAsyncStateMachineBox<TStateMachine>();
 
         /// <summary>
         /// Provides an async state machine box with a finalizer that will fire an EventSource
@@ -606,7 +612,7 @@ namespace System.Runtime.CompilerServices
         {
             Debug.Assert(m_task == null);
             return (m_task = AsyncMethodBuilderCore.TrackAsyncMethodCompletion ?
-                new DebugFinalizableAsyncStateMachineBox<IAsyncStateMachine>() :
+                CreateDebugFinalizableAsyncStateMachineBox<IAsyncStateMachine>() :
                 new AsyncStateMachineBox<IAsyncStateMachine>());
         }
 


### PR DESCRIPTION
Per https://github.com/dotnet/coreclr/pull/20294#discussion_r223690631.

cc: @jkotas