### PR TITLE
Fix for SetGCHandle event not getting emitted when running under Standalone GC

### DIFF
--- a/src/gc/handletable.cpp
+++ b/src/gc/handletable.cpp
@@ -594,8 +594,7 @@ void HndLogSetEvent(OBJECTHANDLE handle, _UNCHECKED_OBJECTREF value)
     STATIC_CONTRACT_MODE_COOPERATIVE;
 
 #if !defined(DACCESS_COMPILE) && defined(FEATURE_EVENT_TRACE)
-    if (ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PRIVATE_PROVIDER_Context, SetGCHandle) ||
-        ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_Context, SetGCHandle))
+    if (EVENT_ENABLED(SetGCHandle) || EVENT_ENABLED(PrvSetGCHandle))
     {
         uint32_t hndType = HandleFetchType(handle);
         ADIndex appDomainIndex = HndGetHandleADIndex(handle);   


### PR DESCRIPTION
Before emitting SetGCHandle events, we were checking the ```MICROSOFT_WINDOWS_DOTNETRUNTIME_PRIVATE_PROVIDER_Context``` to see if it's enabled, but this is not what we check when we are running under Standalone GC. (We need to check the ```GCEventStatus::enabledKeywords``` and ```GCEventStatus::enabledLevels``` instead). 