### PR TITLE
Initial support for normalized 'naked' R2RDump output

### DIFF
--- a/src/tools/r2rdump/CoreDisTools.cs
+++ b/src/tools/r2rdump/CoreDisTools.cs
@@ -91,6 +91,11 @@ namespace R2RDump
         private readonly R2RReader _reader;
 
         /// <summary>
+        /// Dump options
+        /// </summary>
+        private readonly DumpOptions _options;
+
+        /// <summary>
         /// COM interface to the native disassembler in the CoreDisTools.dll library.
         /// </summary>
         private readonly IntPtr _disasm;
@@ -99,9 +104,10 @@ namespace R2RDump
         /// Store the R2R reader and construct the disassembler for the appropriate architecture.
         /// </summary>
         /// <param name="reader"></param>
-        public Disassembler(R2RReader reader)
+        public Disassembler(R2RReader reader, DumpOptions options)
         {
             _reader = reader;
+            _options = options;
             _disasm = CoreDisTools.GetDisasm(_reader.Machine);
         }
 
@@ -135,6 +141,32 @@ namespace R2RDump
             int instrSize = CoreDisTools.GetInstruction(_disasm, rtf, imageOffset, rtfOffset, _reader.Image, out instruction);
             instruction = instruction.Replace('\t', ' ');
 
+            if (_options.Naked)
+            {
+                StringBuilder nakedInstruction = new StringBuilder();
+                foreach (string line in instruction.Split(new char[] { '\n' }, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    int colon = line.IndexOf(':');
+                    if (colon >= 0)
+                    {
+                        colon += 2;
+                        while (colon + 3 <= line.Length &&
+                            IsXDigit(line[colon]) &&
+                            IsXDigit(line[colon + 1]) &&
+                            line[colon + 2] == ' ')
+                        {
+                            colon += 3;
+                        }
+                        nakedInstruction.AppendLine(new string(' ', 32) + line.Substring(colon).TrimStart());
+                    }
+                    else
+                    {
+                        nakedInstruction.AppendLine(line);
+                    }
+                }
+                instruction = nakedInstruction.ToString();
+            }
+
             switch (_reader.Machine)
             {
                 case Machine.Amd64:
@@ -161,6 +193,11 @@ namespace R2RDump
             return instrSize;
         }
 
+        private static bool IsXDigit(char c)
+        {
+            return Char.IsDigit(c) || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
+        }
+
         const string RelIPTag = "[rip ";
 
         /// <summary>
@@ -182,9 +219,24 @@ namespace R2RDump
                 int newline = instruction.LastIndexOf('\n');
                 StringBuilder translated = new StringBuilder();
                 translated.Append(instruction, 0, leftBracket);
-                translated.AppendFormat("[0x{0:x4}]", target);
+                if (_options.Naked)
+                {
+                    String targetName;
+                    if (_reader.ImportCellNames.TryGetValue(target, out targetName))
+                    {
+                        translated.AppendFormat("[{0}]", targetName);
+                    }
+                    else
+                    {
+                        translated.AppendFormat("[0x{0:x4}]", target);
+                    }
+                }
+                else
+                {
+                    translated.AppendFormat("[0x{0:x4}]", target);
 
-                AppendImportCellName(translated, target);
+                    AppendImportCellName(translated, target);
+                }
 
                 translated.Append(instruction, rightBracketPlusOne, newline - rightBracketPlusOne);
 
@@ -216,9 +268,24 @@ namespace R2RDump
 
                 StringBuilder translated = new StringBuilder();
                 translated.Append(instruction, 0, leftBracket);
-                translated.AppendFormat("[0x{0:x4}]", target);
+                if (_options.Naked)
+                {
+                    String targetName;
+                    if (_reader.ImportCellNames.TryGetValue(target, out targetName))
+                    {
+                        translated.AppendFormat("[{0}]", targetName);
+                    }
+                    else
+                    {
+                        translated.AppendFormat("[0x{0:x4}]", target);
+                    }
+                }
+                else
+                {
+                    translated.AppendFormat("[0x{0:x4}]", target);
 
-                AppendImportCellName(translated, target);
+                    AppendImportCellName(translated, target);
+                }
 
                 translated.Append(instruction, rightBracketPlusOne, instruction.Length - rightBracketPlusOne);
                 instruction = translated.ToString();
@@ -239,6 +306,11 @@ namespace R2RDump
         /// <param name="instruction">Textual representation of the instruction</param>
         private void ProbeCommonIntelQuirks(RuntimeFunction rtf, int imageOffset, int rtfOffset, int instrSize, ref string instruction)
         {
+            if (_options.Naked)
+            {
+                // Don't relocate relative offsets in naked mode
+                return;
+            }
             if (instrSize == 2 && IsIntelJumpInstructionWithByteOffset(imageOffset + rtfOffset))
             {
                 sbyte offset = (sbyte)_reader.Image[imageOffset + rtfOffset + 1];

--- a/src/tools/r2rdump/R2RDump.cs
+++ b/src/tools/r2rdump/R2RDump.cs
@@ -19,11 +19,13 @@ namespace R2RDump
     {
         public bool Raw;
         public bool Normalize;
+        public bool Naked;
         public bool Header;
         public bool Disasm;
         public bool Unwind;
         public bool GC;
         public bool SectionContents;
+        public bool EntryPoints;
     }
 
     public abstract class Dumper
@@ -75,6 +77,7 @@ namespace R2RDump
         abstract internal void SkipLine();
         abstract internal void DumpHeader(bool dumpSections);
         abstract internal void DumpSection(R2RSection section, XmlNode parentNode = null);
+        abstract internal void DumpEntryPoints();
         abstract internal void DumpAllMethods();
         abstract internal void DumpMethod(R2RMethod method, XmlNode parentNode = null);
         abstract internal void DumpRuntimeFunction(RuntimeFunction rtf, XmlNode parentNode = null);
@@ -125,6 +128,7 @@ namespace R2RDump
                 syntax.DefineOption("raw", ref _options.Raw, "Dump the raw bytes of each section or runtime function");
                 syntax.DefineOption("header", ref _options.Header, "Dump R2R header");
                 syntax.DefineOption("d|disasm", ref _options.Disasm, "Show disassembly of methods or runtime functions");
+                syntax.DefineOption("naked", ref _options.Naked, "Naked dump suppresses most compilation details like placement addresses");
                 syntax.DefineOptionList("q|query", ref _queries, "Query method by exact name, signature, row id or token");
                 syntax.DefineOptionList("k|keyword", ref _keywords, "Search method by keyword");
                 syntax.DefineOptionList("r|runtimefunction", ref _runtimeFunctions, ArgStringToInt, "Get one runtime function by id or relative virtual address");
@@ -132,6 +136,7 @@ namespace R2RDump
                 syntax.DefineOption("unwind", ref _options.Unwind, "Dump unwindInfo");
                 syntax.DefineOption("gc", ref _options.GC, "Dump gcInfo and slot table");
                 syntax.DefineOption("sc", ref _options.SectionContents, "Dump section contents");
+                syntax.DefineOption("e|entrypoints", ref _options.EntryPoints, "Dump list of method / instance entrypoints in the R2R file");
                 syntax.DefineOption("n|normalize", ref _options.Normalize, "Normalize dump by sorting the various tables and methods (default = unsorted i.e. file order)");
                 syntax.DefineOption("v|verbose", ref verbose, "Dump disassembly, unwindInfo, gcInfo and section contents");
                 syntax.DefineOption("diff", ref _diff, "Compare two R2R images");
@@ -144,6 +149,7 @@ namespace R2RDump
                 _options.Unwind = true;
                 _options.GC = true;
                 _options.SectionContents = true;
+                _options.EntryPoints = true;
             }
 
             return argSyntax;
@@ -266,10 +272,18 @@ namespace R2RDump
 
             if (_queries.Count == 0 && _keywords.Count == 0 && _runtimeFunctions.Count == 0 && _sections.Count == 0) //dump all sections and methods if no queries specified
             {
-                _dumper.WriteDivider("R2R Header");
-                _dumper.DumpHeader(true);
+                if (_options.Header || !_options.EntryPoints)
+                {
+                    _dumper.WriteDivider("R2R Header");
+                    _dumper.DumpHeader(true);
+                }
                 
-                if (!_options.Header)
+                if (_options.EntryPoints)
+                {
+                    _dumper.DumpEntryPoints();
+                }
+
+                if (!_options.Header && !_options.EntryPoints)
                 {
                     _dumper.DumpAllMethods();
                 }
@@ -437,7 +451,7 @@ namespace R2RDump
                     {
                         if (r2r.InputArchitectureSupported() && r2r.DisassemblerArchitectureSupported())
                         {
-                            disassembler = new Disassembler(r2r);
+                            disassembler = new Disassembler(r2r, _options);
                         }
                         else
                         {

--- a/src/tools/r2rdump/R2RReader.cs
+++ b/src/tools/r2rdump/R2RReader.cs
@@ -35,11 +35,17 @@ namespace R2RDump
         /// </summary>
         public uint CellOffset;
 
-        public FixupCell(int index, uint tableIndex, uint cellOffset)
+        /// <summary>
+        /// Fixup cell signature (textual representation of the typesystem object).
+        /// </summary>
+        public string Signature;
+
+        public FixupCell(int index, uint tableIndex, uint cellOffset, string signature)
         {
             Index = index;
             TableIndex = tableIndex;
             CellOffset = cellOffset;
+            Signature = signature;
         }
     }
 
@@ -212,6 +218,10 @@ namespace R2RDump
                         EHLookupTable = new EHLookupTable(Image, GetOffset(exceptionInfoSection.RelativeVirtualAddress), exceptionInfoSection.Size);
                     }
 
+                    ImportSections = new List<R2RImportSection>();
+                    ImportCellNames = new Dictionary<int, string>();
+                    ParseImportSections();
+
                     R2RMethods = new List<R2RMethod>();
                     InstanceMethods = new List<InstanceMethod>();
 
@@ -234,10 +244,6 @@ namespace R2RDump
                     ParseAvailableTypes();
 
                     CompilerIdentifier = ParseCompilerIdentifier();
-
-                    ImportSections = new List<R2RImportSection>();
-                    ImportCellNames = new Dictionary<int, string>();
-                    ParseImportSections();
                 }
             }
         }
@@ -698,7 +704,9 @@ namespace R2RDump
 
                 while (true)
                 {
-                    cells.Add(new FixupCell(cells.Count, curTableIndex, fixupIndex));
+                    R2RImportSection importSection = ImportSections[(int)curTableIndex];
+                    R2RImportSection.ImportSectionEntry entry = importSection.Entries[(int)fixupIndex];
+                    cells.Add(new FixupCell(cells.Count, curTableIndex, fixupIndex, entry.Signature));
 
                     uint delta = reader.ReadUInt();
 

--- a/src/tools/r2rdump/R2RSignature.cs
+++ b/src/tools/r2rdump/R2RSignature.cs
@@ -699,7 +699,8 @@ namespace R2RDump
                     break;
 
                 case CorElementType.ELEMENT_TYPE_PTR:
-                    builder.Append("ptr");
+                    ParseType(builder);
+                    builder.Append('*');
                     break;
 
                 case CorElementType.ELEMENT_TYPE_BYREF:
@@ -717,7 +718,33 @@ namespace R2RDump
                     break;
 
                 case CorElementType.ELEMENT_TYPE_ARRAY:
-                    builder.Append("array");
+                    ParseType(builder);
+                    {
+                        builder.Append('[');
+                        uint rank = ReadUInt();
+                        if (rank != 0)
+                        {
+                            uint sizeCount = ReadUInt(); // number of sizes
+                            for (uint sizeIndex = 0; sizeIndex < sizeCount; sizeIndex++)
+                            {
+                                ReadUInt();
+                            }
+                            uint lowerBoundCount = ReadUInt(); // number of lower bounds
+                            for (uint lowerBoundIndex = 0; lowerBoundIndex < lowerBoundCount; lowerBoundIndex++)
+                            {
+                                ReadUInt();
+                            }
+                            if (rank == 1)
+                            {
+                                builder.Append('*');
+                            }
+                            else
+                            {
+                                builder.Append(new string(',', (int)(rank - 1)));
+                            }
+                        }
+                        builder.Append(']');
+                    }
                     break;
 
                 case CorElementType.ELEMENT_TYPE_GENERICINST:
@@ -745,7 +772,8 @@ namespace R2RDump
                     break;
 
                 case CorElementType.ELEMENT_TYPE_SZARRAY:
-                    builder.Append("szarray");
+                    ParseType(builder);
+                    builder.Append("[]");
                     break;
 
                 case CorElementType.ELEMENT_TYPE_MVAR:

--- a/src/tools/r2rdump/XmlDumper.cs
+++ b/src/tools/r2rdump/XmlDumper.cs
@@ -114,6 +114,17 @@ namespace R2RDump
             }
         }
 
+        internal override void DumpEntryPoints()
+        {
+            XmlNode entryPointsNode = XmlDocument.CreateNode("element", "EntryPoints", "");
+            _rootNode.AppendChild(entryPointsNode);
+            AddXMLAttribute(entryPointsNode, "Count", _r2r.R2RMethods.Count.ToString());
+            foreach (R2RMethod method in NormalizedMethods())
+            {
+                DumpMethod(method, entryPointsNode);
+            }
+        }
+
         internal override void DumpAllMethods()
         {
             XmlNode methodsNode = XmlDocument.CreateNode("element", "Methods", "");


### PR DESCRIPTION
This change introduces a new option "--naked" that takes output
normalization even further - it intentionally leaves out any
position information to make the output easier to diff between
CPAOT and Crossgen.

One other new option is "--entrypoints" which dumps a plain
list of JITted methods in the R2R executable. This can be used
for comparisons between CPAOT and Crossgen and / or for static
analysis of what methods were actually emitted by the compiler.

Thanks

Tomas