### PR TITLE
Fix for CoreRT #6253 Assertion slot != NO_REVERSE_PINVOKE_FRAME' fails

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -3140,6 +3140,14 @@ void CodeGen::genCreateAndStoreGCInfo(unsigned codeSize,
 
 #endif // _TARGET_ARM64_
 
+    if (compiler->opts.IsReversePInvoke())
+    {
+        unsigned reversePInvokeFrameVarNumber = compiler->lvaReversePInvokeFrameVar;
+        assert(reversePInvokeFrameVarNumber != BAD_VAR_NUM && reversePInvokeFrameVarNumber < compiler->lvaRefCount);
+        LclVarDsc& reversePInvokeFrameVar = compiler->lvaTable[reversePInvokeFrameVarNumber];
+        gcInfoEncoder->SetReversePInvokeFrameSlot(reversePInvokeFrameVar.lvStkOffs);
+    }
+
     gcInfoEncoder->Build();
 
     // GC Encoder automatically puts the GC info in the right spot using ICorJitInfo::allocGCInfo(size_t)


### PR DESCRIPTION
@BruceForstall @jkotas @iarischenko @alpencolt 
Please review

https://github.com/dotnet/corert/issues/6253