### PR TITLE
Specify HelixTargetQueues in yaml

### DIFF
--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -16,6 +16,8 @@ jobs:
     osGroup: Linux
     osGroupName: Linux
     containerName: ubuntu_1404_arm_cross_build_image
+    helixQueuesPublic: 'Ubuntu.1404.Arm32.Open'
+    helixQueuesInternal: 'Ubuntu.1404.Arm32.Open'
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux arm64
@@ -26,6 +28,8 @@ jobs:
     osGroup: Linux
     osGroupName: Linux
     containerName: ubuntu_1604_arm64_cross_build_image
+    helixQueuesPublic: 'Debian.9.Arm64.Open,Ubuntu.1604.Arm64.Open,Ubuntu.1804.Arm64.Open'
+    helixQueuesInternal: 'Debian.9.Arm64,Ubuntu.1604.Arm64,Ubuntu.1804.Arm64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux musl
@@ -36,6 +40,8 @@ jobs:
     osGroup: Linux
     osGroupName: Linux_musl
     containerName: musl_x64_build_image
+    helixQueuesPublic: 'Alpine.3.Arm64.Open'
+    helixQueuesInternal: 'Alpine.3.Arm64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # RHEL 6
@@ -46,6 +52,8 @@ jobs:
     osGroup: Linux
     osGroupName: Linux_rhel6
     containerName: centos6_x64_build_image
+    helixQueuesPublic: 'RedHat.6.Amd64.Open'
+    helixQueuesInternal: 'RedHat.6.Amd64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # RHEL 7
@@ -56,6 +64,8 @@ jobs:
     osGroup: Linux
     osGroupName: Linux_rhel7
     containerName: centos7_x64_build_image
+    helixQueuesPublic: 'Centos.7.Amd64.Open,Fedora.28.Amd64.Open,RedHat.7.Amd64.Open'
+    helixQueuesInternal: 'Centos.7.Amd64,Fedora.28.Amd64,RedHat.7.Amd64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux x64
@@ -67,6 +77,8 @@ jobs:
     osGroup: Linux
     osGroupName: Linux
     containerName: ubuntu_1604_x64_build_image
+    helixQueuesPublic: 'Debian.8.Amd64.Open,Ubuntu.1604.Amd64.Open,Ubuntu.1804.Arm64.Open'
+    helixQueuesInternal: 'Debian.8.Amd64,Ubuntu.1604.Amd64,Ubuntu.1804.Arm64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # macOS x64
@@ -77,6 +89,8 @@ jobs:
     archType: x64
     osGroup: OSX
     osGroupName: OSX
+    helixQueuesPublic: 'OSX.1012.Amd64.Open,OSX.1013.Amd64.Open'
+    helixQueuesInternal: 'OSX.1012.Amd64,OSX.1013.Amd64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Windows x64/x86/arm/arm64
@@ -87,6 +101,8 @@ jobs:
     archType: x64
     osGroup: Windows_NT
     osGroupName: Windows_NT
+    helixQueuesPublic: 'Windows.10.Amd64.Open,Windows.10.Nano.Amd64.Open,Windows.7.Amd64.Open,Windows.81.Amd64.Open'
+    helixQueuesInternal: 'Windows.10.Amd64,Windows.10.Nano.Amd64,Windows.10.Amd64.Core,Windows.7.Amd64,Windows.81.Amd64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 - template: ${{ parameters.jobTemplate }}
@@ -95,6 +111,8 @@ jobs:
     archType: x86
     osGroup: Windows_NT
     osGroupName: Windows_NT
+    helixQueuesPublic: 'Windows.10.Amd64.Open,Windows.10.Nano.Amd64.Open,Windows.7.Amd64.Open,Windows.81.Amd64.Open'
+    helixQueuesInternal: 'Windows.10.Amd64,Windows.10.Nano.Amd64,Windows.10.Amd64.Core,Windows.7.Amd64,Windows.81.Amd64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 - template: ${{ parameters.jobTemplate }}
@@ -103,6 +121,8 @@ jobs:
     archType: arm
     osGroup: Windows_NT
     osGroupName: Windows_NT
+    helixQueuesPublic: 'Windows.10.Arm64.Open'
+    helixQueuesInternal: 'Windows.10.Arm64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 - template: ${{ parameters.jobTemplate }}
@@ -111,4 +131,6 @@ jobs:
     archType: arm64
     osGroup: Windows_NT
     osGroupName: Windows_NT
+    helixQueuesPublic: 'Windows.10.Arm64.Open'
+    helixQueuesInternal: 'Windows.10.Arm64'
     ${{ insert }}: ${{ parameters.jobParameters }}

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -17,7 +17,7 @@ jobs:
     osGroupName: Linux
     containerName: ubuntu_1404_arm_cross_build_image
     helixQueuesPublic: 'Ubuntu.1404.Arm32.Open'
-    # Currently we don't have Arm32 internal Helix queues
+    # Currently we don't have Linux/arm32 internal Helix queues
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux arm64

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -17,7 +17,7 @@ jobs:
     osGroupName: Linux
     containerName: ubuntu_1404_arm_cross_build_image
     helixQueuesPublic: 'Ubuntu.1404.Arm32.Open'
-    helixQueuesInternal: 'Ubuntu.1404.Arm32.Open'
+    # Currently we don't have Arm32 internal Helix queues
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux arm64

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -6,6 +6,8 @@ parameters:
   priority: 0
   crossgen: false
   scenarios: ''
+  helixQueuesPublic: ''
+  helixQueuesInternal: ''
 
 ### Test job
 
@@ -53,6 +55,12 @@ jobs:
       - ${{ if eq(parameters.scenarios, '') }}:
         - name: scenariosArg
           value: ''
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - name: helixTargetQueuesArg
+          value: ${{ format('/p:HelixTargetQueues=\"{0}\"', parameters.helixQueuesPublic) }}
+      - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+        - name: helixTargetQueuesArg
+          value: ${{ format('/p:HelixTargetQueues=\"{0}\"', parameters.helixQueuesInternal) }}
 
     # TODO: Enable crossgen in build-test.sh. It currently doesn't
     # accept a crossgen arg, so disable the macos/linux crossgen test
@@ -113,7 +121,7 @@ jobs:
 
     # Send tests to helix
     - ${{ if or(eq(parameters.osGroup, 'Linux'), eq(parameters.osGroup, 'OSX')) }}:
-      - script: ./Tools/dotnetcli/dotnet msbuild tests/helixpublishwitharcade.proj /maxcpucount $(scenariosArg)
+      - script: ./Tools/dotnetcli/dotnet msbuild tests/helixpublishwitharcade.proj /maxcpucount $(scenariosArg) $(helixTargetQueuesArg)
         displayName: Send test jobs to Helix
         env:
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
@@ -123,7 +131,7 @@ jobs:
             # Access token variable for public project
             HelixAccessToken: $(BotAccount-dotnet-github-anon-kaonashi-bot-helix-token)
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-      - script: .\Tools\dotnetcli\dotnet msbuild tests\helixpublishwitharcade.proj /maxcpucount  $(scenariosArg)
+      - script: .\Tools\dotnetcli\dotnet msbuild tests\helixpublishwitharcade.proj /maxcpucount $(scenariosArg) $(helixTargetQueuesArg)
         displayName: Send test jobs to Helix
         env:
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:

--- a/tests/helixpublishwitharcade.proj
+++ b/tests/helixpublishwitharcade.proj
@@ -12,31 +12,6 @@
     <HelixType>test/stuff</HelixType>
     <HelixBuild>$(BUILD_BUILDNUMBER)</HelixBuild>
 
-    <!-- TODO: add target queues for rhel and linux-musl -->
-    <!-- TODO: why don't we currently run tests on windows x86? -->
-    <HelixTargetQueues Condition=" '$(BuildOS)' == 'Windows_NT' ">
-      Windows.10.Amd64;
-      Windows.10.Nano.Amd64;
-      Windows.10.Amd64.Core;
-      Windows.7.Amd64;
-      Windows.81.Amd64
-    </HelixTargetQueues>
-    <HelixTargetQueues Condition=" '$(BuildOS)' == 'Linux' ">
-      debian.82.amd64;
-      fedora.27.amd64;
-      fedora.28.amd64;
-      redhat.73.amd64;
-      ubuntu.1404.amd64;
-      ubuntu.1604.amd64;
-      ubuntu.1804.amd64;
-      opensuse.423.amd64;
-      sles.12.amd64
-    </HelixTargetQueues>
-    <HelixTargetQueues Condition=" '$(BuildOS)' == 'OSX' ">
-      osx.1012.amd64;
-      osx.1013.amd64
-    </HelixTargetQueues>
-
     <EnableXUnitReporter>true</EnableXUnitReporter>
     <WaitForWorkItemCompletion>true</WaitForWorkItemCompletion>
     <SourceDirectory>$(MSBuildProjectDirectory)/..</SourceDirectory>

--- a/tests/runtest_helix.py
+++ b/tests/runtest_helix.py
@@ -22,7 +22,7 @@ test_scenarios = {
                     "COMPlus_JitStress": "2" },
 }
 
-if sys.platform == "linux" or sys.platform == "darwin":
+if sys.platform.startswith('linux') or sys.platform == "darwin":
     platform_type = "unix"
 elif sys.platform == "win32":
     platform_type = "windows"


### PR DESCRIPTION
Update Helix Queues used for public vs internal project and specify them in yaml instead of MSBuild.

Use comma-separated strings (semicolon-separated one won't work on non-Windows)

[Arcade already supports](https://github.com/dotnet/arcade/blob/3178bd93cbc3b781b1144643e35137cca630a78b/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MultiQueue.targets#L51) parsing comma-separated strings for HelixTargetQueues property so no need to do this on our side.