### PR TITLE
Fix "System.Reflection.TargetException: Non-static method requires a target"

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingDataCollector.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingDataCollector.cs
@@ -85,6 +85,15 @@ namespace System.Diagnostics.Tracing
         }
 
         /// <summary>
+        /// Adds a Boolean value to the event payload.
+        /// </summary>
+        /// <param name="value">Value to be added.</param>
+        public void AddScalar(bool value)
+        {
+            DataCollector.ThreadInstance.AddScalar(&value, sizeof(bool));
+        }
+
+        /// <summary>
         /// Adds a null-terminated String value to the event payload.
         /// </summary>
         /// <param name="value">


### PR DESCRIPTION
Attempting to access the HasValue property of a nullable type through reflection tosses when the value is null. This was found to be happening in `System.Diagnostics.Tracing` by the Application Insights team via telemetry data and they raised the issue in corefx [(issue 32606)](https://github.com/dotnet/corefx/issues/32606). This fixes the issue by avoiding reflection and directly checking if the nullable object is null.