### PR TITLE
Fix CancellationTokenRegistration.Token after CTS.Dispose

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/CancellationTokenRegistration.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/CancellationTokenRegistration.cs
@@ -58,7 +58,16 @@ namespace System.Threading
         /// registration isn't associated with a token (such as after the registration has been disposed),
         /// this will return a default token.
         /// </summary>
-        public CancellationToken Token => _node?.Partition.Source.Token ?? default;
+        public CancellationToken Token
+        {
+            get
+            {
+                CancellationTokenSource.CallbackNode node = _node;
+                return node != null ?
+                    new CancellationToken(node.Partition.Source) : // avoid CTS.Token, which throws after disposal
+                    default;
+            }
+        }
 
         /// <summary>
         /// Disposes of the registration and unregisters the target callback from the associated 


### PR DESCRIPTION
CTR.Token should never throw, but it's currently throwing an ObjectDisposedException if the associated CancellationTokenSource has been disposed.

Fixes https://github.com/dotnet/corefx/issues/33844
cc: @kouvel, @tarekgh 