### PR TITLE
Move the perf jobs to Windows.10.Amd64.ClientRS4.DevEx.15.8.Open

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -41,7 +41,7 @@ def static getOSGroup(def os) {
                         def newJob = job(Utilities.getFullJobName(project, jobName, isPR)) {
                             // Set the label.
                             if (isSmoketest) {
-                                label('Windows.Amd64.ClientRS4.DevEx.15.8.Perf')
+                                label('Windows.10.Amd64.ClientRS4.DevEx.15.8.Open')
                                 python = "C:\\python3.7.0\\python.exe"
                             }
                             else {
@@ -768,7 +768,7 @@ def static getFullThroughputJobName(def project, def os, def arch, def isPR) {
     ['x64', 'x86'].each { arch ->
         def architecture = arch
         def newJob = job(Utilities.getFullJobName(project, "sizeondisk_${arch}", false)) {
-            label('Windows.Amd64.ClientRS4.DevEx.15.8.Perf')
+            label('Windows.10.Amd64.ClientRS4.DevEx.15.8.Open')
 
             wrappers {
                 credentialsBinding {
@@ -854,7 +854,7 @@ def static getFullThroughputJobName(def project, def os, def arch, def isPR) {
                 ['full_opt'].each { opt_level ->
                     def architecture = arch
                     def newJob = job(Utilities.getFullJobName(project, "perf_illink_${os}_${arch}_${opt_level}_${jit}", isPR)) {
-                        label('Windows.Amd64.ClientRS4.DevEx.15.8.Perf')
+                        label('Windows.10.Amd64.ClientRS4.DevEx.15.8.Open')
 
                         def testEnv = ""
                         def python = "C:\\python3.7.0\\python.exe"


### PR DESCRIPTION
We have moved the python3 artifact to the base Windows queue, so we do not need to specifically use the Perf queue anymore.