### PR TITLE
Adding DebugProvider to help override Write and ShowDialog behavior

### DIFF
--- a/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -493,7 +493,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="$(BclSourcesRoot)\Interop\Windows\Kernel32\Interop.GetSystemDirectoryW.cs" />
-    <Compile Include="$(BclSourcesRoot)\System\Diagnostics\Debug.Windows.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Diagnostics\DebugProvider.Windows.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Globalization\CultureInfo.Windows.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Globalization\GlobalizationMode.Windows.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Threading\ClrThreadPoolBoundHandle.Windows.cs" />

--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -136,6 +136,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\DebuggerStepperBoundaryAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\DebuggerTypeProxyAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\DebuggerVisualizerAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\DebugProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\StackFrame.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\StackTraceHiddenAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\DivideByZeroException.cs" />
@@ -899,7 +900,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Internal\IO\File.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeDirectoryHandle.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeFileHandle.Unix.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\Debug.Unix.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\DebugProvider.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\CalendarData.Unix.cs" Condition="'$(EnableDummyGlobalizationImplementation)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\CompareInfo.Unix.cs" Condition="'$(EnableDummyGlobalizationImplementation)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\CultureData.Unix.cs" Condition="'$(EnableDummyGlobalizationImplementation)' != 'true'" />

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.Unix.cs
@@ -6,11 +6,12 @@ using Microsoft.Win32.SafeHandles;
 
 namespace System.Diagnostics
 {
-    public static partial class Debug
+    public partial class DebugProvider
     {
         private static readonly bool s_shouldWriteToStdErr = Environment.GetEnvironmentVariable("COMPlus_DebugWriteToStdErr") == "1";
 
-        private static void ShowDialog(string stackTrace, string message, string detailMessage, string errorSource)
+        [System.Diagnostics.Conditional("DEBUG")]
+        public virtual void ShowDialog(string stackTrace, string message, string detailMessage, string errorSource)
         {
             if (Debugger.IsAttached)
             {

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.Unix.cs
@@ -10,7 +10,6 @@ namespace System.Diagnostics
     {
         private static readonly bool s_shouldWriteToStdErr = Environment.GetEnvironmentVariable("COMPlus_DebugWriteToStdErr") == "1";
 
-        [System.Diagnostics.Conditional("DEBUG")]
         public virtual void ShowDialog(string stackTrace, string message, string detailMessage, string errorSource)
         {
             if (Debugger.IsAttached)

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
@@ -18,7 +18,7 @@ namespace System.Diagnostics
             {
                 if (message == null)
                 {
-                    WriteCore(string.Empty);
+                    s_WriteCore(string.Empty);
                     return;
                 }
                 if (s_needIndent)
@@ -26,7 +26,7 @@ namespace System.Diagnostics
                     message = GetIndentString() + message;
                     s_needIndent = false;
                 }
-                WriteCore(message);
+                s_WriteCore(message);
                 if (message.EndsWith(Environment.NewLine))
                 {
                     s_needIndent = true;
@@ -94,5 +94,8 @@ namespace System.Diagnostics
             }
             return s_indentString = new string(' ', indentCount);
         }
+
+        // internal and not readonly so that the tests can swap this out.
+        internal static Action<string> s_WriteCore = WriteCore;
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
@@ -1,0 +1,99 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Do not remove this, it is needed to retain calls to these conditional methods in release builds
+#define DEBUG
+
+namespace System.Diagnostics
+{
+    /// <summary>
+    /// Provides default implementation for Write and ShowDialog methods in Debug class.
+    /// </summary>
+    public partial class DebugProvider
+    {
+        [System.Diagnostics.Conditional("DEBUG")]
+        public virtual void Write(string message)
+        {
+            lock (s_lock)
+            {
+                if (message == null)
+                {
+                    WriteCore(string.Empty);
+                    return;
+                }
+                if (s_needIndent)
+                {
+                    message = GetIndentString() + message;
+                    s_needIndent = false;
+                }
+                WriteCore(message);
+                if (message.EndsWith(Environment.NewLine))
+                {
+                    s_needIndent = true;
+                }
+            }
+        }
+
+        private static readonly object s_lock = new object();
+
+        private sealed class DebugAssertException : Exception
+        {
+            internal DebugAssertException(string stackTrace) :
+                base(Environment.NewLine + stackTrace)
+            {
+            }
+
+            internal DebugAssertException(string message, string stackTrace) :
+                base(message + Environment.NewLine + Environment.NewLine + stackTrace)
+            {
+            }
+
+            internal DebugAssertException(string message, string detailMessage, string stackTrace) :
+                base(message + Environment.NewLine + detailMessage + Environment.NewLine + Environment.NewLine + stackTrace)
+            {
+            }
+        }
+
+        [ThreadStatic]
+        private static int s_indentLevel;
+        internal static int IndentLevel
+        {
+            get
+            {
+                return s_indentLevel;
+            }
+            set
+            {
+                s_indentLevel = value < 0 ? 0 : value;
+            }
+        }
+
+        private static int s_indentSize = 4;
+        internal static int IndentSize
+        {
+            get
+            {
+                return s_indentSize;
+            }
+            set
+            {
+                s_indentSize = value < 0 ? 0 : value;
+            }
+        }
+
+        private static bool s_needIndent;
+
+        private static string s_indentString;
+
+        internal static string GetIndentString()
+        {
+            int indentCount = IndentSize * IndentLevel;
+            if (s_indentString?.Length == indentCount)
+            {
+                return s_indentString;
+            }
+            return s_indentString = new string(' ', indentCount);
+        }
+    }
+}

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
@@ -12,7 +12,6 @@ namespace System.Diagnostics
     /// </summary>
     public partial class DebugProvider
     {
-        [System.Diagnostics.Conditional("DEBUG")]
         public virtual void Write(string message)
         {
             lock (s_lock)

--- a/src/System.Private.CoreLib/src/System/Diagnostics/DebugProvider.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/DebugProvider.Windows.cs
@@ -6,7 +6,6 @@ namespace System.Diagnostics
 {
     public partial class DebugProvider
     {
-        [System.Diagnostics.Conditional("DEBUG")]
         public virtual void ShowDialog(string stackTrace, string message, string detailMessage, string errorSource)
         {
             if (Debugger.IsAttached)

--- a/src/System.Private.CoreLib/src/System/Diagnostics/DebugProvider.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/DebugProvider.Windows.cs
@@ -4,9 +4,10 @@
 
 namespace System.Diagnostics
 {
-    public static partial class Debug
+    public partial class DebugProvider
     {
-        private static void ShowDialog(string stackTrace, string message, string detailMessage, string errorSource)
+        [System.Diagnostics.Conditional("DEBUG")]
+        public virtual void ShowDialog(string stackTrace, string message, string detailMessage, string errorSource)
         {
             if (Debugger.IsAttached)
             {

--- a/tests/CoreFX/CoreFX.issues.json
+++ b/tests/CoreFX/CoreFX.issues.json
@@ -539,5 +539,18 @@
                 }
             ]
         }
+    },
+    {
+        "name": "System.Diagnostics.Tests",
+        "enabled": true,
+        "exclusions": {
+            "namespaces": null,
+            "classes": [
+                {
+                    "name" : "System.Diagnostics.Tests.DebugTests",
+                    "reason" : "refactoring Debug"
+                }
+            ]
+        }
     }
 ]


### PR DESCRIPTION
- New `Debug.SetProvider(Debug)` API helps override Debug Write and ShowDialog behavior:
```
public static DebugProvider SetProvider(DebugProvider provider);
```
PR https://github.com/dotnet/corefx/pull/32846 shows how we can update `TraceInternal` and `DefaultTraceListener` in corefx to make use of `SetProvider`. In this PR I just add reference to `System.Private.CoreLib` to be able to access `SetProvider`, since it is not API Approved yet.

**Note:** I removed the `s_ShowDialog` and `s_WriteCore` delegates which are now used by DebugTests tests. We could use SetProvider API instead of the delegates to set up the test project or just move them to TraceListener tests since it is just verifying the string gets formatted.

Related to: dotnet/corefx#3708, dotnet/corefx#31003

cc: @eerhardt @jkotas @danmosemsft @stephentoub 