### PR TITLE
Disable TraceControl Test

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -242,9 +242,9 @@
         </ExcludeList>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TargetsWindows)' == 'true'">
+    <ItemGroup Condition="'$(XunitTestBinBase)' != ''">
         <ExcludeList Include="$(XunitTestBinBase)/tracing/tracecontrol/tracecontrol/*">
-            <Issue>Unable to write config file to app location</Issue>
+            <Issue>20299</Issue>
         </ExcludeList>
     </ItemGroup>
 


### PR DESCRIPTION
This test is failing intermittently and fairly often.  I will investigate the failures but in the meantime, let's disable the test to avoid affecting other people's workflows.