### PR TITLE
Disable native image usage for collectible assemblies

### DIFF
--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -526,6 +526,13 @@ void Module::Initialize(AllocMemTracker *pamTracker, LPCWSTR szName)
 
     m_dwTransientFlags &= ~((DWORD)CLASSES_FREED);  // Set flag indicating LookupMaps are now in a consistent and destructable state
 
+#ifdef FEATURE_COLLECTIBLE_TYPES
+    if (GetAssembly()->IsCollectible())
+    {
+        FastInterlockOr(&m_dwPersistedFlags, COLLECTIBLE_MODULE);
+    }
+#endif // FEATURE_COLLECTIBLE_TYPES
+
 #ifdef FEATURE_READYTORUN
     if (!HasNativeImage() && !IsResource())
         m_pReadyToRunInfo = ReadyToRunInfo::Initialize(this, pamTracker);
@@ -578,13 +585,6 @@ void Module::Initialize(AllocMemTracker *pamTracker, LPCWSTR szName)
     // this will be initialized a bit later.
     m_ModuleID = NULL;
     m_ModuleIndex.m_dwIndex = (SIZE_T)-1;
-
-#ifdef FEATURE_COLLECTIBLE_TYPES
-    if (GetAssembly()->IsCollectible())
-    {
-        FastInterlockOr(&m_dwPersistedFlags, COLLECTIBLE_MODULE);
-    }
-#endif // FEATURE_COLLECTIBLE_TYPES
 
     // Prepare statics that are known at module load time
     AllocateStatics(pamTracker);

--- a/src/vm/ceeload.h
+++ b/src/vm/ceeload.h
@@ -2594,14 +2594,12 @@ public:
     LPCWSTR GetDebugName() { WRAPPER_NO_CONTRACT; return m_file->GetDebugName(); }
 #endif
 
-    BOOL IsILOnly() { WRAPPER_NO_CONTRACT; return m_file->IsILOnly(); }
-
 #ifdef FEATURE_PREJIT
     BOOL HasNativeImage() 
     { 
         WRAPPER_NO_CONTRACT;
         SUPPORTS_DAC;
-        return m_file->HasNativeImage(); 
+        return m_file->HasNativeImage() && !IsCollectible();
     }
     
     PEImageLayout *GetNativeImage()
@@ -2618,6 +2616,7 @@ public:
         }
         CONTRACT_END;
 
+        _ASSERTE(!IsCollectible());
         RETURN m_file->GetLoadedNative();
     }
 #else

--- a/src/vm/ceeload.h
+++ b/src/vm/ceeload.h
@@ -2599,7 +2599,7 @@ public:
     { 
         WRAPPER_NO_CONTRACT;
         SUPPORTS_DAC;
-        return m_file->HasNativeImage() && !IsCollectible();
+        return m_file->HasNativeImage();
     }
     
     PEImageLayout *GetNativeImage()

--- a/src/vm/readytoruninfo.cpp
+++ b/src/vm/readytoruninfo.cpp
@@ -463,6 +463,12 @@ PTR_ReadyToRunInfo ReadyToRunInfo::Initialize(Module * pModule, AllocMemTracker 
         return NULL;
     }
 
+    if (pModule->IsCollectible())
+    {
+        DoLog("Ready to Run disabled - collectible module");
+        return NULL;
+    }
+
     if (!pFile->HasLoadedIL())
     {
         DoLog("Ready to Run disabled - no loaded IL image");


### PR DESCRIPTION
There are couple of issues with using native images as collectible
assemblies. The most important one is that statics handling is different
for collectible and non-collectible classes. Collectible classes have
statics stored in per class allocated blocks while the non-collectible ones
are all stored per module. So the code that accesses them needs to use
different offsets relative to a statics base address in each of these cases.
The crossgen generates just a single form of code that corresponds to the
non-collectible case and so such code cannot be used when a module is
loaded as collectible.
To mitigate that, we disable using the native code from crossgen-ed
assemblies and JIT all the code instead.
We may want to revisit this in the future and e.g. unify the statics
handling for collectible and non-collectible classes.

Closes #20178