### PR TITLE
Fix test JIT\Regression\VS-ia64-JIT\M00\b80373

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -67,9 +67,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/arglist/vararg/*">
             <Issue>Native varargs not supported on unix</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/VS-ia64-JIT/M00/b80373/b80373/*">
-            <Issue>20024</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- Arm32 All OS -->

--- a/tests/src/JIT/Regression/VS-ia64-JIT/M00/b80373/b80373.il
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/M00/b80373/b80373.il
@@ -46,7 +46,7 @@ End_Orphan_3:
 Start_Orphan_5:
    ldarga Arg_0x4
    ldc.i4.7
-  stind.i
+  stind.i4
 End_Orphan_5:
 Start_Orphan_7:
     newobj     instance void [mscorlib]System.Object::.ctor()


### PR DESCRIPTION
On 64 bit hosts it does a 64 bit store to a 32 bit parameter and corrupts the stack. A previous implementation of fgMarkAddressExposedLocals did not mark the parameter as address exposed, allowing the optimizer to remove the dead store and thus hide the incorrect code.

Fixes #20024