### PR TITLE
Port to 2.1 - Improve performance of cgroup access

### DIFF
--- a/src/gc/unix/cgroup.h
+++ b/src/gc/unix/cgroup.h
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+#ifndef __CGROUP_H__
+#define __CGROUP_H__
+
+void InitializeCGroup();
+void CleanupCGroup();
+
+#endif // __CGROUP_H__
+

--- a/src/gc/unix/gcenv.unix.cpp
+++ b/src/gc/unix/gcenv.unix.cpp
@@ -39,6 +39,7 @@
 #include <errno.h>
 #include <unistd.h> // sysconf
 #include "globals.h"
+#include "cgroup.h"
 
 #if defined(_ARM_) || defined(_ARM64_)
 #define SYSCONF_GET_NUMPROCS _SC_NPROCESSORS_CONF
@@ -118,6 +119,8 @@ bool GCToOSInterface::Initialize()
     }
 #endif // HAVE_MACH_ABSOLUTE_TIME
 
+    InitializeCGroup();
+
     return true;
 }
 
@@ -130,6 +133,8 @@ void GCToOSInterface::Shutdown()
     assert(ret == 0);
 
     munmap(g_helperPage, OS_PAGE_SIZE);
+
+    CleanupCGroup();
 }
 
 // Get numeric id of the current thread if possible on the

--- a/src/pal/src/include/pal/cgroup.h
+++ b/src/pal/src/include/pal/cgroup.h
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+/*++
+
+
+
+Module Name:
+
+    include/pal/cgroup.h
+
+Abstract:
+    
+    Header file for the CGroup related functions.
+    
+
+
+--*/
+
+#ifndef _PAL_CGROUP_H_
+#define _PAL_CGROUP_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif // __cplusplus
+
+void InitializeCGroup();
+void CleanupCGroup();
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
+#endif /* _PAL_CGROUP_H_ */
+

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -44,6 +44,7 @@ SET_DEFAULT_DEBUG_CHANNEL(PAL); // some headers have code with asserts, so do th
 #include "pal/init.h"
 #include "pal/numa.h"
 #include "pal/stackstring.hpp"
+#include "pal/cgroup.h"
 
 #if HAVE_MACH_EXCEPTIONS
 #include "../exception/machexception.h"
@@ -324,6 +325,8 @@ Initialize(
         {
             goto done;
         }
+
+        InitializeCGroup();
 
         // Initialize the environment.
         if (FALSE == EnvironInitialize())
@@ -645,6 +648,7 @@ CLEANUP1a:
 CLEANUP1:
     SHMCleanup();
 CLEANUP0:
+    CleanupCGroup();
     TLSCleanup();
     ERROR("PAL_Initialize failed\n");
     SetLastError(palError);


### PR DESCRIPTION
#### Description
We were creating a CGroup instance on each request for getting used or total physical memory. This has an extra cost of finding filesystem paths of the current cgroup files. I have found that if we do the initialization just once, the performance of getting the used or total memory in a tight loop improves 22 fold. In one of our benchmarks, the fix improved the execution time more than two fold. In general, the more GCs happen in an application, the larger is the effect of this fix.
The slower behavior was a regression introduced in 2.1.5, 2.2 and in the master by a fix to get correct amount of used memory while running in a container.
	
#### Customer Impact
Customer applications that are triggering a lot of GCs can get a perf regression after moving to .NET core 2.1.5 or newer.
	
#### Regression?
Yes
		
#### Risk
None
