### PR TITLE
Fixes issue #21485 and #21484

### DIFF
--- a/src/debug/daccess/task.cpp
+++ b/src/debug/daccess/task.cpp
@@ -2745,7 +2745,12 @@ ClrDataModule::RequestGetModuleData(
         COUNT_T peSize;
         outGMD->LoadedPEAddress = TO_CDADDR(PTR_TO_TADDR(pPEFile->GetLoadedImageContents(&peSize)));
         outGMD->LoadedPESize = (ULONG64)peSize;
-        outGMD->IsFileLayout = pPEFile->GetLoaded()->IsFlat();
+
+        // Can not get the file layout for a dynamic module
+        if (!outGMD->IsDynamic)
+        {
+            outGMD->IsFileLayout = pPEFile->GetLoaded()->IsFlat();
+        }
     }
 
     // If there is a in memory symbol stream

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -2686,6 +2686,7 @@ GetProcessModulesFromHandle(
     if (hPseudoCurrentProcess == hProcess)
     {
         pobjProcess = g_pobjProcess;
+        pobjProcess->AddReference();
     }
     else
     {


### PR DESCRIPTION
Issue #21485: fix EnumProcessModules hPseudoCurrentProcess bug.

Added handle reference.

Issue #21484: createdump segfaults with ASP.NET app

The problem is the ClrDataModule Request faulted on a dynamic module
getting the file layout flag.

Fixed the Request code not get the file layout and in the crash dump
code skip any dynamic modules.