### PR TITLE
Fix DevDiv issue with JitStressRegs=0x3 on arm32.

### DIFF
--- a/src/jit/lsrabuild.cpp
+++ b/src/jit/lsrabuild.cpp
@@ -1581,6 +1581,13 @@ void LinearScan::buildRefPositionsForNode(GenTree* tree, BasicBlock* block, Lsra
                 }
             }
         }
+
+        if (tree->OperIsPutArgSplit())
+        {
+            // If it is a putArgSplit then it can have previous PUTARG_REG nodes that can't be split.
+            // It is costly to calculate their exact number so add max here; -1 stands for this PutArgSplit itself.
+            minRegCount += MAX_REG_ARG - 1;
+        }
         for (refPositionMark++; refPositionMark != refPositions.end(); refPositionMark++)
         {
             RefPosition* newRefPosition    = &(*refPositionMark);

--- a/src/jit/lsrabuild.cpp
+++ b/src/jit/lsrabuild.cpp
@@ -1584,8 +1584,9 @@ void LinearScan::buildRefPositionsForNode(GenTree* tree, BasicBlock* block, Lsra
 
         if (tree->OperIsPutArgSplit())
         {
-            // If it is a putArgSplit then it can have previous PUTARG_REG nodes that can't be spilled.
-            // It is costly to calculate their exact number so add max here; -1 stands for this PutArgSplit itself.
+            // While we have attempted to account for any "specialPutArg" defs above, we're only looking at RefPositions
+            // created for this node. We must be defining at least one register in the PutArgSplit, so conservatively
+            // add one less than the maximum number of registers args to 'minRegCount'.
             minRegCount += MAX_REG_ARG - 1;
         }
         for (refPositionMark++; refPositionMark != refPositions.end(); refPositionMark++)

--- a/src/jit/lsrabuild.cpp
+++ b/src/jit/lsrabuild.cpp
@@ -1584,7 +1584,7 @@ void LinearScan::buildRefPositionsForNode(GenTree* tree, BasicBlock* block, Lsra
 
         if (tree->OperIsPutArgSplit())
         {
-            // If it is a putArgSplit then it can have previous PUTARG_REG nodes that can't be split.
+            // If it is a putArgSplit then it can have previous PUTARG_REG nodes that can't be spilled.
             // It is costly to calculate their exact number so add max here; -1 stands for this PutArgSplit itself.
             minRegCount += MAX_REG_ARG - 1;
         }


### PR DESCRIPTION
Fixes DevDiv_707061.

If you have a call with `PUTARG_SPLIT` that is `isSpecialPutArg` then for such tree:
```
                                                  /--*  t512   ref    
               [000631] -------------      t631 = *  PUTARG_REG ref    REG r0
N048 (  3,  2) [000516] -------------      t516 =    LCL_VAR   ref    V01 arg1         u:1 (last use) $81
                                                  /--*  t516   ref    
               [000632] -------------      t632 = *  PUTARG_REG ref    REG r1
N049 (  3,  2) [000520] -------------      t520 =    LCL_VAR   int    V04 loc2         u:2 (last use) $387
                                                  /--*  t520   int    
               [000633] -------------      t633 = *  PUTARG_REG int    REG r2
N050 (  3,  4) [000526] -------------      t526 =    LCL_FLD   int    V22 tmp15        [+0] $261
N051 (  3,  4) [000528] -------------      t528 =    LCL_FLD   int    V22 tmp15        [+4] $262
N052 (  3,  4) [000530] -------------      t530 =    LCL_FLD   int    V22 tmp15        [+8] $263
N053 (  3,  4) [000532] -------------      t532 =    LCL_FLD   int    V22 tmp15        [+12] $264
                                                  /--*  t526   int    
                                                  +--*  t528   int    
                                                  +--*  t530   int    
                                                  +--*  t532   int    
N057 ( 15, 23) [000527] Hc-----------      t527 = *  FIELD_LIST int    int at offset 0 REG NA $3a4
                                                  /--*  t527   int    
               [000634] -------------      t634 = *  PUTARG_SPLIT struct REG r3
N001 (  3,  7) [000635] -------------      t635 =    CNS_INT(h) int    0x73C8064 ftn
                                                  /--*  t631   ref    this in r0
                                                  +--*  t632   ref    arg1 in r1
                                                  +--*  t633   int    arg2 in r2
                                                  +--*  t634   struct arg3 r3 out+00
                                                  +--*  t635   int    control expr
N062 ( 99, 82) [000178] --CXG--------             *  CALL      void
```
we will use r0-r3 for the arguments, r4 and r5 to construct `t528` and `t530` and won't be able to find a register for `t532` because `JitStressRegs=0x3` will limit available registers to `r0-r5`.

The fix is to increase `minRegCount` for `PutArgSplit` to gurantee that we always have enough registers to construct `FIELD_LIST`.