### PR TITLE
Working towards clean-up comments /**/ in cs

### DIFF
--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
@@ -136,12 +136,6 @@ namespace System.Reflection.Emit
         #endregion
     }
     
-    /// <summary>
-    /// AssemblyBuilder class.
-    /// </summary>
-    /// <remarks>
-    /// Deliberately not [serializable]
-    /// </remarks>
     public sealed class AssemblyBuilder : Assembly
     {
         #region FCALL
@@ -280,10 +274,7 @@ namespace System.Reflection.Emit
         /// to have a strong name and a hash will be computed when the assembly
         /// is saved.
         /// </summary>
-        /// <remarks>
-        /// Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod.
-        /// </remarks>
-        [System.Security.DynamicSecurityMethod]
+        [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod.
         public static AssemblyBuilder DefineDynamicAssembly(
             AssemblyName name,
             AssemblyBuilderAccess access)
@@ -292,11 +283,8 @@ namespace System.Reflection.Emit
             return InternalDefineDynamicAssembly(name, access,
                                                  ref stackMark, null);
         }
-
-        /// <remarks>
-        /// Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod.
-        /// </remarks>
-        [System.Security.DynamicSecurityMethod]
+        
+        [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod.
         public static AssemblyBuilder DefineDynamicAssembly(
             AssemblyName name,
             AssemblyBuilderAccess access,
@@ -342,23 +330,17 @@ namespace System.Reflection.Emit
         /// modules within an Assembly with the same name. This dynamic module is
         /// a transient module.
         /// </summary>
-        /// <remarks>
-        /// Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod.
-        /// </remarks>
-        [System.Security.DynamicSecurityMethod]
+        [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod.
         public ModuleBuilder DefineDynamicModule(
             string name)
         {
             StackCrawlMark stackMark = StackCrawlMark.LookForMyCaller;
             return DefineDynamicModuleInternal(name, false, ref stackMark);
         }
-
-        /// <remarks>
-        /// Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod.
-        /// </remarks>
+        
         /// <param name = "name" ></ param >
         /// <param name = "emitSymbolInfo" >Specify if emit symbol info or not.</ param >
-        [System.Security.DynamicSecurityMethod]
+        [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod.
         public ModuleBuilder DefineDynamicModule(
             string name,
             bool emitSymbolInfo)
@@ -635,11 +617,8 @@ namespace System.Reflection.Emit
         {
             return InternalAssembly.GetLoadedModules(getResourceModules);
         }
-
-        /// <remarks>
-        /// Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
-        /// </remarks>
-        [System.Security.DynamicSecurityMethod]
+        
+        [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod.
         public override Assembly GetSatelliteAssembly(CultureInfo culture)
         {
             StackCrawlMark stackMark = StackCrawlMark.LookForMyCaller;
@@ -649,10 +628,7 @@ namespace System.Reflection.Emit
         /// <sumary> 
         /// Useful for binding to a very specific version of a satellite assembly
         /// </sumary>
-        /// <remarks>
-        /// Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
-        /// </remarks>
-        [System.Security.DynamicSecurityMethod]
+        [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod.
         public override Assembly GetSatelliteAssembly(CultureInfo culture, Version version)
         {
             StackCrawlMark stackMark = StackCrawlMark.LookForMyCaller;

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-//*************************************************************************************************************
+//
 // For each dynamic assembly there will be two AssemblyBuilder objects: the "internal" 
 // AssemblyBuilder object and the "external" AssemblyBuilder object.
 //  1.  The "internal" object is the real assembly object that the VM creates and knows about. However, 
@@ -19,7 +19,7 @@
 //      "internal" object.
 //
 // "internal" and "external" ModuleBuilders are similar
-//*************************************************************************************************************
+//
 
 namespace System.Reflection.Emit
 {

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
@@ -339,8 +339,8 @@ namespace System.Reflection.Emit
         #region DefineDynamicModule
         /// <summary>
         /// Defines a named dynamic module. It is an error to define multiple 
-        /// modules within an Assembly with the same name.This dynamic module is
-        /// transient module.
+        /// modules within an Assembly with the same name. This dynamic module is
+        /// a transient module.
         /// </summary>
         /// <remarks>
         /// Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod.
@@ -356,10 +356,12 @@ namespace System.Reflection.Emit
         /// <remarks>
         /// Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod.
         /// </remarks>
+        /// <param name = "name" ></ param >
+        /// <param name = "emitSymbolInfo" >Specify if emit symbol info or not.</ param >
         [System.Security.DynamicSecurityMethod]
         public ModuleBuilder DefineDynamicModule(
             string name,
-            bool emitSymbolInfo)         // specify if emit symbol info or not
+            bool emitSymbolInfo)
         {
             StackCrawlMark stackMark = StackCrawlMark.LookForMyCaller;
             return DefineDynamicModuleInternal(name, emitSymbolInfo, ref stackMark);
@@ -489,9 +491,7 @@ namespace System.Reflection.Emit
         #endregion
 
         #region Assembly overrides
-        /// <summary>
-        /// Returns the names of all the resources.
-        /// </summary>
+        /// <returns>The names of all the resources.</returns>
         public override string[] GetManifestResourceNames()
         {
             return InternalAssembly.GetManifestResourceNames();
@@ -546,8 +546,10 @@ namespace System.Reflection.Emit
             }
         }
 
-        // Override the EntryPoint method on Assembly.
-        // This doesn't need to be synchronized because it is simple enough
+        /// <sumary>
+        /// Override the EntryPoint method on Assembly.
+        /// This doesn't need to be synchronized because it is simple enough.
+        /// </sumary>
         public override MethodInfo EntryPoint
         {
             get
@@ -556,7 +558,9 @@ namespace System.Reflection.Emit
             }
         }
 
-        // Get an array of all the public types defined in this assembly
+        /// <sumary>
+        /// Get an array of all the public types defined in this assembly.
+        /// </sumary>
         public override Type[] GetExportedTypes()
         {
             return InternalAssembly.GetExportedTypes();
@@ -632,15 +636,23 @@ namespace System.Reflection.Emit
             return InternalAssembly.GetLoadedModules(getResourceModules);
         }
 
-        [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
+        /// <remarks>
+        /// Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
+        /// </remarks>
+        [System.Security.DynamicSecurityMethod]
         public override Assembly GetSatelliteAssembly(CultureInfo culture)
         {
             StackCrawlMark stackMark = StackCrawlMark.LookForMyCaller;
             return InternalAssembly.InternalGetSatelliteAssembly(culture, null, ref stackMark);
         }
 
-        // Useful for binding to a very specific version of a satellite assembly
-        [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
+        /// <sumary> 
+        /// Useful for binding to a very specific version of a satellite assembly
+        /// </sumary>
+        /// <remarks>
+        /// Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
+        /// </remarks>
+        [System.Security.DynamicSecurityMethod]
         public override Assembly GetSatelliteAssembly(CultureInfo culture, Version version)
         {
             StackCrawlMark stackMark = StackCrawlMark.LookForMyCaller;
@@ -657,12 +669,9 @@ namespace System.Reflection.Emit
 
         public override bool IsCollectible => InternalAssembly.IsCollectible;
         #endregion
-
-        /// <summary>
-        /// Return a dynamic module with the specified name.
-        /// </summary>
+        
         /// <param name="name">The name of module for the look up.</param>
-        /// <returns>Dynamic module with the specified name</returns>
+        /// <returns>Dynamic module with the specified name.</returns>
         public ModuleBuilder GetDynamicModule(
             string name)
         {

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
@@ -2,24 +2,24 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-/// <summary>
-/// For each dynamic assembly there will be two AssemblyBuilder objects: the "internal" 
-/// AssemblyBuilder object and the "external" AssemblyBuilder object.
-///  1.  The "internal" object is the real assembly object that the VM creates and knows about. However, 
-///      you can perform RefEmit operations on it only if you have its granted permission. From the AppDomain 
-///      and other "internal" objects like the "internal" ModuleBuilders and runtime types, you can only
-///      get the "internal" objects. This is to prevent low-trust code from getting a hold of the dynamic
-///      AssemblyBuilder/ModuleBuilder/TypeBuilder/MethodBuilder/etc other people have created by simply 
-///      enumerating the AppDomain and inject code in it.
-///  2.  The "external" object is merely an wrapper of the "internal" object and all operations on it
-///      are directed to the internal object. This is the one you get by calling DefineDynamicAssembly
-///      on AppDomain and the one you can always perform RefEmit operations on. You can get other "external"
-///      objects from the "external" AssemblyBuilder, ModuleBuilder, TypeBuilder, MethodBuilder, etc. Note
-///      that VM doesn't know about this object. So every time we call into the VM we need to pass in the
-///      "internal" object.
-///
-/// "internal" and "external" ModuleBuilders are similar
-/// </summary>
+//*************************************************************************************************************
+// For each dynamic assembly there will be two AssemblyBuilder objects: the "internal" 
+// AssemblyBuilder object and the "external" AssemblyBuilder object.
+//  1.  The "internal" object is the real assembly object that the VM creates and knows about. However, 
+//      you can perform RefEmit operations on it only if you have its granted permission. From the AppDomain 
+//      and other "internal" objects like the "internal" ModuleBuilders and runtime types, you can only
+//      get the "internal" objects. This is to prevent low-trust code from getting a hold of the dynamic
+//      AssemblyBuilder/ModuleBuilder/TypeBuilder/MethodBuilder/etc other people have created by simply 
+//      enumerating the AppDomain and inject code in it.
+//  2.  The "external" object is merely an wrapper of the "internal" object and all operations on it
+//      are directed to the internal object. This is the one you get by calling DefineDynamicAssembly
+//      on AppDomain and the one you can always perform RefEmit operations on. You can get other "external"
+//      objects from the "external" AssemblyBuilder, ModuleBuilder, TypeBuilder, MethodBuilder, etc. Note
+//      that VM doesn't know about this object. So every time we call into the VM we need to pass in the
+//      "internal" object.
+//
+// "internal" and "external" ModuleBuilders are similar
+//*************************************************************************************************************
 
 namespace System.Reflection.Emit
 {

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
@@ -2,25 +2,24 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-//*************************************************************************************************************
-// For each dynamic assembly there will be two AssemblyBuilder objects: the "internal" 
-// AssemblyBuilder object and the "external" AssemblyBuilder object.
-//  1.  The "internal" object is the real assembly object that the VM creates and knows about. However, 
-//      you can perform RefEmit operations on it only if you have its granted permission. From the AppDomain 
-//      and other "internal" objects like the "internal" ModuleBuilders and runtime types, you can only
-//      get the "internal" objects. This is to prevent low-trust code from getting a hold of the dynamic
-//      AssemblyBuilder/ModuleBuilder/TypeBuilder/MethodBuilder/etc other people have created by simply 
-//      enumerating the AppDomain and inject code in it.
-//  2.  The "external" object is merely an wrapper of the "internal" object and all operations on it
-//      are directed to the internal object. This is the one you get by calling DefineDynamicAssembly
-//      on AppDomain and the one you can always perform RefEmit operations on. You can get other "external"
-//      objects from the "external" AssemblyBuilder, ModuleBuilder, TypeBuilder, MethodBuilder, etc. Note
-//      that VM doesn't know about this object. So every time we call into the VM we need to pass in the
-//      "internal" object.
-//
-// "internal" and "external" ModuleBuilders are similar
-//*************************************************************************************************************
+/// <summary>
+/// For each dynamic assembly there will be two AssemblyBuilder objects: the "internal" 
+/// AssemblyBuilder object and the "external" AssemblyBuilder object.
+///  1.  The "internal" object is the real assembly object that the VM creates and knows about. However, 
+///      you can perform RefEmit operations on it only if you have its granted permission. From the AppDomain 
+///      and other "internal" objects like the "internal" ModuleBuilders and runtime types, you can only
+///      get the "internal" objects. This is to prevent low-trust code from getting a hold of the dynamic
+///      AssemblyBuilder/ModuleBuilder/TypeBuilder/MethodBuilder/etc other people have created by simply 
+///      enumerating the AppDomain and inject code in it.
+///  2.  The "external" object is merely an wrapper of the "internal" object and all operations on it
+///      are directed to the internal object. This is the one you get by calling DefineDynamicAssembly
+///      on AppDomain and the one you can always perform RefEmit operations on. You can get other "external"
+///      objects from the "external" AssemblyBuilder, ModuleBuilder, TypeBuilder, MethodBuilder, etc. Note
+///      that VM doesn't know about this object. So every time we call into the VM we need to pass in the
+///      "internal" object.
+///
+/// "internal" and "external" ModuleBuilders are similar
+/// </summary>
 
 namespace System.Reflection.Emit
 {
@@ -136,9 +135,13 @@ namespace System.Reflection.Emit
         }
         #endregion
     }
-
-    // AssemblyBuilder class.
-    // deliberately not [serializable]
+    
+    /// <summary>
+    /// AssemblyBuilder class.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not [serializable]
+    /// </remarks>
     public sealed class AssemblyBuilder : Assembly
     {
         #region FCALL
@@ -272,12 +275,15 @@ namespace System.Reflection.Emit
 
         #region DefineDynamicAssembly
 
-        /**********************************************
-        * If an AssemblyName has a public key specified, the assembly is assumed
-        * to have a strong name and a hash will be computed when the assembly
-        * is saved.
-        **********************************************/
-        [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
+        /// <summary>
+        /// If an AssemblyName has a public key specified, the assembly is assumed
+        /// to have a strong name and a hash will be computed when the assembly
+        /// is saved.
+        /// </summary>
+        /// <remarks>
+        /// Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod.
+        /// </remarks>
+        [System.Security.DynamicSecurityMethod]
         public static AssemblyBuilder DefineDynamicAssembly(
             AssemblyName name,
             AssemblyBuilderAccess access)
@@ -287,7 +293,10 @@ namespace System.Reflection.Emit
                                                  ref stackMark, null);
         }
 
-        [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
+        /// <remarks>
+        /// Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod.
+        /// </remarks>
+        [System.Security.DynamicSecurityMethod]
         public static AssemblyBuilder DefineDynamicAssembly(
             AssemblyName name,
             AssemblyBuilderAccess access,
@@ -328,14 +337,15 @@ namespace System.Reflection.Emit
         #endregion
 
         #region DefineDynamicModule
-        /**********************************************
-        *
-        * Defines a named dynamic module. It is an error to define multiple 
-        * modules within an Assembly with the same name. This dynamic module is
-        * a transient module.
-        * 
-        **********************************************/
-        [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
+        /// <summary>
+        /// Defines a named dynamic module. It is an error to define multiple 
+        /// modules within an Assembly with the same name.This dynamic module is
+        /// transient module
+        /// </summary>
+        /// <remarks>
+        /// Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod.
+        /// </remarks>
+        [System.Security.DynamicSecurityMethod]
         public ModuleBuilder DefineDynamicModule(
             string name)
         {
@@ -343,7 +353,10 @@ namespace System.Reflection.Emit
             return DefineDynamicModuleInternal(name, false, ref stackMark);
         }
 
-        [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
+        /// <remarks>
+        /// Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod.
+        /// </remarks>
+        [System.Security.DynamicSecurityMethod]
         public ModuleBuilder DefineDynamicModule(
             string name,
             bool emitSymbolInfo)         // specify if emit symbol info or not
@@ -476,7 +489,9 @@ namespace System.Reflection.Emit
         #endregion
 
         #region Assembly overrides
-        // Returns the names of all the resources
+        /// <summary>
+        /// Returns the names of all the resources.
+        /// </summary>
         public override string[] GetManifestResourceNames()
         {
             return InternalAssembly.GetManifestResourceNames();
@@ -641,14 +656,11 @@ namespace System.Reflection.Emit
         }
         #endregion
 
-
-        /**********************************************
-        *
-        * return a dynamic module with the specified name.
-        *
-        **********************************************/
+        
+        /// <param name="name">The name of module for the look up.</param>
+        /// <returns>Dynamic module with the specified name</returns>
         public ModuleBuilder GetDynamicModule(
-            string name)                   // the name of module for the look up
+            string name)
         {
             lock (SyncRoot)
             {
@@ -656,8 +668,9 @@ namespace System.Reflection.Emit
             }
         }
 
+        /// <param name="name">The name of module for the look up.</param>
         private ModuleBuilder GetDynamicModuleNoLock(
-            string name)                   // the name of module for the look up
+            string name)
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
@@ -676,10 +689,10 @@ namespace System.Reflection.Emit
             return null;
         }
 
-
-        /**********************************************
-        * Use this function if client decides to form the custom attribute blob themselves
-        **********************************************/
+        
+        /// <summary>
+        /// Use this function if client decides to form the custom attribute blob themselves.
+        /// </summary>
         public void SetCustomAttribute(ConstructorInfo con, byte[] binaryAttribute)
         {
             if (con == null)
@@ -710,10 +723,10 @@ namespace System.Reflection.Emit
                 m_assemblyData.AddCustomAttribute(con, binaryAttribute);
             }
         }
-
-        /**********************************************
-        * Use this function if client wishes to build CustomAttribute using CustomAttributeBuilder
-        **********************************************/
+        
+        /// <summary>
+        /// Use this function if client wishes to build CustomAttribute using CustomAttributeBuilder.
+        /// </summary>
         public void SetCustomAttribute(CustomAttributeBuilder customBuilder)
         {
             if (customBuilder == null)

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilderData.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilderData.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////
-// 
-
 namespace System.Reflection.Emit
 {
     using System;
@@ -19,9 +15,11 @@ namespace System.Reflection.Emit
     using System.Runtime.Versioning;
     using System.Diagnostics.SymbolStore;
 
-    // This is a package private class. This class hold all of the managed
-    // data member for AssemblyBuilder. Note that what ever data members added to
-    // this class cannot be accessed from the EE.
+    /// <summary>
+    /// This is a package private class. This class hold all of the managed
+    /// data member for AssemblyBuilder. Note that what ever data members added to
+    /// this class cannot be accessed from the EE.
+    /// </summary>
     internal class AssemblyBuilderData
     {
         internal AssemblyBuilderData(
@@ -37,15 +35,18 @@ namespace System.Reflection.Emit
 
             m_peFileKind = PEFileKinds.Dll;
         }
-
-        // Helper to add a dynamic module into the tracking list
+        
+        /// <summary>
+        /// Helper to add a dynamic module into the tracking list.
+        /// </summary>
         internal void AddModule(ModuleBuilder dynModule)
         {
             m_moduleBuilderList.Add(dynModule);
         }
 
-
-        // Helper to track CAs to persist onto disk
+        /// <summary>
+        /// Helper to track CAs to persist onto disk.
+        /// </summary>
         internal void AddCustomAttribute(CustomAttributeBuilder customBuilder)
         {
             // make sure we have room for this CA
@@ -63,8 +64,10 @@ namespace System.Reflection.Emit
 
             m_iCABuilder++;
         }
-
-        // Helper to track CAs to persist onto disk
+        
+        /// <summary>
+        /// Helper to track CAs to persist onto disk.
+        /// </summary>
         internal void AddCustomAttribute(ConstructorInfo con, byte[] binaryAttribute)
         {
             // make sure we have room for this CA
@@ -93,8 +96,10 @@ namespace System.Reflection.Emit
             m_CACons[m_iCAs] = con;
             m_iCAs++;
         }
-
-        // Helper to ensure the type name is unique underneath assemblyBuilder
+        
+        /// <summary>
+        /// Helper to ensure the type name is unique underneath assemblyBuilder.
+        /// </summary>
         internal void CheckTypeNameConflict(string strTypeName, TypeBuilder enclosingType)
         {
             for (int i = 0; i < m_moduleBuilderList.Count; i++)
@@ -146,14 +151,11 @@ namespace System.Reflection.Emit
         internal bool m_hasUnmanagedVersionInfo;
         internal bool m_OverrideUnmanagedVersionInfo;
     }
-
-
-    /**********************************************
-    *
-    * Internal structure to track the list of ResourceWriter for
-    * AssemblyBuilder & ModuleBuilder.
-    *
-    **********************************************/
+    
+    /// <summary>
+    /// Internal structure to track the list of ResourceWriter for
+    /// AssemblyBuilder & ModuleBuilder.
+    /// </summary>
     internal class ResWriterData
     {
         internal string m_strName;


### PR DESCRIPTION
Cleaning up /**/ style comments - Following https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/recommended-tags-for-documentation-comments

-AssemblyBuilder.cs
-AssemblyBuilderData.cs

#20330