### PR TITLE
Fix unloadability races

### DIFF
--- a/src/debug/daccess/dacdbiimpl.cpp
+++ b/src/debug/daccess/dacdbiimpl.cpp
@@ -3239,7 +3239,7 @@ CORDB_ADDRESS DacDbiInterfaceImpl::GetThreadStaticAddress(VMPTR_FieldDesc vmFiel
     // Find out whether the field is thread local and get its address.
     if (pFieldDesc->IsThreadStatic())
     {
-        fieldAddress = pRuntimeThread->GetStaticFieldAddrNoCreate(pFieldDesc, NULL);
+        fieldAddress = pRuntimeThread->GetStaticFieldAddrNoCreate(pFieldDesc);
     }
     else
     {

--- a/src/debug/daccess/inspect.cpp
+++ b/src/debug/daccess/inspect.cpp
@@ -1431,7 +1431,7 @@ ClrDataValue::NewFromFieldDesc(ClrDataAccess* dac,
         }
 
         baseAddr =
-            TO_CDADDR(tlsThread->GetStaticFieldAddrNoCreate(fieldDesc, NULL));
+            TO_CDADDR(tlsThread->GetStaticFieldAddrNoCreate(fieldDesc));
     }
     else if (fieldDesc->IsStatic())
     {

--- a/src/debug/daccess/request.cpp
+++ b/src/debug/daccess/request.cpp
@@ -3321,25 +3321,18 @@ ClrDataAccess::GetThreadLocalModuleData(CLRDATA_ADDRESS thread, unsigned int ind
     pLocalModuleData->ModuleIndex = index;
     
     PTR_Thread pThread = PTR_Thread(TO_TADDR(thread));
-    PTR_ThreadLocalBlock pLocalBlock = ThreadStatics::GetCurrentTLBIfExists(pThread, NULL);
-    if (!pLocalBlock)
+    PTR_ThreadLocalBlock pLocalBlock = ThreadStatics::GetCurrentTLB(pThread);
+    PTR_ThreadLocalModule pLocalModule = pLocalBlock->GetTLMIfExists(ModuleIndex(index));
+    if (!pLocalModule)
     {
         hr = E_INVALIDARG;
     }
     else
     {
-        PTR_ThreadLocalModule pLocalModule = pLocalBlock->GetTLMIfExists(ModuleIndex(index));
-        if (!pLocalModule)
-        {
-            hr = E_INVALIDARG;
-        }
-        else
-        {
-            pLocalModuleData->pGCStaticDataStart    = TO_CDADDR(PTR_TO_TADDR(pLocalModule->GetPrecomputedGCStaticsBasePointer()));
-            pLocalModuleData->pNonGCStaticDataStart = TO_CDADDR(pLocalModule->GetPrecomputedNonGCStaticsBasePointer());
-            pLocalModuleData->pDynamicClassTable    = PTR_CDADDR(pLocalModule->m_pDynamicClassTable);
-            pLocalModuleData->pClassData            = (TADDR) (PTR_HOST_MEMBER_TADDR(ThreadLocalModule, pLocalModule, m_pDataBlob));
-        }
+        pLocalModuleData->pGCStaticDataStart    = TO_CDADDR(PTR_TO_TADDR(pLocalModule->GetPrecomputedGCStaticsBasePointer()));
+        pLocalModuleData->pNonGCStaticDataStart = TO_CDADDR(pLocalModule->GetPrecomputedNonGCStaticsBasePointer());
+        pLocalModuleData->pDynamicClassTable    = PTR_CDADDR(pLocalModule->m_pDynamicClassTable);
+        pLocalModuleData->pClassData            = (TADDR) (PTR_HOST_MEMBER_TADDR(ThreadLocalModule, pLocalModule, m_pDataBlob));
     }
 
     SOSDacLeave();

--- a/src/gc/objecthandle.cpp
+++ b/src/gc/objecthandle.cpp
@@ -812,9 +812,6 @@ void Ref_DestroyHandleTableBucket(HandleTableBucket *pBucket)
 {
     WRAPPER_NO_CONTRACT;
 
-    // this check is because here we might be called from AppDomain::Terminate after AppDomain::ClearGCRoots,
-    // which calls Ref_RemoveHandleTableBucket itself
-
     Ref_RemoveHandleTableBucket(pBucket);
     for (int uCPUindex=0; uCPUindex < getNumberOfSlots(); uCPUindex++)
     {

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -3242,7 +3242,6 @@ private:
         while (lastStage !=stage) 
             lastStage = (Stage)FastInterlockCompareExchange((LONG*)&m_Stage,stage,lastStage);
     };
-    void ClearGCRoots();
     void UnwindThreads();
     // Return TRUE if EE is stopped
     // Return FALSE if more work is needed

--- a/src/vm/comsynchronizable.cpp
+++ b/src/vm/comsynchronizable.cpp
@@ -1343,7 +1343,7 @@ OBJECTREF ThreadBaseObject::GetManagedThreadCulture(BOOL bUICulture)
 
     if (pFD != NULL)
     {
-        pCurrentCulture = (OBJECTREF*)pThread->GetStaticFieldAddrNoCreate(pFD, NULL);
+        pCurrentCulture = (OBJECTREF*)pThread->GetStaticFieldAddrNoCreate(pFD);
         if (pCurrentCulture)
         {
             return *pCurrentCulture;
@@ -1418,7 +1418,7 @@ void ThreadBaseObject::ResetManagedThreadCulture(BOOL bUICulture)
     {
         OBJECTREF *pCulture = NULL;
         BEGIN_SO_INTOLERANT_CODE_NO_THROW_CHECK_THREAD(COMPlusThrowSO());
-        pCulture = (OBJECTREF*)pThread->GetStaticFieldAddrNoCreate(pFD, NULL);
+        pCulture = (OBJECTREF*)pThread->GetStaticFieldAddrNoCreate(pFD);
         if (pCulture) 
         {
             SetObjectReferenceUnchecked(pCulture, NULL);

--- a/src/vm/loaderallocator.cpp
+++ b/src/vm/loaderallocator.cpp
@@ -801,6 +801,7 @@ LOADERHANDLE LoaderAllocator::AllocateHandle(OBJECTREF value)
                         gc.handleTable = gc.loaderAllocator->GetHandleTable();
                     }
 
+                    slotsUsed = gc.loaderAllocator->GetSlotsUsed();
                     numComponents = gc.handleTable->GetNumComponents();
 
                     if (slotsUsed < numComponents)

--- a/src/vm/methodtable.h
+++ b/src/vm/methodtable.h
@@ -2548,8 +2548,8 @@ public:
     inline PTR_BYTE GetGCThreadStaticsBasePointer();
 #endif //!DACCESS_COMPILE
 
-    inline PTR_BYTE GetNonGCThreadStaticsBasePointer(PTR_Thread pThread, PTR_AppDomain pDomain);
-    inline PTR_BYTE GetGCThreadStaticsBasePointer(PTR_Thread pThread, PTR_AppDomain pDomain);
+    inline PTR_BYTE GetNonGCThreadStaticsBasePointer(PTR_Thread pThread);
+    inline PTR_BYTE GetGCThreadStaticsBasePointer(PTR_Thread pThread);
 
     inline DWORD IsDynamicStatics()
     {

--- a/src/vm/methodtable.inl
+++ b/src/vm/methodtable.inl
@@ -1408,9 +1408,7 @@ inline PTR_BYTE MethodTable::GetNonGCThreadStaticsBasePointer()
     // Get the current module's ModuleIndex
     ModuleIndex index = GetModuleForStatics()->GetModuleIndex();
     
-    PTR_ThreadLocalBlock pTLB = ThreadStatics::GetCurrentTLBIfExists(pThread, NULL);
-    if (pTLB == NULL)
-        return NULL;
+    PTR_ThreadLocalBlock pTLB = ThreadStatics::GetCurrentTLB(pThread);
 
     PTR_ThreadLocalModule pTLM = pTLB->GetTLMIfExists(index);
     if (pTLM == NULL)
@@ -1436,9 +1434,7 @@ inline PTR_BYTE MethodTable::GetGCThreadStaticsBasePointer()
     // Get the current module's ModuleIndex
     ModuleIndex index = GetModuleForStatics()->GetModuleIndex();
     
-    PTR_ThreadLocalBlock pTLB = ThreadStatics::GetCurrentTLBIfExists(pThread, NULL);
-    if (pTLB == NULL)
-        return NULL;
+    PTR_ThreadLocalBlock pTLB = ThreadStatics::GetCurrentTLB(pThread);
 
     PTR_ThreadLocalModule pTLM = pTLB->GetTLMIfExists(index);
     if (pTLM == NULL)
@@ -1450,16 +1446,14 @@ inline PTR_BYTE MethodTable::GetGCThreadStaticsBasePointer()
 #endif //!DACCESS_COMPILE
 
 //==========================================================================================
-inline PTR_BYTE MethodTable::GetNonGCThreadStaticsBasePointer(PTR_Thread pThread, PTR_AppDomain pDomain)
+inline PTR_BYTE MethodTable::GetNonGCThreadStaticsBasePointer(PTR_Thread pThread)
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
     // Get the current module's ModuleIndex
     ModuleIndex index = GetModuleForStatics()->GetModuleIndex();
     
-    PTR_ThreadLocalBlock pTLB = ThreadStatics::GetCurrentTLBIfExists(pThread, pDomain);
-    if (pTLB == NULL)
-        return NULL;
+    PTR_ThreadLocalBlock pTLB = ThreadStatics::GetCurrentTLB(pThread);
 
     PTR_ThreadLocalModule pTLM = pTLB->GetTLMIfExists(index);
     if (pTLM == NULL)
@@ -1469,16 +1463,14 @@ inline PTR_BYTE MethodTable::GetNonGCThreadStaticsBasePointer(PTR_Thread pThread
 }
 
 //==========================================================================================
-inline PTR_BYTE MethodTable::GetGCThreadStaticsBasePointer(PTR_Thread pThread, PTR_AppDomain pDomain)
+inline PTR_BYTE MethodTable::GetGCThreadStaticsBasePointer(PTR_Thread pThread)
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
     // Get the current module's ModuleIndex
     ModuleIndex index = GetModuleForStatics()->GetModuleIndex();
     
-    PTR_ThreadLocalBlock pTLB = ThreadStatics::GetCurrentTLBIfExists(pThread, pDomain);
-    if (pTLB == NULL)
-        return NULL;
+    PTR_ThreadLocalBlock pTLB = ThreadStatics::GetCurrentTLB(pThread);
 
     PTR_ThreadLocalModule pTLM = pTLB->GetTLMIfExists(index);
     if (pTLM == NULL)

--- a/src/vm/proftoeeinterfaceimpl.cpp
+++ b/src/vm/proftoeeinterfaceimpl.cpp
@@ -3513,7 +3513,7 @@ HRESULT ProfToEEInterfaceImpl::GetThreadStaticAddress2(ClassID classId,
     //
     // Store the result and return
     //
-    PTR_VOID pAddress = (void *)(((Thread *)threadId)->GetStaticFieldAddrNoCreate(pFieldDesc, pAppDomain));
+    PTR_VOID pAddress = (void *)(((Thread *)threadId)->GetStaticFieldAddrNoCreate(pFieldDesc));
     if (pAddress == NULL)
     {
         return E_INVALIDARG;

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -62,6 +62,24 @@ SPTR_IMPL(ThreadStore, ThreadStore, s_pThreadStore);
 CONTEXT *ThreadStore::s_pOSContext = NULL;
 CLREvent *ThreadStore::s_pWaitForStackCrawlEvent;
 
+PTR_ThreadLocalModule ThreadLocalBlock::GetTLMIfExists(ModuleIndex index)
+{
+    WRAPPER_NO_CONTRACT;
+    SUPPORTS_DAC;
+
+    if (index.m_dwIndex >= m_TLMTableSize)
+        return NULL;
+
+    return m_pTLMTable[index.m_dwIndex].pTLM;
+}
+
+PTR_ThreadLocalModule ThreadLocalBlock::GetTLMIfExists(MethodTable* pMT)
+{
+    WRAPPER_NO_CONTRACT;
+    ModuleIndex index = pMT->GetModuleForStatics()->GetModuleIndex();
+    return GetTLMIfExists(index);
+}
+
 #ifndef DACCESS_COMPILE
 
 BOOL Thread::s_fCleanFinalizedThread = FALSE;
@@ -114,7 +132,6 @@ template<> void GCAssert<FALSE>::BeginGCAssert()
     STATIC_CONTRACT_MODE_PREEMPTIVE;
 }
 #endif
-
 
 // #define     NEW_TLS     1
 
@@ -1372,9 +1389,6 @@ Thread::Thread()
     m_pClrDebugState = NULL;
     m_ulEnablePreemptiveGCCount  = 0;
 #endif
-
-    // Initialize data members related to thread statics
-    m_pThreadLocalBlock = NULL;
 
     m_dwLockCount = 0;
     m_dwBeginLockCount = 0;
@@ -2732,9 +2746,6 @@ Thread::~Thread()
     }
 
     g_pThinLockThreadIdDispenser->DisposeId(GetThreadId());
-
-    //Ensure DeleteThreadStaticData was executed
-    _ASSERTE(m_pThreadLocalBlock == NULL);
 
 #ifdef FEATURE_PREJIT
     if (m_pIBCInfo) {
@@ -7857,11 +7868,6 @@ void Thread::EnterContextRestricted(Context *pContext, ContextTransitionFrame *p
         }
 #endif // FEATURE_APPDOMAIN_RESOURCE_MONITORING
         
-        // NULL out the Thread's pointer to the current ThreadLocalBlock. On the next
-        // access to thread static data, the Thread's pointer to the current ThreadLocalBlock
-        // will be updated correctly.
-        m_pThreadLocalBlock = NULL;
-
         m_pDomain = pDomain;
         SetAppDomain(m_pDomain);
     }
@@ -7977,11 +7983,6 @@ void Thread::ReturnToContext(ContextTransitionFrame *pFrame)
         //_ASSERTE(!fLinkFrame || pThread->GetFrame() == pFrame);
 
         FlushIBCInfo();
-
-        // NULL out the Thread's pointer to the current ThreadLocalBlock. On the next
-        // access to thread static data, the Thread's pointer to the current ThreadLocalBlock
-        // will be updated correctly.
-        m_pThreadLocalBlock = NULL;
 
         m_pDomain = pReturnDomain;
         SetAppDomain(pReturnDomain);
@@ -8937,7 +8938,7 @@ LPVOID Thread::GetStaticFieldAddress(FieldDesc *pFD)
 // 
 //+----------------------------------------------------------------------------
 
-TADDR Thread::GetStaticFieldAddrNoCreate(FieldDesc *pFD, PTR_AppDomain pDomain)
+TADDR Thread::GetStaticFieldAddrNoCreate(FieldDesc *pFD)
 {
     CONTRACTL {
         NOTHROW;
@@ -8957,11 +8958,11 @@ TADDR Thread::GetStaticFieldAddrNoCreate(FieldDesc *pFD, PTR_AppDomain pDomain)
     if (pFD->GetFieldType() == ELEMENT_TYPE_CLASS ||
         pFD->GetFieldType() == ELEMENT_TYPE_VALUETYPE)
     {
-        base = pMT->GetGCThreadStaticsBasePointer(dac_cast<PTR_Thread>(this), pDomain);
+        base = pMT->GetGCThreadStaticsBasePointer(dac_cast<PTR_Thread>(this));
     }
     else
     {
-        base = pMT->GetNonGCThreadStaticsBasePointer(dac_cast<PTR_Thread>(this), pDomain);
+        base = pMT->GetNonGCThreadStaticsBasePointer(dac_cast<PTR_Thread>(this));
     }
     
     if (base == NULL)
@@ -9055,13 +9056,7 @@ void Thread::DeleteThreadStaticData()
     }
     CONTRACTL_END;
 
-    // Deallocate the memory used by the table of ThreadLocalBlocks
-    if (m_pThreadLocalBlock != NULL)
-    {
-        m_pThreadLocalBlock->FreeTable();
-        delete m_pThreadLocalBlock;
-        m_pThreadLocalBlock = NULL;
-    }
+    m_ThreadLocalBlock.FreeTable();
 }
 
 //+----------------------------------------------------------------------------
@@ -9076,46 +9071,8 @@ void Thread::DeleteThreadStaticData()
 
 void Thread::DeleteThreadStaticData(ModuleIndex index)
 {
-    if (m_pThreadLocalBlock != NULL)
-    {
-        m_pThreadLocalBlock->FreeTLM(index.m_dwIndex, FALSE /* isThreadShuttingDown */);
-    }
+    m_ThreadLocalBlock.FreeTLM(index.m_dwIndex, FALSE /* isThreadShuttingDown */);
 }
-
-//+----------------------------------------------------------------------------
-//
-//  Method:     Thread::DeleteThreadStaticData   protected
-//
-//  Synopsis:   Delete the static data for the given appdomain. This is called
-//              when the appdomain unloads.
-//
-// 
-//+----------------------------------------------------------------------------
-
-void Thread::DeleteThreadStaticData(AppDomain *pDomain)
-{
-    CONTRACTL {
-        NOTHROW;
-        GC_NOTRIGGER;
-    }
-    CONTRACTL_END;
-
-    // Look up the AppDomain index
-    SIZE_T index = pDomain->GetIndex().m_dwIndex;
-
-    ThreadLocalBlock * pTLB = m_pThreadLocalBlock;
-    m_pThreadLocalBlock = NULL;
-
-    if (pTLB != NULL)
-    {
-        // Since the AppDomain is being unloaded anyway, all the memory used by
-        // the TLB will be reclaimed, so we don't really have to call FreeTable()
-        pTLB->FreeTable();
-
-        delete pTLB;
-    }
-}
-
 
 void Thread::InitCultureAccessors()
 {
@@ -10740,10 +10697,7 @@ Thread::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
 
     m_ExceptionState.EnumChainMemoryRegions(flags);
 
-    // Like the old thread static implementation, we only enumerate
-    // the current TLB. Should we be enumerating all of the TLBs?
-    if (m_pThreadLocalBlock.IsValid())
-        m_pThreadLocalBlock->EnumMemoryRegions(flags);
+    m_ThreadLocalBlock.EnumMemoryRegions(flags);
 
     if (flags != CLRDATA_ENUM_MEM_MINI && flags != CLRDATA_ENUM_MEM_TRIAGE)
     {

--- a/src/vm/threads.h
+++ b/src/vm/threads.h
@@ -188,6 +188,79 @@ typedef DPTR(PTR_ThreadLocalBlock) PTR_PTR_ThreadLocalBlock;
 class EventPipeBufferList;
 #endif // FEATURE_PERFTRACING
 
+struct TLMTableEntry;
+
+typedef DPTR(struct TLMTableEntry) PTR_TLMTableEntry;
+typedef DPTR(struct ThreadLocalModule) PTR_ThreadLocalModule;
+
+class ThreadStaticHandleTable;
+struct ThreadLocalModule;
+class Module;
+
+struct ThreadLocalBlock
+{
+    friend class ClrDataAccess;
+
+private:
+    PTR_TLMTableEntry   m_pTLMTable;     // Table of ThreadLocalModules
+    SIZE_T              m_TLMTableSize;  // Current size of table
+    SpinLock            m_TLMTableLock;  // Spinlock used to synchronize growing the table and freeing TLM by other threads
+
+    // Each ThreadLocalBlock has its own ThreadStaticHandleTable. The ThreadStaticHandleTable works
+    // by allocating Object arrays on the GC heap and keeping them alive with pinning handles.
+    //
+    // We use the ThreadStaticHandleTable to allocate space for GC thread statics. A GC thread
+    // static is thread static that is either a reference type or a value type whose layout
+    // contains a pointer to a reference type.
+
+    ThreadStaticHandleTable * m_pThreadStaticHandleTable;
+
+    // Need to keep a list of the pinning handles we've created
+    // so they can be cleaned up when the thread dies
+    ObjectHandleList          m_PinningHandleList;
+
+public: 
+
+#ifndef DACCESS_COMPILE
+    void AddPinningHandleToList(OBJECTHANDLE oh);
+    void FreePinningHandles();
+    void AllocateThreadStaticHandles(Module * pModule, ThreadLocalModule * pThreadLocalModule);
+    OBJECTHANDLE AllocateStaticFieldObjRefPtrs(int nRequested, OBJECTHANDLE* ppLazyAllocate = NULL);
+    void InitThreadStaticHandleTable();
+
+    void AllocateThreadStaticBoxes(MethodTable* pMT);
+#endif
+
+public: // used by code generators
+    static SIZE_T GetOffsetOfModuleSlotsPointer() { return offsetof(ThreadLocalBlock, m_pTLMTable); }
+
+public:
+
+#ifndef DACCESS_COMPILE
+    ThreadLocalBlock()
+      : m_pTLMTable(NULL), m_TLMTableSize(0), m_pThreadStaticHandleTable(NULL) 
+    {
+        m_TLMTableLock.Init(LOCK_TYPE_DEFAULT);
+    }
+
+    void    FreeTLM(SIZE_T i, BOOL isThreadShuttingDown);
+
+    void    FreeTable();
+
+    void    EnsureModuleIndex(ModuleIndex index);
+
+#endif
+
+    void SetModuleSlot(ModuleIndex index, PTR_ThreadLocalModule pLocalModule);
+
+    PTR_ThreadLocalModule GetTLMIfExists(ModuleIndex index);
+    PTR_ThreadLocalModule GetTLMIfExists(MethodTable* pMT);
+
+#ifdef DACCESS_COMPILE
+    void EnumMemoryRegions(CLRDataEnumMemoryFlags flags);
+#endif
+};
+
 #ifdef CROSSGEN_COMPILE
 
 #include "asmconstants.h"
@@ -196,7 +269,7 @@ class Thread
 {
     friend class ThreadStatics;
 
-    PTR_ThreadLocalBlock m_pThreadLocalBlock;
+    ThreadLocalBlock m_ThreadLocalBlock;
 
 public:
     BOOL IsAddressInStack (PTR_VOID addr) const { return TRUE; }
@@ -4253,7 +4326,7 @@ public:
     bool GetDebugCantStop(void);
     
     static LPVOID GetStaticFieldAddress(FieldDesc *pFD);
-    TADDR GetStaticFieldAddrNoCreate(FieldDesc *pFD, PTR_AppDomain pDomain);
+    TADDR GetStaticFieldAddrNoCreate(FieldDesc *pFD);
  
     void SetLoadingFile(DomainFile *pFile)
     {
@@ -4461,20 +4534,11 @@ public:
 
     void EnsurePreallocatedContext();
     
-    // m_pThreadLocalBLock points to the ThreadLocalBlock that corresponds to the 
-    // AppDomain that the Thread is currently in
-    
-    PTR_ThreadLocalBlock m_pThreadLocalBlock;
+    ThreadLocalBlock m_ThreadLocalBlock;
 
     // Called during AssemblyLoadContext teardown to clean up all structures
     // associated with thread statics for the specific Module
     void DeleteThreadStaticData(ModuleIndex index);
-
-protected:
-    
-    // Called during AD teardown to clean up any references this 
-    // thread may have to the AppDomain
-    void DeleteThreadStaticData(AppDomain *pDomain);
 
 private:
 


### PR DESCRIPTION
Running the GC ReliabilityFramework has uncovered the following issues:
* There was a race between thread and ALC shutdown. If `Thread::DeleteThreadStaticData(ModuleIndex index)` and `Thread::DeleteThreadStaticData()` were executed at the same time, it could happen that the `Thread::DeleteThreadStaticData(ModuleIndex index)` got the still valid `m_pThreadLocalBlock` and call its `FreeTLM` member method, but the `Thread::DeleteThreadStaticData()` destroyed the `ThreadLocalBlock` right after that. The `FreeTLM` was still executing.
* When the LoaderAllocator's handle table needed to grow and there was a race between two threads attempting to do that, the thread that lost has forgotten to refresh the `slotsUsed` and allocated the same slot as the other thread.

I have also removed unused `Thread::DeleteThreadStaticData(AppDomain *pDomain)` and also `AppDomain::ClearGCRoots()` that became unused due to this change too.

This change also fixes some recent change when spaces were changed to tabs in the crsttypes.h.