### PR TITLE
Add `KeepAlive` for marshalled classes in `tests\src\Interop\PInvoke\Delegate\MarshalDelegateAsField`

### DIFF
--- a/tests/src/Interop/PInvoke/Delegate/MarshalDelegateAsField/AsDefault/AsDefaultTest.cs
+++ b/tests/src/Interop/PInvoke/Delegate/MarshalDelegateAsField/AsDefault/AsDefaultTest.cs
@@ -31,6 +31,7 @@ class AsDefaultTest
             s.verification = true;
             s.dele = new Dele(CommonMethod);
             Assert.IsTrue(TakeDelegateAsFieldInStruct_Seq(s), "Delegate marshaled as field in struct with Sequential.");
+            GC.KeepAlive(s);
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -39,6 +40,7 @@ class AsDefaultTest
                 s2.verification = true;
                 s2.dele = new Dele(CommonMethod);
                 Assert.IsTrue(TakeDelegateAsFieldInStruct_Exp(s2), "Delegate marshaled as field in struct with Explicit");
+                GC.KeepAlive(s2);
             }
 
             Console.WriteLine("\n\nScenario 3 : Delegate marshaled as field in class with Sequential.");

--- a/tests/src/Interop/PInvoke/Delegate/MarshalDelegateAsField/AsDefault/AsDefaultTest.cs
+++ b/tests/src/Interop/PInvoke/Delegate/MarshalDelegateAsField/AsDefault/AsDefaultTest.cs
@@ -46,6 +46,7 @@ class AsDefaultTest
             c3.verification = true;
             c3.dele = new Dele(CommonMethod);
             Assert.IsTrue(TakeDelegateAsFieldInClass_Seq(c3), "Delegate marshaled as field in class with Sequential.");
+            GC.KeepAlive(c3);
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -54,6 +55,7 @@ class AsDefaultTest
                 c4.verification = true;
                 c4.dele = new Dele(CommonMethod);
                 Assert.IsTrue(TakeDelegateAsFieldInClass_Exp(c4), "Delegate marshaled as field in class with Explicit.");
+                GC.KeepAlive(c4);
             }
             return 100;
         } catch (Exception e){

--- a/tests/src/Interop/PInvoke/Delegate/MarshalDelegateAsField/AsFunctionPtr/AsFunctionPtrTest.cs
+++ b/tests/src/Interop/PInvoke/Delegate/MarshalDelegateAsField/AsFunctionPtr/AsFunctionPtrTest.cs
@@ -46,6 +46,7 @@ class AsFunctionPtrTest
             c3.verification = true;
             c3.dele = new Dele(CommonMethod);
             Assert.IsTrue(TakeDelegateAsFieldInClass_Seq(c3), "Delegate marshaled as field in class with Sequential.");
+            GC.KeepAlive(c3);
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -54,6 +55,7 @@ class AsFunctionPtrTest
                 c4.verification = true;
                 c4.dele = new Dele(CommonMethod);
                 Assert.IsTrue(TakeDelegateAsFieldInClass_Exp(c4), "Delegate marshaled as field in class with Explicit.");
+                GC.KeepAlive(c4);
             }
             return 100;
         } catch (Exception e){

--- a/tests/src/Interop/PInvoke/Delegate/MarshalDelegateAsField/AsFunctionPtr/AsFunctionPtrTest.cs
+++ b/tests/src/Interop/PInvoke/Delegate/MarshalDelegateAsField/AsFunctionPtr/AsFunctionPtrTest.cs
@@ -31,6 +31,7 @@ class AsFunctionPtrTest
             s1.verification = true;
             s1.dele = new Dele(CommonMethod);
             Assert.IsTrue(TakeDelegateAsFieldInStruct_Seq(s1), "Delegate marshaled as field in struct with Sequential.");
+            GC.KeepAlive(s1);
             
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // We don't support marshalling explicit structs by-val on the System V x64 ABI
             {
@@ -39,6 +40,7 @@ class AsFunctionPtrTest
                 s2.verification = true;
                 s2.dele = new Dele(CommonMethod);
                 Assert.IsTrue(TakeDelegateAsFieldInStruct_Exp(s2), "Delegate marshaled as field in struct with Explicit.");
+                GC.KeepAlive(s2);
             }
 
             Console.WriteLine("\n\nScenario 3 : Delegate marshaled as field in class with Sequential.");

--- a/tests/src/Interop/PInvoke/Delegate/MarshalDelegateAsField/AsInterface/AsInterfaceTest.cs
+++ b/tests/src/Interop/PInvoke/Delegate/MarshalDelegateAsField/AsInterface/AsInterfaceTest.cs
@@ -39,6 +39,7 @@ class AsInterfaceTest
             sis.dele += new Dele2(CommonMethod2);
             sis.dele += new Dele2(CommonMethod3);
             Assert.IsTrue(Take_DelegatePtrAsFieldInStruct_Seq(sis), "Delegate marshaled as field in struct with Sequential.");
+            GC.KeepAlive(sis);
 
             Console.WriteLine("\n\nScenario 2 : Delegate marshaled as field in struct with Explicit.");
             Struct3_InterfacePtrAsField2_Exp sie = new Struct3_InterfacePtrAsField2_Exp();
@@ -47,6 +48,7 @@ class AsInterfaceTest
             sie.dele += new Dele2(CommonMethod2);
             sie.dele += new Dele2(CommonMethod3);
             Assert.IsTrue(Take_DelegatePtrAsFieldInStruct_Exp(sie), "Delegate marshaled as field in struct with Explicit.");
+            GC.KeepAlive(sie);
 
             Console.WriteLine("\n\nScenario 3 : Delegate marshaled as field in class with Sequential.");
             Class3_InterfacePtrAsField3_Seq cis = new Class3_InterfacePtrAsField3_Seq();

--- a/tests/src/Interop/PInvoke/Delegate/MarshalDelegateAsField/AsInterface/AsInterfaceTest.cs
+++ b/tests/src/Interop/PInvoke/Delegate/MarshalDelegateAsField/AsInterface/AsInterfaceTest.cs
@@ -55,6 +55,7 @@ class AsInterfaceTest
             cis.dele += new Dele2(CommonMethod2);
             cis.dele += new Dele2(CommonMethod3);
             Assert.IsTrue(Take_DelegatePtrAsFieldInClass_Seq(cis), "Delegate marshaled as field in class with Sequential");
+            GC.KeepAlive(cis);
 
             Console.WriteLine("\n\nScenario 4 : Delegate marshaled as field in class with Sequential.");
             Class3_InterfacePtrAsField4_Exp cie = new Class3_InterfacePtrAsField4_Exp();
@@ -63,6 +64,7 @@ class AsInterfaceTest
             cie.dele += new Dele2(CommonMethod2);
             cie.dele += new Dele2(CommonMethod3);
             Assert.IsTrue(Take_DelegatePtrAsFieldInClass_Exp(cie), "Delegate marshaled as field in class with Sequential");
+            GC.KeepAlive(cie);
 
             return 100;
         } catch (Exception e){


### PR DESCRIPTION
Fixes #20689.

If these classes are collected during tranfer from `preemptive` to `cooperative` mode when native function calls our delegate then we collect the delegate as well.

`extern "C" DLL_EXPORT BOOL STDMETHODCALLTYPE TakeDelegateAsFieldInClass_Exp(Class1_FuncPtrAsField4_Exp *cfe)
` 
does: 
`return cfe->verification && (cfe->funcPtr() == COMMONMETHODCALLED_RIGHT_RETVAL);`

`cfe->funcPtr()` is unmanaged to managed transition, at this point `cfe` must be kept alive.


Note: `AsInterfaceTest` did not fail, but I think it is safer to fix them as well.