### PR TITLE
Delete FEATURE_TREAT_NI_AS_MSIL_DURING_DIAGNOSTICS

### DIFF
--- a/src/inc/switches.h
+++ b/src/inc/switches.h
@@ -193,17 +193,6 @@
 #define FEATURE_MINIMETADATA_IN_TRIAGEDUMPS
 #endif // defined(FEATURE_CORESYSTEM)
 
-#if defined(FEATURE_PREJIT) && defined(FEATURE_CORESYSTEM)
-// Desktop CLR allows profilers and debuggers to opt out of loading NGENd images, and to
-// JIT everything instead. "FEATURE_TREAT_NI_AS_MSIL_DURING_DIAGNOSTICS" is roughly the
-// equivalent for Apollo, where MSIL images may not be available at all.
-// FEATURE_TREAT_NI_AS_MSIL_DURING_DIAGNOSTICS allows profilers or debuggers to state
-// they don't want to use pregenerated code, and to instead load the NGENd image but
-// treat it as if it were MSIL by ignoring the prejitted code and prebaked structures,
-// and instead to JIT and load types at run-time.
-#define FEATURE_TREAT_NI_AS_MSIL_DURING_DIAGNOSTICS
-#endif
-
 // If defined, support interpretation.
 #if !defined(CROSSGEN_COMPILE)
 

--- a/src/vm/domainfile.cpp
+++ b/src/vm/domainfile.cpp
@@ -761,7 +761,6 @@ BOOL DomainFile::IsZapRequired()
     if (!m_pFile->HasMetadata() || !g_pConfig->RequireZap(GetSimpleName()))
         return FALSE;
 
-#if defined(_DEBUG) && defined(FEATURE_TREAT_NI_AS_MSIL_DURING_DIAGNOSTICS)
     // If we're intentionally treating NIs as if they were MSIL assemblies, and the test
     // is flexible enough to accept that (e.g., complus_zaprequired=2), then zaps are not
     // required (i.e., it's ok for m_pFile->m_nativeImage to be NULL), but only if we
@@ -781,7 +780,6 @@ BOOL DomainFile::IsZapRequired()
             return FALSE;
         }
     }
-#endif // defined(_DEBUG) && defined(FEATURE_TREAT_NI_AS_MSIL_DURING_DIAGNOSTICS)
 
     // Does this look like a resource-only assembly?  We assume an assembly is resource-only
     // if it contains no TypeDef (other than the <Module> TypeDef) and no MethodDef.
@@ -1492,27 +1490,6 @@ void DomainAssembly::FindNativeImage()
         STANDARD_VM_CHECK;
     }
     CONTRACTL_END;
-
-    // For non-Apollo builds (i.e., when FEATURE_TREAT_NI_AS_MSIL_DURING_DIAGNOSTICS is
-    // NOT defined), this is how we avoid use of NGEN when diagnostics requests it: By
-    // clearing it out and forcing a load of the MSIL assembly. For Apollo builds
-    // (FEATURE_TREAT_NI_AS_MSIL_DURING_DIAGNOSTICS), though, this doesn't work, as we
-    // don't have MSIL assemblies handy (particularly for Fx Assemblies), so we need to
-    // keep the NGENd image loaded, but to treat it as if it were an MSIL assembly. See
-    // code:PEFile::SetNativeImage.
-#ifndef FEATURE_TREAT_NI_AS_MSIL_DURING_DIAGNOSTICS
-    if (!NGENImagesAllowed())
-    {
-        GetFile()->SetCannotUseNativeImage();
-
-        if (GetFile()->HasNativeImage())
-            GetFile()->ClearNativeImage();
-
-        return;
-    }
-#endif // FEATURE_TREAT_NI_AS_MSIL_DURING_DIAGNOSTICS
-
-
 
     ClearNativeImageStress();
 

--- a/src/vm/domainfile.cpp
+++ b/src/vm/domainfile.cpp
@@ -761,6 +761,7 @@ BOOL DomainFile::IsZapRequired()
     if (!m_pFile->HasMetadata() || !g_pConfig->RequireZap(GetSimpleName()))
         return FALSE;
 
+#if defined(_DEBUG)
     // If we're intentionally treating NIs as if they were MSIL assemblies, and the test
     // is flexible enough to accept that (e.g., complus_zaprequired=2), then zaps are not
     // required (i.e., it's ok for m_pFile->m_nativeImage to be NULL), but only if we
@@ -780,6 +781,7 @@ BOOL DomainFile::IsZapRequired()
             return FALSE;
         }
     }
+#endif // defined(_DEBUG)
 
     // Does this look like a resource-only assembly?  We assume an assembly is resource-only
     // if it contains no TypeDef (other than the <Module> TypeDef) and no MethodDef.

--- a/src/vm/pefile.cpp
+++ b/src/vm/pefile.cpp
@@ -951,15 +951,12 @@ void PEFile::SetNativeImage(PEImage *image)
                     DBG_ADDR(image->GetLoadedLayout()->GetPreferredBase()));
     }
 
-#ifdef FEATURE_TREAT_NI_AS_MSIL_DURING_DIAGNOSTICS
-    // In Apollo, first ask if we're supposed to be ignoring the prejitted code &
+    // First ask if we're supposed to be ignoring the prejitted code &
     // structures in NGENd images. If so, bail now and do not set m_nativeImage. We've
-    // already set m_identity & m_openedILimage (possibly even pointing to the
-    // NGEN/Triton image), and will use those PEImages to find and JIT IL (even if they
-    // point to an NGENd/Tritonized image).
+    // already set m_identity & m_openedILimage), and will use those PEImages to find 
+    // and JIT IL.
     if (ShouldTreatNIAsMSIL())
         RETURN;
-#endif
 
     m_nativeImage = image;
     m_nativeImage->AddRef();
@@ -1463,7 +1460,6 @@ void PEFile::GetNGENDebugFlags(BOOL *fAllowOpt)
 
 
 #ifndef DACCESS_COMPILE
-#ifdef FEATURE_TREAT_NI_AS_MSIL_DURING_DIAGNOSTICS
 
 //---------------------------------------------------------------------------------------
 //
@@ -1506,8 +1502,6 @@ BOOL PEFile::ShouldTreatNIAsMSIL()
 
     return FALSE;
 }
-
-#endif // FEATURE_TREAT_NI_AS_MSIL_DURING_DIAGNOSTICS
 
 #endif  //!DACCESS_COMPILE
 #endif  // FEATURE_PREJIT

--- a/src/vm/pefile.h
+++ b/src/vm/pefile.h
@@ -376,9 +376,7 @@ public:
     static void GetNGENDebugFlags(BOOL *fAllowOpt);
 #endif
 
-#ifdef FEATURE_TREAT_NI_AS_MSIL_DURING_DIAGNOSTICS
     static BOOL ShouldTreatNIAsMSIL();
-#endif // FEATURE_TREAT_NI_AS_MSIL_DURING_DIAGNOSTICS
             
 #endif  // FEATURE_PREJIT
 

--- a/src/vm/peimage.cpp
+++ b/src/vm/peimage.cpp
@@ -127,7 +127,6 @@ CHECK PEImage::CheckILFormat()
         pLayoutToCheck = pLayoutHolder;
     }
 
-#ifdef FEATURE_TREAT_NI_AS_MSIL_DURING_DIAGNOSTICS
     if (PEFile::ShouldTreatNIAsMSIL())
     {
         // This PEImage may intentionally be an NI image, being used as if it were an
@@ -137,7 +136,6 @@ CHECK PEImage::CheckILFormat()
         CHECK(pLayoutToCheck->CheckCORFormat());
     }
     else
-#endif // FEATURE_TREAT_NI_AS_MSIL_DURING_DIAGNOSTICS
     {
         CHECK(pLayoutToCheck->CheckILFormat());
     }


### PR DESCRIPTION
Always defined in .NET Core