### PR TITLE
Vectorize string.IndexOf(..., StringComparison.Ordinal)

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
@@ -235,44 +235,19 @@ namespace System.Globalization
             }
         }
 
-        internal unsafe int IndexOfCore(string source, string target, int startIndex, int count, CompareOptions options, int* matchLengthPtr)
+        internal unsafe int IndexOfPlatform(string source, string target, int startIndex, int count, CompareOptions options, int* matchLengthPtr)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
 
             Debug.Assert(!string.IsNullOrEmpty(source));
             Debug.Assert(target != null);
             Debug.Assert((options & CompareOptions.OrdinalIgnoreCase) == 0);
-
-            int index;
-
-            if (target.Length == 0)
-            {
-                if (matchLengthPtr != null)
-                    *matchLengthPtr = 0;
-                return startIndex;
-            }
-
-            if (options == CompareOptions.Ordinal)
-            {
-                index = SpanHelpers.IndexOf(
-                    ref Unsafe.Add(ref source.GetRawStringData(), startIndex),
-                    count,
-                    ref target.GetRawStringData(),
-                    target.Length);
-
-                if (index != -1)
-                {
-                    index += startIndex;
-                    if (matchLengthPtr != null)
-                        *matchLengthPtr = target.Length;
-                }
-                return index;
-            }
+            Debug.Assert((options & CompareOptions.Ordinal) == 0);
 
 #if CORECLR
             if (_isAsciiEqualityOrdinal && CanUseAsciiOrdinalForOptions(options) && source.IsFastSort() && target.IsFastSort())
             {
-                index = IndexOf(source, target, startIndex, count, GetOrdinalCompareOptions(options));
+                int index = IndexOf(source, target, startIndex, count, GetOrdinalCompareOptions(options));
                 if (index != -1)
                 {
                     if (matchLengthPtr != null)
@@ -285,7 +260,7 @@ namespace System.Globalization
             fixed (char* pSource = source)
             fixed (char* pTarget = target)
             {
-                index = Interop.Globalization.IndexOf(_sortHandle, pTarget, target.Length, pSource + startIndex, count, options, matchLengthPtr);
+                int index = Interop.Globalization.IndexOf(_sortHandle, pTarget, target.Length, pSource + startIndex, count, options, matchLengthPtr);
 
                 return index != -1 ? index + startIndex : -1;
             }

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
@@ -8,6 +8,8 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
 
+using Internal.Runtime.CompilerServices;
+
 namespace System.Globalization
 {
     public partial class CompareInfo
@@ -252,9 +254,15 @@ namespace System.Globalization
 
             if (options == CompareOptions.Ordinal)
             {
-                index = IndexOfOrdinal(source, target, startIndex, count, ignoreCase: false);
+                index = SpanHelpers.IndexOf(
+                    ref Unsafe.Add(ref source.GetRawStringData(), startIndex),
+                    count,
+                    ref target.GetRawStringData(),
+                    target.Length);
+
                 if (index != -1)
                 {
+                    index += startIndex;
                     if (matchLengthPtr != null)
                         *matchLengthPtr = target.Length;
                 }

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
@@ -235,7 +235,7 @@ namespace System.Globalization
             }
         }
 
-        internal unsafe int IndexOfPlatform(string source, string target, int startIndex, int count, CompareOptions options, int* matchLengthPtr)
+        internal unsafe int IndexOfCore(string source, string target, int startIndex, int count, CompareOptions options, int* matchLengthPtr)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
 

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Windows.cs
@@ -4,9 +4,9 @@
 
 using System.Buffers;
 using System.Diagnostics;
-using System.Security;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+
+using Internal.Runtime.CompilerServices;
 
 namespace System.Globalization
 {
@@ -342,12 +342,19 @@ namespace System.Globalization
 
             if ((options & CompareOptions.Ordinal) != 0)
             {
-                int retValue = FastIndexOfString(source, target, startIndex, count, target.Length, findLastIndex: false);
+                int retValue = SpanHelpers.IndexOf(
+                    ref Unsafe.Add(ref source.GetRawStringData(), startIndex),
+                    count,
+                    ref target.GetRawStringData(),
+                    target.Length);
+
                 if (retValue >= 0)
                 {
+                    retValue += startIndex;
                     if (matchLengthPtr != null)
                         *matchLengthPtr = target.Length;
                 }
+
                 return retValue;
             }
             else
@@ -388,7 +395,7 @@ namespace System.Globalization
 
             if ((options & CompareOptions.Ordinal) != 0)
             {
-                return FastIndexOfString(source, target, startIndex, count, target.Length, findLastIndex: true);
+                return FastLastIndexOfString(source, target, startIndex, count, target.Length);
             }
             else
             {
@@ -462,75 +469,43 @@ namespace System.Globalization
         private const int FIND_FROMSTART = 0x00400000;
         private const int FIND_FROMEND = 0x00800000;
 
-        // TODO: Instead of this method could we just have upstack code call IndexOfOrdinal with ignoreCase = false?
-        private static unsafe int FastIndexOfString(string source, string target, int startIndex, int sourceCount, int targetCount, bool findLastIndex)
+        // TODO: Instead of this method could we just have upstack code call LastIndexOfOrdinal with ignoreCase = false?
+        private static unsafe int FastLastIndexOfString(string source, string target, int startIndex, int sourceCount, int targetCount)
         {
             int retValue = -1;
 
-            int sourceStartIndex = findLastIndex ? startIndex - sourceCount + 1 : startIndex;
+            int sourceStartIndex = startIndex - sourceCount + 1;
 
             fixed (char* pSource = source, spTarget = target)
             {
                 char* spSubSource = pSource + sourceStartIndex;
 
-                if (findLastIndex)
+                int startPattern = (sourceCount - 1) - targetCount + 1;
+                if (startPattern < 0)
+                    return -1;
+
+                char patternChar0 = spTarget[0];
+                for (int ctrSrc = startPattern; ctrSrc >= 0; ctrSrc--)
                 {
-                    int startPattern = (sourceCount - 1) - targetCount + 1;
-                    if (startPattern < 0)
-                        return -1;
+                    if (spSubSource[ctrSrc] != patternChar0)
+                        continue;
 
-                    char patternChar0 = spTarget[0];
-                    for (int ctrSrc = startPattern; ctrSrc >= 0; ctrSrc--)
+                    int ctrPat;
+                    for (ctrPat = 1; ctrPat < targetCount; ctrPat++)
                     {
-                        if (spSubSource[ctrSrc] != patternChar0)
-                            continue;
-
-                        int ctrPat;
-                        for (ctrPat = 1; ctrPat < targetCount; ctrPat++)
-                        {
-                            if (spSubSource[ctrSrc + ctrPat] != spTarget[ctrPat])
-                                break;
-                        }
-                        if (ctrPat == targetCount)
-                        {
-                            retValue = ctrSrc;
+                        if (spSubSource[ctrSrc + ctrPat] != spTarget[ctrPat])
                             break;
-                        }
                     }
-
-                    if (retValue >= 0)
+                    if (ctrPat == targetCount)
                     {
-                        retValue += startIndex - sourceCount + 1;
+                        retValue = ctrSrc;
+                        break;
                     }
                 }
-                else
+
+                if (retValue >= 0)
                 {
-                    int endPattern = (sourceCount - 1) - targetCount + 1;
-                    if (endPattern < 0)
-                        return -1;
-
-                    char patternChar0 = spTarget[0];
-                    for (int ctrSrc = 0; ctrSrc <= endPattern; ctrSrc++)
-                    {
-                        if (spSubSource[ctrSrc] != patternChar0)
-                            continue;
-                        int ctrPat;
-                        for (ctrPat = 1; ctrPat < targetCount; ctrPat++)
-                        {
-                            if (spSubSource[ctrSrc + ctrPat] != spTarget[ctrPat])
-                                break;
-                        }
-                        if (ctrPat == targetCount)
-                        {
-                            retValue = ctrSrc;
-                            break;
-                        }
-                    }
-
-                    if (retValue >= 0)
-                    {
-                        retValue += startIndex;
-                    }
+                    retValue += startIndex - sourceCount + 1;
                 }
             }
 

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Windows.cs
@@ -320,7 +320,7 @@ namespace System.Globalization
             }
         }
 
-        internal unsafe int IndexOfPlatform(string source, string target, int startIndex, int count, CompareOptions options, int* matchLengthPtr)
+        internal unsafe int IndexOfCore(string source, string target, int startIndex, int count, CompareOptions options, int* matchLengthPtr)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
 

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
@@ -1036,22 +1036,13 @@ namespace System.Globalization
             return IndexOfCore(source, value, startIndex, count, options, null);
         }
 
-        internal int IndexOfOrdinal(ReadOnlySpan<char> source, ReadOnlySpan<char> value, bool ignoreCase)
+        internal int IndexOfOrdinalIgnoreCase(ReadOnlySpan<char> source, ReadOnlySpan<char> value)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
             Debug.Assert(!source.IsEmpty);
             Debug.Assert(!value.IsEmpty);
 
-            if (!ignoreCase)
-            {
-                return SpanHelpers.IndexOf(
-                    ref MemoryMarshal.GetReference(source),
-                    source.Length,
-                    ref MemoryMarshal.GetReference(value),
-                    value.Length);
-            }
-
-            return IndexOfOrdinalCore(source, value, ignoreCase, fromBeginning: true);
+            return IndexOfOrdinalCore(source, value, ignoreCase: true, fromBeginning: true);
         }
 
         internal int LastIndexOfOrdinal(ReadOnlySpan<char> source, ReadOnlySpan<char> value, bool ignoreCase)

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
@@ -1066,23 +1066,14 @@ namespace System.Globalization
                 *matchLengthPtr = 0;
             }
 
-            if (source.Length == 0)
+            if (value.Length == 0)
             {
-                if (value.Length == 0)
-                {
-                    return 0;
-                }
-                return -1;
+                return startIndex;
             }
 
             if (startIndex >= source.Length)
             {
                 return -1;
-            }
-
-            if (value.Length == 0)
-            {
-                return startIndex;
             }
 
             if (options == CompareOptions.OrdinalIgnoreCase)

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
@@ -974,7 +974,7 @@ namespace System.Globalization
 
             // Validate CompareOptions
             // Ordinal can't be selected with other flags
-            if ((options & ValidIndexMaskOffFlags) != 0 && (options != CompareOptions.Ordinal))
+            if ((options & ValidIndexMaskOffFlags) != 0 && (options != CompareOptions.Ordinal && options != CompareOptions.OrdinalIgnoreCase))
                 throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
 
             return IndexOf(source, new string(value, 1), startIndex, count, options, null);
@@ -1014,7 +1014,7 @@ namespace System.Globalization
 
             // Validate CompareOptions
             // Ordinal can't be selected with other flags
-            if ((options & ValidIndexMaskOffFlags) != 0 && (options != CompareOptions.Ordinal))
+            if ((options & ValidIndexMaskOffFlags) != 0 && (options != CompareOptions.Ordinal && options != CompareOptions.OrdinalIgnoreCase))
                 throw new ArgumentException(SR.Argument_InvalidFlag, nameof(options));
 
             return IndexOf(source, value, startIndex, count, options, null);

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
@@ -1116,6 +1116,49 @@ namespace System.Globalization
             return IndexOfCore(source, value, startIndex, count, options, matchLengthPtr);
         }
 
+        internal unsafe int IndexOfCore(string source, string target, int startIndex, int count, CompareOptions options, int* matchLengthPtr)
+        {
+            Debug.Assert(!GlobalizationMode.Invariant);
+
+            Debug.Assert(source != null);
+            Debug.Assert(target != null);
+            Debug.Assert((options & CompareOptions.OrdinalIgnoreCase) == 0);
+
+            if (target.Length == 0)
+            {
+                if (matchLengthPtr != null)
+                    *matchLengthPtr = 0;
+                return startIndex;
+            }
+
+            if (source.Length == 0)
+            {
+                return -1;
+            }
+
+            if (options == CompareOptions.Ordinal)
+            {
+                int retValue = SpanHelpers.IndexOf(
+                    ref Unsafe.Add(ref source.GetRawStringData(), startIndex),
+                    count,
+                    ref target.GetRawStringData(),
+                    target.Length);
+
+                if (retValue >= 0)
+                {
+                    retValue += startIndex;
+                    if (matchLengthPtr != null)
+                        *matchLengthPtr = target.Length;
+                }
+
+                return retValue;
+            }
+            else
+            {
+                return IndexOfPlatform(source, target, startIndex, count, options, matchLengthPtr);
+            }
+        }
+
         internal int IndexOfOrdinal(string source, string value, int startIndex, int count, bool ignoreCase)
         {
             if (!ignoreCase)

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
@@ -1041,6 +1041,16 @@ namespace System.Globalization
             Debug.Assert(!GlobalizationMode.Invariant);
             Debug.Assert(!source.IsEmpty);
             Debug.Assert(!value.IsEmpty);
+
+            if (!ignoreCase)
+            {
+                return SpanHelpers.IndexOf(
+                    ref MemoryMarshal.GetReference(source),
+                    source.Length,
+                    ref MemoryMarshal.GetReference(value),
+                    value.Length);
+            }
+
             return IndexOfOrdinalCore(source, value, ignoreCase, fromBeginning: true);
         }
 
@@ -1117,6 +1127,17 @@ namespace System.Globalization
 
         internal int IndexOfOrdinal(string source, string value, int startIndex, int count, bool ignoreCase)
         {
+            if (!ignoreCase)
+            {
+                int result = SpanHelpers.IndexOf(
+                    ref Unsafe.Add(ref source.GetRawStringData(), startIndex),
+                    count,
+                    ref value.GetRawStringData(),
+                    value.Length);
+
+                return (result >= 0 ? startIndex : 0) + result;
+            }
+
             if (GlobalizationMode.Invariant)
             {
                 return InvariantIndexOf(source, value, startIndex, count, ignoreCase);

--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
@@ -141,6 +141,15 @@ namespace System
                 return -1;
             }
 
+            if (comparisonType == StringComparison.Ordinal)
+            {
+                return SpanHelpers.IndexOf(
+                    ref MemoryMarshal.GetReference(span),
+                    span.Length,
+                    ref MemoryMarshal.GetReference(value),
+                    value.Length);
+            }
+
             if (GlobalizationMode.Invariant)
             {
                 return CompareInfo.InvariantIndexOf(span, value, string.GetCaseCompareOfComparisonCulture(comparisonType) != CompareOptions.None);

--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
@@ -152,7 +152,7 @@ namespace System
 
             if (GlobalizationMode.Invariant)
             {
-                return CompareInfo.InvariantIndexOf(span, value, ignoreCase: true);
+                return CompareInfo.InvariantIndexOf(span, value, string.GetCaseCompareOfComparisonCulture(comparisonType) != CompareOptions.None);
             }
 
             switch (comparisonType)

--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
@@ -152,7 +152,7 @@ namespace System
 
             if (GlobalizationMode.Invariant)
             {
-                return CompareInfo.InvariantIndexOf(span, value, string.GetCaseCompareOfComparisonCulture(comparisonType) != CompareOptions.None);
+                return CompareInfo.InvariantIndexOf(span, value, ignoreCase: true);
             }
 
             switch (comparisonType)
@@ -166,8 +166,8 @@ namespace System
                     return CompareInfo.Invariant.IndexOf(span, value, string.GetCaseCompareOfComparisonCulture(comparisonType));
 
                 default:
-                    Debug.Assert(comparisonType == StringComparison.Ordinal || comparisonType == StringComparison.OrdinalIgnoreCase);
-                    return CompareInfo.Invariant.IndexOfOrdinal(span, value, string.GetCaseCompareOfComparisonCulture(comparisonType) != CompareOptions.None);
+                    Debug.Assert(comparisonType == StringComparison.OrdinalIgnoreCase);
+                    return CompareInfo.Invariant.IndexOfOrdinalIgnoreCase(span, value);
             }
         }
 

--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.cs
@@ -296,6 +296,12 @@ namespace System
                     span.Length,
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(value)),
                     value.Length);
+            if (typeof(T) == typeof(char))
+                return SpanHelpers.IndexOf(
+                    ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
+                    span.Length,
+                    ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(value)),
+                    value.Length);
 
             return SpanHelpers.IndexOf(ref MemoryMarshal.GetReference(span), span.Length, ref MemoryMarshal.GetReference(value), value.Length);
         }
@@ -423,6 +429,12 @@ namespace System
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                     span.Length,
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(value)),
+                    value.Length);
+            if (typeof(T) == typeof(char))
+                return SpanHelpers.IndexOf(
+                    ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
+                    span.Length,
+                    ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(value)),
                     value.Length);
 
             return SpanHelpers.IndexOf(ref MemoryMarshal.GetReference(span), span.Length, ref MemoryMarshal.GetReference(value), value.Length);

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
@@ -38,9 +38,10 @@ namespace System
                 int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, index), valueHead, remainingSearchSpaceLength);
                 if (relativeIndex == -1)
                     break;
+
+                remainingSearchSpaceLength -= relativeIndex;
                 index += relativeIndex;
 
-                remainingSearchSpaceLength = searchSpaceLength - index - valueTailLength;
                 if (remainingSearchSpaceLength <= 0)
                     break;  // The unsearched portion is now shorter than the sequence we're looking for. So it can't be there.
 

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
@@ -29,25 +29,26 @@ namespace System
             byte valueHead = value;
             ref byte valueTail = ref Unsafe.Add(ref value, 1);
             int valueTailLength = valueLength - 1;
+            int remainingSearchSpaceLength = searchSpaceLength - valueTailLength;
 
             int index = 0;
-            for (; ; )
+            while (remainingSearchSpaceLength > 0)
             {
-                Debug.Assert(0 <= index && index <= searchSpaceLength); // Ensures no deceptive underflows in the computation of "remainingSearchSpaceLength".
-                int remainingSearchSpaceLength = searchSpaceLength - index - valueTailLength;
-                if (remainingSearchSpaceLength <= 0)
-                    break;  // The unsearched portion is now shorter than the sequence we're looking for. So it can't be there.
-
                 // Do a quick search for the first element of "value".
                 int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, index), valueHead, remainingSearchSpaceLength);
                 if (relativeIndex == -1)
                     break;
                 index += relativeIndex;
 
+                remainingSearchSpaceLength = searchSpaceLength - index - valueTailLength;
+                if (remainingSearchSpaceLength <= 0)
+                    break;  // The unsearched portion is now shorter than the sequence we're looking for. So it can't be there.
+
                 // Found the first element of "value". See if the tail matches.
                 if (SequenceEqual(ref Unsafe.Add(ref searchSpace, index + 1), ref valueTail, valueTailLength))
                     return index;  // The tail matched. Return a successful find.
 
+                remainingSearchSpaceLength--;
                 index++;
             }
             return -1;

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
@@ -40,9 +40,10 @@ namespace System
                 int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, index), valueHead, remainingSearchSpaceLength);
                 if (relativeIndex == -1)
                     break;
+
+                remainingSearchSpaceLength -= relativeIndex;
                 index += relativeIndex;
 
-                remainingSearchSpaceLength = searchSpaceLength - index - valueTailLength;
                 if (remainingSearchSpaceLength <= 0)
                     break;  // The unsearched portion is now shorter than the sequence we're looking for. So it can't be there.
 

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
@@ -10,10 +10,56 @@ using System.Numerics;
 using Internal.Runtime.CompilerServices;
 #endif
 
+#if BIT64
+using nuint = System.UInt64;
+#else
+using nuint = System.UInt32;
+#endif
+
 namespace System
 {
     internal static partial class SpanHelpers // .Char
     {
+        public static int IndexOf(ref char searchSpace, int searchSpaceLength, ref char value, int valueLength)
+        {
+            Debug.Assert(searchSpaceLength >= 0);
+            Debug.Assert(valueLength >= 0);
+
+            if (valueLength == 0)
+                return 0;  // A zero-length sequence is always treated as "found" at the start of the search space.
+
+            char valueHead = value;
+            ref char valueTail = ref Unsafe.Add(ref value, 1);
+            int valueTailLength = valueLength - 1;
+
+            int index = 0;
+            for (; ; )
+            {
+                Debug.Assert(0 <= index && index <= searchSpaceLength); // Ensures no deceptive underflows in the computation of "remainingSearchSpaceLength".
+                int remainingSearchSpaceLength = searchSpaceLength - index - valueTailLength;
+                if (remainingSearchSpaceLength <= 0)
+                    break;  // The unsearched portion is now shorter than the sequence we're looking for. So it can't be there.
+
+                // Do a quick search for the first element of "value".
+                int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, index), valueHead, remainingSearchSpaceLength);
+                if (relativeIndex == -1)
+                    break;
+                index += relativeIndex;
+
+                // Found the first element of "value". See if the tail matches.
+                if (SequenceEqual(
+                    ref Unsafe.As<char, byte>(ref Unsafe.Add(ref searchSpace, index + 1)),
+                    ref Unsafe.As<char, byte>(ref valueTail),
+                    (nuint)valueTailLength * 2))
+                {
+                    return index;  // The tail matched. Return a successful find.
+                }
+
+                index++;
+            }
+            return -1;
+        }
+
         public static unsafe int SequenceCompareTo(ref char first, int firstLength, ref char second, int secondLength)
         {
             Debug.Assert(firstLength >= 0);

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
@@ -31,20 +31,20 @@ namespace System
             char valueHead = value;
             ref char valueTail = ref Unsafe.Add(ref value, 1);
             int valueTailLength = valueLength - 1;
+            int remainingSearchSpaceLength = searchSpaceLength - valueTailLength;
 
             int index = 0;
-            for (; ; )
+            while (remainingSearchSpaceLength > 0)
             {
-                Debug.Assert(0 <= index && index <= searchSpaceLength); // Ensures no deceptive underflows in the computation of "remainingSearchSpaceLength".
-                int remainingSearchSpaceLength = searchSpaceLength - index - valueTailLength;
-                if (remainingSearchSpaceLength <= 0)
-                    break;  // The unsearched portion is now shorter than the sequence we're looking for. So it can't be there.
-
                 // Do a quick search for the first element of "value".
                 int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, index), valueHead, remainingSearchSpaceLength);
                 if (relativeIndex == -1)
                     break;
                 index += relativeIndex;
+
+                remainingSearchSpaceLength = searchSpaceLength - index - valueTailLength;
+                if (remainingSearchSpaceLength <= 0)
+                    break;  // The unsearched portion is now shorter than the sequence we're looking for. So it can't be there.
 
                 // Found the first element of "value". See if the tail matches.
                 if (SequenceEqual(
@@ -55,6 +55,7 @@ namespace System
                     return index;  // The tail matched. Return a successful find.
                 }
 
+                remainingSearchSpaceLength--;
                 index++;
             }
             return -1;

--- a/src/System.Private.CoreLib/shared/System/String.Searching.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Searching.cs
@@ -261,6 +261,17 @@ namespace System
             if (count < 0 || startIndex > this.Length - count)
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_Count);
 
+            if (comparisonType == StringComparison.Ordinal)
+            {
+                var result = SpanHelpers.IndexOf(
+                    ref Unsafe.Add(ref this._firstChar, startIndex),
+                    count,
+                    ref value._firstChar,
+                    value.Length);
+
+                return (result >= 0 ? startIndex : 0) + result;
+            }
+
             switch (comparisonType)
             {
                 case StringComparison.CurrentCulture:
@@ -271,7 +282,6 @@ namespace System
                 case StringComparison.InvariantCultureIgnoreCase:
                     return CompareInfo.Invariant.IndexOf(this, value, startIndex, count, GetCaseCompareOfComparisonCulture(comparisonType));
 
-                case StringComparison.Ordinal:
                 case StringComparison.OrdinalIgnoreCase:
                     return CompareInfo.Invariant.IndexOfOrdinal(this, value, startIndex, count, GetCaseCompareOfComparisonCulture(comparisonType) != CompareOptions.None);
 


### PR DESCRIPTION
x  2.5 times faster at position 0
x 11.2 times faster at position 1024

For

```csharp
// where comparisonType == StringComparison.Ordinal 
string.IndexOf(string value, StringComparison comparisonType)
string.IndexOf(string value, int startIndex, StringComparison comparisonType)
string.IndexOf(string value, int startIndex, int count, StringComparison comparisonType)

// where T : char
IndexOf<T>(this Span<T> span, ReadOnlySpan<T> value)
IndexOf<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value)

// where comparisonType == StringComparison.Ordinal
IndexOf(this ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)

// where options = CompareOptions.Ordinal 
CompareInfo.IndexOf(string source, string value, CompareOptions options)
CompareInfo.IndexOf(string source, string value, int startIndex, CompareOptions options)
CompareInfo.IndexOf(string source, string value, int startIndex, int count, CompareOptions options)
```

https://gist.github.com/benaadams/177d989fea110f51fab14cd708239852
```diff
           Method | Position |      Mean |
 ---------------- |--------- |----------:|
- IndexOf_Ordinal |        0 |  35.86 ns |
+ IndexOf_Ordinal |        0 |  14.15 ns |
- IndexOf_Ordinal |        7 |  42.69 ns |
+ IndexOf_Ordinal |        7 |  19.00 ns |
- IndexOf_Ordinal |        8 |  43.13 ns |
+ IndexOf_Ordinal |        8 |  18.90 ns |
- IndexOf_Ordinal |       15 |  49.67 ns |
+ IndexOf_Ordinal |       15 |  19.61 ns |
- IndexOf_Ordinal |       16 |  47.58 ns |
+ IndexOf_Ordinal |       16 |  19.64 ns |
- IndexOf_Ordinal |       31 |  60.92 ns |
+ IndexOf_Ordinal |       31 |  21.09 ns |
- IndexOf_Ordinal |       32 |  62.66 ns |
+ IndexOf_Ordinal |       32 |  21.11 ns |
- IndexOf_Ordinal |       63 | 100.10 ns |
+ IndexOf_Ordinal |       63 |  22.45 ns |
- IndexOf_Ordinal |       64 | 100.82 ns |
+ IndexOf_Ordinal |       64 |  22.54 ns |
- IndexOf_Ordinal |      127 | 156.94 ns |
+ IndexOf_Ordinal |      127 |  27.10 ns |
- IndexOf_Ordinal |      128 | 155.85 ns |
+ IndexOf_Ordinal |      128 |  26.07 ns |
- IndexOf_Ordinal |      255 | 265.79 ns |
+ IndexOf_Ordinal |      255 |  32.93 ns |
- IndexOf_Ordinal |      256 | 266.91 ns |
+ IndexOf_Ordinal |      256 |  32.98 ns |
- IndexOf_Ordinal |     1023 | 918.89 ns |
+ IndexOf_Ordinal |     1023 |  81.13 ns |
- IndexOf_Ordinal |     1024 | 916.90 ns |
+ IndexOf_Ordinal |     1024 |  81.20 ns |
```

Contributes to https://github.com/dotnet/coreclr/issues/19672

/cc @jkotas, @krwq, @tarekgh