### PR TITLE
exclude tests\src\Interop\COM\NativeClients\Primitives from GCStress runs.

### DIFF
--- a/tests/src/Interop/COM/NativeClients/Primitives.csproj
+++ b/tests/src/Interop/COM/NativeClients/Primitives.csproj
@@ -9,6 +9,8 @@
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>
     <DefineConstants>BLOCK_WINDOWS_NANO</DefineConstants>
+	<!-- Issue 21221, https://github.com/dotnet/coreclr/issues/21221 -->
+	<GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(InteropCommonDir)ExeLauncherProgram.cs" />

--- a/tests/src/Interop/COM/NativeClients/Primitives.csproj
+++ b/tests/src/Interop/COM/NativeClients/Primitives.csproj
@@ -9,8 +9,8 @@
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>
     <DefineConstants>BLOCK_WINDOWS_NANO</DefineConstants>
-	<!-- Issue 21221, https://github.com/dotnet/coreclr/issues/21221 -->
-	<GCStressIncompatible>true</GCStressIncompatible>
+    <!-- Issue 21221, https://github.com/dotnet/coreclr/issues/21221 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(InteropCommonDir)ExeLauncherProgram.cs" />


### PR DESCRIPTION

Revert this change when #21221 fixed.