### PR TITLE
Remove AssemblyLoadContext::GetLoadedAssemblies

### DIFF
--- a/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -137,11 +137,6 @@ namespace System.Runtime.Loader
         [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
         private static extern void LoadFromPath(IntPtr ptrNativeAssemblyLoadContet, string ilPath, string niPath, ObjectHandleOnStack retAssembly);
 
-        public static Assembly[] GetLoadedAssemblies()
-        {
-            return AppDomain.CurrentDomain.GetAssemblies(false);
-        }
-
         // These methods load assemblies into the current AssemblyLoadContext 
         // They may be used in the implementation of an AssemblyLoadContext derivation
         public Assembly LoadFromAssemblyPath(string assemblyPath)


### PR DESCRIPTION
`AssemblyLoadContext::GetLoadedAssemblies()` is unused, not part of the ALC API.  Further it is currently implemented incorrectly returning the current `AppDomain`'s assemblies


@jkotas @vitek-karas 