### PR TITLE
Add string.GetHashCode(ROS<char>) and related APIs

### DIFF
--- a/src/System.Private.CoreLib/shared/Interop/Unix/System.Globalization.Native/Interop.Collation.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Unix/System.Globalization.Native/Interop.Collation.cs
@@ -48,7 +48,7 @@ internal static partial class Interop
         internal static extern unsafe bool EndsWith(SafeSortHandle sortHandle, string target, int cwTargetLength, string source, int cwSourceLength, CompareOptions options);
 
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetSortKey")]
-        internal static extern unsafe int GetSortKey(SafeSortHandle sortHandle, string str, int strLength, byte* sortKey, int sortKeyLength, CompareOptions options);
+        internal static extern unsafe int GetSortKey(SafeSortHandle sortHandle, char* str, int strLength, byte* sortKey, int sortKeyLength, CompareOptions options);
 
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_CompareStringOrdinalIgnoreCase")]
         internal static extern unsafe int CompareStringOrdinalIgnoreCase(char* lpStr1, int cwStr1Len, char* lpStr2, int cwStr2Len);

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
@@ -862,8 +862,6 @@ namespace System.Globalization
         internal unsafe int GetHashCodeOfStringCore(ReadOnlySpan<char> source, CompareOptions options)
         {
             Debug.Assert(!_invariantMode);
-
-            Debug.Assert(source != null);
             Debug.Assert((options & (CompareOptions.Ordinal | CompareOptions.OrdinalIgnoreCase)) == 0);
 
             if (source.Length == 0)

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
@@ -798,14 +798,17 @@ namespace System.Globalization
             }
             else
             {
-                int sortKeyLength = Interop.Globalization.GetSortKey(_sortHandle, source, source.Length, null, 0, options);
-                keyData = new byte[sortKeyLength];
-
-                fixed (byte* pSortKey = keyData)
+                fixed (char* pSource = source)
                 {
-                    if (Interop.Globalization.GetSortKey(_sortHandle, source, source.Length, pSortKey, sortKeyLength, options) != sortKeyLength)
+                    int sortKeyLength = Interop.Globalization.GetSortKey(_sortHandle, pSource, source.Length, null, 0, options);
+                    keyData = new byte[sortKeyLength];
+
+                    fixed (byte* pSortKey = keyData)
                     {
-                        throw new ArgumentException(SR.Arg_ExternalException);
+                        if (Interop.Globalization.GetSortKey(_sortHandle, pSource, source.Length, pSortKey, sortKeyLength, options) != sortKeyLength)
+                        {
+                            throw new ArgumentException(SR.Arg_ExternalException);
+                        }
                     }
                 }
             }
@@ -856,7 +859,7 @@ namespace System.Globalization
         // ---- PAL layer ends here ----
         // -----------------------------
 
-        internal unsafe int GetHashCodeOfStringCore(string source, CompareOptions options)
+        internal unsafe int GetHashCodeOfStringCore(ReadOnlySpan<char> source, CompareOptions options)
         {
             Debug.Assert(!_invariantMode);
 
@@ -868,30 +871,33 @@ namespace System.Globalization
                 return 0;
             }
 
-            int sortKeyLength = Interop.Globalization.GetSortKey(_sortHandle, source, source.Length, null, 0, options);
-
-            byte[] borrowedArr = null;
-            Span<byte> span = sortKeyLength <= 512 ?
-                stackalloc byte[512] :
-                (borrowedArr = ArrayPool<byte>.Shared.Rent(sortKeyLength));
-
-            fixed (byte* pSortKey = &MemoryMarshal.GetReference(span))
+            fixed (char* pSource = source)
             {
-                if (Interop.Globalization.GetSortKey(_sortHandle, source, source.Length, pSortKey, sortKeyLength, options) != sortKeyLength)
+                int sortKeyLength = Interop.Globalization.GetSortKey(_sortHandle, pSource, source.Length, null, 0, options);
+
+                byte[] borrowedArr = null;
+                Span<byte> span = sortKeyLength <= 512 ?
+                    stackalloc byte[512] :
+                    (borrowedArr = ArrayPool<byte>.Shared.Rent(sortKeyLength));
+
+                fixed (byte* pSortKey = &MemoryMarshal.GetReference(span))
                 {
-                    throw new ArgumentException(SR.Arg_ExternalException);
+                    if (Interop.Globalization.GetSortKey(_sortHandle, pSource, source.Length, pSortKey, sortKeyLength, options) != sortKeyLength)
+                    {
+                        throw new ArgumentException(SR.Arg_ExternalException);
+                    }
                 }
+
+                int hash = Marvin.ComputeHash32(span.Slice(0, sortKeyLength), Marvin.DefaultSeed);
+
+                // Return the borrowed array if necessary.
+                if (borrowedArr != null)
+                {
+                    ArrayPool<byte>.Shared.Return(borrowedArr);
+                }
+
+                return hash;
             }
-
-            int hash = Marvin.ComputeHash32(span.Slice(0, sortKeyLength), Marvin.DefaultSeed);
-
-            // Return the borrowed array if necessary.
-            if (borrowedArr != null)
-            {
-                ArrayPool<byte>.Shared.Return(borrowedArr);
-            }
-
-            return hash;
         }
 
         private static CompareOptions GetOrdinalCompareOptions(CompareOptions options)

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Windows.cs
@@ -111,12 +111,10 @@ namespace System.Globalization
 
             return FindStringOrdinal(FIND_FROMEND, source, startIndex - count + 1, count, value, value.Length, ignoreCase);
         }
-
+        
         private unsafe int GetHashCodeOfStringCore(ReadOnlySpan<char> source, CompareOptions options)
         {
             Debug.Assert(!_invariantMode);
-
-            Debug.Assert(source != null);
             Debug.Assert((options & (CompareOptions.Ordinal | CompareOptions.OrdinalIgnoreCase)) == 0);
 
             if (source.Length == 0)
@@ -130,7 +128,7 @@ namespace System.Globalization
             {
                 int sortKeyLength = Interop.Kernel32.LCMapStringEx(_sortHandle != IntPtr.Zero ? null : _sortName,
                                                   flags,
-                                                  pSource, source.Length,
+                                                  pSource, source.Length /* in chars */,
                                                   null, 0,
                                                   null, null, _sortHandle);
                 if (sortKeyLength == 0)
@@ -152,7 +150,7 @@ namespace System.Globalization
                 {
                     if (Interop.Kernel32.LCMapStringEx(_sortHandle != IntPtr.Zero ? null : _sortName,
                                                       flags,
-                                                      pSource, source.Length,
+                                                      pSource, source.Length /* in chars */,
                                                       pSortKey, sortKeyLength,
                                                       null, null, _sortHandle) != sortKeyLength)
                     {

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Windows.cs
@@ -112,7 +112,7 @@ namespace System.Globalization
             return FindStringOrdinal(FIND_FROMEND, source, startIndex - count + 1, count, value, value.Length, ignoreCase);
         }
 
-        private unsafe int GetHashCodeOfStringCore(string source, CompareOptions options)
+        private unsafe int GetHashCodeOfStringCore(ReadOnlySpan<char> source, CompareOptions options)
         {
             Debug.Assert(!_invariantMode);
 
@@ -137,6 +137,11 @@ namespace System.Globalization
                 {
                     throw new ArgumentException(SR.Arg_ExternalException);
                 }
+
+                // Note in calls to LCMapStringEx below, the input buffer is specified in wchars (and wchar count),
+                // but the output buffer is specified in bytes (and byte count). This is because when generating
+                // sort keys, LCMapStringEx treats the output buffer as containing opaque binary data.
+                // See https://docs.microsoft.com/en-us/windows/desktop/api/winnls/nf-winnls-lcmapstringex.
 
                 byte[] borrowedArr = null;
                 Span<byte> span = sortKeyLength <= 512 ?

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
@@ -1421,6 +1421,14 @@ namespace System.Globalization
                 throw new ArgumentNullException(nameof(source));
             }
 
+            return GetHashCodeOfString(source.AsSpan(), options);
+        }
+
+        internal int GetHashCodeOfString(ReadOnlySpan<char> source, CompareOptions options)
+        {
+            //
+            //  Parameter validation
+            //
             if ((options & ValidHashCodeOfStringMaskOffFlags) != 0)
             {
                 throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
@@ -1428,7 +1436,7 @@ namespace System.Globalization
 
             if (_invariantMode)
             {
-                return ((options & CompareOptions.IgnoreCase) != 0) ? source.GetHashCodeOrdinalIgnoreCase() : source.GetHashCode();
+                return ((options & CompareOptions.IgnoreCase) != 0) ? string.GetHashCodeOrdinalIgnoreCase(source) : string.GetHashCode(source);
             }
 
             return GetHashCodeOfStringCore(source, options);
@@ -1441,14 +1449,19 @@ namespace System.Globalization
                 throw new ArgumentNullException(nameof(source));
             }
 
+            return GetHashCode(source.AsSpan(), options);
+        }
+
+        public int GetHashCode(ReadOnlySpan<char> source, CompareOptions options)
+        {
             if (options == CompareOptions.Ordinal)
             {
-                return source.GetHashCode();
+                return string.GetHashCode(source);
             }
 
             if (options == CompareOptions.OrdinalIgnoreCase)
             {
-                return source.GetHashCodeOrdinalIgnoreCase();
+                return string.GetHashCodeOrdinalIgnoreCase(source);
             }
 
             //

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
@@ -1420,56 +1420,71 @@ namespace System.Globalization
             {
                 throw new ArgumentNullException(nameof(source));
             }
-
-            return GetHashCodeOfString(source.AsSpan(), options);
-        }
-
-        internal int GetHashCodeOfString(ReadOnlySpan<char> source, CompareOptions options)
-        {
-            //
-            //  Parameter validation
-            //
-            if ((options & ValidHashCodeOfStringMaskOffFlags) != 0)
+            if ((options & ValidHashCodeOfStringMaskOffFlags) == 0)
             {
+                // No unsupported flags are set - continue on with the regular logic
+
+                if (_invariantMode)
+                {
+                    return ((options & CompareOptions.IgnoreCase) != 0) ? source.GetHashCodeOrdinalIgnoreCase() : source.GetHashCode();
+                }
+
+                return GetHashCodeOfStringCore(source, options);
+            }
+            else if (options == CompareOptions.Ordinal)
+            {
+                // We allow Ordinal in isolation
+                return source.GetHashCode();
+            }
+            else if (options == CompareOptions.OrdinalIgnoreCase)
+            {
+                // We allow OrdinalIgnoreCase in isolation
+                return source.GetHashCodeOrdinalIgnoreCase();
+            }
+            else
+            {
+                // Unsupported combination of flags specified
                 throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
             }
-
-            if (_invariantMode)
-            {
-                return ((options & CompareOptions.IgnoreCase) != 0) ? string.GetHashCodeOrdinalIgnoreCase(source) : string.GetHashCode(source);
-            }
-
-            return GetHashCodeOfStringCore(source, options);
         }
 
         public virtual int GetHashCode(string source, CompareOptions options)
         {
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            return GetHashCode(source.AsSpan(), options);
+            // virtual method delegates to non-virtual method
+            return GetHashCodeOfString(source, options);
         }
 
         public int GetHashCode(ReadOnlySpan<char> source, CompareOptions options)
         {
-            if (options == CompareOptions.Ordinal)
+            //
+            //  Parameter validation
+            //
+            if ((options & ValidHashCodeOfStringMaskOffFlags) == 0)
             {
+                // No unsupported flags are set - continue on with the regular logic
+
+                if (_invariantMode)
+                {
+                    return ((options & CompareOptions.IgnoreCase) != 0) ? string.GetHashCodeOrdinalIgnoreCase(source) : string.GetHashCode(source);
+                }
+
+                return GetHashCodeOfStringCore(source, options);
+            }
+            else if (options == CompareOptions.Ordinal)
+            {
+                // We allow Ordinal in isolation
                 return string.GetHashCode(source);
             }
-
-            if (options == CompareOptions.OrdinalIgnoreCase)
+            else if (options == CompareOptions.OrdinalIgnoreCase)
             {
+                // We allow OrdinalIgnoreCase in isolation
                 return string.GetHashCodeOrdinalIgnoreCase(source);
             }
-
-            //
-            // GetHashCodeOfString does more parameters validation. basically will throw when
-            // having Ordinal, OrdinalIgnoreCase and StringSort
-            //
-
-            return GetHashCodeOfString(source, options);
+            else
+            {
+                // Unsupported combination of flags specified
+                throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
+            }
         }
 
         ////////////////////////////////////////////////////////////////////////

--- a/src/System.Private.CoreLib/shared/System/String.Comparison.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Comparison.cs
@@ -773,30 +773,15 @@ namespace System
         // A span-based equivalent of String.GetHashCode(StringComparison). Uses the specified comparison type.
         public static int GetHashCode(ReadOnlySpan<char> value, StringComparison comparisonType)
         {
-            CultureInfo culture;
-            CompareOptions compareOptions;
-
             switch (comparisonType)
             {
                 case StringComparison.CurrentCulture:
-                    culture = CultureInfo.CurrentCulture;
-                    compareOptions = CompareOptions.None;
-                    break;
-
                 case StringComparison.CurrentCultureIgnoreCase:
-                    culture = CultureInfo.CurrentCulture;
-                    compareOptions = CompareOptions.IgnoreCase;
-                    break;
+                    return CultureInfo.CurrentCulture.CompareInfo.GetHashCode(value, GetCaseCompareOfComparisonCulture(comparisonType));
 
                 case StringComparison.InvariantCulture:
-                    culture = CultureInfo.InvariantCulture;
-                    compareOptions = CompareOptions.None;
-                    break;
-
                 case StringComparison.InvariantCultureIgnoreCase:
-                    culture = CultureInfo.InvariantCulture;
-                    compareOptions = CompareOptions.IgnoreCase;
-                    break;
+                    return CultureInfo.InvariantCulture.CompareInfo.GetHashCode(value, GetCaseCompareOfComparisonCulture(comparisonType));
 
                 case StringComparison.Ordinal:
                     return GetHashCode(value);
@@ -806,10 +791,9 @@ namespace System
 
                 default:
                     ThrowHelper.ThrowArgumentException(ExceptionResource.NotSupported_StringComparison, ExceptionArgument.comparisonType);
-                    throw null; // shouldn't be hit
+                    Debug.Fail("Should not reach this point.");
+                    return default;
             }
-
-            return culture.CompareInfo.GetHashCodeOfString(value, compareOptions);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/System.Private.CoreLib/shared/System/String.Comparison.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Comparison.cs
@@ -748,7 +748,7 @@ namespace System
         public override int GetHashCode()
         {
             ulong seed = Marvin.DefaultSeed;
-            return Marvin.ComputeHash32(ref Unsafe.As<char, byte>(ref _firstChar), _stringLength * 2, (uint)seed, (uint)(seed >> 32));
+            return Marvin.ComputeHash32(ref Unsafe.As<char, byte>(ref _firstChar), _stringLength * 2 /* in bytes, not chars */, (uint)seed, (uint)(seed >> 32));
         }
 
         // Gets a hash code for this string and this comparison. If strings A and B and comparison C are such
@@ -759,7 +759,64 @@ namespace System
         internal int GetHashCodeOrdinalIgnoreCase()
         {
             ulong seed = Marvin.DefaultSeed;
-            return Marvin.ComputeHash32OrdinalIgnoreCase(ref _firstChar, _stringLength, (uint)seed, (uint)(seed >> 32));
+            return Marvin.ComputeHash32OrdinalIgnoreCase(ref _firstChar, _stringLength /* in chars, not bytes */, (uint)seed, (uint)(seed >> 32));
+        }
+
+        // A span-based equivalent of String.GetHashCode(). Computes an ordinal hash code.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int GetHashCode(ReadOnlySpan<char> value)
+        {
+            ulong seed = Marvin.DefaultSeed;
+            return Marvin.ComputeHash32(ref Unsafe.As<char, byte>(ref MemoryMarshal.GetReference(value)), value.Length * 2 /* in bytes, not chars */, (uint)seed, (uint)(seed >> 32));
+        }
+
+        // A span-based equivalent of String.GetHashCode(StringComparison). Uses the specified comparison type.
+        public static int GetHashCode(ReadOnlySpan<char> value, StringComparison comparisonType)
+        {
+            CultureInfo culture;
+            CompareOptions compareOptions;
+
+            switch (comparisonType)
+            {
+                case StringComparison.CurrentCulture:
+                    culture = CultureInfo.CurrentCulture;
+                    compareOptions = CompareOptions.None;
+                    break;
+
+                case StringComparison.CurrentCultureIgnoreCase:
+                    culture = CultureInfo.CurrentCulture;
+                    compareOptions = CompareOptions.IgnoreCase;
+                    break;
+
+                case StringComparison.InvariantCulture:
+                    culture = CultureInfo.InvariantCulture;
+                    compareOptions = CompareOptions.None;
+                    break;
+
+                case StringComparison.InvariantCultureIgnoreCase:
+                    culture = CultureInfo.InvariantCulture;
+                    compareOptions = CompareOptions.IgnoreCase;
+                    break;
+
+                case StringComparison.Ordinal:
+                    return GetHashCode(value);
+
+                case StringComparison.OrdinalIgnoreCase:
+                    return GetHashCodeOrdinalIgnoreCase(value);
+
+                default:
+                    ThrowHelper.ThrowArgumentException(ExceptionResource.NotSupported_StringComparison, ExceptionArgument.comparisonType);
+                    throw null; // shouldn't be hit
+            }
+
+            return culture.CompareInfo.GetHashCodeOfString(value, compareOptions);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int GetHashCodeOrdinalIgnoreCase(ReadOnlySpan<char> value)
+        {
+            ulong seed = Marvin.DefaultSeed;
+            return Marvin.ComputeHash32OrdinalIgnoreCase(ref MemoryMarshal.GetReference(value), value.Length /* in chars, not bytes */, (uint)seed, (uint)(seed >> 32));
         }
 
         // Use this if and only if 'Denial of Service' attacks are not a concern (i.e. never used for free-form user input),


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/31302.

Per https://github.com/dotnet/corefx/issues/31302#issuecomment-407542677, the newly added API on `CompareInfo` is non-virtual. Unit tests will be coming through a different PR in corefx. I'll link to that PR when it's ready.

I'll also rerun some of the perf benchmarks to ensure we haven't regressed culture-aware hash code calculation performance.