### PR TITLE
Fix perf regression in master.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -18018,16 +18018,17 @@ public:
         {
             unsigned lclNum = node->AsLclVarCommon()->GetLclNum();
 
-            if (m_compiler->lvaIsImplicitByRefLocal(lclNum))
+            LclVarDsc* varDsc = m_compiler->lvaGetDesc(lclNum);
+            if (varDsc->lvIsStructField)
             {
-                // Keep track of the number of appearances of each implicit
-                // byref (here during address-exposed analysis); fgMakeOutgoingStructArgCopy
-                // checks the ref counts for implicit byref params when deciding if it's legal
-                // to elide certain copies of them.
-                LclVarDsc* varDsc = m_compiler->lvaGetDesc(lclNum);
-                JITDUMP("LocalAddressVisitor incrementing ref count from %d to %d for V%02d\n",
-                        varDsc->lvRefCnt(RCS_EARLY), varDsc->lvRefCnt(RCS_EARLY) + 1, lclNum);
-                varDsc->incLvRefCnt(1, RCS_EARLY);
+                // Promoted field, increase counter for the parent lclVar.
+                assert(!m_compiler->lvaIsImplicitByRefLocal(lclNum));
+                unsigned parentLclNum = varDsc->lvParentLcl;
+                UpdateImplicitByRefCounter(parentLclNum);
+            }
+            else
+            {
+                UpdateImplicitByRefCounter(lclNum);
             }
         }
 
@@ -18415,6 +18416,29 @@ private:
         // TODO-Cleanup: Move fgMorphLocalField implementation here, it's not used anywhere else.
         m_compiler->fgMorphLocalField(node, user);
         INDEBUG(m_stmtModified |= node->OperIs(GT_LCL_VAR);)
+    }
+
+    //------------------------------------------------------------------------
+    // UpdateImplicitByRefCounter: updates the ref count for implicit byref params.
+    //
+    // Arguments:
+    //    lclNum - the local number to update the count for.
+    //
+    // Notes:
+    //    fgMakeOutgoingStructArgCopy checks the ref counts for implicit byref params when deciding
+    //    if it's legal to elide certain copies of them;
+    //    fgRetypeImplicitByRefArgs checks the ref counts when decides to undo promotions.
+    //
+    void UpdateImplicitByRefCounter(unsigned lclNum)
+    {
+        if (!m_compiler->lvaIsImplicitByRefLocal(lclNum))
+        {
+            return;
+        }
+        LclVarDsc* varDsc = m_compiler->lvaGetDesc(lclNum);
+        JITDUMP("LocalAddressVisitor incrementing ref count from %d to %d for V%02d\n", varDsc->lvRefCnt(RCS_EARLY),
+                varDsc->lvRefCnt(RCS_EARLY) + 1, lclNum);
+        varDsc->incLvRefCnt(1, RCS_EARLY);
     }
 };
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17996,7 +17996,7 @@ public:
 #endif // DEBUG
     }
 
-    // Morph promoted struct fields and count promoted implict byref argument occurrences.
+    // Morph promoted struct fields and count implict byref argument occurrences.
     // Also create and push the value produced by the visited node. This is done here
     // rather than in PostOrderVisit because it makes it easy to handle nodes with an
     // arbitrary number of operands - just pop values until the value corresponding
@@ -18020,7 +18020,7 @@ public:
 
             if (m_compiler->lvaIsImplicitByRefLocal(lclNum))
             {
-                // Keep track of the number of appearances of each promoted implicit
+                // Keep track of the number of appearances of each implicit
                 // byref (here during address-exposed analysis); fgMakeOutgoingStructArgCopy
                 // checks the ref counts for implicit byref params when deciding if it's legal
                 // to elide certain copies of them.

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -18024,11 +18024,11 @@ public:
                 // Promoted field, increase counter for the parent lclVar.
                 assert(!m_compiler->lvaIsImplicitByRefLocal(lclNum));
                 unsigned parentLclNum = varDsc->lvParentLcl;
-                UpdateImplicitByRefCounter(parentLclNum);
+                UpdateEarlyRefCountForImplicitByRef(parentLclNum);
             }
             else
             {
-                UpdateImplicitByRefCounter(lclNum);
+                UpdateEarlyRefCountForImplicitByRef(lclNum);
             }
         }
 
@@ -18419,7 +18419,7 @@ private:
     }
 
     //------------------------------------------------------------------------
-    // UpdateImplicitByRefCounter: updates the ref count for implicit byref params.
+    // UpdateEarlyRefCountForImplicitByRef: updates the ref count for implicit byref params.
     //
     // Arguments:
     //    lclNum - the local number to update the count for.
@@ -18429,7 +18429,7 @@ private:
     //    if it's legal to elide certain copies of them;
     //    fgRetypeImplicitByRefArgs checks the ref counts when decides to undo promotions.
     //
-    void UpdateImplicitByRefCounter(unsigned lclNum)
+    void UpdateEarlyRefCountForImplicitByRef(unsigned lclNum)
     {
         if (!m_compiler->lvaIsImplicitByRefLocal(lclNum))
         {

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -18425,9 +18425,9 @@ private:
     //    lclNum - the local number to update the count for.
     //
     // Notes:
-    //    fgMakeOutgoingStructArgCopy checks the ref counts for implicit byref params when deciding
+    //    fgMakeOutgoingStructArgCopy checks the ref counts for implicit byref params when it decides
     //    if it's legal to elide certain copies of them;
-    //    fgRetypeImplicitByRefArgs checks the ref counts when decides to undo promotions.
+    //    fgRetypeImplicitByRefArgs checks the ref counts when it decides to undo promotions.
     //
     void UpdateEarlyRefCountForImplicitByRef(unsigned lclNum)
     {


### PR DESCRIPTION
The PR returns the behavior that we had before #20113:
increase the parent lclVar counter for the promoted vars, so if we have:
```
FIELD _length
\-- ADDR byref
     \-- LCL_VAR struct V01
          |-- byref  V01._pointer (offs=0x00) -> V10 tmp7
          \-- int    V01._length (offs=0x08) -> V11 tmp8
```
we transform it to `V11 tmp8` but need to update counter for the parent `V01`.


There are no diffs between this version after fix and the version before the regression.

Diffs between this version and master are as expected:
no diffs x86, no diffs x64 debug, 
overall improvement for windows x64 checked: 
  -1044 : System.Private.CoreLib.dasm (-0.03% of base),
      -91 : Span\Indexer\Indexer.dasm (-0.86% of base),
      -23 : Span\SpanBench\SpanBench.dasm (-0.15% of base)

Also during this analysis I have found several places where we can improve our promotion desisions and will publish this change later. 

Note 1: the regression  #20678 was caused by a range check that was not  eliminated, but in the future we should think about improving this elimination to support cases where LVL_VARS are not promoted but their values are known (increase analyzing depth in the hot loops when we get branch counters?).

Note 2: `fgMakeOutgoingStructArgCopy` checks counter for the tree that it sees to elide unnecessary copies, maybe it should check parents's counter instead, but the code there is tricky and I wouldn't change it here.

Fixes #20678.