### PR TITLE
Stop running non-PR jobs in release/2.2 branch

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1099,6 +1099,11 @@ def static getJobName(def configuration, def architecture, def os, def scenario,
 
 def static addNonPRTriggers(def job, def branch, def isPR, def architecture, def os, def configuration, def scenario, def isFlowJob, def isWindowsBuildOnlyJob, def bidailyCrossList) {
 
+    // Don't run non-PR jobs in release/2.2 branch: it takes too many Jenkins resources.
+    if (branch == 'release/2.2') {
+        return
+    }
+
     // Limited Windows ARM64 hardware is restricted for non-PR triggers to certain branches.
     if (os == 'Windows_NT') {
         if ((architecture == 'arm64') || (architecture == 'arm') || (architecture == 'armlb')) {


### PR DESCRIPTION
It takes too many machine and Jenkins resources.