### PR TITLE
Fallback to old behavior when marshaling a non-blittable fixed buffer

### DIFF
--- a/src/vm/fieldmarshaler.cpp
+++ b/src/vm/fieldmarshaler.cpp
@@ -660,14 +660,7 @@ do                                                      \
                 {
                     if (IsStructMarshalable(thNestedType))
                     {
-                        if (IsFixedBuffer(pfwalk->m_MD, pInternalImport) && !thNestedType.GetMethodTable()->IsBlittable())
-                        {
-                            INITFIELDMARSHALER(NFT_ILLEGAL, FieldMarshaler_Illegal, (IDS_EE_BADMARSHAL_NOTMARSHALABLE));
-                        }
-                        else
-                        {
-                            INITFIELDMARSHALER(NFT_NESTEDVALUECLASS, FieldMarshaler_NestedValueClass, (thNestedType.GetMethodTable()));
-                        }
+                        INITFIELDMARSHALER(NFT_NESTEDVALUECLASS, FieldMarshaler_NestedValueClass, (thNestedType.GetMethodTable(), IsFixedBuffer(pfwalk->m_MD, pInternalImport)));
                     }
                     else
                     {
@@ -2898,6 +2891,10 @@ VOID FieldMarshaler_NestedValueClass::NestedValueClassUpdateNativeImpl(const VOI
     {
         memcpyNoGCRefs(pNative, (BYTE*)(*ppProtectedCLR) + startoffset, pMT->GetNativeSize());
     }
+    else if (IsFixedBuffer())
+    {
+        COMPlusThrow(kArgumentException, IDS_EE_BADMARSHAL_NOTMARSHALABLE);
+    }
     else
     {
         LayoutUpdateNative((LPVOID*)ppProtectedCLR, startoffset, pMT, (BYTE*)pNative, ppCleanupWorkListOnStack);
@@ -2931,6 +2928,10 @@ VOID FieldMarshaler_NestedValueClass::NestedValueClassUpdateCLRImpl(const VOID *
     if (pMT->IsBlittable())
     {
         memcpyNoGCRefs((BYTE*)(*ppProtectedCLR) + startoffset, pNative, pMT->GetNativeSize());
+    }
+    else if (IsFixedBuffer())
+    {
+        COMPlusThrow(kArgumentException, IDS_EE_BADMARSHAL_NOTMARSHALABLE);
     }
     else
     {

--- a/src/vm/fieldmarshaler.cpp
+++ b/src/vm/fieldmarshaler.cpp
@@ -665,7 +665,6 @@ do                                                      \
 #ifdef _DEBUG
                         INITFIELDMARSHALER(NFT_NESTEDVALUECLASS, FieldMarshaler_NestedValueClass, (thNestedType.GetMethodTable(), IsFixedBuffer(pfwalk->m_MD, pInternalImport)));
 #else
-
                         INITFIELDMARSHALER(NFT_NESTEDVALUECLASS, FieldMarshaler_NestedValueClass, (thNestedType.GetMethodTable()));
 #endif
                     }

--- a/src/vm/fieldmarshaler.h
+++ b/src/vm/fieldmarshaler.h
@@ -712,11 +712,17 @@ private:
 class FieldMarshaler_NestedValueClass : public FieldMarshaler
 {
 public:
+#ifndef _DEBUG
+    FieldMarshaler_NestedValueClass(MethodTable *pMT)
+#else
     FieldMarshaler_NestedValueClass(MethodTable *pMT, BOOL isFixedBuffer)
+#endif
     {
         WRAPPER_NO_CONTRACT;
         m_pNestedMethodTable.SetValueMaybeNull(pMT);
+#ifdef _DEBUG
         m_isFixedBuffer = isFixedBuffer;
+#endif
     }
 
     BOOL IsNestedValueClassMarshalerImpl() const
@@ -764,7 +770,9 @@ public:
     START_COPY_TO_IMPL(FieldMarshaler_NestedValueClass)
     {
         pDestFieldMarshaller->m_pNestedMethodTable.SetValueMaybeNull(GetMethodTable());
+#ifdef _DEBUG
         pDestFieldMarshaller->m_isFixedBuffer = m_isFixedBuffer;
+#endif
     }
     END_COPY_TO_IMPL(FieldMarshaler_NestedValueClass)
 
@@ -797,16 +805,20 @@ public:
         return m_pNestedMethodTable.GetValueMaybeNull();
     }
 
+#ifdef _DEBUG
     BOOL IsFixedBuffer() const
     {
         return m_isFixedBuffer;
     }
+#endif
 
 
 private:
     // MethodTable of nested NStruct.
     RelativeFixupPointer<PTR_MethodTable> m_pNestedMethodTable;
+#ifdef _DEBUG
     BOOL m_isFixedBuffer;
+#endif
 };
 
 

--- a/src/vm/fieldmarshaler.h
+++ b/src/vm/fieldmarshaler.h
@@ -712,10 +712,11 @@ private:
 class FieldMarshaler_NestedValueClass : public FieldMarshaler
 {
 public:
-    FieldMarshaler_NestedValueClass(MethodTable *pMT)
+    FieldMarshaler_NestedValueClass(MethodTable *pMT, BOOL isFixedBuffer)
     {
         WRAPPER_NO_CONTRACT;
         m_pNestedMethodTable.SetValueMaybeNull(pMT);
+        m_isFixedBuffer = isFixedBuffer;
     }
 
     BOOL IsNestedValueClassMarshalerImpl() const
@@ -763,6 +764,7 @@ public:
     START_COPY_TO_IMPL(FieldMarshaler_NestedValueClass)
     {
         pDestFieldMarshaller->m_pNestedMethodTable.SetValueMaybeNull(GetMethodTable());
+        pDestFieldMarshaller->m_isFixedBuffer = m_isFixedBuffer;
     }
     END_COPY_TO_IMPL(FieldMarshaler_NestedValueClass)
 
@@ -795,10 +797,16 @@ public:
         return m_pNestedMethodTable.GetValueMaybeNull();
     }
 
+    BOOL IsFixedBuffer() const
+    {
+        return m_isFixedBuffer;
+    }
+
 
 private:
     // MethodTable of nested NStruct.
     RelativeFixupPointer<PTR_MethodTable> m_pNestedMethodTable;
+    BOOL m_isFixedBuffer;
 };
 
 


### PR DESCRIPTION
After some offline discussions, we've decided to revert back to the old behavior when marshaling a non-blittable fixed buffer since all alternatives will very likely break someone and we don't get much real benefit out of it.

Also, add an assert for debug and checked builds to we can make sure that we don't try to marshal non-blittable fixed buffers while developing runtime features.

Supercedes #20558,  #20263, and #20375  
