### PR TITLE
Re-Enable Windows tests with JitOptSensitive flag

### DIFF
--- a/tests/src/CLRTest.Execute.Batch.targets
+++ b/tests/src/CLRTest.Execute.Batch.targets
@@ -79,16 +79,23 @@ IF NOT "%COMPlus_GCStress%"=="" (
       <BatchCLRTestEnvironmentCompatibilityCheck Condition="'$(JitOptimizationSensitive)' == 'true'">
     <![CDATA[
 $(BatchCLRTestEnvironmentCompatibilityCheck)
-IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_JITMinOpts%"=="" IF "%COMPlus_TailcallStress%"=="" IF "%COMPlus_TieredCompilation%"=="" goto :Compatible1
+REM JitOptimizationSensitive includes our set of tests which cannot run under:
+REM     JitMinOpts=1
+REM     JitStress=*
+REM     JitStressRegs=*
+REM     TailcallStress=1
+REM
+REM TieredCompilation will use minopts. Therefore it is also included in this
+REM set. Unlike the rest, TieredCompilation=0 should run the JitOptimizationSensitive
+REM tests. The following cannot run the test.
+REN
+REM     TieredCompilation=1
+REM     TieredCompilation=
+IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_JITMinOpts%"=="" IF "%COMPlus_TailcallStress%"=="" IF "%COMPlus_TieredCompilation%"=="0" goto :Compatible
   ECHO SKIPPING EXECUTION BECAUSE ONE OR MORE OF (COMPlus_JitStress, COMPlus_JitStressRegs, COMPlus_JITMinOpts, COMPlus_TailcallStress, COMPlus_TieredCompilation) IS SET
   popd
   Exit /b 0
-:Compatible1
-IF "%COMPlus_TieredCompilation%"=="0" goto :Compatible2
-  ECHO SKIPPING EXECUTION BECAUSE COMPlus_TieredCompilation has not been disabled and this test is marked JitOptimizationSensitive
-  popd
-  Exit /b 0
-:Compatible2
+:Compatible
       ]]></BatchCLRTestEnvironmentCompatibilityCheck>
       <BatchCLRTestEnvironmentCompatibilityCheck Condition="'$(HeapVerifyIncompatible)' == 'true'"><![CDATA[
 $(BatchCLRTestEnvironmentCompatibilityCheck)

--- a/tests/src/CLRTest.Execute.Batch.targets
+++ b/tests/src/CLRTest.Execute.Batch.targets
@@ -91,11 +91,16 @@ REM tests. The following cannot run the test.
 REN
 REM     TieredCompilation=1
 REM     TieredCompilation=
-IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_JITMinOpts%"=="" IF "%COMPlus_TailcallStress%"=="" IF "%COMPlus_TieredCompilation%"=="0" goto :Compatible
+IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_JITMinOpts%"=="" IF "%COMPlus_TailcallStress%"=="" goto :Compatible
   ECHO SKIPPING EXECUTION BECAUSE ONE OR MORE OF (COMPlus_JitStress, COMPlus_JitStressRegs, COMPlus_JITMinOpts, COMPlus_TailcallStress, COMPlus_TieredCompilation) IS SET
   popd
   Exit /b 0
 :Compatible
+IF "%COMPlus_TieredCompilation%"=="0" goto :TieredCompilationDisabledCorrectly
+  ECHO SKIPPING EXECUTION BECAUSE COMPlus_TieredCompilation has not been disabled and this test is marked JitOptimizationSensitive
+  popd
+  Exit /b 0
+:TieredCompilationDisabledCorrectly
       ]]></BatchCLRTestEnvironmentCompatibilityCheck>
       <BatchCLRTestEnvironmentCompatibilityCheck Condition="'$(HeapVerifyIncompatible)' == 'true'"><![CDATA[
 $(BatchCLRTestEnvironmentCompatibilityCheck)


### PR DESCRIPTION
The check in batch targets would keep us from running jitOptimiztionSensitiveTests
with COMPlus_TieredCompilation=0.