### PR TITLE
Utf8Formatter: Reduce allocations for floating point

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
@@ -248,7 +248,7 @@ namespace System
         private const int ScaleNAN = unchecked((int)0x80000000);
         private const int ScaleINF = 0x7FFFFFFF;
         private const int MaxUInt32DecDigits = 10;
-        private const int CharStackBufferSize = 32;
+        internal const int CharStackBufferSize = 32; // Utf8Formatter.Float also uses this value
         private const string PosNumberFormat = "#";
 
         private static readonly string[] s_singleDigitStringCache = { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9" };


### PR DESCRIPTION
As discussed in https://github.com/dotnet/corefx/issues/25077#issuecomment-439082212

Can anybody help me how to run the tests for this locally?
In CoreClr there are no tests for the Utf8Formatter.
In CoreFx they are still in the System.Memory.Tests project, I tried to copy both changed files into the related corefx directories and build/run tests. But I'm not really convinced my changed code is actually executed, I tried to throw an exception in the code below and still all the tests were successful.