### PR TITLE
Remove CORCOMPILE_IMPORT_TABLE_ENTRY

### DIFF
--- a/src/debug/daccess/nidump.cpp
+++ b/src/debug/daccess/nidump.cpp
@@ -1272,7 +1272,7 @@ void NativeImageDumper::TraceDumpImport(int idx, NativeImageDumper::Import * imp
     {
         m_display->ErrorPrintF("Import: %d\n", idx);
         m_display->ErrorPrintF("\tDependency: %p\n", import->dependency);
-        m_display->ErrorPrintF("\tAssemblyRid: %d\n", import->assemblyRid);
+        m_display->ErrorPrintF("\tAssemblyRid: %d\n", *(import->assemblyRid));
     }
 }
 void NativeImageDumper::TraceDumpDependency(int idx, NativeImageDumper::Dependency * dependency)
@@ -1942,7 +1942,7 @@ void NativeImageDumper::FixupBlobToString(RVA rva, SString& buf)
         // print assembly/module info
 
         PTR_USHORT assemblyRid = import->assemblyRid;
-        if (assemblyRid != 0)
+        if (*assemblyRid != 0)
         {
             mdToken realRef =
                 MapAssemblyRefToManifest(TokenFromRid(*assemblyRid,
@@ -2226,7 +2226,7 @@ DataToTokenCore:
             Import *targetImport = OpenImport(targetModuleIndex);
 
             PTR_USHORT assemblyRid = targetImport->assemblyRid;
-            if (assemblyRid != 0)
+            if (*assemblyRid != 0)
             {
                 mdToken realRef =
                     MapAssemblyRefToManifest(TokenFromRid(*assemblyRid,

--- a/src/debug/daccess/nidump.h
+++ b/src/debug/daccess/nidump.h
@@ -322,7 +322,7 @@ public:
      */
     struct Import
     {
-        PTR_CORCOMPILE_IMPORT_TABLE_ENTRY entry;
+        PTR_USHORT assemblyRid;
         Dependency *dependency;
     };
 private:

--- a/src/inc/corcompile.h
+++ b/src/inc/corcompile.h
@@ -45,8 +45,6 @@ typedef DPTR(struct CORCOMPILE_EE_INFO_TABLE)
     PTR_CORCOMPILE_EE_INFO_TABLE;
 typedef DPTR(struct CORCOMPILE_HEADER)
     PTR_CORCOMPILE_HEADER;
-typedef DPTR(struct CORCOMPILE_IMPORT_TABLE_ENTRY)
-    PTR_CORCOMPILE_IMPORT_TABLE_ENTRY;
 typedef DPTR(struct CORCOMPILE_COLD_METHOD_ENTRY)
     PTR_CORCOMPILE_COLD_METHOD_ENTRY;
 typedef DPTR(struct CORCOMPILE_EXCEPTION_LOOKUP_TABLE)
@@ -238,7 +236,7 @@ struct CORCOMPILE_HEADER
 
     IMAGE_DATA_DIRECTORY    HelperTable;    // Table of function pointers to JIT helpers indexed by helper number
     IMAGE_DATA_DIRECTORY    ImportSections; // points to array of code:CORCOMPILE_IMPORT_SECTION
-    IMAGE_DATA_DIRECTORY    ImportTable;    // points to table CORCOMPILE_IMPORT_TABLE_ENTRY
+    IMAGE_DATA_DIRECTORY    ImportTable;    // points to table of PTR_USHORT represinting assembly RIDs
     IMAGE_DATA_DIRECTORY    StubsData;      // contains the value to register with the stub manager for the delegate stubs & AMD64 tail call stubs
     IMAGE_DATA_DIRECTORY    VersionInfo;    // points to a code:CORCOMPILE_VERSION_INFO
     IMAGE_DATA_DIRECTORY    Dependencies;   // points to an array of code:CORCOMPILE_DEPENDENCY
@@ -449,12 +447,6 @@ public :
     {
         return ((sectionType & ColdRange) == ColdRange) && ((sectionType & IBCProfiledSection) == IBCProfiledSection); 
     }
-};
-
-struct CORCOMPILE_IMPORT_TABLE_ENTRY
-{
-    USHORT                  wAssemblyRid;
-    USHORT                  wModuleRid;
 };
 
 struct CORCOMPILE_EE_INFO_TABLE

--- a/src/inc/pedecoder.h
+++ b/src/inc/pedecoder.h
@@ -330,7 +330,7 @@ class PEDecoder
     CORCOMPILE_DEPENDENCY * GetNativeDependencies(COUNT_T *pCount = NULL) const;
 
     COUNT_T GetNativeImportTableCount() const;
-    CORCOMPILE_IMPORT_TABLE_ENTRY *GetNativeImportFromIndex(COUNT_T index) const;
+    USHORT *GetNativeImportFromIndex(COUNT_T index) const;
     CHECK CheckNativeImportFromIndex(COUNT_T index) const;
 
     PTR_CORCOMPILE_IMPORT_SECTION GetNativeImportSections(COUNT_T *pCount = NULL) const;

--- a/src/utilcode/pedecoder.cpp
+++ b/src/utilcode/pedecoder.cpp
@@ -2523,12 +2523,12 @@ COUNT_T PEDecoder::GetNativeImportTableCount() const
 
     IMAGE_DATA_DIRECTORY *pDir = &GetNativeHeader()->ImportTable;
 
-    RETURN (VAL32(pDir->Size) / sizeof(CORCOMPILE_IMPORT_TABLE_ENTRY));
+    RETURN (VAL32(pDir->Size) / sizeof(USHORT));
 }
 
-CORCOMPILE_IMPORT_TABLE_ENTRY *PEDecoder::GetNativeImportFromIndex(COUNT_T index) const
+USHORT *PEDecoder::GetNativeImportFromIndex(COUNT_T index) const
 {
-    CONTRACT(CORCOMPILE_IMPORT_TABLE_ENTRY *)
+    CONTRACT(USHORT *)
     {
         PRECONDITION(CheckNativeHeader());
         PRECONDITION(CheckNativeImportFromIndex(index));
@@ -2540,8 +2540,8 @@ CORCOMPILE_IMPORT_TABLE_ENTRY *PEDecoder::GetNativeImportFromIndex(COUNT_T index
 
     IMAGE_DATA_DIRECTORY *pDir = &GetNativeHeader()->ImportTable;
 
-    CORCOMPILE_IMPORT_TABLE_ENTRY *pEntry
-      = (CORCOMPILE_IMPORT_TABLE_ENTRY *) GetDirectoryData(pDir);
+    USHORT *pEntry
+      = (USHORT *) GetDirectoryData(pDir);
 
     RETURN pEntry + index;
 }

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -10280,8 +10280,7 @@ Module *Module::GetModuleFromIndex(DWORD ix)
     if (HasNativeImage())
     {
         PRECONDITION(GetNativeImage()->CheckNativeImportFromIndex(ix));
-        CORCOMPILE_IMPORT_TABLE_ENTRY *p = GetNativeImage()->GetNativeImportFromIndex(ix);
-        RETURN ZapSig::DecodeModuleFromIndexes(this, p->wAssemblyRid, p->wModuleRid);
+        RETURN ZapSig::DecodeModuleFromIndexes(this, ix, 0);
     }
     else
     {
@@ -10319,9 +10318,8 @@ Module *Module::GetModuleFromIndexIfLoaded(DWORD ix)
     CONTRACT_END;
 
 #ifndef DACCESS_COMPILE 
-    CORCOMPILE_IMPORT_TABLE_ENTRY *p = GetNativeImage()->GetNativeImportFromIndex(ix);
 
-    RETURN ZapSig::DecodeModuleFromIndexesIfLoaded(this, p->wAssemblyRid, p->wModuleRid);
+    RETURN ZapSig::DecodeModuleFromIndexesIfLoaded(this, ix, 0);
 #else // DACCESS_COMPILE
     DacNotImpl();
     RETURN NULL;

--- a/src/zap/zapimport.cpp
+++ b/src/zap/zapimport.cpp
@@ -33,12 +33,11 @@ void ZapImportTable::Save(ZapWriter * pZapWriter)
         ModuleReferenceEntry * pModuleReference = m_modules[i];
         _ASSERTE(pModuleReference != NULL);
 
-        CORCOMPILE_IMPORT_TABLE_ENTRY entry;
+        USHORT assemblyRid;
 
-        entry.wAssemblyRid = pModuleReference->m_wAssemblyRid;
-        entry.wModuleRid = pModuleReference->m_wModuleRid;
+        assemblyRid = pModuleReference->m_wAssemblyRid;
 
-        pZapWriter->Write(&entry, sizeof(entry));
+        pZapWriter->Write(&assemblyRid, sizeof(assemblyRid));
     }
 }
 
@@ -69,7 +68,7 @@ ZapImportTable::ModuleReferenceEntry * ZapImportTable::GetModuleReference(CORINF
     pEntry->m_wAssemblyRid = (USHORT) assemblyIndex;
     pEntry->m_wModuleRid = (USHORT) moduleIndex;
 
-    pEntry->m_index = m_modules.GetCount();
+    pEntry->m_index = (USHORT) assemblyIndex;
     m_modules.Append(pEntry);
 
     m_moduleReferences.Add(pEntry);

--- a/src/zap/zapimport.h
+++ b/src/zap/zapimport.h
@@ -449,7 +449,7 @@ public:
 
     virtual DWORD GetSize()
     {
-        return m_modules.GetCount() * sizeof(CORCOMPILE_IMPORT_TABLE_ENTRY);
+        return m_modules.GetCount() * sizeof(USHORT);
     }
 
     virtual UINT GetAlignment()


### PR DESCRIPTION
As per @jkotas 's suggestion, removing CORCOMPILE_IMPORT_TABLE_ENTRY as the wModuleRid field is not needed/supported in CoreCLR. 

[WIP] while I test nidump.exe 
