### PR TITLE
Fix Unix ARM JIT_MemCpy and JIT_MemSet

### DIFF
--- a/src/vm/arm/crthelpers.S
+++ b/src/vm/arm/crthelpers.S
@@ -33,7 +33,7 @@ LEAF_ENTRY JIT_MemSet, _TEXT
         it eq
         bxeq lr
         
-        ldr r3, [r0]
+        ldrb r3, [r0]
         
         b C_PLTFUNC(memset)
 
@@ -43,15 +43,13 @@ LEAF_END_MARKED JIT_MemSet, _TEXT
 //EXTERN_C void __stdcall JIT_MemCpy(void* _dest, const void *_src, size_t count)
 LEAF_ENTRY JIT_MemCpy, _TEXT
 //
-// It only requires 4 byte alignment
-// and doesn't return a value
 
         cmp r2, #0
         it eq
         bxeq lr
         
-        ldr r3, [r0]
-        ldr r3, [r1]
+        ldrb r3, [r0]
+        ldrb r3, [r1]
         
         b C_PLTFUNC(memcpy)
 


### PR DESCRIPTION
The functions were incorrectly using 4 byte loads to probe for
the address validity. While the comment on JIT_MemCpy requires
4 byte aligned address, it doesn't match the way JIT uses it and
the Windows version of the function works with unaligned addresses
too.
This bug was discovered as a crash in an application where the
JIT_MemCpy was called with count=2 and an address that was two
bytes below the end of a memory page where the following page
was not mapped.

Closes #21117