### PR TITLE
more changes to fix packaging on FreeBSD

### DIFF
--- a/build-packages.sh
+++ b/build-packages.sh
@@ -117,6 +117,8 @@ if [ $__IsPortableBuild == 1 ]; then
         export __DistroRid="linux-$__Arch"
     elif [ "$__BuildOS" == "OSX" ]; then
         export __DistroRid="osx-$__Arch"
+    elif [ "$__BuildOS" == "FreeBSD" ]; then
+        export __DistroRid="freebsd-$__Arch"
     fi
 else
     # init the host distro name

--- a/buildpipeline/DotNet-CoreClr-Trusted-FreeBSD.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-FreeBSD.json
@@ -55,7 +55,7 @@
       },
       "inputs": {
         "filename": "$(Agent.BuildDirectory)/s/build.sh",
-        "arguments": "$(PB_BuildType) $(Architecture) skipnuget -skiprestore stripSymbols -OfficialBuildId=$(OfficialBuildId) -clang6.0 -osgroup FreeBSD -msbuildonunsupportedplatform -portablebuild=false",
+        "arguments": "$(PB_BuildType) $(Architecture) skipnuget -skiprestore stripSymbols -OfficialBuildId=$(OfficialBuildId) -clang6.0",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -75,7 +75,7 @@
       },
       "inputs": {
         "filename": "$(Agent.BuildDirectory)/s/build-packages.sh",
-        "arguments": "-BuildType=$(PB_BuildType) -BuildArch=$(Architecture) -portablebuild=false -- /p:OfficialBuildId=$(OfficialBuildId)",
+        "arguments": "-BuildType=$(PB_BuildType) -BuildArch=$(Architecture) -- /p:OfficialBuildId=$(OfficialBuildId)",
         "workingFolder": "",
         "failOnStandardError": "false"
       }

--- a/src/.nuget/dir.props
+++ b/src/.nuget/dir.props
@@ -84,6 +84,13 @@
         <PackageRID Condition="'$(PortableBuild)' == 'true'">osx-$(ArchGroup)</PackageRID>
       </PropertyGroup>
     </When>
+    <When Condition="'$(_runtimeOSFamily)' == 'freebsd'">
+      <PropertyGroup>
+        <PackageRID>freebsd.11-$(ArchGroup)</PackageRID>
+        <!-- Set the platform part of the RID if we are doing a portable build -->
+        <PackageRID Condition="'$(PortableBuild)' == 'true'">freebsd-$(ArchGroup)</PackageRID>
+      </PropertyGroup>
+    </When>
     <When Condition="'$(_runtimeOSFamily)' == 'android'">
       <PropertyGroup>
         <PackageRID>android.21-$(ArchGroup)</PackageRID>
@@ -150,6 +157,9 @@
   </ItemGroup>
   <ItemGroup Condition="$(SupportedPackageOSGroups.Contains(';OSX;'))">
     <OfficialBuildRID Include="osx-x64" />
+  </ItemGroup>
+  <ItemGroup Condition="$(SupportedPackageOSGroups.Contains(';FreeBSD;'))">
+    <OfficialBuildRID Include="freebsd-x64" />
   </ItemGroup>
   <ItemGroup Condition="$(SupportedPackageOSGroups.Contains(';Windows_NT;'))">
     <OfficialBuildRID Include="win-x86">


### PR DESCRIPTION
runtime.json now contains freebsd-x64 and portable build/packaging works.
(e.g. uses freebsd instead of linux) 

This also removes extra parameters for pipeline and makes it more like OSX. 