### PR TITLE
Fixing a few small issues with the SIMD vs SIMD HWIntrinsics

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7536,12 +7536,12 @@ private:
 #ifdef FEATURE_HW_INTRINSICS
 #if defined(_TARGET_ARM64_)
         CORINFO_CLASS_HANDLE Vector64FloatHandle;
-        CORINFO_CLASS_HANDLE Vector64UIntHandle;
+        CORINFO_CLASS_HANDLE Vector64IntHandle;
         CORINFO_CLASS_HANDLE Vector64UShortHandle;
         CORINFO_CLASS_HANDLE Vector64UByteHandle;
         CORINFO_CLASS_HANDLE Vector64ShortHandle;
         CORINFO_CLASS_HANDLE Vector64ByteHandle;
-        CORINFO_CLASS_HANDLE Vector64IntHandle;
+        CORINFO_CLASS_HANDLE Vector64UIntHandle;
 #endif // defined(_TARGET_ARM64_)
         CORINFO_CLASS_HANDLE Vector128FloatHandle;
         CORINFO_CLASS_HANDLE Vector128DoubleHandle;

--- a/src/jit/hwintrinsic.cpp
+++ b/src/jit/hwintrinsic.cpp
@@ -117,8 +117,8 @@ CORINFO_CLASS_HANDLE Compiler::gtGetStructHandleForHWSIMD(var_types simdType, va
         {
             case TYP_FLOAT:
                 return m_simdHandleCache->Vector64FloatHandle;
-            case TYP_UINT:
-                return m_simdHandleCache->Vector64UIntHandle;
+            case TYP_INT:
+                return m_simdHandleCache->Vector64IntHandle;
             case TYP_USHORT:
                 return m_simdHandleCache->Vector64UShortHandle;
             case TYP_UBYTE:
@@ -127,8 +127,8 @@ CORINFO_CLASS_HANDLE Compiler::gtGetStructHandleForHWSIMD(var_types simdType, va
                 return m_simdHandleCache->Vector64ShortHandle;
             case TYP_BYTE:
                 return m_simdHandleCache->Vector64ByteHandle;
-            case TYP_INT:
-                return m_simdHandleCache->Vector64IntHandle;
+            case TYP_UINT:
+                return m_simdHandleCache->Vector64UIntHandle;
             default:
                 assert(!"Didn't find a class handle for simdType");
         }

--- a/src/jit/lowerarmarch.cpp
+++ b/src/jit/lowerarmarch.cpp
@@ -357,7 +357,7 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
                 addr->ClearContained();
             }
         }
-        else if (!source->IsMultiRegCall() && !source->OperIsSIMD())
+        else if (!source->IsMultiRegCall() && !source->OperIsSIMDorSimdHWintrinsic())
         {
             assert(source->IsLocal());
             MakeSrcContained(blkNode, source);

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -1594,8 +1594,9 @@ void fgArgInfo::ArgsComplete()
                 else if (isMultiRegArg && varTypeIsSIMD(argx->TypeGet()))
                 {
                     // SIMD types do not need the optimization below due to their sizes
-                    if (argx->OperIs(GT_SIMD) || (argx->OperIs(GT_OBJ) && argx->AsObj()->gtOp1->OperIs(GT_ADDR) &&
-                                                  argx->AsObj()->gtOp1->gtOp.gtOp1->OperIs(GT_SIMD)))
+                    if (argx->OperIsSIMDorSimdHWintrinsic() ||
+                        (argx->OperIs(GT_OBJ) && argx->AsObj()->gtOp1->OperIs(GT_ADDR) &&
+                         argx->AsObj()->gtOp1->gtOp.gtOp1->OperIsSIMDorSimdHWintrinsic()))
                     {
                         curArgTabEntry->needTmp = true;
                     }

--- a/src/jit/simd.cpp
+++ b/src/jit/simd.cpp
@@ -439,7 +439,7 @@ var_types Compiler::getBaseTypeAndSizeOfSIMDType(CORINFO_CLASS_HANDLE typeHnd, u
         }
         else
 #endif // defined(_TARGET_XARCH)
-        if (typeHnd == m_simdHandleCache->Vector128FloatHandle)
+            if (typeHnd == m_simdHandleCache->Vector128FloatHandle)
         {
             simdBaseType = TYP_FLOAT;
             size         = Vector128SizeBytes;
@@ -501,7 +501,7 @@ var_types Compiler::getBaseTypeAndSizeOfSIMDType(CORINFO_CLASS_HANDLE typeHnd, u
         }
         else
 #if defined(_TARGET_ARM64_)
-             if (typeHnd == m_simdHandleCache->Vector64FloatHandle)
+            if (typeHnd == m_simdHandleCache->Vector64FloatHandle)
         {
             simdBaseType = TYP_FLOAT;
             size         = Vector64SizeBytes;

--- a/src/jit/simd.cpp
+++ b/src/jit/simd.cpp
@@ -437,15 +437,15 @@ var_types Compiler::getBaseTypeAndSizeOfSIMDType(CORINFO_CLASS_HANDLE typeHnd, u
             size         = Vector256SizeBytes;
             JITDUMP("  Known type Vector256<ulong>\n");
         }
-        else if (typeHnd == m_simdHandleCache->Vector256FloatHandle)
-        {
-            simdBaseType = TYP_FLOAT;
-            size         = Vector256SizeBytes;
-            JITDUMP("  Known type Vector256<float>\n");
-        }
         else
 #endif // defined(_TARGET_XARCH)
-            if (typeHnd == m_simdHandleCache->Vector128DoubleHandle)
+        if (typeHnd == m_simdHandleCache->Vector128FloatHandle)
+        {
+            simdBaseType = TYP_FLOAT;
+            size         = Vector128SizeBytes;
+            JITDUMP("  Known type Vector128<float>\n");
+        }
+        else if (typeHnd == m_simdHandleCache->Vector128DoubleHandle)
         {
             simdBaseType = TYP_DOUBLE;
             size         = Vector128SizeBytes;
@@ -499,7 +499,14 @@ var_types Compiler::getBaseTypeAndSizeOfSIMDType(CORINFO_CLASS_HANDLE typeHnd, u
             size         = Vector128SizeBytes;
             JITDUMP("  Known type Vector128<ulong>\n");
         }
+        else
 #if defined(_TARGET_ARM64_)
+             if (typeHnd == m_simdHandleCache->Vector64FloatHandle)
+        {
+            simdBaseType = TYP_FLOAT;
+            size         = Vector64SizeBytes;
+            JITDUMP("  Known type Vector64<float>\n");
+        }
         else if (typeHnd == m_simdHandleCache->Vector64IntHandle)
         {
             simdBaseType = TYP_INT;


### PR DESCRIPTION
This makes the following changes:
* ~Adds handles for `Vector64<double>`, `Vector64<long>`, and `Vector64<ulong>`~
  * ~These are supported by the CPU, even though they these types are essentially the same as the "scalar" versions~
* Fixes the handle caching to cover `Vector64FloatHandle` and `Vector128FloatHandle`
* Fixes two places in the ARM code that were only checking `OperIsSIMD`, when they should have also been checking for SIMDHWIntrinsic

Removed the new `Vector64<double/long/ulong>` handles, the CPU supports them for a limited set of instructions and if we want to carry the info through, it will require more changes