### PR TITLE
Disable running ILAsm round-trip build on COM Tests

### DIFF
--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -245,19 +245,8 @@ fi
       </PropertyGroup>
       <PropertyGroup>
       <_CLRTestRunFile Condition="'$(CLRTestIsHosted)'=='true'">"$CORE_ROOT/corerun"</_CLRTestRunFile>
-      <BashCLRTestLaunchCmds><![CDATA[
-if [ -z "$DoLink" -a ! -z "$RunningIlasmRoundTrip" ];
-then
-  echo $(_CLRTestRunFile) $(TargetAssemblyName) $CLRTestExecutionArguments
-  $(_CLRTestRunFile) $(TargetAssemblyName) $CLRTestExecutionArguments
-  if [  $? -ne $CLRTestExpectedExitCode ]
-  then
-    echo END EXECUTION OF IL{D}ASM BINARY - FAILED $? vs $CLRTestExpectedExitCode
-    echo FAILED
-    exit 1
-  fi
-fi
-      ]]></BashCLRTestLaunchCmds>
+      
+      <BashCLRTestLaunchCmds>$(BashIlrtTestLaunchCmds)</BashCLRTestLaunchCmds>
 
       <BashCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun'">
     <![CDATA[

--- a/tests/src/CLRTest.Jit.targets
+++ b/tests/src/CLRTest.Jit.targets
@@ -68,9 +68,13 @@ if defined RunningJitDisasm (
     </PropertyGroup>
   </Target>
 
+  <PropertyGroup>
+    <ILAsmTestKind Condition="'$(ILAsmTestKind)' == ''">$(CLRTestKind)</ILAsmTestKind>
+  </PropertyGroup>
+
   <Target
       Name="GetIlasmRoundTripBashScript"
-      Returns="$(IlasmRoundTripBashScript)">
+      Returns="$(IlasmRoundTripBashScript);$(BashIlrtTestLaunchCmds)">
     <PropertyGroup>
       <InputAssemblyName Condition="'$(CLRTestKind)' == 'RunOnly'">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)).Replace("\","/"))</InputAssemblyName>
       <InputAssemblyName Condition="'$(CLRTestKind)' == 'BuildAndRun'">$(MSBuildProjectName).exe</InputAssemblyName>
@@ -106,6 +110,22 @@ then
 fi
         ]]>
       </IlasmRoundTripBashScript>
+      
+      <BashIlrtTestLaunchCmds Condition="'$(ILAsmTestKind)' != 'BuildOnly'">
+        <![CDATA[
+if [ -z "$DoLink" -a ! -z "$RunningIlasmRoundTrip" ];
+then
+  echo $(_CLRTestRunFile) $(TargetAssemblyName) $CLRTestExecutionArguments
+  $(_CLRTestRunFile) $(TargetAssemblyName) $CLRTestExecutionArguments
+  if [  $? -ne $CLRTestExpectedExitCode ]
+  then
+    echo END EXECUTION OF IL{D}ASM BINARY - FAILED $? vs $CLRTestExpectedExitCode
+    echo FAILED
+    exit 1
+  fi
+fi
+        ]]>
+      </BashIlrtTestLaunchCmds>
     </PropertyGroup>
   </Target>
 
@@ -142,7 +162,7 @@ IF NOT DEFINED DoLink (
 )
         ]]>
       </IlasmRoundTripBatchScript>
-      <BatchIlrtTestLaunchCmds><![CDATA[
+      <BatchIlrtTestLaunchCmds Condition="'$(ILAsmTestKind)' != 'BuildOnly'"><![CDATA[
 IF NOT DEFINED DoLink (
   if defined RunningIlasmRoundTrip (
     ECHO %LAUNCHER% $(TargetAssemblyName) %CLRTestExecutionArguments% %Host_Args%

--- a/tests/src/Interop/COM/NETClients/Aggregation/NETClientAggregation.csproj
+++ b/tests/src/Interop/COM/NETClients/Aggregation/NETClientAggregation.csproj
@@ -11,6 +11,9 @@
     <ProjectTypeGuids>{209912F9-0DA1-4184-9CC1-8D583BAF4A28};{87799F5D-CEBD-499D-BDBA-B2C6105CD766}</ProjectTypeGuids>
     <ApplicationManifest>App.manifest</ApplicationManifest>
 
+    <!-- Blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/coreclr/issues/20819 -->
+    <ILAsmTestKind>BuildOnly</ILAsmTestKind>
+
     <!-- Test unsupported outside of windows -->
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>

--- a/tests/src/Interop/COM/NETClients/IDispatch/NETClientIDispatch.csproj
+++ b/tests/src/Interop/COM/NETClients/IDispatch/NETClientIDispatch.csproj
@@ -11,6 +11,9 @@
     <ProjectTypeGuids>{209912F9-0DA1-4184-9CC1-8D583BAF4A28};{87799F5D-CEBD-499D-BDBA-B2C6105CD766}</ProjectTypeGuids>
     <ApplicationManifest>App.manifest</ApplicationManifest>
 
+    <!-- Blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/coreclr/issues/20819 -->
+    <ILAsmTestKind>BuildOnly</ILAsmTestKind>
+
     <!-- Test unsupported outside of windows -->
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>

--- a/tests/src/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
+++ b/tests/src/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
@@ -11,6 +11,9 @@
     <ProjectTypeGuids>{209912F9-0DA1-4184-9CC1-8D583BAF4A28};{87799F5D-CEBD-499D-BDBA-B2C6105CD766}</ProjectTypeGuids>
     <ApplicationManifest>App.manifest</ApplicationManifest>
 
+    <!-- Blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/coreclr/issues/20819 -->
+    <ILAsmTestKind>BuildOnly</ILAsmTestKind>
+
     <!-- Test unsupported outside of windows -->
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>


### PR DESCRIPTION
As per #20801, the COM tests require ILAsm to have support for embedding resources. Currently, ILAsm in .NET Core is unable to correctly do so (see #20819). So, we should disable these tests on the ilasm/ildasm round trip testing.