### PR TITLE
Verify the application group container directory exists in Mac Sandbox

### DIFF
--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -113,6 +113,7 @@ static int Initialize(int argc, const char *const argv[], DWORD flags);
 static BOOL INIT_IncreaseDescriptorLimit(void);
 static LPWSTR INIT_FormatCommandLine (int argc, const char * const *argv);
 static LPWSTR INIT_ConvertEXEPath(LPCSTR exe_name);
+static bool INIT_SharedFilesPath(void);
 
 #ifdef _DEBUG
 extern void PROCDumpThreadList(void);
@@ -364,41 +365,9 @@ Initialize(
             goto done;
         }
 
-#ifdef __APPLE__
-        // Store application group Id. It will be null if not set
-        gApplicationGroupId = getenv("DOTNET_SANDBOX_APPLICATION_GROUP_ID");
-
-        if (nullptr != gApplicationGroupId)
+        if (!INIT_SharedFilesPath())
         {
-            // Verify the length of the application group ID
-            gApplicationGroupIdLength = strlen(gApplicationGroupId);
-            if (gApplicationGroupIdLength > MAX_APPLICATION_GROUP_ID_LENGTH)
-            {
-                SetLastError(ERROR_BAD_LENGTH);
-                goto done;
-            }
-
-            // In sandbox, all IPC files (locks, pipes) should be written to the application group
-            // container. There will be no write permissions to TEMP_DIRECTORY_PATH
-            if (!GetApplicationContainerFolder(*gSharedFilesPath, gApplicationGroupId, gApplicationGroupIdLength))
-            {
-                SetLastError(ERROR_NOT_ENOUGH_MEMORY);
-                goto done;
-            }
-
-            // Verify the size of the path won't exceed maximum allowed size
-            if (gSharedFilesPath->GetCount() + SHARED_MEMORY_MAX_FILE_PATH_CHAR_COUNT + 1 /* null terminator */ > MAX_LONGPATH)
-            {
-                SetLastError(ERROR_FILENAME_EXCED_RANGE);
-            }
-        }
-        else
-#endif // __APPLE__
-        {
-            gSharedFilesPath->Set(TEMP_DIRECTORY_PATH);
-
-            // We can verify statically the non sandboxed case, since the size is known during compile time
-            static_assert_no_msg(string_countof(TEMP_DIRECTORY_PATH) + SHARED_MEMORY_MAX_FILE_PATH_CHAR_COUNT + 1 /* null terminator */ <= MAX_LONGPATH);
+            goto done;
         }
 
         fFirstTimeInit = true;
@@ -1381,4 +1350,64 @@ static LPWSTR INIT_ConvertEXEPath(LPCSTR exe_path)
     }
 
     return return_value;
+}
+
+/*++
+Function:
+  INIT_SharedFilesPath
+
+Abstract:
+    Initializes the shared application
+--*/
+static bool INIT_SharedFilesPath(void)
+{
+#ifdef __APPLE__
+    // Store application group Id. It will be null if not set
+    gApplicationGroupId = getenv("DOTNET_SANDBOX_APPLICATION_GROUP_ID");
+
+    if (nullptr != gApplicationGroupId)
+    {
+        // Verify the length of the application group ID
+        gApplicationGroupIdLength = strlen(gApplicationGroupId);
+        if (gApplicationGroupIdLength > MAX_APPLICATION_GROUP_ID_LENGTH)
+        {
+            SetLastError(ERROR_BAD_LENGTH);
+            return false;
+        }
+
+        // In sandbox, all IPC files (locks, pipes) should be written to the application group
+        // container. There will be no write permissions to TEMP_DIRECTORY_PATH
+        if (!GetApplicationContainerFolder(*gSharedFilesPath, gApplicationGroupId, gApplicationGroupIdLength))
+        {
+            SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+            return false;
+        }
+
+        // Verify the size of the path won't exceed maximum allowed size
+        if (gSharedFilesPath->GetCount() + SHARED_MEMORY_MAX_FILE_PATH_CHAR_COUNT + 1 /* null terminator */ > MAX_LONGPATH)
+        {
+            SetLastError(ERROR_FILENAME_EXCED_RANGE);
+            return false;
+        }
+
+        // Check if the path already exists and it's a directory
+        struct stat statInfo;
+        int statResult = stat(*gSharedFilesPath, &statInfo);
+
+        // If the path exists, check that it's a directory
+        if (statResult != 0 || !(statInfo.st_mode & S_IFDIR))
+        {
+            SetLastError(ERROR_PATH_NOT_FOUND);
+            return false;
+        }
+
+        return true;
+    }
+#endif // __APPLE__
+
+    // If we are here, then we are not in sandbox mode, resort to TEMP_DIRECTORY_PATH as shared files path
+    return gSharedFilesPath->Set(TEMP_DIRECTORY_PATH) != FALSE;
+
+    // We can verify statically the non sandboxed case, since the size is known during compile time
+    static_assert_no_msg(string_countof(TEMP_DIRECTORY_PATH) + SHARED_MEMORY_MAX_FILE_PATH_CHAR_COUNT + 1 /* null terminator */ <= MAX_LONGPATH);
 }


### PR DESCRIPTION
Added an additional check to verify that the shared files directory based on the application group ID exists when running in a Mac sandbox. If it doesn't then the initialization will fail.

As part of this change, also refactored the logic the sets the shared file path into a separate method.