### PR TITLE
Optimize Span.GetPinnableReference

### DIFF
--- a/src/System.Private.CoreLib/shared/System/ReadOnlySpan.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/ReadOnlySpan.Fast.cs
@@ -155,7 +155,7 @@ namespace System
         [EditorBrowsable(EditorBrowsableState.Never)]
         public unsafe ref readonly T GetPinnableReference()
         {
-            // Ensure that the native code has just one forward branch that is predicated-not-taken.
+            // Ensure that the native code has just one forward branch that is predicted-not-taken.
             ref T ret = ref Unsafe.AsRef<T>(null);
             if (_length != 0) ret = ref _pointer.Value;
             return ref ret;

--- a/src/System.Private.CoreLib/shared/System/ReadOnlySpan.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/ReadOnlySpan.Fast.cs
@@ -153,7 +153,13 @@ namespace System
         /// It can be used for pinning and is required to support the use of span within a fixed statement.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public unsafe ref readonly T GetPinnableReference() => ref (_length != 0) ? ref _pointer.Value : ref Unsafe.AsRef<T>(null);
+        public unsafe ref readonly T GetPinnableReference()
+        {
+            // Ensure that the native code has just one forward branch that is predicated-not-taken.
+            ref T ret = ref Unsafe.AsRef<T>(null);
+            if (_length != 0) ret = ref _pointer.Value;
+            return ref ret;
+        }
 
         /// <summary>
         /// Copies the contents of this read-only span into destination span. If the source

--- a/src/System.Private.CoreLib/shared/System/Span.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/Span.Fast.cs
@@ -158,7 +158,13 @@ namespace System
         /// It can be used for pinning and is required to support the use of span within a fixed statement.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public unsafe ref T GetPinnableReference() => ref (_length != 0) ? ref _pointer.Value : ref Unsafe.AsRef<T>(null);
+        public unsafe ref T GetPinnableReference()
+        {
+            // Ensure that the native code has just one forward branch that is predicated-not-taken.
+            ref T ret = ref Unsafe.AsRef<T>(null);
+            if (_length != 0) ret = ref _pointer.Value;
+            return ref ret;
+        }
 
         /// <summary>
         /// Clears the contents of this span.

--- a/src/System.Private.CoreLib/shared/System/Span.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/Span.Fast.cs
@@ -160,7 +160,7 @@ namespace System
         [EditorBrowsable(EditorBrowsableState.Never)]
         public unsafe ref T GetPinnableReference()
         {
-            // Ensure that the native code has just one forward branch that is predicated-not-taken.
+            // Ensure that the native code has just one forward branch that is predicted-not-taken.
             ref T ret = ref Unsafe.AsRef<T>(null);
             if (_length != 0) ret = ref _pointer.Value;
             return ref ret;


### PR DESCRIPTION
Related to discussion in https://github.com/dotnet/corefx/pull/32669

`Span.GetPinnableReference` compiles into one conditional branch and one unconditional branch on the hot path. This change tweaks the implementation to make it compile to just one well-predicted conditional branch on the hot path.

Test (extracted from https://github.com/eerhardt/machinelearning/commit/56b849c6d54bfd9e73d8bec8c119660d3e5b6dc1#diff-0f95f507da073f50b5077ef70802a793R1191 - thanks @eerhardt!) :
```
    [MethodImpl(MethodImplOptions.NoInlining)]
    static float DotU(float*p, float* q, int count) => 0;

    [MethodImpl(MethodImplOptions.NoInlining)]
    public static float DotProductDense(ReadOnlySpan<float> a, ReadOnlySpan<float> b, int count)
    {
        fixed (float* pa = a)
        fixed (float* pb = b)
            return DotU(pa, pb, count);
    }

    static void DoStuff()
    {
        float[] a = new float[100]; 
        float[] b = new float[100];
        for (int i = 0; i < 1000000000; i++) DotProductDense(a, b, 100);
    }
```

Before this change: 4800ms
After this change: 4110ms
(for reference) Pinning using MemoryMarshal.GetReference: 3930ms

Disassembly for `DotProductDense` method before:
```
sub     rsp,38h
vzeroupper
xor     eax,eax
mov     qword ptr [rsp+30h],rax
mov     qword ptr [rsp+28h],rax
cmp     dword ptr [rcx+8],0
jne     test!Test.DotProductDense(System.ReadOnlySpan`1<Single>, System.ReadOnlySpan`1<Single>, Int32)+0x1cd
xor     eax,eax
jmp     test!Test.DotProductDense(System.ReadOnlySpan`1<Single>, System.ReadOnlySpan`1<Single>, Int32)+0x1d0
mov     rax,qword ptr [rcx]
mov     qword ptr [rsp+30h],rax
cmp     dword ptr [rdx+8],0
jne     test!Test.DotProductDense(System.ReadOnlySpan`1<Single>, System.ReadOnlySpan`1<Single>, Int32)+0x1df
xor     ecx,ecx
jmp     test!Test.DotProductDense(System.ReadOnlySpan`1<Single>, System.ReadOnlySpan`1<Single>, Int32)+0x1e2
mov     rcx,qword ptr [rdx]
mov     qword ptr [rsp+28h],rcx
mov     rdx,rcx
mov     rcx,qword ptr [rsp+30h]
call    Test.DotU(Single*, Single*, Int32) (00007fff`28ac1218)
nop
add     rsp,38h
ret
```

Disassembly for `DotProductDense` method after:
```
sub     rsp,38h
vzeroupper
xor     eax,eax
mov     qword ptr [rsp+30h],rax
mov     qword ptr [rsp+28h],rax
xor     eax,eax
cmp     dword ptr [rcx+8],0
je      test!Test.DotProductDense(System.ReadOnlySpan`1<Single>, System.ReadOnlySpan`1<Single>, Int32)+0x26e (00007fff`272b3f2e)
mov     rax,qword ptr [rcx]
mov     qword ptr [rsp+30h],rax
xor     ecx,ecx
cmp     dword ptr [rdx+8],0
je      test!Test.DotProductDense(System.ReadOnlySpan`1<Single>, System.ReadOnlySpan`1<Single>, Int32)+0x27e (00007fff`272b3f3e)
mov     rcx,qword ptr [rdx]
mov     qword ptr [rsp+28h],rcx
mov     rdx,rcx
mov     rcx,qword ptr [rsp+30h]
call    Test.DotU(Single*, Single*, Int32) (00007fff`2728a770)
nop
add     rsp,38h
ret
```