### PR TITLE
Disable obsolete collectible corefx tests

### DIFF
--- a/tests/CoreFX/CoreFX.issues.json
+++ b/tests/CoreFX/CoreFX.issues.json
@@ -598,6 +598,26 @@
                 {
                     "name" : "System.Runtime.InteropServices.Tests.GetFunctionPointerForDelegateTests.GetFunctionPointerForDelegate_DelegateCollectible_ThrowsNotSupportedException",
                     "reason" : "outdated"
+                },
+                {
+                    "name" : "System.Runtime.InteropServices.Tests.GetComInterfaceForObjectTests.GetComInterfaceForObject_ObjectNotCollectible_ThrowsNotSupportedException",
+                    "reason" : "outdated"
+                },
+                {
+                    "name" : "System.Runtime.InteropServices.Tests.ChangeWrapperHandleStrengthTests.ChangeWrapperHandleStrength_ObjectNotCollectible_ThrowsNotSupportedException",
+                    "reason" : "outdated"
+                },
+                {
+                    "name" : "System.Runtime.InteropServices.Tests.CreateAggregatedObjectTests.CreateAggregatedObject_ObjectNotCollectible_ReturnsExpected",
+                    "reason" : "outdated"
+                },
+                {
+                    "name" : "System.Runtime.InteropServices.Tests.GetNativeVariantForObjectTests.GetNativeVariantForObject_ObjectNotCollectible_ThrowsNotSupportedException",
+                    "reason" : "outdated"
+                },
+                {
+                    "name" : "System.Runtime.InteropServices.Tests.GetIUnknownForObjectTests.GetIUnknownForObject_ObjectNotCollectible_ThrowsNotSupportedException",
+                    "reason" : "outdated"
                 }
             ]
         }


### PR DESCRIPTION
Now that the COM interop support for collectible classes is in, we need
to disable couple of corefx tests that were checking that it fails.

Close #21398