### PR TITLE
Fix loop hoist ordering (part I - "swap" case)

### DIFF
--- a/src/jit/arraystack.h
+++ b/src/jit/arraystack.h
@@ -71,6 +71,13 @@ public:
         return data[tosIndex];
     }
 
+    // Pop `count` elements from the stack
+    void Pop(int count)
+    {
+        assert(tosIndex >= count);
+        tosIndex -= count;
+    }
+
     T Top()
     {
         assert(tosIndex > 0);

--- a/src/jit/arraystack.h
+++ b/src/jit/arraystack.h
@@ -78,30 +78,18 @@ public:
         tosIndex -= count;
     }
 
-    T Top()
+    // Return the i'th element from the top
+    T Top(int i = 0)
     {
-        assert(tosIndex > 0);
-        return data[tosIndex - 1];
+        assert(tosIndex > i);
+        return data[tosIndex - 1 - i];
     }
 
-    T& TopRef()
+    // Return a reference to the i'th element from the top
+    T& TopRef(int i = 0)
     {
-        assert(tosIndex > 0);
-        return data[tosIndex - 1];
-    }
-
-    // return the i'th from the top
-    T Index(int idx)
-    {
-        assert(tosIndex > idx);
-        return data[tosIndex - 1 - idx];
-    }
-
-    // return a reference to the i'th from the top
-    T& IndexRef(int idx)
-    {
-        assert(tosIndex > idx);
-        return data[tosIndex - 1 - idx];
+        assert(tosIndex > i);
+        return data[tosIndex - 1 - i];
     }
 
     int Height()
@@ -114,25 +102,18 @@ public:
         return tosIndex == 0;
     }
 
-    // return the bottom of the stack
-    T Bottom()
+    // Return the i'th element from the bottom
+    T Bottom(int i = 0)
     {
-        assert(tosIndex > 0);
-        return data[0];
+        assert(tosIndex > i);
+        return data[i];
     }
 
-    // return the i'th from the bottom
-    T Bottom(int indx)
+    // Return a reference to the i'th element from the bottom
+    T& BottomRef(int i = 0)
     {
-        assert(tosIndex > indx);
-        return data[indx];
-    }
-
-    // return a reference to the i'th from the bottom
-    T& BottomRef(int indx)
-    {
-        assert(tosIndex > indx);
-        return data[indx];
+        assert(tosIndex > i);
+        return data[i];
     }
 
     void Reset()

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -699,7 +699,7 @@ void CodeGen::genRestoreCalleeSavedRegisterGroup(regMaskTP regsMask, int spDelta
             stackDelta = spDelta;
         }
 
-        RegPair regPair = regStack.Index(i);
+        RegPair regPair = regStack.Top(i);
         if (regPair.reg2 != REG_NA)
         {
             spOffset -= 2 * slotSize;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5686,7 +5686,7 @@ protected:
     // Hoist all expressions in "blk" that are invariant in loop "lnum" (an index into the optLoopTable)
     // outside of that loop.  Exempt expressions whose value number is in "m_hoistedInParentLoops"; add VN's of hoisted
     // expressions to "hoistInLoop".
-    void optHoistLoopExprsForBlock(BasicBlock* block, unsigned loopNum, LoopHoistContext* hoistContext);
+    void optHoistLoopBlocks(unsigned loopNum, ArrayStack<BasicBlock*>* blocks, LoopHoistContext* hoistContext);
 
     // Return true if the tree looks profitable to hoist out of loop 'lnum'.
     bool optIsProfitableToHoistableTree(GenTree* tree, unsigned lnum);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5686,22 +5686,10 @@ protected:
     // Hoist all expressions in "blk" that are invariant in loop "lnum" (an index into the optLoopTable)
     // outside of that loop.  Exempt expressions whose value number is in "m_hoistedInParentLoops"; add VN's of hoisted
     // expressions to "hoistInLoop".
-    void optHoistLoopExprsForBlock(BasicBlock* blk, unsigned lnum, LoopHoistContext* hoistCtxt);
+    void optHoistLoopExprsForBlock(BasicBlock* block, unsigned loopNum, LoopHoistContext* hoistContext);
 
     // Return true if the tree looks profitable to hoist out of loop 'lnum'.
     bool optIsProfitableToHoistableTree(GenTree* tree, unsigned lnum);
-
-    // Hoist all proper sub-expressions of "tree" (which occurs in "stmt", which occurs in "blk")
-    // that are invariant in loop "lnum" (an index into the optLoopTable)
-    // outside of that loop.  Exempt expressions whose value number is in "hoistedInParents"; add VN's of hoisted
-    // expressions to "hoistInLoop".
-    // Returns "true" iff "tree" is loop-invariant (wrt "lnum").
-    // Assumes that the value of "*firstBlockAndBeforeSideEffect" indicates that we're in the first block, and before
-    // any possible globally visible side effects.  Assume is called in evaluation order, and updates this.
-    void optHoistLoopExprsForStmt(GenTreeStmt*      stmt,
-                                  unsigned          loopNum,
-                                  LoopHoistContext* hoistContext,
-                                  bool*             firstBlockAndBeforeSideEffect);
 
     // Performs the hoisting 'tree' into the PreHeader for loop 'lnum'
     void optHoistCandidate(GenTree* tree, unsigned lnum, LoopHoistContext* hoistCtxt);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5699,12 +5699,6 @@ protected:
     //   VNPhi's connect VN's to the SSA definition, so we can know if the SSA def occurs in the loop.
     bool optVNIsLoopInvariant(ValueNum vn, unsigned lnum, VNToBoolMap* recordedVNs);
 
-    // Returns "true" iff "tree" is valid at the head of loop "lnum", in the context of the hoist substitution
-    // "subst".  If "tree" is a local SSA var, it is valid if its SSA definition occurs outside of the loop, or
-    // if it is in the domain of "subst" (meaning that it's definition has been previously hoisted, with a "standin"
-    // local.)  If tree is a constant, it is valid.  Otherwise, if it is an operator, it is valid iff its children are.
-    bool optTreeIsValidAtLoopHead(GenTree* tree, unsigned lnum);
-
     // If "blk" is the entry block of a natural loop, returns true and sets "*pLnum" to the index of the loop
     // in the loop table.
     bool optBlockIsLoopEntry(BasicBlock* blk, unsigned* pLnum);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5698,12 +5698,10 @@ protected:
     // Returns "true" iff "tree" is loop-invariant (wrt "lnum").
     // Assumes that the value of "*firstBlockAndBeforeSideEffect" indicates that we're in the first block, and before
     // any possible globally visible side effects.  Assume is called in evaluation order, and updates this.
-    bool optHoistLoopExprsForTree(GenTree*          tree,
-                                  unsigned          lnum,
-                                  LoopHoistContext* hoistCtxt,
-                                  bool*             firstBlockAndBeforeSideEffect,
-                                  bool*             pHoistable,
-                                  bool*             pCctorDependent);
+    void optHoistLoopExprsForStmt(GenTreeStmt*      stmt,
+                                  unsigned          loopNum,
+                                  LoopHoistContext* hoistContext,
+                                  bool*             firstBlockAndBeforeSideEffect);
 
     // Performs the hoisting 'tree' into the PreHeader for loop 'lnum'
     void optHoistCandidate(GenTree* tree, unsigned lnum, LoopHoistContext* hoistCtxt);

--- a/src/jit/copyprop.cpp
+++ b/src/jit/copyprop.cpp
@@ -62,7 +62,7 @@ void Compiler::optDumpCopyPropStack(LclNumToGenTreePtrStack* curSsaName)
     JITDUMP("{ ");
     for (LclNumToGenTreePtrStack::KeyIterator iter = curSsaName->Begin(); !iter.Equal(curSsaName->End()); ++iter)
     {
-        GenTree* node = iter.GetValue()->Index(0);
+        GenTree* node = iter.GetValue()->Top();
         JITDUMP("%d-[%06d]:V%02u ", iter.Get(), dspTreeID(node), node->AsLclVarCommon()->gtLclNum);
     }
     JITDUMP("}\n\n");
@@ -165,7 +165,7 @@ void Compiler::optCopyProp(BasicBlock* block, GenTreeStmt* stmt, GenTree* tree, 
     {
         unsigned newLclNum = iter.Get();
 
-        GenTree* op = iter.GetValue()->Index(0);
+        GenTree* op = iter.GetValue()->Top();
 
         // Nothing to do if same.
         if (lclNum == newLclNum)

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -8164,7 +8164,6 @@ unsigned GenTree::NumChildren()
 GenTree* GenTree::GetChild(unsigned childNum)
 {
     assert(childNum < NumChildren()); // Precondition.
-    assert(NumChildren() <= MAX_CHILDREN);
     assert(!(OperIsConst() || OperIsLeaf()));
     if (OperIsUnary())
     {

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -109,7 +109,7 @@ struct IndentStack
         for (unsigned i = 0; i < indentCount; i++)
         {
             unsigned index = indentCount - 1 - i;
-            switch (stack.Index(index))
+            switch (stack.Top(index))
             {
                 case Compiler::IndentInfo::IINone:
                     printf("   ");
@@ -15159,7 +15159,7 @@ bool Compiler::gtHasCatchArg(GenTree* tree)
 {
     for (int i = 0; i < parentStack->Height(); i++)
     {
-        GenTree* node = parentStack->Index(i);
+        GenTree* node = parentStack->Top(i);
         if (node->OperGet() == GT_CALL)
         {
             return true;

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -2113,9 +2113,6 @@ private:
 public:
     bool Precedes(GenTree* other);
 
-    // The maximum possible # of children of any node.
-    static const int MAX_CHILDREN = 6;
-
     bool IsReuseRegVal() const
     {
         // This can be extended to non-constant nodes, but not to local or indir nodes.

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2699,7 +2699,7 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
         {
             for (int i = 0; i < args.Height(); i++)
             {
-                if (node == args.Index(i).node)
+                if (node == args.Top(i).node)
                 {
                     return i;
                 }
@@ -2725,7 +2725,7 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
         {
             for (int i = 0; i < args.Height(); i++)
             {
-                NonStandardArg& nsa = args.IndexRef(i);
+                NonStandardArg& nsa = args.TopRef(i);
                 if (node == nsa.node)
                 {
                     *pReg = nsa.reg;
@@ -2749,7 +2749,7 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
         //
         void Replace(int index, GenTree* node)
         {
-            args.IndexRef(index).node = node;
+            args.TopRef(index).node = node;
         }
 
     } nonStandardArgs(getAllocator(CMK_ArrayStack));
@@ -18309,7 +18309,7 @@ private:
 
     Value& TopValue(unsigned index)
     {
-        return m_valueStack.IndexRef(index);
+        return m_valueStack.TopRef(index);
     }
 
     void PopValue()

--- a/src/jit/objectalloc.cpp
+++ b/src/jit/objectalloc.cpp
@@ -171,7 +171,7 @@ void ObjectAllocator::MarkEscapingVarsAndBuildConnGraph()
             if ((tree->OperGet() == GT_LCL_VAR) && (type == TYP_REF || type == TYP_BYREF || type == TYP_I_IMPL))
             {
                 unsigned int lclNum = tree->AsLclVar()->GetLclNum();
-                assert(tree == m_ancestors.Index(0));
+                assert(tree == m_ancestors.Top());
 
                 if (m_allocator->CanLclVarEscapeViaParentStack(&m_ancestors, lclNum))
                 {
@@ -588,8 +588,8 @@ bool ObjectAllocator::CanLclVarEscapeViaParentStack(ArrayStack<GenTree*>* parent
         }
 
         canLclVarEscapeViaParentStack = true;
-        GenTree* tree                 = parentStack->Index(parentIndex - 1);
-        GenTree* parent               = parentStack->Index(parentIndex);
+        GenTree* tree                 = parentStack->Top(parentIndex - 1);
+        GenTree* parent               = parentStack->Top(parentIndex);
         keepChecking                  = false;
 
         switch (parent->OperGet())
@@ -643,7 +643,7 @@ bool ObjectAllocator::CanLclVarEscapeViaParentStack(ArrayStack<GenTree*>* parent
                 break;
 
             case GT_COMMA:
-                if (parent->AsOp()->gtGetOp1() == parentStack->Index(parentIndex - 1))
+                if (parent->AsOp()->gtGetOp1() == parentStack->Top(parentIndex - 1))
                 {
                     // Left child of GT_COMMA, it will be discarded
                     canLclVarEscapeViaParentStack = false;
@@ -663,7 +663,7 @@ bool ObjectAllocator::CanLclVarEscapeViaParentStack(ArrayStack<GenTree*>* parent
             {
                 int grandParentIndex = parentIndex + 1;
                 if ((parentStack->Height() > grandParentIndex) &&
-                    (parentStack->Index(grandParentIndex)->OperGet() == GT_ADDR))
+                    (parentStack->Top(grandParentIndex)->OperGet() == GT_ADDR))
                 {
                     // Check if the address of the field/ind escapes.
                     parentIndex += 2;
@@ -727,7 +727,7 @@ void ObjectAllocator::UpdateAncestorTypes(GenTree* tree, ArrayStack<GenTree*>* p
 
     while (keepChecking && (parentStack->Height() > parentIndex))
     {
-        GenTree* parent = parentStack->Index(parentIndex);
+        GenTree* parent = parentStack->Top(parentIndex);
         keepChecking    = false;
 
         switch (parent->OperGet())
@@ -750,7 +750,7 @@ void ObjectAllocator::UpdateAncestorTypes(GenTree* tree, ArrayStack<GenTree*>* p
                 break;
 
             case GT_COMMA:
-                if (parent->AsOp()->gtGetOp1() == parentStack->Index(parentIndex - 1))
+                if (parent->AsOp()->gtGetOp1() == parentStack->Top(parentIndex - 1))
                 {
                     // Left child of GT_COMMA, it will be discarded
                     break;
@@ -787,7 +787,7 @@ void ObjectAllocator::UpdateAncestorTypes(GenTree* tree, ArrayStack<GenTree*>* p
 
                 if (parentStack->Height() > grandParentIndex)
                 {
-                    GenTree* grandParent = parentStack->Index(grandParentIndex);
+                    GenTree* grandParent = parentStack->Top(grandParentIndex);
                     if (grandParent->OperGet() == GT_ADDR)
                     {
                         if (grandParent->TypeGet() == TYP_REF)
@@ -807,7 +807,7 @@ void ObjectAllocator::UpdateAncestorTypes(GenTree* tree, ArrayStack<GenTree*>* p
 
         if (keepChecking)
         {
-            tree = parentStack->Index(parentIndex - 1);
+            tree = parentStack->Top(parentIndex - 1);
         }
     }
 

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -6875,9 +6875,9 @@ bool Compiler::optHoistLoopExprsForTree(GenTree*          tree,
                                          (tree->OperIs(GT_CNS_INT) && ((tree->gtFlags & GTF_ICON_INITCLASS) != 0)));
             bool treeIsInvariant = true;
             int  childCount;
-            for (childCount = 0; m_valueStack.IndexRef(childCount).Node() != tree; childCount++)
+            for (childCount = 0; m_valueStack.TopRef(childCount).Node() != tree; childCount++)
             {
-                Value& child = m_valueStack.IndexRef(childCount);
+                Value& child = m_valueStack.TopRef(childCount);
 
                 if (!child.m_invariant)
                 {

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -7180,23 +7180,11 @@ bool Compiler::optVNIsLoopInvariant(ValueNum vn, unsigned lnum, VNToBoolMap* loo
     {
         if (funcApp.m_func == VNF_PhiDef)
         {
-            // First, make sure it's a "proper" phi -- the definition is a Phi application.
-            VNFuncApp phiDefValFuncApp;
-            if (!vnStore->GetVNFunc(funcApp.m_args[2], &phiDefValFuncApp) || phiDefValFuncApp.m_func != VNF_Phi)
-            {
-                // It's not *really* a definition, rather a pass-through of some other VN.
-                // (This could occur, say if both sides of an if-then-else diamond made the
-                // same assignment to a variable.)
-                res = optVNIsLoopInvariant(funcApp.m_args[2], lnum, loopVnInvariantCache);
-            }
-            else
-            {
-                // Is the definition within the loop?  If so, is not loop-invariant.
-                unsigned      lclNum = funcApp.m_args[0];
-                unsigned      ssaNum = funcApp.m_args[1];
-                LclSsaVarDsc* ssaDef = lvaTable[lclNum].GetPerSsaData(ssaNum);
-                res                  = !optLoopContains(lnum, ssaDef->m_defLoc.m_blk->bbNatLoopNum);
-            }
+            // Is the definition within the loop?  If so, is not loop-invariant.
+            unsigned      lclNum = funcApp.m_args[0];
+            unsigned      ssaNum = funcApp.m_args[1];
+            LclSsaVarDsc* ssaDef = lvaTable[lclNum].GetPerSsaData(ssaNum);
+            res                  = !optLoopContains(lnum, ssaDef->m_defLoc.m_blk->bbNatLoopNum);
         }
         else if (funcApp.m_func == VNF_PhiMemoryDef)
         {

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -7116,17 +7116,8 @@ void Compiler::optHoistLoopBlocks(unsigned loopNum, ArrayStack<BasicBlock*>* blo
 
 void Compiler::optHoistCandidate(GenTree* tree, unsigned lnum, LoopHoistContext* hoistCtxt)
 {
-    if (lnum == BasicBlock::NOT_IN_LOOP)
-    {
-        // The hoisted expression isn't valid at any loop head so don't hoist this expression.
-        return;
-    }
-
-    // The outer loop also must be suitable for hoisting...
-    if ((optLoopTable[lnum].lpFlags & LPFLG_HOISTABLE) == 0)
-    {
-        return;
-    }
+    assert(lnum != BasicBlock::NOT_IN_LOOP);
+    assert((optLoopTable[lnum].lpFlags & LPFLG_HOISTABLE) != 0);
 
     // It must pass the hoistable profitablity tests for this loop level
     if (!optIsProfitableToHoistableTree(tree, lnum))

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -7023,15 +7023,6 @@ void Compiler::optHoistLoopBlocks(unsigned loopNum, ArrayStack<BasicBlock*>* blo
                         m_beforeSideEffect = false;
                     }
                 }
-                else if (tree->OperIsCopyBlkOp())
-                {
-                    GenTree* args = tree->gtOp.gtOp1;
-                    assert(args->OperGet() == GT_LIST);
-                    if (args->gtOp.gtOp1->gtFlags & GTF_GLOB_REF)
-                    {
-                        m_beforeSideEffect = false;
-                    }
-                }
             }
 
             // If this 'tree' is hoistable then we return and the caller will

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -6814,8 +6814,9 @@ void Compiler::optHoistLoopBlocks(unsigned loopNum, ArrayStack<BasicBlock*>* blo
                 m_valueStack.Reset();
             }
 
-            // We don't visit every block in the loop so once we visited the first block
-            // we need to assume the worst, that not visited blocks have side effects.
+            // Only uncondtionally executed blocks in the loop are visited (see optHoistThisLoop)
+            // so after we're done visiting the first block we need to assume the worst, that the
+            // blocks that are not visisted have side effects.
             m_beforeSideEffect = false;
         }
 
@@ -7038,7 +7039,11 @@ void Compiler::optHoistLoopBlocks(unsigned loopNum, ArrayStack<BasicBlock*>* blo
                 // At this point the stack contains (in top to bottom order):
                 //   - the current node's children
                 //   - the current node
-                //   - previously traversed nodes (descendants of some current node's ancestor)
+                //   - ancestors of the current node and some of their descendants
+                //
+                // The ancestors have not been visited yet in post order so they're not hoistable
+                // (and they cannot become hoistable because the current node is not) but some of
+                // their descendants may have already been traversed and be hoistable.
                 //
                 // The execution order is actually bottom to top so we'll start hoisting from
                 // the bottom of the stack, skipping the current node (which is expected to not

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -165,7 +165,7 @@ void Rationalizer::RewriteNodeAsCall(GenTree**             use,
     // Replace "tree" with "call"
     if (parents.Height() > 1)
     {
-        parents.Index(1)->ReplaceOperand(use, call);
+        parents.Top(1)->ReplaceOperand(use, call);
     }
     else
     {
@@ -181,7 +181,7 @@ void Rationalizer::RewriteNodeAsCall(GenTree**             use,
     // 0 is current node, so start at 1
     for (int i = 1; i < parents.Height(); i++)
     {
-        parents.Index(i)->gtFlags |= (call->gtFlags & GTF_ALL_EFFECT) | GTF_CALL;
+        parents.Top(i)->gtFlags |= (call->gtFlags & GTF_ALL_EFFECT) | GTF_CALL;
     }
 
     // Since "tree" is replaced with "call", pop "tree" node (i.e the current node)
@@ -593,7 +593,7 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, Compiler::Ge
     }
     else
     {
-        use = LIR::Use(BlockRange(), useEdge, parentStack.Index(1));
+        use = LIR::Use(BlockRange(), useEdge, parentStack.Top(1));
     }
 
     assert(node == use.Def());

--- a/tests/src/JIT/Regression/JitBlue/GitHub_7147/GitHub_7147.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_7147/GitHub_7147.cs
@@ -1,0 +1,95 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace N
+{
+    public class C
+    {
+        int f = 2;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static bool cross(int k, int y, C c)
+        {
+            bool b = false;
+
+            for (int i = 0; i < k; ++i)
+            {
+                // Here "c.f" is invariant, but is evaluated after "i / y"
+                // which may throw a different kind of exception, so can't
+                // be hoisted without potentially changing the exception kind
+                // thrown.
+                b = (i / y < i + c.f);
+            }
+
+            return b;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static bool swap(int k, int x, int y, C c)
+        {
+            bool b = false;
+
+            for (int i = 0; i < k; ++i)
+            {
+                // Sub-expressions "x / y" and "c.f" are both invariant
+                // w.r.t. this loop, and can be hoisted.  Since each can
+                // raise an exception, and the exceptions have different
+                // types, their relative order must be preserved -- the
+                // hoisted copy of "x / y" must be evaluated before the
+                // hoisted copy of "c.f"
+                b = (x / y < i + c.f);
+            }
+
+            return b;
+        }
+
+        public static int Main(string[] args)
+        {
+            int errors = 0;
+
+#if NOT_FIXED
+            try
+            {
+                cross(10, 0, null);
+                // DivByZero should be raised from 'swap'; normal return
+                // is an error.
+                errors |= 1;
+            }
+            catch (DivideByZeroException)
+            {
+                // This is the correct result -- i / y should be evaluated and
+                // raise this exception (before c.f raises nulllref).
+            }
+            catch
+            {
+                // Any exception other than DivideByZero is a failure
+                errors |= 2;
+            }
+#endif
+
+            try
+            {
+                swap(10, 11, 0, null);
+                // DivByZero should be raised from 'swap'; normal return
+                // is an error.
+                errors |= 4;
+            }
+            catch (DivideByZeroException)
+            {
+                // This is the correct result -- x / y should be evaluated and
+                // raise this exception (before c.f raises nulllref).
+            }
+            catch
+            {
+                // Any exception other than DivideByZero is a failure
+                errors |= 8;
+            }
+
+            return 100 + errors;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_7147/GitHub_7147.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_7147/GitHub_7147.csproj
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_7147/GitHub_7147.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_7147/GitHub_7147.csproj
@@ -1,17 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <OutputType>Exe</OutputType>
-    <DebugType>None</DebugType>
+    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
-  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
 </Project>


### PR DESCRIPTION
This change fixes the "swap" case from #7147 and at the same time eliminates 2 uses of `GenTree::NumChildren/GetChild`. These 2 functions aren't used in a lot of places, `gtUpdateNodeSideEffects`, `fgGetFirstNode` and some debug/dump code. Once we get rid of `GT_LIST` we can also remove `NumChildren` and `GetChild`.

The fix for "swap" is pretty trivial, once the necessary infrastructure is in place. When a non-hoistable node is reached, the existing code simply hoists its children. But ancestors of the non-hoistable node may have hoistable descendants and those need to be hoisted too, in the execution order. The existing code does hoist those descendants, but it does that when post-visiting the ancestors. That's too late and results in the order of the hoisted trees being swapped.

The same technique used in `LocalAddressVisitor` can help here too. The value stack keeps track of visited trees and if they're hoistable or not. When necessary, the stack can be traversed from bottom to top to hoist all hoistable trees.

I'm hoping to fix the "cross" case as well in the future. I've a partial fix that uses VN exceptions but it's pretty large and I need more time to finish it.

There are a few cleanup changes included as well, since I spent time understanding the code I might as well removed the bad stuff, see commit list for details. Most notably, `optTreeIsValidAtLoopHead` is gone, that was one ridiculous piece of code that I have no idea why it existed. Perhaps some legacy code.

Diff best viewed with "ignore whitespace changes".

Contributes to #7147
Contributes to #19876