### PR TITLE
Structured dump of instance entrypoints and decoding generic lookups

### DIFF
--- a/src/tools/r2rdump/R2RReader.cs
+++ b/src/tools/r2rdump/R2RReader.cs
@@ -56,6 +56,18 @@ namespace R2RDump
         Unknown = -1
     }
 
+    public struct InstanceMethod
+    {
+        public byte Bucket;
+        public R2RMethod Method;
+
+        public InstanceMethod(byte bucket, R2RMethod method)
+        {
+            Bucket = bucket;
+            Method = method;
+        }
+    }
+
     public class R2RReader
     {
         /// <summary>
@@ -106,6 +118,11 @@ namespace R2RDump
         /// The runtime functions and method signatures of each method
         /// </summary>
         public IList<R2RMethod> R2RMethods { get; }
+
+        /// <summary>
+        /// Parsed instance entrypoint table entries.
+        /// </summary>
+        public IList<InstanceMethod> InstanceMethods { get; }
 
         /// <summary>
         /// The available types from READYTORUN_SECTION_AVAILABLE_TYPES
@@ -196,6 +213,8 @@ namespace R2RDump
                     }
 
                     R2RMethods = new List<R2RMethod>();
+                    InstanceMethods = new List<InstanceMethod>();
+
                     if (R2RHeader.Sections.ContainsKey(R2RSection.SectionType.READYTORUN_SECTION_RUNTIME_FUNCTIONS))
                     {
                         int runtimeFunctionSize = CalculateRuntimeFunctionSize();
@@ -350,6 +369,7 @@ namespace R2RDump
                     isEntryPoint[method.EntryPointRuntimeFunctionId] = true;
                 }
                 R2RMethods.Add(method);
+                InstanceMethods.Add(new InstanceMethod(curParser.LowHashcode, method));
                 curParser = allEntriesEnum.GetNext();
             }
         }

--- a/src/tools/r2rdump/R2RSignature.cs
+++ b/src/tools/r2rdump/R2RSignature.cs
@@ -444,20 +444,21 @@ namespace R2RDump
             switch ((ReadyToRunFixupKind)fixupType)
             {
                 case ReadyToRunFixupKind.READYTORUN_FIXUP_ThisObjDictionaryLookup:
-                    builder.Append("THIS_OBJ_DICTIONARY_LOOKUP");
-                    // TODO
+                    builder.Append("THISOBJ_DICTIONARY_LOOKUP @ ");
+                    ParseType(builder);
+                    builder.Append(": ");
+                    ParseSignature(builder);
                     break;
 
                 case ReadyToRunFixupKind.READYTORUN_FIXUP_TypeDictionaryLookup:
-                    builder.Append("TYPE_DICTIONARY_LOOKUP");
-                    // TODO
+                    builder.Append("TYPE_DICTIONARY_LOOKUP: ");
+                    ParseSignature(builder);
                     break;
 
                 case ReadyToRunFixupKind.READYTORUN_FIXUP_MethodDictionaryLookup:
-                    builder.Append("METHOD_DICTIONARY_LOOKUP");
-                    // TODO
+                    builder.Append("METHOD_DICTIONARY_LOOKUP: ");
+                    ParseSignature(builder);
                     break;
-
 
                 case ReadyToRunFixupKind.READYTORUN_FIXUP_TypeHandle:
                     ParseType(builder);
@@ -465,8 +466,8 @@ namespace R2RDump
                     break;
 
                 case ReadyToRunFixupKind.READYTORUN_FIXUP_MethodHandle:
-                    builder.Append("METHOD_HANDLE");
-                    // TODO
+                    ParseMethod(builder);
+                    builder.Append(" (METHOD_HANDLE)");
                     break;
 
                 case ReadyToRunFixupKind.READYTORUN_FIXUP_FieldHandle:
@@ -507,8 +508,11 @@ namespace R2RDump
                     break;
 
                 case ReadyToRunFixupKind.READYTORUN_FIXUP_VirtualEntry_Slot:
-                    builder.Append("VIRTUAL_ENTRY_SLOT");
-                    // TODO
+                    {
+                        uint slot = ReadUInt();
+                        ParseType(builder);
+                        builder.Append($@" #{slot} (VIRTUAL_ENTRY_SLOT)");
+                    }
                     break;
 
 
@@ -708,7 +712,8 @@ namespace R2RDump
                     break;
 
                 case CorElementType.ELEMENT_TYPE_VAR:
-                    builder.Append("var");
+                    builder.Append("var #");
+                    builder.Append(ReadUInt());
                     break;
 
                 case CorElementType.ELEMENT_TYPE_ARRAY:
@@ -744,7 +749,8 @@ namespace R2RDump
                     break;
 
                 case CorElementType.ELEMENT_TYPE_MVAR:
-                    builder.Append("mvar");
+                    builder.Append("mvar #");
+                    builder.Append(ReadUInt());
                     break;
 
                 case CorElementType.ELEMENT_TYPE_CMOD_REQD:

--- a/src/tools/r2rdump/TextDumper.cs
+++ b/src/tools/r2rdump/TextDumper.cs
@@ -266,6 +266,11 @@ namespace R2RDump
                     NativeParser instanceParser = new NativeParser(_r2r.Image, instanceSectionOffset);
                     NativeHashtable instMethodEntryPoints = new NativeHashtable(_r2r.Image, instanceParser, (uint)(instanceSectionOffset + section.Size));
                     _writer.Write(instMethodEntryPoints.ToString());
+                    _writer.WriteLine();
+                    foreach (InstanceMethod instanceMethod in _r2r.InstanceMethods)
+                    {
+                        _writer.WriteLine($@"0x{instanceMethod.Bucket:X2} -> {instanceMethod.Method.SignatureString}");
+                    }
                     break;
                 case R2RSection.SectionType.READYTORUN_SECTION_RUNTIME_FUNCTIONS:
                     int rtfOffset = _r2r.GetOffset(section.RelativeVirtualAddress);


### PR DESCRIPTION
1) Dump method signatures in the INSTANCE_METHOD_ENTRYPOINTS section;

2) Add logic for decoding generic lookups;

3) Add previously missing support for dumping MVAR index.

Thanks

Tomas