### PR TITLE
Fix broken float compare mapping to VNFunc

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -17204,16 +17204,15 @@ void GenTree::ParseArrayAddress(
             // Perform ((inxVN / elemSizeVN) + vnForConstInd)
             if (!canFoldDiv)
             {
-                ValueNum vnForElemSize = vnStore->VNForPtrSizeIntCon(elemSize);
-                ValueNum vnForScaledInx =
-                    vnStore->VNForFunc(TYP_I_IMPL, GetVNFuncForOper(GT_DIV, VOK_Default), inxVN, vnForElemSize);
-                *pInxVN = vnForScaledInx;
+                ValueNum vnForElemSize  = vnStore->VNForPtrSizeIntCon(elemSize);
+                ValueNum vnForScaledInx = vnStore->VNForFunc(TYP_I_IMPL, VNFunc(GT_DIV), inxVN, vnForElemSize);
+                *pInxVN                 = vnForScaledInx;
             }
 
             if (constInd != 0)
             {
                 ValueNum vnForConstInd = comp->GetValueNumStore()->VNForPtrSizeIntCon(constInd);
-                VNFunc   vnFunc        = GetVNFuncForOper(GT_ADD, VOK_Default);
+                VNFunc   vnFunc        = VNFunc(GT_ADD);
 
                 *pInxVN = comp->GetValueNumStore()->VNForFunc(TYP_I_IMPL, vnFunc, *pInxVN, vnForConstInd);
             }
@@ -17331,7 +17330,7 @@ void GenTree::ParseArrayAddressWork(Compiler*       comp,
         if (inputMul != 1)
         {
             ValueNum mulVN = comp->GetValueNumStore()->VNForLongCon(inputMul);
-            vn = comp->GetValueNumStore()->VNForFunc(TypeGet(), GetVNFuncForOper(GT_MUL, VOK_Default), mulVN, vn);
+            vn             = comp->GetValueNumStore()->VNForFunc(TypeGet(), VNFunc(GT_MUL), mulVN, vn);
         }
         if (*pInxVN == ValueNumStore::NoVN)
         {
@@ -17339,8 +17338,7 @@ void GenTree::ParseArrayAddressWork(Compiler*       comp,
         }
         else
         {
-            *pInxVN =
-                comp->GetValueNumStore()->VNForFunc(TypeGet(), GetVNFuncForOper(GT_ADD, VOK_Default), *pInxVN, vn);
+            *pInxVN = comp->GetValueNumStore()->VNForFunc(TypeGet(), VNFunc(GT_ADD), *pInxVN, vn);
         }
     }
 }

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -274,7 +274,7 @@ TFp FpRem(TFp dividend, TFp divisor)
 //
 VNFunc GetVNFuncForNode(GenTree* node)
 {
-    static const VNFunc relopFuncs[]{VNF_LT_UN, VNF_LE_UN, VNF_GE_UN, VNF_GT_UN};
+    static const VNFunc relopUnFuncs[]{VNF_LT_UN, VNF_LE_UN, VNF_GE_UN, VNF_GT_UN};
     static_assert_no_msg(GT_LE - GT_LT == 1);
     static_assert_no_msg(GT_GE - GT_LT == 2);
     static_assert_no_msg(GT_GT - GT_LT == 3);
@@ -311,7 +311,7 @@ VNFunc GetVNFuncForNode(GenTree* node)
                 assert(varTypeIsFloating(node->gtGetOp2()));
                 if ((node->gtFlags & GTF_RELOP_NAN_UN) != 0)
                 {
-                    return relopFuncs[node->OperGet() - GT_LT];
+                    return relopUnFuncs[node->OperGet() - GT_LT];
                 }
             }
             else
@@ -320,7 +320,7 @@ VNFunc GetVNFuncForNode(GenTree* node)
                 assert(varTypeIsIntegralOrI(node->gtGetOp2()));
                 if (node->IsUnsigned())
                 {
-                    return relopFuncs[node->OperGet() - GT_LT];
+                    return relopUnFuncs[node->OperGet() - GT_LT];
                 }
             }
             break;

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -257,215 +257,102 @@ TFp FpRem(TFp dividend, TFp divisor)
 }
 
 //--------------------------------------------------------------------------------
-// VNGetOperKind:   - Given two bools: isUnsigned and overFlowCheck
-//                    return the correct VNOperKind for them.
+// GetVNFuncForNode: Given a GenTree node, this returns the proper VNFunc to use
+// for ValueNumbering
 //
 // Arguments:
-//    isUnsigned    - The operKind returned should have the unsigned property
-//    overflowCheck - The operKind returned should have the overflow check property
+//    node - The GenTree node that we need the VNFunc for.
 //
 // Return Value:
-//                  - The VNOperKind to use for this pair of (isUnsigned, overflowCheck)
+//    The VNFunc to use for this GenTree node
 //
-VNOperKind VNGetOperKind(bool isUnsigned, bool overflowCheck)
-{
-    if (!isUnsigned)
-    {
-        if (!overflowCheck)
-        {
-            return VOK_Default;
-        }
-        else
-        {
-            return VOK_OverflowCheck;
-        }
-    }
-    else // isUnsigned
-    {
-        if (!overflowCheck)
-        {
-            return VOK_Unsigned;
-        }
-        else
-        {
-            return VOK_Unsigned_OverflowCheck;
-        }
-    }
-}
-
-//--------------------------------------------------------------------------------
-// GetVNFuncForOper:  - Given a genTreeOper this function Returns the correct
-//                         VNFunc to use for ValueNumbering
-//
-// Arguments:
-//    oper            - The gtOper value from the GenTree node
-//    operKind        - An enum that supports Normal, Unsigned, OverflowCheck,
-//                      and Unsigned_OverflowCheck,
-//
-// Return Value:
-//               - The VNFunc to use for this pair of (oper, operKind)
-//
-// Notes:        - An assert will fire when the oper does not support
-//                 the operKInd that is supplied.
-//
-VNFunc GetVNFuncForOper(genTreeOps oper, VNOperKind operKind)
-{
-    VNFunc result  = VNF_COUNT; // An illegal value
-    bool   invalid = false;
-
-    // For most genTreeOpers we just use the VNFunc with the same enum value as the oper
-    //
-    if (operKind == VOK_Default)
-    {
-        // We can directly use the enum value of oper
-        result = VNFunc(oper);
-    }
-    else if ((oper == GT_EQ) || (oper == GT_NE))
-    {
-        if (operKind == VOK_Unsigned)
-        {
-            // We will permit unsignedOper to be used with GT_EQ and GT_NE (as it is a no-op)
-            //
-            // Again we directly use the enum value of oper
-            result = VNFunc(oper);
-        }
-        else
-        {
-            invalid = true;
-        }
-    }
-    else // We will need to use a VNF_ function
-    {
-        switch (oper)
-        {
-            case GT_LT:
-                if (operKind == VOK_Unsigned)
-                {
-                    result = VNF_LT_UN;
-                }
-                else
-                {
-                    invalid = true;
-                }
-                break;
-
-            case GT_LE:
-                if (operKind == VOK_Unsigned)
-                {
-                    result = VNF_LE_UN;
-                }
-                else
-                {
-                    invalid = true;
-                }
-                break;
-
-            case GT_GE:
-                if (operKind == VOK_Unsigned)
-                {
-                    result = VNF_GE_UN;
-                }
-                else
-                {
-                    invalid = true;
-                }
-                break;
-
-            case GT_GT:
-                if (operKind == VOK_Unsigned)
-                {
-                    result = VNF_GT_UN;
-                }
-                else
-                {
-                    invalid = true;
-                }
-                break;
-
-            case GT_ADD:
-                if (operKind == VOK_OverflowCheck)
-                {
-                    result = VNF_ADD_OVF;
-                }
-                else if (operKind == VOK_Unsigned_OverflowCheck)
-                {
-                    result = VNF_ADD_UN_OVF;
-                }
-                else
-                {
-                    invalid = true;
-                }
-                break;
-
-            case GT_SUB:
-                if (operKind == VOK_OverflowCheck)
-                {
-                    result = VNF_SUB_OVF;
-                }
-                else if (operKind == VOK_Unsigned_OverflowCheck)
-                {
-                    result = VNF_SUB_UN_OVF;
-                }
-                else
-                {
-                    invalid = true;
-                }
-                break;
-
-            case GT_MUL:
-                if (operKind == VOK_OverflowCheck)
-                {
-                    result = VNF_MUL_OVF;
-                }
-                else if (operKind == VOK_Unsigned_OverflowCheck)
-                {
-                    result = VNF_MUL_UN_OVF;
-                }
-#ifndef _TARGET_64BIT_
-                else if (operKind == VOK_Unsigned)
-                {
-                    // This is the special 64-bit unsigned multiply used on 32-bit targets
-                    result = VNF_MUL64_UN;
-                }
-#endif
-                else
-                {
-                    invalid = true;
-                }
-                break;
-
-            default:
-                // Will trigger the noway_assert below.
-                break;
-        }
-    }
-    noway_assert(!invalid && (result != VNF_COUNT));
-
-    return result;
-}
-
-//--------------------------------------------------------------------------------
-// GetVNFuncForNode:  - Given a GenTree node, this returns the proper
-//                      VNFunc to use for ValueNumbering
-//
-// Arguments:
-//    node            - The GenTree node that we need the VNFunc for.
-//
-// Return Value:
-//               - The VNFunc to use for this GenTree node
-//
-// Notes:        - The gtFlags from the node are used to set operKind
-//                 to one of Normal, Unsigned, OverflowCheck,
-//                 or Unsigned_OverflowCheck. Also see GetVNFuncForOper()
+// Notes:
+//    Some opers have their semantics affected by GTF flags so they need to be
+//    replaced by special VNFunc values:
+//      - relops are affected by GTF_UNSIGNED/GTF_RELOP_NAN_UN
+//      - ADD/SUB/MUL are affected by GTF_OVERFLOW and GTF_UNSIGNED
 //
 VNFunc GetVNFuncForNode(GenTree* node)
 {
-    bool       isUnsignedOper   = ((node->gtFlags & GTF_UNSIGNED) != 0);
-    bool       hasOverflowCheck = node->gtOverflowEx();
-    VNOperKind operKind         = VNGetOperKind(isUnsignedOper, hasOverflowCheck);
-    VNFunc     result           = GetVNFuncForOper(node->gtOper, operKind);
+    static const VNFunc relopFuncs[]{VNF_LT_UN, VNF_LE_UN, VNF_GE_UN, VNF_GT_UN};
+    static_assert_no_msg(GT_LE - GT_LT == 1);
+    static_assert_no_msg(GT_GE - GT_LT == 2);
+    static_assert_no_msg(GT_GT - GT_LT == 3);
 
-    return result;
+    static const VNFunc binopOvfFuncs[]{VNF_ADD_OVF, VNF_SUB_OVF, VNF_MUL_OVF};
+    static const VNFunc binopUnOvfFuncs[]{VNF_ADD_UN_OVF, VNF_SUB_UN_OVF, VNF_MUL_UN_OVF};
+    static_assert_no_msg(GT_SUB - GT_ADD == 1);
+    static_assert_no_msg(GT_MUL - GT_ADD == 2);
+
+    switch (node->OperGet())
+    {
+        case GT_EQ:
+            if (varTypeIsFloating(node->gtGetOp1()))
+            {
+                assert(varTypeIsFloating(node->gtGetOp2()));
+                assert((node->gtFlags & GTF_RELOP_NAN_UN) == 0);
+            }
+            break;
+
+        case GT_NE:
+            if (varTypeIsFloating(node->gtGetOp1()))
+            {
+                assert(varTypeIsFloating(node->gtGetOp2()));
+                assert((node->gtFlags & GTF_RELOP_NAN_UN) != 0);
+            }
+            break;
+
+        case GT_LT:
+        case GT_LE:
+        case GT_GT:
+        case GT_GE:
+            if (varTypeIsFloating(node->gtGetOp1()))
+            {
+                assert(varTypeIsFloating(node->gtGetOp2()));
+                if ((node->gtFlags & GTF_RELOP_NAN_UN) != 0)
+                {
+                    return relopFuncs[node->OperGet() - GT_LT];
+                }
+            }
+            else
+            {
+                assert(varTypeIsIntegralOrI(node->gtGetOp1()));
+                assert(varTypeIsIntegralOrI(node->gtGetOp2()));
+                if (node->IsUnsigned())
+                {
+                    return relopFuncs[node->OperGet() - GT_LT];
+                }
+            }
+            break;
+
+        case GT_ADD:
+        case GT_SUB:
+        case GT_MUL:
+            if (varTypeIsIntegralOrI(node->gtGetOp1()) && node->gtOverflow())
+            {
+                assert(varTypeIsIntegralOrI(node->gtGetOp2()));
+                if (node->IsUnsigned())
+                {
+                    return binopUnOvfFuncs[node->OperGet() - GT_ADD];
+                }
+                else
+                {
+                    return binopOvfFuncs[node->OperGet() - GT_ADD];
+                }
+            }
+            break;
+
+        case GT_CAST:
+            // GT_CAST can overflow but it has special handling and it should not appear here.
+            unreached();
+
+        default:
+            // Make sure we don't miss an onverflow oper, if a new one is ever added.
+            assert(!GenTree::OperMayOverflow(node->OperGet()));
+            break;
+    }
+
+    return VNFunc(node->OperGet());
 }
 
 unsigned ValueNumStore::VNFuncArity(VNFunc vnf)
@@ -3520,55 +3407,48 @@ ValueNum ValueNumStore::EvalUsingMathIdentity(var_types typ, VNFunc func, ValueN
                 break;
 
             case GT_EQ:
+                // (null == non-null) == false
+                // (non-null == null) == false
+                if (((arg0VN == VNForNull()) && IsKnownNonNull(arg1VN)) ||
+                    ((arg1VN == VNForNull()) && IsKnownNonNull(arg0VN)))
+                {
+                    resultVN = VNZeroForType(typ);
+                    break;
+                }
+                // (x == x) == true (integer only)
+                __fallthrough;
             case GT_GE:
             case GT_LE:
-                // (x == x) == true,  (null == non-null) == false,  (non-null == null) == false
-                // (x <= x) == true,  (null <= non-null) == false,  (non-null <= null) == false
-                // (x >= x) == true,  (null >= non-null) == false,  (non-null >= null) == false
-                //
-                // This identity does not apply for floating point (when x == NaN)
-                //
-
-                if (arg0VN == arg1VN)
+                // (x <= x) == true (integer only)
+                // (x >= x) == true (integer only)
+                if ((arg0VN == arg1VN) && varTypeIsIntegralOrI(TypeOfVN(arg0VN)))
                 {
-                    if (varTypeIsIntegralOrI(TypeOfVN(arg0VN)))
-                    {
-                        resultVN = VNOneForType(typ);
-                    }
-                }
-                else
-                {
-                    if (((arg0VN == VNForNull()) && IsKnownNonNull(arg1VN)) ||
-                        (IsKnownNonNull(arg0VN) && (arg1VN == VNForNull())))
-                    {
-                        resultVN = VNZeroForType(typ);
-                    }
+                    resultVN = VNOneForType(typ);
                 }
                 break;
 
             case GT_NE:
+                // (null != non-null) == true
+                // (non-null != null) == true
+                if (((arg0VN == VNForNull()) && IsKnownNonNull(arg1VN)) ||
+                    ((arg1VN == VNForNull()) && IsKnownNonNull(arg0VN)))
+                {
+                    resultVN = VNOneForType(typ);
+                }
+                // (x != x) == false (integer only)
+                else if ((arg0VN == arg1VN) && varTypeIsIntegralOrI(TypeOfVN(arg0VN)))
+                {
+                    resultVN = VNZeroForType(typ);
+                }
+                break;
+
             case GT_GT:
             case GT_LT:
-                // (x != x) == false,  (null != non-null) == true,  (non-null != null) == true
-                // (x > x)  == false,  (null > non-null) == true,  (non-null > null) == true
-                // (x < x)  == false,  (null < non-null) == true,  (non-null < null) == true
-                //
-                // This identity does not apply for floating point (when x == NaN)
-                //
+                // (x > x) == false (integer & floating point)
+                // (x < x) == false (integer & floating point)
                 if (arg0VN == arg1VN)
                 {
-                    if (varTypeIsIntegralOrI(TypeOfVN(arg0VN)))
-                    {
-                        resultVN = VNZeroForType(typ);
-                    }
-                }
-                else
-                {
-                    if (((arg0VN == VNForNull()) && IsKnownNonNull(arg1VN)) ||
-                        (IsKnownNonNull(arg0VN) && (arg1VN == VNForNull())))
-                    {
-                        resultVN = VNOneForType(typ);
-                    }
+                    resultVN = VNZeroForType(typ);
                 }
                 break;
 
@@ -3606,17 +3486,10 @@ ValueNum ValueNumStore::EvalUsingMathIdentity(var_types typ, VNFunc func, ValueN
             case VNF_LE_UN:
                 // (0 <= x) == true
                 // (x <= x) == true
-                // TODO-Bug: Unlike (x < x) and (x > x), (x >= x) and (x <= x) also apply to
-                // floating point comparisons: x is either equal to itself or is unordered
-                // if it's NaN.
-                // However, GetVNFuncForNode is broken for floating point comparisons and creates
-                // VNF_LT/GT/GE/LE_UN based on the GTF_UNSIGNED flag instead of the GTF_RELOP_NAN_UN
-                // flag. This happens to work in many cases because the importer sets both but
-                // sometimes the 2 flags can get out of sync (e.g. gtReverseCond flips only
-                // GTF_RELOP_NAN_UN).
-                // In summary - attempting to eval floating point comparisons here triggers a bug.
-                if (varTypeIsIntegralOrI(TypeOfVN(arg0VN)) &&
-                    ((arg0VN == VNZeroForType(TypeOfVN(arg0VN))) || (arg0VN == arg1VN)))
+                // Unlike (x < x) and (x > x), (x >= x) and (x <= x) also apply to floating
+                // point comparisons: x is either equal to itself or is unordered if it's NaN.
+                if ((varTypeIsIntegralOrI(TypeOfVN(arg0VN)) && (arg0VN == VNZeroForType(TypeOfVN(arg0VN)))) ||
+                    (arg0VN == arg1VN))
                 {
                     resultVN = VNOneForType(typ);
                 }

--- a/src/jit/valuenum.h
+++ b/src/jit/valuenum.h
@@ -47,26 +47,7 @@ enum VNFunc
     VNF_COUNT
 };
 
-enum VNOperKind
-{
-    VOK_Default,
-    VOK_Unsigned,
-    VOK_OverflowCheck,
-    VOK_Unsigned_OverflowCheck
-};
-
-// Given the bool values isUnsigned and overflowCheck return the proper VNOperKInd enum
-//
-VNOperKind VNGetOperKind(bool isUnsigned, bool overflowCheck);
-
-// Given an "oper" and associated flags with it, transform the oper into a
-// more accurate oper that can be used in evaluation.
-// For example, (GT_ADD, true, false) transforms to GT_ADD_UN
-// and (GT_ADD, false, true) transforms to GT_ADD_OVF
-//
-VNFunc GetVNFuncForOper(genTreeOps oper, VNOperKind operKind);
-
-// Given a GenTree node return the VNFunc that shodul be used when value numbering
+// Given a GenTree node return the VNFunc that should be used when value numbering
 //
 VNFunc GetVNFuncForNode(GenTree* node);
 

--- a/src/jit/valuenumfuncs.h
+++ b/src/jit/valuenumfuncs.h
@@ -147,8 +147,6 @@ ValueNumFuncDef(LE_UN, 2, false, false, false)
 ValueNumFuncDef(GE_UN, 2, false, false, false)
 ValueNumFuncDef(GT_UN, 2, false, false, false)
 
-ValueNumFuncDef(MUL64_UN, 2, true, false, false)    // unsigned multiplication (used by 32-bit targets)
-
 // currently we won't constant fold the next six
 
 ValueNumFuncDef(ADD_OVF, 2, true, false, false)     // overflow checking operations


### PR DESCRIPTION
This fixes some issues in VN's mapping of GenTree opers to VN funcs:
* for floating point relops `GTF_RELOP_NAN_UN` should be used to detect unordered comparisons, not `GTF_UNSIGNED`. The importer sets both so it may appear that it works fine, until `gtReverseCond` is used. For floating point relops that one toggles only `GTF_RELOP_NAN_UN`, not `GTF_UNSIGNED`.
* more generally, the existing `GetVNFuncForNode` attempts to extract `GTF_UNSIGNED` and `GTF_OVERFLOW` without first checking what operator and type the node has. This is somewhat risky, as flags may have been left set after an operator change. It probably won't happen in the case of `GTF_OVERFLOW` but still, it's preferable to check the flags only when they are relevant.
* remove a strange mapping of an unsigned `GT_MUL` to `VNF_MUL64_UN` on 32 bit. This was probably intended to handle `GTF_MUL_64RSLT` but that doesn't make sense, that flag doesn't affect the semantics of `GT_MUL` in any way. It's mainly a marker flag for morph to not attempt to detect such multiplications a second time. In fact, it can probably be removed.

At the same time I also cleaned up `EvalUsingMathIdentity` a bit:
* it was claimed that `(x VNF_GE_UN x) == true` does not hold for floating point due to NaN. But it does hold since it's an unordered comparison so NaN >= NaN is true. Same for `x GT_GT x`, it's false for both non-NaN and NaN. While not exactly useful for CQ it seems preferable to handle these cases for the sake of clarity.
* signed comparisons included the strange case of 
```
// (null > non-null) == true,  (non-null > null) == true
// (null < non-null) == true,  (non-null < null) == true
```
I'm not sure how null can be greater than non-null. Nor is null < non-null 100% accurate, these are signed comparisons and in rare cases (Windows 32 bit + /3GB switch) you could probably get negative object addresses. But more importantly, these should not be needed, comparing object references/managed pointers using GT/LT/GE/LE is supposed to be invalid in IL.