### PR TITLE
Use clean contexts for IO Thread callbacks

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskContinuation.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskContinuation.cs
@@ -637,8 +637,8 @@ namespace System.Threading.Tasks
             {
                 // We're not inside of a task, so t_currentTask doesn't need to be specially maintained.
                 // We're on a thread pool thread with no higher-level callers, so exceptions can just propagate.
-
-                ExecutionContext.CheckThreadPoolAndContextsAreDefault();
+                Debug.Assert(Thread.CurrentThread.IsThreadPoolThread);
+                ExecutionContext.CheckContextsAreDefault();
                 // If there's no execution context or Default, just invoke the delegate as ThreadPool is on Default context.
                 // We don't have to use ExecutionContext.Run for the Default context here as there is no extra processing after the delegate
                 if (context == null || context.IsDefault)
@@ -648,7 +648,7 @@ namespace System.Threading.Tasks
                 // If there is an execution context, get the cached delegate and run the action under the context.
                 else
                 {
-                    ExecutionContext.RunForThreadPoolUnsafe(context, s_invokeAction, m_action);
+                    ExecutionContext.RunForThreadLoopUnsafe(Thread.CurrentThread, context, s_invokeAction, m_action);
                 }
 
                 // ThreadPoolWorkQueue.Dispatch handles notifications and reset context back to default

--- a/src/System.Private.CoreLib/shared/System/Threading/ThreadPool.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ThreadPool.cs
@@ -640,7 +640,7 @@ namespace System.Threading
                     outerWorkItem = workItem = null;
 
                     // Return to clean ExecutionContext and SynchronizationContext
-                    ExecutionContext.ResetThreadPoolThread(currentThread);
+                    ExecutionContext.ResetThreadLoopThread(currentThread);
 
                     // 
                     // Notify the VM that we executed this workitem.  This is also our opportunity to ask whether Hill Climbing wants
@@ -796,7 +796,7 @@ namespace System.Threading
         {
             base.Execute();
 
-            ExecutionContext.RunForThreadPoolUnsafe(_context, s_executionContextShim, this);
+            ExecutionContext.RunForThreadLoopUnsafe(Thread.CurrentThread, _context, s_executionContextShim, this);
         }
     }
 
@@ -823,7 +823,7 @@ namespace System.Threading
             Action<TState> callback = _callback;
             _callback = null;
 
-            ExecutionContext.RunForThreadPoolUnsafe(_context, callback, in _state);
+            ExecutionContext.RunForThreadLoopUnsafe(Thread.CurrentThread, _context, callback, in _state);
         }
     }
 
@@ -842,7 +842,8 @@ namespace System.Threading
 
         public override void Execute()
         {
-            ExecutionContext.CheckThreadPoolAndContextsAreDefault();
+            Debug.Assert(Thread.CurrentThread.IsThreadPoolThread);
+            ExecutionContext.CheckContextsAreDefault();
             base.Execute();
 
             Debug.Assert(_callback != null);
@@ -870,7 +871,8 @@ namespace System.Threading
 
         public override void Execute()
         {
-            ExecutionContext.CheckThreadPoolAndContextsAreDefault();
+            Debug.Assert(Thread.CurrentThread.IsThreadPoolThread);
+            ExecutionContext.CheckContextsAreDefault();
             base.Execute();
 
             Debug.Assert(_callback != null);


### PR DESCRIPTION
For `PerformIOCompletionCallback` skips the use of `_IOCompletionCallback` when  `ExecutionContext` flow is suppressed or Default.

However, if any changes were made by the callback to the `ExecutionContext`; they would not be undone, nor fire change notifications with `ThreadContextChanged == true`; additionally those changes would then flow into the next flow suppressed callback or Default context callback.

This change starts the `PerformIOCompletionCallback` thread on the Default (null) context; then after each loop iteration it also undoes any changes made in the callback to the context; including firing `ThreadContextChanged == true` notifications; so they no longer can flow into the next iteration or activation of `PerformIOCompletionCallback`.

Additionally it includes the optimization from https://github.com/dotnet/coreclr/pull/21320 of only looking up the `Thread.CurrentThread` once per loop; and using the fast-path ExecutionContext.Run that the ThreadPool uses (renamed in this from `RunForThreadPoolUnsafe` to `RunForThreadLoopUnsafe`).

/cc @stephentoub @jkotas @kouvel 