### PR TITLE
Disable warnings to fix build break with latest Visual Studio update …

### DIFF
--- a/src/vm/i386/profiler.cpp
+++ b/src/vm/i386/profiler.cpp
@@ -15,6 +15,8 @@
 #ifdef PROFILING_SUPPORTED
 #include "proftoeeinterfaceimpl.h"
 
+#pragma warning(disable:4644) // usage of the macro-based offsetof pattern in constant expressions is non-standard; use offsetof defined in the C++ standard library instead
+
 //
 // The following structure is the format on x86 builds of the data
 // being passed in plaformSpecificHandle for ProfileEnter/Leave/Tailcall


### PR DESCRIPTION
…(#20124)