### PR TITLE
Eliminate the requirement that abort requires no lock held on the current thread

### DIFF
--- a/src/vm/threadsuspend.cpp
+++ b/src/vm/threadsuspend.cpp
@@ -1121,12 +1121,6 @@ BOOL Thread::ReadyForAsyncException()
         return FALSE;
     }
 
-    // If we are doing safe abort, we can not abort a thread if it has locks.
-    if (m_AbortType == EEPolicy::TA_Safe && HasLockInCurrentDomain()) {
-        STRESS_LOG0(LF_APPDOMAIN, LL_INFO10, "in Thread::ReadyForAbort  HasLock\n");
-        return FALSE;
-    }
-
     REGDISPLAY rd;
 
     Frame *pStartFrame = NULL;


### PR DESCRIPTION
If an expression evaluation hits a path that calls `NotifyOfCrossThreadDependency()` - the VS debugger will abort the evaluation by calling `ICorDebugEval::Abort()`. Eventually, it turns into a `ThreadAbortException` that will help us to unwind back to the original state and make sure the finally blocks are executed. However, if the thread is currently holding a lock (acquired by the FuncEval or otherwise), the runtime will not throw the `ThreadAbortException` and get stuck - the debugger will wait longer and eventually give up by not doing any clean up, just setting the context back to what it was - if we do this, the process is pretty much toasted.

The change here remedies the situation (of getting stuck failing to abort when a lock is held while calling `NotifyOfCrossThreadDependency()`) by giving the debugger an opportunity to force throwing the `ThreadAbortException`. The debugger will decide if they wanted to force throw but setting the private static field, and then the debuggee will follow its order.

The manual throwing on the `ThreadAbortException` is not ideal because it could be caught if the code being evaluated has a catch clause - the `ThreadAbortException` thrown by the runtime has a special semantics that pass through catches. Doing it the right way is non-trivial, so this fix is a compromise that we settle on for now and we will re-visit later.