### PR TITLE
Properly DACize TLB access for thread local statics

### DIFF
--- a/src/vm/threadstatics.h
+++ b/src/vm/threadstatics.h
@@ -533,7 +533,7 @@ class ThreadStatics
     {
         SUPPORTS_DAC;
 
-        return dac_cast<PTR_ThreadLocalBlock>(&pThread->m_ThreadLocalBlock);
+        return dac_cast<PTR_ThreadLocalBlock>(PTR_TO_MEMBER_TADDR(Thread, pThread, m_ThreadLocalBlock));
     }
 
 #ifndef DACCESS_COMPILE


### PR DESCRIPTION
Commit 488d2a70 introduced . The DAC will try to cast a host pointer to a target pointer, but it will fail to do so as it's not a base object pointer. This uses the proper macro to just calculate teh address based on offsets and turn it into a TADDR. The cast will then just act as a C style cast so this should be safe.