### PR TITLE
Fix behavior of TextWriter.Write with null StringBuilder

### DIFF
--- a/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
@@ -290,12 +290,11 @@ namespace System.IO
         /// <param name="value">The string (as a StringBuilder) to write to the stream</param>
         public virtual void Write(StringBuilder value)
         {
-            if (value == null)
+            if (value != null)
             {
-                throw new ArgumentNullException(nameof(value));
+                foreach (ReadOnlyMemory<char> chunk in value.GetChunks())
+                    Write(chunk);
             }
-            foreach (ReadOnlyMemory<char> chunk in value.GetChunks())
-                Write(chunk);
         }
 
         // Writes out a formatted string.  Uses the same semantics as


### PR DESCRIPTION
With other overloads (including Write(object)) if you passed null it just wouldn't write anything out, so we shouldn't throw for the StringBuilder overload either.

I thought I'd already fixed this, but apparently I only did the async overloads: https://github.com/dotnet/coreclr/pull/18578.

cc: @JeremyKuhne 