### PR TITLE
Allow ArrayPool.Shared devirtualization

### DIFF
--- a/src/System.Private.CoreLib/shared/Internal/Win32/RegistryKey.cs
+++ b/src/System.Private.CoreLib/shared/Internal/Win32/RegistryKey.cs
@@ -112,7 +112,10 @@ namespace Internal.Win32
         public string[] GetSubKeyNames()
         {
             var names = new List<string>();
-            char[] name = ArrayPool<char>.Shared.Rent(MaxKeyLength + 1);
+            // Use simple variable to call ArrayPool.Shared.Rent to allow devirtualization
+            // https://github.com/dotnet/coreclr/issues/15783
+            int length = MaxKeyLength + 1;
+            char[] name = ArrayPool<char>.Shared.Rent(length);
 
             try
             {
@@ -192,7 +195,10 @@ namespace Internal.Win32
                                 int oldLength = oldName.Length;
                                 name = null;
                                 ArrayPool<char>.Shared.Return(oldName);
-                                name = ArrayPool<char>.Shared.Rent(checked(oldLength * 2));
+                                // Use simple variables to call ArrayPool.Shared.Rent to allow devirtualization
+                                // https://github.com/dotnet/coreclr/issues/15783
+                                int length = checked(oldLength * 2);
+                                name = ArrayPool<char>.Shared.Rent(length);
                             }
                             break;
                         default:

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/ValueListBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/ValueListBuilder.cs
@@ -69,7 +69,10 @@ namespace System.Collections.Generic
 
         private void Grow()
         {
-            T[] array = ArrayPool<T>.Shared.Rent(_span.Length * 2);
+            // Use simple variable to call ArrayPool.Shared.Rent to allow devirtualization
+            // https://github.com/dotnet/coreclr/issues/15783
+            int length = _span.Length * 2;
+            T[] array = ArrayPool<T>.Shared.Rent(length);
 
             bool success = _span.TryCopyTo(array);
             Debug.Assert(success);

--- a/src/System.Private.CoreLib/shared/System/IO/BinaryWriter.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/BinaryWriter.cs
@@ -398,11 +398,14 @@ namespace System.IO
             }
             else
             {
-                byte[] array = ArrayPool<byte>.Shared.Rent(buffer.Length);
+                // Use simple variable to call ArrayPool.Shared.Rent to allow devirtualization
+                // https://github.com/dotnet/coreclr/issues/15783
+                int length = buffer.Length;
+                byte[] array = ArrayPool<byte>.Shared.Rent(length);
                 try
                 {
                     buffer.CopyTo(array);
-                    Write(array, 0, buffer.Length);
+                    Write(array, 0, length);
                 }
                 finally
                 {
@@ -413,7 +416,10 @@ namespace System.IO
 
         public virtual void Write(ReadOnlySpan<char> chars)
         {
-            byte[] bytes = ArrayPool<byte>.Shared.Rent(_encoding.GetMaxByteCount(chars.Length));
+            // Use simple variable to call ArrayPool.Shared.Rent to allow devirtualization
+            // https://github.com/dotnet/coreclr/issues/15783
+            int length = _encoding.GetMaxByteCount(chars.Length);
+            byte[] bytes = ArrayPool<byte>.Shared.Rent(length);
             try
             {
                 int bytesWritten = _encoding.GetBytes(chars, bytes);

--- a/src/System.Private.CoreLib/shared/System/IO/TextReader.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/TextReader.cs
@@ -104,12 +104,15 @@ namespace System.IO
         //
         public virtual int Read(Span<char> buffer)
         {
-            char[] array = ArrayPool<char>.Shared.Rent(buffer.Length);
+            // Use simple variable to call ArrayPool.Shared.Rent to allow devirtualization
+            // https://github.com/dotnet/coreclr/issues/15783
+            int length = buffer.Length;
+            char[] array = ArrayPool<char>.Shared.Rent(length);
 
             try
             {
-                int numRead = Read(array, 0, buffer.Length);
-                if ((uint)numRead > buffer.Length)
+                int numRead = Read(array, 0, length);
+                if ((uint)numRead > (uint)length)
                 {
                     throw new IOException(SR.IO_InvalidReadLength);
                 }
@@ -154,12 +157,15 @@ namespace System.IO
         //
         public virtual int ReadBlock(Span<char> buffer)
         {
-            char[] array = ArrayPool<char>.Shared.Rent(buffer.Length);
+            // Use simple variable to call ArrayPool.Shared.Rent to allow devirtualization
+            // https://github.com/dotnet/coreclr/issues/15783
+            int length = buffer.Length;
+            char[] array = ArrayPool<char>.Shared.Rent(length);
 
             try
             {
-                int numRead = ReadBlock(array, 0, buffer.Length);
-                if ((uint)numRead > buffer.Length)
+                int numRead = ReadBlock(array, 0, length);
+                if ((uint)numRead > (uint)length)
                 {
                     throw new IOException(SR.IO_InvalidReadLength);
                 }

--- a/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
@@ -170,12 +170,15 @@ namespace System.IO
         //
         public virtual void Write(ReadOnlySpan<char> buffer)
         {
-            char[] array = ArrayPool<char>.Shared.Rent(buffer.Length);
+            // Use simple variable to call ArrayPool.Shared.Rent to allow devirtualization
+            // https://github.com/dotnet/coreclr/issues/15783
+            int length = buffer.Length;
+            char[] array = ArrayPool<char>.Shared.Rent(length);
 
             try
             {
                 buffer.CopyTo(new Span<char>(array));
-                Write(array, 0, buffer.Length);
+                Write(array, 0, length);
             }
             finally
             {
@@ -366,12 +369,15 @@ namespace System.IO
 
         public virtual void WriteLine(ReadOnlySpan<char> buffer)
         {
-            char[] array = ArrayPool<char>.Shared.Rent(buffer.Length);
+            // Use simple variable to call ArrayPool.Shared.Rent to allow devirtualization
+            // https://github.com/dotnet/coreclr/issues/15783
+            int length = buffer.Length;
+            char[] array = ArrayPool<char>.Shared.Rent(length);
 
             try
             {
                 buffer.CopyTo(new Span<char>(array));
-                WriteLine(array, 0, buffer.Length);
+                WriteLine(array, 0, length);
             }
             finally
             {

--- a/src/System.Private.CoreLib/shared/System/Text/ValueStringBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/ValueStringBuilder.cs
@@ -264,7 +264,10 @@ namespace System.Text
         {
             Debug.Assert(requiredAdditionalCapacity > 0);
 
-            char[] poolArray = ArrayPool<char>.Shared.Rent(Math.Max(_pos + requiredAdditionalCapacity, _chars.Length * 2));
+            // Use simple variable to call ArrayPool.Shared.Rent to allow devirtualization
+            // https://github.com/dotnet/coreclr/issues/15783
+            int length = Math.Max(_pos + requiredAdditionalCapacity, _chars.Length * 2);
+            char[] poolArray = ArrayPool<char>.Shared.Rent(length);
 
             _chars.CopyTo(poolArray);
 


### PR DESCRIPTION
Follow up to https://github.com/dotnet/coreclr/pull/15743

Pre
* No devirtualization

Commit 1 (crossgen coreclr)
* 10x `Devirtualized virtual call to ArrayPool'1:Rent; now direct call to TlsOverPerCoreLockedStacksArrayPool'1:Rent [final class]`
* 32x `Devirtualized virtual call to ArrayPool'1:Return; now direct call to TlsOverPerCoreLockedStacksArrayPool'1:Return [final class]`

Commit 2 (crossgen coreclr)
* 21x `Devirtualized virtual call to ArrayPool'1:Rent; now direct call to TlsOverPerCoreLockedStacksArrayPool'1:Rent [final class]`
* 32x `Devirtualized virtual call to ArrayPool'1:Return; now direct call to TlsOverPerCoreLockedStacksArrayPool'1:Return [final class]`

@stephentoub @jkotas @AndyAyersMS  PTAL