### PR TITLE
Adding some AggressiveInlining attributes to the Vector64/128/256 helper methods

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128_1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128_1.cs
@@ -59,6 +59,7 @@ namespace System.Runtime.Intrinsics
 
         internal static bool IsSupported
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
                 return (typeof(T) == typeof(byte)) ||
@@ -74,6 +75,7 @@ namespace System.Runtime.Intrinsics
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void ThrowIfUnsupportedType()
         {
             if (!IsSupported)
@@ -86,6 +88,7 @@ namespace System.Runtime.Intrinsics
         /// <typeparam name="U">The type of the vector the current instance should be reinterpreted as.</typeparam>
         /// <returns>The current instance reinterpreted as a new <see cref="Vector128{U}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) or the type of the target (<typeparamref name="U" />) is not supported.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Vector128<U> As<U>() where U : struct
         {
             ThrowIfUnsupportedType();

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256_1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256_1.cs
@@ -61,6 +61,7 @@ namespace System.Runtime.Intrinsics
 
         internal static bool IsSupported
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
                 return (typeof(T) == typeof(byte)) ||
@@ -76,6 +77,7 @@ namespace System.Runtime.Intrinsics
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void ThrowIfUnsupportedType()
         {
             if (!IsSupported)
@@ -88,6 +90,7 @@ namespace System.Runtime.Intrinsics
         /// <typeparam name="U">The type of the vector the current instance should be reinterpreted as.</typeparam>
         /// <returns>The current instance reinterpreted as a new <see cref="Vector256{U}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) or the type of the target (<typeparamref name="U" />) is not supported.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Vector256<U> As<U>() where U : struct
         {
             ThrowIfUnsupportedType();

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector64_1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector64_1.cs
@@ -58,6 +58,7 @@ namespace System.Runtime.Intrinsics
 
         internal static bool IsSupported
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
                 return (typeof(T) == typeof(byte)) ||
@@ -73,6 +74,7 @@ namespace System.Runtime.Intrinsics
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void ThrowIfUnsupportedType()
         {
             if (!IsSupported)
@@ -85,6 +87,7 @@ namespace System.Runtime.Intrinsics
         /// <typeparam name="U">The type of the vector the current instance should be reinterpreted as.</typeparam>
         /// <returns>The current instance reinterpreted as a new <see cref="Vector64{U}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) or the type of the target (<typeparamref name="U" />) is not supported.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Vector64<U> As<U>() where U : struct
         {
             ThrowIfUnsupportedType();


### PR DESCRIPTION
@GrabYourPitchforks noticed this earlier when working with some of these helper methods.

Adding the JIT support (which I'm working on) should also help, but this ensures that the pure software implementations are also efficient.