### PR TITLE
Update fgCanFastTailCall to use new fgArgInfo

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1478,9 +1478,9 @@ public:
             return { this->numRegs, 0 };
         }
     }
-
-    __declspec(property(get = getHfaType)) var_types hfaType;
-    var_types getHfaType()
+    
+    __declspec(property(get = GetHfaType)) var_types hfaType;
+    var_types GetHfaType()
     {
 #ifdef FEATURE_HFA
         return HfaTypeFromElemKind(_hfaElemKind);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1461,22 +1461,45 @@ public:
 #endif
     }
 
-    jitstd::pair<unsigned, unsigned> getNumIntRegAndFloatRegForStructArg()
+    unsigned intRegCount()
     {
-        assert (this->isStruct);
-
 #if defined(UNIX_AMD64_ABI)
-        return { this->structIntRegs, this->structFloatRegs };
-#endif // UNIX_AMD64_ABI
+        if (this->isStruct)
+        {
+            return this->structIntRegs;
+        }
+#endif // defined(UNIX_AMD64_ABI)
+
+        if (!this->isPassedInFloatRegisters())
+        {
+            return this->numRegs;
+        }
+
+        return 0;
+
+    }
+    
+    unsigned floatRegCount()
+    {
+#if defined(UNIX_AMD64_ABI)
+        if (this->isStruct)
+        {
+            return this->structFloatRegs;
+        }
+#endif // defined(UNIX_AMD64_ABI)
 
         if (this->isPassedInFloatRegisters())
         {
-            return { 0, this->numRegs };
+            return this->numRegs;
         }
-        else
-        {
-            return { this->numRegs, 0 };
-        }
+
+        return 0;
+
+    }
+
+    unsigned stackSize()
+    {
+        return (TARGET_POINTER_SIZE * this->numSlots);
     }
     
     __declspec(property(get = GetHfaType)) var_types hfaType;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5372,7 +5372,7 @@ private:
     GenTree* fgMorphCast(GenTree* tree);
     GenTree* fgUnwrapProxy(GenTree* objRef);
     GenTreeFieldList* fgMorphLclArgToFieldlist(GenTreeLclVarCommon* lcl);
-    void fgInitArgInfo(GenTreeCall* call, bool reInitArgInfo = false);
+    void fgInitArgInfo(GenTreeCall* call);
     GenTreeCall* fgMorphArgs(GenTreeCall* call);
     GenTreeArgList* fgMorphArgList(GenTreeArgList* args, MorphAddrContext* mac);
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5372,7 +5372,7 @@ private:
     GenTree* fgMorphCast(GenTree* tree);
     GenTree* fgUnwrapProxy(GenTree* objRef);
     GenTreeFieldList* fgMorphLclArgToFieldlist(GenTreeLclVarCommon* lcl);
-    void fgInitArgInfo(GenTreeCall* call);
+    void fgInitArgInfo(GenTreeCall* call, bool reInitArgInfo = false);
     GenTreeCall* fgMorphArgs(GenTreeCall* call);
     GenTreeArgList* fgMorphArgList(GenTreeArgList* args, MorphAddrContext* mac);
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1476,9 +1476,8 @@ public:
         }
 
         return 0;
-
     }
-    
+
     unsigned floatRegCount()
     {
 #if defined(UNIX_AMD64_ABI)
@@ -1494,14 +1493,13 @@ public:
         }
 
         return 0;
-
     }
 
     unsigned stackSize()
     {
         return (TARGET_POINTER_SIZE * this->numSlots);
     }
-    
+
     __declspec(property(get = GetHfaType)) var_types hfaType;
     var_types GetHfaType()
     {

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1327,6 +1327,14 @@ public:
                       // Note that on ARM, if we have a double hfa, this reflects the number
                       // of DOUBLE registers.
 
+#if defined(UNIX_AMD64_ABI)
+    // Unix amd64 will split floating point types and integer types in structs
+    // between floating point and general purpose registers. Keep track of that
+    // information so we do not need to re-compute it later.
+    unsigned structIntRegs;
+    unsigned structFloatRegs;
+#endif // UNIX_AMD64_ABI
+
     // A slot is a pointer sized region in the OutArg area.
     unsigned slotNum;  // When an argument is passed in the OutArg area this is the slot number in the OutArg area
     unsigned numSlots; // Count of number of slots that this argument uses
@@ -1453,8 +1461,26 @@ public:
 #endif
     }
 
-    __declspec(property(get = GetHfaType)) var_types hfaType;
-    var_types GetHfaType()
+    jitstd::pair<unsigned, unsigned> getNumIntRegAndFloatRegForStructArg()
+    {
+        assert (this->isStruct);
+
+#if defined(UNIX_AMD64_ABI)
+        return { this->structIntRegs, this->structFloatRegs };
+#endif // UNIX_AMD64_ABI
+
+        if (this->isPassedInFloatRegisters())
+        {
+            return { 0, this->numRegs };
+        }
+        else
+        {
+            return { this->numRegs, 0 };
+        }
+    }
+
+    __declspec(property(get = getHfaType)) var_types hfaType;
+    var_types getHfaType()
     {
 #ifdef FEATURE_HFA
         return HfaTypeFromElemKind(_hfaElemKind);
@@ -1728,6 +1754,8 @@ public:
                              const bool                                                       isStruct,
                              const bool                                                       isVararg,
                              const regNumber                                                  otherRegNum,
+                             const unsigned                                                   structIntRegs,
+                             const unsigned                                                   structFloatRegs,
                              const SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR* const structDescPtr = nullptr);
 #endif // UNIX_AMD64_ABI
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1330,7 +1330,7 @@ public:
 #if defined(UNIX_AMD64_ABI)
     // Unix amd64 will split floating point types and integer types in structs
     // between floating point and general purpose registers. Keep track of that
-    // information so we do not need to re-compute it later.
+    // information so we do not need to recompute it later.
     unsigned structIntRegs;
     unsigned structFloatRegs;
 #endif // UNIX_AMD64_ABI
@@ -1466,12 +1466,23 @@ public:
 #if defined(UNIX_AMD64_ABI)
         if (this->isStruct)
         {
+            if (this->numSlots > 0)
+            {
+                return 0;
+            }
             return this->structIntRegs;
         }
 #endif // defined(UNIX_AMD64_ABI)
 
         if (!this->isPassedInFloatRegisters())
         {
+#if !defined(FEATURE_ARG_SPLIT)
+            if (this->numSlots > 0)
+            {
+                return 0;
+            }
+#endif // !(FEATURE_ARG_SPLIT)
+
             return this->numRegs;
         }
 
@@ -1483,12 +1494,24 @@ public:
 #if defined(UNIX_AMD64_ABI)
         if (this->isStruct)
         {
+            if (this->numSlots > 0)
+            {
+                return 0;
+            }
+
             return this->structFloatRegs;
         }
 #endif // defined(UNIX_AMD64_ABI)
 
         if (this->isPassedInFloatRegisters())
         {
+#if !defined(FEATURE_ARG_SPLIT)
+            if (this->numSlots > 0)
+            {
+                return 0;
+            }
+#endif // !(FEATURE_ARG_SPLIT)
+
             return this->numRegs;
         }
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1466,23 +1466,12 @@ public:
 #if defined(UNIX_AMD64_ABI)
         if (this->isStruct)
         {
-            if (this->numSlots > 0)
-            {
-                return 0;
-            }
             return this->structIntRegs;
         }
 #endif // defined(UNIX_AMD64_ABI)
 
         if (!this->isPassedInFloatRegisters())
         {
-#if !defined(FEATURE_ARG_SPLIT)
-            if (this->numSlots > 0)
-            {
-                return 0;
-            }
-#endif // !(FEATURE_ARG_SPLIT)
-
             return this->numRegs;
         }
 
@@ -1494,24 +1483,12 @@ public:
 #if defined(UNIX_AMD64_ABI)
         if (this->isStruct)
         {
-            if (this->numSlots > 0)
-            {
-                return 0;
-            }
-
             return this->structFloatRegs;
         }
 #endif // defined(UNIX_AMD64_ABI)
 
         if (this->isPassedInFloatRegisters())
         {
-#if !defined(FEATURE_ARG_SPLIT)
-            if (this->numSlots > 0)
-            {
-                return 0;
-            }
-#endif // !(FEATURE_ARG_SPLIT)
-
             return this->numRegs;
         }
 

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -1078,11 +1078,11 @@ bool GenTreeCall::AreArgsComplete() const
         assert((gtCallLateArgs != nullptr) || !fgArgInfo->HasRegArgs());
         return true;
     }
-    
+
 #if defined(FEATURE_FASTTAILCALL)
-    // If we have FEATURE_FASTTAILCALL, 'fgCanFastTailCall()' can call 'fgInitArgInfo()', and in that
-    // scenario it is valid to have 'fgArgInfo' be non-null when 'fgMorphArgs()' first queries this,
-    // when it hasn't yet morphed the arguments.
+// If we have FEATURE_FASTTAILCALL, 'fgCanFastTailCall()' can call 'fgInitArgInfo()', and in that
+// scenario it is valid to have 'fgArgInfo' be non-null when 'fgMorphArgs()' first queries this,
+// when it hasn't yet morphed the arguments.
 #else
     assert(gtCallArgs == nullptr);
 #endif

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -1078,7 +1078,15 @@ bool GenTreeCall::AreArgsComplete() const
         assert((gtCallLateArgs != nullptr) || !fgArgInfo->HasRegArgs());
         return true;
     }
+    
+#if FEATURE_FASTTAILCALL
+    // If the args are not complete and fgArgInfo is not null. Then most
+    // most likely the argInfo has been populated in fgCanFastTailCall and
+    // we are just re-querying this information in fgMorphArgs.
+#else
     assert(gtCallArgs == nullptr);
+#endif
+
     return false;
 }
 

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -1079,10 +1079,10 @@ bool GenTreeCall::AreArgsComplete() const
         return true;
     }
     
-#if defined(FEATURE_FASTTAILCALL) || defined(FEATURE_TAILCALL)
-    // If the args are not complete and fgArgInfo is not null. Then most
-    // most likely the argInfo has been populated in fgCanFastTailCall and
-    // we are just re-querying this information in fgMorphArgs.
+#if defined(FEATURE_FASTTAILCALL)
+    // If we have FEATURE_FASTTAILCALL, 'fgCanFastTailCall()' can call 'fgInitArgInfo()', and in that
+    // scenario it is valid to have 'fgArgInfo' be non-null when 'fgMorphArgs()' first queries this,
+    // when it hasn't yet morphed the arguments.
 #else
     assert(gtCallArgs == nullptr);
 #endif

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -1079,7 +1079,7 @@ bool GenTreeCall::AreArgsComplete() const
         return true;
     }
     
-#if FEATURE_FASTTAILCALL
+#if defined(FEATURE_FASTTAILCALL) || defined(FEATURE_TAILCALL)
     // If the args are not complete and fgArgInfo is not null. Then most
     // most likely the argInfo has been populated in fgCanFastTailCall and
     // we are just re-querying this information in fgMorphArgs.

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1008,13 +1008,7 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo)
             {
                 varDscInfo->hasMultiSlotStruct = true;
             }
-
-#if FEATURE_FASTTAILCALL
-            if (cSlots > 1)
-            {
-                varDscInfo->hasMultiSlotStruct = true;
-            }
-
+            
             varDscInfo->stackArgSize += roundUp(argSize, TARGET_POINTER_SIZE);
 #endif // FEATURE_FASTTAILCALL
         }

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1003,6 +1003,7 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo)
 
 #endif // _TARGET_XXX_
 
+#if FEATURE_FASTTAILCALL
             if (cSlots > 1)
             {
                 varDscInfo->hasMultiSlotStruct = true;

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1003,6 +1003,11 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo)
 
 #endif // _TARGET_XXX_
 
+            if (cSlots > 1)
+            {
+                varDscInfo->hasMultiSlotStruct = true;
+            }
+
 #if FEATURE_FASTTAILCALL
             if (cSlots > 1)
             {

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1008,7 +1008,7 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo)
             {
                 varDscInfo->hasMultiSlotStruct = true;
             }
-            
+
             varDscInfo->stackArgSize += roundUp(argSize, TARGET_POINTER_SIZE);
 #endif // FEATURE_FASTTAILCALL
         }

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2015,7 +2015,6 @@ void Lowering::LowerFastTailCall(GenTreeCall* call)
         fgArgTabEntry* argTabEntry = comp->gtArgEntryByNode(call, putArgStkNode);
         assert(argTabEntry);
         unsigned callerArgNum = argTabEntry->argNum - calleeNonStandardArgCount;
-        noway_assert(callerArgNum < comp->info.compArgsCount);
 
         unsigned   callerArgLclNum = callerArgNum;
         LclVarDsc* callerArgDsc    = comp->lvaTable + callerArgLclNum;

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7072,7 +7072,7 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
 
     // Count user args while tracking whether any of them has a larger than one
     // stack slot sized requirement. This requirement is required to support
-    // lowering the fast tail call. Which, currently only supports copying
+    // lowering the fast tail call, which, currently only supports copying
     // stack slot arguments which have only one stack slot.
     //
     // Note that we don't need to count
@@ -7080,7 +7080,7 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
     // these won't contribute to out-going arg size.
     // 
     // For each struct arg, determine whether the argument would have  > 1 stack 
-    // slot if on the stack If it has > 1 stack slot we will not fastTailCall. 
+    // slot if on the stack. If it has > 1 stack slot we will not fastTailCall. 
     // This is an implementation limitation of LowerFastTailCall that is tracked by:
     // https://github.com/dotnet/coreclr/issues/12644.
 
@@ -7090,7 +7090,7 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
 
     for (unsigned index = 0; index < nCalleeArgs; ++index)
     {
-        fgArgTabEntry* arg = argInfo->GetArgEntry(index);
+        fgArgTabEntry* arg = argInfo->GetArgEntry(index, false);
 
         if (!arg->isStruct)
         {

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -6954,14 +6954,14 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result)
 //    callee(int, int, float, int)
 //
 //    -- Callee requires stack space that is equal to the caller --
-//    caller({ int, int }, { int, int }, { int }, { int }, { int }, { int }) -- 6 int register arguments, 16 byte stack
+//    caller({ long, long }, { int, int }, { int }, { int }, { int }, { int }) -- 6 int register arguments, 16 byte stack
 //    space
 //    callee(int, int, int, int, int, int, int, int) -- 6 int register arguments, 16 byte stack space
 //
 //    -- Callee requires stack space that is less than the caller --
-//    caller({ int, int }, int, { int, int }, int, { int, int }, { int, int }) 6 int register arguments, 32 byte stack
+//    caller({ long, long }, int, { long, long }, int, { long, long }, { long, long }) 6 int register arguments, 32 byte stack
 //    space
-//    callee(int, int, int, int, int, int, { int, int } ) // 6 int register arguments, 16 byte stack space
+//    callee(int, int, int, int, int, int, { long, long } ) // 6 int register arguments, 16 byte stack space
 //
 //    -- Callee will have all register arguments --
 //    caller(int)

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -5129,6 +5129,8 @@ void Compiler::fgMakeOutgoingStructArgCopy(GenTreeCall*         call,
                 // struct parameters if they are passed as arguments to a tail call.
                 if (!call->IsTailCallViaHelper() && (varDsc->lvRefCnt(RCS_EARLY) == 1) && !fgMightHaveLoop())
                 {
+                    assert(!call->IsTailCall());
+
                     varDsc->setLvRefCnt(0, RCS_EARLY);
                     args->gtOp.gtOp1 = lcl;
                     argEntry->node   = lcl;

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7118,14 +7118,14 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
         {
             hasNonEnregisterableStructs = argStackSize > 0 ? true : hasNonEnregisterableStructs;
             hasLargerThanOneStackSlotSizedStruct = countRegistersUsedForArg > 1 ? true : hasLargerThanOneStackSlotSizedStruct;
-        }
 
-        // Byref arguments are not allowed to fast tail call as the information
-        // of the caller's stack is lost when the callee is compiled.
-        if (arg->passedByRef)
-        {
-            hasByrefParameter = true;
-            break;
+            // Byref struct arguments are not allowed to fast tail call as the information
+            // of the caller's stack is lost when the callee is compiled.
+            if (arg->passedByRef)
+            {
+                hasByrefParameter = true;
+                break;
+            }
         }
     }
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7158,11 +7158,6 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
     // as non-interruptible for fast tail calls.
 
 #ifdef WINDOWS_AMD64_ABI
-    assert(calleeStackSize == 0);
-    size_t calleeStackSlots = ((calleeArgRegCount + calleeFloatArgRegCount) > maxRegArgs)
-                                  ? (calleeArgRegCount + calleeFloatArgRegCount) - maxRegArgs
-                                  : 0;
-    calleeStackSize        = calleeStackSlots * TARGET_POINTER_SIZE;
     size_t callerStackSize = info.compArgStackSize;
 
     bool hasStackArgs = false;
@@ -7191,15 +7186,7 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
     // that we are not dealing with structs that are >8 bytes.
 
     bool   hasStackArgs    = false;
-    size_t maxFloatRegArgs = MAX_FLOAT_REG_ARG;
-
-    size_t calleeIntStackArgCount = calleeArgRegCount > maxRegArgs ? calleeArgRegCount - maxRegArgs : 0;
-    size_t calleeFloatStackArgCount =
-        calleeFloatArgRegCount > maxFloatRegArgs ? calleeFloatArgRegCount - maxFloatRegArgs : 0;
-
-    size_t calleeStackArgCount = calleeIntStackArgCount + calleeFloatStackArgCount;
     size_t callerStackSize     = info.compArgStackSize;
-    calleeStackSize += calleeStackArgCount * TARGET_POINTER_SIZE;
 
     if (callerStackSize > 0 || calleeStackSize > 0)
     {

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -6898,7 +6898,7 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result)
 //    caller(int, int, int, int)
 //    callee(int, int, float, int)
 //
-//    -- Callee requires stack space that is equal to the caller --
+//    -- Callee requires stack space that is equal or less than the caller --
 //    caller(struct, struct, struct, struct, struct, struct)
 //    callee(int, int, int, int, int, int)
 //
@@ -6915,6 +6915,10 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result)
 //    -- Callee requires stack space that is larger than the caller --
 //    caller(struct, double, struct, float, struct, struct)
 //    callee(int, int, int, int, int, double, double, double)
+//
+//    -- Callee has a byref struct argument --
+//    caller(int, int, int)
+//    callee(struct(size 3 bytes))
 //
 // Unix Amd64 && Arm64:
 //    A fastTailCall decision can be made whenever the callee's stack space is
@@ -6940,12 +6944,6 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result)
 //    will be placed on the stack or enregistered. Therefore, the conservative
 //    decision of do not fast tail call is taken. This limitations should be
 //    removed if/when fgMorphArgs no longer depends on fgCanFastTailCall.
-//
-//    4) Arm64 Only, if there are HFA arguments and the callee has stack
-//    arguments, the decision will be reported as cannot fast tail call.
-//    This is because before fgMorphArgs is done, the struct is unknown whether it
-//    will be placed on the stack or enregistered. Therefore, the conservative
-//    decision of do not fast tail call is taken.
 //
 // Can fast tail call examples (amd64 Unix):
 //

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7161,15 +7161,15 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
     }
 
     const unsigned maxRegArgs = MAX_REG_ARG;
-    hasTwoSlotSizedStruct     = hasTwoSlotSizedStruct || info.compHasMultiSlotArgs;
+    hasLargerThanOneStackSlotSizedStruct = hasLargerThanOneStackSlotSizedStruct || info.compHasMultiSlotArgs;
 
-// If we reached here means that callee has only those argument types which can be passed in
-// a register and if passed on stack will occupy exactly one stack slot in out-going arg area.
-// If we are passing args on stack for the callee and it has more args passed on stack than
-// the caller, then fast tail call cannot be performed.
-//
-// Note that the GC'ness of on stack args need not match since the arg setup area is marked
-// as non-interruptible for fast tail calls.
+    // If we reached here means that callee has only those argument types which can be passed in
+    // a register and if passed on stack will occupy exactly one stack slot in out-going arg area.
+    // If we are passing args on stack for the callee and it has more args passed on stack than
+    // the caller, then fast tail call cannot be performed.
+    //
+    // Note that the GC'ness of on stack args need not match since the arg setup area is marked
+    // as non-interruptible for fast tail calls.
 
 #ifdef WINDOWS_AMD64_ABI
     assert(calleeStackSize == 0);

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2588,10 +2588,7 @@ GenTree* Compiler::fgInsertCommaFormTemp(GenTree** ppTree, CORINFO_CLASS_HANDLE 
 // fgInitArgInfo: Construct the fgArgInfo for the call with the fgArgEntry for each arg
 //
 // Arguments:
-//    callNode      - the call for which we are generating the fgArgInfo
-//    reInitArgInfo - force the argInfo to be regenerated. This is only useful
-//                    if the arguments have changed between the first and
-//                    subsequent calls. Defaults to false.
+//    callNode - the call for which we are generating the fgArgInfo
 //
 // Return Value:
 //    None

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -1217,13 +1217,13 @@ fgArgTabEntry* fgArgInfo::AddStkArg(unsigned argNum,
     nextSlotNum = roundUp(nextSlotNum, alignment);
 
     curArgTabEntry->setRegNum(0, REG_STK);
-    curArgTabEntry->argNum     = argNum;
-    curArgTabEntry->node       = node;
-    curArgTabEntry->argType    = node->TypeGet();
-    curArgTabEntry->parent     = parent;
-    curArgTabEntry->slotNum    = nextSlotNum;
-    curArgTabEntry->numRegs    = 0;
-#if defined (UNIX_AMD64_ABI)
+    curArgTabEntry->argNum  = argNum;
+    curArgTabEntry->node    = node;
+    curArgTabEntry->argType = node->TypeGet();
+    curArgTabEntry->parent  = parent;
+    curArgTabEntry->slotNum = nextSlotNum;
+    curArgTabEntry->numRegs = 0;
+#if defined(UNIX_AMD64_ABI)
     curArgTabEntry->structIntRegs   = 0;
     curArgTabEntry->structFloatRegs = 0;
 #endif // defined(UNIX_AMD64_ABI)
@@ -7148,10 +7148,10 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
     }
 
     const unsigned maxRegArgs            = MAX_REG_ARG;
-    size_t callerStackSize = info.compArgStackSize;
+    size_t         callerStackSize       = info.compArgStackSize;
     hasLargerThanOneStackSlotSizedStruct = hasLargerThanOneStackSlotSizedStruct || info.compHasMultiSlotArgs;
 
-    bool   hasStackArgs    = false;
+    bool hasStackArgs = false;
     if (callerStackSize > 0 || calleeStackSize > 0)
     {
         hasStackArgs = true;
@@ -7176,8 +7176,8 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
     // arguments is less than the caller's
     if (hasStackArgs && (calleeStackSize > callerStackSize))
     {
-        reportFastTailCallDecision("Will not fastTailCall hasStackArgs && (calleeStackSize > callerStackSize)", callerStackSize,
-                                   calleeStackSize);
+        reportFastTailCallDecision("Will not fastTailCall hasStackArgs && (calleeStackSize > callerStackSize)",
+                                   callerStackSize, calleeStackSize);
         return false;
     }
 
@@ -7218,8 +7218,8 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
     // for more information.
     if (hasStackArgs && (calleeStackSize > callerStackSize))
     {
-        reportFastTailCallDecision("Will not fastTailCall hasStackArgs && (calleeStackSize > callerStackSize)", callerStackSize,
-                                   calleeStackSize);
+        reportFastTailCallDecision("Will not fastTailCall hasStackArgs && (calleeStackSize > callerStackSize)",
+                                   callerStackSize, calleeStackSize);
         return false;
     }
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -1223,6 +1223,10 @@ fgArgTabEntry* fgArgInfo::AddStkArg(unsigned argNum,
     curArgTabEntry->parent     = parent;
     curArgTabEntry->slotNum    = nextSlotNum;
     curArgTabEntry->numRegs    = 0;
+#if defined (UNIX_AMD64_ABI)
+    curArgTabEntry->structIntRegs   = 0;
+    curArgTabEntry->structFloatRegs = 0;
+#endif // defined(UNIX_AMD64_ABI)
     curArgTabEntry->numSlots   = numSlots;
     curArgTabEntry->alignment  = alignment;
     curArgTabEntry->lateArgInx = UINT_MAX;

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8322,10 +8322,11 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
         // fast calls.
         if (!canFastTailCall)
         {
+            fgMorphTailCall(call, pfnCopyArgs);
+
             // Force re-evaluating the argInfo. fgMorphTailCall will modify the
             // argument list, invalidating the argInfo.
             call->fgArgInfo = nullptr;
-            fgMorphTailCall(call, pfnCopyArgs);
         }
 
         // Implementation note : If we optimize tailcall to do a direct jump

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -1184,8 +1184,8 @@ fgArgTabEntry* fgArgInfo::AddRegArg(unsigned                                    
     fgArgTabEntry* curArgTabEntry = AddRegArg(argNum, node, parent, regNum, numRegs, alignment, isStruct, isVararg);
     assert(curArgTabEntry != nullptr);
 
-    curArgTabEntry->isStruct = isStruct; // is this a struct arg
-    curArgTabEntry->structIntRegs = structIntRegs;
+    curArgTabEntry->isStruct        = isStruct; // is this a struct arg
+    curArgTabEntry->structIntRegs   = structIntRegs;
     curArgTabEntry->structFloatRegs = structFloatRegs;
 
     curArgTabEntry->checkIsStruct();
@@ -2962,7 +2962,8 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
 
         // This is a register argument - put it in the table.
         call->fgArgInfo->AddRegArg(argIndex, argx, nullptr, genMapIntRegArgNumToRegNum(intArgRegNum), 1, 1, false,
-                                   callIsVararg UNIX_AMD64_ABI_ONLY_ARG(REG_STK) UNIX_AMD64_ABI_ONLY_ARG(0) UNIX_AMD64_ABI_ONLY_ARG(0) UNIX_AMD64_ABI_ONLY_ARG(nullptr));
+                                   callIsVararg UNIX_AMD64_ABI_ONLY_ARG(REG_STK) UNIX_AMD64_ABI_ONLY_ARG(0)
+                                       UNIX_AMD64_ABI_ONLY_ARG(0) UNIX_AMD64_ABI_ONLY_ARG(nullptr));
 
         intArgRegNum++;
 #ifdef WINDOWS_AMD64_ABI
@@ -3564,10 +3565,10 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
 
             // This is a register argument - put it in the table
             newArgEntry = call->fgArgInfo->AddRegArg(argIndex, argx, args, nextRegNum, size, argAlign, isStructArg,
-                                                     callIsVararg UNIX_AMD64_ABI_ONLY_ARG(nextOtherRegNum) 
+                                                     callIsVararg UNIX_AMD64_ABI_ONLY_ARG(nextOtherRegNum)
                                                          UNIX_AMD64_ABI_ONLY_ARG(structIntRegs)
-                                                         UNIX_AMD64_ABI_ONLY_ARG(structFloatRegs)
-                                                         UNIX_AMD64_ABI_ONLY_ARG(&structDesc));
+                                                             UNIX_AMD64_ABI_ONLY_ARG(structFloatRegs)
+                                                                 UNIX_AMD64_ABI_ONLY_ARG(&structDesc));
 
             newArgEntry->SetIsBackFilled(isBackFilled);
             newArgEntry->isNonStandard = isNonStandard;
@@ -6954,12 +6955,14 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result)
 //    callee(int, int, float, int)
 //
 //    -- Callee requires stack space that is equal to the caller --
-//    caller({ long, long }, { int, int }, { int }, { int }, { int }, { int }) -- 6 int register arguments, 16 byte stack
+//    caller({ long, long }, { int, int }, { int }, { int }, { int }, { int }) -- 6 int register arguments, 16 byte
+//    stack
 //    space
 //    callee(int, int, int, int, int, int, int, int) -- 6 int register arguments, 16 byte stack space
 //
 //    -- Callee requires stack space that is less than the caller --
-//    caller({ long, long }, int, { long, long }, int, { long, long }, { long, long }) 6 int register arguments, 32 byte stack
+//    caller({ long, long }, int, { long, long }, int, { long, long }, { long, long }) 6 int register arguments, 32 byte
+//    stack
 //    space
 //    callee(int, int, int, int, int, int, { long, long } ) // 6 int register arguments, 16 byte stack space
 //
@@ -7051,17 +7054,17 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
 #endif // DEBUG
     };
 
-    // Note on vararg methods:
-    // If the caller is vararg method, we don't know the number of arguments passed by caller's caller.
-    // But we can be sure that in-coming arg area of vararg caller would be sufficient to hold its
-    // fixed args. Therefore, we can allow a vararg method to fast tail call other methods as long as
-    // out-going area required for callee is bounded by caller's fixed argument space.
-    //
-    // Note that callee being a vararg method is not a problem since we can account the params being passed.
-    //
-    // We will currently decide to not fast tail call on Windows armarch if the caller or callee is a vararg
-    // method. This is due to the ABI differences for native vararg methods for these platforms. There is
-    // work required to shuffle arguments to the correct locations.
+// Note on vararg methods:
+// If the caller is vararg method, we don't know the number of arguments passed by caller's caller.
+// But we can be sure that in-coming arg area of vararg caller would be sufficient to hold its
+// fixed args. Therefore, we can allow a vararg method to fast tail call other methods as long as
+// out-going area required for callee is bounded by caller's fixed argument space.
+//
+// Note that callee being a vararg method is not a problem since we can account the params being passed.
+//
+// We will currently decide to not fast tail call on Windows armarch if the caller or callee is a vararg
+// method. This is due to the ABI differences for native vararg methods for these platforms. There is
+// work required to shuffle arguments to the correct locations.
 
 #if (defined(_TARGET_WINDOWS_) && defined(_TARGET_ARM_)) || (defined(_TARGET_WINDOWS_) && defined(_TARGET_ARM64_))
     if (info.compIsVarArgs || callee->IsVarargs())
@@ -7087,9 +7090,9 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
     // stack slot sized requirement. This requirement is required to support
     // lowering the fast tail call, which, currently only supports copying
     // stack slot arguments which have only one stack slot.
-    // 
-    // For each struct arg, determine whether the argument would have  > 1 stack 
-    // slot if on the stack. If it has > 1 stack slot we will not fastTailCall. 
+    //
+    // For each struct arg, determine whether the argument would have  > 1 stack
+    // slot if on the stack. If it has > 1 stack slot we will not fastTailCall.
     // This is an implementation limitation of LowerFastTailCall that is tracked by:
     // https://github.com/dotnet/coreclr/issues/12644.
 
@@ -7102,9 +7105,9 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
     {
         fgArgTabEntry* arg = argInfo->GetArgEntry(index, false);
 
-        unsigned argStackSize = arg->stackSize();
+        unsigned argStackSize     = arg->stackSize();
         unsigned argFloatRegCount = arg->floatRegCount();
-        unsigned argIntRegCount = arg->intRegCount();
+        unsigned argIntRegCount   = arg->intRegCount();
 
         unsigned countRegistersUsedForArg = argIntRegCount + argFloatRegCount;
 
@@ -7117,7 +7120,8 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
         if (arg->isStruct)
         {
             hasNonEnregisterableStructs = argStackSize > 0 ? true : hasNonEnregisterableStructs;
-            hasLargerThanOneStackSlotSizedStruct = countRegistersUsedForArg > 1 ? true : hasLargerThanOneStackSlotSizedStruct;
+            hasLargerThanOneStackSlotSizedStruct =
+                countRegistersUsedForArg > 1 ? true : hasLargerThanOneStackSlotSizedStruct;
 
             // Byref struct arguments are not allowed to fast tail call as the information
             // of the caller's stack is lost when the callee is compiled.
@@ -7140,7 +7144,7 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
         }
     }
 
-    const unsigned maxRegArgs = MAX_REG_ARG;
+    const unsigned maxRegArgs            = MAX_REG_ARG;
     hasLargerThanOneStackSlotSizedStruct = hasLargerThanOneStackSlotSizedStruct || info.compHasMultiSlotArgs;
 
     if (hasByrefParameter)
@@ -7149,13 +7153,13 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
         return false;
     }
 
-    // If we reached here means that callee has only those argument types which can be passed in
-    // a register and if passed on stack will occupy exactly one stack slot in out-going arg area.
-    // If we are passing args on stack for the callee and it haas a larger stack size than
-    // the caller, then fast tail call cannot be performed.
-    //
-    // Note that the GC'ness of on stack args need not match since the arg setup area is marked
-    // as non-interruptible for fast tail calls.
+// If we reached here means that callee has only those argument types which can be passed in
+// a register and if passed on stack will occupy exactly one stack slot in out-going arg area.
+// If we are passing args on stack for the callee and it haas a larger stack size than
+// the caller, then fast tail call cannot be performed.
+//
+// Note that the GC'ness of on stack args need not match since the arg setup area is marked
+// as non-interruptible for fast tail calls.
 
 #ifdef WINDOWS_AMD64_ABI
     size_t callerStackSize = info.compArgStackSize;
@@ -7167,7 +7171,7 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
         hasStackArgs = true;
     }
 
-    // x64 Windows: If we have stack args then make sure the callee's incoming 
+    // x64 Windows: If we have stack args then make sure the callee's incoming
     // arguments is less than the caller's
     if (hasStackArgs && (nCalleeArgs > nCallerArgs))
     {
@@ -7186,7 +7190,7 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
     // that we are not dealing with structs that are >8 bytes.
 
     bool   hasStackArgs    = false;
-    size_t callerStackSize     = info.compArgStackSize;
+    size_t callerStackSize = info.compArgStackSize;
 
     if (callerStackSize > 0 || calleeStackSize > 0)
     {
@@ -7200,8 +7204,8 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
     // shuffle arguments in LowerFastTailCall. See https://github.com/dotnet/coreclr/issues/12468.
     if (hasLargerThanOneStackSlotSizedStruct && calleeStackSize)
     {
-        reportFastTailCallDecision("Will not fastTailCall hasLargerThanOneStackSlotSizedStruct && calleeStackSize", callerStackSize,
-                                   calleeStackSize);
+        reportFastTailCallDecision("Will not fastTailCall hasLargerThanOneStackSlotSizedStruct && calleeStackSize",
+                                   callerStackSize, calleeStackSize);
         return false;
     }
 
@@ -8605,7 +8609,7 @@ NO_TAIL_CALL:
                 {
                     // Force re-evaluating the argInfo as the return argument has changed.
                     call->fgArgInfo = nullptr;
-                    origDest = dest;
+                    origDest        = dest;
 
                     retValTmpNum = lvaGrabTemp(true DEBUGARG("substitute local for ret buff arg"));
                     lvaSetStruct(retValTmpNum, structHnd, true);

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2602,7 +2602,7 @@ GenTree* Compiler::fgInsertCommaFormTemp(GenTree** ppTree, CORINFO_CLASS_HANDLE 
 //    This method only computes the arg table and arg entries for the call (the fgArgInfo),
 //    and makes no modification of the args themselves.
 //
-void Compiler::fgInitArgInfo(GenTreeCall* call, bool reInitArgInfo/*=false*/)
+void Compiler::fgInitArgInfo(GenTreeCall* call)
 {
     GenTree* args;
     GenTree* argx;
@@ -2626,7 +2626,7 @@ void Compiler::fgInitArgInfo(GenTreeCall* call, bool reInitArgInfo/*=false*/)
     const unsigned maxRegArgs = MAX_REG_ARG; // other arch: fixed constant number
 #endif
 
-    if (call->fgArgInfo != nullptr && !reInitArgInfo)
+    if (call->fgArgInfo != nullptr)
     {
         // We've already initialized and set the fgArgInfo.
         return;
@@ -7629,9 +7629,6 @@ void Compiler::fgMorphTailCall(GenTreeCall* call, void* pfnCopyArgs)
     // The function is responsible for doing explicit null check when it is necessary.
     assert(!call->NeedsNullCheck());
 
-    // Force, re-evaluating the args as we have just changed the argument list.
-    fgInitArgInfo(call, /*reInitArgInfo=*/true);
-
     JITDUMP("fgMorphTailCall (after):\n");
     DISPTREE(call);
 }
@@ -8234,6 +8231,9 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
                 //     temp = call
                 //     ret temp
 
+                // Force re-evaluating the argInfo as the return argument has changed.
+                call->fgArgInfo = nullptr;
+
                 // Create a new temp.
                 unsigned tmpNum =
                     lvaGrabTemp(false DEBUGARG("Return value temp for multi-reg return (rejected tail call)."));
@@ -8321,6 +8321,9 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
         // fast calls.
         if (!canFastTailCall)
         {
+            // Force re-evaluating the argInfo. fgMorphTailCall will modify the
+            // argument list, invalidating the argInfo.
+            call->fgArgInfo = nullptr;
             fgMorphTailCall(call, pfnCopyArgs);
         }
 
@@ -8603,6 +8606,8 @@ NO_TAIL_CALL:
                 if (info.compCompHnd->isStructRequiringStackAllocRetBuf(structHnd) &&
                     !(dest->OperGet() == GT_LCL_VAR && dest->gtLclVar.gtLclNum == info.compRetBuffArg))
                 {
+                    // Force re-evaluating the argInfo as the return argument has changed.
+                    call->fgArgInfo = nullptr;
                     origDest = dest;
 
                     retValTmpNum = lvaGrabTemp(true DEBUGARG("substitute local for ret buff arg"));

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7168,13 +7168,6 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
 // as non-interruptible for fast tail calls.
 
 #ifdef WINDOWS_AMD64_ABI
-    bool hasStackArgs = false;
-
-    if (callerStackSize > 0 || calleeStackSize > 0)
-    {
-        hasStackArgs = true;
-    }
-
     // x64 Windows: If we have stack args then make sure the callee's incoming
     // arguments is less than the caller's
     if (hasStackArgs && (calleeStackSize > callerStackSize))

--- a/tests/src/JIT/opt/FastTailCall/FastTailCallCandidates.cs
+++ b/tests/src/JIT/opt/FastTailCall/FastTailCallCandidates.cs
@@ -65,6 +65,12 @@ public class FastTailCallCandidates
         CheckOutput(DoubleCountRetBuffCaller(1));
         CheckOutput(Struct32CallerWrapper());
         CheckOutput(Struct32CallerWrapperCalleeHasStack(2));
+        CheckOutput(CallerEnregisterableAmd64WindowsStructs8Bytes(1, 2));
+        CheckOutput(CallerAmd64WindowsStructs7Bytes(1, 2));
+        CheckOutput(CallerAmd64WindowsStructs6Bytes(1, 2));
+        CheckOutput(CallerAmd64WindowsStructs5Bytes(1, 2));
+        CheckOutput(CallerAmd64WindowsStructs4Bytes(1, 2));
+        CheckOutput(CallerAmd64WindowsStructs3Bytes(1, 2));
 
         return s_ret_value;
 
@@ -1471,7 +1477,7 @@ public class FastTailCallCandidates
     /// The callee uses 6 integer registers, 32 bytes of stack (3 args)
     ///
     /// Return 100 is a pass.
-    /// Return 113 is a failure.
+    /// Return 114 is a failure.
     ///
     /// </remarks>
     public static int Struct32CallerWrapperCalleeHasStack(int two)
@@ -1493,6 +1499,373 @@ public class FastTailCallCandidates
         }
 
         return 100;
+    }
+
+    /// <summary>
+    /// Decision to fast tail call. See CallerEnregisterableAmd64WindowsStructs8Bytes for more
+    /// information.
+    /// </summary>
+    public static int CalleeEnregisterableAmd64WindowsStructs8Bytes(StructSizeEightNotExplicit eightByteStruct)
+    {
+        long a = eightByteStruct.a;
+
+        // Force this to not be inlined
+        int count = 0;
+        for (int i = 0; i < a; ++i)
+        {
+            if (i % 2 == 0)
+            {
+                ++count;
+            }
+        }
+
+        if (count == 1000000)
+        {
+            a = count;
+        }
+
+        if (count == 1)
+        {
+            a = 100;
+        }
+        else
+        {
+            a = 115;
+        }
+
+        return (int)a;
+    }
+
+    /// <summary>
+    /// Windows x64 tail call tests
+    /// </summary>
+    /// <remarks>
+    ///
+    /// All targets will fast tail call
+    ///
+    /// The caller uses 2 integer registers (2 args)
+    /// The callee uses 1 integer registers (1 args)
+    ///
+    /// Return 100 is a pass.
+    /// Return 115 is a failure.
+    ///
+    /// </remarks>
+    public static int CallerEnregisterableAmd64WindowsStructs8Bytes(int a, int b)
+    {
+        if (a % 2 == 0)
+        {
+            return CalleeEnregisterableAmd64WindowsStructs8Bytes(new StructSizeEightNotExplicit(a));
+        }
+        else
+        {
+            return CalleeEnregisterableAmd64WindowsStructs8Bytes(new StructSizeEightNotExplicit(b));
+        }
+    }
+
+    /// <summary>
+    /// Decision to fast tail call. See CallerAmd64WindowsStructs7Bytes for more
+    /// information.
+    /// </summary>
+    public static int CalleeAmd64WindowsStructs7Bytes(StructSizeSevenNotExplicit sevenByteStruct)
+    {
+        int a = sevenByteStruct.a;
+
+        // Force this to not be inlined
+        int count = 0;
+        for (int i = 0; i < a; ++i)
+        {
+            if (i % 2 == 0)
+            {
+                ++count;
+            }
+        }
+
+        if (count == 1000000)
+        {
+            a = count;
+        }
+
+        if (count == 1)
+        {
+            a = 100;
+        }
+        else
+        {
+            a = 116;
+        }
+
+        return (int)a;
+    }
+
+    /// <summary>
+    /// Windows x64 tail call tests
+    /// </summary>
+    /// <remarks>
+    ///
+    /// All targets will fast tail call
+    ///
+    /// The caller uses 2 integer registers (2 args)
+    /// The callee uses 1 integer registers (1 args)
+    ///
+    /// Return 100 is a pass.
+    /// Return 116 is a failure.
+    ///
+    /// </remarks>
+    public static int CallerAmd64WindowsStructs7Bytes(int a, int b)
+    {
+        if (a % 2 == 0)
+        {
+            return CalleeAmd64WindowsStructs7Bytes(new StructSizeSevenNotExplicit(a, 1, 2, 3));
+        }
+        else
+        {
+            return CalleeAmd64WindowsStructs7Bytes(new StructSizeSevenNotExplicit(b, 1, 2, 3));
+        }
+    }
+
+    /// <summary>
+    /// Decision to fast tail call. See CallerAmd64WindowsStructs6Bytes for more
+    /// information.
+    /// </summary>
+    public static int CalleeAmd64WindowsStructs6Bytes(StructSizeSixNotExplicit sixByteStruct)
+    {
+        int a = sixByteStruct.a;
+
+        // Force this to not be inlined
+        int count = 0;
+        for (int i = 0; i < a; ++i)
+        {
+            if (i % 2 == 0)
+            {
+                ++count;
+            }
+        }
+
+        if (count == 1000000)
+        {
+            a = count;
+        }
+
+        if (count == 1)
+        {
+            a = 100;
+        }
+        else
+        {
+            a = 117;
+        }
+
+        return (int)a;
+    }
+
+    /// <summary>
+    /// Windows x64 tail call tests
+    /// </summary>
+    /// <remarks>
+    ///
+    /// All targets will fast tail call
+    ///
+    /// The caller uses 2 integer registers (2 args)
+    /// The callee uses 1 integer registers (1 args)
+    ///
+    /// Return 100 is a pass.
+    /// Return 117 is a failure.
+    ///
+    /// </remarks>
+    public static int CallerAmd64WindowsStructs6Bytes(int a, int b)
+    {
+        if (a % 2 == 0)
+        {
+            return CalleeAmd64WindowsStructs6Bytes(new StructSizeSixNotExplicit(a, 1, 2));
+        }
+        else
+        {
+            return CalleeAmd64WindowsStructs6Bytes(new StructSizeSixNotExplicit(b, 1, 2));
+        }
+    }
+
+    /// <summary>
+    /// Decision to fast tail call. See CallerAmd64WindowsStructs5Bytes for more
+    /// information.
+    /// </summary>
+    public static int CalleeAmd64WindowsStructs5Bytes(StructSizeFiveNotExplicit fiveByteStruct)
+    {
+        int a = fiveByteStruct.a;
+
+        // Force this to not be inlined
+        int count = 0;
+        for (int i = 0; i < a; ++i)
+        {
+            if (i % 2 == 0)
+            {
+                ++count;
+            }
+        }
+
+        if (count == 1000000)
+        {
+            a = count;
+        }
+
+        if (count == 1)
+        {
+            a = 100;
+        }
+        else
+        {
+            a = 118;
+        }
+
+        return (int)a;
+    }
+
+    /// <summary>
+    /// Windows x64 tail call tests
+    /// </summary>
+    /// <remarks>
+    ///
+    /// All targets will fast tail call
+    ///
+    /// The caller uses 2 integer registers (2 args)
+    /// The callee uses 1 integer registers (1 args)
+    ///
+    /// Return 100 is a pass.
+    /// Return 118 is a failure.
+    ///
+    /// </remarks>
+    public static int CallerAmd64WindowsStructs5Bytes(int a, int b)
+    {
+        if (a % 2 == 0)
+        {
+            return CalleeAmd64WindowsStructs5Bytes(new StructSizeFiveNotExplicit(a, 1));
+        }
+        else
+        {
+            return CalleeAmd64WindowsStructs5Bytes(new StructSizeFiveNotExplicit(b, 1));
+        }
+    }
+
+    /// <summary>
+    /// Decision to fast tail call. See CallerAmd64WindowsStructs4Bytes for more
+    /// information.
+    /// </summary>
+    public static int CalleeAmd64WindowsStructs4Bytes(StructSizeFourNotExplicit fourByteStruct)
+    {
+        int a = fourByteStruct.a;
+
+        // Force this to not be inlined
+        int count = 0;
+        for (int i = 0; i < a; ++i)
+        {
+            if (i % 2 == 0)
+            {
+                ++count;
+            }
+        }
+
+        if (count == 1000000)
+        {
+            a = count;
+        }
+
+        if (count == 1)
+        {
+            a = 100;
+        }
+        else
+        {
+            a = 119;
+        }
+
+        return (int)a;
+    }
+
+    /// <summary>
+    /// Windows x64 tail call tests
+    /// </summary>
+    /// <remarks>
+    ///
+    /// All targets will fast tail call
+    ///
+    /// The caller uses 2 integer registers (2 args)
+    /// The callee uses 1 integer registers (1 args)
+    ///
+    /// Return 100 is a pass.
+    /// Return 119 is a failure.
+    ///
+    /// </remarks>
+    public static int CallerAmd64WindowsStructs4Bytes(int a, int b)
+    {
+        if (a % 2 == 0)
+        {
+            return CalleeAmd64WindowsStructs4Bytes(new StructSizeFourNotExplicit(a));
+        }
+        else
+        {
+            return CalleeAmd64WindowsStructs4Bytes(new StructSizeFourNotExplicit(a));
+        }
+    }
+
+    /// <summary>
+    /// Decision to fast tail call. See CallerAmd64WindowsStructs3Bytes for more
+    /// information.
+    /// </summary>
+    public static int CalleeAmd64WindowsStructs3Bytes(StructSizeThreeNotExplicit threeByteStruct)
+    {
+        int a = threeByteStruct.a;
+
+        // Force this to not be inlined
+        int count = 0;
+        for (int i = 0; i < a; ++i)
+        {
+            if (i % 2 == 0)
+            {
+                ++count;
+            }
+        }
+
+        if (count == 1000000)
+        {
+            a = count;
+        }
+
+        if (count == 1)
+        {
+            a = 100;
+        }
+        else
+        {
+            a = 120;
+        }
+
+        return (int)a;
+    }
+
+    /// <summary>
+    /// Windows x64 tail call tests
+    /// </summary>
+    /// <remarks>
+    ///
+    /// x64 windows will not fast tail call because the struct is passed
+    /// byref.
+    ///
+    /// The caller uses 2 integer registers (2 args)
+    /// The callee uses 1 integer registers (1 args)
+    ///
+    /// Return 100 is a pass.
+    /// Return 120 is a failure.
+    ///
+    /// </remarks>
+    public static int CallerAmd64WindowsStructs3Bytes(byte a, byte b)
+    {
+        if (a % 2 == 0)
+        {
+            return CalleeAmd64WindowsStructs3Bytes(new StructSizeThreeNotExplicit(a, a, a));
+        }
+        else
+        {
+            return CalleeAmd64WindowsStructs3Bytes(new StructSizeThreeNotExplicit(b, b, b));
+        }
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/tests/src/JIT/opt/FastTailCall/FastTailCallCandidates.cs
+++ b/tests/src/JIT/opt/FastTailCall/FastTailCallCandidates.cs
@@ -844,6 +844,94 @@ public class FastTailCallCandidates
     // Stack Based args.
     ////////////////////////////////////////////////////////////////////////////
 
+    public struct StructSizeOneNotExplicit
+    {
+        public byte a;
+
+        public StructSizeOneNotExplicit(byte a)
+        {
+            this.a = a;
+        }
+    }
+
+    public struct StructSizeTwoNotExplicit
+    {
+        public byte a;
+        public byte b;
+
+        public StructSizeTwoNotExplicit(byte a, byte b)
+        {
+            this.a = a;
+            this.b = b;
+        }
+    }
+
+    public struct StructSizeThreeNotExplicit
+    {
+        public byte a;
+        public byte b;
+        public byte c;
+
+        public StructSizeThreeNotExplicit(byte a, byte b, byte c)
+        {
+            this.a = a;
+            this.b = b;
+            this.c = c;
+        }
+    }
+
+    public struct StructSizeFourNotExplicit
+    {
+        public int a;
+
+        public StructSizeFourNotExplicit(int a)
+        {
+            this.a = a;
+        }
+    }
+
+    public struct StructSizeFiveNotExplicit
+    {
+        public int a;
+        public byte b;
+
+        public StructSizeFiveNotExplicit(int a, byte b)
+        {
+            this.a = a;
+            this.b = b;
+        }
+    }
+
+    public struct StructSizeSixNotExplicit
+    {
+        public int a;
+        public byte b;
+        public byte c;
+
+        public StructSizeSixNotExplicit(int a, byte b, byte c)
+        {
+            this.a = a;
+            this.b = b;
+            this.c = c;
+        }
+    }
+
+    public struct StructSizeSevenNotExplicit
+    {
+        public int a;
+        public byte b;
+        public byte c;
+        public byte d;
+
+        public StructSizeSevenNotExplicit(int a, byte b, byte c, byte d)
+        {
+            this.a = a;
+            this.b = b;
+            this.c = c;
+            this.d = d;
+        }
+    }
+
     public struct StructSizeEightNotExplicit
     {
         public long a;
@@ -876,7 +964,32 @@ public class FastTailCallCandidates
             this.a = a;
             this.b = b;
         }
+    }
 
+    public struct StructSize24NotExplicit
+    {
+        public long a;
+        public long b;
+        public long c;
+
+        public StructSize24NotExplicit(long a, long b, long c)
+        {
+            this.a = a;
+            this.b = b;
+            this.c = c;
+        }
+    }
+
+    public struct StructSize48Nested
+    {
+        public StructSize24NotExplicit a;
+        public StructSize24NotExplicit b;
+
+        public StructSize48Nested(long a, long b, long c, long d, long e, long f)
+        {
+            this.a = new StructSize24NotExplicit(a, b, c);
+            this.b = new StructSize24NotExplicit(d, e, f);
+        }
     }
 
     /// <summary>
@@ -974,10 +1087,10 @@ public class FastTailCallCandidates
     [StructLayout(LayoutKind.Explicit, Size=8, CharSet=CharSet.Ansi)]
     public struct StructSizeThirtyTwo
     {
-        [FieldOffset(0)]  public int a;
-        [FieldOffset(8)] public int b;
-        [FieldOffset(16)] public int c;
-        [FieldOffset(24)] public int d;
+        [FieldOffset(0)]  public long a;
+        [FieldOffset(8)]  public long b;
+        [FieldOffset(16)] public long c;
+        [FieldOffset(24)] public long d;
 
         public StructSizeThirtyTwo(int a, int b, int c, int d)
         {
@@ -991,9 +1104,9 @@ public class FastTailCallCandidates
     [StructLayout(LayoutKind.Explicit, Size=8, CharSet=CharSet.Ansi)]
     public struct StructSizeTwentyFour
     {
-        [FieldOffset(0)] public int a;
-        [FieldOffset(8)] public int b;
-        [FieldOffset(16)] public int c;
+        [FieldOffset(0)] public long a;
+        [FieldOffset(8)] public long b;
+        [FieldOffset(16)] public long c;
 
         public StructSizeTwentyFour(int a, int b, int c)
         {
@@ -1010,6 +1123,7 @@ public class FastTailCallCandidates
     public static int StackBasedCallee(int a, int b, StructSizeThirtyTwo sstt)
     {
         int count = 0;
+        long max = sstt.a;
         for (int i = 0; i < sstt.a; ++i)
         {
             if (i % 10 == 0)
@@ -1098,17 +1212,23 @@ public class FastTailCallCandidates
     {
         if (a % 2 == 0)
         {
-            StructSizeEightIntNotExplicit eightBytes = new StructSizeEightIntNotExplicit(a, a);
             a = 1;
             b = b + 2;
-            return DoubleCountRetBuffCallee(eightBytes, eightBytes, eightBytes, eightBytes, eightBytes);
+            return DoubleCountRetBuffCallee(new StructSizeEightIntNotExplicit(a, a), 
+                                            new StructSizeEightIntNotExplicit(a, a), 
+                                            new StructSizeEightIntNotExplicit(a, a), 
+                                            new StructSizeEightIntNotExplicit(a, a),
+                                            new StructSizeEightIntNotExplicit(a, a));
         }
         else
         {
-            StructSizeEightIntNotExplicit eightBytes = new StructSizeEightIntNotExplicit(b, b);
             a = 4;
             b = b + 1;
-            return DoubleCountRetBuffCallee(eightBytes, eightBytes, eightBytes, eightBytes, eightBytes);
+            return DoubleCountRetBuffCallee(new StructSizeEightIntNotExplicit(b, b), 
+                                            new StructSizeEightIntNotExplicit(b, b), 
+                                            new StructSizeEightIntNotExplicit(b, b), 
+                                            new StructSizeEightIntNotExplicit(b, b),
+                                            new StructSizeEightIntNotExplicit(b, b));
         }
     }
 
@@ -1132,7 +1252,7 @@ public class FastTailCallCandidates
         {
             StructSizeThirtyTwo retVal = DoubleCountRetBuffCallerWrapper(4, 2);
             
-            if (retVal.b == 4.0)
+            if (retVal.b == 6.0)
             {
                 return 100;
             }
@@ -1145,7 +1265,7 @@ public class FastTailCallCandidates
         {
             StructSizeThirtyTwo retVal = DoubleCountRetBuffCallerWrapper(3, 1);
             
-            if (retVal.b == 1.0)
+            if (retVal.b == 2.0)
             {
                 return 100;
             }

--- a/tests/src/JIT/opt/FastTailCall/FastTailCallCandidates.cs
+++ b/tests/src/JIT/opt/FastTailCall/FastTailCallCandidates.cs
@@ -1123,7 +1123,6 @@ public class FastTailCallCandidates
     public static int StackBasedCallee(int a, int b, StructSizeThirtyTwo sstt)
     {
         int count = 0;
-        long max = sstt.a;
         for (int i = 0; i < sstt.a; ++i)
         {
             if (i % 10 == 0)

--- a/tests/src/JIT/opt/FastTailCall/FastTailCallCandidates.cs
+++ b/tests/src/JIT/opt/FastTailCall/FastTailCallCandidates.cs
@@ -1092,7 +1092,7 @@ public class FastTailCallCandidates
         [FieldOffset(16)] public long c;
         [FieldOffset(24)] public long d;
 
-        public StructSizeThirtyTwo(int a, int b, int c, int d)
+        public StructSizeThirtyTwo(long a, long b, long c, long d)
         {
             this.a = a;
             this.b = b;
@@ -1212,7 +1212,6 @@ public class FastTailCallCandidates
         if (a % 2 == 0)
         {
             a = 1;
-            b = b + 2;
             return DoubleCountRetBuffCallee(new StructSizeEightIntNotExplicit(a, a), 
                                             new StructSizeEightIntNotExplicit(a, a), 
                                             new StructSizeEightIntNotExplicit(a, a), 
@@ -1221,7 +1220,6 @@ public class FastTailCallCandidates
         }
         else
         {
-            a = 4;
             b = b + 1;
             return DoubleCountRetBuffCallee(new StructSizeEightIntNotExplicit(b, b), 
                                             new StructSizeEightIntNotExplicit(b, b), 

--- a/tests/src/JIT/opt/FastTailCall/FastTailCallCandidates.csproj
+++ b/tests/src/JIT/opt/FastTailCall/FastTailCallCandidates.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
-    <DebugType>None</DebugType>
+    <DebugType>PdbOnly</DebugType>
     <NoLogo>True</NoLogo>
     <NoStandardLib>True</NoStandardLib>
     <Noconfig>True</Noconfig>


### PR DESCRIPTION
Update fgCanFastTailCall to use init fgArgInfo. Note that fgCanFastTailCall will now do all of the argInfo init and fgMorphArgs will now just re-query the ArgInfo for #FEATURE_FAST_TAILCALL && the call is a possible fast tail call candidate.

The change also includes other changes such as:

1. Saving the struct's int and float reg count in the fgArgTabEntry for x64 unix.
2. Removes the multibyte decision for not fastTailCalling. This is now changed to a much less complicated decision in which all calls which have a byref **struct** argument will be not fast tail called. See logic below.
3. It changes some of the older logic calling out the problems in LowerFastTailCall to move stack slot arguments > 1 stack slot size.
4. Simplifies the fgCanFastTailCall logic to rely on the fgArgEntry information instead of recomputing the arguments size and abi information. 

https://github.com/dotnet/coreclr/pull/20643/files#diff-bd2d23afdb1936d1982f699f760429d2R7070 summarizes the reason to not allow byref types in fast tail calls. Which is that although it is theoretically possible to use the caller's allocated structure and manipulate it by pointer there is more work required to force using the caller's memory when passing the struct to subsequent callees. Take the following example on windows x64:

```
public static void callee(int a, int b, int c, int d, 32ByteStruct s) {
    // At this point we would create an outgoing 32byte struct on our stack 
    // however, the caller has no stack allocated to it, this operation is illegal
    // and best case will AV.
    //
    // One could imagine a theoretical option to reuse the existing byref as the
    // copy, as s is dead after before call in a fast tail call.
    callee(1, 2, 3, 4, s);
}

public static void caller(32ByteStruct s) {
    // Outgoing 32byte struct is placed on the stack and passed byref
    callee(1, 2, 3, 4, s);
}
```