### PR TITLE
Re-enable some corefx tests

### DIFF
--- a/tests/CoreFX/CoreFX.issues.json
+++ b/tests/CoreFX/CoreFX.issues.json
@@ -486,14 +486,6 @@
                 {
                     "name": "System.Buffers.Text.Tests.FormatterTests.TestFormatterDecimal",
                     "reason": "https://github.com/dotnet/coreclr/pull/19775"
-                },
-                {
-                    "name": "System.SpanTests.MemoryMarshalTests.CreateFromPinnedArrayIntSliceRemainsPinned",
-                    "reason": "https://github.com/dotnet/corefx/pull/32994"
-                },
-                {
-                    "name": "System.SpanTests.MemoryMarshalTests.CreateFromPinnedArrayIntReadOnlyMemorySliceRemainsPinned",
-                    "reason": "https://github.com/dotnet/corefx/pull/32994"
                 }
             ]
         }


### PR DESCRIPTION
These tests were temporarily disabled during the Memory<T>.Span changes, but they've since been updated to pass