### PR TITLE
WIP Delay attribution of ARM finally targets until just before codegen

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -358,6 +358,12 @@ void CodeGen::genPrepForEHCodegen()
 {
     assert(!compiler->fgSafeBasicBlockCreation);
 
+#if FEATURE_EH_FUNCLETS && defined(_TARGET_ARM_)
+    // For ARM, we need to mark all the targets of finally returns specially, to prepare
+    // to generate code for them.
+    compiler->fgAddFinallyTargetFlags();
+#endif // FEATURE_EH_FUNCLETS && defined(_TARGET_ARM_)
+
     EHblkDsc* HBtab;
     EHblkDsc* HBtabEnd;
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4132,17 +4132,7 @@ public:
 
     void fgCleanupContinuation(BasicBlock* continuation);
 
-    void fgUpdateFinallyTargetFlags();
-
-    void fgClearAllFinallyTargetBits();
-
     void fgAddFinallyTargetFlags();
-
-#if FEATURE_EH_FUNCLETS && defined(_TARGET_ARM_)
-    // Sometimes we need to defer updating the BBF_FINALLY_TARGET bit. fgNeedToAddFinallyTargetBits signals
-    // when this is necessary.
-    bool fgNeedToAddFinallyTargetBits;
-#endif // FEATURE_EH_FUNCLETS && defined(_TARGET_ARM_)
 
     bool fgRetargetBranchesToCanonicalCallFinally(BasicBlock*      block,
                                                   BasicBlock*      handler,
@@ -4796,9 +4786,6 @@ public:
     BasicBlock* fgRelocateEHRange(unsigned regionIndex, FG_RELOCATE_TYPE relocateType);
 
 #if FEATURE_EH_FUNCLETS
-#if defined(_TARGET_ARM_)
-    void fgClearFinallyTargetBit(BasicBlock* block);
-#endif // defined(_TARGET_ARM_)
     bool fgIsIntraHandlerPred(BasicBlock* predBlock, BasicBlock* block);
     bool fgAnyIntraHandlerPreds(BasicBlock* block);
     void fgInsertFuncletPrologBlock(BasicBlock* block);

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -2821,23 +2821,6 @@ inline void Compiler::fgConvertBBToThrowBB(BasicBlock* block)
         leaveBlk->bbFlags &= ~BBF_DONT_REMOVE;
         leaveBlk->bbRefs  = 0;
         leaveBlk->bbPreds = nullptr;
-
-#if FEATURE_EH_FUNCLETS && defined(_TARGET_ARM_)
-        // This function (fgConvertBBToThrowBB) can be called before the predecessor lists are created (e.g., in
-        // fgMorph). The fgClearFinallyTargetBit() function to update the BBF_FINALLY_TARGET bit depends on these
-        // predecessor lists. If there are no predecessor lists, we immediately clear all BBF_FINALLY_TARGET bits
-        // (to allow subsequent dead code elimination to delete such blocks without asserts), and set a flag to
-        // recompute them later, before they are required.
-        if (fgComputePredsDone)
-        {
-            fgClearFinallyTargetBit(leaveBlk->bbJumpDest);
-        }
-        else
-        {
-            fgClearAllFinallyTargetBits();
-            fgNeedToAddFinallyTargetBits = true;
-        }
-#endif // FEATURE_EH_FUNCLETS && defined(_TARGET_ARM_)
     }
 
     block->bbJumpKind = BBJ_THROW;

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -9217,15 +9217,6 @@ void Compiler::impImportLeave(BasicBlock* block)
                                               // exit) returns to this block
                 step->bbJumpDest->bbRefs++;
 
-#if defined(_TARGET_ARM_)
-                if (stepType == ST_FinallyReturn)
-                {
-                    assert(step->bbJumpKind == BBJ_ALWAYS);
-                    // Mark the target of a finally return
-                    step->bbJumpDest->bbFlags |= BBF_FINALLY_TARGET;
-                }
-#endif // defined(_TARGET_ARM_)
-
                 /* The new block will inherit this block's weight */
                 exitBlock->setBBWeight(block->bbWeight);
                 exitBlock->bbFlags |= (block->bbFlags & BBF_RUN_RARELY) | BBF_IMPORTED;
@@ -9362,15 +9353,6 @@ void Compiler::impImportLeave(BasicBlock* block)
                                               // finally in the chain)
                 step->bbJumpDest->bbRefs++;
 
-#if defined(_TARGET_ARM_)
-                if (stepType == ST_FinallyReturn)
-                {
-                    assert(step->bbJumpKind == BBJ_ALWAYS);
-                    // Mark the target of a finally return
-                    step->bbJumpDest->bbFlags |= BBF_FINALLY_TARGET;
-                }
-#endif // defined(_TARGET_ARM_)
-
                 /* The new block will inherit this block's weight */
                 callBlock->setBBWeight(block->bbWeight);
                 callBlock->bbFlags |= (block->bbFlags & BBF_RUN_RARELY) | BBF_IMPORTED;
@@ -9467,14 +9449,6 @@ void Compiler::impImportLeave(BasicBlock* block)
                 step->bbJumpDest = catchStep;
                 step->bbJumpDest->bbRefs++;
 
-#if defined(_TARGET_ARM_)
-                if (stepType == ST_FinallyReturn)
-                {
-                    // Mark the target of a finally return
-                    step->bbJumpDest->bbFlags |= BBF_FINALLY_TARGET;
-                }
-#endif // defined(_TARGET_ARM_)
-
                 /* The new block will inherit this block's weight */
                 catchStep->setBBWeight(block->bbWeight);
                 catchStep->bbFlags |= (block->bbFlags & BBF_RUN_RARELY) | BBF_IMPORTED;
@@ -9523,15 +9497,6 @@ void Compiler::impImportLeave(BasicBlock* block)
     else
     {
         step->bbJumpDest = leaveTarget; // this is the ultimate destination of the LEAVE
-
-#if defined(_TARGET_ARM_)
-        if (stepType == ST_FinallyReturn)
-        {
-            assert(step->bbJumpKind == BBJ_ALWAYS);
-            // Mark the target of a finally return
-            step->bbJumpDest->bbFlags |= BBF_FINALLY_TARGET;
-        }
-#endif // defined(_TARGET_ARM_)
 
 #ifdef DEBUG
         if (verbose)

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -16776,8 +16776,6 @@ void Compiler::fgMorph()
 
     EndPhase(PHASE_CLONE_FINALLY);
 
-    fgUpdateFinallyTargetFlags();
-
     /* For x64 and ARM64 we need to mark irregular parameters */
 
     lvaRefCountState = RCS_EARLY;
@@ -16817,15 +16815,6 @@ void Compiler::fgMorph()
     JITDUMP("trees after fgMorphBlocks\n");
     DBEXEC(VERBOSE, fgDispBasicBlocks(true));
 #endif
-
-#if FEATURE_EH_FUNCLETS && defined(_TARGET_ARM_)
-    if (fgNeedToAddFinallyTargetBits)
-    {
-        // We previously wiped out the BBF_FINALLY_TARGET bits due to some morphing; add them back.
-        fgAddFinallyTargetFlags();
-        fgNeedToAddFinallyTargetBits = false;
-    }
-#endif // FEATURE_EH_FUNCLETS && defined(_TARGET_ARM_)
 
     /* Decide the kind of code we want to generate */
 

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -1755,23 +1755,6 @@ public:
             return false;
         }
 
-#if FEATURE_EH_FUNCLETS && defined(_TARGET_ARM_)
-        // Disqualify loops where the first block of the loop is a finally target.
-        // The main problem is when multiple loops share a 'first' block that is a finally
-        // target and we canonicalize the loops by adding a new loop head. In that case, we
-        // need to update the blocks so the finally target bit is moved to the newly created
-        // block, and removed from the old 'first' block. This is 'hard', so at this point
-        // in the RyuJIT codebase (when we don't expect to keep the "old" ARM32 code generator
-        // long-term), it's easier to disallow the loop than to update the flow graph to
-        // support this case.
-
-        if ((first->bbFlags & BBF_FINALLY_TARGET) != 0)
-        {
-            JITDUMP("Loop 'first' " FMT_BB " is a finally target. Rejecting loop.\n", first->bbNum);
-            return false;
-        }
-#endif // FEATURE_EH_FUNCLETS && defined(_TARGET_ARM_)
-
         // Compact the loop (sweep through it and move out any blocks that aren't part of the
         // flow cycle), and find the exits.
         if (!MakeCompactAndFindExits())


### PR DESCRIPTION
Currently, the `BBF_FINALLY_TARGET` bit is set on import and must
be maintained through optimization phases of the compiler. This is quite
difficult. Instead, add the bits immediately before code generation.

Note that optimizations still can't change program behavior: the
finally target must still exist, and must be exactly the code that
should be executed after the finally is executed. It must be in the
proper EH region, to ensure exceptions nested in the 'finally'
are properly processed.

Fixes https://github.com/dotnet/coreclr/issues/13084