### PR TITLE
Remove Hostx86/arm CrossGen and Simplify build.sh command line arguments for Linux/arm cross build (Part 2)

### DIFF
--- a/Documentation/building/linux-instructions.md
+++ b/Documentation/building/linux-instructions.md
@@ -121,7 +121,7 @@ The CI system and official builds use Docker to build ARM for Linux (for example
 
 ```
 ROOT=/Users/me/git/coreclr
-DOCKER_ARGS="run -i --rm -v ${ROOT}:/mnt/coreclr -w /mnt/coreclr -e ROOTFS_DIR=/crossrootfs/arm -e CAC_ROOTFS_DIR=/crossrootfs/x86 microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-e435274-20180426002420"
+DOCKER_ARGS="run -i --rm -v ${ROOT}:/mnt/coreclr -w /mnt/coreclr -e ROOTFS_DIR=/crossrootfs/arm microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-e435274-20180426002420"
 docker ${DOCKER_ARGS} /mnt/coreclr/build.sh arm checked cross
 docker ${DOCKER_ARGS} /mnt/coreclr/build-test.sh arm checked cross generatelayoutonly
 ```

--- a/build.sh
+++ b/build.sh
@@ -346,11 +346,9 @@ build_cross_architecture_components()
 
     __SkipCrossArchBuild=1
     # check supported cross-architecture components host(__HostArch)/target(__BuildArch) pair
-    if [[ ("$__BuildArch" == "arm" || "$__BuildArch" == "armel") && "$__CrossArch" == "x86" ]]; then
+    if [[ ("$__BuildArch" == "arm" || "$__BuildArch" == "armel") && ("$__CrossArch" == "x86" || "$__CrossArch" == "x64") ]]; then
         __SkipCrossArchBuild=0
-    elif [[ ("$__BuildArch" == "arm64") && "$__CrossArch" == "x64" ]]; then
-        __SkipCrossArchBuild=0
-    elif [[ ("$__BuildArch" == "arm" || "$__BuildArch" == "armel") && "$__CrossArch" == "x64" ]]; then
+    elif [[ "$__BuildArch" == "arm64" && "$__CrossArch" == "x64" ]]; then
         __SkipCrossArchBuild=0
     else
         # not supported

--- a/build.sh
+++ b/build.sh
@@ -815,11 +815,6 @@ while :; do
             __SkipCoreCLR=1
             ;;
 
-        crosscomponent|-crosscomponent)
-            # Accept "crosscomponent" for backward-compatibility but ignore it.
-            echo "WARNING: 'crosscomponent' is obsolete and should not be used"
-            ;;
-
         skipmanaged|-skipmanaged)
             __SkipManaged=1
             ;;

--- a/build.sh
+++ b/build.sh
@@ -1050,11 +1050,6 @@ build_native $__SkipCoreCLR "$__BuildArch" "$__IntermediatesDir" "$__ExtraCmakeA
 # Build cross-architecture components
 if [[ $__CrossBuild == 1 ]]; then
     build_cross_architecture_components "$__CrossArch"
-
-    # For now, continue building Hostx86/arm crossgen
-    if [[ "$__HostArch" == "x64" && "$__BuildArch" == "arm" ]]; then
-        build_cross_architecture_components "x86"
-    fi
 fi
 
 # Build System.Private.CoreLib.

--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,6 @@ if [ "$PYTHON" == "" ] ; then
        exit 1
     fi
 fi
-
 # validate python-dependency
 # useful in case of explicitly set option.
 if ! command -v $PYTHON > /dev/null
@@ -337,10 +336,8 @@ build_native()
 
 build_cross_architecture_components()
 {
-    local crossArch="$1"
-
-    local intermediatesForBuild="$__IntermediatesDir/Host$crossArch/crossgen"
-    local crossArchBinDir="$__BinDir/$crossArch"
+    local intermediatesForBuild="$__IntermediatesDir/Host$__CrossArch/crossgen"
+    local crossArchBinDir="$__BinDir/$__CrossArch"
 
     mkdir -p "$intermediatesForBuild"
     mkdir -p "$crossArchBinDir"
@@ -349,11 +346,11 @@ build_cross_architecture_components()
 
     __SkipCrossArchBuild=1
     # check supported cross-architecture components host(__HostArch)/target(__BuildArch) pair
-    if [[ ("$__BuildArch" == "arm" || "$__BuildArch" == "armel") && "$crossArch" == "x86" ]]; then
+    if [[ ("$__BuildArch" == "arm" || "$__BuildArch" == "armel") && "$__CrossArch" == "x86" ]]; then
         __SkipCrossArchBuild=0
-    elif [[ ("$__BuildArch" == "arm64") && "$crossArch" == "x64" ]]; then
+    elif [[ ("$__BuildArch" == "arm64") && "$__CrossArch" == "x64" ]]; then
         __SkipCrossArchBuild=0
-    elif [[ ("$__BuildArch" == "arm" || "$__BuildArch" == "armel") && "$crossArch" == "x64" ]]; then
+    elif [[ ("$__BuildArch" == "arm" || "$__BuildArch" == "armel") && "$__CrossArch" == "x64" ]]; then
         __SkipCrossArchBuild=0
     else
         # not supported
@@ -364,7 +361,7 @@ build_cross_architecture_components()
     export CROSSCOMPILE=0
 
     __ExtraCmakeArgs="-DCLR_CMAKE_TARGET_ARCH=$__BuildArch -DCLR_CMAKE_TARGET_OS=$__BuildOS -DCLR_CMAKE_PACKAGES_DIR=$__PackagesDir -DCLR_CMAKE_PGO_INSTRUMENT=$__PgoInstrument -DCLR_CMAKE_OPTDATA_VERSION=$__PgoOptDataVersion -DCLR_CMAKE_PGO_OPTIMIZE=$__PgoOptimize -DCLR_CROSS_COMPONENTS_BUILD=1"
-    build_native $__SkipCrossArchBuild "$crossArch" "$intermediatesForBuild" "$__ExtraCmakeArgs" "cross-architecture components"
+    build_native $__SkipCrossArchBuild "$__CrossArch" "$intermediatesForBuild" "$__ExtraCmakeArgs" "cross-architecture components"
 
     export CROSSCOMPILE=1
 }
@@ -1027,7 +1024,7 @@ build_native $__SkipCoreCLR "$__BuildArch" "$__IntermediatesDir" "$__ExtraCmakeA
 
 # Build cross-architecture components
 if [[ $__CrossBuild == 1 ]]; then
-    build_cross_architecture_components "$__CrossArch"
+    build_cross_architecture_components
 fi
 
 # Build System.Private.CoreLib.

--- a/build.sh
+++ b/build.sh
@@ -348,21 +348,12 @@ build_cross_architecture_components()
     generate_event_logging_sources "$intermediatesForBuild" "the crossarch build system"
 
     __SkipCrossArchBuild=1
-    TARGET_ROOTFS=""
     # check supported cross-architecture components host(__HostArch)/target(__BuildArch) pair
     if [[ ("$__BuildArch" == "arm" || "$__BuildArch" == "armel") && "$crossArch" == "x86" ]]; then
-        export CROSSCOMPILE=0
         __SkipCrossArchBuild=0
-
-        # building x64-host/arm-target cross-architecture component need to use cross toolchain of x86
-        if [ "$__HostArch" == "x64" ]; then
-            export CROSSCOMPILE=1
-        fi
     elif [[ ("$__BuildArch" == "arm64") && "$crossArch" == "x64" ]]; then
-        export CROSSCOMPILE=0
         __SkipCrossArchBuild=0
     elif [[ ("$__BuildArch" == "arm" || "$__BuildArch" == "armel") && "$crossArch" == "x64" ]]; then
-        export CROSSCOMPILE=0
         __SkipCrossArchBuild=0
     else
         # not supported
@@ -370,24 +361,11 @@ build_cross_architecture_components()
     fi
 
     export __CMakeBinDir="$crossArchBinDir"
-    export CROSSCOMPONENT=1
-
-    if [ $CROSSCOMPILE == 1 ]; then
-        TARGET_ROOTFS="$ROOTFS_DIR"
-        if [ -n "$CAC_ROOTFS_DIR" ]; then
-            export ROOTFS_DIR="$CAC_ROOTFS_DIR"
-        else
-            export ROOTFS_DIR="$__ProjectRoot/cross/rootfs/$__CrossArch"
-        fi
-    fi
+    export CROSSCOMPILE=0
 
     __ExtraCmakeArgs="-DCLR_CMAKE_TARGET_ARCH=$__BuildArch -DCLR_CMAKE_TARGET_OS=$__BuildOS -DCLR_CMAKE_PACKAGES_DIR=$__PackagesDir -DCLR_CMAKE_PGO_INSTRUMENT=$__PgoInstrument -DCLR_CMAKE_OPTDATA_VERSION=$__PgoOptDataVersion -DCLR_CMAKE_PGO_OPTIMIZE=$__PgoOptimize -DCLR_CROSS_COMPONENTS_BUILD=1"
     build_native $__SkipCrossArchBuild "$crossArch" "$intermediatesForBuild" "$__ExtraCmakeArgs" "cross-architecture components"
 
-    # restore ROOTFS_DIR and CROSSCOMPILE
-    if [ -n "$TARGET_ROOTFS" ]; then
-        export ROOTFS_DIR="$TARGET_ROOTFS"
-    fi
     export CROSSCOMPILE=1
 }
 

--- a/buildpipeline/DotNet-CoreClr-Trusted-Linux-Crossbuild.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Linux-Crossbuild.json
@@ -179,7 +179,7 @@
       },
       "inputs": {
         "filename": "docker",
-        "arguments": "run --rm -e ROOTFS_DIR=$(ROOTFS_DIR) -e CAC_ROOTFS_DIR=$(CAC_ROOTFS_DIR) $(DockerCommonRunArgs) ./build.sh $(PB_BuildType) $(Architecture) skipnuget cross -skiprestore stripSymbols -OfficialBuildId=$(OfficialBuildId) -- /flp:\"v=diag\"",
+        "arguments": "run --rm -e ROOTFS_DIR=$(ROOTFS_DIR) $(DockerCommonRunArgs) ./build.sh $(PB_BuildType) $(Architecture) skipnuget cross -skiprestore stripSymbols -OfficialBuildId=$(OfficialBuildId) -- /flp:\"v=diag\"",
         "workingFolder": "",
         "failOnStandardError": "false"
       }
@@ -519,10 +519,6 @@
     },
     "ROOTFS_DIR": {
       "value": "/crossrootfs/$(Architecture)"
-    },
-    "CAC_ROOTFS_DIR": {
-      "value": "",
-      "allowOverride": true
     },
     "DockerVolumeName": {
       "value": "coreclr-cross-$(Build.BuildId)"

--- a/buildpipeline/pipelines.json
+++ b/buildpipeline/pipelines.json
@@ -148,9 +148,7 @@
             "DockerTag": "ubuntu-14.04-cross-e435274-20180426002420",
             "Architecture": "arm",
             "Rid": "linux",
-            "CrossArchitecture": "x86",
-            "CrossArchBuildPackagesArgs": "-__DoCrossArchBuild=1",
-            "CAC_ROOTFS_DIR": "/crossrootfs/$(CrossArchitecture)"
+            "CrossArchBuildPackagesArgs": "-__DoCrossArchBuild=1"
           },
           "ReportingParameters": {
             "OperatingSystem": "Linux",

--- a/dir.props
+++ b/dir.props
@@ -164,8 +164,6 @@
     <CrossTargetComponentFolder Condition="'$(PackagePlatform)' == 'arm64'">x64</CrossTargetComponentFolder>
     <CrossTargetComponentFolder Condition="'$(PackagePlatform)' == 'arm' and '$(TargetsWindows)' == 'true'">x86</CrossTargetComponentFolder>
     <CrossTargetComponentFolder Condition="'$(PackagePlatform)' == 'arm' and '$(TargetsLinux)' == 'true'">x64</CrossTargetComponentFolder>
-    <_HasObsoleteCrossTargetComponents Condition="'$(TargetsLinux)' == 'true' and '$(PackagePlatform)' =='arm' and '$(__DoCrossArchBuild)' == '1'">true</_HasObsoleteCrossTargetComponents>
-    <_ObsoleteCrossTargetComponentFolder Condition="'$(PackagePlatform)' == 'arm'">x86</_ObsoleteCrossTargetComponentFolder>
 
     <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(PackagesBinDir)/pkg/</PackageOutputPath>
     <SymbolPackageOutputPath Condition="'$(SymbolPackageOutputPath)' == ''">$(PackagesBinDir)/symbolpkg/</SymbolPackageOutputPath>

--- a/netci.groovy
+++ b/netci.groovy
@@ -2508,11 +2508,6 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                     // Add some useful information to the log file. Ignore return codes.
                     buildCommands += "uname -a || true"
 
-                    def additionalOpts = ""
-                    if (architecture == 'arm') {
-                        additionalOpts = "-e CAC_ROOTFS_DIR=/crossrootfs/x86"
-                    }
-
                     // Cross build the Ubuntu/arm product using docker with a docker image that contains the correct
                     // Ubuntu cross-compilation toolset (running on a Ubuntu x64 host).
                     // For CoreFX testing, we only need the product build; we don't need to generate the layouts. The product
@@ -2520,7 +2515,7 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                     // ZIP up the generated CoreFX runtime and tests.
 
                     def dockerImage = getDockerImageName(architecture, os, true)
-                    def dockerCmd = "docker run -i --rm -v \${WORKSPACE}:\${WORKSPACE} -w \${WORKSPACE} -e ROOTFS_DIR=/crossrootfs/${architecture} ${additionalOpts} ${dockerImage} "
+                    def dockerCmd = "docker run -i --rm -v \${WORKSPACE}:\${WORKSPACE} -w \${WORKSPACE} -e ROOTFS_DIR=/crossrootfs/${architecture} ${dockerImage} "
 
                     buildCommands += "${dockerCmd}\${WORKSPACE}/build.sh ${lowerConfiguration} ${architecture} cross"
 

--- a/perf.groovy
+++ b/perf.groovy
@@ -462,9 +462,8 @@ def static getFullThroughputJobName(def project, def os, def arch, def isPR) {
             python = "python3.6"
             def buildCommands = []
             def newBuildJob = job(fullBuildJobName) {
-                def additionalOpts = "-e CAC_ROOTFS_DIR=/crossrootfs/x86"
                 def dockerImage = getDockerImageName(architecture, 'Ubuntu', true)
-                def dockerCmd = "docker run -i --rm -v \${WORKSPACE}:\${WORKSPACE} -w \${WORKSPACE} -e ROOTFS_DIR=/crossrootfs/${architecture} ${additionalOpts} ${dockerImage} "
+                def dockerCmd = "docker run -i --rm -v \${WORKSPACE}:\${WORKSPACE} -w \${WORKSPACE} -e ROOTFS_DIR=/crossrootfs/${architecture} ${dockerImage} "
 
                 buildCommands += "${dockerCmd}\${WORKSPACE}/build.sh release ${architecture} cross"
 

--- a/src/.nuget/Microsoft.NETCore.Jit/runtime.Linux.Microsoft.NETCore.Jit.props
+++ b/src/.nuget/Microsoft.NETCore.Jit/runtime.Linux.Microsoft.NETCore.Jit.props
@@ -3,6 +3,5 @@
   <ItemGroup>
     <NativeBinary Include="$(BinDir)libclrjit.so" />
     <CrossArchitectureSpecificNativeFileAndSymbol Condition="'$(HasCrossTargetComponents)' == 'true'" Include="$(BinDir)$(CrossTargetComponentFolder)\libclrjit.so" />
-    <_ObsoleteCrossArchitectureSpecificNativeFileAndSymbol Condition="'$(_HasObsoleteCrossTargetComponents)' == 'true'" Include="$(BinDir)$(_ObsoleteCrossTargetComponentFolder)\libclrjit.so" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -26,6 +26,5 @@
     <ArchitectureSpecificLibFile Include="$(BinDir)SOS.NETCore.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
     <CrossArchitectureSpecificToolFile Condition="'$(HasCrossTargetComponents)' == 'true'" Include="$(BinDir)$(CrossTargetComponentFolder)\crossgen" />
-    <_ObsoleteCrossArchitectureSpecificToolFile Condition="'$(_HasObsoleteCrossTargetComponents)' == 'true'" Include="$(BinDir)$(_ObsoleteCrossTargetComponentFolder)\crossgen" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/dir.targets
+++ b/src/.nuget/dir.targets
@@ -39,15 +39,6 @@
       </NativeWithSymbolFile>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(_HasObsoleteCrossTargetComponents)'=='true'">
-      <NativeWithSymbolFile Include="@(_ObsoleteCrossArchitectureSpecificNativeFileAndSymbol)">
-        <TargetPath>runtimes/$(_ObsoleteCrossTargetComponentFolder)_$(Platform)/native</TargetPath>
-      </NativeWithSymbolFile>
-      <NativeWithSymbolFile Include="@(_ObsoleteCrossArchitectureSpecificToolFile)">
-        <TargetPath>tools/$(_ObsoleteCrossTargetComponentFolder)_$(Platform)</TargetPath>
-      </NativeWithSymbolFile>
-   </ItemGroup>
-
     <ItemGroup>
       <!-- The symbols for these files are already in place together with respective *.ni.pdb -->
       <IlForCrossGenedFile Include="@(CrossGenBinary -> '%(RootDir)%(Directory)IL\%(Filename).dll')">

--- a/tests/scripts/run-pmi-diffs.py
+++ b/tests/scripts/run-pmi-diffs.py
@@ -44,7 +44,7 @@ Jitutils_url = 'https://github.com/dotnet/jitutils.git'
 # The Docker file and possibly options should be hoisted out to a text file to be shared between scripts.
 
 Docker_name_arm32 = 'microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-e435274-20180426002420'
-Docker_opts_arm32 = '-e ROOTFS_DIR=/crossrootfs/arm -e CAC_ROOTFS_DIR=/crossrootfs/x86'
+Docker_opts_arm32 = '-e ROOTFS_DIR=/crossrootfs/arm'
 
 Docker_name_arm64 = 'microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-cross-arm64-a3ae44b-20180315221921'
 Docker_opts_arm64 = '-e ROOTFS_DIR=/crossrootfs/arm64'

--- a/tests/scripts/run-pmi-diffs.py
+++ b/tests/scripts/run-pmi-diffs.py
@@ -313,7 +313,7 @@ def baseline_build():
                 dockerOpts = Docker_opts_arm64
 
             dockerCmd = 'docker run -i --rm -v %s:%s -w %s %s %s ' % (baseCoreClrPath, baseCoreClrPath, baseCoreClrPath, dockerOpts, dockerFile)
-            buildOpts = 'cross crosscomponent'
+            buildOpts = 'cross'
             scriptPath = baseCoreClrPath
 
         # Build a checked baseline jit 


### PR DESCRIPTION
This removes an ability to build Hostx86/arm CrossGen on Linux/x64 as well as *-crosscomponents* command line flag and all the related logic in build.sh. Also we don't need to specify CAC_ROOTFS_DIR anymore