### PR TITLE
Add support for RVA fields to crossgen/R2R

### DIFF
--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -13964,11 +13964,35 @@ InfoAccessType CEEInfo::emptyStringLiteral(void ** ppValue)
 void* CEEInfo::getFieldAddress(CORINFO_FIELD_HANDLE fieldHnd,
                                   void **ppIndirection)
 {
-    LIMITED_METHOD_CONTRACT;
-    _ASSERTE(isVerifyOnly());
+    CONTRACTL{
+        SO_TOLERANT;
+        THROWS;
+        GC_TRIGGERS;
+        MODE_PREEMPTIVE;
+    } CONTRACTL_END;
+
+    void *result = NULL;
+
     if (ppIndirection != NULL)
         *ppIndirection = NULL;
-    return (void *)0x10;
+
+    // Do not bother with initialization if we are only verifying the method.
+    if (isVerifyOnly())
+    {
+        return (void *)0x10;
+    }
+
+    JIT_TO_EE_TRANSITION();
+
+    FieldDesc* field = (FieldDesc*)fieldHnd;
+
+    _ASSERTE(field->IsRVA());
+
+    result = field->GetStaticAddressHandle(NULL);
+
+    EE_TO_JIT_TRANSITION();
+
+    return result;
 }
 
 CORINFO_CLASS_HANDLE CEEInfo::getStaticFieldCurrentClass(CORINFO_FIELD_HANDLE fieldHnd,

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -1715,6 +1715,9 @@ ReadyToRunHelper MapReadyToRunHelper(CorInfoHelpFunc func, bool * pfOptimizeForS
     case corInfoHelpFunc: flags return readyToRunHelper;
 #include "readytorunhelpers.h"
 
+    case CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPEHANDLE:
+        return READYTORUN_HELPER_GetRuntimeTypeHandle;
+
     case CORINFO_HELP_STRCNS_CURRENT_MODULE:
         *pfOptimizeForSize = true;
         return READYTORUN_HELPER_GetString;

--- a/tests/src/readytorun/tests/main.cs
+++ b/tests/src/readytorun/tests/main.cs
@@ -415,6 +415,13 @@ class Program
         }
     }
 
+    static void RVAFieldTest()
+    {
+        ReadOnlySpan<byte> value = new byte[] { 9, 8, 7, 6, 5, 4, 3, 1, 0 };
+        for (byte i = 0; i < value.Length; i++)
+            Assert.AreEqual(value[i], (byte)(9 - i));
+    }
+
     static void RunAllTests()
     {
         TestVirtualMethodCalls();
@@ -467,6 +474,8 @@ class Program
         TestOpenClosedDelegate();
         
         GenericLdtokenFieldsTest();
+
+        RVAFieldTest();
     }
 
     static int Main()

--- a/tests/src/readytorun/tests/main.cs
+++ b/tests/src/readytorun/tests/main.cs
@@ -417,7 +417,7 @@ class Program
 
     static void RVAFieldTest()
     {
-        ReadOnlySpan<byte> value = new byte[] { 9, 8, 7, 6, 5, 4, 3, 1, 0 };
+        ReadOnlySpan<byte> value = new byte[] { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
         for (byte i = 0; i < value.Length; i++)
             Assert.AreEqual(value[i], (byte)(9 - i));
     }


### PR DESCRIPTION
RVA fields are became more common with pre-inititialized ReadOnlySpan<byte>. Fix crossgen to deal with them for R2R.