### PR TITLE
Removing configEnableISA and fixing up Compiler::compSetProcessor to be consistent with EEJitManager::SetCpuInfo in how ISA support checks are done

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7518,10 +7518,7 @@ private:
             return SIMD_AVX2_Supported;
         }
 
-        // SIMD_SSE4_Supported actually requires all of SSE3, SSSE3, SSE4.1, and SSE4.2
-        // to be supported. We can only enable it if all four are enabled in the compiler
-        if (compSupports(InstructionSet_SSE42) && compSupports(InstructionSet_SSE41) &&
-            compSupports(InstructionSet_SSSE3) && compSupports(InstructionSet_SSE3))
+        if (compSupports(InstructionSet_SSE42))
         {
             return SIMD_SSE4_Supported;
         }

--- a/src/jit/ee_il_dll.cpp
+++ b/src/jit/ee_il_dll.cpp
@@ -402,7 +402,12 @@ unsigned CILJit::getMaxIntrinsicSIMDVectorLength(CORJIT_FLAGS cpuCompileFlags)
     if (!jitFlags.IsSet(JitFlags::JIT_FLAG_PREJIT) && jitFlags.IsSet(JitFlags::JIT_FLAG_FEATURE_SIMD) &&
         jitFlags.IsSet(JitFlags::JIT_FLAG_USE_AVX2))
     {
-        if (JitConfig.EnableAVX() != 0 && JitConfig.EnableAVX2() != 0)
+        // Since the ISAs can be disabled individually and since they are hierarchical in nature (that is
+        // disabling SSE also disables SSE2 through AVX2), we need to check each ISA in the hierarchy to
+        // ensure that AVX2 is actually supported. Otherwise, we will end up getting asserts downstream.
+        if ((JitConfig.EnableAVX2() != 0) && (JitConfig.EnableAVX() != 0) && (JitConfig.EnableSSE42() != 0) &&
+            (JitConfig.EnableSSE41() != 0) && (JitConfig.EnableSSSE3() != 0) && (JitConfig.EnableSSE3() != 0) &&
+            (JitConfig.EnableSSE2() != 0) && (JitConfig.EnableSSE() != 0) && (JitConfig.EnableHWIntrinsic() != 0))
         {
             if (GetJitTls() != nullptr && JitTls::GetCompiler() != nullptr)
             {

--- a/src/vm/codeman.cpp
+++ b/src/vm/codeman.cpp
@@ -1263,6 +1263,7 @@ void EEJitManager::SetCpuInfo()
 
     //
     // NOTE: This function needs to be kept in sync with Zapper::CompileAssembly()
+    // NOTE: This function needs to be kept in sync with compSetProcesor() in jit\compiler.cpp
     //
 
     CORJIT_FLAGS CPUCompileFlags;


### PR DESCRIPTION
We have multiple configuration knobs which control support for the individual HWIntrinsic ISAs and as of https://github.com/dotnet/coreclr/pull/20501, these knobs are available in release mode and meant to match the actual ISA hierarchy (such that disabling `SSE` would also disable anything dependent on `SSE`).

This PR fixes up some issues that existed around these configuration knobs to ensure that they properly follow the ISA hierarchy and resolves some issues around the `AVX` configuration knob which was pre-existing and impacted how `S.N.Vector<T>` worked.

CC. @CarolEidt, @fiigii 