### PR TITLE
Delete Free of the released GCHandle in tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13621.cs

### DIFF
--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13621/b13621.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13621/b13621.cs
@@ -45,7 +45,6 @@ namespace DefaultNamespace
 
         ~RootMem()
         {
-            root[n - 1].Free();
         }
     }
 }


### PR DESCRIPTION
As https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.gchandle.free?view=netframework-4.7.2 says "The caller must ensure that for a given handle, Free is called only once.".

So delete the second call to `Free()`. (the second was introduced in #18476, this change deletes the original one).

I believe it changes the desired behavior for this test but it was added before 2010 (via source depo) and there are no comments about the regression that it was able to repro, so it is not worth to investigate the original desire for this test and try to keep the original behaviour for this test (and morover we are not sure that the current version reproduces the original issue because it was changes several times since adding).

Fixes #20519 