### PR TITLE
Disable stale Unix_NonExistentPath_Nop corefx test

### DIFF
--- a/tests/CoreFX/CoreFX.issues.json
+++ b/tests/CoreFX/CoreFX.issues.json
@@ -279,6 +279,10 @@
                 {
                     "name": "System.IO.Tests.EncryptDecrypt.NullArg_ThrowsException",
                     "reason": "outdated"
+                },
+                {
+                    "name": "System.IO.Tests.File_Delete.Unix_NonExistentPath_Nop",
+                    "reason": "outdated (deleted from corefx)"
                 }
             ]
         }


### PR DESCRIPTION
Closes https://github.com/dotnet/coreclr/issues/20507