### PR TITLE
Add missing methods info to CoreFX.issues.json

### DIFF
--- a/tests/CoreFX/CoreFX.issues.json
+++ b/tests/CoreFX/CoreFX.issues.json
@@ -562,7 +562,8 @@
                     "name" : "System.Diagnostics.Tests.DebugTests",
                     "reason" : "refactoring Debug"
                 }
-            ]
+            ],
+            "methods": null
         }
     }
 ]


### PR DESCRIPTION
CoreFX exclusion json is failing validation: see #20447.