### PR TITLE
Fix loop cloning array index recognition for arm64

### DIFF
--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -8410,7 +8410,7 @@ bool Compiler::optExtractArrIndex(GenTree* tree, ArrIndex* result, unsigned lhsN
     {
         return false;
     }
-#ifdef _TARGET_AMD64_ // TODO-ARM64: should this be _TARGET_64BIT_? If not, add comment why not.
+#ifdef _TARGET_64BIT_
     if (index->gtOper != GT_CAST)
     {
         return false;


### PR DESCRIPTION
arm64 Checked PMI altjit frameworks asm diffs:
```
Found 95 files with textual diffs.

Summary:
(Lower is better)

Total bytes of diff: 30144 (0.15% of base)
    diff is a regression.

Top file regressions by size (bytes):
       11772 : System.Private.CoreLib.dasm (2.06% of base)
        1768 : Microsoft.CodeAnalysis.dasm (0.26% of base)
        1764 : System.Private.DataContractSerialization.dasm (0.19% of base)
        1692 : Microsoft.CSharp.dasm (0.49% of base)
        1436 : System.Collections.Immutable.dasm (0.16% of base)

Top file improvements by size (bytes):
         -80 : NuGet.Packaging.dasm (-0.04% of base)
         -28 : xunit.execution.dotnet.dasm (-0.10% of base)
         -24 : Microsoft.Win32.Registry.dasm (-0.10% of base)
         -20 : Microsoft.DotNet.ProjectModel.dasm (-0.01% of base)
          -4 : System.IO.Compression.dasm (-0.01% of base)

39 total files with size differences (6 improved, 33 regressed), 90 unchanged.

Top method regressions by size (bytes):
        5908 (83.87% of base) : System.Private.CoreLib.dasm - System.DefaultBinder:BindToMethod(int,ref,byref,ref,ref,ref,byref):ref:this
         884 (62.96% of base) : Microsoft.CSharp.dasm - Microsoft.CSharp.RuntimeBinder.Errors.ErrorHandling:Error(int,ref):ref
         740 (38.14% of base) : Microsoft.VisualBasic.dasm - Microsoft.VisualBasic.CompilerServices.OverloadResolution:MoreSpecificProcedure(ref,ref,ref,ref,int,byref,bool):ref
         728 (48.02% of base) : System.Private.CoreLib.dasm - System.DefaultBinder:SelectMethod(int,ref,ref,ref):ref:this
         668 (38.84% of base) : System.Private.CoreLib.dasm - System.DefaultBinder:SelectProperty(int,ref,ref,ref,ref):ref:this

Top method improvements by size (bytes):
         -80 (-2.42% of base) : NuGet.Packaging.dasm - <<InstallFromSourceAsync>b__0>d:MoveNext():this
         -40 (-10.10% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Utilities.DirectoryUtilities:Clean(ref):int
         -32 (-5.63% of base) : System.Private.DataContractSerialization.dasm - System.Xml.XmlDictionaryReader:ReadContentAs(ref,ref):ref:this
         -28 (-3.24% of base) : xunit.execution.dotnet.dasm - Xunit.Serialization.XunitSerializationInfo:CanSerializeObject(ref):bool
         -24 (-2.38% of base) : Microsoft.CSharp.dasm - Microsoft.CSharp.RuntimeBinder.SymbolTable:AddConversionsForOneType(ref)

Top method regressions by size (percentage):
         468 (110.38% of base) : System.Data.Common.dasm - System.Data.ConstraintCollection:BaseGroupSwitch(ref,int,ref,int):this
        5908 (83.87% of base) : System.Private.CoreLib.dasm - System.DefaultBinder:BindToMethod(int,ref,byref,ref,ref,ref,byref):ref:this
         480 (82.76% of base) : System.Web.HttpUtility.dasm - System.Web.Util.HttpEncoder:UrlEncodeUnicode(ref):ref
         624 (78.00% of base) : System.Private.CoreLib.dasm - System.DefaultBinder:FindMostSpecific(ref,ref,ref,ref,ref,ref,ref,ref):int
         148 (74.00% of base) : System.Private.Xml.dasm - System.Xml.ValidateNames:ParseNmtokenNoNamespaces(ref,int):int

Top method improvements by size (percentage):
          -4 (-14.29% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableStack`1[Int32][System.Int32]:System.Collections.Immutable.IImmutableStack<T>.Pop():ref:this
         -40 (-10.10% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Utilities.DirectoryUtilities:Clean(ref):int
          -4 (-6.67% of base) : System.Collections.Immutable.dasm - System.Collections.Immutable.ImmutableStack`1[Int32][System.Int32]:Pop(byref):ref:this
         -20 (-6.58% of base) : Microsoft.DotNet.ProjectModel.dasm - Microsoft.DotNet.ProjectModel.Resolution.FrameworkReferenceResolver:GetFrameworkInformation(ref):ref:this
         -32 (-5.63% of base) : System.Private.DataContractSerialization.dasm - System.Xml.XmlDictionaryReader:ReadContentAs(ref,ref):ref:this

180 total methods with size differences (36 improved, 144 regressed), 100761 unchanged.

18 files had text diffs but not size diffs.
System.Resources.Writer.dasm had 171 diffs
System.Security.Permissions.dasm had 76 diffs
System.IO.FileSystem.dasm had 40 diffs
System.IO.IsolatedStorage.dasm had 34 diffs
NuGet.Frameworks.dasm had 26 diffs
```