### PR TITLE
Add initial async iterators support to System.Private.CoreLib

### DIFF
--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -2620,6 +2620,9 @@
   <data name="InvalidOperation_TimeoutsNotSupported" xml:space="preserve">
     <value>Timeouts are not supported on this stream.</value>
   </data>
+  <data name="InvalidOperation_TimerAlreadyClosed" xml:space="preserve">
+    <value>The Timer was already closed using an incompatible Dispose method.</value>
+  </data>
   <data name="InvalidOperation_TypeCannotBeBoxed" xml:space="preserve">
     <value>The given type cannot be boxed.</value>
   </data>

--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -72,6 +72,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Collections\DictionaryEntry.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Generic\ArraySortHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Generic\Dictionary.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Generic\IAsyncEnumerable.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Generic\IAsyncEnumerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Generic\ICollection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Generic\ICollectionDebugView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Collections\Generic\IComparer.cs" />

--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -636,6 +636,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\TaskToApm.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\TaskSchedulerException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\ValueTask.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\Sources\ManualResetValueTaskSourceLogic.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\Sources\IValueTaskSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\ThreadAbortException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\ThreadInterruptedException.cs" />

--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -208,6 +208,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Guid.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\HashCode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\HResults.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\IAsyncDisposable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IAsyncResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\ICloneable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IComparable.cs" />

--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -424,6 +424,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Resources\SatelliteContractVersionAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Resources\UltimateResourceFallbackLocation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AccessedThroughPropertyAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncIteratorMethodBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncMethodBuilderAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncStateMachineAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncValueTaskMethodBuilder.cs" />

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/IAsyncEnumerable.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/IAsyncEnumerable.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Collections.Generic
+{
+    public interface IAsyncEnumerable<out T>
+    {
+        IAsyncEnumerator<T> GetAsyncEnumerator();
+    }
+}

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/IAsyncEnumerator.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/IAsyncEnumerator.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+
+namespace System.Collections.Generic
+{
+    public interface IAsyncEnumerator<out T> : IAsyncDisposable
+    {
+        ValueTask<bool> MoveNextAsync();
+        T Current { get; }
+    }
+}

--- a/src/System.Private.CoreLib/shared/System/IAsyncDisposable.cs
+++ b/src/System.Private.CoreLib/shared/System/IAsyncDisposable.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+
+namespace System
+{
+    public interface IAsyncDisposable
+    {
+        ValueTask DisposeAsync();
+    }
+}

--- a/src/System.Private.CoreLib/shared/System/IO/FileStream.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileStream.Unix.cs
@@ -269,6 +269,12 @@ namespace System.IO
             }
         }
 
+        public override ValueTask DisposeAsync() =>
+            // On Unix, we'll always end up doing what's in Dispose anyway,
+            // so just delegate to the base to queue it.  We maintain an explicit override for
+            // consistency with Windows, which has a more complicated implementation.
+            base.DisposeAsync();
+
         /// <summary>Flushes the OS buffer.  This does not flush the internal read/write buffer.</summary>
         private void FlushOSBuffer()
         {

--- a/src/System.Private.CoreLib/shared/System/IO/MemoryStream.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/MemoryStream.cs
@@ -141,6 +141,17 @@ namespace System.IO
             }
         }
 
+        public override ValueTask DisposeAsync()
+        {
+            if (GetType() != typeof(MemoryStream))
+            {
+                return base.DisposeAsync();
+            }
+
+            Dispose(disposing: true);
+            return default;
+        }
+
         // returns a bool saying whether we allocated a new array.
         private bool EnsureCapacity(int value)
         {

--- a/src/System.Private.CoreLib/shared/System/IO/PinnedBufferMemoryStream.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/PinnedBufferMemoryStream.cs
@@ -15,8 +15,9 @@
 ===========================================================*/
 
 using System;
-using System.Runtime.InteropServices;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 
 namespace System.IO
 {
@@ -55,6 +56,12 @@ namespace System.IO
             }
 
             base.Dispose(disposing);
+        }
+
+        public override ValueTask DisposeAsync()
+        {
+            Dispose(disposing: true);
+            return default;
         }
     }
 }

--- a/src/System.Private.CoreLib/shared/System/IO/Stream.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/Stream.cs
@@ -25,7 +25,7 @@ using System.Threading.Tasks;
 
 namespace System.IO
 {
-    public abstract partial class Stream : MarshalByRefObject, IDisposable
+    public abstract partial class Stream : MarshalByRefObject, IDisposable, IAsyncDisposable
     {
         public static readonly Stream Null = new NullStream();
 
@@ -232,6 +232,12 @@ namespace System.IO
             // Note: Never change this to call other virtual methods on Stream
             // like Write, since the state on subclasses has already been 
             // torn down.  This is the last code to run on cleanup for a stream.
+        }
+
+        public virtual ValueTask DisposeAsync()
+        {
+            return new ValueTask(Task.Factory.StartNew(s => ((Stream)s).Close(), this,
+                CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default));
         }
 
         public abstract void Flush();
@@ -899,6 +905,8 @@ namespace System.IO
                 // Do nothing - we don't want NullStream singleton (static) to be closable
             }
 
+            public override ValueTask DisposeAsync() => default;
+
             public override void Flush()
             {
             }
@@ -1200,6 +1208,12 @@ namespace System.IO
                         base.Dispose(disposing);
                     }
                 }
+            }
+
+            public override ValueTask DisposeAsync()
+            {
+                lock (_stream)
+                    return _stream.DisposeAsync();
             }
 
             public override void Flush()

--- a/src/System.Private.CoreLib/shared/System/IO/StreamWriter.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/StreamWriter.cs
@@ -195,32 +195,67 @@ namespace System.IO
             }
             finally
             {
-                // Dispose of our resources if this StreamWriter is closable. 
-                // Note: Console.Out and other such non closable streamwriters should be left alone 
-                if (!LeaveOpen && _stream != null)
+                CloseStreamFromDispose(disposing);
+            }
+        }
+
+        private void CloseStreamFromDispose(bool disposing)
+        {
+            // Dispose of our resources if this StreamWriter is closable. 
+            if (!LeaveOpen && _stream != null)
+            {
+                try
                 {
-                    try
+                    // Attempt to close the stream even if there was an IO error from Flushing.
+                    // Note that Stream.Close() can potentially throw here (may or may not be
+                    // due to the same Flush error). In this case, we still need to ensure 
+                    // cleaning up internal resources, hence the finally block.  
+                    if (disposing)
                     {
-                        // Attempt to close the stream even if there was an IO error from Flushing.
-                        // Note that Stream.Close() can potentially throw here (may or may not be
-                        // due to the same Flush error). In this case, we still need to ensure 
-                        // cleaning up internal resources, hence the finally block.  
-                        if (disposing)
-                        {
-                            _stream.Close();
-                        }
-                    }
-                    finally
-                    {
-                        _stream = null;
-                        _byteBuffer = null;
-                        _charBuffer = null;
-                        _encoding = null;
-                        _encoder = null;
-                        _charLen = 0;
-                        base.Dispose(disposing);
+                        _stream.Close();
                     }
                 }
+                finally
+                {
+                    _stream = null;
+                    _byteBuffer = null;
+                    _charBuffer = null;
+                    _encoding = null;
+                    _encoder = null;
+                    _charLen = 0;
+                    base.Dispose(disposing);
+                }
+            }
+        }
+
+        public override ValueTask DisposeAsync()
+        {
+            if (GetType() != typeof(StreamWriter))
+            {
+                // Since this is a derived StreamWriter, delegate to whatever logic
+                // the derived implementation already has in Dispose.
+                return new ValueTask(Task.Factory.StartNew(s => ((StreamWriter)s).Dispose(), this,
+                    CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default));
+            }
+
+            return DisposeAsyncCore();
+        }
+
+        private async ValueTask DisposeAsyncCore()
+        {
+            Debug.Assert(GetType() == typeof(StreamWriter));
+
+            // Same logic as in Dispose(true), but async.
+            try
+            {
+                if (_stream != null)
+                {
+                    await FlushAsync().ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                CloseStreamFromDispose(disposing: true);
             }
         }
 

--- a/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
@@ -809,8 +809,13 @@ namespace System.IO
                     ((IDisposable)_out).Dispose();
             }
 
-            [MethodImpl(MethodImplOptions.Synchronized)]
-            public override ValueTask DisposeAsync() => _out.DisposeAsync();
+            // [MethodImpl(MethodImplOptions.Synchronized)]
+            public override ValueTask DisposeAsync()
+            {
+                // TODO: https://github.com/dotnet/coreclr/issues/20499
+                // Manual synchronization should be replaced by Synchronized.
+                lock (this) return _out.DisposeAsync();
+            }
 
             [MethodImpl(MethodImplOptions.Synchronized)]
             public override void Flush() => _out.Flush();

--- a/src/System.Private.CoreLib/shared/System/IO/UnmanagedMemoryStream.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/UnmanagedMemoryStream.cs
@@ -231,6 +231,17 @@ namespace System.IO
             base.Dispose(disposing);
         }
 
+        public override ValueTask DisposeAsync()
+        {
+            if (GetType() != typeof(UnmanagedMemoryStream))
+            {
+                return base.DisposeAsync();
+            }
+
+            Dispose(disposing: true);
+            return default;
+        }
+
         private void EnsureNotClosed()
         {
             if (!_isOpen)

--- a/src/System.Private.CoreLib/shared/System/IO/UnmanagedMemoryStreamWrapper.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/UnmanagedMemoryStreamWrapper.cs
@@ -59,6 +59,11 @@ namespace System.IO
             }
         }
 
+        public override ValueTask DisposeAsync()
+        {
+            return _unmanagedStream.DisposeAsync();
+        }
+
         public override void Flush()
         {
             _unmanagedStream.Flush();

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncIteratorMethodBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncIteratorMethodBuilder.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>Represents a builder for asynchronous iterators.</summary>
+    [StructLayout(LayoutKind.Auto)]
+    public struct AsyncIteratorMethodBuilder
+    {
+        // AsyncIteratorMethodBuilder is used by the language compiler as part of generating
+        // async iterators. For now, the implementation just wraps AsyncTaskMethodBuilder, as
+        // most of the logic is shared.  However, in the future this could be changed and
+        // optimized.  For example, we do need to allocate an object (once) to flow state like
+        // ExecutionContext, which AsyncTaskMethodBuilder handles, but it handles it by
+        // allocating a Task-derived object.  We could optimize this further by removing
+        // the Task from the hierarchy, but in doing so we'd also lose a variety of optimizations
+        // related to it, so we'd need to replicate all of those optimizations (e.g. storing
+        // that box object directly into a Task's continuation field).
+
+        private AsyncTaskMethodBuilder _methodBuilder; // mutable struct; do not make it readonly
+
+        /// <summary>Creates an instance of the <see cref="AsyncIteratorMethodBuilder"/> struct.</summary>
+        /// <returns>The initialized instance.</returns>
+        public static AsyncIteratorMethodBuilder Create() =>
+#if CORERT
+            // corert's AsyncTaskMethodBuilder.Create() currently does additional debugger-related
+            // work, so we need to delegate to it.
+            new AsyncIteratorMethodBuilder() { _methodBuilder = AsyncTaskMethodBuilder.Create() };
+#else
+            default; // coreclr's AsyncTaskMethodBuilder.Create just returns default as well
+#endif
+
+        /// <summary>Invokes <see cref="IAsyncStateMachine.MoveNext"/> on the state machine while guarding the <see cref="ExecutionContext."/></summary>
+        /// <typeparam name="TStateMachine">The type of the state machine.</typeparam>
+        /// <param name="stateMachine">The state machine instance, passed by reference.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void MoveNext<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine =>
+#if CORERT
+            _methodBuilder.Start(ref stateMachine);
+#else
+            AsyncMethodBuilderCore.Start(ref stateMachine);
+#endif
+
+        /// <summary>Schedules the state machine to proceed to the next action when the specified awaiter completes.</summary>
+        /// <typeparam name="TAwaiter">The type of the awaiter.</typeparam>
+        /// <typeparam name="TStateMachine">The type of the state machine.</typeparam>
+        /// <param name="awaiter">The awaiter.</param>
+        /// <param name="stateMachine">The state machine.</param>
+        public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
+            where TAwaiter : INotifyCompletion
+            where TStateMachine : IAsyncStateMachine =>
+            _methodBuilder.AwaitOnCompleted(ref awaiter, ref stateMachine);
+
+        /// <summary>Schedules the state machine to proceed to the next action when the specified awaiter completes.</summary>
+        /// <typeparam name="TAwaiter">The type of the awaiter.</typeparam>
+        /// <typeparam name="TStateMachine">The type of the state machine.</typeparam>
+        /// <param name="awaiter">The awaiter.</param>
+        /// <param name="stateMachine">The state machine.</param>
+        public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
+            where TAwaiter : ICriticalNotifyCompletion
+            where TStateMachine : IAsyncStateMachine =>
+            _methodBuilder.AwaitUnsafeOnCompleted(ref awaiter, ref stateMachine);
+
+        /// <summary>Marks iteration as being completed, whether successfully or otherwise.</summary>
+        public void Complete() =>
+            _methodBuilder.SetResult();
+
+        /// <summary>Gets an object that may be used to uniquely identify this builder to the debugger.</summary>
+        internal object ObjectIdForDebugger =>
+            _methodBuilder.ObjectIdForDebugger;
+    }
+}

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/Sources/ManualResetValueTaskSourceLogic.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/Sources/ManualResetValueTaskSourceLogic.cs
@@ -1,0 +1,273 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
+
+namespace System.Threading.Tasks.Sources
+{
+    /// <summary>Provides the core logic for implementing a manual-reset <see cref="IValueTaskSource"/> or <see cref="IValueTaskSource{TResult}"/>.</summary>
+    /// <typeparam name="TResult"></typeparam>
+    [StructLayout(LayoutKind.Auto)]
+    public struct ManualResetValueTaskSourceLogic<TResult>
+    {
+        /// <summary>
+        /// The callback to invoke when the operation completes if <see cref="OnCompleted"/> was called before the operation completed,
+        /// or <see cref="ManualResetValueTaskSourceLogicShared.s_sentinel"/> if the operation completed before a callback was supplied,
+        /// or null if a callback hasn't yet been provided and the operation hasn't yet completed.
+        /// </summary>
+        private Action<object> _continuation;
+        /// <summary>State to pass to <see cref="_continuation"/>.</summary>
+        private object _continuationState;
+        /// <summary><see cref="ExecutionContext"/> to flow to the callback, or null if no flowing is required.</summary>
+        private ExecutionContext _executionContext;
+        /// <summary>
+        /// A "captured" <see cref="SynchronizationContext"/> or <see cref="TaskScheduler"/> with which to invoke the callback,
+        /// or null if no special context is required.
+        /// </summary>
+        private object _capturedContext;
+        /// <summary>Whether the current operation has completed.</summary>
+        private bool _completed;
+        /// <summary>The result with which the operation succeeded, or the default value if it hasn't yet completed or failed.</summary>
+        private TResult _result;
+        /// <summary>The exception with which the operation failed, or null if it hasn't yet completed or completed successfully.</summary>
+        private ExceptionDispatchInfo _error;
+        /// <summary>The current version of this value, used to help prevent misuse.</summary>
+        private short _version;
+
+        /// <summary>Gets or sets whether to force continuations to run asynchronously.</summary>
+        /// <remarks>Continuations may run asynchronously if this is false, but they'll never run synchronously if this is true.</remarks>
+        public bool RunContinuationsAsynchronously { get; set; }
+
+        /// <summary>Resets to prepare for the next operation.</summary>
+        public void Reset()
+        {
+            // Reset/update state for the next use/await of this instance.
+            _version++;
+            _completed = false;
+            _result = default;
+            _error = null;
+            _executionContext = null;
+            _capturedContext = null;
+            _continuation = null;
+            _continuationState = null;
+        }
+
+        /// <summary>Completes with a successful result.</summary>
+        /// <param name="result">The result.</param>
+        public void SetResult(TResult result)
+        {
+            _result = result;
+            SignalCompletion();
+        }
+
+        /// <summary>Complets with an error.</summary>
+        /// <param name="error"></param>
+        public void SetException(Exception error)
+        {
+            _error = ExceptionDispatchInfo.Capture(error);
+            SignalCompletion();
+        }
+
+        /// <summary>Gets the operation version.</summary>
+        public short Version => _version;
+
+        /// <summary>Gets the status of the operation.</summary>
+        /// <param name="token">Opaque value that was provided to the <see cref="ValueTask"/>'s constructor.</param>
+        public ValueTaskSourceStatus GetStatus(short token)
+        {
+            ValidateToken(token);
+            return
+                !_completed ? ValueTaskSourceStatus.Pending :
+                _error == null ? ValueTaskSourceStatus.Succeeded :
+                _error.SourceException is OperationCanceledException ? ValueTaskSourceStatus.Canceled :
+                ValueTaskSourceStatus.Faulted;
+        }
+
+        /// <summary>Gets the result of the operation.</summary>
+        /// <param name="token">Opaque value that was provided to the <see cref="ValueTask"/>'s constructor.</param>
+        public TResult GetResult(short token)
+        {
+            ValidateToken(token);
+            if (!_completed)
+            {
+                ManualResetValueTaskSourceLogicShared.ThrowInvalidOperationException();
+            }
+
+            _error?.Throw();
+            return _result;
+        }
+
+        /// <summary>Schedules the continuation action for this operation.</summary>
+        /// <param name="continuation">The continuation to invoke when the operation has completed.</param>
+        /// <param name="state">The state object to pass to <paramref name="continuation"/> when it's invoked.</param>
+        /// <param name="token">Opaque value that was provided to the <see cref="ValueTask"/>'s constructor.</param>
+        /// <param name="flags">The flags describing the behavior of the continuation.</param>
+        public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+        {
+            if (continuation == null)
+            {
+                throw new ArgumentNullException(nameof(continuation));
+            }
+            ValidateToken(token);
+
+            if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) != 0)
+            {
+                _executionContext = ExecutionContext.Capture();
+            }
+
+            if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) != 0)
+            {
+                SynchronizationContext sc = SynchronizationContext.Current;
+                if (sc != null && sc.GetType() != typeof(SynchronizationContext))
+                {
+                    _capturedContext = sc;
+                }
+                else
+                {
+                    TaskScheduler ts = TaskScheduler.Current;
+                    if (ts != TaskScheduler.Default)
+                    {
+                        _capturedContext = ts;
+                    }
+                }
+            }
+
+            // We need to set the continuation state before we swap in the delegate, so that
+            // if there's a race between this and SetResult/Exception and SetResult/Exception
+            // sees the _continuation as non-null, it'll be able to invoke it with the state
+            // stored here.  However, this also means that if this is used incorrectly (e.g.
+            // awaited twice concurrently), _continuationState might get erroneously overwritten.
+            // To minimize the chances of that, we check preemptively whether _continuation
+            // is already set to something other than the completion sentinel.
+            object currentContinuation = _continuation;
+            if (currentContinuation != null &&
+                !ReferenceEquals(currentContinuation, ManualResetValueTaskSourceLogicShared.s_sentinel))
+            {
+                ManualResetValueTaskSourceLogicShared.ThrowInvalidOperationException();
+            }
+            _continuationState = state;
+
+            Action<object> oldContinuation = Interlocked.CompareExchange(ref _continuation, continuation, null);
+            if (oldContinuation != null)
+            {
+                switch (_capturedContext)
+                {
+                    case null:
+                        if (_executionContext != null)
+                        {
+                            ThreadPool.QueueUserWorkItem(continuation, state, preferLocal: true);
+                        }
+                        else
+                        {
+                            ThreadPool.UnsafeQueueUserWorkItem(continuation, state, preferLocal: true);
+                        }
+                        break;
+
+                    case SynchronizationContext sc:
+                        sc.Post(s =>
+                        {
+                            var tuple = (Tuple<Action<object>, object>)s;
+                            tuple.Item1(tuple.Item2);
+                        }, Tuple.Create(continuation, state));
+                        break;
+
+                    case TaskScheduler ts:
+                        Task.Factory.StartNew(continuation, state, CancellationToken.None, TaskCreationOptions.DenyChildAttach, ts);
+                        break;
+                }
+            }
+        }
+
+        /// <summary>Ensures that the specified token matches the current version.</summary>
+        /// <param name="token">The token supplied by <see cref="ValueTask"/>.</param>
+        private void ValidateToken(short token)
+        {
+            if (token != _version)
+            {
+                ManualResetValueTaskSourceLogicShared.ThrowInvalidOperationException();
+            }
+        }
+
+        /// <summary>Signals that that the operation has completed.  Invoked after the result or error has been set.</summary>
+        private void SignalCompletion()
+        {
+            if (_completed)
+            {
+                ManualResetValueTaskSourceLogicShared.ThrowInvalidOperationException();
+            }
+            _completed = true;
+
+            if (Interlocked.CompareExchange(ref _continuation, ManualResetValueTaskSourceLogicShared.s_sentinel, null) != null)
+            {
+                if (_executionContext != null)
+                {
+                    ExecutionContext.RunInternal(
+                        _executionContext,
+                        (ref ManualResetValueTaskSourceLogic<TResult> s) => s.InvokeContinuation(),
+                        ref this);
+                }
+                else
+                {
+                    InvokeContinuation();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Invokes the continuation with the appropriate captured context / scheduler.
+        /// This assumes that if <see cref="_executionContext"/> is not null we're already
+        /// running within that <see cref="ExecutionContext"/>.
+        /// </summary>
+        private void InvokeContinuation()
+        {
+            switch (_capturedContext)
+            {
+                case null:
+                    if (RunContinuationsAsynchronously)
+                    {
+                        if (_executionContext != null)
+                        {
+                            ThreadPool.QueueUserWorkItem(_continuation, _continuationState, preferLocal: true);
+                        }
+                        else
+                        {
+                            ThreadPool.UnsafeQueueUserWorkItem(_continuation, _continuationState, preferLocal: true);
+                        }
+                    }
+                    else
+                    {
+                        _continuation(_continuationState);
+                    }
+                    break;
+
+                case SynchronizationContext sc:
+                    sc.Post(s =>
+                    {
+                        var state = (Tuple<Action<object>, object>)s;
+                        state.Item1(state.Item2);
+                    }, Tuple.Create(_continuation, _continuationState));
+                    break;
+
+                case TaskScheduler ts:
+                    Task.Factory.StartNew(_continuation, _continuationState, CancellationToken.None, TaskCreationOptions.DenyChildAttach, ts);
+                    break;
+            }
+        }
+    }
+
+    internal static class ManualResetValueTaskSourceLogicShared
+    {
+        internal static void ThrowInvalidOperationException() =>
+            throw new InvalidOperationException();
+
+        internal static readonly Action<object> s_sentinel = new Action<object>(s =>
+        {
+            Debug.Fail("The sentinel delegate should never be invoked.");
+            ThrowInvalidOperationException();
+        });
+    }
+}

--- a/src/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace System.Threading
 {
@@ -784,6 +785,33 @@ namespace System.Threading
             {
                 sw.SpinOnce();  // spin, as we assume callback execution is fast and that this situation is rare.
             }
+        }
+
+        /// <summary>
+        /// Asynchronously wait for a single callback to complete (or, more specifically, to not be running).
+        /// It is ok to call this method if the callback has already finished.
+        /// Calling this method before the target callback has been selected for execution would be an error.
+        /// </summary>
+        internal ValueTask WaitForCallbackToCompleteAsync(long id)
+        {
+            // If the currently executing callback is not the target one, then the target one has already
+            // completed and we can simply return.  This should be the most common case, as the caller
+            // calls if we're currently canceling but doesn't know what callback is running, if any.
+            if (ExecutingCallback != id)
+            {
+                return default;
+            }
+
+            // The specified callback is actually running: queue a task that'll poll for the currently
+            // executing callback to complete. In general scheduling such a work item that polls is a really
+            // thing to do.  However, we expect this to be a rare case (disposing while the associated
+            // callback is running), and brief when it happens (so the polling will be minimal), and making
+            // this work with a callback mechanism will add additional cost to other more common cases.
+            return new ValueTask(Task.Factory.StartNew(s =>
+            {
+                var state = (Tuple<CancellationTokenSource, long>)s;
+                state.Item1.WaitForCallbackToComplete(state.Item2);
+            }, Tuple.Create(this, id), CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default));
         }
 
         private sealed class Linked1CancellationTokenSource : CancellationTokenSource

--- a/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
@@ -1332,6 +1332,22 @@ namespace System.Threading
             return true;
         }
 
+        // TODO: https://github.com/dotnet/corefx/issues/32547. Make public.
+        internal static bool UnsafeQueueUserWorkItem<TState>(Action<TState> callBack, TState state, bool preferLocal)
+        {
+            if (callBack == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.callBack);
+            }
+
+            EnsureVMInitialized();
+
+            ThreadPoolGlobals.workQueue.Enqueue(
+                new QueueUserWorkItemCallback<TState>(callBack, state, null), forceGlobal: !preferLocal);
+
+            return true;
+        }
+
         public static bool UnsafeQueueUserWorkItem(WaitCallback callBack, object state)
         {
             if (callBack == null)


### PR DESCRIPTION
- Adds the `IAsyncEnumerable<T>`, `IAsyncEnumerator<T>`, and `IAsyncDisposable` interfaces
- Adds the `AsyncIteratorMethodBuilder` struct for the compilers
- Adds `IAsyncDisposable` implementations to the types in System.Private.CoreLib that benefit from it
- Adds the `ManualResetValueTaskSourceLogic` type that the compilers use to implement async iterators.
- Adds a few helpers on `ExecutionContext` and `ThreadPool` to support `ManualResetValueTaskSourceLogic` (these helpers are currently internal but could potentially be public in the future).

Contributes to https://github.com/dotnet/corefx/issues/32640
Contributes to https://github.com/dotnet/corefx/issues/32665
Contributes to https://github.com/dotnet/corefx/issues/32664

All of this still needs unit tests and to be exposed in the refs in corefx (this will not be merged until I have that ready and validated locally).  There will also be additional work in corefx to complete the above issues, e.g. more Stream-derived types that'll override DisposeAsync.  And all of this is still subject to an upcoming API review.  I'm putting it up now to get a jump on everything so we can get it merged as soon as possible.

cc: @jcouv, @terrajobst, @jaredpar, @MadsTorgersen, @benaadams, @kouvel 