### PR TITLE
Adding a note to the genBaseIntrinsic function header about operand assumptions

### DIFF
--- a/src/jit/hwintrinsiccodegenxarch.cpp
+++ b/src/jit/hwintrinsiccodegenxarch.cpp
@@ -1247,6 +1247,9 @@ void CodeGen::genHWIntrinsicJumpTableFallback(NamedIntrinsic            intrinsi
 // Arguments:
 //    node - The hardware intrinsic node
 //
+// Note:
+//    We currently assume that all base intrinsics only have a single operand.
+//
 void CodeGen::genBaseIntrinsic(GenTreeHWIntrinsic* node)
 {
     NamedIntrinsic intrinsicId = node->gtHWIntrinsicId;


### PR DESCRIPTION
Adding the comment @CarolEidt requested in https://github.com/dotnet/coreclr/pull/21351#discussion_r239643723