### PR TITLE
Fix a warning due to bool-int usage 

### DIFF
--- a/src/debug/ee/controller.cpp
+++ b/src/debug/ee/controller.cpp
@@ -9007,7 +9007,7 @@ bool DebuggerContinuableExceptionBreakpoint::SendEvent(Thread *thread, bool fIpC
     if (hitDataBp)
     {
         CONTEXT contextToAdjust;
-        bool adjustedContext = false;
+        BOOL adjustedContext = FALSE;
         memcpy(&contextToAdjust, pContext, sizeof(CONTEXT));
         adjustedContext = g_pEEInterface->AdjustContextForWriteBarrierForDebugger(&contextToAdjust);        
         if (adjustedContext)


### PR DESCRIPTION
Fix a compile warning because of bool vs BOOL incompatibality.

Fixes a build break when using the new VS compiler:
coreclr\src\debug\ee\controller.cpp(9012): warning C4800: 'BOOL': forcing value to bool 'true' or 'false' (performance warning) [D:\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\ee\wks\cordbee_wks.vcxproj]