### PR TITLE
Avoid implicit long casts in uint compares

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Guid.cs
+++ b/src/System.Private.CoreLib/shared/System/Guid.cs
@@ -601,7 +601,7 @@ namespace System
             }
 
             // Check for '{'
-            if ((uint)guidString.Length <= numStart + numLen + 1 || guidString[numStart + numLen + 1] != '{')
+            if ((uint)guidString.Length <= (uint)(numStart + numLen + 1) || guidString[numStart + numLen + 1] != '{')
             {
                 result.SetFailure(overflow: false, nameof(SR.Format_GuidBrace));
                 return false;

--- a/src/System.Private.CoreLib/shared/System/IO/Stream.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/Stream.cs
@@ -727,7 +727,7 @@ namespace System.IO
             try
             {
                 int numRead = Read(sharedBuffer, 0, buffer.Length);
-                if ((uint)numRead > buffer.Length)
+                if ((uint)numRead > (uint)buffer.Length)
                 {
                     throw new IOException(SR.IO_StreamTooLong);
                 }

--- a/src/System.Private.CoreLib/shared/System/IO/TextReader.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/TextReader.cs
@@ -109,7 +109,7 @@ namespace System.IO
             try
             {
                 int numRead = Read(array, 0, buffer.Length);
-                if ((uint)numRead > buffer.Length)
+                if ((uint)numRead > (uint)buffer.Length)
                 {
                     throw new IOException(SR.IO_InvalidReadLength);
                 }
@@ -159,7 +159,7 @@ namespace System.IO
             try
             {
                 int numRead = ReadBlock(array, 0, buffer.Length);
-                if ((uint)numRead > buffer.Length)
+                if ((uint)numRead > (uint)buffer.Length)
                 {
                     throw new IOException(SR.IO_InvalidReadLength);
                 }

--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.cs
@@ -910,7 +910,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Span<T> AsSpan<T>(this ArraySegment<T> segment, int start)
         {
-            if (((uint)start) > segment.Count)
+            if (((uint)start) > (uint)segment.Count)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 
             return new Span<T>(segment.Array, segment.Offset + start, segment.Count - start);
@@ -931,9 +931,9 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Span<T> AsSpan<T>(this ArraySegment<T> segment, int start, int length)
         {
-            if (((uint)start) > segment.Count)
+            if (((uint)start) > (uint)segment.Count)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
-            if (((uint)length) > segment.Count - start)
+            if (((uint)length) > (uint)(segment.Count - start))
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
 
             return new Span<T>(segment.Array, segment.Offset + start, length);
@@ -989,7 +989,7 @@ namespace System
         /// </exception>
         public static Memory<T> AsMemory<T>(this ArraySegment<T> segment, int start)
         {
-            if (((uint)start) > segment.Count)
+            if (((uint)start) > (uint)segment.Count)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 
             return new Memory<T>(segment.Array, segment.Offset + start, segment.Count - start);
@@ -1009,9 +1009,9 @@ namespace System
         /// </exception>
         public static Memory<T> AsMemory<T>(this ArraySegment<T> segment, int start, int length)
         {
-            if (((uint)start) > segment.Count)
+            if (((uint)start) > (uint)segment.Count)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
-            if (((uint)length) > segment.Count - start)
+            if (((uint)length) > (uint)(segment.Count - start))
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
 
             return new Memory<T>(segment.Array, segment.Offset + start, length);


### PR DESCRIPTION
A comparison like `(uint)intVar0 <= intVar1` adds implicit casts to long and becomes 
`(long)(uint)intVar0 <= (long)intVar1` adding the second `uint` cast avoids this.

/cc @jkotas 