### PR TITLE
try to use Exclude on same line as Include instead of Remove to avoid issues with FreeBSD symbols

### DIFF
--- a/src/publish.proj
+++ b/src/publish.proj
@@ -142,8 +142,7 @@
       <ConvertPortablePdbsToWindowsPdbs Condition="'$(ConvertPortablePdbsToWindowsPdbs)'==''">true</ConvertPortablePdbsToWindowsPdbs>
     </PropertyGroup>
     <ItemGroup>
-      <SymbolPackagesToPublish Include="$(SymbolsPackagesPattern)" />
-      <SymbolPackagesToPublish Remove="$(PackagePatternDir)symbolpkg\*freebsd*.nupkg" />
+      <SymbolPackagesToPublish Include="$(SymbolsPackagesPattern)" Exclude="$(PackagePatternDir)symbolpkg\*freebsd*.nupkg"/>
     </ItemGroup>
     <Error Condition="'$(SymbolServerPath)'==''" Text="Missing property SymbolServerPath" />
     <Error Condition="'$(SymbolServerPAT)'==''" Text="Missing property SymbolServerPAT" />


### PR DESCRIPTION
This is another attempt to fix the symbol publishing. It uses pattern seen here: https://blogs.msdn.microsoft.com/msbuild/2006/03/08/how-to-exclude-multiple-files-from-a-wildcard/

It uses include & exclude in single step instead of trying to remove freebsd later. 
I could not reproduce failure locally but I did look at expansion of variables and it did look reasonable. 