### PR TITLE
Fixed bug where "DCI_NUMA" was missing from debug channel names (#21454)

### DIFF
--- a/src/pal/src/include/pal/dbgmsg.h
+++ b/src/pal/src/include/pal/dbgmsg.h
@@ -195,6 +195,9 @@ typedef enum
     DCI_SXS,
 #endif // FEATURE_PAL_SXS
     DCI_NUMA,
+    // Please make sure to update dbg_channel_names when adding entries here.
+
+    // Do not remove this line, as it indicates the end of the list
     DCI_LAST
 } DBG_CHANNEL_ID;
 

--- a/src/pal/src/misc/dbgmsg.cpp
+++ b/src/pal/src/misc/dbgmsg.cpp
@@ -101,7 +101,11 @@ static const char *dbg_channel_names[]=
 #ifdef FEATURE_PAL_SXS
   , "SXS"
 #endif // FEATURE_PAL_SXS
+  , "DCI_NUMA"
 };
+
+// Verify the number of elements in dbg_channel_names
+static_assert_no_msg(_countof(dbg_channel_names) == DCI_LAST);
 
 static const char *dbg_level_names[]=
 {


### PR DESCRIPTION
In additional to adding "DCI_NUMA" to dbg_channel_names, a static assertion was added to verify that  dbg_channel_names length is valid. Also added some comments to help developpers not to forget to add corresponding entries in dbg_channel_names.

FIxes #21454