### PR TITLE
Optimize StackTrace.ToString() generation

### DIFF
--- a/src/System.Private.CoreLib/src/System/Diagnostics/Stacktrace.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Stacktrace.cs
@@ -347,7 +347,7 @@ namespace System.Diagnostics
                     Type declaringType = mb.DeclaringType;
                     string methodName = mb.Name;
                     bool methodChanged = false;
-                    if (declaringType != null && declaringType.IsDefined(typeof(CompilerGeneratedAttribute)))
+                    if (declaringType != null && declaringType.IsDefined(typeof(CompilerGeneratedAttribute), inherit: false))
                     {
                         isAsync = typeof(IAsyncStateMachine).IsAssignableFrom(declaringType);
                         if (isAsync || typeof(IEnumerator).IsAssignableFrom(declaringType))
@@ -502,7 +502,7 @@ namespace System.Diagnostics
 
             foreach (MethodInfo candidateMethod in methods)
             {
-                IEnumerable<StateMachineAttribute> attributes = candidateMethod.GetCustomAttributes<StateMachineAttribute>();
+                IEnumerable<StateMachineAttribute> attributes = candidateMethod.GetCustomAttributes<StateMachineAttribute>(inherit: false);
                 if (attributes == null)
                 {
                     continue;


### PR DESCRIPTION
This is optimizing [`StackTrace.ToString()`](https://github.com/dotnet/coreclr/blob/142e77d60e60442b6f31fcea0f06e0c904140337/src/System.Private.CoreLib/src/System/Diagnostics/Stacktrace.cs#L317) in general. The newer version of `StackTrace` makes async stack traces far more usable, but also introduces overhead due to System.Reflection being...less than awesome.

The code in question is trying to take what is an async stack frame and find the "user" method that goes with it. This happens by checking if the type we're on is decorated with `[CompilerGenerated]` (via `.IsDefined()`) and if so, looping through all methods in the parent class decorated with `[AsyncStateMachine]`, looping at their Type property, and seeing which one we belong with.

With the above info, we know we need not look at parents in the reflection path. This introduces additional overhead in both `.IsDefined()` and `.GetCustomAttributes<T>()` in pretty much every call to them. Since this resolution runs for every stack frame in every exception, so the multiplicative impact is quite large.

#### Details
For `.GetCustomAttributes<T>()`:
This eventually calls down [to `CustomAttribute.GetCustomAttributes()`](https://github.com/dotnet/coreclr/blob/57f8358221a3c4ad7f1608f625bc3c5936618505/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs#L1302). By looking at the short circuit path in: https://github.com/dotnet/coreclr/blob/57f8358221a3c4ad7f1608f625bc3c5936618505/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs#L1315-L1320

We can avoid [the list allocation](https://github.com/dotnet/coreclr/blob/57f8358221a3c4ad7f1608f625bc3c5936618505/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs#L1322), [the array from `.ToArray()`](https://github.com/dotnet/coreclr/blob/57f8358221a3c4ad7f1608f625bc3c5936618505/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs#L1341), and [the resulting combined array](https://github.com/dotnet/coreclr/blob/57f8358221a3c4ad7f1608f625bc3c5936618505/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs#L1340) by not looking for inherited attributed members that cannot exist for our purposes of creating a stack trace.

For `.IsDefined()`:
This eventually calls down [to `CustomAttribute.IsDefined()`](https://github.com/NickCraver/coreclr/blob/5135e9878839f721c0262c4bad03d44e3c612eb1/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs#L1123). We can [also short circuit overhead there](https://github.com/NickCraver/coreclr/blob/5135e9878839f721c0262c4bad03d44e3c612eb1/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs#L1136).

#### Impact
In a test deploy of some .NET Core code for websockets at Stack Overflow, we were throwing a few thousand exceptions *per minute* (not that many) and racked up millions of arrays from these code paths. Here's a quick summary of that memory dump:
![image](https://user-images.githubusercontent.com/454813/47045112-083bc300-d160-11e8-8b25-65ee3b42faf4.png)

Note that Gen 0 is not being cleared correctly (that's a separate issue), but we needn't be allocating these arrays in the first place.

I'll open another PR tomorrow (thanks to @benaadams for digging with me!) where we have a plan to utilize `Array.Empty<T>()` in the reflection miss (no attributes found) path that's another optimization on top of this with quick wins for all reflection consumers.

cc @benaadams @mgravell @deanward81