### PR TITLE
Move GetReadDirRBufferSize pinvoke out of static cctor

### DIFF
--- a/src/System.Private.CoreLib/shared/Interop/Unix/System.Native/Interop.ReadDir.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Unix/System.Native/Interop.ReadDir.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        private static readonly int s_readBufferSize = GetReadDirRBufferSize();
+        private static volatile int s_readBufferSize = -1;
 
         internal enum NodeType : int
         {
@@ -58,6 +58,9 @@ internal static partial class Interop
             bool addedRef = false;
             try
             {
+                if (s_readBufferSize == -1)
+                    s_readBufferSize = GetReadDirRBufferSize();
+
                 // We avoid a native string copy into InternalDirectoryEntry.
                 // - If the platform suppors reading into a buffer, the data is read directly into the buffer. The
                 //   data can be read as long as the buffer is valid.


### PR DESCRIPTION
An alternative solution is to remove this pinvoke at all and replace `stackalloc byte[s_readBufferSize]` with `stackalloc byte[2048]` (see https://github.com/dotnet/corefx/blob/cec9910fcaa0321cd33b6fd43924a2794c5f3bb3/src/Native/Unix/System.Native/pal_io.c#L410).

I didn't add `lock` here, initially I wanted to get rid of static constructor but I guess it stays because of `=-1`.