### PR TITLE
Move ILLink and SizeOnDisk testing to Helix Queue

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -753,6 +753,7 @@ def static getFullThroughputJobName(def project, def os, def arch, def isPR) {
     ['x64', 'x86'].each { arch ->
         def architecture = arch
         def newJob = job(Utilities.getFullJobName(project, "sizeondisk_${arch}", false)) {
+            label('Windows.Amd64.ClientRS4.DevEx.15.8.Perf')
 
             wrappers {
                 credentialsBinding {
@@ -802,8 +803,6 @@ def static getFullThroughputJobName(def project, def os, def arch, def isPR) {
             }
         }
 
-        Utilities.setMachineAffinity(newJob, "Windows_NT", '20170427-elevated')
-
         def archiveSettings = new ArchivalSettings()
         archiveSettings.addFiles('bin/toArchive/**')
         archiveSettings.addFiles('machinedata.json')
@@ -839,6 +838,7 @@ def static getFullThroughputJobName(def project, def os, def arch, def isPR) {
                 ['full_opt'].each { opt_level ->
                     def architecture = arch
                     def newJob = job(Utilities.getFullJobName(project, "perf_illink_${os}_${arch}_${opt_level}_${jit}", isPR)) {
+                        label('Windows.Amd64.ClientRS4.DevEx.15.8.Perf')
 
                         def testEnv = ""
                         wrappers {
@@ -900,7 +900,6 @@ def static getFullThroughputJobName(def project, def os, def arch, def isPR) {
                     archiveSettings.setAlwaysArchive()
 
                     // Set the label (currently we are only measuring size, therefore we are running on VM).
-                    Utilities.setMachineAffinity(newJob, "Windows_NT", '20170427-elevated')
                     Utilities.addArchival(newJob, archiveSettings)
                     Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
 


### PR DESCRIPTION
CoreCLR requires VS2017 to build and perf testing requires python3 to push to benchview, so update the SOD and ILLink tests, which are run on VMs, to the same helix queue that we run our smoketests on.