### PR TITLE
Optimization: Further reduce allocations in GetCustomAtttributes() paths

### DIFF
--- a/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -61,7 +61,7 @@ namespace System.Reflection
             Debug.Assert(target != null);
 
             IList<CustomAttributeData> cad = GetCustomAttributes(target.GetRuntimeModule(), target.MetadataToken);
-            RuntimeType.ListBuilder<Attribute> pcas = PseudoCustomAttribute.GetCustomAttributes((RuntimeType)target, (RuntimeType)typeof(object));
+            PseudoCustomAttribute.GetCustomAttributes((RuntimeType)target, (RuntimeType)typeof(object), out RuntimeType.ListBuilder<Attribute> pcas);
             return GetCombinedList(cad, ref pcas);
         }
 
@@ -1221,7 +1221,7 @@ namespace System.Reflection
             if (type.IsGenericType && !type.IsGenericTypeDefinition)
                 type = type.GetGenericTypeDefinition() as RuntimeType;
 
-            RuntimeType.ListBuilder<Attribute> pcas = PseudoCustomAttribute.GetCustomAttributes(type, caType);
+            PseudoCustomAttribute.GetCustomAttributes(type, caType, out RuntimeType.ListBuilder<Attribute> pcas);
 
             // if we are asked to go up the hierarchy chain we have to do it now and regardless of the
             // attribute usage for the specific attribute because a derived attribute may override the usage...           
@@ -1846,29 +1846,26 @@ namespace System.Reflection
         #endregion
 
         #region Internal Static
-        internal static RuntimeType.ListBuilder<Attribute> GetCustomAttributes(RuntimeType type, RuntimeType caType)
+        internal static void GetCustomAttributes(RuntimeType type, RuntimeType caType, out RuntimeType.ListBuilder<Attribute> attributes)
         {
             Debug.Assert(type != null);
             Debug.Assert(caType != null);
+            attributes = new RuntimeType.ListBuilder<Attribute>(0);
 
             bool all = caType == typeof(object) || caType == typeof(Attribute);
             if (!all && !s_pca.ContainsKey(caType))
-                return default;
-
-            RuntimeType.ListBuilder<Attribute> pcas = new RuntimeType.ListBuilder<Attribute>(0);
+                return;
 
             if (all || caType == typeof(SerializableAttribute))
             {
                 if ((type.Attributes & TypeAttributes.Serializable) != 0)
-                    pcas.Add(new SerializableAttribute());
+                    attributes.Add(new SerializableAttribute());
             }
             if (all || caType == typeof(ComImportAttribute))
             {
                 if ((type.Attributes & TypeAttributes.Import) != 0)
-                    pcas.Add(new ComImportAttribute());
+                    attributes.Add(new ComImportAttribute());
             }
-
-            return pcas;
         }
         internal static bool IsDefined(RuntimeType type, RuntimeType caType)
         {

--- a/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -62,7 +62,7 @@ namespace System.Reflection
 
             IList<CustomAttributeData> cad = GetCustomAttributes(target.GetRuntimeModule(), target.MetadataToken);
             RuntimeType.ListBuilder<Attribute> pcas = PseudoCustomAttribute.GetCustomAttributes((RuntimeType)target, (RuntimeType)typeof(object));
-            return GetCombinedList(cad, pcas);
+            return GetCombinedList(cad, ref pcas);
         }
 
         internal static IList<CustomAttributeData> GetCustomAttributesInternal(RuntimeFieldInfo target)
@@ -71,7 +71,7 @@ namespace System.Reflection
 
             IList<CustomAttributeData> cad = GetCustomAttributes(target.GetRuntimeModule(), target.MetadataToken);
             RuntimeType.ListBuilder<Attribute> pcas = PseudoCustomAttribute.GetCustomAttributes((RuntimeFieldInfo)target, (RuntimeType)typeof(object));
-            return GetCombinedList(cad, pcas);
+            return GetCombinedList(cad, ref pcas);
         }
 
         internal static IList<CustomAttributeData> GetCustomAttributesInternal(RuntimeMethodInfo target)
@@ -80,7 +80,7 @@ namespace System.Reflection
 
             IList<CustomAttributeData> cad = GetCustomAttributes(target.GetRuntimeModule(), target.MetadataToken);
             RuntimeType.ListBuilder<Attribute> pcas = PseudoCustomAttribute.GetCustomAttributes((RuntimeMethodInfo)target, (RuntimeType)typeof(object));
-            return GetCombinedList(cad, pcas);
+            return GetCombinedList(cad, ref pcas);
         }
 
         internal static IList<CustomAttributeData> GetCustomAttributesInternal(RuntimeConstructorInfo target)
@@ -120,7 +120,7 @@ namespace System.Reflection
 
             IList<CustomAttributeData> cad = GetCustomAttributes((RuntimeModule)target.ManifestModule, RuntimeAssembly.GetToken(target.GetNativeHandle()));
             RuntimeType.ListBuilder<Attribute> pcas = PseudoCustomAttribute.GetCustomAttributes(target, (RuntimeType)typeof(object));
-            return GetCombinedList(cad, pcas);
+            return GetCombinedList(cad, ref pcas);
         }
 
         internal static IList<CustomAttributeData> GetCustomAttributesInternal(RuntimeParameterInfo target)
@@ -129,19 +129,19 @@ namespace System.Reflection
 
             IList<CustomAttributeData> cad = GetCustomAttributes(target.GetRuntimeModule(), target.MetadataToken);
             RuntimeType.ListBuilder<Attribute> pcas = PseudoCustomAttribute.GetCustomAttributes(target, (RuntimeType)typeof(object));
-            return GetCombinedList(cad, pcas);
+            return GetCombinedList(cad, ref pcas);
         }
 
-        private static IList<CustomAttributeData> GetCombinedList(IList<CustomAttributeData> customAttributes, RuntimeType.ListBuilder<Attribute> psuedoAttributes)
+        private static IList<CustomAttributeData> GetCombinedList(IList<CustomAttributeData> customAttributes, ref RuntimeType.ListBuilder<Attribute> pseudoAttributes)
         {
-            if (psuedoAttributes.Count == 0)
+            if (pseudoAttributes.Count == 0)
                 return customAttributes;
 
-            CustomAttributeData[] pca = new CustomAttributeData[customAttributes.Count + psuedoAttributes.Count];
-            customAttributes.CopyTo(pca, psuedoAttributes.Count);
-            for (int i = 0; i < psuedoAttributes.Count; i++)
+            CustomAttributeData[] pca = new CustomAttributeData[customAttributes.Count + pseudoAttributes.Count];
+            customAttributes.CopyTo(pca, pseudoAttributes.Count);
+            for (int i = 0; i < pseudoAttributes.Count; i++)
             {
-                pca[i] = new CustomAttributeData(psuedoAttributes[i]);
+                pca[i] = new CustomAttributeData(pseudoAttributes[i]);
             }
 
             return Array.AsReadOnly(pca);

--- a/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -1855,7 +1855,7 @@ namespace System.Reflection
             if (!all && !s_pca.ContainsKey(caType))
                 return default;
 
-            RuntimeType.ListBuilder<Attribute> pcas = new RuntimeType.ListBuilder<Attribute>(all ? 2 : 1);
+            RuntimeType.ListBuilder<Attribute> pcas = new RuntimeType.ListBuilder<Attribute>(0);
 
             if (all || caType == typeof(SerializableAttribute))
             {
@@ -1899,7 +1899,7 @@ namespace System.Reflection
             if (!all && !s_pca.ContainsKey(caType))
                 return default;
 
-            RuntimeType.ListBuilder<Attribute> pcas = new RuntimeType.ListBuilder<Attribute>(all ? 2 : 1);
+            RuntimeType.ListBuilder<Attribute> pcas = new RuntimeType.ListBuilder<Attribute>(0);
             Attribute pca;
 
             if (all || caType == typeof(DllImportAttribute))
@@ -1944,7 +1944,7 @@ namespace System.Reflection
             if (!all && !s_pca.ContainsKey(caType))
                 return default;
 
-            RuntimeType.ListBuilder<Attribute> pcas = new RuntimeType.ListBuilder<Attribute>(all ? 4 : 1);
+            RuntimeType.ListBuilder<Attribute> pcas = new RuntimeType.ListBuilder<Attribute>(0);
             Attribute pca;
 
             if (all || caType == typeof(InAttribute))
@@ -2010,7 +2010,7 @@ namespace System.Reflection
             if (!all && !s_pca.ContainsKey(caType))
                 return default;
 
-            RuntimeType.ListBuilder<Attribute> pcas = new RuntimeType.ListBuilder<Attribute>(all ? 3 : 1);
+            RuntimeType.ListBuilder<Attribute> pcas = new RuntimeType.ListBuilder<Attribute>(0);
             Attribute pca;
 
             if (all || caType == typeof(MarshalAsAttribute))

--- a/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -119,6 +119,7 @@ namespace System.Reflection
             Debug.Assert(target != null);
 
             // No pseudo attributes for RuntimeAssembly
+
             return GetCustomAttributes((RuntimeModule)target.ManifestModule, RuntimeAssembly.GetToken(target.GetNativeHandle()));
         }
 
@@ -1138,6 +1139,7 @@ namespace System.Reflection
             Debug.Assert(caType != null);
 
             // No pseudo attributes for RuntimeConstructorInfo
+
             return IsCustomAttributeDefined(ctor.GetRuntimeModule(), ctor.MetadataToken, caType);
         }
 
@@ -1147,6 +1149,7 @@ namespace System.Reflection
             Debug.Assert(caType != null);
 
             // No pseudo attributes for RuntimePropertyInfo
+
             return IsCustomAttributeDefined(property.GetRuntimeModule(), property.MetadataToken, caType);
         }
 
@@ -1156,6 +1159,7 @@ namespace System.Reflection
             Debug.Assert(caType != null);
 
             // No pseudo attributes for RuntimeEventInfo
+
             return IsCustomAttributeDefined(e.GetRuntimeModule(), e.MetadataToken, caType);
         }
 
@@ -1196,6 +1200,7 @@ namespace System.Reflection
             Debug.Assert(caType != null);
 
             // No pseudo attributes for RuntimeModule
+
             return IsCustomAttributeDefined(module, module.MetadataToken, caType);
         }
 
@@ -1294,6 +1299,7 @@ namespace System.Reflection
             Debug.Assert(caType != null);
 
             // No pseudo attributes for RuntimeConstructorInfo
+
             return GetCustomAttributes(ctor.GetRuntimeModule(), ctor.MetadataToken, 0, caType);
         }
 
@@ -1303,6 +1309,7 @@ namespace System.Reflection
             Debug.Assert(caType != null);
 
             // No pseudo attributes for RuntimePropertyInfo
+
             return GetCustomAttributes(property.GetRuntimeModule(), property.MetadataToken, 0, caType);
         }
 
@@ -1312,6 +1319,7 @@ namespace System.Reflection
             Debug.Assert(caType != null);
 
             // No pseudo attributes for RuntimeEventInfo
+
             return GetCustomAttributes(e.GetRuntimeModule(), e.MetadataToken, 0, caType);
         }
 
@@ -1343,6 +1351,7 @@ namespace System.Reflection
             Debug.Assert(caType != null);
 
             // No pseudo attributes for RuntimeAssembly
+
             int assemblyToken = RuntimeAssembly.GetToken(assembly.GetNativeHandle());
             return GetCustomAttributes(assembly.ManifestModule as RuntimeModule, assemblyToken, 0, caType);
         }
@@ -1353,6 +1362,7 @@ namespace System.Reflection
             Debug.Assert(caType != null);
 
             // No pseudo attributes for RuntimeModule
+
             return GetCustomAttributes(module, module.MetadataToken, 0, caType);
         }
 


### PR DESCRIPTION
This is a continuation of #20779 optimizing various `Attribute` allocations.

Two items addressed here (split into 3 commits) are:
1. `PseudoCustomAttribute`'s intermediate array allocation (used when synthesize `Attribute` instances from things like `[Serializable]` under the covers). Previously in the case of any synthesized attributes being present, an `Attribute[]` array was created to return these to the caller method, and was discarded afterwards. It also DRYs up a lot of repeated code there.
2. `GetCustomAttributes()` inner-most methods was doing similar, returning an `object[]` each time. When crawling up a class's inheritance hierarchy in the `inherit: true` case, this resulted in an array per parent. Then were then copied to the overall list and the array was discarded. The other overload calling into the core method here actually uses the created `object[]` array to return it back to the external caller (and remains necessary). The split here adds to the `ListBuilder<object>` instead for the inner method, and the array is only created when needed in the second caller. So now, when crawling up the hierarchy of parents we just add to the same list each time.
3. A small bit of cleanup removing unused code.

Note: the `GetCustomAttributes()` => `AddCustomAttributes()` split could use careful eyes around the behavior difference of the iteration levels.
- *Before*: the delayed copy into the main list meant that calls into `FilterCustomAttributeRecord()` had the `derivedAttributes` list of the previous inheritor at the time of evaluation.
- *After*: now since attributes are added as they are encountered, attributes found at the current inheritance level are included in the `FilterCustomAttributeRecord()` evaluation.

Looking at `FilterCustomAttributeRecord` and how it's evaluated, I don't *think* this matters...but yeah: should be scrutinized. I wouldn't be surprised if tests didn't cover a difference here if there is one that matters.

Based on the same benchmarks as before (source in #20779):
#### Before
|                               Method |       Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------------------------------------- |-----------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
|               'Class: Hit (inherit)' | 2,132.5 ns | 42.672 ns | 55.486 ns |      0.1297 |           - |           - |               416 B |
|              'Class: Miss (inherit)' |   522.8 ns | 10.242 ns | 10.958 ns |           - |           - |           - |                   - |
|            'Class: Hit (no inherit)' | 1,649.3 ns | 15.553 ns | 14.548 ns |      0.1221 |           - |           - |               384 B |
|           'Class: Miss (no inherit)' |   229.8 ns |  2.511 ns |  2.349 ns |           - |           - |           - |                   - |
|     'Method Override: Hit (inherit)' | 3,312.8 ns | 24.021 ns | 22.470 ns |      0.2251 |           - |           - |               720 B |
|    'Method Override: Miss (inherit)' | 1,945.2 ns | 31.742 ns | 29.691 ns |      0.1297 |           - |           - |               416 B |
|  'Method Override: Hit (no inherit)' | 1,694.2 ns |  6.668 ns |  5.911 ns |      0.1259 |           - |           - |               400 B |
| 'Method Override: Miss (no inherit)' | 1,689.9 ns | 33.668 ns | 71.018 ns |      0.1221 |           - |           - |               384 B |
|         'Method Base: Hit (inherit)' | 1,928.4 ns | 25.686 ns | 21.449 ns |      0.1297 |           - |           - |               416 B |
|        'Method Base: Miss (inherit)' |   344.0 ns |  3.167 ns |  2.963 ns |           - |           - |           - |                   - |
|      'Method Base: Hit (no inherit)' | 1,678.6 ns | 10.756 ns |  8.982 ns |      0.1221 |           - |           - |               384 B |
|     'Method Base: Miss (no inherit)' |   231.9 ns |  4.167 ns |  3.694 ns |           - |           - |           - |                   - |
#### After
|                               Method |       Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------------------------------------- |-----------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
|               'Class: Hit (inherit)' | 1,757.9 ns | 10.445 ns |  9.259 ns |      0.1221 |           - |           - |               384 B |
|              'Class: Miss (inherit)' |   386.1 ns |  2.424 ns |  2.267 ns |           - |           - |           - |                   - |
|            'Class: Hit (no inherit)' | 1,585.4 ns | 15.031 ns | 13.325 ns |      0.1221 |           - |           - |               384 B |
|           'Class: Miss (no inherit)' |   233.5 ns |  1.760 ns |  1.646 ns |           - |           - |           - |                   - |
|     'Method Override: Hit (inherit)' | 2,663.0 ns | 17.049 ns | 15.947 ns |      0.2060 |           - |           - |               656 B |
|    'Method Override: Miss (inherit)' | 1,618.0 ns | 10.219 ns |  9.559 ns |      0.1221 |           - |           - |               384 B |
|  'Method Override: Hit (no inherit)' | 1,602.1 ns | 13.484 ns | 11.260 ns |      0.1259 |           - |           - |               400 B |
| 'Method Override: Miss (no inherit)' | 1,599.2 ns |  7.126 ns |  6.666 ns |      0.1221 |           - |           - |               384 B |
|         'Method Base: Hit (inherit)' | 1,621.4 ns |  8.812 ns |  8.243 ns |      0.1221 |           - |           - |               384 B |
|        'Method Base: Miss (inherit)' |   275.0 ns |  1.786 ns |  1.671 ns |           - |           - |           - |                   - |
|      'Method Base: Hit (no inherit)' | 1,615.2 ns | 16.760 ns | 13.995 ns |      0.1221 |           - |           - |               384 B |
|     'Method Base: Miss (no inherit)' |   258.2 ns |  2.453 ns |  2.175 ns |           - |           - |           - |                   - |
