### PR TITLE
Remove per-AppDomain TLB

### DIFF
--- a/src/vm/threads.h
+++ b/src/vm/threads.h
@@ -197,8 +197,6 @@ class Thread
     friend class ThreadStatics;
 
     PTR_ThreadLocalBlock m_pThreadLocalBlock;
-    PTR_PTR_ThreadLocalBlock m_pTLBTable;
-    SIZE_T m_TLBTableSize;
 
 public:
     BOOL IsAddressInStack (PTR_VOID addr) const { return TRUE; }
@@ -4490,41 +4488,8 @@ public:
     
     // m_pThreadLocalBLock points to the ThreadLocalBlock that corresponds to the 
     // AppDomain that the Thread is currently in
-
-    // m_pTLBTable points to the this Thread's table of ThreadLocalBlocks, indexed by
-    // ADIndex. It's important to note that ADIndexes get recycled when AppDomains are
-    // torn down. m_TLBTableSize holds to current size the size of this Thread's TLB table.
-    // See "ThreadStatics.h" for more information.
     
     PTR_ThreadLocalBlock m_pThreadLocalBlock;
-    PTR_PTR_ThreadLocalBlock m_pTLBTable;
-    SIZE_T m_TLBTableSize;
-
-    // This getter is used by SOS; if m_pThreadLocalBlock is NULL, it's
-    // important that we look in the TLB table as well
-    /*
-    PTR_ThreadLocalBlock GetThreadLocalBlock()
-    {
-        // If the current TLB pointer is NULL, search the TLB table
-        if (m_pThreadLocalBlock != NULL)
-            return m_pThreadLocalBlock;
-        
-        ADIndex index = GetDomain()->GetIndex();
-
-        // Check to see if we have a ThreadLocalBlock for the the current AppDomain,
-        if (index.m_dwIndex < m_TLBTableSize)
-        {
-            // Update the current ThreadLocalBlock pointer,
-            // but only on non-DAC builds
-#ifndef DACCESS_COMPILE
-            m_pThreadLocalBlock = m_pTLBTable[index.m_dwIndex];
-#endif
-            return m_pTLBTable[index.m_dwIndex];
-        }
-    
-        return NULL;
-    }
-    */
 
     // Called during AssemblyLoadContext teardown to clean up all structures
     // associated with thread statics for the specific Module

--- a/src/vm/threadstatics.cpp
+++ b/src/vm/threadstatics.cpp
@@ -697,7 +697,7 @@ PTR_ThreadLocalModule ThreadStatics::GetTLM(MethodTable * pMT) //static
     return GetTLM(pModule->GetModuleIndex(), pModule);
 }
 
-PTR_ThreadLocalBlock ThreadStatics::AllocateTLB(PTR_Thread pThread, ADIndex index) //static
+PTR_ThreadLocalBlock ThreadStatics::AllocateTLB(PTR_Thread pThread) //static
 {
     CONTRACTL
     {
@@ -709,21 +709,9 @@ PTR_ThreadLocalBlock ThreadStatics::AllocateTLB(PTR_Thread pThread, ADIndex inde
     CONTRACTL_END;
     _ASSERTE(pThread->m_pThreadLocalBlock == NULL);
 
-    // Grow the TLB table so that it has room to store the newly allocated 
-    // ThreadLocalBlock. If this growing the table fails we cannot proceed.
-    ThreadStatics::EnsureADIndex(pThread, index);
-
     // Allocate a new TLB and update this Thread's pointer to the current 
     // ThreadLocalBlock. Constructor zeroes out everything for us.
     pThread->m_pThreadLocalBlock = new ThreadLocalBlock();
-
-    // Store the newly allocated ThreadLocalBlock in the TLB table
-    if (pThread->m_pThreadLocalBlock != NULL)
-    {
-        // We grew the TLB table earlier, so it should have room
-        _ASSERTE(index.m_dwIndex >= 0 && index.m_dwIndex < pThread->m_TLBTableSize);
-        pThread->m_pTLBTable[index.m_dwIndex] = pThread->m_pThreadLocalBlock;
-    }
 
     return pThread->m_pThreadLocalBlock;
 }
@@ -758,24 +746,3 @@ PTR_ThreadLocalModule ThreadStatics::AllocateTLM(Module * pModule)
 }
 
 #endif
-
-PTR_ThreadLocalBlock ThreadStatics::GetTLBIfExists(PTR_Thread pThread, ADIndex index) //static
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_ANY;
-        SUPPORTS_DAC;
-        SO_TOLERANT;
-    }
-    CONTRACTL_END;
-
-    // Check to see if we have a ThreadLocalBlock for the this AppDomain, 
-    if (index.m_dwIndex < pThread->m_TLBTableSize)
-    {
-        return pThread->m_pTLBTable[index.m_dwIndex];
-    }
-    
-    return NULL;
-}


### PR DESCRIPTION
Since there is only one AppDomain, there is no need for a per-AppDomain
TLB table for each Thread. This change removes that table and thus gets
rid of the extra indirection needed to access the TLB.