### PR TITLE
Remove some unnecessary spinning

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Collections/Concurrent/ConcurrentQueueSegment.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Concurrent/ConcurrentQueueSegment.cs
@@ -112,7 +112,6 @@ namespace System.Collections.Concurrent
                 _frozenForEnqueues = true;
 
                 // Increase the tail by FreezeOffset, spinning until we're successful in doing so.
-                var spinner = new SpinWait();
                 while (true)
                 {
                     int tail = Volatile.Read(ref _headAndTail.Tail);
@@ -120,7 +119,6 @@ namespace System.Collections.Concurrent
                     {
                         break;
                     }
-                    spinner.SpinOnce();
                 }
             }
         }

--- a/src/System.Private.CoreLib/shared/System/Collections/Concurrent/ConcurrentQueueSegment.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Concurrent/ConcurrentQueueSegment.cs
@@ -112,13 +112,15 @@ namespace System.Collections.Concurrent
                 _frozenForEnqueues = true;
 
                 // Increase the tail by FreezeOffset, spinning until we're successful in doing so.
+                int tail = Volatile.Read(ref _headAndTail.Tail);
                 while (true)
                 {
-                    int tail = Volatile.Read(ref _headAndTail.Tail);
-                    if (Interlocked.CompareExchange(ref _headAndTail.Tail, tail + FreezeOffset, tail) == tail)
+                    int oldTail = Interlocked.CompareExchange(ref _headAndTail.Tail, tail + FreezeOffset, tail);
+                    if (oldTail == tail)
                     {
                         break;
                     }
+                    tail = oldTail;
                 }
             }
         }

--- a/src/System.Private.CoreLib/shared/System/Collections/Concurrent/ConcurrentQueueSegment.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Concurrent/ConcurrentQueueSegment.cs
@@ -112,7 +112,7 @@ namespace System.Collections.Concurrent
                 _frozenForEnqueues = true;
 
                 // Increase the tail by FreezeOffset, spinning until we're successful in doing so.
-                int tail = Volatile.Read(ref _headAndTail.Tail);
+                int tail = _headAndTail.Tail;
                 while (true)
                 {
                     int oldTail = Interlocked.CompareExchange(ref _headAndTail.Tail, tail + FreezeOffset, tail);

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -721,7 +721,6 @@ namespace System.Threading.Tasks
 
         private bool AtomicStateUpdateSlow(int newBits, int illegalBits)
         {
-            var sw = new SpinWait();
             do
             {
                 int oldFlags = m_stateFlags;
@@ -730,13 +729,11 @@ namespace System.Threading.Tasks
                 {
                     return true;
                 }
-                sw.SpinOnce();
             } while (true);
         }
 
         internal bool AtomicStateUpdate(int newBits, int illegalBits, ref int oldFlags)
         {
-            SpinWait sw = new SpinWait();
             do
             {
                 oldFlags = m_stateFlags;
@@ -745,7 +742,6 @@ namespace System.Threading.Tasks
                 {
                     return true;
                 }
-                sw.SpinOnce();
             } while (true);
         }
 
@@ -772,13 +768,11 @@ namespace System.Threading.Tasks
             else
             {
                 // Atomically clear the END_AWAIT_NOTIFICATION bit
-                SpinWait sw = new SpinWait();
                 while (true)
                 {
                     int oldFlags = m_stateFlags;
                     int newFlags = oldFlags & (~TASK_STATE_WAIT_COMPLETION_NOTIFICATION);
                     if (Interlocked.CompareExchange(ref m_stateFlags, newFlags, oldFlags) == oldFlags) break;
-                    sw.SpinOnce();
                 }
             }
         }


### PR DESCRIPTION
Most of the use of SpinWait in CoreLib involves waiting for some short-lived operation to complete on another thread, in which case the spinning thread should backoff as it's unable to make forward progress until the other operation completes.  In a few cases, however, SpinWait is being used just around CompareExchange operations, such that at least one thread running this code path is guaranteed to make forward progress, and the backoff in the spinning doesn't actually help (in theory it could help to reduce contention if lots of threads were all trying to CompareExchange concurrently, but in such cases you'd actually want more randomized backoff, as otherwise it's likely all the threads would re-attempt at around the same time and similarly re-encounter contention).

cc: @kouvel, @jkotas