### PR TITLE
Only get Thread.CurrentThread once in PerformIOCompletionCallback

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
@@ -374,6 +374,21 @@ namespace System.Threading
             // ThreadPoolWorkQueue.Dispatch will handle notifications and reset EC and SyncCtx back to default
         }
 
+        internal static void RestoreNonDefaultFromDefaultContext(Thread currentThread, ExecutionContext executionContext)
+        {
+            Debug.Assert(Thread.CurrentThread == currentThread);
+            Debug.Assert(Thread.CurrentThread.ExecutionContext == null);
+            Debug.Assert(Thread.CurrentThread.SynchronizationContext == null);
+            Debug.Assert(executionContext != null && !executionContext.m_isDefault);
+
+            // Restore Non-Default context
+            currentThread.ExecutionContext = executionContext;
+            if (executionContext.HasChangeNotifications)
+            {
+                OnValuesChanged(previousExecutionCtx: null, executionContext);
+            }
+        }
+
         // Inline as only called in one place and always called
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void ResetThreadPoolThread(Thread currentThread)

--- a/src/System.Private.CoreLib/src/System/Threading/Overlapped.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Overlapped.cs
@@ -42,15 +42,6 @@ namespace System.Threading
             _ioCompletionCallback = ioCompletionCallback;
             _executionContext = executionContext;
         }
-        // Context callback: same sig for SendOrPostCallback and ContextCallback
-        internal static ContextCallback _ccb = new ContextCallback(IOCompletionCallback_Context);
-        internal static void IOCompletionCallback_Context(object state)
-        {
-            _IOCompletionCallback helper = (_IOCompletionCallback)state;
-            Debug.Assert(helper != null, "_IOCompletionCallback cannot be null");
-            helper._ioCompletionCallback(helper._errorCode, helper._numBytes, helper._pNativeOverlapped);
-        }
-
 
         // call back helper
         internal static unsafe void PerformIOCompletionCallback(uint errorCode, uint numBytes, NativeOverlapped* pNativeOverlapped)
@@ -85,6 +76,7 @@ namespace System.Threading
 
                     if (!executionContext.IsDefault)
                     {
+                        // Not on default context, restore it
                         ExecutionContext.RestoreNonDefaultFromDefaultContext(currentThread, executionContext);
                     }
 


### PR DESCRIPTION
Accessing `Thread.CurrentThread` on each pass of the loop (via `ExecutionContext.RunInternal`) is a significant contributor of `PerformIOCompletionCallback` (when the callback is fast)

![image](https://user-images.githubusercontent.com/1142958/49325832-cf558300-f540-11e8-927e-a390f2175e96.png)

This can be cached and reused for the loop in the same way `ThreadPool.Dispatch` does.

Am assuming it doesn't need the exception handling EC restore semantics that `ExecutionContext.RunInternal` provides as its just throwing the exception into the wind (as per `ThreadPool.Dispatch`)

/cc @stephentoub not sure if this is spilling out of ExecutionContext too much?