### PR TITLE
Fix build parallelism on Windows with NUMA

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -332,9 +332,11 @@ REM NumberOfCores is an WMI property providing number of physical cores on machi
 REM processor(s). It is used to set optimal level of CL parallelism during native build step
 if not defined NumberOfCores (
     REM Determine number of physical processor cores available on machine
+    set TotalNumberOfCores=0
     for /f "tokens=*" %%I in (
         'wmic cpu get NumberOfCores /value ^| find "=" 2^>NUL'
-    ) do set %%I
+    ) do set %%I & set /a TotalNumberOfCores=TotalNumberOfCores+NumberOfCores
+    set NumberOfCores=!TotalNumberOfCores!
 )
 echo %__MsgPrefix%Number of processor cores %NumberOfCores%
 


### PR DESCRIPTION
When multiple NUMA nodes are enabled on the machine where coreclr is
built, we incorrectly detect the number of cores that we use for build
parallelism of the native part of the build (NumberOfCores) as only
a number in the last NUMA node.
The reason is that the `wmic cpu get NumberOfCores /value` returns
multiple lines, one per each NUMA node.
This change fixes it by summing values from all the lines.