### PR TITLE
Fix Interop/PInvoke/Miscellaneous/HandleRef tests under GCStress

### DIFF
--- a/src/vm/ilmarshalers.cpp
+++ b/src/vm/ilmarshalers.cpp
@@ -2557,14 +2557,13 @@ MarshalerOverrideStatus ILHandleRefMarshaler::ArgumentOverride(NDirectStubLinker
 
         // HandleRefs are valuetypes, so pinning is not needed.
         // The argument address is on the stack and will not move.
-        pcsDispatch->EmitLDARGA(argidx);
-        pcsDispatch->EmitLDC(offsetof(HANDLEREF, m_handle));
-        pcsDispatch->EmitADD();
-        pcsDispatch->EmitLDIND_I();
+        mdFieldDef handleField = pcsDispatch->GetToken(MscorlibBinder::GetField(FIELD__HANDLE_REF__HANDLE));
+        pcsDispatch->EmitLDARG(argidx);
+        pcsDispatch->EmitLDFLD(handleField);
 
-        mdFieldDef field = pcsUnmarshal->GetToken(MscorlibBinder::GetField(FIELD__HANDLE_REF__WRAPPER));
+        mdFieldDef wrapperField = pcsUnmarshal->GetToken(MscorlibBinder::GetField(FIELD__HANDLE_REF__WRAPPER));
         pcsUnmarshal->EmitLDARG(argidx);
-        pcsUnmarshal->EmitLDFLD(field);
+        pcsUnmarshal->EmitLDFLD(wrapperField);
         pcsUnmarshal->EmitCALL(METHOD__GC__KEEP_ALIVE, 1, 0);
 
         return OVERRIDDEN;

--- a/src/vm/ilmarshalers.cpp
+++ b/src/vm/ilmarshalers.cpp
@@ -2548,6 +2548,7 @@ MarshalerOverrideStatus ILHandleRefMarshaler::ArgumentOverride(NDirectStubLinker
 
     ILCodeStream* pcsMarshal    = psl->GetMarshalCodeStream();
     ILCodeStream* pcsDispatch   = psl->GetDispatchCodeStream();
+    ILCodeStream* pcsUnmarshal  = psl->GetUnmarshalCodeStream();
 
     if (fManagedToNative && !byref)
     {
@@ -2560,6 +2561,12 @@ MarshalerOverrideStatus ILHandleRefMarshaler::ArgumentOverride(NDirectStubLinker
         pcsDispatch->EmitLDC(offsetof(HANDLEREF, m_handle));
         pcsDispatch->EmitADD();
         pcsDispatch->EmitLDIND_I();
+
+        mdFieldDef field = pcsUnmarshal->GetToken(MscorlibBinder::GetField(FIELD__HANDLE_REF__WRAPPER));
+        pcsUnmarshal->EmitLDARG(argidx);
+        pcsUnmarshal->EmitLDFLD(field);
+        pcsUnmarshal->EmitCALL(METHOD__GC__KEEP_ALIVE, 1, 0);
+
         return OVERRIDDEN;
     }
     else

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -241,7 +241,7 @@ DEFINE_METHOD(CRITICAL_HANDLE,      DISPOSE_BOOL,           Dispose,            
 
 DEFINE_CLASS(HANDLE_REF,            Interop,                HandleRef)
 DEFINE_FIELD(HANDLE_REF,            WRAPPER,                _wrapper)
-DEFINE_FIELD(HANDLE_REF,            HANDLE,                _handle)
+DEFINE_FIELD(HANDLE_REF,            HANDLE,                 _handle)
 
 DEFINE_CLASS(CRITICAL_FINALIZER_OBJECT, ConstrainedExecution, CriticalFinalizerObject)
 DEFINE_METHOD(CRITICAL_FINALIZER_OBJECT, FINALIZE,          Finalize,                   IM_RetVoid)

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -239,6 +239,9 @@ DEFINE_METHOD(CRITICAL_HANDLE,      GET_IS_INVALID,         get_IsInvalid,      
 DEFINE_METHOD(CRITICAL_HANDLE,      DISPOSE,                Dispose,                    IM_RetVoid)
 DEFINE_METHOD(CRITICAL_HANDLE,      DISPOSE_BOOL,           Dispose,                    IM_Bool_RetVoid)
 
+DEFINE_CLASS(HANDLE_REF,            Interop,                HandleRef)
+DEFINE_FIELD(HANDLE_REF,            WRAPPER,                _wrapper)
+
 DEFINE_CLASS(CRITICAL_FINALIZER_OBJECT, ConstrainedExecution, CriticalFinalizerObject)
 DEFINE_METHOD(CRITICAL_FINALIZER_OBJECT, FINALIZE,          Finalize,                   IM_RetVoid)
 

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -241,6 +241,7 @@ DEFINE_METHOD(CRITICAL_HANDLE,      DISPOSE_BOOL,           Dispose,            
 
 DEFINE_CLASS(HANDLE_REF,            Interop,                HandleRef)
 DEFINE_FIELD(HANDLE_REF,            WRAPPER,                _wrapper)
+DEFINE_FIELD(HANDLE_REF,            HANDLE,                _handle)
 
 DEFINE_CLASS(CRITICAL_FINALIZER_OBJECT, ConstrainedExecution, CriticalFinalizerObject)
 DEFINE_METHOD(CRITICAL_FINALIZER_OBJECT, FINALIZE,          Finalize,                   IM_RetVoid)

--- a/tests/src/Interop/PInvoke/Miscellaneous/HandleRef/HandleRefTest.cs
+++ b/tests/src/Interop/PInvoke/Miscellaneous/HandleRef/HandleRefTest.cs
@@ -77,7 +77,8 @@ class HandleRefTest
             Action gcCallback = () => { Console.WriteLine("GC callback now"); GC.Collect(2, GCCollectionMode.Forced); GC.WaitForPendingFinalizers(); GC.Collect(2, GCCollectionMode.Forced); };
             Assert.AreEqual(intReturn, TestNoGC(hr4, gcCallback), "The return value is wrong");
             Console.WriteLine("Native code finished");
-
+            GC.KeepAlive(boxedInt);
+            
             return 100;
         } catch (Exception e){
             Console.WriteLine($"Test Failure: {e}"); 

--- a/tests/src/Interop/PInvoke/Miscellaneous/HandleRef/HandleRefTest.cs
+++ b/tests/src/Interop/PInvoke/Miscellaneous/HandleRef/HandleRefTest.cs
@@ -8,11 +8,6 @@ using System.Reflection;
 using System.Text;
 using TestLibrary;
 
-class BoxedInt
-{
-    public int MyInt;
-}
-
 class HandleRefTest
 {
     [DllImport(@"HandleRefNative", CallingConvention = CallingConvention.Winapi)]
@@ -60,16 +55,7 @@ class HandleRefTest
             // stay rooted until the end of the method. 
             Console.WriteLine("TestNoGC");
 
-            // Keep the int boxed and pinned to prevent it from getting collected.
-            // That way, we can safely reference it from finalizers that run on shutdown.
-            BoxedInt boxedInt = new BoxedInt();
-            GCHandle.Alloc(boxedInt, GCHandleType.Normal);
-            int* int4Ptr;
-            fixed (int* tempIntPtr = &boxedInt.MyInt)
-            {
-                // Smuggle the pointer out of the fixed scope
-                int4Ptr = tempIntPtr;
-            }
+            int* int4Ptr = Marshal.AllocHGlobal(sizeof(int));
             Console.WriteLine("2");
             *int4Ptr = intManaged;
             CollectableClass collectableClass = new CollectableClass(int4Ptr);
@@ -77,8 +63,8 @@ class HandleRefTest
             Action gcCallback = () => { Console.WriteLine("GC callback now"); GC.Collect(2, GCCollectionMode.Forced); GC.WaitForPendingFinalizers(); GC.Collect(2, GCCollectionMode.Forced); };
             Assert.AreEqual(intReturn, TestNoGC(hr4, gcCallback), "The return value is wrong");
             Console.WriteLine("Native code finished");
-            GC.KeepAlive(boxedInt);
-            
+            Marshal.FreeHGlobal((IntPtr)int4Ptr);
+
             return 100;
         } catch (Exception e){
             Console.WriteLine($"Test Failure: {e}"); 

--- a/tests/src/Interop/PInvoke/Miscellaneous/HandleRef/HandleRefTest.cs
+++ b/tests/src/Interop/PInvoke/Miscellaneous/HandleRef/HandleRefTest.cs
@@ -55,7 +55,7 @@ class HandleRefTest
             // stay rooted until the end of the method. 
             Console.WriteLine("TestNoGC");
 
-            int* int4Ptr = Marshal.AllocHGlobal(sizeof(int));
+            int* int4Ptr = (int*)Marshal.AllocHGlobal(sizeof(int)); // We don't free this memory so we don't have to worry about a GC run between freeing and return (possible in a GCStress mode).
             Console.WriteLine("2");
             *int4Ptr = intManaged;
             CollectableClass collectableClass = new CollectableClass(int4Ptr);
@@ -63,7 +63,6 @@ class HandleRefTest
             Action gcCallback = () => { Console.WriteLine("GC callback now"); GC.Collect(2, GCCollectionMode.Forced); GC.WaitForPendingFinalizers(); GC.Collect(2, GCCollectionMode.Forced); };
             Assert.AreEqual(intReturn, TestNoGC(hr4, gcCallback), "The return value is wrong");
             Console.WriteLine("Native code finished");
-            Marshal.FreeHGlobal((IntPtr)int4Ptr);
 
             return 100;
         } catch (Exception e){


### PR DESCRIPTION
Emit a `GC.KeepAlive` call for the object wrapped in a `HandleRef` when marshalling a `HandleRef` to native code. Also, add an extra `GC.KeepAlive` for an object in the test that needs to live across the call but wasn't referenced after the P/Invoke originally.

Fixes #21115 