### PR TITLE
[WIP] Specify xunit console dll version

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -38,7 +38,7 @@
     <PgoDataPackageVersion>99.99.99-master-20181112-0043</PgoDataPackageVersion>
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>3.0.0-preview-27112-01</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <MicrosoftNETCoreAppPackageVersion>3.0.0-preview-27109-05</MicrosoftNETCoreAppPackageVersion>
-    <XunitPackageVersion>2.4.1-pre.build.4059</XunitPackageVersion>
+    <XunitPackageVersion>2.4.1</XunitPackageVersion>
     <IbcDataPackageVersion>99.99.99-master-20181112-0045</IbcDataPackageVersion>
     <IbcMergePackageVersion>4.6.0-alpha-00001</IbcMergePackageVersion>
     <XunitPerformanceApiPackageVersion>1.0.0-beta-build0015</XunitPerformanceApiPackageVersion>

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -809,7 +809,7 @@ def run_tests(host_os,
 
     urlretrieve = urllib.urlretrieve if sys.version_info.major < 3 else urllib.request.urlretrieve
     zipfilename = os.path.join(tempfile.gettempdir(), "xunit.console.dll.zip")
-    url = r"https://clrjit.blob.core.windows.net/xunit-console/xunit.console.dll.zip"
+    url = r"https://clrjit.blob.core.windows.net/xunit-console/xunit.console.dll-v2.4.1.zip"
     urlretrieve(url, zipfilename)
 
     with zipfile.ZipFile(zipfilename,"r") as ziparch:


### PR DESCRIPTION
Use custom built xunit.console.dll with specified assembly version to avoid issues with Ready2Run jobs