### PR TITLE
fix issue where we wouldn't throw OOM after failing to allocate more space for finalize queue

### DIFF
--- a/src/vm/comutilnative.cpp
+++ b/src/vm/comutilnative.cpp
@@ -1279,7 +1279,10 @@ FCIMPL1(void, GCInterface::ReRegisterForFinalize, Object *obj)
     if (obj->GetMethodTable()->HasFinalizer())
     {
         HELPER_METHOD_FRAME_BEGIN_1(obj);
-        GCHeapUtilities::GetGCHeap()->RegisterForFinalization(-1, obj);
+        if (!GCHeapUtilities::GetGCHeap()->RegisterForFinalization(-1, obj))
+        {
+            ThrowOutOfMemory();
+        }
         HELPER_METHOD_FRAME_END();
     }
 }


### PR DESCRIPTION
As part of the local GC work we changed GCHeap::RegisterForFinalization to not throw and return a bool, but we didn't respect that bool anywhere