### PR TITLE
Add hack for arm64/x86 to skip build tools restore

### DIFF
--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -86,10 +86,12 @@ if NOT exist "%DOTNET_LOCAL_PATH%" (
 :afterdotnetrestore
 
 REM We do not need the build tools for arm64/x86
-if /i "%_Arch%" == "x86" (
-  if defined __SkipBuildTools__ (
-    goto :EOF
-  )
+if /i "%PROCESSOR_ARCHITEW6432%" == "x86" (
+  goto :EOF
+)
+
+if /i "%PROCESSOR_ARCHITECTURE%" == "arm64" (
+  goto :EOF
 )
 
 if exist "%BUILD_TOOLS_PATH%" goto :afterbuildtoolsrestore

--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -87,7 +87,9 @@ if NOT exist "%DOTNET_LOCAL_PATH%" (
 
 REM We do not need the build tools for arm64/x86
 if /i "%_Arch%" == "x86" (
-  goto :EOF
+  if defined __SkipBuildTools__ (
+    goto :EOF
+  )
 )
 
 if exist "%BUILD_TOOLS_PATH%" goto :afterbuildtoolsrestore

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -1907,11 +1907,6 @@ def do_setup(host_os,
     global gc_stress_c
 
     # Setup the tools for the repo.
-    if arch == "arm64" and host_os == "Windows_NT":
-        # Hack to avoid restoring build tools on x86/arm64 using init-tools.cmd.
-        # When we have an arm64 cli this can be safely removed when init-tools.cmd
-        # is updated.
-        os.environ["__SkipBuildTools__"] = "1"
     setup_tools(host_os, coreclr_repo_location)
 
     if unprocessed_args.generate_layout:

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -1907,6 +1907,11 @@ def do_setup(host_os,
     global gc_stress_c
 
     # Setup the tools for the repo.
+    if arch == "arm64" and host_os == "Windows_NT":
+        # Hack to avoid restoring build tools on x86/arm64 using init-tools.cmd.
+        # When we have an arm64 cli this can be safely removed when init-tools.cmd
+        # is updated.
+        os.environ["__SkipBuildTools__"] = "1"
     setup_tools(host_os, coreclr_repo_location)
 
     if unprocessed_args.generate_layout:


### PR DESCRIPTION
Addresses issue caused by #20370. Unfortunately as we do not entirely know when x86 is actually x86 or arm64 easily I have added an environment variable from the parent caller which will skip the build tools restore.

Summary below:
>This change basically breaks any x64 build of coreclr in a normal cmd window (ie, one that has its processor architecture set to x86). With it, I get the following error: