### PR TITLE
Combine ExcludeList in AltJit scenarios for both host and altjit archs

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -2219,9 +2219,11 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
 
                             if (architecture == 'x86_arm_altjit') {
                                 buildCommandsStr += envScriptAppendExistingScript(os, "%WORKSPACE%\\tests\\x86_arm_altjit.cmd", envScriptPath)
+                                testOpts += " altjitarch arm"
                             }
                             else if (architecture == 'x64_arm64_altjit') {
                                 buildCommandsStr += envScriptAppendExistingScript(os, "%WORKSPACE%\\tests\\x64_arm64_altjit.cmd", envScriptPath)
+                                testOpts += " altjitarch arm64"
                             }
 
                             envScriptFinalize(os, envScriptPath)
@@ -2233,9 +2235,11 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                         }
                         else if (architecture == 'x86_arm_altjit') {
                             envScriptPath = "%WORKSPACE%\\tests\\x86_arm_altjit.cmd"
+                            testOpts += " altjitarch arm"
                         }
                         else if (architecture == 'x64_arm64_altjit') {
                             envScriptPath = "%WORKSPACE%\\tests\\x64_arm64_altjit.cmd"
+                            testOpts += " altjitarch arm64"
                         }
                         if (envScriptPath != '') {
                             testOpts += " TestEnv ${envScriptPath}"

--- a/tests/dir.props
+++ b/tests/dir.props
@@ -64,6 +64,8 @@
     <BinDir Condition="'$(__BinDir)'==''">$(RootBinDir)Product\$(BuildOS).$(BuildArch).$(BuildType)\</BinDir>
 
     <CoreCLRBinDir>$(RootBinDir)Product\$(__BuildOS).$(__BuildArch).$(__BuildType)\</CoreCLRBinDir>
+
+    <AltJitArch>$(__AltJitArch)</AltJitArch>
   </PropertyGroup>
 
 <!-- Default Test platform to deploy the netstandard compiled tests to -->

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -69,7 +69,7 @@
     </ItemGroup>
 
     <!-- Arm32 All OS -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(BuildArch)' == 'arm' or '$(__AltJitArch)' == 'arm')">
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(BuildArch)' == 'arm' or '$(AltJitArch)' == 'arm')">
         <ExcludeList Include="$(XunitTestBinBase)/CoreMangLib/cti/system/reflection/emit/DynMethodJumpStubTests/DynMethodJumpStubTests/*">
             <Issue>needs triage</Issue>
         </ExcludeList>
@@ -202,7 +202,7 @@
     </ItemGroup>
 
     <!-- Arm64 All OS -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(BuildArch)' == 'arm64' or '$(__AltJitArch)' == 'arm64')">
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(BuildArch)' == 'arm64' or '$(AltJitArch)' == 'arm64')">
         <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/opt/cse/hugeexpr1/hugeexpr1/*">
             <Issue>needs triage</Issue>
         </ExcludeList>
@@ -320,7 +320,7 @@
     </ItemGroup>
 
     <!-- Windows arm32 specific excludes -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(BuildArch)' == 'arm' or '$(__AltJitArch)' == 'arm') and '$(TargetsWindows)' == 'true'">
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(BuildArch)' == 'arm' or '$(AltJitArch)' == 'arm') and '$(TargetsWindows)' == 'true'">
         <ExcludeList Include="$(XunitTestBinBase)/Interop/COM/NETClients/Primitives/NETClientPrimitives/*">
             <Issue>20682</Issue>
         </ExcludeList>
@@ -336,7 +336,7 @@
     </ItemGroup>
 
     <!-- Windows arm64 specific excludes -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(BuildArch)' == 'arm64' or '$(__AltJitArch)' == 'arm64') and '$(TargetsWindows)' == 'true'">
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(BuildArch)' == 'arm64' or '$(AltJitArch)' == 'arm64') and '$(TargetsWindows)' == 'true'">
         <ExcludeList Include="$(XunitTestBinBase)/GC/Features/HeapExpansion/bestfit-threaded/*">
             <Issue>15016</Issue>
         </ExcludeList>
@@ -451,7 +451,7 @@
     </ItemGroup>
 
     <!-- arm32 All OS specific excludes -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and  ('$(BuildArch)' == 'arm' or '$(__AltJitArch)' == 'arm')">
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and  ('$(BuildArch)' == 'arm' or '$(AltJitArch)' == 'arm')">
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/tailcall_v4/hijacking/*">
             <Issue>6217</Issue>
         </ExcludeList>
@@ -564,7 +564,7 @@
     </ItemGroup>
 
     <!-- Unix arm64 specific -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(BuildArch)' == 'arm64' or '$(__AltJitArch)' == 'arm64') and '$(TargetsWindows)' != 'true' and '$(BuildTestsAgainstPackages)' != 'true'">
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(BuildArch)' == 'arm64' or '$(AltJitArch)' == 'arm64') and '$(TargetsWindows)' != 'true' and '$(BuildTestsAgainstPackages)' != 'true'">
         <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/eh/FinallyExec/nonlocalexitinhandler/*">
             <Issue>Test times out</Issue>
         </ExcludeList>
@@ -592,7 +592,7 @@
     </ItemGroup>
 
     <!-- Unix arm32 specific -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(BuildArch)' == 'arm' or '$(__AltJitArch)' == 'arm') and '$(TargetsWindows)' != 'true' and '$(BuildTestsAgainstPackages)' != 'true'">
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(BuildArch)' == 'arm' or '$(AltJitArch)' == 'arm') and '$(TargetsWindows)' != 'true' and '$(BuildTestsAgainstPackages)' != 'true'">
         <ExcludeList Include="$(XunitTestBinBase)/tracing/runtimeeventsource/runtimeeventsource/*">
             <Issue>19340</Issue>
         </ExcludeList>

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -69,7 +69,7 @@
     </ItemGroup>
 
     <!-- Arm32 All OS -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(BuildArch)' == 'arm'">
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(BuildArch)' == 'arm' or '$(__AltJitArch)' == 'arm')">
         <ExcludeList Include="$(XunitTestBinBase)/CoreMangLib/cti/system/reflection/emit/DynMethodJumpStubTests/DynMethodJumpStubTests/*">
             <Issue>needs triage</Issue>
         </ExcludeList>
@@ -202,7 +202,7 @@
     </ItemGroup>
 
     <!-- Arm64 All OS -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(BuildArch)' == 'arm64'">
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(BuildArch)' == 'arm64' or '$(__AltJitArch)' == 'arm64')">
         <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/opt/cse/hugeexpr1/hugeexpr1/*">
             <Issue>needs triage</Issue>
         </ExcludeList>
@@ -320,7 +320,7 @@
     </ItemGroup>
 
     <!-- Windows arm32 specific excludes -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(BuildArch)' == 'arm' and '$(TargetsWindows)' == 'true'">
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(BuildArch)' == 'arm' or '$(__AltJitArch)' == 'arm') and '$(TargetsWindows)' == 'true'">
         <ExcludeList Include="$(XunitTestBinBase)/Interop/COM/NETClients/Primitives/NETClientPrimitives/*">
             <Issue>20682</Issue>
         </ExcludeList>
@@ -336,7 +336,7 @@
     </ItemGroup>
 
     <!-- Windows arm64 specific excludes -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(BuildArch)' == 'arm64' and '$(TargetsWindows)' == 'true'">
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(BuildArch)' == 'arm64' or '$(__AltJitArch)' == 'arm64') and '$(TargetsWindows)' == 'true'">
         <ExcludeList Include="$(XunitTestBinBase)/GC/Features/HeapExpansion/bestfit-threaded/*">
             <Issue>15016</Issue>
         </ExcludeList>
@@ -451,7 +451,7 @@
     </ItemGroup>
 
     <!-- arm32 All OS specific excludes -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(BuildArch)' == 'arm'">
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and  ('$(BuildArch)' == 'arm' or '$(__AltJitArch)' == 'arm')">
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/tailcall_v4/hijacking/*">
             <Issue>6217</Issue>
         </ExcludeList>
@@ -564,7 +564,7 @@
     </ItemGroup>
 
     <!-- Unix arm64 specific -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(BuildArch)' == 'arm64' and '$(TargetsWindows)' != 'true' and '$(BuildTestsAgainstPackages)' != 'true'">
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(BuildArch)' == 'arm64' or '$(__AltJitArch)' == 'arm64') and '$(TargetsWindows)' != 'true' and '$(BuildTestsAgainstPackages)' != 'true'">
         <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/eh/FinallyExec/nonlocalexitinhandler/*">
             <Issue>Test times out</Issue>
         </ExcludeList>
@@ -592,7 +592,7 @@
     </ItemGroup>
 
     <!-- Unix arm32 specific -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(BuildArch)' == 'arm' and '$(TargetsWindows)' != 'true' and '$(BuildTestsAgainstPackages)' != 'true'">
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(BuildArch)' == 'arm' or '$(__AltJitArch)' == 'arm') and '$(TargetsWindows)' != 'true' and '$(BuildTestsAgainstPackages)' != 'true'">
         <ExcludeList Include="$(XunitTestBinBase)/tracing/runtimeeventsource/runtimeeventsource/*">
             <Issue>19340</Issue>
         </ExcludeList>

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -48,6 +48,7 @@ set __CoreFXTestsRunAllAvailable=
 set __SkipGenerateLayout=
 set __BuildXUnitWrappers=
 set __PrintLastResultsOnly=
+set __AltJitArch=
 
 :Arg_Loop
 if "%1" == "" goto ArgsDone
@@ -98,6 +99,7 @@ REM tieredcompilation is on by default now, but setting this environment variabl
 if /i "%1" == "tieredcompilation"     (set COMPLUS_TieredCompilation=1&shift&goto Arg_Loop)
 if /i "%1" == "gcname"                (set COMPlus_GCName=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "timeout"               (set __TestTimeout=%2&shift&shift&goto Arg_Loop)
+if /i "%1" == "altjitarch"            (set __AltJitArch=%2&shift&shift&goto Arg_Loop)
 
 REM change it to COMPlus_GCStress when we stop using xunit harness
 if /i "%1" == "gcstresslevel"         (set COMPlus_GCStress=%2&set __TestTimeout=1800000&shift&shift&goto Arg_Loop)

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -48,7 +48,6 @@ set __CoreFXTestsRunAllAvailable=
 set __SkipGenerateLayout=
 set __BuildXUnitWrappers=
 set __PrintLastResultsOnly=
-set __AltJitArch=
 
 :Arg_Loop
 if "%1" == "" goto ArgsDone
@@ -208,6 +207,10 @@ if defined __DoCrossgen (
 
 if defined __PrintLastResultsOnly (
     set __RuntestPyArgs=%__RuntestPyArgs% --analyze_results_only
+)
+
+if defined __AltJitArch (
+    set __RuntestPyArgs=%__RuntestPyArgs% -altjit_arch %__AltJitArch%
 )
 
 REM __ProjectDir is poorly named, it is actually <projectDir>/tests

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -103,6 +103,7 @@ parser.add_argument("-product_location", dest="product_location", nargs='?', def
 parser.add_argument("-coreclr_repo_location", dest="coreclr_repo_location", default=os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 parser.add_argument("-test_env", dest="test_env", default=None)
 parser.add_argument("-crossgen_altjit", dest="crossgen_altjit", default=None)
+parser.add_argument("-altjit_arch", dest="altjit_arch", default=None)
 
 # Optional arguments which change execution.
 
@@ -1490,7 +1491,8 @@ def build_test_wrappers(host_os,
                         arch, 
                         build_type, 
                         coreclr_repo_location,
-                        test_location):
+                        test_location,
+                        altjit_arch=None):
     """ Build the coreclr test wrappers
 
     Args:
@@ -2008,12 +2010,18 @@ def do_setup(host_os,
         # Line ending only need to be corrected if this is a cross build.
         correct_line_endings(host_os, test_location)
 
+    # If we are inside altjit scenario, we ought to re-build Xunit test wrappers to consider
+    # ExcludeList items in issues.targets for both build arch and altjit arch
+    is_altjit_scenario = not args.altjit_arch is None
+
     if unprocessed_args.build_test_wrappers:
         build_test_wrappers(host_os, arch, build_type, coreclr_repo_location, test_location)
     elif build_info is None:
         build_test_wrappers(host_os, arch, build_type, coreclr_repo_location, test_location)
     elif not (is_same_os and is_same_arch and is_same_build_type):
         build_test_wrappers(host_os, arch, build_type, coreclr_repo_location, test_location)
+    elif is_altjit_scenario:
+        build_test_wrappers(host_os, arch, build_type, coreclr_repo_location, test_location, args.altjit_arch)
 
     return run_tests(host_os, 
               arch,

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -1546,6 +1546,9 @@ def build_test_wrappers(host_os,
                 "/p:__BuildType=%s" % build_type,
                 "/p:__LogsDir=%s" % logs_dir]
 
+    if not altjit_arch is None:
+        command += ["/p:__AltJitArch=%s" % altjit_arch]
+
     print("Creating test wrappers...")
     print(" ".join(command))
 


### PR DESCRIPTION
Right now during x86_arm altjit scenario we combine all exclusions defined in ExcludeList in issues.targets for BuildArch==x86 (but not for BuildArch==arm). However, some of the tests would fail when arm targeting JIT runs (e.g. #20631).
This change would combine exclusions for both BuildArch and AltJitArch.

@jashook I re-did these PR as you suggested in https://github.com/dotnet/coreclr/pull/20827
Also confirmed in dev/unix_test_workflow that this indeed re-build xunit wrappers during runtest.py and solves the original issue.

Fixes #20631