### PR TITLE
Invalid setting csharp_new_line_within_query_expression_clauses in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,6 @@ root = true
 # Default settings:
 # A newline ending every file
 # Use 4 spaces as indentation
-# Trim trailing whitespace
 [*]
 insert_final_newline = true
 indent_style = space
@@ -22,7 +21,7 @@ csharp_new_line_before_catch = true
 csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
-csharp_new_line_within_query_expression_clauses = true
+csharp_new_line_between_query_expression_clauses = true
 
 # Indentation preferences
 csharp_indent_block_contents = true


### PR DESCRIPTION
Same as in https://github.com/dotnet/corefx/issues/25991.

Roslyn doesn't support csharp_new_line_within_query_expression_clauses.
But Roslyn does support csharp_new_line_between_query_expression_clauses and it's missing from .editorconfig.

I also removed the comment "# Trim trailing whitespace" because that option is not set.