### PR TITLE
Improve performance of Enum.{Try}Parse

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Char.cs
+++ b/src/System.Private.CoreLib/shared/System/Char.cs
@@ -214,7 +214,7 @@ namespace System
             return (CharUnicodeInfo.GetUnicodeCategory(c) == UnicodeCategory.DecimalDigitNumber);
         }
 
-        private static bool IsInRange(char c, char min, char max) => (uint)(c - min) <= (uint)(max - min);
+        internal static bool IsInRange(char c, char min, char max) => (uint)(c - min) <= (uint)(max - min);
 
         private static bool IsInRange(UnicodeCategory c, UnicodeCategory min, UnicodeCategory max) => (uint)(c - min) <= (uint)(max - min);
 

--- a/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
@@ -510,7 +510,7 @@ namespace System
         }
 
         /// <summary>Parses int limited to styles that make up NumberStyles.Integer.</summary>
-        private static bool TryParseInt32IntegerStyle(ReadOnlySpan<char> value, NumberStyles styles, NumberFormatInfo info, out int result, ref bool failureIsOverflow)
+        internal static bool TryParseInt32IntegerStyle(ReadOnlySpan<char> value, NumberStyles styles, NumberFormatInfo info, out int result, ref bool failureIsOverflow)
         {
             Debug.Assert((styles & ~NumberStyles.Integer) == 0, "Only handles subsets of Integer format");
             Debug.Assert(!failureIsOverflow, $"failureIsOverflow should have been initialized to false");
@@ -681,7 +681,7 @@ namespace System
         }
 
         /// <summary>Parses long inputs limited to styles that make up NumberStyles.Integer.</summary>
-        private static bool TryParseInt64IntegerStyle(
+        internal static bool TryParseInt64IntegerStyle(
             ReadOnlySpan<char> value, NumberStyles styles, NumberFormatInfo info, out long result, ref bool failureIsOverflow)
         {
             Debug.Assert((styles & ~NumberStyles.Integer) == 0, "Only handles subsets of Integer format");
@@ -919,7 +919,7 @@ namespace System
         }
 
         /// <summary>Parses uint limited to styles that make up NumberStyles.Integer.</summary>
-        private static bool TryParseUInt32IntegerStyle(
+        internal static bool TryParseUInt32IntegerStyle(
             ReadOnlySpan<char> value, NumberStyles styles, NumberFormatInfo info, out uint result, ref bool failureIsOverflow)
         {
             Debug.Assert((styles & ~NumberStyles.Integer) == 0, "Only handles subsets of Integer format");
@@ -1240,7 +1240,7 @@ namespace System
         }
 
         /// <summary>Parses ulong limited to styles that make up NumberStyles.Integer.</summary>
-        private static bool TryParseUInt64IntegerStyle(
+        internal static bool TryParseUInt64IntegerStyle(
             ReadOnlySpan<char> value, NumberStyles styles, NumberFormatInfo info, out ulong result, ref bool failureIsOverflow)
         {
             Debug.Assert((styles & ~NumberStyles.Integer) == 0, "Only handles subsets of Integer format");


### PR DESCRIPTION
- Non-generic TryParse with a string (e.g. "Wednesday" for DayOfWeek) is ~10% faster.
- Non-generic TryParse with a value (e.g. "3") is ~2x faster and with 50% less allocation.
- Generic {Try}Parse with a string is ~2.2x faster and with 0 allocation.
- Generic {Try}Parse with a value is ~5.5x faster and with 0 allocation.
- Avoids an exception being thrown/caught in both generic/non-generic TryParse with input like "3W", which makes that corner case hundreds of times faster.

| Method                        | Before Allocation (b) | After Allocation (b) | Allocation Reduction | Before Time (ns) | After Time (ns) | Time Improvement | 
|-------------------------------|-----------------------|----------------------|----------------------|------------------|-----------------|------------------| 
| NameGenericByte       | 24                    | 0                    | 100%                 | 181.8            | 82.6            | 2.20x            | 
| NameGenericSByte      | 24                    | 0                    | 100%                 | 178.8            | 82.98           | 2.15x            | 
| NameGenericInt16      | 24                    | 0                    | 100%                 | 183              | 83.75           | 2.19x            | 
| NameGenericUInt16     | 24                    | 0                    | 100%                 | 177              | 80.42           | 2.20x            | 
| NameGenericInt32      | 24                    | 0                    | 100%                 | 184.7            | 82.18           | 2.25x            | 
| NameGenericUInt32     | 24                    | 0                    | 100%                 | 181.6            | 80.96           | 2.24x            | 
| NameGenericInt64      | 24                    | 0                    | 100%                 | 175.9            | 80.68           | 2.18x            | 
| NameGenericUInt64     | 24                    | 0                    | 100%                 | 173.3            | 83.19           | 2.08x            | 
| ValueGenericByte      | 48                    | 0                    | 100%                 | 259.2            | 53.38           | 4.86x            | 
| ValueGenericSByte     | 48                    | 0                    | 100%                 | 285.2            | 50.8            | 5.61x            | 
| ValueGenericInt16     | 48                    | 0                    | 100%                 | 285              | 50.69           | 5.62x            | 
| ValueGenericUInt16    | 48                    | 0                    | 100%                 | 282.9            | 51.7            | 5.47x            | 
| ValueGenericInt32     | 48                    | 0                    | 100%                 | 287.6            | 51.5            | 5.58x            | 
| ValueGenericUInt32    | 48                    | 0                    | 100%                 | 287.6            | 50.73           | 5.67x            | 
| ValueGenericInt64     | 48                    | 0                    | 100%                 | 267.8            | 51.39           | 5.21x            | 
| ValueGenericUInt64    | 48                    | 0                    | 100%                 | 260.1            | 51.21           | 5.08x            | 
| NameNonGenericByte    | 24                    | 24                   | 0%                   | 185.8            | 166.09          | 1.12x            | 
| NameNonGenericSByte   | 24                    | 24                   | 0%                   | 179.5            | 164.55          | 1.09x            | 
| NameNonGenericInt16   | 24                    | 24                   | 0%                   | 180              | 166.05          | 1.08x            | 
| NameNonGenericUInt16  | 24                    | 24                   | 0%                   | 182.2            | 165.6           | 1.10x            | 
| NameNonGenericInt32   | 24                    | 24                   | 0%                   | 196.7            | 166.21          | 1.18x            | 
| NameNonGenericUInt32  | 24                    | 24                   | 0%                   | 188.5            | 163.2           | 1.16x            | 
| NameNonGenericInt64   | 24                    | 24                   | 0%                   | 188.2            | 168.33          | 1.12x            | 
| NameNonGenericUInt64  | 24                    | 24                   | 0%                   | 186.3            | 164.1           | 1.14x            | 
| ValueNonGenericByte   | 48                    | 24                   | 50%                  | 269              | 135.52          | 1.98x            | 
| ValueNonGenericSByte  | 48                    | 24                   | 50%                  | 269.9            | 138.3           | 1.95x            | 
| ValueNonGenericInt16  | 48                    | 24                   | 50%                  | 269.4            | 140.55          | 1.92x            | 
| ValueNonGenericUInt16 | 48                    | 24                   | 50%                  | 269.2            | 132.48          | 2.03x            | 
| ValueNonGenericInt32  | 48                    | 24                   | 50%                  | 270.7            | 135.12          | 2.00x            | 
| ValueNonGenericUInt32 | 48                    | 24                   | 50%                  | 268.6            | 132.63          | 2.03x            | 
| ValueNonGenericInt64  | 48                    | 24                   | 50%                  | 274              | 134.89          | 2.03x            | 
| ValueNonGenericUInt64 | 48                    | 24                   | 50%                  | 266.1            | 134.63          | 1.98x            | 
| FailNonGeneric        | 576                   | 0                    | 100%                 | 32,366.10     | 99.99           | 323.69x          | 

Fixes https://github.com/dotnet/corefx/issues/594
Fixes https://github.com/dotnet/corefx/issues/11073
Contributes to https://github.com/dotnet/corefx/issues/15453
cc: @ahsonkhan, @jkotas, @GrabYourPitchforks, @joperezr  