### PR TITLE
Add back support for deserialization of BinaryFormatted resources

### DIFF
--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -1933,6 +1933,9 @@
   <data name="BadImageFormat_ParameterSignatureMismatch" xml:space="preserve">
     <value>The parameters and the signature of the method don't match.</value>
   </data>
+  <data name="BadImageFormat_ResType_SerBlobMismatch" xml:space="preserve">
+    <value>The type serialized in the .resources file was not the same type that the .resources file said it contained. Expected '{0}' but read '{1}'.</value>
+  </data>
   <data name="BadImageFormat_ResourceDataLengthInvalid" xml:space="preserve">
     <value>Corrupt .resources file.  The specified data length '{0}' is not a valid position in the stream.</value>
   </data>

--- a/src/System.Private.CoreLib/shared/System/Resources/ResourceReader.cs
+++ b/src/System.Private.CoreLib/shared/System/Resources/ResourceReader.cs
@@ -96,7 +96,20 @@ namespace System.Resources
         private unsafe int* _namePositionsPtr;  // If we're using UnmanagedMemoryStream
         private Type[] _typeTable;    // Lazy array of Types for resource values.
         private int[] _typeNamePositions;  // To delay initialize type table
-        private int _numResources;    // Num of resources files, in case arrays aren't allocated.        
+        private int _numResources;    // Num of resources files, in case arrays aren't allocated.
+
+        private bool _permitDeserialization;  // bool indicating if this ResourceReader deserialize BinaryFormatted resources
+        private object _binaryFormatter; // binary formatter instance to use for deserializing
+
+        // statics used to dynamically call into BinaryFormatter
+        // When successfully located s_binaryFormatterType will point to the BinaryFormatter type
+        // and s_deserializeMethod will point to an unbound delegate to the deserialize method.
+        // When it cannot be located s_binaryFormatterType will point to typeof(object) and 
+        // s_deserializeMethod will be null.
+        private static Type s_binaryFormatterType;
+        private static Func<object, Stream, object> s_deserializeMethod;
+
+
 
         // We'll include a separate code path that uses UnmanagedMemoryStream to
         // avoid allocating String objects and the like.
@@ -141,7 +154,7 @@ namespace System.Resources
         // passing in the stream to read from and the RuntimeResourceSet's 
         // internal hash table (hash table of names with file offsets
         // and values, coupled to this ResourceReader).
-        internal ResourceReader(Stream stream, Dictionary<string, ResourceLocator> resCache)
+        internal ResourceReader(Stream stream, Dictionary<string, ResourceLocator> resCache, bool permitDeserialization)
         {
             Debug.Assert(stream != null, "Need a stream!");
             Debug.Assert(stream.CanRead, "Stream should be readable!");
@@ -151,6 +164,8 @@ namespace System.Resources
             _store = new BinaryReader(stream, Encoding.UTF8);
 
             _ums = stream as UnmanagedMemoryStream;
+
+            _permitDeserialization = permitDeserialization;
 
             ReadResources();
         }
@@ -591,7 +606,7 @@ namespace System.Resources
             }
             else
             {
-                throw new NotSupportedException(SR.NotSupported_ResourceObjectSerialization);
+                return DeserializeObject(typeIndex);
             }
         }
 
@@ -743,7 +758,81 @@ namespace System.Resources
             }
 
             // Normal serialized objects
-            throw new NotSupportedException(SR.NotSupported_ResourceObjectSerialization);
+            int typeIndex = typeCode - ResourceTypeCode.StartOfUserTypes;
+            return DeserializeObject(typeIndex);
+        }
+
+        // Helper method to deserialize a type
+        private Object DeserializeObject(int typeIndex)
+        {
+            if (!_permitDeserialization)
+            {
+                throw new NotSupportedException(SR.NotSupported_ResourceObjectSerialization);
+            }
+
+            if (_binaryFormatter == null)
+            {
+                InitializeBinaryFormatter();
+            }
+
+            Type type = FindType(typeIndex);
+ 
+            // Ensure that the object we deserialized is exactly the same
+            // type of object we thought we should be deserializing. 
+            Object graph;
+            graph = s_deserializeMethod(_binaryFormatter, _store.BaseStream);
+            
+            // This check is about correctness, not security at this point.
+            if (graph.GetType() != type)
+                throw new BadImageFormatException(SR.Format(SR.BadImageFormat_ResType_SerBlobMismatch, type.FullName, graph.GetType().FullName));
+ 
+            return graph;
+        }
+
+        private void InitializeBinaryFormatter()
+        {
+            if (s_binaryFormatterType == null)
+            {
+                Type binaryFormatterType = Type.GetType(
+                    "System.Runtime.Serialization.Formatters.Binary.BinaryFormatter, System.Runtime.Serialization.Formatters, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+                    throwOnError: false);
+                if (binaryFormatterType != null)
+                {
+                    ConstructorInfo binaryFormatterCtor = binaryFormatterType.GetConstructor(new Type[0]);
+                    MethodInfo binaryFormatterDeserialize = binaryFormatterType.GetMethod("Deserialize", new Type[] { typeof(Stream) });
+
+                    s_binaryFormatterType = binaryFormatterType;
+                    // create an unbound delegate that can accept a BinaryFormatter instance as object
+                    s_deserializeMethod = (Func<object, Stream, object>)typeof(ResourceReader)
+                                           .GetMethod(nameof(CreateUntypedDelegate), BindingFlags.NonPublic | BindingFlags.Static)
+                                           .MakeGenericMethod(binaryFormatterType)
+                                           .Invoke(null, new object[] { binaryFormatterDeserialize });
+                }
+                else
+                {
+                    // set a sentinel to indicate that BinaryFormatter wasn't found
+                    s_binaryFormatterType = typeof(object);
+                    s_deserializeMethod = null;
+                }
+            }
+
+            if (s_binaryFormatterType != null && s_deserializeMethod == null)
+            {
+                // we couldn't find the type
+                throw new NotSupportedException(SR.NotSupported_ResourceObjectSerialization);
+            }
+
+            _binaryFormatter = Activator.CreateInstance(s_binaryFormatterType);
+        }
+
+        // generic method that we specialize at runtime once we've loaded the BinaryFormatter type
+        // permits creating an unbound delegate so that we can avoid reflection after the initial
+        // lightup code completes.
+        private static Func<object, Stream, object> CreateUntypedDelegate<TInstance>(MethodInfo method)
+        {
+            Func<TInstance, Stream, object> typedDelegate = (Func<TInstance, Stream, object>)Delegate.CreateDelegate(typeof(Func<TInstance, Stream, object>), null, method);
+
+            return (obj, stream) => typedDelegate((TInstance)obj, stream);
         }
 
         // Reads in the header information for a .resources file.  Verifies some

--- a/src/System.Private.CoreLib/shared/System/Resources/ResourceReader.cs
+++ b/src/System.Private.CoreLib/shared/System/Resources/ResourceReader.cs
@@ -29,6 +29,7 @@ namespace System.Resources
     using System.Runtime.Versioning;
     using System.Diagnostics;
     using System.Diagnostics.Contracts;
+    using System.Threading;
 
     // Provides the default implementation of IResourceReader, reading
     // .resources file from the system default binary format.  This class
@@ -98,18 +99,14 @@ namespace System.Resources
         private int[] _typeNamePositions;  // To delay initialize type table
         private int _numResources;    // Num of resources files, in case arrays aren't allocated.
 
-        private bool _permitDeserialization;  // bool indicating if this ResourceReader deserialize BinaryFormatted resources
+        private readonly bool _permitDeserialization;  // can deserialize BinaryFormatted resources
         private object _binaryFormatter; // binary formatter instance to use for deserializing
 
         // statics used to dynamically call into BinaryFormatter
         // When successfully located s_binaryFormatterType will point to the BinaryFormatter type
         // and s_deserializeMethod will point to an unbound delegate to the deserialize method.
-        // When it cannot be located s_binaryFormatterType will point to typeof(object) and 
-        // s_deserializeMethod will be null.
         private static Type s_binaryFormatterType;
         private static Func<object, Stream, object> s_deserializeMethod;
-
-
 
         // We'll include a separate code path that uses UnmanagedMemoryStream to
         // avoid allocating String objects and the like.
@@ -762,8 +759,7 @@ namespace System.Resources
             return DeserializeObject(typeIndex);
         }
 
-        // Helper method to deserialize a type
-        private Object DeserializeObject(int typeIndex)
+        private object DeserializeObject(int typeIndex)
         {
             if (!_permitDeserialization)
             {
@@ -776,13 +772,10 @@ namespace System.Resources
             }
 
             Type type = FindType(typeIndex);
- 
-            // Ensure that the object we deserialized is exactly the same
-            // type of object we thought we should be deserializing. 
-            Object graph;
-            graph = s_deserializeMethod(_binaryFormatter, _store.BaseStream);
+  
+            object graph = s_deserializeMethod(_binaryFormatter, _store.BaseStream);
             
-            // This check is about correctness, not security at this point.
+            // guard against corrupted resources
             if (graph.GetType() != type)
                 throw new BadImageFormatException(SR.Format(SR.BadImageFormat_ResType_SerBlobMismatch, type.FullName, graph.GetType().FullName));
  
@@ -791,36 +784,20 @@ namespace System.Resources
 
         private void InitializeBinaryFormatter()
         {
-            if (s_binaryFormatterType == null)
-            {
-                Type binaryFormatterType = Type.GetType(
-                    "System.Runtime.Serialization.Formatters.Binary.BinaryFormatter, System.Runtime.Serialization.Formatters, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
-                    throwOnError: false);
-                if (binaryFormatterType != null)
-                {
-                    ConstructorInfo binaryFormatterCtor = binaryFormatterType.GetConstructor(new Type[0]);
-                    MethodInfo binaryFormatterDeserialize = binaryFormatterType.GetMethod("Deserialize", new Type[] { typeof(Stream) });
+            LazyInitializer.EnsureInitialized(ref s_binaryFormatterType, () =>
+                Type.GetType("System.Runtime.Serialization.Formatters.Binary.BinaryFormatter, System.Runtime.Serialization.Formatters, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+                throwOnError: true));
 
-                    s_binaryFormatterType = binaryFormatterType;
+            LazyInitializer.EnsureInitialized(ref s_deserializeMethod, () =>
+               {
+                   MethodInfo binaryFormatterDeserialize = s_binaryFormatterType.GetMethod("Deserialize", new Type[] { typeof(Stream) });
+
                     // create an unbound delegate that can accept a BinaryFormatter instance as object
-                    s_deserializeMethod = (Func<object, Stream, object>)typeof(ResourceReader)
-                                           .GetMethod(nameof(CreateUntypedDelegate), BindingFlags.NonPublic | BindingFlags.Static)
-                                           .MakeGenericMethod(binaryFormatterType)
-                                           .Invoke(null, new object[] { binaryFormatterDeserialize });
-                }
-                else
-                {
-                    // set a sentinel to indicate that BinaryFormatter wasn't found
-                    s_binaryFormatterType = typeof(object);
-                    s_deserializeMethod = null;
-                }
-            }
-
-            if (s_binaryFormatterType != null && s_deserializeMethod == null)
-            {
-                // we couldn't find the type
-                throw new NotSupportedException(SR.NotSupported_ResourceObjectSerialization);
-            }
+                    return (Func<object, Stream, object>)typeof(ResourceReader)
+                            .GetMethod(nameof(CreateUntypedDelegate), BindingFlags.NonPublic | BindingFlags.Static)
+                            .MakeGenericMethod(s_binaryFormatterType)
+                            .Invoke(null, new object[] { binaryFormatterDeserialize });
+               });
 
             _binaryFormatter = Activator.CreateInstance(s_binaryFormatterType);
         }

--- a/src/System.Private.CoreLib/shared/System/Resources/RuntimeResourceSet.cs
+++ b/src/System.Private.CoreLib/shared/System/Resources/RuntimeResourceSet.cs
@@ -195,14 +195,14 @@ namespace System.Resources
         {
             _resCache = new Dictionary<string, ResourceLocator>(FastResourceComparer.Default);
             Stream stream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read);
-            _defaultReader = new ResourceReader(stream, _resCache);
+            _defaultReader = new ResourceReader(stream, _resCache, false);
             Reader = _defaultReader;
         }
 
-        internal RuntimeResourceSet(Stream stream) : base(false)
+        internal RuntimeResourceSet(Stream stream, bool permitDeserialization = false) : base(false)
         {
             _resCache = new Dictionary<string, ResourceLocator>(FastResourceComparer.Default);
-            _defaultReader = new ResourceReader(stream, _resCache);
+            _defaultReader = new ResourceReader(stream, _resCache, permitDeserialization);
             Reader = _defaultReader;
         }
 

--- a/src/System.Private.CoreLib/src/System/Resources/ManifestBasedResourceGroveler.cs
+++ b/src/System.Private.CoreLib/src/System/Resources/ManifestBasedResourceGroveler.cs
@@ -238,7 +238,7 @@ namespace System.Resources
                     // the abbreviated ones emitted by InternalResGen.
                     if (CanUseDefaultResourceClasses(readerTypeName, resSetTypeName))
                     {
-                        return new RuntimeResourceSet(store, true);
+                        return new RuntimeResourceSet(store, permitDeserialization: true);
                     }
                     else
                     {
@@ -276,7 +276,7 @@ namespace System.Resources
 
             if (_mediator.UserResourceSet == null)
             {
-                return new RuntimeResourceSet(store, true);
+                return new RuntimeResourceSet(store, permitDeserialization:true);
             }
             else
             {

--- a/src/System.Private.CoreLib/src/System/Resources/ManifestBasedResourceGroveler.cs
+++ b/src/System.Private.CoreLib/src/System/Resources/ManifestBasedResourceGroveler.cs
@@ -238,7 +238,7 @@ namespace System.Resources
                     // the abbreviated ones emitted by InternalResGen.
                     if (CanUseDefaultResourceClasses(readerTypeName, resSetTypeName))
                     {
-                        return new RuntimeResourceSet(store);
+                        return new RuntimeResourceSet(store, true);
                     }
                     else
                     {
@@ -276,7 +276,7 @@ namespace System.Resources
 
             if (_mediator.UserResourceSet == null)
             {
-                return new RuntimeResourceSet(store);
+                return new RuntimeResourceSet(store, true);
             }
             else
             {


### PR DESCRIPTION
This adds back support for using BinaryFormatter to deserialize resources when loaded
from assembly.

We conditionally load BinaryFormatter and will throw if asked to deserialize binary formatted
resources and cannot find it.

I'll put up a CoreFx PR shortly with tests.