### PR TITLE
Store CurrentThread in ThreadStatic

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -16,17 +16,11 @@ using Internal.Runtime.Augments;
 
 namespace System.Threading
 {
-    using System.Threading;
-    using System.Runtime;
     using System.Runtime.InteropServices;
     using System;
     using System.Globalization;
-    using System.Collections.Generic;
-    using System.Runtime.Serialization;
     using System.Runtime.CompilerServices;
     using System.Runtime.ConstrainedExecution;
-    using System.Security;
-    using System.Runtime.Versioning;
     using System.Diagnostics;
 
     internal class ThreadHelper
@@ -145,6 +139,8 @@ namespace System.Threading
         internal static CultureInfo m_CurrentCulture;
         [ThreadStatic]
         internal static CultureInfo m_CurrentUICulture;
+        [ThreadStatic]
+        private static Thread s_currentThread;
 
         // Adding an empty default ctor for annotation purposes
         internal Thread() { }
@@ -331,13 +327,14 @@ namespace System.Threading
             return YieldInternal();
         }
 
-        public static new Thread CurrentThread
+        public static new Thread CurrentThread => s_currentThread ?? InitializeCurrentThread();
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Thread InitializeCurrentThread()
         {
-            get
-            {
-                return GetCurrentThreadNative();
-            }
+            return (s_currentThread = GetCurrentThreadNative());
         }
+
         [MethodImplAttribute(MethodImplOptions.InternalCall), ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         private static extern Thread GetCurrentThreadNative();
 

--- a/src/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -140,7 +140,7 @@ namespace System.Threading
         [ThreadStatic]
         internal static CultureInfo m_CurrentUICulture;
         [ThreadStatic]
-        private static Thread s_currentThread;
+        private static Thread t_currentThread;
 
         // Adding an empty default ctor for annotation purposes
         internal Thread() { }
@@ -327,12 +327,12 @@ namespace System.Threading
             return YieldInternal();
         }
 
-        public static new Thread CurrentThread => s_currentThread ?? InitializeCurrentThread();
+        public static new Thread CurrentThread => t_currentThread ?? InitializeCurrentThread();
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static Thread InitializeCurrentThread()
         {
-            return (s_currentThread = GetCurrentThreadNative());
+            return (t_currentThread = GetCurrentThreadNative());
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall), ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]


### PR DESCRIPTION
Accessing `Thread.CurrentThread` via a `[ThreadStatic]` is 26% faster than via the InternalCall `GetCurrentThreadNative`; so cache `GetCurrentThreadNative` in a `[ThreadStatic]`
```
BenchmarkDotNet=v0.11.3, OS=Windows 10.0.18290
Intel Core i7-4720HQ CPU 2.60GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100-preview-009812
  [Host]     : .NET Core 3.0.0-preview-27122-01 (CoreCLR 4.6.27121.03, CoreFX 4.7.18.57103), 64bit RyuJIT
  DefaultJob : .NET Core 3.0.0-preview-27122-01 (CoreCLR 4.6.27121.03, CoreFX 4.7.18.57103), 64bit RyuJIT


                     Method |     Mean |     Error |    StdDev | Ratio | RatioSD |
--------------------------- |---------:|----------:|----------:|------:|--------:|
       Thread_CurrentThread | 5.244 ns | 0.0509 ns | 0.0476 ns |  1.00 |    0.00 |
 ThreadStatic_CurrentThread | 4.168 ns | 0.0832 ns | 0.0778 ns |  0.79 |    0.02 |
```

```csharp
public class Program
{
    static void Main(string[] args) => BenchmarkRunner.Run<Program>();

    [Benchmark(Baseline = true)]
    public static Thread Thread_CurrentThread() => Thread.CurrentThread;

    [Benchmark]
    public static Thread ThreadStatic_CurrentThread() => CurrentThread;

    [ThreadStatic]
    private static Thread s_currentThread;

    private static Thread CurrentThread => s_currentThread ?? InitaliseCurrentThread();

    [MethodImpl(MethodImplOptions.NoInlining)]
    private static Thread InitaliseCurrentThread() => (s_currentThread = Thread.CurrentThread);
}
```
As its used very commonly (`ExecutionContext.Capture()` and `ExecutionContext.Run(...)` being the main examples for my usage)