### PR TITLE
Use "-parallel collections" on Linux/arm to avoid OutOfMemory

### DIFF
--- a/tests/tests.targets
+++ b/tests/tests.targets
@@ -31,6 +31,8 @@
 
     <PropertyGroup>
       <ExcludeTraits Condition="'$(ExcludeTraits)'==''">category=outerloop;category=failing</ExcludeTraits>
+      <!-- Run one assembly at a time on Linux/arm to avoid OutOfMemory (see https://github.com/dotnet/coreclr/issues/20328) -->
+      <ParallelRun Condition="'$(ParallelRun)'=='' and '$(__BuildOS)'=='Linux' and '$(__BuildArch)'=='arm'">collections</ParallelRun>
       <ParallelRun Condition="'$(ParallelRun)'==''">all</ParallelRun>
     </PropertyGroup>
     <ItemGroup>


### PR DESCRIPTION
Run with `-parallel collections` on Linux/arm to avoid OutOfMemory during Xunit run (which uses `-parallel all` by default)(see https://github.com/dotnet/coreclr/issues/20328). 

Below are the data comparing test running times for:
1. Ubuntu arm Pri1 using Xunit and
2. the last succesful Pri1 tests run using Bash scripts  

There is a slight speed-up as you can see.

However, there is no advantage of using this option for Windows_NT/arm or other architectures.

**Ubuntu arm Cross Release normal Build and Test**
```
15:33:09 Build succeeded.
15:33:09     0 Warning(s)
15:33:09     0 Error(s)
15:33:09 
15:33:09 Time Elapsed 00:32:35.67
15:33:25 Test run finished.
15:33:25 Parsing test results from (/ssd/j/workspace/dotnet_coreclr/master/arm_cross_release_ubuntu_tst_prtest/bin/Logs/TestRunResults_Linux_arm_Release)
15:33:25 
15:33:25 Total tests run    : 11170
15:33:25 Total passing tests: 11170
15:33:25 Total failed tests : 0
15:33:25 Total skipped tests: 0
```

Last successful test run using Bash scripts (https://ci.dot.net/job/dotnet_coreclr/job/master/job/arm_cross_release_ubuntu_tst/131):
```
07:56:11 =======================
07:56:11      Test Results
07:56:11 =======================
07:56:11 # CoreCLR Bin Dir  : 
07:56:11 # Tests Discovered : 12383
07:56:11 # Passed           : 11551
07:56:11 # Failed           : 0
07:56:11 # Skipped          : 832
07:56:11 =======================
07:56:12 39 minutes and 40 seconds taken to run CoreCLR tests.
```

**Ubuntu arm Cross Checked normal Build and Test**
```
16:33:26 Build succeeded.
16:33:26     0 Warning(s)
16:33:26     0 Error(s)
16:33:26 
16:33:26 Time Elapsed 01:16:53.30
16:33:42 Test run finished.
16:33:42 Parsing test results from (/ssd/j/workspace/dotnet_coreclr/master/arm_cross_checked_ubuntu_tst_prtest/bin/Logs/TestRunResults_Linux_arm_Checked)
16:33:42 
16:33:42 Total tests run    : 11170
16:33:42 Total passing tests: 11170
16:33:42 Total failed tests : 0
16:33:42 Total skipped tests: 0
```
Last successful test run using Bash scripts 
(https://ci.dot.net/job/dotnet_coreclr/job/master/job/arm_cross_checked_ubuntu_tst/133)
```
04:45:44 =======================
04:45:44      Test Results
04:45:44 =======================
04:45:44 # CoreCLR Bin Dir  : 
04:45:44 # Tests Discovered : 12383
04:45:44 # Passed           : 11551
04:45:44 # Failed           : 0
04:45:44 # Skipped          : 832
04:45:44 =======================
04:45:46 84 minutes and 29 seconds taken to run CoreCLR tests.
```

Fixes #20328