### PR TITLE
Run IBCMerge step for Linux on Windows

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -969,6 +969,8 @@ echo -nopgooptimize: do not use profile guided optimizations.
 echo -enforcepgo: verify after the build that PGO was used for key DLLs, and fail the build if not
 echo -pgoinstrument: generate instrumented code for profile guided optimization enabled binaries.
 echo -ibcinstrument: generate IBC-tuning-enabled native images when invoking crossgen.
+echo -ibcoptimize: use IBC data to optimize System.Private.CoreLib.dll
+echo -ibconly: only run the ibcoptimize step. Assumes an appropriate build already exists
 echo -configureonly: skip all builds; only run CMake ^(default: CMake and builds are run^)
 echo -skipconfigure: skip CMake ^(default: CMake is run^)
 echo -skipmscorlib: skip building System.Private.CoreLib ^(default: System.Private.CoreLib is built^).

--- a/build.sh
+++ b/build.sh
@@ -48,6 +48,7 @@ usage()
     echo "-skipnuget - skip building nuget packages."
     echo "-skiprestoreoptdata - skip restoring optimization data used by profile-based optimizations."
     echo "-skipcrossgen - skip native image generation"
+    echo "-crossgenonly - only run native image generation"
     echo "-verbose - optional argument to enable verbose build output."
     echo "-skiprestore: skip restoring packages ^(default: packages are restored during build^)."
     echo "-disableoss: Disable Open Source Signing for System.Private.CoreLib."
@@ -659,6 +660,7 @@ __SkipCoreCLR=0
 __SkipMSCorLib=0
 __SkipRestoreOptData=0
 __SkipCrossgen=0
+__CrossgenOnly=0
 __SkipTests=0
 __CrossBuild=0
 __ClangMajorVersion=0
@@ -858,6 +860,12 @@ while :; do
             __SkipCrossgen=1
             ;;
 
+        crossgenonly|-crossgenonly)
+            __SkipMSCorLib=1
+            __SkipCoreCLR=1
+            __CrossgenOnly=1
+            ;;
+
         skiptests|-skiptests)
             __SkipTests=1
             ;;
@@ -1044,6 +1052,10 @@ fi
 # Build System.Private.CoreLib.
 
 build_CoreLib
+
+if [[ $__CrossgenOnly ==1]]; then
+    build_CoreLib_ni "$__BinDir/crossgen"
+fi
 
 # Generate nuget packages
 if [ $__SkipNuget != 1 ]; then

--- a/build.sh
+++ b/build.sh
@@ -529,7 +529,7 @@ generate_NugetPackages()
     fi
 
     # Since we can build mscorlib for this OS, did we build the native components as well?
-    if [ $__SkipCoreCLR == 1 ]; then
+    if [[ $__SkipCoreCLR == 1 && $__CrossgenOnly == 0 ]]; then
         echo "Unable to generate nuget packages since native components were not built."
         return
     fi

--- a/build.sh
+++ b/build.sh
@@ -49,6 +49,7 @@ usage()
     echo "-skiprestoreoptdata - skip restoring optimization data used by profile-based optimizations."
     echo "-skipcrossgen - skip native image generation"
     echo "-crossgenonly - only run native image generation"
+    echo "-partialngen - build CoreLib as PartialNGen"
     echo "-verbose - optional argument to enable verbose build output."
     echo "-skiprestore: skip restoring packages ^(default: packages are restored during build^)."
     echo "-disableoss: Disable Open Source Signing for System.Private.CoreLib."
@@ -429,6 +430,10 @@ build_CoreLib_ni()
 {
     local __CrossGenExec=$1
 
+    if [ $__PartialNgen == 1 ]; then
+        export COMPlus_PartialNGen=1
+    fi
+
     if [ -e $__CrossGenCoreLibLog ]; then
         rm $__CrossGenCoreLibLog
     fi
@@ -661,6 +666,7 @@ __SkipMSCorLib=0
 __SkipRestoreOptData=0
 __SkipCrossgen=0
 __CrossgenOnly=0
+__PartialNgen=0
 __SkipTests=0
 __CrossBuild=0
 __ClangMajorVersion=0
@@ -865,6 +871,9 @@ while :; do
             __SkipCoreCLR=1
             __CrossgenOnly=1
             ;;
+        partialngen|-partialngen)
+            __PartialNgen=1
+            ;;
 
         skiptests|-skiptests)
             __SkipTests=1
@@ -1053,7 +1062,7 @@ fi
 
 build_CoreLib
 
-if [[ $__CrossgenOnly ==1]]; then
+if [ $__CrossgenOnly ==1 ]; then
     build_CoreLib_ni "$__BinDir/crossgen"
 fi
 

--- a/dependencies.props
+++ b/dependencies.props
@@ -39,7 +39,7 @@
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>3.0.0-preview1-27011-04</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <MicrosoftNETCoreAppPackageVersion>3.0.0-preview1-27011-01</MicrosoftNETCoreAppPackageVersion>
     <XunitPackageVersion>2.4.0-beta.2.build4010</XunitPackageVersion>
-    <IbcDataPackageVersion>99.99.99-master-20181008-0042</IbcDataPackageVersion>
+    <IbcDataPackageVersion>99.99.99-master-20181019-1034</IbcDataPackageVersion>
     <IbcMergePackageVersion>4.6.0-alpha-00001</IbcMergePackageVersion>
     <XunitPerformanceApiPackageVersion>1.0.0-beta-build0015</XunitPerformanceApiPackageVersion>
     <MicrosoftDiagnosticsTracingTraceEventPackageVersion>2.0.4</MicrosoftDiagnosticsTracingTraceEventPackageVersion>

--- a/dependencies.props
+++ b/dependencies.props
@@ -39,7 +39,7 @@
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>3.0.0-preview1-27011-04</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <MicrosoftNETCoreAppPackageVersion>3.0.0-preview1-27011-01</MicrosoftNETCoreAppPackageVersion>
     <XunitPackageVersion>2.4.0-beta.2.build4010</XunitPackageVersion>
-    <IbcDataPackageVersion>99.99.99-master-20181019-1034</IbcDataPackageVersion>
+    <IbcDataPackageVersion>99.99.99-master-20181008-0042</IbcDataPackageVersion>
     <IbcMergePackageVersion>4.6.0-alpha-00001</IbcMergePackageVersion>
     <XunitPerformanceApiPackageVersion>1.0.0-beta-build0015</XunitPerformanceApiPackageVersion>
     <MicrosoftDiagnosticsTracingTraceEventPackageVersion>2.0.4</MicrosoftDiagnosticsTracingTraceEventPackageVersion>


### PR DESCRIPTION
This change does the following:

* Move the IBCOptimize step out of the Crossgen section and into the CoreLib build section of build.cmd
* Adds -ibconly which will skip building System.Private.CoreLib and only run the ibcmerge step
* Adds crossgenonly and partialngen flags to build.sh

These three changes facilitate our ability to apply IBC data to Linux assemblies on Windows and the perform the crossgen step on Linux, which will be our flow for official builds when we want to apply IBC data since IBCMerge cannot run on non-Windows platforms