### PR TITLE
JIT: improve simplification of IND(ADDR(x))

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -13118,6 +13118,12 @@ DONE_MORPHING_CHILDREN:
                         tree->gtType = typ = temp->TypeGet();
                         foldAndReturnTemp  = true;
                     }
+                    else if (!varTypeIsStruct(typ) && (lvaTable[lclNum].lvType == typ) &&
+                             !lvaTable[lclNum].lvNormalizeOnLoad())
+                    {
+                        tree->gtType = typ = temp->TypeGet();
+                        foldAndReturnTemp  = true;
+                    }
                     else
                     {
                         // Assumes that when Lookup returns "false" it will leave "fieldSeq" unmodified (i.e.


### PR DESCRIPTION
Some `IND(ADDR(x))` trees were not being optimized to `x` by morph,
particularly when `x` was the promoted pointer field of a `Span`.
Instead they were creating local fields that blocked enregistration
and lead to store-load pairs like:

```asm
       mov      bword ptr [rsp+20H], rax
       mov      rax, bword ptr [rsp+20H]
```

Add logic to `fgMorphSmpOp`'s `GT_IND` clause to recognize and simplify
these cases.