### PR TITLE
Fixing the Vector64/128/256<T>.ToString(string) methods to pass `null` for the formatProvider

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128_1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128_1.cs
@@ -323,7 +323,7 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         public string ToString(string format)
         {
-            return ToString(format, CultureInfo.CurrentCulture);
+            return ToString(format, formatProvider: null);
         }
 
         /// <summary>Converts the current instance to an equivalent string representation using the specified format.</summary>

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256_1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256_1.cs
@@ -325,7 +325,7 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         public string ToString(string format)
         {
-            return ToString(format, CultureInfo.CurrentCulture);
+            return ToString(format, formatProvider: null);
         }
 
         /// <summary>Converts the current instance to an equivalent string representation using the specified format.</summary>

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector64_1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector64_1.cs
@@ -270,7 +270,7 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         public string ToString(string format)
         {
-            return ToString(format, CultureInfo.CurrentCulture);
+            return ToString(format, formatProvider: null);
         }
 
         /// <summary>Converts the current instance to an equivalent string representation using the specified format.</summary>


### PR DESCRIPTION
This was suggested by @eerhardt in https://github.com/dotnet/coreclr/pull/21259 (see https://github.com/dotnet/coreclr/pull/21259#discussion_r237553106) and the change never got pushed.