### PR TITLE
Disable non-PR triggers in dev/unix_test_workflow branch

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1310,7 +1310,12 @@ def static getJobName(def configuration, def architecture, def os, def scenario,
 }
 
 def static addNonPRTriggers(def job, def branch, def isPR, def architecture, def os, def configuration, def scenario, def isFlowJob, def isWindowsBuildOnlyJob, def bidailyCrossList) {
-    def isNormalOrInnerloop = (scenario == "normal" || scenario == "innerloop")
+
+    // The dev/unix_test_workflow branch is used for Jenkins CI testing. We generally do not need any non-PR
+    // triggers in the branch, because that would use machine resources unnecessarily.
+    if (branch == 'dev/unix_test_workflow') {
+        return
+    }
 
     // Limited hardware is restricted for non-PR triggers to certain branches.
     if (jobRequiresLimitedHardware(architecture, os) && (!(branch in Constants.LimitedHardwareBranches))) {
@@ -1322,6 +1327,8 @@ def static addNonPRTriggers(def job, def branch, def isPR, def architecture, def
     if (architecture == 'x86' && os == 'Ubuntu') {
         return
     }
+
+    def isNormalOrInnerloop = (scenario == "normal" || scenario == "innerloop")
 
     // Check scenario.
     switch (scenario) {


### PR DESCRIPTION
This has already gone into the dev/unix_test_workflow branch with https://github.com/dotnet/coreclr/pull/20709. But we often blast that branch with master, so put the change in master so we don't lose it when updating dev/unix_test_workflow.