### PR TITLE
Mark Object.GetHashCode as intrinsic

### DIFF
--- a/src/System.Private.CoreLib/src/System/Object.cs
+++ b/src/System.Private.CoreLib/src/System/Object.cs
@@ -82,6 +82,10 @@ namespace System
         // it will technically meet the needs of a hash function, but it's less than ideal.
         // Objects (& especially value classes) should override this method.
         // 
+        // This method receives special treatment in AOT compilation to optimize out
+        // boxing when calling GetHashCode for enum types by internally changing them
+        // to direct calls to GetHashCode on their underlying types.
+        [Intrinsic]
         public virtual int GetHashCode()
         {
             return RuntimeHelpers.GetHashCode(this);


### PR DESCRIPTION
Per JanK's suggestion I'm marking Object.GetHashCode as intrinsic.
This is to indicate that the method receives special treatment
in the CPAOT compiler - in particular, constrained calls to this
method on enum types get internally converted to calls on their
underlying types to avoid boxing - as well as to speed up the
compiler because it can first make a cheap check for this flag
before performing a more costly string comparison for the
method name in CorInfoImpl (a rough equivalent of jitinterface.cpp
in CoreRT).

Thanks

Tomas

P.S. We could probably slightly increase Crossgen compilation speed
by adding the same intrinsic check to jitinterface.cpp. For now
I haven't attempted to make this change as I assume that Crossgen
is planned to be obsoleted. Please let me know if you want me to make
this additional change nonetheless.