### PR TITLE
Simplify build.sh command line arguments for Linux/arm cross build (Part 1)

### DIFF
--- a/Documentation/building/linux-instructions.md
+++ b/Documentation/building/linux-instructions.md
@@ -122,7 +122,7 @@ The CI system and official builds use Docker to build ARM for Linux (for example
 ```
 ROOT=/Users/me/git/coreclr
 DOCKER_ARGS="run -i --rm -v ${ROOT}:/mnt/coreclr -w /mnt/coreclr -e ROOTFS_DIR=/crossrootfs/arm -e CAC_ROOTFS_DIR=/crossrootfs/x86 microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-e435274-20180426002420"
-docker ${DOCKER_ARGS} /mnt/coreclr/build.sh arm checked cross crosscomponent
+docker ${DOCKER_ARGS} /mnt/coreclr/build.sh arm checked cross
 docker ${DOCKER_ARGS} /mnt/coreclr/build-test.sh arm checked cross generatelayoutonly
 ```
 

--- a/build-test.sh
+++ b/build-test.sh
@@ -528,8 +528,6 @@ usage()
     echo "clangx.y - optional argument to build using clang version x.y - supported version 3.5 - 6.0"
     echo "cross - optional argument to signify cross compilation,"
     echo "      - will use ROOTFS_DIR environment variable if set."
-    echo "crosscomponent - optional argument to build cross-architecture component,"
-    echo "               - will use CAC_ROOTFS_DIR environment variable if set."
     echo "portableLinux - build for Portable Linux Distribution"
     echo "portablebuild - Use portable build."
     echo "verbose - optional argument to enable verbose build output."

--- a/build.sh
+++ b/build.sh
@@ -381,14 +381,13 @@ build_cross_architecture_components()
         fi
     fi
 
-    __ExtraCmakeArgs="-DCLR_CMAKE_TARGET_ARCH=$__BuildArch -DCLR_CMAKE_TARGET_OS=$__BuildOS -DCLR_CMAKE_PACKAGES_DIR=$__PackagesDir -DCLR_CMAKE_PGO_INSTRUMENT=$__PgoInstrument -DCLR_CMAKE_OPTDATA_VERSION=$__PgoOptDataVersion -DCLR_CMAKE_PGO_OPTIMIZE=$__PgoOptimize"
+    __ExtraCmakeArgs="-DCLR_CMAKE_TARGET_ARCH=$__BuildArch -DCLR_CMAKE_TARGET_OS=$__BuildOS -DCLR_CMAKE_PACKAGES_DIR=$__PackagesDir -DCLR_CMAKE_PGO_INSTRUMENT=$__PgoInstrument -DCLR_CMAKE_OPTDATA_VERSION=$__PgoOptDataVersion -DCLR_CMAKE_PGO_OPTIMIZE=$__PgoOptimize -DCLR_CROSS_COMPONENTS_BUILD=1"
     build_native $__SkipCrossArchBuild "$crossArch" "$intermediatesForBuild" "$__ExtraCmakeArgs" "cross-architecture components"
 
-    # restore ROOTFS_DIR, CROSSCOMPONENT, and CROSSCOMPILE
+    # restore ROOTFS_DIR and CROSSCOMPILE
     if [ -n "$TARGET_ROOTFS" ]; then
         export ROOTFS_DIR="$TARGET_ROOTFS"
     fi
-    export CROSSCOMPONENT=
     export CROSSCOMPILE=1
 }
 

--- a/build.sh
+++ b/build.sh
@@ -509,9 +509,9 @@ build_CoreLib()
            exit 1
        fi
     else
-       if [[ ( "$__CrossArch" == "x86" ) && ( "$__BuildArch" == "arm" || "$__BuildArch" == "armel" ) ]]; then
+       if [[ ( "$__CrossArch" == "x86" ) && ( "$__BuildArch" == "arm" ) ]]; then
            build_CoreLib_ni "$__CrossComponentBinDir/crossgen"
-       elif [[ ( "$__CrossArch" == "x64" ) && ( "$__BuildArch" == "arm" || "$__BuildArch" == "armel" ) ]]; then
+       elif [[ ( "$__CrossArch" == "x64" ) && ( "$__BuildArch" == "arm" ) ]]; then
            build_CoreLib_ni "$__CrossComponentBinDir/crossgen"
        elif [[ ( "$__HostArch" == "x64" ) && ( "$__BuildArch" == "arm64" ) ]]; then
            build_CoreLib_ni "$__CrossComponentBinDir/crossgen"

--- a/build.sh
+++ b/build.sh
@@ -1052,7 +1052,7 @@ if [[ $__CrossBuild == 1 ]]; then
     build_cross_architecture_components "$__CrossArch"
 
     # For now, continue building Hostx86/arm crossgen
-    if [[ "$__HostArch" == "x64" && ("$__BuildArch" == "arm" || "$__BuildArch" == "armel") ]]; then
+    if [[ "$__HostArch" == "x64" && "$__BuildArch" == "arm" ]]; then
         build_cross_architecture_components "x86"
     fi
 fi

--- a/buildpipeline/DotNet-CoreClr-Trusted-Linux-Crossbuild.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Linux-Crossbuild.json
@@ -179,7 +179,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm -e ROOTFS_DIR=$(ROOTFS_DIR) -e CAC_ROOTFS_DIR=$(CAC_ROOTFS_DIR) $(DockerCommonRunArgs) ./build.sh $(PB_BuildType) $(Architecture) skipnuget cross $(CrossArchBuildArgs) -skiprestore stripSymbols -OfficialBuildId=$(OfficialBuildId) -- /flp:\"v=diag\"",
+        "arguments": "run --rm -e ROOTFS_DIR=$(ROOTFS_DIR) -e CAC_ROOTFS_DIR=$(CAC_ROOTFS_DIR) $(DockerCommonRunArgs) ./build.sh $(PB_BuildType) $(Architecture) skipnuget cross -skiprestore stripSymbols -OfficialBuildId=$(OfficialBuildId) -- /flp:\"v=diag\"",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -505,10 +505,6 @@
     },
     "Architecture": {
       "value": "arm"
-    },
-    "CrossArchBuildArgs": {
-      "value": "",
-      "allowOverride": true
     },
     "CrossArchBuildPackagesArgs": {
        "value": "",

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -149,7 +149,6 @@
             "Architecture": "arm",
             "Rid": "linux",
             "CrossArchitecture": "x86",
-            "CrossArchBuildArgs": "crosscomponent",
             "CrossArchBuildPackagesArgs": "-__DoCrossArchBuild=1",
             "CAC_ROOTFS_DIR": "/crossrootfs/$(CrossArchitecture)"
           },
@@ -167,7 +166,6 @@
             "DockerTag": "ubuntu-16.04-cross-arm64-a3ae44b-20180315221921",
             "Architecture": "arm64",
             "Rid": "linux",
-            "CrossArchBuildArgs": "crosscomponent",
             "CrossArchBuildPackagesArgs": "-__DoCrossArchBuild=1"
           },
           "ReportingParameters": {

--- a/netci.groovy
+++ b/netci.groovy
@@ -2530,7 +2530,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                     def dockerImage = getDockerImageName(architecture, os, true)
                     def dockerCmd = "docker run -i --rm -v \${WORKSPACE}:\${WORKSPACE} -w \${WORKSPACE} -e ROOTFS_DIR=/crossrootfs/${architecture} ${additionalOpts} ${dockerImage} "
 
-                    buildCommands += "${dockerCmd}\${WORKSPACE}/build.sh ${lowerConfiguration} ${architecture} cross crosscomponent"
+                    buildCommands += "${dockerCmd}\${WORKSPACE}/build.sh ${lowerConfiguration} ${architecture} cross"
 
                     if (doCoreFxTesting) {
                         def scriptFileName = "\$WORKSPACE/set_stress_test_env.sh"

--- a/perf.groovy
+++ b/perf.groovy
@@ -462,7 +462,7 @@ def static getFullThroughputJobName(def project, def os, def arch, def isPR) {
                 def dockerImage = getDockerImageName(architecture, 'Ubuntu', true)
                 def dockerCmd = "docker run -i --rm -v \${WORKSPACE}:\${WORKSPACE} -w \${WORKSPACE} -e ROOTFS_DIR=/crossrootfs/${architecture} ${additionalOpts} ${dockerImage} "
 
-                buildCommands += "${dockerCmd}\${WORKSPACE}/build.sh release ${architecture} cross crosscomponent"
+                buildCommands += "${dockerCmd}\${WORKSPACE}/build.sh release ${architecture} cross"
 
                 steps {
                     buildCommands.each { buildCommand ->

--- a/src/pal/tools/gen-buildsys-clang.sh
+++ b/src/pal/tools/gen-buildsys-clang.sh
@@ -112,9 +112,6 @@ fi
 if [[ -n "$LLDB_INCLUDE_DIR" ]]; then
     cmake_extra_defines="$cmake_extra_defines -DWITH_LLDB_INCLUDES=$LLDB_INCLUDE_DIR"
 fi
-if [[ -n "$CROSSCOMPONENT" ]]; then
-    cmake_extra_defines="$cmake_extra_defines -DCLR_CROSS_COMPONENTS_BUILD=1"
-fi
 if [ "$CROSSCOMPILE" == "1" ]; then
     if ! [[ -n "$ROOTFS_DIR" ]]; then
         echo "ROOTFS_DIR not set for crosscompile"


### PR DESCRIPTION
Stop using crosscomponent|-crosscomponent in build.sh, buildpipeline, netci.groovy and perf.groovy.
Print a message saying that this is an obsolete command line argument.

Changes in src/pal/tools/gen-buildsys-clang.sh is to make it consistent with src/pal/tools/gen-buildsys-win.bat - DCLR_CROSS_COMPONENTS_BUILD=1 is passed as an extra CMake argument and not determined inside based on presence of CROSSCOMPONENT environment variable.