### PR TITLE
Added support for running in a sandbox on Mac

### DIFF
--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -442,6 +442,16 @@ BOOL
 PALAPI
 PAL_NotifyRuntimeStarted(VOID);
 
+PALIMPORT
+LPCSTR
+PALAPI
+PAL_GetApplicationGroupId();
+
+PALIMPORT
+BOOL
+PALAPI
+PAL_IsApplicationSandboxed();
+
 static const int MAX_DEBUGGER_TRANSPORT_PIPE_NAME_LENGTH = MAX_PATH;
 
 PALIMPORT

--- a/src/pal/src/include/pal/palinternal.h
+++ b/src/pal/src/include/pal/palinternal.h
@@ -614,6 +614,8 @@ function_name() to call the system's implementation
    we'll catch any definition conflicts */
 #include <sys/socket.h>
 
+#include <pal/stackstring.hpp>
+
 #if !HAVE_INFTIM
 #define INFTIM  -1
 #endif // !HAVE_INFTIM
@@ -622,6 +624,8 @@ function_name() to call the system's implementation
 
 #undef assert
 #define assert (Use__ASSERTE_instead_of_assert) assert
+
+#define string_countof(a) (sizeof(a) / sizeof(a[0]) - 1)
 
 #ifndef __ANDROID__
 #define TEMP_DIRECTORY_PATH "/tmp/"
@@ -632,6 +636,14 @@ function_name() to call the system's implementation
 #endif
 
 #define PROCESS_PIPE_NAME_PREFIX ".dotnet-pal-processpipe"
+
+#define APPLICATION_CONTAINER_BASE_PATH_SUFFIX "/Library/Group Containers/"
+
+// Not much to go with, but Max semaphore length on Mac is 31 characters. In a sandbox, the semaphore name
+// must be prefixed with an application group ID. This will be 10 characters for developer ID and extra 2 
+// characters for group name. For example ABCDEFGHIJ.MS. We still need some characters left
+// for the actual semaphore names.
+#define MAX_APPLICATION_GROUP_ID_LENGTH 13
 
 #ifdef __cplusplus
 extern "C"
@@ -655,6 +667,9 @@ typedef enum _TimeConversionConstants
 
 bool
 ReadMemoryValueFromFile(const char* filename, size_t* val);
+
+bool
+GetApplicationContainerFolder(PathCharString& buffer, const char *applicationGroupId, int applicationGroupIdLength);
 
 /* This is duplicated in utilcode.h for CLR, with cooler type-traits */
 template <typename T>

--- a/src/pal/src/include/pal/process.h
+++ b/src/pal/src/include/pal/process.h
@@ -24,6 +24,7 @@ Revision History:
 #define _PAL_PROCESS_H_
 
 #include "pal/palinternal.h"
+#include "pal/stackstring.hpp"
 
 #ifdef __cplusplus
 extern "C"
@@ -42,6 +43,11 @@ extern DWORD gPID;
 extern DWORD gSID;
 
 extern LPWSTR pAppDir;
+
+// The Mac sandbox application group ID (if exists) and container (shared) path
+extern LPCSTR gApplicationGroupId;
+extern int gApplicationGroupIdLength;
+extern PathCharString gApplicationContainerPath;
 
 /*++
 Function:

--- a/src/pal/src/include/pal/sharedmemory.inl
+++ b/src/pal/src/include/pal/sharedmemory.inl
@@ -11,43 +11,13 @@
 
 #include <string.h>
 
-template<SIZE_T DestinationByteCount, SIZE_T SourceByteCount>
-SIZE_T SharedMemoryHelpers::CopyString(
-    char (&destination)[DestinationByteCount],
-    SIZE_T destinationStartOffset,
-    const char(&source)[SourceByteCount])
+template<SIZE_T SuffixByteCount>
+void SharedMemoryHelpers::CopyPath(
+    PathCharString& destination,
+    const char (&suffix)[SuffixByteCount])
 {
-    return CopyString(destination, destinationStartOffset, source, SourceByteCount - 1);
+    CopyPath(destination, suffix, SuffixByteCount - 1);
 }
 
-template<SIZE_T DestinationByteCount>
-SIZE_T SharedMemoryHelpers::CopyString(
-    char (&destination)[DestinationByteCount],
-    SIZE_T destinationStartOffset,
-    LPCSTR source,
-    SIZE_T sourceCharCount)
-{
-    _ASSERTE(destinationStartOffset < DestinationByteCount);
-    _ASSERTE(sourceCharCount < DestinationByteCount - destinationStartOffset);
-    _ASSERTE(strlen(source) == sourceCharCount);
-
-    memcpy_s(&destination[destinationStartOffset], DestinationByteCount - destinationStartOffset, source, sourceCharCount + 1);
-    return destinationStartOffset + sourceCharCount;
-}
-
-template<SIZE_T DestinationByteCount>
-SIZE_T SharedMemoryHelpers::AppendUInt32String(
-    char (&destination)[DestinationByteCount],
-    SIZE_T destinationStartOffset,
-    UINT32 value)
-{
-    _ASSERTE(destination != nullptr);
-    _ASSERTE(destinationStartOffset < DestinationByteCount);
-
-    int valueCharCount =
-        sprintf_s(&destination[destinationStartOffset], DestinationByteCount - destinationStartOffset, "%u", value);
-    _ASSERTE(valueCharCount > 0);
-    return destinationStartOffset + valueCharCount;
-}
 
 #endif // !_PAL_SHARED_MEMORY_INL_

--- a/src/pal/src/include/pal/stackstring.hpp
+++ b/src/pal/src/include/pal/stackstring.hpp
@@ -129,6 +129,12 @@ public:
         return Set(s.m_buffer, s.m_count);
     }
 
+    template<SIZE_T bufferLength> BOOL Set(const T (&buffer)[bufferLength])
+    {
+        // bufferLength includes terminator character
+        return Set(buffer, bufferLength - 1);
+    }
+
     SIZE_T GetCount() const
     {
         return m_count;
@@ -155,6 +161,11 @@ public:
             result = (T *)m_buffer;
         }
         return result;
+    }
+
+    T * OpenStringBuffer()
+    {
+        return m_buffer;
     }
 
     //count should not include the terminating null
@@ -198,21 +209,38 @@ public:
     {
         return Append(s.GetString(), s.GetCount());
     }
-   
-   BOOL IsEmpty()
-   {
-       return 0 == m_buffer[0];
-   }
 
-   void Clear()
-   {
-       m_count = 0;
-       NullTerminate();
-   }
-   ~StackString()
-   {
-       DeleteBuffer();
-   }
+    template<SIZE_T bufferLength> BOOL Append(const T (&buffer)[bufferLength])
+    {
+        // bufferLength includes terminator character
+        return Append(buffer, bufferLength - 1);
+    }
+
+    BOOL Append(T ch)
+    {
+        SIZE_T endpos = m_count;
+        if (!Resize(m_count + 1))
+            return FALSE;
+
+        m_buffer[endpos] = ch;
+        NullTerminate();
+        return TRUE;
+    }
+
+    BOOL IsEmpty()
+    {
+        return 0 == m_buffer[0];
+    }
+
+    void Clear()
+    {
+        m_count = 0;
+        NullTerminate();
+    }
+    ~StackString()
+    {
+        DeleteBuffer();
+    }
 };
 
 #if _DEBUG

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -139,6 +139,11 @@ Volatile<LONG> terminator = 0;
 DWORD gPID = (DWORD) -1;
 DWORD gSID = (DWORD) -1;
 
+// Application group ID for this process
+LPCSTR gApplicationGroupId = nullptr;
+int gApplicationGroupIdLength = 0;
+PathCharString gApplicationContainerPath;
+
 // The lowest common supported semaphore length, including null character
 // NetBSD-7.99.25: 15 characters
 // MacOSX 10.11: 31 -- Core 1.0 RC2 compatibility
@@ -1981,6 +1986,20 @@ exit:
         sem_close(continueSem);
     }
     return launched;
+}
+
+LPCSTR
+PALAPI
+PAL_GetApplicationGroupId()
+{
+    return gApplicationGroupId;
+}
+
+BOOL
+PALAPI
+PAL_IsApplicationSandboxed()
+{
+    return gApplicationGroupId != nullptr;
 }
 
 /*++
@@ -3943,6 +3962,19 @@ PROCGetProcessStatusExit:
     }
     
     return palError;
+}
+
+bool GetApplicationContainerFolder(PathCharString& buffer, const char *applicationGroupId, int applicationGroupIdLength)
+{
+    const char *homeDir = getpwuid(getuid())->pw_dir;
+    int homeDirLength = strlen(homeDir);
+
+    // The application group container folder is defined as:
+    // /user/{loginname}/Library/Group Containers/{AppGroupId}/
+    return buffer.Set(homeDir, homeDirLength)
+        && buffer.Append(APPLICATION_CONTAINER_BASE_PATH_SUFFIX)
+        && buffer.Append(applicationGroupId, applicationGroupIdLength)
+        && buffer.Append('/');
 }
 
 #ifdef _DEBUG


### PR DESCRIPTION
When running in a sandbox, the Mac operating system will limit access to resources, esp. the file system. Right now both Mutex and SharedMemory in the PAL are accessing the /tmp folder for which Mac does not provide the application permissions to access.

Instead, the sandbox provides the ability to share information between applications by using a shared container folder. This is done by registering the application with an Application Group ID. Using this ID, we can access the shared folder and read/write from it.

Since the .Net runtime can be loaded in multiple ways, we decided that the easiest way to let the runtime know what the application group ID is via an environment variable. Thus, if the NETCOREAPP_SANDBOX_APPLICATION_GROUP_ID environment variable is set (on Mac), the runtime will assume we are sandboxed, and will use the value provided as the application group ID. Note that due to limitations on semaphore file lengths, we will not allow application group IDs longer than 13 characters. This gives us 10 characters for the developer ID, and 3 extra characters for the group name.

When sandbox is disabled (the environment variable is empty) then the folder for Mutex and SharedMemory will continue to be rooted in /tmp. However when the sandbox is enabled, these files will be created under /user/{loginname}/Library/Group Containers/{AppGroupId}/.

Fixes #20473