### PR TITLE
Allow Task.WaitAny completion to run synchronously

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/Task.cs
@@ -4394,7 +4394,7 @@ namespace System.Threading.Tasks
             AddCompletionAction(action, addBeforeOthers: false);
         }
 
-        private void AddCompletionAction(ITaskCompletionAction action, bool addBeforeOthers)
+        internal void AddCompletionAction(ITaskCompletionAction action, bool addBeforeOthers)
         {
             if (!AddTaskContinuation(action, addBeforeOthers))
                 action.Invoke(this); // run the action directly if we failed to queue the continuation (i.e., the task completed)
@@ -5127,7 +5127,7 @@ namespace System.Threading.Tasks
 
             if (signaledTaskIndex == -1 && tasks.Length != 0)
             {
-                Task<Task> firstCompleted = TaskFactory.CommonCWAnyLogic(tasks);
+                Task<Task> firstCompleted = TaskFactory.CommonCWAnyLogic(tasks, isSyncBlocking: true);
                 bool waitCompleted = firstCompleted.Wait(millisecondsTimeout, cancellationToken);
                 if (waitCompleted)
                 {


### PR DESCRIPTION
Following on from "Allow some ITaskCompletionActions to always run synchronously" https://github.com/dotnet/coreclr/pull/2718 which worked for `Task.Wait` and `Task.WaitAll` to release the calling thread rather than queuing a callback when not a valid inline; extend this to `Task.WaitAny` which is also releasing a blocked thread in same way, rather than running potentially unknown long running code.

@stephentoub I think this is a correct approach?