### PR TITLE
Avoid comparing capacity in StringBuilder.Equals

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
@@ -1777,7 +1777,7 @@ namespace System.Text
         {
             if (sb == null)
                 return false;
-            if (Capacity != sb.Capacity || MaxCapacity != sb.MaxCapacity || Length != sb.Length)
+            if (Length != sb.Length)
                 return false;
             if (sb == this)
                 return true;


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/32932.

Tests are in https://github.com/dotnet/corefx/pull/32991.

cc: @stephentoub 