### PR TITLE
Disable COM tests being CrossGen'd

### DIFF
--- a/tests/src/CLRTest.CrossGen.targets
+++ b/tests/src/CLRTest.CrossGen.targets
@@ -25,10 +25,11 @@ WARNING:   When setting properties based on their current state (for example:
   <ItemGroup>
     <CLRTestBashEnvironmentVariable  Condition="'$(CrossGenTest)' == 'true'" Include = "export RunCrossGen=1"/>
     <CLRTestBatchEnvironmentVariable Condition="'$(CrossGenTest)' == 'true'" Include = "set RunCrossGen=1"/>
+    <CLRTestBashEnvironmentVariable  Condition="'$(CrossGenTest)' == 'false'" Include = "unset RunCrossGen"/>
+    <CLRTestBatchEnvironmentVariable Condition="'$(CrossGenTest)' == 'false'" Include = "set RunCrossGen="/>
   </ItemGroup>
 
   <!--
-    Target: GetCrossgenBatctchcript
     This returns the portion of the execution script that generates the required lines to crossgen the test executable.
   -->
   <Target Name="GetCrossgenBashScript">

--- a/tests/src/Interop/COM/NETClients/Aggregation/NETClientAggregation.csproj
+++ b/tests/src/Interop/COM/NETClients/Aggregation/NETClientAggregation.csproj
@@ -14,6 +14,9 @@
     <!-- Blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/coreclr/issues/20819 -->
     <IlrtTestKind>BuildOnly</IlrtTestKind>
 
+    <!-- Blocked on CrossGen.exe supporting embedding resources. See https://github.com/dotnet/coreclr/issues/21006 -->
+    <CrossGenTest>false</CrossGenTest>
+
     <!-- Test unsupported outside of windows -->
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>

--- a/tests/src/Interop/COM/NETClients/IDispatch/NETClientIDispatch.csproj
+++ b/tests/src/Interop/COM/NETClients/IDispatch/NETClientIDispatch.csproj
@@ -14,6 +14,9 @@
     <!-- Blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/coreclr/issues/20819 -->
     <IlrtTestKind>BuildOnly</IlrtTestKind>
 
+    <!-- Blocked on CrossGen.exe supporting embedding resources. See https://github.com/dotnet/coreclr/issues/21006 -->
+    <CrossGenTest>false</CrossGenTest>
+
     <!-- Test unsupported outside of windows -->
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>

--- a/tests/src/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
+++ b/tests/src/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
@@ -14,6 +14,9 @@
     <!-- Blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/coreclr/issues/20819 -->
     <IlrtTestKind>BuildOnly</IlrtTestKind>
 
+    <!-- Blocked on CrossGen.exe supporting embedding resources. See https://github.com/dotnet/coreclr/issues/21006 -->
+    <CrossGenTest>false</CrossGenTest>
+
     <!-- Test unsupported outside of windows -->
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>

--- a/tests/src/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.csproj
+++ b/tests/src/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.csproj
@@ -27,6 +27,7 @@
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
   <PropertyGroup>
+    <CrossGenTest>false</CrossGenTest>
     <CLRTestBatchPreCommands>
       <![CDATA[
 $(CLRTestBatchPreCommands)
@@ -34,7 +35,6 @@ set COMPlus_TieredCompilation=0
 set COMPlus_JitMinOpts=0
 set COMPlus_JitDebuggable=0
 set COMPlus_JitStressModeNamesNot=STRESS_RANDOM_INLINE
-set RunCrossGen=
 set COMPlus_JitObjectStackAllocation=1
 ]]>
     </CLRTestBatchPreCommands>
@@ -45,7 +45,6 @@ export COMPlus_TieredCompilation=0
 export COMPlus_JitMinOpts=0
 export COMPlus_JitDebuggable=0
 export COMPlus_JitStressModeNamesNot=STRESS_RANDOM_INLINE
-unset RunCrossGen
 export COMPlus_JitObjectStackAllocation=1
 ]]>
     </BashCLRTestPreCommands>


### PR DESCRIPTION
The CrossGen tool doesn't support propagating embedded app manifests on Windows so add support to skip running the CrossGen tool on tests.

#20986 
#21006

cc @jkoritzinsky @erozenfeld @echesakovMSFT 

