### PR TITLE
Use C# compiler's static data support in Encoding.Preamble

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Text/UTF32Encoding.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/UTF32Encoding.cs
@@ -39,9 +39,6 @@ namespace System.Text
         internal static readonly UTF32Encoding s_default = new UTF32Encoding(bigEndian: false, byteOrderMark: true);
         internal static readonly UTF32Encoding s_bigEndianDefault = new UTF32Encoding(bigEndian: true, byteOrderMark: true);
 
-        private static ReadOnlySpan<byte> BigEndianPreamble => new byte[4] { 0x00, 0x00, 0xFE, 0xFF }; // uses C# compiler's optimization for static byte[] data
-        private static ReadOnlySpan<byte> LittleEndianPreamble => new byte[4] { 0xFF, 0xFE, 0x00, 0x00 };
-
         private readonly bool _emitUTF32ByteOrderMark = false;
         private readonly bool _isThrowException = false;
         private readonly bool _bigEndian = false;
@@ -1156,8 +1153,9 @@ namespace System.Text
 
         public override ReadOnlySpan<byte> Preamble =>
             GetType() != typeof(UTF32Encoding) ? new ReadOnlySpan<byte>(GetPreamble()) : // in case a derived UTF32Encoding overrode GetPreamble
-            _emitUTF32ByteOrderMark ? (_bigEndian ? BigEndianPreamble : LittleEndianPreamble) :
-            default;
+            !_emitUTF32ByteOrderMark ? default :
+            _bigEndian ? (ReadOnlySpan<byte>)new byte[4] { 0x00, 0x00, 0xFE, 0xFF } : // uses C# compiler's optimization for static byte[] data
+            (ReadOnlySpan<byte>)new byte[4] { 0xFF, 0xFE, 0x00, 0x00 };      
 
         public override bool Equals(object value)
         {

--- a/src/System.Private.CoreLib/shared/System/Text/UTF32Encoding.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/UTF32Encoding.cs
@@ -39,8 +39,8 @@ namespace System.Text
         internal static readonly UTF32Encoding s_default = new UTF32Encoding(bigEndian: false, byteOrderMark: true);
         internal static readonly UTF32Encoding s_bigEndianDefault = new UTF32Encoding(bigEndian: true, byteOrderMark: true);
 
-        private static readonly byte[] s_bigEndianPreamble = new byte[4] { 0x00, 0x00, 0xFE, 0xFF };
-        private static readonly byte[] s_littleEndianPreamble = new byte[4] { 0xFF, 0xFE, 0x00, 0x00 };
+        private static ReadOnlySpan<byte> BigEndianPreamble => new byte[4] { 0x00, 0x00, 0xFE, 0xFF }; // uses C# compiler's optimization for static byte[] data
+        private static ReadOnlySpan<byte> LittleEndianPreamble => new byte[4] { 0xFF, 0xFE, 0x00, 0x00 };
 
         private readonly bool _emitUTF32ByteOrderMark = false;
         private readonly bool _isThrowException = false;
@@ -1155,9 +1155,9 @@ namespace System.Text
         }
 
         public override ReadOnlySpan<byte> Preamble =>
-            GetType() != typeof(UTF32Encoding) ? GetPreamble() : // in case a derived UTF32Encoding overrode GetPreamble
-            _emitUTF32ByteOrderMark ? (_bigEndian ? s_bigEndianPreamble : s_littleEndianPreamble) :
-            Array.Empty<byte>();
+            GetType() != typeof(UTF32Encoding) ? new ReadOnlySpan<byte>(GetPreamble()) : // in case a derived UTF32Encoding overrode GetPreamble
+            _emitUTF32ByteOrderMark ? (_bigEndian ? BigEndianPreamble : LittleEndianPreamble) :
+            default;
 
         public override bool Equals(object value)
         {

--- a/src/System.Private.CoreLib/shared/System/Text/UTF8Encoding.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/UTF8Encoding.cs
@@ -55,14 +55,14 @@ namespace System.Text
         {
             public UTF8EncodingSealed(bool encoderShouldEmitUTF8Identifier) : base(encoderShouldEmitUTF8Identifier) { }
 
-            public override ReadOnlySpan<byte> Preamble => _emitUTF8Identifier ? s_preamble : Array.Empty<byte>();
+            public override ReadOnlySpan<byte> Preamble => _emitUTF8Identifier ? PreambleSpan : default;
         }
 
         // Used by Encoding.UTF8 for lazy initialization
         // The initialization code will not be run until a static member of the class is referenced
         internal static readonly UTF8EncodingSealed s_default = new UTF8EncodingSealed(encoderShouldEmitUTF8Identifier: true);
 
-        internal static readonly byte[] s_preamble = new byte[3] { 0xEF, 0xBB, 0xBF };
+        internal static ReadOnlySpan<byte> PreambleSpan => new byte[3] { 0xEF, 0xBB, 0xBF }; // uses C# compiler's optimization for static byte[] data
 
         // Yes, the idea of emitting U+FEFF as a UTF-8 identifier has made it into
         // the standard.
@@ -2549,9 +2549,9 @@ namespace System.Text
         }
 
         public override ReadOnlySpan<byte> Preamble =>
-            GetType() != typeof(UTF8Encoding) ? GetPreamble() : // in case a derived UTF8Encoding overrode GetPreamble
-            _emitUTF8Identifier ? s_preamble :
-            Array.Empty<byte>();
+            GetType() != typeof(UTF8Encoding) ? new ReadOnlySpan<byte>(GetPreamble()) : // in case a derived UTF8Encoding overrode GetPreamble
+            _emitUTF8Identifier ? PreambleSpan :
+            default;
 
         public override bool Equals(object value)
         {

--- a/src/System.Private.CoreLib/shared/System/Text/UnicodeEncoding.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/UnicodeEncoding.cs
@@ -26,9 +26,6 @@ namespace System.Text
         internal static readonly UnicodeEncoding s_bigEndianDefault = new UnicodeEncoding(bigEndian: true, byteOrderMark: true);
         internal static readonly UnicodeEncoding s_littleEndianDefault = new UnicodeEncoding(bigEndian: false, byteOrderMark: true);
 
-        private static ReadOnlySpan<byte> BigEndianPreamble => new byte[2] { 0xfe, 0xff }; // uses C# compiler's optimization for static byte[] data
-        private static ReadOnlySpan<byte> LittleEndianPreamble => new byte[2] { 0xff, 0xfe };
-
         private readonly bool isThrowException = false;
 
         private readonly bool bigEndian = false;
@@ -1794,8 +1791,9 @@ namespace System.Text
 
         public override ReadOnlySpan<byte> Preamble =>
             GetType() != typeof(UnicodeEncoding) ? new ReadOnlySpan<byte>(GetPreamble()) : // in case a derived UnicodeEncoding overrode GetPreamble
-            byteOrderMark ? (bigEndian ? BigEndianPreamble : LittleEndianPreamble) :
-            default;
+            !byteOrderMark ? default :
+            bigEndian ? (ReadOnlySpan<byte>)new byte[2] { 0xfe, 0xff } : // uses C# compiler's optimization for static byte[] data
+            (ReadOnlySpan<byte>)new byte[2] { 0xff, 0xfe };
 
         public override int GetMaxByteCount(int charCount)
         {

--- a/src/System.Private.CoreLib/shared/System/Text/UnicodeEncoding.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/UnicodeEncoding.cs
@@ -26,8 +26,8 @@ namespace System.Text
         internal static readonly UnicodeEncoding s_bigEndianDefault = new UnicodeEncoding(bigEndian: true, byteOrderMark: true);
         internal static readonly UnicodeEncoding s_littleEndianDefault = new UnicodeEncoding(bigEndian: false, byteOrderMark: true);
 
-        private static readonly byte[] s_bigEndianPreamble = new byte[2] { 0xfe, 0xff };
-        private static readonly byte[] s_littleEndianPreamble = new byte[2] { 0xff, 0xfe };
+        private static ReadOnlySpan<byte> BigEndianPreamble => new byte[2] { 0xfe, 0xff }; // uses C# compiler's optimization for static byte[] data
+        private static ReadOnlySpan<byte> LittleEndianPreamble => new byte[2] { 0xff, 0xfe };
 
         private readonly bool isThrowException = false;
 
@@ -1793,9 +1793,9 @@ namespace System.Text
         }
 
         public override ReadOnlySpan<byte> Preamble =>
-            GetType() != typeof(UnicodeEncoding) ? GetPreamble() : // in case a derived UnicodeEncoding overrode GetPreamble
-            byteOrderMark ? (bigEndian ? s_bigEndianPreamble : s_littleEndianPreamble) :
-            Array.Empty<byte>();
+            GetType() != typeof(UnicodeEncoding) ? new ReadOnlySpan<byte>(GetPreamble()) : // in case a derived UnicodeEncoding overrode GetPreamble
+            byteOrderMark ? (bigEndian ? BigEndianPreamble : LittleEndianPreamble) :
+            default;
 
         public override int GetMaxByteCount(int charCount)
         {


### PR DESCRIPTION
Also avoid Array.Empty and just use default span for an empty preamble.

Example IL (for UTF8Encoding.PreambleSpan):
```
  IL_0000:  ldsflda    valuetype '<PrivateImplementationDetails>'/'__StaticArrayInitTypeSize=3' '<PrivateImplementationDetails>'::'57218C316B6921E2CD61027A2387EDC31A2D9471'
  IL_0005:  ldc.i4.3
  IL_0006:  newobj     instance void valuetype System.ReadOnlySpan`1<uint8>::.ctor(void*, int32)
  IL_000b:  ret
```

cc: @jkotas, @tarekgh 