### PR TITLE
Fix normalize on load handling in assertion propagation

### DIFF
--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -1182,6 +1182,13 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
                         goto DONE_ASSERTION; // Don't make an assertion
                     }
 
+                    // If we're making a copy of a "normalize on load" lclvar then the destination
+                    // has to be "normalize on load" as well, otherwise we risk skipping normalization.
+                    if (lclVar2->lvNormalizeOnLoad() && !lclVar->lvNormalizeOnLoad())
+                    {
+                        goto DONE_ASSERTION; // Don't make an assertion
+                    }
+
                     //  If the local variable has its address exposed then bail
                     if (lclVar2->lvAddrExposed)
                     {

--- a/tests/src/JIT/Regression/JitBlue/GitHub_18867/GitHub_18867.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_18867/GitHub_18867.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+interface IRT
+{
+    void WriteLine<T>(T val);
+}
+
+class CRT : IRT
+{
+    public static object line;
+    public void WriteLine<T>(T val) => line = val;
+}
+
+public class Program
+{
+    static IRT s_rt;
+    static byte[] s_1 = new byte[] { 0 };
+    static int s_3;
+    static short[] s_8 = new short[] { -1 };
+
+    public static int Main()
+    {
+        s_rt = new CRT();
+        M11(s_8, 0, 0, 0, true, s_1);
+        return ((int)CRT.line == -1) ? 100 : 1;
+    }
+
+    // Test case for a lvNormalizeOnLoad related issue in assertion propagation.
+    // A "normal" lclvar is substituted with a "normalize on load" lclvar (arg3),
+    // that results in load normalization being skipped.
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static ushort M11(short[] arg0, ushort arg1, short arg3, byte arg4, bool arg7, byte[] arg10)
+    {
+        if (arg7)
+        {
+            ulong var4 = (ulong)s_3;
+
+            // mov edi, gword ptr [classVar[0x2c44174]]
+            // cmp dword ptr [edi + 4], 0
+            // jbe SHORT G_M17557_IG06
+            // movsx edi, word ptr [edi + 8]
+            // mov word ptr [ebp + 14H], di ; word only store
+            arg3 = s_8[0];
+
+            short var5 = arg3;
+            s_rt.WriteLine(var4);
+
+            // call CORINFO_HELP_VIRTUAL_FUNC_PTR
+            // mov ecx, edi
+            // mov edx, dword ptr [ebp + 14H] ; dword load, no sign extension
+            // call eax
+            s_rt.WriteLine((int)var5);
+        }
+
+        if (!arg7)
+        {
+            var vr7 = arg0[0];
+        }
+
+        arg10[0] = arg4;
+        return arg1;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_18867/GitHub_18867.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_18867/GitHub_18867.csproj
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Assertion propagation must not generate a copy assertion when the source variable requires load normalization and the destination variable does not. Doing so would result in normalization being skipped because existing uses of the destination variable lack the cast node that performs normalization.

The test is slightly different from the original one - it uses `short` instead of `ushort` and the value is -1 instead of 1. This increases the chance of observing a side effect of the bad codegen. With the original `ushort` and 1 there's a good chance that no ill side effects are observed because the upper bits happen to be 0 anyway. That's why the original test failed only on ARM32, despite the fact that bad code was generated on x86 as well.

No FX diffs.

Fixes #18867
