### PR TITLE
Disable CoreFX collectible COM unsupported test

### DIFF
--- a/tests/CoreFX/CoreFX.issues.json
+++ b/tests/CoreFX/CoreFX.issues.json
@@ -616,6 +616,10 @@
                 {
                     "name" : "System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unsupported_ThreadStaticAndFixedAddressValueType",
                     "reason" : "outdated"
+                },
+                {
+                    "name" : "System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unsupported_COMInterop",
+                    "reason" : "outdated"
                 }
             ]
         }


### PR DESCRIPTION
The test is now obsolete as we support COM interop with collectible
classes.