### PR TITLE
Make RyuJIT tolerate null CLASSID_RUNTIME_TYPE

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -15162,8 +15162,7 @@ Compiler::TypeProducerKind Compiler::gtGetTypeProducerKind(GenTree* tree)
         bool                 isNonNull = false;
         CORINFO_CLASS_HANDLE clsHnd    = gtGetClassHandle(tree, &isExact, &isNonNull);
 
-        if (clsHnd != NO_CLASS_HANDLE &&
-            clsHnd == info.compCompHnd->getBuiltinClass(CLASSID_RUNTIME_TYPE))
+        if (clsHnd != NO_CLASS_HANDLE && clsHnd == info.compCompHnd->getBuiltinClass(CLASSID_RUNTIME_TYPE))
         {
             return TPK_Other;
         }

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -15162,7 +15162,7 @@ Compiler::TypeProducerKind Compiler::gtGetTypeProducerKind(GenTree* tree)
         bool                 isNonNull = false;
         CORINFO_CLASS_HANDLE clsHnd    = gtGetClassHandle(tree, &isExact, &isNonNull);
 
-        if (clsHnd != (CORINFO_CLASS_HANDLE) nullptr &&
+        if (clsHnd != NO_CLASS_HANDLE &&
             clsHnd == info.compCompHnd->getBuiltinClass(CLASSID_RUNTIME_TYPE))
         {
             return TPK_Other;
@@ -16374,7 +16374,7 @@ CORINFO_CLASS_HANDLE Compiler::gtGetClassHandle(GenTree* tree, bool* pIsExact, b
             if (intrinsic->gtIntrinsicId == CORINFO_INTRINSIC_Object_GetType)
             {
                 CORINFO_CLASS_HANDLE runtimeType = info.compCompHnd->getBuiltinClass(CLASSID_RUNTIME_TYPE);
-                assert(runtimeType != (CORINFO_CLASS_HANDLE) nullptr);
+                assert(runtimeType != NO_CLASS_HANDLE);
 
                 objClass    = runtimeType;
                 *pIsExact   = false;
@@ -16531,7 +16531,7 @@ CORINFO_CLASS_HANDLE Compiler::gtGetHelperCallClassHandle(GenTreeCall* call, boo
             const bool           helperResultNonNull = (helper == CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPE);
             CORINFO_CLASS_HANDLE runtimeType         = info.compCompHnd->getBuiltinClass(CLASSID_RUNTIME_TYPE);
 
-            assert(runtimeType != (CORINFO_CLASS_HANDLE) nullptr);
+            assert(runtimeType != NO_CLASS_HANDLE);
 
             objClass    = runtimeType;
             *pIsNonNull = helperResultNonNull;

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -15158,12 +15158,11 @@ Compiler::TypeProducerKind Compiler::gtGetTypeProducerKind(GenTree* tree)
     }
     else
     {
-        bool                 isExact        = false;
-        bool                 isNonNull      = false;
-        CORINFO_CLASS_HANDLE clsHnd         = gtGetClassHandle(tree, &isExact, &isNonNull);
-        CORINFO_CLASS_HANDLE runtimeTypeHnd = info.compCompHnd->getBuiltinClass(CLASSID_RUNTIME_TYPE);
+        bool                 isExact   = false;
+        bool                 isNonNull = false;
+        CORINFO_CLASS_HANDLE clsHnd    = gtGetClassHandle(tree, &isExact, &isNonNull);
 
-        if (runtimeTypeHnd != (CORINFO_CLASS_HANDLE)nullptr && clsHnd == runtimeTypeHnd)
+        if (clsHnd != (CORINFO_CLASS_HANDLE) nullptr && clsHnd == info.compCompHnd->getBuiltinClass(CLASSID_RUNTIME_TYPE))
         {
             return TPK_Other;
         }
@@ -16374,7 +16373,7 @@ CORINFO_CLASS_HANDLE Compiler::gtGetClassHandle(GenTree* tree, bool* pIsExact, b
             if (intrinsic->gtIntrinsicId == CORINFO_INTRINSIC_Object_GetType)
             {
                 CORINFO_CLASS_HANDLE runtimeType = info.compCompHnd->getBuiltinClass(CLASSID_RUNTIME_TYPE);
-                assert(runtimeType != (CORINFO_CLASS_HANDLE)nullptr);
+                assert(runtimeType != (CORINFO_CLASS_HANDLE) nullptr);
 
                 objClass    = runtimeType;
                 *pIsExact   = false;
@@ -16530,8 +16529,8 @@ CORINFO_CLASS_HANDLE Compiler::gtGetHelperCallClassHandle(GenTreeCall* call, boo
             // need to claim exactness here.
             const bool           helperResultNonNull = (helper == CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPE);
             CORINFO_CLASS_HANDLE runtimeType         = info.compCompHnd->getBuiltinClass(CLASSID_RUNTIME_TYPE);
-            
-            assert(runtimeType != (CORINFO_CLASS_HANDLE)nullptr);
+
+            assert(runtimeType != (CORINFO_CLASS_HANDLE) nullptr);
 
             objClass    = runtimeType;
             *pIsNonNull = helperResultNonNull;

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -15162,7 +15162,8 @@ Compiler::TypeProducerKind Compiler::gtGetTypeProducerKind(GenTree* tree)
         bool                 isNonNull = false;
         CORINFO_CLASS_HANDLE clsHnd    = gtGetClassHandle(tree, &isExact, &isNonNull);
 
-        if (clsHnd != (CORINFO_CLASS_HANDLE) nullptr && clsHnd == info.compCompHnd->getBuiltinClass(CLASSID_RUNTIME_TYPE))
+        if (clsHnd != (CORINFO_CLASS_HANDLE) nullptr &&
+            clsHnd == info.compCompHnd->getBuiltinClass(CLASSID_RUNTIME_TYPE))
         {
             return TPK_Other;
         }

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -15158,11 +15158,12 @@ Compiler::TypeProducerKind Compiler::gtGetTypeProducerKind(GenTree* tree)
     }
     else
     {
-        bool                 isExact   = false;
-        bool                 isNonNull = false;
-        CORINFO_CLASS_HANDLE clsHnd    = gtGetClassHandle(tree, &isExact, &isNonNull);
+        bool                 isExact        = false;
+        bool                 isNonNull      = false;
+        CORINFO_CLASS_HANDLE clsHnd         = gtGetClassHandle(tree, &isExact, &isNonNull);
+        CORINFO_CLASS_HANDLE runtimeTypeHnd = info.compCompHnd->getBuiltinClass(CLASSID_RUNTIME_TYPE);
 
-        if (clsHnd == info.compCompHnd->getBuiltinClass(CLASSID_RUNTIME_TYPE))
+        if (runtimeTypeHnd != (CORINFO_CLASS_HANDLE)nullptr && clsHnd == runtimeTypeHnd)
         {
             return TPK_Other;
         }
@@ -16373,9 +16374,11 @@ CORINFO_CLASS_HANDLE Compiler::gtGetClassHandle(GenTree* tree, bool* pIsExact, b
             if (intrinsic->gtIntrinsicId == CORINFO_INTRINSIC_Object_GetType)
             {
                 CORINFO_CLASS_HANDLE runtimeType = info.compCompHnd->getBuiltinClass(CLASSID_RUNTIME_TYPE);
-                objClass                         = runtimeType;
-                *pIsExact                        = false;
-                *pIsNonNull                      = true;
+                assert(runtimeType != (CORINFO_CLASS_HANDLE)nullptr);
+
+                objClass    = runtimeType;
+                *pIsExact   = false;
+                *pIsNonNull = true;
             }
 
             break;
@@ -16527,6 +16530,8 @@ CORINFO_CLASS_HANDLE Compiler::gtGetHelperCallClassHandle(GenTreeCall* call, boo
             // need to claim exactness here.
             const bool           helperResultNonNull = (helper == CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPE);
             CORINFO_CLASS_HANDLE runtimeType         = info.compCompHnd->getBuiltinClass(CLASSID_RUNTIME_TYPE);
+            
+            assert(runtimeType != (CORINFO_CLASS_HANDLE)nullptr);
 
             objClass    = runtimeType;
             *pIsNonNull = helperResultNonNull;


### PR DESCRIPTION
If we're compiling a class library that has no concept of reflection (and runtime types), EE cannot provide a class handle for this class. Make RyuJIT tolerant to null coming back.