### PR TITLE
Replace 'VSCode' by 'Visual Studio Code' in Editing and Debugging doc

### DIFF
--- a/Documentation/workflow/EditingAndDebugging.md
+++ b/Documentation/workflow/EditingAndDebugging.md
@@ -3,14 +3,14 @@
 
 If you are editing on the Windows Operating system, Using Visual Studio 2015 is a good option for editing
 the code in this repository.    You can of course also use the editor of your choice.   One further option
-is to use [VSCode](https://code.visualstudio.com/) which is a light weight, cross-platform tool that like
+is to use [Visual Studio Code](https://code.visualstudio.com/) which is a light weight, cross-platform tool that like
 Visual Studio, is optimized for development workflow (code editing and debugging) but works on more platforms
 (in particular OSX and Linux)
 
-[VSCode](https://code.visualstudio.com/) has built-in support for syntax highlighting and previewing 
+[Visual Studio Code](https://code.visualstudio.com/) has built-in support for syntax highlighting and previewing 
 markdown (`*.md`) files that GIT repositories like this one use for documentation.   If you want to modify
-the docs, VSCode is a good choice.  See [Markdown and VSCOde](https://code.visualstudio.com/Docs/languages/markdown)
-for more on VSCode support and [Mastering Markdown](https://guides.github.com/features/mastering-markdown/) for 
+the docs, Visual Studio Code is a good choice.  See [Markdown and Visual Studio Code](https://code.visualstudio.com/Docs/languages/markdown)
+for more on Visual Studio Code support and [Mastering Markdown](https://guides.github.com/features/mastering-markdown/) for 
 more on Markdown in general.  
 
 # Visual Studio Solutions 


### PR DESCRIPTION
I know Visual Studio Code is also broadly known as VSCode. 
But since this document already contained a typo and Visual Studio Code is not referred as VSCode elsewhere in the CoreCLR documentation I figured it could be nice to _clean_ this documentation page.