### PR TITLE
Fix getting the Absolute path while looking up the TZ files (v2.2)

### DIFF
--- a/src/mscorlib/shared/System/TimeZoneInfo.Unix.cs
+++ b/src/mscorlib/shared/System/TimeZoneInfo.Unix.cs
@@ -384,8 +384,8 @@ namespace System
             string symlinkPath = Interop.Sys.ReadLink(tzFilePath);
             if (symlinkPath != null)
             {
-                // Use Path.Combine to resolve links that contain a relative path (e.g. /etc/localtime).
-                symlinkPath = Path.Combine(tzFilePath, symlinkPath);
+                // symlinkPath can be relative path, use Path to get the full absolute path.
+                symlinkPath = Path.GetFullPath(symlinkPath, Path.GetDirectoryName(tzFilePath));
 
                 string timeZoneDirectory = GetTimeZoneDirectory();
                 if (symlinkPath.StartsWith(timeZoneDirectory, StringComparison.Ordinal))


### PR DESCRIPTION
Original commit by @tarekgh 

I got hit by the issue fixed in PR #17711 on .Net Core 2.1 running on CentOS 7.5.

ReadLink returns a relative path and the timezone scan returns `posix/US/Eastern` instead of `America/New_York`. This is an interoperability issue since `posix/US/Eastern` is not a valid tzdb id. For instance, NodaTime will fail its resolution by id and wrongly guess that the TZ is `America/Indiana/Indianapolis` instead of `America/New_York`.

I noticed the fix is only in .Net Core 3.0, would you consider merging it to 2.2? It seems low risk.

CC @eerhardt @JeremyKuhne @jkotas 