### PR TITLE
Add PNSE implementations of other custom marshalers

### DIFF
--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -3163,6 +3163,12 @@
   <data name="PlatformNotSupported_OverlappedIO" xml:space="preserve">
     <value>This API is specific to the way in which Windows handles asynchronous I/O, and is not supported on this platform.</value>
   </data>
+  <data name="PlatformNotSupported_ITypeInfo" xml:space="preserve">
+    <value>Marshalling a System.Type to an unmanaged ITypeInfo or marshalling an ITypeInfo to a System.Type is not supported on this platform.</value>
+  </data>
+  <data name="PlatformNotSupported_IExpando" xml:space="preserve">
+    <value>Marshalling an IDispatchEx to an IReflect or IExpando is not supported on this platform.</value>
+  </data>
   <data name="Policy_CannotLoadSemiTrustAssembliesDuringInit" xml:space="preserve">
     <value>All assemblies loaded as part of AppDomain initialization must be fully trusted.</value>
   </data>

--- a/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -373,6 +373,8 @@
     <Compile Include="$(BclSourcesRoot)\System\Runtime\InteropServices\CustomMarshalers\EnumerableViewOfDispatch.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\InteropServices\CustomMarshalers\EnumeratorToEnumVariantMarshaler.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\InteropServices\CustomMarshalers\EnumeratorViewOfEnumVariant.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Runtime\InteropServices\CustomMarshalers\ExpandoToDispatchExMarshaler.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Runtime\InteropServices\CustomMarshalers\TypeToTypeInfoMarshaler.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\InteropServices\DispatchWrapper.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\InteropServices\IDispatch.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\InteropServices\WindowsRuntime\Attributes.cs" />

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/CustomMarshalers/ExpandoToDispatchExMarshaler.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/CustomMarshalers/ExpandoToDispatchExMarshaler.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.InteropServices.ComTypes;
+using System.Text;
+
+namespace System.Runtime.InteropServices.CustomMarshalers
+{
+    internal class ExpandoToDispatchExMarshaler : ICustomMarshaler
+    {
+        private static readonly ExpandoToDispatchExMarshaler s_ExpandoToDispatchExMarshaler = new ExpandoToDispatchExMarshaler();
+
+        public static ICustomMarshaler GetInstance(string cookie) => s_ExpandoToDispatchExMarshaler;
+
+        private ExpandoToDispatchExMarshaler()
+        {
+        }
+
+        public void CleanUpManagedData(object ManagedObj)
+        {
+        }
+
+        public void CleanUpNativeData(IntPtr pNativeData)
+        {
+        }
+
+        public int GetNativeDataSize()
+        {
+            // Return -1 to indicate the managed type this marshaler handles is not a value type.
+            return -1;
+        }
+
+        public IntPtr MarshalManagedToNative(object ManagedObj)
+        {
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_IExpando);
+        }
+
+        public object MarshalNativeToManaged(IntPtr pNativeData)
+        {
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_IExpando);
+        }
+    }
+}

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/CustomMarshalers/TypeToTypeInfoMarshaler.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/CustomMarshalers/TypeToTypeInfoMarshaler.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.InteropServices.ComTypes;
+using System.Text;
+
+namespace System.Runtime.InteropServices.CustomMarshalers
+{
+    internal class TypeToTypeInfoMarshaler : ICustomMarshaler
+    {
+        private static readonly TypeToTypeInfoMarshaler s_typeToTypeInfoMarshaler = new TypeToTypeInfoMarshaler();
+
+        public static ICustomMarshaler GetInstance(string cookie) => s_typeToTypeInfoMarshaler;
+
+        private TypeToTypeInfoMarshaler()
+        {
+        }
+
+        public void CleanUpManagedData(object ManagedObj)
+        {
+        }
+
+        public void CleanUpNativeData(IntPtr pNativeData)
+        {
+        }
+
+        public int GetNativeDataSize()
+        {
+            // Return -1 to indicate the managed type this marshaler handles is not a value type.
+            return -1;
+        }
+
+        public IntPtr MarshalManagedToNative(object ManagedObj)
+        {
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ITypeInfo);
+        }
+
+        public object MarshalNativeToManaged(IntPtr pNativeData)
+        {
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ITypeInfo);
+        }
+    }
+}


### PR DESCRIPTION
Add PNSE implementations of unsupported built-in custom marshalers to enable good error messages on PIAs that could possibly directly use them.
