### PR TITLE
Fix lots of malformed XML comments

### DIFF
--- a/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -26,7 +26,7 @@
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);618</WarningsNotAsErrors>
-    <NoWarn>649,3019,414,169,3015</NoWarn>
+    <NoWarn>649,3019,414,169,3015,591,1573,1591,0419</NoWarn>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <SignAssembly>true</SignAssembly>
     <DelaySign>true</DelaySign>
@@ -37,6 +37,7 @@
     <_FullFrameworkReferenceAssemblyPaths>$(MSBuildThisFileDirectory)/Documentation</_FullFrameworkReferenceAssemblyPaths>
     <SkipCommonResourcesIncludes>true</SkipCommonResourcesIncludes>
     <LangVersion>latest</LangVersion>
+    <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
   </PropertyGroup>
   <!-- Add Serviceable attribute to the project's metadata -->
   <ItemGroup>

--- a/src/System.Private.CoreLib/shared/System/Buffers/StandardFormat.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/StandardFormat.cs
@@ -67,7 +67,7 @@ namespace System.Buffers
         public static implicit operator StandardFormat(char symbol) => new StandardFormat(symbol);
 
         /// <summary>
-        /// Converts a ReadOnlySpan<char> into a StandardFormat
+        /// Converts a <see cref="ReadOnlySpan{Char}"/> into a StandardFormat
         /// </summary>
         public static StandardFormat Parse(ReadOnlySpan<char> format)
         {
@@ -82,7 +82,7 @@ namespace System.Buffers
         public static StandardFormat Parse(string format) => format == null ? default : Parse(format.AsSpan());
 
         /// <summary>
-        /// Tries to convert a ReadOnlySpan<char> into a StandardFormat. A return value indicates whether the conversion succeeded or failed.
+        /// Tries to convert a <see cref="ReadOnlySpan{Char}"/> into a StandardFormat. A return value indicates whether the conversion succeeded or failed.
         /// </summary>
         public static bool TryParse(ReadOnlySpan<char> format, out StandardFormat result)
         {

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/IEnumerable.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/IEnumerable.cs
@@ -14,7 +14,6 @@ namespace System.Collections.Generic
     {
         // Returns an IEnumerator for this enumerable Object.  The enumerator provides
         // a simple way to access all the contents of a collection.
-        /// <include file='doc\IEnumerable.uex' path='docs/doc[@for="IEnumerable.GetEnumerator"]/*' />
         new IEnumerator<T> GetEnumerator();
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/IEnumerator.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/IEnumerator.cs
@@ -16,8 +16,6 @@ namespace System.Collections.Generic
         // call to MoveNext that returned false. Multiple calls to
         // GetCurrent with no intervening calls to MoveNext 
         // will return the same object.
-        // 
-        /// <include file='doc\IEnumerator.uex' path='docs/doc[@for="IEnumerator.Current"]/*' />
         new T Current
         {
             get;

--- a/src/System.Private.CoreLib/shared/System/Convert.Base64.cs
+++ b/src/System.Private.CoreLib/shared/System/Convert.Base64.cs
@@ -20,6 +20,7 @@ namespace System
         /// <param name="bytes">The output span which contains the result of the operation, i.e. the decoded binary data.</param>
         /// <param name="consumed">The number of input bytes consumed during the operation. This can be used to slice the input for subsequent calls, if necessary.</param>
         /// <param name="written">The number of bytes written into the output span. This can be used to slice the output for subsequent calls, if necessary.</param>
+        /// </summary> 
         /// <returns>Returns:
         /// - true  - The entire input span was successfully parsed.
         /// - false - Only a part of the input span was successfully parsed. Failure causes may include embedded or trailing whitespace, 
@@ -29,8 +30,7 @@ namespace System
         ///           
         /// Note: This is a cut down version of the implementation of Base64.DecodeFromUtf8(), modified the accept UTF16 chars and act as a fast-path
         /// helper for the Convert routines when the input string contains no whitespace.
-        ///           
-        /// </summary> 
+        /// </returns>
         private static bool TryDecodeFromUtf16(ReadOnlySpan<char> utf16, Span<byte> bytes, out int consumed, out int written)
         {
             ref char srcChars = ref MemoryMarshal.GetReference(utf16);

--- a/src/System.Private.CoreLib/shared/System/Decimal.DecCalc.cs
+++ b/src/System.Private.CoreLib/shared/System/Decimal.DecCalc.cs
@@ -528,7 +528,7 @@ PosRem:
             /// Perform needed scaling. Adjust scale factor accordingly.
             /// </summary>
             /// <param name="bufRes">Array of uints with value, least-significant first</param>
-            /// <param name="hiRes">Index of last non-zero value in bufRes
+            /// <param name="hiRes">Index of last non-zero value in bufRes</param>
             /// <param name="scale">Scale factor for this value, range 0 - 2 * DEC_SCALE_MAX</param>
             /// <returns>Returns new scale factor. bufRes updated in place, always 3 uints.</returns>
             private static unsafe int ScaleResult(Buf24* bufRes, uint hiRes, int scale)

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/TraceLogging/InvokeTypeInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/TraceLogging/InvokeTypeInfo.cs
@@ -16,9 +16,6 @@ namespace System.Diagnostics.Tracing
     /// for arbitrary types. It writes all public instance properties of
     /// the type.
     /// </summary>
-    /// <typeparam name="ContainerType">
-    /// Type from which to read values.
-    /// </typeparam>
     internal sealed class InvokeTypeInfo : TraceLoggingTypeInfo
     {
         internal readonly PropertyAnalysis[] properties;

--- a/src/System.Private.CoreLib/shared/System/Lazy.cs
+++ b/src/System.Private.CoreLib/shared/System/Lazy.cs
@@ -218,7 +218,7 @@ namespace System
         /// </summary>
         /// <remarks>
         /// An instance created with this constructor should be usable by multiple threads
-        //  concurrently.
+        /// concurrently.
         /// </remarks>
         public Lazy(T value)
         {
@@ -499,7 +499,7 @@ namespace System
         /// </exception>
         /// <remarks>
         /// If <see cref="IsValueCreated"/> is false, accessing <see cref="Value"/> will force initialization.
-        /// Please <see cref="System.Threading.LazyThreadSafetyMode"> for more information on how <see cref="T:System.Threading.Lazy{T}"/> will behave if an exception is thrown
+        /// Please <see cref="System.Threading.LazyThreadSafetyMode"/> for more information on how <see cref="T:System.Threading.Lazy{T}"/> will behave if an exception is thrown
         /// from initialization delegate.
         /// </remarks>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]

--- a/src/System.Private.CoreLib/shared/System/Progress.cs
+++ b/src/System.Private.CoreLib/shared/System/Progress.cs
@@ -43,7 +43,7 @@ namespace System
         /// A handler to invoke for each reported progress value.  This handler will be invoked
         /// in addition to any delegates registered with the <see cref="ProgressChanged"/> event.
         /// Depending on the <see cref="System.Threading.SynchronizationContext"/> instance captured by 
-        /// the <see cref="Progress"/> at construction, it's possible that this handler instance
+        /// the <see cref="Progress{T}"/> at construction, it's possible that this handler instance
         /// could be invoked concurrently with itself.
         /// </param>
         /// <exception cref="System.ArgumentNullException">The <paramref name="handler"/> is null (Nothing in Visual Basic).</exception>

--- a/src/System.Private.CoreLib/shared/System/ReadOnlySpan.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/ReadOnlySpan.Fast.cs
@@ -39,7 +39,6 @@ namespace System
         /// </summary>
         /// <param name="array">The target array.</param>
         /// <remarks>Returns default when <paramref name="array"/> is null.</remarks>
-        /// reference (Nothing in Visual Basic).</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ReadOnlySpan(T[] array)
         {
@@ -61,7 +60,6 @@ namespace System
         /// <param name="start">The index at which to begin the read-only span.</param>
         /// <param name="length">The number of items in the read-only span.</param>
         /// <remarks>Returns default when <paramref name="array"/> is null.</remarks>
-        /// reference (Nothing in Visual Basic).</exception>
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown when the specified <paramref name="start"/> or end index is not in the range (&lt;0 or &gt;=Length).
         /// </exception>
@@ -214,6 +212,7 @@ namespace System
             }
         }
 
+        /// <summary>
         /// Copies the contents of this read-only span into destination span. If the source
         /// and destinations overlap, this method behaves as if the original values in
         /// a temporary location before the destination is overwritten.

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncIteratorMethodBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncIteratorMethodBuilder.cs
@@ -35,7 +35,7 @@ namespace System.Runtime.CompilerServices
             default; // coreclr's AsyncTaskMethodBuilder.Create just returns default as well
 #endif
 
-        /// <summary>Invokes <see cref="IAsyncStateMachine.MoveNext"/> on the state machine while guarding the <see cref="ExecutionContext."/></summary>
+        /// <summary>Invokes <see cref="IAsyncStateMachine.MoveNext"/> on the state machine while guarding the <see cref="ExecutionContext"/>.</summary>
         /// <typeparam name="TStateMachine">The type of the state machine.</typeparam>
         /// <param name="stateMachine">The state machine instance, passed by reference.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/TaskAwaiter.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/TaskAwaiter.cs
@@ -227,12 +227,8 @@ namespace System.Runtime.CompilerServices
 #if CORECLR
         /// <summary>Schedules the continuation onto the <see cref="System.Threading.Tasks.Task"/> associated with this <see cref="TaskAwaiter"/>.</summary>
         /// <param name="task">The task being awaited.</param>
-        /// <param name="continuation">The action to invoke when the await operation completes.</param>
+        /// <param name="stateMachineBox">The box to invoke when the await operation completes.</param>
         /// <param name="continueOnCapturedContext">Whether to capture and marshal back to the current context.</param>
-        /// <param name="flowExecutionContext">Whether to flow ExecutionContext across the await.</param>
-        /// <exception cref="System.ArgumentNullException">The <paramref name="continuation"/> argument is null (Nothing in Visual Basic).</exception>
-        /// <exception cref="System.NullReferenceException">The awaiter was not properly initialized.</exception>
-        /// <remarks>This method is intended for compiler user rather than use directly in code.</remarks>
         internal static void UnsafeOnCompletedInternal(Task task, IAsyncStateMachineBox stateMachineBox, bool continueOnCapturedContext)
         {
             Debug.Assert(stateMachineBox != null);

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Aes.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Aes.PlatformNotSupported.cs
@@ -13,25 +13,25 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
     public static class Aes
     {
         public static bool IsSupported {  get { return false; } }
-        // <summary>
+        /// <summary>
         /// Performs AES single round decryption
         /// vaesdq_u8 (uint8x16_t data, uint8x16_t key)
         ///</summary>
         public static Vector128<byte> Decrypt(Vector128<byte> value, Vector128<byte> roundKey) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
+        /// <summary>
         /// Performs AES single round encryption
         /// vaeseq_u8 (uint8x16_t data, uint8x16_t key)
         ///</summary>
         public static Vector128<byte> Encrypt(Vector128<byte> value, Vector128<byte> roundKey) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
+        /// <summary>
         /// Performs AES  Mix Columns
         /// vaesmcq_u8 (uint8x16_t data)
         ///</summary>
         public static Vector128<byte> MixColumns(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
+        /// <summary>
         /// Performs AES inverse mix columns
         /// vaesimcq_u8  (uint8x16_t data)
         ///</summary>

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Sha1.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Sha1.PlatformNotSupported.cs
@@ -15,37 +15,37 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
 
         public static bool IsSupported {  get { return false; } }
 
-        // <summary>
+        /// <summary>
         /// Performs SHA1 hash update choose form.
         /// vsha1cq_u32 (uint32x4_t hash_abcd, uint32_t hash_e, uint32x4_t wk)
         ///</summary>
         public static Vector128<uint> HashChoose(Vector128<uint> hash_abcd, uint hash_e, Vector128<uint>wk) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
+        /// <summary>
         /// Performs SHA1 hash update majority form.
         /// vsha1mq_u32 (uint32x4_t hash_abcd, uint32_t hash_e, uint32x4_t wk)
         ///</summary>
         public static Vector128<uint> HashMajority(Vector128<uint> hash_abcd, uint hash_e, Vector128<uint>wk) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
+        /// <summary>
         /// Performs SHA1 hash update parity form.
         /// vsha1pq_u32 (uint32x4_t hash_abcd, uint32_t hash_e, uint32x4_t wk)
         ///</summary>
         public static Vector128<uint> HashParity(Vector128<uint> hash_abcd, uint hash_e, Vector128<uint>wk) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
+        /// <summary>
         /// Performs SHA1 fixed rotate
         /// vsha1h_u32 (uint32_t hash_e)
         ///</summary>
         public static uint FixedRotate(uint hash_e) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
+        /// <summary>
         /// Performs SHA1 schedule update 0
         /// vsha1su0q_u32 (uint32x4_t w0_3, uint32x4_t w4_7, uint32x4_t w8_11)
         ///</summary>
         public static Vector128<uint> SchedulePart1(Vector128<uint> w0_3, Vector128<uint> w4_7, Vector128<uint> w8_11) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
+        /// <summary>
         /// Performs SHA1 schedule update 1
         /// vsha1su1q_u32 (uint32x4_t tw0_3, uint32x4_t w12_15)
         ///</summary>

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Sha256.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Sha256.PlatformNotSupported.cs
@@ -14,25 +14,25 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
     {
         public static bool IsSupported { get { return false; } }
 
-        // <summary>
+        /// <summary>
         /// Performs SHA256 hash update (part 1).
         /// vsha256hq_u32 (uint32x4_t hash_abcd, uint32x4_t hash_efgh, uint32x4_t wk)
         ///</summary>
         public static Vector128<uint> HashLower(Vector128<uint> hash_abcd, Vector128<uint> hash_efgh, Vector128<uint> wk) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
+        /// <summary>
         /// Performs SHA256 hash update (part 2).
         /// vsha256h2q_u32 (uint32x4_t hash_efgh, uint32x4_t hash_abcd, uint32x4_t wk)
         ///</summary>
         public static Vector128<uint> HashUpper(Vector128<uint> hash_efgh, Vector128<uint> hash_abcd, Vector128<uint> wk) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
+        /// <summary>
         /// Performs SHA256 schedule update 0
         /// vsha256su0q_u32 (uint32x4_t w0_3, uint32x4_t w4_7)
         ///</summary>
         public static Vector128<uint> SchedulePart1(Vector128<uint> w0_3, Vector128<uint> w4_7) { throw new PlatformNotSupportedException(); }
 
-        // <summary>
+        /// <summary>
         /// Performs SHA256 schedule update 1
         /// vsha256su1q_u32 (uint32x4_t w0_3, uint32x4_t w8_11, uint32x4_t w12_15)
         ///</summary>

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Simd.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Simd.PlatformNotSupported.cs
@@ -21,7 +21,7 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
 
         /// <summary>
         /// Vector abs
-        /// Corresponds to vector forms of ARM64 ABS & FABS
+        /// Corresponds to vector forms of ARM64 ABS &amp; FABS
         /// </summary>
         public static Vector64<byte>    Abs(Vector64<sbyte>   value) { throw new PlatformNotSupportedException(); }
         public static Vector64<ushort>  Abs(Vector64<short>   value) { throw new PlatformNotSupportedException(); }
@@ -36,7 +36,7 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
 
         /// <summary>
         /// Vector add
-        /// Corresponds to vector forms of ARM64 ADD & FADD
+        /// Corresponds to vector forms of ARM64 ADD &amp; FADD
         /// </summary>
         public static Vector64<T>  Add<T>(Vector64<T>  left, Vector64<T>  right) where T : struct { throw new PlatformNotSupportedException(); }
         public static Vector128<T> Add<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw new PlatformNotSupportedException(); }
@@ -58,7 +58,7 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
         /// <summary>
         /// Vector BitwiseSelect
         /// For each bit in the vector result[bit] = sel[bit] ? left[bit] : right[bit]
-        /// Corresponds to vector forms of ARM64 BSL (Also BIF & BIT)
+        /// Corresponds to vector forms of ARM64 BSL (Also BIF &amp; BIT)
         /// </summary>
         public static Vector64<T>  BitwiseSelect<T>(Vector64<T>  sel, Vector64<T>  left, Vector64<T>  right) where T : struct { throw new PlatformNotSupportedException(); }
         public static Vector128<T> BitwiseSelect<T>(Vector128<T> sel, Vector128<T> left, Vector128<T> right) where T : struct { throw new PlatformNotSupportedException(); }
@@ -66,7 +66,7 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
         /// <summary>
         /// Vector CompareEqual
         /// For each element result[elem] = (left[elem] == right[elem]) ? ~0 : 0
-        /// Corresponds to vector forms of ARM64 CMEQ & FCMEQ
+        /// Corresponds to vector forms of ARM64 CMEQ &amp; FCMEQ
         /// </summary>
         public static Vector64<T>  CompareEqual<T>(Vector64<T>  left, Vector64<T>  right) where T : struct { throw new PlatformNotSupportedException(); }
         public static Vector128<T> CompareEqual<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw new PlatformNotSupportedException(); }
@@ -74,7 +74,7 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
         /// <summary>
         /// Vector CompareEqualZero
         /// For each element result[elem] = (left[elem] == 0) ? ~0 : 0
-        /// Corresponds to vector forms of ARM64 CMEQ & FCMEQ
+        /// Corresponds to vector forms of ARM64 CMEQ &amp; FCMEQ
         /// </summary>
         public static Vector64<T>  CompareEqualZero<T>(Vector64<T>  value) where T : struct { throw new PlatformNotSupportedException(); }
         public static Vector128<T> CompareEqualZero<T>(Vector128<T> value) where T : struct { throw new PlatformNotSupportedException(); }
@@ -82,7 +82,7 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
         /// <summary>
         /// Vector CompareGreaterThan
         /// For each element result[elem] = (left[elem] > right[elem]) ? ~0 : 0
-        /// Corresponds to vector forms of ARM64 CMGT/CMHI & FCMGT
+        /// Corresponds to vector forms of ARM64 CMGT/CMHI &amp; FCMGT
         /// </summary>
         public static Vector64<T>  CompareGreaterThan<T>(Vector64<T>  left, Vector64<T>  right) where T : struct { throw new PlatformNotSupportedException(); }
         public static Vector128<T> CompareGreaterThan<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw new PlatformNotSupportedException(); }
@@ -90,7 +90,7 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
         /// <summary>
         /// Vector CompareGreaterThanZero
         /// For each element result[elem] = (left[elem] > 0) ? ~0 : 0
-        /// Corresponds to vector forms of ARM64 CMGT & FCMGT
+        /// Corresponds to vector forms of ARM64 CMGT &amp; FCMGT
         /// </summary>
         public static Vector64<T>  CompareGreaterThanZero<T>(Vector64<T>  value) where T : struct { throw new PlatformNotSupportedException(); }
         public static Vector128<T> CompareGreaterThanZero<T>(Vector128<T> value) where T : struct { throw new PlatformNotSupportedException(); }
@@ -98,7 +98,7 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
         /// <summary>
         /// Vector CompareGreaterThanOrEqual
         /// For each element result[elem] = (left[elem] >= right[elem]) ? ~0 : 0
-        /// Corresponds to vector forms of ARM64 CMGE/CMHS & FCMGE
+        /// Corresponds to vector forms of ARM64 CMGE/CMHS &amp; FCMGE
         /// </summary>
         public static Vector64<T>  CompareGreaterThanOrEqual<T>(Vector64<T>  left, Vector64<T>    right) where T : struct { throw new PlatformNotSupportedException(); }
         public static Vector128<T> CompareGreaterThanOrEqual<T>(Vector128<T> left, Vector128<T>   right) where T : struct { throw new PlatformNotSupportedException(); }
@@ -106,30 +106,30 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
         /// <summary>
         /// Vector CompareGreaterThanOrEqualZero
         /// For each element result[elem] = (left[elem] >= 0) ? ~0 : 0
-        /// Corresponds to vector forms of ARM64 CMGE & FCMGE
+        /// Corresponds to vector forms of ARM64 CMGE &amp; FCMGE
         /// </summary>
         public static Vector64<T>  CompareGreaterThanOrEqualZero<T>(Vector64<T>  value) where T : struct { throw new PlatformNotSupportedException(); }
         public static Vector128<T> CompareGreaterThanOrEqualZero<T>(Vector128<T> value) where T : struct { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// Vector CompareLessThanZero
-        /// For each element result[elem] = (left[elem] < 0) ? ~0 : 0
-        /// Corresponds to vector forms of ARM64 CMGT & FCMGT
+        /// For each element result[elem] = (left[elem] &lt; 0) ? ~0 : 0
+        /// Corresponds to vector forms of ARM64 CMGT &amp; FCMGT
         /// </summary>
         public static Vector64<T>  CompareLessThanZero<T>(Vector64<T>  value) where T : struct { throw new PlatformNotSupportedException(); }
         public static Vector128<T> CompareLessThanZero<T>(Vector128<T> value) where T : struct { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// Vector CompareLessThanOrEqualZero
-        /// For each element result[elem] = (left[elem] < 0) ? ~0 : 0
-        /// Corresponds to vector forms of ARM64 CMGT & FCMGT
+        /// For each element result[elem] = (left[elem] &lt; 0) ? ~0 : 0
+        /// Corresponds to vector forms of ARM64 CMGT &amp; FCMGT
         /// </summary>
         public static Vector64<T>  CompareLessThanOrEqualZero<T>(Vector64<T>  value) where T : struct { throw new PlatformNotSupportedException(); }
         public static Vector128<T> CompareLessThanOrEqualZero<T>(Vector128<T> value) where T : struct { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// Vector CompareTest
-        /// For each element result[elem] = (left[elem] & right[elem]) ? ~0 : 0
+        /// For each element result[elem] = (left[elem] &amp; right[elem]) ? ~0 : 0
         /// Corresponds to vector forms of ARM64 CMTST
         /// </summary>
         public static Vector64<T>  CompareTest<T>(Vector64<T>  left, Vector64<T>  right) where T : struct { throw new PlatformNotSupportedException(); }
@@ -202,7 +202,7 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
 
         /// <summary>
         /// Vector max
-        /// Corresponds to vector forms of ARM64 SMAX, UMAX & FMAX
+        /// Corresponds to vector forms of ARM64 SMAX, UMAX &amp; FMAX
         /// </summary>
         public static Vector64<byte>    Max(Vector64<byte>    left, Vector64<byte>    right) { throw new PlatformNotSupportedException(); }
         public static Vector64<sbyte>   Max(Vector64<sbyte>   left, Vector64<sbyte>   right) { throw new PlatformNotSupportedException(); }
@@ -222,7 +222,7 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
 
         /// <summary>
         /// Vector min
-        /// Corresponds to vector forms of ARM64 SMIN, UMIN & FMIN
+        /// Corresponds to vector forms of ARM64 SMIN, UMIN &amp; FMIN
         /// </summary>
         public static Vector64<byte>    Min(Vector64<byte>    left, Vector64<byte>    right) { throw new PlatformNotSupportedException(); }
         public static Vector64<sbyte>   Min(Vector64<sbyte>   left, Vector64<sbyte>   right) { throw new PlatformNotSupportedException(); }
@@ -247,7 +247,7 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
         ///
         /// For each element result[elem] = left[elem] * right[elem]
         ///
-        /// Corresponds to vector forms of ARM64 MUL & FMUL
+        /// Corresponds to vector forms of ARM64 MUL &amp; FMUL
         /// </summary>
         public static Vector64<byte>    Multiply(Vector64<byte>    left, Vector64<byte>    right) { throw new PlatformNotSupportedException(); }
         public static Vector64<sbyte>   Multiply(Vector64<sbyte>   left, Vector64<sbyte>   right) { throw new PlatformNotSupportedException(); }
@@ -267,7 +267,7 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
 
         /// <summary>
         /// Vector negate
-        /// Corresponds to vector forms of ARM64 NEG & FNEG
+        /// Corresponds to vector forms of ARM64 NEG &amp; FNEG
         /// </summary>
         public static Vector64<sbyte>   Negate(Vector64<sbyte>   value) { throw new PlatformNotSupportedException(); }
         public static Vector64<short>   Negate(Vector64<short>   value) { throw new PlatformNotSupportedException(); }
@@ -328,7 +328,7 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
 
         /// <summary>
         /// Vector subtract
-        /// Corresponds to vector forms of ARM64 SUB & FSUB
+        /// Corresponds to vector forms of ARM64 SUB &amp; FSUB
         /// </summary>
         public static Vector64<T>  Subtract<T>(Vector64<T>  left, Vector64<T>  right) where T : struct { throw new PlatformNotSupportedException(); }
         public static Vector128<T> Subtract<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw new PlatformNotSupportedException(); }

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128.cs
@@ -10,9 +10,9 @@ namespace System.Runtime.Intrinsics
     {
         internal const int Size = 16;
 
-        /// <summary>Creates a new <see cref="Vector128{byte}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Byte}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{byte}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector128{Byte}" /> with all elements initialized to <paramref name="value" />.</returns>
         public static unsafe Vector128<byte> Create(byte value)
         {
             var pResult = stackalloc byte[16]
@@ -38,9 +38,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<byte>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{double}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Double}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{double}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector128{Double}" /> with all elements initialized to <paramref name="value" />.</returns>
         public static unsafe Vector128<double> Create(double value)
         {
             var pResult = stackalloc double[2]
@@ -52,9 +52,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<double>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{short}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Int16}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{short}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector128{Int16}" /> with all elements initialized to <paramref name="value" />.</returns>
         public static unsafe Vector128<short> Create(short value)
         {
             var pResult = stackalloc short[8]
@@ -72,9 +72,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<short>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{int}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Int32}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{int}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector128{Int32}" /> with all elements initialized to <paramref name="value" />.</returns>
         public static unsafe Vector128<int> Create(int value)
         {
             var pResult = stackalloc int[4]
@@ -88,9 +88,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<int>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{long}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Int64}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{long}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector128{Int64}" /> with all elements initialized to <paramref name="value" />.</returns>
         public static unsafe Vector128<long> Create(long value)
         {
             var pResult = stackalloc long[2]
@@ -102,9 +102,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<long>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{sbyte}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector128{SByte}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{sbyte}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector128{SByte}" /> with all elements initialized to <paramref name="value" />.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector128<sbyte> Create(sbyte value)
         {
@@ -131,9 +131,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<sbyte>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{float}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Single}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{float}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector128{Single}" /> with all elements initialized to <paramref name="value" />.</returns>
         public static unsafe Vector128<float> Create(float value)
         {
             var pResult = stackalloc float[4]
@@ -147,9 +147,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<float>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{ushort}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector128{UInt16}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{ushort}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector128{UInt16}" /> with all elements initialized to <paramref name="value" />.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector128<ushort> Create(ushort value)
         {
@@ -168,9 +168,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<ushort>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{uint}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector128{UInt32}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{uint}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector128{UInt32}" /> with all elements initialized to <paramref name="value" />.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector128<uint> Create(uint value)
         {
@@ -185,9 +185,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<uint>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{ulong}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector128{UInt64}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{ulong}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector128{UInt64}" /> with all elements initialized to <paramref name="value" />.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector128<ulong> Create(ulong value)
         {
@@ -200,7 +200,7 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<ulong>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{byte}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Byte}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
         /// <param name="e2">The value that element 2 will be initialized to.</param>
@@ -217,7 +217,7 @@ namespace System.Runtime.Intrinsics
         /// <param name="e13">The value that element 13 will be initialized to.</param>
         /// <param name="e14">The value that element 14 will be initialized to.</param>
         /// <param name="e15">The value that element 15 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{byte}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector128{Byte}" /> with each element initialized to corresponding specified value.</returns>
         public static unsafe Vector128<byte> Create(byte e0, byte e1, byte e2, byte e3, byte e4, byte e5, byte e6, byte e7, byte e8, byte e9, byte e10, byte e11, byte e12, byte e13, byte e14, byte e15)
         {
             var pResult = stackalloc byte[16]
@@ -243,10 +243,10 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<byte>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{double}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Double}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{double}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector128{Double}" /> with each element initialized to corresponding specified value.</returns>
         public static unsafe Vector128<double> Create(double e0, double e1)
         {
             var pResult = stackalloc double[2]
@@ -258,7 +258,7 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<double>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{short}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Int16}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
         /// <param name="e2">The value that element 2 will be initialized to.</param>
@@ -267,7 +267,7 @@ namespace System.Runtime.Intrinsics
         /// <param name="e5">The value that element 5 will be initialized to.</param>
         /// <param name="e6">The value that element 6 will be initialized to.</param>
         /// <param name="e7">The value that element 7 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{short}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector128{Int16}" /> with each element initialized to corresponding specified value.</returns>
         public static unsafe Vector128<short> Create(short e0, short e1, short e2, short e3, short e4, short e5, short e6, short e7)
         {
             var pResult = stackalloc short[8]
@@ -285,12 +285,12 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<short>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{int}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Int32}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
         /// <param name="e2">The value that element 2 will be initialized to.</param>
         /// <param name="e3">The value that element 3 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{int}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector128{Int32}" /> with each element initialized to corresponding specified value.</returns>
         public static unsafe Vector128<int> Create(int e0, int e1, int e2, int e3)
         {
             var pResult = stackalloc int[4]
@@ -304,10 +304,10 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<int>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{long}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Int64}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{long}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector128{Int64}" /> with each element initialized to corresponding specified value.</returns>
         public static unsafe Vector128<long> Create(long e0, long e1)
         {
             var pResult = stackalloc long[2]
@@ -319,7 +319,7 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<long>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{sbyte}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector128{SByte}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
         /// <param name="e2">The value that element 2 will be initialized to.</param>
@@ -336,7 +336,7 @@ namespace System.Runtime.Intrinsics
         /// <param name="e13">The value that element 13 will be initialized to.</param>
         /// <param name="e14">The value that element 14 will be initialized to.</param>
         /// <param name="e15">The value that element 15 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{sbyte}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector128{SByte}" /> with each element initialized to corresponding specified value.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector128<sbyte> Create(sbyte e0, sbyte e1, sbyte e2, sbyte e3, sbyte e4, sbyte e5, sbyte e6, sbyte e7, sbyte e8, sbyte e9, sbyte e10, sbyte e11, sbyte e12, sbyte e13, sbyte e14, sbyte e15)
         {
@@ -363,12 +363,12 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<sbyte>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{float}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Single}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
         /// <param name="e2">The value that element 2 will be initialized to.</param>
         /// <param name="e3">The value that element 3 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{float}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector128{Single}" /> with each element initialized to corresponding specified value.</returns>
         public static unsafe Vector128<float> Create(float e0, float e1, float e2, float e3)
         {
             var pResult = stackalloc float[4]
@@ -382,7 +382,7 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<float>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{ushort}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector128{UInt16}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
         /// <param name="e2">The value that element 2 will be initialized to.</param>
@@ -391,7 +391,7 @@ namespace System.Runtime.Intrinsics
         /// <param name="e5">The value that element 5 will be initialized to.</param>
         /// <param name="e6">The value that element 6 will be initialized to.</param>
         /// <param name="e7">The value that element 7 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{ushort}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector128{UInt16}" /> with each element initialized to corresponding specified value.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector128<ushort> Create(ushort e0, ushort e1, ushort e2, ushort e3, ushort e4, ushort e5, ushort e6, ushort e7)
         {
@@ -410,12 +410,12 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<ushort>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{uint}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector128{UInt32}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
         /// <param name="e2">The value that element 2 will be initialized to.</param>
         /// <param name="e3">The value that element 3 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{uint}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector128{UInt32}" /> with each element initialized to corresponding specified value.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector128<uint> Create(uint e0, uint e1, uint e2, uint e3)
         {
@@ -430,10 +430,10 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<uint>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{ulong}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector128{UInt64}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{ulong}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector128{UInt64}" /> with each element initialized to corresponding specified value.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector128<ulong> Create(ulong e0, ulong e1)
         {
@@ -446,10 +446,10 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<ulong>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{byte}" /> instance from two <see cref="Vector64{byte}" /> instances.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Byte}" /> instance from two <see cref="Vector64{Byte}" /> instances.</summary>
         /// <param name="lower">The value that the lower 64-bits will be initialized to.</param>
         /// <param name="upper">The value that the upper 64-bits will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{byte}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
+        /// <returns>A new <see cref="Vector128{Byte}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
         public static unsafe Vector128<byte> Create(Vector64<byte> lower, Vector64<byte> upper)
         {
             Vector128<byte> result128 = Vector128<byte>.Zero;
@@ -461,10 +461,10 @@ namespace System.Runtime.Intrinsics
             return result128;
         }
 
-        /// <summary>Creates a new <see cref="Vector128{double}" /> instance from two <see cref="Vector64{double}" /> instances.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Double}" /> instance from two <see cref="Vector64{Double}" /> instances.</summary>
         /// <param name="lower">The value that the lower 64-bits will be initialized to.</param>
         /// <param name="upper">The value that the upper 64-bits will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{double}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
+        /// <returns>A new <see cref="Vector128{Double}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
         public static unsafe Vector128<double> Create(Vector64<double> lower, Vector64<double> upper)
         {
             Vector128<double> result128 = Vector128<double>.Zero;
@@ -476,10 +476,10 @@ namespace System.Runtime.Intrinsics
             return result128;
         }
 
-        /// <summary>Creates a new <see cref="Vector128{short}" /> instance from two <see cref="Vector64{short}" /> instances.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Int16}" /> instance from two <see cref="Vector64{Int16}" /> instances.</summary>
         /// <param name="lower">The value that the lower 64-bits will be initialized to.</param>
         /// <param name="upper">The value that the upper 64-bits will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{short}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
+        /// <returns>A new <see cref="Vector128{Int16}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
         public static unsafe Vector128<short> Create(Vector64<short> lower, Vector64<short> upper)
         {
             Vector128<short> result128 = Vector128<short>.Zero;
@@ -491,10 +491,10 @@ namespace System.Runtime.Intrinsics
             return result128;
         }
 
-        /// <summary>Creates a new <see cref="Vector128{int}" /> instance from two <see cref="Vector64{int}" /> instances.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Int32}" /> instance from two <see cref="Vector64{Int32}" /> instances.</summary>
         /// <param name="lower">The value that the lower 64-bits will be initialized to.</param>
         /// <param name="upper">The value that the upper 64-bits will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{int}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
+        /// <returns>A new <see cref="Vector128{Int32}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
         public static unsafe Vector128<int> Create(Vector64<int> lower, Vector64<int> upper)
         {
             Vector128<int> result128 = Vector128<int>.Zero;
@@ -506,10 +506,10 @@ namespace System.Runtime.Intrinsics
             return result128;
         }
 
-        /// <summary>Creates a new <see cref="Vector128{long}" /> instance from two <see cref="Vector64{long}" /> instances.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Int64}" /> instance from two <see cref="Vector64{Int64}" /> instances.</summary>
         /// <param name="lower">The value that the lower 64-bits will be initialized to.</param>
         /// <param name="upper">The value that the upper 64-bits will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{long}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
+        /// <returns>A new <see cref="Vector128{Int64}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
         public static unsafe Vector128<long> Create(Vector64<long> lower, Vector64<long> upper)
         {
             Vector128<long> result128 = Vector128<long>.Zero;
@@ -521,10 +521,10 @@ namespace System.Runtime.Intrinsics
             return result128;
         }
 
-        /// <summary>Creates a new <see cref="Vector128{sbyte}" /> instance from two <see cref="Vector64{sbyte}" /> instances.</summary>
+        /// <summary>Creates a new <see cref="Vector128{SByte}" /> instance from two <see cref="Vector64{SByte}" /> instances.</summary>
         /// <param name="lower">The value that the lower 64-bits will be initialized to.</param>
         /// <param name="upper">The value that the upper 64-bits will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{sbyte}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
+        /// <returns>A new <see cref="Vector128{SByte}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector128<sbyte> Create(Vector64<sbyte> lower, Vector64<sbyte> upper)
         {
@@ -537,10 +537,10 @@ namespace System.Runtime.Intrinsics
             return result128;
         }
 
-        /// <summary>Creates a new <see cref="Vector128{float}" /> instance from two <see cref="Vector64{float}" /> instances.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Single}" /> instance from two <see cref="Vector64{Single}" /> instances.</summary>
         /// <param name="lower">The value that the lower 64-bits will be initialized to.</param>
         /// <param name="upper">The value that the upper 64-bits will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{float}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
+        /// <returns>A new <see cref="Vector128{Single}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
         public static unsafe Vector128<float> Create(Vector64<float> lower, Vector64<float> upper)
         {
             Vector128<float> result128 = Vector128<float>.Zero;
@@ -552,10 +552,10 @@ namespace System.Runtime.Intrinsics
             return result128;
         }
 
-        /// <summary>Creates a new <see cref="Vector128{ushort}" /> instance from two <see cref="Vector64{ushort}" /> instances.</summary>
+        /// <summary>Creates a new <see cref="Vector128{UInt16}" /> instance from two <see cref="Vector64{UInt16}" /> instances.</summary>
         /// <param name="lower">The value that the lower 64-bits will be initialized to.</param>
         /// <param name="upper">The value that the upper 64-bits will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{ushort}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
+        /// <returns>A new <see cref="Vector128{UInt16}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector128<ushort> Create(Vector64<ushort> lower, Vector64<ushort> upper)
         {
@@ -568,10 +568,10 @@ namespace System.Runtime.Intrinsics
             return result128;
         }
 
-        /// <summary>Creates a new <see cref="Vector128{uint}" /> instance from two <see cref="Vector64{uint}" /> instances.</summary>
+        /// <summary>Creates a new <see cref="Vector128{UInt32}" /> instance from two <see cref="Vector64{UInt32}" /> instances.</summary>
         /// <param name="lower">The value that the lower 64-bits will be initialized to.</param>
         /// <param name="upper">The value that the upper 64-bits will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{uint}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
+        /// <returns>A new <see cref="Vector128{UInt32}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector128<uint> Create(Vector64<uint> lower, Vector64<uint> upper)
         {
@@ -584,10 +584,10 @@ namespace System.Runtime.Intrinsics
             return result128;
         }
 
-        /// <summary>Creates a new <see cref="Vector128{ulong}" /> instance from two <see cref="Vector64{ulong}" /> instances.</summary>
+        /// <summary>Creates a new <see cref="Vector128{UInt64}" /> instance from two <see cref="Vector64{UInt64}" /> instances.</summary>
         /// <param name="lower">The value that the lower 64-bits will be initialized to.</param>
         /// <param name="upper">The value that the upper 64-bits will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{ulong}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
+        /// <returns>A new <see cref="Vector128{UInt64}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector128<ulong> Create(Vector64<ulong> lower, Vector64<ulong> upper)
         {
@@ -600,9 +600,9 @@ namespace System.Runtime.Intrinsics
             return result128;
         }
 
-        /// <summary>Creates a new <see cref="Vector128{byte}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Byte}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{byte}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector128{Byte}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
         public static unsafe Vector128<byte> CreateScalar(byte value)
         {
             var result = Vector128<byte>.Zero;
@@ -610,9 +610,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector128{double}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Double}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{double}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector128{Double}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
         public static unsafe Vector128<double> CreateScalar(double value)
         {
             var result = Vector128<double>.Zero;
@@ -620,9 +620,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector128{short}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Int16}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{short}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector128{Int16}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
         public static unsafe Vector128<short> CreateScalar(short value)
         {
             var result = Vector128<short>.Zero;
@@ -630,9 +630,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector128{int}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Int32}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{int}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector128{Int32}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
         public static unsafe Vector128<int> CreateScalar(int value)
         {
             var result = Vector128<int>.Zero;
@@ -640,9 +640,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector128{long}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Int64}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{long}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector128{Int64}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
         public static unsafe Vector128<long> CreateScalar(long value)
         {
             var result = Vector128<long>.Zero;
@@ -650,9 +650,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector128{sbyte}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector128{SByte}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{sbyte}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector128{SByte}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector128<sbyte> CreateScalar(sbyte value)
         {
@@ -661,9 +661,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector128{float}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Single}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{float}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector128{Single}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
         public static unsafe Vector128<float> CreateScalar(float value)
         {
             var result = Vector128<float>.Zero;
@@ -671,9 +671,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector128{ushort}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector128{UInt16}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{ushort}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector128{UInt16}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector128<ushort> CreateScalar(ushort value)
         {
@@ -682,9 +682,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector128{uint}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector128{UInt32}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{uint}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector128{UInt32}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector128<uint> CreateScalar(uint value)
         {
@@ -693,9 +693,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector128{ulong}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector128{UInt64}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{ulong}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector128{UInt64}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector128<ulong> CreateScalar(ulong value)
         {
@@ -704,9 +704,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector128{byte}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Byte}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{byte}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector128{Byte}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements left uninitialized.</returns>
         public static unsafe Vector128<byte> CreateScalarUnsafe(byte value)
         {
             // This relies on us stripping the "init" flag from the ".locals"
@@ -717,9 +717,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<byte>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{double}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Double}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{double}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector128{Double}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements left uninitialized.</returns>
         public static unsafe Vector128<double> CreateScalarUnsafe(double value)
         {
             // This relies on us stripping the "init" flag from the ".locals"
@@ -730,9 +730,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<double>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{short}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Int16}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{short}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector128{Int16}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements left uninitialized.</returns>
         public static unsafe Vector128<short> CreateScalarUnsafe(short value)
         {
             // This relies on us stripping the "init" flag from the ".locals"
@@ -743,9 +743,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<short>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{int}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Int32}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{int}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector128{Int32}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements left uninitialized.</returns>
         public static unsafe Vector128<int> CreateScalarUnsafe(int value)
         {
             // This relies on us stripping the "init" flag from the ".locals"
@@ -756,9 +756,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<int>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{long}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Int64}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{long}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector128{Int64}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements left uninitialized.</returns>
         public static unsafe Vector128<long> CreateScalarUnsafe(long value)
         {
             // This relies on us stripping the "init" flag from the ".locals"
@@ -769,9 +769,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<long>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{sbyte}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector128{SByte}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{sbyte}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector128{SByte}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements left uninitialized.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector128<sbyte> CreateScalarUnsafe(sbyte value)
         {
@@ -783,9 +783,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<sbyte>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{float}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector128{Single}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{float}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector128{Single}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements left uninitialized.</returns>
         public static unsafe Vector128<float> CreateScalarUnsafe(float value)
         {
             // This relies on us stripping the "init" flag from the ".locals"
@@ -796,9 +796,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<float>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{ushort}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector128{UInt16}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{ushort}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector128{UInt16}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements left uninitialized.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector128<ushort> CreateScalarUnsafe(ushort value)
         {
@@ -810,9 +810,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<ushort>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{uint}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector128{UInt32}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{uint}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector128{UInt32}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements left uninitialized.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector128<uint> CreateScalarUnsafe(uint value)
         {
@@ -824,9 +824,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector128<uint>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector128{ulong}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector128{UInt64}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector128{ulong}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector128{UInt64}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements left uninitialized.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector128<ulong> CreateScalarUnsafe(ulong value)
         {

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128_1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128_1.cs
@@ -101,65 +101,65 @@ namespace System.Runtime.Intrinsics
             return Unsafe.As<Vector128<T>, Vector128<U>>(ref Unsafe.AsRef(in this));
         }
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector128{byte}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector128{byte}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector128{Byte}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector128{Byte}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         public Vector128<byte> AsByte() => As<byte>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector128{double}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector128{double}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector128{Double}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector128{Double}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         public Vector128<double> AsDouble() => As<double>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector128{short}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector128{short}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector128{Int16}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector128{Int16}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         public Vector128<short> AsInt16() => As<short>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector128{int}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector128{int}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector128{Int32}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector128{Int32}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         public Vector128<int> AsInt32() => As<int>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector128{long}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector128{long}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector128{Int64}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector128{Int64}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         public Vector128<long> AsInt64() => As<long>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector128{sbyte}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector128{sbyte}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector128{SByte}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector128{SByte}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
         public Vector128<sbyte> AsSByte() => As<sbyte>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector128{float}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector128{float}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector128{Single}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector128{Single}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         public Vector128<float> AsSingle() => As<float>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector128{ushort}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector128{ushort}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector128{UInt16}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector128{UInt16}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
         public Vector128<ushort> AsUInt16() => As<ushort>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector128{uint}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector128{uint}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector128{UInt32}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector128{UInt32}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
         public Vector128<uint> AsUInt32() => As<uint>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector128{ulong}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector128{ulong}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector128{UInt64}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector128{UInt64}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256.cs
@@ -10,9 +10,9 @@ namespace System.Runtime.Intrinsics
     {
         internal const int Size = 32;
 
-        /// <summary>Creates a new <see cref="Vector256{byte}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Byte}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{byte}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector256{Byte}" /> with all elements initialized to <paramref name="value" />.</returns>
         public static unsafe Vector256<byte> Create(byte value)
         {
             var pResult = stackalloc byte[32]
@@ -54,9 +54,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<byte>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{double}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Double}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{double}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector256{Double}" /> with all elements initialized to <paramref name="value" />.</returns>
         public static unsafe Vector256<double> Create(double value)
         {
             var pResult = stackalloc double[4]
@@ -70,9 +70,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<double>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{short}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Int16}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{short}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector256{Int16}" /> with all elements initialized to <paramref name="value" />.</returns>
         public static unsafe Vector256<short> Create(short value)
         {
             var pResult = stackalloc short[16]
@@ -98,9 +98,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<short>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{int}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Int32}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{int}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector256{Int32}" /> with all elements initialized to <paramref name="value" />.</returns>
         public static unsafe Vector256<int> Create(int value)
         {
             var pResult = stackalloc int[8]
@@ -118,9 +118,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<int>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{long}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Int64}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{long}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector256{Int64}" /> with all elements initialized to <paramref name="value" />.</returns>
         public static unsafe Vector256<long> Create(long value)
         {
             var pResult = stackalloc long[4]
@@ -134,9 +134,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<long>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{sbyte}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector256{SByte}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{sbyte}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector256{SByte}" /> with all elements initialized to <paramref name="value" />.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector256<sbyte> Create(sbyte value)
         {
@@ -179,9 +179,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<sbyte>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{float}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Single}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{float}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector256{Single}" /> with all elements initialized to <paramref name="value" />.</returns>
         public static unsafe Vector256<float> Create(float value)
         {
             var pResult = stackalloc float[8]
@@ -199,9 +199,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<float>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{ushort}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector256{UInt16}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{ushort}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector256{UInt16}" /> with all elements initialized to <paramref name="value" />.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector256<ushort> Create(ushort value)
         {
@@ -228,9 +228,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<ushort>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{uint}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector256{UInt32}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{uint}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector256{UInt32}" /> with all elements initialized to <paramref name="value" />.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector256<uint> Create(uint value)
         {
@@ -249,9 +249,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<uint>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{ulong}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector256{UInt64}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{ulong}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector256{UInt64}" /> with all elements initialized to <paramref name="value" />.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector256<ulong> Create(ulong value)
         {
@@ -266,7 +266,7 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<ulong>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{byte}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Byte}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
         /// <param name="e2">The value that element 2 will be initialized to.</param>
@@ -299,7 +299,7 @@ namespace System.Runtime.Intrinsics
         /// <param name="e29">The value that element 29 will be initialized to.</param>
         /// <param name="e30">The value that element 30 will be initialized to.</param>
         /// <param name="e31">The value that element 31 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{byte}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector256{Byte}" /> with each element initialized to corresponding specified value.</returns>
         public static unsafe Vector256<byte> Create(byte e0, byte e1, byte e2, byte e3, byte e4, byte e5, byte e6, byte e7, byte e8, byte e9, byte e10, byte e11, byte e12, byte e13, byte e14, byte e15, byte e16, byte e17, byte e18, byte e19, byte e20, byte e21, byte e22, byte e23, byte e24, byte e25, byte e26, byte e27, byte e28, byte e29, byte e30, byte e31)
         {
             var pResult = stackalloc byte[32]
@@ -341,12 +341,12 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<byte>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{double}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Double}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
         /// <param name="e2">The value that element 2 will be initialized to.</param>
         /// <param name="e3">The value that element 3 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{double}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector256{Double}" /> with each element initialized to corresponding specified value.</returns>
         public static unsafe Vector256<double> Create(double e0, double e1, double e2, double e3)
         {
             var pResult = stackalloc double[4]
@@ -360,7 +360,7 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<double>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{short}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Int16}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
         /// <param name="e2">The value that element 2 will be initialized to.</param>
@@ -377,7 +377,7 @@ namespace System.Runtime.Intrinsics
         /// <param name="e13">The value that element 13 will be initialized to.</param>
         /// <param name="e14">The value that element 14 will be initialized to.</param>
         /// <param name="e15">The value that element 15 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{short}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector256{Int16}" /> with each element initialized to corresponding specified value.</returns>
         public static unsafe Vector256<short> Create(short e0, short e1, short e2, short e3, short e4, short e5, short e6, short e7, short e8, short e9, short e10, short e11, short e12, short e13, short e14, short e15)
         {
             var pResult = stackalloc short[16]
@@ -403,7 +403,7 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<short>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{int}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Int32}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
         /// <param name="e2">The value that element 2 will be initialized to.</param>
@@ -412,7 +412,7 @@ namespace System.Runtime.Intrinsics
         /// <param name="e5">The value that element 5 will be initialized to.</param>
         /// <param name="e6">The value that element 6 will be initialized to.</param>
         /// <param name="e7">The value that element 7 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{int}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector256{Int32}" /> with each element initialized to corresponding specified value.</returns>
         public static unsafe Vector256<int> Create(int e0, int e1, int e2, int e3, int e4, int e5, int e6, int e7)
         {
             var pResult = stackalloc int[8]
@@ -430,12 +430,12 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<int>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{long}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Int64}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
         /// <param name="e2">The value that element 2 will be initialized to.</param>
         /// <param name="e3">The value that element 3 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{long}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector256{Int64}" /> with each element initialized to corresponding specified value.</returns>
         public static unsafe Vector256<long> Create(long e0, long e1, long e2, long e3)
         {
             var pResult = stackalloc long[4]
@@ -449,7 +449,7 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<long>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{sbyte}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector256{SByte}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
         /// <param name="e2">The value that element 2 will be initialized to.</param>
@@ -482,7 +482,7 @@ namespace System.Runtime.Intrinsics
         /// <param name="e29">The value that element 29 will be initialized to.</param>
         /// <param name="e30">The value that element 30 will be initialized to.</param>
         /// <param name="e31">The value that element 31 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{sbyte}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector256{SByte}" /> with each element initialized to corresponding specified value.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector256<sbyte> Create(sbyte e0, sbyte e1, sbyte e2, sbyte e3, sbyte e4, sbyte e5, sbyte e6, sbyte e7, sbyte e8, sbyte e9, sbyte e10, sbyte e11, sbyte e12, sbyte e13, sbyte e14, sbyte e15, sbyte e16, sbyte e17, sbyte e18, sbyte e19, sbyte e20, sbyte e21, sbyte e22, sbyte e23, sbyte e24, sbyte e25, sbyte e26, sbyte e27, sbyte e28, sbyte e29, sbyte e30, sbyte e31)
         {
@@ -525,7 +525,7 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<sbyte>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{float}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Single}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
         /// <param name="e2">The value that element 2 will be initialized to.</param>
@@ -534,7 +534,7 @@ namespace System.Runtime.Intrinsics
         /// <param name="e5">The value that element 5 will be initialized to.</param>
         /// <param name="e6">The value that element 6 will be initialized to.</param>
         /// <param name="e7">The value that element 7 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{float}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector256{Single}" /> with each element initialized to corresponding specified value.</returns>
         public static unsafe Vector256<float> Create(float e0, float e1, float e2, float e3, float e4, float e5, float e6, float e7)
         {
             var pResult = stackalloc float[8]
@@ -552,7 +552,7 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<float>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{ushort}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector256{UInt16}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
         /// <param name="e2">The value that element 2 will be initialized to.</param>
@@ -569,7 +569,7 @@ namespace System.Runtime.Intrinsics
         /// <param name="e13">The value that element 13 will be initialized to.</param>
         /// <param name="e14">The value that element 14 will be initialized to.</param>
         /// <param name="e15">The value that element 15 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{ushort}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector256{UInt16}" /> with each element initialized to corresponding specified value.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector256<ushort> Create(ushort e0, ushort e1, ushort e2, ushort e3, ushort e4, ushort e5, ushort e6, ushort e7, ushort e8, ushort e9, ushort e10, ushort e11, ushort e12, ushort e13, ushort e14, ushort e15)
         {
@@ -596,7 +596,7 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<ushort>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{uint}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector256{UInt32}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
         /// <param name="e2">The value that element 2 will be initialized to.</param>
@@ -605,7 +605,7 @@ namespace System.Runtime.Intrinsics
         /// <param name="e5">The value that element 5 will be initialized to.</param>
         /// <param name="e6">The value that element 6 will be initialized to.</param>
         /// <param name="e7">The value that element 7 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{uint}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector256{UInt32}" /> with each element initialized to corresponding specified value.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector256<uint> Create(uint e0, uint e1, uint e2, uint e3, uint e4, uint e5, uint e6, uint e7)
         {
@@ -624,12 +624,12 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<uint>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{ulong}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector256{UInt64}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
         /// <param name="e2">The value that element 2 will be initialized to.</param>
         /// <param name="e3">The value that element 3 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{ulong}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector256{UInt64}" /> with each element initialized to corresponding specified value.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector256<ulong> Create(ulong e0, ulong e1, ulong e2, ulong e3)
         {
@@ -644,10 +644,10 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<ulong>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{byte}" /> instance from two <see cref="Vector128{byte}" /> instances.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Byte}" /> instance from two <see cref="Vector128{Byte}" /> instances.</summary>
         /// <param name="lower">The value that the lower 128-bits will be initialized to.</param>
         /// <param name="upper">The value that the upper 128-bits will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{byte}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
+        /// <returns>A new <see cref="Vector256{Byte}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
         public static unsafe Vector256<byte> Create(Vector128<byte> lower, Vector128<byte> upper)
         {
             Vector256<byte> result256 = Vector256<byte>.Zero;
@@ -659,10 +659,10 @@ namespace System.Runtime.Intrinsics
             return result256;
         }
 
-        /// <summary>Creates a new <see cref="Vector256{double}" /> instance from two <see cref="Vector128{double}" /> instances.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Double}" /> instance from two <see cref="Vector128{Double}" /> instances.</summary>
         /// <param name="lower">The value that the lower 128-bits will be initialized to.</param>
         /// <param name="upper">The value that the upper 128-bits will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{double}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
+        /// <returns>A new <see cref="Vector256{Double}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
         public static unsafe Vector256<double> Create(Vector128<double> lower, Vector128<double> upper)
         {
             Vector256<double> result256 = Vector256<double>.Zero;
@@ -674,10 +674,10 @@ namespace System.Runtime.Intrinsics
             return result256;
         }
 
-        /// <summary>Creates a new <see cref="Vector256{short}" /> instance from two <see cref="Vector128{short}" /> instances.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Int16}" /> instance from two <see cref="Vector128{Int16}" /> instances.</summary>
         /// <param name="lower">The value that the lower 128-bits will be initialized to.</param>
         /// <param name="upper">The value that the upper 128-bits will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{short}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
+        /// <returns>A new <see cref="Vector256{Int16}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
         public static unsafe Vector256<short> Create(Vector128<short> lower, Vector128<short> upper)
         {
             Vector256<short> result256 = Vector256<short>.Zero;
@@ -689,10 +689,10 @@ namespace System.Runtime.Intrinsics
             return result256;
         }
 
-        /// <summary>Creates a new <see cref="Vector256{int}" /> instance from two <see cref="Vector128{int}" /> instances.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Int32}" /> instance from two <see cref="Vector128{Int32}" /> instances.</summary>
         /// <param name="lower">The value that the lower 128-bits will be initialized to.</param>
         /// <param name="upper">The value that the upper 128-bits will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{int}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
+        /// <returns>A new <see cref="Vector256{Int32}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
         public static unsafe Vector256<int> Create(Vector128<int> lower, Vector128<int> upper)
         {
             Vector256<int> result256 = Vector256<int>.Zero;
@@ -704,10 +704,10 @@ namespace System.Runtime.Intrinsics
             return result256;
         }
 
-        /// <summary>Creates a new <see cref="Vector256{long}" /> instance from two <see cref="Vector128{long}" /> instances.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Int64}" /> instance from two <see cref="Vector128{Int64}" /> instances.</summary>
         /// <param name="lower">The value that the lower 128-bits will be initialized to.</param>
         /// <param name="upper">The value that the upper 128-bits will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{long}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
+        /// <returns>A new <see cref="Vector256{Int64}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
         public static unsafe Vector256<long> Create(Vector128<long> lower, Vector128<long> upper)
         {
             Vector256<long> result256 = Vector256<long>.Zero;
@@ -719,10 +719,10 @@ namespace System.Runtime.Intrinsics
             return result256;
         }
 
-        /// <summary>Creates a new <see cref="Vector256{sbyte}" /> instance from two <see cref="Vector128{sbyte}" /> instances.</summary>
+        /// <summary>Creates a new <see cref="Vector256{SByte}" /> instance from two <see cref="Vector128{SByte}" /> instances.</summary>
         /// <param name="lower">The value that the lower 128-bits will be initialized to.</param>
         /// <param name="upper">The value that the upper 128-bits will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{sbyte}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
+        /// <returns>A new <see cref="Vector256{SByte}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector256<sbyte> Create(Vector128<sbyte> lower, Vector128<sbyte> upper)
         {
@@ -735,10 +735,10 @@ namespace System.Runtime.Intrinsics
             return result256;
         }
 
-        /// <summary>Creates a new <see cref="Vector256{float}" /> instance from two <see cref="Vector128{float}" /> instances.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Single}" /> instance from two <see cref="Vector128{Single}" /> instances.</summary>
         /// <param name="lower">The value that the lower 128-bits will be initialized to.</param>
         /// <param name="upper">The value that the upper 128-bits will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{float}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
+        /// <returns>A new <see cref="Vector256{Single}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
         public static unsafe Vector256<float> Create(Vector128<float> lower, Vector128<float> upper)
         {
             Vector256<float> result256 = Vector256<float>.Zero;
@@ -750,10 +750,10 @@ namespace System.Runtime.Intrinsics
             return result256;
         }
 
-        /// <summary>Creates a new <see cref="Vector256{ushort}" /> instance from two <see cref="Vector128{ushort}" /> instances.</summary>
+        /// <summary>Creates a new <see cref="Vector256{UInt16}" /> instance from two <see cref="Vector128{UInt16}" /> instances.</summary>
         /// <param name="lower">The value that the lower 128-bits will be initialized to.</param>
         /// <param name="upper">The value that the upper 128-bits will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{ushort}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
+        /// <returns>A new <see cref="Vector256{UInt16}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector256<ushort> Create(Vector128<ushort> lower, Vector128<ushort> upper)
         {
@@ -766,10 +766,10 @@ namespace System.Runtime.Intrinsics
             return result256;
         }
 
-        /// <summary>Creates a new <see cref="Vector256{uint}" /> instance from two <see cref="Vector128{uint}" /> instances.</summary>
+        /// <summary>Creates a new <see cref="Vector256{UInt32}" /> instance from two <see cref="Vector128{UInt32}" /> instances.</summary>
         /// <param name="lower">The value that the lower 128-bits will be initialized to.</param>
         /// <param name="upper">The value that the upper 128-bits will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{uint}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
+        /// <returns>A new <see cref="Vector256{UInt32}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector256<uint> Create(Vector128<uint> lower, Vector128<uint> upper)
         {
@@ -782,10 +782,10 @@ namespace System.Runtime.Intrinsics
             return result256;
         }
 
-        /// <summary>Creates a new <see cref="Vector256{ulong}" /> instance from two <see cref="Vector128{ulong}" /> instances.</summary>
+        /// <summary>Creates a new <see cref="Vector256{UInt64}" /> instance from two <see cref="Vector128{UInt64}" /> instances.</summary>
         /// <param name="lower">The value that the lower 128-bits will be initialized to.</param>
         /// <param name="upper">The value that the upper 128-bits will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{ulong}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
+        /// <returns>A new <see cref="Vector256{UInt64}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector256<ulong> Create(Vector128<ulong> lower, Vector128<ulong> upper)
         {
@@ -798,9 +798,9 @@ namespace System.Runtime.Intrinsics
             return result256;
         }
 
-        /// <summary>Creates a new <see cref="Vector256{byte}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Byte}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{byte}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector256{Byte}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
         public static unsafe Vector256<byte> CreateScalar(byte value)
         {
             var result = Vector256<byte>.Zero;
@@ -808,9 +808,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector256{double}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Double}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{double}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector256{Double}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
         public static unsafe Vector256<double> CreateScalar(double value)
         {
             var result = Vector256<double>.Zero;
@@ -818,9 +818,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector256{short}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Int16}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{short}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector256{Int16}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
         public static unsafe Vector256<short> CreateScalar(short value)
         {
             var result = Vector256<short>.Zero;
@@ -828,9 +828,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector256{int}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Int32}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{int}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector256{Int32}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
         public static unsafe Vector256<int> CreateScalar(int value)
         {
             var result = Vector256<int>.Zero;
@@ -838,9 +838,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector256{long}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Int64}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{long}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector256{Int64}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
         public static unsafe Vector256<long> CreateScalar(long value)
         {
             var result = Vector256<long>.Zero;
@@ -848,9 +848,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector256{sbyte}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector256{SByte}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{sbyte}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector256{SByte}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector256<sbyte> CreateScalar(sbyte value)
         {
@@ -859,9 +859,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector256{float}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Single}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{float}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector256{Single}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
         public static unsafe Vector256<float> CreateScalar(float value)
         {
             var result = Vector256<float>.Zero;
@@ -869,9 +869,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector256{ushort}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector256{UInt16}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{ushort}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector256{UInt16}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector256<ushort> CreateScalar(ushort value)
         {
@@ -880,9 +880,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector256{uint}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector256{UInt32}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{uint}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector256{UInt32}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector256<uint> CreateScalar(uint value)
         {
@@ -891,9 +891,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector256{ulong}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector256{UInt64}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{ulong}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector256{UInt64}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector256<ulong> CreateScalar(ulong value)
         {
@@ -902,9 +902,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector256{byte}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Byte}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{byte}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector256{Byte}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements left uninitialized.</returns>
         public static unsafe Vector256<byte> CreateScalarUnsafe(byte value)
         {
             // This relies on us stripping the "init" flag from the ".locals"
@@ -915,9 +915,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<byte>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{double}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Double}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{double}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector256{Double}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements left uninitialized.</returns>
         public static unsafe Vector256<double> CreateScalarUnsafe(double value)
         {
             // This relies on us stripping the "init" flag from the ".locals"
@@ -928,9 +928,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<double>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{short}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Int16}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{short}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector256{Int16}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements left uninitialized.</returns>
         public static unsafe Vector256<short> CreateScalarUnsafe(short value)
         {
             // This relies on us stripping the "init" flag from the ".locals"
@@ -941,9 +941,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<short>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{int}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Int32}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{int}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector256{Int32}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements left uninitialized.</returns>
         public static unsafe Vector256<int> CreateScalarUnsafe(int value)
         {
             // This relies on us stripping the "init" flag from the ".locals"
@@ -954,9 +954,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<int>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{long}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Int64}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{long}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector256{Int64}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements left uninitialized.</returns>
         public static unsafe Vector256<long> CreateScalarUnsafe(long value)
         {
             // This relies on us stripping the "init" flag from the ".locals"
@@ -967,9 +967,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<long>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{sbyte}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector256{SByte}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{sbyte}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector256{SByte}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements left uninitialized.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector256<sbyte> CreateScalarUnsafe(sbyte value)
         {
@@ -981,9 +981,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<sbyte>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{float}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector256{Single}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{float}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector256{Single}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements left uninitialized.</returns>
         public static unsafe Vector256<float> CreateScalarUnsafe(float value)
         {
             // This relies on us stripping the "init" flag from the ".locals"
@@ -994,9 +994,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<float>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{ushort}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector256{UInt16}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{ushort}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector256{UInt16}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements left uninitialized.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector256<ushort> CreateScalarUnsafe(ushort value)
         {
@@ -1008,9 +1008,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<ushort>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{uint}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector256{UInt32}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{uint}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector256{UInt32}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements left uninitialized.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector256<uint> CreateScalarUnsafe(uint value)
         {
@@ -1022,9 +1022,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector256<uint>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector256{ulong}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector256{UInt64}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector256{ulong}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector256{UInt64}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements left uninitialized.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector256<ulong> CreateScalarUnsafe(ulong value)
         {

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256_1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256_1.cs
@@ -103,65 +103,65 @@ namespace System.Runtime.Intrinsics
             return Unsafe.As<Vector256<T>, Vector256<U>>(ref Unsafe.AsRef(in this));
         }
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector256{byte}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector256{byte}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector256{Byte}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector256{Byte}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         public Vector256<byte> AsByte() => As<byte>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector256{double}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector256{double}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector256{Double}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector256{Double}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         public Vector256<double> AsDouble() => As<double>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector256{short}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector256{short}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector256{Int16}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector256{Int16}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         public Vector256<short> AsInt16() => As<short>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector256{int}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector256{int}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector256{Int32}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector256{Int32}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         public Vector256<int> AsInt32() => As<int>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector256{long}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector256{long}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector256{Int64}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector256{Int64}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         public Vector256<long> AsInt64() => As<long>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector256{sbyte}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector256{sbyte}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector256{SByte}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector256{SByte}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
         public Vector256<sbyte> AsSByte() => As<sbyte>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector256{float}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector256{float}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector256{Single}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector256{Single}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         public Vector256<float> AsSingle() => As<float>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector256{ushort}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector256{ushort}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector256{UInt16}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector256{UInt16}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
         public Vector256<ushort> AsUInt16() => As<ushort>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector256{uint}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector256{uint}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector256{UInt32}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector256{UInt32}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
         public Vector256<uint> AsUInt32() => As<uint>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector256{ulong}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector256{ulong}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector256{UInt64}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector256{UInt64}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector64.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector64.cs
@@ -10,9 +10,9 @@ namespace System.Runtime.Intrinsics
     {
         internal const int Size = 8;
 
-        /// <summary>Creates a new <see cref="Vector64{byte}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector64{Byte}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{byte}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector64{Byte}" /> with all elements initialized to <paramref name="value" />.</returns>
         public static unsafe Vector64<byte> Create(byte value)
         {
             var pResult = stackalloc byte[8]
@@ -30,17 +30,17 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector64<byte>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector64{double}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector64{Double}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{double}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector64{Double}" /> with all elements initialized to <paramref name="value" />.</returns>
         public static unsafe Vector64<double> Create(double value)
         {
             return Unsafe.As<double, Vector64<double>>(ref value);
         }
 
-        /// <summary>Creates a new <see cref="Vector64{short}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector64{Int16}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{short}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector64{Int16}" /> with all elements initialized to <paramref name="value" />.</returns>
         public static unsafe Vector64<short> Create(short value)
         {
             var pResult = stackalloc short[4]
@@ -54,9 +54,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector64<short>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector64{int}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector64{Int32}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{int}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector64{Int32}" /> with all elements initialized to <paramref name="value" />.</returns>
         public static unsafe Vector64<int> Create(int value)
         {
             var pResult = stackalloc int[2]
@@ -68,17 +68,17 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector64<int>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector64{long}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector64{Int64}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{long}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector64{Int64}" /> with all elements initialized to <paramref name="value" />.</returns>
         public static unsafe Vector64<long> Create(long value)
         {
             return Unsafe.As<long, Vector64<long>>(ref value);
         }
 
-        /// <summary>Creates a new <see cref="Vector64{sbyte}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector64{SByte}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{sbyte}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector64{SByte}" /> with all elements initialized to <paramref name="value" />.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector64<sbyte> Create(sbyte value)
         {
@@ -97,9 +97,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector64<sbyte>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector64{float}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector64{Single}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{float}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector64{Single}" /> with all elements initialized to <paramref name="value" />.</returns>
         public static unsafe Vector64<float> Create(float value)
         {
             var pResult = stackalloc float[2]
@@ -111,9 +111,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector64<float>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector64{ushort}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector64{UInt16}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{ushort}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector64{UInt16}" /> with all elements initialized to <paramref name="value" />.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector64<ushort> Create(ushort value)
         {
@@ -128,9 +128,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector64<ushort>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector64{uint}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector64{UInt32}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{uint}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector64{UInt32}" /> with all elements initialized to <paramref name="value" />.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector64<uint> Create(uint value)
         {
@@ -143,16 +143,16 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector64<uint>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector64{ulong}" /> instance with all elements initialized to the specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector64{UInt64}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{ulong}" /> with all elements initialized to <paramref name="value" />.</returns>
+        /// <returns>A new <see cref="Vector64{UInt64}" /> with all elements initialized to <paramref name="value" />.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector64<ulong> Create(ulong value)
         {
             return Unsafe.As<ulong, Vector64<ulong>>(ref value);
         }
 
-        /// <summary>Creates a new <see cref="Vector64{byte}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector64{Byte}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
         /// <param name="e2">The value that element 2 will be initialized to.</param>
@@ -161,7 +161,7 @@ namespace System.Runtime.Intrinsics
         /// <param name="e5">The value that element 5 will be initialized to.</param>
         /// <param name="e6">The value that element 6 will be initialized to.</param>
         /// <param name="e7">The value that element 7 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{byte}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector64{Byte}" /> with each element initialized to corresponding specified value.</returns>
         public static unsafe Vector64<byte> Create(byte e0, byte e1, byte e2, byte e3, byte e4, byte e5, byte e6, byte e7)
         {
             var pResult = stackalloc byte[8]
@@ -179,12 +179,12 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector64<byte>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector64{short}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector64{Int16}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
         /// <param name="e2">The value that element 2 will be initialized to.</param>
         /// <param name="e3">The value that element 3 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{short}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector64{Int16}" /> with each element initialized to corresponding specified value.</returns>
         public static unsafe Vector64<short> Create(short e0, short e1, short e2, short e3)
         {
             var pResult = stackalloc short[4]
@@ -198,10 +198,10 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector64<short>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector64{int}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector64{Int32}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{int}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector64{Int32}" /> with each element initialized to corresponding specified value.</returns>
         public static unsafe Vector64<int> Create(int e0, int e1)
         {
             var pResult = stackalloc int[2]
@@ -213,7 +213,7 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector64<int>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector64{sbyte}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector64{SByte}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
         /// <param name="e2">The value that element 2 will be initialized to.</param>
@@ -222,7 +222,7 @@ namespace System.Runtime.Intrinsics
         /// <param name="e5">The value that element 5 will be initialized to.</param>
         /// <param name="e6">The value that element 6 will be initialized to.</param>
         /// <param name="e7">The value that element 7 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{sbyte}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector64{SByte}" /> with each element initialized to corresponding specified value.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector64<sbyte> Create(sbyte e0, sbyte e1, sbyte e2, sbyte e3, sbyte e4, sbyte e5, sbyte e6, sbyte e7)
         {
@@ -241,10 +241,10 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector64<sbyte>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector64{float}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector64{Single}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{float}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector64{Single}" /> with each element initialized to corresponding specified value.</returns>
         public static unsafe Vector64<float> Create(float e0, float e1)
         {
             var pResult = stackalloc float[2]
@@ -256,12 +256,12 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector64<float>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector64{ushort}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector64{UInt16}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
         /// <param name="e2">The value that element 2 will be initialized to.</param>
         /// <param name="e3">The value that element 3 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{ushort}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector64{UInt16}" /> with each element initialized to corresponding specified value.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector64<ushort> Create(ushort e0, ushort e1, ushort e2, ushort e3)
         {
@@ -276,10 +276,10 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector64<ushort>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector64{uint}" /> instance with each element initialized to the corresponding specified value.</summary>
+        /// <summary>Creates a new <see cref="Vector64{UInt32}" /> instance with each element initialized to the corresponding specified value.</summary>
         /// <param name="e0">The value that element 0 will be initialized to.</param>
         /// <param name="e1">The value that element 1 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{uint}" /> with each element initialized to corresponding specified value.</returns>
+        /// <returns>A new <see cref="Vector64{UInt32}" /> with each element initialized to corresponding specified value.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector64<uint> Create(uint e0, uint e1)
         {
@@ -292,9 +292,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector64<uint>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector64{byte}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector64{Byte}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{byte}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector64{Byte}" /> instance with the first element initialized to <paramref name="value"/> and the remaining elements initialized to zero.</returns>
         public static unsafe Vector64<byte> CreateScalar(byte value)
         {
             var result = Vector64<byte>.Zero;
@@ -302,9 +302,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector64{short}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector64{Int16}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{short}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector64{Int16}" /> instance with the first element initialized to <paramref name="value"/> and the remaining elements initialized to zero.</returns>
         public static unsafe Vector64<short> CreateScalar(short value)
         {
             var result = Vector64<short>.Zero;
@@ -312,9 +312,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector64{int}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector64{Int32}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{int}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector64{Int32}" /> instance with the first element initialized to <paramref name="value"/> and the remaining elements initialized to zero.</returns>
         public static unsafe Vector64<int> CreateScalar(int value)
         {
             var result = Vector64<int>.Zero;
@@ -322,9 +322,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector64{sbyte}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector64{SByte}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{sbyte}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector64{SByte}" /> instance with the first element initialized to <paramref name="value"/> and the remaining elements initialized to zero.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector64<sbyte> CreateScalar(sbyte value)
         {
@@ -333,9 +333,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector64{float}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector64{Single}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{float}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector64{Single}" /> instance with the first element initialized to <paramref name="value"/> and the remaining elements initialized to zero.</returns>
         public static unsafe Vector64<float> CreateScalar(float value)
         {
             var result = Vector64<float>.Zero;
@@ -343,9 +343,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector64{ushort}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector64{UInt16}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{ushort}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector64{UInt16}" /> instance with the first element initialized to <paramref name="value"/> and the remaining elements initialized to zero.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector64<ushort> CreateScalar(ushort value)
         {
@@ -354,9 +354,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector64{uint}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
+        /// <summary>Creates a new <see cref="Vector64{UInt32}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{uint}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements initialized to zero.</returns>
+        /// <returns>A new <see cref="Vector64{UInt32}" /> instance with the first element initialized to <paramref name="value"/> and the remaining elements initialized to zero.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector64<uint> CreateScalar(uint value)
         {
@@ -365,9 +365,9 @@ namespace System.Runtime.Intrinsics
             return result;
         }
 
-        /// <summary>Creates a new <see cref="Vector64{byte}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector64{Byte}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{byte}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector64{Byte}" /> instance with the first element initialized to <paramref name="value"/> and the remaining elements left uninitialized.</returns>
         public static unsafe Vector64<byte> CreateScalarUnsafe(byte value)
         {
             // This relies on us stripping the "init" flag from the ".locals"
@@ -378,9 +378,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector64<byte>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector64{short}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector64{Int16}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{short}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector64{Int16}" /> instance with the first element initialized to <paramref name="value"/> and the remaining elements left uninitialized.</returns>
         public static unsafe Vector64<short> CreateScalarUnsafe(short value)
         {
             // This relies on us stripping the "init" flag from the ".locals"
@@ -391,9 +391,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector64<short>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector64{int}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector64{Int32}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{int}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector64{Int32}" /> instance with the first element initialized to <paramref name="value"/> and the remaining elements left uninitialized.</returns>
         public static unsafe Vector64<int> CreateScalarUnsafe(int value)
         {
             // This relies on us stripping the "init" flag from the ".locals"
@@ -404,9 +404,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector64<int>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector64{sbyte}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector64{SByte}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{sbyte}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector64{SByte}" /> instance with the first element initialized to <paramref name="value"/> and the remaining elements left uninitialized.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector64<sbyte> CreateScalarUnsafe(sbyte value)
         {
@@ -418,9 +418,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector64<sbyte>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector64{float}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector64{Single}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{float}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector64{Single}" /> instance with the first element initialized to <paramref name="value"/> and the remaining elements left uninitialized.</returns>
         public static unsafe Vector64<float> CreateScalarUnsafe(float value)
         {
             // This relies on us stripping the "init" flag from the ".locals"
@@ -431,9 +431,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector64<float>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector64{ushort}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector64{UInt16}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{ushort}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector64{UInt16}" /> instance with the first element initialized to <paramref name="value"/> and the remaining elements left uninitialized.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector64<ushort> CreateScalarUnsafe(ushort value)
         {
@@ -445,9 +445,9 @@ namespace System.Runtime.Intrinsics
             return Unsafe.AsRef<Vector64<ushort>>(pResult);
         }
 
-        /// <summary>Creates a new <see cref="Vector64{uint}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
+        /// <summary>Creates a new <see cref="Vector64{UInt32}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
-        /// <returns>A new <see cref="Vector64{uint}" /> instance with the first element initialized to <see cref="value" /> and the remaining elements left uninitialized.</returns>
+        /// <returns>A new <see cref="Vector64{UInt32}" /> instance with the first element initialized to <paramref name="value"/> and the remaining elements left uninitialized.</returns>
         [CLSCompliant(false)]
         public static unsafe Vector64<uint> CreateScalarUnsafe(uint value)
         {

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector64_1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector64_1.cs
@@ -99,65 +99,65 @@ namespace System.Runtime.Intrinsics
             return Unsafe.As<Vector64<T>, Vector64<U>>(ref Unsafe.AsRef(in this));
         }
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector64{byte}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector64{byte}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector64{Byte}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector64{Byte}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         public Vector64<byte> AsByte() => As<byte>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector64{double}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector64{double}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector64{Double}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector64{Double}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         public Vector64<double> AsDouble() => As<double>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector64{short}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector64{short}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector64{Int16}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector64{Int16}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         public Vector64<short> AsInt16() => As<short>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector64{int}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector64{int}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector64{Int32}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector64{Int32}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         public Vector64<int> AsInt32() => As<int>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector64{long}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector64{long}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector64{Int64}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector64{Int64}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         public Vector64<long> AsInt64() => As<long>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector64{sbyte}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector64{sbyte}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector64{SByte}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector64{SByte}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
         public Vector64<sbyte> AsSByte() => As<sbyte>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector64{float}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector64{float}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector64{Single}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector64{Single}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         public Vector64<float> AsSingle() => As<float>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector64{ushort}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector64{ushort}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector64{Int16}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector64{Int16}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
         public Vector64<ushort> AsUInt16() => As<ushort>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector64{uint}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector64{uint}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector64{UInt32}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector64{UInt32}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
         public Vector64<uint> AsUInt32() => As<uint>();
 
-        /// <summary>Reinterprets the current instance as a new <see cref="Vector64{ulong}" />.</summary>
-        /// <returns>The current instance reinterpreted as a new <see cref="Vector64{ulong}" />.</returns>
+        /// <summary>Reinterprets the current instance as a new <see cref="Vector64{UInt64}" />.</summary>
+        /// <returns>The current instance reinterpreted as a new <see cref="Vector64{UInt64}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Avx2.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Avx2.cs
@@ -735,7 +735,8 @@ namespace System.Runtime.Intrinsics.X86
         ///   VEXTRACTI128 xmm, ymm, imm8
         /// </summary>
         public new static Vector128<sbyte> ExtractVector128(Vector256<sbyte> value, byte index) => ExtractVector128(value, index);
-        // <summary>
+
+        /// <summary>
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)
         ///   VEXTRACTI128 m128, ymm, imm8
         /// </summary>

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse2.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse2.cs
@@ -1603,7 +1603,7 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// __m128i _mm_unpackhi_epi16 (__m128i a,  __m128i b)
         ///   PUNPCKHWD xmm, xmm/m128
-        /// </summary
+        /// </summary>
         public static Vector128<ushort> UnpackHigh(Vector128<ushort> left, Vector128<ushort> right) => UnpackHigh(left, right);
         /// <summary>
         /// __m128i _mm_unpackhi_epi32 (__m128i a,  __m128i b)

--- a/src/System.Private.CoreLib/shared/System/Span.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/Span.Fast.cs
@@ -39,7 +39,6 @@ namespace System
         /// </summary>
         /// <param name="array">The target array.</param>
         /// <remarks>Returns default when <paramref name="array"/> is null.</remarks>
-        /// reference (Nothing in Visual Basic).</exception>
         /// <exception cref="System.ArrayTypeMismatchException">Thrown when <paramref name="array"/> is covariant and array's type is not exactly T[].</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Span(T[] array)
@@ -64,7 +63,6 @@ namespace System
         /// <param name="start">The index at which to begin the span.</param>
         /// <param name="length">The number of items in the span.</param>
         /// <remarks>Returns default when <paramref name="array"/> is null.</remarks>
-        /// reference (Nothing in Visual Basic).</exception>
         /// <exception cref="System.ArrayTypeMismatchException">Thrown when <paramref name="array"/> is covariant and array's type is not exactly T[].</exception>
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown when the specified <paramref name="start"/> or end index is not in the range (&lt;0 or &gt;=Length).
@@ -131,6 +129,7 @@ namespace System
             _length = length;
         }
 
+        /// <summary>
         /// Returns a reference to specified element of the Span.
         /// </summary>
         /// <param name="index"></param>

--- a/src/System.Private.CoreLib/shared/System/Text/Rune.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/Rune.cs
@@ -148,7 +148,7 @@ namespace System.Text
         public int Utf16SequenceLength => UnicodeUtility.GetUtf16SequenceLength(_value);
 
         /// <summary>
-        /// Returns the length in code units (<see cref="Utf8Char"/>) of the
+        /// Returns the length in code units of the
         /// UTF-8 sequence required to represent this scalar value.
         /// </summary>
         /// <remarks>
@@ -420,7 +420,7 @@ namespace System.Text
         /// Encodes this <see cref="Rune"/> to a destination buffer as UTF-8 bytes.
         /// </summary>
         /// <param name="destination">The buffer to which to write this value as UTF-8.</param>
-        /// <param name="charsWritten">
+        /// <param name="bytesWritten">
         /// The number of <see cref="byte"/>s written to <paramref name="destination"/>,
         /// or 0 if the destination buffer is not large enough to contain the output.</param>
         /// <returns>True if the value was written to the buffer; otherwise, false.</returns>

--- a/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
@@ -562,7 +562,7 @@ namespace System.Text
         /// thus can be used in a C# 'foreach' statements to retreive the data in the StringBuilder
         /// as chunks (ReadOnlyMemory) of characters.  An example use is:
         /// 
-        ///      foreach (ReadOnlyMemory<char> chunk in sb.GetChunks())
+        ///      foreach (ReadOnlyMemory&lt;char&gt; chunk in sb.GetChunks())
         ///         foreach(char c in chunk.Span)
         ///             { /* operation on c }
         ///
@@ -577,10 +577,10 @@ namespace System.Text
         /// compared to the fetching of the character, so create a local variable for the SPAN 
         /// if you need to use it in a nested for statement.  For example 
         /// 
-        ///    foreach (ReadOnlyMemory<char> chunk in sb.GetChunks())
+        ///    foreach (ReadOnlyMemory&lt;char&gt; chunk in sb.GetChunks())
         ///    {
         ///         var span = chunk.Span;
-        ///         for(int i = 0; i < span.Length; i++)
+        ///         for(int i = 0; i &lt; span.Length; i++)
         ///             { /* operation on span[i] */ }
         ///    }
         /// </summary>
@@ -1819,9 +1819,9 @@ namespace System.Text
         }
 
         /// <summary>
-        /// Determines if the contents of this builder are equal to the contents of ReadOnlySpan<char>.
+        /// Determines if the contents of this builder are equal to the contents of <see cref="ReadOnlySpan{Char}"/>.
         /// </summary>
-        /// <param name="span">The ReadOnlySpan{char}.</param>
+        /// <param name="span">The <see cref="ReadOnlySpan{Char}"/>.</param>
         public bool Equals(ReadOnlySpan<char> span)
         {
             if (span.Length != Length)

--- a/src/System.Private.CoreLib/shared/System/Text/UnicodeUtility.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/UnicodeUtility.cs
@@ -154,9 +154,9 @@ namespace System.Text
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsSurrogateCodePoint(uint value) => IsInRangeInclusive(value, 0xD800U, 0xDFFFU);
-        
+
         /// <summary>
-        /// Returns <see langword="true"/> iff <paramref name="value"/> is a valid Unicode code
+        /// Returns <see langword="true"/> iff <paramref name="codePoint"/> is a valid Unicode code
         /// point, i.e., is in [ U+0000..U+10FFFF ], inclusive.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/System.Private.CoreLib/shared/System/Threading/LazyInitializer.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/LazyInitializer.cs
@@ -153,7 +153,7 @@ namespace System.Threading
         /// <param name="target">A reference to the target to be initialized.</param>
         /// <param name="initialized">A reference to a location tracking whether the target has been initialized.</param>
         /// <param name="syncLock">A reference to a location containing a mutual exclusive lock. If <paramref name="syncLock"/> is null, 
-        /// a new object will be instantiated.</param>
+        /// a new object will be instantiated.
         /// </param>
         /// <returns>The initialized object.</returns>
         private static T EnsureInitializedCore<T>(ref T target, ref bool initialized, ref object syncLock)

--- a/src/System.Private.CoreLib/shared/System/Threading/SemaphoreSlim.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/SemaphoreSlim.cs
@@ -547,9 +547,6 @@ namespace System.Threading
         /// A <see cref="System.TimeSpan"/> that represents the number of milliseconds
         /// to wait, or a <see cref="System.TimeSpan"/> that represents -1 milliseconds to wait indefinitely.
         /// </param>
-        /// <param name="cancellationToken">
-        /// The <see cref="T:System.Threading.CancellationToken"/> token to observe.
-        /// </param>
         /// <returns>
         /// A task that will complete with a result of true if the current thread successfully entered 
         /// the <see cref="SemaphoreSlim"/>, otherwise with a result of false.
@@ -573,6 +570,9 @@ namespace System.Threading
         /// <param name="timeout">
         /// A <see cref="System.TimeSpan"/> that represents the number of milliseconds
         /// to wait, or a <see cref="System.TimeSpan"/> that represents -1 milliseconds to wait indefinitely.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The <see cref="T:System.Threading.CancellationToken"/> token to observe.
         /// </param>
         /// <returns>
         /// A task that will complete with a result of true if the current thread successfully entered 
@@ -711,6 +711,7 @@ namespace System.Threading
         }
 
         /// <summary>Performs the asynchronous wait.</summary>
+        /// <param name="asyncWaiter">The asynchronous waiter.</param>
         /// <param name="millisecondsTimeout">The timeout.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The task to return to the caller.</returns>

--- a/src/System.Private.CoreLib/shared/System/Threading/SpinWait.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/SpinWait.cs
@@ -103,7 +103,7 @@ namespace System.Threading
         private int _count;
 
         /// <summary>
-        /// Gets the number of times <see cref="SpinOnce"/> has been called on this instance.
+        /// Gets the number of times <see cref="SpinOnce()"/> has been called on this instance.
         /// </summary>
         public int Count
         {
@@ -116,14 +116,14 @@ namespace System.Threading
         }
 
         /// <summary>
-        /// Gets whether the next call to <see cref="SpinOnce"/> will yield the processor, triggering a
+        /// Gets whether the next call to <see cref="SpinOnce()"/> will yield the processor, triggering a
         /// forced context switch.
         /// </summary>
-        /// <value>Whether the next call to <see cref="SpinOnce"/> will yield the processor, triggering a
+        /// <value>Whether the next call to <see cref="SpinOnce()"/> will yield the processor, triggering a
         /// forced context switch.</value>
         /// <remarks>
-        /// On a single-CPU machine, <see cref="SpinOnce"/> always yields the processor. On machines with
-        /// multiple CPUs, <see cref="SpinOnce"/> may yield after an unspecified number of calls.
+        /// On a single-CPU machine, <see cref="SpinOnce()"/> always yields the processor. On machines with
+        /// multiple CPUs, <see cref="SpinOnce()"/> may yield after an unspecified number of calls.
         /// </remarks>
         public bool NextSpinWillYield => _count >= YieldThreshold || PlatformHelper.IsSingleProcessor;
 
@@ -132,7 +132,7 @@ namespace System.Threading
         /// </summary>
         /// <remarks>
         /// This is typically called in a loop, and may change in behavior based on the number of times a
-        /// <see cref="SpinOnce"/> has been called thus far on this instance.
+        /// <see cref="SpinOnce()"/> has been called thus far on this instance.
         /// </remarks>
         public void SpinOnce()
         {
@@ -151,7 +151,7 @@ namespace System.Threading
         /// </exception>
         /// <remarks>
         /// This is typically called in a loop, and may change in behavior based on the number of times a
-        /// <see cref="SpinOnce"/> has been called thus far on this instance.
+        /// <see cref="SpinOnce()"/> has been called thus far on this instance.
         /// </remarks>
         public void SpinOnce(int sleep1Threshold)
         {
@@ -257,8 +257,8 @@ namespace System.Threading
         /// Resets the spin counter.
         /// </summary>
         /// <remarks>
-        /// This makes <see cref="SpinOnce"/> and <see cref="NextSpinWillYield"/> behave as though no calls
-        /// to <see cref="SpinOnce"/> had been issued on this instance. If a <see cref="SpinWait"/> instance
+        /// This makes <see cref="SpinOnce()"/> and <see cref="NextSpinWillYield"/> behave as though no calls
+        /// to <see cref="SpinOnce()"/> had been issued on this instance. If a <see cref="SpinWait"/> instance
         /// is reused many times, it may be useful to reset it to avoid yielding too soon.
         /// </remarks>
         public void Reset()

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskExtensions.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskExtensions.cs
@@ -29,9 +29,9 @@ namespace System.Threading.Tasks
                 Task.FromCanceled(new CancellationToken(true));
         }
 
-        /// <summary>Creates a proxy <see cref="Task{TResult}"/> that represents the asynchronous operation of a <see cref="Task{Task{TResult}}"/>.</summary>
-        /// <param name="task">The <see cref="Task{Task{TResult}}"/> to unwrap.</param>
-        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous operation of the provided <see cref="Task{Task{TResult}}"/>.</returns>
+        /// <summary>Creates a proxy <see cref="Task{TResult}"/> that represents the asynchronous operation of a wrapped <see cref="Task{TResult}"/>.</summary>
+        /// <param name="task">The wrapped <see cref="Task{TResult}"/> to unwrap.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that represents the asynchronous operation of the provided wrapped <see cref="Task{TResult}"/>.</returns>
         public static Task<TResult> Unwrap<TResult>(this Task<Task<TResult>> task)
         {
             if (task == null)

--- a/src/System.Private.CoreLib/shared/System/TimeZoneInfo.Win32.cs
+++ b/src/System.Private.CoreLib/shared/System/TimeZoneInfo.Win32.cs
@@ -323,7 +323,7 @@ namespace System
         }
 
         /// <summary>
-        /// Helper function for retrieving a TimeZoneInfo object by <time_zone_name>.
+        /// Helper function for retrieving a TimeZoneInfo object by time_zone_name.
         /// This function wraps the logic necessary to keep the private
         /// SystemTimeZones cache in working order
         ///
@@ -521,7 +521,7 @@ namespace System
 
         /// <summary>
         /// Helper function that takes:
-        ///  1. A string representing a <time_zone_name> registry key name.
+        ///  1. A string representing a time_zone_name registry key name.
         ///  2. A REG_TZI_FORMAT struct containing the default rule.
         ///  3. An AdjustmentRule[] out-parameter.
         /// </summary>
@@ -905,7 +905,7 @@ namespace System
         }
 
         /// <summary>
-        /// Helper function that takes a string representing a <time_zone_name> registry key name
+        /// Helper function that takes a string representing a time_zone_name registry key name
         /// and returns a TimeZoneInfo instance.
         /// </summary>
         private static TimeZoneInfoResult TryGetTimeZoneFromLocalMachine(string id, out TimeZoneInfo value, out Exception e)

--- a/src/System.Private.CoreLib/shared/System/TimeZoneInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/TimeZoneInfo.cs
@@ -789,7 +789,7 @@ namespace System
         public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(_id);
 
         /// <summary>
-        /// Returns a ReadOnlyCollection<TimeZoneInfo> containing all valid TimeZone's
+        /// Returns a <see cref="ReadOnlyCollection{TimeZoneInfo}"/> containing all valid TimeZone's
         /// from the local machine. The entries in the collection are sorted by
         /// <see cref="DisplayName"/>.
         /// This method does *not* throw TimeZoneNotFoundException or InvalidTimeZoneException.
@@ -1831,7 +1831,7 @@ namespace System
         }
 
         /// <summary>
-        /// Helper function for retrieving a TimeZoneInfo object by <time_zone_name>.
+        /// Helper function for retrieving a TimeZoneInfo object by time_zone_name.
         ///
         /// This function may return null.
         ///

--- a/src/System.Private.CoreLib/src/Microsoft/Win32/Win32Native.cs
+++ b/src/System.Private.CoreLib/src/Microsoft/Win32/Win32Native.cs
@@ -11,7 +11,7 @@
 **
 **
 ===========================================================*/
-/**
+/*
  * Notes to PInvoke users:  Getting the syntax exactly correct is crucial, and
  * more than a little confusing.  Here's some guidelines.
  *
@@ -51,7 +51,7 @@
  * but your function prototype must use different syntax depending on your 
  * choice.  For example, if your native method is prototyped as such:
  *
- *    bool GetVersionEx(OSVERSIONINFO & lposvi);
+ *    bool GetVersionEx(OSVERSIONINFO &amp; lposvi);
  *
  *
  * you must use EITHER THIS OR THE NEXT syntax:
@@ -76,7 +76,7 @@
  * Also note the CharSet.Auto on GetVersionEx - while it does not take a String
  * as a parameter, the OSVERSIONINFO contains an embedded array of TCHARs, so
  * the size of the struct varies on different platforms, and there's a
- * GetVersionExA & a GetVersionExW.  Also, the OSVERSIONINFO struct has a sizeof
+ * GetVersionExA &amp; a GetVersionExW.  Also, the OSVERSIONINFO struct has a sizeof
  * field so the OS can ensure you've passed in the correctly-sized copy of an
  * OSVERSIONINFO.  You must explicitly set this using Marshal.SizeOf(Object);
  *

--- a/src/System.Private.CoreLib/src/System/Diagnostics/Contracts/Contracts.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Contracts/Contracts.cs
@@ -243,7 +243,7 @@ namespace System.Diagnostics.Contracts
         /// </summary>
         /// <param name="condition">Expression to assume will always be true.</param>
         /// <remarks>
-        /// At runtime this is equivalent to an <seealso cref="System.Diagnostics.Contracts.Debug.Assert(bool)"/>.
+        /// At runtime this is equivalent to an <seealso cref="System.Diagnostics.Contracts.Contract.Assert(bool)"/>.
         /// </remarks>
         [Pure]
         [Conditional("DEBUG")]
@@ -262,7 +262,7 @@ namespace System.Diagnostics.Contracts
         /// <param name="condition">Expression to assume will always be true.</param>
         /// <param name="userMessage">If it is not a constant string literal, then the contract may not be understood by tools.</param>
         /// <remarks>
-        /// At runtime this is equivalent to an <seealso cref="System.Diagnostics.Contracts.Debug.Assert(bool)"/>.
+        /// At runtime this is equivalent to an <seealso cref="System.Diagnostics.Contracts.Contract.Assert(bool)"/>.
         /// </remarks>
         [Pure]
         [Conditional("DEBUG")]

--- a/src/System.Private.CoreLib/src/System/Diagnostics/Contracts/ContractsBCL.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Contracts/ContractsBCL.cs
@@ -248,9 +248,9 @@ namespace System.Runtime.CompilerServices
         /// 1. Call any contract hooks (such as listeners to Contract failed events)
         /// 2. Determine if the listeners deem the failure as handled (then resultFailureMessage should be set to null)
         /// 3. Produce a localized resultFailureMessage used in advertising the failure subsequently.
-        /// </summary>
         /// On exit: null if the event was handled and should not trigger a failure.
-        ///          Otherwise, returns the localized failure message</param>
+        ///          Otherwise, returns the localized failure message.
+        /// </summary>
         [System.Diagnostics.DebuggerNonUserCode]
         public static string RaiseContractFailedEvent(ContractFailureKind failureKind, string userMessage, string conditionText, Exception innerException)
         {

--- a/src/System.Private.CoreLib/src/System/RtType.cs
+++ b/src/System.Private.CoreLib/src/System/RtType.cs
@@ -4532,7 +4532,7 @@ namespace System
 
         /// <summary>
         /// Helper to invoke the default (parameterless) constructor.
-        /// <summary>
+        /// </summary>
         [DebuggerStepThrough]
         [DebuggerHidden]
         internal object CreateInstanceDefaultCtor(bool publicOnly, bool skipCheckThis, bool fillCache, bool wrapExceptions)

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -522,7 +522,6 @@ namespace System.Runtime.CompilerServices
 
         /// <summary>A strongly-typed box for Task-based async state machines.</summary>
         /// <typeparam name="TStateMachine">Specifies the type of the state machine.</typeparam>
-        /// <typeparam name="TResult">Specifies the type of the Task's result.</typeparam>
         private class AsyncStateMachineBox<TStateMachine> : // SOS DumpAsync command depends on this name
             Task<TResult>, IAsyncStateMachineBox
             where TStateMachine : IAsyncStateMachine
@@ -530,14 +529,14 @@ namespace System.Runtime.CompilerServices
             /// <summary>Delegate used to invoke on an ExecutionContext when passed an instance of this box type.</summary>
             private static readonly ContextCallback s_callback = s => ((AsyncStateMachineBox<TStateMachine>)s).StateMachine.MoveNext();
 
-            /// <summary>A delegate to the <see cref="MoveNext"/> method.</summary>
+            /// <summary>A delegate to the <see cref="MoveNext()"/> method.</summary>
             private Action _moveNextAction;
             /// <summary>The state machine itself.</summary>
             public TStateMachine StateMachine; // mutable struct; do not make this readonly. SOS DumpAsync command depends on this name.
             /// <summary>Captured ExecutionContext with which to invoke <see cref="MoveNextAction"/>; may be null.</summary>
             public ExecutionContext Context;
 
-            /// <summary>A delegate to the <see cref="MoveNext"/> method.</summary>
+            /// <summary>A delegate to the <see cref="MoveNext()"/> method.</summary>
             public Action MoveNextAction => _moveNextAction ?? (_moveNextAction = new Action(MoveNext));
 
             internal sealed override void ExecuteFromThreadPool(Thread threadPoolThread) => MoveNext(threadPoolThread);
@@ -910,7 +909,7 @@ namespace System.Runtime.CompilerServices
     }
 
     /// <summary>
-    /// An interface implemented by all <see cref="AsyncStateMachineBox{TStateMachine, TResult}"/> instances, regardless of generics.
+    /// An interface implemented by all <see cref="AsyncTaskMethodBuilder{TResult}.AsyncStateMachineBox{TStateMachine}"/> instances, regardless of generics.
     /// </summary>
     internal interface IAsyncStateMachineBox
     {
@@ -1067,7 +1066,7 @@ namespace System.Runtime.CompilerServices
         /// the action after that is and after that.   To solve this problem we create a 'ContinuationWrapper 
         /// which when invoked just does the original action (the invoke action), but also remembers other information
         /// (like the action after that (which is also a ContinuationWrapper and thus form a linked list).  
-        //  We also store that task if the action is associate with at task.  
+        ///  We also store that task if the action is associate with at task.  
         /// </summary>
         private sealed class ContinuationWrapper
         {

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -1767,7 +1767,7 @@ namespace System.Runtime.InteropServices
         /// NativeLibrary Loader: Simple API
         /// This method is a wrapper around OS loader, using "default" flags.
         /// </summary>
-        /// <param name="libraryName">The name of the native library to be loaded</param>
+        /// <param name="libraryPath">The name of the native library to be loaded</param>
         /// <returns>The handle for the loaded native library</returns>  
         /// <exception cref="System.ArgumentNullException">If libraryPath is null</exception>
         /// <exception cref="System.DllNotFoundException ">If the library can't be found.</exception>
@@ -1783,7 +1783,7 @@ namespace System.Runtime.InteropServices
         /// <summary>
         /// NativeLibrary Loader: Simple API that doesn't throw
         /// </summary>
-        /// <param name="libraryName">The name of the native library to be loaded</param>
+        /// <param name="libraryPath">The name of the native library to be loaded</param>
         /// <param name="handle">The out-parameter for the loaded native library handle</param>
         /// <returns>True on successful load, false otherwise</returns>  
         /// <exception cref="System.ArgumentNullException">If libraryPath is null</exception>
@@ -1807,8 +1807,8 @@ namespace System.Runtime.InteropServices
         /// * AssemblyLoadContext.LoadUnmanagedDll()
         /// </summary>
         /// <param name="libraryName">The name of the native library to be loaded</param>
-        /// <param name="dllImportSearchPath">The search path</param>
         /// <param name="assembly">The assembly loading the native library</param>
+        /// <param name="searchPath">The search path</param>
         /// <returns>The handle for the loaded library</returns>  
         /// <exception cref="System.ArgumentNullException">If libraryPath or assembly is null</exception>
         /// <exception cref="System.ArgumentException">If assembly is not a RuntimeAssembly</exception>
@@ -1834,7 +1834,7 @@ namespace System.Runtime.InteropServices
         /// NativeLibrary Loader: High-level API that doesn't throw.
         /// </summary>
         /// <param name="libraryName">The name of the native library to be loaded</param>
-        /// <param name="dllImportSearchPath">The search path</param>
+        /// <param name="searchPath">The search path</param>
         /// <param name="assembly">The assembly loading the native library</param>
         /// <param name="handle">The out-parameter for the loaded native library handle</param>
         /// <returns>True on successful load, false otherwise</returns>  

--- a/src/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
@@ -17,7 +17,7 @@ namespace System.Threading
     /// token may have cancellation requested by calling to the source's <see cref="Cancel()"/> method.
     /// </para>
     /// <para>
-    /// All members of this class, except <see cref="Dispose"/>, are thread-safe and may be used
+    /// All members of this class, except <see cref="Dispose()"/>, are thread-safe and may be used
     /// concurrently from multiple threads.
     /// </para>
     /// </remarks>
@@ -908,7 +908,7 @@ namespace System.Threading
             public readonly CancellationTokenSource Source;
             /// <summary>Lock that protects all state in the partition.</summary>
             public SpinLock Lock = new SpinLock(enableThreadOwnerTracking: false); // mutable struct; do not make this readonly
-            /// <summary>Doubly-linked list of callbacks registered with the partition. Callbacks are removed during unregistration and as they're invoked.</remarks>
+            /// <summary>Doubly-linked list of callbacks registered with the partition. Callbacks are removed during unregistration and as they're invoked.</summary>
             public CallbackNode Callbacks;
             /// <summary>Singly-linked list of free nodes that can be used for subsequent callback registrations.</summary>
             public CallbackNode FreeNodeList;

--- a/src/System.Private.CoreLib/src/System/Threading/ClrThreadPoolBoundHandle.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ClrThreadPoolBoundHandle.cs
@@ -239,7 +239,7 @@ namespace System.Threading
 
         /// <summary>
         ///     Returns the user-provided object specified when the <see cref="NativeOverlapped"/> instance was
-        ///     allocated using the <see cref="AllocateNativeOverlapped(IOCompletionCallback, object, byte[])"/>.
+        ///     allocated using the <see cref="AllocateNativeOverlapped(IOCompletionCallback, object, object)"/>.
         /// </summary>
         /// <param name="overlapped">
         ///     An unmanaged pointer to the <see cref="NativeOverlapped"/> structure from which to return the 

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/FutureFactory.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/FutureFactory.cs
@@ -1227,7 +1227,7 @@ namespace System.Threading.Tasks
         /// and delegate allocations.
         /// </summary>
         /// <typeparam name="TInstance">Specifies the type of the instance on which the APM implementation lives.</typeparam>
-        /// <typeparam name="TArg1">Specifies the type containing the arguments.</typeparam>
+        /// <typeparam name="TArgs">Specifies the type containing the arguments.</typeparam>
         /// <param name="thisRef">The instance from which the begin and end methods are invoked.</param>
         /// <param name="beginMethod">The begin method.</param>
         /// <param name="endMethod">The end method.</param>
@@ -1326,10 +1326,6 @@ namespace System.Threading.Tasks
             /// <param name="thisRef">The target instance on which the end method should be called.</param>
             /// <param name="endMethod">The end method to call to retrieve the result.</param>
             /// <param name="asyncResult">The IAsyncResult for the async operation.</param>
-            /// <permission cref="requiresSynchronization">
-            /// Whether completing the task requires synchronization.  This should be true
-            /// unless absolutely sure that the task has not yet been handed out to any consumers.
-            /// </permission>
             internal void Complete(
                 TInstance thisRef, Func<TInstance, IAsyncResult, TResult> endMethod, IAsyncResult asyncResult,
                 bool requiresSynchronization)

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/ProducerConsumerQueues.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/ProducerConsumerQueues.cs
@@ -357,7 +357,7 @@ namespace System.Threading.Tasks
             private readonly SingleProducerSingleConsumerQueue<T> m_queue;
 
             /// <summary>Initializes the debug view.</summary>
-            /// <param name="enumerable">The queue being debugged.</param>
+            /// <param name="queue">The queue being debugged.</param>
             public SingleProducerSingleConsumerQueue_DebugView(SingleProducerSingleConsumerQueue<T> queue)
             {
                 Debug.Assert(queue != null, "Expected a non-null queue.");

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/TPLETWProvider.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/TPLETWProvider.cs
@@ -320,9 +320,10 @@ namespace System.Threading.Tasks
         /// <param name="OriginatingTaskID">The task ID.</param>
         /// <param name="TaskID">The task ID.</param>
         /// <param name="Behavior">Configured behavior for the wait.</param>
-        /// <param name="ContinueWithTaskID">If known, if 'TaskID' has a 'continueWith' task, mention give its ID here.  
-        ///      0 means unknown.   This allows better visualization of the common sequential chaining case.</param>
-        /// </summary>
+        /// <param name="ContinueWithTaskID">
+        /// If known, if 'TaskID' has a 'continueWith' task, mention give its ID here.  
+        /// 0 means unknown.   This allows better visualization of the common sequential chaining case.
+        /// </param>
         [Event(TASKWAITBEGIN_ID, Version = 3, Task = TplEtwProvider.Tasks.TaskWait, Opcode = EventOpcode.Send,
          Level = EventLevel.Informational, Keywords = Keywords.TaskTransfer | Keywords.Tasks)]
         public void TaskWaitBegin(
@@ -383,8 +384,6 @@ namespace System.Threading.Tasks
         /// <summary>
         /// Fired when the work (method) associated with a TaskWaitEnd completes
         /// </summary>
-        /// <param name="OriginatingTaskSchedulerID">The scheduler ID.</param>
-        /// <param name="OriginatingTaskID">The task ID.</param>
         /// <param name="TaskID">The task ID.</param>
         [Event(TASKWAITCONTINUATIONCOMPLETE_ID,
          Level = EventLevel.Verbose, Keywords = Keywords.TaskStops)]
@@ -398,8 +397,6 @@ namespace System.Threading.Tasks
         /// <summary>
         /// Fired when the work (method) associated with a TaskWaitEnd completes
         /// </summary>
-        /// <param name="OriginatingTaskSchedulerID">The scheduler ID.</param>
-        /// <param name="OriginatingTaskID">The task ID.</param>
         /// <param name="TaskID">The task ID.</param>
         [Event(TASKWAITCONTINUATIONSTARTED_ID,
          Level = EventLevel.Verbose, Keywords = Keywords.TaskStops)]
@@ -415,7 +412,6 @@ namespace System.Threading.Tasks
         /// </summary>
         /// <param name="OriginatingTaskSchedulerID">The scheduler ID.</param>
         /// <param name="OriginatingTaskID">The task ID.</param>
-        /// <param name="TaskID">The activityId for the continuation.</param>
         [Event(AWAITTASKCONTINUATIONSCHEDULED_ID, Task = Tasks.AwaitTaskContinuationScheduled, Opcode = EventOpcode.Send,
          Level = EventLevel.Informational, Keywords = Keywords.TaskTransfer | Keywords.Tasks)]
         public void AwaitTaskContinuationScheduled(

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -1266,7 +1266,7 @@ namespace System.Threading.Tasks
         /// Gets the Task instance currently executing if the specified creation options
         /// contain AttachedToParent.
         /// </summary>
-        /// <param name="options">The options to check.</param>
+        /// <param name="creationOptions">The options to check.</param>
         /// <returns>The current task if there is one and if AttachToParent is in the options; otherwise, null.</returns>
         internal static Task InternalCurrentIfAttached(TaskCreationOptions creationOptions)
         {
@@ -5100,7 +5100,6 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>Creates a <see cref="Task{TResult}"/> that's completed exceptionally with the specified exception.</summary>
-        /// <typeparam name="TResult">The type of the result returned by the task.</typeparam>
         /// <param name="exception">The exception with which to complete the task.</param>
         /// <returns>The faulted task.</returns>
         public static Task FromException(Exception exception)
@@ -6633,7 +6632,7 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>Transfer the completion status from "task" to ourself.</summary>
-        /// <param name="task">The source task whose results should be transfered to <paramref name="promise"/>.</param>
+        /// <param name="task">The source task whose results should be transfered to this.</param>
         /// <param name="lookForOce">Whether or not to look for OperationCanceledExceptions in task's exceptions if it faults.</param>
         /// <returns>true if the transfer was successful; otherwise, false.</returns>
         private bool TrySetFromTask(Task task, bool lookForOce)

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
@@ -223,7 +223,7 @@ namespace System.Threading.Tasks
     {
         /// <summary>Inlines or schedules the continuation.</summary>
         /// <param name="completedTask">The antecedent task that has completed.</param>
-        /// <param name="canInlineContinuationTask">true if inlining is permitted; otherwise, false.</param>
+        /// <param name="bCanInlineContinuationTask">true if inlining is permitted; otherwise, false.</param>
         internal abstract void Run(Task completedTask, bool bCanInlineContinuationTask);
 
         /// <summary>Tries to run the task on the current thread, if possible; otherwise, schedules it.</summary>
@@ -395,7 +395,7 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>Inlines or schedules the continuation.</summary>
-        /// <param name="ignored">The antecedent task, which is ignored.</param>
+        /// <param name="task">The antecedent task, which is ignored.</param>
         /// <param name="canInlineContinuationTask">true if inlining is permitted; otherwise, false.</param>
         internal sealed override void Run(Task task, bool canInlineContinuationTask)
         {
@@ -565,7 +565,7 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>Inlines or schedules the continuation onto the default scheduler.</summary>
-        /// <param name="ignored">The antecedent task, which is ignored.</param>
+        /// <param name="task">The antecedent task, which is ignored.</param>
         /// <param name="canInlineContinuationTask">true if inlining is permitted; otherwise, false.</param>
         internal override void Run(Task task, bool canInlineContinuationTask)
         {
@@ -809,6 +809,7 @@ namespace System.Threading.Tasks
 
         /// <summary>Schedules the action to be executed.  No ExecutionContext work is performed used.</summary>
         /// <param name="action">The action to invoke or queue.</param>
+        /// <param name="task">The task scheduling the action.</param>
         internal static void UnsafeScheduleAction(Action action, Task task)
         {
             AwaitTaskContinuation atc = new AwaitTaskContinuation(action, flowExecutionContext: false);

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/future.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/future.cs
@@ -1466,6 +1466,7 @@ namespace System.Threading.Tasks
 
         #endregion
 
+#if SUPPORT_IOBSERVABLE
         /// <summary>
         /// Subscribes an <see cref="IObserver{TResult}"/> to receive notification of the final state of this <see cref="Task{TResult}"/>.
         /// </summary>
@@ -1480,7 +1481,6 @@ namespace System.Threading.Tasks
         /// <exception cref="T:System.ArgumentNullException">
         /// The <paramref name="observer"/> argument is null.
         /// </exception>
-#if SUPPORT_IOBSERVABLE
         IDisposable IObservable<TResult>.Subscribe(IObserver<TResult> observer)
         {
             if (observer == null)

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/future.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/future.cs
@@ -66,9 +66,6 @@ namespace System.Threading.Tasks
     [DebuggerTypeProxy(typeof(SystemThreadingTasks_FutureDebugView<>))]
     [DebuggerDisplay("Id = {Id}, Status = {Status}, Method = {DebuggerDisplayMethodDescription}, Result = {DebuggerDisplayResultDescription}")]
     public class Task<TResult> : Task
-#if SUPPORT_IOBSERVABLE        
-        ,  IObservable<TResult>
-#endif
     {
         internal TResult m_result; // The value itself, if set.
 
@@ -1465,74 +1462,7 @@ namespace System.Threading.Tasks
         #endregion
 
         #endregion
-
-#if SUPPORT_IOBSERVABLE
-        /// <summary>
-        /// Subscribes an <see cref="IObserver{TResult}"/> to receive notification of the final state of this <see cref="Task{TResult}"/>.
-        /// </summary>
-        /// <param name="observer">
-        /// The <see cref="IObserver{TResult}"/> to call on task completion. If this Task throws an exception, 
-        /// observer.OnError is called with this Task's AggregateException. If this Task RanToCompletion, 
-        /// observer.OnNext is called with this Task's result, followed by a call to observer.OnCompleted.
-        /// If this Task is Canceled,  observer.OnError is called with a TaskCanceledException
-        /// containing this Task's CancellationToken
-        /// </param>
-        /// <returns>An IDisposable object <see cref="Task"/>.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
-        /// The <paramref name="observer"/> argument is null.
-        /// </exception>
-        IDisposable IObservable<TResult>.Subscribe(IObserver<TResult> observer)
-        {
-            if (observer == null)
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.observer);
-
-            
-            var continuationTask = 
-                this.ContinueWith(delegate(Task<TResult> observedTask, object taskObserverObject)
-                {
-                    IObserver<TResult> taskObserver = (IObserver<TResult>)taskObserverObject;
-                    if (observedTask.IsFaulted)
-                        taskObserver.OnError(observedTask.Exception);
-                    else if (observedTask.IsCanceled)
-                        taskObserver.OnError(new TaskCanceledException(observedTask));
-                    else
-                    {
-                        taskObserver.OnNext(observedTask.Result);
-                        taskObserver.OnCompleted();
-                    }
-
-                }, observer, TaskScheduler.Default);
-    
-            return new DisposableSubscription(this, continuationTask);
-        }
-#endif
     }
-
-#if SUPPORT_IOBSERVABLE
-    // Class that calls RemoveContinuation if Dispose() is called before task completion
-    internal class DisposableSubscription : IDisposable
-    {
-        private Task _notifyObserverContinuationTask;
-        private Task _observedTask;
-        
-        internal DisposableSubscription(Task observedTask, Task notifyObserverContinuationTask)
-        {
-            _observedTask = observedTask;
-            _notifyObserverContinuationTask = notifyObserverContinuationTask;
-        }
-        void IDisposable.Dispose()
-        {
-            Task localObservedTask = _observedTask;
-            Task localNotifyingContinuationTask = _notifyObserverContinuationTask;
-            if (localObservedTask != null && localNotifyingContinuationTask != null && !localObservedTask.IsCompleted)
-            {
-                localObservedTask.RemoveContinuation(localNotifyingContinuationTask);
-            }
-            _observedTask = null;
-            _notifyObserverContinuationTask = null;
-        }
-    }
-#endif
 
     // Proxy class for better debugging experience
     internal class SystemThreadingTasks_FutureDebugView<TResult>


### PR DESCRIPTION
These are causing errors in the source.dot.net build.  Turning on DocumentationFile and suppressing 1591, 1573, and 0419, Corelib builds clean after these changes.

cc: @danmosemsft, @jkotas