### PR TITLE
Delete `FixupIfSIMDLocal`.

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -226,14 +226,14 @@ regMaskTP LinearScan::allRegs(RegisterType rt)
     else if (rt == TYP_DOUBLE)
     {
         return availableDoubleRegs;
-#ifdef FEATURE_SIMD
-        // TODO-Cleanup: Add an RBM_ALLSIMD
     }
+#ifdef FEATURE_SIMD
+    // TODO-Cleanup: Add an RBM_ALLSIMD
     else if (varTypeIsSIMD(rt))
     {
         return availableDoubleRegs;
-#endif // FEATURE_SIMD
     }
+#endif // FEATURE_SIMD
     else
     {
         return availableIntRegs;

--- a/src/jit/lsrabuild.cpp
+++ b/src/jit/lsrabuild.cpp
@@ -2944,12 +2944,11 @@ int LinearScan::BuildSimple(GenTree* tree)
 //    tree - The node of interest
 //
 // Return Value:
-//    None.
+//    The number of sources consumed by this node.
 //
 int LinearScan::BuildReturn(GenTree* tree)
 {
-    int      srcCount = 0;
-    GenTree* op1      = tree->gtGetOp1();
+    GenTree* op1 = tree->gtGetOp1();
 
 #if !defined(_TARGET_64BIT_)
     if (tree->TypeGet() == TYP_LONG)
@@ -2957,17 +2956,15 @@ int LinearScan::BuildReturn(GenTree* tree)
         assert((op1->OperGet() == GT_LONG) && op1->isContained());
         GenTree* loVal = op1->gtGetOp1();
         GenTree* hiVal = op1->gtGetOp2();
-        srcCount       = 2;
         BuildUse(loVal, RBM_LNGRET_LO);
         BuildUse(hiVal, RBM_LNGRET_HI);
+        return 2;
     }
     else
 #endif // !defined(_TARGET_64BIT_)
         if ((tree->TypeGet() != TYP_VOID) && !op1->isContained())
     {
         regMaskTP useCandidates = RBM_NONE;
-
-        srcCount = 1;
 
 #if FEATURE_MULTIREG_RET
         if (varTypeIsStruct(tree))
@@ -2982,12 +2979,13 @@ int LinearScan::BuildReturn(GenTree* tree)
                 noway_assert(op1->IsMultiRegCall());
 
                 ReturnTypeDesc* retTypeDesc = op1->AsCall()->GetReturnTypeDesc();
-                srcCount                    = retTypeDesc->GetReturnRegCount();
+                int             srcCount    = retTypeDesc->GetReturnRegCount();
                 useCandidates               = retTypeDesc->GetABIReturnRegs();
                 for (int i = 0; i < srcCount; i++)
                 {
                     BuildUse(op1, useCandidates, i);
                 }
+                return srcCount;
             }
         }
         else
@@ -3014,11 +3012,12 @@ int LinearScan::BuildReturn(GenTree* tree)
                     break;
             }
             BuildUse(op1, useCandidates);
+            return 1;
         }
     }
-    // No kills or defs
 
-    return srcCount;
+    // No kills or defs.
+    return 0;
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/rationalize.h
+++ b/src/jit/rationalize.h
@@ -38,7 +38,6 @@ private:
 
     // SIMD related
     void RewriteSIMDOperand(LIR::Use& use, bool keepBlk);
-    void FixupIfSIMDLocal(GenTreeLclVarCommon* node);
 
     // Intrinsic related transformations
     void RewriteNodeAsCall(GenTree**             use,


### PR DESCRIPTION
The first version of this function was added in 2014 with such comment:
`// Once TYP_SIMD is plumbed through the frontend, this will no longer be required.`

This function changed trees like:
`Return long -> LCL_FIELD long` back to `Return long -> LCL_VAR simd8`.
That was unprofitable but allowed Jit to keep the old behaviour.

Fixes #18895. On x64 there was no issue with that because we did not recignize 'Vector64<float>` as simd8 there (because Vector64<T> works only for arm64). For Vector2 we always keep the return type as `struct` and do not change it to `long`.

Some info about ABI colllected for this issue:

| C# type | HFA | IsIntrinsicType | returned via | return type |
| -------- | -------- |-------- | -------- | -------- |
| Vector2   | Yes   | No | s0, s1 | struct |
| Vector4   | Yes   | No | s0, s1, s2, s3 | struct |
| Vector64\<float>   | No | Yes | x0 | long|
| Vector128\<float>   | No   | No | x0, x1 | struct |

There are no diffs in system.private.corelib (collected with -pmi), but there are some expected improvements in SIMD tests (`coreclr\tests\src\JIT\SIMD`).

Now instead of
```
       vmovsd   xmm0, qword ptr [rbp-18H]
       vmovd    rax, xmm0
```
we generate 
```
       mov      rax, qword ptr [rbp-18H]
```
when return Vector2 from a `lclVar`.


7be172b4b6: Fix the strange `ifdef ` placement.

49877b14ea: Fix comments/refactoring of `LinearScan::BuildReturn`.

4b3e0cd24a: Delete `FixupIfSIMDLocal`.

Do not change `LCL_FLD(long)` back to `LCL_VAR(simd8)`,