### PR TITLE
Fix duplicate cast in RuntimeMethodInfo.GetCustomAttributes()

### DIFF
--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
@@ -257,7 +257,7 @@ namespace System.Reflection
         #region ICustomAttributeProvider
         public override object[] GetCustomAttributes(bool inherit)
         {
-            return CustomAttribute.GetCustomAttributes(this, typeof(object) as RuntimeType as RuntimeType, inherit);
+            return CustomAttribute.GetCustomAttributes(this, typeof(object) as RuntimeType, inherit);
         }
 
         public override object[] GetCustomAttributes(Type attributeType, bool inherit)


### PR DESCRIPTION
The `as RuntimeType as RuntimeType` cast was redundant here - noticed this when digging into other `Attribute` issues. I couldn't trace how far back this goes due to file moves, but full framework has the same code issue.

cc @benaadams @stephentoub 