### PR TITLE
Disable test Dev10_630880

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -47,6 +47,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/GitHub_11408/GitHub_11408/*">
             <Issue>11408</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/reflection/regression/dev10bugs/Dev10_630880/*">
+            <Issue>21173</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/StackTracePreserve/StackTracePreserveTests/*">
             <Issue>20322</Issue>
         </ExcludeList>


### PR DESCRIPTION
It was made obsolete by https://github.com/dotnet/coreclr/pull/21157
