### PR TITLE
Add test coverage for custom modifiers

### DIFF
--- a/tests/src/reflection/Modifiers/modifiers.cs
+++ b/tests/src/reflection/Modifiers/modifiers.cs
@@ -1,0 +1,152 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+
+class Program
+{
+    static int Main()
+    {
+        var baseClass = new BaseClass();
+        var derivedClass = new DerivedClass();
+        var superDerivedClass = new SuperDerivedClass();
+
+        //
+        // C# will generate a call to the unmodified version of the method so this is easy to check statically
+        //
+
+        if (baseClass.Override(0) != 3)
+            return 1;
+
+        if (derivedClass.Override(0) != 103)
+            return 2;
+
+        if (superDerivedClass.Override(0) != 203)
+            return 3;
+
+        //
+        // Reflection-locate rest of the `Override` method overloads
+        //
+
+        MethodInfo paramModoptFoo = null;
+        MethodInfo paramModoptBar = null;
+        MethodInfo paramModreqFoo = null;
+        MethodInfo paramUnmodified = null;
+        MethodInfo returnModoptFoo = null;
+        MethodInfo arrayModopt1 = null;
+        MethodInfo arrayModopt2 = null;
+        foreach (var method in typeof(BaseClass).GetTypeInfo().DeclaredMethods)
+        {
+            ParameterInfo param = method.GetParameters()[0];
+            Type[] paramRequiredModifiers = param.GetRequiredCustomModifiers();
+            Type[] paramOptionalModifiers = param.GetOptionalCustomModifiers();
+
+            ParameterInfo retParam = method.ReturnParameter;
+            Type[] retParamOptionalModifiers = retParam.GetOptionalCustomModifiers();
+
+            if (param.ParameterType != typeof(int) && param.ParameterType != typeof(int[]))
+                throw new Exception();
+
+            if (paramRequiredModifiers.Length > 0)
+            {
+                if (paramRequiredModifiers.Length > 1 || paramRequiredModifiers[0] != typeof(FooModifier))
+                    throw new Exception();
+                else
+                    paramModreqFoo = method;
+            }
+            else if (paramOptionalModifiers.Length > 0)
+            {
+                if (paramOptionalModifiers.Length > 1)
+                    throw new Exception();
+                else if (paramOptionalModifiers[0] == typeof(FooModifier))
+                    paramModoptFoo = method;
+                else if (paramOptionalModifiers[0] == typeof(BarModifier))
+                    paramModoptBar = method;
+                else
+                    throw new Exception();
+            }
+            else if (retParamOptionalModifiers.Length > 0)
+            {
+                if (retParamOptionalModifiers.Length > 1 || retParamOptionalModifiers[0] != typeof(FooModifier))
+                    throw new Exception();
+                else
+                    returnModoptFoo = method;
+            }
+            else
+            {
+                if (param.ParameterType == typeof(int))
+                    paramUnmodified = method;
+                else if (param.ParameterType == typeof(int[]))
+                {
+                    // Reflection can't distinguish between the two overloads
+
+                    if (arrayModopt1 == null)
+                        arrayModopt1 = method;
+                    else if (arrayModopt2 == null)
+                        arrayModopt2 = method;
+                    else
+                        throw new Exception();
+                }
+                else
+                    throw new Exception();
+            }
+        }
+
+        if ((int)paramModoptFoo.Invoke(baseClass, new object[] { 0 }) != 0)
+            return 101;
+        if ((int)paramModoptBar.Invoke(baseClass, new object[] { 0 }) != 1)
+            return 102;
+        if ((int)paramModreqFoo.Invoke(baseClass, new object[] { 0 }) != 2)
+            return 103;
+        if ((int)paramUnmodified.Invoke(baseClass, new object[] { 0 }) != 3)
+            return 104;
+        if ((int)returnModoptFoo.Invoke(baseClass, new object[] { 0 }) != 4)
+            return 105;
+
+        if ((int)paramModoptFoo.Invoke(derivedClass, new object[] { 0 }) != 100)
+            return 201;
+        if ((int)paramModoptBar.Invoke(derivedClass, new object[] { 0 }) != 101)
+            return 202;
+        if ((int)paramModreqFoo.Invoke(derivedClass, new object[] { 0 }) != 102)
+            return 203;
+        if ((int)paramUnmodified.Invoke(derivedClass, new object[] { 0 }) != 103)
+            return 204;
+        if ((int)returnModoptFoo.Invoke(derivedClass, new object[] { 0 }) != 104)
+            return 205;
+
+        if ((int)arrayModopt1.Invoke(baseClass, new object[] { null }) + 100 != (int)arrayModopt1.Invoke(derivedClass, new object[] { null }))
+            return 301;
+
+        if ((int)arrayModopt2.Invoke(baseClass, new object[] { null }) + 100 != (int)arrayModopt2.Invoke(derivedClass, new object[] { null }))
+            return 302;
+
+        //
+        // Make sure modifiers are ignored for newobj/box
+        //
+
+        object tryAllocWithModifiedArrayResult = Factory.TryAllocWithModifiedArray();
+        if (!(tryAllocWithModifiedArrayResult is GenericClass<int[]>))
+            return 401;
+        if (tryAllocWithModifiedArrayResult.GetType() != typeof(GenericClass<int[]>))
+            return 402;
+
+        object tryBoxWithModifiedPointerResult = Factory.TryBoxWithModifiedPointer();
+        if (!(tryBoxWithModifiedPointerResult is GenericStruct<int*[]>))
+            return 501;
+        if (tryBoxWithModifiedPointerResult.GetType() != typeof(GenericStruct<int*[]>))
+            return 502;
+
+        return 100;
+    }
+
+    class SuperDerivedClass : DerivedClass
+    {
+        public override int Override(int A_0)
+        {
+            Console.WriteLine("In int32 SuperDerivedClass::Override(int32)");
+            return 203;
+        }
+    }
+}

--- a/tests/src/reflection/Modifiers/modifiers.csproj
+++ b/tests/src/reflection/Modifiers/modifiers.csproj
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>modifiers</AssemblyName>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="modifiers.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="modifiersdata.ilproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/tests/src/reflection/Modifiers/modifiersdata.il
+++ b/tests/src/reflection/Modifiers/modifiersdata.il
@@ -1,0 +1,171 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib { }
+.assembly modifiersdata { }
+
+.class public BaseClass
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ldarg.0
+    call instance void [mscorlib]System.Object::.ctor()
+    ret
+  }
+
+  .method public hidebysig virtual newslot instance int32 Override(int32 modopt (FooModifier))
+  {
+    ldstr "In int32 BaseClass::Override(int32 modopt (FooModifier))"
+    call void class [mscorlib]System.Console::WriteLine(string)
+    ldc.i4.0
+    ret
+  }
+
+  .method public hidebysig virtual newslot instance int32 Override(int32 modopt (BarModifier))
+  {
+    ldstr "In int32 BaseClass::Override(int32 modopt (BarModifier))"
+    call void class [mscorlib]System.Console::WriteLine(string)
+    ldc.i4.1
+    ret
+  }
+
+  .method public hidebysig virtual newslot instance int32 Override(int32 modreq (FooModifier))
+  {
+    ldstr "In int32 BaseClass::Override(int32 modreq (FooModifier))"
+    call void class [mscorlib]System.Console::WriteLine(string)
+    ldc.i4.2
+    ret
+  }
+
+  .method public hidebysig virtual newslot instance int32 Override(int32)
+  {
+    ldstr "In int32 BaseClass::Override(int32)"
+    call void class [mscorlib]System.Console::WriteLine(string)
+    ldc.i4.3
+    ret
+  }
+
+  .method public hidebysig virtual newslot instance int32 modopt (FooModifier) Override(int32)
+  {
+    ldstr "In int32 modopt (FooModifier) BaseClass::Override(int32)"
+    call void class [mscorlib]System.Console::WriteLine(string)
+    ldc.i4.4
+    ret
+  }
+
+  .method public hidebysig virtual newslot instance int32 Override(int32 modopt (FooModifier)[])
+  {
+    ldstr "In int32 BaseClass::Override(int32 modopt (FooModifier)[])"
+    call void class [mscorlib]System.Console::WriteLine(string)
+    ldc.i4.5
+    ret
+  }
+
+  .method public hidebysig virtual newslot instance int32 Override(int32 modopt (BarModifier)[])
+  {
+    ldstr "In int32 BaseClass::Override(int32 modopt (BarModifier)[])"
+    call void class [mscorlib]System.Console::WriteLine(string)
+    ldc.i4.6
+    ret
+  }
+
+}
+
+.class public DerivedClass extends BaseClass
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ldarg.0
+    call instance void BaseClass::.ctor()
+    ret
+  }
+
+  .method public hidebysig virtual instance int32 Override(int32 modopt (FooModifier))
+  {
+    ldstr "In int32 DerivedClass::Override(int32 modopt (FooModifier))"
+    call void class [mscorlib]System.Console::WriteLine(string)
+    ldc.i4 100
+    ret
+  }
+
+  .method public hidebysig virtual instance int32 Override(int32 modopt (BarModifier))
+  {
+    ldstr "In int32 DerivedClass::Override(int32 modopt (BarModifier))"
+    call void class [mscorlib]System.Console::WriteLine(string)
+    ldc.i4 101
+    ret
+  }
+
+  .method public hidebysig virtual instance int32 Override(int32 modreq (FooModifier))
+  {
+    ldstr "In int32 DerivedClass::Override(int32 modreq (FooModifier))"
+    call void class [mscorlib]System.Console::WriteLine(string)
+    ldc.i4 102
+    ret
+  }
+
+  .method public hidebysig virtual instance int32 Override(int32)
+  {
+    ldstr "In int32 DerivedClass::Override(int32)"
+    call void class [mscorlib]System.Console::WriteLine(string)
+    ldc.i4 103
+    ret
+  }
+
+  .method public hidebysig virtual instance int32 modopt (FooModifier) Override(int32)
+  {
+    ldstr "In int32 modopt (FooModifier) DerivedClass::Override(int32)"
+    call void class [mscorlib]System.Console::WriteLine(string)
+    ldc.i4 104
+    ret
+  }
+
+  .method public hidebysig virtual instance int32 Override(int32 modopt (FooModifier)[])
+  {
+    ldstr "In int32 DerivedClass::Override(int32 modopt (FooModifier)[])"
+    call void class [mscorlib]System.Console::WriteLine(string)
+    ldc.i4 105
+    ret
+  }
+
+  .method public hidebysig virtual instance int32 Override(int32 modopt (BarModifier)[])
+  {
+    ldstr "In int32 DerivedClass::Override(int32 modopt (BarModifier)[])"
+    call void class [mscorlib]System.Console::WriteLine(string)
+    ldc.i4 106
+    ret
+  }
+}
+
+.class public GenericClass`1<T>
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    ldarg.0
+    call instance void [mscorlib]System.Object::.ctor()
+    ret
+  }
+}
+
+.class public value sequential GenericStruct`1<T> { .size 1 }
+
+.class public Factory
+{
+  .method public static hidebysig object TryAllocWithModifiedArray()
+  {
+    newobj void class GenericClass`1<int32 modopt (FooModifier)[]>::.ctor()
+    ret
+  }
+
+  .method public static hidebysig object TryBoxWithModifiedPointer()
+  {
+    .locals init (valuetype GenericStruct`1<int32 modreq (BarModifier)*[]>)
+    ldloc 0
+    box valuetype GenericStruct`1<int32 modreq (BarModifier)*[]>
+    ret
+  }
+}
+
+.class public FooModifier { }
+.class public BarModifier { }

--- a/tests/src/reflection/Modifiers/modifiersdata.ilproj
+++ b/tests/src/reflection/Modifiers/modifiersdata.ilproj
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>modifiersdata</AssemblyName>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="modifiersdata.il" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/tests/src/reflection/ldtoken/modifiers.il
+++ b/tests/src/reflection/ldtoken/modifiers.il
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern System.Runtime { auto }
+.assembly modifiers { }
+
+.method private hidebysig static int32  Main() cil managed
+{
+  .locals init (valuetype [System.Runtime]System.RuntimeTypeHandle)
+  .entrypoint
+
+  ldtoken string[]
+  stloc.0
+  ldloca 0
+  ldtoken string modopt (MyModifier)[]
+  call instance bool valuetype [System.Runtime]System.RuntimeTypeHandle::Equals(valuetype [System.Runtime]System.RuntimeTypeHandle)
+  brtrue StringArrayModifiedStringArrayOK
+  ldc.i4.1
+  ret
+StringArrayModifiedStringArrayOK:
+
+  ldtoken int32[]
+  stloc.0
+  ldloca 0
+  ldtoken int32 modreq (MyModifier)[]
+  call instance bool valuetype [System.Runtime]System.RuntimeTypeHandle::Equals(valuetype [System.Runtime]System.RuntimeTypeHandle)
+  brtrue IntArrayModifiedIntArrayOK
+  ldc.i4.2
+  ret
+IntArrayModifiedIntArrayOK:
+
+  ldtoken int32 * modreq(MyModifier) []
+  stloc.0
+  ldloca 0
+  ldtoken int32 modreq (MyModifier) * []
+  call instance bool valuetype [System.Runtime]System.RuntimeTypeHandle::Equals(valuetype [System.Runtime]System.RuntimeTypeHandle)
+  brtrue IntPtrArrayModifiedIntPtrArrayOK
+  ldc.i4.3
+  ret
+IntPtrArrayModifiedIntPtrArrayOK:
+
+  ldtoken uint32[]
+  stloc.0
+  ldloca 0
+  ldtoken uint32 modreq (int32)[]
+  call instance bool valuetype [System.Runtime]System.RuntimeTypeHandle::Equals(valuetype [System.Runtime]System.RuntimeTypeHandle)
+  brtrue UIntArrayModifiedUIntArrayOK
+  ldc.i4.4
+  ret
+UIntArrayModifiedUIntArrayOK:
+
+  ldtoken valuetype MyStruct*
+  stloc.0
+  ldloca 0
+  ldtoken valuetype MyStruct modreq (MyModifier) *
+  call instance bool valuetype [System.Runtime]System.RuntimeTypeHandle::Equals(valuetype [System.Runtime]System.RuntimeTypeHandle)
+  brtrue MyStructPtrModifiedMyStructPtrOK
+  ldc.i4.5
+  ret
+MyStructPtrModifiedMyStructPtrOK:
+
+  ldc.i4 100
+  ret
+}
+
+.class public MyModifier { }
+
+.class value sequential public MyStruct { .size 1 }

--- a/tests/src/reflection/ldtoken/modifiers.ilproj
+++ b/tests/src/reflection/ldtoken/modifiers.ilproj
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>modifiers</AssemblyName>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="modifiers.il" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
Custom modifiers are only lightly tested within the CLR test codebase (both closed and open). This adds targeted tests for:

* Resolution and overriding
* Various places that should ignore them
* Reflection