### PR TITLE
Add unloadability support to ReliabilityFramework

### DIFF
--- a/tests/src/GC/Stress/Framework/LoaderClass.cs
+++ b/tests/src/GC/Stress/Framework/LoaderClass.cs
@@ -35,7 +35,9 @@ public class LoaderClass
 {
     private Assembly assem;
     string assembly;
-    object myRf;
+#if !PROJECTK_BUILD
+    ReliabilityFramework myRf;
+#endif 
 
     public LoaderClass()
     {
@@ -45,15 +47,20 @@ public class LoaderClass
     {
         Console.SetOut(System.IO.TextWriter.Null);
     }
-#if !PROJECTK_BUILD
+
     /// <summary>
     /// Executes a LoadFrom in the app domain LoaderClass has been loaded into.  Attempts to load a given assembly, looking in the
     /// given paths & the current directory.
     /// </summary>
     /// <param name="path">The assembly to load</param>
     /// <param name="paths">Paths to search for the given assembly</param>
-    public void LoadFrom(string path, string[] paths, ReliabilityFramework rf)
+    public void LoadFrom(string path, string[] paths
+#if !PROJECTK_BUILD
+        , ReliabilityFramework rf
+#endif
+        )
     {
+#if !PROJECTK_BUILD
         myRf = rf;
 
         AssemblyName an = new AssemblyName();
@@ -62,113 +69,17 @@ public class LoaderClass
         //register AssemblyLoad and DomainUnload events
         AppDomain.CurrentDomain.AssemblyLoad += new AssemblyLoadEventHandler(this.UnloadOnAssemblyLoad);
         AppDomain.CurrentDomain.DomainUnload += new EventHandler(this.UnloadOnDomainUnload);
-
-        try
-        {
-            assem = Assembly.Load(an);
-        }
-        catch
-        {
-            try
-            {
-                FileInfo fi = new FileInfo(path);
-
-                an = new AssemblyName();
-                an.CodeBase = assembly = fi.FullName;
-
-                assem = Assembly.Load(an);
-            }
-            catch
-            {
-                if (paths != null)
-                {
-                    foreach (string basePath in paths)
-                    {
-                        try
-                        {
-                            an = new AssemblyName();
-                            an.CodeBase = assembly = ReliabilityConfig.ConvertPotentiallyRelativeFilenameToFullPath(basePath, path);
-
-                            assem = Assembly.Load(an);
-                        }
-                        catch
-                        {
-                            continue;
-                        }
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
-    /// <summary>
-    /// Attempts to load an assembly w/ a simple name, looking in the given paths if a normal load fails
-    /// </summary>
-    /// <param name="assemblyName">The assembly name to load</param>
-    /// <param name="paths">paths to look in if the initial load fails</param>
-    public void Load(string assemblyName, string[] paths, ReliabilityFramework rf)
-    {
-        myRf = rf;
-
-        AssemblyName an = new AssemblyName(assemblyName);
-        assembly = assemblyName;
-
-        try
-        {
-            assem = Assembly.Load(an);
-        }
-        catch
-        {
-            Console.WriteLine("Load failed for: {0}", assemblyName);
-            LoadFrom(assemblyName, paths, rf);	// couldn't load the assembly, try doing a LoadFrom with paths.
-
-        }
-    }
-
-    /// <summary>
-    /// Checks the test's entry point for an STA or MTA thread attribute.  Returns
-    /// the apartment state if set, or ApartmentState.Unknown
-    /// </summary>
-    /// <returns></returns>
-    public ApartmentState CheckMainForThreadType()
-    {
-        if (assem != null)
-        {
-            MethodInfo mi = assem.EntryPoint;
-            object[] attrs = mi.GetCustomAttributes(typeof(STAThreadAttribute), false);
-            if (attrs != null && attrs.Length > 0)
-            {
-                return (ApartmentState.STA);
-            }
-            attrs = mi.GetCustomAttributes(typeof(MTAThreadAttribute), false);
-            if (attrs != null && attrs.Length > 0)
-            {
-                return (ApartmentState.MTA);
-            }
-        }
-        return (ApartmentState.Unknown);
-    }
 #else
-    /// <summary>
-    /// Executes a LoadFrom in the app domain LoaderClass has been loaded into.  Attempts to load a given assembly, looking in the
-    /// given paths & the current directory.
-    /// </summary>
-    /// <param name="path">The assembly to load</param>
-    /// <param name="paths">Paths to search for the given assembly</param>
-    public void LoadFrom(string path, string[] paths, object rf)
-    {
-        myRf = rf;
         AssemblyLoadContext alc = AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly());
-
-        //register AssemblyLoad and DomainUnload events
-        //AppDomain.CurrentDomain.AssemblyLoad += new AssemblyLoadEventHandler(this.UnloadOnAssemblyLoad);
-        //AppDomain.CurrentDomain.DomainUnload += new EventHandler(this.UnloadOnDomainUnload);
-
+#endif
         try
         {
+#if !PROJECTK_BUILD
+            assem = Assembly.Load(an);
+#else
             assembly = path;
             assem = alc.LoadFromAssemblyPath(assembly);
+#endif
         }
         catch
         {
@@ -176,7 +87,14 @@ public class LoaderClass
             {
                 FileInfo fi = new FileInfo(path);
                 assembly = fi.FullName;
+#if !PROJECTK_BUILD
+                an = new AssemblyName();
+                an.CodeBase = assembly;
+
+                assem = Assembly.Load(an);
+#else
                 assem = alc.LoadFromAssemblyPath(assembly);
+#endif
             }
             catch
             {
@@ -187,20 +105,22 @@ public class LoaderClass
                         try
                         {
                             assembly = ReliabilityConfig.ConvertPotentiallyRelativeFilenameToFullPath(basePath, path);
+#if !PROJECTK_BUILD
+                            an = new AssemblyName();
+                            an.CodeBase = assembly;
+
+                            assem = Assembly.Load(an);
+#else
                             assem = alc.LoadFromAssemblyPath(assembly);
+#endif
                             break;
                         }
                         catch
                         {
-
                         }
                     }
                 }
             }
-        }
-        if (assem == null)
-        {
-            Console.WriteLine($"Failed to load {path}");
         }
     }
 
@@ -209,16 +129,33 @@ public class LoaderClass
     /// </summary>
     /// <param name="assemblyName">The assembly name to load</param>
     /// <param name="paths">paths to look in if the initial load fails</param>
-    public void Load(string assemblyName, string[] paths, object rf)
+    public void Load(string assemblyName, string[] paths
+#if !PROJECTK_BUILD
+        , ReliabilityFramework rf
+#endif
+        )
     {
+#if !PROJECTK_BUILD
+        myRf = rf;
+
+        AssemblyName an = new AssemblyName(assemblyName);
+        assembly = assemblyName;
+#endif
         try
         {
-            LoadFrom(assemblyName + ".exe", paths, rf);	// couldn't load the assembly, try doing a LoadFrom with paths.
+#if !PROJECTK_BUILD
+            assem = Assembly.Load(an);
+#else
+            LoadFrom(assemblyName + ".exe", paths);
+#endif
         }
         catch
         {
-            LoadFrom(assemblyName + ".dll", paths, rf);	// couldn't load the assembly, try doing a LoadFrom with paths.
+            Console.WriteLine("Load failed for: {0}", assemblyName);
 
+#if !PROJECTK_BUILD
+            LoadFrom(assemblyName, paths, rf);	// couldn't load the assembly, try doing a LoadFrom with paths.
+#endif
         }
     }
 
@@ -244,27 +181,6 @@ public class LoaderClass
             }
         }
         return (ApartmentState.Unknown);
-    }
-
-#endif 
-    /// <summary>
-    /// Helper function to call into the app domain and make sure that we're still functioning in a sane way.
-    /// </summary>
-    public bool StillAlive()
-    {
-        return (true);
-    }
-
-#if !PROJECTK_BUILD
-    /// <summary>
-    /// Gets the full path to the loaded assembly.
-    /// </summary>
-    public string FullPath
-    {
-        get
-        {
-            return (assembly);
-        }
     }
 
     /// <summary>
@@ -297,6 +213,7 @@ public class LoaderClass
             {
                 if (t.GetInterface("ISingleReliabilityTest") != null || t.GetInterface("IMultipleReliabilityTest") != null)
                 {
+#if !PROJECTK_BUILD
                     ObjectHandle handle;
                     if (assembly.IndexOf("\\") != -1)
                         handle = AppDomain.CurrentDomain.CreateInstanceFrom(assembly, t.FullName);
@@ -309,6 +226,9 @@ public class LoaderClass
                         ourObj = handle.Unwrap();
                         break;
                     }
+#else
+                    ourObj = Activator.CreateInstance(t);
+#endif
                 }
 
             }
@@ -316,11 +236,14 @@ public class LoaderClass
 
         if (ourObj == null)
             return (assembly);
+#if !PROJECTK_BUILD
         if (!(ourObj is MarshalByRefObject))
             throw new ArgumentException("All tests implementing ISingleReliabilityTest or IMultipleReliabilityTest must inherit from MarshalByRefObject");
+#endif
 
         return (ourObj);
     }
+#if !PROJECTK_BUILD
     /// <summary>
     /// This stops our MBR from being deallocated by the distributed GC mechanism in remoting.
     /// </summary>
@@ -337,48 +260,6 @@ public class LoaderClass
     {
         myRf.UnloadOnEvent(AppDomain.CurrentDomain, eReasonForUnload.AppDomainUnload);
     }
-#else
-    /// <summary>
-    /// Gets back the test object.  If the test is an assembly (to be executed) we return a string which is the full path.
-    /// If we're an ISingleReliabilityTest or IMultipleReliabilityTest we return the object it's self.
-    /// </summary>
-    /// <returns>a string (executable test) or a ISingleReliabilityTest or IMultipleReliabilityTest</returns>
-    public object GetTest()
-    {
-        if (assem == null)
-            throw new Exception("Could not load specified assembly: " + assembly);
-
-        Type[] assemTypes = null;
-        try
-        {
-            assemTypes = assem.GetTypes();
-        }
-        catch (System.Reflection.ReflectionTypeLoadException e)
-        {
-            if (assembly.ToLower().IndexOf(".exe") != -1)
-                return (assembly);
-            throw new Exception(string.Format("Couldn't GetTypes for {0} ({1})", assembly, e.Message));
-        }
-
-        // now create an instance of the correct type in the app domain
-        object ourObj = null;
-        if (assemTypes != null)
-        {
-            foreach (Type t in assemTypes)
-            {
-                if (t.GetInterface("ISingleReliabilityTest") != null || t.GetInterface("IMultipleReliabilityTest") != null)
-                {
-                    ourObj = Activator.CreateInstance(t);
-                }
-            }
-        }
-
-        if (ourObj == null)
-            return (assembly);
-
-        return (ourObj);
-    }
-
 #endif
 }
 

--- a/tests/src/GC/Stress/Framework/ReliabilityConfiguration.cs
+++ b/tests/src/GC/Stress/Framework/ReliabilityConfiguration.cs
@@ -19,10 +19,19 @@ using System.IO;
 public enum TestStartModeEnum
 {
     AppDomainLoader,
-    ProcessLoader
+    ProcessLoader,
+    AssemblyLoadContextLoader
 }
 
 public enum AppDomainLoaderMode
+{
+    FullIsolation,
+    Normal,
+    RoundRobin,
+    Lazy
+}
+
+public enum AssemblyLoadContextLoaderMode
 {
     FullIsolation,
     Normal,
@@ -41,8 +50,9 @@ public enum LoggingLevels
     Logging = 0x20,
     UrtFrameworks = 0x40,
     TestStarter = 0x80,
+    AssemblyLoadContext = 0x100,
 
-    All = (0x01 | 0x02 | 0x04 | 0x08 | 0x10 | 0x20 | 0x80)
+    All = (0x01 | 0x02 | 0x04 | 0x08 | 0x10 | 0x20 | 0x80 | 0x100)
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -97,7 +107,9 @@ public class ReliabilityConfig : IEnumerable, IEnumerator
     private const string configULWaitTime = "ulWaitTime";
     private const string configCcFailMail = "ccFailMail";
     private const string configAppDomainLoaderMode = "appDomainLoaderMode";
+    private const string configAssemblyLoadContextLoaderMode = "assemblyLoadContextLoaderMode";
     private const string configRoundRobinAppDomainCount = "numAppDomains";
+    private const string configRoundRobinAssemblyLoadContextCount = "numAssemblyLoadContexts";
     // Attributes for the <Assembly ...> tag
     private const string configAssemblyName = "id";
     private const string configAssemblyFilename = "filename";
@@ -137,6 +149,7 @@ public class ReliabilityConfig : IEnumerable, IEnumerator
     // Test start modes
     private const string configTestStartModeAppDomainLoader = "appDomainLoader";
     private const string configTestStartModeProcessLoader = "processLoader";
+    private const string configTestStartModeAssemblyLoadContextLoader = "assemblyLoadContextLoader";
     private const string configTestStartModeTaskLoader = "taskLoader";
 
     // APp domain loader modes
@@ -144,6 +157,12 @@ public class ReliabilityConfig : IEnumerable, IEnumerator
     private const string configAppDomainLoaderModeNormal = "normal";
     private const string configAppDomainLoaderModeRoundRobin = "roundRobin";
     private const string configAppDomainLoaderModeLazy = "lazy";
+
+    // AssemblyLoadContext loader modes
+    private const string configAssemblyLoadContextLoaderModeFullIsolation = "fullIsolation";
+    private const string configAssemblyLoadContextLoaderModeNormal = "normal";
+    private const string configAssemblyLoadContextLoaderModeRoundRobin = "roundRobin";
+    private const string configAssemblyLoadContextLoaderModeLazy = "lazy";
 
 
     /// <summary>
@@ -496,6 +515,9 @@ public class ReliabilityConfig : IEnumerable, IEnumerator
                                                     }
                                                     _curTestSet.DefaultTestStartMode = TestStartModeEnum.AppDomainLoader;
                                                     break;
+                                                case configTestStartModeAssemblyLoadContextLoader:
+                                                    _curTestSet.DefaultTestStartMode = TestStartModeEnum.AssemblyLoadContextLoader;
+                                                    break;
                                                 case configTestStartModeProcessLoader:
                                                     _curTestSet.DefaultTestStartMode = TestStartModeEnum.ProcessLoader;
                                                     break;
@@ -510,6 +532,20 @@ public class ReliabilityConfig : IEnumerable, IEnumerator
                                                 if (_curTestSet.NumAppDomains <= 0)
                                                 {
                                                     throw new Exception("Number of app domains must be greater than zero!");
+                                                }
+                                            }
+                                            catch
+                                            {
+                                                throw new Exception(String.Format("The value {0} is not an integer", currentXML.Value));
+                                            }
+                                            break;
+                                        case configRoundRobinAssemblyLoadContextCount:
+                                            try
+                                            {
+                                                _curTestSet.NumAssemblyLoadContexts = Convert.ToInt32(currentXML.Value);
+                                                if (_curTestSet.NumAssemblyLoadContexts <= 0)
+                                                {
+                                                    throw new Exception("Number of AssemblyLoadContexts must be greater than zero!");
                                                 }
                                             }
                                             catch
@@ -535,6 +571,26 @@ public class ReliabilityConfig : IEnumerable, IEnumerator
 
                                                 default:
                                                     throw new Exception(String.Format("Unknown AD Loader mode {0} specified!", currentXML.Value));
+                                            }
+                                            break;
+                                        case configAssemblyLoadContextLoaderMode:
+                                            switch (currentXML.Value)
+                                            {
+                                                case configAssemblyLoadContextLoaderModeFullIsolation:
+                                                    _curTestSet.AssemblyLoadContextLoaderMode = AssemblyLoadContextLoaderMode.FullIsolation;
+                                                    break;
+                                                case configAssemblyLoadContextLoaderModeNormal:
+                                                    _curTestSet.AssemblyLoadContextLoaderMode = AssemblyLoadContextLoaderMode.Normal;
+                                                    break;
+                                                case configAssemblyLoadContextLoaderModeRoundRobin:
+                                                    _curTestSet.AssemblyLoadContextLoaderMode = AssemblyLoadContextLoaderMode.RoundRobin;
+                                                    break;
+                                                case configAssemblyLoadContextLoaderModeLazy:
+                                                    _curTestSet.AssemblyLoadContextLoaderMode = AssemblyLoadContextLoaderMode.Lazy;
+                                                    break;
+
+                                                default:
+                                                    throw new Exception(String.Format("Unknown ALC Loader mode {0} specified!", currentXML.Value));
                                             }
                                             break;
                                         case configPercentPassIsPass:
@@ -813,6 +869,9 @@ public class ReliabilityConfig : IEnumerable, IEnumerator
                                                 case configTestStartModeProcessLoader:
                                                     rt.TestStartMode = TestStartModeEnum.ProcessLoader;
                                                     break;
+                                                case configTestStartModeAssemblyLoadContextLoader:
+                                                    rt.TestStartMode = TestStartModeEnum.AssemblyLoadContextLoader;
+                                                    break;
                                                 default:
                                                     throw new Exception(String.Format("Unknown test starter {0} specified!", currentXML.Value));
                                             }
@@ -891,15 +950,17 @@ public class ReliabilityConfig : IEnumerable, IEnumerator
                                 }
 
                                 int testCopies = 1;
-                                if (_curTestSet.AppDomainLoaderMode == AppDomainLoaderMode.FullIsolation)
+                                if (_curTestSet.AppDomainLoaderMode == AppDomainLoaderMode.FullIsolation || 
+                                    _curTestSet.AssemblyLoadContextLoaderMode == AssemblyLoadContextLoaderMode.FullIsolation)
                                 {
-                                    // in this mode each copy of the test is ran in it's own app domain,
+                                    // in this mode each copy of the test is ran in it's own app domain or AssemblyLoadContext,
                                     // fully isolated from all other copies of the test.  If the user
                                     // specified a cloning level we need to duplicate the test.
                                     testCopies = rt.ConcurrentCopies;
                                     rt.ConcurrentCopies = 1;
                                 }
-                                else if (_curTestSet.AppDomainLoaderMode == AppDomainLoaderMode.RoundRobin)
+                                else if (_curTestSet.AppDomainLoaderMode == AppDomainLoaderMode.RoundRobin ||
+                                         _curTestSet.AssemblyLoadContextLoaderMode == AssemblyLoadContextLoaderMode.RoundRobin)
                                 {
                                     // In this mode each test is ran in an app domain w/ other tests.
                                     testCopies = rt.ConcurrentCopies;
@@ -907,7 +968,7 @@ public class ReliabilityConfig : IEnumerable, IEnumerator
                                 }
                                 else
                                 {
-                                    // Normal mode - tests are ran in app domains w/ copies of themselves
+                                    // Normal mode - tests are ran in app domains / AssemblyLoadContexts w/ copies of themselves
                                 }
 
                                 string refOrId = rt.RefOrID;

--- a/tests/src/GC/Stress/Framework/ReliabilityTestSet.cs
+++ b/tests/src/GC/Stress/Framework/ReliabilityTestSet.cs
@@ -37,7 +37,9 @@ public class ReliabilityTestSet
     private Guid _bvtCategory = Guid.Empty;
     private string _ccFailMail;
     private AppDomainLoaderMode _adLoaderMode = AppDomainLoaderMode.Normal;
+    private AssemblyLoadContextLoaderMode _alcLoaderMode = AssemblyLoadContextLoaderMode.Normal;
     private int _numAppDomains = 10; //used for roundRobin scheduling, our app domain index
+    private int _numAssemblyLoadContexts = 10; //used for roundRobin scheduling, our AssemblyLoadContext index
     private Random _rand = new Random();
     private LoggingLevels _loggingLevel = LoggingLevels.All;	// by default log everything
 
@@ -319,6 +321,33 @@ public class ReliabilityTestSet
         set
         {
             _adLoaderMode = value;
+        }
+    }
+
+    public AssemblyLoadContextLoaderMode AssemblyLoadContextLoaderMode
+    {
+        get
+        {
+            return (_alcLoaderMode);
+        }
+        set
+        {
+            _alcLoaderMode = value;
+        }
+    }
+
+    /// <summary>
+    /// Used for round-robin scheduling.  Number of AssemblyLoadContexts domains to schedule tests into.
+    /// </summary>
+    public int NumAssemblyLoadContexts
+    {
+        get
+        {
+            return (_numAssemblyLoadContexts);
+        }
+        set
+        {
+            _numAssemblyLoadContexts = value;
         }
     }
 

--- a/tests/src/GC/Stress/testmix_gc.config
+++ b/tests/src/GC/Stress/testmix_gc.config
@@ -3,7 +3,7 @@
             id="NightlyRun" 
             maximumTestRuns="-1" 
             maximumExecutionTime="15:15:00" 
-            defaultTestLoader="processLoader" 
+            defaultTestLoader="processLoader"
             minimumCPU="0" 
             minimumMem="0" 
             maximumTests="0" 


### PR DESCRIPTION
This change adds support for unloadable AssemblyLoadContext to the GC
ReliabilityFramework. It basically mimics what was there ifdef-ed out
for AppDomains.
It allows stress testing GC when running inside of an unloadable
AssemblyLoadContext. GC has some special handling for collectible
classes and this allows testing the respective code paths.