### PR TITLE
Remove unnecessary interpreter fallback

### DIFF
--- a/src/jit/error.cpp
+++ b/src/jit/error.cpp
@@ -302,18 +302,6 @@ extern "C" void __cdecl assertAbort(const char* why, const char* file, unsigned 
     {
         fatal(CORJIT_SKIPPED);
     }
-#elif defined(_TARGET_ARM64_)
-    // TODO-ARM64-NYI: remove this after the JIT no longer asserts during startup
-    //
-    // When we are bringing up the new Arm64 JIT we set COMPlus_ContinueOnAssert=1
-    // We only want to hit one assert then we will fall back to the interpreter.
-    //
-    bool interpreterFallback = (JitConfig.InterpreterFallback() != 0);
-
-    if (interpreterFallback)
-    {
-        fatal(CORJIT_SKIPPED);
-    }
 #endif
 }
 

--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -28,8 +28,6 @@ CONFIG_INTEGER(DisplayLsraStats, W("JitLsraStats"), 0)       // Display JIT Line
 CONFIG_INTEGER(DumpJittedMethods, W("DumpJittedMethods"), 0) // Prints all jitted methods to the console
 CONFIG_INTEGER(EnablePCRelAddr, W("JitEnablePCRelAddr"), 1)  // Whether absolute addr be encoded as PC-rel offset by
                                                              // RyuJIT where possible
-CONFIG_INTEGER(InterpreterFallback, W("InterpreterFallback"), 0) // Fallback to the interpreter when the JIT compiler
-                                                                 // fails
 CONFIG_INTEGER(JitAssertOnMaxRAPasses, W("JitAssertOnMaxRAPasses"), 0)
 CONFIG_INTEGER(JitBreakEmitOutputInstr, W("JitBreakEmitOutputInstr"), -1)
 CONFIG_INTEGER(JitBreakMorphTree, W("JitBreakMorphTree"), 0xffffffff)


### PR DESCRIPTION
This was added for arm64 bring-up. Remove it, and the associated TODO.

Fixes #19696