### PR TITLE
Adding missing overloads of the Sse2 and Sse41 Extract methods

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse2.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse2.PlatformNotSupported.cs
@@ -678,6 +678,11 @@ namespace System.Runtime.Intrinsics.X86
         /// int _mm_extract_epi16 (__m128i a,  int immediate)
         ///   PEXTRW reg, xmm, imm8
         /// </summary>
+        public static short Extract(Vector128<short> value, byte index) { throw new PlatformNotSupportedException(); }
+        /// <summary>
+        /// int _mm_extract_epi16 (__m128i a,  int immediate)
+        ///   PEXTRW reg, xmm, imm8
+        /// </summary>
         public static ushort Extract(Vector128<ushort> value, byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse2.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse2.cs
@@ -679,6 +679,11 @@ namespace System.Runtime.Intrinsics.X86
         /// int _mm_extract_epi16 (__m128i a,  int immediate)
         ///   PEXTRW reg, xmm, imm8
         /// </summary>
+        public static short Extract(Vector128<short> value, byte index) => Extract(value, index);
+        /// <summary>
+        /// int _mm_extract_epi16 (__m128i a,  int immediate)
+        ///   PEXTRW reg, xmm, imm8
+        /// </summary>
         public static ushort Extract(Vector128<ushort> value, byte index) => Extract(value, index);
 
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse41.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse41.PlatformNotSupported.cs
@@ -255,6 +255,11 @@ namespace System.Runtime.Intrinsics.X86
         /// </summary>
         public static byte Extract(Vector128<byte> value, byte index) { throw new PlatformNotSupportedException(); }
         /// <summary>
+        /// int _mm_extract_epi8 (__m128i a, const int imm8)
+        ///   PEXTRB reg/m8, xmm, imm8
+        /// </summary>
+        public static byte Extract(Vector128<sbyte> value, byte index) { throw new PlatformNotSupportedException(); }
+        /// <summary>
         /// int _mm_extract_epi32 (__m128i a, const int imm8)
         ///   PEXTRD reg/m32, xmm, imm8
         /// </summary>

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse41.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse41.cs
@@ -255,6 +255,11 @@ namespace System.Runtime.Intrinsics.X86
         /// </summary>
         public static byte Extract(Vector128<byte> value, byte index) => Extract(value, index);
         /// <summary>
+        /// int _mm_extract_epi8 (__m128i a, const int imm8)
+        ///   PEXTRB reg/m8, xmm, imm8
+        /// </summary>
+        public static byte Extract(Vector128<sbyte> value, byte index) => Extract(value, index);
+        /// <summary>
         /// int _mm_extract_epi32 (__m128i a, const int imm8)
         ///   PEXTRD reg/m32, xmm, imm8
         /// </summary>


### PR DESCRIPTION
We were missing the signed overloads of a few of these methods.