### PR TITLE
JIT: emit debug info for locals for minopts/tier0

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -10977,6 +10977,14 @@ void Compiler::fgRemoveBlock(BasicBlock* block, bool unreachable)
         /* First update the loop table and bbWeights */
         optUpdateLoopsBeforeRemoveBlock(block, skipUnmarkLoop);
 
+        // Update successor block start IL offset, if empty predecessor
+        // covers the immediately preceding range.
+        if ((block->bbCodeOffsEnd == succBlock->bbCodeOffs) && (block->bbCodeOffs != BAD_IL_OFFSET))
+        {
+            assert(block->bbCodeOffs <= succBlock->bbCodeOffs);
+            succBlock->bbCodeOffs = block->bbCodeOffs;
+        }
+
         /* Remove the block */
 
         if (bPrev == nullptr)

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -456,16 +456,16 @@ void CodeGen::siBeginBlock(BasicBlock* block)
         return;
     }
 
-    if (!compiler->opts.compDbgCode)
+    // If we have tracked locals, use liveness to update the debug state.
+    //
+    // Note: we can improve on this some day -- if there are any tracked
+    // locals, untracked locals will fail to be reported.
+    if (compiler->lvaTrackedCount > 0)
     {
-        /* For non-debuggable code */
-
         // End scope of variables which are not live for this block
-
         siUpdate();
 
         // Check that vars which are live on entry have an open scope
-
         VarSetOps::Iter iter(compiler, block->bbLiveIn);
         unsigned        varIndex = 0;
         while (iter.NextElem(&varIndex))
@@ -484,71 +484,86 @@ void CodeGen::siBeginBlock(BasicBlock* block)
     }
     else
     {
+        // There aren't any tracked locals.
+        //
         // For debuggable code, scopes can begin only on block boundaries.
+        // For other codegen modes (eg minopts/tier0) we report on a best-faith effort.
+        //
         // Check if there are any scopes on the current block's start boundary.
+        VarScopeDsc* varScope = nullptr;
 
-        VarScopeDsc* varScope;
+        // Do some offset sanity checking in debug codegen where things should
+        // be predictably simple.
+        if (compiler->opts.compDbgCode)
+        {
 
 #if FEATURE_EH_FUNCLETS
 
-        // If we find a spot where the code offset isn't what we expect, because
-        // there is a gap, it might be because we've moved the funclets out of
-        // line. Catch up with the enter and exit scopes of the current block.
-        // Ignore the enter/exit scope changes of the missing scopes, which for
-        // funclets must be matched.
-
-        if (siLastEndOffs != beginOffs)
-        {
-            assert(beginOffs > 0);
-            assert(siLastEndOffs < beginOffs);
-
-            JITDUMP("Scope info: found offset hole. lastOffs=%u, currOffs=%u\n", siLastEndOffs, beginOffs);
-
-            // Skip enter scopes
-            while ((varScope = compiler->compGetNextEnterScope(beginOffs - 1, true)) != nullptr)
+            // If we find a spot where the code offset isn't what we expect, because
+            // there is a gap, it might be because we've moved the funclets out of
+            // line. Catch up with the enter and exit scopes of the current block.
+            // Ignore the enter/exit scope changes of the missing scopes, which for
+            // funclets must be matched.
+            if (siLastEndOffs != beginOffs)
             {
-                /* do nothing */
-                JITDUMP("Scope info: skipping enter scope, LVnum=%u\n", varScope->vsdLVnum);
-            }
+                assert(beginOffs > 0);
+                assert(siLastEndOffs < beginOffs);
 
-            // Skip exit scopes
-            while ((varScope = compiler->compGetNextExitScope(beginOffs - 1, true)) != nullptr)
-            {
-                /* do nothing */
-                JITDUMP("Scope info: skipping exit scope, LVnum=%u\n", varScope->vsdLVnum);
+                JITDUMP("Scope info: found offset hole. lastOffs=%u, currOffs=%u\n", siLastEndOffs, beginOffs);
+
+                // Skip enter scopes
+                while ((varScope = compiler->compGetNextEnterScope(beginOffs - 1, true)) != nullptr)
+                {
+                    /* do nothing */
+                    JITDUMP("Scope info: skipping enter scope, LVnum=%u\n", varScope->vsdLVnum);
+                }
+
+                // Skip exit scopes
+                while ((varScope = compiler->compGetNextExitScope(beginOffs - 1, true)) != nullptr)
+                {
+                    /* do nothing */
+                    JITDUMP("Scope info: skipping exit scope, LVnum=%u\n", varScope->vsdLVnum);
+                }
             }
-        }
 
 #else // FEATURE_EH_FUNCLETS
 
-        if (siLastEndOffs != beginOffs)
-        {
-            assert(siLastEndOffs < beginOffs);
-            return;
-        }
+            if (siLastEndOffs != beginOffs)
+            {
+                assert(siLastEndOffs < beginOffs);
+                return;
+            }
 
 #endif // FEATURE_EH_FUNCLETS
+        }
 
         while ((varScope = compiler->compGetNextEnterScope(beginOffs)) != nullptr)
         {
-            // brace-matching editor workaround for following line: (
-            JITDUMP("Scope info: opening scope, LVnum=%u [%03X..%03X)\n", varScope->vsdLVnum, varScope->vsdLifeBeg,
-                    varScope->vsdLifeEnd);
+            LclVarDsc* lclVarDsc1 = &compiler->lvaTable[varScope->vsdVarNum];
 
-            siNewScope(varScope->vsdLVnum, varScope->vsdVarNum);
+            // Only report locals that have a stack slot...
+            if (lclVarDsc1->lvStkOffs != BAD_STK_OFFS)
+            {
+                // brace-matching editor workaround for following line: (
+                JITDUMP("Scope info: opening scope, LVnum=%u [%03X..%03X)\n", varScope->vsdLVnum, varScope->vsdLifeBeg,
+                        varScope->vsdLifeEnd);
+
+                siNewScope(varScope->vsdLVnum, varScope->vsdVarNum);
 
 #ifdef DEBUG
-            LclVarDsc* lclVarDsc1 = &compiler->lvaTable[varScope->vsdVarNum];
-            if (VERBOSE)
-            {
-                printf("Scope info: >> new scope, VarNum=%u, tracked? %s, VarIndex=%u, bbLiveIn=%s ",
-                       varScope->vsdVarNum, lclVarDsc1->lvTracked ? "yes" : "no", lclVarDsc1->lvVarIndex,
-                       VarSetOps::ToString(compiler, block->bbLiveIn));
-                dumpConvertedVarSet(compiler, block->bbLiveIn);
-                printf("\n");
-            }
-            assert(!lclVarDsc1->lvTracked || VarSetOps::IsMember(compiler, block->bbLiveIn, lclVarDsc1->lvVarIndex));
+
+                if (VERBOSE)
+                {
+                    printf("Scope info: >> new scope, VarNum=%u, tracked? %s, VarIndex=%u, bbLiveIn=%s ",
+                           varScope->vsdVarNum, lclVarDsc1->lvTracked ? "yes" : "no", lclVarDsc1->lvVarIndex,
+                           VarSetOps::ToString(compiler, block->bbLiveIn));
+                    dumpConvertedVarSet(compiler, block->bbLiveIn);
+                    printf("\n");
+                }
+                assert(!lclVarDsc1->lvTracked ||
+                       VarSetOps::IsMember(compiler, block->bbLiveIn, lclVarDsc1->lvVarIndex));
 #endif // DEBUG
+            }
         }
     }
 

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -541,9 +541,12 @@ void CodeGen::siBeginBlock(BasicBlock* block)
         {
             LclVarDsc* lclVarDsc1 = &compiler->lvaTable[varScope->vsdVarNum];
 
-            // Only report locals that have a stack slot...
-            if (lclVarDsc1->lvStkOffs != BAD_STK_OFFS)
+            // Only report locals that were referenced
+            if (lclVarDsc1->lvRefCnt() > 0)
             {
+                // If referenced, we expect a valid stack slot.
+                assert(lclVarDsc1->lvStkOffs != BAD_STK_OFFS);
+
                 // brace-matching editor workaround for following line: (
                 JITDUMP("Scope info: opening scope, LVnum=%u [%03X..%03X)\n", varScope->vsdLVnum, varScope->vsdLifeBeg,
                         varScope->vsdLifeEnd);
@@ -551,7 +554,6 @@ void CodeGen::siBeginBlock(BasicBlock* block)
                 siNewScope(varScope->vsdLVnum, varScope->vsdVarNum);
 
 #ifdef DEBUG
-
                 if (VERBOSE)
                 {
                     printf("Scope info: >> new scope, VarNum=%u, tracked? %s, VarIndex=%u, bbLiveIn=%s ",


### PR DESCRIPTION
The jit no longer tracks locals when running at minopts. But untracked
local debug emission was tied to `cmpDebugCode. Change untracked local
debug emission to instead check if there are no tracked locals.

Fixes #20421.

Note we could improve things further in the case where there is a mixture
of tracked and untracked locals. I have opened #20465 for that as my first
attempts here had that ambition but ran into problems.