### PR TITLE
Use AppContext.BaseDirectory to Search for EventPipeConfig File

### DIFF
--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeController.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeController.cs
@@ -94,7 +94,7 @@ namespace System.Diagnostics.Tracing
         private EventPipeController()
         {
             // Set the config file path.
-            m_configFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, BuildConfigFileName());
+            m_configFilePath = Path.Combine(AppContext.BaseDirectory, BuildConfigFileName());
 
             // Initialize the timer, but don't set it to run.
             // The timer will be set to run each time PollForTracingCommand is called.


### PR DESCRIPTION
Use ```AppContext.BaseDirectory``` instead of ```AppDomain.CurrentDomain.BaseDirectory``` as the search path for the eventpipeconfig file.  This ensures that if it is set, the value for ```APP_CONTEXT_BASE_DIRECTORY``` provided by the host is used.  If not, ```AppContext.BaseDirectory``` will default to ```AppDomain.CurrentDomain.BaseDirectory```.

The dotnet.exe host always specifies ```APP_CONTEXT_BASE_DIRECTORY``` from what I can see.

Fixes #20454.