### PR TITLE
Mark the String.Empty field as Intrinsic

### DIFF
--- a/src/System.Private.CoreLib/src/System/String.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/String.CoreCLR.cs
@@ -16,11 +16,13 @@ namespace System
         //
         // These fields map directly onto the fields in an EE StringObject.  See object.h for the layout.
         //
-        [NonSerialized] private int _stringLength;
+        [NonSerialized]
+        private int _stringLength;
 
         // For empty strings, this will be '\0' since
         // strings are both null-terminated and length prefixed
-        [NonSerialized] private char _firstChar;
+        [NonSerialized]
+        private char _firstChar;
 
         // The Empty constant holds the empty string value. It is initialized by the EE during startup.
         // It is treated as intrinsic by the JIT as so the static constructor would never run.
@@ -29,7 +31,8 @@ namespace System
         // We need to call the String constructor so that the compiler doesn't mark this as a literal.
         // Marking this as a literal would mean that it doesn't show up as a field which we can access 
         // from native.
-        [Intrinsic] public static readonly string Empty;
+        [Intrinsic]
+        public static readonly string Empty;
 
         // Gets the character at a specified position.
         //

--- a/src/System.Private.CoreLib/src/System/String.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/String.CoreCLR.cs
@@ -29,7 +29,7 @@ namespace System
         // We need to call the String constructor so that the compiler doesn't mark this as a literal.
         // Marking this as a literal would mean that it doesn't show up as a field which we can access 
         // from native.
-        public static readonly string Empty;
+        [Intrinsic] public static readonly string Empty;
 
         // Gets the character at a specified position.
         //


### PR DESCRIPTION
This is required so that the CPAOT compiler can recognize this field as a RyuJIT intrinsic.