### PR TITLE
Reduce the number of expected Pri-1 tests

### DIFF
--- a/tests/runtest.proj
+++ b/tests/runtest.proj
@@ -59,7 +59,7 @@
        to only build the Priority 0 tests. This target is run after a test build to verify that the basic number of tests that were
        built is basically what was expected. When this was written, there were about 2500 Priority 0 tests and about 12270 Priority 1
        tests (differing slightly based on platform). We currently check that the number of Priority 0 tests is greater than 2000 and
-       less than 3000, and the number of Priority 1 tests is greater than 11000.
+       less than 3000, and the number of Priority 1 tests is greater than 10000.
   -->
   <Target Name="CheckTestBuild" DependsOnTargets="GetListOfTestCmds">
     <Error Condition="!Exists('$(XunitTestBinBase)')"
@@ -73,7 +73,7 @@
 
     <Error Condition="'$(CLRTestPriorityToBuild)' == '0' and '$(TestCount)' &lt;= 2000" Text="Unexpected test count. Expected &gt; 2000, found $(TestCount).'" />
     <Error Condition="'$(CLRTestPriorityToBuild)' == '0' and '$(TestCount)' &gt;= 3000" Text="Unexpected test count. Expected &lt; 3000, found $(TestCount).'" />
-    <Error Condition="'$(CLRTestPriorityToBuild)' == '1' and '$(TestCount)' &lt;= 11000" Text="Unexpected test count. Expected &gt; 11000, found $(TestCount).'" />
+    <Error Condition="'$(CLRTestPriorityToBuild)' == '1' and '$(TestCount)' &lt;= 10000" Text="Unexpected test count. Expected &gt; 10000, found $(TestCount).'" />
     <Error Condition="'$(CLRTestPriorityToBuild)' != '0' and '$(CLRTestPriorityToBuild)' != '1'" Text="Unknown priority $(CLRTestPriorityToBuild)" />
   </Target>
 


### PR DESCRIPTION
The number has shrunk lately due to removing CoreMangLib tests.