### PR TITLE
Remove need for full GC for unloadable stuff

### DIFF
--- a/src/gc/env/gcenv.ee.h
+++ b/src/gc/env/gcenv.ee.h
@@ -72,7 +72,6 @@ public:
 
     static void HandleFatalError(unsigned int exitCode);
     static bool ShouldFinalizeObjectForUnload(void* pDomain, Object* obj);
-    static bool ForceFullGCToBeBlocking();
     static bool EagerFinalized(Object* obj);
     static MethodTable* GetFreeObjectMethodTable();
     static bool GetBooleanConfigValue(const char* key, bool* value);

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -15133,22 +15133,6 @@ exit:
         }
     }
 
-    if (n == max_generation && GCToEEInterface::ForceFullGCToBeBlocking())
-    {
-#ifdef BACKGROUND_GC
-        // do not turn stress-induced collections into blocking GCs, unless there
-        // have already been more full BGCs than full NGCs
-#if 0
-        // This exposes DevDiv 94129, so we'll leave this out for now
-        if (!settings.stress_induced ||
-            full_gc_counts[gc_type_blocking] <= full_gc_counts[gc_type_background])
-#endif // 0
-#endif // BACKGROUND_GC
-        {
-            *blocking_collection_p = TRUE;
-        }
-    }
-
     return n;
 }
 

--- a/src/gc/gcenv.ee.standalone.inl
+++ b/src/gc/gcenv.ee.standalone.inl
@@ -197,12 +197,6 @@ inline bool GCToEEInterface::ShouldFinalizeObjectForUnload(void* pDomain, Object
     return g_theGCToCLR->ShouldFinalizeObjectForUnload(pDomain, obj);
 }
 
-inline bool GCToEEInterface::ForceFullGCToBeBlocking()
-{
-    assert(g_theGCToCLR != nullptr);
-    return g_theGCToCLR->ForceFullGCToBeBlocking();
-}
-
 inline bool GCToEEInterface::EagerFinalized(Object* obj)
 {
     assert(g_theGCToCLR != nullptr);

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -329,12 +329,6 @@ public:
     virtual
     bool EagerFinalized(Object* obj) = 0;
 
-    // Asks the EE if it wishes for the current GC to be a blocking GC. The GC will
-    // only invoke this callback when it intends to do a full GC, so at this point
-    // the EE can opt to elevate that collection to be a blocking GC and not a background one.
-    virtual
-    bool ForceFullGCToBeBlocking() = 0;
-
     // Retrieves the method table for the free object, a special kind of object used by the GC
     // to keep the heap traversable. Conceptually, the free object is similar to a managed array
     // of bytes: it consists of an object header (like all objects) and a "numComponents" field,

--- a/src/gc/sample/gcenv.ee.cpp
+++ b/src/gc/sample/gcenv.ee.cpp
@@ -283,11 +283,6 @@ bool GCToEEInterface::ShouldFinalizeObjectForUnload(void* pDomain, Object* obj)
     return true;
 }
 
-bool GCToEEInterface::ForceFullGCToBeBlocking()
-{
-    return false;
-}
-
 bool GCToEEInterface::EagerFinalized(Object* obj)
 {
     // The sample does not finalize anything eagerly.

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -999,19 +999,6 @@ bool GCToEEInterface::ShouldFinalizeObjectForUnload(void* pDomain, Object* obj)
     return true;
 }
 
-bool GCToEEInterface::ForceFullGCToBeBlocking()
-{
-    // In theory, there is nothing fundamental that requires an AppDomain unload to induce
-    // a blocking GC. In the past, this workaround was done to fix an Stress AV, but the root
-    // cause of the AV was never discovered and this workaround remains in place.
-    //
-    // It would be nice if this were not necessary. However, it's not clear if the aforementioned
-    // stress bug is still lurking and will return if this workaround is removed. We should
-    // do some experiments: remove this workaround and see if the stress bug still repros.
-    // If so, we should find the root cause instead of relying on this.
-    return !!SystemDomain::System()->RequireAppDomainCleanup();
-}
-
 bool GCToEEInterface::EagerFinalized(Object* obj)
 {
     MethodTable* pMT = obj->GetGCSafeMethodTable();

--- a/src/vm/gcenv.ee.h
+++ b/src/vm/gcenv.ee.h
@@ -50,7 +50,6 @@ public:
     void EnableFinalization(bool foundFinalizers);
     void HandleFatalError(unsigned int exitCode);
     bool ShouldFinalizeObjectForUnload(void* pDomain, Object* obj);
-    bool ForceFullGCToBeBlocking();
     bool EagerFinalized(Object* obj);
     MethodTable* GetFreeObjectMethodTable();
     bool GetBooleanConfigValue(const char* key, bool* value);


### PR DESCRIPTION
This change removes enforcing of full GC after native LoaderAllocator is
destroyed. It turns out it was not needed. There is no regression in
running coreclr pri 1 tests inside an unloadable AssemblyLoadContext and
unloading the context after a test completes for each test.
I've tested it with background gc enabled and disabled for both server and 
workstation GC.
Closes #20165