### PR TITLE
Improve performance of Memory<T>.Span property getter

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Memory.cs
+++ b/src/System.Private.CoreLib/shared/System/Memory.cs
@@ -30,9 +30,7 @@ namespace System
         private readonly object _object;
         private readonly int _index;
         private readonly int _length;
-
-        private const int RemoveFlagsBitMask = 0x7FFFFFFF;
-
+        
         /// <summary>
         /// Creates a new memory over the entirety of the target array.
         /// </summary>
@@ -324,7 +322,7 @@ namespace System
                     // least to be in-bounds when compared with the original Memory<T> instance, so using the span won't
                     // AV the process.
 
-                    int desiredStartIndex = _index & RemoveFlagsBitMask;
+                    int desiredStartIndex = _index & ReadOnlyMemory<T>.RemoveFlagsBitMask;
                     int desiredLength = _length;
 
                     if ((uint)desiredStartIndex > (uint)lengthOfUnderlyingSpan || (uint)desiredLength > (uint)(lengthOfUnderlyingSpan - desiredStartIndex))
@@ -401,7 +399,7 @@ namespace System
                     // Array is already pre-pinned
                     if (_index < 0)
                     {
-                        void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref Unsafe.As<T[]>(tmpObject).GetRawSzArrayData()), _index & RemoveFlagsBitMask);
+                        void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref Unsafe.As<T[]>(tmpObject).GetRawSzArrayData()), _index & ReadOnlyMemory<T>.RemoveFlagsBitMask);
                         return new MemoryHandle(pointer);
                     }
                     else
@@ -467,18 +465,7 @@ namespace System
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode()
         {
-            return _object != null ? CombineHashCodes(RuntimeHelpers.GetHashCode(_object), _index.GetHashCode(), _length.GetHashCode()) : 0;
+            return ReadOnlyMemory<T>.CombineHashCodes((_object != null) ? RuntimeHelpers.GetHashCode(_object) : 0, _index, _length);
         }
-
-        private static int CombineHashCodes(int left, int right)
-        {
-            return ((left << 5) + left) ^ right;
-        }
-
-        private static int CombineHashCodes(int h1, int h2, int h3)
-        {
-            return CombineHashCodes(CombineHashCodes(h1, h2), h3);
-        }
-
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Memory.cs
+++ b/src/System.Private.CoreLib/shared/System/Memory.cs
@@ -24,14 +24,9 @@ namespace System
         // NOTE: With the current implementation, Memory<T> and ReadOnlyMemory<T> must have the same layout,
         // as code uses Unsafe.As to cast between them.
 
-        // The highest order bit of _index is used to discern whether _object is an array/string or an owned memory
-        // if (_index >> 31) == 1, object _object is an MemoryManager<T>
-        // else, object _object is a T[] or a string.
-        //     if (_length >> 31) == 1, _object is a pre-pinned array, so Pin() will not allocate a new GCHandle
-        //     else, Pin() needs to allocate a new GCHandle to pin the object.
-        // It can only be a string if the Memory<T> was created by
-        // using unsafe / marshaling code to reinterpret a ReadOnlyMemory<char> wrapped around a string as
-        // a Memory<T>.
+        // The highest order bit of _index is used to discern whether _object is a pre-pinned array.
+        // (_index < 0) => _object is a pre-pinned array, so Pin() will not allocate a new GCHandle
+        //       (else) => Pin() needs to allocate a new GCHandle to pin the object.
         private readonly object _object;
         private readonly int _index;
         private readonly int _length;
@@ -137,8 +132,7 @@ namespace System
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 
             _object = manager;
-            _index = (1 << 31); // Mark as MemoryManager type
-            // Before using _index, check if _index < 0, then 'and' it with RemoveFlagsBitMask
+            _index = 0;
             _length = length;
         }
 
@@ -162,15 +156,18 @@ namespace System
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 
             _object = manager;
-            _index = start | (1 << 31); // Mark as MemoryManager type
-            // Before using _index, check if _index < 0, then 'and' it with RemoveFlagsBitMask
+            _index = start;
             _length = length;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal Memory(object obj, int start, int length)
         {
-            // No validation performed; caller must provide any necessary validation.
+            // No validation performed in release builds; caller must provide any necessary validation.
+
+            // 'obj is T[]' below also handles things like int[] <-> uint[] being convertible
+            Debug.Assert((obj == null) || (typeof(T) == typeof(char) && obj is string) || (obj is T[]) || (obj is MemoryManager<T>));
+
             _object = obj;
             _index = start;
             _length = length;
@@ -200,12 +197,12 @@ namespace System
         /// <summary>
         /// The number of items in the memory.
         /// </summary>
-        public int Length => _length & RemoveFlagsBitMask;
+        public int Length => _length;
 
         /// <summary>
         /// Returns true if Length is 0.
         /// </summary>
-        public bool IsEmpty => (_length & RemoveFlagsBitMask) == 0;
+        public bool IsEmpty => _length == 0;
 
         /// <summary>
         /// For <see cref="Memory{Char}"/>, returns a new instance of string that represents the characters pointed to by the memory.
@@ -215,9 +212,9 @@ namespace System
         {
             if (typeof(T) == typeof(char))
             {
-                return (_object is string str) ? str.Substring(_index, _length & RemoveFlagsBitMask) : Span.ToString();
+                return (_object is string str) ? str.Substring(_index, _length) : Span.ToString();
             }
-            return string.Format("System.Memory<{0}>[{1}]", typeof(T).Name, _length & RemoveFlagsBitMask);
+            return string.Format("System.Memory<{0}>[{1}]", typeof(T).Name, _length);
         }
 
         /// <summary>
@@ -230,16 +227,13 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Memory<T> Slice(int start)
         {
-            // Used to maintain the high-bit which indicates whether the Memory has been pre-pinned or not.
-            int capturedLength = _length;
-            int actualLength = capturedLength & RemoveFlagsBitMask;
-            if ((uint)start > (uint)actualLength)
+            if ((uint)start > (uint)_length)
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
             }
 
-            // It is expected for (capturedLength - start) to be negative if the memory is already pre-pinned.
-            return new Memory<T>(_object, _index + start, capturedLength - start);
+            // It is expected for _index + start to be negative if the memory is already pre-pinned.
+            return new Memory<T>(_object, _index + start, _length - start);
         }
 
         /// <summary>
@@ -253,54 +247,96 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Memory<T> Slice(int start, int length)
         {
-            // Used to maintain the high-bit which indicates whether the Memory has been pre-pinned or not.
-            int capturedLength = _length;
-            int actualLength = capturedLength & RemoveFlagsBitMask;
+
 #if BIT64
             // See comment in Span<T>.Slice for how this works.
-            if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)actualLength)
+            if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)_length)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 #else
-            if ((uint)start > (uint)actualLength || (uint)length > (uint)(actualLength - start))
+            if ((uint)start > (uint)_length || (uint)length > (uint)(_length - start))
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 #endif
 
-            // Set the high-bit to match the this._length high bit (1 for pre-pinned, 0 for unpinned).
-            return new Memory<T>(_object, _index + start, length | (capturedLength & ~RemoveFlagsBitMask));
+            // It is expected for _index + start to be negative if the memory is already pre-pinned.
+            return new Memory<T>(_object, _index + start, length);
         }
 
         /// <summary>
         /// Returns a span from the memory.
         /// </summary>
-        public Span<T> Span
+        public unsafe Span<T> Span
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                if (_index < 0)
+                // This property getter has special support for returning a mutable Span<char> that wraps
+                // an immutable String instance. This is obviously a dangerous feature and breaks type safety.
+                // However, we need to handle the case where a ReadOnlyMemory<char> was created from a string
+                // and then cast to a Memory<T>. Such a cast can only be done with unsafe or marshaling code,
+                // in which case that's the dangerous operation performed by the dev, and we're just following
+                // suit here to make it work as best as possible.
+
+                ref T refToReturn = ref Unsafe.AsRef<T>(null);
+                int lengthOfUnderlyingSpan = 0;
+
+                // Copy this field into a local so that it can't change out from under us mid-operation.
+
+                object tmpObject = _object;
+                if (tmpObject != null)
                 {
-                    Debug.Assert(_length >= 0);
-                    Debug.Assert(_object != null);
-                    return ((MemoryManager<T>)_object).GetSpan().Slice(_index & RemoveFlagsBitMask, _length);
+                    if (typeof(T) == typeof(char) && tmpObject.GetType() == typeof(string))
+                    {
+                        // Special-case string since it's the most common for ROM<char>.
+
+                        refToReturn = ref Unsafe.As<char, T>(ref Unsafe.As<string>(tmpObject).GetRawStringData());
+                        lengthOfUnderlyingSpan = Unsafe.As<string>(tmpObject).Length;
+                    }
+                    else if (RuntimeHelpers.ObjectHasComponentSize(tmpObject))
+                    {
+                        // We know the object is not null, it's not a string, and it is variable-length. The only
+                        // remaining option is for it to be a T[] (or a U[] which is blittable to T[], like int[]
+                        // and uint[]). Otherwise somebody used private reflection to set this field, and we're not
+                        // too worried about type safety violations at this point.
+
+                        // 'tmpObject is T[]' below also handles things like int[] <-> uint[] being convertible
+                        Debug.Assert(tmpObject is T[]);
+
+                        refToReturn = ref Unsafe.As<byte, T>(ref Unsafe.As<T[]>(tmpObject).GetRawSzArrayData());
+                        lengthOfUnderlyingSpan = Unsafe.As<T[]>(tmpObject).Length;
+                    }
+                    else
+                    {
+                        // We know the object is not null, and it's not variable-length, so it must be a MemoryManager<T>.
+                        // Otherwise somebody used private reflection to set this field, and we're not too worried about
+                        // type safety violations at that point. Note that it can't be a MemoryManager<U>, even if U and
+                        // T are blittable (e.g., MemoryManager<int> to MemoryManager<uint>), since there exists no
+                        // constructor or other public API which would allow such a conversion.
+
+                        Debug.Assert(tmpObject is MemoryManager<T>);
+                        Span<T> memoryManagerSpan = Unsafe.As<MemoryManager<T>>(tmpObject).GetSpan();
+                        refToReturn = ref MemoryMarshal.GetReference(memoryManagerSpan);
+                        lengthOfUnderlyingSpan = memoryManagerSpan.Length;
+                    }
+
+                    // If the Memory<T> or ReadOnlyMemory<T> instance is torn, this property getter has undefined behavior.
+                    // We try to detect this condition and throw an exception, but it's possible that a torn struct might
+                    // appear to us to be valid, and we'll return an undesired span. Such a span is always guaranteed at
+                    // least to be in-bounds when compared with the original Memory<T> instance, so using the span won't
+                    // AV the process.
+
+                    int desiredStartIndex = _index & RemoveFlagsBitMask;
+                    int desiredLength = _length;
+
+                    if ((uint)desiredStartIndex > (uint)lengthOfUnderlyingSpan || (uint)desiredLength > (uint)(lengthOfUnderlyingSpan - desiredStartIndex))
+                    {
+                        ThrowHelper.ThrowArgumentOutOfRangeException();
+                    }
+
+                    refToReturn = ref Unsafe.Add(ref refToReturn, desiredStartIndex);
+                    lengthOfUnderlyingSpan = desiredLength;
                 }
-                else if (typeof(T) == typeof(char) && _object is string s)
-                {
-                    Debug.Assert(_length >= 0);
-                    // This is dangerous, returning a writable span for a string that should be immutable.
-                    // However, we need to handle the case where a ReadOnlyMemory<char> was created from a string
-                    // and then cast to a Memory<T>. Such a cast can only be done with unsafe or marshaling code,
-                    // in which case that's the dangerous operation performed by the dev, and we're just following
-                    // suit here to make it work as best as possible.
-                    return new Span<T>(ref Unsafe.As<char, T>(ref s.GetRawStringData()), s.Length).Slice(_index, _length);
-                }
-                else if (_object != null)
-                {
-                    return new Span<T>((T[])_object, _index, _length & RemoveFlagsBitMask);
-                }
-                else
-                {
-                    return default;
-                }
+
+                return new Span<T>(ref refToReturn, lengthOfUnderlyingSpan);
             }
         }
 
@@ -337,37 +373,51 @@ namespace System
         /// </summary>
         public unsafe MemoryHandle Pin()
         {
-            if (_index < 0)
+            // Just like the Span property getter, we have special support for a mutable Memory<char>
+            // that wraps an immutable String instance. This might happen if a caller creates an
+            // immutable ROM<char> wrapping a String, then uses Unsafe.As to create a mutable M<char>.
+            // This needs to work, however, so that code that uses a single Memory<char> field to store either
+            // a readable ReadOnlyMemory<char> or a writable Memory<char> can still be pinned and
+            // used for interop purposes.
+
+            // It's possible that the below logic could result in an AV if the struct
+            // is torn. This is ok since the caller is expecting to use raw pointers,
+            // and we're not required to keep this as safe as the other Span-based APIs.
+
+            object tmpObject = _object;
+            if (tmpObject != null)
             {
-                Debug.Assert(_object != null);
-                return ((MemoryManager<T>)_object).Pin((_index & RemoveFlagsBitMask));
-            }
-            else if (typeof(T) == typeof(char) && _object is string s)
-            {
-                // This case can only happen if a ReadOnlyMemory<char> was created around a string
-                // and then that was cast to a Memory<char> using unsafe / marshaling code.  This needs
-                // to work, however, so that code that uses a single Memory<char> field to store either
-                // a readable ReadOnlyMemory<char> or a writable Memory<char> can still be pinned and
-                // used for interop purposes.
-                GCHandle handle = GCHandle.Alloc(s, GCHandleType.Pinned);
-                void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref s.GetRawStringData()), _index);
-                return new MemoryHandle(pointer, handle);
-            }
-            else if (_object is T[] array)
-            {
-                // Array is already pre-pinned
-                if (_length < 0)
+                if (typeof(T) == typeof(char) && tmpObject is string s)
                 {
-                    void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref array.GetRawSzArrayData()), _index);
-                    return new MemoryHandle(pointer);
+                    GCHandle handle = GCHandle.Alloc(tmpObject, GCHandleType.Pinned);
+                    ref char stringData = ref Unsafe.Add(ref s.GetRawStringData(), _index);
+                    return new MemoryHandle(Unsafe.AsPointer(ref stringData), handle);
+                }
+                else if (RuntimeHelpers.ObjectHasComponentSize(tmpObject))
+                {
+                    // 'tmpObject is T[]' below also handles things like int[] <-> uint[] being convertible
+                    Debug.Assert(tmpObject is T[]);
+
+                    // Array is already pre-pinned
+                    if (_index < 0)
+                    {
+                        void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref Unsafe.As<T[]>(tmpObject).GetRawSzArrayData()), _index & RemoveFlagsBitMask);
+                        return new MemoryHandle(pointer);
+                    }
+                    else
+                    {
+                        GCHandle handle = GCHandle.Alloc(tmpObject, GCHandleType.Pinned);
+                        void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref Unsafe.As<T[]>(tmpObject).GetRawSzArrayData()), _index);
+                        return new MemoryHandle(pointer, handle);
+                    }
                 }
                 else
                 {
-                    GCHandle handle = GCHandle.Alloc(array, GCHandleType.Pinned);
-                    void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref array.GetRawSzArrayData()), _index);
-                    return new MemoryHandle(pointer, handle);
+                    Debug.Assert(tmpObject is MemoryManager<T>);
+                    return Unsafe.As<MemoryManager<T>>(tmpObject).Pin(_index);
                 }
             }
+
             return default;
         }
 
@@ -417,7 +467,7 @@ namespace System
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode()
         {
-            return _object != null ? CombineHashCodes(_object.GetHashCode(), _index.GetHashCode(), _length.GetHashCode()) : 0;
+            return _object != null ? CombineHashCodes(RuntimeHelpers.GetHashCode(_object), _index.GetHashCode(), _length.GetHashCode()) : 0;
         }
 
         private static int CombineHashCodes(int left, int right)

--- a/src/System.Private.CoreLib/shared/System/Memory.cs
+++ b/src/System.Private.CoreLib/shared/System/Memory.cs
@@ -245,7 +245,6 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Memory<T> Slice(int start, int length)
         {
-
 #if BIT64
             // See comment in Span<T>.Slice for how this works.
             if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)_length)

--- a/src/System.Private.CoreLib/shared/System/Memory.cs
+++ b/src/System.Private.CoreLib/shared/System/Memory.cs
@@ -465,7 +465,7 @@ namespace System
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode()
         {
-            return ReadOnlyMemory<T>.CombineHashCodes((_object != null) ? RuntimeHelpers.GetHashCode(_object) : 0, _index, _length);
+            return (_object != null) ? ReadOnlyMemory<T>.CombineHashCodes(RuntimeHelpers.GetHashCode(_object), _index, _length) : 0;
         }
     }
 }

--- a/src/System.Private.CoreLib/shared/System/ReadOnlyMemory.cs
+++ b/src/System.Private.CoreLib/shared/System/ReadOnlyMemory.cs
@@ -374,7 +374,7 @@ namespace System
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode()
         {
-            return _object != null ? CombineHashCodes(RuntimeHelpers.GetHashCode(_object), _index.GetHashCode(), _length.GetHashCode()) : 0;
+            return CombineHashCodes((_object != null) ? RuntimeHelpers.GetHashCode(_object) : 0, _index, _length);
         }
 
         private static int CombineHashCodes(int left, int right)
@@ -382,7 +382,7 @@ namespace System
             return ((left << 5) + left) ^ right;
         }
 
-        private static int CombineHashCodes(int h1, int h2, int h3)
+        internal static int CombineHashCodes(int h1, int h2, int h3)
         {
             return CombineHashCodes(CombineHashCodes(h1, h2), h3);
         }

--- a/src/System.Private.CoreLib/shared/System/ReadOnlyMemory.cs
+++ b/src/System.Private.CoreLib/shared/System/ReadOnlyMemory.cs
@@ -374,7 +374,7 @@ namespace System
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode()
         {
-            return CombineHashCodes((_object != null) ? RuntimeHelpers.GetHashCode(_object) : 0, _index, _length);
+            return (_object != null) ? CombineHashCodes(RuntimeHelpers.GetHashCode(_object), _index, _length) : 0;
         }
 
         private static int CombineHashCodes(int left, int right)

--- a/src/System.Private.CoreLib/shared/System/ReadOnlyMemory.cs
+++ b/src/System.Private.CoreLib/shared/System/ReadOnlyMemory.cs
@@ -24,11 +24,9 @@ namespace System
         // NOTE: With the current implementation, Memory<T> and ReadOnlyMemory<T> must have the same layout,
         // as code uses Unsafe.As to cast between them.
 
-        // The highest order bit of _index is used to discern whether _object is an array/string or an owned memory
-        // if (_index >> 31) == 1, _object is an MemoryManager<T>
-        // else, _object is a T[] or string.
-        //     if (_length >> 31) == 1, _object is a pre-pinned array, so Pin() will not allocate a new GCHandle
-        //     else, Pin() needs to allocate a new GCHandle to pin the object.
+        // The highest order bit of _index is used to discern whether _object is a pre-pinned array.
+        // (_index < 0) => _object is a pre-pinned array, so Pin() will not allocate a new GCHandle
+        //       (else) => Pin() needs to allocate a new GCHandle to pin the object.
         private readonly object _object;
         private readonly int _index;
         private readonly int _length;
@@ -98,7 +96,11 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal ReadOnlyMemory(object obj, int start, int length)
         {
-            // No validation performed; caller must provide any necessary validation.
+            // No validation performed in release builds; caller must provide any necessary validation.
+
+            // 'obj is T[]' below also handles things like int[] <-> uint[] being convertible
+            Debug.Assert((obj == null) || (typeof(T) == typeof(char) && obj is string) || (obj is T[]) || (obj is MemoryManager<T>));
+
             _object = obj;
             _index = start;
             _length = length;
@@ -122,12 +124,12 @@ namespace System
         /// <summary>
         /// The number of items in the memory.
         /// </summary>
-        public int Length => _length & RemoveFlagsBitMask;
+        public int Length => _length;
 
         /// <summary>
         /// Returns true if Length is 0.
         /// </summary>
-        public bool IsEmpty => (_length & RemoveFlagsBitMask) == 0;
+        public bool IsEmpty => _length == 0;
 
         /// <summary>
         /// For <see cref="ReadOnlyMemory{Char}"/>, returns a new instance of string that represents the characters pointed to by the memory.
@@ -137,9 +139,9 @@ namespace System
         {
             if (typeof(T) == typeof(char))
             {
-                return (_object is string str) ? str.Substring(_index, _length & RemoveFlagsBitMask) : Span.ToString();
+                return (_object is string str) ? str.Substring(_index, _length) : Span.ToString();
             }
-            return string.Format("System.ReadOnlyMemory<{0}>[{1}]", typeof(T).Name, _length & RemoveFlagsBitMask);
+            return string.Format("System.ReadOnlyMemory<{0}>[{1}]", typeof(T).Name, _length);
         }
 
         /// <summary>
@@ -152,16 +154,13 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ReadOnlyMemory<T> Slice(int start)
         {
-            // Used to maintain the high-bit which indicates whether the Memory has been pre-pinned or not.
-            int capturedLength = _length;
-            int actualLength = capturedLength & RemoveFlagsBitMask;
-            if ((uint)start > (uint)actualLength)
+            if ((uint)start > (uint)_length)
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
             }
 
-            // It is expected for (capturedLength - start) to be negative if the memory is already pre-pinned.
-            return new ReadOnlyMemory<T>(_object, _index + start, capturedLength - start);
+            // It is expected for _index + start to be negative if the memory is already pre-pinned.
+            return new ReadOnlyMemory<T>(_object, _index + start, _length - start);
         }
 
         /// <summary>
@@ -175,49 +174,88 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ReadOnlyMemory<T> Slice(int start, int length)
         {
-            // Used to maintain the high-bit which indicates whether the Memory has been pre-pinned or not.
-            int capturedLength = _length;
-            int actualLength = _length & RemoveFlagsBitMask;
 #if BIT64
             // See comment in Span<T>.Slice for how this works.
-            if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)actualLength)
+            if ((ulong)(uint)start + (ulong)(uint)_length > (ulong)(uint)_length)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 #else
-            if ((uint)start > (uint)actualLength || (uint)length > (uint)(actualLength - start))
+            if ((uint)start > (uint)_length || (uint)length > (uint)(_length - start))
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 #endif
 
-            // Set the high-bit to match the this._length high bit (1 for pre-pinned, 0 for unpinned).
-            return new ReadOnlyMemory<T>(_object, _index + start, length | (capturedLength & ~RemoveFlagsBitMask));
+            // It is expected for _index + start to be negative if the memory is already pre-pinned.
+            return new ReadOnlyMemory<T>(_object, _index + start, length);
         }
 
         /// <summary>
         /// Returns a span from the memory.
         /// </summary>
-        public ReadOnlySpan<T> Span
+        public unsafe ReadOnlySpan<T> Span
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                if (_index < 0)
+                ref T refToReturn = ref Unsafe.AsRef<T>(null);
+                int lengthOfUnderlyingSpan = 0;
+
+                // Copy this field into a local so that it can't change out from under us mid-operation.
+
+                object tmpObject = _object;
+                if (tmpObject != null)
                 {
-                    Debug.Assert(_length >= 0);
-                    Debug.Assert(_object != null);
-                    return ((MemoryManager<T>)_object).GetSpan().Slice(_index & RemoveFlagsBitMask, _length);
+                    if (typeof(T) == typeof(char) && tmpObject.GetType() == typeof(string))
+                    {
+                        // Special-case string since it's the most common for ROM<char>.
+
+                        refToReturn = ref Unsafe.As<char, T>(ref Unsafe.As<string>(tmpObject).GetRawStringData());
+                        lengthOfUnderlyingSpan = Unsafe.As<string>(tmpObject).Length;
+                    }
+                    else if (RuntimeHelpers.ObjectHasComponentSize(tmpObject))
+                    {
+                        // We know the object is not null, it's not a string, and it is variable-length. The only
+                        // remaining option is for it to be a T[] (or a U[] which is blittable to T[], like int[]
+                        // and uint[]). Otherwise somebody used private reflection to set this field, and we're not
+                        // too worried about type safety violations at this point.
+
+                        // 'tmpObject is T[]' below also handles things like int[] <-> uint[] being convertible
+                        Debug.Assert(tmpObject is T[]);
+
+                        refToReturn = ref Unsafe.As<byte, T>(ref Unsafe.As<T[]>(tmpObject).GetRawSzArrayData());
+                        lengthOfUnderlyingSpan = Unsafe.As<T[]>(tmpObject).Length;
+                    }
+                    else
+                    {
+                        // We know the object is not null, and it's not variable-length, so it must be a MemoryManager<T>.
+                        // Otherwise somebody used private reflection to set this field, and we're not too worried about
+                        // type safety violations at that point. Note that it can't be a MemoryManager<U>, even if U and
+                        // T are blittable (e.g., MemoryManager<int> to MemoryManager<uint>), since there exists no
+                        // constructor or other public API which would allow such a conversion.
+
+                        Debug.Assert(tmpObject is MemoryManager<T>);
+                        Span<T> memoryManagerSpan = Unsafe.As<MemoryManager<T>>(tmpObject).GetSpan();
+                        refToReturn = ref MemoryMarshal.GetReference(memoryManagerSpan);
+                        lengthOfUnderlyingSpan = memoryManagerSpan.Length;
+                    }
+
+                    // If the Memory<T> or ReadOnlyMemory<T> instance is torn, this property getter has undefined behavior.
+                    // We try to detect this condition and throw an exception, but it's possible that a torn struct might
+                    // appear to us to be valid, and we'll return an undesired span. Such a span is always guaranteed at
+                    // least to be in-bounds when compared with the original Memory<T> instance, so using the span won't
+                    // AV the process.
+
+                    int desiredStartIndex = _index & RemoveFlagsBitMask;
+                    int desiredLength = _length;
+
+                    if ((uint)desiredStartIndex > (uint)lengthOfUnderlyingSpan || (uint)desiredLength > (uint)(lengthOfUnderlyingSpan - desiredStartIndex))
+                    {
+                        ThrowHelper.ThrowArgumentOutOfRangeException();
+                    }
+
+                    refToReturn = ref Unsafe.Add(ref refToReturn, desiredStartIndex);
+                    lengthOfUnderlyingSpan = desiredLength;
                 }
-                else if (typeof(T) == typeof(char) && _object is string s)
-                {
-                    Debug.Assert(_length >= 0);
-                    return new ReadOnlySpan<T>(ref Unsafe.As<char, T>(ref s.GetRawStringData()), s.Length).Slice(_index, _length);
-                }
-                else if (_object != null)
-                {
-                    return new ReadOnlySpan<T>((T[])_object, _index, _length & RemoveFlagsBitMask);
-                }
-                else
-                {
-                    return default;
-                }
+
+                return new ReadOnlySpan<T>(ref refToReturn, lengthOfUnderlyingSpan);
             }
         }
 
@@ -254,32 +292,44 @@ namespace System
         /// </summary>
         public unsafe MemoryHandle Pin()
         {
-            if (_index < 0)
+            // It's possible that the below logic could result in an AV if the struct
+            // is torn. This is ok since the caller is expecting to use raw pointers,
+            // and we're not required to keep this as safe as the other Span-based APIs.
+
+            object tmpObject = _object;
+            if (tmpObject != null)
             {
-                Debug.Assert(_object != null);
-                return ((MemoryManager<T>)_object).Pin((_index & RemoveFlagsBitMask));
-            }
-            else if (typeof(T) == typeof(char) && _object is string s)
-            {
-                GCHandle handle = GCHandle.Alloc(s, GCHandleType.Pinned);
-                void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref s.GetRawStringData()), _index);
-                return new MemoryHandle(pointer, handle);
-            }
-            else if (_object is T[] array)
-            {
-                // Array is already pre-pinned
-                if (_length < 0)
+                if (typeof(T) == typeof(char) && tmpObject is string s)
                 {
-                    void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref array.GetRawSzArrayData()), _index);
-                    return new MemoryHandle(pointer);
+                    GCHandle handle = GCHandle.Alloc(tmpObject, GCHandleType.Pinned);
+                    ref char stringData = ref Unsafe.Add(ref s.GetRawStringData(), _index);
+                    return new MemoryHandle(Unsafe.AsPointer(ref stringData), handle);
+                }
+                else if (RuntimeHelpers.ObjectHasComponentSize(tmpObject))
+                {
+                    // 'tmpObject is T[]' below also handles things like int[] <-> uint[] being convertible
+                    Debug.Assert(tmpObject is T[]);
+
+                    // Array is already pre-pinned
+                    if (_index < 0)
+                    {
+                        void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref Unsafe.As<T[]>(tmpObject).GetRawSzArrayData()), _index & RemoveFlagsBitMask);
+                        return new MemoryHandle(pointer);
+                    }
+                    else
+                    {
+                        GCHandle handle = GCHandle.Alloc(tmpObject, GCHandleType.Pinned);
+                        void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref Unsafe.As<T[]>(tmpObject).GetRawSzArrayData()), _index);
+                        return new MemoryHandle(pointer, handle);
+                    }
                 }
                 else
                 {
-                    GCHandle handle = GCHandle.Alloc(array, GCHandleType.Pinned);
-                    void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref array.GetRawSzArrayData()), _index);
-                    return new MemoryHandle(pointer, handle);
+                    Debug.Assert(tmpObject is MemoryManager<T>);
+                    return Unsafe.As<MemoryManager<T>>(tmpObject).Pin(_index);
                 }
             }
+
             return default;
         }
 
@@ -324,7 +374,7 @@ namespace System
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode()
         {
-            return _object != null ? CombineHashCodes(_object.GetHashCode(), _index.GetHashCode(), _length.GetHashCode()) : 0;
+            return _object != null ? CombineHashCodes(RuntimeHelpers.GetHashCode(_object), _index.GetHashCode(), _length.GetHashCode()) : 0;
         }
 
         private static int CombineHashCodes(int left, int right)

--- a/src/System.Private.CoreLib/shared/System/ReadOnlyMemory.cs
+++ b/src/System.Private.CoreLib/shared/System/ReadOnlyMemory.cs
@@ -176,7 +176,7 @@ namespace System
         {
 #if BIT64
             // See comment in Span<T>.Slice for how this works.
-            if ((ulong)(uint)start + (ulong)(uint)_length > (ulong)(uint)_length)
+            if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)_length)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 #else
             if ((uint)start > (uint)_length || (uint)length > (uint)(_length - start))

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -198,7 +198,7 @@ namespace System.Runtime.CompilerServices
         }
 
         // Returns true iff the object has a component size;
-        // i.e., is variable length like string, array, Utf8String.
+        // i.e., is variable length like System.String or Array.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe bool ObjectHasComponentSize(object obj)
         {

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -13,6 +13,7 @@
 namespace System.Runtime.CompilerServices
 {
     using System;
+    using System.Diagnostics;
     using System.Security;
     using System.Runtime;
     using System.Runtime.CompilerServices;
@@ -21,6 +22,7 @@ namespace System.Runtime.CompilerServices
     using System.Runtime.Serialization;
     using System.Threading;
     using System.Runtime.Versioning;
+    using Internal.Runtime.CompilerServices;
 
     public static class RuntimeHelpers
     {
@@ -194,6 +196,45 @@ namespace System.Runtime.CompilerServices
             // See getILIntrinsicImplementation for how this happens.
             throw new InvalidOperationException();
         }
+
+        // Returns true iff the object has a component size;
+        // i.e., is variable length like string, array, Utf8String.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static unsafe bool ObjectHasComponentSize(object obj)
+        {
+            // CLR objects are laid out in memory as follows.
+            // [ pMethodTable || .. object data .. ]
+            //   ^-- the object reference points here
+            //
+            // The first DWORD of the method table class will have its high bit set if the
+            // method table has component size info stored somewhere. See member
+            // MethodTable:IsStringOrArray in src\vm\methodtable.h for full details.
+            //
+            // So in effect this method is the equivalent of
+            // return ((MethodTable*)(*obj))->IsStringOrArray();
+
+            Debug.Assert(obj != null);
+            return *(int*)GetObjectMethodTablePointer(obj) < 0;
+        }
+
+        // Given an object reference, returns its MethodTable* as an IntPtr.
+        //[Intrinsic]
+        //[NonVersionable]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static IntPtr GetObjectMethodTablePointer(object obj)
+        {
+            Debug.Assert(obj != null);
+
+            // We know that the first data field in any managed object is immediately after the
+            // method table pointer, so just back up one pointer and immediately deref.
+            // This is not ideal in terms of minimizing instruction count but is the best we can do at the moment.
+
+            return Unsafe.Add(ref Unsafe.As<byte, IntPtr>(ref JitHelpers.GetPinningHelper(obj).m_data), -1);
+
+            // Ideally this method would be replaced by the VM with:
+            // ldarg.0
+            // ldind.i
+            // ret
+        }
     }
 }
-

--- a/tests/CoreFX/CoreFX.issues.json
+++ b/tests/CoreFX/CoreFX.issues.json
@@ -486,6 +486,14 @@
                 {
                     "name": "System.Buffers.Text.Tests.FormatterTests.TestFormatterDecimal",
                     "reason": "https://github.com/dotnet/coreclr/pull/19775"
+                },
+                {
+                    "name": "System.SpanTests.MemoryMarshalTests.CreateFromPinnedArrayIntSliceRemainsPinned",
+                    "reason": "https://github.com/dotnet/corefx/pull/32994"
+                },
+                {
+                    "name": "System.SpanTests.MemoryMarshalTests.CreateFromPinnedArrayIntReadOnlyMemorySliceRemainsPinned",
+                    "reason": "https://github.com/dotnet/corefx/pull/32994"
                 }
             ]
         }


### PR DESCRIPTION
Perf results for accessing the `Memory<T>.Span` property getter given different backing objects:

|                      Method |        Toolchain |        Mean |      Error |     StdDev | Scaled |
|---------------------------- |----------------- |------------:|-----------:|-----------:|-------:|
|              CharFromString | baseline (27008) |  3,360.8 ns |  31.849 ns |  28.233 ns |   1.00 |
|              CharFromString |       w/ changes |  2,946.9 ns |  24.783 ns |  21.969 ns |   0.88 |
|                             |                  |             |            |            |        |
|         CharFromArrayOfChar | baseline (27008) |  9,092.7 ns | 156.120 ns | 146.035 ns |   1.00 |
|         CharFromArrayOfChar |       w/ changes |  3,551.1 ns |  40.715 ns |  36.093 ns |   0.39 |
|                             |                  |             |            |            |        |
| CharFromMemoryManagerOfChar | baseline (27008) |  9,088.1 ns |  83.590 ns |  78.190 ns |   1.00 |
| CharFromMemoryManagerOfChar |       w/ changes |  6,460.6 ns |  36.038 ns |  28.136 ns |   0.71 |
|                             |                  |             |            |            |        |
|         ByteFromArrayOfByte | baseline (27008) |  8,479.8 ns | 219.163 ns | 277.172 ns |   1.00 |
|         ByteFromArrayOfByte |       w/ changes |  3,233.9 ns |  30.808 ns |  27.310 ns |   0.38 |
|                             |                  |             |            |            |        |
|        ByteFromArrayOfSByte | baseline (27008) | 42,603.5 ns | 685.866 ns | 641.559 ns |   1.00 |
|        ByteFromArrayOfSByte |       w/ changes |  3,381.6 ns |  71.574 ns | 155.597 ns |   0.08 |
|                             |                  |             |            |            |        |
| ByteFromMemoryManagerOfByte | baseline (27008) |  8,816.3 ns | 175.853 ns | 164.493 ns |   1.00 |
| ByteFromMemoryManagerOfByte |       w/ changes |  6,569.5 ns |  35.088 ns |  31.105 ns |   0.75 |
|                             |                  |             |            |            |        |
|      GetSpanFromEmptyMemory | baseline (27008) |  1,207.4 ns |  22.214 ns |  19.693 ns |   1.00 |
|      GetSpanFromEmptyMemory |       w/ changes |    887.2 ns |   4.268 ns |   3.784 ns |   0.74 |

Various optimizations include:

* We can rely on the `Memory<T>` ctor and factory methods to ensure that an object of an unexpected type never makes it in to the `_object` backing field, even in the face of a torn struct. This allows us to use unsafe code, bypassing the runtime type checks, but still requires that we perform bounds checks as appropriate.

* Single exit from the _Span_ property getter allows the JIT to optimize stack usage and minimize unnecessary data copying.

* Since we're part of coreclr, we can use deep knowledge of runtime object layout and method table layout to further skip some type checks. This is particularly useful in the case where an array is the backing store.

* The _Length_ property getter is once again just a simple field access with no bitmask logic.

* The _Span_ property getter's code gen size shrinks by around 60%.

Unit tests will not pass until the corresponding corefx change comes online since the unit tests perform private reflection over the `Memory<T>` backing fields.

I realize that this may be contentious, especially considering the fact that this proposes probing into the internals of how objects are represented within the runtime. But coreclr code is uniquely positioned to take advantage of these implementation details since the managed code can evolve in sync with any VM changes.

I'm also open to any recommendations people might have for real-world benchmarks so that we can test whether these changes are actually useful in practice.