### PR TITLE
Re-enabling some CoreFX parsing/formatting tests

### DIFF
--- a/tests/CoreFX/CoreFX.issues.json
+++ b/tests/CoreFX/CoreFX.issues.json
@@ -484,46 +484,12 @@
             "classes": null,
             "methods": [
                 {
-                    "name": "System.Buffers.Text.Tests.FormatterTests.TestFormatterDecimal",
-                    "reason": "https://github.com/dotnet/coreclr/pull/19775"
-                },
-                {
                     "name": "System.SpanTests.MemoryMarshalTests.CreateFromPinnedArrayIntSliceRemainsPinned",
                     "reason": "https://github.com/dotnet/corefx/pull/32994"
                 },
                 {
                     "name": "System.SpanTests.MemoryMarshalTests.CreateFromPinnedArrayIntReadOnlyMemorySliceRemainsPinned",
                     "reason": "https://github.com/dotnet/corefx/pull/32994"
-                },
-                {
-                    "name": "System.Buffers.Text.Tests.ParserTests.TestParserSingle",
-                    "reason": "https://github.com/dotnet/coreclr/pull/20707"
-                },
-                {
-                    "name": "System.Buffers.Text.Tests.ParserTests.TestParserDouble",
-                    "reason": "https://github.com/dotnet/coreclr/pull/20707"
-                },
-            ]
-        }
-    },
-    {
-        "name": "System.Runtime.Extensions.Tests",
-        "enabled": true,
-        "exclusions": {
-            "namespaces": null,
-            "classes": null,
-            "methods": [
-                {
-                    "name": "System.Tests.ConvertToStringTests.FromBoxedObject",
-                    "reason": "https://github.com/dotnet/coreclr/pull/19775"
-                },
-                {
-                    "name": "System.Tests.ConvertToDoubleTests.FromString",
-                    "reason": "https://github.com/dotnet/coreclr/pull/20707"
-                },
-                {
-                    "name": "System.Tests.ConvertToSingleTests.FromString",
-                    "reason": "https://github.com/dotnet/coreclr/pull/20707"
                 },
             ]
         }
@@ -698,74 +664,6 @@
                     "name": "System.Tests.DecimalTests+BigIntegerMod.Test",
                     "reason": "https://github.com/dotnet/coreclr/issues/12605"
                 }
-            ]
-        }
-    },
-    {
-        "name": "System.Xml.Linq.SDMSample.Tests",
-        "enabled": true,
-        "exclusions": {
-            "namespaces": null,
-            "classes": null,
-            "methods": [
-                {
-                    "name": "XDocumentTests.SDMSample.SDM_Attribute.AttributeExplicitToDouble",
-                    "reason": "https://github.com/dotnet/coreclr/pull/20707"
-                },
-                {
-                    "name": "XDocumentTests.SDMSample.SDM_Attribute.AttributeExplicitToFloat",
-                    "reason": "https://github.com/dotnet/coreclr/pull/20707"
-                },
-                {
-                    "name": "XDocumentTests.SDMSample.SDM_Element.ElementExplicitToFloat",
-                    "reason": "https://github.com/dotnet/coreclr/pull/20707"
-                },
-                {
-                    "name": "XDocumentTests.SDMSample.SDM_Element.ElementExplicitToDouble",
-                    "reason": "https://github.com/dotnet/coreclr/pull/20707"
-                },
-            ]
-        }
-    },
-    {
-        "name": "System.Json.Tests",
-        "enabled": true,
-        "exclusions": {
-            "namespaces": null,
-            "classes": null,
-            "methods": [
-                {
-                    "name": "System.Json.Tests.JsonValueTests.Parse_DoubleTooLarge_ThrowsOverflowException",
-                    "reason": "https://github.com/dotnet/coreclr/pull/20707"
-                },
-            ]
-        }
-    },
-    {
-        "name": "System.Xml.RW.XmlWriterApi.Tests",
-        "enabled": true,
-        "exclusions": {
-            "namespaces": null,
-            "classes": null,
-            "methods": [
-                {
-                    "name": "System.Xml.Tests.TCFullEndElement+TCWriteValue.writeValue_27",
-                    "reason": "https://github.com/dotnet/coreclr/pull/20707"
-                },
-            ]
-        }
-    },
-    {
-        "name": "System.ComponentModel.Annotations.Tests",
-        "enabled": true,
-        "exclusions": {
-            "namespaces": null,
-            "classes": null,
-            "methods": [
-                {
-                    "name": "System.ComponentModel.DataAnnotations.Tests.RangeAttributeTests.Validate_DoubleConversionOverflows_ThrowsOverflowException",
-                    "reason": "https://github.com/dotnet/coreclr/pull/20707"
-                },
             ]
         }
     },


### PR DESCRIPTION
These were disabled in https://github.com/dotnet/coreclr/pull/19775 and https://github.com/dotnet/coreclr/pull/20707 and have since been fixed up.