### PR TITLE
Display offset in TimeZoneInfo.DisplayName

### DIFF
--- a/src/System.Private.CoreLib/shared/System/TimeZoneInfo.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/TimeZoneInfo.Unix.cs
@@ -75,12 +75,10 @@ namespace System
                 }
             }
             GetDisplayName(Interop.Globalization.TimeZoneDisplayNameType.Standard, ref _standardDisplayName);
-            if (_baseUtcOffset == TimeSpan.Zero)
-                _displayName = $"(UTC) {_standardDisplayName}";
-            else if (_baseUtcOffset > TimeSpan.Zero)
-                _displayName = $"(UTC+{_baseUtcOffset:hh\\mm}) {_standardDisplayName}";
+            if (_baseUtcOffset > TimeSpan.Zero)
+                _displayName = $"(UTC+{_baseUtcOffset:hh\\:mm}) {_standardDisplayName}";
             else
-                _displayName = $"(UTC{_baseUtcOffset:hh\\mm}) {_standardDisplayName}";
+                _displayName = $"(UTC-{_baseUtcOffset:hh\\:mm}) {_standardDisplayName}";
             GetDisplayName(Interop.Globalization.TimeZoneDisplayNameType.DaylightSavings, ref _daylightDisplayName);
 
             // TZif supports seconds-level granularity with offsets but TimeZoneInfo only supports minutes since it aligns

--- a/src/System.Private.CoreLib/shared/System/TimeZoneInfo.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/TimeZoneInfo.Unix.cs
@@ -74,12 +74,19 @@ namespace System
                     }
                 }
             }
+            _displayName = _standardDisplayName;
+
+            GetDisplayName(Interop.Globalization.TimeZoneDisplayNameType.Generic, ref _displayName);
             GetDisplayName(Interop.Globalization.TimeZoneDisplayNameType.Standard, ref _standardDisplayName);
-            if (_baseUtcOffset >= TimeSpan.Zero)
-                _displayName = $"(UTC+{_baseUtcOffset:hh\\:mm}) {_standardDisplayName}";
-            else
-                _displayName = $"(UTC-{_baseUtcOffset:hh\\:mm}) {_standardDisplayName}";
             GetDisplayName(Interop.Globalization.TimeZoneDisplayNameType.DaylightSavings, ref _daylightDisplayName);
+
+            if (_standardDisplayName == _displayName)
+            {
+                if (_baseUtcOffset >= TimeSpan.Zero)
+                    _displayName = $"(UTC+{_baseUtcOffset:hh\\:mm}) {_standardDisplayName}";
+                else
+                    _displayName = $"(UTC-{_baseUtcOffset:hh\\:mm}) {_standardDisplayName}";
+            }
 
             // TZif supports seconds-level granularity with offsets but TimeZoneInfo only supports minutes since it aligns
             // with DateTimeOffset, SQL Server, and the W3C XML Specification

--- a/src/System.Private.CoreLib/shared/System/TimeZoneInfo.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/TimeZoneInfo.Unix.cs
@@ -74,10 +74,13 @@ namespace System
                     }
                 }
             }
-            _displayName = _standardDisplayName;
-
-            GetDisplayName(Interop.Globalization.TimeZoneDisplayNameType.Generic, ref _displayName);
             GetDisplayName(Interop.Globalization.TimeZoneDisplayNameType.Standard, ref _standardDisplayName);
+            if (_baseUtcOffset == TimeSpan.Zero)
+                _displayName = $"(UTC) {_standardDisplayName}";
+            else if (_baseUtcOffset > TimeSpan.Zero)
+                _displayName = $"(UTC+{_baseUtcOffset:hh\\mm}) {_standardDisplayName}";
+            else
+                _displayName = $"(UTC{_baseUtcOffset:hh\\mm}) {_standardDisplayName}";
             GetDisplayName(Interop.Globalization.TimeZoneDisplayNameType.DaylightSavings, ref _daylightDisplayName);
 
             // TZif supports seconds-level granularity with offsets but TimeZoneInfo only supports minutes since it aligns

--- a/src/System.Private.CoreLib/shared/System/TimeZoneInfo.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/TimeZoneInfo.Unix.cs
@@ -75,7 +75,7 @@ namespace System
                 }
             }
             GetDisplayName(Interop.Globalization.TimeZoneDisplayNameType.Standard, ref _standardDisplayName);
-            if (_baseUtcOffset > TimeSpan.Zero)
+            if (_baseUtcOffset >= TimeSpan.Zero)
                 _displayName = $"(UTC+{_baseUtcOffset:hh\\:mm}) {_standardDisplayName}";
             else
                 _displayName = $"(UTC-{_baseUtcOffset:hh\\:mm}) {_standardDisplayName}";


### PR DESCRIPTION
Consider the following snippet:
```csharp
Console.WriteLine(TimeZoneInfo.Local.DisplayName + "; " + TimeZoneInfo.Local.StandardName);
```
On Windows it prints:
```
(UTC+03:00) Moscow, St. Petersburg, Volgograd; Russia TZ 2 Standard Time
```
On Unix (e.g. macOS):
```
Moscow Standard Time; Moscow Standard Time
```

So currently `TimeZoneInfo.DisplayName` simply displays `StandardData`, it calls a pinvoke to ICU but still uses the same flag [UCAL_STANDARD](https://github.com/dotnet/coreclr/blob/030a3ea9b8dbeae89c90d34441d4d9a1cf4a7de6/src/corefx/System.Globalization.Native/timeZoneInfo.cpp#L42).
We can at least remove that redundant pinvoke or also add an offset-prefix for consistency with Windows if it's not a breaking change.

so the snippet becomes:
`(UTC+03:00) Moscow Standard Time; Moscow Standard Time`

**Results:**
```csharp
foreach (var tz in TimeZoneInfo.GetSystemTimeZones())
    Console.WriteLine($"{tz.DisplayName.PadRight(64, ' ')} StandardName:{tz.StandardName}");
```
Windows (current behavior): https://gist.github.com/EgorBo/5da22525ea659c7b036b1e67980fc803
macOS (old behavior): https://gist.github.com/EgorBo/d5e51c32f89036f6cc52bca2f8757ca7
macOS (new behavior): https://gist.github.com/EgorBo/350a41871cbc009b98a3d67e6ae361d5
PS: the main UTC zone is not included into `GetSystemTimeZones()` on macOS
