### PR TITLE
[2.2] Disable tiered compilation by default for 2.2 RTM

### DIFF
--- a/Documentation/project-docs/clr-configuration-knobs.md
+++ b/Documentation/project-docs/clr-configuration-knobs.md
@@ -770,7 +770,7 @@ Name | Description | Type | Class | Default Value | Flags
 
 Name | Description | Type | Class | Default Value | Flags 
 -----|-------------|------|-------|---------------|-------
-`TieredCompilation` | Enables tiered compilation | `DWORD` | `EXTERNAL` | `1` | 
+`TieredCompilation` | Enables tiered compilation | `DWORD` | `EXTERNAL` | `0` | 
 `TieredCompilation_Test_CallCounting` | Enabled by default (only activates when TieredCompilation is also enabled). If disabled immediately backpatches prestub, and likely prevents any tier1 promotion | `DWORD` | `UNSUPPORTED` | `1` | 
 `TieredCompilation_Test_OptimizeTier0` | Use optimized codegen (normally used by tier1) in tier0 | `DWORD` | `UNSUPPORTED` | `0` | 
 `TieredCompilation_Tier1CallCountingDelayMs` | Delay in milliseconds since process startup or the last tier 0 JIT before call counting begins for tier 1 promotion. | `DWORD` | `UNSUPPORTED` | `100` | 

--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -650,11 +650,7 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_HillClimbing_GainExponent,                    
 /// Tiered Compilation
 ///
 #ifdef FEATURE_TIERED_COMPILATION
-#ifdef _TARGET_ARM64_
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_TieredCompilation, W("TieredCompilation"), 0, "Enables tiered compilation")
-#else // !_TARGET_ARM64_
-RETAIL_CONFIG_DWORD_INFO(EXTERNAL_TieredCompilation, W("TieredCompilation"), 1, "Enables tiered compilation")
-#endif // _TARGET_ARM64_
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_TieredCompilation_Tier1CallCountThreshold, W("TieredCompilation_Tier1CallCountThreshold"), 30, "Number of times a method must be called after which it is promoted to tier 1.")
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_TieredCompilation_Tier1CallCountingDelayMs, W("TieredCompilation_Tier1CallCountingDelayMs"), 100, "A perpetual delay in milliseconds that is applied to tier 1 call counting and jitting, while there is tier 0 activity.")
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_TieredCompilation_Tier1DelaySingleProcMultiplier, W("TieredCompilation_Tier1DelaySingleProcMultiplier"), 10, "Multiplier for TieredCompilation_Tier1CallCountingDelayMs that is applied on a single-processor machine or when the process is affinitized to a single processor.")

--- a/tests/scripts/run-xunit-perf.py
+++ b/tests/scripts/run-xunit-perf.py
@@ -460,6 +460,8 @@ def main(args):
         myEnv['COMPlus_TieredCompilation'] = '0'
     elif optLevel == 'full_opt':
         myEnv['COMPlus_TieredCompilation'] = '0'
+    elif optLevel == 'tiered':
+        myEnv['COMPLUS_TieredCompilation'] = '1'
 
     if not 'XUNIT_PERFORMANCE_MAX_ITERATION' in myEnv:
         myEnv['XUNIT_PERFORMANCE_MAX_ITERATION'] = '21'

--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -89,9 +89,9 @@ then
   echo "SKIPPING EXECUTION BECAUSE ONE OR MORE OF (COMPlus_JitStress, COMPlus_JitStressRegs, COMPlus_JITMinOpts, COMPlus_TailcallStress) IS SET"
   exit $(GCBashScriptExitCode)
 fi
-if [[ "$COMPlus_TieredCompilation" != "0" ]]
+if [[ "$COMPlus_TieredCompilation" != "" && "$COMPlus_TieredCompilation" != "0" ]]
 then
-  echo "SKIPPING EXECUTION BECAUSE COMPlus_TieredCompilation has not been disabled and this test is marked JitOptimizationSensitive"
+  echo "SKIPPING EXECUTION BECAUSE COMPlus_TieredCompilation has been enabled and this test is marked JitOptimizationSensitive"
   exit $(GCBashScriptExitCode)
 fi
       ]]></BashCLRTestEnvironmentCompatibilityCheck>

--- a/tests/src/CLRTest.Execute.Batch.targets
+++ b/tests/src/CLRTest.Execute.Batch.targets
@@ -79,13 +79,14 @@ IF NOT "%COMPlus_GCStress%"=="" (
       <BatchCLRTestEnvironmentCompatibilityCheck Condition="'$(JitOptimizationSensitive)' == 'true'">
     <![CDATA[
 $(BatchCLRTestEnvironmentCompatibilityCheck)
-IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_JITMinOpts%"=="" IF "%COMPlus_TailcallStress%"=="" IF "%COMPlus_TieredCompilation%"=="" goto :Compatible1
-  ECHO SKIPPING EXECUTION BECAUSE ONE OR MORE OF (COMPlus_JitStress, COMPlus_JitStressRegs, COMPlus_JITMinOpts, COMPlus_TailcallStress, COMPlus_TieredCompilation) IS SET
+IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_JITMinOpts%"=="" IF "%COMPlus_TailcallStress%"=="" goto :Compatible1
+  ECHO SKIPPING EXECUTION BECAUSE ONE OR MORE OF (COMPlus_JitStress, COMPlus_JitStressRegs, COMPlus_JITMinOpts, COMPlus_TailcallStress) IS SET
   popd
   Exit /b 0
 :Compatible1
+IF "%COMPlus_TieredCompilation%"=="" goto :Compatible2
 IF "%COMPlus_TieredCompilation%"=="0" goto :Compatible2
-  ECHO SKIPPING EXECUTION BECAUSE COMPlus_TieredCompilation has not been disabled and this test is marked JitOptimizationSensitive
+  ECHO SKIPPING EXECUTION BECAUSE COMPlus_TieredCompilation has been enabled and this test is marked JitOptimizationSensitive
   popd
   Exit /b 0
 :Compatible2

--- a/tests/src/performance/Scenario/JitBench/Runner/BenchmarkConfiguration.cs
+++ b/tests/src/performance/Scenario/JitBench/Runner/BenchmarkConfiguration.cs
@@ -16,9 +16,9 @@ namespace JitBench
         public string Name { get; set; }
         public Dictionary<string, string> EnvironmentVariables { get; private set; }
 
-        public BenchmarkConfiguration WithoutTiering()
+        public BenchmarkConfiguration WithTiering()
         {
-            return WithModifier("NoTiering", "COMPlus_TieredCompilation", "0");
+            return WithModifier("Tiering", "COMPlus_TieredCompilation", "1");
         }
 
         public BenchmarkConfiguration WithMinOpts()

--- a/tests/src/performance/Scenario/JitBench/Runner/Program.cs
+++ b/tests/src/performance/Scenario/JitBench/Runner/Program.cs
@@ -168,9 +168,9 @@ namespace JitBench
             string r2rEnv = Environment.GetEnvironmentVariable("COMPlus_ReadyToRun");
             string noNgenEnv = Environment.GetEnvironmentVariable("COMPlus_ZapDisable");
             BenchmarkConfiguration envConfig = new BenchmarkConfiguration();
-            if(tieredEnv != null && tieredEnv == "0")
+            if(tieredEnv != null && tieredEnv != "0")
             {
-                envConfig.WithoutTiering();
+                envConfig.WithTiering();
             }
             if (minoptsEnv != null && minoptsEnv != "0")
             {
@@ -196,25 +196,12 @@ namespace JitBench
                 yield break;
             }
 
-            // The minopts config name by itself implies without tiering
-            var minOptsConfig = new BenchmarkConfiguration().WithMinOpts();
-            string minOptsConfigName = minOptsConfig.Name;
-            minOptsConfig = minOptsConfig.WithoutTiering();
-            minOptsConfig.Name = minOptsConfigName;
-
             BenchmarkConfiguration[] possibleConfigs = new BenchmarkConfiguration[]
             {
-                new BenchmarkConfiguration(),
-                new BenchmarkConfiguration().WithoutTiering(),
-                minOptsConfig,
-                new BenchmarkConfiguration().WithMinOpts().WithoutTiering(),
-                new BenchmarkConfiguration().WithoutTiering().WithMinOpts(),
+                new BenchmarkConfiguration().WithTiering(),
+                new BenchmarkConfiguration().WithMinOpts(),
                 new BenchmarkConfiguration().WithNoR2R(),
-                new BenchmarkConfiguration().WithNoR2R().WithoutTiering(),
-                new BenchmarkConfiguration().WithoutTiering().WithNoR2R(),
-                new BenchmarkConfiguration().WithNoNgen(),
-                new BenchmarkConfiguration().WithNoNgen().WithoutTiering(),
-                new BenchmarkConfiguration().WithoutTiering().WithNoNgen()
+                new BenchmarkConfiguration().WithNoNgen()
             };
             foreach(string configName in configNames)
             {


### PR DESCRIPTION
#### Description

A fix for https://github.com/dotnet/coreclr/issues/19752 appears to be desired before enabling tiered compilation by default for 2.2. Some small steady-state performance regressions (~5%) have been seen in TechEmpower benchmarks running without the R2R (TechEmpower runs benchmarks on aspnetcore with `COMPlus_ReadyToRun=0`). In default mode, where R2R is enabled and the aspnetcore shared framework is used, tiered compilation typically improves steady-state performance. The fix is not too small and involves some risk that does not appear to be appropriate for 2.2, so this change disables tiered compilation by default for 2.2 RTM.

#### Customer impact

- Eliminates regressions from tiered compilation
- Improvements from tiered compilation being enabled would be lost by default. Customers may still choose to enable tiered compilation.

#### Regression?

No

#### Packaging reviewed?

Yes, no impact (coreclr only)

#### Risk

Low, CI has also been testing with tiered compilation disabled