### PR TITLE
Fix ObjectStackAllocationTests on Linux under minopts

### DIFF
--- a/tests/src/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.csproj
+++ b/tests/src/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.csproj
@@ -32,7 +32,7 @@
       <![CDATA[
 $(CLRTestBatchPreCommands)
 set COMPlus_TieredCompilation=0
-set COMPlus_JitMinOpts=0
+set COMPlus_JITMinOpts=0
 set COMPlus_JitDebuggable=0
 set COMPlus_JitStressModeNamesNot=STRESS_RANDOM_INLINE
 set COMPlus_JitObjectStackAllocation=1
@@ -42,7 +42,7 @@ set COMPlus_JitObjectStackAllocation=1
       <![CDATA[
 $(BashCLRTestPreCommands)
 export COMPlus_TieredCompilation=0
-export COMPlus_JitMinOpts=0
+export COMPlus_JITMinOpts=0
 export COMPlus_JitDebuggable=0
 export COMPlus_JitStressModeNamesNot=STRESS_RANDOM_INLINE
 export COMPlus_JitObjectStackAllocation=1


### PR DESCRIPTION
Fix the capitalization of COMPlus_JITMinOpts variable, which
is case-sensitive on Linux.

Fixes #21266