### PR TITLE
Updating some test timeouts

### DIFF
--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -595,10 +595,10 @@ REM ============================================================================
 
 :: Long GC tests take about 10 minutes per test on average, so
 :: they often bump up against the default 10 minute timeout.
-:: 20 minutes is more than enough time for a test to complete successfully.
+:: 30 minutes is more than enough time for a test to complete successfully.
 if defined __LongGCTests (
-    echo %__MsgPrefix%Running Long GC tests, extending timeout to 20 minutes
-    set __TestTimeout=1200000
+    echo %__MsgPrefix%Running Long GC tests, extending timeout to 30 minutes
+    set __TestTimeout=1800000
     set RunningLongGCTests=1
 )
 

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -735,13 +735,13 @@ def run_tests(host_os,
     # Setup the dotnetcli location
     dotnetcli_location = os.path.join(coreclr_repo_location, "Tools", "dotnetcli", "dotnet%s" % (".exe" if host_os == "Windows_NT" else ""))
 
-    # Default timeout for unix is 15 minutes
-    os.environ["__TestTimeout"] = str(15*60*1000) # 900,000 ms
+    # Default timeout for unix is 30 minutes
+    os.environ["__TestTimeout"] = str(30*60*1000) # 1,800,000 ms
 
     # Setup the environment
     if is_long_gc:
-        print("Running Long GC Tests, extending timeout to 20 minutes.")
-        os.environ["__TestTimeout"] = str(20*60*1000) # 1,200,000 ms
+        print("Running Long GC Tests, extending timeout to 30 minutes.")
+        os.environ["__TestTimeout"] = str(30*60*1000) # 1,800,000 ms
         os.environ["RunningLongGCTests"] = "1"
     
     if is_gcsimulator:


### PR DESCRIPTION
CC. @CarolEidt, @jkotas 

We have a number of tests (especially on Unix) that are timing out in CI (and have been for some time).

This updates the "Long GC tests" to 30 minutes (which matches what we currently have in our `netci.groovy` file [here](https://github.com/dotnet/coreclr/blob/master/netci.groovy#L2182)) and the default test timeout (which appears to be what most of the failing tests are using) to 30m as well (originally tried 20m, but still had 22 of the original 33 tests timeout).

For reference:
* https://ci.dot.net/job/dotnet_coreclr/job/master/job/jitstress/job/x64_checked_ubuntu_gcstress0x3_tst/lastCompletedBuild/testReport/
* https://ci.dot.net/job/dotnet_coreclr/job/master/job/jitstress/job/x64_checked_ubuntu_gcstress0xc_tst/
* etc