### PR TITLE
Added support for debugging a sandboxed app on Mac

### DIFF
--- a/src/debug/debug-pal/CMakeLists.txt
+++ b/src/debug/debug-pal/CMakeLists.txt
@@ -12,6 +12,7 @@ if(WIN32)
 
     set(TWO_WAY_PIPE_SOURCES 
         win/twowaypipe.cpp
+        win/processdescriptor.cpp
     )
 endif(WIN32)
 
@@ -24,6 +25,7 @@ if(CLR_CMAKE_PLATFORM_UNIX)
 
     set(TWO_WAY_PIPE_SOURCES
       unix/twowaypipe.cpp
+      unix/processdescriptor.cpp
     )
 
 endif(CLR_CMAKE_PLATFORM_UNIX)

--- a/src/debug/debug-pal/unix/processdescriptor.cpp
+++ b/src/debug/debug-pal/unix/processdescriptor.cpp
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include <pal.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <limits.h>
+#include <pal_assert.h>
+#include "processdescriptor.h"
+
+ProcessDescriptor ProcessDescriptor::FromCurrentProcess()
+{
+    return Create(GetCurrentProcessId(), PAL_GetApplicationGroupId());
+}

--- a/src/debug/debug-pal/unix/processdescriptor.cpp
+++ b/src/debug/debug-pal/unix/processdescriptor.cpp
@@ -13,5 +13,9 @@
 
 ProcessDescriptor ProcessDescriptor::FromCurrentProcess()
 {
+#ifdef __APPLE__
     return Create(GetCurrentProcessId(), PAL_GetApplicationGroupId());
+#else    
+    return Create(GetCurrentProcessId(), nullptr);
+#endif    
 }

--- a/src/debug/debug-pal/unix/twowaypipe.cpp
+++ b/src/debug/debug-pal/unix/twowaypipe.cpp
@@ -14,15 +14,14 @@
 // Creates a server side of the pipe. 
 // Id is used to create pipes names and uniquely identify the pipe on the machine. 
 // true - success, false - failure (use GetLastError() for more details)
-bool TwoWayPipe::CreateServer(DWORD id)
+bool TwoWayPipe::CreateServer(const ProcessDescriptor& pd)
 {
     _ASSERTE(m_state == NotInitialized);
     if (m_state != NotInitialized)
         return false;
 
-    m_id = id;
-    PAL_GetTransportPipeName(m_inPipeName, id, "in");
-    PAL_GetTransportPipeName(m_outPipeName, id, "out");
+    PAL_GetTransportPipeName(m_inPipeName, pd.m_Pid, pd.m_ApplicationGroupId, "in");
+    PAL_GetTransportPipeName(m_outPipeName, pd.m_Pid, pd.m_ApplicationGroupId, "out");
 
     unlink(m_inPipeName);
 
@@ -47,16 +46,15 @@ bool TwoWayPipe::CreateServer(DWORD id)
 // Connects to a previously opened server side of the pipe.
 // Id is used to locate the pipe on the machine. 
 // true - success, false - failure (use GetLastError() for more details)
-bool TwoWayPipe::Connect(DWORD id)
+bool TwoWayPipe::Connect(const ProcessDescriptor& pd)
 {
     _ASSERTE(m_state == NotInitialized);
     if (m_state != NotInitialized)
         return false;
 
-    m_id = id;
     //"in" and "out" are switched deliberately, because we're on the client
-    PAL_GetTransportPipeName(m_inPipeName, id, "out");
-    PAL_GetTransportPipeName(m_outPipeName, id, "in");
+    PAL_GetTransportPipeName(m_inPipeName, pd.m_Pid, pd.m_ApplicationGroupId, "out");
+    PAL_GetTransportPipeName(m_outPipeName, pd.m_Pid, pd.m_ApplicationGroupId, "in");
 
     // Pipe opening order is reversed compared to WaitForConnection()
     // in order to avaid deadlock.

--- a/src/debug/debug-pal/win/processdescriptor.cpp
+++ b/src/debug/debug-pal/win/processdescriptor.cpp
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include <windows.h>
+#include <stdio.h> 
+#include <wchar.h>
+#include <assert.h>
+#include "processdescriptor.h"
+
+ProcessDescriptor ProcessDescriptor::FromCurrentProcess()
+{
+    return FromPid(GetCurrentProcessId());
+}

--- a/src/debug/debug-pal/win/twowaypipe.cpp
+++ b/src/debug/debug-pal/win/twowaypipe.cpp
@@ -17,19 +17,19 @@
 // Creates a server side of the pipe. 
 // Id is used to create pipes names and uniquely identify the pipe on the machine. 
 // true - success, false - failure (use GetLastError() for more details)
-bool TwoWayPipe::CreateServer(DWORD id)
+bool TwoWayPipe::CreateServer(const ProcessDescriptor& pd)
 {
     _ASSERTE(m_state == NotInitialized);
     if (m_state != NotInitialized)
         return false;
 
-    m_inboundPipe = CreateOneWayPipe(id, true);
+    m_inboundPipe = CreateOneWayPipe(pd.m_Pid, true);
     if (m_inboundPipe == INVALID_HANDLE_VALUE)
     {
         return false;
     }
 
-    m_outboundPipe = CreateOneWayPipe(id, false);
+    m_outboundPipe = CreateOneWayPipe(pd.m_Pid, false);
     if (m_outboundPipe == INVALID_HANDLE_VALUE)
     {
         CloseHandle(m_inboundPipe);
@@ -45,19 +45,19 @@ bool TwoWayPipe::CreateServer(DWORD id)
 // Connects to a previously opened server side of the pipe.
 // Id is used to locate the pipe on the machine. 
 // true - success, false - failure (use GetLastError() for more details)
-bool TwoWayPipe::Connect(DWORD id)
+bool TwoWayPipe::Connect(const ProcessDescriptor& pd)
 {
     _ASSERTE(m_state == NotInitialized);
     if (m_state != NotInitialized)
         return false;
 
-    m_inboundPipe = OpenOneWayPipe(id, true);
+    m_inboundPipe = OpenOneWayPipe(pd.m_Pid, true);
     if (m_inboundPipe == INVALID_HANDLE_VALUE)
     {
         return false;
     }
 
-    m_outboundPipe = OpenOneWayPipe(id, false);
+    m_outboundPipe = OpenOneWayPipe(pd.m_Pid, false);
     if (m_outboundPipe == INVALID_HANDLE_VALUE)
     {
         CloseHandle(m_inboundPipe);

--- a/src/debug/di/dbgtransportmanager.cpp
+++ b/src/debug/di/dbgtransportmanager.cpp
@@ -47,12 +47,13 @@ void DbgTransportTarget::Shutdown()
 // Given a PID attempt to find or create a DbgTransportSession instance to manage a connection to a runtime in
 // that process. Returns E_UNEXPECTED if the process can't be found. Also returns a handle that can be waited
 // on for process termination.
-HRESULT DbgTransportTarget::GetTransportForProcess(DWORD                   dwPID,
-                                                   DbgTransportSession   **ppTransport,
-                                                   HANDLE                 *phProcessHandle)
+HRESULT DbgTransportTarget::GetTransportForProcess(const ProcessDescriptor  *pProcessDescriptor,
+                                                   DbgTransportSession     **ppTransport,
+                                                   HANDLE                   *phProcessHandle)
 {
     RSLockHolder lock(&m_sLock);
     HRESULT hr = S_OK;
+    DWORD dwPID = pProcessDescriptor->m_Pid;
 
     ProcessEntry *entry = LocateProcessByPID(dwPID);
 
@@ -78,7 +79,7 @@ HRESULT DbgTransportTarget::GetTransportForProcess(DWORD                   dwPID
        }
 
        // Initialize it (this immediately starts the remote connection process).
-       hr = transport->Init(dwPID, hProcess);
+       hr = transport->Init(*pProcessDescriptor, hProcess);
        if (FAILED(hr))
        {
            transport->Shutdown();

--- a/src/debug/di/dbgtransportmanager.h
+++ b/src/debug/di/dbgtransportmanager.h
@@ -20,13 +20,16 @@
 // Usual lifecycle looks like this:
 // Debug a new process:
 // * CreateProcess(&pid)
-// * GetTransportForProcess(pid, &transport) 
+// * On Mac, Optionally obtain an application group ID from a user
+// * Create a ProcessDescriptor pd
+// * GetTransportForProcess(&pd, &transport) 
 // * ReleaseTransport(transport)
 // * KillProcess(pid)
 
 // Attach to an existing process:
-// * Obtain pid from a user
-// * GetTransportForProcess(pid, &transport) 
+// * Obtain pid (and optionally application group ID on Mac) from a user
+// * Create a ProcessDescriptor pd
+// * GetTransportForProcess(&pd, &transport) 
 // * ReleaseTransport(transport)
 
 class DbgTransportTarget
@@ -37,7 +40,7 @@ public:
     // Given a PID attempt to find or create a DbgTransportSession instance to manage a connection to a
     // runtime in that process. Returns E_UNEXPECTED if the process can't be found. Also returns a handle that
     // can be waited on for process termination.
-    HRESULT GetTransportForProcess(DWORD dwPID, DbgTransportSession **ppTransport, HANDLE *phProcessHandle);
+    HRESULT GetTransportForProcess(const ProcessDescriptor *pProcessDescriptor, DbgTransportSession **ppTransport, HANDLE *phProcessHandle);
 
     // Give back a previously acquired transport (if nobody else is using the transport it will close down the
     // connection at this point).

--- a/src/debug/di/eventchannel.h
+++ b/src/debug/di/eventchannel.h
@@ -257,7 +257,7 @@ public:
 
 HRESULT NewEventChannelForThisPlatform(CORDB_ADDRESS pLeftSideDCB, 
                                        ICorDebugMutableDataTarget * pMutableDataTarget,
-                                       DWORD dwProcessId,
+                                       const ProcessDescriptor * pProcessDescriptor,
                                        MachineInfo machineInfo,
                                        IEventChannel ** ppEventChannel);
 

--- a/src/debug/di/eventredirectionpipeline.cpp
+++ b/src/debug/di/eventredirectionpipeline.cpp
@@ -293,13 +293,13 @@ HRESULT EventRedirectionPipeline::CreateProcessUnderDebugger(
 
 
 // Attach
-HRESULT EventRedirectionPipeline::DebugActiveProcess(MachineInfo machineInfo, DWORD processId)
+HRESULT EventRedirectionPipeline::DebugActiveProcess(MachineInfo machineInfo, const ProcessDescriptor& processDescriptor)
 {
-    m_dwProcessId = processId;
+    m_dwProcessId = processDescriptor.m_Pid;
 
     // Use redirected pipeline
     // Spin up debugger to attach to target.
-    return AttachDebuggerToTarget(m_AttachParams.Value(), processId);
+    return AttachDebuggerToTarget(m_AttachParams.Value(), processDescriptor.m_Pid);
 }
 
 // Detach

--- a/src/debug/di/eventredirectionpipeline.h
+++ b/src/debug/di/eventredirectionpipeline.h
@@ -59,7 +59,7 @@ public:
         LPPROCESS_INFORMATION lpProcessInformation);
 
     // Attach
-    virtual HRESULT DebugActiveProcess(MachineInfo machineInfo, DWORD processId);
+    virtual HRESULT DebugActiveProcess(MachineInfo machineInfo, const ProcessDescriptor& processDescriptor);
 
     // Detach
     virtual HRESULT DebugActiveProcessStop(DWORD processId);

--- a/src/debug/di/localeventchannel.cpp
+++ b/src/debug/di/localeventchannel.cpp
@@ -115,7 +115,7 @@ private:
 // Allocate and return an old-style event channel object for this target platform.
 HRESULT NewEventChannelForThisPlatform(CORDB_ADDRESS pLeftSideDCB, 
                                        ICorDebugMutableDataTarget * pMutableDataTarget, 
-                                       DWORD dwProcessId,
+                                       const ProcessDescriptor * pProcessDescriptor,
                                        MachineInfo machineInfo,
                                        IEventChannel ** ppEventChannel)
 {

--- a/src/debug/di/nativepipeline.h
+++ b/src/debug/di/nativepipeline.h
@@ -67,7 +67,7 @@ public:
         LPPROCESS_INFORMATION lpProcessInformation) = 0;
 
     // Attach
-    virtual HRESULT DebugActiveProcess(MachineInfo machineInfo, DWORD processId) = 0;
+    virtual HRESULT DebugActiveProcess(MachineInfo machineInfo, const ProcessDescriptor& processDescriptor) = 0;
 
     // Detach
     virtual HRESULT DebugActiveProcessStop(DWORD processId) =0;

--- a/src/debug/di/remoteeventchannel.cpp
+++ b/src/debug/di/remoteeventchannel.cpp
@@ -90,7 +90,7 @@ private:
 // Allocate and return an old-style event channel object for this target platform.
 HRESULT NewEventChannelForThisPlatform(CORDB_ADDRESS pLeftSideDCB, 
                                        ICorDebugMutableDataTarget * pMutableDataTarget,
-                                       DWORD dwProcessId,
+                                       const ProcessDescriptor * pProcessDescriptor,
                                        MachineInfo machineInfo,
                                        IEventChannel ** ppEventChannel)
 {
@@ -105,7 +105,7 @@ HRESULT NewEventChannelForThisPlatform(CORDB_ADDRESS pLeftSideDCB,
     DbgTransportTarget *   pProxy     = g_pDbgTransportTarget;
     DbgTransportSession *  pTransport = NULL;
 
-    hr = pProxy->GetTransportForProcess(dwProcessId, &pTransport, &hDummy);
+    hr = pProxy->GetTransportForProcess(pProcessDescriptor, &pTransport, &hDummy);
     if (FAILED(hr))
     {
         goto Label_Exit;

--- a/src/debug/di/rspriv.h
+++ b/src/debug/di/rspriv.h
@@ -44,6 +44,7 @@
 
 struct MachineInfo;
 
+#include "processdescriptor.h"
 #include "nativepipeline.h"
 #include "stringcopyholder.h"
 
@@ -2226,7 +2227,7 @@ public:
 #if defined(FEATURE_DBGIPC_TRANSPORT_DI)
     static COM_METHOD CreateObjectTelesto(REFIID id, void ** pObject);
 #endif // FEATURE_DBGIPC_TRANSPORT_DI
-    static COM_METHOD CreateObject(CorDebugInterfaceVersion iDebuggerVersion, REFIID id, void **object);
+    static COM_METHOD CreateObject(CorDebugInterfaceVersion iDebuggerVersion, DWORD pid, LPCWSTR lpApplicationGroupId, REFIID id, void **object);
 
     //-----------------------------------------------------------
     // ICorDebugRemote
@@ -2297,6 +2298,9 @@ public:
                                        CordbAppDomain *appDomain,
                                        DebuggerIPCEvent* event);
 
+private:
+    Cordb(CorDebugInterfaceVersion iDebuggerVersion, const ProcessDescriptor& pd);
+
     //-----------------------------------------------------------
     // Data members
     //-----------------------------------------------------------
@@ -2331,6 +2335,9 @@ private:
 
     // This is the version of the ICorDebug APIs that the debugger believes it's consuming.
     CorDebugInterfaceVersion    m_debuggerSpecifiedVersion;
+
+    // Store information about the process to be debugged
+    ProcessDescriptor m_pd;
 
 //Note - this code could be useful outside coresystem, but keeping the change localized
 // because we are late in the win8 release
@@ -2804,8 +2811,8 @@ void DeleteIPCEventHelper(DebuggerIPCEvent *pDel);
 class IProcessShimHooks
 {
 public:
-    // Get the OS Process ID of the target.
-    virtual DWORD GetPid() = 0;
+    // Get the OS Process descriptor of the target.
+    virtual const ProcessDescriptor* GetProcessDescriptor() = 0;
 
     // Request a synchronization for attach. 
     // This essentially just sends an AsyncBreak to the left-side. Once the target is
@@ -2932,7 +2939,7 @@ class CordbProcess :
 #endif
 {
     // Ctor is private. Use OpenVirtualProcess instead. 
-    CordbProcess(ULONG64 clrInstanceId, IUnknown * pDataTarget, HMODULE hDacModule,  Cordb * pCordb, DWORD dwProcessID, ShimProcess * pShim);
+    CordbProcess(ULONG64 clrInstanceId, IUnknown * pDataTarget, HMODULE hDacModule,  Cordb * pCordb, const ProcessDescriptor * pProcessDescriptor, ShimProcess * pShim);
 
 public:    
 
@@ -2952,7 +2959,7 @@ public:
                                       IUnknown * pDataTarget, 
                                       HMODULE hDacModule,
                                       Cordb * pCordb, 
-                                      DWORD dwProcessID, 
+                                      const ProcessDescriptor * pProcessDescriptor, 
                                       ShimProcess * pShim, 
                                       CordbProcess ** ppProcess);
 
@@ -3266,8 +3273,8 @@ public:
 
     bool IsThreadSuspendedOrHijacked(ICorDebugThread * pICorDebugThread);
 
-    // Helper to get PID internally.
-    DWORD GetPid();
+    // Helper to get ProcessDescriptor internally.
+    const ProcessDescriptor* GetProcessDescriptor();
 
     HRESULT GetRuntimeOffsets();
         
@@ -3707,6 +3714,9 @@ private:
     // For Mac debugging, this handle is of course not the real process handle.  This is just a handle to
     // wait on for process termination.
     HANDLE                m_handle;
+
+    // Process descriptor - holds PID and App group ID for Mac debugging
+    ProcessDescriptor m_processDescriptor;
 
 public:
     // Wrapper to get the OS process handle. This is unsafe because it breaks the data-target abstraction.
@@ -10084,7 +10094,7 @@ public:
                                    CorDebugCreateProcessFlags corDebugFlags);
 
     HRESULT SendDebugActiveProcessEvent(MachineInfo machineInfo,
-                                        DWORD pid,
+                                        const ProcessDescriptor *pProcessDescriptor,
                                         bool fWin32Attach,
                                         CordbProcess *pProcess);
 
@@ -10183,12 +10193,12 @@ private:
 
         struct
         {
-            MachineInfo     machineInfo;
-            DWORD           processId;
+            MachineInfo machineInfo;
+            ProcessDescriptor processDescriptor;
 #if !defined(FEATURE_DBGIPC_TRANSPORT_DI)
-            bool            fWin32Attach;
+            bool fWin32Attach;
 #endif
-            CordbProcess    *pProcess;
+            CordbProcess *pProcess;
 
             // Wrapper to determine if we're interop-debugging.
             bool IsInteropDebugging()
@@ -10715,7 +10725,7 @@ private:
 class CorpubProcess : public CordbCommonBase, public ICorPublishProcess
 {
 public:
-    CorpubProcess(DWORD dwProcessId, 
+    CorpubProcess(const ProcessDescriptor * pProcessDescriptor,
         bool fManaged, 
         HANDLE hProcess,
         HANDLE hMutex, 
@@ -10774,7 +10784,7 @@ public:
     bool IsExited();
 
 public:
-    DWORD                           m_dwProcessId;
+    ProcessDescriptor               m_processDescriptor;
 
 private:
     bool                            m_fIsManaged;

--- a/src/debug/di/shimdatatarget.h
+++ b/src/debug/di/shimdatatarget.h
@@ -126,7 +126,7 @@ protected:
 //
 
 HRESULT BuildPlatformSpecificDataTarget(MachineInfo machineInfo,
-                                        DWORD processId, 
+                                        const ProcessDescriptor * pProcessDescriptor,
                                         ShimDataTarget ** ppDataTarget);
 
 #endif //  SHIMDATATARGET_H_

--- a/src/debug/di/shimlocaldatatarget.cpp
+++ b/src/debug/di/shimlocaldatatarget.cpp
@@ -208,7 +208,7 @@ void ShimLocalDataTarget::Dispose()
 //
 
 HRESULT BuildPlatformSpecificDataTarget(MachineInfo machineInfo,
-                                        DWORD processId, 
+                                        const ProcessDescriptor * pProcessDescriptor,
                                         ShimDataTarget ** ppDataTarget)
 {
     HRESULT hr = S_OK;
@@ -226,7 +226,7 @@ HRESULT BuildPlatformSpecificDataTarget(MachineInfo machineInfo,
         PROCESS_VM_WRITE          |
         SYNCHRONIZE,
         FALSE,
-        processId);
+        pProcessDescriptor->m_Pid);
 
     if (hProcess == NULL)
     {
@@ -247,7 +247,7 @@ HRESULT BuildPlatformSpecificDataTarget(MachineInfo machineInfo,
     {
         goto Label_Exit;
     }
-    pLocalDataTarget = new (nothrow) ShimLocalDataTarget(processId, hProcess);
+    pLocalDataTarget = new (nothrow) ShimLocalDataTarget(pProcessDescriptor->m_Pid, hProcess);
     if (pLocalDataTarget == NULL)
     {
         hr = E_OUTOFMEMORY;

--- a/src/debug/di/shimpriv.h
+++ b/src/debug/di/shimpriv.h
@@ -358,7 +358,7 @@ public:
     // 3. Create OS-debugging pipeline. This establishes the physical OS process and gets us a pid/handle
     // 4. pShim->InitializeDataTarget - this creates a reader/writer abstraction around the OS process.
     // 5. pShim->SetProcess() - this connects the Shim to the ICDProcess object.
-    HRESULT InitializeDataTarget(DWORD processId);
+    HRESULT InitializeDataTarget(const ProcessDescriptor * pProcessDescriptor);
     void SetProcess(ICorDebugProcess * pProcess);
 
     //-----------------------------------------------------------
@@ -384,7 +384,7 @@ public:
     static HRESULT DebugActiveProcess(
         Cordb * pCordb,
         ICorDebugRemoteTarget * pRemoteTarget,
-        DWORD pid,
+        const ProcessDescriptor * pProcessDescriptor,
         BOOL win32Attach
 
     );

--- a/src/debug/di/shimprocess.cpp
+++ b/src/debug/di/shimprocess.cpp
@@ -132,7 +132,7 @@ void ShimProcess::SetProcess(ICorDebugProcess * pProcess)
     if (pProcess != NULL)
     {
         // Verify that DataTarget + new process have the same pid?
-        _ASSERTE(m_pProcess->GetPid() == m_pLiveDataTarget->GetPid());
+        _ASSERTE(m_pProcess->GetProcessDescriptor()->m_Pid == m_pLiveDataTarget->GetPid());
     }
 }
 
@@ -152,12 +152,12 @@ void ShimProcess::SetProcess(ICorDebugProcess * pProcess)
 // Notes:
 //    Only call this once, during the initialization dance. 
 //
-HRESULT ShimProcess::InitializeDataTarget(DWORD processId)
+HRESULT ShimProcess::InitializeDataTarget(const ProcessDescriptor * pProcessDescriptor)
 {
     _ASSERTE(m_pLiveDataTarget == NULL);
 
     
-    HRESULT hr = BuildPlatformSpecificDataTarget(GetMachineInfo(), processId, &m_pLiveDataTarget);
+    HRESULT hr = BuildPlatformSpecificDataTarget(GetMachineInfo(), pProcessDescriptor, &m_pLiveDataTarget);
     if (FAILED(hr))
     {
         _ASSERTE(m_pLiveDataTarget == NULL);

--- a/src/debug/di/shimremotedatatarget.cpp
+++ b/src/debug/di/shimremotedatatarget.cpp
@@ -154,7 +154,7 @@ void ShimRemoteDataTarget::Dispose()
 //
 
 HRESULT BuildPlatformSpecificDataTarget(MachineInfo machineInfo,
-                                        DWORD processId, 
+                                        const ProcessDescriptor * pProcessDescriptor,
                                         ShimDataTarget ** ppDataTarget)
 {
     HandleHolder hDummy;
@@ -164,7 +164,7 @@ HRESULT BuildPlatformSpecificDataTarget(MachineInfo machineInfo,
     DbgTransportTarget *   pProxy = g_pDbgTransportTarget;
     DbgTransportSession *  pTransport = NULL;
 
-    hr = pProxy->GetTransportForProcess(processId, &pTransport, &hDummy);
+    hr = pProxy->GetTransportForProcess(pProcessDescriptor, &pTransport, &hDummy);
     if (FAILED(hr))
     {
         goto Label_Exit;
@@ -176,7 +176,7 @@ HRESULT BuildPlatformSpecificDataTarget(MachineInfo machineInfo,
         goto Label_Exit;
     }
 
-    pRemoteDataTarget = new (nothrow) ShimRemoteDataTarget(processId, pProxy, pTransport);
+    pRemoteDataTarget = new (nothrow) ShimRemoteDataTarget(pProcessDescriptor->m_Pid, pProxy, pTransport);
     if (pRemoteDataTarget == NULL)
     {
         hr = E_OUTOFMEMORY;

--- a/src/debug/di/windowspipeline.cpp
+++ b/src/debug/di/windowspipeline.cpp
@@ -74,7 +74,7 @@ public:
         LPPROCESS_INFORMATION lpProcessInformation);
 
     // Attach
-    virtual HRESULT DebugActiveProcess(MachineInfo machineInfo, DWORD processId);
+    virtual HRESULT DebugActiveProcess(MachineInfo machineInfo, const ProcessDescriptor& processDescriptor);
 
     // Detach
     virtual HRESULT DebugActiveProcessStop(DWORD processId);
@@ -205,15 +205,15 @@ HRESULT WindowsNativePipeline::CreateProcessUnderDebugger(
 }
 
 // Attach the debugger to this process.
-HRESULT WindowsNativePipeline::DebugActiveProcess(MachineInfo machineInfo, DWORD processId)
+HRESULT WindowsNativePipeline::DebugActiveProcess(MachineInfo machineInfo, const ProcessDescriptor& processDescriptor)
 {
     HRESULT hr = E_FAIL;
-    BOOL ret = ::DebugActiveProcess(processId);
+    BOOL ret = ::DebugActiveProcess(processDescriptor.m_Pid);
 
     if (ret)
     {
         hr = S_OK;
-        m_dwProcessId = processId;
+        m_dwProcessId = processDescriptor.m_Pid;
         UpdateDebugSetProcessKillOnExit();
     }
     else
@@ -233,7 +233,7 @@ HRESULT WindowsNativePipeline::DebugActiveProcess(MachineInfo machineInfo, DWORD
             // attached.  But I think it's better to only return the specific error code if we know for sure
             // the case is true.
             BOOL fIsDebuggerPresent = FALSE;
-            if (SUCCEEDED(IsRemoteDebuggerPresent(processId, &fIsDebuggerPresent)))
+            if (SUCCEEDED(IsRemoteDebuggerPresent(processDescriptor.m_Pid, &fIsDebuggerPresent)))
             {
                 if (fIsDebuggerPresent)
                 {

--- a/src/debug/inc/dbgtransportsession.h
+++ b/src/debug/inc/dbgtransportsession.h
@@ -318,7 +318,7 @@ public:
     // requires the addresses of a couple of runtime data structures to service certain debugger requests that
     // may be delivered once the session is established.
 #ifdef RIGHT_SIDE_COMPILE
-    HRESULT Init(DWORD pid, HANDLE hProcessExited);
+    HRESULT Init(const ProcessDescriptor& pd, HANDLE hProcessExited);
 #else
     HRESULT Init(DebuggerIPCControlBlock * pDCB, AppDomainEnumerationIPCBlock * pADB);
 #endif // RIGHT_SIDE_COMPILE
@@ -717,11 +717,11 @@ private:
 
 #ifdef RIGHT_SIDE_COMPILE
     // On the RS the transport thread needs to know the IP address and port number to Connect() to.
-    DWORD           m_pid;                  // Id of a process we're talking to.
+    ProcessDescriptor m_pd;                  // Descriptor of a process we're talking to.
 
-    HANDLE          m_hProcessExited;       // event which will be signaled when the debuggee is terminated
+    HANDLE            m_hProcessExited;       // event which will be signaled when the debuggee is terminated
 
-    bool            m_fDebuggerAttached;
+    bool              m_fDebuggerAttached;
 #endif
 
     // Debugger event handling. To improve performance we allow the debugger to send as many events as it

--- a/src/debug/inc/processdescriptor.h
+++ b/src/debug/inc/processdescriptor.h
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//*****************************************************************************
+
+#ifndef _PROCESSCONTEXT_H
+#define _PROCESSCONTEXT_H
+
+struct ProcessDescriptor
+{
+    const static DWORD UNINITIALIZED_PID = 0;
+
+    static ProcessDescriptor Create(DWORD pid, LPCSTR applicationGroupId)
+    {
+        ProcessDescriptor pd;
+        pd.m_Pid = pid;
+        pd.m_ApplicationGroupId = applicationGroupId;
+
+        return pd;
+    }
+
+    static ProcessDescriptor FromCurrentProcess();
+    static ProcessDescriptor FromPid(DWORD pid)
+    {
+        return Create(pid, nullptr);
+    }
+    static ProcessDescriptor CreateUninitialized()
+    {
+        return Create(UNINITIALIZED_PID, nullptr);
+    }
+
+    bool IsInitialized() const { return m_Pid != UNINITIALIZED_PID; }
+
+    DWORD m_Pid;
+    LPCSTR m_ApplicationGroupId;
+};
+
+#endif // _PROCESSCONTEXT_H

--- a/src/debug/inc/twowaypipe.h
+++ b/src/debug/inc/twowaypipe.h
@@ -6,6 +6,8 @@
 #ifndef TwoWayPipe_H
 #define TwoWayPipe_H
 
+#include "processdescriptor.h"
+
 #ifdef FEATURE_PAL
 #define INVALID_PIPE -1
 #else
@@ -43,14 +45,14 @@ public:
     }
 
     // Creates a server side of the pipe. 
-    // Id is used to create pipes names and uniquely identify the pipe on the machine. 
+    // pd is used to create pipes names and uniquely identify the pipe on the machine. 
     // true - success, false - failure (use GetLastError() for more details)
-    bool CreateServer(DWORD id);
+    bool CreateServer(const ProcessDescriptor& pd);
 
     // Connects to a previously opened server side of the pipe.
-    // Id is used to locate the pipe on the machine. 
+    // pd is used to locate the pipe on the machine. 
     // true - success, false - failure (use GetLastError() for more details)
-    bool Connect(DWORD id);
+    bool Connect(const ProcessDescriptor& pd);
 
     // Waits for incoming client connections, assumes GetState() == Created
     // true - success, false - failure (use GetLastError() for more details)
@@ -83,7 +85,6 @@ private:
 
 #ifdef FEATURE_PAL
 
-    int m_id;                               // id that was passed to CreateServer() or Connect()
     int m_inboundPipe, m_outboundPipe;      // two one sided pipes used for communication
     char m_inPipeName[MAX_DEBUGGER_TRANSPORT_PIPE_NAME_LENGTH];   // filename of the inbound pipe
     char m_outPipeName[MAX_DEBUGGER_TRANSPORT_PIPE_NAME_LENGTH];  // filename of the outbound pipe

--- a/src/dlls/dbgshim/dbgshim.cpp
+++ b/src/dlls/dbgshim/dbgshim.cpp
@@ -194,10 +194,60 @@ GetContinueStartupEvent(
 
 // Functions that we'll look for in the loaded Mscordbi module.
 typedef HRESULT (STDAPICALLTYPE *FPCoreCLRCreateCordbObject)(
-    int iDebuggerVersion, 
-    DWORD pid, 
-    HMODULE hmodTargetCLR, 
+    int iDebuggerVersion,
+    DWORD pid,
+    HMODULE hmodTargetCLR,
     IUnknown **ppCordb);
+
+typedef HRESULT (STDAPICALLTYPE *FPCoreCLRCreateCordbObjectEx)(
+    int iDebuggerVersion,
+    DWORD pid,
+    LPCWSTR lpApplicationGroupId,
+    HMODULE hmodTargetCLR,
+    IUnknown **ppCordb);
+
+HRESULT CreateCoreDbgWithSandboxSupport(
+    HMODULE hCLRModule, HMODULE hDBIModule, DWORD processId, LPCWSTR lpApplicationGroupId, int iDebuggerVersion, IUnknown **ppCordb)
+{
+    FPCoreCLRCreateCordbObjectEx fpCreate =
+        (FPCoreCLRCreateCordbObjectEx)GetProcAddress(hDBIModule, "CoreCLRCreateCordbObjectEx");
+    if (fpCreate == NULL)
+    {
+        return CORDBG_E_INCOMPATIBLE_PROTOCOL;
+    }
+
+    return fpCreate(iDebuggerVersion, processId, lpApplicationGroupId, hCLRModule, ppCordb);
+}
+
+HRESULT CreateCoreDbgWithoutSandboxSupport(
+    HMODULE hCLRModule, HMODULE hDBIModule, DWORD processId, int iDebuggerVersion, IUnknown **ppCordb)
+{
+    FPCoreCLRCreateCordbObject fpCreate =
+        (FPCoreCLRCreateCordbObject)GetProcAddress(hDBIModule, "CoreCLRCreateCordbObject");
+    if (fpCreate == NULL)
+    {
+        return CORDBG_E_INCOMPATIBLE_PROTOCOL;
+    }
+
+    return fpCreate(iDebuggerVersion, processId, hCLRModule, ppCordb);
+}
+
+HRESULT CreateCoreDbg(
+    HMODULE hCLRModule, HMODULE hDBIModule, DWORD processId, LPCWSTR lpApplicationGroupId, int iDebuggerVersion, IUnknown **ppCordb)
+{
+    HRESULT hr = S_OK;
+
+    if (lpApplicationGroupId != NULL)
+    {
+        hr = CreateCoreDbgWithSandboxSupport(hCLRModule, hDBIModule, processId, lpApplicationGroupId, iDebuggerVersion, ppCordb);
+    }
+    else
+    {
+        hr = CreateCoreDbgWithoutSandboxSupport(hCLRModule, hDBIModule, processId, iDebuggerVersion, ppCordb);
+    }
+
+    return hr;
+}
 
 //
 // Helper class for RegisterForRuntimeStartup
@@ -210,6 +260,7 @@ class RuntimeStartupHelper
     PVOID m_parameter;
 #ifdef FEATURE_PAL
     PVOID m_unregisterToken;
+    LPCWSTR m_applicationGroupId;
 #else
     bool m_canceled;
     HANDLE m_startupEvent;
@@ -218,13 +269,14 @@ class RuntimeStartupHelper
 #endif // FEATURE_PAL
 
 public:
-    RuntimeStartupHelper(DWORD dwProcessId, PSTARTUP_CALLBACK pfnCallback, PVOID parameter) :
+    RuntimeStartupHelper(DWORD dwProcessId, LPCWSTR lpApplicationGroupId, PSTARTUP_CALLBACK pfnCallback, PVOID parameter) :
         m_ref(1),
         m_processId(dwProcessId),
         m_callback(pfnCallback),
         m_parameter(parameter),
 #ifdef FEATURE_PAL
-        m_unregisterToken(NULL)
+        m_unregisterToken(NULL),
+        m_applicationGroupId(lpApplicationGroupId)
 #else
         m_canceled(false),
         m_startupEvent(NULL),
@@ -268,7 +320,7 @@ public:
 
     HRESULT Register()
     {
-        DWORD pe = PAL_RegisterForRuntimeStartup(m_processId, RuntimeStartupHandler, this, &m_unregisterToken);
+        DWORD pe = PAL_RegisterForRuntimeStartup(m_processId, m_applicationGroupId, RuntimeStartupHandler, this, &m_unregisterToken);
         if (pe != NO_ERROR)
         {
             return HRESULT_FROM_WIN32(pe);
@@ -297,7 +349,6 @@ public:
 
         PAL_CPP_TRY
         {
-            FPCoreCLRCreateCordbObject fpCreate = NULL;
             char dbiPath[MAX_LONGPATH];
 
             char *pszLast = strrchr(pszModulePath, DIRECTORY_SEPARATOR_CHAR_A);
@@ -318,14 +369,7 @@ public:
                 goto exit;
             }
 
-            fpCreate = (FPCoreCLRCreateCordbObject)GetProcAddress(hMod, "CoreCLRCreateCordbObject");
-            if (fpCreate == NULL)
-            {
-                hr = CORDBG_E_INCOMPATIBLE_PROTOCOL;
-                goto exit;
-            }
-
-            HRESULT hr = fpCreate(CorDebugVersion_2_0, m_processId, hModule, &pCordb);
+            HRESULT hr = CreateCoreDbg(hModule, hMod, m_processId, m_applicationGroupId, CorDebugVersion_2_0, &pCordb);
             _ASSERTE((pCordb == NULL) == FAILED(hr));
             if (FAILED(hr))
             {
@@ -623,7 +667,28 @@ StartupHelperThread(LPVOID p)
 //-----------------------------------------------------------------------------
 // Public API.
 //
-// RegisterForRuntimeStartup -- executes the callback when the coreclr runtime 
+// RegisterForRuntimeStartup -- Refer to RegisterForRuntimeStartupEx.
+//      This method calls RegisterForRuntimeStartupEx with null application group ID value
+//
+// dwProcessId -- process id of the target process
+// pfnCallback -- invoked when coreclr runtime starts
+// parameter -- data to pass to callback
+// ppUnregisterToken -- pointer to put the UnregisterForRuntimeStartup token.
+//
+//-----------------------------------------------------------------------------
+HRESULT
+RegisterForRuntimeStartup(
+    __in DWORD dwProcessId,
+    __in PSTARTUP_CALLBACK pfnCallback,
+    __in PVOID parameter,
+    __out PVOID *ppUnregisterToken)
+{
+    return RegisterForRuntimeStartupEx(dwProcessId, NULL, pfnCallback, parameter, ppUnregisterToken);
+}
+//-----------------------------------------------------------------------------
+// Public API.
+//
+// RegisterForRuntimeStartupEx -- executes the callback when the coreclr runtime 
 //      starts in the specified process. The callback is passed the proper ICorDebug
 //      instance for the version of the runtime or an error if something fails. This
 //      API works for launch and attach (and even the attach scenario if the runtime
@@ -643,14 +708,18 @@ StartupHelperThread(LPVOID p)
 //      supported.
 //
 // dwProcessId -- process id of the target process
+// lpApplicationGroupId - A string representing the application group ID of a sandboxed
+//                        process running in Mac. Pass NULL if the process is not 
+//                        running in a sandbox and other platforms.
 // pfnCallback -- invoked when coreclr runtime starts
 // parameter -- data to pass to callback
 // ppUnregisterToken -- pointer to put the UnregisterForRuntimeStartup token.
 //
 //-----------------------------------------------------------------------------
 HRESULT
-RegisterForRuntimeStartup(
+RegisterForRuntimeStartupEx(
     __in DWORD dwProcessId,
+    __in LPCWSTR lpApplicationGroupId,
     __in PSTARTUP_CALLBACK pfnCallback,
     __in PVOID parameter,
     __out PVOID *ppUnregisterToken)
@@ -664,7 +733,7 @@ RegisterForRuntimeStartup(
 
     HRESULT hr = S_OK;
 
-    RuntimeStartupHelper *helper = new (nothrow) RuntimeStartupHelper(dwProcessId, pfnCallback, parameter);
+    RuntimeStartupHelper *helper = new (nothrow) RuntimeStartupHelper(dwProcessId, lpApplicationGroupId, pfnCallback, parameter);
     if (helper == NULL)
     {
         hr = E_OUTOFMEMORY;
@@ -1628,6 +1697,35 @@ CreateDebuggingInterfaceFromVersionEx(
     __in LPCWSTR szDebuggeeVersion,
     __out IUnknown ** ppCordb)
 {
+    return CreateDebuggingInterfaceFromVersion2(iDebuggerVersion, szDebuggeeVersion, NULL, ppCordb);
+}
+
+//-----------------------------------------------------------------------------
+// Public API.
+// Given a version string, create the matching mscordbi.dll for it.
+// Create a managed debugging interface for the specified version.
+//
+// Parameters:
+//    iDebuggerVersion - the version of interface the debugger (eg, Cordbg) expects.
+//    szDebuggeeVersion - the version of the debuggee. This will map to a version of mscordbi.dll
+//    lpApplicationGroupId - A string representing the application group ID of a sandboxed
+//                           process running in Mac. Pass NULL if the process is not 
+//                           running in a sandbox and other platforms.
+//    ppCordb - the outparameter used to return the debugging interface object.
+//
+// Return:
+//  S_OK on success. *ppCordb will be non-null.
+//  CORDBG_E_INCOMPATIBLE_PROTOCOL - if the proper DBI is not available. This can be a very common error if
+//    the right debug pack is not installed.
+//  else Error. (*ppCordb will be null)
+//-----------------------------------------------------------------------------
+HRESULT 
+CreateDebuggingInterfaceFromVersion2(
+    __in int iDebuggerVersion,
+    __in LPCWSTR szDebuggeeVersion,
+    __in LPCWSTR szApplicationGroupId,
+    __out IUnknown ** ppCordb)
+{
     PUBLIC_CONTRACT;
 
     HRESULT hrIgnore = S_OK; // ignored HResult
@@ -1707,17 +1805,8 @@ CreateDebuggingInterfaceFromVersionEx(
 
     //
     // Step 3: Now that module is loaded, instantiate an ICorDebug.
-    // 
-    fpCreate2 = (FPCoreCLRCreateCordbObject)GetProcAddress(hMod, "CoreCLRCreateCordbObject");
-    if (fpCreate2 == NULL)
-    {
-        // New-style creation API didn't exist - this DBI must be the wrong version, for the Mix07 protocol
-        hr = CORDBG_E_INCOMPATIBLE_PROTOCOL;
-        goto Exit;
-    }
-
-    // Invoke to instantiate an ICorDebug. This export was introduced after the Mix'07 release.
-    hr = fpCreate2(iDebuggerVersion, pidDebuggee, hmodTargetCLR, &pCordb);
+    //
+    hr = CreateCoreDbg(hmodTargetCLR, hMod, pidDebuggee, szApplicationGroupId, iDebuggerVersion, &pCordb);
     _ASSERTE((pCordb == NULL) == FAILED(hr));
 
 Exit:

--- a/src/dlls/dbgshim/dbgshim.cpp
+++ b/src/dlls/dbgshim/dbgshim.cpp
@@ -288,7 +288,12 @@ public:
 
     ~RuntimeStartupHelper()
     {
-#ifndef FEATURE_PAL
+#ifdef FEATURE_PAL
+        if (m_applicationGroupId != NULL)
+        {
+            delete m_applicationGroupId;
+        }
+#else // FEATURE_PAL
         if (m_startupEvent != NULL)
         {
             CloseHandle(m_startupEvent);
@@ -296,10 +301,6 @@ public:
         if (m_threadHandle != NULL)
         {
             CloseHandle(m_threadHandle);
-        }
-        if (m_applicationGroupId != NULL)
-        {
-            delete m_applicationGroupId;
         }
 #endif // FEATURE_PAL
     }
@@ -417,7 +418,7 @@ public:
 
 #else // FEATURE_PAL
 
-    HRESULT Register()
+    HRESULT Register(LPCWSTR lpApplicationGroupId)
     {
         HRESULT hr = GetStartupNotificationEvent(m_processId, &m_startupEvent);
         if (FAILED(hr))

--- a/src/dlls/dbgshim/dbgshim.h
+++ b/src/dlls/dbgshim/dbgshim.h
@@ -35,6 +35,14 @@ RegisterForRuntimeStartup(
     __out PVOID *ppUnregisterToken);
 
 EXTERN_C HRESULT
+RegisterForRuntimeStartupEx(
+    __in DWORD dwProcessId,
+    __in LPCWSTR szApplicationGroupId,
+    __in PSTARTUP_CALLBACK pfnCallback,
+    __in PVOID parameter,
+    __out PVOID *ppUnregisterToken);
+
+EXTERN_C HRESULT
 UnregisterForRuntimeStartup(
     __in PVOID pUnregisterToken);
 
@@ -67,6 +75,13 @@ EXTERN_C HRESULT
 CreateDebuggingInterfaceFromVersionEx(
     __in int iDebuggerVersion,
     __in LPCWSTR szDebuggeeVersion,
+    __out IUnknown ** ppCordb);
+
+EXTERN_C HRESULT 
+CreateDebuggingInterfaceFromVersion2(
+    __in int iDebuggerVersion,
+    __in LPCWSTR szDebuggeeVersion,
+    __in LPCWSTR szApplicationGroupId,
     __out IUnknown ** ppCordb);
 
 EXTERN_C HRESULT 

--- a/src/dlls/dbgshim/dbgshim.ntdef
+++ b/src/dlls/dbgshim/dbgshim.ntdef
@@ -15,4 +15,5 @@ EXPORTS
 	CreateVersionStringFromModule
 	CreateDebuggingInterfaceFromVersion
 	CreateDebuggingInterfaceFromVersionEx
+	CreateDebuggingInterfaceFromVersion2
 	CLRCreateInstance

--- a/src/dlls/dbgshim/dbgshim.ntdef
+++ b/src/dlls/dbgshim/dbgshim.ntdef
@@ -7,6 +7,7 @@ EXPORTS
         ResumeProcess
         CloseResumeHandle
         RegisterForRuntimeStartup
+	RegisterForRuntimeStartupEx
         UnregisterForRuntimeStartup
 	GetStartupNotificationEvent
 	EnumerateCLRs

--- a/src/dlls/dbgshim/dbgshim_unixexports.src
+++ b/src/dlls/dbgshim/dbgshim_unixexports.src
@@ -14,4 +14,5 @@ CloseCLREnumeration
 CreateVersionStringFromModule
 CreateDebuggingInterfaceFromVersion
 CreateDebuggingInterfaceFromVersionEx
+CreateDebuggingInterfaceFromVersion2
 CLRCreateInstance

--- a/src/dlls/dbgshim/dbgshim_unixexports.src
+++ b/src/dlls/dbgshim/dbgshim_unixexports.src
@@ -6,6 +6,7 @@ CreateProcessForLaunch
 ResumeProcess
 CloseResumeHandle
 RegisterForRuntimeStartup
+RegisterForRuntimeStartupEx
 UnregisterForRuntimeStartup
 GetStartupNotificationEvent
 EnumerateCLRs

--- a/src/dlls/mscordbi/mscordbi.src
+++ b/src/dlls/mscordbi/mscordbi.src
@@ -20,6 +20,7 @@ EXPORTS
     OpenVirtualProcess2
 
     CoreCLRCreateCordbObject private
+    CoreCLRCreateCordbObjectEx private
 
 #if defined(FEATURE_DBGIPC_TRANSPORT_DI)
     DllGetClassObject private

--- a/src/dlls/mscordbi/mscordbi_unixexports.src
+++ b/src/dlls/mscordbi/mscordbi_unixexports.src
@@ -8,6 +8,7 @@ DllGetClassObject
 
 ; CoreClr API
 CoreCLRCreateCordbObject
+CoreCLRCreateCordbObjectEx
 
 ; Out-of-proc creation path from the shim - ICLRDebugging
 OpenVirtualProcessImpl

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -448,10 +448,12 @@ BOOL
 PALAPI
 PAL_NotifyRuntimeStarted(VOID);
 
+#ifdef __APPLE__
 PALIMPORT
 LPCSTR
 PALAPI
 PAL_GetApplicationGroupId();
+#endif
 
 static const int MAX_DEBUGGER_TRANSPORT_PIPE_NAME_LENGTH = MAX_PATH;
 

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -432,6 +432,7 @@ DWORD
 PALAPI
 PAL_RegisterForRuntimeStartup(
     IN DWORD dwProcessId,
+    IN LPCWSTR lpApplicationGroupId,
     IN PPAL_STARTUP_CALLBACK pfnCallback,
     IN PVOID parameter,
     OUT PVOID *ppUnregisterToken);
@@ -447,12 +448,10 @@ BOOL
 PALAPI
 PAL_NotifyRuntimeStarted(VOID);
 
-#ifdef __APPLE__
 PALIMPORT
 LPCSTR
 PALAPI
 PAL_GetApplicationGroupId();
-#endif // __APPLE__
 
 static const int MAX_DEBUGGER_TRANSPORT_PIPE_NAME_LENGTH = MAX_PATH;
 
@@ -462,6 +461,7 @@ PALAPI
 PAL_GetTransportPipeName(
     OUT char *name,
     IN DWORD id,
+    IN const char *applicationGroupId, 
     IN const char *suffix);
 
 PALIMPORT

--- a/src/pal/src/include/pal/stackstring.hpp
+++ b/src/pal/src/include/pal/stackstring.hpp
@@ -244,12 +244,51 @@ public:
     }
 };
 
+template <SIZE_T STACKCOUNT>
+using CharString = StackString<STACKCOUNT, CHAR>;
+template <SIZE_T STACKCOUNT>
+using WCharString = StackString<STACKCOUNT, WCHAR>;
+
+template <SIZE_T STACKCOUNT>
+BOOL CharStringFromLPCWSTR(CharString<STACKCOUNT>& lpBuffer, LPCWSTR szString)
+{
+    int length = 0;
+
+    if (szString != nullptr)
+    {
+        length = WideCharToMultiByte(CP_ACP, 0, szString, -1, NULL, 0, NULL, NULL);
+
+        char *lpTemp = lpBuffer.OpenStringBuffer(length);
+
+        if (lpTemp != nullptr)
+        {
+            /* Convert to ASCII */
+            length = WideCharToMultiByte(CP_ACP, 0, szString, -1, lpTemp, length, NULL, NULL);
+        }
+        else
+        {
+            length = 0;
+        }
+    }
+
+    if (length > 0)
+    {
+        lpBuffer.CloseBuffer(length - 1);
+        return TRUE;
+    }
+    else
+    {
+        lpBuffer.Clear();
+        return FALSE;
+    }
+}
+
 #if _DEBUG
-typedef StackString<32, CHAR> PathCharString;
-typedef StackString<32, WCHAR> PathWCharString; 
+typedef CharString<32> PathCharString;
+typedef WCharString<32> PathWCharString; 
 #else
-typedef StackString<260, CHAR> PathCharString;
-typedef StackString<260, WCHAR> PathWCharString; 
+typedef CharString<MAX_PATH> PathCharString;
+typedef WCharString<MAX_PATH> PathWCharString; 
 #endif
 #endif
 

--- a/src/pal/src/include/pal/stackstring.hpp
+++ b/src/pal/src/include/pal/stackstring.hpp
@@ -109,7 +109,7 @@ private:
 
 public:
     StackString()
-        : m_buffer(m_innerBuffer), m_size(0), m_count(0)
+        : m_buffer(m_innerBuffer), m_size(STACKCOUNT+1), m_count(0)
     {
     }
 
@@ -237,6 +237,7 @@ public:
         m_count = 0;
         NullTerminate();
     }
+
     ~StackString()
     {
         DeleteBuffer();

--- a/src/pal/src/include/pal/stackstring.hpp
+++ b/src/pal/src/include/pal/stackstring.hpp
@@ -244,51 +244,12 @@ public:
     }
 };
 
-template <SIZE_T STACKCOUNT>
-using CharString = StackString<STACKCOUNT, CHAR>;
-template <SIZE_T STACKCOUNT>
-using WCharString = StackString<STACKCOUNT, WCHAR>;
-
-template <SIZE_T STACKCOUNT>
-BOOL CharStringFromLPCWSTR(CharString<STACKCOUNT>& lpBuffer, LPCWSTR szString)
-{
-    int length = 0;
-
-    if (szString != nullptr)
-    {
-        length = WideCharToMultiByte(CP_ACP, 0, szString, -1, NULL, 0, NULL, NULL);
-
-        char *lpTemp = lpBuffer.OpenStringBuffer(length);
-
-        if (lpTemp != nullptr)
-        {
-            /* Convert to ASCII */
-            length = WideCharToMultiByte(CP_ACP, 0, szString, -1, lpTemp, length, NULL, NULL);
-        }
-        else
-        {
-            length = 0;
-        }
-    }
-
-    if (length > 0)
-    {
-        lpBuffer.CloseBuffer(length - 1);
-        return TRUE;
-    }
-    else
-    {
-        lpBuffer.Clear();
-        return FALSE;
-    }
-}
-
 #if _DEBUG
-typedef CharString<32> PathCharString;
-typedef WCharString<32> PathWCharString; 
+typedef StackString<32, CHAR> PathCharString;
+typedef StackString<32, WCHAR> PathWCharString; 
 #else
-typedef CharString<MAX_PATH> PathCharString;
-typedef WCharString<MAX_PATH> PathWCharString; 
+typedef StackString<MAX_PATH, CHAR> PathCharString;
+typedef StackString<MAX_PATH, WCHAR> PathWCharString; 
 #endif
 #endif
 

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -1539,7 +1539,9 @@ class PAL_RuntimeStartupHelper
     DWORD m_threadId;
     HANDLE m_threadHandle;
     DWORD m_processId;
+#ifdef __APPLE__    
     CharString<MAX_APPLICATION_GROUP_ID_LENGTH> m_applicationGroupId;
+#endif // __APPLE__    
     SemaphoreNameString m_startupSemName;
     SemaphoreNameString m_continueSemName;
 
@@ -1556,7 +1558,11 @@ class PAL_RuntimeStartupHelper
 
     LPCSTR GetApplicationGroupId() const
     {
+#ifdef __APPLE__        
         return m_applicationGroupId.GetCount() == 0 ? nullptr : m_applicationGroupId;
+#else // __APPLE__
+        return nullptr;
+#endif // __APPLE__        
     }
 
 public:
@@ -1571,7 +1577,9 @@ public:
         m_startupSem(SEM_FAILED),
         m_continueSem(SEM_FAILED)
     {
+#ifdef __APPLE__        
         CharStringFromLPCWSTR(m_applicationGroupId, lpApplicationGroupId);
+#endif // __APPLE__        
     }
 
     ~PAL_RuntimeStartupHelper()
@@ -1648,6 +1656,7 @@ public:
         BOOL ret;
         UnambiguousProcessDescriptor unambiguousProcessDescriptor;
 
+#ifdef __APPLE__
         // Verify the length of the application group ID
         if (m_applicationGroupId.GetCount() > MAX_APPLICATION_GROUP_ID_LENGTH)
         {
@@ -1655,6 +1664,7 @@ public:
             pe = ERROR_BAD_LENGTH;
             goto exit;
         }
+#endif // __APPLE__
 
         // See semaphore name format for details about this value. We store it so that
         // it can be used by the cleanup code that removes the semaphore with sem_unlink.
@@ -2271,7 +2281,7 @@ PAL_GetTransportPipeName(
     // to 0. We expect that anyone else making the pipe name will also fail and thus will
     // also try to use 0 as the value.
     _ASSERTE(ret == TRUE || disambiguationKey == 0);
-
+#ifdef __APPLE
     if (nullptr != applicationGroupId)
     {
         // Verify the length of the application group ID
@@ -2299,6 +2309,7 @@ PAL_GetTransportPipeName(
         }
     }
     else
+#endif // __APPLE__    
     {
         // Get a temp file location
         dwRetVal = ::GetTempPathA(MAX_DEBUGGER_TRANSPORT_PIPE_NAME_LENGTH, formatBuffer);

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -2075,7 +2075,7 @@ const int SEMAPHORE_ENCODED_NAME_LENGTH =
 
 static_assert_no_msg(MAX_APPLICATION_GROUP_ID_LENGTH
     + 1 /* For / */
-    + 2 /* For DN header */
+    + 2 /* For ST/CO name prefix */
     + SEMAPHORE_ENCODED_NAME_LENGTH /* For encoded name string */
     + 1 /* For null terminator */
     <= CLR_SEM_MAX_NAMELEN);
@@ -2091,13 +2091,13 @@ void EncodeSemaphoreName(char *encodedSemName, const UnambiguousProcessDescripto
     char *extraEncodingBits = encodedSemName + sizeof(UnambiguousProcessDescriptor);
 
     // Reset the extra encoding bit area
-    for (int i=0;i<SEMAPHORE_ENCODED_NAME_EXTRA_LENGTH;i++)
+    for (int i=0; i<SEMAPHORE_ENCODED_NAME_EXTRA_LENGTH; i++)
     {
         extraEncodingBits[i] = 0x80;
     }
 
     // Encode each byte in unambiguousProcessDescriptor
-    for (int i=0;i<sizeof(UnambiguousProcessDescriptor);i++)
+    for (int i=0; i<sizeof(UnambiguousProcessDescriptor); i++)
     {
         unsigned char b = buffer[i];
         encodedSemName[i] = b ? b : 1;

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -1997,8 +1997,12 @@ PAL_NotifyRuntimeStarted()
     _ASSERTE(ret == TRUE || processIdDisambiguationKey == 0);
 
     UnambiguousProcessDescriptor unambiguousProcessDescriptor(gPID, processIdDisambiguationKey);
-    LPCSTR applicationGroupId = PAL_GetApplicationGroupId();
-
+    LPCSTR applicationGroupId = 
+#ifdef __APPLE__    
+        PAL_GetApplicationGroupId();
+#else
+        nullptr;
+#endif
     CreateSemaphoreName(startupSemName, RuntimeStartupSemaphoreName, unambiguousProcessDescriptor, applicationGroupId);
     CreateSemaphoreName(continueSemName, RuntimeContinueSemaphoreName, unambiguousProcessDescriptor, applicationGroupId);
 
@@ -2048,18 +2052,13 @@ exit:
     return launched;
 }
 
+#ifdef __APPLE__
 LPCSTR
 PALAPI
 PAL_GetApplicationGroupId()
 {
-#ifdef __APPLE__
     return gApplicationGroupId;
-#else // __APPLE
-    return nullptr;
-#endif
 }
-
-#ifdef __APPLE__
 
 // We use 7bits from each byte
 constexpr int BitNum2ByteNum(UINT number)

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -2063,12 +2063,12 @@ PAL_GetApplicationGroupId()
     return gApplicationGroupId;
 }
 
-// We use 7bits from each byte
-constexpr int BitNum2ByteNum(UINT number)
+// We use 7bits from each byte, so this computes the extra size we need to encode a given byte count
+constexpr int GetExtraEncodedAreaSize(UINT rawByteCount)
 {
-    return (number+6)/7;
+    return (rawByteCount+6)/7;
 }
-const int SEMAPHORE_ENCODED_NAME_EXTRA_LENGTH = BitNum2ByteNum(sizeof(UnambiguousProcessDescriptor));
+const int SEMAPHORE_ENCODED_NAME_EXTRA_LENGTH = GetExtraEncodedAreaSize(sizeof(UnambiguousProcessDescriptor));
 const int SEMAPHORE_ENCODED_NAME_LENGTH =
     sizeof(UnambiguousProcessDescriptor) + /* For process ID + disambiguationKey */
     SEMAPHORE_ENCODED_NAME_EXTRA_LENGTH; /* For base 255 extra encoding space */

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -2299,7 +2299,7 @@ PAL_GetTransportPipeName(
     // to 0. We expect that anyone else making the pipe name will also fail and thus will
     // also try to use 0 as the value.
     _ASSERTE(ret == TRUE || disambiguationKey == 0);
-#ifdef __APPLE
+#ifdef __APPLE__
     if (nullptr != applicationGroupId)
     {
         // Verify the length of the application group ID

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -186,9 +186,9 @@ enum FILETYPE
 };
 
 #pragma pack(push,1)
-// We later on reference this structure as a byte array in order to encode its data into a string.
-// Its important to make sure there is no padding between the fields and also at the end of the buffer. 
-// Hence, this structure is defined inside a pack(1)
+// When creating the semaphore name on Mac running in a sandbox, We reference this structure as a byte array 
+// in order to encode its data into a string. Its important to make sure there is no padding between the fields
+// and also at the end of the buffer. Hence, this structure is defined inside a pack(1)
 struct UnambiguousProcessDescriptor
 {
     UnambiguousProcessDescriptor()

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -186,6 +186,9 @@ enum FILETYPE
 };
 
 #pragma pack(push,1)
+// We later on reference this structure as a byte array in order to encode its data into a string.
+// Its important to make sure there is no padding between the fields and also at the end of the buffer. 
+// Hence, this structure is defined inside a pack(1)
 struct UnambiguousProcessDescriptor
 {
     UnambiguousProcessDescriptor()

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -1987,8 +1987,10 @@ PAL_NotifyRuntimeStarted()
     _ASSERTE(ret == TRUE || processIdDisambiguationKey == 0);
 
     UnambiguousProcessDescriptor unambiguousProcessDescriptor(gPID, processIdDisambiguationKey);
-    CreateSemaphoreName(startupSemName, unambiguousProcessDescriptor, gApplicationGroupId);
-    CreateSemaphoreName(continueSemName, unambiguousProcessDescriptor, gApplicationGroupId);
+    LPCSTR applicationGroupId = PAL_GetApplicationGroupId();
+
+    CreateSemaphoreName(startupSemName, unambiguousProcessDescriptor, applicationGroupId);
+    CreateSemaphoreName(continueSemName, unambiguousProcessDescriptor, applicationGroupId);
 
     TRACE("PAL_NotifyRuntimeStarted opening continue '%s' startup '%s'\n", (const char*)continueSemName, (const char*)startupSemName);
 
@@ -2040,7 +2042,11 @@ LPCSTR
 PALAPI
 PAL_GetApplicationGroupId()
 {
+#ifdef __APPLE__
     return gApplicationGroupId;
+#else // __APPLE
+    return nullptr;
+#endif
 }
 
 #ifdef __APPLE__

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -63,6 +63,7 @@ SET_DEFAULT_DEBUG_CHANNEL(PROCESS); // some headers have code with asserts, so d
 
 #ifdef __APPLE__
 #include <sys/sysctl.h>
+#include <sys/posix_sem.h>
 #endif
 
 #ifdef __NetBSD__
@@ -151,9 +152,13 @@ PathCharString* gSharedFilesPath = nullptr;
 // MacOSX 10.11: 31 -- Core 1.0 RC2 compatibility
 #if defined(__NetBSD__)
 #define CLR_SEM_MAX_NAMELEN 15
+#elif defined(__APPLE__)
+#define CLR_SEM_MAX_NAMELEN PSEMNAMLEN
 #else
-#define CLR_SEM_MAX_NAMELEN (NAME_MAX - 4)
+#define CLR_SEM_MAX_NAMELEN NAME_MAX - 4
 #endif
+
+static_assert_no_msg(CLR_SEM_MAX_NAMELEN <= MAX_PATH);
 
 // Function to call during PAL/process shutdown/abort
 Volatile<PSHUTDOWN_CALLBACK> g_shutdownCallback = nullptr;
@@ -180,6 +185,30 @@ enum FILETYPE
     FILE_DIR   /*Directory*/
 };
 
+#pragma pack(push,1)
+struct UnambiguousProcessDescriptor
+{
+    UnambiguousProcessDescriptor()
+    {
+    }
+
+    UnambiguousProcessDescriptor(DWORD processId, UINT64 disambiguationKey)
+    {
+        Init(processId, disambiguationKey);
+    }
+
+    void Init(DWORD processId, UINT64 disambiguationKey)
+    {
+        m_processId = processId;
+        m_disambiguationKey = disambiguationKey;
+    }
+    UINT64 m_disambiguationKey;
+    DWORD m_processId;
+};
+#pragma pack(pop)
+
+typedef CharString<CLR_SEM_MAX_NAMELEN-1> SemaphoreNameString;
+
 static
 DWORD
 PALAPI
@@ -198,6 +227,13 @@ PROCGetProcessStatus(
     HANDLE hProcess,
     PROCESS_STATE *pps,
     DWORD *pdwExitCode);
+
+static
+void 
+CreateSemaphoreName(
+    SemaphoreNameString& semName,
+    const UnambiguousProcessDescriptor& unambiguousProcessDescriptor,
+    LPCSTR applicationGroupId);
 
 static BOOL getFileName(LPCWSTR lpApplicationName, LPWSTR lpCommandLine, PathCharString& lpFileName);
 static char ** buildArgv(LPCWSTR lpCommandLine, PathCharString& lpAppPath, UINT *pnArg, BOOL prependLoader);
@@ -1480,7 +1516,7 @@ static const char* RuntimeStartupSemaphoreName = "/clrst%08llx";
 static const char* RuntimeContinueSemaphoreName = "/clrco%08llx";
 #else
 static const char* RuntimeStartupSemaphoreName = "/clrst%08x%016llx";
-static const char* RuntimeContinueSemaphoreName = "/clrco%08x%016llx";
+static const char* RuntimeContinueSspemaphoreName = "/clrco%08x%016llx";
 #endif
 
 #if defined(__NetBSD__)
@@ -1503,6 +1539,9 @@ class PAL_RuntimeStartupHelper
     DWORD m_threadId;
     HANDLE m_threadHandle;
     DWORD m_processId;
+    CharString<MAX_APPLICATION_GROUP_ID_LENGTH> m_applicationGroupId;
+    SemaphoreNameString m_startupSemName;
+    SemaphoreNameString m_continueSemName;
 
     // A value that, used in conjunction with the process ID, uniquely identifies a process.
     // See the format we use for debugger semaphore names for why this is necessary.
@@ -1515,8 +1554,13 @@ class PAL_RuntimeStartupHelper
     // registered (m_callback) returns.
     sem_t *m_continueSem;
 
+    LPCSTR GetApplicationGroupId() const
+    {
+        return m_applicationGroupId.GetCount() == 0 ? nullptr : m_applicationGroupId;
+    }
+
 public:
-    PAL_RuntimeStartupHelper(DWORD dwProcessId, PPAL_STARTUP_CALLBACK pfnCallback, PVOID parameter) :
+    PAL_RuntimeStartupHelper(DWORD dwProcessId, LPCWSTR lpApplicationGroupId, PPAL_STARTUP_CALLBACK pfnCallback, PVOID parameter) :
         m_ref(1),
         m_canceled(false),
         m_callback(pfnCallback),
@@ -1527,34 +1571,21 @@ public:
         m_startupSem(SEM_FAILED),
         m_continueSem(SEM_FAILED)
     {
+        CharStringFromLPCWSTR(m_applicationGroupId, lpApplicationGroupId);
     }
 
     ~PAL_RuntimeStartupHelper()
     {
         if (m_startupSem != SEM_FAILED)
         {
-            char startupSemName[CLR_SEM_MAX_NAMELEN];
-            sprintf_s(startupSemName,
-                      sizeof(startupSemName),
-                      RuntimeStartupSemaphoreName,
-                      HashSemaphoreName(m_processId,
-                                        m_processIdDisambiguationKey));
-
             sem_close(m_startupSem);
-            sem_unlink(startupSemName);
+            sem_unlink(m_startupSemName);
         }
 
         if (m_continueSem != SEM_FAILED)
         {
-            char continueSemName[CLR_SEM_MAX_NAMELEN];
-            sprintf_s(continueSemName,
-                      sizeof(continueSemName),
-                      RuntimeContinueSemaphoreName,
-                      HashSemaphoreName(m_processId,
-                                        m_processIdDisambiguationKey));
-
             sem_close(m_continueSem);
-            sem_unlink(continueSemName);
+            sem_unlink(m_continueSemName);
         }
 
         if (m_threadHandle != NULL)
@@ -1613,36 +1644,36 @@ public:
     PAL_ERROR Register()
     {
         CPalThread *pThread = InternalGetCurrentThread();
-        char startupSemName[CLR_SEM_MAX_NAMELEN];
-        char continueSemName[CLR_SEM_MAX_NAMELEN];
         PAL_ERROR pe = NO_ERROR;
+        BOOL ret;
+        UnambiguousProcessDescriptor unambiguousProcessDescriptor;
+
+        // Verify the length of the application group ID
+        if (m_applicationGroupId.GetCount() > MAX_APPLICATION_GROUP_ID_LENGTH)
+        {
+            TRACE("applicationGroupId: (%s) is too long. Maximum allowed length is %u\n", (const char *)m_applicationGroupId, MAX_APPLICATION_GROUP_ID_LENGTH);
+            pe = ERROR_BAD_LENGTH;
+            goto exit;
+        }
 
         // See semaphore name format for details about this value. We store it so that
         // it can be used by the cleanup code that removes the semaphore with sem_unlink.
-        BOOL ret = GetProcessIdDisambiguationKey(m_processId, &m_processIdDisambiguationKey);
+        ret = GetProcessIdDisambiguationKey(m_processId, &m_processIdDisambiguationKey);
 
         // If GetProcessIdDisambiguationKey failed for some reason, it should set the value 
         // to 0. We expect that anyone else opening the semaphore name will also fail and thus 
         // will also try to use 0 as the value.
         _ASSERTE(ret == TRUE || m_processIdDisambiguationKey == 0);
 
-        sprintf_s(startupSemName,
-                  sizeof(startupSemName),
-                  RuntimeStartupSemaphoreName,
-                  HashSemaphoreName(m_processId,
-                                    m_processIdDisambiguationKey));
+        unambiguousProcessDescriptor.Init(m_processId, m_processIdDisambiguationKey);
+        CreateSemaphoreName(m_startupSemName, unambiguousProcessDescriptor, GetApplicationGroupId());
+        CreateSemaphoreName(m_continueSemName, unambiguousProcessDescriptor, GetApplicationGroupId());
 
-        sprintf_s(continueSemName,
-                  sizeof(continueSemName),
-                  RuntimeContinueSemaphoreName,
-                  HashSemaphoreName(m_processId,
-                                    m_processIdDisambiguationKey));
-
-        TRACE("PAL_RuntimeStartupHelper.Register creating startup '%s' continue '%s'\n", startupSemName, continueSemName);
+        TRACE("PAL_RuntimeStartupHelper.Register creating startup '%s' continue '%s'\n", (const char*)m_startupSemName, (const char*)m_continueSemName);
 
         // Create the continue semaphore first so we don't race with PAL_NotifyRuntimeStarted. This open will fail if another 
         // debugger is trying to attach to this process because the name will already exist.
-        m_continueSem = sem_open(continueSemName, O_CREAT | O_EXCL, S_IRWXU, 0);
+        m_continueSem = sem_open(m_continueSemName, O_CREAT | O_EXCL, S_IRWXU, 0);
         if (m_continueSem == SEM_FAILED)
         {
             TRACE("sem_open(continue) failed: errno is %d (%s)\n", errno, strerror(errno));
@@ -1651,7 +1682,7 @@ public:
         }
 
         // Create the debuggee startup semaphore so the runtime (debuggee) knows to wait for a debugger connection.
-        m_startupSem = sem_open(startupSemName, O_CREAT | O_EXCL, S_IRWXU, 0);
+        m_startupSem = sem_open(m_startupSemName, O_CREAT | O_EXCL, S_IRWXU, 0);
         if (m_startupSem == SEM_FAILED)
         {
             TRACE("sem_open(startup) failed: errno is %d (%s)\n", errno, strerror(errno));
@@ -1727,7 +1758,7 @@ public:
     {
         char pipeName[MAX_DEBUGGER_TRANSPORT_PIPE_NAME_LENGTH];  
 
-        PAL_GetTransportPipeName(pipeName, m_processId, "in");
+        PAL_GetTransportPipeName(pipeName, m_processId, GetApplicationGroupId(), "in");
 
         struct stat buf;
         if (stat(pipeName, &buf) == 0) 
@@ -1842,6 +1873,9 @@ StartupHelperThread(LPVOID p)
 
 Parameters:
     dwProcessId - process id of runtime process
+    lpApplicationGroupId - A string representing the application group ID of a sandboxed
+                           process running in Mac. Pass NULL if the process is not 
+                           running in a sandbox and other platforms.
     pfnCallback - function to callback for coreclr module found
     parameter - data to pass to callback
     ppUnregisterToken - pointer to put PAL_UnregisterForRuntimeStartup token.
@@ -1862,6 +1896,7 @@ DWORD
 PALAPI
 PAL_RegisterForRuntimeStartup(
     IN DWORD dwProcessId,
+    IN LPCWSTR lpApplicationGroupId,
     IN PPAL_STARTUP_CALLBACK pfnCallback,
     IN PVOID parameter,
     OUT PVOID *ppUnregisterToken)
@@ -1869,7 +1904,7 @@ PAL_RegisterForRuntimeStartup(
     _ASSERTE(pfnCallback != NULL);
     _ASSERTE(ppUnregisterToken != NULL);
 
-    PAL_RuntimeStartupHelper *helper = InternalNew<PAL_RuntimeStartupHelper>(dwProcessId, pfnCallback, parameter);
+    PAL_RuntimeStartupHelper *helper = InternalNew<PAL_RuntimeStartupHelper>(dwProcessId, lpApplicationGroupId, pfnCallback, parameter);
 
     // Create the debuggee startup semaphore so the runtime (debuggee) knows to wait for 
     // a debugger connection.
@@ -1927,8 +1962,8 @@ BOOL
 PALAPI
 PAL_NotifyRuntimeStarted()
 {
-    char startupSemName[CLR_SEM_MAX_NAMELEN];
-    char continueSemName[CLR_SEM_MAX_NAMELEN];
+    SemaphoreNameString startupSemName;
+    SemaphoreNameString continueSemName;
     sem_t *startupSem = SEM_FAILED;
     sem_t *continueSem = SEM_FAILED;
     BOOL launched = FALSE;
@@ -1941,23 +1976,24 @@ PAL_NotifyRuntimeStarted()
     // will also try to use 0 as the value.
     _ASSERTE(ret == TRUE || processIdDisambiguationKey == 0);
 
-    sprintf_s(startupSemName, sizeof(startupSemName), RuntimeStartupSemaphoreName, HashSemaphoreName(gPID, processIdDisambiguationKey));
-    sprintf_s(continueSemName, sizeof(continueSemName), RuntimeContinueSemaphoreName, HashSemaphoreName(gPID, processIdDisambiguationKey));
+    UnambiguousProcessDescriptor unambiguousProcessDescriptor(gPID, processIdDisambiguationKey);
+    CreateSemaphoreName(startupSemName, unambiguousProcessDescriptor, gApplicationGroupId);
+    CreateSemaphoreName(continueSemName, unambiguousProcessDescriptor, gApplicationGroupId);
 
-    TRACE("PAL_NotifyRuntimeStarted opening continue '%s' startup '%s'\n", continueSemName, startupSemName);
+    TRACE("PAL_NotifyRuntimeStarted opening continue '%s' startup '%s'\n", (const char*)continueSemName, (const char*)startupSemName);
 
     // Open the debugger startup semaphore. If it doesn't exists, then we do nothing and return
     startupSem = sem_open(startupSemName, 0);
     if (startupSem == SEM_FAILED)
     {
-        TRACE("sem_open(%s) failed: %d (%s)\n", startupSemName, errno, strerror(errno));
+        TRACE("sem_open(%s) failed: %d (%s)\n", (const char*)startupSemName, errno, strerror(errno));
         goto exit;
     }
 
     continueSem = sem_open(continueSemName, 0);
     if (continueSem == SEM_FAILED)
     {
-        ASSERT("sem_open(%s) failed: %d (%s)\n", continueSemName, errno, strerror(errno));
+        ASSERT("sem_open(%s) failed: %d (%s)\n", (const char*)continueSemName, errno, strerror(errno));
         goto exit;
     }
 
@@ -1990,14 +2026,86 @@ exit:
     return launched;
 }
 
-#ifdef __APPLE__
 LPCSTR
 PALAPI
 PAL_GetApplicationGroupId()
 {
     return gApplicationGroupId;
 }
-#endif // __APPLE__
+
+#ifdef __APPLE__
+
+// We use 7bits from each byte
+constexpr int BitNum2ByteNum(UINT number)
+{
+    return (number+6)/7;
+}
+const int SEMAPHORE_ENCODED_NAME_EXTRA_LENGTH = BitNum2ByteNum(sizeof(UnambiguousProcessDescriptor));
+const int SEMAPHORE_ENCODED_NAME_LENGTH =
+    sizeof(UnambiguousProcessDescriptor) + /* For process ID + disambiguationKey */
+    SEMAPHORE_ENCODED_NAME_EXTRA_LENGTH; /* For base 255 extra encoding space */
+
+static_assert_no_msg(MAX_APPLICATION_GROUP_ID_LENGTH
+    + 1 /* For / */
+    + 2 /* For DN header */
+    + SEMAPHORE_ENCODED_NAME_LENGTH /* For encoded name string */
+    + 1 /* For null terminator */
+    <= CLR_SEM_MAX_NAMELEN);
+
+// In Apple we are limited by the length of the semaphore name. However, the characters which can be used in the
+// name can be anything between 1 and 255 (since 0 will terminate the string). Thus, we encode each byte b in 
+// unambiguousProcessDescriptor as b ? b : 1, and mark an additional bit indicating if b is 0 or not. We use 7 bits
+// out of each extra byte so 1 bit will always be '1'. This will ensure that our extra bytes are never 0 which are
+// invalid characters. Thus we need an extra byte for each 7 input bytes. Hence, only extra 2 bytes for the name string.
+void EncodeSemaphoreName(char *encodedSemName, const UnambiguousProcessDescriptor& unambiguousProcessDescriptor)
+{
+    const unsigned char *buffer = (const unsigned char *)&unambiguousProcessDescriptor;
+    char *extraEncodingBits = encodedSemName + sizeof(UnambiguousProcessDescriptor);
+
+    // Reset the extra encoding bit area
+    for (int i=0;i<SEMAPHORE_ENCODED_NAME_EXTRA_LENGTH;i++)
+    {
+        extraEncodingBits[i] = 0x80;
+    }
+
+    // Encode each byte in unambiguousProcessDescriptor
+    for (int i=0;i<sizeof(UnambiguousProcessDescriptor);i++)
+    {
+        unsigned char b = buffer[i];
+        encodedSemName[i] = b ? b : 1;
+        extraEncodingBits[i/7] |= (b ? 0 : 1) << (i%7);
+    }
+}
+#endif
+
+void CreateSemaphoreName(SemaphoreNameString& semNameString, const UnambiguousProcessDescriptor& unambiguousProcessDescriptor, LPCSTR applicationGroupId)
+{
+    int length = 0;
+    char *semName = semNameString.OpenStringBuffer();
+
+#ifdef __APPLE__
+    if (applicationGroupId != nullptr)
+    {
+        // We assume here that applicationGroupId has been already tested for length and is less than MAX_APPLICATION_GROUP_ID_LENGTH
+        length = sprintf_s(semName, CLR_SEM_MAX_NAMELEN, "%s/DN", applicationGroupId);
+        _ASSERTE(length > 0 && length < CLR_SEM_MAX_NAMELEN);
+
+        EncodeSemaphoreName(semName+length, unambiguousProcessDescriptor);
+        length += SEMAPHORE_ENCODED_NAME_LENGTH;
+        semName[length] = 0;
+    }
+    else
+#endif // __APPLE__    
+    {
+        length = sprintf_s(
+            semName,
+            CLR_SEM_MAX_NAMELEN,
+            RuntimeStartupSemaphoreName,
+            HashSemaphoreName(unambiguousProcessDescriptor.m_processId, unambiguousProcessDescriptor.m_disambiguationKey));
+    }
+
+    _ASSERTE(length > 0 && length < CLR_SEM_MAX_NAMELEN );
+}
 
 /*++
  Function:
@@ -2144,33 +2252,69 @@ PALAPI
 PAL_GetTransportPipeName(
     OUT char *name,
     IN DWORD id,
+    IN const char *applicationGroupId,
     IN const char *suffix)
 {
     *name = '\0';
     DWORD dwRetVal = 0;
     UINT64 disambiguationKey = 0;
-    char formatBuffer[MAX_DEBUGGER_TRANSPORT_PIPE_NAME_LENGTH];
+    PathCharString formatBufferString;
     BOOL ret = GetProcessIdDisambiguationKey(id, &disambiguationKey);
+    char *formatBuffer = formatBufferString.OpenStringBuffer(MAX_DEBUGGER_TRANSPORT_PIPE_NAME_LENGTH-1);
+    if (formatBuffer == nullptr)
+    {
+        ERROR("Out Of Memory");
+        return;
+    }
 
     // If GetProcessIdDisambiguationKey failed for some reason, it should set the value 
     // to 0. We expect that anyone else making the pipe name will also fail and thus will
     // also try to use 0 as the value.
     _ASSERTE(ret == TRUE || disambiguationKey == 0);
 
-    // Get a temp file location
-    dwRetVal = ::GetTempPathA(MAX_DEBUGGER_TRANSPORT_PIPE_NAME_LENGTH, formatBuffer);
-    if (dwRetVal == 0)
+    if (nullptr != applicationGroupId)
     {
-        ERROR("GetTempPath failed (0x%08x)", ::GetLastError());
-        return;
+        // Verify the length of the application group ID
+        int applicationGroupIdLength = strlen(applicationGroupId);
+        if (applicationGroupIdLength > MAX_APPLICATION_GROUP_ID_LENGTH)
+        {
+            ERROR("The length of applicationGroupId is larger than MAX_APPLICATION_GROUP_ID_LENGTH");
+            return;
+        }
+
+        // In sandbox, all IPC files (locks, pipes) should be written to the application group
+        // container. The path returned by GetTempPathA will be unique for each process and cannot
+        // be used for IPC between two different processes
+        if (!GetApplicationContainerFolder(formatBufferString, applicationGroupId, applicationGroupIdLength))
+        {
+            ERROR("Out Of Memory");
+            return;
+        }
+
+        // Verify the size of the path won't exceed maximum allowed size
+        if (formatBufferString.GetCount() >= MAX_DEBUGGER_TRANSPORT_PIPE_NAME_LENGTH)
+        {
+            ERROR("GetApplicationContainerFolder returned a path that was larger than MAX_DEBUGGER_TRANSPORT_PIPE_NAME_LENGTH");
+            return;
+        }
     }
-    if (dwRetVal > MAX_DEBUGGER_TRANSPORT_PIPE_NAME_LENGTH)
+    else
     {
-        ERROR("GetTempPath returned a path that was larger than MAX_DEBUGGER_TRANSPORT_PIPE_NAME_LENGTH");
-        return;
+        // Get a temp file location
+        dwRetVal = ::GetTempPathA(MAX_DEBUGGER_TRANSPORT_PIPE_NAME_LENGTH, formatBuffer);
+        if (dwRetVal == 0)
+        {
+            ERROR("GetTempPath failed (0x%08x)", ::GetLastError());
+            return;
+        }
+        if (dwRetVal > MAX_DEBUGGER_TRANSPORT_PIPE_NAME_LENGTH)
+        {
+            ERROR("GetTempPath returned a path that was larger than MAX_DEBUGGER_TRANSPORT_PIPE_NAME_LENGTH");
+            return;
+        }
     }
 
-    if (strncat_s(formatBuffer, _countof(formatBuffer), PipeNameFormat, strlen(PipeNameFormat)) == STRUNCATE)
+    if (strncat_s(formatBuffer, MAX_DEBUGGER_TRANSPORT_PIPE_NAME_LENGTH, PipeNameFormat, strlen(PipeNameFormat)) == STRUNCATE)
     {
         ERROR("TransportPipeName was larger than MAX_DEBUGGER_TRANSPORT_PIPE_NAME_LENGTH");
         return;


### PR DESCRIPTION
This change fixes the usage of IPC while debugging while running in a sandbox. When running in a sandbox, the temporary folder for each process will be different. Thus the pipes being created in TwoWayPipe right now would be created in different directories in the debugger process and the process being debugged.
This change configures the folder to be used based on the application group ID that the sandboxed app belongs to.

For the same reasons, the names sempahores being used to synchronize the debugger attach need to be prefixed with the application group ID. This change was abit more involved since the name of the semaphore is limited to 31 characters, so we had to encode the semaphore names differently to make them shorter.

Last, new APIs to the debugger shim were added to support this new feature. This change only handles the runtime side and the dbgshim. An additional change to vsdbg needs to be done to use the new APIs.

fixes #21066 