### PR TITLE
Remove EventPipe Debug-Only File Writing Code

### DIFF
--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -31,10 +31,6 @@ EventPipeBufferManager* EventPipe::s_pBufferManager = NULL;
 EventPipeFile* EventPipe::s_pFile = NULL;
 EventPipeEventSource* EventPipe::s_pEventSource = NULL;
 LPCWSTR EventPipe::s_pCommandLine = NULL;
-#ifdef _DEBUG
-EventPipeFile* EventPipe::s_pSyncFile = NULL;
-EventPipeJsonFile* EventPipe::s_pJsonFile = NULL;
-#endif // _DEBUG
 
 #ifdef FEATURE_PAL
 // This function is auto-generated from /src/scripts/genEventPipe.py
@@ -311,21 +307,6 @@ EventPipeSessionID EventPipe::Enable(LPCWSTR strOutputPath, EventPipeSession *pS
         s_pFile = new EventPipeFile(eventPipeFileOutputPath);
     }
 
-#ifdef _DEBUG
-    if((CLRConfig::GetConfigValue(CLRConfig::INTERNAL_EnableEventPipe) & 2) == 2)
-    {
-        // Create a synchronous file.
-        SString eventPipeSyncFileOutputPath;
-        eventPipeSyncFileOutputPath.Printf("Process-%d.sync.netperf", GetCurrentProcessId());
-        s_pSyncFile = new EventPipeFile(eventPipeSyncFileOutputPath);
-
-        // Create a JSON file.
-        SString outputFilePath;
-        outputFilePath.Printf("Process-%d.PerfView.json", GetCurrentProcessId());
-        s_pJsonFile = new EventPipeJsonFile(outputFilePath);
-    }
-#endif // _DEBUG
-
     // Save the session.
     s_pSession = pSession;
 
@@ -420,18 +401,6 @@ void EventPipe::Disable(EventPipeSessionID id)
             delete(s_pFile);
             s_pFile = NULL;
         }
-#ifdef _DEBUG
-        if(s_pSyncFile != NULL)
-        {
-            delete(s_pSyncFile);
-            s_pSyncFile = NULL;
-        }
-        if(s_pJsonFile != NULL)
-        {
-            delete(s_pJsonFile);
-            s_pJsonFile = NULL;
-        }
-#endif // _DEBUG
 
         // De-allocate buffers.
         s_pBufferManager->DeAllocateBuffers();
@@ -606,11 +575,7 @@ void EventPipe::WriteEventInternal(EventPipeEvent &event, EventPipeEventPayload 
 
     if(!s_pConfig->RundownEnabled() && s_pBufferManager != NULL)
     {
-        if(!s_pBufferManager->WriteEvent(pThread, *s_pSession, event, payload, pActivityId, pRelatedActivityId))
-        {
-            // This is used in DEBUG to make sure that we don't log an event synchronously that we didn't log to the buffer.
-            return;
-        }
+        s_pBufferManager->WriteEvent(pThread, *s_pSession, event, payload, pActivityId, pRelatedActivityId);
     }
     else if(s_pConfig->RundownEnabled())
     {
@@ -655,39 +620,6 @@ void EventPipe::WriteEventInternal(EventPipeEvent &event, EventPipeEventPayload 
             }
         }
     }
-
-// This section requires a call to GCX_PREEMP which violates the GC_NOTRIGGER contract
-// It should only be enabled when debugging this specific component and contracts are off
-#ifdef DEBUG_JSON_EVENT_FILE
-    {
-        GCX_PREEMP();
-
-        BYTE *pData = payload.GetFlatData();
-        if (pData != NULL)
-        {
-            // Create an instance of the event for the synchronous path.
-            EventPipeEventInstance instance(
-                event,
-                pThread->GetOSThreadId(),
-                pData,
-                payload.GetSize(),
-                pActivityId,
-                pRelatedActivityId);
-
-            // Write to the EventPipeFile if it exists.
-            if(s_pSyncFile != NULL)
-            {
-                s_pSyncFile->WriteEvent(instance);
-            }
-
-            // Write to the EventPipeJsonFile if it exists.
-            if(s_pJsonFile != NULL)
-            {
-                s_pJsonFile->WriteEvent(instance);
-            }
-        }
-    }
-#endif // DEBUG_JSON_EVENT_FILE
 }
 
 void EventPipe::WriteSampleProfileEvent(Thread *pSamplingThread, EventPipeEvent *pEvent, Thread *pTargetThread, StackContents &stackContents, BYTE *pData, unsigned int length)
@@ -707,34 +639,8 @@ void EventPipe::WriteSampleProfileEvent(Thread *pSamplingThread, EventPipeEvent 
     {
         // Specify the sampling thread as the "current thread", so that we select the right buffer.
         // Specify the target thread so that the event gets properly attributed.
-        if(!s_pBufferManager->WriteEvent(pSamplingThread, *s_pSession, *pEvent, payload, NULL /* pActivityId */, NULL /* pRelatedActivityId */, pTargetThread, &stackContents))
-        {
-            // This is used in DEBUG to make sure that we don't log an event synchronously that we didn't log to the buffer.
-            return;
-        }
+        s_pBufferManager->WriteEvent(pSamplingThread, *s_pSession, *pEvent, payload, NULL /* pActivityId */, NULL /* pRelatedActivityId */, pTargetThread, &stackContents);
     }
-
-#ifdef _DEBUG
-    {
-        GCX_PREEMP();
-
-        // Create an instance for the synchronous path.
-        SampleProfilerEventInstance instance(*s_pSession, *pEvent, pTargetThread, pData, length);
-        stackContents.CopyTo(instance.GetStack());
-
-        // Write to the EventPipeFile.
-        if(s_pSyncFile != NULL)
-        {
-            s_pSyncFile->WriteEvent(instance);
-        }
-
-        // Write to the EventPipeJsonFile if it exists.
-        if(s_pJsonFile != NULL)
-        {
-            s_pJsonFile->WriteEvent(instance);
-        }
-    }
-#endif // _DEBUG
 }
 
 bool EventPipe::WalkManagedStackForCurrentThread(StackContents &stackContents)

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -310,10 +310,6 @@ class EventPipe
         static EventPipeFile *s_pFile;
         static EventPipeEventSource *s_pEventSource;
         static LPCWSTR s_pCommandLine;
-#ifdef _DEBUG
-        static EventPipeFile *s_pSyncFile;
-        static EventPipeJsonFile *s_pJsonFile;
-#endif // _DEBUG
 };
 
 struct EventPipeProviderConfiguration

--- a/src/vm/eventpipefile.cpp
+++ b/src/vm/eventpipefile.cpp
@@ -12,12 +12,7 @@
 #ifdef FEATURE_PERFTRACING
 
 EventPipeFile::EventPipeFile(
-    SString &outputFilePath
-#ifdef _DEBUG
-    ,
-    bool lockOnWrite
-#endif // _DEBUG
-)
+    SString &outputFilePath)
 {
     CONTRACTL
     {
@@ -31,10 +26,6 @@ EventPipeFile::EventPipeFile(
     SetMinReaderVersion(0);
 
     m_pBlock = new EventPipeBlock(100 * 1024);
-
-#ifdef _DEBUG
-    m_lockOnWrite = lockOnWrite;
-#endif // _DEBUG
 
     // File start time information.
     GetSystemTime(&m_fileOpenSystemTime);
@@ -157,16 +148,6 @@ void EventPipeFile::WriteToBlock(EventPipeEventInstance &instance, unsigned int 
     {
         return; // the block is not full, we added the event and continue
     }
-
-#ifdef _DEBUG
-    if (m_lockOnWrite)
-    {
-        // Take the serialization lock.
-        // This is used for synchronous file writes.
-        // The circular buffer path only writes from one thread.
-        SpinLockHolder _slh(&m_serializationLock);
-    }
-#endif // _DEBUG
 
     // we can't write this event to the current block (it's full)
     // so we write what we have in the block to the serializer

--- a/src/vm/eventpipefile.h
+++ b/src/vm/eventpipefile.h
@@ -18,12 +18,7 @@ class EventPipeFile : public FastSerializableObject
 {
     public:
 
-        EventPipeFile(SString &outputFilePath
-#ifdef _DEBUG
-            ,
-            bool lockOnWrite = false
-#endif // _DEBUG
-        );
+        EventPipeFile(SString &outputFilePath);
         ~EventPipeFile();
 
         void WriteEvent(EventPipeEventInstance &instance);
@@ -98,10 +93,6 @@ class EventPipeFile : public FastSerializableObject
         MapSHashWithRemove<EventPipeEvent*, unsigned int> *m_pMetadataIds;
 
         Volatile<LONG> m_metadataIdCounter;
-
-#ifdef _DEBUG
-        bool m_lockOnWrite;
-#endif // _DEBUG
 };
 
 #endif // FEATURE_PERFTRACING


### PR DESCRIPTION
When EventPipe was originally written, we had some synchronous file writing code used for debugging of the circular buffer.  This code does not work properly and is no longer used.  Thus, it should be removed.