### PR TITLE
Suppress a CMake Warning

### DIFF
--- a/tests/src/Interop/PInvoke/DllImportPath/CMakeLists.txt
+++ b/tests/src/Interop/PInvoke/DllImportPath/CMakeLists.txt
@@ -8,7 +8,9 @@ set(SOURCES
 
 # Set CMP0037 to OLD for this directory, so that
 # CMake doesn't complain about the libraries with Unicode characters.
-cmake_policy(SET CMP0037 OLD)
+if(NOT (CMAKE_MAJOR_VERSION LESS 3)) 
+    cmake_policy(SET CMP0037 OLD)
+endif()
   
 # Additional files to reference: 
 # add the executable 

--- a/tests/src/Interop/PInvoke/DllImportPath/CMakeLists.txt
+++ b/tests/src/Interop/PInvoke/DllImportPath/CMakeLists.txt
@@ -5,6 +5,11 @@ include_directories(${INC_PLATFORM_DIR})
 set(SOURCES 
     DllImportPathNative.cpp 
 ) 
+
+# Set CMP0037 to OLD for this directory, so that
+# CMake doesn't complain about the libraries with Unicode characters.
+cmake_policy(SET CMP0037 OLD)
+  
 # Additional files to reference: 
 # add the executable 
 add_library (DllImportPath_Local SHARED ${SOURCES})


### PR DESCRIPTION
This change adds a local cmake_policy rule to suppress
warnings about libraries with unicode names.

```
CMake Warning (dev) at tests/src/Interop/PInvoke/DllImportPath/CMakeLists.txt:14 (add_library):
  Policy CMP0037 is not set: Target names should not be reserved and should
  match a validity pattern.  Run "cmake --help-policy CMP0037" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  The target name "DllImportPath_U�n�i�c�o�d�e" is reserved or
  not valid for certain CMake features, such as generator expressions, and
  may result in undefined behavior.
This warning is for project developers.  Use -Wno-dev to suppress it.
```