### PR TITLE
Making Debug and Trace behavior consistent with eachother and Desktop

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Debug.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Debug.cs
@@ -13,8 +13,6 @@ namespace System.Diagnostics
     /// </summary>
     public static class Debug
     {
-        private static readonly object s_lock = new object();
-
         private static DebugProvider s_provider = new DebugProvider();
 
         public static DebugProvider SetProvider(DebugProvider provider)
@@ -37,11 +35,8 @@ namespace System.Diagnostics
             }
             set
             {
-                lock (s_lock)
-                {
-                    t_indentLevel = value < 0 ? 0 : value;
-                    s_provider.OnIndentLevelChanged(t_indentLevel);
-                }
+                t_indentLevel = value < 0 ? 0 : value;
+                s_provider.OnIndentLevelChanged(t_indentLevel);
             }
         }
 
@@ -54,11 +49,8 @@ namespace System.Diagnostics
             }
             set
             {
-                lock (s_lock)
-                {
-                    s_indentSize = value < 0 ? 0 : value;
-                    s_provider.OnIndentSizeChanged(s_indentSize);
-                }
+                s_indentSize = value < 0 ? 0 : value;
+                s_provider.OnIndentSizeChanged(s_indentSize);
             }
         }
 
@@ -71,19 +63,13 @@ namespace System.Diagnostics
         [System.Diagnostics.Conditional("DEBUG")]
         public static void Indent()
         {
-            lock (s_lock)
-            {
-                IndentLevel++;
-            }
+            IndentLevel++;
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
         public static void Unindent()
         {
-            lock (s_lock)
-            {
-                IndentLevel--;
-            }
+            IndentLevel--;
         }
 
         [System.Diagnostics.Conditional("DEBUG")]

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Debug.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Debug.cs
@@ -40,7 +40,7 @@ namespace System.Diagnostics
             }
         }
 
-        private static volatile int  s_indentSize = 4;
+        private static volatile int s_indentSize = 4;
         public static int IndentSize
         {
             get

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Debug.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Debug.cs
@@ -29,11 +29,11 @@ namespace System.Diagnostics
         {
             get
             {
-                return DebugProvider.IndentLevel;
+                return s_provider.IndentLevel;
             }
             set
             {
-                DebugProvider.IndentLevel = value;
+                s_provider.IndentLevel = value;
             }
         }
 
@@ -41,11 +41,11 @@ namespace System.Diagnostics
         {
             get
             {
-                return DebugProvider.IndentSize;
+                return s_provider.IndentSize;
             }
             set
             {
-                DebugProvider.IndentSize = value;
+                s_provider.IndentSize = value;
             }
         }
 
@@ -58,13 +58,13 @@ namespace System.Diagnostics
         [System.Diagnostics.Conditional("DEBUG")]
         public static void Indent()
         {
-            IndentLevel++;
+            s_provider.IndentLevel++;
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
         public static void Unindent()
         {
-            IndentLevel--;
+            s_provider.IndentLevel--;
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
@@ -105,7 +105,7 @@ namespace System.Diagnostics
                 {
                     stackTrace = "";
                 }
-                WriteLine(FormatAssert(stackTrace, message, detailMessage));
+                WriteLine(FormatAssert(stackTrace, message, detailMessage, s_provider.GetIndentString()));
                 s_provider.ShowDialog(stackTrace, message, detailMessage, "Assertion Failed");
             }
         }
@@ -123,7 +123,7 @@ namespace System.Diagnostics
                 {
                     stackTrace = "";
                 }
-                WriteLine(FormatAssert(stackTrace, message, detailMessage));
+                WriteLine(FormatAssert(stackTrace, message, detailMessage, s_provider.GetIndentString()));
                 s_provider.ShowDialog(stackTrace, message, detailMessage, SR.GetResourceString(failureKindMessage));
             }
         }
@@ -140,9 +140,9 @@ namespace System.Diagnostics
             Assert(false, message, detailMessage);
         }
 
-        private static string FormatAssert(string stackTrace, string message, string detailMessage)
+        private static string FormatAssert(string stackTrace, string message, string detailMessage, string indentString)
         {
-            string newLine = DebugProvider.GetIndentString() + Environment.NewLine;
+            string newLine = indentString + Environment.NewLine;
             return SR.DebugAssertBanner + newLine
                    + SR.DebugAssertShortMessage + newLine
                    + message + newLine
@@ -160,7 +160,7 @@ namespace System.Diagnostics
         [System.Diagnostics.Conditional("DEBUG")]
         public static void WriteLine(string message)
         {
-            Write(message + Environment.NewLine);
+            s_provider.WriteLine(message);
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
@@ -196,7 +196,7 @@ namespace System.Diagnostics
             }
             else
             {
-                WriteLine(category + ":" + message);
+                WriteLine(category + ": " + message);
             }
         }
 
@@ -215,7 +215,7 @@ namespace System.Diagnostics
             }
             else
             {
-                Write(category + ":" + message);
+                Write(category + ": " + message);
             }
         }
 

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Debug.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Debug.cs
@@ -13,7 +13,7 @@ namespace System.Diagnostics
     /// </summary>
     public static class Debug
     {
-        private static DebugProvider s_provider = new DebugProvider();
+        private static volatile DebugProvider s_provider = new DebugProvider();
 
         public static DebugProvider SetProvider(DebugProvider provider)
         {
@@ -40,7 +40,7 @@ namespace System.Diagnostics
             }
         }
 
-        private static int s_indentSize = 4;
+        private static volatile int  s_indentSize = 4;
         public static int IndentSize
         {
             get

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.Unix.cs
@@ -38,7 +38,7 @@ namespace System.Diagnostics
             }
         }
 
-        public virtual void WriteCore(string message)
+        public static void WriteCore(string message)
         {
             if (s_WriteCore != null)
             {

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.Unix.cs
@@ -38,8 +38,14 @@ namespace System.Diagnostics
             }
         }
 
-        private static void WriteCore(string message)
+        public virtual void WriteCore(string message)
         {
+            if (s_WriteCore != null)
+            {
+                s_WriteCore(message); 
+                return;
+            }
+
             WriteToDebugger(message);
 
             if (s_shouldWriteToStdErr)

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
@@ -39,6 +39,10 @@ namespace System.Diagnostics
             Write(message + Environment.NewLine);
         }
 
+        public virtual void OnIndentLevelChanged(int indentLevel) { }
+
+        public virtual void OnIndentSizeChanged(int indentSize) { }
+
         private static readonly object s_lock = new object();
 
         private sealed class DebugAssertException : Exception
@@ -59,40 +63,13 @@ namespace System.Diagnostics
             }
         }
 
-        [ThreadStatic]
-        private static int s_indentLevel;
-        public virtual int IndentLevel
-        {
-            get
-            {
-                return s_indentLevel;
-            }
-            set
-            {
-                s_indentLevel = value < 0 ? 0 : value;
-            }
-        }
-
-        private static int s_indentSize = 4;
-        public virtual int IndentSize
-        {
-            get
-            {
-                return s_indentSize;
-            }
-            set
-            {
-                s_indentSize = value < 0 ? 0 : value;
-            }
-        }
-
         private bool _needIndent = true;
 
         private string _indentString;
 
-        internal string GetIndentString()
+        private string GetIndentString()
         {
-            int indentCount = IndentSize * IndentLevel;
+            int indentCount = Debug.IndentSize * Debug.IndentLevel;
             if (_indentString?.Length == indentCount)
             {
                 return _indentString;

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
@@ -88,7 +88,7 @@ namespace System.Diagnostics
 
         private static bool s_needIndent = true;
 
-        private static string s_indentString;
+        private string s_indentString;
 
         internal string GetIndentString()
         {

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
@@ -21,15 +21,15 @@ namespace System.Diagnostics
                     s_WriteCore(string.Empty);
                     return;
                 }
-                if (s_needIndent)
+                if (_needIndent)
                 {
                     message = GetIndentString() + message;
-                    s_needIndent = false;
+                    _needIndent = false;
                 }
                 s_WriteCore(message);
                 if (message.EndsWith(Environment.NewLine))
                 {
-                    s_needIndent = true;
+                    _needIndent = true;
                 }
             }
         }
@@ -86,18 +86,18 @@ namespace System.Diagnostics
             }
         }
 
-        private static bool s_needIndent = true;
+        private bool _needIndent = true;
 
-        private string s_indentString;
+        private string _indentString;
 
         internal string GetIndentString()
         {
             int indentCount = IndentSize * IndentLevel;
-            if (s_indentString?.Length == indentCount)
+            if (_indentString?.Length == indentCount)
             {
-                return s_indentString;
+                return _indentString;
             }
-            return s_indentString = new string(' ', indentCount);
+            return _indentString = new string(' ', indentCount);
         }
 
         // internal and not readonly so that the tests can swap this out.

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
@@ -33,6 +33,11 @@ namespace System.Diagnostics
                 }
             }
         }
+        
+        public virtual void WriteLine(string message)
+        {
+            Write(message + Environment.NewLine);
+        }
 
         private static readonly object s_lock = new object();
 
@@ -56,7 +61,7 @@ namespace System.Diagnostics
 
         [ThreadStatic]
         private static int s_indentLevel;
-        internal static int IndentLevel
+        public virtual int IndentLevel
         {
             get
             {
@@ -69,7 +74,7 @@ namespace System.Diagnostics
         }
 
         private static int s_indentSize = 4;
-        internal static int IndentSize
+        public virtual int IndentSize
         {
             get
             {
@@ -81,11 +86,11 @@ namespace System.Diagnostics
             }
         }
 
-        private static bool s_needIndent;
+        private static bool s_needIndent = true;
 
         private static string s_indentString;
 
-        internal static string GetIndentString()
+        internal string GetIndentString()
         {
             int indentCount = IndentSize * IndentLevel;
             if (s_indentString?.Length == indentCount)

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
@@ -18,7 +18,7 @@ namespace System.Diagnostics
             {
                 if (message == null)
                 {
-                    s_WriteCore(string.Empty);
+                    WriteCore(string.Empty);
                     return;
                 }
                 if (_needIndent)
@@ -26,7 +26,7 @@ namespace System.Diagnostics
                     message = GetIndentString() + message;
                     _needIndent = false;
                 }
-                s_WriteCore(message);
+                WriteCore(message);
                 if (message.EndsWith(Environment.NewLine))
                 {
                     _needIndent = true;
@@ -78,6 +78,6 @@ namespace System.Diagnostics
         }
 
         // internal and not readonly so that the tests can swap this out.
-        internal static Action<string> s_WriteCore = WriteCore;
+        internal static Action<string> s_WriteCore;
     }
 }

--- a/src/System.Private.CoreLib/src/System/Diagnostics/DebugProvider.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/DebugProvider.Windows.cs
@@ -36,8 +36,14 @@ namespace System.Diagnostics
 
         private static readonly object s_ForLock = new object();
 
-        private static void WriteCore(string message)
+        public virtual void WriteCore(string message)
         {
+            if (s_WriteCore != null)
+            {
+                s_WriteCore(message); 
+                return;
+            }
+
             // really huge messages mess up both VS and dbmon, so we chop it up into 
             // reasonable chunks if it's too big. This is the number of characters 
             // that OutputDebugstring chunks at.

--- a/src/System.Private.CoreLib/src/System/Diagnostics/DebugProvider.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/DebugProvider.Windows.cs
@@ -36,7 +36,7 @@ namespace System.Diagnostics
 
         private static readonly object s_ForLock = new object();
 
-        public virtual void WriteCore(string message)
+        public static void WriteCore(string message)
         {
             if (s_WriteCore != null)
             {


### PR DESCRIPTION
Making Debug and Trace behavior consistent with eachother and Desktop

Syncs IndentLevel and IndentSize for Debug and Trace

Fixes Debug indentation bugs, adds tests (https://github.com/dotnet/corefx/pull/33020 shows all the tests that are now fixed)

Completing DebugProvider APIs. Fixing Indentation bugs

cc: @jkotas @eerhardt @danmosemsft 

Related to: dotnet/corefx#3708, dotnet/corefx#31003