### PR TITLE
Fix arm64 PUTARG_STK(contained OBJ(contained LCL_FLD_ADDR)).

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -336,15 +336,15 @@ GenTree* Lowering::LowerNode(GenTree* node)
             break;
 #endif
 
-#ifndef _TARGET_ARM_
-        // TODO-ARM-CQ: We should contain this as long as the offset fits.
+#ifndef _TARGET_ARMARCH_
+        // TODO-ARMARCH-CQ: We should contain this as long as the offset fits.
         case GT_OBJ:
             if (node->AsObj()->Addr()->OperIsLocalAddr())
             {
                 node->AsObj()->Addr()->SetContained();
             }
             break;
-#endif // !_TARGET_ARM_
+#endif // !_TARGET_ARMARCH_
 
         default:
             break;

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_718151/DevDiv_718151.cs
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_718151/DevDiv_718151.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// The test originally showed unsupported PUTARG_STK(OBJ(LCL_FLD_ADDR)) when both OBJ and LCL_FLD_ADDR were contained.
+// codegenarmarch `genPutArgStk` did not expect that.
+
+using System;
+using System.Runtime.CompilerServices;
+
+struct Struct16bytes
+{
+    public int a;
+    public int b;
+    public int c;
+    public int d;
+}
+
+struct StructWithStructField
+{
+    public bool a;
+    public Struct16bytes structField;
+}
+
+class DevDiv_714266
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    int foo(int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, Struct16bytes s)
+    {
+        Console.WriteLine(s.a);
+        return s.a;
+    }
+
+
+    static int Main()
+    {
+        StructWithStructField s = new StructWithStructField();
+        s.structField.a = 100;
+
+        DevDiv_714266 test = new DevDiv_714266();
+        return test.foo(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, s.structField);
+    }
+
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_718151/DevDiv_718151.csproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_718151/DevDiv_718151.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
It was found on desktop (DEVDIV_718151).

LIR example:
```
N009 (  3,  4) [000993] -c--G--N----       t993 =    LCL_FLD_ADDR byref  V34 loc22        [+32] Fseq[Map]
                                                 /--*  t993   byref  
N011 (  9,  9) [001007] nc--G-------      t1007 = *  OBJ(16)   struct <l:$4cc, c:$5c4>
                                                 /--*  t1007  struct 
               [003552] ----G-------              *  PUTARG_STK [+0x00] void   (2 slots)
```

The test fails with https://github.com/dotnet/coreclr/blob/2e7d443bb9b43b39b59da8d7c66b206a6c1f2ee6/src/jit/emitarm64.cpp#L5666

because nobody generates `LCL_FLD_ADDR` and `reg3 == REG_COUNT`. It is marked as contained under `OBJ` that is also contained under `PUTARG_STK` that does not know how to work with contained obj.

The nice fix will be to teach https://github.com/dotnet/coreclr/blob/2e7d443bb9b43b39b59da8d7c66b206a6c1f2ee6/src/jit/codegenarmarch.cpp#L542 how to work with contained, but it can be done later.