### PR TITLE
Fix perf issues with GetCurrentThreadHomeHeapNumber

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -35208,25 +35208,6 @@ int GCHeap::GetNumberOfHeaps ()
 #endif //MULTIPLE_HEAPS
 }
 
-/*
-  in this way we spend extra time cycling through all the heaps while create the handle
-  it ought to be changed by keeping alloc_context.home_heap as number (equals heap_number)
-*/
-int GCHeap::GetHomeHeapNumber ()
-{
-#ifdef MULTIPLE_HEAPS
-    Thread *pThread = GCToEEInterface::GetThread();
-    if (!pThread)
-        return 0;
-
-    gc_alloc_context* ctx = GCToEEInterface::GetAllocContext();
-    GCHeap *hp = static_cast<alloc_context*>(ctx)->get_home_heap();
-    return (hp ? hp->pGenGCHeap->heap_number : 0);
-#else
-    return 0;
-#endif //MULTIPLE_HEAPS
-}
-
 unsigned int GCHeap::GetCondemnedGeneration()
 { 
     return gc_heap::settings.condemned_generation;

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -35216,16 +35216,12 @@ int GCHeap::GetHomeHeapNumber ()
 {
 #ifdef MULTIPLE_HEAPS
     Thread *pThread = GCToEEInterface::GetThread();
-    for (int i = 0; i < gc_heap::n_heaps; i++)
-    {
-        if (pThread)
-        {
-            gc_alloc_context* ctx = GCToEEInterface::GetAllocContext();
-            GCHeap *hp = static_cast<alloc_context*>(ctx)->get_home_heap();
-            if (hp == gc_heap::g_heaps[i]->vm_heap) return i;
-        }
-    }
-    return 0;
+    if (!pThread)
+        return 0;
+
+    gc_alloc_context* ctx = GCToEEInterface::GetAllocContext();
+    GCHeap *hp = static_cast<alloc_context*>(ctx)->get_home_heap();
+    return (hp ? hp->pGenGCHeap->heap_number : 0);
 #else
     return 0;
 #endif //MULTIPLE_HEAPS

--- a/src/gc/gc.h
+++ b/src/gc/gc.h
@@ -237,8 +237,7 @@ public:
 private:
     virtual Object* AllocAlign8Common (void* hp, alloc_context* acontext, size_t size, uint32_t flags) = 0;
 public:
-    virtual int GetNumberOfHeaps () = 0; 
-    virtual int GetHomeHeapNumber () = 0;
+    virtual int GetNumberOfHeaps () = 0;
     virtual size_t GetPromotedBytes(int heap_index) = 0;
 
     unsigned GetMaxGeneration()

--- a/src/gc/gcimpl.h
+++ b/src/gc/gcimpl.h
@@ -118,7 +118,6 @@ public:
     static GCHeap* GetHeap (int);
 #endif //MULTIPLE_HEAPS
 
-    int GetHomeHeapNumber ();
     bool IsThreadUsingAllocationContextHeap(gc_alloc_context* acontext, int thread_number);
     int GetNumberOfHeaps ();
     void HideAllocContext(alloc_context*);

--- a/src/gc/objecthandle.cpp
+++ b/src/gc/objecthandle.cpp
@@ -1817,11 +1817,19 @@ void Ref_VerifyHandleTable(uint32_t condemned, uint32_t maxgen, ScanContext* sc)
 
 int GetCurrentThreadHomeHeapNumber()
 {
-    WRAPPER_NO_CONTRACT;
-
-    if (g_theGCHeap == nullptr)
+    LIMITED_METHOD_CONTRACT;
+    
+#ifdef MULTIPLE_HEAPS
+    Thread *pThread = GCToEEInterface::GetThread();
+    if (!pThread)
         return 0;
-    return g_theGCHeap->GetHomeHeapNumber();
+
+    gc_alloc_context* ctx = GCToEEInterface::GetAllocContext();
+    GCHeap *hp = static_cast<alloc_context*>(ctx)->get_home_heap();
+    return (hp ? hp->pGenGCHeap->heap_number : 0);
+#else
+    return 0;
+#endif //MULTIPLE_HEAPS
 }
 
 bool HandleTableBucket::Contains(OBJECTHANDLE handle)


### PR DESCRIPTION
It was doing unnecessary work, and did not have to involve a virtual call.