### PR TITLE
Minor dump improvements in R2RDump

### DIFF
--- a/src/tools/r2rdump/R2RDump.cs
+++ b/src/tools/r2rdump/R2RDump.cs
@@ -299,7 +299,7 @@ namespace R2RDump
         {
             int id;
             bool isNum = ArgStringToInt(query, out id);
-            bool idMatch = isNum && (method.Rid == id || MetadataTokens.GetRowNumber(method.MetadataReader, method.MethodHandle) == id);
+            bool idMatch = isNum && (method.Rid == id || MetadataTokens.GetRowNumber(method.R2RReader.MetadataReader, method.MethodHandle) == id);
 
             bool sigMatch = false;
             if (exact)

--- a/src/tools/r2rdump/R2RImportSection.cs
+++ b/src/tools/r2rdump/R2RImportSection.cs
@@ -20,13 +20,15 @@ namespace R2RDump
             [XmlAttribute("Index")]
             public int Index { get; set; }
             public int StartOffset { get; set; }
+            public int StartRVA { get; set; }
             public long Section { get; set; }
             public uint SignatureRVA { get; set; }
             public string Signature { get; set; }
-            public ImportSectionEntry(int index, int startOffset, long section, uint signatureRVA, string signature)
+            public ImportSectionEntry(int index, int startOffset, int startRVA, long section, uint signatureRVA, string signature)
             {
                 Index = index;
                 StartOffset = startOffset;
+                StartRVA = startRVA;
                 Section = section;
                 SignatureRVA = signatureRVA;
                 Signature = signature;
@@ -36,6 +38,7 @@ namespace R2RDump
             {
                 StringBuilder builder = new StringBuilder();
                 builder.AppendFormat("+{0:X4}", StartOffset);
+                builder.AppendFormat(" ({0:X4})", StartRVA);
                 builder.AppendFormat("  Section: 0x{0:X8}", Section);
                 builder.AppendFormat("  SignatureRVA: 0x{0:X8}", SignatureRVA);
                 builder.AppendFormat("  {0}", Signature);

--- a/src/tools/r2rdump/R2RMethod.cs
+++ b/src/tools/r2rdump/R2RMethod.cs
@@ -214,7 +214,7 @@ namespace R2RDump
         /// <summary>
         /// ECMA metadata reader for the method module.
         /// </summary>
-        public MetadataReader MetadataReader { get; }
+        public R2RReader R2RReader { get; }
 
         /// <summary>
         /// An unique index for the method
@@ -271,7 +271,7 @@ namespace R2RDump
         /// </summary>
         public R2RMethod(
             int index, 
-            MetadataReader mdReader, 
+            R2RReader r2rReader, 
             EntityHandle methodHandle, 
             int entryPointId, 
             string owningType, 
@@ -283,7 +283,7 @@ namespace R2RDump
             MethodHandle = methodHandle;
             EntryPointRuntimeFunctionId = entryPointId;
 
-            MetadataReader = mdReader;
+            R2RReader = r2rReader;
             RuntimeFunctions = new List<RuntimeFunction>();
 
             EntityHandle owningTypeHandle;
@@ -297,8 +297,8 @@ namespace R2RDump
             {
                 case HandleKind.MethodDefinition:
                     {
-                        MethodDefinition methodDef = MetadataReader.GetMethodDefinition((MethodDefinitionHandle)MethodHandle);
-                        Name = MetadataReader.GetString(methodDef.Name);
+                        MethodDefinition methodDef = R2RReader.MetadataReader.GetMethodDefinition((MethodDefinitionHandle)MethodHandle);
+                        Name = R2RReader.MetadataReader.GetString(methodDef.Name);
                         Signature = methodDef.DecodeSignature<string, DisassemblingGenericContext>(typeProvider, genericContext);
                         owningTypeHandle = methodDef.GetDeclaringType();
                         genericParams = methodDef.GetGenericParameters();
@@ -307,8 +307,8 @@ namespace R2RDump
 
                 case HandleKind.MemberReference:
                     {
-                        MemberReference memberRef = MetadataReader.GetMemberReference((MemberReferenceHandle)MethodHandle);
-                        Name = MetadataReader.GetString(memberRef.Name);
+                        MemberReference memberRef = R2RReader.MetadataReader.GetMemberReference((MemberReferenceHandle)MethodHandle);
+                        Name = R2RReader.MetadataReader.GetString(memberRef.Name);
                         Signature = memberRef.DecodeMethodSignature<string, DisassemblingGenericContext>(typeProvider, genericContext);
                         owningTypeHandle = memberRef.Parent;
                     }
@@ -324,7 +324,7 @@ namespace R2RDump
             }
             else
             {
-                DeclaringType = MetadataNameFormatter.FormatHandle(MetadataReader, owningTypeHandle);
+                DeclaringType = MetadataNameFormatter.FormatHandle(R2RReader.MetadataReader, owningTypeHandle);
             }
 
             Fixups = fixups;
@@ -378,8 +378,8 @@ namespace R2RDump
 
             sb.AppendLine(SignatureString);
 
-            sb.AppendLine($"Handle: 0x{MetadataTokens.GetToken(MetadataReader, MethodHandle):X8}");
-            sb.AppendLine($"Rid: {MetadataTokens.GetRowNumber(MetadataReader, MethodHandle)}");
+            sb.AppendLine($"Handle: 0x{MetadataTokens.GetToken(R2RReader.MetadataReader, MethodHandle):X8}");
+            sb.AppendLine($"Rid: {MetadataTokens.GetRowNumber(R2RReader.MetadataReader, MethodHandle)}");
             sb.AppendLine($"EntryPointRuntimeFunctionId: {EntryPointRuntimeFunctionId}");
             sb.AppendLine($"Number of RuntimeFunctions: {RuntimeFunctions.Count}");
             if (Fixups != null)
@@ -387,7 +387,9 @@ namespace R2RDump
                 sb.AppendLine($"Number of fixups: {Fixups.Count()}");
                 foreach (FixupCell cell in Fixups)
                 {
-                    sb.AppendLine($"    TableIndex {cell.TableIndex}, Offset {cell.CellOffset:X4}");
+                    R2RImportSection importSection = R2RReader.ImportSections[(int)cell.TableIndex];
+                    R2RImportSection.ImportSectionEntry entry = importSection.Entries[(int)cell.CellOffset];
+                    sb.AppendLine($"    TableIndex {cell.TableIndex}, Offset {cell.CellOffset:X4}: {entry.Signature}");
                 }
             }
 

--- a/src/tools/r2rdump/R2RMethod.cs
+++ b/src/tools/r2rdump/R2RMethod.cs
@@ -212,7 +212,7 @@ namespace R2RDump
         private const int _mdtMethodDef = 0x06000000;
 
         /// <summary>
-        /// ECMA metadata reader for the method module.
+        /// R2R reader representing the method module.
         /// </summary>
         public R2RReader R2RReader { get; }
 

--- a/src/tools/r2rdump/R2RReader.cs
+++ b/src/tools/r2rdump/R2RReader.cs
@@ -272,7 +272,7 @@ namespace R2RDump
                     int runtimeFunctionId;
                     FixupCell[] fixups;
                     GetRuntimeFunctionIndexFromOffset(offset, out runtimeFunctionId, out fixups);
-                    R2RMethod method = new R2RMethod(R2RMethods.Count, MetadataReader, methodHandle, runtimeFunctionId, owningType: null, constrainedType: null, instanceArgs: null, fixups: fixups);
+                    R2RMethod method = new R2RMethod(R2RMethods.Count, this, methodHandle, runtimeFunctionId, owningType: null, constrainedType: null, instanceArgs: null, fixups: fixups);
 
                     if (method.EntryPointRuntimeFunctionId < 0 || method.EntryPointRuntimeFunctionId >= isEntryPoint.Length)
                     {
@@ -344,7 +344,7 @@ namespace R2RDump
                 int runtimeFunctionId;
                 FixupCell[] fixups;
                 GetRuntimeFunctionIndexFromOffset((int)decoder.Offset, out runtimeFunctionId, out fixups);
-                R2RMethod method = new R2RMethod(R2RMethods.Count, MetadataReader, methodHandle, runtimeFunctionId, owningType, constrainedType, methodTypeArgs, fixups);
+                R2RMethod method = new R2RMethod(R2RMethods.Count, this, methodHandle, runtimeFunctionId, owningType, constrainedType, methodTypeArgs, fixups);
                 if (method.EntryPointRuntimeFunctionId >= 0 && method.EntryPointRuntimeFunctionId < isEntryPoint.Length)
                 {
                     isEntryPoint[method.EntryPointRuntimeFunctionId] = true;
@@ -452,8 +452,6 @@ namespace R2RDump
                 return;
             }
 
-            HashSet<uint> added = new HashSet<uint>();
-
             R2RSection availableTypesSection = R2RHeader.Sections[R2RSection.SectionType.READYTORUN_SECTION_AVAILABLE_TYPES];
             int availableTypesOffset = GetOffset(availableTypesSection.RelativeVirtualAddress);
             NativeParser parser = new NativeParser(Image, (uint)availableTypesOffset);
@@ -463,10 +461,6 @@ namespace R2RDump
             while (!curParser.IsNull())
             {
                 uint rid = curParser.GetUnsigned();
-                if (!added.Add(rid))
-                {
-                    continue;
-                }
 
                 bool isExportedType = (rid & 1) != 0;
                 rid = rid >> 1;
@@ -564,7 +558,7 @@ namespace R2RDump
                     uint sigRva = NativeReader.ReadUInt32(Image, ref signatureOffset);
                     int sigOffset = GetOffset((int)sigRva);
                     string cellName = MetadataNameFormatter.FormatSignature(this, sigOffset);
-                    entries.Add(new R2RImportSection.ImportSectionEntry(entries.Count, entryOffset, section, sigRva, cellName));
+                    entries.Add(new R2RImportSection.ImportSectionEntry(entries.Count, entryOffset, entryOffset + rva, section, sigRva, cellName));
                     ImportCellNames.Add(rva + entrySize * i, cellName);
                 }
 


### PR DESCRIPTION
1) Don't silently unify available types;

2) Display RVA's for import cells to enable searching the cell by RVA
in the dump;

3) Display cell signatures for method precodes.