### PR TITLE
Fix MacOS launch bug when spaces in module names.

### DIFF
--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -2716,6 +2716,9 @@ CreateProcessModules(
     // Stack                  00007fff5a930000-00007fff5b130000 [ 8192K    32K    32K     0K] rw-/rwx SM=PRV          thread 0
     // __TEXT                 00007fffa4a0b000-00007fffa4a0d000 [    8K     8K     0K     0K] r-x/r-x SM=COW          /usr/lib/libSystem.B.dylib
     // __TEXT                 00007fffa4bbe000-00007fffa4c15000 [  348K   348K     0K     0K] r-x/r-x SM=COW          /usr/lib/libc++.1.dylib
+
+    // NOTE: the module path can have spaces in the name
+    // __TEXT                 0000000196220000-00000001965b4000 [ 3664K  2340K     0K     0K] r-x/rwx SM=COW          /Volumes/Builds/builds/devmain/rawproduct/debug/build/out/Applications/Microsoft Excel.app/Contents/SharedSupport/PowerQuery/libcoreclr.dylib
     char *line = NULL;
     size_t lineLen = 0;
     int count = 0;
@@ -2737,7 +2740,7 @@ CreateProcessModules(
         void *startAddress, *endAddress;
         char moduleName[PATH_MAX];
 
-        if (sscanf_s(line, "__TEXT %p-%p [ %*[0-9K ]] %*[-/rwxsp] SM=%*[A-Z] %s\n", &startAddress, &endAddress, moduleName, _countof(moduleName)) == 3)
+        if (sscanf_s(line, "__TEXT %p-%p [ %*[0-9K ]] %*[-/rwxsp] SM=%*[A-Z] %[^\n]", &startAddress, &endAddress, moduleName, _countof(moduleName)) == 3)
         {
             bool dup = false;
             for (ProcessModules *entry = listHead; entry != NULL; entry = entry->Next)


### PR DESCRIPTION
### Shiproom template

#### Description

The libdbgshim.dylib launch/attach helper had a bug with module names with spaces in them. The Excel (Oded Hanson) ran into this because ship the .NET Core in a sub-directory with a space in the path.

This causes launch (or attach) with VS (VSCode or VS for Mac) to hang..

The fix is to change the vmmap output parsing to include the rest of the line as the module name.

#### Customer Impact
Without this fix, Excel can not debug their product and an official build is needed to get the dbgshim for insertion into VS vsdbg to fix the problem.

#### Regression?
No.

#### Risk
Low. 

#### Link to issue
https://github.com/dotnet/coreclr/issues/20401