### PR TITLE
Fix #21209

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -807,6 +807,9 @@
     <!-- The following are tests that fail on non-Windows, which we must not run when building against packages -->
 
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(BuildTestsAgainstPackages)' == 'true' and '$(TargetsWindows)' != 'true'">
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/MarshalAPI/NativeLibrary/NativeLibraryTests/*">
+            <Issue>Issue building native components for the test. Since tests are currently built on Windows, the native components end up at Core_Root instead of Test directory, which is not suitable for the test.</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/CoreMangLib/cti/system/byte/ByteToString3/*">
             <Issue>needs triage</Issue>
         </ExcludeList>

--- a/tests/src/Interop/MarshalAPI/NativeLibrary/NativeLibraryTests.cs
+++ b/tests/src/Interop/MarshalAPI/NativeLibrary/NativeLibraryTests.cs
@@ -106,14 +106,15 @@ public class NativeLibraryTest
 
         if (TestLibrary.Utilities.IsWindows)
         {
+            libName = GetWin32LibName();
+
             // Calls on a valid library from System32 directory
-            libName = GetNativeLibraryPlainName();
-            success &= EXPECT(LoadLibraryAdvanced("mapi32", assembly, DllImportSearchPath.System32));
-            success &= EXPECT(TryLoadLibraryAdvanced("mapi32", assembly, DllImportSearchPath.System32));
+            success &= EXPECT(LoadLibraryAdvanced(libName, assembly, DllImportSearchPath.System32));
+            success &= EXPECT(TryLoadLibraryAdvanced(libName, assembly, DllImportSearchPath.System32));
 
             // Calls on a valid library from application directory
-            success &= EXPECT(LoadLibraryAdvanced("mapi32", assembly, DllImportSearchPath.ApplicationDirectory), TestResult.DllNotFound);
-            success &= EXPECT(TryLoadLibraryAdvanced("mapi32", assembly, DllImportSearchPath.ApplicationDirectory), TestResult.ReturnFailure);
+            success &= EXPECT(LoadLibraryAdvanced(libName, assembly, DllImportSearchPath.ApplicationDirectory), TestResult.DllNotFound);
+            success &= EXPECT(TryLoadLibraryAdvanced(libName, assembly, DllImportSearchPath.ApplicationDirectory), TestResult.ReturnFailure);
         }
 
         // Calls with null libName input
@@ -177,6 +178,11 @@ public class NativeLibraryTest
     static string GetNativeLibraryPlainName()
     {
         return "NativeLibrary";
+    }
+
+    static string GetWin32LibName()
+    {
+        return "msi.dll";
     }
 
     static string GetNativeLibraryName()


### PR DESCRIPTION
This commit has two changes to Native Load Library Tests fix the failures in:
https://github.com/dotnet/coreclr/issues/21209

1) Windows: The test tried to load a DLL from Win32 directory which doesn't exist
   in Windows server 2016. So changed to use a file that exists.
2) Linux: Disable the test when run against packages -- because in this configuration
   the tests are built on Windows and the native DLL is build separately and copied
   over to the CORE_ROOT directory instead of the test directory.
   [Several other tests are disabled with the comment "Issue building native DLL" on Linux]