### PR TITLE
Add work item dumping support to SOS' ThreadPool command

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Collections/Concurrent/ConcurrentQueue.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Concurrent/ConcurrentQueue.cs
@@ -56,7 +56,7 @@ namespace System.Collections.Concurrent
         /// <summary>The current tail segment.</summary>
         private volatile ConcurrentQueueSegment<T> _tail;
         /// <summary>The current head segment.</summary>
-        private volatile ConcurrentQueueSegment<T> _head;
+        private volatile ConcurrentQueueSegment<T> _head; // SOS's ThreadPool command depends on this name
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConcurrentQueue{T}"/> class.

--- a/src/System.Private.CoreLib/shared/System/Collections/Concurrent/ConcurrentQueueSegment.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Concurrent/ConcurrentQueueSegment.cs
@@ -20,7 +20,7 @@ namespace System.Collections.Concurrent
         // http://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue
 
         /// <summary>The array of items in this queue.  Each slot contains the item in that slot and its "sequence number".</summary>
-        internal readonly Slot[] _slots;
+        internal readonly Slot[] _slots; // SOS's ThreadPool command depends on this name
         /// <summary>Mask for quickly accessing a position within the queue's array.</summary>
         internal readonly int _slotsMask;
         /// <summary>The head and tail positions, with padding to help avoid false sharing contention.</summary>
@@ -33,7 +33,7 @@ namespace System.Collections.Concurrent
         internal bool _frozenForEnqueues;
 #pragma warning disable 0649 // some builds don't assign to this field
         /// <summary>The segment following this one in the queue, or null if this segment is the last in the queue.</summary>
-        internal ConcurrentQueueSegment<T> _nextSegment;
+        internal ConcurrentQueueSegment<T> _nextSegment; // SOS's ThreadPool command depends on this name
 #pragma warning restore 0649
 
         /// <summary>Creates the segment.</summary>
@@ -315,7 +315,7 @@ namespace System.Collections.Concurrent
         internal struct Slot
         {
             /// <summary>The item.</summary>
-            public T Item;
+            public T Item; // SOS's ThreadPool command depends on this being at the beginning of the struct when T is a reference type
             /// <summary>The sequence number for this slot, used to synchronize between enqueuers and dequeuers.</summary>
             public int SequenceNumber;
         }

--- a/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
@@ -110,7 +110,7 @@ namespace System.Threading
         internal sealed class WorkStealingQueue
         {
             private const int INITIAL_SIZE = 32;
-            internal volatile object[] m_array = new object[INITIAL_SIZE];
+            internal volatile object[] m_array = new object[INITIAL_SIZE]; // SOS's ThreadPool command depends on this name
             private volatile int m_mask = INITIAL_SIZE - 1;
 
 #if DEBUG
@@ -377,7 +377,7 @@ namespace System.Threading
         }
 
         internal bool loggingEnabled;
-        internal readonly ConcurrentQueue<object> workItems = new ConcurrentQueue<object>();
+        internal readonly ConcurrentQueue<object> workItems = new ConcurrentQueue<object>(); // SOS's ThreadPool command depends on this name
 
         private Internal.PaddingFor32 pad1;
 
@@ -933,7 +933,7 @@ namespace System.Threading
 
     internal sealed class QueueUserWorkItemCallback : QueueUserWorkItemCallbackBase
     {
-        private WaitCallback _callback;
+        private WaitCallback _callback; // SOS's ThreadPool command depends on this name
         private readonly object _state;
         private readonly ExecutionContext _context;
 
@@ -972,7 +972,7 @@ namespace System.Threading
 
     internal sealed class QueueUserWorkItemCallback<TState> : QueueUserWorkItemCallbackBase
     {
-        private Action<TState> _callback;
+        private Action<TState> _callback; // SOS's ThreadPool command depends on this name
         private readonly TState _state;
         private readonly ExecutionContext _context;
 
@@ -1011,7 +1011,7 @@ namespace System.Threading
 
     internal sealed class QueueUserWorkItemCallbackDefaultContext : QueueUserWorkItemCallbackBase
     {
-        private WaitCallback _callback;
+        private WaitCallback _callback; // SOS's ThreadPool command depends on this name
         private readonly object _state;
 
         internal static readonly ContextCallback s_executionContextShim = state =>
@@ -1038,7 +1038,7 @@ namespace System.Threading
 
     internal sealed class QueueUserWorkItemCallbackDefaultContext<TState> : QueueUserWorkItemCallbackBase
     {
-        private Action<TState> _callback;
+        private Action<TState> _callback; // SOS's ThreadPool command depends on this name
         private readonly TState _state;
 
         internal static readonly ContextCallback s_executionContextShim = state =>


### PR DESCRIPTION
Adds a -wi switch to the ThreadPool command that will enumerate all queues dumping out all found work items.

For example, given this program:
```C#
using System;
using System.Linq;
using System.Threading;
using System.Threading.Tasks;

class Program
{
    static void Main()
    {
        for (int i = 0; i < Environment.ProcessorCount; i++) Task.Run(QueueWork);
        QueueWork();
        Console.ReadLine();
    }

    static void QueueWork()
    {
        Task.Run(A);
        ThreadPool.QueueUserWorkItem(B, null);
        ThreadPool.QueueUserWorkItem(C, 42, true);
        Task.Run(D);
    }

    static void A() => Thread.CurrentThread.Join();
    static void B(object s) => Thread.CurrentThread.Join();
    static void C(int s) => Thread.CurrentThread.Join();
    static async Task D() { await Task.Yield(); Thread.CurrentThread.Join(); }
}
```
running it and quickly attaching WinDBG/sos yielded the following output:
```
0:022> !threadpool -wi
CPU utilization: 19%
Worker Thread: Total: 11 Running: 11 Idle: 0 MaxLimit: 32767 MinLimit: 8
Work Request in Queue: 1
    AsyncTimerCallbackCompletion TimerInfo@000001d831d959b0

Queued work items:
           Queue          Address Work Item
        [Global] 000001d819a337d0 System.Threading.QueueUserWorkItemCallbackDefaultContext => Program.B(System.Object)
        [Global] 000001d819a38300 System.Threading.QueueUserWorkItemCallbackDefaultContext => Program.B(System.Object)
        [Global] 000001d819a3a308 System.Threading.QueueUserWorkItemCallbackDefaultContext => Program.B(System.Object)
        [Global] 000001d819a3c310 System.Threading.QueueUserWorkItemCallbackDefaultContext => Program.B(System.Object)
        [Global] 000001d819a3e318 System.Threading.QueueUserWorkItemCallbackDefaultContext => Program.B(System.Object)
        [Global] 000001d819a40320 System.Threading.QueueUserWorkItemCallbackDefaultContext => Program.B(System.Object)
        [Global] 000001d819a42328 System.Threading.QueueUserWorkItemCallbackDefaultContext => Program.B(System.Object)
        [Global] 000001d819a33830 System.Threading.QueueUserWorkItemCallbackDefaultContext`1[[System.Int32, System.Private.CoreLib]] => Program.C(Int32)
        [Global] 000001d819a33890 System.Threading.Tasks.Task`1[[System.Threading.Tasks.Task, System.Private.CoreLib]] => Program.D()
        [Global] 000001d819a40498 System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[[System.Threading.Tasks.VoidTaskResult, System.Private.CoreLib],[Program+d__5, test]]
        [Global] 000001d819a36470 System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[[System.Threading.Tasks.VoidTaskResult, System.Private.CoreLib],[Program+d__5, test]]
        [Global] 000001d819a3e490 System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[[System.Threading.Tasks.VoidTaskResult, System.Private.CoreLib],[Program+d__5, test]]
        [Global] 000001d819a3c488 System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[[System.Threading.Tasks.VoidTaskResult, System.Private.CoreLib],[Program+d__5, test]]
        [Global] 000001d819a3a480 System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[[System.Threading.Tasks.VoidTaskResult, System.Private.CoreLib],[Program+d__5, test]]
        [Global] 000001d819a424a0 System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[[System.Threading.Tasks.VoidTaskResult, System.Private.CoreLib],[Program+d__5, test]]
        [Global] 000001d819a38528 System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[[System.Threading.Tasks.VoidTaskResult, System.Private.CoreLib],[Program+d__5, test]]
        [Global] 000001d819a34480 System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[[System.Threading.Tasks.VoidTaskResult, System.Private.CoreLib],[Program+d__5, test]]
000001d819a34080 000001d819a34288 System.Threading.Tasks.Task => Program.A()
000001d819a36080 000001d819a36278 System.Threading.Tasks.Task => Program.A()
000001d819a38080 000001d819a38280 System.Threading.Tasks.Task => Program.A()
000001d819a3a080 000001d819a3a288 System.Threading.Tasks.Task => Program.A()
000001d819a3c080 000001d819a3c290 System.Threading.Tasks.Task => Program.A()
000001d819a3e080 000001d819a3e298 System.Threading.Tasks.Task => Program.A()
000001d819a40080 000001d819a402a0 System.Threading.Tasks.Task => Program.A()
000001d819a42080 000001d819a422a8 System.Threading.Tasks.Task => Program.A()
Statistics:
              MT    Count    TotalSize Class Name
00007ffee06b8e60        1           32 System.Threading.QueueUserWorkItemCallbackDefaultContext`1[[System.Int32, System.Private.CoreLib]]
00007fff34ecc928        1           72 System.Threading.Tasks.Task`1[[System.Threading.Tasks.Task, System.Private.CoreLib]]
00007fff34eddb70        7          224 System.Threading.QueueUserWorkItemCallbackDefaultContext
00007fff34eca440        8          512 System.Threading.Tasks.Task
00007ffee07814d8        8          896 System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[[System.Threading.Tasks.VoidTaskResult, System.Private.CoreLib],[Program+<D>d__5, test]]
Total 25 objects

--------------------------------------
Number of Timers: 1
--------------------------------------
Completion Port Thread:Total: 0 Free: 0 MaxFree: 16 CurrentLimit: 0 MaxLimit: 1000 MinLimit: 8
```

cc: @noahfalk, @mikem8361, @kouvel 