### PR TITLE
Improve performance of String.Equals(..., OrdinalIgnoreCase)

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
@@ -16,7 +16,7 @@ using System.Reflection;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
-using System.Buffers;
+using System.Text;
 using Internal.Runtime.CompilerServices;
 
 namespace System.Globalization
@@ -595,37 +595,87 @@ namespace System.Globalization
         }
 
 
-        internal static bool EqualsOrdinalIgnoreCase(ref char strA, ref char strB, int length)
+        internal static bool EqualsOrdinalIgnoreCase(ref char charA, ref char charB, int length)
         {
-            ref char charA = ref strA;
-            ref char charB = ref strB;
-
-            // in InvariantMode we support all range and not only the ascii characters.
-            char maxChar = (GlobalizationMode.Invariant ? (char)0xFFFF : (char)0x7F);
-
-            while (length != 0 && charA <= maxChar && charB <= maxChar)
+            if (!GlobalizationMode.Invariant)
             {
-                // Ordinal equals or lowercase equals if the result ends up in the a-z range 
-                if (charA == charB ||
-                    ((charA | 0x20) == (charB | 0x20) &&
-                        (uint)((charA | 0x20) - 'a') <= (uint)('z' - 'a')))
+                IntPtr byteOffset = IntPtr.Zero;
+                while ((uint)length >= 2)
                 {
-                    length--;
-                    charA = ref Unsafe.Add(ref charA, 1);
-                    charB = ref Unsafe.Add(ref charB, 1);
-                }
-                else
-                {
-                    return false;
-                }
-            }
+                    // Read 2 chars (32 bits) at a time from each string
+                    uint valueA = Unsafe.ReadUnaligned<uint>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charA, byteOffset)));
+                    uint valueB = Unsafe.ReadUnaligned<uint>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charB, byteOffset)));
 
-            if (length == 0)
+                    if (!Utf16Utility.AllCharsInUInt32AreAscii(valueA | valueB))
+                    {
+                        goto NonAscii; // one of the inputs contains non-ASCII data
+                    }
+
+                    // Generally, the caller has likely performed a first-pass check that the input strings
+                    // are likely equal. Consider a dictionary which computes the hash code of its key before
+                    // performing a proper deep equality check of the string contents. We want to optimize for
+                    // the case where the equality check is likely to succeed, which means that we want to avoid
+                    // branching within this loop unless we're about to exit the loop, either due to failure or
+                    // due to us running out of input data.
+
+                    if (!Utf16Utility.UInt32OrdinalIgnoreCaseAscii(valueA, valueB))
+                    {
+                        return false;
+                    }
+
+                    byteOffset += 2;
+                    length -= 2;
+                }
+
+                if (length != 0)
+                {
+                    Debug.Assert(length == 1);
+
+                    uint valueA = Unsafe.AddByteOffset(ref charA, byteOffset);
+                    uint valueB = Unsafe.AddByteOffset(ref charB, byteOffset);
+
+                    if ((valueA | valueB) > 0x7Fu)
+                    {
+                        goto NonAscii; // one of the inputs contains non-ASCII data
+                    }
+
+                    if (valueA == valueB)
+                    {
+                        return true;
+                    }
+
+                    valueA |= 0x20u;
+                    return ((uint)(valueA - 'a') <= (uint)('z' - 'a'))
+                        && (valueA == (valueB | 0x20u));
+                }
+
+                Debug.Assert(length == 0);
                 return true;
 
-            Debug.Assert(!GlobalizationMode.Invariant);
+            NonAscii:
+                return CompareStringOrdinalIgnoreCase(ref Unsafe.AddByteOffset(ref charA, byteOffset), length, ref Unsafe.AddByteOffset(ref charB, byteOffset), length) == 0;
+            }
+            else
+            {
+                while (length != 0)
+                {
+                    // Ordinal equals or lowercase equals if the result ends up in the a-z range 
+                    if (charA == charB ||
+                        ((charA | 0x20) == (charB | 0x20) &&
+                            (uint)((charA | 0x20) - 'a') <= (uint)('z' - 'a')))
+                    {
+                        length--;
+                        charA = ref Unsafe.Add(ref charA, 1);
+                        charB = ref Unsafe.Add(ref charB, 1);
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
 
-            return CompareStringOrdinalIgnoreCase(ref charA, length, ref charB, length) == 0;
+                return true;
+            }
         }
 
         ////////////////////////////////////////////////////////////////////////

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
@@ -597,76 +597,124 @@ namespace System.Globalization
 
         internal static bool EqualsOrdinalIgnoreCase(ref char charA, ref char charB, int length)
         {
+            IntPtr byteOffset = IntPtr.Zero;
+
+#if BIT64
+            // Read 4 chars (64 bits) at a time from each string
+            while ((uint)length >= 4)
+            {
+                ulong valueA = Unsafe.ReadUnaligned<ulong>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charA, byteOffset)));
+                ulong valueB = Unsafe.ReadUnaligned<ulong>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charB, byteOffset)));
+
+                if (!Utf16Utility.AllCharsInUInt64AreAscii(valueA | valueB))
+                {
+                    goto NonAscii; // one of the inputs contains non-ASCII data
+                }
+
+                // Generally, the caller has likely performed a first-pass check that the input strings
+                // are likely equal. Consider a dictionary which computes the hash code of its key before
+                // performing a proper deep equality check of the string contents. We want to optimize for
+                // the case where the equality check is likely to succeed, which means that we want to avoid
+                // branching within this loop unless we're about to exit the loop, either due to failure or
+                // due to us running out of input data.
+
+                if (!Utf16Utility.UInt64OrdinalIgnoreCaseAscii(valueA, valueB))
+                {
+                    return false;
+                }
+
+                byteOffset += 8;
+                length -= 4;
+            }
+#endif
+
+            // Read 2 chars (32 bits) at a time from each string
+#if BIT64
+            if ((uint)length >= 2)
+#else
+            while ((uint)length >= 2)
+#endif
+            {
+                uint valueA = Unsafe.ReadUnaligned<uint>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charA, byteOffset)));
+                uint valueB = Unsafe.ReadUnaligned<uint>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charB, byteOffset)));
+
+                if (!Utf16Utility.AllCharsInUInt32AreAscii(valueA | valueB))
+                {
+                    goto NonAscii; // one of the inputs contains non-ASCII data
+                }
+
+                // Generally, the caller has likely performed a first-pass check that the input strings
+                // are likely equal. Consider a dictionary which computes the hash code of its key before
+                // performing a proper deep equality check of the string contents. We want to optimize for
+                // the case where the equality check is likely to succeed, which means that we want to avoid
+                // branching within this loop unless we're about to exit the loop, either due to failure or
+                // due to us running out of input data.
+
+                if (!Utf16Utility.UInt32OrdinalIgnoreCaseAscii(valueA, valueB))
+                {
+                    return false;
+                }
+
+                byteOffset += 4;
+                length -= 2;
+            }
+
+            if (length != 0)
+            {
+                Debug.Assert(length == 1);
+
+                uint valueA = Unsafe.AddByteOffset(ref charA, byteOffset);
+                uint valueB = Unsafe.AddByteOffset(ref charB, byteOffset);
+
+                if ((valueA | valueB) > 0x7Fu)
+                {
+                    goto NonAscii; // one of the inputs contains non-ASCII data
+                }
+
+                if (valueA == valueB)
+                {
+                    return true;
+                }
+
+                valueA |= 0x20u;
+                return ((uint)(valueA - 'a') <= (uint)('z' - 'a'))
+                    && (valueA == (valueB | 0x20u));
+            }
+
+            Debug.Assert(length == 0);
+            return true;
+
+        NonAscii:
+            // The non-ASCII case is factored out into its own helper method so that the JIT
+            // doesn't need to emit a complex prolog for its caller (this method).
+            return EqualsOrdinalIgnoreCaseNonAscii(ref Unsafe.AddByteOffset(ref charA, byteOffset), ref Unsafe.AddByteOffset(ref charB, byteOffset), length);
+        }
+
+        private static bool EqualsOrdinalIgnoreCaseNonAscii(ref char charA, ref char charB, int length)
+        {
             if (!GlobalizationMode.Invariant)
             {
-                IntPtr byteOffset = IntPtr.Zero;
-                while ((uint)length >= 2)
-                {
-                    // Read 2 chars (32 bits) at a time from each string
-                    uint valueA = Unsafe.ReadUnaligned<uint>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charA, byteOffset)));
-                    uint valueB = Unsafe.ReadUnaligned<uint>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charB, byteOffset)));
-
-                    if (!Utf16Utility.AllCharsInUInt32AreAscii(valueA | valueB))
-                    {
-                        goto NonAscii; // one of the inputs contains non-ASCII data
-                    }
-
-                    // Generally, the caller has likely performed a first-pass check that the input strings
-                    // are likely equal. Consider a dictionary which computes the hash code of its key before
-                    // performing a proper deep equality check of the string contents. We want to optimize for
-                    // the case where the equality check is likely to succeed, which means that we want to avoid
-                    // branching within this loop unless we're about to exit the loop, either due to failure or
-                    // due to us running out of input data.
-
-                    if (!Utf16Utility.UInt32OrdinalIgnoreCaseAscii(valueA, valueB))
-                    {
-                        return false;
-                    }
-
-                    byteOffset += 2;
-                    length -= 2;
-                }
-
-                if (length != 0)
-                {
-                    Debug.Assert(length == 1);
-
-                    uint valueA = Unsafe.AddByteOffset(ref charA, byteOffset);
-                    uint valueB = Unsafe.AddByteOffset(ref charB, byteOffset);
-
-                    if ((valueA | valueB) > 0x7Fu)
-                    {
-                        goto NonAscii; // one of the inputs contains non-ASCII data
-                    }
-
-                    if (valueA == valueB)
-                    {
-                        return true;
-                    }
-
-                    valueA |= 0x20u;
-                    return ((uint)(valueA - 'a') <= (uint)('z' - 'a'))
-                        && (valueA == (valueB | 0x20u));
-                }
-
-                Debug.Assert(length == 0);
-                return true;
-
-            NonAscii:
-                return CompareStringOrdinalIgnoreCase(ref Unsafe.AddByteOffset(ref charA, byteOffset), length, ref Unsafe.AddByteOffset(ref charB, byteOffset), length) == 0;
+                return CompareStringOrdinalIgnoreCase(ref charA, length, ref charB, length) == 0;
             }
             else
             {
+                // If we don't have localization tables to consult, we'll still perform a case-insensitive
+                // check for ASCII characters, but if we see anything outside the ASCII range we'll immediately
+                // fail if it doesn't have true bitwise equality.
+
+                IntPtr byteOffset = IntPtr.Zero;
                 while (length != 0)
                 {
                     // Ordinal equals or lowercase equals if the result ends up in the a-z range 
-                    if (charA == charB ||
-                        ((charA | 0x20) == (charB | 0x20) &&
-                            (uint)((charA | 0x20) - 'a') <= (uint)('z' - 'a')))
+                    uint valueA = Unsafe.AddByteOffset(ref charA, byteOffset);
+                    uint valueB = Unsafe.AddByteOffset(ref charB, byteOffset);
+
+                    if (valueA == valueB ||
+                        ((valueA | 0x20) == (valueB | 0x20) &&
+                            (uint)((valueA | 0x20) - 'a') <= (uint)('z' - 'a')))
                     {
+                        byteOffset += 2;
                         length--;
-                        charA = ref Unsafe.Add(ref charA, 1);
-                        charB = ref Unsafe.Add(ref charB, 1);
                     }
                     else
                     {

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
@@ -684,14 +684,9 @@ namespace System.Globalization
                     return false; // not exact match, and first input isn't in [A-Za-z]
                 }
 
-                if (valueA == (valueB | 0x20u))
-                {
-                    return true;
-                }
-                else
-                {
-                    return false;
-                }
+                // The ternary operator below seems redundant but helps RyuJIT generate more optimal code.
+                // See https://github.com/dotnet/coreclr/issues/914.
+                return (valueA == (valueB | 0x20u)) ? true : false;
             }
 
             Debug.Assert(length == 0);

--- a/src/System.Private.CoreLib/shared/System/StringComparer.cs
+++ b/src/System.Private.CoreLib/shared/System/StringComparer.cs
@@ -293,7 +293,7 @@ namespace System
                 {
                     return false;
                 }
-                return string.Equals(x, y, StringComparison.OrdinalIgnoreCase);
+                return CompareInfo.EqualsOrdinalIgnoreCase(ref x.GetRawStringData(), ref y.GetRawStringData(), x.Length);
             }
             return x.Equals(y);
         }
@@ -367,7 +367,20 @@ namespace System
 
         public override int Compare(string x, string y) => string.Compare(x, y, StringComparison.OrdinalIgnoreCase);
 
-        public override bool Equals(string x, string y) => string.Equals(x, y, StringComparison.OrdinalIgnoreCase);
+        public override bool Equals(string x, string y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            if (x is null || y is null)
+            {
+                return false;
+            }
+
+            return CompareInfo.EqualsOrdinalIgnoreCase(ref x.GetRawStringData(), ref y.GetRawStringData(), x.Length);
+        }
 
         public override int GetHashCode(string obj)
         {

--- a/src/System.Private.CoreLib/shared/System/StringComparer.cs
+++ b/src/System.Private.CoreLib/shared/System/StringComparer.cs
@@ -379,6 +379,11 @@ namespace System
                 return false;
             }
 
+            if (x.Length != y.Length)
+            {
+                return false;
+            }
+
             return CompareInfo.EqualsOrdinalIgnoreCase(ref x.GetRawStringData(), ref y.GetRawStringData(), x.Length);
         }
 

--- a/src/System.Private.CoreLib/shared/System/Text/Utf16Utility.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/Utf16Utility.cs
@@ -15,7 +15,7 @@ namespace System.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool AllCharsInUInt32AreAscii(uint value)
         {
-            return (value & ~0x007F007Fu) == 0;
+            return (value & ~0x007F_007Fu) == 0;
         }
 
         /// <summary>
@@ -24,7 +24,7 @@ namespace System.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool AllCharsInUInt64AreAscii(ulong value)
         {
-            return (value & ~0x007F007F007F007Ful) == 0;
+            return (value & ~0x007F_007F_007F_007Ful) == 0;
         }
 
         /// <summary>
@@ -42,16 +42,16 @@ namespace System.Text
             Debug.Assert(AllCharsInUInt32AreAscii(value));
 
             // the 0x80 bit of each word of 'lowerIndicator' will be set iff the word has value >= 'A'
-            uint lowerIndicator = value + 0x00800080u - 0x00410041u;
+            uint lowerIndicator = value + 0x0080_0080u - 0x0041_0041u;
 
             // the 0x80 bit of each word of 'upperIndicator' will be set iff the word has value > 'Z'
-            uint upperIndicator = value + 0x00800080u - 0x005B005Bu;
+            uint upperIndicator = value + 0x0080_0080u - 0x005B_005Bu;
 
             // the 0x80 bit of each word of 'combinedIndicator' will be set iff the word has value >= 'A' and <= 'Z'
             uint combinedIndicator = (lowerIndicator ^ upperIndicator);
 
             // the 0x20 bit of each word of 'mask' will be set iff the word has value >= 'A' and <= 'Z'
-            uint mask = (combinedIndicator & 0x00800080u) >> 2;
+            uint mask = (combinedIndicator & 0x0080_0080u) >> 2;
 
             return value ^ mask; // bit flip uppercase letters [A-Z] => [a-z]
         }
@@ -71,16 +71,16 @@ namespace System.Text
             Debug.Assert(AllCharsInUInt32AreAscii(value));
 
             // the 0x80 bit of each word of 'lowerIndicator' will be set iff the word has value >= 'a'
-            uint lowerIndicator = value + 0x00800080u - 0x00610061u;
+            uint lowerIndicator = value + 0x0080_0080u - 0x0061_0061u;
 
             // the 0x80 bit of each word of 'upperIndicator' will be set iff the word has value > 'z'
-            uint upperIndicator = value + 0x00800080u - 0x007B007Bu;
+            uint upperIndicator = value + 0x0080_0080u - 0x007B_007Bu;
 
             // the 0x80 bit of each word of 'combinedIndicator' will be set iff the word has value >= 'a' and <= 'z'
             uint combinedIndicator = (lowerIndicator ^ upperIndicator);
 
             // the 0x20 bit of each word of 'mask' will be set iff the word has value >= 'a' and <= 'z'
-            uint mask = (combinedIndicator & 0x00800080u) >> 2;
+            uint mask = (combinedIndicator & 0x0080_0080u) >> 2;
 
             return value ^ mask; // bit flip lowercase letters [a-z] => [A-Z]
         }
@@ -99,15 +99,15 @@ namespace System.Text
             Debug.Assert(AllCharsInUInt32AreAscii(value));
 
             // the 0x80 bit of each word of 'lowerIndicator' will be set iff the word has value >= 'a'
-            uint lowerIndicator = value + 0x00800080u - 0x00610061u;
+            uint lowerIndicator = value + 0x0080_0080u - 0x0061_0061u;
 
             // the 0x80 bit of each word of 'upperIndicator' will be set iff the word has value > 'z'
-            uint upperIndicator = value + 0x00800080u - 0x007B007Bu;
+            uint upperIndicator = value + 0x0080_0080u - 0x007B_007Bu;
 
             // the 0x80 bit of each word of 'combinedIndicator' will be set iff the word has value >= 'a' and <= 'z'
             uint combinedIndicator = (lowerIndicator ^ upperIndicator);
 
-            return (combinedIndicator & 0x00800080u) != 0;
+            return (combinedIndicator & 0x0080_0080u) != 0;
         }
 
         /// <summary>
@@ -124,15 +124,15 @@ namespace System.Text
             Debug.Assert(AllCharsInUInt32AreAscii(value));
 
             // the 0x80 bit of each word of 'lowerIndicator' will be set iff the word has value >= 'A'
-            uint lowerIndicator = value + 0x00800080u - 0x00410041u;
+            uint lowerIndicator = value + 0x0080_0080u - 0x0041_0041u;
 
             // the 0x80 bit of each word of 'upperIndicator' will be set iff the word has value > 'Z'
-            uint upperIndicator = value + 0x00800080u - 0x005B005Bu;
+            uint upperIndicator = value + 0x0080_0080u - 0x005B_005Bu;
 
             // the 0x80 bit of each word of 'combinedIndicator' will be set iff the word has value >= 'A' and <= 'Z'
             uint combinedIndicator = (lowerIndicator ^ upperIndicator);
 
-            return (combinedIndicator & 0x00800080u) != 0;
+            return (combinedIndicator & 0x0080_0080u) != 0;
         }
 
         /// <summary>
@@ -153,20 +153,27 @@ namespace System.Text
             uint differentBits = valueA ^ valueB;
 
             // the 0x80 bit of each word of 'lowerIndicator' will be set iff the word has value < 'A'
-            uint lowerIndicator = valueA + 0x01000100u - 0x00410041u;
+            uint lowerIndicator = valueA + 0x0100_0100u - 0x0041_0041u;
 
             // the 0x80 bit of each word of 'upperIndicator' will be set iff (word | 0x20) has value > 'z'
-            uint upperIndicator = (valueA | 0x00200020u) + 0x00800080u - 0x007B007Bu;
+            uint upperIndicator = (valueA | 0x0020_0020u) + 0x0080_0080u - 0x007B_007Bu;
 
             // the 0x80 bit of each word of 'combinedIndicator' will be set iff the word is *not* [A-Za-z]
             uint combinedIndicator = lowerIndicator | upperIndicator;
 
-            // Shift all the 0x80 bits of 'combinedIndicator' into the 0x20 positions, then
-            // set all bits aside from 0x20. The combined indicator is now a mask detailing which
-            // bits *must not* be different between the input values A and B for them to be treated
-            // as equal using an ordinal case-insensitive comparison.
+            // Shift all the 0x80 bits of 'combinedIndicator' into the 0x20 positions, then set all bits
+            // aside from 0x20. This creates a mask where all bits are set *except* for the 0x20 bits
+            // which correspond to alpha chars (either lower or upper). For these alpha chars only, the
+            // 0x20 bit is allowed to differ between the two input values. Every other char must be an
+            // exact bitwise match between the two input values. In other words, (valueA & mask) will
+            // convert valueA to uppercase, so (valueA & mask) == (valueB & mask) answers "is the uppercase
+            // form of valueA equal to the uppercase form of valueB?" (Technically if valueA has an alpha
+            // char in the same position as a non-alpha char in valueB, or vice versa, this operation will
+            // result in nonsense, but it'll still compute as inequal regardless, which is what we want ultimately.)
+            // The line below is a more efficient way of doing the same check taking advantage of the XOR
+            // computation we performed at the beginning of the method.
 
-            return (((combinedIndicator >> 2) | ~0x00200020u) & differentBits) == 0;
+            return (((combinedIndicator >> 2) | ~0x0020_0020u) & differentBits) == 0;
         }
 
         /// <summary>
@@ -182,21 +189,25 @@ namespace System.Text
             // ASSUMPTION: Caller has validated that input values are ASCII.
             Debug.Assert(AllCharsInUInt64AreAscii(valueA));
             Debug.Assert(AllCharsInUInt64AreAscii(valueB));
-            
+
             // the 0x80 bit of each word of 'lowerIndicator' will be set iff the word has value >= 'A'
-            ulong lowerIndicator = valueA + 0x0080008000800080ul - 0x0041004100410041ul;
+            ulong lowerIndicator = valueA + 0x0080_0080_0080_0080ul - 0x0041_0041_0041_0041ul;
 
             // the 0x80 bit of each word of 'upperIndicator' will be set iff (word | 0x20) has value <= 'z'
-            ulong upperIndicator = (valueA | 0x0020002000200020ul) + 0x0100010001000100ul - 0x007B007B007B007Bul;
+            ulong upperIndicator = (valueA | 0x0020_0020_0020_0020ul) + 0x0100_0100_0100_0100ul - 0x007B_007B_007B_007Bul;
 
             // the 0x20 bit of each word of 'combinedIndicator' will be set iff the word is [A-Za-z]
-            ulong combinedIndicator = (0x0080008000800080ul & lowerIndicator & upperIndicator) >> 2;
+            ulong combinedIndicator = (0x0080_0080_0080_0080ul & lowerIndicator & upperIndicator) >> 2;
 
             // Convert both values to lowercase (using the combined indicator from the first value)
             // and compare for equality. It's possible that the first value will contain an alpha character
             // where the second value doesn't (or vice versa), and applying the combined indicator will
             // create nonsensical data, but the comparison would have failed anyway in this case so it's
             // a safe operation to perform.
+            //
+            // This 64-bit method is similar to the 32-bit method, but it performs the equivalent of convert-to-
+            // lowercase-then-compare rather than convert-to-uppercase-and-compare. This particular operation
+            // happens to be faster on x64.
 
             return (valueA | combinedIndicator) == (valueB | combinedIndicator);
         }


### PR DESCRIPTION
This improves the throughput of `OrdinalIgnoreCase` string comparisons, especially for smaller inputs.

(Edit: Removed the earlier posted benchmark numbers since they're outdated. See updated numbers at https://github.com/dotnet/coreclr/pull/20734#issuecomment-435132314.)

The performance gains come primarily from two changes. First, the inner loop is now checking 2 characters at a time instead of one character at a time. Second, the internal branching within the inner loop has been eliminated, which helps avoid branch mispredictions when mixed-case input is provided. The source code comment in the inner loop explains this in more detail.

This code isn't vectorized because strings being compared for equality tend to be small - dictionary keys, identifiers, and the like. I also experimented with performing operations on 4 chars (64 bits) at a time on 64-bit platforms. It provides for inputs of 4+ chars an approx. 15% throughput boost above and beyond what this PR provides. Ultimately I didn't include the 64-bit code because I thought it would complicate the method for too little gain. If consensus is that the gain is worth it I can reintroduce the 64-bit-specific code paths.