### PR TITLE
Add new rounding modes to System.Math, System.MathF

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Decimal.cs
+++ b/src/System.Private.CoreLib/shared/System/Decimal.cs
@@ -617,7 +617,7 @@ namespace System
         {
             if ((uint)decimals > 28)
                 throw new ArgumentOutOfRangeException(nameof(decimals), SR.ArgumentOutOfRange_DecimalRound);
-            if ((uint)mode > (uint)MidpointRounding.AwayFromZero)
+            if ((uint)mode > (uint)MidpointRounding.ToPositiveInfinity)
                 throw new ArgumentException(SR.Format(SR.Argument_InvalidEnumValue, mode, nameof(MidpointRounding)), nameof(mode));
 
             int scale = d.Scale - decimals;

--- a/src/System.Private.CoreLib/shared/System/Decimal.cs
+++ b/src/System.Private.CoreLib/shared/System/Decimal.cs
@@ -327,7 +327,7 @@ namespace System
         {
             int flags = d.flags;
             if ((flags & ScaleMask) != 0)
-                DecCalc.InternalRound(ref AsMutable(ref d), (byte)(flags >> ScaleShift), DecCalc.RoundingMode.Ceiling);
+                DecCalc.InternalRound(ref AsMutable(ref d), (byte)(flags >> ScaleShift), MidpointRounding.ToPositiveInfinity);
             return d;
         }
 
@@ -407,7 +407,7 @@ namespace System
         {
             int flags = d.flags;
             if ((flags & ScaleMask) != 0)
-                DecCalc.InternalRound(ref AsMutable(ref d), (byte)(flags >> ScaleShift), DecCalc.RoundingMode.Floor);
+                DecCalc.InternalRound(ref AsMutable(ref d), (byte)(flags >> ScaleShift), MidpointRounding.ToNegativeInfinity);
             return d;
         }
 
@@ -622,7 +622,7 @@ namespace System
 
             int scale = d.Scale - decimals;
             if (scale > 0)
-                DecCalc.InternalRound(ref AsMutable(ref d), (uint)scale, (DecCalc.RoundingMode)mode);
+                DecCalc.InternalRound(ref AsMutable(ref d), (uint)scale, mode);
             return d;
         }
 
@@ -829,7 +829,7 @@ namespace System
         {
             int flags = d.flags;
             if ((flags & ScaleMask) != 0)
-                DecCalc.InternalRound(ref AsMutable(ref d), (byte)(flags >> ScaleShift), DecCalc.RoundingMode.Truncate);
+                DecCalc.InternalRound(ref AsMutable(ref d), (byte)(flags >> ScaleShift), MidpointRounding.ToZero);
         }
 
         public static implicit operator decimal(byte value)

--- a/src/System.Private.CoreLib/shared/System/Math.cs
+++ b/src/System.Private.CoreLib/shared/System/Math.cs
@@ -916,9 +916,10 @@ namespace System
                 {
                     var fraction = ModF(value, &value);
 
-                    if (Abs(fraction) <= 0.5)
+                    if (Abs(fraction) > 0.5)
                     {
-                        value -= Sign(fraction);
+                        value += Sign(fraction);
+                    }
                 }
                 else
                 {

--- a/src/System.Private.CoreLib/shared/System/Math.cs
+++ b/src/System.Private.CoreLib/shared/System/Math.cs
@@ -892,7 +892,7 @@ namespace System
                 throw new ArgumentOutOfRangeException(nameof(digits), SR.ArgumentOutOfRange_RoundingDigits);
             }
 
-            if (mode < MidpointRounding.ToEven || mode > MidpointRounding.AwayFromZero)
+            if (mode < MidpointRounding.ToEven || mode > MidpointRounding.ToZero)
             {
                 throw new ArgumentException(SR.Format(SR.Argument_InvalidEnumValue, mode, nameof(MidpointRounding)), nameof(mode));
             }
@@ -911,6 +911,14 @@ namespace System
                     {
                         value += Sign(fraction);
                     }
+                }
+                else if (mode == MidpointRounding.ToZero)
+                {
+                    var fraction = ModF(value, &value);
+
+                    if (Abs(fraction) <= 0.5)
+                    {
+                        value -= Sign(fraction);
                 }
                 else
                 {

--- a/src/System.Private.CoreLib/shared/System/Math.cs
+++ b/src/System.Private.CoreLib/shared/System/Math.cs
@@ -905,10 +905,14 @@ namespace System
 
                 if (mode is MidpointRounding.ToEven)
                 {
+                    // Rounds to the nearest value; if the number falls midway,
+                    // it is rounded to the nearest value with an even least significant digit
                     value = Round(value);
                 }
                 else if (mode is MidpointRounding.AwayFromZero)
                 {
+                    // Rounds to the nearest value; if the number falls midway,
+                    // it is rounded to the nearest value above (for positive numbers) or below (for negative numbers)
                     double fraction = ModF(value, &value);
 
                     if (Abs(fraction) >= 0.5)
@@ -918,14 +922,17 @@ namespace System
                 }
                 else if (mode is MidpointRounding.ToZero)
                 {
+                    // Directed rounding: Round toward zero, to nearest value above (positive numbers) or below (negative numbers)
                     value = Truncate(value);
                 }
                 else if (mode is MidpointRounding.ToNegativeInfinity)
                 {
+                    // Directed Rounding: Round down to the next value, toward −∞
                     value = Floor(value);
                 }      
                 else if (mode is MidpointRounding.ToPositiveInfinity)
                 {
+                    // Directed rounding: Round up to the next value, toward +∞
                     value = Ceiling(value);
                 }
 

--- a/src/System.Private.CoreLib/shared/System/Math.cs
+++ b/src/System.Private.CoreLib/shared/System/Math.cs
@@ -909,7 +909,7 @@ namespace System
                 }
                 else if (mode is MidpointRounding.AwayFromZero)
                 {
-                    var fraction = ModF(value, &value);
+                    double fraction = ModF(value, &value);
 
                     if (Abs(fraction) >= 0.5)
                     {
@@ -918,11 +918,11 @@ namespace System
                 }
                 else if (mode is MidpointRounding.ToZero)
                 {
-                    ModF(value, &value);
+                    value = Truncate(value);
                 }
                 else if (mode is MidpointRounding.ToNegativeInfinity)
                 {
-                    var fraction = ModF(value, &value);
+                    double fraction = ModF(value, &value);
 
                     if (Sign(fraction) == -1)
                     {
@@ -931,7 +931,7 @@ namespace System
                 }      
                 else if (mode is MidpointRounding.ToPositiveInfinity)
                 {
-                    var fraction = ModF(value, &value);
+                    double fraction = ModF(value, &value);
 
                     if (Sign(fraction) == 1)
                     {

--- a/src/System.Private.CoreLib/shared/System/Math.cs
+++ b/src/System.Private.CoreLib/shared/System/Math.cs
@@ -918,37 +918,24 @@ namespace System
                 }
                 else if (mode is MidpointRounding.ToZero)
                 {
-                    var fraction = ModF(value, &value);
-
-                    if (Abs(fraction) > 0.5)
-                    {
-                        value += Sign(fraction);
-                    }
+                    ModF(value, &value);
                 }
                 else if (mode is MidpointRounding.ToNegativeInfinity)
                 {
                     var fraction = ModF(value, &value);
 
-                    if (Abs(fraction) == 0.5) 
+                    if (Sign(fraction) == -1)
                     {
-                        value = value + fraction + -0.5;
-                    }
-                    else if (Abs(fraction) > 0.5)
-                    {
-                        value += Sign(fraction);
+                        value--;
                     }
                 }      
                 else if (mode is MidpointRounding.ToPositiveInfinity)
                 {
                     var fraction = ModF(value, &value);
 
-                    if (Abs(fraction) == 0.5)
+                    if (Sign(fraction) == 1)
                     {
-                        value = value + fraction + 0.5;
-                    }
-                    else if (Abs(fraction) > 0.5)
-                    {
-                        value += Sign(fraction); 
+                        value++;
                     }
                 }
 

--- a/src/System.Private.CoreLib/shared/System/Math.cs
+++ b/src/System.Private.CoreLib/shared/System/Math.cs
@@ -903,39 +903,52 @@ namespace System
 
                 value *= power10;
 
-                if (mode is MidpointRounding.ToEven)
+                switch (mode)
                 {
                     // Rounds to the nearest value; if the number falls midway,
                     // it is rounded to the nearest value with an even least significant digit
-                    value = Round(value);
-                }
-                else if (mode is MidpointRounding.AwayFromZero)
-                {
+                    case MidpointRounding.ToEven:
+                    {
+                        value = Round(value);
+                        break;
+                    }
                     // Rounds to the nearest value; if the number falls midway,
                     // it is rounded to the nearest value above (for positive numbers) or below (for negative numbers)
-                    double fraction = ModF(value, &value);
-
-                    if (Abs(fraction) >= 0.5)
+                    case MidpointRounding.AwayFromZero:
                     {
-                        value += Sign(fraction);
+                        double fraction = ModF(value, &value);
+
+                        if (Abs(fraction) >= 0.5)
+                        {
+                            value += Sign(fraction);
+                        }
+
+                        break;
+                    }
+                    // Directed rounding: Round to the nearest value, toward to zero
+                    case MidpointRounding.ToZero:
+                    {
+                        value = Truncate(value);
+                        break;
+                    }
+                    // Directed Rounding: Round down to the next value, toward negative infinity
+                    case MidpointRounding.ToNegativeInfinity:
+                    {
+                        value = Floor(value);
+                        break;
+                    }
+                    // Directed rounding: Round up to the next value, toward positive infinity
+                    case MidpointRounding.ToPositiveInfinity:
+                    {  
+                        value = Ceiling(value);
+                        break;
+                    }
+                    default:
+                    {
+                        throw new ArgumentException(SR.Format(SR.Argument_InvalidEnumValue, mode, nameof(MidpointRounding)), nameof(mode));
                     }
                 }
-                else if (mode is MidpointRounding.ToZero)
-                {
-                    // Directed rounding: Round toward zero, to nearest value above (positive numbers) or below (negative numbers)
-                    value = Truncate(value);
-                }
-                else if (mode is MidpointRounding.ToNegativeInfinity)
-                {
-                    // Directed Rounding: Round down to the next value, toward −∞
-                    value = Floor(value);
-                }      
-                else if (mode is MidpointRounding.ToPositiveInfinity)
-                {
-                    // Directed rounding: Round up to the next value, toward +∞
-                    value = Ceiling(value);
-                }
-
+                
                 value /= power10;
             }
 

--- a/src/System.Private.CoreLib/shared/System/Math.cs
+++ b/src/System.Private.CoreLib/shared/System/Math.cs
@@ -892,7 +892,7 @@ namespace System
                 throw new ArgumentOutOfRangeException(nameof(digits), SR.ArgumentOutOfRange_RoundingDigits);
             }
 
-            if (mode < MidpointRounding.ToEven || mode > MidpointRounding.ToZero)
+            if (mode < MidpointRounding.ToEven || mode > MidpointRounding.ToPositiveInfinity)
             {
                 throw new ArgumentException(SR.Format(SR.Argument_InvalidEnumValue, mode, nameof(MidpointRounding)), nameof(mode));
             }
@@ -903,7 +903,11 @@ namespace System
 
                 value *= power10;
 
-                if (mode == MidpointRounding.AwayFromZero)
+                if (mode is MidpointRounding.ToEven)
+                {
+                    value = Round(value);
+                }
+                else if (mode is MidpointRounding.AwayFromZero)
                 {
                     var fraction = ModF(value, &value);
 
@@ -912,7 +916,7 @@ namespace System
                         value += Sign(fraction);
                     }
                 }
-                else if (mode == MidpointRounding.ToZero)
+                else if (mode is MidpointRounding.ToZero)
                 {
                     var fraction = ModF(value, &value);
 
@@ -921,9 +925,31 @@ namespace System
                         value += Sign(fraction);
                     }
                 }
-                else
+                else if (mode is MidpointRounding.ToNegativeInfinity)
                 {
-                    value = Round(value);
+                    var fraction = ModF(value, &value);
+
+                    if (Abs(fraction) == 0.5) 
+                    {
+                        value = value + fraction + -0.5;
+                    }
+                    else if (Abs(fraction) > 0.5)
+                    {
+                        value += Sign(fraction);
+                    }
+                }      
+                else if (mode is MidpointRounding.ToPositiveInfinity)
+                {
+                    var fraction = ModF(value, &value);
+
+                    if (Abs(fraction) == 0.5)
+                    {
+                        value = value + fraction + 0.5;
+                    }
+                    else if (Abs(fraction) > 0.5)
+                    {
+                        value += Sign(fraction); 
+                    }
                 }
 
                 value /= power10;

--- a/src/System.Private.CoreLib/shared/System/Math.cs
+++ b/src/System.Private.CoreLib/shared/System/Math.cs
@@ -922,21 +922,11 @@ namespace System
                 }
                 else if (mode is MidpointRounding.ToNegativeInfinity)
                 {
-                    double fraction = ModF(value, &value);
-
-                    if (Sign(fraction) == -1)
-                    {
-                        value--;
-                    }
+                    value = Floor(value);
                 }      
                 else if (mode is MidpointRounding.ToPositiveInfinity)
                 {
-                    double fraction = ModF(value, &value);
-
-                    if (Sign(fraction) == 1)
-                    {
-                        value++;
-                    }
+                    value = Ceiling(value);
                 }
 
                 value /= power10;

--- a/src/System.Private.CoreLib/shared/System/MathF.cs
+++ b/src/System.Private.CoreLib/shared/System/MathF.cs
@@ -319,10 +319,14 @@ namespace System
 
                 if (mode is MidpointRounding.ToEven)
                 {
+                    // Rounds to the nearest value; if the number falls midway,
+                    // it is rounded to the nearest value with an even least significant digit
                     x = Round(x);
                 }
                 else if (mode is MidpointRounding.AwayFromZero)
                 {
+                    // Rounds to the nearest value; if the number falls midway,
+                    // it is rounded to the nearest value above (for positive numbers) or below (for negative numbers)
                     float fraction = ModF(x, &x);
 
                     if (Abs(fraction) >= 0.5f)
@@ -332,25 +336,18 @@ namespace System
                 }
                 else if (mode is MidpointRounding.ToZero)
                 {
+                    // Directed rounding: Round toward zero, to nearest value above (positive numbers) or below (negative numbers)
                     x = Truncate(x);
                 }
                 else if (mode is MidpointRounding.ToNegativeInfinity)
                 {
-                    float fraction = ModF(x, &x);
-
-                    if (Sign(fraction) == -1)
-                    {
-                        x--;
-                    }
+                    // Directed Rounding: Round down to the next value, toward −∞
+                    x = Floor(x);
                 }      
                 else if (mode is MidpointRounding.ToPositiveInfinity)
                 {
-                    float fraction = ModF(x, &x);
-
-                    if (Sign(fraction) == 1)
-                    {
-                        x++;
-                    }
+                    // Directed rounding: Round up to the next value, toward +∞
+                    x = Ceiling(x);
                 }
 
                 x /= power10;

--- a/src/System.Private.CoreLib/shared/System/MathF.cs
+++ b/src/System.Private.CoreLib/shared/System/MathF.cs
@@ -325,46 +325,33 @@ namespace System
                 {
                     var fraction = ModF(x, &x);
 
-                    if (Abs(fraction) >= 0.5f)
+                    if (Abs(fraction) >= 0.5)
                     {
                         x += Sign(fraction);
                     }
                 }
                 else if (mode is MidpointRounding.ToZero)
                 {
-                    var fraction = ModF(x, &x);
-
-                    if (Abs(fraction) > 0.5f)
-                    {
-                        x += Sign(fraction);
-                    }
+                    ModF(x, &x);
                 }
                 else if (mode is MidpointRounding.ToNegativeInfinity)
                 {
                     var fraction = ModF(x, &x);
 
-                    if (Abs(fraction) == 0.5f) 
+                    if (Sign(fraction) == -1)
                     {
-                        x = x + fraction + -0.5f;
+                        x--;
                     }
-                    else if (Abs(fraction) > 0.5f)
-                    {
-                        x += Sign(fraction);
-                    }
-                }     
+                }      
                 else if (mode is MidpointRounding.ToPositiveInfinity)
                 {
                     var fraction = ModF(x, &x);
 
-                    if (Abs(fraction) == 0.5f)
+                    if (Sign(fraction) == 1)
                     {
-                        x = x + fraction + 0.5f;
+                        x++;
                     }
-                    else if (Abs(fraction) > 0.5f)
-                    {
-                        x += Sign(fraction); 
-                    }
-                }           
+                }
 
                 x /= power10;
             }

--- a/src/System.Private.CoreLib/shared/System/MathF.cs
+++ b/src/System.Private.CoreLib/shared/System/MathF.cs
@@ -323,20 +323,20 @@ namespace System
                 }
                 else if (mode is MidpointRounding.AwayFromZero)
                 {
-                    var fraction = ModF(x, &x);
+                    float fraction = ModF(x, &x);
 
-                    if (Abs(fraction) >= 0.5)
+                    if (Abs(fraction) >= 0.5f)
                     {
                         x += Sign(fraction);
                     }
                 }
                 else if (mode is MidpointRounding.ToZero)
                 {
-                    ModF(x, &x);
+                    x = Truncate(x);
                 }
                 else if (mode is MidpointRounding.ToNegativeInfinity)
                 {
-                    var fraction = ModF(x, &x);
+                    float fraction = ModF(x, &x);
 
                     if (Sign(fraction) == -1)
                     {
@@ -345,7 +345,7 @@ namespace System
                 }      
                 else if (mode is MidpointRounding.ToPositiveInfinity)
                 {
-                    var fraction = ModF(x, &x);
+                    float fraction = ModF(x, &x);
 
                     if (Sign(fraction) == 1)
                     {

--- a/src/System.Private.CoreLib/shared/System/MathF.cs
+++ b/src/System.Private.CoreLib/shared/System/MathF.cs
@@ -308,7 +308,7 @@ namespace System
 
             if (mode < MidpointRounding.ToEven || mode > MidpointRounding.ToPositiveInfinity)
             {
-                throw new ArgumentException(SR.Format(SR.Argument_InvalidEnum, mode, nameof(MidpointRounding)), nameof(mode));
+                throw new ArgumentException(SR.Format(SR.Argument_InvalidEnumValue, mode, nameof(MidpointRounding)), nameof(mode));
             }
 
             if (Abs(x) < singleRoundLimit)
@@ -317,39 +317,52 @@ namespace System
 
                 x *= power10;
 
-                if (mode is MidpointRounding.ToEven)
+                switch (mode)
                 {
                     // Rounds to the nearest value; if the number falls midway,
                     // it is rounded to the nearest value with an even least significant digit
-                    x = Round(x);
-                }
-                else if (mode is MidpointRounding.AwayFromZero)
-                {
+                    case MidpointRounding.ToEven:
+                    {
+                        x = Round(x);
+                        break;
+                    }
                     // Rounds to the nearest value; if the number falls midway,
                     // it is rounded to the nearest value above (for positive numbers) or below (for negative numbers)
-                    float fraction = ModF(x, &x);
-
-                    if (Abs(fraction) >= 0.5f)
+                    case MidpointRounding.AwayFromZero:
                     {
-                        x += Sign(fraction);
+                        float fraction = ModF(x, &x);
+
+                        if (Abs(fraction) >= 0.5)
+                        {
+                            x += Sign(fraction);
+                        }
+
+                        break;
+                    }
+                    // Directed rounding: Round to the nearest value, toward to zero
+                    case MidpointRounding.ToZero:
+                    {
+                        x = Truncate(x);
+                        break;
+                    }
+                    // Directed Rounding: Round down to the next value, toward negative infinity
+                    case MidpointRounding.ToNegativeInfinity:
+                    {
+                        x = Floor(x);
+                        break;
+                    }
+                    // Directed rounding: Round up to the next value, toward positive infinity
+                    case MidpointRounding.ToPositiveInfinity:
+                    {  
+                        x = Ceiling(x);
+                        break;
+                    }
+                    default:
+                    {
+                        throw new ArgumentException(SR.Format(SR.Argument_InvalidEnumValue, mode, nameof(MidpointRounding)), nameof(mode));
                     }
                 }
-                else if (mode is MidpointRounding.ToZero)
-                {
-                    // Directed rounding: Round toward zero, to nearest value above (positive numbers) or below (negative numbers)
-                    x = Truncate(x);
-                }
-                else if (mode is MidpointRounding.ToNegativeInfinity)
-                {
-                    // Directed Rounding: Round down to the next value, toward −∞
-                    x = Floor(x);
-                }      
-                else if (mode is MidpointRounding.ToPositiveInfinity)
-                {
-                    // Directed rounding: Round up to the next value, toward +∞
-                    x = Ceiling(x);
-                }
-
+                
                 x /= power10;
             }
 

--- a/src/System.Private.CoreLib/shared/System/MathF.cs
+++ b/src/System.Private.CoreLib/shared/System/MathF.cs
@@ -306,7 +306,7 @@ namespace System
                 throw new ArgumentOutOfRangeException(nameof(digits), SR.ArgumentOutOfRange_RoundingDigits);
             }
 
-            if (mode < MidpointRounding.ToEven || mode > MidpointRounding.AwayFromZero)
+            if (mode < MidpointRounding.ToEven || mode > MidpointRounding.ToPositiveInfinity)
             {
                 throw new ArgumentException(SR.Format(SR.Argument_InvalidEnum, mode, nameof(MidpointRounding)), nameof(mode));
             }
@@ -317,7 +317,11 @@ namespace System
 
                 x *= power10;
 
-                if (mode == MidpointRounding.AwayFromZero)
+                if (mode is MidpointRounding.ToEven)
+                {
+                    x = Round(x);
+                }
+                else if (mode is MidpointRounding.AwayFromZero)
                 {
                     var fraction = ModF(x, &x);
 
@@ -326,10 +330,41 @@ namespace System
                         x += Sign(fraction);
                     }
                 }
-                else
+                else if (mode is MidpointRounding.ToZero)
                 {
-                    x = Round(x);
+                    var fraction = ModF(x, &x);
+
+                    if (Abs(fraction) > 0.5f)
+                    {
+                        x += Sign(fraction);
+                    }
                 }
+                else if (mode is MidpointRounding.ToNegativeInfinity)
+                {
+                    var fraction = ModF(x, &x);
+
+                    if (Abs(fraction) == 0.5f) 
+                    {
+                        x = x + fraction + -0.5f;
+                    }
+                    else if (Abs(fraction) > 0.5f)
+                    {
+                        x += Sign(fraction);
+                    }
+                }     
+                else if (mode is MidpointRounding.ToPositiveInfinity)
+                {
+                    var fraction = ModF(x, &x);
+
+                    if (Abs(fraction) == 0.5f)
+                    {
+                        x = x + fraction + 0.5f;
+                    }
+                    else if (Abs(fraction) > 0.5f)
+                    {
+                        x += Sign(fraction); 
+                    }
+                }           
 
                 x /= power10;
             }

--- a/src/System.Private.CoreLib/shared/System/MidpointRounding.cs
+++ b/src/System.Private.CoreLib/shared/System/MidpointRounding.cs
@@ -8,8 +8,8 @@ namespace System
     {
         ToEven = 0,
         AwayFromZero = 1,
-        ToPositiveInfinity = 2,
+        ToZero = 2,
         ToNegativeInfinity = 3,
-        ToZero = 4
+        ToPositiveInfinity = 4
     }
 }

--- a/src/System.Private.CoreLib/shared/System/MidpointRounding.cs
+++ b/src/System.Private.CoreLib/shared/System/MidpointRounding.cs
@@ -8,5 +8,8 @@ namespace System
     {
         ToEven = 0,
         AwayFromZero = 1,
+        ToPositiveInfinity = 2,
+        ToNegativeInfinity = 3,
+        ToZero = 4
     }
 }

--- a/tests/CoreFX/CoreFX.issues.json
+++ b/tests/CoreFX/CoreFX.issues.json
@@ -1035,6 +1035,10 @@
                     "reason": "https://github.com/dotnet/coreclr/issues/12605"
                 },
                 {
+                    "name": "System.Tests.DecimalTests.Round_InvalidMidpointRounding_ThrowsArgumentException",
+                    "reason": "outdated"
+                }, 
+                {
                     "name": "System.Tests.ArrayTests.Copy",
                     "reason": "Needs updates for XUnit 2.4"
                 },


### PR DESCRIPTION
resolves dotnet/corefx#31902

Adding new rounding modes to MidpointRounding for use with Math.Round and MathF.Round.

My unit tests are over on corefx at the moment. If I understand correctly I need my changes to be mirrored there by the bot and corefx be built with my coreclr version to run tests. 

See https://github.com/hamish-rose/corefx/blob/MidpointRoundingmodes%2331902/src/System.Runtime.Extensions/tests/System/Math.cs#L1469

