### PR TITLE
[release/2.2] Fix CancellationTokenRegistration.Token after CTS.Dispose

### DIFF
--- a/src/mscorlib/src/System/Threading/CancellationTokenRegistration.cs
+++ b/src/mscorlib/src/System/Threading/CancellationTokenRegistration.cs
@@ -41,7 +41,16 @@ namespace System.Threading
         /// registration isn't associated with a token (such as after the registration has been disposed),
         /// this will return a default token.
         /// </summary>
-        public CancellationToken Token => _node?.Partition.Source.Token ?? default(CancellationToken);
+        public CancellationToken Token
+        {
+            get
+            {
+                CancellationTokenSource.CallbackNode node = _node;
+                return node != null ?
+                    new CancellationToken(node.Partition.Source) : // avoid CTS.Token, which throws after disposal
+                    default;
+            }
+        }
 
         /// <summary>
         /// Disposes of the registration and unregisters the target callback from the associated 


### PR DESCRIPTION
CTR.Token should never throw, but it's currently throwing an ObjectDisposedException if the associated CancellationTokenSource has been disposed.

Ports https://github.com/dotnet/coreclr/pull/21394 to release/2.2
Fixes https://github.com/dotnet/corefx/issues/33844