### PR TITLE
Disable stress random inlining for object stack allocation tests.

### DIFF
--- a/tests/src/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.csproj
+++ b/tests/src/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.csproj
@@ -33,6 +33,7 @@ $(CLRTestBatchPreCommands)
 set COMPlus_TieredCompilation=0
 set COMPlus_JitMinOpts=0
 set COMPlus_JitDebuggable=0
+set COMPlus_JitStressModeNamesNot=STRESS_RANDOM_INLINE
 set COMPlus_JitObjectStackAllocation=1
 ]]>
     </CLRTestBatchPreCommands>
@@ -42,6 +43,7 @@ $(BashCLRTestPreCommands)
 export COMPlus_TieredCompilation=0
 export COMPlus_JitMinOpts=0
 export COMPlus_JitDebuggable=0
+export COMPlus_JitStressModeNamesNot=STRESS_RANDOM_INLINE
 export COMPlus_JitObjectStackAllocation=1
 ]]>
     </BashCLRTestPreCommands>


### PR DESCRIPTION
ObjectStackAllocationTests are sensitive to inlining so we need
to disable stress random inlining.

Fixes #20944.