### PR TITLE
JIT: recover types from helper calls and more

### DIFF
--- a/src/System.Private.CoreLib/src/System/Internal.cs
+++ b/src/System.Private.CoreLib/src/System/Internal.cs
@@ -202,6 +202,7 @@ namespace System
         // typed as matching instantiations of mscorlib copies of WinRT interfaces (IIterable<T>, IVector<T>,
         // IMap<K, V>, ...) which is necessary to generate all required IL stubs.
 
+        [MethodImplAttribute(MethodImplOptions.NoOptimization)]
         private static void CommonlyUsedWinRTRedirectedInterfaceStubs()
         {
             WinRT_IEnumerable<byte>(null, null, null);

--- a/src/System.Private.CoreLib/src/System/RtType.cs
+++ b/src/System.Private.CoreLib/src/System/RtType.cs
@@ -4532,6 +4532,10 @@ namespace System
             }
         }
 
+        // This method looks like an attractive inline but expands to two calls,
+        // neither of which can be inlined or optimized further. So block it
+        // from inlining.
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private string GetCachedName(TypeNameKind kind)
         {
             return Cache.GetName(kind);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2612,12 +2612,16 @@ public:
     CORINFO_CLASS_HANDLE gtGetStructHandle(GenTree* tree);
     // Get the handle for a ref type.
     CORINFO_CLASS_HANDLE gtGetClassHandle(GenTree* tree, bool* isExact, bool* isNonNull);
+    // Get the class handle for an helper call
+    CORINFO_CLASS_HANDLE gtGetHelperCallClassHandle(GenTreeCall* call, bool* isExact, bool* isNonNull);
     // Get the element handle for an array of ref type.
     CORINFO_CLASS_HANDLE gtGetArrayElementClassHandle(GenTree* array);
     // Get a class handle from a helper call argument
     CORINFO_CLASS_HANDLE gtGetHelperArgClassHandle(GenTree*  array,
                                                    unsigned* runtimeLookupCount = nullptr,
                                                    GenTree** handleTree         = nullptr);
+    // Check if this tree is a gc static base helper call
+    bool gtIsStaticGCBaseHelperCall(GenTree* tree);
 
 //-------------------------------------------------------------------------
 // Functions to display the trees

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -16590,7 +16590,6 @@ CORINFO_CLASS_HANDLE Compiler::gtGetClassHandle(GenTree* tree, bool* isExact, bo
                     case CORINFO_HELP_CHKCASTARRAY:
                     case CORINFO_HELP_CHKCASTINTERFACE:
                     case CORINFO_HELP_CHKCASTCLASS_SPECIAL:
-                    case CORINFO_HELP_READYTORUN_CHKCAST:
                         isCastHelper = true;
                         __fallthrough;
 
@@ -16598,7 +16597,6 @@ CORINFO_CLASS_HANDLE Compiler::gtGetClassHandle(GenTree* tree, bool* isExact, bo
                     case CORINFO_HELP_ISINSTANCEOFARRAY:
                     case CORINFO_HELP_ISINSTANCEOFCLASS:
                     case CORINFO_HELP_ISINSTANCEOFANY:
-                    case CORINFO_HELP_READYTORUN_ISINSTANCEOF:
                     {
                         // Fetch the class handle from the helper call arglist
                         GenTreeArgList*      args    = call->gtCallArgs;

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -16563,6 +16563,116 @@ CORINFO_CLASS_HANDLE Compiler::gtGetClassHandle(GenTree* tree, bool* isExact, bo
                     objClass = sig.retTypeClass;
                 }
             }
+            else if (call->gtCallType == CT_HELPER)
+            {
+                const CorInfoHelpFunc helper       = eeGetHelperNum(call->gtCallMethHnd);
+                bool                  isCastHelper = false;
+
+                switch (helper)
+                {
+                    case CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPE:
+                    case CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPE_MAYBENULL:
+                    {
+                        // Note for some runtimes these helpers return exact types.
+                        //
+                        // But in those cases the types are also sealed, so there's no
+                        // need to claim exactness here.
+                        const bool           helperResultNonNull = (helper == CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPE);
+                        CORINFO_CLASS_HANDLE runtimeType = info.compCompHnd->getBuiltinClass(CLASSID_RUNTIME_TYPE);
+
+                        objClass   = runtimeType;
+                        *isNonNull = helperResultNonNull;
+                        break;
+                    }
+
+                    case CORINFO_HELP_CHKCASTCLASS:
+                    case CORINFO_HELP_CHKCASTANY:
+                    case CORINFO_HELP_CHKCASTARRAY:
+                    case CORINFO_HELP_CHKCASTINTERFACE:
+                    case CORINFO_HELP_CHKCASTCLASS_SPECIAL:
+                    case CORINFO_HELP_READYTORUN_CHKCAST:
+                        isCastHelper = true;
+                        __fallthrough;
+
+                    case CORINFO_HELP_ISINSTANCEOFINTERFACE:
+                    case CORINFO_HELP_ISINSTANCEOFARRAY:
+                    case CORINFO_HELP_ISINSTANCEOFCLASS:
+                    case CORINFO_HELP_ISINSTANCEOFANY:
+                    case CORINFO_HELP_READYTORUN_ISINSTANCEOF:
+                    {
+                        // Fetch the class handle from the helper call arglist
+                        GenTreeArgList*      args    = call->gtCallArgs;
+                        GenTree*             typeArg = args->Current();
+                        CORINFO_CLASS_HANDLE castHnd = gtGetHelperArgClassHandle(typeArg);
+
+                        // We generally assume the type being cast to the best type
+                        // for the result, unless it is an interface type.
+                        //
+                        // Todo: when we have default interface methods then this
+                        // might not be the best assumption.
+                        if (castHnd != nullptr)
+                        {
+                            DWORD attrs = info.compCompHnd->getClassAttribs(castHnd);
+
+                            if ((attrs & CORINFO_FLG_INTERFACE) != 0)
+                            {
+                                castHnd = nullptr;
+                            }
+                        }
+
+                        // If we don't have a good estimate for the type we can use the
+                        // type from the value being cast instead.
+                        if (castHnd == nullptr)
+                        {
+                            GenTree* valueArg = args->Rest()->Current();
+                            castHnd           = gtGetClassHandle(valueArg, isExact, isNonNull);
+                        }
+
+                        // We don't know at jit time if the cast will succeed or fail, but if it
+                        // fails at runtime then an exception is thrown for cast helpers, or the
+                        // result is set null for instance helpers.
+                        //
+                        // So it safe to claim the result has the cast type, and that if we have a
+                        // cast the result is not null.
+                        //
+                        // Note we don't know for sure that it is exactly this type.
+                        if (castHnd != nullptr)
+                        {
+                            objClass   = castHnd;
+                            *isExact   = false;
+                            *isNonNull = isCastHelper;
+                        }
+
+                        break;
+                    }
+
+                    default:
+                        break;
+                }
+            }
+
+            break;
+        }
+
+        case GT_INTRINSIC:
+        {
+            GenTreeIntrinsic* intrinsic = obj->AsIntrinsic();
+
+            switch (intrinsic->gtIntrinsicId)
+            {
+                case CORINFO_INTRINSIC_Object_GetType:
+                {
+                    CORINFO_CLASS_HANDLE runtimeType = info.compCompHnd->getBuiltinClass(CLASSID_RUNTIME_TYPE);
+
+                    objClass   = runtimeType;
+                    *isExact   = false;
+                    *isNonNull = true;
+                    break;
+                }
+
+                default:
+                    break;
+            }
 
             break;
         }
@@ -16606,7 +16716,65 @@ CORINFO_CLASS_HANDLE Compiler::gtGetClassHandle(GenTree* tree, bool* isExact, bo
                     *isExact   = false;
                     *isNonNull = false;
                 }
+                else if (base->OperGet() == GT_ADD)
+                {
+                    // This could be a static field access.
+                    //
+                    // See if op1 is a static field base helper call
+                    // and if so, op2 will have the field info.
+                    GenTree* op1 = base->gtOp.gtOp1;
+                    GenTree* op2 = base->gtOp.gtOp2;
+
+                    bool op1IsStaticFieldBase = false;
+
+                    if (op1->OperGet() == GT_CALL)
+                    {
+                        GenTreeCall* op1Call = op1->AsCall();
+
+                        if (op1Call->gtCallType == CT_HELPER)
+                        {
+                            const CorInfoHelpFunc helper = eeGetHelperNum(op1Call->gtCallMethHnd);
+                            switch (helper)
+                            {
+                                // We are looking for a REF type so only need to check for the GC base helpers
+                                case CORINFO_HELP_GETGENERICS_GCSTATIC_BASE:
+                                case CORINFO_HELP_GETSHARED_GCSTATIC_BASE:
+                                case CORINFO_HELP_GETSHARED_GCSTATIC_BASE_NOCTOR:
+                                case CORINFO_HELP_GETSHARED_GCSTATIC_BASE_DYNAMICCLASS:
+                                case CORINFO_HELP_GETGENERICS_GCTHREADSTATIC_BASE:
+                                case CORINFO_HELP_GETSHARED_GCTHREADSTATIC_BASE:
+                                case CORINFO_HELP_GETSHARED_GCTHREADSTATIC_BASE_NOCTOR:
+                                case CORINFO_HELP_GETSHARED_GCTHREADSTATIC_BASE_DYNAMICCLASS:
+                                    op1IsStaticFieldBase = true;
+                                default:
+                                    break;
+                            }
+                        }
+                    }
+
+                    if (op1IsStaticFieldBase && (op2->OperGet() == GT_CNS_INT))
+                    {
+                        FieldSeqNode* fieldSeq = op2->AsIntCon()->gtFieldSeq;
+
+                        if (fieldSeq != nullptr)
+                        {
+                            while (fieldSeq->m_next != nullptr)
+                            {
+                                fieldSeq = fieldSeq->m_next;
+                            }
+
+                            CORINFO_FIELD_HANDLE fieldHnd     = fieldSeq->m_fieldHnd;
+                            CORINFO_CLASS_HANDLE fieldClass   = nullptr;
+                            CorInfoType          fieldCorType = info.compCompHnd->getFieldType(fieldHnd, &fieldClass);
+                            if (fieldCorType == CORINFO_TYPE_CLASS)
+                            {
+                                objClass = fieldClass;
+                            }
+                        }
+                    }
+                }
             }
+
             break;
         }
 

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -16590,9 +16590,6 @@ CORINFO_CLASS_HANDLE Compiler::gtGetClassHandle(GenTree* tree, bool* isExact, bo
                     case CORINFO_HELP_CHKCASTARRAY:
                     case CORINFO_HELP_CHKCASTINTERFACE:
                     case CORINFO_HELP_CHKCASTCLASS_SPECIAL:
-                        isCastHelper = true;
-                        __fallthrough;
-
                     case CORINFO_HELP_ISINSTANCEOFINTERFACE:
                     case CORINFO_HELP_ISINSTANCEOFARRAY:
                     case CORINFO_HELP_ISINSTANCEOFCLASS:
@@ -16630,15 +16627,11 @@ CORINFO_CLASS_HANDLE Compiler::gtGetClassHandle(GenTree* tree, bool* isExact, bo
                         // fails at runtime then an exception is thrown for cast helpers, or the
                         // result is set null for instance helpers.
                         //
-                        // So it safe to claim the result has the cast type, and that if we have a
-                        // cast the result is not null.
-                        //
+                        // So it safe to claim the result has the cast type.
                         // Note we don't know for sure that it is exactly this type.
                         if (castHnd != nullptr)
                         {
-                            objClass   = castHnd;
-                            *isExact   = false;
-                            *isNonNull = isCastHelper;
+                            objClass = castHnd;
                         }
 
                         break;

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -10098,7 +10098,10 @@ GenTree* Compiler::impCastClassOrIsInstToTree(GenTree*                op1,
     unsigned tmp = lvaGrabTemp(true DEBUGARG("spilling QMark2"));
     impAssignTempGen(tmp, qmarkNull, (unsigned)CHECK_SPILL_NONE);
 
-    // TODO: Is it possible op1 has a better type?
+    // TODO-CQ: Is it possible op1 has a better type?
+    //
+    // See also gtGetHelperCallClassHandle where we make the same
+    // determination for the helper call variants.
     lvaSetClass(tmp, pResolvedToken->hClass);
     return gtNewLclvNode(tmp, TYP_REF);
 #endif


### PR DESCRIPTION
The jit needs to recover class handles in order to devirtualize and do other
type-based optimizations. This change allows the jit to find the type for more
trees: in particular, helper calls, intrinsics, and expanded static field accesses.

Also, annotate a few methods to control jit optimization

We don't want to optimize special methods that are used to inform crossgen
about desirable generic instantiations. `CommonlyUsedGenericInstantiations`
was already annotated but `CommonlyUsedWinRTRedirectedInterfaceStubs` wasn't.

Because `RuntimeType` is sealed calls through types are now often
devirtualized. Name lookups on types are frequent, especially on error paths.
The method `GetCachedName` looks like an attractive inline but simply expands
into a larger sequence of two other calls. So block it from being inlined.


