### PR TITLE
Fixing Utf8Parser.Number to not modify the value of 'c'

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/Utf8Parser.Number.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/Utf8Parser.Number.cs
@@ -84,8 +84,9 @@ namespace System.Buffers.Text
             while (srcIndex != source.Length)
             {
                 c = source[srcIndex];
+                int value = (byte)(c - (byte)('0'));
 
-                if ((c -= (byte)('0')) > 9)
+                if (value > 9)
                 {
                     break;
                 }
@@ -102,7 +103,7 @@ namespace System.Buffers.Text
                     // for an input that falls evenly between two representable
                     // results.
 
-                    hasNonZeroTail |= c;
+                    hasNonZeroTail |= value;
                 }
             }
             number.HasNonZeroTail = (hasNonZeroTail != 0);
@@ -138,8 +139,9 @@ namespace System.Buffers.Text
                 while (srcIndex != source.Length)
                 {
                     c = source[srcIndex];
+                    int value = (byte)(c - (byte)('0'));
 
-                    if ((c -= (byte)('0')) > 9)
+                    if (value > 9)
                     {
                         break;
                     }
@@ -156,7 +158,7 @@ namespace System.Buffers.Text
                         // for an input that falls evenly between two representable
                         // results.
 
-                        hasNonZeroTail |= c;
+                        hasNonZeroTail |= value;
                     }
                 }
                 number.HasNonZeroTail = (hasNonZeroTail != 0);


### PR DESCRIPTION
CC. @GrabYourPitchforks, @stephentoub 

Can't modify the value of `c` in place, because it is checked for equality to decimal point on L129