### PR TITLE
Utilize popcount intrinsics in hashbv

### DIFF
--- a/src/jit/hashbv.cpp
+++ b/src/jit/hashbv.cpp
@@ -118,6 +118,13 @@ bool hashBvNode::belongsIn(indexType index)
 
 int countBitsInWord(unsigned int bits)
 {
+#if defined(__GNUC__) || defined(__clang__)
+    return __builtin_popcountl(bits);
+#elif defined(_MSC_VER) && (defined(_ARM_) || defined(_ARM64_))
+    return (int)_CountOneBits(bits);
+#else
+    // TODO: Utilize __popcnt() here with MSVC targeting x86/x64
+    //       when supported by the processor.
     // In-place adder tree: perform 16 1-bit adds, 8 2-bit adds,
     // 4 4-bit adds, 2 8=bit adds, and 1 16-bit add.
     bits = ((bits >> 1) & 0x55555555) + (bits & 0x55555555);
@@ -126,10 +133,18 @@ int countBitsInWord(unsigned int bits)
     bits = ((bits >> 8) & 0x00FF00FF) + (bits & 0x00FF00FF);
     bits = ((bits >> 16) & 0x0000FFFF) + (bits & 0x0000FFFF);
     return (int)bits;
+#endif // __GNUC__ || __clang__
 }
 
 int countBitsInWord(unsigned __int64 bits)
 {
+#if defined(__GNUC__) || defined(__clang__)
+    return __builtin_popcountll(bits);
+#elif defined(_MSC_VER) && (defined(_ARM_) || defined(_ARM64_))
+    return (int)_CountOneBits64(bits);
+#else
+    // TODO: Utilize __popcnt64() here with MSVC targeting x86/x64
+    //       when supported by the processor.
     bits = ((bits >> 1) & 0x5555555555555555) + (bits & 0x5555555555555555);
     bits = ((bits >> 2) & 0x3333333333333333) + (bits & 0x3333333333333333);
     bits = ((bits >> 4) & 0x0F0F0F0F0F0F0F0F) + (bits & 0x0F0F0F0F0F0F0F0F);
@@ -137,6 +152,7 @@ int countBitsInWord(unsigned __int64 bits)
     bits = ((bits >> 16) & 0x0000FFFF0000FFFF) + (bits & 0x0000FFFF0000FFFF);
     bits = ((bits >> 32) & 0x00000000FFFFFFFF) + (bits & 0x00000000FFFFFFFF);
     return (int)bits;
+#endif // __GNUC__ || __clang__
 }
 
 int hashBvNode::countBits()


### PR DESCRIPTION
The ``hashbv`` / ``hashBvNode`` data structure has a couple of helper functions for computing the number of set bits ("population count") in 32/64-bit unsigned integers. Most modern hardware can do this with a single instruction now (e.g. ``popcnt`` on x86) -- we should utilize it for better performance when possible.

Note, there's no way (at least that I know of) to choose to use the ``__popcnt()`` / ``__popcnt64()`` intrinsics at compile time with MSVC on x86/x64. We could sort of get there by checking whether the ``__AVX__`` symbol is defined since most (all?) x86 hardware supporting AVX also supports ``popcnt``, but I'd like to get some other opinions before I add that in case there's some interesting way for it to go wrong.