### PR TITLE
Fix index out of range exception thrown in ArrayPool trimming

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
@@ -230,9 +230,10 @@ namespace System.Buffers
             if (log.IsEnabled())
                 log.BufferTrimPoll(milliseconds, (int)pressure);
 
-            foreach (PerCoreLockedStacks bucket in _buckets)
+            PerCoreLockedStacks[] perCoreBuckets = _buckets;
+            for (int i = 0; i < perCoreBuckets.Length; i++)
             {
-                bucket?.Trim((uint)milliseconds, Id, pressure, _bucketArraySizes);
+                perCoreBuckets[i]?.Trim((uint)milliseconds, Id, pressure, _bucketArraySizes[i]);
             }
 
             if (pressure == MemoryPressure.High)
@@ -370,14 +371,13 @@ namespace System.Buffers
                 return null;
             }
 
-            public bool Trim(uint tickCount, int id, MemoryPressure pressure, int[] bucketSizes)
+            public void Trim(uint tickCount, int id, MemoryPressure pressure, int bucketSize)
             {
                 LockedStack[] stacks = _perCoreStacks;
                 for (int i = 0; i < stacks.Length; i++)
                 {
-                    stacks[i].Trim(tickCount, id, pressure, bucketSizes[i]);
+                    stacks[i].Trim(tickCount, id, pressure, bucketSize);
                 }
-                return true;
             }
         }
 

--- a/src/System.Private.CoreLib/shared/System/Gen2GcCallback.cs
+++ b/src/System.Private.CoreLib/shared/System/Gen2GcCallback.cs
@@ -64,6 +64,10 @@ namespace System
             catch
             {
                 // Ensure that we still get a chance to resurrect this object, even if the callback throws an exception.
+#if DEBUG
+                // Except in DEBUG, as we really shouldn't be hitting any exceptions here.
+                throw;
+#endif
             }
 
             // Resurrect ourselves by re-registering for finalization.


### PR DESCRIPTION
The trim method had the wrong logic to get the relevant bucket size, resulting in IndexOutOfRangeException exceptions being thrown and eaten on the finalizer thread on higher-core count machines (machines with > 17 cores).

Fixes https://github.com/dotnet/coreclr/issues/20930
cc: @jkotas, @JeremyKuhne 