### PR TITLE
High entropy ASLR for native images

### DIFF
--- a/src/zap/zapimage.cpp
+++ b/src/zap/zapimage.cpp
@@ -1539,6 +1539,10 @@ void ZapImage::OutputTables()
 #endif // _DEBUG
         {
             dllCharacteristics |= IMAGE_DLLCHARACTERISTICS_DYNAMIC_BASE;
+#ifdef _TARGET_64BIT_
+            // Large address aware, required for High Entry VA, is always enabled for 64bit native images.
+            dllCharacteristics |= IMAGE_DLLCHARACTERISTICS_HIGH_ENTROPY_VA;
+#endif
         }
 
         SetDllCharacteristics(dllCharacteristics);


### PR DESCRIPTION
Enable high entropy for 64bit native images, which expands the set of virtual address bases a native image can be loaded at.