### PR TITLE
Fixed signatures of ref readonly methods in JIT ETW events

### DIFF
--- a/src/utilcode/prettyprintsig.cpp
+++ b/src/utilcode/prettyprintsig.cpp
@@ -686,10 +686,6 @@ static HRESULT PrettyPrintTypeA(
         str = "class "; 
         goto DO_CLASS;
         
-    case ELEMENT_TYPE_CMOD_REQD:
-        str = "required_modifier ";
-        goto DO_CLASS;
-        
     case ELEMENT_TYPE_CMOD_OPT:
         str = "optional_modifier ";
         goto DO_CLASS;
@@ -733,7 +729,14 @@ static HRESULT PrettyPrintTypeA(
             IfFailGo(appendStrA(out, pN));
         }
         break;
-        
+
+    case ELEMENT_TYPE_CMOD_REQD:
+        str = "required_modifier ";
+        IfFailGo(appendStrA(out, str));
+        typePtr += CorSigUncompressToken(typePtr, &tk);
+        IfFailGo(PrettyPrintTypeA(typePtr, (typeEnd - typePtr), out, pIMDI));
+        break;
+
     case ELEMENT_TYPE_SZARRAY:
         IfFailGo(PrettyPrintTypeA(typePtr, (typeEnd - typePtr), out, pIMDI)); 
         IfFailGo(appendStrA(out, "[]"));


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/20754

The method 
```csharp 
ref readonly long Foo(int i)
```
now produces the ETW signature `required_modifier int64&  (int32)`

I don't think I broke any tests with this change, but I also couldn't find any that test these signatures. Are there tests that need to be adapted?

cc @jkotas