### PR TITLE
Allows Debug.Fail to go through Trace Listeners

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Debug.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Debug.cs
@@ -119,7 +119,7 @@ namespace System.Diagnostics
                     stackTrace = "";
                 }
                 s_provider.WriteAssert(stackTrace, message, detailMessage);
-                DebugProvider.ShowDialog(stackTrace, message, detailMessage, SR.GetResourceString(failureKindMessage));
+                DebugProvider.FailCore(stackTrace, message, detailMessage, SR.GetResourceString(failureKindMessage));
             }
         }
 

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Debug.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Debug.cs
@@ -101,17 +101,7 @@ namespace System.Diagnostics
         {
             if (!condition)
             {
-                string stackTrace;
-                try
-                {
-                    stackTrace = new StackTrace(0, true).ToString(System.Diagnostics.StackTrace.TraceFormat.Normal);
-                }
-                catch
-                {
-                    stackTrace = "";
-                }
-                WriteAssert(stackTrace, message, detailMessage);
-                s_provider.ShowDialog(stackTrace, message, detailMessage, "Assertion Failed");
+                Fail(message, detailMessage);
             }
         }
 
@@ -128,31 +118,21 @@ namespace System.Diagnostics
                 {
                     stackTrace = "";
                 }
-                WriteAssert(stackTrace, message, detailMessage);
-                s_provider.ShowDialog(stackTrace, message, detailMessage, SR.GetResourceString(failureKindMessage));
+                s_provider.WriteAssert(stackTrace, message, detailMessage);
+                DebugProvider.ShowDialog(stackTrace, message, detailMessage, SR.GetResourceString(failureKindMessage));
             }
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
         public static void Fail(string message)
         {
-            Assert(false, message, string.Empty);
+            Fail(message, string.Empty);
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
         public static void Fail(string message, string detailMessage)
         {
-            Assert(false, message, detailMessage);
-        }
-
-        private static void WriteAssert(string stackTrace, string message, string detailMessage)
-        {
-            WriteLine(SR.DebugAssertBanner + Environment.NewLine
-                   + SR.DebugAssertShortMessage + Environment.NewLine
-                   + message + Environment.NewLine
-                   + SR.DebugAssertLongMessage + Environment.NewLine
-                   + detailMessage + Environment.NewLine
-                   + stackTrace);
+            s_provider.Fail(message, detailMessage);
         }
 
         [System.Diagnostics.Conditional("DEBUG")]

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.Unix.cs
@@ -10,8 +10,14 @@ namespace System.Diagnostics
     {
         private static readonly bool s_shouldWriteToStdErr = Environment.GetEnvironmentVariable("COMPlus_DebugWriteToStdErr") == "1";
 
-        public virtual void ShowDialog(string stackTrace, string message, string detailMessage, string errorSource)
+        public static void ShowDialog(string stackTrace, string message, string detailMessage, string errorSource)
         {
+            if (s_ShowDialog != null)
+            {
+                s_ShowDialog(stackTrace, message, detailMessage, errorSource); 
+                return;
+            }
+
             if (Debugger.IsAttached)
             {
                 Debugger.Break();

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.Unix.cs
@@ -10,11 +10,11 @@ namespace System.Diagnostics
     {
         private static readonly bool s_shouldWriteToStdErr = Environment.GetEnvironmentVariable("COMPlus_DebugWriteToStdErr") == "1";
 
-        public static void ShowDialog(string stackTrace, string message, string detailMessage, string errorSource)
+        public static void FailCore(string stackTrace, string message, string detailMessage, string errorSource)
         {
-            if (s_ShowDialog != null)
+            if (s_FailCore != null)
             {
-                s_ShowDialog(stackTrace, message, detailMessage, errorSource); 
+                s_FailCore(stackTrace, message, detailMessage, errorSource); 
                 return;
             }
 

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
@@ -24,7 +24,7 @@ namespace System.Diagnostics
                 stackTrace = "";
             }
             WriteAssert(stackTrace, message, detailMessage);
-            ShowDialog(stackTrace, message, detailMessage, "Assertion Failed");
+            FailCore(stackTrace, message, detailMessage, "Assertion Failed");
         }
 
         internal void WriteAssert(string stackTrace, string message, string detailMessage)
@@ -103,7 +103,7 @@ namespace System.Diagnostics
         }
 
         // internal and not readonly so that the tests can swap this out.
-        internal static Action<string, string, string, string> s_ShowDialog = null;
+        internal static Action<string, string, string, string> s_FailCore = null;
         internal static Action<string> s_WriteCore = null;
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
@@ -8,10 +8,35 @@
 namespace System.Diagnostics
 {
     /// <summary>
-    /// Provides default implementation for Write and ShowDialog methods in Debug class.
+    /// Provides default implementation for Write and Fail methods in Debug class.
     /// </summary>
     public partial class DebugProvider
     {
+        public virtual void Fail(string message, string detailMessage)
+        {
+            string stackTrace;
+            try
+            {
+                stackTrace = new StackTrace(0, true).ToString(System.Diagnostics.StackTrace.TraceFormat.Normal);
+            }
+            catch
+            {
+                stackTrace = "";
+            }
+            WriteAssert(stackTrace, message, detailMessage);
+            ShowDialog(stackTrace, message, detailMessage, "Assertion Failed");
+        }
+
+        internal void WriteAssert(string stackTrace, string message, string detailMessage)
+        {
+            WriteLine(SR.DebugAssertBanner + Environment.NewLine
+                   + SR.DebugAssertShortMessage + Environment.NewLine
+                   + message + Environment.NewLine
+                   + SR.DebugAssertLongMessage + Environment.NewLine
+                   + detailMessage + Environment.NewLine
+                   + stackTrace);
+        }
+
         public virtual void Write(string message)
         {
             lock (s_lock)
@@ -78,6 +103,7 @@ namespace System.Diagnostics
         }
 
         // internal and not readonly so that the tests can swap this out.
+        internal static Action<string, string, string, string> s_ShowDialog = null;
         internal static Action<string> s_WriteCore = null;
     }
 }

--- a/src/System.Private.CoreLib/src/System/Diagnostics/DebugProvider.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/DebugProvider.Windows.cs
@@ -6,11 +6,11 @@ namespace System.Diagnostics
 {
     public partial class DebugProvider
     {
-        public static void ShowDialog(string stackTrace, string message, string detailMessage, string errorSource)
+        public static void FailCore(string stackTrace, string message, string detailMessage, string errorSource)
         {
-            if (s_ShowDialog != null)
+            if (s_FailCore != null)
             {
-                s_ShowDialog(stackTrace, message, detailMessage, errorSource); 
+                s_FailCore(stackTrace, message, detailMessage, errorSource); 
                 return;
             }
 

--- a/src/System.Private.CoreLib/src/System/Diagnostics/DebugProvider.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/DebugProvider.Windows.cs
@@ -6,8 +6,14 @@ namespace System.Diagnostics
 {
     public partial class DebugProvider
     {
-        public virtual void ShowDialog(string stackTrace, string message, string detailMessage, string errorSource)
+        public static void ShowDialog(string stackTrace, string message, string detailMessage, string errorSource)
         {
+            if (s_ShowDialog != null)
+            {
+                s_ShowDialog(stackTrace, message, detailMessage, errorSource); 
+                return;
+            }
+
             if (Debugger.IsAttached)
             {
                 Debugger.Break();


### PR DESCRIPTION
Note: 
@jkotas:

- I added back s_ShowDialog delegate for use only in tests to exercise the code path on DefaultTraceListener.Fail and DebugProvider.Fail. 

Arguably, as mentioned by you earlier in https://github.com/dotnet/corefx/issues/33110 and as illustrated [here](https://github.com/dotnet/corefx/pull/33212/files#diff-dc9ad0fc1d1a292765f9407dcca816acR261), Trace Listeners can be used to show a custom dialog.
As a result, I couldn't find enough reason for adding any public API for ShowDialog.

This PR helps link Debug.Assert and Debug.Fail with Trace Listeners.

corefx PR: https://github.com/dotnet/corefx/pull/33212
cc: @jkotas @danmosemsft @eerhardt 

`UPDATE`
- Renamed ShowDialog to FailCore since in .NET Core it is not really showing dialog