### PR TITLE
Fix `JitStressRegs=0x1` issue with `RefTypeUpperVectorSaveDef`.

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -5557,6 +5557,7 @@ void LinearScan::allocateRegisters()
                 if (refType == RefTypeUpperVectorSaveDef)
                 {
                     // TODO-CQ: Determine whether copying to two integer callee-save registers would be profitable.
+                    // TODO CQ: Save the value directly to memory, #18144.
                     // TODO-ARM64-CQ: Determine whether copying to one integer callee-save registers would be
                     // profitable.
 

--- a/src/jit/lsrabuild.cpp
+++ b/src/jit/lsrabuild.cpp
@@ -1611,6 +1611,13 @@ void LinearScan::buildRefPositionsForNode(GenTree* tree, BasicBlock* block, Lsra
             {
                 minRegCountForRef++;
             }
+#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+            else if (newRefPosition->refType == RefTypeUpperVectorSaveDef)
+            {
+                minRegCountForRef += 1;
+            }
+#endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+
             newRefPosition->minRegCandidateCount = minRegCountForRef;
             if (newRefPosition->IsActualRef() && doReverseCallerCallee())
             {
@@ -2492,7 +2499,7 @@ void LinearScan::BuildDefsWithKills(GenTree* tree, int dstCount, regMaskTP dstCa
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
     VARSET_TP liveLargeVectors(VarSetOps::UninitVal());
     bool      doLargeVectorRestore = false;
-#endif
+#endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
     if (killMask != RBM_NONE)
     {
         buildKillPositionsForNode(tree, currentLoc + 1, killMask);
@@ -2505,7 +2512,7 @@ void LinearScan::BuildDefsWithKills(GenTree* tree, int dstCount, regMaskTP dstCa
                                     buildUpperVectorSaveRefPositions(tree, currentLoc + 1, killMask));
             doLargeVectorRestore = true;
         }
-#endif
+#endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
     }
 
     // Now, create the Def(s)

--- a/src/jit/lsrabuild.cpp
+++ b/src/jit/lsrabuild.cpp
@@ -1614,6 +1614,7 @@ void LinearScan::buildRefPositionsForNode(GenTree* tree, BasicBlock* block, Lsra
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
             else if (newRefPosition->refType == RefTypeUpperVectorSaveDef)
             {
+                // TODO-Cleanup: won't need a register once #18144 is fixed.
                 minRegCountForRef += 1;
             }
 #endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_714266/DevDiv_714266.cs
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_714266/DevDiv_714266.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+// Based on DevDiv_714266, the issue reporoduced with JitStressRegs=0x1.
+// `minRegCandidateCount` for `RefTypeUpperVectorSaveDef` did not count one temporary register
+// that it used for the save. So if we had a call that did not require any registers (no defs/uses)
+// then we set `minRegCandidateCount = 0`for `RefTypeUpperVectorSaveDef` `refPosition` 
+// and was not able to find a register for do the saving.
+
+class DevDiv_714266
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+
+    public static void CallWithoutUsesAndDefs()
+    {
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void MethodWithManyLiveVectors()
+    {
+        Vector<float> v = new Vector<float>();
+
+        Vector<float> v0 = -v;
+        Vector<float> v1 = -v;
+        Vector<float> v2 = -v;
+        Vector<float> v3 = -v;
+        Vector<float> v4 = -v;
+        Vector<float> v5 = -v;
+        Vector<float> v6 = -v;
+        Vector<float> v7 = -v;
+        Vector<float> v8 = -v;
+        Vector<float> v9 = -v;
+
+        CallWithoutUsesAndDefs();
+
+        GC.KeepAlive(new object[10]
+        {
+            v1,
+            v2,
+            v3,
+            v4,
+            v5,
+            v6,
+            v7,
+            v8,
+            v9,
+            v0
+        });
+    }
+
+    static int Main()
+    {
+        MethodWithManyLiveVectors();
+        return 100;
+    }
+
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_714266/DevDiv_714266.csproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_714266/DevDiv_714266.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
The value of `newRefPosition->minRegCandidateCount` did not count the temp var that the saving uses and could be equal to 0. In this case, the jit wasn't able to allocate a free register under a stress mode because the candidate mask was empty and hit "Assertion failed 'candidates != RBM_NONE'".