### PR TITLE
Add EventPipe Config File Option MultiFileSec

### DIFF
--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipe.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipe.cs
@@ -80,6 +80,7 @@ namespace System.Diagnostics.Tracing
         private uint m_circularBufferSizeInMB;
         private List<EventPipeProviderConfiguration> m_providers;
         private TimeSpan m_minTimeBetweenSamples = TimeSpan.FromMilliseconds(1);
+        private ulong m_multiFileTraceLengthInSeconds = 0;
 
         internal EventPipeConfiguration(
             string outputFile,
@@ -106,6 +107,11 @@ namespace System.Diagnostics.Tracing
         internal uint CircularBufferSizeInMB
         {
             get { return m_circularBufferSizeInMB; }
+        }
+
+        internal ulong MultiFileTraceLengthInSeconds
+        {
+            get { return m_multiFileTraceLengthInSeconds; }
         }
 
         internal EventPipeProviderConfiguration[] Providers
@@ -149,6 +155,11 @@ namespace System.Diagnostics.Tracing
 
             m_minTimeBetweenSamples = minTimeBetweenSamples;
         }
+
+        internal void SetMultiFileTraceLength(ulong traceLengthInSeconds)
+        {
+            m_multiFileTraceLengthInSeconds = traceLengthInSeconds;
+        }
     }
 
     internal static class EventPipe
@@ -174,7 +185,8 @@ namespace System.Diagnostics.Tracing
                 configuration.CircularBufferSizeInMB,
                 configuration.ProfilerSamplingRateInNanoseconds,
                 providers,
-                providers.Length);
+                providers.Length,
+                configuration.MultiFileTraceLengthInSeconds);
         }
 
         internal static void Disable()
@@ -189,7 +201,7 @@ namespace System.Diagnostics.Tracing
         // These PInvokes are used by the configuration APIs to interact with EventPipe.
         //
         [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
-        internal static extern UInt64 Enable(string outputFile, uint circularBufferSizeInMB, long profilerSamplingRateInNanoseconds, EventPipeProviderConfiguration[] providers, int numProviders);
+        internal static extern UInt64 Enable(string outputFile, uint circularBufferSizeInMB, long profilerSamplingRateInNanoseconds, EventPipeProviderConfiguration[] providers, int numProviders, ulong multiFileTraceLengthInSeconds);
 
         [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
         internal static extern void Disable(UInt64 sessionID);

--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeController.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeController.cs
@@ -49,6 +49,7 @@ namespace System.Diagnostics.Tracing
         private const string ConfigKey_CircularMB = "CircularMB";
         private const string ConfigKey_OutputPath = "OutputPath";
         private const string ConfigKey_ProcessID = "ProcessID";
+        private const string ConfigKey_MultiFileSec = "MultiFileSec";
 
         // The default set of providers/keywords/levels.  Used if an alternative configuration is not specified.
         private static readonly EventPipeProviderConfiguration[] DefaultProviderConfiguration = new EventPipeProviderConfiguration[]
@@ -70,6 +71,8 @@ namespace System.Diagnostics.Tracing
 
         internal static void Initialize()
         {
+            System.Diagnostics.Debugger.Launch();
+
             // Don't allow failures to propagate upstream.  Ensure program correctness without tracing.
             try
             {
@@ -161,6 +164,7 @@ namespace System.Diagnostics.Tracing
             string strProviderConfig = null;
             string strCircularMB = null;
             string strProcessID = null;
+            string strMultiFileSec = null;
 
             // Split the configuration entries by line.
             string[] configEntries = strConfigContents.Split(ConfigFileLineDelimiters, StringSplitOptions.RemoveEmptyEntries);
@@ -187,6 +191,10 @@ namespace System.Diagnostics.Tracing
                     {
                         strProcessID = entryComponents[1];
                     }
+                    else if (key.Equals(ConfigKey_MultiFileSec))
+                    {
+                        strMultiFileSec = entryComponents[1];
+                    }
                 }
             }
 
@@ -207,8 +215,15 @@ namespace System.Diagnostics.Tracing
                 throw new ArgumentNullException(nameof(outputPath));
             }
 
+            // Check to see if MultiFileSec is specified.
+            ulong multiFileSec = 0;
+            if (!string.IsNullOrEmpty(strMultiFileSec))
+            {
+                multiFileSec = Convert.ToUInt64(strMultiFileSec);
+            }
+
             // Build the full path to the trace file.
-            string traceFileName = BuildTraceFileName();
+            string traceFileName = BuildTraceFileName(multiFileSec > 0);
             string outputFile = Path.Combine(outputPath, traceFileName);
 
             // Get the circular buffer size.
@@ -220,6 +235,7 @@ namespace System.Diagnostics.Tracing
 
             // Initialize a new configuration object.
             EventPipeConfiguration config = new EventPipeConfiguration(outputFile, circularMB);
+            config.SetMultiFileTraceLength(multiFileSec);
 
             // Set the provider configuration if specified.
             if (!string.IsNullOrEmpty(strProviderConfig))
@@ -238,7 +254,7 @@ namespace System.Diagnostics.Tracing
         private static EventPipeConfiguration BuildConfigFromEnvironment()
         {
             // Build the full path to the trace file.
-            string traceFileName = BuildTraceFileName();
+            string traceFileName = BuildTraceFileName(false);
             string outputFilePath = Path.Combine(Config_EventPipeOutputPath, traceFileName);
 
             // Create a new configuration object.
@@ -267,9 +283,19 @@ namespace System.Diagnostics.Tracing
             return GetAppName() + ConfigFileSuffix;
         }
 
-        private static string BuildTraceFileName()
+        private static string BuildTraceFileName(bool multiFile)
         {
-            return GetAppName() + "." + Win32Native.GetCurrentProcessId() + NetPerfFileExtension;
+            string traceFileName;
+            if (multiFile)
+            {
+                traceFileName = GetAppName() + "." + Win32Native.GetCurrentProcessId();
+            }
+            else
+            {
+                traceFileName = GetAppName() + "." + Win32Native.GetCurrentProcessId() + NetPerfFileExtension;
+            }
+
+            return traceFileName;
         }
 
         private static string GetAppName()

--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeController.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeController.cs
@@ -221,7 +221,7 @@ namespace System.Diagnostics.Tracing
             }
 
             // Build the full path to the trace file.
-            string traceFileName = BuildTraceFileName(multiFileSec > 0);
+            string traceFileName = BuildTraceFileName();
             string outputFile = Path.Combine(outputPath, traceFileName);
 
             // Get the circular buffer size.
@@ -252,7 +252,7 @@ namespace System.Diagnostics.Tracing
         private static EventPipeConfiguration BuildConfigFromEnvironment()
         {
             // Build the full path to the trace file.
-            string traceFileName = BuildTraceFileName(false);
+            string traceFileName = BuildTraceFileName();
             string outputFilePath = Path.Combine(Config_EventPipeOutputPath, traceFileName);
 
             // Create a new configuration object.
@@ -281,19 +281,9 @@ namespace System.Diagnostics.Tracing
             return GetAppName() + ConfigFileSuffix;
         }
 
-        private static string BuildTraceFileName(bool multiFile)
+        private static string BuildTraceFileName()
         {
-            string traceFileName;
-            if (multiFile)
-            {
-                traceFileName = GetAppName() + "." + Win32Native.GetCurrentProcessId();
-            }
-            else
-            {
-                traceFileName = GetAppName() + "." + Win32Native.GetCurrentProcessId() + NetPerfFileExtension;
-            }
-
-            return traceFileName;
+            return GetAppName() + "." + Win32Native.GetCurrentProcessId() + NetPerfFileExtension;
         }
 
         private static string GetAppName()

--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeController.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeController.cs
@@ -71,8 +71,6 @@ namespace System.Diagnostics.Tracing
 
         internal static void Initialize()
         {
-            System.Diagnostics.Debugger.Launch();
-
             // Don't allow failures to propagate upstream.  Ensure program correctness without tracing.
             try
             {

--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeEventDispatcher.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeEventDispatcher.cs
@@ -110,7 +110,7 @@ namespace System.Diagnostics.Tracing
                 new EventPipeProviderConfiguration(RuntimeEventSource.EventSourceName, (ulong) aggregatedKeywords, (uint) highestLevel)
             };
 
-            m_sessionID = EventPipeInternal.Enable(null, 1024, 1, providerConfiguration, 1);
+            m_sessionID = EventPipeInternal.Enable(null, 1024, 1, providerConfiguration, 1, 0);
             Debug.Assert(m_sessionID != 0);
 
             // Get the session information that is required to properly dispatch events.

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -618,13 +618,21 @@ void EventPipe::GetNextFilePath(EventPipeSession *pSession, SString &nextTraceFi
     }
     CONTRACTL_END;
 
-    // If multiFileTraceLengthInSeconds == 0 then s_pOutputPath is the full path to the trace file.
-    // Otherwise s_pOutputPath is the path and base name of the trace file.  It needs the file index and suffix appended to it to produce the fill path.
+    // Set the full path to the requested trace file as the next file path.
     nextTraceFilePath.Set(s_pOutputPath);
 
+    // If multiple files have been requested, then add a sequence number to the trace file name.
     UINT64 multiFileTraceLengthInSeconds = pSession->GetMultiFileTraceLengthInSeconds();
     if(multiFileTraceLengthInSeconds > 0)
     {
+        // Remove the ".netperf" file extension if it exists.
+        SString::Iterator netPerfExtension = nextTraceFilePath.End();
+        if(nextTraceFilePath.FindBack(netPerfExtension, W(".netperf")))
+        {
+            nextTraceFilePath.Truncate(netPerfExtension);
+        }
+
+        // Add the sequence number and the ".netperf" file extension.
         WCHAR strNextIndex[21];
         swprintf_s(strNextIndex, 21, W(".%u.netperf"), s_nextFileIndex++);
         nextTraceFilePath.Append(strNextIndex);

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -483,6 +483,7 @@ void EventPipe::CreateFileSwitchTimer()
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
+        PRECONDITION(GetLock()->OwnedByCurrentThread());
     }
     CONTRACTL_END
 
@@ -491,7 +492,6 @@ void EventPipe::CreateFileSwitchTimer()
     {
         return;
     }
-//    timerContextHolder->AppDomainId = m_domainId;
     timerContextHolder->TimerId = 0;
 
     bool success = false;
@@ -502,8 +502,8 @@ void EventPipe::CreateFileSwitchTimer()
                 &s_fileSwitchTimerHandle,
                 SwitchToNextFileTimerCallback,
                 timerContextHolder,
-                1000,
-                1000, 
+                FileSwitchTimerPeriodMS,
+                FileSwitchTimerPeriodMS,
                 0 /* flags */))
         {
             _ASSERTE(s_fileSwitchTimerHandle != NULL);
@@ -530,6 +530,7 @@ void EventPipe::DeleteFileSwitchTimer()
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
+        PRECONDITION(GetLock()->OwnedByCurrentThread());
     }
     CONTRACTL_END
 
@@ -579,6 +580,7 @@ void EventPipe::SwitchToNextFile()
         GC_TRIGGERS;
         MODE_PREEMPTIVE;
         PRECONDITION(s_pSession != NULL);
+        PRECONDITION(GetLock()->OwnedByCurrentThread());
     }
     CONTRACTL_END
 
@@ -612,6 +614,7 @@ void EventPipe::GetNextFilePath(EventPipeSession *pSession, SString &nextTraceFi
         GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(pSession != NULL);
+        PRECONDITION(GetLock()->OwnedByCurrentThread());
     }
     CONTRACTL_END;
 

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -506,6 +506,7 @@ void EventPipe::CreateFileSwitchTimer()
                 1000, 
                 0 /* flags */))
         {
+            _ASSERTE(s_fileSwitchTimerHandle != NULL);
             success = true;
         }
     }
@@ -529,11 +530,10 @@ void EventPipe::DeleteFileSwitchTimer()
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        PRECONDITION(s_fileSwitchTimerHandle != NULL);
     }
     CONTRACTL_END
 
-    if(ThreadpoolMgr::DeleteTimerQueueTimer(s_fileSwitchTimerHandle, NULL))
+    if((s_fileSwitchTimerHandle != NULL) && (ThreadpoolMgr::DeleteTimerQueueTimer(s_fileSwitchTimerHandle, NULL)))
     {
         s_fileSwitchTimerHandle = NULL;
     }

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -239,10 +239,15 @@ class EventPipe
             LPCWSTR strOutputPath,
             unsigned int circularBufferSizeInMB,
             EventPipeProviderConfiguration *pProviders,
-            int numProviders);
+            int numProviders,
+            UINT64 multiFileTraceLengthInSeconds);
 
         // Disable tracing via the event pipe.
         static void Disable(EventPipeSessionID id);
+
+        // Performs one polling operation to determine if it is necessary to switch to a new file.
+        // If the polling operation decides it is time, it will perform the switch.
+        static void PollSwitchToNextFile();
 
         // Get the session for the specified session ID.
         static EventPipeSession* GetSession(EventPipeSessionID id);
@@ -292,6 +297,13 @@ class EventPipe
         // Enable the specified EventPipe session.
         static EventPipeSessionID Enable(LPCWSTR strOutputPath, EventPipeSession *pSession);
 
+        // If event pipe has been configured to write multiple files, switch to the next file.
+        static void SwitchToNextFile();
+
+        // Generate the file path for the next trace file.
+        // This is used when event pipe has been configured to create multiple trace files with a specified maximum length of time.
+        static void GetNextFilePath(EventPipeSession *pSession, SString &nextTraceFilePath);
+
         // Callback function for the stack walker.  For each frame walked, this callback is invoked.
         static StackWalkAction StackWalkCallback(CrawlFrame *pCf, StackContents *pData);
 
@@ -307,6 +319,8 @@ class EventPipe
         static EventPipeConfiguration *s_pConfig;
         static EventPipeSession *s_pSession;
         static EventPipeBufferManager *s_pBufferManager;
+        static LPCWSTR s_pOutputPath;
+        static unsigned long s_nextFileIndex;
         static EventPipeFile *s_pFile;
         static EventPipeEventSource *s_pEventSource;
         static LPCWSTR s_pCommandLine;
@@ -314,6 +328,7 @@ class EventPipe
         static EventPipeFile *s_pSyncFile;
         static EventPipeJsonFile *s_pJsonFile;
 #endif // _DEBUG
+        static ULONGLONG s_lastFileSwitchTime;
 };
 
 struct EventPipeProviderConfiguration
@@ -406,7 +421,8 @@ public:
         UINT32 circularBufferSizeInMB,
         INT64 profilerSamplingRateInNanoseconds,
         EventPipeProviderConfiguration *pProviders,
-        INT32 numProviders);
+        INT32 numProviders,
+        UINT64 multiFileTraceLengthInSeconds);
 
     static void QCALLTYPE Disable(UINT64 sessionID);
 

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -333,6 +333,7 @@ class EventPipe
         static EventPipeFile *s_pSyncFile;
         static EventPipeJsonFile *s_pJsonFile;
 #endif // _DEBUG
+        const static DWORD FileSwitchTimerPeriodMS = 1000;
         static HANDLE s_fileSwitchTimerHandle;
         static ULONGLONG s_lastFileSwitchTime;
 };

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -245,10 +245,6 @@ class EventPipe
         // Disable tracing via the event pipe.
         static void Disable(EventPipeSessionID id);
 
-        // Performs one polling operation to determine if it is necessary to switch to a new file.
-        // If the polling operation decides it is time, it will perform the switch.
-        static void PollSwitchToNextFile();
-
         // Get the session for the specified session ID.
         static EventPipeSession* GetSession(EventPipeSessionID id);
 
@@ -297,6 +293,15 @@ class EventPipe
         // Enable the specified EventPipe session.
         static EventPipeSessionID Enable(LPCWSTR strOutputPath, EventPipeSession *pSession);
 
+        static void CreateFileSwitchTimer();
+
+        static void DeleteFileSwitchTimer();
+
+        // Performs one polling operation to determine if it is necessary to switch to a new file.
+        // If the polling operation decides it is time, it will perform the switch.
+        // Called directly from the timer when the timer is triggered.
+        static void WINAPI SwitchToNextFileTimerCallback(PVOID parameter, BOOLEAN timerFired);
+
         // If event pipe has been configured to write multiple files, switch to the next file.
         static void SwitchToNextFile();
 
@@ -328,6 +333,7 @@ class EventPipe
         static EventPipeFile *s_pSyncFile;
         static EventPipeJsonFile *s_pJsonFile;
 #endif // _DEBUG
+        static HANDLE s_fileSwitchTimerHandle;
         static ULONGLONG s_lastFileSwitchTime;
 };
 

--- a/src/vm/eventpipeconfiguration.cpp
+++ b/src/vm/eventpipeconfiguration.cpp
@@ -309,7 +309,7 @@ size_t EventPipeConfiguration::GetCircularBufferSize() const
     return ret;
 }
 
-EventPipeSession* EventPipeConfiguration::CreateSession(EventPipeSessionType sessionType, unsigned int circularBufferSizeInMB, EventPipeProviderConfiguration *pProviders, unsigned int numProviders)
+EventPipeSession* EventPipeConfiguration::CreateSession(EventPipeSessionType sessionType, unsigned int circularBufferSizeInMB, EventPipeProviderConfiguration *pProviders, unsigned int numProviders, UINT64 multiFileTraceLengthInSeconds)
 {
     CONTRACTL
     {
@@ -319,7 +319,7 @@ EventPipeSession* EventPipeConfiguration::CreateSession(EventPipeSessionType ses
     }
     CONTRACTL_END;
 
-    return new EventPipeSession(sessionType, circularBufferSizeInMB, pProviders, numProviders);
+    return new EventPipeSession(sessionType, circularBufferSizeInMB, pProviders, numProviders, multiFileTraceLengthInSeconds);
 }
 
 void EventPipeConfiguration::DeleteSession(EventPipeSession *pSession)

--- a/src/vm/eventpipeconfiguration.h
+++ b/src/vm/eventpipeconfiguration.h
@@ -54,7 +54,7 @@ public:
     EventPipeProvider* GetProvider(const SString &providerID);
 
     // Create a new session.
-    EventPipeSession* CreateSession(EventPipeSessionType sessionType, unsigned int circularBufferSizeInMB, EventPipeProviderConfiguration *pProviders, unsigned int numProviders);
+    EventPipeSession* CreateSession(EventPipeSessionType sessionType, unsigned int circularBufferSizeInMB, EventPipeProviderConfiguration *pProviders, unsigned int numProviders, UINT64 multiFileTraceLengthInSeconds = 0);
 
     // Delete a session.
     void DeleteSession(EventPipeSession *pSession);

--- a/src/vm/eventpipesession.cpp
+++ b/src/vm/eventpipesession.cpp
@@ -13,7 +13,8 @@ EventPipeSession::EventPipeSession(
     EventPipeSessionType sessionType,
     unsigned int circularBufferSizeInMB,
     EventPipeProviderConfiguration *pProviders,
-    unsigned int numProviders)
+    unsigned int numProviders,
+    UINT64 multiFileTraceLengthInSeconds)
 {
     CONTRACTL
     {
@@ -29,6 +30,7 @@ EventPipeSession::EventPipeSession(
     m_pProviderList = new EventPipeSessionProviderList(
         pProviders,
         numProviders);
+    m_multiFileTraceLengthInSeconds = multiFileTraceLengthInSeconds;
     GetSystemTimeAsFileTime(&m_sessionStartTime);
     QueryPerformanceCounter(&m_sessionStartTimeStamp);
 }

--- a/src/vm/eventpipesession.h
+++ b/src/vm/eventpipesession.h
@@ -40,6 +40,9 @@ private:
     // Start timestamp.
     LARGE_INTEGER m_sessionStartTimeStamp;
 
+    // The maximum trace length in seconds.  Used to determine when to flush the current file and start a new one.
+    UINT64 m_multiFileTraceLengthInSeconds;
+
 public:
 
     // TODO: This needs to be exposed via EventPipe::CreateSession() and EventPipe::DeleteSession() to avoid memory ownership issues.
@@ -47,7 +50,8 @@ public:
         EventPipeSessionType sessionType,
         unsigned int circularBufferSizeInMB,
         EventPipeProviderConfiguration *pProviders,
-        unsigned int numProviders);
+        unsigned int numProviders,
+        UINT64 multiFileTraceLengthInSeconds);
 
     ~EventPipeSession();
 
@@ -94,6 +98,12 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
         return m_sessionStartTimeStamp;
+    }
+
+    UINT64 GetMultiFileTraceLengthInSeconds() const
+    {
+        LIMITED_METHOD_CONTRACT;
+        return m_multiFileTraceLengthInSeconds;
     }
 
     // Add a new provider to the session.

--- a/src/vm/finalizerthread.cpp
+++ b/src/vm/finalizerthread.cpp
@@ -17,10 +17,6 @@
 #include "profattach.h"
 #endif // FEATURE_PROFAPI_ATTACH_DETACH 
 
-#ifdef FEATURE_PERFTRACING
-#include "eventpipe.h"
-#endif
-
 BOOL FinalizerThread::fRunFinalizersOnUnload = FALSE;
 BOOL FinalizerThread::fQuitFinalizer = FALSE;
 
@@ -555,13 +551,6 @@ VOID FinalizerThread::FinalizerThreadWorker(void *args)
             
             LastHeapDumpTime = CLRGetTickCount64();
             g_TriggerHeapDump = FALSE;
-        }
-#endif
-
-#ifdef FEATURE_PERFTRACING
-        if (EventPipe::Enabled())
-        {
-            EventPipe::PollSwitchToNextFile();
         }
 #endif
 

--- a/src/vm/finalizerthread.cpp
+++ b/src/vm/finalizerthread.cpp
@@ -17,6 +17,10 @@
 #include "profattach.h"
 #endif // FEATURE_PROFAPI_ATTACH_DETACH 
 
+#ifdef FEATURE_PERFTRACING
+#include "eventpipe.h"
+#endif
+
 BOOL FinalizerThread::fRunFinalizersOnUnload = FALSE;
 BOOL FinalizerThread::fQuitFinalizer = FALSE;
 
@@ -551,6 +555,13 @@ VOID FinalizerThread::FinalizerThreadWorker(void *args)
             
             LastHeapDumpTime = CLRGetTickCount64();
             g_TriggerHeapDump = FALSE;
+        }
+#endif
+
+#ifdef FEATURE_PERFTRACING
+        if (EventPipe::Enabled())
+        {
+            EventPipe::PollSwitchToNextFile();
         }
 #endif
 


### PR DESCRIPTION
Adds the capability to have EventPipe roll-over to a new file every N seconds.  This is configured via the eventpipeconfig file and is specified via the MultiFileSec keyword.

Rundown only occurs in the last trace during the disable operation, which ensures that we don't negatively impact the running process.  No events should be lost on transition to a new file - they continue to be written to the circular buffer for inclusion in the next file.