### PR TITLE
Vectorize some Guid APIs (ctor, TryWriteBytes)

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Guid.cs
+++ b/src/System.Private.CoreLib/shared/System/Guid.cs
@@ -51,6 +51,7 @@ namespace System
             if ((uint)b.Length != 16)
                 throw new ArgumentException(SR.Format(SR.Arg_GuidArrayCtor, "16"), nameof(b));
 
+            _k = b[15];
             _a = b[3] << 24 | b[2] << 16 | b[1] << 8 | b[0];
             _b = (short)(b[5] << 8 | b[4]);
             _c = (short)(b[7] << 8 | b[6]);
@@ -61,7 +62,6 @@ namespace System
             _h = b[12];
             _i = b[13];
             _j = b[14];
-            _k = b[15];
         }
 
         [CLSCompliant(false)]
@@ -93,6 +93,7 @@ namespace System
             _a = a;
             _b = b;
             _c = c;
+            _k = d[7];
             _d = d[0];
             _e = d[1];
             _f = d[2];
@@ -100,7 +101,6 @@ namespace System
             _h = d[4];
             _i = d[5];
             _j = d[6];
-            _k = d[7];
         }
 
         // Creates a new GUID initialized to the value represented by the
@@ -771,6 +771,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void WriteByteHelper(Span<byte> destination)
         {
+            destination[15] = _k;
             destination[0] = (byte)(_a);
             destination[1] = (byte)(_a >> 8);
             destination[2] = (byte)(_a >> 16);
@@ -786,7 +787,6 @@ namespace System
             destination[12] = _h;
             destination[13] = _i;
             destination[14] = _j;
-            destination[15] = _k;
         }
 
         // Returns an unsigned byte array containing the GUID.
@@ -841,8 +841,12 @@ namespace System
             // Now compare each of the elements
             return g._a == _a &&
                 Unsafe.Add(ref g._a, 1) == Unsafe.Add(ref _a, 1) &&
+#if BIT64
+                Unsafe.Add(ref Unsafe.As<int, ulong>(ref g._a), 1) == Unsafe.Add(ref Unsafe.As<int, ulong>(ref _a), 1);
+#else
                 Unsafe.Add(ref g._a, 2) == Unsafe.Add(ref _a, 2) &&
                 Unsafe.Add(ref g._a, 3) == Unsafe.Add(ref _a, 3);
+#endif
         }
 
         private int GetResult(uint me, uint them)

--- a/src/System.Private.CoreLib/shared/System/Guid.cs
+++ b/src/System.Private.CoreLib/shared/System/Guid.cs
@@ -6,8 +6,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics;
-using System.Runtime.Intrinsics.X86;
 
 using Internal.Runtime.CompilerServices;
 
@@ -773,13 +771,9 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void WriteByteHelper(Span<byte> destination)
         {
-            if (Sse2.IsSupported)
+            if (BitConverter.IsLittleEndian)
             {
-                fixed (byte* dstPtr = &destination[0])
-                fixed (int* thisPtr = &_a)
-                {
-                    Sse2.Store((int*) dstPtr, Sse2.LoadVector128(thisPtr));
-                }
+                MemoryMarshal.Write(destination, ref this);
             }
             else
             {

--- a/src/System.Private.CoreLib/shared/System/Guid.cs
+++ b/src/System.Private.CoreLib/shared/System/Guid.cs
@@ -6,6 +6,8 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
 
 using Internal.Runtime.CompilerServices;
 
@@ -771,22 +773,33 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void WriteByteHelper(Span<byte> destination)
         {
-            destination[15] = _k;
-            destination[0] = (byte)(_a);
-            destination[1] = (byte)(_a >> 8);
-            destination[2] = (byte)(_a >> 16);
-            destination[3] = (byte)(_a >> 24);
-            destination[4] = (byte)(_b);
-            destination[5] = (byte)(_b >> 8);
-            destination[6] = (byte)(_c);
-            destination[7] = (byte)(_c >> 8);
-            destination[8] = _d;
-            destination[9] = _e;
-            destination[10] = _f;
-            destination[11] = _g;
-            destination[12] = _h;
-            destination[13] = _i;
-            destination[14] = _j;
+            if (Sse2.IsSupported)
+            {
+                fixed (byte* dstPtr = &destination[0])
+                fixed (int* thisPtr = &_a)
+                {
+                    Sse2.Store((int*) dstPtr, Sse2.LoadVector128(thisPtr));
+                }
+            }
+            else
+            {
+                destination[15] = _k;
+                destination[0] = (byte)(_a);
+                destination[1] = (byte)(_a >> 8);
+                destination[2] = (byte)(_a >> 16);
+                destination[3] = (byte)(_a >> 24);
+                destination[4] = (byte)(_b);
+                destination[5] = (byte)(_b >> 8);
+                destination[6] = (byte)(_c);
+                destination[7] = (byte)(_c >> 8);
+                destination[8] = _d;
+                destination[9] = _e;
+                destination[10] = _f;
+                destination[11] = _g;
+                destination[12] = _h;
+                destination[13] = _i;
+                destination[14] = _j;
+            }
         }
 
         // Returns an unsigned byte array containing the GUID.

--- a/src/System.Private.CoreLib/shared/System/Guid.cs
+++ b/src/System.Private.CoreLib/shared/System/Guid.cs
@@ -839,11 +839,12 @@ namespace System
         public bool Equals(Guid g)
         {
             // Now compare each of the elements
+#if BIT64
+            return Unsafe.As<int, ulong>(ref g._a) == Unsafe.As<int, ulong>(ref _a) &&
+                   Unsafe.Add(ref Unsafe.As<int, ulong>(ref g._a), 1) == Unsafe.Add(ref Unsafe.As<int, ulong>(ref _a), 1);
+#else
             return g._a == _a &&
                 Unsafe.Add(ref g._a, 1) == Unsafe.Add(ref _a, 1) &&
-#if BIT64
-                Unsafe.Add(ref Unsafe.As<int, ulong>(ref g._a), 1) == Unsafe.Add(ref Unsafe.As<int, ulong>(ref _a), 1);
-#else
                 Unsafe.Add(ref g._a, 2) == Unsafe.Add(ref _a, 2) &&
                 Unsafe.Add(ref g._a, 3) == Unsafe.Add(ref _a, 3);
 #endif

--- a/src/System.Private.CoreLib/shared/System/Guid.cs
+++ b/src/System.Private.CoreLib/shared/System/Guid.cs
@@ -786,16 +786,14 @@ namespace System
         // Returns whether bytes are sucessfully written to given span.
         public bool TryWriteBytes(Span<byte> destination)
         {
-            if (destination.Length < 16)
-                return false;
-
             if (BitConverter.IsLittleEndian)
             {
-                MemoryMarshal.Write(destination, ref this);
+                return MemoryMarshal.TryWrite(destination, ref this);
             }
-            else
+
+            // slower path for BigEndian
+            if ((uint)destination.Length >= 16)
             {
-                destination[15] = _k;
                 destination[0] = (byte)(_a);
                 destination[1] = (byte)(_a >> 8);
                 destination[2] = (byte)(_a >> 16);
@@ -811,8 +809,10 @@ namespace System
                 destination[12] = _h;
                 destination[13] = _i;
                 destination[14] = _j;
+                destination[15] = _k;
+                return true;
             }
-            return true;
+            return false;
         }
 
         // Returns the guid in "registry" format.

--- a/src/System.Private.CoreLib/shared/System/Guid.cs
+++ b/src/System.Private.CoreLib/shared/System/Guid.cs
@@ -768,16 +768,33 @@ namespace System
             str[i] == '0' &&
             (str[i + 1] | 0x20) == 'x';
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void WriteByteHelper(Span<byte> destination)
+        // Returns an unsigned byte array containing the GUID.
+        public byte[] ToByteArray()
         {
+            var g = new byte[16];
+            if (BitConverter.IsLittleEndian)
+            {
+                MemoryMarshal.TryWrite<Guid>(g, ref this);
+            }
+            else
+            {
+                TryWriteBytes(g);
+            }
+            return g;
+        }
+
+        // Returns whether bytes are sucessfully written to given span.
+        public bool TryWriteBytes(Span<byte> destination)
+        {
+            if ((uint)destination.Length < 16)
+                return false;
+
             if (BitConverter.IsLittleEndian)
             {
                 MemoryMarshal.Write(destination, ref this);
             }
             else
             {
-                destination[15] = _k;
                 destination[0] = (byte)(_a);
                 destination[1] = (byte)(_a >> 8);
                 destination[2] = (byte)(_a >> 16);
@@ -793,24 +810,8 @@ namespace System
                 destination[12] = _h;
                 destination[13] = _i;
                 destination[14] = _j;
+                destination[15] = _k;
             }
-        }
-
-        // Returns an unsigned byte array containing the GUID.
-        public byte[] ToByteArray()
-        {
-            var g = new byte[16];
-            WriteByteHelper(g);
-            return g;
-        }
-
-        // Returns whether bytes are sucessfully written to given span.
-        public bool TryWriteBytes(Span<byte> destination)
-        {
-            if (destination.Length < 16)
-                return false;
-
-            WriteByteHelper(destination);
             return true;
         }
 

--- a/src/System.Private.CoreLib/shared/System/Guid.cs
+++ b/src/System.Private.CoreLib/shared/System/Guid.cs
@@ -53,12 +53,12 @@ namespace System
 
             if (BitConverter.IsLittleEndian)
             {
-                this = MemoryMarshal.Read(b);
+                this = MemoryMarshal.Read<Guid>(b);
                 return;
             }
 
             // slower path for BigEndian:
-            _k = b[15];
+            _k = b[15];  // hoist bounds checks
             _a = b[3] << 24 | b[2] << 16 | b[1] << 8 | b[0];
             _b = (short)(b[5] << 8 | b[4]);
             _c = (short)(b[7] << 8 | b[6]);
@@ -100,7 +100,7 @@ namespace System
             _a = a;
             _b = b;
             _c = c;
-            _k = d[7];
+            _k = d[7]; // hoist bounds checks
             _d = d[0];
             _e = d[1];
             _f = d[2];
@@ -802,7 +802,7 @@ namespace System
             if (destination.Length < 16)
                 return false;
 
-            destination[15] = _k;
+            destination[15] = _k; // hoist bounds checks
             destination[0] = (byte)(_a);
             destination[1] = (byte)(_a >> 8);
             destination[2] = (byte)(_a >> 16);

--- a/src/System.Private.CoreLib/shared/System/Guid.cs
+++ b/src/System.Private.CoreLib/shared/System/Guid.cs
@@ -786,7 +786,7 @@ namespace System
         // Returns whether bytes are sucessfully written to given span.
         public bool TryWriteBytes(Span<byte> destination)
         {
-            if ((uint)destination.Length < 16)
+            if (destination.Length < 16)
                 return false;
 
             if (BitConverter.IsLittleEndian)
@@ -795,6 +795,7 @@ namespace System
             }
             else
             {
+                destination[15] = _k;
                 destination[0] = (byte)(_a);
                 destination[1] = (byte)(_a >> 8);
                 destination[2] = (byte)(_a >> 16);
@@ -810,7 +811,6 @@ namespace System
                 destination[12] = _h;
                 destination[13] = _i;
                 destination[14] = _j;
-                destination[15] = _k;
             }
             return true;
         }


### PR DESCRIPTION
1. `Guid.TryWriteBytes(Span<byte>)`:
```csharp
[Benchmark]
[ArgumentsSource(nameof(TestData))]
public Span<byte> TryWriteBytes(Guid id)
{
    Span<byte> s = new byte[20];
    id.TryWriteBytes(s);
    return s;
}
```
|            Method |     Mean |     Error |    StdDev |
|------------------ |---------:|----------:|----------:|
| TryWriteBytes_new | 4.960 ns | 0.0818 ns | 0.0292 ns |
| TryWriteBytes_old | 8.541 ns | 0.0362 ns | 0.0129 ns |
</br>

2. `new Guid(byte[])` and `new Guid(ReadOnlySpan<byte>)`:
```csharp
[Benchmark]
[ArgumentsSource(nameof(TestData))]
public Guid GuidCtor(byte[] data)
{
    return new Guid(data);
}
```

|       Method |     Mean |     Error |    StdDev |
|------------- |---------:|----------:|----------:|
| GuidCtor_new | 2.615 ns | 0.0275 ns | 0.0098 ns |
| GuidCtor_old | 7.483 ns | 0.0146 ns | 0.0052 ns |
 
</br>

3. `Guid.ToByteArray()`:
```csharp
[Benchmark]
[ArgumentsSource(nameof(TestData))]
public byte[] ToByteArray(Guid id)
{
    return id.ToByteArray();
}
```
|          Method |     Mean |     Error |    StdDev |
|---------------- |---------:|----------:|----------:|
| ToByteArray_new | 3.569 ns | 0.0192 ns | 0.0068 ns |
| ToByteArray_old | 6.265 ns | 0.0776 ns | 0.0202 ns |

 
</br>

Environment:
``` ini

BenchmarkDotNet=v0.11.3, OS=Windows 10.0.17134.407 (1803/April2018Update/Redstone4)
Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
Frequency=3609372 Hz, Resolution=277.0565 ns, Timer=TSC
.NET Core SDK=3.0.100-preview-009812
  [Host]     : .NET Core 3.0.0-preview-27122-01 (CoreCLR 4.6.27121.03, CoreFX 4.7.18.57103), 64bit RyuJIT
  Job-CIYVXD : .NET Core 3.0.0-preview-27122-01 (CoreCLR 4.6.27121.03, CoreFX 4.7.18.57103), 64bit RyuJIT

IterationCount=6  WarmupCount=6  

```