### PR TITLE
Fix path to python on sod and illink jobs

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -773,7 +773,7 @@ def static getFullThroughputJobName(def project, def os, def arch, def isPR) {
             def testBin = "%WORKSPACE%\\bin\\tests\\${os}.${architecture}.${configuration}"
             def coreRoot = "${testBin}\\Tests\\Core_Root"
             def benchViewTools = "%WORKSPACE%\\Microsoft.BenchView.JSONFormat\\tools"
-            def python = "C:\\Python35\\python.exe"
+            def python = "C:\\python3.7.0\\python.exe"
 
             steps {
                 // Install nuget and get BenchView tools
@@ -847,7 +847,7 @@ def static getFullThroughputJobName(def project, def os, def arch, def isPR) {
                         label('Windows.Amd64.ClientRS4.DevEx.15.8.Perf')
 
                         def testEnv = ""
-                        def python = "C:\\Python35\\python.exe"
+                        def python = "C:\\python3.7.0\\python.exe"
                         wrappers {
                             credentialsBinding {
                                 string('BV_UPLOAD_SAS_TOKEN', 'CoreCLR Perf BenchView Sas')


### PR DESCRIPTION
Size on Disk and ILLink jobs are on the helix queue, so use the path where python is installed on the helix queues.