### PR TITLE
Don't change LCL_FLD node type when replacing param with its shadow copy

### DIFF
--- a/src/jit/gschecks.cpp
+++ b/src/jit/gschecks.cpp
@@ -369,11 +369,9 @@ bool Compiler::gsFindVulnerableParams()
     return hasOneVulnerable;
 }
 
-/*****************************************************************************
- * gsParamsToShadows
- * Copy each vulnerable param ptr or buffer to a local shadow copy and replace
- * uses of the param by the shadow copy
- */
+// gsParamsToShadows
+// Copy each vulnerable param ptr or buffer to a local shadow copy and replace
+// uses of the param by the shadow copy
 void Compiler::gsParamsToShadows()
 {
     // Cache old count since we'll add new variables, and
@@ -440,8 +438,66 @@ void Compiler::gsParamsToShadows()
         gsShadowVarInfo[lclNum].shadowCopy = shadowVar;
     }
 
-    // Replace param uses with shadow copy
-    fgWalkAllTreesPre(gsReplaceShadowParams, (void*)this);
+    class ReplaceShadowParamsVisitor final : public GenTreeVisitor<ReplaceShadowParamsVisitor>
+    {
+    // Walk the locals of the method (i.e. GT_LCL_FLD and GT_LCL_VAR nodes) and replace the ones that correspond to
+    // "vulnerable" parameters with their shadow copies. If an original local variable has small type than replace
+    // the GT_LCL_VAR node type with TYP_INT.
+    public:
+        enum
+        {
+            DoPreOrder    = true,
+            DoLclVarsOnly = true
+        };
+
+        ReplaceShadowParamsVisitor(Compiler* compiler) : GenTreeVisitor<ReplaceShadowParamsVisitor>(compiler)
+        {
+        }
+
+        Compiler::fgWalkResult PreOrderVisit(GenTree** use, GenTree* user)
+        {
+            GenTree* tree = *use;
+            assert(tree != nullptr);
+            assert(tree->IsLocal());
+
+            unsigned int lclNum       = tree->AsLclVarCommon()->GetLclNum();
+            unsigned int shadowLclNum = m_compiler->gsShadowVarInfo[lclNum].shadowCopy;
+
+            if (shadowLclNum != NO_SHADOW_COPY)
+            {
+                LclVarDsc* varDsc = m_compiler->lvaTable + lclNum;
+                assert(ShadowParamVarInfo::mayNeedShadowCopy(varDsc));
+
+                tree->AsLclVarCommon()->SetLclNum(shadowLclNum);
+
+                if (varTypeIsSmall(varDsc->TypeGet()))
+                {
+                    if (user->OperIs(GT_ASG))
+                    {
+                        user->gtType = TYP_INT;
+                    }
+
+                    if (tree->OperIs(GT_LCL_VAR))
+                    {
+                        tree->gtType = TYP_INT;
+                    }
+                }
+            }
+
+            return WALK_CONTINUE;
+        }
+    };
+
+    BasicBlock* block;
+
+    foreach_block(this, block)
+    {
+        for (GenTreeStmt* stmt = block->firstStmt(); stmt; stmt = stmt->gtNextStmt)
+        {
+            ReplaceShadowParamsVisitor replaceShadowParamsVisitor(this);
+            replaceShadowParamsVisitor.WalkTree(&stmt->gtStmtExpr, nullptr);
+        }
+    }
 
     // Now insert code to copy the params to their shadow copy.
     for (UINT lclNum = 0; lclNum < lvaOldCount; lclNum++)
@@ -538,49 +594,4 @@ void Compiler::gsParamsToShadows()
             }
         }
     }
-}
-
-/*****************************************************************************
- * gsReplaceShadowParams (tree-walk call-back)
- * Replace all vulnerable param uses by it's shadow copy.
- */
-
-Compiler::fgWalkResult Compiler::gsReplaceShadowParams(GenTree** pTree, fgWalkData* data)
-{
-    Compiler* comp = data->compiler;
-    GenTree*  tree = *pTree;
-    GenTree*  asg  = nullptr;
-
-    if (tree->gtOper == GT_ASG)
-    {
-        asg  = tree;             // "asg" is the assignment tree.
-        tree = tree->gtOp.gtOp1; // "tree" is the local var tree at the left-hand size of the assignment.
-    }
-
-    if (tree->gtOper == GT_LCL_VAR || tree->gtOper == GT_LCL_FLD)
-    {
-        UINT paramNum = tree->gtLclVarCommon.gtLclNum;
-
-        if (!ShadowParamVarInfo::mayNeedShadowCopy(&comp->lvaTable[paramNum]) ||
-            comp->gsShadowVarInfo[paramNum].shadowCopy == NO_SHADOW_COPY)
-        {
-            return WALK_CONTINUE;
-        }
-
-        tree->gtLclVarCommon.SetLclNum(comp->gsShadowVarInfo[paramNum].shadowCopy);
-
-        // In gsParamsToShadows(), we create a shadow var of TYP_INT for every small type param.
-        // Make sure we update the type of the local var tree as well.
-        if (varTypeIsSmall(comp->lvaTable[paramNum].TypeGet()))
-        {
-            tree->gtType = TYP_INT;
-            if (asg)
-            {
-                // If this is an assignment tree, propagate the type to it as well.
-                asg->gtType = TYP_INT;
-            }
-        }
-    }
-
-    return WALK_CONTINUE;
 }

--- a/src/jit/gschecks.cpp
+++ b/src/jit/gschecks.cpp
@@ -440,9 +440,9 @@ void Compiler::gsParamsToShadows()
 
     class ReplaceShadowParamsVisitor final : public GenTreeVisitor<ReplaceShadowParamsVisitor>
     {
-    // Walk the locals of the method (i.e. GT_LCL_FLD and GT_LCL_VAR nodes) and replace the ones that correspond to
-    // "vulnerable" parameters with their shadow copies. If an original local variable has small type than replace
-    // the GT_LCL_VAR node type with TYP_INT.
+        // Walk the locals of the method (i.e. GT_LCL_FLD and GT_LCL_VAR nodes) and replace the ones that correspond to
+        // "vulnerable" parameters with their shadow copies. If an original local variable has small type than replace
+        // the GT_LCL_VAR node type with TYP_INT.
     public:
         enum
         {

--- a/tests/src/JIT/Regression/JitBlue/GitHub_20799/GitHub_20799.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_20799/GitHub_20799.il
@@ -35,8 +35,7 @@
   }
 
   .method private hidebysig static int32
-          Run(int8 arg1,
-              int8 arg2) cil managed noinlining
+          Run(int8 arg1, int8 arg2, int8 arg3, int8 arg4, int8 arg5, int8 arg6, int8 arg7, int8 arg8, int8 arg9) cil managed noinlining
   {
     .maxstack  8
     IL_0000:  ldc.i4.4
@@ -46,57 +45,63 @@
     IL_0002:  localloc
     IL_0004:  ldind.i4
     IL_0005:  call       void GitHub_20799.Program::Use(int32)
-    IL_000a:  ldarga.s   arg1
-    IL_000c:  ldarg.0
-    IL_000d:  box        [System.Runtime]System.SByte
+    IL_000a:  ldarga.s   arg9
+    IL_000c:  ldarg.s    arg9
 
-    // arg1 becomes a "vulnerable" parameter
-    IL_0012:  call       instance bool [System.Runtime]System.SByte::Equals(object)
-    IL_0017:  call       void GitHub_20799.Program::Use(bool)
+    // arg9 becomes a "vulnerable" parameter
+    IL_000e:  box        [System.Runtime]System.SByte
+    IL_0013:  call       instance bool [System.Runtime]System.SByte::Equals(object)
+    IL_0018:  call       void GitHub_20799.Program::Use(bool)
 
-    // A shadow copy of arg1 is being used instead
-    IL_001c:  ldarga.s   arg1
-    IL_001e:  ldfld      int8 GitHub_20799.SByte::m_value
-    IL_0023:  conv.u1
-    IL_0024:  ldarga.s   arg2
-    IL_0026:  ldfld      int8 GitHub_20799.SByte::m_value
-    IL_002b:  conv.u1
-    IL_002c:  beq.s      IL_0030
-    IL_002e:  ldc.i4.1
-    IL_002f:  ret
-    IL_0030:  ldc.i4.s   100
-    IL_0032:  ret
+    IL_001d:  ldarga.s   arg1
+    IL_001f:  ldfld      int8 GitHub_20799.SByte::m_value
+    IL_0024:  conv.u1
+
+    // A shadow copy of arg9 is being used instead
+    IL_0025:  ldarga.s   arg9
+    IL_0027:  ldfld      int8 GitHub_20799.SByte::m_value
+    IL_002c:  conv.u1
+    IL_002d:  beq.s      IL_0031
+
+    IL_002f:  ldc.i4.1
+    IL_0030:  ret
+
+    IL_0031:  ldc.i4.s   100
+    IL_0033:  ret
   }
 
   .method private hidebysig static int32
-          Run(int16 arg1,
-              int16 arg2) cil managed noinlining
+          Run(int16 arg1, int16 arg2, int16 arg3, int16 arg4, int16 arg5, int16 arg6, int16 arg7, int16 arg8, int16 arg9) cil managed noinlining
   {
     .maxstack  8
     IL_0000:  ldc.i4.4
     IL_0001:  conv.u
 
     // Unsafe buffer would require GSSecurityCookie
-    IL_0002:  localloc    IL_0004:  ldind.i4
+    IL_0002:  localloc
+    IL_0004:  ldind.i4
     IL_0005:  call       void GitHub_20799.Program::Use(int32)
-    IL_000a:  ldarga.s   arg1
+    IL_000a:  ldarga.s   arg9
     IL_000c:  ldarg.0
-    IL_000d:  box        [System.Runtime]System.Int16
 
-    // arg1 becomes a "vulnerable" parameter
+    // arg9 becomes a "vulnerable" parameter
+    IL_000d:  box        [System.Runtime]System.Int16
     IL_0012:  call       instance bool [System.Runtime]System.Int16::Equals(object)
     IL_0017:  call       void GitHub_20799.Program::Use(bool)
 
-    // A shadow copy of arg1 is being used instead
     IL_001c:  ldarga.s   arg1
     IL_001e:  ldfld      int16 GitHub_20799.Int16::m_value
     IL_0023:  conv.u2
-    IL_0024:  ldarga.s   arg2
+
+    // A shadow copy of arg9 is being used instead
+    IL_0024:  ldarga.s   arg9
     IL_0026:  ldfld      int16 GitHub_20799.Int16::m_value
     IL_002b:  conv.u2
     IL_002c:  beq.s      IL_0030
+
     IL_002e:  ldc.i4.1
     IL_002f:  ret
+
     IL_0030:  ldc.i4.s   100
     IL_0032:  ret
   }
@@ -105,35 +110,53 @@
           Main(string[] args) cil managed
   {
     .entrypoint
-    .maxstack  2
+
+    .maxstack  16
     .locals init (int32 V_0)
     IL_0000:  ldc.i4.s   100
     IL_0002:  stloc.0
     IL_0003:  ldc.i4.s   -127
     IL_0005:  ldc.i4.s   -127
-    IL_0007:  call       int32 GitHub_20799.Program::Run(int8, int8)
-    IL_000c:  ldc.i4.s   100
-    IL_000e:  beq.s      IL_001c
-    IL_0010:  ldstr      "FAILED: sbyte"
-    IL_0015:  call       void [System.Console]System.Console::WriteLine(string)
-    IL_001a:  ldc.i4.1
-    IL_001b:  stloc.0
-    IL_001c:  ldc.i4     0xffffaec1
-    IL_0021:  ldc.i4     0xffffaec1
-    IL_0026:  call       int32 GitHub_20799.Program::Run(int16, int16)
-    IL_002b:  ldc.i4.s   100
-    IL_002d:  beq.s      IL_003b
-    IL_002f:  ldstr      "FAILED: short"
-    IL_0034:  call       void [System.Console]System.Console::WriteLine(string)
-    IL_0039:  ldc.i4.1
-    IL_003a:  stloc.0
-    IL_003b:  ldloc.0
-    IL_003c:  ldc.i4.s   100
-    IL_003e:  bne.un.s   IL_004a
-    IL_0040:  ldstr      "PASS"
-    IL_0045:  call       void [System.Console]System.Console::WriteLine(string)
-    IL_004a:  ldloc.0
-    IL_004b:  ret
+    IL_0007:  ldc.i4.s   -127
+    IL_0009:  ldc.i4.s   -127
+    IL_000b:  ldc.i4.s   -127
+    IL_000d:  ldc.i4.s   -127
+    IL_000f:  ldc.i4.s   -127
+    IL_0011:  ldc.i4.s   -127
+    IL_0013:  ldc.i4.s   -127
+    IL_0015:  call       int32 GitHub_20799.Program::Run(int8, int8, int8, int8, int8, int8, int8, int8, int8)
+    IL_001a:  ldc.i4.s   100
+    IL_001c:  beq.s      IL_002a
+
+    IL_001e:  ldstr      "FAILED: sbyte"
+    IL_0023:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_0028:  ldc.i4.1
+    IL_0029:  stloc.0
+    IL_002a:  ldc.i4     -20799
+    IL_002f:  ldc.i4     -20799
+    IL_0034:  ldc.i4     -20799
+    IL_0039:  ldc.i4     -20799
+    IL_003e:  ldc.i4     -20799
+    IL_0043:  ldc.i4     -20799
+    IL_0048:  ldc.i4     -20799
+    IL_004d:  ldc.i4     -20799
+    IL_0052:  ldc.i4     -20799
+    IL_0057:  call       int32 GitHub_20799.Program::Run(int16, int16, int16, int16, int16, int16, int16, int16, int16)
+    IL_005c:  ldc.i4.s   100
+    IL_005e:  beq.s      IL_006c
+
+    IL_0060:  ldstr      "FAILED: short"
+    IL_0065:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_006a:  ldc.i4.1
+    IL_006b:  stloc.0
+    IL_006c:  ldloc.0
+    IL_006d:  ldc.i4.s   100
+    IL_006f:  bne.un.s   IL_007b
+
+    IL_0071:  ldstr      "PASS"
+    IL_0076:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_007b:  ldloc.0
+    IL_007c:  ret
   }
 
   .method public hidebysig specialname rtspecialname

--- a/tests/src/JIT/Regression/JitBlue/GitHub_20799/GitHub_20799.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_20799/GitHub_20799.il
@@ -1,0 +1,147 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern System.Runtime { }
+.assembly extern System.Console { }
+.assembly GitHub_20799 { }
+.module GitHub_20799.exe
+
+.class private sequential ansi sealed beforefieldinit GitHub_20799.SByte
+       extends [System.Runtime]System.ValueType
+{
+  .field public int8 m_value
+}
+
+.class private sequential ansi sealed beforefieldinit GitHub_20799.Int16
+       extends [System.Runtime]System.ValueType
+{
+  .field public int16 m_value
+}
+
+.class private auto ansi beforefieldinit GitHub_20799.Program
+       extends [System.Runtime]System.Object
+{
+  .method private hidebysig static void  Use(bool arg1) cil managed noinlining
+  {
+    .maxstack  8
+    IL_0000:  ret
+  }
+
+  .method private hidebysig static void  Use(int32 arg1) cil managed noinlining
+  {
+    .maxstack  8
+    IL_0000:  ret
+  }
+
+  .method private hidebysig static int32
+          Run(int8 arg1,
+              int8 arg2) cil managed noinlining
+  {
+    .maxstack  8
+    IL_0000:  ldc.i4.4
+    IL_0001:  conv.u
+
+    // Unsafe buffer would require GSSecurityCookie
+    IL_0002:  localloc
+    IL_0004:  ldind.i4
+    IL_0005:  call       void GitHub_20799.Program::Use(int32)
+    IL_000a:  ldarga.s   arg1
+    IL_000c:  ldarg.0
+    IL_000d:  box        [System.Runtime]System.SByte
+
+    // arg1 becomes a "vulnerable" parameter
+    IL_0012:  call       instance bool [System.Runtime]System.SByte::Equals(object)
+    IL_0017:  call       void GitHub_20799.Program::Use(bool)
+
+    // A shadow copy of arg1 is being used instead
+    IL_001c:  ldarga.s   arg1
+    IL_001e:  ldfld      int8 GitHub_20799.SByte::m_value
+    IL_0023:  conv.u1
+    IL_0024:  ldarga.s   arg2
+    IL_0026:  ldfld      int8 GitHub_20799.SByte::m_value
+    IL_002b:  conv.u1
+    IL_002c:  beq.s      IL_0030
+    IL_002e:  ldc.i4.1
+    IL_002f:  ret
+    IL_0030:  ldc.i4.s   100
+    IL_0032:  ret
+  }
+
+  .method private hidebysig static int32
+          Run(int16 arg1,
+              int16 arg2) cil managed noinlining
+  {
+    .maxstack  8
+    IL_0000:  ldc.i4.4
+    IL_0001:  conv.u
+
+    // Unsafe buffer would require GSSecurityCookie
+    IL_0002:  localloc    IL_0004:  ldind.i4
+    IL_0005:  call       void GitHub_20799.Program::Use(int32)
+    IL_000a:  ldarga.s   arg1
+    IL_000c:  ldarg.0
+    IL_000d:  box        [System.Runtime]System.Int16
+
+    // arg1 becomes a "vulnerable" parameter
+    IL_0012:  call       instance bool [System.Runtime]System.Int16::Equals(object)
+    IL_0017:  call       void GitHub_20799.Program::Use(bool)
+
+    // A shadow copy of arg1 is being used instead
+    IL_001c:  ldarga.s   arg1
+    IL_001e:  ldfld      int16 GitHub_20799.Int16::m_value
+    IL_0023:  conv.u2
+    IL_0024:  ldarga.s   arg2
+    IL_0026:  ldfld      int16 GitHub_20799.Int16::m_value
+    IL_002b:  conv.u2
+    IL_002c:  beq.s      IL_0030
+    IL_002e:  ldc.i4.1
+    IL_002f:  ret
+    IL_0030:  ldc.i4.s   100
+    IL_0032:  ret
+  }
+
+  .method private hidebysig static int32
+          Main(string[] args) cil managed
+  {
+    .entrypoint
+    .maxstack  2
+    .locals init (int32 V_0)
+    IL_0000:  ldc.i4.s   100
+    IL_0002:  stloc.0
+    IL_0003:  ldc.i4.s   -127
+    IL_0005:  ldc.i4.s   -127
+    IL_0007:  call       int32 GitHub_20799.Program::Run(int8, int8)
+    IL_000c:  ldc.i4.s   100
+    IL_000e:  beq.s      IL_001c
+    IL_0010:  ldstr      "FAILED: sbyte"
+    IL_0015:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_001a:  ldc.i4.1
+    IL_001b:  stloc.0
+    IL_001c:  ldc.i4     0xffffaec1
+    IL_0021:  ldc.i4     0xffffaec1
+    IL_0026:  call       int32 GitHub_20799.Program::Run(int16, int16)
+    IL_002b:  ldc.i4.s   100
+    IL_002d:  beq.s      IL_003b
+    IL_002f:  ldstr      "FAILED: short"
+    IL_0034:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_0039:  ldc.i4.1
+    IL_003a:  stloc.0
+    IL_003b:  ldloc.0
+    IL_003c:  ldc.i4.s   100
+    IL_003e:  bne.un.s   IL_004a
+    IL_0040:  ldstr      "PASS"
+    IL_0045:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_004a:  ldloc.0
+    IL_004b:  ret
+  }
+
+  .method public hidebysig specialname rtspecialname
+          instance void  .ctor() cil managed
+  {
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+    IL_0006:  ret
+  }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_20799/GitHub_20799.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_20799/GitHub_20799.il
@@ -35,7 +35,7 @@
   }
 
   .method private hidebysig static int32
-          Run(int8 arg1, int8 arg2, int8 arg3, int8 arg4, int8 arg5, int8 arg6, int8 arg7, int8 arg8, int8 arg9) cil managed noinlining
+          Ldfld(int8 arg1, int8 arg2, int8 arg3, int8 arg4, int8 arg5, int8 arg6, int8 arg7, int8 arg8, int8 arg9) cil managed noinlining
   {
     .maxstack  8
     IL_0000:  ldc.i4.4
@@ -71,7 +71,43 @@
   }
 
   .method private hidebysig static int32
-          Run(int16 arg1, int16 arg2, int16 arg3, int16 arg4, int16 arg5, int16 arg6, int16 arg7, int16 arg8, int16 arg9) cil managed noinlining
+          Ldind(int8 arg1, int8 arg2, int8 arg3, int8 arg4, int8 arg5, int8 arg6, int8 arg7, int8 arg8, int8 arg9) cil managed noinlining
+  {
+    .maxstack  8
+    IL_0000:  ldc.i4.4
+    IL_0001:  conv.u
+
+    // Unsafe buffer would require GSSecurityCookie
+    IL_0002:  localloc
+    IL_0004:  ldind.i4
+    IL_0005:  call       void GitHub_20799.Program::Use(int32)
+    IL_000a:  ldarga.s   arg9
+    IL_000c:  ldarg.s    arg9
+
+    // arg9 becomes a "vulnerable" parameter
+    IL_000e:  box        [System.Runtime]System.SByte
+    IL_0013:  call       instance bool [System.Runtime]System.SByte::Equals(object)
+    IL_0018:  call       void GitHub_20799.Program::Use(bool)
+
+    IL_001d:  ldarga.s   arg1
+    IL_001f:  ldind.i1
+    IL_0020:  conv.u1
+
+    // A shadow copy of arg9 is being used instead
+    IL_0021:  ldarga.s   arg9
+    IL_0023:  ldind.i1
+    IL_0024:  conv.u1
+    IL_0025:  beq.s      IL_0029
+
+    IL_0027:  ldc.i4.1
+    IL_0028:  ret
+
+    IL_0029:  ldc.i4.s   100
+    IL_002b:  ret
+  }
+
+  .method private hidebysig static int32
+          Ldfld(int16 arg1, int16 arg2, int16 arg3, int16 arg4, int16 arg5, int16 arg6, int16 arg7, int16 arg8, int16 arg9) cil managed noinlining
   {
     .maxstack  8
     IL_0000:  ldc.i4.4
@@ -106,6 +142,42 @@
     IL_0032:  ret
   }
 
+   .method private hidebysig static int32
+          Ldind(int16 arg1, int16 arg2, int16 arg3, int16 arg4, int16 arg5, int16 arg6, int16 arg7, int16 arg8, int16 arg9) cil managed noinlining
+  {
+    .maxstack  8
+    IL_0000:  ldc.i4.4
+    IL_0001:  conv.u
+
+    // Unsafe buffer would require GSSecurityCookie
+    IL_0002:  localloc
+    IL_0004:  ldind.i4
+    IL_0005:  call       void GitHub_20799.Program::Use(int32)
+    IL_000a:  ldarga.s   arg9
+    IL_000c:  ldarg.0
+
+    // arg9 becomes a "vulnerable" parameter
+    IL_000d:  box        [System.Runtime]System.Int16
+    IL_0012:  call       instance bool [System.Runtime]System.Int16::Equals(object)
+    IL_0017:  call       void GitHub_20799.Program::Use(bool)
+
+    IL_001c:  ldarga.s   arg1
+    IL_001e:  ldind.i2
+    IL_001f:  conv.u2
+
+    // A shadow copy of arg9 is being used instead
+    IL_0020:  ldarga.s   arg9
+    IL_0022:  ldind.i2
+    IL_0023:  conv.u2
+    IL_0024:  beq.s      IL_0028
+
+    IL_0026:  ldc.i4.1
+    IL_0027:  ret
+
+    IL_0028:  ldc.i4.s   100
+    IL_002a:  ret
+  }
+
   .method private hidebysig static int32
           Main(string[] args) cil managed
   {
@@ -124,39 +196,73 @@
     IL_000f:  ldc.i4.s   -127
     IL_0011:  ldc.i4.s   -127
     IL_0013:  ldc.i4.s   -127
-    IL_0015:  call       int32 GitHub_20799.Program::Run(int8, int8, int8, int8, int8, int8, int8, int8, int8)
+    IL_0015:  call       int32 GitHub_20799.Program::Ldfld(int8, int8, int8, int8, int8, int8, int8, int8, int8)
     IL_001a:  ldc.i4.s   100
     IL_001c:  beq.s      IL_002a
 
-    IL_001e:  ldstr      "FAILED: sbyte"
+    IL_001e:  ldstr      "FAILED: ldfld sbyte"
     IL_0023:  call       void [System.Console]System.Console::WriteLine(string)
     IL_0028:  ldc.i4.1
     IL_0029:  stloc.0
-    IL_002a:  ldc.i4     -20799
-    IL_002f:  ldc.i4     -20799
-    IL_0034:  ldc.i4     -20799
-    IL_0039:  ldc.i4     -20799
-    IL_003e:  ldc.i4     -20799
-    IL_0043:  ldc.i4     -20799
-    IL_0048:  ldc.i4     -20799
-    IL_004d:  ldc.i4     -20799
-    IL_0052:  ldc.i4     -20799
-    IL_0057:  call       int32 GitHub_20799.Program::Run(int16, int16, int16, int16, int16, int16, int16, int16, int16)
-    IL_005c:  ldc.i4.s   100
-    IL_005e:  beq.s      IL_006c
+    IL_002a:  ldc.i4.s   -127
+    IL_002c:  ldc.i4.s   -127
+    IL_002e:  ldc.i4.s   -127
+    IL_0030:  ldc.i4.s   -127
+    IL_0032:  ldc.i4.s   -127
+    IL_0034:  ldc.i4.s   -127
+    IL_0036:  ldc.i4.s   -127
+    IL_0038:  ldc.i4.s   -127
+    IL_003a:  ldc.i4.s   -127
+    IL_003c:  call       int32 GitHub_20799.Program::Ldind(int8, int8, int8, int8, int8, int8, int8, int8, int8)
+    IL_0041:  ldc.i4.s   100
+    IL_0043:  beq.s      IL_0051
 
-    IL_0060:  ldstr      "FAILED: short"
-    IL_0065:  call       void [System.Console]System.Console::WriteLine(string)
-    IL_006a:  ldc.i4.1
-    IL_006b:  stloc.0
-    IL_006c:  ldloc.0
-    IL_006d:  ldc.i4.s   100
-    IL_006f:  bne.un.s   IL_007b
+    IL_0045:  ldstr      "FAILED: ldind sbyte"
+    IL_004a:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_004f:  ldc.i4.1
+    IL_0050:  stloc.0
+    IL_0051:  ldc.i4     -20799
+    IL_0056:  ldc.i4     -20799
+    IL_005b:  ldc.i4     -20799
+    IL_0060:  ldc.i4     -20799
+    IL_0065:  ldc.i4     -20799
+    IL_006a:  ldc.i4     -20799
+    IL_006f:  ldc.i4     -20799
+    IL_0074:  ldc.i4     -20799
+    IL_0079:  ldc.i4     -20799
+    IL_007e:  call       int32 GitHub_20799.Program::Ldfld(int16, int16, int16, int16, int16, int16, int16, int16, int16)
+    IL_0083:  ldc.i4.s   100
+    IL_0085:  beq.s      IL_0093
 
-    IL_0071:  ldstr      "PASS"
-    IL_0076:  call       void [System.Console]System.Console::WriteLine(string)
-    IL_007b:  ldloc.0
-    IL_007c:  ret
+    IL_0087:  ldstr      "FAILED: ldfld short"
+    IL_008c:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_0091:  ldc.i4.1
+    IL_0092:  stloc.0
+    IL_0093:  ldc.i4     -20799
+    IL_0098:  ldc.i4     -20799
+    IL_009d:  ldc.i4     -20799
+    IL_00a2:  ldc.i4     -20799
+    IL_00a7:  ldc.i4     -20799
+    IL_00ac:  ldc.i4     -20799
+    IL_00b1:  ldc.i4     -20799
+    IL_00b6:  ldc.i4     -20799
+    IL_00bb:  ldc.i4     -20799
+    IL_00c0:  call       int32 GitHub_20799.Program::Ldind(int16, int16, int16, int16, int16, int16, int16, int16, int16)
+    IL_00c5:  ldc.i4.s   100
+    IL_00c7:  beq.s      IL_00d5
+
+    IL_00c9:  ldstr      "FAILED: ldind short"
+    IL_00ce:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_00d3:  ldc.i4.1
+    IL_00d4:  stloc.0
+    IL_00d5:  ldloc.0
+    IL_00d6:  ldc.i4.s   100
+    IL_00d8:  bne.un.s   IL_00e4
+
+    IL_00da:  ldstr      "PASS"
+    IL_00df:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_00e4:  ldloc.0
+    IL_00e5:  ret
   }
 
   .method public hidebysig specialname rtspecialname

--- a/tests/src/JIT/Regression/JitBlue/GitHub_20799/GitHub_20799.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_20799/GitHub_20799.il
@@ -9,7 +9,7 @@
 
 // GitHub 20799: a bug is reproduced when
 // 1) a method requires GSSecurityCookie (e.g. when allocating unsafe buffer using localloc)
-// 2) one of the method parameter is "vulnerable" and requires a shadow variable to be created
+// 2) one of the method parameters is "vulnerable" and requires a shadow variable to be created
 //    and used instead of the original parameter variable
 // 3) the method parameter has small signed integer type (i.e. int8 or int16)
 // 4) the value of the parameter is converted to unsigned type (e.g. uint8 or uint16)
@@ -18,7 +18,7 @@
 // * conv.u1(ldfld(ldarga arg1))
 // * conv.u1(ldind.i1(ldarga arg1))
 //
-// In the process of replacement arg1 with a shadow variable the node type was also changed to TYP_INT and,
+// In the process of replacement of arg1 with a shadow variable the node type was also changed to TYP_INT and,
 // as a consequence, 'mov dstReg, dword ptr [shadowVarLoc]' was generated for such conversion
 // instead of 'movzx dstReg, byte ptr [shadowVarLoc]'.
 
@@ -47,6 +47,20 @@
   {
     .maxstack  8
     IL_0000:  ret
+  }
+
+  .method private hidebysig static int8  Nop(int8 arg1) cil managed noinlining
+  {
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  ret
+  }
+
+  .method private hidebysig static int16  Nop(int16 arg1) cil managed noinlining
+  {
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  ret
   }
 
   .method private hidebysig static int32
@@ -122,6 +136,82 @@
   }
 
   .method private hidebysig static int32
+          Starg(int8 arg1, int8 arg2, int8 arg3, int8 arg4, int8 arg5, int8 arg6, int8 arg7, int8 arg8, int8 arg9) cil managed noinlining
+  {
+    .maxstack  8
+
+    IL_0000:  ldc.i4.4
+    IL_0001:  conv.u
+
+    // Unsafe buffer would require GSSecurityCookie
+    IL_0002:  localloc
+    IL_0004:  ldind.i4
+    IL_0005:  call       void GitHub_20799.Program::Use(int32)
+    IL_000a:  ldarga.s   arg9
+    IL_000c:  ldarg.s    arg9
+
+    // arg9 becomes a "vulnerable" parameter
+    IL_000e:  box        [System.Runtime]System.SByte
+    IL_0013:  call       instance bool [System.Runtime]System.SByte::Equals(object)
+    IL_0018:  call       void GitHub_20799.Program::Use(bool)
+
+    IL_001d:  ldarg.0
+
+    // This is needed to not "contaminate" arg1 with "vulnerability" of arg9
+    IL_001e:  call       int8 GitHub_20799.Program::Nop(int8)
+
+    // A shadow copy of arg9 is being used instead
+    IL_0023:  starg.s    arg9
+    IL_0025:  ldarg.0
+    IL_0026:  ldarg.s    arg9
+    IL_0028:  beq.s      IL_002c
+
+    IL_002a:  ldc.i4.1
+    IL_002b:  ret
+
+    IL_002c:  ldc.i4.s   100
+    IL_002e:  ret
+  }
+
+  .method private hidebysig static int32
+          Stind(int8 arg1, int8 arg2, int8 arg3, int8 arg4, int8 arg5, int8 arg6, int8 arg7, int8 arg8, int8 arg9) cil managed noinlining
+  {
+    .maxstack  8
+
+    IL_0000:  ldc.i4.4
+    IL_0001:  conv.u
+
+    // Unsafe buffer would require GSSecurityCookie
+    IL_0002:  localloc
+    IL_0004:  ldind.i4
+    IL_0005:  call       void GitHub_20799.Program::Use(int32)
+    IL_000a:  ldarga.s   arg9
+    IL_000c:  ldarg.s    arg9
+
+    // arg9 becomes a "vulnerable" parameter
+    IL_000e:  box        [System.Runtime]System.SByte
+    IL_0013:  call       instance bool [System.Runtime]System.SByte::Equals(object)
+    IL_0018:  call       void GitHub_20799.Program::Use(bool)
+
+    // A shadow copy of arg9 is being used instead
+    IL_001d:  ldarga.s   arg9
+    IL_001f:  ldarg.0
+
+    // This is needed to not "contaminate" arg1 with "vulnerability" of arg9
+    IL_0020:  call       int8 GitHub_20799.Program::Nop(int8)
+    IL_0025:  stind.i1
+    IL_0026:  ldarg.0
+    IL_0027:  ldarg.s    arg9
+    IL_0029:  beq.s      IL_002d
+
+    IL_002b:  ldc.i4.1
+    IL_002c:  ret
+
+    IL_002d:  ldc.i4.s   100
+    IL_002f:  ret
+  }
+
+  .method private hidebysig static int32
           Ldfld(int16 arg1, int16 arg2, int16 arg3, int16 arg4, int16 arg5, int16 arg6, int16 arg7, int16 arg8, int16 arg9) cil managed noinlining
   {
     .maxstack  8
@@ -193,6 +283,83 @@
     IL_002a:  ret
   }
 
+
+  .method private hidebysig static int32
+          Starg(int16 arg1, int16 arg2, int16 arg3, int16 arg4, int16 arg5, int16 arg6, int16 arg7, int16 arg8, int16 arg9) cil managed noinlining
+  {
+    .maxstack  8
+
+    IL_0000:  ldc.i4.4
+    IL_0001:  conv.u
+
+    // Unsafe buffer would require GSSecurityCookie
+    IL_0002:  localloc
+    IL_0004:  ldind.i4
+    IL_0005:  call       void GitHub_20799.Program::Use(int32)
+    IL_000a:  ldarga.s   arg9
+    IL_000c:  ldarg.s    arg9
+
+    // arg9 becomes a "vulnerable" parameter
+    IL_000e:  box        [System.Runtime]System.Int16
+    IL_0013:  call       instance bool [System.Runtime]System.Int16::Equals(object)
+    IL_0018:  call       void GitHub_20799.Program::Use(bool)
+
+    IL_001d:  ldarg.0
+
+    // This is needed to not "contaminate" arg1 with "vulnerability" of arg9
+    IL_001e:  call       int16 GitHub_20799.Program::Nop(int16)
+
+    // A shadow copy of arg9 is being used instead
+    IL_0023:  starg.s    arg9
+    IL_0025:  ldarg.0
+    IL_0026:  ldarg.s    arg9
+    IL_0028:  beq.s      IL_002c
+
+    IL_002a:  ldc.i4.1
+    IL_002b:  ret
+
+    IL_002c:  ldc.i4.s   100
+    IL_002e:  ret
+  }
+
+  .method private hidebysig static int32
+          Stind(int16 arg1, int16 arg2, int16 arg3, int16 arg4, int16 arg5, int16 arg6, int16 arg7, int16 arg8, int16 arg9) cil managed noinlining
+  {
+    .maxstack  8
+
+    IL_0000:  ldc.i4.4
+    IL_0001:  conv.u
+
+    // Unsafe buffer would require GSSecurityCookie
+    IL_0002:  localloc
+    IL_0004:  ldind.i4
+    IL_0005:  call       void GitHub_20799.Program::Use(int32)
+    IL_000a:  ldarga.s   arg9
+    IL_000c:  ldarg.s    arg9
+
+    // arg9 becomes a "vulnerable" parameter
+    IL_000e:  box        [System.Runtime]System.Int16
+    IL_0013:  call       instance bool [System.Runtime]System.Int16::Equals(object)
+    IL_0018:  call       void GitHub_20799.Program::Use(bool)
+
+    // A shadow copy of arg9 is being used instead
+    IL_001d:  ldarga.s   arg9
+    IL_001f:  ldarg.0
+
+    // This is needed to not "contaminate" arg1 with "vulnerability" of arg9
+    IL_0020:  call       int16 GitHub_20799.Program::Nop(int16)
+    IL_0025:  stind.i2
+    IL_0026:  ldarg.0
+    IL_0027:  ldarg.s    arg9
+    IL_0029:  beq.s      IL_002d
+
+    IL_002b:  ldc.i4.1
+    IL_002c:  ret
+
+    IL_002d:  ldc.i4.s   100
+    IL_002f:  ret
+  }
+
   .method private hidebysig static int32
           Main(string[] args) cil managed
   {
@@ -236,48 +403,116 @@
     IL_004a:  call       void [System.Console]System.Console::WriteLine(string)
     IL_004f:  ldc.i4.1
     IL_0050:  stloc.0
-    IL_0051:  ldc.i4     -20799
-    IL_0056:  ldc.i4     -20799
-    IL_005b:  ldc.i4     -20799
-    IL_0060:  ldc.i4     -20799
-    IL_0065:  ldc.i4     -20799
-    IL_006a:  ldc.i4     -20799
-    IL_006f:  ldc.i4     -20799
-    IL_0074:  ldc.i4     -20799
-    IL_0079:  ldc.i4     -20799
-    IL_007e:  call       int32 GitHub_20799.Program::Ldfld(int16, int16, int16, int16, int16, int16, int16, int16, int16)
-    IL_0083:  ldc.i4.s   100
-    IL_0085:  beq.s      IL_0093
+    IL_0051:  ldc.i4.s   -127
+    IL_0053:  ldc.i4.s   -127
+    IL_0055:  ldc.i4.s   -127
+    IL_0057:  ldc.i4.s   -127
+    IL_0059:  ldc.i4.s   -127
+    IL_005b:  ldc.i4.s   -127
+    IL_005d:  ldc.i4.s   -127
+    IL_005f:  ldc.i4.s   -127
+    IL_0061:  ldc.i4.s   -127
+    IL_0063:  call       int32 GitHub_20799.Program::Starg(int8, int8, int8, int8, int8, int8, int8, int8, int8)
+    IL_0068:  ldc.i4.s   100
+    IL_006a:  beq.s      IL_0078
 
-    IL_0087:  ldstr      "FAILED: ldfld short"
-    IL_008c:  call       void [System.Console]System.Console::WriteLine(string)
-    IL_0091:  ldc.i4.1
-    IL_0092:  stloc.0
-    IL_0093:  ldc.i4     -20799
-    IL_0098:  ldc.i4     -20799
-    IL_009d:  ldc.i4     -20799
-    IL_00a2:  ldc.i4     -20799
-    IL_00a7:  ldc.i4     -20799
-    IL_00ac:  ldc.i4     -20799
-    IL_00b1:  ldc.i4     -20799
-    IL_00b6:  ldc.i4     -20799
-    IL_00bb:  ldc.i4     -20799
-    IL_00c0:  call       int32 GitHub_20799.Program::Ldind(int16, int16, int16, int16, int16, int16, int16, int16, int16)
-    IL_00c5:  ldc.i4.s   100
-    IL_00c7:  beq.s      IL_00d5
+    IL_006c:  ldstr      "FAILED: starg sbyte"
+    IL_0071:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_0076:  ldc.i4.1
+    IL_0077:  stloc.0
+    IL_0078:  ldc.i4.s   -127
+    IL_007a:  ldc.i4.s   -127
+    IL_007c:  ldc.i4.s   -127
+    IL_007e:  ldc.i4.s   -127
+    IL_0080:  ldc.i4.s   -127
+    IL_0082:  ldc.i4.s   -127
+    IL_0084:  ldc.i4.s   -127
+    IL_0086:  ldc.i4.s   -127
+    IL_0088:  ldc.i4.s   -127
+    IL_008a:  call       int32 GitHub_20799.Program::Stind(int8, int8, int8, int8, int8, int8, int8, int8, int8)
+    IL_008f:  ldc.i4.s   100
+    IL_0091:  beq.s      IL_009f
 
-    IL_00c9:  ldstr      "FAILED: ldind short"
-    IL_00ce:  call       void [System.Console]System.Console::WriteLine(string)
-    IL_00d3:  ldc.i4.1
-    IL_00d4:  stloc.0
-    IL_00d5:  ldloc.0
-    IL_00d6:  ldc.i4.s   100
-    IL_00d8:  bne.un.s   IL_00e4
+    IL_0093:  ldstr      "FAILED: stind sbyte"
+    IL_0098:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_009d:  ldc.i4.1
+    IL_009e:  stloc.0
+    IL_009f:  ldc.i4     -20799
+    IL_00a4:  ldc.i4     -20799
+    IL_00a9:  ldc.i4     -20799
+    IL_00ae:  ldc.i4     -20799
+    IL_00b3:  ldc.i4     -20799
+    IL_00b8:  ldc.i4     -20799
+    IL_00bd:  ldc.i4     -20799
+    IL_00c2:  ldc.i4     -20799
+    IL_00c7:  ldc.i4     -20799
+    IL_00cc:  call       int32 GitHub_20799.Program::Ldfld(int16, int16, int16, int16, int16, int16, int16, int16, int16)
+    IL_00d1:  ldc.i4.s   100
+    IL_00d3:  beq.s      IL_00e1
 
-    IL_00da:  ldstr      "PASS"
-    IL_00df:  call       void [System.Console]System.Console::WriteLine(string)
-    IL_00e4:  ldloc.0
-    IL_00e5:  ret
+    IL_00d5:  ldstr      "FAILED: ldfld short"
+    IL_00da:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_00df:  ldc.i4.1
+    IL_00e0:  stloc.0
+    IL_00e1:  ldc.i4     -20799
+    IL_00e6:  ldc.i4     -20799
+    IL_00eb:  ldc.i4     -20799
+    IL_00f0:  ldc.i4     -20799
+    IL_00f5:  ldc.i4     -20799
+    IL_00fa:  ldc.i4     -20799
+    IL_00ff:  ldc.i4     -20799
+    IL_0104:  ldc.i4     -20799
+    IL_0109:  ldc.i4     -20799
+    IL_010e:  call       int32 GitHub_20799.Program::Ldind(int16, int16, int16, int16, int16, int16, int16, int16, int16)
+    IL_0113:  ldc.i4.s   100
+    IL_0115:  beq.s      IL_0123
+
+    IL_0117:  ldstr      "FAILED: ldind short"
+    IL_011c:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_0121:  ldc.i4.1
+    IL_0122:  stloc.0
+    IL_0123:  ldc.i4     -20799
+    IL_0128:  ldc.i4     -20799
+    IL_012d:  ldc.i4     -20799
+    IL_0132:  ldc.i4     -20799
+    IL_0137:  ldc.i4     -20799
+    IL_013c:  ldc.i4     -20799
+    IL_0141:  ldc.i4     -20799
+    IL_0146:  ldc.i4     -20799
+    IL_014b:  ldc.i4     -20799
+    IL_0150:  call       int32 GitHub_20799.Program::Starg(int16, int16, int16, int16, int16, int16, int16, int16, int16)
+    IL_0155:  ldc.i4.s   100
+    IL_0157:  beq.s      IL_0165
+
+    IL_0159:  ldstr      "FAILED: starg short"
+    IL_015e:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_0163:  ldc.i4.1
+    IL_0164:  stloc.0
+    IL_0165:  ldc.i4     -20799
+    IL_016a:  ldc.i4     -20799
+    IL_016f:  ldc.i4     -20799
+    IL_0174:  ldc.i4     -20799
+    IL_0179:  ldc.i4     -20799
+    IL_017e:  ldc.i4     -20799
+    IL_0183:  ldc.i4     -20799
+    IL_0188:  ldc.i4     -20799
+    IL_018d:  ldc.i4     -20799
+    IL_0192:  call       int32 GitHub_20799.Program::Stind(int16, int16, int16, int16, int16, int16, int16, int16, int16)
+    IL_0197:  ldc.i4.s   100
+    IL_0199:  beq.s      IL_01a7
+
+    IL_019b:  ldstr      "FAILED: stind short"
+    IL_01a0:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_01a5:  ldc.i4.1
+    IL_01a6:  stloc.0
+    IL_01a7:  ldloc.0
+    IL_01a8:  ldc.i4.s   100
+    IL_01aa:  bne.un.s   IL_01b6
+
+    IL_01ac:  ldstr      "PASS"
+    IL_01b1:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_01b6:  ldloc.0
+    IL_01b7:  ret
   }
 
   .method public hidebysig specialname rtspecialname

--- a/tests/src/JIT/Regression/JitBlue/GitHub_20799/GitHub_20799.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_20799/GitHub_20799.il
@@ -7,6 +7,21 @@
 .assembly GitHub_20799 { }
 .module GitHub_20799.exe
 
+// GitHub 20799: a bug is reproduced when
+// 1) a method requires GSSecurityCookie (e.g. when allocating unsafe buffer using localloc)
+// 2) one of the method parameter is "vulnerable" and requires a shadow variable to be created
+//    and used instead of the original parameter variable
+// 3) the method parameter has small signed integer type (i.e. int8 or int16)
+// 4) the value of the parameter is converted to unsigned type (e.g. uint8 or uint16)
+//
+// For example, these IL patterns are morphed by JIT into a GT_LCL_FLD(uint8, arg1) node
+// * conv.u1(ldfld(ldarga arg1))
+// * conv.u1(ldind.i1(ldarga arg1))
+//
+// In the process of replacement arg1 with a shadow variable the node type was also changed to TYP_INT and,
+// as a consequence, 'mov dstReg, dword ptr [shadowVarLoc]' was generated for such conversion
+// instead of 'movzx dstReg, byte ptr [shadowVarLoc]'.
+
 .class private sequential ansi sealed beforefieldinit GitHub_20799.SByte
        extends [System.Runtime]System.ValueType
 {

--- a/tests/src/JIT/Regression/JitBlue/GitHub_20799/GitHub_20799.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_20799/GitHub_20799.ilproj
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_20799.il" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
**gsReplaceShadowParams** can change semantic of a tree by "upgrading" gtType of LCL_FLD and LCL_VAR from small type to TYP_INT.

For example, this statement tree
```
fgMorphTree BB07, stmt 11 (after)
               [000113] -----+------                    /--*  CNS_INT   int    16
               [000114] ----G+------                 /--*  LSH       int   
               [000111] -----+------                 |  \--*  LCL_FLD   short  V00 arg0         [+0]
               [000115] ----G+------              /--*  OR        int   
               [000107] -----+------              |  \--*  LCL_FLD   ushort V00 arg0         [+0]
               [000042] -A--G+------              *  ASG       int   
               [000041] D----+-N----              \--*  LCL_VAR   int    V05 tmp3         
```
would get transformed by **gsReplaceShadowParams** into the following
```
***** BB07, stmt 13
               [000043] ------------              *  STMT      void  (IL   ???...  ???)
               [000113] -----+------              |        /--*  CNS_INT   int    16
               [000114] ----G+------              |     /--*  LSH       int   
               [000111] -----+------              |     |  \--*  LCL_FLD   int    V10 tmp8         [+0]
               [000115] ----G+------              |  /--*  OR        int   
               [000107] -----+------              |  |  \--*  LCL_FLD   int    V10 tmp8         [+0]
               [000042] -A--G+------              \--*  ASG       int   
               [000041] D----+-N----                 \--*  LCL_VAR   int    V05 tmp3         

```

Below you can find the code generated for such "transformed" tree that computes the value in **eax** register and the code for its original version computing the value in **edx** register. 
If say, both **[rsp+2CH]** and **[rsp+58H]** have the same value of 0xFFFF_AEC1 then at the end edx is 0xAEC1_AEC1 while eax is 0xFFFF_AEC1

```asm
       8B44242C             mov      eax, dword ptr [rsp+2CH]  ; eax is 0xFFFF_AEC1
       C1E010               shl      eax, 16                   ; eax is 0xAEC1_0000
       0B44242C             or       eax, dword ptr [rsp+2CH]  ; eax is 0xFFFF_AEC1
       0FB7542458           movzx    rdx, word  ptr [rsp+58H]  ; rdx is 0x0000_0000_0000_AEC1
       480FBF4C2458         movsx    rcx, word  ptr [rsp+58H]  ; rcx is 0xFFFF_FFFF_FFFF_AEC1
       C1E110               shl      ecx, 16                   ; ecx is 0xAEC1_0000
       0BD1                 or       edx, ecx                  ; edx is 0xAEC1_AEC1
       3BD0                 cmp      edx, eax
```

Fixes one of the test failures in https://github.com/dotnet/coreclr/issues/20799 *(System.Tests.Int16Tests.Equals(i1: -789, obj: -789, expected: True))*