### PR TITLE
Defer Initialization of FrameworkEventSource During EventPipeController Initialization

### DIFF
--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeController.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeController.cs
@@ -62,6 +62,9 @@ namespace System.Diagnostics.Tracing
         // Singleton controller instance.
         private static EventPipeController s_controllerInstance = null;
 
+        // Initialization flag used to avoid initializing FrameworkEventSource on the startup path.
+        private static bool s_initializing = false;
+
         // Controller object state.
         private Timer m_timer;
         private string m_configFilePath;
@@ -69,11 +72,18 @@ namespace System.Diagnostics.Tracing
         private string m_traceFilePath = null;
         private bool m_configFileExists = false;
 
+        internal static bool Initializing
+        {
+            get { return s_initializing; }
+        }
+
         internal static void Initialize()
         {
             // Don't allow failures to propagate upstream.  Ensure program correctness without tracing.
             try
             {
+                s_initializing = true;
+
                 if (s_controllerInstance == null)
                 {
                     if (Config_EnableEventPipe > 0)
@@ -90,6 +100,10 @@ namespace System.Diagnostics.Tracing
                 }
             }
             catch { }
+            finally
+            {
+                s_initializing = false;
+            }
         }
 
         private EventPipeController()

--- a/src/System.Private.CoreLib/src/System/Threading/Timer.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Timer.cs
@@ -567,6 +567,7 @@ namespace System.Threading
                 }
                 else
                 {
+                    // Don't emit this event during EventPipeController.  This avoids initializing FrameworkEventSource during start-up which is expensive relative to the rest of start-up.
                     if (!EventPipeController.Initializing && FrameworkEventSource.IsInitialized && FrameworkEventSource.Log.IsEnabled(EventLevel.Informational, FrameworkEventSource.Keywords.ThreadTransfer))
                         FrameworkEventSource.Log.ThreadTransferSendObj(this, 1, string.Empty, true, (int)dueTime, (int)period);
 

--- a/src/System.Private.CoreLib/src/System/Threading/Timer.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Timer.cs
@@ -567,7 +567,7 @@ namespace System.Threading
                 }
                 else
                 {
-                    if (FrameworkEventSource.IsInitialized && FrameworkEventSource.Log.IsEnabled(EventLevel.Informational, FrameworkEventSource.Keywords.ThreadTransfer))
+                    if (!EventPipeController.Initializing && FrameworkEventSource.IsInitialized && FrameworkEventSource.Log.IsEnabled(EventLevel.Informational, FrameworkEventSource.Keywords.ThreadTransfer))
                         FrameworkEventSource.Log.ThreadTransferSendObj(this, 1, string.Empty, true, (int)dueTime, (int)period);
 
                     success = m_associatedTimerQueue.UpdateTimer(this, dueTime, period);


### PR DESCRIPTION
EventPipeController is initialized right before Main is called.  The goal is to do very little work during initialization unless tracing is enabled.  Because EventPipeController initialization creates a timer, and timer creation uses FrameworkEventSource, this path faults in initialization of FrameworkEventSource on the start-up path.

To fix this, we don't emit the FrameworkEventSource event for timer creation during EventPipeController initialization.  With this change we no longer see the following class constructor call for FrameworkEventSource:

```
+ system.private.corelib!EventSource.Initialize
+ system.private.corelib!System.Diagnostics.Tracing.FrameworkEventSource..ctor()
+ system.private.corelib!System.Diagnostics.Tracing.FrameworkEventSource..cctor()
+ coreclr!CallDescrWorkerInternal
+ coreclr!DispatchCallDebuggerWrapper
+ coreclr!DispatchCallSimple
+ coreclr!MethodTable::RunClassInitEx
+ coreclr!MethodTable::DoRunClassInitThrowing
+ coreclr!MethodTable::CheckRunClassInitThrowing
+ coreclr!JIT_GetSharedGCStaticBase_Helper
+ system.private.corelib!TimerQueueTimer.Change
+ system.private.corelib!EventPipeController.PollForTracingCommand
+ system.private.corelib!EventPipeController.Initialize
+ system.private.corelib!StartupHookProvider.ProcessStartupHooks
+ coreclr!CallDescrWorkerInternal
```