### PR TITLE
Don't throw an exception when getting native size of a struct containing a nonblittable fixed buffer.

### DIFF
--- a/src/vm/fieldmarshaler.cpp
+++ b/src/vm/fieldmarshaler.cpp
@@ -660,14 +660,7 @@ do                                                      \
                 {
                     if (IsStructMarshalable(thNestedType))
                     {
-                        if (IsFixedBuffer(pfwalk->m_MD, pInternalImport) && !thNestedType.GetMethodTable()->IsBlittable())
-                        {
-                            INITFIELDMARSHALER(NFT_ILLEGAL, FieldMarshaler_Illegal, (IDS_EE_BADMARSHAL_NOTMARSHALABLE));
-                        }
-                        else
-                        {
-                            INITFIELDMARSHALER(NFT_NESTEDVALUECLASS, FieldMarshaler_NestedValueClass, (thNestedType.GetMethodTable()));
-                        }
+                        INITFIELDMARSHALER(NFT_NESTEDVALUECLASS, FieldMarshaler_NestedValueClass, (thNestedType.GetMethodTable(), IsFixedBuffer(pfwalk->m_MD, pInternalImport)));
                     }
                     else
                     {
@@ -2898,6 +2891,10 @@ VOID FieldMarshaler_NestedValueClass::NestedValueClassUpdateNativeImpl(const VOI
     {
         memcpyNoGCRefs(pNative, (BYTE*)(*ppProtectedCLR) + startoffset, pMT->GetNativeSize());
     }
+    else if (IsFixedBuffer())
+    {
+        COMPlusThrow(kArgumentException, IDS_EE_BADMARSHAL_NOTMARSHALABLE);
+    }
     else
     {
         LayoutUpdateNative((LPVOID*)ppProtectedCLR, startoffset, pMT, (BYTE*)pNative, ppCleanupWorkListOnStack);
@@ -2931,6 +2928,10 @@ VOID FieldMarshaler_NestedValueClass::NestedValueClassUpdateCLRImpl(const VOID *
     if (pMT->IsBlittable())
     {
         memcpyNoGCRefs((BYTE*)(*ppProtectedCLR) + startoffset, pNative, pMT->GetNativeSize());
+    }
+    else if (IsFixedBuffer())
+    {
+        COMPlusThrow(kArgumentException, IDS_EE_BADMARSHAL_NOTMARSHALABLE);
     }
     else
     {

--- a/src/vm/fieldmarshaler.h
+++ b/src/vm/fieldmarshaler.h
@@ -712,10 +712,11 @@ private:
 class FieldMarshaler_NestedValueClass : public FieldMarshaler
 {
 public:
-    FieldMarshaler_NestedValueClass(MethodTable *pMT)
+    FieldMarshaler_NestedValueClass(MethodTable *pMT, BOOL isFixedBuffer)
     {
         WRAPPER_NO_CONTRACT;
         m_pNestedMethodTable.SetValueMaybeNull(pMT);
+        m_isFixedBuffer = isFixedBuffer;
     }
 
     BOOL IsNestedValueClassMarshalerImpl() const
@@ -763,6 +764,7 @@ public:
     START_COPY_TO_IMPL(FieldMarshaler_NestedValueClass)
     {
         pDestFieldMarshaller->m_pNestedMethodTable.SetValueMaybeNull(GetMethodTable());
+        pDestFieldMarshaller->m_isFixedBuffer = m_isFixedBuffer;
     }
     END_COPY_TO_IMPL(FieldMarshaler_NestedValueClass)
 
@@ -795,10 +797,16 @@ public:
         return m_pNestedMethodTable.GetValueMaybeNull();
     }
 
+    BOOL IsFixedBuffer() const
+    {
+        return m_isFixedBuffer;
+    }
+
 
 private:
     // MethodTable of nested NStruct.
     RelativeFixupPointer<PTR_MethodTable> m_pNestedMethodTable;
+    BOOL m_isFixedBuffer;
 };
 
 


### PR DESCRIPTION
Throw an exception only when attempting to marshal nonblittable fixed buffers to/from native instead of on all marshalling operations.

This ensures that we can still call `Marshal.SizeOf` with types containing non-blittable fixed buffers while also still throwing an exception when trying to marshal the data to/from native code.