### PR TITLE
Moving various Vector128/256 helper method to be implemented using other intrinsics

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128.cs
@@ -49,9 +49,9 @@ namespace System.Runtime.Intrinsics
                 return Sse2.Shuffle(result.AsUInt32(), 0x00).AsByte();                      // < v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v >
             }
 
-            return CreateSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector128<byte> CreateSoftware(byte x)
+            Vector128<byte> SoftwareFallback(byte x)
             {
                 var pResult = stackalloc byte[16]
                 {
@@ -95,9 +95,9 @@ namespace System.Runtime.Intrinsics
                 return Sse.MoveLowToHigh(result.AsSingle(), result.AsSingle()).AsDouble();  // < v, v >
             }
 
-            return CreateSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector128<double> CreateSoftware(double x)
+            Vector128<double> SoftwareFallback(double x)
             {
                 var pResult = stackalloc double[2]
                 {
@@ -128,9 +128,9 @@ namespace System.Runtime.Intrinsics
                 return Sse2.Shuffle(result.AsInt32(), 0x00).AsInt16();                      // < v, v, v, v, v, v, v, v >
             }
 
-            return CreateSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector128<short> CreateSoftware(short x)
+            Vector128<short> SoftwareFallback(short x)
             {
                 var pResult = stackalloc short[8]
                 {
@@ -166,9 +166,9 @@ namespace System.Runtime.Intrinsics
                 return Sse2.Shuffle(result, 0x00);                                          // < v, v, v, v >
             }
 
-            return CreateSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector128<int> CreateSoftware(int x)
+            Vector128<int> SoftwareFallback(int x)
             {
                 var pResult = stackalloc int[4]
                 {
@@ -202,9 +202,9 @@ namespace System.Runtime.Intrinsics
                 }
             }
 
-            return CreateSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector128<long> CreateSoftware(long x)
+            Vector128<long> SoftwareFallback(long x)
             {
                 var pResult = stackalloc long[2]
                 {
@@ -243,9 +243,9 @@ namespace System.Runtime.Intrinsics
                 return Sse2.Shuffle(result.AsInt32(), 0x00).AsSByte();                      // < v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v >
             }
 
-            return CreateSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector128<sbyte> CreateSoftware(sbyte x)
+            Vector128<sbyte> SoftwareFallback(sbyte x)
             {
                 var pResult = stackalloc sbyte[16]
                 {
@@ -295,9 +295,9 @@ namespace System.Runtime.Intrinsics
                 return Sse.Shuffle(result, result, 0x00);                                   // < v, v, v, v >
             }
 
-            return CreateSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector128<float> CreateSoftware(float x)
+            Vector128<float> SoftwareFallback(float x)
             {
                 var pResult = stackalloc float[4]
                 {
@@ -331,9 +331,9 @@ namespace System.Runtime.Intrinsics
                 return Sse2.Shuffle(result.AsUInt32(), 0x00).AsUInt16();                    // < v, v, v, v, v, v, v, v >
             }
 
-            return CreateSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector128<ushort> CreateSoftware(ushort x)
+            Vector128<ushort> SoftwareFallback(ushort x)
             {
                 var pResult = stackalloc ushort[8]
                 {
@@ -370,9 +370,9 @@ namespace System.Runtime.Intrinsics
                 return Sse2.Shuffle(result, 0x00);                                          // < v, v, v, v >
             }
 
-            return CreateSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector128<uint> CreateSoftware(uint x)
+            Vector128<uint> SoftwareFallback(uint x)
             {
                 var pResult = stackalloc uint[4]
                 {
@@ -407,9 +407,9 @@ namespace System.Runtime.Intrinsics
                 }
             }
 
-            return CreateSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector128<ulong> CreateSoftware(ulong x)
+            Vector128<ulong> SoftwareFallback(ulong x)
             {
                 var pResult = stackalloc ulong[2]
                 {
@@ -832,9 +832,9 @@ namespace System.Runtime.Intrinsics
                 return Sse2.ConvertScalarToVector128UInt32(value).AsByte();
             }
 
-            return CreateScalarSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector128<byte> CreateScalarSoftware(byte x)
+            Vector128<byte> SoftwareFallback(byte x)
             {
                 var result = Vector128<byte>.Zero;
                 Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<byte>, byte>(ref result), x);
@@ -853,9 +853,9 @@ namespace System.Runtime.Intrinsics
                 return Sse2.MoveScalar(Vector128<double>.Zero, CreateScalarUnsafe(value));
             }
 
-            return CreateScalarSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector128<double> CreateScalarSoftware(double x)
+            Vector128<double> SoftwareFallback(double x)
             {
                 var result = Vector128<double>.Zero;
                 Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<double>, byte>(ref result), x);
@@ -874,9 +874,9 @@ namespace System.Runtime.Intrinsics
                 return Sse2.ConvertScalarToVector128UInt32((ushort)(value)).AsInt16();
             }
 
-            return CreateScalarSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector128<short> CreateScalarSoftware(short x)
+            Vector128<short> SoftwareFallback(short x)
             {
                 var result = Vector128<short>.Zero;
                 Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<short>, byte>(ref result), value);
@@ -895,9 +895,9 @@ namespace System.Runtime.Intrinsics
                 return Sse2.ConvertScalarToVector128Int32(value);
             }
 
-            return CreateScalarSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector128<int> CreateScalarSoftware(int x)
+            Vector128<int> SoftwareFallback(int x)
             {
                 var result = Vector128<int>.Zero;
                 Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<int>, byte>(ref result), value);
@@ -915,9 +915,9 @@ namespace System.Runtime.Intrinsics
                 return Sse2.X64.ConvertScalarToVector128Int64(value);
             }
 
-            return CreateScalarSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector128<long> CreateScalarSoftware(long x)
+            Vector128<long> SoftwareFallback(long x)
             {
                 var result = Vector128<long>.Zero;
                 Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<long>, byte>(ref result), value);
@@ -938,9 +938,9 @@ namespace System.Runtime.Intrinsics
                 return Sse2.ConvertScalarToVector128UInt32((byte)(value)).AsSByte();
             }
 
-            return CreateScalarSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector128<sbyte> CreateScalarSoftware(sbyte x)
+            Vector128<sbyte> SoftwareFallback(sbyte x)
             {
                 var result = Vector128<sbyte>.Zero;
                 Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<sbyte>, byte>(ref result), value);
@@ -959,9 +959,9 @@ namespace System.Runtime.Intrinsics
                 return Sse.MoveScalar(Vector128<float>.Zero, CreateScalarUnsafe(value));
             }
 
-            return CreateScalarSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector128<float> CreateScalarSoftware(float x)
+            Vector128<float> SoftwareFallback(float x)
             {
                 var result = Vector128<float>.Zero;
                 Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<float>, byte>(ref result), value);
@@ -981,9 +981,9 @@ namespace System.Runtime.Intrinsics
                 return Sse2.ConvertScalarToVector128UInt32(value).AsUInt16();
             }
 
-            return CreateScalarSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector128<ushort> CreateScalarSoftware(ushort x)
+            Vector128<ushort> SoftwareFallback(ushort x)
             {
                 var result = Vector128<ushort>.Zero;
                 Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<ushort>, byte>(ref result), value);
@@ -1003,9 +1003,9 @@ namespace System.Runtime.Intrinsics
                 return Sse2.ConvertScalarToVector128UInt32(value);
             }
 
-            return CreateScalarSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector128<uint> CreateScalarSoftware(uint x)
+            Vector128<uint> SoftwareFallback(uint x)
             {
                 var result = Vector128<uint>.Zero;
                 Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<uint>, byte>(ref result), value);
@@ -1025,9 +1025,9 @@ namespace System.Runtime.Intrinsics
                 return Sse2.X64.ConvertScalarToVector128UInt64(value);
             }
 
-            return CreateScalarSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector128<ulong> CreateScalarSoftware(ulong x)
+            Vector128<ulong> SoftwareFallback(ulong x)
             {
                 var result = Vector128<ulong>.Zero;
                 Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<ulong>, byte>(ref result), value);

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128_1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128_1.cs
@@ -189,7 +189,7 @@ namespace System.Runtime.Intrinsics
             if (Sse.IsSupported && (typeof(T) == typeof(float)))
             {
                 Vector128<float> result = Sse.CompareEqual(AsSingle(), other.AsSingle());
-                return Sse.MoveMask(result) == 0b1111;
+                return Sse.MoveMask(result) == 0b1111; // We have one bit per element
             }
 
             if (Sse2.IsSupported)
@@ -197,7 +197,7 @@ namespace System.Runtime.Intrinsics
                 if (typeof(T) == typeof(double))
                 {
                     Vector128<double> result = Sse2.CompareEqual(AsDouble(), other.AsDouble());
-                    return Sse2.MoveMask(result) == 0b11;
+                    return Sse2.MoveMask(result) == 0b11; // We have one bit per element
                 }
                 else
                 {
@@ -207,7 +207,7 @@ namespace System.Runtime.Intrinsics
 
                     Debug.Assert((typeof(T) != typeof(float)) && (typeof(T) != typeof(double)));
                     Vector128<byte> result = Sse2.CompareEqual(AsByte(), other.AsByte());
-                    return Sse2.MoveMask(result) == 0b1111_1111_1111_1111;
+                    return Sse2.MoveMask(result) == 0b1111_1111_1111_1111; // We have one bit per element
                 }
             }
 

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128_1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128_1.cs
@@ -211,9 +211,9 @@ namespace System.Runtime.Intrinsics
                 }
             }
 
-            return EqualsSoftware(in this, other);
+            return SoftwareFallback(in this, other);
 
-            bool EqualsSoftware(in Vector128<T> x, Vector128<T> y)
+            bool SoftwareFallback(in Vector128<T> x, Vector128<T> y)
             {
                 for (int i = 0; i < Count; i++)
                 {

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128_1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128_1.cs
@@ -6,11 +6,23 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics.X86;
 using System.Text;
 using Internal.Runtime.CompilerServices;
 
 namespace System.Runtime.Intrinsics
 {
+    // We mark certain methods with AggressiveInlining to ensure that the JIT will
+    // inline them. The JIT would otherwise not inline the method since it, at the
+    // point it tries to determine inline profability, currently cannot determine
+    // that most of the code-paths will be optimized away as "dead code".
+    //
+    // We then manually inline cases (such as certain intrinsic code-paths) that
+    // will generate code small enough to make the AgressiveInlining profitable. The
+    // other cases (such as the software fallback) are placed in their own method.
+    // This ensures we get good codegen for the "fast-path" and allows the JIT to
+    // determine inline profitability of the other paths as it would normally.
+
     [Intrinsic]
     [DebuggerDisplay("{DisplayString,nq}")]
     [DebuggerTypeProxy(typeof(Vector128DebugView<>))]
@@ -169,19 +181,50 @@ namespace System.Runtime.Intrinsics
         /// <param name="other">The <see cref="Vector128{T}" /> to compare with the current instance.</param>
         /// <returns><c>true</c> if <paramref name="other" /> is equal to the current instance; otherwise, <c>false</c>.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(Vector128<T> other)
         {
             ThrowIfUnsupportedType();
 
-            for (int i = 0; i < Count; i++)
+            if (Sse.IsSupported && (typeof(T) == typeof(float)))
             {
-                if (!((IEquatable<T>)(GetElement(i))).Equals(other.GetElement(i)))
+                Vector128<float> result = Sse.CompareEqual(AsSingle(), other.AsSingle());
+                return Sse.MoveMask(result) == 0b1111;
+            }
+
+            if (Sse2.IsSupported)
+            {
+                if (typeof(T) == typeof(double))
                 {
-                    return false;
+                    Vector128<double> result = Sse2.CompareEqual(AsDouble(), other.AsDouble());
+                    return Sse2.MoveMask(result) == 0b11;
+                }
+                else
+                {
+                    // Unlike float/double, there are no special values to consider
+                    // for integral types and we can just do a comparison that all
+                    // bytes are exactly the same.
+
+                    Debug.Assert((typeof(T) != typeof(float)) && (typeof(T) != typeof(double)));
+                    Vector128<byte> result = Sse2.CompareEqual(AsByte(), other.AsByte());
+                    return Sse2.MoveMask(result) == 0b1111_1111_1111_1111;
                 }
             }
 
-            return true;
+            return EqualsSoftware(in this, other);
+
+            bool EqualsSoftware(in Vector128<T> x, Vector128<T> y)
+            {
+                for (int i = 0; i < Count; i++)
+                {
+                    if (!((IEquatable<T>)(x.GetElement(i))).Equals(y.GetElement(i)))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
         }
 
         /// <summary>Determines whether the specified object is equal to the current instance.</summary>

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256.cs
@@ -26,257 +26,441 @@ namespace System.Runtime.Intrinsics
         /// <summary>Creates a new <see cref="Vector256{Byte}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
         /// <returns>A new <see cref="Vector256{Byte}" /> with all elements initialized to <paramref name="value" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector256<byte> Create(byte value)
         {
-            var pResult = stackalloc byte[32]
+            if (Avx2.IsSupported)
             {
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-            };
+                Vector128<byte> result = Vector128.CreateScalarUnsafe(value);           // < v, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? >
+                return Avx2.BroadcastScalarToVector256(result);                         // < v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v >
+            }
 
-            return Unsafe.AsRef<Vector256<byte>>(pResult);
+            if (Avx.IsSupported)
+            {
+                Vector128<byte> result = Vector128.Create(value);                       // < v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? >
+                return Avx.InsertVector128(result.ToVector256Unsafe(), result, 1);      // < v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v >
+            }
+
+            return CreateSoftware(value);
+
+            Vector256<byte> CreateSoftware(byte x)
+            {
+                var pResult = stackalloc byte[32]
+                {
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                };
+
+                return Unsafe.AsRef<Vector256<byte>>(pResult);
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector256{Double}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
         /// <returns>A new <see cref="Vector256{Double}" /> with all elements initialized to <paramref name="value" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector256<double> Create(double value)
         {
-            var pResult = stackalloc double[4]
+            if (Avx2.IsSupported)
             {
-                value,
-                value,
-                value,
-                value,
-            };
+                Vector128<double> result = Vector128.CreateScalarUnsafe(value);         // < v, ?, ?, ? >
+                return Avx2.BroadcastScalarToVector256(result);                         // < v, v, v, v >
+            }
 
-            return Unsafe.AsRef<Vector256<double>>(pResult);
+            if (Avx.IsSupported)
+            {
+                Vector128<double> result = Vector128.Create(value);                     // < v, v, ?, ? >
+                return Avx.InsertVector128(result.ToVector256Unsafe(), result, 1);      // < v, v, v, v >
+            }
+
+            return CreateSoftware(value);
+
+            Vector256<double> CreateSoftware(double x)
+            {
+                var pResult = stackalloc double[4]
+                {
+                    x,
+                    x,
+                    x,
+                    x,
+                };
+
+                return Unsafe.AsRef<Vector256<double>>(pResult);
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector256{Int16}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
         /// <returns>A new <see cref="Vector256{Int16}" /> with all elements initialized to <paramref name="value" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector256<short> Create(short value)
         {
-            var pResult = stackalloc short[16]
+            if (Avx2.IsSupported)
             {
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-            };
+                Vector128<short> result = Vector128.CreateScalarUnsafe(value);          // < v, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? >
+                return Avx2.BroadcastScalarToVector256(result);                         // < v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v >
+            }
 
-            return Unsafe.AsRef<Vector256<short>>(pResult);
+            if (Avx.IsSupported)
+            {
+                Vector128<short> result = Vector128.Create(value);                      // < v, v, v, v, v, v, v, v, ?, ?, ?, ?, ?, ?, ?, ? >
+                return Avx.InsertVector128(result.ToVector256Unsafe(), result, 1);      // < v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v >
+            }
+
+            return CreateSoftware(value);
+
+            Vector256<short> CreateSoftware(short x)
+            {
+                var pResult = stackalloc short[16]
+                {
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                };
+
+                return Unsafe.AsRef<Vector256<short>>(pResult);
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector256{Int32}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
         /// <returns>A new <see cref="Vector256{Int32}" /> with all elements initialized to <paramref name="value" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector256<int> Create(int value)
         {
-            var pResult = stackalloc int[8]
+            if (Avx2.IsSupported)
             {
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-            };
+                Vector128<int> result = Vector128.CreateScalarUnsafe(value);            // < v, ?, ?, ?, ?, ?, ?, ? >
+                return Avx2.BroadcastScalarToVector256(result);                         // < v, v, v, v, v, v, v, v >
+            }
 
-            return Unsafe.AsRef<Vector256<int>>(pResult);
+            if (Avx.IsSupported)
+            {
+                Vector128<int> result = Vector128.Create(value);                        // < v, v, v, v, ?, ?, ?, ? >
+                return Avx.InsertVector128(result.ToVector256Unsafe(), result, 1);      // < v, v, v, v, v, v, v, v >
+            }
+
+            return CreateSoftware(value);
+
+            Vector256<int> CreateSoftware(int x)
+            {
+                var pResult = stackalloc int[8]
+                {
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                };
+
+                return Unsafe.AsRef<Vector256<int>>(pResult);
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector256{Int64}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
         /// <returns>A new <see cref="Vector256{Int64}" /> with all elements initialized to <paramref name="value" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector256<long> Create(long value)
         {
-            var pResult = stackalloc long[4]
+            if (Sse2.X64.IsSupported)
             {
-                value,
-                value,
-                value,
-                value,
-            };
+                if (Avx2.IsSupported)
+                {
+                    Vector128<long> result = Vector128.CreateScalarUnsafe(value);           // < v, ?, ?, ? >
+                    return Avx2.BroadcastScalarToVector256(result);                         // < v, v, v, v >
+                }
+                else if (Avx.IsSupported)
+                {
+                    Vector128<long> result = Vector128.Create(value);                       // < v, v, ?, ? >
+                    return Avx.InsertVector128(result.ToVector256Unsafe(), result, 1);      // < v, v, v, v >
+                }
+            }
 
-            return Unsafe.AsRef<Vector256<long>>(pResult);
+            return CreateSoftware(value);
+
+            Vector256<long> CreateSoftware(long x)
+            {
+                var pResult = stackalloc long[4]
+                {
+                    x,
+                    x,
+                    x,
+                    x,
+                };
+
+                return Unsafe.AsRef<Vector256<long>>(pResult);
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector256{SByte}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
         /// <returns>A new <see cref="Vector256{SByte}" /> with all elements initialized to <paramref name="value" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
         public static unsafe Vector256<sbyte> Create(sbyte value)
         {
-            var pResult = stackalloc sbyte[32]
+            if (Avx2.IsSupported)
             {
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-            };
+                Vector128<sbyte> result = Vector128.CreateScalarUnsafe(value);          // < v, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? >
+                return Avx2.BroadcastScalarToVector256(result);                         // < v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v >
+            }
 
-            return Unsafe.AsRef<Vector256<sbyte>>(pResult);
+            if (Avx.IsSupported)
+            {
+                Vector128<sbyte> result = Vector128.Create(value);                      // < v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? >
+                return Avx.InsertVector128(result.ToVector256Unsafe(), result, 1);      // < v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v >
+            }
+
+            return CreateSoftware(value);
+
+            Vector256<sbyte> CreateSoftware(sbyte x)
+            {
+                var pResult = stackalloc sbyte[32]
+                {
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                };
+
+                return Unsafe.AsRef<Vector256<sbyte>>(pResult);
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector256{Single}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
         /// <returns>A new <see cref="Vector256{Single}" /> with all elements initialized to <paramref name="value" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector256<float> Create(float value)
         {
-            var pResult = stackalloc float[8]
+            if (Avx2.IsSupported)
             {
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-            };
+                Vector128<float> result = Vector128.CreateScalarUnsafe(value);          // < v, ?, ?, ?, ?, ?, ?, ? >
+                return Avx2.BroadcastScalarToVector256(result);                         // < v, v, v, v, v, v, v, v >
+            }
 
-            return Unsafe.AsRef<Vector256<float>>(pResult);
+            if (Avx.IsSupported)
+            {
+                Vector128<float> result = Vector128.Create(value);                      // < v, v, v, v, ?, ?, ?, ? >   
+                return Avx.InsertVector128(result.ToVector256Unsafe(), result, 1);      // < v, v, v, v, v, v, v, v >
+            }
+
+            return CreateSoftware(value);
+
+            Vector256<float> CreateSoftware(float x)
+            {
+                var pResult = stackalloc float[8]
+                {
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                };
+
+                return Unsafe.AsRef<Vector256<float>>(pResult);
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector256{UInt16}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
         /// <returns>A new <see cref="Vector256{UInt16}" /> with all elements initialized to <paramref name="value" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
         public static unsafe Vector256<ushort> Create(ushort value)
         {
-            var pResult = stackalloc ushort[16]
+            if (Avx2.IsSupported)
             {
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-            };
+                Vector128<ushort> result = Vector128.CreateScalarUnsafe(value);         // < v, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? >
+                return Avx2.BroadcastScalarToVector256(result);                         // < v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v >
+            }
 
-            return Unsafe.AsRef<Vector256<ushort>>(pResult);
+            if (Avx.IsSupported)
+            {
+                Vector128<ushort> result = Vector128.Create(value);                     // < v, v, v, v, v, v, v, v, ?, ?, ?, ?, ?, ?, ?, ? >
+                return Avx.InsertVector128(result.ToVector256Unsafe(), result, 1);      // < v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v >
+            }
+
+            return CreateSoftware(value);
+
+            Vector256<ushort> CreateSoftware(ushort x)
+            {
+                var pResult = stackalloc ushort[16]
+                {
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                };
+
+                return Unsafe.AsRef<Vector256<ushort>>(pResult);
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector256{UInt32}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
         /// <returns>A new <see cref="Vector256{UInt32}" /> with all elements initialized to <paramref name="value" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
         public static unsafe Vector256<uint> Create(uint value)
         {
-            var pResult = stackalloc uint[8]
+            if (Avx2.IsSupported)
             {
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-                value,
-            };
+                Vector128<uint> result = Vector128.CreateScalarUnsafe(value);           // < v, ?, ?, ?, ?, ?, ?, ? >
+                return Avx2.BroadcastScalarToVector256(result);                         // < v, v, v, v, v, v, v, v >
+            }
 
-            return Unsafe.AsRef<Vector256<uint>>(pResult);
+            if (Avx.IsSupported)
+            {
+                Vector128<uint> result = Vector128.Create(value);                       // < v, v, v, v, ?, ?, ?, ? >
+                return Avx.InsertVector128(result.ToVector256Unsafe(), result, 1);      // < v, v, v, v, v, v, v, v >
+            }
+
+            return CreateSoftware(value);
+
+            Vector256<uint> CreateSoftware(uint x)
+            {
+                var pResult = stackalloc uint[8]
+                {
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                    x,
+                };
+
+                return Unsafe.AsRef<Vector256<uint>>(pResult);
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector256{UInt64}" /> instance with all elements initialized to the specified value.</summary>
         /// <param name="value">The value that all elements will be initialized to.</param>
         /// <returns>A new <see cref="Vector256{UInt64}" /> with all elements initialized to <paramref name="value" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
         public static unsafe Vector256<ulong> Create(ulong value)
         {
-            var pResult = stackalloc ulong[4]
+            if (Sse2.X64.IsSupported)
             {
-                value,
-                value,
-                value,
-                value,
-            };
+                if (Avx2.IsSupported)
+                {
+                    Vector128<ulong> result = Vector128.CreateScalarUnsafe(value);          // < v, ?, ?, ? >
+                    return Avx2.BroadcastScalarToVector256(result);                         // < v, v, v, v >
+                }
+                else if (Avx.IsSupported)
+                {
+                    Vector128<ulong> result = Vector128.Create(value);                      // < v, v, ?, ? >
+                    return Avx.InsertVector128(result.ToVector256Unsafe(), result, 1);      // < v, v, v, v >
+                }
+            }
 
-            return Unsafe.AsRef<Vector256<ulong>>(pResult);
+            return CreateSoftware(value);
+
+            Vector256<ulong> CreateSoftware(ulong x)
+            {
+                var pResult = stackalloc ulong[4]
+            {
+                    x,
+                    x,
+                    x,
+                    x,
+                };
+
+                return Unsafe.AsRef<Vector256<ulong>>(pResult);
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector256{Byte}" /> instance with each element initialized to the corresponding specified value.</summary>

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256.cs
@@ -3,10 +3,22 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics.X86;
 using Internal.Runtime.CompilerServices;
 
 namespace System.Runtime.Intrinsics
 {
+    // We mark certain methods with AggressiveInlining to ensure that the JIT will
+    // inline them. The JIT would otherwise not inline the method since it, at the
+    // point it tries to determine inline profability, currently cannot determine
+    // that most of the code-paths will be optimized away as "dead code".
+    //
+    // We then manually inline cases (such as certain intrinsic code-paths) that
+    // will generate code small enough to make the AgressiveInlining profitable. The
+    // other cases (such as the software fallback) are placed in their own method.
+    // This ensures we get good codegen for the "fast-path" and allows the JIT to
+    // determine inline profitability of the other paths as it would normally.
+
     public static class Vector256
     {
         internal const int Size = 32;
@@ -802,105 +814,215 @@ namespace System.Runtime.Intrinsics
         /// <summary>Creates a new <see cref="Vector256{Byte}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
         /// <returns>A new <see cref="Vector256{Byte}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector256<byte> CreateScalar(byte value)
         {
-            var result = Vector256<byte>.Zero;
-            Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<byte>, byte>(ref result), value);
-            return result;
+            if (Avx.IsSupported)
+            {
+                return Vector128.CreateScalar(value).ToVector256();
+            }
+
+            return CreateScalarSoftware(value);
+
+            Vector256<byte> CreateScalarSoftware(byte x)
+            {
+                var result = Vector256<byte>.Zero;
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<byte>, byte>(ref result), value);
+                return result;
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector256{Double}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
         /// <returns>A new <see cref="Vector256{Double}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector256<double> CreateScalar(double value)
         {
-            var result = Vector256<double>.Zero;
-            Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<double>, byte>(ref result), value);
-            return result;
+            if (Avx.IsSupported)
+            {
+                return Vector128.CreateScalar(value).ToVector256();
+            }
+
+            return CreateScalarSoftware(value);
+
+            Vector256<double> CreateScalarSoftware(double x)
+            {
+                var result = Vector256<double>.Zero;
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<double>, byte>(ref result), value);
+                return result;
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector256{Int16}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
         /// <returns>A new <see cref="Vector256{Int16}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector256<short> CreateScalar(short value)
         {
-            var result = Vector256<short>.Zero;
-            Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<short>, byte>(ref result), value);
-            return result;
+            if (Avx.IsSupported)
+            {
+                return Vector128.CreateScalar(value).ToVector256();
+            }
+
+            return CreateScalarSoftware(value);
+
+            Vector256<short> CreateScalarSoftware(short x)
+            {
+                var result = Vector256<short>.Zero;
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<short>, byte>(ref result), value);
+                return result;
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector256{Int32}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
         /// <returns>A new <see cref="Vector256{Int32}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector256<int> CreateScalar(int value)
         {
-            var result = Vector256<int>.Zero;
-            Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<int>, byte>(ref result), value);
-            return result;
+            if (Avx.IsSupported)
+            {
+                return Vector128.CreateScalar(value).ToVector256();
+            }
+
+            return CreateScalarSoftware(value);
+
+            Vector256<int> CreateScalarSoftware(int x)
+            {
+                var result = Vector256<int>.Zero;
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<int>, byte>(ref result), value);
+                return result;
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector256{Int64}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
         /// <returns>A new <see cref="Vector256{Int64}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector256<long> CreateScalar(long value)
         {
-            var result = Vector256<long>.Zero;
-            Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<long>, byte>(ref result), value);
-            return result;
+            if (Sse2.X64.IsSupported && Avx.IsSupported)
+            {
+                return Vector128.CreateScalar(value).ToVector256();
+            }
+
+            return CreateScalarSoftware(value);
+
+            Vector256<long> CreateScalarSoftware(long x)
+            {
+                var result = Vector256<long>.Zero;
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<long>, byte>(ref result), value);
+                return result;
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector256{SByte}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
         /// <returns>A new <see cref="Vector256{SByte}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
         public static unsafe Vector256<sbyte> CreateScalar(sbyte value)
         {
-            var result = Vector256<sbyte>.Zero;
-            Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<sbyte>, byte>(ref result), value);
-            return result;
+            if (Avx.IsSupported)
+            {
+                return Vector128.CreateScalar(value).ToVector256();
+            }
+
+            return CreateScalarSoftware(value);
+
+            Vector256<sbyte> CreateScalarSoftware(sbyte x)
+            {
+                var result = Vector256<sbyte>.Zero;
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<sbyte>, byte>(ref result), value);
+                return result;
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector256{Single}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
         /// <returns>A new <see cref="Vector256{Single}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector256<float> CreateScalar(float value)
         {
-            var result = Vector256<float>.Zero;
-            Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<float>, byte>(ref result), value);
-            return result;
+            if (Avx.IsSupported)
+            {
+                return Vector128.CreateScalar(value).ToVector256();
+            }
+
+            return CreateScalarSoftware(value);
+
+            Vector256<float> CreateScalarSoftware(float x)
+            {
+                var result = Vector256<float>.Zero;
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<float>, byte>(ref result), value);
+                return result;
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector256{UInt16}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
         /// <returns>A new <see cref="Vector256{UInt16}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
         public static unsafe Vector256<ushort> CreateScalar(ushort value)
         {
-            var result = Vector256<ushort>.Zero;
-            Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<ushort>, byte>(ref result), value);
-            return result;
+            if (Avx.IsSupported)
+            {
+                return Vector128.CreateScalar(value).ToVector256();
+            }
+
+            return CreateScalarSoftware(value);
+
+            Vector256<ushort> CreateScalarSoftware(ushort x)
+            {
+                var result = Vector256<ushort>.Zero;
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<ushort>, byte>(ref result), value);
+                return result;
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector256{UInt32}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
         /// <returns>A new <see cref="Vector256{UInt32}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
         public static unsafe Vector256<uint> CreateScalar(uint value)
         {
-            var result = Vector256<uint>.Zero;
-            Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<uint>, byte>(ref result), value);
-            return result;
+            if (Avx.IsSupported)
+            {
+                return Vector128.CreateScalar(value).ToVector256();
+            }
+
+            return CreateScalarSoftware(value);
+
+            Vector256<uint> CreateScalarSoftware(uint x)
+            {
+                var result = Vector256<uint>.Zero;
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<uint>, byte>(ref result), value);
+                return result;
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector256{UInt64}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
         /// <param name="value">The value that element 0 will be initialized to.</param>
         /// <returns>A new <see cref="Vector256{UInt64}" /> instance with the first element initialized to <paramref name="value" /> and the remaining elements initialized to zero.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
         public static unsafe Vector256<ulong> CreateScalar(ulong value)
         {
-            var result = Vector256<ulong>.Zero;
-            Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<ulong>, byte>(ref result), value);
-            return result;
+            if (Sse2.X64.IsSupported && Avx.IsSupported)
+            {
+                return Vector128.CreateScalar(value).ToVector256();
+            }
+
+            return CreateScalarSoftware(value);
+
+            Vector256<ulong> CreateScalarSoftware(ulong x)
+            {
+                var result = Vector256<ulong>.Zero;
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<ulong>, byte>(ref result), value);
+                return result;
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector256{Byte}" /> instance with the first element initialized to the specified value and the remaining elements left uninitialized.</summary>

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256.cs
@@ -41,9 +41,9 @@ namespace System.Runtime.Intrinsics
                 return Avx.InsertVector128(result.ToVector256Unsafe(), result, 1);      // < v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v >
             }
 
-            return CreateSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector256<byte> CreateSoftware(byte x)
+            Vector256<byte> SoftwareFallback(byte x)
             {
                 var pResult = stackalloc byte[32]
                 {
@@ -103,9 +103,9 @@ namespace System.Runtime.Intrinsics
                 return Avx.InsertVector128(result.ToVector256Unsafe(), result, 1);      // < v, v, v, v >
             }
 
-            return CreateSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector256<double> CreateSoftware(double x)
+            Vector256<double> SoftwareFallback(double x)
             {
                 var pResult = stackalloc double[4]
                 {
@@ -137,9 +137,9 @@ namespace System.Runtime.Intrinsics
                 return Avx.InsertVector128(result.ToVector256Unsafe(), result, 1);      // < v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v >
             }
 
-            return CreateSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector256<short> CreateSoftware(short x)
+            Vector256<short> SoftwareFallback(short x)
             {
                 var pResult = stackalloc short[16]
                 {
@@ -183,9 +183,9 @@ namespace System.Runtime.Intrinsics
                 return Avx.InsertVector128(result.ToVector256Unsafe(), result, 1);      // < v, v, v, v, v, v, v, v >
             }
 
-            return CreateSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector256<int> CreateSoftware(int x)
+            Vector256<int> SoftwareFallback(int x)
             {
                 var pResult = stackalloc int[8]
                 {
@@ -223,9 +223,9 @@ namespace System.Runtime.Intrinsics
                 }
             }
 
-            return CreateSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector256<long> CreateSoftware(long x)
+            Vector256<long> SoftwareFallback(long x)
             {
                 var pResult = stackalloc long[4]
                 {
@@ -258,9 +258,9 @@ namespace System.Runtime.Intrinsics
                 return Avx.InsertVector128(result.ToVector256Unsafe(), result, 1);      // < v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v >
             }
 
-            return CreateSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector256<sbyte> CreateSoftware(sbyte x)
+            Vector256<sbyte> SoftwareFallback(sbyte x)
             {
                 var pResult = stackalloc sbyte[32]
                 {
@@ -320,9 +320,9 @@ namespace System.Runtime.Intrinsics
                 return Avx.InsertVector128(result.ToVector256Unsafe(), result, 1);      // < v, v, v, v, v, v, v, v >
             }
 
-            return CreateSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector256<float> CreateSoftware(float x)
+            Vector256<float> SoftwareFallback(float x)
             {
                 var pResult = stackalloc float[8]
                 {
@@ -359,9 +359,9 @@ namespace System.Runtime.Intrinsics
                 return Avx.InsertVector128(result.ToVector256Unsafe(), result, 1);      // < v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v >
             }
 
-            return CreateSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector256<ushort> CreateSoftware(ushort x)
+            Vector256<ushort> SoftwareFallback(ushort x)
             {
                 var pResult = stackalloc ushort[16]
                 {
@@ -406,9 +406,9 @@ namespace System.Runtime.Intrinsics
                 return Avx.InsertVector128(result.ToVector256Unsafe(), result, 1);      // < v, v, v, v, v, v, v, v >
             }
 
-            return CreateSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector256<uint> CreateSoftware(uint x)
+            Vector256<uint> SoftwareFallback(uint x)
             {
                 var pResult = stackalloc uint[8]
                 {
@@ -447,9 +447,9 @@ namespace System.Runtime.Intrinsics
                 }
             }
 
-            return CreateSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector256<ulong> CreateSoftware(ulong x)
+            Vector256<ulong> SoftwareFallback(ulong x)
             {
                 var pResult = stackalloc ulong[4]
             {
@@ -1006,9 +1006,9 @@ namespace System.Runtime.Intrinsics
                 return Vector128.CreateScalar(value).ToVector256();
             }
 
-            return CreateScalarSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector256<byte> CreateScalarSoftware(byte x)
+            Vector256<byte> SoftwareFallback(byte x)
             {
                 var result = Vector256<byte>.Zero;
                 Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<byte>, byte>(ref result), value);
@@ -1027,9 +1027,9 @@ namespace System.Runtime.Intrinsics
                 return Vector128.CreateScalar(value).ToVector256();
             }
 
-            return CreateScalarSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector256<double> CreateScalarSoftware(double x)
+            Vector256<double> SoftwareFallback(double x)
             {
                 var result = Vector256<double>.Zero;
                 Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<double>, byte>(ref result), value);
@@ -1048,9 +1048,9 @@ namespace System.Runtime.Intrinsics
                 return Vector128.CreateScalar(value).ToVector256();
             }
 
-            return CreateScalarSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector256<short> CreateScalarSoftware(short x)
+            Vector256<short> SoftwareFallback(short x)
             {
                 var result = Vector256<short>.Zero;
                 Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<short>, byte>(ref result), value);
@@ -1069,9 +1069,9 @@ namespace System.Runtime.Intrinsics
                 return Vector128.CreateScalar(value).ToVector256();
             }
 
-            return CreateScalarSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector256<int> CreateScalarSoftware(int x)
+            Vector256<int> SoftwareFallback(int x)
             {
                 var result = Vector256<int>.Zero;
                 Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<int>, byte>(ref result), value);
@@ -1090,9 +1090,9 @@ namespace System.Runtime.Intrinsics
                 return Vector128.CreateScalar(value).ToVector256();
             }
 
-            return CreateScalarSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector256<long> CreateScalarSoftware(long x)
+            Vector256<long> SoftwareFallback(long x)
             {
                 var result = Vector256<long>.Zero;
                 Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<long>, byte>(ref result), value);
@@ -1112,9 +1112,9 @@ namespace System.Runtime.Intrinsics
                 return Vector128.CreateScalar(value).ToVector256();
             }
 
-            return CreateScalarSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector256<sbyte> CreateScalarSoftware(sbyte x)
+            Vector256<sbyte> SoftwareFallback(sbyte x)
             {
                 var result = Vector256<sbyte>.Zero;
                 Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<sbyte>, byte>(ref result), value);
@@ -1133,9 +1133,9 @@ namespace System.Runtime.Intrinsics
                 return Vector128.CreateScalar(value).ToVector256();
             }
 
-            return CreateScalarSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector256<float> CreateScalarSoftware(float x)
+            Vector256<float> SoftwareFallback(float x)
             {
                 var result = Vector256<float>.Zero;
                 Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<float>, byte>(ref result), value);
@@ -1155,9 +1155,9 @@ namespace System.Runtime.Intrinsics
                 return Vector128.CreateScalar(value).ToVector256();
             }
 
-            return CreateScalarSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector256<ushort> CreateScalarSoftware(ushort x)
+            Vector256<ushort> SoftwareFallback(ushort x)
             {
                 var result = Vector256<ushort>.Zero;
                 Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<ushort>, byte>(ref result), value);
@@ -1177,9 +1177,9 @@ namespace System.Runtime.Intrinsics
                 return Vector128.CreateScalar(value).ToVector256();
             }
 
-            return CreateScalarSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector256<uint> CreateScalarSoftware(uint x)
+            Vector256<uint> SoftwareFallback(uint x)
             {
                 var result = Vector256<uint>.Zero;
                 Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<uint>, byte>(ref result), value);
@@ -1199,9 +1199,9 @@ namespace System.Runtime.Intrinsics
                 return Vector128.CreateScalar(value).ToVector256();
             }
 
-            return CreateScalarSoftware(value);
+            return SoftwareFallback(value);
 
-            Vector256<ulong> CreateScalarSoftware(ulong x)
+            Vector256<ulong> SoftwareFallback(ulong x)
             {
                 var result = Vector256<ulong>.Zero;
                 Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<ulong>, byte>(ref result), value);

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256_1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256_1.cs
@@ -190,13 +190,13 @@ namespace System.Runtime.Intrinsics
                 if (typeof(T) == typeof(float))
                 {
                     Vector256<float> result = Avx.Compare(AsSingle(), other.AsSingle(), FloatComparisonMode.EqualOrderedNonSignaling);
-                    return Avx.MoveMask(result) == 0b1111_1111;
+                    return Avx.MoveMask(result) == 0b1111_1111; // We have one bit per element
                 }
 
                 if (typeof(T) == typeof(double))
                 {
                     Vector256<double> result = Avx.Compare(AsDouble(), other.AsDouble(), FloatComparisonMode.EqualOrderedNonSignaling);
-                    return Avx.MoveMask(result) == 0b1111;
+                    return Avx.MoveMask(result) == 0b1111; // We have one bit per element
                 }
             }
 
@@ -208,7 +208,7 @@ namespace System.Runtime.Intrinsics
 
                 Debug.Assert((typeof(T) != typeof(float)) && (typeof(T) != typeof(double)));
                 Vector256<byte> result = Avx2.CompareEqual(AsByte(), other.AsByte());
-                return Avx2.MoveMask(result) == unchecked((int)(0b1111_1111_1111_1111_1111_1111_1111_1111));
+                return Avx2.MoveMask(result) == unchecked((int)(0b1111_1111_1111_1111_1111_1111_1111_1111)); // We have one bit per element
             }
 
             return EqualsSoftware(in this, other);

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256_1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256_1.cs
@@ -307,41 +307,89 @@ namespace System.Runtime.Intrinsics
         /// <param name="value">The value of the lower 128-bits as a <see cref="Vector128{T}" />.</param>
         /// <returns>A new <see cref="Vector256{T}" /> with the lower 128-bits set to the specified value and the lower 128-bits set to the same value as that in the current instance.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Vector256<T> WithLower(Vector128<T> value)
         {
             ThrowIfUnsupportedType();
             Vector128<T>.ThrowIfUnsupportedType();
 
-            Vector256<T> result = this;
-            Unsafe.As<Vector256<T>, Vector128<T>>(ref result) = value;
-            return result;
+            if (Avx2.IsSupported && ((typeof(T) != typeof(float)) && (typeof(T) != typeof(double))))
+            {
+                return Avx2.InsertVector128(AsByte(), value.AsByte(), 0).As<T>();
+            }
+
+            if (Avx.IsSupported)
+            {
+                return Avx.InsertVector128(AsSingle(), value.AsSingle(), 0).As<T>();
+            }
+
+            return WithLowerSoftware(in this, value);
+
+            Vector256<T> WithLowerSoftware(in Vector256<T> t, Vector128<T> x)
+            {
+                Vector256<T> result = t;
+                Unsafe.As<Vector256<T>, Vector128<T>>(ref result) = x;
+                return result;
+            }
         }
 
         /// <summary>Gets the value of the upper 128-bits as a new <see cref="Vector128{T}" />.</summary>
         /// <returns>The value of the upper 128-bits as a new <see cref="Vector128{T}" />.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Vector128<T> GetUpper()
         {
             ThrowIfUnsupportedType();
             Vector128<T>.ThrowIfUnsupportedType();
 
-            ref Vector128<T> lower = ref Unsafe.As<Vector256<T>, Vector128<T>>(ref Unsafe.AsRef(in this));
-            return Unsafe.Add(ref lower, 1);
+            if (Avx2.IsSupported && ((typeof(T) != typeof(float)) && (typeof(T) != typeof(double))))
+            {
+                return Avx2.ExtractVector128(AsByte(), 1).As<T>();
+            }
+
+            if (Avx.IsSupported)
+            {
+                return Avx.ExtractVector128(AsSingle(), 1).As<T>();
+            }
+
+            return GetUpperSoftware(in this);
+
+            Vector128<T> GetUpperSoftware(in Vector256<T> t)
+            {
+                ref Vector128<T> lower = ref Unsafe.As<Vector256<T>, Vector128<T>>(ref Unsafe.AsRef(in t));
+                return Unsafe.Add(ref lower, 1);
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector256{T}" /> with the upper 128-bits set to the specified value and the upper 128-bits set to the same value as that in the current instance.</summary>
         /// <param name="value">The value of the upper 128-bits as a <see cref="Vector128{T}" />.</param>
         /// <returns>A new <see cref="Vector256{T}" /> with the upper 128-bits set to the specified value and the upper 128-bits set to the same value as that in the current instance.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Vector256<T> WithUpper(Vector128<T> value)
         {
             ThrowIfUnsupportedType();
             Vector128<T>.ThrowIfUnsupportedType();
 
-            Vector256<T> result = this;
-            ref Vector128<T> lower = ref Unsafe.As<Vector256<T>, Vector128<T>>(ref result);
-            Unsafe.Add(ref lower, 1) = value;
-            return result;
+            if (Avx2.IsSupported && ((typeof(T) != typeof(float)) && (typeof(T) != typeof(double))))
+            {
+                return Avx2.InsertVector128(AsByte(), value.AsByte(), 1).As<T>();
+            }
+
+            if (Avx.IsSupported)
+            {
+                return Avx.InsertVector128(AsSingle(), value.AsSingle(), 1).As<T>();
+            }
+
+            return WithUpperSoftware(in this, value);
+
+            Vector256<T> WithUpperSoftware(in Vector256<T> t, Vector128<T> x)
+            {
+                Vector256<T> result = t;
+                ref Vector128<T> lower = ref Unsafe.As<Vector256<T>, Vector128<T>>(ref result);
+                Unsafe.Add(ref lower, 1) = x;
+                return result;
+            }
         }
 
         /// <summary>Converts the current instance to a scalar containing the value of the first element.</summary>

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256_1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256_1.cs
@@ -211,9 +211,9 @@ namespace System.Runtime.Intrinsics
                 return Avx2.MoveMask(result) == unchecked((int)(0b1111_1111_1111_1111_1111_1111_1111_1111)); // We have one bit per element
             }
 
-            return EqualsSoftware(in this, other);
+            return SoftwareFallback(in this, other);
 
-            bool EqualsSoftware(in Vector256<T> x, Vector256<T> y)
+            bool SoftwareFallback(in Vector256<T> x, Vector256<T> y)
             {
                 for (int i = 0; i < Count; i++)
                 {
@@ -323,9 +323,9 @@ namespace System.Runtime.Intrinsics
                 return Avx.InsertVector128(AsSingle(), value.AsSingle(), 0).As<T>();
             }
 
-            return WithLowerSoftware(in this, value);
+            return SoftwareFallback(in this, value);
 
-            Vector256<T> WithLowerSoftware(in Vector256<T> t, Vector128<T> x)
+            Vector256<T> SoftwareFallback(in Vector256<T> t, Vector128<T> x)
             {
                 Vector256<T> result = t;
                 Unsafe.As<Vector256<T>, Vector128<T>>(ref result) = x;
@@ -352,9 +352,9 @@ namespace System.Runtime.Intrinsics
                 return Avx.ExtractVector128(AsSingle(), 1).As<T>();
             }
 
-            return GetUpperSoftware(in this);
+            return SoftwareFallback(in this);
 
-            Vector128<T> GetUpperSoftware(in Vector256<T> t)
+            Vector128<T> SoftwareFallback(in Vector256<T> t)
             {
                 ref Vector128<T> lower = ref Unsafe.As<Vector256<T>, Vector128<T>>(ref Unsafe.AsRef(in t));
                 return Unsafe.Add(ref lower, 1);
@@ -381,9 +381,9 @@ namespace System.Runtime.Intrinsics
                 return Avx.InsertVector128(AsSingle(), value.AsSingle(), 1).As<T>();
             }
 
-            return WithUpperSoftware(in this, value);
+            return SoftwareFallback(in this, value);
 
-            Vector256<T> WithUpperSoftware(in Vector256<T> t, Vector128<T> x)
+            Vector256<T> SoftwareFallback(in Vector256<T> t, Vector128<T> x)
             {
                 Vector256<T> result = t;
                 ref Vector128<T> lower = ref Unsafe.As<Vector256<T>, Vector128<T>>(ref result);

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -4157,6 +4157,29 @@ GenTree* Compiler::impBaseIntrinsic(NamedIntrinsic        intrinsic,
 
     switch (intrinsic)
     {
+#if defined(_TARGET_XARCH_)
+        case NI_Base_Vector256_As:
+        case NI_Base_Vector256_AsByte:
+        case NI_Base_Vector256_AsDouble:
+        case NI_Base_Vector256_AsInt16:
+        case NI_Base_Vector256_AsInt32:
+        case NI_Base_Vector256_AsInt64:
+        case NI_Base_Vector256_AsSByte:
+        case NI_Base_Vector256_AsSingle:
+        case NI_Base_Vector256_AsUInt16:
+        case NI_Base_Vector256_AsUInt32:
+        case NI_Base_Vector256_AsUInt64:
+        {
+            if (!compSupports(InstructionSet_AVX))
+            {
+                // We don't want to deal with TYP_SIMD32 if the compiler doesn't otherwise support the type.
+                break;
+            }
+
+            __fallthrough;
+        }
+#endif // _TARGET_XARCH_
+
 #if defined(_TARGET_ARM64_)
         case NI_Base_Vector64_AsByte:
         case NI_Base_Vector64_AsInt16:
@@ -4177,19 +4200,6 @@ GenTree* Compiler::impBaseIntrinsic(NamedIntrinsic        intrinsic,
         case NI_Base_Vector128_AsUInt16:
         case NI_Base_Vector128_AsUInt32:
         case NI_Base_Vector128_AsUInt64:
-#if defined(_TARGET_XARCH_)
-        case NI_Base_Vector256_As:
-        case NI_Base_Vector256_AsByte:
-        case NI_Base_Vector256_AsDouble:
-        case NI_Base_Vector256_AsInt16:
-        case NI_Base_Vector256_AsInt32:
-        case NI_Base_Vector256_AsInt64:
-        case NI_Base_Vector256_AsSByte:
-        case NI_Base_Vector256_AsSingle:
-        case NI_Base_Vector256_AsUInt16:
-        case NI_Base_Vector256_AsUInt32:
-        case NI_Base_Vector256_AsUInt64:
-#endif // _TARGET_XARCH_
         {
             // We fold away the cast here, as it only exists to satisfy
             // the type system. It is safe to do this here since the retNode type


### PR DESCRIPTION
As per the title, this updates various helper method for `Vector128` and `Vector256` to be implemented using other intrinsics