### PR TITLE
Exclude tests/src/Regressions/coreclr/16355/boring && 16775/sharedinterfacemethod from GCStress.

### DIFF
--- a/tests/src/Regressions/coreclr/16355/boring.ilproj
+++ b/tests/src/Regressions/coreclr/16355/boring.ilproj
@@ -15,6 +15,9 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
+	
+    <!-- Issue 21044, https://github.com/dotnet/coreclr/issues/21044 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/src/Regressions/coreclr/16775/sharedinterfacemethod.ilproj
+++ b/tests/src/Regressions/coreclr/16775/sharedinterfacemethod.ilproj
@@ -15,6 +15,9 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
+	
+    <!-- Issue 21044, https://github.com/dotnet/coreclr/issues/21044 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Revert it when #21044 is fixed.