### PR TITLE
[x86] Do not support hardware intrinsics on x86 unix

### DIFF
--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -930,7 +930,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Security\SecureString.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\TimeZoneInfo.Unix.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(FeatureHardwareIntrinsics)' == 'true' AND ('$(Platform)' == 'x64' OR '$(Platform)' == 'x86')">
+  <ItemGroup Condition="'$(FeatureHardwareIntrinsics)' == 'true' AND ('$(Platform)' == 'x64' OR ('$(Platform)' == 'x86' AND '$(TargetsUnix)' != 'true'))">
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Aes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Avx.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Avx2.cs" />
@@ -947,7 +947,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Sse42.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Ssse3.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(FeatureHardwareIntrinsics)' != 'true' OR ('$(Platform)' != 'x64' AND '$(Platform)' != 'x86')">
+  <ItemGroup Condition="'$(FeatureHardwareIntrinsics)' != 'true' OR ('$(Platform)' != 'x64' AND ('$(Platform)' != 'x86' OR ('$(Platform)' == 'x86' AND '$(TargetsUnix)' == 'true')))">
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Aes.PlatformNotSupported.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Avx.PlatformNotSupported.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\X86\Avx2.PlatformNotSupported.cs" />


### PR DESCRIPTION
On x86 unix jit is compiled without hardware intrinsic support
https://github.com/dotnet/coreclr/blob/5e4e286ea2bffa4a5cb2467721ed89f27959d253/src/jit/CMakeLists.txt#L7
but System.Private.CoreLib is built with it. This leads to errors, like:
```
GC/API/GCHandle/Alloc_neg2/Alloc_neg2.sh
               BEGIN EXECUTION
               /dotnet/corert/tests/../Tools/msbuild.sh /m /p:IlcPath=/dotnet/corert/tests/../bin/Linux.armel.Debug /p:IlcTarget=armel /p:LinkerFlags=-target arm-linux-gnueabi --sysroot=/dotnet/corert/tests/../cross/rootfs/armel -B/dotnet/corert/tests/../cross/rootfs/armel/usr/lib/gcc/armv7l-tizen-linux-gnueabi/6.2.1 -L/dotnet/corert/tests/../cross/rootfs/armel/usr/lib/gcc/armv7l-tizen-linux-gnueabi/6.2.1 -lssl -lcrypto -lkeyutils -v -Wl,-v /p:Configuration=Debug Test.csproj
               Microsoft (R) Build Engine version 15.8.166+gd4e8d81a88 for .NET Core
               Copyright (C) Microsoft Corporation. All rights reserved.
               
                 /usr/bin/clang-3.9
                 Generating native code
                 
                 Unhandled Exception: System.InvalidProgramException: The JIT compiler encountered invalid IL code or an internal limitation.
                    at System.Runtime.Intrinsics.X86.Lzcnt.get_IsSupported()
                    at System.Buffers.Utilities.SelectBucketIndex(Int32 bufferSize)
                    at System.Buffers.TlsOverPerCoreLockedStacksArrayPool`1.Rent(Int32 minimumLength)
                    at System.Text.ValueUtf8Converter.ConvertAndTerminateString(ReadOnlySpan`1 value)
                    at Interop.Sys.Stat(ReadOnlySpan`1 path, FileStatus& output)
                    at System.IO.FileSystem.FileExists(ReadOnlySpan`1 fullPath, Int32 fileType, ErrorInfo& errorInfo)
                    at System.IO.FileSystem.FileExists(ReadOnlySpan`1 fullPath)
                    at System.IO.File.Exists(String path)
                    at System.CommandLine.ArgumentSyntax.ParseResponseFile(String fileName)
                    at System.CommandLine.ArgumentLexer.ExpandResponseFiles(IEnumerable`1 args, Func`2 responseFileReader)+MoveNext()
                    at System.CommandLine.ArgumentLexer.Lex(IEnumerable`1 args, Func`2 responseFileReader)
                    at System.CommandLine.ArgumentParser..ctor(IEnumerable`1 arguments, Func`2 responseFileReader)
                    at System.CommandLine.ArgumentSyntax.get_Parser()
                    at System.CommandLine.ArgumentSyntax.DefineOption[T](String name, T defaultValue, Func`2 valueConverter)
                    at System.CommandLine.ArgumentSyntax.DefineOption[T](String name, T& value, Func`2 valueConverter, String help)
                    at System.CommandLine.ArgumentSyntax.DefineOption(String name, Boolean& value, String help)
                    at ILCompiler.Program.<>c__DisplayClass44_0.<ParseCommandLine>b__0(ArgumentSyntax syntax)
                    at System.CommandLine.ArgumentSyntax.Parse(IEnumerable`1 arguments, Action`1 defineAction)
                    at ILCompiler.Program.ParseCommandLine(String[] args)
                    at ILCompiler.Program.Run(String[] args)
                    at ILCompiler.Program.Main(String[] args)
                 Aborted (core dumped)
```
This change disables support for hardware intrinsics in System.Private.CoreLib on x86 Unix.