### PR TITLE
Add a run time check for Windows.Nano to all COM related tests.

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -47,16 +47,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/GitHub_11408/GitHub_11408/*">
             <Issue>11408</Issue>
         </ExcludeList>
-        <!-- Disable COM tests since they don't properly run on Windows.Nano and at present there is no way to special case that OS flavor. -->
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/COM/NETClients/Primitives/NETClientPrimitives/NETClientPrimitives.cmd">
-            <Issue>19164</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/COM/NativeClients/Primitives/Primitives.cmd">
-            <Issue>19164</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/COM/NETClients/IDispatch/NETClientIDispatch/NETClientIDispatch.cmd">
-            <Issue>19164</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/StackTracePreserve/StackTracePreserveTests/*">
             <Issue>20322</Issue>
         </ExcludeList>

--- a/tests/src/Interop/COM/NETClients/Aggregation/Program.cs
+++ b/tests/src/Interop/COM/NETClients/Aggregation/Program.cs
@@ -29,6 +29,12 @@ namespace NetClient
 
         static int Main(string[] doNotUse)
         {
+            // RegFree COM is not supported on Windows Nano
+            if (Utilities.IsWindowsNanoServer)
+            {
+                return 100;
+            }
+
             try
             {
                 ValidateNativeOuter();

--- a/tests/src/Interop/COM/NETClients/IDispatch/Program.cs
+++ b/tests/src/Interop/COM/NETClients/IDispatch/Program.cs
@@ -153,6 +153,12 @@ namespace NetClient
 
         static int Main(string[] doNotUse)
         {
+            // RegFree COM is not supported on Windows Nano
+            if (Utilities.IsWindowsNanoServer)
+            {
+                return 100;
+            }
+
             try
             {
                 Validate_Numeric_In_ReturnByRef();

--- a/tests/src/Interop/COM/NETClients/Primitives/Program.cs
+++ b/tests/src/Interop/COM/NETClients/Primitives/Program.cs
@@ -10,6 +10,12 @@ namespace NetClient
     {
         static int Main(string[] doNotUse)
         {
+            // RegFree COM is not supported on Windows Nano
+            if (TestLibrary.Utilities.IsWindowsNanoServer)
+            {
+                return 100;
+            }
+
             try
             {
                 new NumericTests().Run();

--- a/tests/src/Interop/COM/NativeClients/Primitives.csproj
+++ b/tests/src/Interop/COM/NativeClients/Primitives.csproj
@@ -8,6 +8,7 @@
 
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>
+    <DefineConstants>BLOCK_WINDOWS_NANO</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(InteropCommonDir)ExeLauncherProgram.cs" />
@@ -15,6 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="Primitives/CMakeLists.txt"/>
     <ProjectReference Include="../NetServer/NetServer.csproj" />
+    <ProjectReference Include="../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/tests/src/Interop/common/ExeLauncherProgram.cs
+++ b/tests/src/Interop/common/ExeLauncherProgram.cs
@@ -22,6 +22,14 @@ public class Program
             return 100;
         }
 
+#if BLOCK_WINDOWS_NANO
+        // Not supported on Windows Nano
+        if (TestLibrary.Utilities.IsWindowsNanoServer)
+        {
+            return 100;
+        }
+#endif
+
         string workingDir = Environment.CurrentDirectory;
         Console.WriteLine($"Searching for exe to launch in {workingDir}...");
 


### PR DESCRIPTION
@davidwrighton Once you add back in the ARM64 COM dispatch support all these tests should pass on ARM64.

See #19047, #19048, #19164 and #20614