### PR TITLE
Don't treat the Vector64/128/256<T> helper methods as intrinsic if featureSIMD is disabled

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -4106,7 +4106,13 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
 //
 GenTree* Compiler::impBaseIntrinsic(NamedIntrinsic intrinsic, CORINFO_METHOD_HANDLE method, CORINFO_SIG_INFO* sig)
 {
-    GenTree*  retNode  = nullptr;
+    GenTree* retNode = nullptr;
+
+    if (!featureSIMD)
+    {
+        return nullptr;
+    }
+
     unsigned  simdSize = 0;
     var_types baseType = getBaseTypeAndSizeOfSIMDType(sig->retTypeClass, &simdSize);
     var_types retType  = getSIMDTypeForSize(simdSize);


### PR DESCRIPTION
This resolves https://github.com/dotnet/coreclr/issues/21257