### PR TITLE
Fix Formatting Japanese First Year on Linux

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Globalization/DateTimeFormat.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/DateTimeFormat.cs
@@ -657,9 +657,8 @@ namespace System
                         if (isJapaneseCalendar &&
                             !AppContextSwitches.FormatJapaneseFirstYearAsANumber &&
                             year == 1 &&
-                            i + tokenLen < format.Length - 1 &&
-                            format[i + tokenLen] == '\'' &&
-                            format[i + tokenLen + 1] == DateTimeFormatInfoScanner.CJKYearSuff[0])
+                            ((i + tokenLen < format.Length && format[i + tokenLen] == DateTimeFormatInfoScanner.CJKYearSuff[0]) ||
+                            (i + tokenLen < format.Length - 1 && format[i + tokenLen] == '\'' && format[i + tokenLen + 1] == DateTimeFormatInfoScanner.CJKYearSuff[0])))
                         {
                             // We are formatting a Japanese date with year equals 1 and the year number is followed by the year sign \u5e74
                             // In Japanese dates, the first year in the era is not formatted as a number 1 instead it is formatted as \u5143 which means


### PR DESCRIPTION
When formatting the first year with Gannen symbol we are checking if the year is followed by single quote which this is the case on Windows but it is not necessary the case on Linux