### PR TITLE
Fix Getting Max Japanese Era

### DIFF
--- a/src/corefx/System.Globalization.Native/calendarData.cpp
+++ b/src/corefx/System.Globalization.Native/calendarData.cpp
@@ -581,7 +581,8 @@ extern "C" int32_t GlobalizationNative_GetLatestJapaneseEra()
     if (U_FAILURE(err))
         return 0;
 
-    int32_t ret = ucal_getLimit(pCal, UCAL_ERA, UCAL_MAXIMUM, &err);
+    ucal_set(pCal, UCAL_EXTENDED_YEAR, 9999);
+    int32_t ret = ucal_get(pCal, UCAL_ERA, &err);
 
     return U_SUCCESS(err) ? ret : 0;
 }


### PR DESCRIPTION
We were using the ICU API ucal_getLimit and asking to get the maximum value of the Japanese eras. it looks this API is just return the era matching the current system clock which prevent returning any future defined era in the system (which ICU 63.1 can support with some environment variable).
We raised the issue to the ICU owners but would be better just to get the era of Gregorian year 9999 which always should return the max era anyway.