### PR TITLE
Add IsCollectible property to Assembly and necessary backing functions

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Reflection/Assembly.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Assembly.cs
@@ -69,6 +69,7 @@ namespace System.Reflection
         public virtual bool IsDynamic => false;
         public virtual string Location { get { throw NotImplemented.ByDesign; } }
         public virtual bool ReflectionOnly { get { throw NotImplemented.ByDesign; } }
+        public virtual bool IsCollectible => true;
 
         public virtual ManifestResourceInfo GetManifestResourceInfo(string resourceName) { throw NotImplemented.ByDesign; }
         public virtual string[] GetManifestResourceNames() { throw NotImplemented.ByDesign; }

--- a/src/System.Private.CoreLib/src/System/Reflection/Assembly.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Assembly.CoreCLR.cs
@@ -227,5 +227,8 @@ namespace System.Reflection
                 domainManager = new AppDomainManager();
             return domainManager.EntryAssembly;
         }
+
+        // Check whether this assembly is collectible by GC
+        public abstract bool IsCollectible { get; }
     }
 }

--- a/src/System.Private.CoreLib/src/System/Reflection/Assembly.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Assembly.CoreCLR.cs
@@ -227,8 +227,5 @@ namespace System.Reflection
                 domainManager = new AppDomainManager();
             return domainManager.EntryAssembly;
         }
-
-        // Check whether this assembly is collectible by GC
-        public abstract bool IsCollectible { get; }
     }
 }

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
@@ -639,6 +639,14 @@ namespace System.Reflection.Emit
                 return true;
             }
         }
+
+        public override bool IsCollectible
+        {
+            get
+            {
+                return InternalAssembly.IsCollectible;
+            }
+        }
         #endregion
 
 

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
@@ -640,13 +640,7 @@ namespace System.Reflection.Emit
             }
         }
 
-        public override bool IsCollectible
-        {
-            get
-            {
-                return InternalAssembly.IsCollectible;
-            }
-        }
+        public override bool IsCollectible => InternalAssembly.IsCollectible;
         #endregion
 
 

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -201,6 +201,20 @@ namespace System.Reflection
             }
         }
 
+        [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool GetIsCollectible(RuntimeAssembly assembly);
+
+        public override bool IsCollectible
+        {
+            get
+            {
+                bool isCollectible = false;
+                isCollectible = GetIsCollectible(GetNativeHandle());
+                return isCollectible;
+            }
+        }
+
         // Load a resource based on the NameSpace of the type.
         [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
         public override Stream GetManifestResourceStream(Type type, string name)

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -205,15 +205,7 @@ namespace System.Reflection
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool GetIsCollectible(RuntimeAssembly assembly);
 
-        public override bool IsCollectible
-        {
-            get
-            {
-                bool isCollectible = false;
-                isCollectible = GetIsCollectible(GetNativeHandle());
-                return isCollectible;
-            }
-        }
+        public override bool IsCollectible => GetIsCollectible(GetNativeHandle());
 
         // Load a resource based on the NameSpace of the type.
         [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod

--- a/src/vm/assemblynative.cpp
+++ b/src/vm/assemblynative.cpp
@@ -730,6 +730,21 @@ BOOL QCALLTYPE AssemblyNative::GetNeutralResourcesLanguageAttribute(QCall::Assem
     return retVal;
 }
 
+BOOL QCALLTYPE AssemblyNative::GetIsCollectible(QCall::AssemblyHandle pAssembly)
+{
+    QCALL_CONTRACT;
+
+    BOOL retVal = FALSE;
+
+    BEGIN_QCALL;
+
+    retVal = pAssembly->IsCollectible();
+
+    END_QCALL;
+
+    return retVal;
+}
+
 void QCALLTYPE AssemblyNative::GetModule(QCall::AssemblyHandle pAssembly, LPCWSTR wszFileName, QCall::ObjectHandleOnStack retModule)
 {
     QCALL_CONTRACT;

--- a/src/vm/assemblynative.hpp
+++ b/src/vm/assemblynative.hpp
@@ -113,6 +113,8 @@ public:
     static 
     void QCALLTYPE GetImageRuntimeVersion(QCall::AssemblyHandle pAssembly, QCall::StringHandleOnStack retString);
 
+    static BOOL QCALLTYPE GetIsCollectible(QCall::AssemblyHandle pAssembly);
+
     //
     // PEFile QCalls
     // 

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -538,6 +538,7 @@ FCFuncStart(gAssemblyFuncs)
     QCFuncElement("GetImageRuntimeVersion", AssemblyNative::GetImageRuntimeVersion)
     FCFuncElement("GetManifestModule", AssemblyHandle::GetManifestModule)
     FCFuncElement("GetToken", AssemblyHandle::GetToken)
+    QCFuncElement("GetIsCollectible", AssemblyNative::GetIsCollectible)
 FCFuncEnd()
 
 FCFuncStart(gAssemblyExtensionsFuncs)


### PR DESCRIPTION
Expose API to check whether the referenced `Assembly` is collectible, i.e., has been loaded into an Assembly Load Context that has been marked as Collectible.

CC - @sergiy-k 