### PR TITLE
Disable R2R for object stack allocation tests.

### DIFF
--- a/tests/src/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.csproj
+++ b/tests/src/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.csproj
@@ -34,6 +34,7 @@ set COMPlus_TieredCompilation=0
 set COMPlus_JitMinOpts=0
 set COMPlus_JitDebuggable=0
 set COMPlus_JitStressModeNamesNot=STRESS_RANDOM_INLINE
+set RunCrossGen=
 set COMPlus_JitObjectStackAllocation=1
 ]]>
     </CLRTestBatchPreCommands>
@@ -44,6 +45,7 @@ export COMPlus_TieredCompilation=0
 export COMPlus_JitMinOpts=0
 export COMPlus_JitDebuggable=0
 export COMPlus_JitStressModeNamesNot=STRESS_RANDOM_INLINE
+unset RunCrossGen
 export COMPlus_JitObjectStackAllocation=1
 ]]>
     </BashCLRTestPreCommands>


### PR DESCRIPTION
Object stack allocation currently doesn't work in R2R mode
because we lower R2R allocations to helper calls in the importer.
That will be fixed but for now we need to disable R2R for these tests.

Fixes #20977.