### PR TITLE
Perf improvements to Span and Memory

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Memory.cs
+++ b/src/System.Private.CoreLib/shared/System/Memory.cs
@@ -105,6 +105,7 @@ namespace System
             if (default(T) == null && array.GetType() != typeof(T[]))
                 ThrowHelper.ThrowArrayTypeMismatchException();
 #if BIT64
+            // See comment in Span<T>.Slice for how this works.
             if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)array.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 #else
@@ -256,6 +257,7 @@ namespace System
             int capturedLength = _length;
             int actualLength = capturedLength & RemoveFlagsBitMask;
 #if BIT64
+            // See comment in Span<T>.Slice for how this works.
             if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)actualLength)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 #else

--- a/src/System.Private.CoreLib/shared/System/Memory.cs
+++ b/src/System.Private.CoreLib/shared/System/Memory.cs
@@ -104,8 +104,13 @@ namespace System
             }
             if (default(T) == null && array.GetType() != typeof(T[]))
                 ThrowHelper.ThrowArrayTypeMismatchException();
+#if BIT64
+            if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)array.Length)
+                ThrowHelper.ThrowArgumentOutOfRangeException();
+#else
             if ((uint)start > (uint)array.Length || (uint)length > (uint)(array.Length - start))
                 ThrowHelper.ThrowArgumentOutOfRangeException();
+#endif
 
             _object = array;
             _index = start;
@@ -250,10 +255,13 @@ namespace System
             // Used to maintain the high-bit which indicates whether the Memory has been pre-pinned or not.
             int capturedLength = _length;
             int actualLength = capturedLength & RemoveFlagsBitMask;
-            if ((uint)start > (uint)actualLength || (uint)length > (uint)(actualLength - start))
-            {
+#if BIT64
+            if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)actualLength)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
-            }
+#else
+            if ((uint)start > (uint)actualLength || (uint)length > (uint)(actualLength - start))
+                ThrowHelper.ThrowArgumentOutOfRangeException();
+#endif
 
             // Set the high-bit to match the this._length high bit (1 for pre-pinned, 0 for unpinned).
             return new Memory<T>(_object, _index + start, length | (capturedLength & ~RemoveFlagsBitMask));

--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
@@ -450,8 +450,13 @@ namespace System
                 return default;
             }
 
+#if BIT64
+            if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)text.Length)
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+#else
             if ((uint)start > (uint)text.Length || (uint)length > (uint)(text.Length - start))
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+#endif
 
             return new ReadOnlySpan<char>(ref Unsafe.Add(ref text.GetRawStringData(), start), length);
         }
@@ -506,8 +511,13 @@ namespace System
                 return default;
             }
 
+#if BIT64
+            if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)text.Length)
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+#else
             if ((uint)start > (uint)text.Length || (uint)length > (uint)(text.Length - start))
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+#endif
 
             return new ReadOnlyMemory<char>(text, start, length);
         }

--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
@@ -451,6 +451,7 @@ namespace System
             }
 
 #if BIT64
+            // See comment in Span<T>.Slice for how this works.
             if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)text.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 #else
@@ -512,6 +513,7 @@ namespace System
             }
 
 #if BIT64
+            // See comment in Span<T>.Slice for how this works.
             if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)text.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 #else

--- a/src/System.Private.CoreLib/shared/System/ReadOnlyMemory.cs
+++ b/src/System.Private.CoreLib/shared/System/ReadOnlyMemory.cs
@@ -77,8 +77,13 @@ namespace System
                 this = default;
                 return; // returns default
             }
+#if BIT64
+            if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)array.Length)
+                ThrowHelper.ThrowArgumentOutOfRangeException();
+#else
             if ((uint)start > (uint)array.Length || (uint)length > (uint)(array.Length - start))
                 ThrowHelper.ThrowArgumentOutOfRangeException();
+#endif
 
             _object = array;
             _index = start;
@@ -172,10 +177,13 @@ namespace System
             // Used to maintain the high-bit which indicates whether the Memory has been pre-pinned or not.
             int capturedLength = _length;
             int actualLength = _length & RemoveFlagsBitMask;
-            if ((uint)start > (uint)actualLength || (uint)length > (uint)(actualLength - start))
-            {
+#if BIT64
+            if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)actualLength)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
-            }
+#else
+            if ((uint)start > (uint)actualLength || (uint)length > (uint)(actualLength - start))
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+#endif
 
             // Set the high-bit to match the this._length high bit (1 for pre-pinned, 0 for unpinned).
             return new ReadOnlyMemory<T>(_object, _index + start, length | (capturedLength & ~RemoveFlagsBitMask));

--- a/src/System.Private.CoreLib/shared/System/ReadOnlyMemory.cs
+++ b/src/System.Private.CoreLib/shared/System/ReadOnlyMemory.cs
@@ -78,6 +78,7 @@ namespace System
                 return; // returns default
             }
 #if BIT64
+            // See comment in Span<T>.Slice for how this works.
             if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)array.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 #else
@@ -178,6 +179,7 @@ namespace System
             int capturedLength = _length;
             int actualLength = _length & RemoveFlagsBitMask;
 #if BIT64
+            // See comment in Span<T>.Slice for how this works.
             if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)actualLength)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
 #else

--- a/src/System.Private.CoreLib/shared/System/ReadOnlySpan.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/ReadOnlySpan.Fast.cs
@@ -75,8 +75,13 @@ namespace System
                 this = default;
                 return; // returns default
             }
+#if BIT64
+            if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)array.Length)
+                ThrowHelper.ThrowArgumentOutOfRangeException();
+#else
             if ((uint)start > (uint)array.Length || (uint)length > (uint)(array.Length - start))
                 ThrowHelper.ThrowArgumentOutOfRangeException();
+#endif
 
             _pointer = new ByReference<T>(ref Unsafe.Add(ref Unsafe.As<byte, T>(ref array.GetRawSzArrayData()), start));
             _length = length;
@@ -259,8 +264,13 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ReadOnlySpan<T> Slice(int start, int length)
         {
+#if BIT64
+            if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)_length)
+                ThrowHelper.ThrowArgumentOutOfRangeException();
+#else
             if ((uint)start > (uint)_length || (uint)length > (uint)(_length - start))
                 ThrowHelper.ThrowArgumentOutOfRangeException();
+#endif
 
             return new ReadOnlySpan<T>(ref Unsafe.Add(ref _pointer.Value, start), length);
         }

--- a/src/System.Private.CoreLib/shared/System/ReadOnlySpan.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/ReadOnlySpan.Fast.cs
@@ -76,6 +76,7 @@ namespace System
                 return; // returns default
             }
 #if BIT64
+            // See comment in Span<T>.Slice for how this works.
             if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)array.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 #else
@@ -265,6 +266,7 @@ namespace System
         public ReadOnlySpan<T> Slice(int start, int length)
         {
 #if BIT64
+            // See comment in Span<T>.Slice for how this works.
             if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)_length)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 #else

--- a/src/System.Private.CoreLib/shared/System/Span.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/Span.Fast.cs
@@ -82,6 +82,7 @@ namespace System
             if (default(T) == null && array.GetType() != typeof(T[]))
                 ThrowHelper.ThrowArrayTypeMismatchException();
 #if BIT64
+            // See comment in Span<T>.Slice for how this works.
             if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)array.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 #else
@@ -344,6 +345,12 @@ namespace System
         public Span<T> Slice(int start, int length)
         {
 #if BIT64
+            // Since start and length are both 32-bit, their sum can be computed across a 64-bit domain
+            // without loss of fidelity. The cast to uint before the cast to ulong ensures that the
+            // extension from 32- to 64-bit is zero-extending rather than sign-extending. The end result
+            // of this is that if either input is negative or if the input sum overflows past Int32.MaxValue,
+            // that information is captured correctly in the comparison against the backing _length field.
+            // We don't use this same mechanism in a 32-bit process due to the overhead of 64-bit arithmetic.
             if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)_length)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 #else

--- a/src/System.Private.CoreLib/shared/System/Span.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/Span.Fast.cs
@@ -81,8 +81,13 @@ namespace System
             }
             if (default(T) == null && array.GetType() != typeof(T[]))
                 ThrowHelper.ThrowArrayTypeMismatchException();
+#if BIT64
+            if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)array.Length)
+                ThrowHelper.ThrowArgumentOutOfRangeException();
+#else
             if ((uint)start > (uint)array.Length || (uint)length > (uint)(array.Length - start))
                 ThrowHelper.ThrowArgumentOutOfRangeException();
+#endif
 
             _pointer = new ByReference<T>(ref Unsafe.Add(ref Unsafe.As<byte, T>(ref array.GetRawSzArrayData()), start));
             _length = length;
@@ -338,8 +343,13 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Span<T> Slice(int start, int length)
         {
+#if BIT64
+            if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)_length)
+                ThrowHelper.ThrowArgumentOutOfRangeException();
+#else
             if ((uint)start > (uint)_length || (uint)length > (uint)(_length - start))
                 ThrowHelper.ThrowArgumentOutOfRangeException();
+#endif
 
             return new Span<T>(ref Unsafe.Add(ref _pointer.Value, start), length);
         }


### PR DESCRIPTION
This improves the performance of `MemoryExtensions.AsSpan<T>`, `Span<T>..ctor`, and `Span<T>.Slice` (and the read-only and `Memory<T>` equivalents) when the caller is responsible for providing both a start index and an offset parameter. Currently this is implemented via two branches that the JIT can't always elide. With this PR, on 64-bit machines, this is implemented as a single branch _and_ allows the JIT to perform constant-time folding where applicable, which offers performance gains in span-heavy parsing / formatting code.

As an example, I've provided metrics for `Guid.Parse(string) : Guid` and `WebUtility.HtmlEncode(string) : string`. `Guid.Parse` uses `Span.Slice` heavily, which is shown by the substantial increase in overall throughput between the baseline and this PR. `WebUtility.HtmlEncode` uses `ValueStringBuilder` under the covers, which uses `Span.Slice` internally but is a bit more conservative with those calls, so you'll see some throughput increase but nothing quite as substantial as `Guid`'s code did.

|     Method |       Toolchain |                value |     Mean |     Error |    StdDev | Ratio |
|----------- |---------------- |--------------------- |---------:|----------:|----------:|------:|
| **Guid_Parse** |        **baseline (27012-03)** | **2153e(...)c7c13 [36]** | **23.62 ms** | **0.3638 ms** | **0.3225 ms** |  **1.00** |
| Guid_Parse | experimental | 2153e(...)c7c13 [36] | 13.61 ms | 0.1180 ms | 0.1104 ms |  0.58 |
|            |                 |                      |                      |          |           |           |       |
| **HtmlEncode** |        **baseline (27012-03)** | **&amp;&lt;&gt;&amp;&lt;(...)&lt;&gt;&amp;&lt;&gt; [48]** | **71.50 ms** | **0.9397 ms** | **0.8331 ms** |  **1.00** |
| HtmlEncode | experimental | &amp;&lt;&gt;&amp;&lt;(...)&lt;&gt;&amp;&lt;&gt; [48] | 68.85 ms | 1.0039 ms | 0.9391 ms |  0.96 |