### PR TITLE
Local GC - Fix GCToOSInterface::GetPhysicalMemoryLimit

### DIFF
--- a/src/gc/windows/gcenv.windows.cpp
+++ b/src/gc/windows/gcenv.windows.cpp
@@ -956,12 +956,9 @@ uint64_t GCToOSInterface::GetPhysicalMemoryLimit()
         return restricted_limit;
 
     MEMORYSTATUSEX memStatus;
-    if (::GlobalMemoryStatusEx(&memStatus))
-    {
-        return memStatus.ullTotalPhys;
-    }
-
-    return 0;
+    GetProcessMemoryLoad(&memStatus);
+    assert(memStatus.ullTotalPhys != 0);
+    return memStatus.ullTotalPhys;
 }
 
 // Get memory status

--- a/src/gc/windows/gcenv.windows.cpp
+++ b/src/gc/windows/gcenv.windows.cpp
@@ -935,12 +935,9 @@ uint32_t GCToOSInterface::GetCurrentProcessCpuCount()
 size_t GCToOSInterface::GetVirtualMemoryLimit()
 {
     MEMORYSTATUSEX memStatus;
-    if (::GlobalMemoryStatusEx(&memStatus))
-    {
-        return (size_t)memStatus.ullAvailVirtual;
-    }
-
-    return 0;
+    GetProcessMemoryLoad(&memStatus);
+    assert(memStatus.ullAvailVirtual != 0);
+    return (size_t)memStatus.ullAvailVirtual;
 }
 
 // Get the physical memory that this process can use.


### PR DESCRIPTION
We weren't setting memStatus->dwLength so the call to GlobalMemoryStatusEx would fail and we would return 0. This caused the standalone GC to get in to a state where we wouldn't allocate more memory for the GC heap even if there was plenty available on the machine.