### PR TITLE
Fixes for Azure DevOps official build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,10 +3,11 @@ resources:
   # shared library repository
   - repository: arcade
     type: github
-    ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      endpoint: DotNet-Bot GitHub Internal Connection
-    ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      endpoint: DotNet-Bot GitHub Connection
+#    ${{ if ne(variables['System.TeamProject'], 'public') }}:
+#      endpoint: DotNet-Bot GitHub Internal Connection
+#    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+#      endpoint: DotNet-Bot GitHub Connection
+    endpoint: morganbr
     name: dotnet/arcade
     ref: refs/heads/master
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,11 +3,10 @@ resources:
   # shared library repository
   - repository: arcade
     type: github
-#    ${{ if ne(variables['System.TeamProject'], 'public') }}:
-#      endpoint: DotNet-Bot GitHub Internal Connection
-#    ${{ if eq(variables['System.TeamProject'], 'public') }}:
-#      endpoint: DotNet-Bot GitHub Connection
-    endpoint: morganbr
+    ${{ if ne(variables['System.TeamProject'], 'public') }}:
+      endpoint: DotNet-Bot GitHub Internal Connection
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      endpoint: DotNet-Bot GitHub Connection
     name: dotnet/arcade
     ref: refs/heads/master
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,10 @@ resources:
   # shared library repository
   - repository: arcade
     type: github
-    endpoint: DotNet-Bot GitHub Connection
+    ${{ if ne(variables['System.TeamProject'], 'public') }}:
+      endpoint: DotNet-Bot GitHub Internal Connection
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      endpoint: DotNet-Bot GitHub Connection
     name: dotnet/arcade
     ref: refs/heads/master
 

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -41,7 +41,7 @@ jobs:
       ${{ if eq(parameters.crossgen, 'false') }}:
         crossgenArg: ''
       ${{ if ne(parameters.scenarios, '') }}:
-        scenariosArg: ${{ format('/p:"Scenarios={0}"', parameters.scenarios) }}
+        scenariosArg: ${{ format('/p:Scenarios=\"{0}\"', parameters.scenarios) }}
       ${{ if eq(parameters.scenarios, '') }}:
         scenariosArg: ''
 

--- a/eng/xplat-job.yml
+++ b/eng/xplat-job.yml
@@ -30,7 +30,7 @@ jobs:
         name: dotnet-internal-temp
       ${{ if and(eq(parameters.osGroup, 'Windows_NT'), eq(variables['System.TeamProject'], 'public')) }}:
         name: dotnet-external-temp
-      timeoutInMinutes: 180
+      timeoutInMinutes: 240
 
     ${{ if eq(parameters.osGroup, 'Linux') }}:
       agentOs: Ubuntu

--- a/eng/xplat-job.yml
+++ b/eng/xplat-job.yml
@@ -22,9 +22,13 @@ jobs:
     queue:
       ${{ if eq(parameters.osGroup, 'Linux') }}:
         name: Hosted Ubuntu 1604
-      ${{ if eq(parameters.osGroup, 'OSX') }}:
-        name: Hosted macOS
-      ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+      ${{ if and(eq(parameters.osGroup, 'Windows_NT'), ne(variables['System.TeamProject'], 'public')) }}:
+        name: Hosted Mac Internal
+      ${{ if and(eq(parameters.osGroup, 'Windows_NT'), eq(variables['System.TeamProject'], 'public')) }}:
+        name: Hosted MacOS
+      ${{ if and(eq(parameters.osGroup, 'Windows_NT'), ne(variables['System.TeamProject'], 'public')) }}:
+        name: dotnet-internal-temp
+      ${{ if and(eq(parameters.osGroup, 'Windows_NT'), eq(variables['System.TeamProject'], 'public')) }}:
         name: dotnet-external-temp
       timeoutInMinutes: 180
 


### PR DESCRIPTION
Fixes that allow us to run official builds in Azure DevOps. This is enough for Windows and Linux builds and testing. Once this is in, we'll be able to create an official build definition pointed at master.