### PR TITLE
PMI asm diffs changes

### DIFF
--- a/src/publish.proj
+++ b/src/publish.proj
@@ -143,6 +143,7 @@
     </PropertyGroup>
     <ItemGroup>
       <SymbolPackagesToPublish Include="$(SymbolsPackagesPattern)" />
+      <SymbolPackagesToPublish Remove="*freebsd*.symbols.nupkg" />
     </ItemGroup>
     <Error Condition="'$(SymbolServerPath)'==''" Text="Missing property SymbolServerPath" />
     <Error Condition="'$(SymbolServerPAT)'==''" Text="Missing property SymbolServerPAT" />


### PR DESCRIPTION
1. Fix Ubuntu arm32 on-hardware asm diffs. Need to copy the "Product" tree to the arm32 device for jitutils.
2. Change the diffs to do framework diffs, not just corelib. I also enabled benchmarks, but that doesn't quite work because I currently don't build the test tree (and then copy it, in the case of arm32/arm64). That can be done as a subsequent step.
