### PR TITLE
Fix System.Reflection.TargetException: Non-static method requires a target

### DIFF
--- a/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingDataCollector.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingDataCollector.cs
@@ -85,6 +85,15 @@ namespace System.Diagnostics.Tracing
         }
 
         /// <summary>
+        /// Adds a Boolean value to the event payload.
+        /// </summary>
+        /// <param name="value">Value to be added.</param>
+        public void AddScalar(bool value)
+        {
+            DataCollector.ThreadInstance.AddScalar(&value, sizeof(bool));
+        }
+
+        /// <summary>
         /// Adds a null-terminated String value to the event payload.
         /// </summary>
         /// <param name="value">


### PR DESCRIPTION
#### Description
Attempting to access the HasValue property of a nullable type through reflection tosses when the value is null. This was found to be happening in System.Diagnostics.Tracing by the Application Insights team via telemetry data and they raised the issue in corefx (issue 32606). This fixes the issue by avoiding reflection and directly checking if the nullable object is null.

This is a port of https://github.com/dotnet/coreclr/pull/20350

#### Customer Impact
The customer impact (to fill out the template) as follows:
-	~2500 of Application Insights Resources receiving data from 3 most recent stable versions of Application Insights SDK are affected by this issue. TargetException is Top-2 and 5 out of Top-10 issues AI customers are experiencing. The impact on the customer end is exclusively monitoring-related and does not cause app crash as per our knowledge. However, customers would miss certain exceptions AI would’ve reported otherwise, thus suffers from the data trustworthiness issue, equally important in the telemetry collection space.

#### Regression?
No

#### Risk
The root cause of the Application Insights bug is but in the EventSource logging code in .NET Core.     This code has the ability to serialize various datatypes including the special System.Nullable<T> type.    The EventSource code that handles this case was broken for the case that the value is null. To our knowledge this is the first time a Nullable<T> with a null value has been passed as a data value to EventSource.

The fix is small (~7 lines of code changed), and does not affect any other cases but the serialization of a Nullable<T> by an EventSource. Thus the risk is very low (because it was broken before, it is unlikely that other scenarios were event executing the code that was changed. In addition this code is only active when EventSource logging is turned on, and EventSource is already set up to swallow exceptions that happen during logging (in general it is better to lose logging than crash the app). This further mitigates the risk (at worst, a mistake in this fix will cause loss of logging, not application crash).

#### Issue
https://github.com/dotnet/corefx/issues/32606