### PR TITLE
enable build-id on FreeBSD

### DIFF
--- a/configurecompiler.cmake
+++ b/configurecompiler.cmake
@@ -331,6 +331,11 @@ if(CLR_CMAKE_PLATFORM_LINUX)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--build-id=sha1")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--build-id=sha1")
 endif(CLR_CMAKE_PLATFORM_LINUX)
+if(CLR_CMAKE_PLATFORM_FREEBSD)
+  set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Wa,--noexecstack")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=lld -Xlinker --build-id=sha1")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld -Xlinker --build-id=sha1")
+endif(CLR_CMAKE_PLATFORM_FREEBSD)
 
 #------------------------------------
 # Definitions (for platform)

--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -846,7 +846,6 @@ if(CLR_CMAKE_PLATFORM_UNIX)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
 set(VM_SOURCES_DAC_ARCH
-    gcinfodecoder.cpp
     exceptionhandling.cpp
 )
 


### PR DESCRIPTION

ldd from clang also complained about duplicate symbols:

```
/usr/local/llvm60/bin/ld.lld: error: duplicate symbol: GcInfoDecoder::ReportStackSlotToGC(int, GcStackSlotBase, unsigned int, REGDISPLAY*, unsigned int, void (*)(void*, __DPtr<Object>*, unsigned int, _DAC_SLOT_LOCATION), void*)
>>> defined at gcinfodecoder.cpp:1817 (/home/furt/git/wfurt-coreclr/src/vm/gcinfodecoder.cpp:1817)
>>>            gcinfodecoder.cpp.o:(GcInfoDecoder::ReportStackSlotToGC(int, GcStackSlotBase, unsigned int, REGDISPLAY*, unsigned int, void (*)(void*, __DPtr<Object>*, unsigned int, _DAC_SLOT_LOCATION), void*)) in archive ../../vm/dac/libcee_dac.a
>>> defined at gcinfodecoder.cpp:1817 (/home/furt/git/wfurt-coreclr/src/gcdump/../vm/gcinfodecoder.cpp:1817)
>>>            nidump.cpp.o:(.text+0x37450) in archive ../../debug/daccess/libdaccess.a
```

I was able to reproduce it on Linux as well with LLVM's ldd. It seems  like we use gcinfodecoder.cpp multiple times. (but legacy ldd does not care) 