### PR TITLE
Fixing an assert in `gtGetStructHandleForSIMD` to validate the size of the simdType is less than or equal to the largest support TYP_SIMD

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7650,7 +7650,7 @@ private:
                     unreached();
             }
         }
-        assert(simdType == getSIMDVectorType());
+        assert(emitTypeSize(simdType) <= maxSIMDStructBytes());
         switch (simdBaseType)
         {
             case TYP_FLOAT:


### PR DESCRIPTION
This resolves https://github.com/dotnet/coreclr/issues/21542

CC. @CarolEidt, @fiigii 