### PR TITLE
Fix LTTng-UST: Error (-17) while registering... error when debugging

### DIFF
--- a/src/dlls/mscoree/coreclr/CMakeLists.txt
+++ b/src/dlls/mscoree/coreclr/CMakeLists.txt
@@ -121,6 +121,7 @@ else()
     list(APPEND CORECLR_LIBRARIES
         ${START_WHOLE_ARCHIVE} # force all PAL objects to be included so all exports are available
         coreclrpal
+        tracepointprovider
         ${END_WHOLE_ARCHIVE}
         mscorrc_debug
         palrt

--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -196,7 +196,6 @@ set(SOURCES
   misc/strutil.cpp
   misc/sysinfo.cpp
   misc/time.cpp
-  misc/tracepointprovider.cpp
   misc/utils.cpp
   numa/numa.cpp
   objmgr/palobjbase.cpp
@@ -259,6 +258,11 @@ add_library(coreclrpal
   ${ARCH_SOURCES}
   ${PLATFORM_SOURCES}
   ${LIBUNWIND_OBJECTS}
+)
+
+add_library(tracepointprovider
+  STATIC
+  misc/tracepointprovider.cpp
 )
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)


### PR DESCRIPTION
Fixes issue #20205.

This has been happening in more and more scenarios:

1) SOS when the coreclr hosting the SOS managed code is a different version that the one being debugged
2) Lee ran into it with ClrMD for Linux
3) The dotnet-diagnostictests repo with the current arcade build changes because the coreclr version hosting mdbg is different than the version running the debuggees.

This fix is simple: only link the tracepointprovider.cpp code that loads libcoreclrtraceptprovider.so into libcoreclr.so and not in any other module that uses the PAL library (libdbgshim.so, libmscordaccore.so, etc.). Create a new "tracepointprovider" library with the tracepointprovider.cpp source file in it and remove it from the "coreclrpal".  Link this new lib into libcoreclr.so.