### PR TITLE
Update var life for multireg local

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -1296,6 +1296,7 @@ void CodeGen::genMultiRegCallStoreToLocal(GenTree* treeNode)
             offset += genTypeSize(type);
         }
 
+        genUpdateLife(treeNode);
         varDsc->lvRegNum = REG_STK;
     }
 }

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -512,15 +512,30 @@ void CodeGen::genCodeForBBlist()
         // it up to date for vars that are not register candidates
         // (it would be nice to have a xor set function)
 
-        VARSET_TP extraLiveVars(VarSetOps::Diff(compiler, block->bbLiveOut, compiler->compCurLife));
-        VarSetOps::UnionD(compiler, extraLiveVars, VarSetOps::Diff(compiler, compiler->compCurLife, block->bbLiveOut));
-        VarSetOps::Iter extraLiveVarIter(compiler, extraLiveVars);
-        unsigned        extraLiveVarIndex = 0;
-        while (extraLiveVarIter.NextElem(&extraLiveVarIndex))
+        VARSET_TP mismatchLiveVars(VarSetOps::Diff(compiler, block->bbLiveOut, compiler->compCurLife));
+        VarSetOps::UnionD(compiler, mismatchLiveVars,
+                          VarSetOps::Diff(compiler, compiler->compCurLife, block->bbLiveOut));
+        VarSetOps::Iter mismatchLiveVarIter(compiler, mismatchLiveVars);
+        unsigned        mismatchLiveVarIndex  = 0;
+        bool            foundMismatchedRegVar = false;
+        while (mismatchLiveVarIter.NextElem(&mismatchLiveVarIndex))
         {
-            unsigned   varNum = compiler->lvaTrackedToVarNum[extraLiveVarIndex];
+            unsigned   varNum = compiler->lvaTrackedToVarNum[mismatchLiveVarIndex];
             LclVarDsc* varDsc = compiler->lvaTable + varNum;
-            assert(!varDsc->lvIsRegCandidate());
+            if (varDsc->lvIsRegCandidate())
+            {
+                if (!foundMismatchedRegVar)
+                {
+                    JITDUMP("Mismatched live reg vars after BB%02u:", block->bbNum);
+                    foundMismatchedRegVar = true;
+                }
+                JITDUMP(" V%02u", varNum);
+            }
+        }
+        if (foundMismatchedRegVar)
+        {
+            assert(!"Found mismatched live reg var(s) after block");
+            JITDUMP("\n");
         }
 #endif
 


### PR DESCRIPTION
When a multi-reg var is defined by a call, but doesn't currently reside in a register,
we must still update liveness.

Fix #21500