### PR TITLE
exclude freebsd symbols from publishing

### DIFF
--- a/src/publish.proj
+++ b/src/publish.proj
@@ -13,6 +13,7 @@
     <PackagesPattern Condition="'$(PackagesPattern)' == ''">$(PackagesPatternDir)pkg\*.nupkg</PackagesPattern>
     <TestNativeBinariesPattern Condition="'$(TestNativeBinariesPattern)' == ''">$(OutputPath)\bin\**</TestNativeBinariesPattern>
     <SymbolsPackagesPattern Condition="'$(SymbolPackagesPattern)' == ''">$(PackagesPatternDir)symbolpkg\*.nupkg</SymbolsPackagesPattern>
+    <SymbolsExcludePattern Condition="'$(SymbolsExcludePattern)' == ''">$(PackagesPatternDir)symbolpkg\*freebsd*.nupkg</SymbolsExcludePattern>
     <PublishFlatContainer Condition="'$(PublishFlatContainer)' == ''">true</PublishFlatContainer>
     <RelativePathWithSlash>$(RelativePath)</RelativePathWithSlash>
     <RelativePathWithSlash Condition="'$(RelativePathWithSlash)' != '' and !HasTrailingSlash('$(RelativePathWithSlash)')">$(RelativePathWithSlash)/</RelativePathWithSlash>
@@ -142,7 +143,7 @@
       <ConvertPortablePdbsToWindowsPdbs Condition="'$(ConvertPortablePdbsToWindowsPdbs)'==''">true</ConvertPortablePdbsToWindowsPdbs>
     </PropertyGroup>
     <ItemGroup>
-      <SymbolPackagesToPublish Include="$(SymbolsPackagesPattern)" Exclude="$(PackagePatternDir)symbolpkg\*freebsd*.nupkg"/>
+      <SymbolPackagesToPublish Include="$(SymbolsPackagesPattern)" Exclude="$(SymbolsExcludePattern)" />
     </ItemGroup>
     <Error Condition="'$(SymbolServerPath)'==''" Text="Missing property SymbolServerPath" />
     <Error Condition="'$(SymbolServerPAT)'==''" Text="Missing property SymbolServerPAT" />

--- a/src/publish.proj
+++ b/src/publish.proj
@@ -142,8 +142,7 @@
       <ConvertPortablePdbsToWindowsPdbs Condition="'$(ConvertPortablePdbsToWindowsPdbs)'==''">true</ConvertPortablePdbsToWindowsPdbs>
     </PropertyGroup>
     <ItemGroup>
-      <SymbolPackagesToPublish Include="$(SymbolsPackagesPattern)" />
-      <SymbolPackagesToPublish Remove="$(PackagePatternDir)symbolpkg\*freebsd*.nupkg" />
+      <SymbolPackagesToPublish Include="$(SymbolsPackagesPattern)" Exclude="$(PackagePatternDir)symbolpkg\*freebsd*.nupkg"/>
     </ItemGroup>
     <Error Condition="'$(SymbolServerPath)'==''" Text="Missing property SymbolServerPath" />
     <Error Condition="'$(SymbolServerPAT)'==''" Text="Missing property SymbolServerPAT" />


### PR DESCRIPTION
One more update. This time I was able to get local repro and verify that freebsd packages are missing in 
```
Done executing task "Message".
Task "Message"
  Publishing C:\Users\toweinfu\source\repos\coreclr\bin\Product\Windows_NT.x64.Debug\.nuget\symbolpkg\Microsoft.NET.Sdk.IL.3.0.0-preview-27106-0.symbols.nupkg;C:\Users\toweinfu\sour
  ce\repos\coreclr\bin\Product\Windows_NT.x64.Debug\.nuget\symbolpkg\Microsoft.NETCore.ILAsm.3.0.0-preview-27105-0.symbols.nupkg;C:\Users\toweinfu\source\repos\coreclr\bin\Product\W
  indows_NT.x64.Debug\.nuget\symbolpkg\Microsoft.NETCore.ILAsm.3.0.0-preview-27106-0.symbols.nupkg;C:\Users\toweinfu\source\repos\coreclr\bin\Product\Windows_NT.x64.Debug\.nuget\sym
  bolpkg\Microsoft.NETCore.ILDAsm.3.0.0-preview-27105-0.symbols.nupkg;C:\Users\toweinfu\source\repos\coreclr\bin\Product\Windows_NT.x64.Debug\.nuget\symbolpkg\Microsoft.NETCore.ILDA
  sm.3.0.0-preview-27106-0.symbols.nupkg;C:\Users\toweinfu\source\repos\coreclr\bin\Product\Windows_NT.x64.Debug\.nuget\symbolpkg\Microsoft.NETCore.Jit.3.0.0-preview-27105-0.symbols
  .nupkg;C:\Users\toweinfu\source\repos\coreclr\bin\Product\Windows_NT.x64.Debug\.nuget\symbolpkg\Microsoft.NETCore.Jit.3.0.0-preview-27106-0.symbols.nupkg;C:\Users\toweinfu\source\
  repos\coreclr\bin\Product\Windows_NT.x64.Debug\.nuget\symbolpkg\Microsoft.NETCore.Native.3.0.0-preview-27105-0.symbols.nupkg;C:\Users\toweinfu\source\repos\coreclr\bin\Product\Win
  dows_NT.x64.Debug\.nuget\symbolpkg\Microsoft.NETCore.Native.3.0.0-preview-27106-0.symbols.nupkg;C:\Users\toweinfu\source\repos\coreclr\bin\Product\Windows_NT.x64.Debug\.nuget\symb
  olpkg\Microsoft.NETCore.Runtime.CoreCLR.3.0.0-preview-27105-0.symbols.nupkg;C:\Users\toweinfu\source\repos\coreclr\bin\Product\Windows_NT.x64.Debug\.nuget\symbolpkg\Microsoft.NETC
  ore.Runtime.CoreCLR.3.0.0-preview-27106-0.symbols.nupkg;C:\Users\toweinfu\source\repos\coreclr\bin\Product\Windows_NT.x64.Debug\.nuget\symbolpkg\Microsoft.NETCore.TestHost.3.0.0-p
  review-27105-0.symbols.nupkg;C:\Users\toweinfu\source\repos\coreclr\bin\Product\Windows_NT.x64.Debug\.nuget\symbolpkg\Microsoft.NETCore.TestHost.3.0.0-preview-27106-0.symbols.nupk
  g;C:\Users\toweinfu\source\repos\coreclr\bin\Product\Windows_NT.x64.Debug\.nuget\symbolpkg\Microsoft.TargetingPack.Private.CoreCLR.3.0.0-preview-27106-0.symbols.nupkg;C:\Users\tow
  einfu\source\repos\coreclr\bin\Product\Windows_NT.x64.Debug\.nuget\symbolpkg\runtime.win-x64.Microsoft.NETCore.ILAsm.3.0.0-preview-27106-0.symbols.nupkg;C:\Users\toweinfu\source\r
  epos\coreclr\bin\Product\Windows_NT.x64.Debug\.nuget\symbolpkg\runtime.win-x64.Microsoft.NETCore.ILDAsm.3.0.0-preview-27106-0.symbols.nupkg;C:\Users\toweinfu\source\repos\coreclr\
  bin\Product\Windows_NT.x64.Debug\.nuget\symbolpkg\runtime.win-x64.Microsoft.NETCore.Jit.3.0.0-preview-27106-0.symbols.nupkg;C:\Users\toweinfu\source\repos\coreclr\bin\Product\Wind
  ows_NT.x64.Debug\.nuget\symbolpkg\runtime.win-x64.Microsoft.NETCore.Runtime.CoreCLR.3.0.0-preview-27106-0.symbols.nupkg;C:\Users\toweinfu\source\repos\coreclr\bin\Product\Windows_
  NT.x64.Debug\.nuget\symbolpkg\runtime.win-x64.Microsoft.NETCore.TestHost.3.0.0-preview-27106-0.symbols.nupkg to http://foo.com
```
message. It seems like the problem was that the `PackagePatternDir` was not expanded in the Remove/Exclude statements. So I added new variable to hold list of packages to exclude and that seems to work OK. 