### PR TITLE
[arm64] Print target arch during JIT_Disasm

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2269,9 +2269,9 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
         }
 
 #if defined(_TARGET_WINDOWS_)
-        printf(" - Windows")
+        printf(" - Windows");
 #elif defined(_TARGET_UNIX_)
-        printf(" - Unix")
+        printf(" - Unix");
 #endif
 
         printf("\n");

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2263,6 +2263,16 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
         {
             printf("generic ARM64 CPU");
         }
+        else
+        {
+            printf("unknown architecture");
+        }
+
+#if defined(_TARGET_WINDOWS_)
+        printf(" - Windows")
+#elif defined(_TARGET_UNIX_)
+        printf(" - Unix")
+#endif
 
         printf("\n");
 

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2255,10 +2255,13 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
                 printf("X64 CPU with SSE2");
             }
         }
-
         else if (compiler->info.genCPU == CPU_ARM)
         {
             printf("generic ARM CPU");
+        }
+        else if (compiler->info.genCPU == CPU_ARM64)
+        {
+            printf("generic ARM64 CPU");
         }
 
         printf("\n");

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -2387,9 +2387,9 @@ void Compiler::compSetProcessor()
 #if defined(_TARGET_ARM_)
     info.genCPU = CPU_ARM;
 #elif defined(_TARGET_ARM64_)
-    info.genCPU = CPU_ARM64;
+    info.genCPU       = CPU_ARM64;
 #elif defined(_TARGET_AMD64_)
-    info.genCPU       = CPU_X64;
+    info.genCPU                   = CPU_X64;
 #elif defined(_TARGET_X86_)
     if (jitFlags.IsSet(JitFlags::JIT_FLAG_TARGET_P4))
         info.genCPU = CPU_X86_PENTIUM_4;

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -2386,6 +2386,8 @@ void Compiler::compSetProcessor()
 
 #if defined(_TARGET_ARM_)
     info.genCPU = CPU_ARM;
+#elif defined(_TARGET_ARM64_)
+    info.genCPU = CPU_ARM64;
 #elif defined(_TARGET_AMD64_)
     info.genCPU       = CPU_X64;
 #elif defined(_TARGET_X86_)

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -8525,7 +8525,7 @@ public:
 #define CPU_AMD_X64 0x0210   // AMD x64 CPU
 #define CPU_INTEL_X64 0x0240 // Intel x64 CPU
 
-#define CPU_ARM 0x0300 // The generic ARM CPU
+#define CPU_ARM 0x0300   // The generic ARM CPU
 #define CPU_ARM64 0x0400 // The generic ARM64 CPU
 
         unsigned genCPU; // What CPU are we running on

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -8526,6 +8526,7 @@ public:
 #define CPU_INTEL_X64 0x0240 // Intel x64 CPU
 
 #define CPU_ARM 0x0300 // The generic ARM CPU
+#define CPU_ARM64 0x0400 // The generic ARM64 CPU
 
         unsigned genCPU; // What CPU are we running on
     } info;


### PR DESCRIPTION
Print target architecture during JIT_Disasm on arm64
```
; Assembly listing for method AllocOutgoingArgSpaceVar.Program:Xor5(int):int
; Emitting BLENDED_CODE for generic ARM64 CPU
; optimized code
; fp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T00] (  3,  3   )     int  ->   x0
;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [sp+0x00]
;
; Lcl frame size = 0

G_M14160_IG01:
        A9BF7BFD          stp     fp, lr, [sp,#-16]!
        910003FD          mov     fp, sp

G_M14160_IG02:
        528000A1          mov     w1, #5
        4A010000          eor     w0, w0, w1

G_M14160_IG03:
        A8C17BFD          ldp     fp, lr, [sp],#16
        D65F03C0          ret     lr

; Total bytes of code 24, prolog size 8 for method AllocOutgoingArgSpaceVar.Program:Xor5(int):int
; ============================================================
```
@AndyAyersMS @BruceForstall 
/cc @dotnet/jit-contrib 