### PR TITLE
Remove redundant zero-initializations for long-lifetime structs.

### DIFF
--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -4208,13 +4208,14 @@ inline void Compiler::CLR_API_Leave(API_ICorJitInfo_Names ename)
 //             false otherwise
 //
 // Notes:
-//     Structs with GC pointer fields are fully zero-initialized in the prolog if compInitMem is true.
-//     Therefore, we don't need to insert zero-initialization if this block is not in a loop.
+//     If compInitMem is true, structs with GC pointer fields and long-lifetime structs
+//     are fully zero-initialized in the prologue. Therefore, we don't need to insert
+//     zero-initialization in this block if it is not in a loop.
 
 bool Compiler::fgStructTempNeedsExplicitZeroInit(LclVarDsc* varDsc, BasicBlock* block)
 {
     bool containsGCPtr = (varDsc->lvStructGcCount > 0);
-    return (!containsGCPtr || !info.compInitMem || ((block->bbFlags & BBF_BACKWARD_JUMP) != 0));
+    return (!info.compInitMem || ((block->bbFlags & BBF_BACKWARD_JUMP) != 0) || (!containsGCPtr && varDsc->lvIsTemp));
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
When compInitMem is true long-lifetime structs (i.e., the ones with lvIsTemp set to false)
are zero-initialized in the prolog: https://github.com/dotnet/coreclr/blob/c8a63947382b0db428db602238199ca81badbe8e/src/jit/codegencommon.cpp#L4765

Therefore, these structs don't need an explicit zero-initialization in blocks that are not in a loop.