### PR TITLE
Changing Number.NumberBuffer to carry a `Span<byte>` rather than a `Span<char>`

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Number.Dragon4.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Dragon4.cs
@@ -248,7 +248,7 @@ namespace System
             number.Digits[precision] = (byte)('\0');
 
             number.Scale++;
-            number.Sign = double.IsNegative(value);
+            number.IsNegative = double.IsNegative(value);
         }
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Number.Dragon4.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Dragon4.cs
@@ -168,7 +168,7 @@ namespace System
                     break;
                 }
 
-                number.Digits[digitsNum] = (char)('0' + currentDigit);
+                number.Digits[digitsNum] = (byte)('0' + currentDigit);
                 digitsNum++;
 
                 r.Multiply10();
@@ -196,12 +196,12 @@ namespace System
 
             if (isRoundDown)
             {
-                number.Digits[digitsNum] = (char)('0' + currentDigit);
+                number.Digits[digitsNum] = (byte)('0' + currentDigit);
                 digitsNum++;
             }
             else
             {
-                char* pCurrentDigit = (number.GetDigitsPointer() + digitsNum);
+                byte* pCurrentDigit = (number.GetDigitsPointer() + digitsNum);
 
                 // Rounding up for 9 is special.
                 if (currentDigit == 9)
@@ -213,7 +213,7 @@ namespace System
                         if (pCurrentDigit == number.GetDigitsPointer())
                         {
                             // Output 1 at the next highest exponent
-                            *pCurrentDigit = '1';
+                            *pCurrentDigit = (byte)('1');
                             digitsNum++;
                             number.Scale += 1;
                             break;
@@ -225,7 +225,7 @@ namespace System
                         if (*pCurrentDigit != '9')
                         {
                             // increment the digit
-                            *pCurrentDigit += (char)(1);
+                            *pCurrentDigit += 1;
                             digitsNum++;
                             break;
                         }
@@ -234,18 +234,18 @@ namespace System
                 else
                 {
                     // It's simple if the digit is not 9.
-                    *pCurrentDigit = (char)('0' + currentDigit + 1);
+                    *pCurrentDigit = (byte)('0' + currentDigit + 1);
                     digitsNum++;
                 }
             }
 
             while (digitsNum < precision)
             {
-                number.Digits[digitsNum] = '0';
+                number.Digits[digitsNum] = (byte)('0');
                 digitsNum++;
             }
 
-            number.Digits[precision] = '\0';
+            number.Digits[precision] = (byte)('\0');
 
             number.Scale++;
             number.Sign = double.IsNegative(value);

--- a/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
@@ -344,7 +344,7 @@ namespace System
         private static unsafe void DecimalToNumber(ref decimal d, ref NumberBuffer number)
         {
             byte* buffer = number.GetDigitsPointer();
-            number.Precision = DecimalPrecision;
+            number.DigitsCount = DecimalPrecision;
             number.IsNegative = d.IsNegative;
 
             byte* p = buffer + DecimalPrecision;
@@ -968,7 +968,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // called from only one location
         private static unsafe void Int32ToNumber(int value, ref NumberBuffer number)
         {
-            number.Precision = Int32Precision;
+            number.DigitsCount = Int32Precision;
 
             if (value >= 0)
             {
@@ -1094,7 +1094,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // called from only one location
         private static unsafe void UInt32ToNumber(uint value, ref NumberBuffer number)
         {
-            number.Precision = UInt32Precision;
+            number.DigitsCount = UInt32Precision;
             number.IsNegative = false;
 
             byte* buffer = number.GetDigitsPointer();
@@ -1218,7 +1218,7 @@ namespace System
         {
             ulong value = (ulong)input;
             number.IsNegative = input < 0;
-            number.Precision = Int64Precision;
+            number.DigitsCount = Int64Precision;
             if (number.IsNegative)
             {
                 value = (ulong)(-input);
@@ -1361,7 +1361,7 @@ namespace System
 
         private static unsafe void UInt64ToNumber(ulong value, ref NumberBuffer number)
         {
-            number.Precision = UInt64Precision;
+            number.DigitsCount = UInt64Precision;
             number.IsNegative = false;
 
             byte* buffer = number.GetDigitsPointer();
@@ -1580,7 +1580,7 @@ namespace System
                         else
                         {
                             // This ensures that the PAL code pads out to the correct place even when we use the default precision
-                            nMaxDigits = number.Precision;
+                            nMaxDigits = number.DigitsCount;
                         }
                     }
 
@@ -2040,7 +2040,7 @@ namespace System
 
                     groupSizeIndex = 0;
                     int digitCount = 0;
-                    int digLength = number.Precision;
+                    int digLength = number.DigitsCount;
                     int digStart = (digPos < digLength) ? digPos : digLength;
                     fixed (char* spanPtr = &MemoryMarshal.GetReference(sb.AppendSpan(bufferSize)))
                     {
@@ -2333,7 +2333,7 @@ namespace System
 
         private static unsafe void DoubleToNumber(double value, int precision, ref NumberBuffer number)
         {
-            number.Precision = precision;
+            number.DigitsCount = precision;
 
             if (!double.IsFinite(value))
             {

--- a/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
@@ -345,7 +345,7 @@ namespace System
         {
             byte* buffer = number.GetDigitsPointer();
             number.Precision = DecimalPrecision;
-            number.Sign = d.IsNegative;
+            number.IsNegative = d.IsNegative;
 
             byte* p = buffer + DecimalPrecision;
             while ((d.Mid | d.High) != 0)
@@ -410,7 +410,7 @@ namespace System
                     }
                     else if (number.Scale == ScaleINF)
                     {
-                        return number.Sign ? info.NegativeInfinitySymbol : info.PositiveInfinitySymbol;
+                        return number.IsNegative ? info.NegativeInfinitySymbol : info.PositiveInfinitySymbol;
                     }
 
                     double roundTrip = NumberToDouble(ref number);
@@ -454,7 +454,7 @@ namespace System
             }
             else if (number.Scale == ScaleINF)
             {
-                return number.Sign ? info.NegativeInfinitySymbol : info.PositiveInfinitySymbol;
+                return number.IsNegative ? info.NegativeInfinitySymbol : info.PositiveInfinitySymbol;
             }
 
             if (fmt != 0)
@@ -514,7 +514,7 @@ namespace System
                     }
                     else if (number.Scale == ScaleINF)
                     {
-                        return number.Sign ? info.NegativeInfinitySymbol : info.PositiveInfinitySymbol;
+                        return number.IsNegative ? info.NegativeInfinitySymbol : info.PositiveInfinitySymbol;
                     }
 
                     float roundTrip = NumberToSingle(ref number);
@@ -557,7 +557,7 @@ namespace System
             }
             else if (number.Scale == ScaleINF)
             {
-                return number.Sign ? info.NegativeInfinitySymbol : info.PositiveInfinitySymbol;
+                return number.IsNegative ? info.NegativeInfinitySymbol : info.PositiveInfinitySymbol;
             }
 
             if (fmt != 0)
@@ -972,11 +972,11 @@ namespace System
 
             if (value >= 0)
             {
-                number.Sign = false;
+                number.IsNegative = false;
             }
             else
             {
-                number.Sign = true;
+                number.IsNegative = true;
                 value = -value;
             }
 
@@ -1095,7 +1095,7 @@ namespace System
         private static unsafe void UInt32ToNumber(uint value, ref NumberBuffer number)
         {
             number.Precision = UInt32Precision;
-            number.Sign = false;
+            number.IsNegative = false;
 
             byte* buffer = number.GetDigitsPointer();
             byte* p = UInt32ToDecChars(buffer + UInt32Precision, value, 0);
@@ -1217,9 +1217,9 @@ namespace System
         private static unsafe void Int64ToNumber(long input, ref NumberBuffer number)
         {
             ulong value = (ulong)input;
-            number.Sign = input < 0;
+            number.IsNegative = input < 0;
             number.Precision = Int64Precision;
-            if (number.Sign)
+            if (number.IsNegative)
             {
                 value = (ulong)(-input);
             }
@@ -1362,7 +1362,7 @@ namespace System
         private static unsafe void UInt64ToNumber(ulong value, ref NumberBuffer number)
         {
             number.Precision = UInt64Precision;
-            number.Sign = false;
+            number.IsNegative = false;
 
             byte* buffer = number.GetDigitsPointer();
             byte* p = buffer + UInt64Precision;
@@ -1528,7 +1528,7 @@ namespace System
 
                     RoundNumber(ref number, number.Scale + nMaxDigits);
 
-                    if (number.Sign)
+                    if (number.IsNegative)
                         sb.Append(info.NegativeSign);
 
                     FormatFixed(ref sb, ref number, nMaxDigits, info, null, info.NumberDecimalSeparator, null);
@@ -1558,7 +1558,7 @@ namespace System
 
                     RoundNumber(ref number, nMaxDigits);
 
-                    if (number.Sign)
+                    if (number.IsNegative)
                         sb.Append(info.NegativeSign);
 
                     FormatScientific(ref sb, ref number, nMaxDigits, info, format);
@@ -1587,7 +1587,7 @@ namespace System
                     RoundNumber(ref number, nMaxDigits);
 
                 SkipRounding:
-                    if (number.Sign)
+                    if (number.IsNegative)
                         sb.Append(info.NegativeSign);
 
                     FormatGeneral(ref sb, ref number, nMaxDigits, info, (char)(format - ('G' - 'E')), noRounding);
@@ -1635,7 +1635,7 @@ namespace System
             byte* dig = number.GetDigitsPointer();
             char ch;
 
-            section = FindSection(format, dig[0] == 0 ? 2 : number.Sign ? 1 : 0);
+            section = FindSection(format, dig[0] == 0 ? 2 : number.IsNegative ? 1 : 0);
 
             while (true)
             {
@@ -1813,7 +1813,7 @@ namespace System
                 }
             }
 
-            if (number.Sign && (section == 0) && (number.Scale != 0))
+            if (number.IsNegative && (section == 0) && (number.Scale != 0))
                 sb.Append(info.NegativeSign);
 
             bool decimalWritten = false;
@@ -1972,13 +1972,13 @@ namespace System
                 }
             }
 
-            if (number.Sign && (section == 0) && (number.Scale == 0) && (sb.Length > 0))
+            if (number.IsNegative && (section == 0) && (number.Scale == 0) && (sb.Length > 0))
                 sb.Insert(0, info.NegativeSign);
         }
 
         private static void FormatCurrency(ref ValueStringBuilder sb, ref NumberBuffer number, int nMaxDigits, NumberFormatInfo info)
         {
-            string fmt = number.Sign ?
+            string fmt = number.IsNegative ?
                 s_negCurrencyFormats[info.CurrencyNegativePattern] :
                 s_posCurrencyFormats[info.CurrencyPositivePattern];
 
@@ -2106,7 +2106,7 @@ namespace System
 
         private static void FormatNumber(ref ValueStringBuilder sb, ref NumberBuffer number, int nMaxDigits, NumberFormatInfo info)
         {
-            string fmt = number.Sign ?
+            string fmt = number.IsNegative ?
                 s_negNumberFormats[info.NumberNegativePattern] :
                 PosNumberFormat;
 
@@ -2213,7 +2213,7 @@ namespace System
 
         private static void FormatPercent(ref ValueStringBuilder sb, ref NumberBuffer number, int nMaxDigits, NumberFormatInfo info)
         {
-            string fmt = number.Sign ?
+            string fmt = number.IsNegative ?
                 s_negPercentFormats[info.PercentNegativePattern] :
                 s_posPercentFormats[info.PercentPositivePattern];
 
@@ -2272,7 +2272,7 @@ namespace System
 
                 if (number.Kind == NumberBufferKind.Integer)
                 {
-                    number.Sign = false;
+                    number.IsNegative = false;
                 }
             }
             dig[i] = (byte)('\0');
@@ -2338,13 +2338,13 @@ namespace System
             if (!double.IsFinite(value))
             {
                 number.Scale = double.IsNaN(value) ? ScaleNAN : ScaleINF;
-                number.Sign = double.IsNegative(value);
+                number.IsNegative = double.IsNegative(value);
                 number.Digits[0] = (byte)('\0');
             }
             else if (value == 0.0)
             {
                 number.Scale = 0;
-                number.Sign = double.IsNegative(value);
+                number.IsNegative = double.IsNegative(value);
                 number.Digits[0] = (byte)('\0');
             }
             else if (!Grisu3.Run(value, precision, ref number))

--- a/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
@@ -347,6 +347,8 @@ namespace System
             p = UInt32ToDecChars(p, d.Low, 0);
 
             int i = (int)((buffer + DecimalPrecision) - p);
+
+            number.DigitsCount = i;
             number.Scale = i - d.Scale;
 
             byte* dst = number.GetDigitsPointer();
@@ -964,8 +966,10 @@ namespace System
 
             byte* buffer = number.GetDigitsPointer();
             byte* p = UInt32ToDecChars(buffer + Int32Precision, (uint)value, 0);
+
             int i = (int)(buffer + Int32Precision - p);
 
+            number.DigitsCount = i;
             number.Scale = i;
 
             byte* dst = number.GetDigitsPointer();
@@ -1083,7 +1087,10 @@ namespace System
 
             byte* buffer = number.GetDigitsPointer();
             byte* p = UInt32ToDecChars(buffer + UInt32Precision, value, 0);
+
             int i = (int)(buffer + UInt32Precision - p);
+
+            number.DigitsCount = i;
             number.Scale = i;
 
             byte* dst = number.GetDigitsPointer();
@@ -1215,8 +1222,10 @@ namespace System
             while (High32(value) != 0)
                 p = UInt32ToDecChars(p, Int64DivMod1E9(ref value), 9);
             p = UInt32ToDecChars(p, Low32(value), 0);
+
             int i = (int)(buffer + Int64Precision - p);
 
+            number.DigitsCount = i;
             number.Scale = i;
 
             byte* dst = number.GetDigitsPointer();
@@ -1358,8 +1367,10 @@ namespace System
             while (High32(value) != 0)
                 p = UInt32ToDecChars(p, Int64DivMod1E9(ref value), 9);
             p = UInt32ToDecChars(p, Low32(value), 0);
+
             int i = (int)(buffer + UInt64Precision - p);
 
+            number.DigitsCount = i;
             number.Scale = i;
 
             byte* dst = number.GetDigitsPointer();
@@ -2265,7 +2276,10 @@ namespace System
                     number.IsNegative = false;
                 }
             }
+
             dig[i] = (byte)('\0');
+            number.DigitsCount = i;
+            number.CheckConsistency();
         }
 
         private static unsafe int FindSection(ReadOnlySpan<char> format, int section)
@@ -2323,8 +2337,6 @@ namespace System
 
         private static unsafe void DoubleToNumber(double value, int precision, ref NumberBuffer number)
         {
-            number.DigitsCount = precision;
-
             if (!double.IsFinite(value))
             {
                 number.Scale = double.IsNaN(value) ? ScaleNAN : ScaleINF;
@@ -2337,9 +2349,14 @@ namespace System
                 number.IsNegative = double.IsNegative(value);
                 number.Digits[0] = (byte)('\0');
             }
-            else if (!Grisu3.Run(value, precision, ref number))
+            else
             {
-                Dragon4(value, precision, ref number);
+                number.DigitsCount = precision;
+
+                if (!Grisu3.Run(value, precision, ref number))
+                {
+                    Dragon4(value, precision, ref number);
+                }
             }
 
             number.CheckConsistency();

--- a/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
@@ -289,7 +289,7 @@ namespace System
         {
             char fmt = ParseFormatSpecifier(format, out int digits);
 
-            char* pDigits = stackalloc char[DecimalNumberBufferLength];
+            byte* pDigits = stackalloc byte[DecimalNumberBufferLength];
             NumberBuffer number = new NumberBuffer(NumberBufferKind.Decimal, pDigits, DecimalNumberBufferLength);
 
             DecimalToNumber(ref value, ref number);
@@ -317,7 +317,7 @@ namespace System
         {
             char fmt = ParseFormatSpecifier(format, out int digits);
 
-            char* pDigits = stackalloc char[DecimalNumberBufferLength];
+            byte* pDigits = stackalloc byte[DecimalNumberBufferLength];
             NumberBuffer number = new NumberBuffer(NumberBufferKind.Decimal, pDigits, DecimalNumberBufferLength);
 
             DecimalToNumber(ref value, ref number);
@@ -343,26 +343,26 @@ namespace System
 
         private static unsafe void DecimalToNumber(ref decimal d, ref NumberBuffer number)
         {
-            char* buffer = number.GetDigitsPointer();
+            byte* buffer = number.GetDigitsPointer();
             number.Precision = DecimalPrecision;
             number.Sign = d.IsNegative;
 
-            char* p = buffer + DecimalPrecision;
+            byte* p = buffer + DecimalPrecision;
             while ((d.Mid | d.High) != 0)
             {
                 p = UInt32ToDecChars(p, decimal.DecDivMod1E9(ref d), 9);
             }
             p = UInt32ToDecChars(p, d.Low, 0);
 
-            int i = (int)((byte*)(buffer + DecimalPrecision) - (byte*)p) >> 1;
+            int i = (int)((buffer + DecimalPrecision) - p);
             number.Scale = i - d.Scale;
 
-            char* dst = number.GetDigitsPointer();
+            byte* dst = number.GetDigitsPointer();
             while (--i >= 0)
             {
                 *dst++ = *p++;
             }
-            *dst = '\0';
+            *dst = (byte)('\0');
         }
 
         public static string FormatDouble(double value, string format, NumberFormatInfo info)
@@ -392,7 +392,7 @@ namespace System
             char fmt = ParseFormatSpecifier(format, out int digits);
             int precision = DoublePrecision;
 
-            char* pDigits = stackalloc char[DoubleNumberBufferLength];
+            byte* pDigits = stackalloc byte[DoubleNumberBufferLength];
             NumberBuffer number = new NumberBuffer(NumberBufferKind.FloatingPoint, pDigits, DoubleNumberBufferLength);
 
             switch (fmt)
@@ -496,7 +496,7 @@ namespace System
             char fmt = ParseFormatSpecifier(format, out int digits);
             int precision = SinglePrecision;
 
-            char* pDigits = stackalloc char[SingleNumberBufferLength];
+            byte* pDigits = stackalloc byte[SingleNumberBufferLength];
             NumberBuffer number = new NumberBuffer(NumberBufferKind.FloatingPoint, pDigits, SingleNumberBufferLength);
 
             switch (fmt)
@@ -611,7 +611,7 @@ namespace System
             {
                 NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
 
-                char* pDigits = stackalloc char[Int32NumberBufferLength];
+                byte* pDigits = stackalloc byte[Int32NumberBufferLength];
                 NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, Int32NumberBufferLength);
 
                 Int32ToNumber(value, ref number);
@@ -659,7 +659,7 @@ namespace System
             {
                 NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
 
-                char* pDigits = stackalloc char[Int32NumberBufferLength];
+                byte* pDigits = stackalloc byte[Int32NumberBufferLength];
                 NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, Int32NumberBufferLength);
 
                 Int32ToNumber(value, ref number);
@@ -705,7 +705,7 @@ namespace System
             {
                 NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
 
-                char* pDigits = stackalloc char[UInt32NumberBufferLength];
+                byte* pDigits = stackalloc byte[UInt32NumberBufferLength];
                 NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, UInt32NumberBufferLength);
 
                 UInt32ToNumber(value, ref number);
@@ -751,7 +751,7 @@ namespace System
             {
                 NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
 
-                char* pDigits = stackalloc char[UInt32NumberBufferLength];
+                byte* pDigits = stackalloc byte[UInt32NumberBufferLength];
                 NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, UInt32NumberBufferLength);
 
                 UInt32ToNumber(value, ref number);
@@ -800,7 +800,7 @@ namespace System
             {
                 NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
 
-                char* pDigits = stackalloc char[Int64NumberBufferLength];
+                byte* pDigits = stackalloc byte[Int64NumberBufferLength];
                 NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, Int64NumberBufferLength);
 
                 Int64ToNumber(value, ref number);
@@ -849,7 +849,7 @@ namespace System
             {
                 NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
 
-                char* pDigits = stackalloc char[Int64NumberBufferLength];
+                byte* pDigits = stackalloc byte[Int64NumberBufferLength];
                 NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, Int64NumberBufferLength);
 
                 Int64ToNumber(value, ref number);
@@ -896,7 +896,7 @@ namespace System
             {
                 NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
 
-                char* pDigits = stackalloc char[UInt64NumberBufferLength];
+                byte* pDigits = stackalloc byte[UInt64NumberBufferLength];
                 NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, UInt64NumberBufferLength);
 
                 UInt64ToNumber(value, ref number);
@@ -943,7 +943,7 @@ namespace System
             {
                 NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
 
-                char* pDigits = stackalloc char[UInt64NumberBufferLength];
+                byte* pDigits = stackalloc byte[UInt64NumberBufferLength];
                 NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, UInt64NumberBufferLength);
 
                 UInt64ToNumber(value, ref number);
@@ -980,16 +980,16 @@ namespace System
                 value = -value;
             }
 
-            char* buffer = number.GetDigitsPointer();
-            char* p = UInt32ToDecChars(buffer + Int32Precision, (uint)value, 0);
+            byte* buffer = number.GetDigitsPointer();
+            byte* p = UInt32ToDecChars(buffer + Int32Precision, (uint)value, 0);
             int i = (int)(buffer + Int32Precision - p);
 
             number.Scale = i;
 
-            char* dst = number.GetDigitsPointer();
+            byte* dst = number.GetDigitsPointer();
             while (--i >= 0)
                 *dst++ = *p++;
-            *dst = '\0';
+            *dst = (byte)('\0');
         }
 
         private static unsafe string NegativeInt32ToDecStr(int value, int digits, string sNegative)
@@ -1097,15 +1097,27 @@ namespace System
             number.Precision = UInt32Precision;
             number.Sign = false;
 
-            char* buffer = number.GetDigitsPointer();
-            char* p = UInt32ToDecChars(buffer + UInt32Precision, value, 0);
+            byte* buffer = number.GetDigitsPointer();
+            byte* p = UInt32ToDecChars(buffer + UInt32Precision, value, 0);
             int i = (int)(buffer + UInt32Precision - p);
             number.Scale = i;
 
-            char* dst = number.GetDigitsPointer();
+            byte* dst = number.GetDigitsPointer();
             while (--i >= 0)
                 *dst++ = *p++;
-            *dst = '\0';
+            *dst = (byte)('\0');
+        }
+
+        internal static unsafe byte* UInt32ToDecChars(byte* bufferEnd, uint value, int digits)
+        {
+            while (--digits >= 0 || value != 0)
+            {
+                // TODO https://github.com/dotnet/coreclr/issues/3439
+                uint newValue = value / 10;
+                *(--bufferEnd) = (byte)(value - (newValue * 10) + '0');
+                value = newValue;
+            }
+            return bufferEnd;
         }
 
         internal static unsafe char* UInt32ToDecChars(char* bufferEnd, uint value, int digits)
@@ -1212,8 +1224,8 @@ namespace System
                 value = (ulong)(-input);
             }
 
-            char* buffer = number.GetDigitsPointer();
-            char* p = buffer + Int64Precision;
+            byte* buffer = number.GetDigitsPointer();
+            byte* p = buffer + Int64Precision;
             while (High32(value) != 0)
                 p = UInt32ToDecChars(p, Int64DivMod1E9(ref value), 9);
             p = UInt32ToDecChars(p, Low32(value), 0);
@@ -1221,10 +1233,10 @@ namespace System
 
             number.Scale = i;
 
-            char* dst = number.GetDigitsPointer();
+            byte* dst = number.GetDigitsPointer();
             while (--i >= 0)
                 *dst++ = *p++;
-            *dst = '\0';
+            *dst = (byte)('\0');
         }
 
         private static unsafe string NegativeInt64ToDecStr(long input, int digits, string sNegative)
@@ -1352,8 +1364,8 @@ namespace System
             number.Precision = UInt64Precision;
             number.Sign = false;
 
-            char* buffer = number.GetDigitsPointer();
-            char* p = buffer + UInt64Precision;
+            byte* buffer = number.GetDigitsPointer();
+            byte* p = buffer + UInt64Precision;
 
             while (High32(value) != 0)
                 p = UInt32ToDecChars(p, Int64DivMod1E9(ref value), 9);
@@ -1362,10 +1374,10 @@ namespace System
 
             number.Scale = i;
 
-            char* dst = number.GetDigitsPointer();
+            byte* dst = number.GetDigitsPointer();
             while (--i >= 0)
                 *dst++ = *p++;
-            *dst = '\0';
+            *dst = (byte)('\0');
         }
 
         private static unsafe string UInt64ToDecStr(ulong value, int digits)
@@ -1620,7 +1632,7 @@ namespace System
 
             int section;
             int src;
-            char* dig = number.GetDigitsPointer();
+            byte* dig = number.GetDigitsPointer();
             char ch;
 
             section = FindSection(format, dig[0] == 0 ? 2 : number.Sign ? 1 : 0);
@@ -1808,7 +1820,7 @@ namespace System
 
             fixed (char* pFormat = &MemoryMarshal.GetReference(format))
             {
-                char* cur = dig;
+                byte* cur = dig;
 
                 while (src < format.Length && (ch = pFormat[src++]) != 0 && ch != ';')
                 {
@@ -1823,7 +1835,7 @@ namespace System
                                 {
                                     // digPos will be one greater than thousandsSepPos[thousandsSepCtr] since we are at
                                     // the character after which the groupSeparator needs to be appended.
-                                    sb.Append(*cur != 0 ? *cur++ : '0');
+                                    sb.Append(*cur != 0 ? (char)(*cur++) : '0');
                                     if (thousandSeps && digPos > 1 && thousandsSepCtr >= 0)
                                     {
                                         if (digPos == thousandsSepPos[thousandsSepCtr] + 1)
@@ -1851,7 +1863,7 @@ namespace System
                             }
                             else
                             {
-                                ch = *cur != 0 ? *cur++ : digPos > lastDigit ? '0' : '\0';
+                                ch = *cur != 0 ? (char)(*cur++) : digPos > lastDigit ? '0' : '\0';
                             }
                             if (ch != 0)
                             {
@@ -1993,7 +2005,7 @@ namespace System
         private static unsafe void FormatFixed(ref ValueStringBuilder sb, ref NumberBuffer number, int nMaxDigits, NumberFormatInfo info, int[] groupDigits, string sDecimal, string sGroup)
         {
             int digPos = number.Scale;
-            char* dig = number.GetDigitsPointer();
+            byte* dig = number.GetDigitsPointer();
 
             if (digPos > 0)
             {
@@ -2028,14 +2040,14 @@ namespace System
 
                     groupSizeIndex = 0;
                     int digitCount = 0;
-                    int digLength = string.wcslen(dig);
+                    int digLength = number.Precision;
                     int digStart = (digPos < digLength) ? digPos : digLength;
                     fixed (char* spanPtr = &MemoryMarshal.GetReference(sb.AppendSpan(bufferSize)))
                     {
                         char* p = spanPtr + bufferSize - 1;
                         for (int i = digPos - 1; i >= 0; i--)
                         {
-                            *(p--) = (i < digStart) ? dig[i] : '0';
+                            *(p--) = (i < digStart) ? (char)(dig[i]) : '0';
 
                             if (groupSize > 0)
                             {
@@ -2063,7 +2075,7 @@ namespace System
                 {
                     do
                     {
-                        sb.Append(*dig != 0 ? *dig++ : '0');
+                        sb.Append(*dig != 0 ? (char)(*dig++) : '0');
                     }
                     while (--digPos > 0);
                 }
@@ -2086,7 +2098,7 @@ namespace System
 
                 while (nMaxDigits > 0)
                 {
-                    sb.Append((*dig != 0) ? *dig++ : '0');
+                    sb.Append((*dig != 0) ? (char)(*dig++) : '0');
                     nMaxDigits--;
                 }
             }
@@ -2117,15 +2129,15 @@ namespace System
 
         private static unsafe void FormatScientific(ref ValueStringBuilder sb, ref NumberBuffer number, int nMaxDigits, NumberFormatInfo info, char expChar)
         {
-            char* dig = number.GetDigitsPointer();
+            byte* dig = number.GetDigitsPointer();
 
-            sb.Append((*dig != 0) ? *dig++ : '0');
+            sb.Append((*dig != 0) ? (char)(*dig++) : '0');
 
             if (nMaxDigits != 1) // For E0 we would like to suppress the decimal point
                 sb.Append(info.NumberDecimalSeparator);
 
             while (--nMaxDigits > 0)
-                sb.Append((*dig != 0) ? *dig++ : '0');
+                sb.Append((*dig != 0) ? (char)(*dig++) : '0');
 
             int e = number.Digits[0] == 0 ? 0 : number.Scale - 1;
             FormatExponent(ref sb, info, e, expChar, 3, true);
@@ -2167,13 +2179,13 @@ namespace System
                 }
             }
 
-            char* dig = number.GetDigitsPointer();
+            byte* dig = number.GetDigitsPointer();
 
             if (digPos > 0)
             {
                 do
                 {
-                    sb.Append((*dig != 0) ? *dig++ : '0');
+                    sb.Append((*dig != 0) ? (char)(*dig++) : '0');
                 } while (--digPos > 0);
             }
             else
@@ -2192,7 +2204,7 @@ namespace System
                 }
 
                 while (*dig != 0)
-                    sb.Append(*dig++);
+                    sb.Append((char)(*dig++));
             }
 
             if (scientific)
@@ -2227,7 +2239,7 @@ namespace System
 
         private static unsafe void RoundNumber(ref NumberBuffer number, int pos)
         {
-            char* dig = number.GetDigitsPointer();
+            byte* dig = number.GetDigitsPointer();
 
             int i = 0;
             while (i < pos && dig[i] != 0)
@@ -2245,7 +2257,7 @@ namespace System
                 else
                 {
                     number.Scale++;
-                    dig[0] = '1';
+                    dig[0] = (byte)('1');
                     i = 1;
                 }
             }
@@ -2263,7 +2275,7 @@ namespace System
                     number.Sign = false;
                 }
             }
-            dig[i] = '\0';
+            dig[i] = (byte)('\0');
         }
 
         private static unsafe int FindSection(ReadOnlySpan<char> format, int section)
@@ -2327,13 +2339,13 @@ namespace System
             {
                 number.Scale = double.IsNaN(value) ? ScaleNAN : ScaleINF;
                 number.Sign = double.IsNegative(value);
-                number.Digits[0] = '\0';
+                number.Digits[0] = (byte)('\0');
             }
             else if (value == 0.0)
             {
                 number.Scale = 0;
                 number.Sign = double.IsNegative(value);
-                number.Digits[0] = '\0';
+                number.Digits[0] = (byte)('\0');
             }
             else if (!Grisu3.Run(value, precision, ref number))
             {

--- a/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
@@ -294,12 +294,8 @@ namespace System
 
             DecimalToNumber(ref value, ref number);
 
-            ValueStringBuilder sb;
-            unsafe
-            {
-                char* stackPtr = stackalloc char[CharStackBufferSize];
-                sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
-            }
+            char* stackPtr = stackalloc char[CharStackBufferSize];
+            ValueStringBuilder sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
 
             if (fmt != 0)
             {
@@ -322,12 +318,8 @@ namespace System
 
             DecimalToNumber(ref value, ref number);
 
-            ValueStringBuilder sb;
-            unsafe
-            {
-                char* stackPtr = stackalloc char[CharStackBufferSize];
-                sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
-            }
+            char* stackPtr = stackalloc char[CharStackBufferSize];
+            ValueStringBuilder sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
 
             if (fmt != 0)
             {
@@ -363,6 +355,8 @@ namespace System
                 *dst++ = *p++;
             }
             *dst = (byte)('\0');
+
+            number.CheckConsistency();
         }
 
         public static string FormatDouble(double value, string format, NumberFormatInfo info)
@@ -404,6 +398,7 @@ namespace System
                     // number using 15 digits and then determine if it round trips to the same value. If it does, we
                     // convert that NUMBER to a string, otherwise we reparse using 17 digits and display that.
                     DoubleToNumber(value, DoublePrecision, ref number);
+
                     if (number.Scale == ScaleNAN)
                     {
                         return info.NaNSymbol;
@@ -448,6 +443,7 @@ namespace System
             }
 
             DoubleToNumber(value, precision, ref number);
+
             if (number.Scale == ScaleNAN)
             {
                 return info.NaNSymbol;
@@ -508,6 +504,7 @@ namespace System
                     // number using 7 digits and then determine if it round trips to the same value. If it does, we
                     // convert that NUMBER to a string, otherwise we reparse using 9 digits and display that.
                     DoubleToNumber(value, SinglePrecision, ref number);
+
                     if (number.Scale == ScaleNAN)
                     {
                         return info.NaNSymbol;
@@ -551,6 +548,7 @@ namespace System
             }
 
             DoubleToNumber(value, precision, ref number);
+
             if (number.Scale == ScaleNAN)
             {
                 return info.NaNSymbol;
@@ -615,12 +613,10 @@ namespace System
                 NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, Int32NumberBufferLength);
 
                 Int32ToNumber(value, ref number);
-                ValueStringBuilder sb;
-                unsafe
-                {
-                    char* stackPtr = stackalloc char[CharStackBufferSize];
-                    sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
-                }
+
+                char* stackPtr = stackalloc char[CharStackBufferSize];
+                ValueStringBuilder sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
+
                 if (fmt != 0)
                 {
                     NumberToString(ref sb, ref number, fmt, digits, info);
@@ -663,12 +659,10 @@ namespace System
                 NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, Int32NumberBufferLength);
 
                 Int32ToNumber(value, ref number);
-                ValueStringBuilder sb;
-                unsafe
-                {
-                    char* stackPtr = stackalloc char[CharStackBufferSize];
-                    sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
-                }
+
+                char* stackPtr = stackalloc char[CharStackBufferSize];
+                ValueStringBuilder sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
+
                 if (fmt != 0)
                 {
                     NumberToString(ref sb, ref number, fmt, digits, info);
@@ -709,12 +703,10 @@ namespace System
                 NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, UInt32NumberBufferLength);
 
                 UInt32ToNumber(value, ref number);
-                ValueStringBuilder sb;
-                unsafe
-                {
-                    char* stackPtr = stackalloc char[CharStackBufferSize];
-                    sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
-                }
+
+                char* stackPtr = stackalloc char[CharStackBufferSize];
+                ValueStringBuilder sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
+
                 if (fmt != 0)
                 {
                     NumberToString(ref sb, ref number, fmt, digits, info);
@@ -755,12 +747,10 @@ namespace System
                 NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, UInt32NumberBufferLength);
 
                 UInt32ToNumber(value, ref number);
-                ValueStringBuilder sb;
-                unsafe
-                {
-                    char* stackPtr = stackalloc char[CharStackBufferSize];
-                    sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
-                }
+
+                char* stackPtr = stackalloc char[CharStackBufferSize];
+                ValueStringBuilder sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
+
                 if (fmt != 0)
                 {
                     NumberToString(ref sb, ref number, fmt, digits, info);
@@ -804,12 +794,10 @@ namespace System
                 NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, Int64NumberBufferLength);
 
                 Int64ToNumber(value, ref number);
-                ValueStringBuilder sb;
-                unsafe
-                {
-                    char* stackPtr = stackalloc char[CharStackBufferSize];
-                    sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
-                }
+
+                char* stackPtr = stackalloc char[CharStackBufferSize];
+                ValueStringBuilder sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
+
                 if (fmt != 0)
                 {
                     NumberToString(ref sb, ref number, fmt, digits, info);
@@ -853,12 +841,10 @@ namespace System
                 NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, Int64NumberBufferLength);
 
                 Int64ToNumber(value, ref number);
-                ValueStringBuilder sb;
-                unsafe
-                {
-                    char* stackPtr = stackalloc char[CharStackBufferSize];
-                    sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
-                }
+
+                char* stackPtr = stackalloc char[CharStackBufferSize];
+                ValueStringBuilder sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
+
                 if (fmt != 0)
                 {
                     NumberToString(ref sb, ref number, fmt, digits, info);
@@ -900,12 +886,10 @@ namespace System
                 NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, UInt64NumberBufferLength);
 
                 UInt64ToNumber(value, ref number);
-                ValueStringBuilder sb;
-                unsafe
-                {
-                    char* stackPtr = stackalloc char[CharStackBufferSize];
-                    sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
-                }
+
+                char* stackPtr = stackalloc char[CharStackBufferSize];
+                ValueStringBuilder sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
+
                 if (fmt != 0)
                 {
                     NumberToString(ref sb, ref number, fmt, digits, info);
@@ -947,12 +931,10 @@ namespace System
                 NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, UInt64NumberBufferLength);
 
                 UInt64ToNumber(value, ref number);
-                ValueStringBuilder sb;
-                unsafe
-                {
-                    char* stackPtr = stackalloc char[CharStackBufferSize];
-                    sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
-                }
+
+                char* stackPtr = stackalloc char[CharStackBufferSize];
+                ValueStringBuilder sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
+
                 if (fmt != 0)
                 {
                     NumberToString(ref sb, ref number, fmt, digits, info);
@@ -990,6 +972,8 @@ namespace System
             while (--i >= 0)
                 *dst++ = *p++;
             *dst = (byte)('\0');
+
+            number.CheckConsistency();
         }
 
         private static unsafe string NegativeInt32ToDecStr(int value, int digits, string sNegative)
@@ -1106,6 +1090,8 @@ namespace System
             while (--i >= 0)
                 *dst++ = *p++;
             *dst = (byte)('\0');
+
+            number.CheckConsistency();
         }
 
         internal static unsafe byte* UInt32ToDecChars(byte* bufferEnd, uint value, int digits)
@@ -1237,6 +1223,8 @@ namespace System
             while (--i >= 0)
                 *dst++ = *p++;
             *dst = (byte)('\0');
+
+            number.CheckConsistency();
         }
 
         private static unsafe string NegativeInt64ToDecStr(long input, int digits, string sNegative)
@@ -1378,6 +1366,8 @@ namespace System
             while (--i >= 0)
                 *dst++ = *p++;
             *dst = (byte)('\0');
+
+            number.CheckConsistency();
         }
 
         private static unsafe string UInt64ToDecStr(ulong value, int digits)
@@ -1503,7 +1493,7 @@ namespace System
 
         internal static unsafe void NumberToString(ref ValueStringBuilder sb, ref NumberBuffer number, char format, int nMaxDigits, NumberFormatInfo info)
         {
-            Debug.Assert(number.Kind != NumberBufferKind.Unknown);
+            number.CheckConsistency();
 
             switch (format)
             {
@@ -1616,7 +1606,7 @@ namespace System
 
         internal static unsafe void NumberToStringFormat(ref ValueStringBuilder sb, ref NumberBuffer number, ReadOnlySpan<char> format, NumberFormatInfo info)
         {
-            Debug.Assert(number.Kind != NumberBufferKind.Unknown);
+            number.CheckConsistency();
 
             int digitCount;
             int decimalPos;
@@ -2351,6 +2341,8 @@ namespace System
             {
                 Dragon4(value, precision, ref number);
             }
+
+            number.CheckConsistency();
         }
 
         private static long ExtractFractionAndBiasedExponent(double value, out int exponent)

--- a/src/System.Private.CoreLib/shared/System/Number.Grisu3.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Grisu3.cs
@@ -341,11 +341,11 @@ namespace System
                 if (double.IsNegative(value))
                 {
                     value = -value;
-                    number.Sign = true;
+                    number.IsNegative = true;
                 }
                 else
                 {
-                    number.Sign = false;
+                    number.IsNegative = false;
                 }
 
                 // Step 1: Determine the normalized DiyFp w.

--- a/src/System.Private.CoreLib/shared/System/Number.Grisu3.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Grisu3.cs
@@ -370,7 +370,7 @@ namespace System
 
                 if (isSuccess)
                 {
-                    number.Digits[precision] = '\0';
+                    number.Digits[precision] = (byte)('\0');
                     number.Scale = (length - decimalExponent + kappa);
                 }
 
@@ -549,7 +549,7 @@ namespace System
                 decimalExponent = s_CachedPowerDecimalExponents[index];
             }
 
-            private static bool DigitGen(ref DiyFp mp, int precision, char* digits, out int length, out int k)
+            private static bool DigitGen(ref DiyFp mp, int precision, byte* digits, out int length, out int k)
             {
                 // Split the input mp to two parts. Part 1 is integral. Part 2 can be used to calculate
                 // fractional.
@@ -604,7 +604,7 @@ namespace System
                 while (kappa > 0)
                 {
                     int d = (int)(Math.DivRem(p1, div, out p1));
-                    digits[index] = (char)('0' + d);
+                    digits[index] = (byte)('0' + d);
 
                     index++;
                     precision--;
@@ -643,7 +643,7 @@ namespace System
                     p2 *= 10;
 
                     int d = (int)(p2 >> oneNegE);
-                    digits[index] = (char)('0' + d);
+                    digits[index] = (byte)('0' + d);
 
                     index++;
                     precision--;
@@ -673,7 +673,7 @@ namespace System
                 return (int)(Math.Ceiling((Alpha - e + DiyFp.SignificandLength - 1) * D1Log210));
             }
 
-            private static bool RoundWeed(char* buffer, int len, ulong rest, ulong tenKappa, ulong ulp, ref int kappa)
+            private static bool RoundWeed(byte* buffer, int len, ulong rest, ulong tenKappa, ulong ulp, ref int kappa)
             {
                 Debug.Assert(rest < tenKappa);
 
@@ -700,14 +700,14 @@ namespace System
                     buffer[len - 1]++;
                     for (int i = len - 1; i > 0; i--)
                     {
-                        if (buffer[i] != (char)('0' + 10))
+                        if (buffer[i] != (byte)('0' + 10))
                         {
                             // We end up a number less than 9.
                             break;
                         }
 
                         // Current number becomes 0 and add the promotion to the next number.
-                        buffer[i] = '0';
+                        buffer[i] = (byte)('0');
                         buffer[i - 1]++;
                     }
 
@@ -715,7 +715,7 @@ namespace System
                     {
                         // First number is '0' + 10 means all numbers are 9.
                         // We simply make the first number to 1 and increase the kappa.
-                        buffer[0] = '1';
+                        buffer[0] = (byte)('1');
                         kappa++;
                     }
 

--- a/src/System.Private.CoreLib/shared/System/Number.NumberBuffer.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.NumberBuffer.cs
@@ -20,7 +20,7 @@ namespace System
 
         internal unsafe ref struct NumberBuffer
         {
-            public int Precision;
+            public int DigitsCount;
             public int Scale;
             public bool IsNegative;
             public bool HasNonZeroTail;
@@ -35,7 +35,7 @@ namespace System
                 Debug.Assert(digits != null);
                 Debug.Assert(digitsLength > 0);
 
-                Precision = 0;
+                DigitsCount = 0;
                 Scale = 0;
                 IsNegative = false;
                 HasNonZeroTail = false;

--- a/src/System.Private.CoreLib/shared/System/Number.NumberBuffer.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.NumberBuffer.cs
@@ -22,7 +22,7 @@ namespace System
         {
             public int Precision;
             public int Scale;
-            public bool Sign;
+            public bool IsNegative;
             public bool HasNonZeroTail;
             public NumberBufferKind Kind;
             public Span<byte> Digits;
@@ -37,7 +37,7 @@ namespace System
 
                 Precision = 0;
                 Scale = 0;
-                Sign = false;
+                IsNegative = false;
                 HasNonZeroTail = false;
                 Kind = kind;
                 Digits = new Span<byte>(digits, digitsLength);

--- a/src/System.Private.CoreLib/shared/System/Number.NumberBuffer.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.NumberBuffer.cs
@@ -42,9 +42,10 @@ namespace System
 
 #if DEBUG
                 Digits.Fill(0xCC);
+#endif
+
                 Digits[0] = (byte)('\0');
                 CheckConsistency();
-#endif
             }
 
             [Conditional("DEBUG")]
@@ -65,14 +66,6 @@ namespace System
                     }
 
                     Debug.Assert((digit >= '0') && (digit <= '9'), "Unexpected character found in Number");
-                }
-
-                Debug.Assert(Digits[numDigits] == 0);
-
-                for (int i = numDigits + 1; i < Digits.Length; i++)
-                {
-                    byte digit = Digits[i];
-                    Debug.Assert(digit == 0xCC);
                 }
 
                 Debug.Assert(numDigits == DigitsCount, "Null terminator found in unexpected location in Number");

--- a/src/System.Private.CoreLib/shared/System/Number.NumberBuffer.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.NumberBuffer.cs
@@ -25,9 +25,9 @@ namespace System
             public bool Sign;
             public bool HasNonZeroTail;
             public NumberBufferKind Kind;
-            public Span<char> Digits;
+            public Span<byte> Digits;
 
-            public NumberBuffer(NumberBufferKind kind, char* digits, int digitsLength)
+            public NumberBuffer(NumberBufferKind kind, byte* digits, int digitsLength)
             {
                 Debug.Assert(kind == NumberBufferKind.Integer
                     || kind == NumberBufferKind.Decimal
@@ -40,13 +40,13 @@ namespace System
                 Sign = false;
                 HasNonZeroTail = false;
                 Kind = kind;
-                Digits = new Span<char>(digits, digitsLength);
+                Digits = new Span<byte>(digits, digitsLength);
             }
 
-            public char* GetDigitsPointer()
+            public byte* GetDigitsPointer()
             {
                 // This is safe to do since we are a ref struct
-                return (char*)(Unsafe.AsPointer(ref Digits[0]));
+                return (byte*)(Unsafe.AsPointer(ref Digits[0]));
             }
         }
 

--- a/src/System.Private.CoreLib/shared/System/Number.NumberToFloatingPointBits.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.NumberToFloatingPointBits.cs
@@ -110,7 +110,7 @@ namespace System
         {
             result = new BigInteger(0);
 
-            char* src = number.GetDigitsPointer() + firstIndex;
+            byte* src = number.GetDigitsPointer() + firstIndex;
             uint remaining = lastIndex - firstIndex;
 
             while (remaining != 0)
@@ -298,11 +298,11 @@ namespace System
         }
 
         // get 32-bit integer from at most 9 digits
-        private static uint DigitsToUInt32(char* p, int count)
+        private static uint DigitsToUInt32(byte* p, int count)
         {
             Debug.Assert((1 <= count) && (count <= 9));
 
-            char* end = (p + count);
+            byte* end = (p + count);
             uint res = (uint)(p[0] - '0');
 
             for (p++; p < end; p++)
@@ -314,11 +314,11 @@ namespace System
         }
 
         // get 64-bit integer from at most 19 digits
-        private static ulong DigitsToUInt64(char* p, int count)
+        private static ulong DigitsToUInt64(byte* p, int count)
         {
             Debug.Assert((1 <= count) && (count <= 19));
 
-            char* end = (p + count);
+            byte* end = (p + count);
             ulong res = (ulong)(p[0] - '0');
 
             for (p++; p < end; p++)
@@ -358,7 +358,7 @@ namespace System
             // computed to the infinitely precise result and then rounded, which means that
             // we can rely on it to produce the correct result when both inputs are exact.
 
-            char* src = number.GetDigitsPointer();
+            byte* src = number.GetDigitsPointer();
 
             if (totalDigits == 0)
             {

--- a/src/System.Private.CoreLib/shared/System/Number.NumberToFloatingPointBits.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.NumberToFloatingPointBits.cs
@@ -341,7 +341,7 @@ namespace System
             // If the exponent is zero or negative, then the integer part is empty.  In
             // either case, the remaining digits form the fractional part of the mantissa.
 
-            uint totalDigits = (uint)(number.Precision);
+            uint totalDigits = (uint)(number.DigitsCount);
             uint positiveExponent = (uint)(Math.Max(0, number.Scale));
 
             uint integerDigitsPresent = Math.Min(positiveExponent, totalDigits);
@@ -422,7 +422,7 @@ namespace System
             // have and we don't need to round).
             uint requiredBitsOfPrecision = (uint)(info.NormalMantissaBits + 1);
 
-            uint totalDigits = (uint)(number.Precision);
+            uint totalDigits = (uint)(number.DigitsCount);
             uint integerDigitsMissing = positiveExponent - integerDigitsPresent;
 
             uint integerFirstIndex = 0;

--- a/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
@@ -74,7 +74,7 @@ namespace System
                     n += (*p++ - '0');
                 }
             }
-            if (number.Sign)
+            if (number.IsNegative)
             {
                 n = -n;
                 if (n > 0)
@@ -115,7 +115,7 @@ namespace System
                     n += (*p++ - '0');
                 }
             }
-            if (number.Sign)
+            if (number.IsNegative)
             {
                 n = -n;
                 if (n > 0)
@@ -137,7 +137,7 @@ namespace System
         private static unsafe bool TryNumberToUInt32(ref NumberBuffer number, ref uint value)
         {
             int i = number.Scale;
-            if (i > UInt32Precision || i < number.Precision || number.Sign)
+            if (i > UInt32Precision || i < number.Precision || number.IsNegative)
             {
                 return false;
             }
@@ -169,7 +169,7 @@ namespace System
         private static unsafe bool TryNumberToUInt64(ref NumberBuffer number, ref ulong value)
         {
             int i = number.Scale;
-            if (i > UInt64Precision || i < number.Precision || number.Sign)
+            if (i > UInt64Precision || i < number.Precision || number.IsNegative)
             {
                 return false;
             }
@@ -254,7 +254,7 @@ namespace System
 
             Debug.Assert(number.Precision == 0);
             Debug.Assert(number.Scale == 0);
-            Debug.Assert(number.Sign == false);
+            Debug.Assert(number.IsNegative == false);
             Debug.Assert(number.HasNonZeroTail == false);
             Debug.Assert(number.Kind != NumberBufferKind.Unknown);
 
@@ -290,7 +290,7 @@ namespace System
                 // "-Kr 1231.47" is legal but "- 1231.47" is not.
                 if (!IsWhite(ch) || (styles & NumberStyles.AllowLeadingWhite) == 0 || ((state & StateSign) != 0 && ((state & StateCurrency) == 0 && info.NumberNegativePattern != 2)))
                 {
-                    if ((((styles & NumberStyles.AllowLeadingSign) != 0) && (state & StateSign) == 0) && ((next = MatchChars(p, strEnd, info.PositiveSign)) != null || ((next = MatchChars(p, strEnd, info.NegativeSign)) != null && (number.Sign = true))))
+                    if ((((styles & NumberStyles.AllowLeadingSign) != 0) && (state & StateSign) == 0) && ((next = MatchChars(p, strEnd, info.PositiveSign)) != null || ((next = MatchChars(p, strEnd, info.NegativeSign)) != null && (number.IsNegative = true))))
                     {
                         state |= StateSign;
                         p = next - 1;
@@ -298,7 +298,7 @@ namespace System
                     else if (ch == '(' && ((styles & NumberStyles.AllowParentheses) != 0) && ((state & StateSign) == 0))
                     {
                         state |= StateSign | StateParens;
-                        number.Sign = true;
+                        number.IsNegative = true;
                     }
                     else if (currSymbol != null && (next = MatchChars(p, strEnd, currSymbol)) != null)
                     {
@@ -425,7 +425,7 @@ namespace System
                 {
                     if (!IsWhite(ch) || (styles & NumberStyles.AllowTrailingWhite) == 0)
                     {
-                        if (((styles & NumberStyles.AllowTrailingSign) != 0 && ((state & StateSign) == 0)) && ((next = MatchChars(p, strEnd, info.PositiveSign)) != null || (((next = MatchChars(p, strEnd, info.NegativeSign)) != null) && (number.Sign = true))))
+                        if (((styles & NumberStyles.AllowTrailingSign) != 0 && ((state & StateSign) == 0)) && ((next = MatchChars(p, strEnd, info.PositiveSign)) != null || (((next = MatchChars(p, strEnd, info.NegativeSign)) != null) && (number.IsNegative = true))))
                         {
                             state |= StateSign;
                             p = next - 1;
@@ -456,7 +456,7 @@ namespace System
                         }
                         if ((state & StateDecimal) == 0)
                         {
-                            number.Sign = false;
+                            number.IsNegative = false;
                         }
                     }
                     str = p;
@@ -1534,7 +1534,7 @@ namespace System
         {
             byte* p = number.GetDigitsPointer();
             int e = number.Scale;
-            bool sign = number.Sign;
+            bool sign = number.IsNegative;
             uint c = *p;
             if (c == 0)
             {
@@ -1827,14 +1827,14 @@ namespace System
         {
             ulong bits = NumberToFloatingPointBits(ref number, in FloatingPointInfo.Double);
             double result = BitConverter.Int64BitsToDouble((long)(bits));
-            return number.Sign ? -result : result;
+            return number.IsNegative ? -result : result;
         }
 
         private static float NumberToSingle(ref NumberBuffer number)
         {
             uint bits = (uint)(NumberToFloatingPointBits(ref number, in FloatingPointInfo.Single));
             float result = BitConverter.Int32BitsToSingle((int)(bits));
-            return number.Sign ? -result : result;
+            return number.IsNegative ? -result : result;
         }
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
@@ -55,7 +55,7 @@ namespace System
         private static unsafe bool TryNumberToInt32(ref NumberBuffer number, ref int value)
         {
             int i = number.Scale;
-            if (i > Int32Precision || i < number.Precision)
+            if (i > Int32Precision || i < number.DigitsCount)
             {
                 return false;
             }
@@ -96,7 +96,7 @@ namespace System
         private static unsafe bool TryNumberToInt64(ref NumberBuffer number, ref long value)
         {
             int i = number.Scale;
-            if (i > Int64Precision || i < number.Precision)
+            if (i > Int64Precision || i < number.DigitsCount)
             {
                 return false;
             }
@@ -137,7 +137,7 @@ namespace System
         private static unsafe bool TryNumberToUInt32(ref NumberBuffer number, ref uint value)
         {
             int i = number.Scale;
-            if (i > UInt32Precision || i < number.Precision || number.IsNegative)
+            if (i > UInt32Precision || i < number.DigitsCount || number.IsNegative)
             {
                 return false;
             }
@@ -169,7 +169,7 @@ namespace System
         private static unsafe bool TryNumberToUInt64(ref NumberBuffer number, ref ulong value)
         {
             int i = number.Scale;
-            if (i > UInt64Precision || i < number.Precision || number.IsNegative)
+            if (i > UInt64Precision || i < number.DigitsCount || number.IsNegative)
             {
                 return false;
             }
@@ -252,7 +252,7 @@ namespace System
             const int StateDecimal = 0x0010;
             const int StateCurrency = 0x0020;
 
-            Debug.Assert(number.Precision == 0);
+            Debug.Assert(number.DigitsCount == 0);
             Debug.Assert(number.Scale == 0);
             Debug.Assert(number.IsNegative == false);
             Debug.Assert(number.HasNonZeroTail == false);
@@ -376,7 +376,7 @@ namespace System
             }
 
             bool negExp = false;
-            number.Precision = digEnd;
+            number.DigitsCount = digEnd;
             number.Digits[digEnd] = (byte)('\0');
             if ((state & StateDigits) != 0)
             {

--- a/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
@@ -59,7 +59,7 @@ namespace System
             {
                 return false;
             }
-            char* p = number.GetDigitsPointer();
+            byte* p = number.GetDigitsPointer();
             Debug.Assert(p != null);
             int n = 0;
             while (--i >= 0)
@@ -100,7 +100,7 @@ namespace System
             {
                 return false;
             }
-            char* p = number.GetDigitsPointer();
+            byte* p = number.GetDigitsPointer();
             Debug.Assert(p != null);
             long n = 0;
             while (--i >= 0)
@@ -141,7 +141,7 @@ namespace System
             {
                 return false;
             }
-            char* p = number.GetDigitsPointer();
+            byte* p = number.GetDigitsPointer();
             Debug.Assert(p != null);
             uint n = 0;
             while (--i >= 0)
@@ -173,7 +173,7 @@ namespace System
             {
                 return false;
             }
-            char* p = number.GetDigitsPointer();
+            byte* p = number.GetDigitsPointer();
             Debug.Assert(p != null);
             ulong n = 0;
             while (--i >= 0)
@@ -330,7 +330,7 @@ namespace System
                     {
                         if (digCount < maxDigCount)
                         {
-                            number.Digits[digCount++] = ch;
+                            number.Digits[digCount++] = (byte)(ch);
                             if ((ch != '0') || (number.Kind != NumberBufferKind.Integer))
                             {
                                 digEnd = digCount;
@@ -377,7 +377,7 @@ namespace System
 
             bool negExp = false;
             number.Precision = digEnd;
-            number.Digits[digEnd] = '\0';
+            number.Digits[digEnd] = (byte)('\0');
             if ((state & StateDigits) != 0)
             {
                 if ((ch == 'E' || ch == 'e') && ((styles & NumberStyles.AllowExponent) != 0))
@@ -483,7 +483,7 @@ namespace System
                 return TryParseUInt32HexNumberStyle(value, styles, out Unsafe.As<int, uint>(ref result), ref failureIsOverflow);
             }
 
-            char* pDigits = stackalloc char[Int32NumberBufferLength];
+            byte* pDigits = stackalloc byte[Int32NumberBufferLength];
             NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, Int32NumberBufferLength);
 
             if (!TryStringToNumber(value, styles, ref number, info))
@@ -859,7 +859,7 @@ namespace System
                 return TryParseUInt64HexNumberStyle(value, styles, out Unsafe.As<long, ulong>(ref result), ref failureIsOverflow);
             }
 
-            char* pDigits = stackalloc char[Int64NumberBufferLength];
+            byte* pDigits = stackalloc byte[Int64NumberBufferLength];
             NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, Int64NumberBufferLength);
 
             if (!TryStringToNumber(value, styles, ref number, info))
@@ -892,7 +892,7 @@ namespace System
                 return TryParseUInt32HexNumberStyle(value, styles, out result, ref failureIsOverflow);
             }
 
-            char* pDigits = stackalloc char[UInt32NumberBufferLength];
+            byte* pDigits = stackalloc byte[UInt32NumberBufferLength];
             NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, UInt32NumberBufferLength);
 
             if (!TryStringToNumber(value, styles, ref number, info))
@@ -1214,7 +1214,7 @@ namespace System
                 return TryParseUInt64HexNumberStyle(value, styles, out result, ref failureIsOverflow);
             }
 
-            char* pDigits = stackalloc char[UInt64NumberBufferLength];
+            byte* pDigits = stackalloc byte[UInt64NumberBufferLength];
             NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, UInt64NumberBufferLength);
 
             if (!TryStringToNumber(value, styles, ref number, info))
@@ -1532,7 +1532,7 @@ namespace System
 
         private static unsafe bool TryNumberToDecimal(ref NumberBuffer number, ref decimal value)
         {
-            char* p = number.GetDigitsPointer();
+            byte* p = number.GetDigitsPointer();
             int e = number.Scale;
             bool sign = number.Sign;
             uint c = *p;
@@ -1655,7 +1655,7 @@ namespace System
 
         internal static unsafe bool TryParseDecimal(ReadOnlySpan<char> value, NumberStyles styles, NumberFormatInfo info, out decimal result, out bool failureIsOverflow)
         {
-            char* pDigits = stackalloc char[DecimalNumberBufferLength];
+            byte* pDigits = stackalloc byte[DecimalNumberBufferLength];
             NumberBuffer number = new NumberBuffer(NumberBufferKind.Decimal, pDigits, DecimalNumberBufferLength);
 
             result = 0;
@@ -1677,7 +1677,7 @@ namespace System
 
         internal static unsafe bool TryParseDouble(ReadOnlySpan<char> value, NumberStyles styles, NumberFormatInfo info, out double result)
         {
-            char* pDigits = stackalloc char[DoubleNumberBufferLength];
+            byte* pDigits = stackalloc byte[DoubleNumberBufferLength];
             NumberBuffer number = new NumberBuffer(NumberBufferKind.FloatingPoint, pDigits, DoubleNumberBufferLength);
 
             if (!TryStringToNumber(value, styles, ref number, info))
@@ -1712,7 +1712,7 @@ namespace System
 
         internal static unsafe bool TryParseSingle(ReadOnlySpan<char> value, NumberStyles styles, NumberFormatInfo info, out float result)
         {
-            char* pDigits = stackalloc char[SingleNumberBufferLength];
+            byte* pDigits = stackalloc byte[SingleNumberBufferLength];
             NumberBuffer number = new NumberBuffer(NumberBufferKind.FloatingPoint, pDigits, SingleNumberBufferLength);
 
             if (!TryStringToNumber(value, styles, ref number, info))

--- a/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
@@ -54,6 +54,8 @@ namespace System
 
         private static unsafe bool TryNumberToInt32(ref NumberBuffer number, ref int value)
         {
+            number.CheckConsistency();
+
             int i = number.Scale;
             if (i > Int32Precision || i < number.DigitsCount)
             {
@@ -95,6 +97,8 @@ namespace System
 
         private static unsafe bool TryNumberToInt64(ref NumberBuffer number, ref long value)
         {
+            number.CheckConsistency();
+
             int i = number.Scale;
             if (i > Int64Precision || i < number.DigitsCount)
             {
@@ -136,6 +140,8 @@ namespace System
 
         private static unsafe bool TryNumberToUInt32(ref NumberBuffer number, ref uint value)
         {
+            number.CheckConsistency();
+
             int i = number.Scale;
             if (i > UInt32Precision || i < number.DigitsCount || number.IsNegative)
             {
@@ -168,6 +174,8 @@ namespace System
 
         private static unsafe bool TryNumberToUInt64(ref NumberBuffer number, ref ulong value)
         {
+            number.CheckConsistency();
+
             int i = number.Scale;
             if (i > UInt64Precision || i < number.DigitsCount || number.IsNegative)
             {
@@ -256,7 +264,8 @@ namespace System
             Debug.Assert(number.Scale == 0);
             Debug.Assert(number.IsNegative == false);
             Debug.Assert(number.HasNonZeroTail == false);
-            Debug.Assert(number.Kind != NumberBufferKind.Unknown);
+
+            number.CheckConsistency();
 
             string decSep;                  // decimal separator from NumberFormatInfo.
             string groupSep;                // group separator from NumberFormatInfo.
@@ -900,7 +909,6 @@ namespace System
                 return false;
             }
 
-
             if (!TryNumberToUInt32(ref number, ref result))
             {
                 failureIsOverflow = true;
@@ -1222,7 +1230,6 @@ namespace System
                 return false;
             }
 
-
             if (!TryNumberToUInt64(ref number, ref result))
             {
                 failureIsOverflow = true;
@@ -1532,6 +1539,8 @@ namespace System
 
         private static unsafe bool TryNumberToDecimal(ref NumberBuffer number, ref decimal value)
         {
+            number.CheckConsistency();
+
             byte* p = number.GetDigitsPointer();
             int e = number.Scale;
             bool sign = number.IsNegative;
@@ -1762,10 +1771,12 @@ namespace System
                 if (!TryParseNumber(ref p, p + value.Length, styles, ref number, info)
                     || (p - stringPointer < value.Length && !TrailingZeros(value, (int)(p - stringPointer))))
                 {
+                    number.CheckConsistency();
                     return false;
                 }
             }
 
+            number.CheckConsistency();
             return true;
         }
 
@@ -1825,6 +1836,8 @@ namespace System
 
         private static double NumberToDouble(ref NumberBuffer number)
         {
+            number.CheckConsistency();
+
             ulong bits = NumberToFloatingPointBits(ref number, in FloatingPointInfo.Double);
             double result = BitConverter.Int64BitsToDouble((long)(bits));
             return number.IsNegative ? -result : result;
@@ -1832,6 +1845,8 @@ namespace System
 
         private static float NumberToSingle(ref NumberBuffer number)
         {
+            number.CheckConsistency();
+
             uint bits = (uint)(NumberToFloatingPointBits(ref number, in FloatingPointInfo.Single));
             float result = BitConverter.Int32BitsToSingle((int)(bits));
             return number.IsNegative ? -result : result;


### PR DESCRIPTION
As per https://github.com/dotnet/coreclr/pull/20873#issuecomment-437090892, I split the PR into multiple.

This is the first PR and changes `Number.NumberBuffer` to carry a `Span<byte>`, rather than a `Span<char>`. This will allow easier sharing with the `Utf8Formatter` and `Utf8Parser`.
* The span is already only handling the ASCII characters `0-9` and the null terminator character, so there shouldn't be any issues.