### PR TITLE
Defer Initialization of FrameworkEventSource During EventPipeController Initialization

### DIFF
--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventPipeController.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventPipeController.cs
@@ -60,6 +60,9 @@ namespace System.Diagnostics.Tracing
         // Singleton controller instance.
         private static EventPipeController s_controllerInstance = null;
 
+        // Initialization flag used to avoid initializing FrameworkEventSource on the startup path.
+        private static bool s_initializing = false;
+
         // Controller object state.
         private Timer m_timer;
         private string m_configFilePath;
@@ -67,11 +70,18 @@ namespace System.Diagnostics.Tracing
         private string m_traceFilePath = null;
         private bool m_configFileExists = false;
 
+        internal static bool Initializing
+        {
+            get { return s_initializing; }
+        }
+
         internal static void Initialize()
         {
             // Don't allow failures to propagate upstream.  Ensure program correctness without tracing.
             try
             {
+                s_initializing = true;
+
                 if (s_controllerInstance == null)
                 {
                     if (Config_EnableEventPipe > 0)
@@ -88,6 +98,10 @@ namespace System.Diagnostics.Tracing
                 }
             }
             catch { }
+            finally
+            {
+                s_initializing = false;
+            }
         }
 
         private EventPipeController()

--- a/src/mscorlib/src/System/Threading/Timer.cs
+++ b/src/mscorlib/src/System/Threading/Timer.cs
@@ -479,7 +479,8 @@ namespace System.Threading
                     }
                     else
                     {
-                        if (FrameworkEventSource.IsInitialized && FrameworkEventSource.Log.IsEnabled(EventLevel.Informational, FrameworkEventSource.Keywords.ThreadTransfer))
+                        // Don't emit this event during EventPipeController.  This avoids initializing FrameworkEventSource during start-up which is expensive relative to the rest of start-up.
+                        if (!EventPipeController.Initializing && FrameworkEventSource.IsInitialized && FrameworkEventSource.Log.IsEnabled(EventLevel.Informational, FrameworkEventSource.Keywords.ThreadTransfer))
                             FrameworkEventSource.Log.ThreadTransferSendObj(this, 1, string.Empty, true);
 
                         success = m_associatedTimerQueue.UpdateTimer(this, dueTime, period);


### PR DESCRIPTION
#### Description
Start-up of all managed processes has increased CPU usage.  This is caused by the addition of a new Timer object created before Main is called to schedule a check for whether to enable tracing.  The bulk of the cost comes from initialization of FrameworkEventSource, which occurs because the new Timer object emits an event via FrameworkEventSource.

The solution is to defer initialization of FrameworkEventSource when creating the Timer.

#### Customer Impact
Without this fix there is a regression in CPU of up to 50% of runtime start-up.  The actual wall-clock time varies and in many cases is quite low.  In testing prior to the release of 2.2, this did not show up nearly as heavily.

This was reported by Matt Warren: https://twitter.com/matthewwarren/status/1067789388485140481

#### Regression?
This was a regression in .NET Core 2.2.  Future regressions in this space should be captured by investments we plan to make for start-up performance testing.

#### Risk
The risk of this fix is low and is isolated to tracing capabilities.