### PR TITLE
Enable PinPlugAtGCTime event for standalone GC

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -21680,7 +21680,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
             generation_plan_allocation_start (temp_gen)));
     }
 
-    BOOL fire_pinned_plug_events_p = ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PRIVATE_PROVIDER_Context, PinPlugAtGCTime);
+    BOOL fire_pinned_plug_events_p = EVENT_ENABLED(PinPlugAtGCTime);
     size_t last_plug_len = 0;
 
     while (1)
@@ -21966,9 +21966,8 @@ void gc_heap::plan_phase (int condemned_gen_number)
             if (pinned_plug_p)
             {
                 if (fire_pinned_plug_events_p)
-                    FireEtwPinPlugAtGCTime(plug_start, plug_end, 
-                                           (merge_with_last_pin_p ? 0 : (uint8_t*)node_gap_size (plug_start)),
-                                           GetClrInstanceId());
+                    FIRE_EVENT(PinPlugAtGCTime, plug_start, plug_end, 
+                               (merge_with_last_pin_p ? 0 : (uint8_t*)node_gap_size (plug_start)));
 
                 if (merge_with_last_pin_p)
                 {

--- a/src/gc/gcevents.h
+++ b/src/gc/gcevents.h
@@ -25,6 +25,7 @@ KNOWN_EVENT(GCAllocationTick_V1, GCEventProvider_Default, GCEventLevel_Verbose, 
 KNOWN_EVENT(GCAllocationTick_V3, GCEventProvider_Default, GCEventLevel_Verbose, GCEventKeyword_GC)
 KNOWN_EVENT(PinObjectAtGCTime, GCEventProvider_Default, GCEventLevel_Verbose, GCEventKeyword_GC)
 KNOWN_EVENT(GCPerHeapHistory_V3, GCEventProvider_Default, GCEventLevel_Information, GCEventKeyword_GC)
+KNOWN_EVENT(PinPlugAtGCTime, GCEventProvider_Private, GCEventLevel_Verbose, GCEventKeyword_GC)
 
 KNOWN_EVENT(SetGCHandle, GCEventProvider_Default, GCEventLevel_Information, GCEventKeyword_GCHandle)
 KNOWN_EVENT(DestroyGCHandle, GCEventProvider_Default, GCEventLevel_Information, GCEventKeyword_GCHandle)

--- a/src/gc/gcinterface.ee.h
+++ b/src/gc/gcinterface.ee.h
@@ -106,6 +106,9 @@ public:
     void FirePinObjectAtGCTime(void* object, uint8_t** ppObject) = 0;
 
     virtual
+    void FirePinPlugAtGCTime(uint8_t* plug_start, uint8_t* plug_end, uint8_t* gapBeforeSize) = 0;
+
+    virtual
     void FireGCPerHeapHistory_V3(void *freeListAllocated,
                                  void *freeListRejected,
                                  void *endOfSegAllocated,

--- a/src/vm/gctoclreventsink.cpp
+++ b/src/vm/gctoclreventsink.cpp
@@ -205,6 +205,12 @@ void GCToCLREventSink::FirePinObjectAtGCTime(void* object, uint8_t** ppObject)
     EX_END_CATCH(SwallowAllExceptions)
 }
 
+void GCToCLREventSink::FirePinPlugAtGCTime(uint8_t* plugStart, uint8_t* plugEnd, uint8_t* gapBeforeSize)
+{
+    LIMITED_METHOD_CONTRACT;
+    FireEtwPinPlugAtGCTime(plugStart, plugEnd, gapBeforeSize, GetClrInstanceId());
+}
+
 void GCToCLREventSink::FireGCPerHeapHistory_V3(void *freeListAllocated,
                                                void *freeListRejected,
                                                void *endOfSegAllocated,

--- a/src/vm/gctoclreventsink.h
+++ b/src/vm/gctoclreventsink.h
@@ -45,6 +45,7 @@ public:
     void FireGCAllocationTick_V1(uint32_t allocationAmount, uint32_t allocationKind);
     void FireGCAllocationTick_V3(uint64_t allocationAmount, uint32_t allocationKind, uint32_t heapIndex, void* objectAddress);
     void FirePinObjectAtGCTime(void* object, uint8_t** ppObject);
+    void FirePinPlugAtGCTime(uint8_t* plug_start, uint8_t* plug_end, uint8_t* gapBeforeSize);
     void FireGCPerHeapHistory_V3(void *freeListAllocated,
                                  void *freeListRejected,
                                  void *endOfSegAllocated,


### PR DESCRIPTION
PinPlugAtGCTime event was never ported to use the new interface we have for emitting GC events. This is a fix to address that. 