### PR TITLE
Workaround XUnit FileLoadException issues

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -765,6 +765,39 @@ def run_tests(host_os,
     if test_env is not None:
         os.environ["__TestEnv"] = test_env
 
+    #=====================================================================================================================================================
+    #
+    # This is a workaround needed to unblock our CI (in particular, Linux/arm and Linux/arm64 jobs) from the following failures appearing almost in every
+    # pull request (but hard to reproduce locally)
+    #
+    #   System.IO.FileLoadException: Could not load file or assembly 'Exceptions.Finalization.XUnitWrapper, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. 
+    #   An operation is not legal in the current state. (Exception from HRESULT: 0x80131509 (COR_E_INVALIDOPERATION))
+    #
+    # COR_E_INVALIDOPERATION comes from System.InvalidOperationException that is thrown during AssemblyLoadContext.ResolveUsingResolvingEvent
+    # when multiple threads attempt to modify an instance of Dictionary (managedAssemblyCache) during Xunit.DependencyContextAssemblyCache.LoadManagedDll call.
+    #
+    # In order to mitigate the failure we built our own xunit.console.dll with ConcurrentDictionary used for managedAssemblyCache and use this instead of
+    # the one pulled from NuGet. The exact code that got built can be found at the following fork of Xunit
+    #  * https://github.com/echesakovMSFT/xunit/tree/UseConcurrentDictionaryInDependencyContextAssemblyCache
+    #
+    # The assembly was built using Microsoft Visual Studio v15.9.0-pre.4.0 Developer Command Prompt using the following commands
+    #  1) git clone https://github.com/echesakovMSFT/xunit.git --branch UseConcurrentDictionaryInDependencyContextAssemblyCache --single-branch
+    #  2) cd xunit
+    #  3) git submodule update --init
+    #  4) powershell .\build.ps1
+    #
+    # Then file "xunit\src\xunit.console\bin\Release\netcoreapp2.0\xunit.console.dll" was archived and uploaded to the clrjit blob storage.
+    #
+    # Ideally, this code should be removed when we find a more robust way of running Xunit tests.
+    #  
+    # References:
+    #  * https://github.com/dotnet/coreclr/issues/20392
+    #  * https://github.com/dotnet/coreclr/issues/20594
+    #  * https://github.com/xunit/xunit/issues/1842 
+    #  * https://github.com/xunit/xunit/pull/1846
+    #
+    #=====================================================================================================================================================
+
     print("Download and overwrite xunit.console.dll in Core_Root")
 
     try:
@@ -782,6 +815,7 @@ def run_tests(host_os,
         ziparch.extractall(core_root)
 
     os.remove(zipfilename)
+
 
     # Call msbuild.
     return call_msbuild(coreclr_repo_location,

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -777,7 +777,7 @@ def run_tests(host_os,
     # This is a workaround needed to unblock our CI (in particular, Linux/arm and Linux/arm64 jobs) from the following failures appearing almost in every
     # pull request (but hard to reproduce locally)
     #
-    #   System.IO.FileLoadException: Could not load file or assembly 'Exceptions.Finalization.XUnitWrapper, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'. 
+    #   System.IO.FileLoadException: Could not load file or assembly 'Exceptions.Finalization.XUnitWrapper, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
     #   An operation is not legal in the current state. (Exception from HRESULT: 0x80131509 (COR_E_INVALIDOPERATION))
     #
     # COR_E_INVALIDOPERATION comes from System.InvalidOperationException that is thrown during AssemblyLoadContext.ResolveUsingResolvingEvent

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -59,6 +59,13 @@ import xml.etree.ElementTree
 from collections import defaultdict
 from sys import platform as _platform
 
+# Version specific imports
+
+if sys.version_info.major < 3:
+    import urllib
+else:
+    import urllib.request
+
 ################################################################################
 # Argument Parser
 ################################################################################
@@ -789,24 +796,18 @@ def run_tests(host_os,
     # Then file "xunit\src\xunit.console\bin\Release\netcoreapp2.0\xunit.console.dll" was archived and uploaded to the clrjit blob storage.
     #
     # Ideally, this code should be removed when we find a more robust way of running Xunit tests.
-    #  
+    #
     # References:
     #  * https://github.com/dotnet/coreclr/issues/20392
     #  * https://github.com/dotnet/coreclr/issues/20594
-    #  * https://github.com/xunit/xunit/issues/1842 
+    #  * https://github.com/xunit/xunit/issues/1842
     #  * https://github.com/xunit/xunit/pull/1846
     #
     #=====================================================================================================================================================
 
     print("Download and overwrite xunit.console.dll in Core_Root")
 
-    try:
-        import urllib.request
-        urlretrieve = urllib.request.urlretrieve
-    except ImportError:
-        import urllib
-        urlretrieve = urllib.urlretrieve
-
+    urlretrieve = urllib.urlretrieve if sys.version_info.major < 3 else urllib.request.urlretrieve
     zipfilename = os.path.join(tempfile.gettempdir(), "xunit.console.dll.zip")
     url = r"https://clrjit.blob.core.windows.net/xunit-console/xunit.console.dll.zip"
     urlretrieve(url, zipfilename)
@@ -815,7 +816,7 @@ def run_tests(host_os,
         ziparch.extractall(core_root)
 
     os.remove(zipfilename)
-
+    assert not os.path.isfile(zipfilename)
 
     # Call msbuild.
     return call_msbuild(coreclr_repo_location,

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -52,6 +52,7 @@ import tempfile
 import time
 import re
 import string
+import zipfile
 
 import xml.etree.ElementTree
 
@@ -763,6 +764,24 @@ def run_tests(host_os,
     # Set test env if exists
     if test_env is not None:
         os.environ["__TestEnv"] = test_env
+
+    print("Download and overwrite xunit.console.dll in Core_Root")
+
+    try:
+        import urllib.request
+        urlretrieve = urllib.request.urlretrieve
+    except ImportError:
+        import urllib
+        urlretrieve = urllib.urlretrieve
+
+    zipfilename = os.path.join(tempfile.gettempdir(), "xunit.console.dll.zip")
+    url = r"https://clrjit.blob.core.windows.net/xunit-console/xunit.console.dll.zip"
+    urlretrieve(url, zipfilename)
+
+    with zipfile.ZipFile(zipfilename,"r") as ziparch:
+        ziparch.extractall(core_root)
+
+    os.remove(zipfilename)
 
     # Call msbuild.
     return call_msbuild(coreclr_repo_location,

--- a/tests/src/Common/external/external.depproj
+++ b/tests/src/Common/external/external.depproj
@@ -90,7 +90,7 @@
     <ItemGroup>
       <ReferenceCopyLocalPaths
         Include="$(PackagesDir)\$(XUnitRunnerPackageId)\$(XUnitPackageVersion)\tools\$(XUnitRunnerTargetFramework)\*.*"
-        Exclude="$(PackagesDir)\$(XUnitRunnerPackageId)\$(XUnitPackageVersion)\tools\$(XUnitRunnerTargetFramework)\xunit.console.dll.config"
+        Exclude="$(PackagesDir)\$(XUnitRunnerPackageId)\$(XUnitPackageVersion)\tools\$(XUnitRunnerTargetFramework)\xunit.console.dll*"
       >
         <Private>false</Private>
         <NuGetPackageId>$(XUnitRunnerPackageId)</NuGetPackageId>

--- a/tests/src/Common/external/external.depproj
+++ b/tests/src/Common/external/external.depproj
@@ -90,7 +90,7 @@
     <ItemGroup>
       <ReferenceCopyLocalPaths
         Include="$(PackagesDir)\$(XUnitRunnerPackageId)\$(XUnitPackageVersion)\tools\$(XUnitRunnerTargetFramework)\*.*"
-        Exclude="$(PackagesDir)\$(XUnitRunnerPackageId)\$(XUnitPackageVersion)\tools\$(XUnitRunnerTargetFramework)\xunit.console.dll*"
+        Exclude="$(PackagesDir)\$(XUnitRunnerPackageId)\$(XUnitPackageVersion)\tools\$(XUnitRunnerTargetFramework)\xunit.console.dll.config"
       >
         <Private>false</Private>
         <NuGetPackageId>$(XUnitRunnerPackageId)</NuGetPackageId>


### PR DESCRIPTION
To workaround XUnit FileLoadException issues use custom xunit.console.dll (2.4.1-pre-4059) with the following changes https://github.com/xunit/xunit/pull/1846 https://github.com/echesakovMSFT/xunit/tree/UseConcurrentDictionaryInDependencyContextAssemblyCache


**Related issues:** https://github.com/dotnet/coreclr/issues/20392 https://github.com/dotnet/coreclr/issues/20594 https://github.com/xunit/xunit/issues/1842

@RussKeldorph @BruceForstall @jashook PTAL