### PR TITLE
Remove superfluous 'const' qualifier from trivial return types

### DIFF
--- a/src/binder/inc/applicationcontext.hpp
+++ b/src/binder/inc/applicationcontext.hpp
@@ -38,7 +38,7 @@ namespace BINDER_SPACE
         typedef PCWSTR key_t;
         static const FileNameMapEntry Null() { FileNameMapEntry e; e.m_wszFileName = nullptr; return e; }
         static bool IsNull(const FileNameMapEntry & e) { return e.m_wszFileName == nullptr; }
-        static const key_t GetKey(const FileNameMapEntry & e)
+        static key_t GetKey(const FileNameMapEntry & e)
         {
             key_t key;
             key = e.m_wszFileName;
@@ -65,7 +65,7 @@ namespace BINDER_SPACE
         typedef PCWSTR key_t;
         static const SimpleNameToFileNameMapEntry Null() { SimpleNameToFileNameMapEntry e; e.m_wszSimpleName = nullptr; return e; }
         static bool IsNull(const SimpleNameToFileNameMapEntry & e) { return e.m_wszSimpleName == nullptr; }
-        static const key_t GetKey(const SimpleNameToFileNameMapEntry & e)
+        static key_t GetKey(const SimpleNameToFileNameMapEntry & e)
         {
             key_t key;
             key = e.m_wszSimpleName;

--- a/src/binder/inc/assemblyhashtraits.hpp
+++ b/src/binder/inc/assemblyhashtraits.hpp
@@ -45,7 +45,7 @@ namespace BINDER_SPACE
         {
             return pAssemblyName->Hash(dwAssemblyNameFlags);
         }
-        static const element_t Null()
+        static element_t Null()
         {
             return NULL;
         }

--- a/src/binder/inc/assemblyidentitycache.hpp
+++ b/src/binder/inc/assemblyidentitycache.hpp
@@ -88,7 +88,7 @@ namespace BINDER_SPACE
             else
                 return HashStringA(textualIdentity); 
         }
-        static const element_t Null()
+        static element_t Null()
         {
             return NULL;
         }

--- a/src/binder/inc/failurecachehashtraits.hpp
+++ b/src/binder/inc/failurecachehashtraits.hpp
@@ -73,7 +73,7 @@ namespace BINDER_SPACE
         {
             return HashCaseInsensitive(pAssemblyNameOrPath);
         }
-        static const element_t Null()
+        static element_t Null()
         {
             return NULL;
         }

--- a/src/binder/inc/propertyhashtraits.hpp
+++ b/src/binder/inc/propertyhashtraits.hpp
@@ -80,7 +80,7 @@ namespace BINDER_SPACE
         {
             return pPropertyName->Hash();
         }
-        static const element_t Null()
+        static element_t Null()
         {
             return NULL;
         }

--- a/src/debug/createdump/crashinfo.h
+++ b/src/debug/createdump/crashinfo.h
@@ -55,9 +55,9 @@ public:
     static bool GetStatus(pid_t pid, pid_t* ppid, pid_t* tgid, char** name);
     static const MemoryRegion* SearchMemoryRegions(const std::set<MemoryRegion>& regions, const MemoryRegion& search);
 
-    inline const pid_t Pid() const { return m_pid; }
-    inline const pid_t Ppid() const { return m_ppid; }
-    inline const pid_t Tgid() const { return m_tgid; }
+    inline pid_t Pid() const { return m_pid; }
+    inline pid_t Ppid() const { return m_ppid; }
+    inline pid_t Tgid() const { return m_tgid; }
     inline const char* Name() const { return m_name; }
     inline ICLRDataTarget* DataTarget() const { return m_dataTarget; }
 
@@ -66,7 +66,7 @@ public:
     inline const std::set<MemoryRegion> OtherMappings() const { return m_otherMappings; }
     inline const std::set<MemoryRegion> MemoryRegions() const { return m_memoryRegions; }
     inline const std::vector<elf_aux_entry> AuxvEntries() const { return m_auxvEntries; }
-    inline const size_t GetAuxvSize() const { return m_auxvEntries.size() * sizeof(elf_aux_entry); }
+    inline size_t GetAuxvSize() const { return m_auxvEntries.size() * sizeof(elf_aux_entry); }
 
     // IUnknown
     STDMETHOD(QueryInterface)(___in REFIID InterfaceId, ___out PVOID* Interface);

--- a/src/debug/createdump/dumpwriter.h
+++ b/src/debug/createdump/dumpwriter.h
@@ -55,9 +55,9 @@ private:
     bool WriteThread(const ThreadInfo& thread, int fatal_signal);
     bool WriteData(const void* buffer, size_t length);
 
-    const size_t GetProcessInfoSize() const { return sizeof(Nhdr) + 8 + sizeof(prpsinfo_t); }
-    const size_t GetAuxvInfoSize() const { return sizeof(Nhdr) + 8 + m_crashInfo.GetAuxvSize(); }
-    const size_t GetThreadInfoSize() const 
+    size_t GetProcessInfoSize() const { return sizeof(Nhdr) + 8 + sizeof(prpsinfo_t); }
+    size_t GetAuxvInfoSize() const { return sizeof(Nhdr) + 8 + m_crashInfo.GetAuxvSize(); }
+    size_t GetThreadInfoSize() const
     {
         return m_crashInfo.Threads().size() * ((sizeof(Nhdr) + 8 + sizeof(prstatus_t))
 #if defined(__i386__) || defined(__x86_64__) || defined(__arm__)

--- a/src/debug/createdump/memoryregion.h
+++ b/src/debug/createdump/memoryregion.h
@@ -100,13 +100,13 @@ public:
     {
     }
 
-    const uint32_t Permissions() const { return m_flags & MEMORY_REGION_FLAG_PERMISSIONS_MASK; }
-    const uint32_t Flags() const { return m_flags; }
-    const bool IsBackedByMemory() const { return (m_flags & MEMORY_REGION_FLAG_MEMORY_BACKED) != 0; }
-    const uint64_t StartAddress() const { return m_startAddress; }
-    const uint64_t EndAddress() const { return m_endAddress; }
-    const uint64_t Size() const { return m_endAddress - m_startAddress; }
-    const uint64_t Offset() const { return m_offset; }
+    uint32_t Permissions() const { return m_flags & MEMORY_REGION_FLAG_PERMISSIONS_MASK; }
+    uint32_t Flags() const { return m_flags; }
+    bool IsBackedByMemory() const { return (m_flags & MEMORY_REGION_FLAG_MEMORY_BACKED) != 0; }
+    uint64_t StartAddress() const { return m_startAddress; }
+    uint64_t EndAddress() const { return m_endAddress; }
+    uint64_t Size() const { return m_endAddress - m_startAddress; }
+    uint64_t Offset() const { return m_offset; }
     const char* FileName() const { return m_fileName; }
 
     bool operator<(const MemoryRegion& rhs) const

--- a/src/debug/createdump/threadinfo.h
+++ b/src/debug/createdump/threadinfo.h
@@ -41,9 +41,9 @@ public:
     void GetThreadStack(CrashInfo& crashInfo);
     void GetThreadContext(uint32_t flags, CONTEXT* context) const;
 
-    inline const pid_t Tid() const { return m_tid; }
-    inline const pid_t Ppid() const { return m_ppid; }
-    inline const pid_t Tgid() const { return m_tgid; }
+    inline pid_t Tid() const { return m_tid; }
+    inline pid_t Ppid() const { return m_ppid; }
+    inline pid_t Tgid() const { return m_tgid; }
 
     inline const user_regs_struct* GPRegisters() const { return &m_gpRegisters; }
     inline const user_fpregs_struct* FPRegisters() const { return &m_fpRegisters; }

--- a/src/debug/inc/dbgipcevents.h
+++ b/src/debug/inc/dbgipcevents.h
@@ -1002,7 +1002,7 @@ const size_t nameCount = sizeof(DbgIPCEventTypeNames) / sizeof(DbgIPCEventTypeNa
 
 struct MSLAYOUT IPCENames // We use a class/struct so that the function can remain in a shared header file
 {
-    static const DebuggerIPCEventType GetEventType(__in_z char * strEventType)
+    static DebuggerIPCEventType GetEventType(__in_z char * strEventType)
     {
         // pass in the string of event name and find the matching enum value
         // This is a linear search which is pretty slow. However, this is only used

--- a/src/ilasm/assembler.cpp
+++ b/src/ilasm/assembler.cpp
@@ -193,7 +193,7 @@ public:
         return memcmp(ptr_, t->ptr_, len_);
     }
     // The only public data we need
-    const mdToken Token() const { return token_; }
+    mdToken Token() const { return token_; }
 };
 
 static RBTREE<TypeSpecContainer> typeSpecCache;

--- a/src/inc/shash.h
+++ b/src/inc/shash.h
@@ -117,8 +117,8 @@ class DefaultSHashTraits
 
     static const bool s_supports_remove = true;
 
-    static const ELEMENT Null() { return (const ELEMENT) 0; }
-    static const ELEMENT Deleted() { return (const ELEMENT) -1; }
+    static ELEMENT Null() { return (const ELEMENT) 0; }
+    static ELEMENT Deleted() { return (const ELEMENT) -1; }
     static bool IsNull(const ELEMENT &e) { return e == (const ELEMENT) 0; }
     static bool IsDeleted(const ELEMENT &e) { return e == (const ELEMENT) -1; }
 
@@ -612,7 +612,7 @@ public:
     typedef typename PARENT::count_t count_t;
 
     static const bool s_supports_remove = false;
-    static const element_t Deleted() { UNREACHABLE(); }
+    static element_t Deleted() { UNREACHABLE(); }
     static bool IsDeleted(const element_t &e) { LIMITED_METHOD_DAC_CONTRACT; return false; }
 };
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -778,7 +778,7 @@ public:
         return roundUp(lvExactSize, TARGET_POINTER_SIZE);
     }
 
-    const size_t lvArgStackSize() const;
+    size_t lvArgStackSize() const;
 
     unsigned lvSlotNum; // original slot # (if remapped)
 
@@ -7134,7 +7134,7 @@ public:
         return codeGen->getEmitter();
     }
 
-    const bool isFramePointerUsed()
+    bool isFramePointerUsed()
     {
         return codeGen->isFramePointerUsed();
     }

--- a/src/jit/hwintrinsicxarch.h
+++ b/src/jit/hwintrinsicxarch.h
@@ -207,127 +207,127 @@ struct HWIntrinsicInfo
 
     // Flags lookup
 
-    static const bool IsCommutative(NamedIntrinsic id)
+    static bool IsCommutative(NamedIntrinsic id)
     {
         HWIntrinsicFlag flags = lookupFlags(id);
         return (flags & HW_Flag_Commutative) != 0;
     }
 
-    static const bool HasFullRangeImm(NamedIntrinsic id)
+    static bool HasFullRangeImm(NamedIntrinsic id)
     {
         HWIntrinsicFlag flags = lookupFlags(id);
         return (flags & HW_Flag_FullRangeIMM) != 0;
     }
 
-    static const bool IsOneTypeGeneric(NamedIntrinsic id)
+    static bool IsOneTypeGeneric(NamedIntrinsic id)
     {
         HWIntrinsicFlag flags = lookupFlags(id);
         return (flags & HW_Flag_OneTypeGeneric) != 0;
     }
 
-    static const bool IsTwoTypeGeneric(NamedIntrinsic id)
+    static bool IsTwoTypeGeneric(NamedIntrinsic id)
     {
         HWIntrinsicFlag flags = lookupFlags(id);
         return (flags & HW_Flag_TwoTypeGeneric) != 0;
     }
 
-    static const bool RequiresCodegen(NamedIntrinsic id)
+    static bool RequiresCodegen(NamedIntrinsic id)
     {
         HWIntrinsicFlag flags = lookupFlags(id);
         return (flags & HW_Flag_NoCodeGen) == 0;
     }
 
-    static const bool HasFixedSimdSize(NamedIntrinsic id)
+    static bool HasFixedSimdSize(NamedIntrinsic id)
     {
         HWIntrinsicFlag flags = lookupFlags(id);
         return (flags & HW_Flag_UnfixedSIMDSize) == 0;
     }
 
-    static const bool GeneratesMultipleIns(NamedIntrinsic id)
+    static bool GeneratesMultipleIns(NamedIntrinsic id)
     {
         HWIntrinsicFlag flags = lookupFlags(id);
         return (flags & HW_Flag_MultiIns) != 0;
     }
 
-    static const bool SupportsContainment(NamedIntrinsic id)
+    static bool SupportsContainment(NamedIntrinsic id)
     {
         HWIntrinsicFlag flags = lookupFlags(id);
         return (flags & HW_Flag_NoContainment) == 0;
     }
 
-    static const bool CopiesUpperBits(NamedIntrinsic id)
+    static bool CopiesUpperBits(NamedIntrinsic id)
     {
         HWIntrinsicFlag flags = lookupFlags(id);
         return (flags & HW_Flag_CopyUpperBits) != 0;
     }
 
-    static const bool BaseTypeFromFirstArg(NamedIntrinsic id)
+    static bool BaseTypeFromFirstArg(NamedIntrinsic id)
     {
         HWIntrinsicFlag flags = lookupFlags(id);
         return (flags & HW_Flag_BaseTypeFromFirstArg) != 0;
     }
 
-    static const bool IsFloatingPointUsed(NamedIntrinsic id)
+    static bool IsFloatingPointUsed(NamedIntrinsic id)
     {
         HWIntrinsicFlag flags = lookupFlags(id);
         return (flags & HW_Flag_NoFloatingPointUsed) == 0;
     }
 
-    static const bool MaybeImm(NamedIntrinsic id)
+    static bool MaybeImm(NamedIntrinsic id)
     {
         HWIntrinsicFlag flags = lookupFlags(id);
         return (flags & HW_Flag_MaybeIMM) != 0;
     }
 
-    static const bool MaybeMemoryLoad(NamedIntrinsic id)
+    static bool MaybeMemoryLoad(NamedIntrinsic id)
     {
         HWIntrinsicFlag flags = lookupFlags(id);
         return (flags & HW_Flag_MaybeMemoryLoad) != 0;
     }
 
-    static const bool MaybeMemoryStore(NamedIntrinsic id)
+    static bool MaybeMemoryStore(NamedIntrinsic id)
     {
         HWIntrinsicFlag flags = lookupFlags(id);
         return (flags & HW_Flag_MaybeMemoryStore) != 0;
     }
 
-    static const bool NoJmpTableImm(NamedIntrinsic id)
+    static bool NoJmpTableImm(NamedIntrinsic id)
     {
         HWIntrinsicFlag flags = lookupFlags(id);
         return (flags & HW_Flag_NoJmpTableIMM) != 0;
     }
 
-    static const bool Is64BitOnly(NamedIntrinsic id)
+    static bool Is64BitOnly(NamedIntrinsic id)
     {
         HWIntrinsicFlag flags = lookupFlags(id);
         return (flags & HW_Flag_64BitOnly) != 0;
     }
 
-    static const bool SecondArgMaybe64Bit(NamedIntrinsic id)
+    static bool SecondArgMaybe64Bit(NamedIntrinsic id)
     {
         HWIntrinsicFlag flags = lookupFlags(id);
         return (flags & HW_Flag_SecondArgMaybe64Bit) != 0;
     }
 
-    static const bool BaseTypeFromSecondArg(NamedIntrinsic id)
+    static bool BaseTypeFromSecondArg(NamedIntrinsic id)
     {
         HWIntrinsicFlag flags = lookupFlags(id);
         return (flags & HW_Flag_BaseTypeFromSecondArg) != 0;
     }
 
-    static const bool HasSpecialCodegen(NamedIntrinsic id)
+    static bool HasSpecialCodegen(NamedIntrinsic id)
     {
         HWIntrinsicFlag flags = lookupFlags(id);
         return (flags & HW_Flag_SpecialCodeGen) != 0;
     }
 
-    static const bool HasRMWSemantics(NamedIntrinsic id)
+    static bool HasRMWSemantics(NamedIntrinsic id)
     {
         HWIntrinsicFlag flags = lookupFlags(id);
         return (flags & HW_Flag_NoRMWSemantics) == 0;
     }
 
-    static const bool HasSpecialImport(NamedIntrinsic id)
+    static bool HasSpecialImport(NamedIntrinsic id)
     {
         HWIntrinsicFlag flags = lookupFlags(id);
         return (flags & HW_Flag_SpecialImport) != 0;

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -3467,7 +3467,7 @@ void LclVarDsc::lvaDisqualifyVar()
 /**********************************************************************************
 * Get stack size of the varDsc.
 */
-const size_t LclVarDsc::lvArgStackSize() const
+size_t LclVarDsc::lvArgStackSize() const
 {
     // Make sure this will have a stack size
     assert(!this->lvIsRegArg);

--- a/src/vm/amd64/virtualcallstubcpu.hpp
+++ b/src/vm/amd64/virtualcallstubcpu.hpp
@@ -206,7 +206,7 @@ struct DispatchStub
         e_TYPE_LONG,
     };
 
-    inline DispatchStubType const type() const
+    inline DispatchStubType type() const
     {
         LIMITED_METHOD_CONTRACT;
         CONSISTENCY_CHECK(DispatchStubShort::isShortStub(reinterpret_cast<LPCBYTE>(this + 1))

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -3721,8 +3721,8 @@ private:
             return (count_t)(dac_cast<TADDR>(key));
         }
         
-        static const element_t Null() { return NULL; }
-        static const element_t Deleted() { return (element_t)(TADDR)-1; }
+        static element_t Null() { return NULL; }
+        static element_t Deleted() { return (element_t)(TADDR)-1; }
         static bool IsNull(const element_t & e) { return e == NULL; }
         static bool IsDeleted(const element_t & e) { return dac_cast<TADDR>(e) == (TADDR)-1; }
     };

--- a/src/vm/ceeload.h
+++ b/src/vm/ceeload.h
@@ -986,7 +986,7 @@ public:
         LIMITED_METHOD_CONTRACT;
         return (count_t) k->Hash();
     }
-    static const element_t Null() 
+    static element_t Null()
     { 
         LIMITED_METHOD_CONTRACT; 
         return NULL; 

--- a/src/vm/codeversion.h
+++ b/src/vm/codeversion.h
@@ -487,7 +487,7 @@ public:
         return (count_t)(size_t)dac_cast<TADDR>(k);
     }
 
-    static const element_t Null() { LIMITED_METHOD_CONTRACT; return dac_cast<PTR_MethodDescVersioningState>(nullptr); }
+    static element_t Null() { LIMITED_METHOD_CONTRACT; return dac_cast<PTR_MethodDescVersioningState>(nullptr); }
     static bool IsNull(const element_t &e) { LIMITED_METHOD_CONTRACT; return e == NULL; }
 };
 
@@ -549,7 +549,7 @@ public:
         return (count_t)k.Hash();
     }
 
-    static const element_t Null() { LIMITED_METHOD_CONTRACT; return dac_cast<PTR_ILCodeVersioningState>(nullptr); }
+    static element_t Null() { LIMITED_METHOD_CONTRACT; return dac_cast<PTR_ILCodeVersioningState>(nullptr); }
     static bool IsNull(const element_t &e) { LIMITED_METHOD_CONTRACT; return e == NULL; }
 };
 

--- a/src/vm/dataimage.cpp
+++ b/src/vm/dataimage.cpp
@@ -111,7 +111,7 @@ public:
         return (count_t)k.m_dwSize ^ (count_t)k.m_kind ^ HashBytes((BYTE *)k.m_data, k.m_dwSize);
     }
 
-    static const element_t Null() { LIMITED_METHOD_CONTRACT; return NULL; }
+    static element_t Null() { LIMITED_METHOD_CONTRACT; return NULL; }
     static bool IsNull(const element_t &e) { LIMITED_METHOD_CONTRACT; return e == NULL; }
 };
 

--- a/src/vm/eedbginterface.h
+++ b/src/vm/eedbginterface.h
@@ -165,7 +165,7 @@ public:
 
     virtual size_t GetFunctionSize(MethodDesc *pFD) = 0;
 
-    virtual const PCODE GetFunctionAddress(MethodDesc *pFD) = 0;
+    virtual PCODE GetFunctionAddress(MethodDesc *pFD) = 0;
 
 #ifndef DACCESS_COMPILE
 

--- a/src/vm/eedbginterfaceimpl.cpp
+++ b/src/vm/eedbginterfaceimpl.cpp
@@ -641,7 +641,7 @@ size_t EEDbgInterfaceImpl::GetFunctionSize(MethodDesc *pFD)
 }
 #endif //!DACCESS_COMPILE
 
-const PCODE EEDbgInterfaceImpl::GetFunctionAddress(MethodDesc *pFD)
+PCODE EEDbgInterfaceImpl::GetFunctionAddress(MethodDesc *pFD)
 { 
     CONTRACTL
     {

--- a/src/vm/eedbginterfaceimpl.h
+++ b/src/vm/eedbginterfaceimpl.h
@@ -146,7 +146,7 @@ public:
 
     size_t GetFunctionSize(MethodDesc *pFD) DAC_UNEXPECTED();
 
-    const PCODE GetFunctionAddress(MethodDesc *pFD);
+    PCODE GetFunctionAddress(MethodDesc *pFD);
 
     void DisablePreemptiveGC(void);
 

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -2722,7 +2722,7 @@ public:
         return (e == NULL);
     }
 
-    static const element_t Null()
+    static element_t Null()
     {
         LIMITED_METHOD_CONTRACT;
         return NULL; 

--- a/src/vm/frames.h
+++ b/src/vm/frames.h
@@ -487,7 +487,7 @@ public:
 
     // indicate the current X86 IP address within the current method
     // return 0 if the information is not available
-    virtual const PTR_BYTE GetIP()
+    virtual PTR_BYTE GetIP()
     {
         LIMITED_METHOD_CONTRACT;
         return NULL;

--- a/src/vm/ibclogger.h
+++ b/src/vm/ibclogger.h
@@ -191,7 +191,7 @@ public:
 #endif // POINTER_BITS
     }
 
-    static const element_t Null() 
+    static element_t Null()
 {
         WRAPPER_NO_CONTRACT;
         return NULL;
@@ -203,7 +203,7 @@ public:
         return e == NULL;
     }
 
-    static const element_t Deleted()
+    static element_t Deleted()
     {
         WRAPPER_NO_CONTRACT;
         return (element_t)-1;

--- a/src/vm/peimage.h
+++ b/src/vm/peimage.h
@@ -162,7 +162,7 @@ public:
     BOOL Equals(PEImage *pImage);
 
     void GetMVID(GUID *pMvid);
-    const BOOL HasV1Metadata();
+    BOOL HasV1Metadata();
     IMDInternalImport* GetMDImport();
     BOOL MDImportLoaded();
     IMDInternalImport* GetNativeMDImport(BOOL loadAllowed = TRUE);    
@@ -198,26 +198,26 @@ public:
     const SString &GetModuleFileNameHintForDAC();
 #endif
 
-    const BOOL HasNTHeaders();
-    const BOOL HasCorHeader(); 
-    const BOOL HasReadyToRunHeader();
+    BOOL HasNTHeaders();
+    BOOL HasCorHeader();
+    BOOL HasReadyToRunHeader();
     void SetPassiveDomainOnly();
     BOOL PassiveDomainOnly();
     BOOL IsReferenceAssembly();
-#ifdef FEATURE_PREJIT  
-    const BOOL IsNativeILILOnly();
-    const BOOL IsNativeILDll();
+#ifdef FEATURE_PREJIT
+    BOOL IsNativeILILOnly();
+    BOOL IsNativeILDll();
     void GetNativeILPEKindAndMachine(DWORD* pdwKind, DWORD* pdwMachine);
     PTR_CVOID GetNativeManifestMetadata(COUNT_T *pSize = NULL);
 #endif
-    const BOOL HasDirectoryEntry(int entry);
-    const mdToken GetEntryPointToken();
-    const DWORD GetCorHeaderFlags(); 
-    const BOOL IsILOnly();
-    const BOOL IsDll();
-    const WORD GetSubsystem();
+    BOOL HasDirectoryEntry(int entry);
+    mdToken GetEntryPointToken();
+    DWORD GetCorHeaderFlags();
+    BOOL IsILOnly();
+    BOOL IsDll();
+    WORD GetSubsystem();
     BOOL  IsFileLocked();
-    const BOOL HasStrongNameSignature();
+    BOOL HasStrongNameSignature();
 
     BOOL IsIbcOptimized();
     BOOL Has32BitNTHeaders();

--- a/src/vm/peimage.inl
+++ b/src/vm/peimage.inl
@@ -175,7 +175,7 @@ inline BOOL PEImage::IsReferenceAssembly()
 }
 
 
-inline const BOOL PEImage::HasNTHeaders()   
+inline BOOL PEImage::HasNTHeaders()
 {
     WRAPPER_NO_CONTRACT;
     if (HasLoadedLayout())
@@ -187,7 +187,7 @@ inline const BOOL PEImage::HasNTHeaders()
     }
 }
 
-inline const BOOL PEImage::HasCorHeader()   
+inline BOOL PEImage::HasCorHeader()
 {
     WRAPPER_NO_CONTRACT;
     if (HasLoadedLayout())
@@ -199,7 +199,7 @@ inline const BOOL PEImage::HasCorHeader()
     }
 }
 
-inline const BOOL PEImage::HasReadyToRunHeader()   
+inline BOOL PEImage::HasReadyToRunHeader()
 {
     WRAPPER_NO_CONTRACT;
     if (HasLoadedLayout())
@@ -223,7 +223,7 @@ inline BOOL PEImage::PassiveDomainOnly()
     return m_bPassiveDomainOnly;
 }
 
-inline const BOOL PEImage::HasDirectoryEntry(int entry)   
+inline BOOL PEImage::HasDirectoryEntry(int entry)
 {
     WRAPPER_NO_CONTRACT;
     if (HasLoadedLayout())
@@ -235,7 +235,7 @@ inline const BOOL PEImage::HasDirectoryEntry(int entry)
     }
 }
 
-inline const mdToken PEImage::GetEntryPointToken()
+inline mdToken PEImage::GetEntryPointToken()
 {
     WRAPPER_NO_CONTRACT;
     if (HasLoadedLayout())
@@ -254,7 +254,7 @@ inline const mdToken PEImage::GetEntryPointToken()
     }
 }
 
-inline const DWORD PEImage::GetCorHeaderFlags()   
+inline DWORD PEImage::GetCorHeaderFlags()
 {
     WRAPPER_NO_CONTRACT;
 
@@ -275,13 +275,13 @@ inline BOOL PEImage::MDImportLoaded()
     return m_pMDImport != NULL;
 }
 
-inline const BOOL PEImage::HasV1Metadata()   
+inline BOOL PEImage::HasV1Metadata()
 {
     WRAPPER_NO_CONTRACT;
     return GetMDImport()->GetMetadataStreamVersion()==MD_STREAM_VER_1X;
 }
 
-inline const BOOL PEImage::IsILOnly()   
+inline BOOL PEImage::IsILOnly()
 {
     WRAPPER_NO_CONTRACT;
     if (HasLoadedLayout())
@@ -293,7 +293,7 @@ inline const BOOL PEImage::IsILOnly()
     }
 }
 
-inline const WORD PEImage::GetSubsystem()   
+inline WORD PEImage::GetSubsystem()
 {
     WRAPPER_NO_CONTRACT;
     SUPPORTS_DAC;
@@ -307,8 +307,8 @@ inline const WORD PEImage::GetSubsystem()
     }
 }
 
-#ifdef FEATURE_PREJIT    
-inline const BOOL PEImage::IsNativeILILOnly()   
+#ifdef FEATURE_PREJIT
+inline BOOL PEImage::IsNativeILILOnly()
 {
     WRAPPER_NO_CONTRACT;
     if (HasLoadedLayout())
@@ -332,7 +332,7 @@ inline void PEImage::GetNativeILPEKindAndMachine(DWORD* pdwKind, DWORD* pdwMachi
     }
 }
 
-inline const BOOL PEImage::IsNativeILDll()   
+inline BOOL PEImage::IsNativeILDll()
 {
     WRAPPER_NO_CONTRACT;
     if (HasLoadedLayout())
@@ -345,7 +345,7 @@ inline const BOOL PEImage::IsNativeILDll()
 }
 #endif // FEATURE_PREJIT
 
-inline const BOOL PEImage::IsDll()   
+inline BOOL PEImage::IsDll()
 {
     WRAPPER_NO_CONTRACT;
     if (HasLoadedLayout())
@@ -357,7 +357,7 @@ inline const BOOL PEImage::IsDll()
     }
 }
 
-inline const BOOL PEImage::HasStrongNameSignature()   
+inline BOOL PEImage::HasStrongNameSignature()
 {
     WRAPPER_NO_CONTRACT;
     if (HasLoadedLayout())
@@ -416,7 +416,7 @@ inline PTR_CVOID PEImage::GetMetadata(COUNT_T *pSize)
     }
 }
 
-inline BOOL PEImage::HasNativeHeader() 
+inline BOOL PEImage::HasNativeHeader()
 {
     WRAPPER_NO_CONTRACT;
     if (HasLoadedLayout())

--- a/src/zap/zapcode.h
+++ b/src/zap/zapcode.h
@@ -317,7 +317,7 @@ class ZapMethodEntryPointTable
             return (count_t)(size_t)k.m_handle ^ (count_t)k.m_accessFlags;
         }
 
-        static const element_t Null() { LIMITED_METHOD_CONTRACT; return NULL; }
+        static element_t Null() { LIMITED_METHOD_CONTRACT; return NULL; }
         static bool IsNull(const element_t &e) { LIMITED_METHOD_CONTRACT; return e == NULL; }
     };
 
@@ -517,7 +517,7 @@ class ZapUnwindDataTable
             return ZapBlob::SHashTraits::Hash(k.m_unwindData) ^ k.m_fIsFilterFunclet;
         }
 
-        static const element_t Null() { LIMITED_METHOD_CONTRACT; return NULL; }
+        static element_t Null() { LIMITED_METHOD_CONTRACT; return NULL; }
         static bool IsNull(const element_t &e) { LIMITED_METHOD_CONTRACT; return e == NULL; }
     };
     // Hashtable with all unwind data blobs. If two methods have unwind data
@@ -638,7 +638,7 @@ class ZapGCInfoTable
             return ZapBlob::SHashTraits::Hash(k.m_gcInfo) ^ ZapBlob::SHashTraits::Hash(k.m_unwindInfo);
         }
 
-        static const element_t Null() { LIMITED_METHOD_CONTRACT; return NULL; }
+        static element_t Null() { LIMITED_METHOD_CONTRACT; return NULL; }
         static bool IsNull(const element_t &e) { LIMITED_METHOD_CONTRACT; return e == NULL; }
     };
 

--- a/src/zap/zapimage.h
+++ b/src/zap/zapimage.h
@@ -478,7 +478,7 @@ private:
         static BOOL Equals(key_t k1, key_t k2);
         static COUNT_T Hash(key_t k);
 
-        static const element_t Null() { LIMITED_METHOD_CONTRACT; return NULL; }
+        static element_t Null() { LIMITED_METHOD_CONTRACT; return NULL; }
         static bool IsNull(const element_t &e) { LIMITED_METHOD_CONTRACT; return e == NULL; }
     };
 

--- a/src/zap/zapimport.h
+++ b/src/zap/zapimport.h
@@ -190,7 +190,7 @@ class ZapImportTable : public ZapNode
             return (count_t)(size_t)k.m_handle ^ ((count_t)(size_t)k.m_handle2 << 1) ^ k.m_type;
         }
 
-        static const element_t Null() { LIMITED_METHOD_CONTRACT; return NULL; }
+        static element_t Null() { LIMITED_METHOD_CONTRACT; return NULL; }
         static bool IsNull(const element_t &e) { LIMITED_METHOD_CONTRACT; return e == NULL; }
     };
 
@@ -229,7 +229,7 @@ class ZapImportTable : public ZapNode
             return (count_t)(size_t)k;
         }
 
-        static const element_t Null() { LIMITED_METHOD_CONTRACT; return NULL; }
+        static element_t Null() { LIMITED_METHOD_CONTRACT; return NULL; }
         static bool IsNull(const element_t &e) { LIMITED_METHOD_CONTRACT; return e == NULL; }
     };
 

--- a/src/zap/zapinnerptr.h
+++ b/src/zap/zapinnerptr.h
@@ -114,7 +114,7 @@ class ZapInnerPtrTable
             return (count_t)(size_t)k.m_pBase ^ (count_t)k.m_offset;
         }
 
-        static const element_t Null() { LIMITED_METHOD_CONTRACT; return NULL; }
+        static element_t Null() { LIMITED_METHOD_CONTRACT; return NULL; }
         static bool IsNull(const element_t &e) { LIMITED_METHOD_CONTRACT; return e == NULL; }
     };
 

--- a/src/zap/zapmetadata.h
+++ b/src/zap/zapmetadata.h
@@ -212,7 +212,7 @@ private:
             return (count_t)k;
         }
 
-        static const element_t Null() { LIMITED_METHOD_CONTRACT; return NULL; }
+        static element_t Null() { LIMITED_METHOD_CONTRACT; return NULL; }
         static bool IsNull(const element_t &e) { LIMITED_METHOD_CONTRACT; return e == NULL; }
     };
 

--- a/src/zap/zapwrapper.h
+++ b/src/zap/zapwrapper.h
@@ -86,7 +86,7 @@ class ZapWrapperTable
             return (count_t)(size_t)k;
         }
 
-        static const element_t Null() { LIMITED_METHOD_CONTRACT; return NULL; }
+        static element_t Null() { LIMITED_METHOD_CONTRACT; return NULL; }
         static bool IsNull(const element_t &e) { LIMITED_METHOD_CONTRACT; return e == NULL; }
     };
 


### PR DESCRIPTION
The 'const' used in this context has no meaning