### PR TITLE
Remove TypedReference.MakeTypedReference readonly restriction

### DIFF
--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -1499,7 +1499,7 @@
     <value>The DaylightTransitionStart property must not equal the DaylightTransitionEnd property.</value>
   </data>
   <data name="Argument_TypedReferenceInvalidField" xml:space="preserve">
-    <value>Field '{0}' in TypedReferences cannot be static or init only.</value>
+    <value>Field '{0}' in TypedReferences cannot be static.</value>
   </data>
   <data name="Argument_TypeIsWinRTType" xml:space="preserve">
     <value>The type must not be a Windows Runtime type.</value>

--- a/src/System.Private.CoreLib/src/System/TypedReference.cs
+++ b/src/System.Private.CoreLib/src/System/TypedReference.cs
@@ -41,7 +41,7 @@ namespace System
                 if (field == null)
                     throw new ArgumentException(SR.Argument_MustBeRuntimeFieldInfo);
 
-                if (field.IsInitOnly || field.IsStatic)
+                if (field.IsStatic)
                     throw new ArgumentException(SR.Format(SR.Argument_TypedReferenceInvalidField, field.Name));
 
                 if (targetType != field.GetDeclaringTypeInternal() && !targetType.IsSubclassOf(field.GetDeclaringTypeInternal()))


### PR DESCRIPTION
TypedReference.MakeTypedReference validates that the fields aren't readonly, which limits our ability to make fields readonly in core while maintaining BinaryFormatter compatibility.  This restriction isn't useful for a variety of reasons, though: reflection allows readonly fields to be set, but more importantly, TypedReference.SetTypedReference has always thrown NotSupportedException, so it's not even actually usable.

This change just removes the readonly check from MakeTypedReference.

Fixes https://github.com/dotnet/corefx/issues/33655
cc: @jkotas, @ViktorHofer 