### PR TITLE
Use string.Create in ConvertFromUtf32

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Char.cs
+++ b/src/System.Private.CoreLib/shared/System/Char.cs
@@ -931,19 +931,16 @@ namespace System
             if (utf32 < UNICODE_PLANE01_START)
             {
                 // This is a BMP character.
-                return (char.ToString((char)utf32));
+                return ToString((char)utf32);
             }
 
-            unsafe
+            // This is a supplementary character.  Convert it to a surrogate pair in UTF-16.
+            utf32 -= UNICODE_PLANE01_START;
+            return string.Create(2, utf32, (span, value) =>
             {
-                // This is a supplementary character.  Convert it to a surrogate pair in UTF-16.
-                utf32 -= UNICODE_PLANE01_START;
-                uint surrogate = 0; // allocate 2 chars worth of stack space
-                char* address = (char*)&surrogate;
-                address[0] = (char)((utf32 / 0x400) + (int)CharUnicodeInfo.HIGH_SURROGATE_START);
-                address[1] = (char)((utf32 % 0x400) + (int)CharUnicodeInfo.LOW_SURROGATE_START);
-                return new string(address, 0, 2);
-            }
+                span[1] = (char)((value % 0x400) + CharUnicodeInfo.LOW_SURROGATE_START);
+                span[0] = (char)((value / 0x400) + CharUnicodeInfo.HIGH_SURROGATE_START);
+            });
         }
 
 

--- a/src/System.Private.CoreLib/shared/System/Char.cs
+++ b/src/System.Private.CoreLib/shared/System/Char.cs
@@ -15,6 +15,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace System
 {
@@ -921,26 +922,12 @@ namespace System
 
         public static string ConvertFromUtf32(int utf32)
         {
-            // For UTF32 values from U+00D800 ~ U+00DFFF, we should throw.  They
-            // are considered as irregular code unit sequence, but they are not illegal.
-            if (((uint)utf32 > UNICODE_PLANE16_END) || (utf32 >= CharUnicodeInfo.HIGH_SURROGATE_START && utf32 <= CharUnicodeInfo.LOW_SURROGATE_END))
+            if (!UnicodeUtility.IsValidUnicodeScalar((uint)utf32))
             {
                 throw new ArgumentOutOfRangeException(nameof(utf32), SR.ArgumentOutOfRange_InvalidUTF32);
             }
 
-            if (utf32 < UNICODE_PLANE01_START)
-            {
-                // This is a BMP character.
-                return ToString((char)utf32);
-            }
-
-            // This is a supplementary character.  Convert it to a surrogate pair in UTF-16.
-            utf32 -= UNICODE_PLANE01_START;
-            return string.Create(2, utf32, (span, value) =>
-            {
-                span[1] = (char)((value % 0x400) + CharUnicodeInfo.LOW_SURROGATE_START);
-                span[0] = (char)((value / 0x400) + CharUnicodeInfo.HIGH_SURROGATE_START);
-            });
+            return Rune.UnsafeCreate((uint)utf32).ToString();
         }
 
 

--- a/src/System.Private.CoreLib/shared/System/String.cs
+++ b/src/System.Private.CoreLib/shared/System/String.cs
@@ -11,6 +11,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
+using Internal.Runtime.CompilerServices;
 
 namespace System
 {
@@ -496,6 +497,14 @@ namespace System
         {
             string result = FastAllocateString(1);
             result._firstChar = c;
+            return result;
+        }
+
+        internal static string CreateFromChar(char c1, char c2)
+        {
+            string result = FastAllocateString(2);
+            result._firstChar = c1;
+            Unsafe.Add(ref result._firstChar, 1) = c2;
             return result;
         }
 

--- a/src/System.Private.CoreLib/shared/System/Text/Rune.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/Rune.cs
@@ -335,8 +335,15 @@ namespace System.Text
         /// </summary>
         public override string ToString()
         {
-            Span<char> chars = stackalloc char[2]; // worst case
-            return new string(chars.Slice(0, EncodeToUtf16(chars)));
+            if (IsBmp)
+            {
+                return string.CreateFromChar((char)_value);
+            }
+            else
+            {
+                UnicodeUtility.GetUtf16SurrogatesFromSupplementaryPlaneScalar(_value, out char high, out char low);
+                return string.CreateFromChar(high, low);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Removes the unsafe code from the method.

Also happens to make it a bit faster.  This:
```C#
[Benchmark] public string ConvertFromUtf32() => char.ConvertFromUtf32(0x1D161);
```
results in this before:
```
           Method |     Mean |     Error |    StdDev |  Gen 0 | Allocated |
----------------- |---------:|----------:|----------:|-------:|----------:|
 ConvertFromUtf32 | 13.48 ns | 0.4161 ns | 0.3893 ns | 0.0076 |      32 B |
```
and this after:
```
           Method |     Mean |     Error |    StdDev |  Gen 0 | Allocated |
----------------- |---------:|----------:|----------:|-------:|----------:|
 ConvertFromUtf32 | 9.318 ns | 0.0690 ns | 0.0645 ns | 0.0076 |      32 B |
```