### PR TITLE
Clean up string literal implicit const casting and some two-phase lookup nits on Windows

### DIFF
--- a/src/inc/contract.h
+++ b/src/inc/contract.h
@@ -1137,7 +1137,7 @@ class BaseContract
         }
     }
 
-    void DoChecks(UINT testmask, __in_z const char *szFunction, __in_z char *szFile, int lineNum);
+    void DoChecks(UINT testmask, __in_z const char *szFunction, __in_z const char *szFile, int lineNum);
     void Disable()
     {
     }
@@ -1380,8 +1380,9 @@ typedef __SafeToUsePostCondition __PostConditionOK;
     Contract::Returner<_returntype> ___returner(RETVAL);                \
     Contract::RanPostconditions ___ran(__FUNCTION__);                   \
     Contract::Operation ___op = Contract::Setup;                        \
+    BOOL ___contract_enabled = FALSE;                                   \
     DEBUG_ASSURE_NO_RETURN_BEGIN(CONTRACT)                              \
-    BOOL ___contract_enabled = Contract::EnforceContract();             \
+    ___contract_enabled = Contract::EnforceContract();                  \
     enum {___disabled = 0};                                             \
     if (!___contract_enabled)                                           \
         ___contract.Disable();                                          \
@@ -1897,7 +1898,7 @@ public:
     DEBUG_NOINLINE ~AutoCleanupContractViolationHolder()
     {
         SCAN_SCOPE_END;
-        LeaveInternal();
+        this->LeaveInternal();
     };
 };
 

--- a/src/inc/contract.inl
+++ b/src/inc/contract.inl
@@ -40,7 +40,7 @@ void SoTolerantViolationHelper(const char *szFunction,
 #endif
 
 
-inline void BaseContract::DoChecks(UINT testmask, __in_z const char *szFunction, __in_z char *szFile, int lineNum)
+inline void BaseContract::DoChecks(UINT testmask, __in_z const char *szFunction, __in_z const char *szFile, int lineNum)
 {
     STATIC_CONTRACT_DEBUG_ONLY;
     STATIC_CONTRACT_NOTHROW;

--- a/src/inc/shash.inl
+++ b/src/inc/shash.inl
@@ -403,7 +403,7 @@ SHash<TRAITS>::AllocateNewTable(count_t requestedSize, count_t * pcNewTableSize)
         GC_NOTRIGGER;
         INSTANCE_CHECK;
         PRECONDITION(requestedSize >= 
-                     (count_t) (GetCount() * s_density_factor_denominator / s_density_factor_numerator));
+                     (count_t) (GetCount() * TRAITS::s_density_factor_denominator / TRAITS::s_density_factor_numerator));
     }
     CONTRACT_END;
 
@@ -434,7 +434,7 @@ SHash<TRAITS>::ReplaceTable(element_t * newTable, count_t newTableSize)
         GC_NOTRIGGER;
         INSTANCE_CHECK;
         PRECONDITION(newTableSize >= 
-                     (count_t) (GetCount() * s_density_factor_denominator / s_density_factor_numerator));
+                     (count_t) (GetCount() * TRAITS::s_density_factor_denominator / TRAITS::s_density_factor_numerator));
     }
     CONTRACT_END;
     

--- a/src/jit/unwind.h
+++ b/src/jit/unwind.h
@@ -95,7 +95,7 @@ protected:
         return uwiComp->dspOffset(o);
     }
 
-    static char* dspBool(bool b)
+    static const char* dspBool(bool b)
     {
         return (b) ? "true" : "false";
     }

--- a/src/pal/tools/windows-compiler-override.txt
+++ b/src/pal/tools/windows-compiler-override.txt
@@ -1,10 +1,10 @@
-SET (CMAKE_C_FLAGS_INIT                "/Wall /FC")
+SET (CMAKE_C_FLAGS_INIT                "/Wall /FC /Zc:strictStrings")
 SET (CMAKE_C_FLAGS_DEBUG_INIT          "/Od /Zi")
 SET (CLR_C_FLAGS_CHECKED_INIT          "/O1 /Zi")
 SET (CMAKE_C_FLAGS_RELEASE_INIT        "/Ox /Zi")
 SET (CMAKE_C_FLAGS_RELWITHDEBINFO_INIT "/O2 /Zi")
 
-SET (CMAKE_CXX_FLAGS_INIT                "/Wall /FC")
+SET (CMAKE_CXX_FLAGS_INIT                "/Wall /FC /Zc:strictStrings")
 SET (CMAKE_CXX_FLAGS_DEBUG_INIT          "/Od /Zi")
 SET (CLR_CXX_FLAGS_CHECKED_INIT          "/O1 /Zi")
 SET (CMAKE_CXX_FLAGS_RELEASE_INIT        "/Ox /Zi")

--- a/src/utilcode/debug.cpp
+++ b/src/utilcode/debug.cpp
@@ -284,7 +284,7 @@ BOOL LaunchJITDebugger()
         STARTUPINFO StartupInfo;
         memset(&StartupInfo, 0, sizeof(StartupInfo));
         StartupInfo.cb = sizeof(StartupInfo);
-        StartupInfo.lpDesktop = W("Winsta0\\Default");
+        StartupInfo.lpDesktop = const_cast<LPWSTR>(W("Winsta0\\Default"));
 
         PROCESS_INFORMATION ProcessInformation;
         if (WszCreateProcess(NULL, cmdLine, NULL, NULL, TRUE, 0, NULL, NULL, &StartupInfo, &ProcessInformation))

--- a/src/utilcode/winfix.cpp
+++ b/src/utilcode/winfix.cpp
@@ -52,7 +52,7 @@ static BOOL gWinWrapperContractRecursionBreak = FALSE;
 class WinWrapperContract
 {
     public:
-        WinWrapperContract(char *szFunction, char *szFile, int lineNum)
+        WinWrapperContract(const char *szFunction, const char *szFile, int lineNum)
         {
             CANNOT_HAVE_CONTRACT;
 

--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -6125,7 +6125,7 @@ LPCWSTR AppDomain::GetFriendlyName(BOOL fDebuggerCares/*=TRUE*/)
 
 LPCWSTR AppDomain::GetFriendlyNameForLogging()
 {
-    CONTRACT(LPWSTR)
+    CONTRACT(LPCWSTR)
     {
         NOTHROW;
         GC_NOTRIGGER;

--- a/src/vm/binder.cpp
+++ b/src/vm/binder.cpp
@@ -646,7 +646,7 @@ static void FCallCheckSignature(MethodDesc* pMD, PCODE pImpl)
 {
     STANDARD_VM_CONTRACT;
 
-    char* pUnmanagedSig = NULL;
+    const char* pUnmanagedSig = NULL;
 
     FCSigCheck* pSigCheck = FCSigCheck::g_pFCSigCheck;
     while (pSigCheck != NULL)
@@ -661,7 +661,7 @@ static void FCallCheckSignature(MethodDesc* pMD, PCODE pImpl)
     MetaSig msig(pMD);   
     int argIndex = -2; // start with return value
     int enregisteredArguments = 0;
-    char* pUnmanagedArg = pUnmanagedSig;
+    const char* pUnmanagedArg = pUnmanagedSig;
     for (;;)
     {
         CorElementType argType = ELEMENT_TYPE_END;
@@ -755,9 +755,9 @@ static void FCallCheckSignature(MethodDesc* pMD, PCODE pImpl)
                 ("Unexpected end of managed fcall signature\n"
                 "Method: %s:%s\n", pMD->m_pszDebugClassName, pMD->m_pszDebugMethodName));
 
-            char* pUnmanagedArgEnd = strchr(pUnmanagedArg, ',');
+            const char* pUnmanagedArgEnd = strchr(pUnmanagedArg, ',');
 
-            char* pUnmanagedTypeEnd = (pUnmanagedArgEnd != NULL) ? 
+            const char* pUnmanagedTypeEnd = (pUnmanagedArgEnd != NULL) ? 
                 pUnmanagedArgEnd : (pUnmanagedArg + strlen(pUnmanagedArg));
 
             if (argIndex != -2)

--- a/src/vm/eecontract.cpp
+++ b/src/vm/eecontract.cpp
@@ -23,7 +23,7 @@ void EEContract::Disable()
     BaseContract::Disable();
 }
 
-void EEContract::DoChecks(UINT testmask, __in_z const char *szFunction, __in_z char *szFile, int lineNum)
+void EEContract::DoChecks(UINT testmask, __in_z const char *szFunction, __in_z const char *szFile, int lineNum)
 {
     SCAN_IGNORE_THROW;      // Tell the static contract analyzer to ignore contract violations
     SCAN_IGNORE_FAULT;      // due to the contract checking logic itself.

--- a/src/vm/eecontract.h
+++ b/src/vm/eecontract.h
@@ -42,7 +42,7 @@ class EEContract : public BaseContract
     }
 
     void Disable();
-    void DoChecks(UINT testmask, __in_z const char *szFunction, __in_z char *szFile, int lineNum);
+    void DoChecks(UINT testmask, __in_z const char *szFunction, __in_z const char *szFile, int lineNum);
 };
 
 

--- a/src/vm/exceptmacros.h
+++ b/src/vm/exceptmacros.h
@@ -434,7 +434,7 @@ VOID DECLSPEC_NORETURN DispatchManagedException(PAL_SEHException& ex, bool isHar
 #define CANNOTTHROWCOMPLUSEXCEPTION() ANNOTATION_NOTHROW; \
     COMPlusCannotThrowExceptionHelper _dummyvariable(TRUE, __FUNCTION__, __FILE__, __LINE__);
 
-extern char *g_ExceptionFile;
+extern const char *g_ExceptionFile;
 extern DWORD g_ExceptionLine;
 
 #define THROWLOG() ( g_ExceptionFile = __FILE__, g_ExceptionLine = __LINE__, TRUE )

--- a/src/vm/fcall.h
+++ b/src/vm/fcall.h
@@ -967,7 +967,7 @@ extern int FC_NO_TAILCALL;
 #ifdef CHECK_FCALL_SIGNATURE
 struct FCSigCheck {
 public:
-    FCSigCheck(void* fnc, char* sig)
+    FCSigCheck(void* fnc, const char* sig)
     {
         LIMITED_METHOD_CONTRACT;
         func = fnc;
@@ -978,7 +978,7 @@ public:
 
     FCSigCheck* next;
     void* func;
-    char* signature;
+    const char* signature;
 
     static FCSigCheck* g_pFCSigCheck;
 };

--- a/src/vm/interoputil.cpp
+++ b/src/vm/interoputil.cpp
@@ -6273,13 +6273,13 @@ VOID IntializeInteropLogging()
     g_TraceCount = g_pConfig->GetTraceWrapper();
 }
 
-VOID LogInterop(__in_z LPSTR szMsg)
+VOID LogInterop(__in_z LPCSTR szMsg)
 {
     LIMITED_METHOD_CONTRACT;
     LOG( (LF_INTEROP, LL_INFO10, "%s\n",szMsg) );
 }
 
-VOID LogInterop(__in_z LPWSTR wszMsg)
+VOID LogInterop(__in_z LPCWSTR wszMsg)
 {
     LIMITED_METHOD_CONTRACT;
     LOG( (LF_INTEROP, LL_INFO10, "%S\n", wszMsg) );

--- a/src/vm/interoputil.h
+++ b/src/vm/interoputil.h
@@ -401,8 +401,8 @@ ClassFactoryBase *GetComClassFactory(MethodTable* pClassMT);
 
 #ifdef _DEBUG
 
-VOID LogInterop(__in_z LPSTR szMsg);
-VOID LogInterop(__in_z LPWSTR szMsg);
+VOID LogInterop(__in_z LPCSTR szMsg);
+VOID LogInterop(__in_z LPCWSTR szMsg);
 
 VOID LogInteropLeak(IUnkEntry * pEntry);
 VOID LogInteropLeak(IUnknown* pItf);

--- a/src/vm/threads.h
+++ b/src/vm/threads.h
@@ -3647,7 +3647,7 @@ private:
     static void __stdcall RedirectedHandledJITCaseForGCThreadControl();
     static void __stdcall RedirectedHandledJITCaseForUserSuspend();
 #if defined(HAVE_GCCOVER) && defined(USE_REDIRECT_FOR_GCSTRESS) // GCCOVER
-    static void __stdcall Thread::RedirectedHandledJITCaseForGCStress();
+    static void __stdcall RedirectedHandledJITCaseForGCStress();
 #endif // defined(HAVE_GCCOVER) && USE_REDIRECT_FOR_GCSTRESS
 
     friend void CPFH_AdjustContextForThreadSuspensionRace(T_CONTEXT *pContext, Thread *pThread);

--- a/src/vm/vars.cpp
+++ b/src/vm/vars.cpp
@@ -39,7 +39,7 @@ BBSweep              g_BBSweep;
 Volatile<LONG>       g_trtChgStamp = 0;
 Volatile<LONG>       g_trtChgInFlight = 0;
 
-char *               g_ExceptionFile;   // Source of the last thrown exception (COMPLUSThrow())
+const char *         g_ExceptionFile;   // Source of the last thrown exception (COMPLUSThrow())
 DWORD                g_ExceptionLine;   // ... ditto ...
 void *               g_ExceptionEIP;    // Managed EIP of the last guy to call JITThrow.
 #endif // _DEBUG

--- a/src/vm/vars.hpp
+++ b/src/vm/vars.hpp
@@ -352,7 +352,7 @@ EXTERN IBCLogger            g_IBCLogger;
 // that does not allow g_TrapReturningThreads to creep up unchecked.
 EXTERN Volatile<LONG>       g_trtChgStamp;
 EXTERN Volatile<LONG>       g_trtChgInFlight;
-EXTERN char *               g_ExceptionFile;
+EXTERN const char *         g_ExceptionFile;
 EXTERN DWORD                g_ExceptionLine;
 EXTERN void *               g_ExceptionEIP;
 #endif


### PR DESCRIPTION
Remove implicit C-string `const` casting and clean up some C++ standards conformance bugs related to two-phase lookup.

Also, fix a possible bug where contracts might be assumed to be enabled when they aren't due to a `goto` skipping initialization of the `___contract_enabled` variable in contract.h.


Turn on the `/Zc:strictStrings` switch on MSVC to try to keep us from adding in more implicit casts from string literals that we don't need.
