### PR TITLE
Exclude IDispatch test for Windows Arm64

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -429,7 +429,7 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/mcc/interop/mcc_i73/*">
             <Issue>Needs Triage</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/COM/NETClients/IDispatch/*">
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/COM/NETClients/IDispatch/NETClientIDispatch/*">
             <Issue>20580</Issue>
         </ExcludeList>
     </ItemGroup>

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -429,6 +429,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/mcc/interop/mcc_i73/*">
             <Issue>Needs Triage</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/COM/NETClients/IDispatch/*">
+            <Issue>20580</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- arm32 All OS specific excludes -->


### PR DESCRIPTION
Disable for now while failures are investigated. See #20580.