### PR TITLE
Add CancellationToken parameter to GetAsyncEnumerator

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/IAsyncEnumerable.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/IAsyncEnumerable.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading;
+
 namespace System.Collections.Generic
 {
     /// <summary>Exposes an enumerator that provides asynchronous iteration over values of a specified type.</summary>
@@ -9,7 +11,8 @@ namespace System.Collections.Generic
     public interface IAsyncEnumerable<out T>
     {
         /// <summary>Returns an enumerator that iterates asynchronously through the collection.</summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> that may be used to cancel the asynchronous iteration.</param>
         /// <returns>An enumerator that can be used to iterate asynchronously through the collection.</returns>
-        IAsyncEnumerator<T> GetAsyncEnumerator();
+        IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default);
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/ConfiguredAsyncEnumerable.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/ConfiguredAsyncEnumerable.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Sources;
 
@@ -21,8 +22,8 @@ namespace System.Runtime.CompilerServices
             _continueOnCapturedContext = continueOnCapturedContext;
         }
 
-        public Enumerator GetAsyncEnumerator() =>
-            new Enumerator(_enumerable.GetAsyncEnumerator(), _continueOnCapturedContext);
+        public Enumerator GetAsyncEnumerator(CancellationToken cancellationToken = default) =>
+            new Enumerator(_enumerable.GetAsyncEnumerator(cancellationToken), _continueOnCapturedContext);
 
         public readonly struct Enumerator
         {


### PR DESCRIPTION
Per https://github.com/dotnet/corefx/issues/33338#issuecomment-444728011

@jcouv, presumably this (and the corresponding contract change in corefx) will lead to problems with the compiler targeting .NET Core 3 until it's updated with the new interface knowledge as well?  Assuming yes, should we coordinate in some way / should I hold off on merging this until you've done the corresponding work on the compiler side?

cc: @MadsTorgersen, @terrajobst, @bartonjs, @kouvel, @tarekgh 