### PR TITLE
[WIP] Eliminate array/Span index sign-extension

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -2948,7 +2948,7 @@ GenTree* Compiler::impImplicitIorI4Cast(GenTree* tree, var_types dstTyp)
         else if (varTypeIsI(wantedType) && (currType == TYP_INT))
         {
             // Note that this allows TYP_INT to be cast to a TYP_I_IMPL when wantedType is a TYP_BYREF or TYP_REF
-            tree = gtNewCastNode(TYP_I_IMPL, tree, false, TYP_I_IMPL);
+            tree = gtNewCastNode(TYP_I_IMPL, tree, false, varTypeIsUnsigned(dstTyp) ? TYP_UINT : TYP_I_IMPL);
         }
         else if ((wantedType == TYP_INT) && varTypeIsI(currType))
         {
@@ -3920,7 +3920,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 GenTreeBoundsChk(GT_ARR_BOUNDS_CHECK, TYP_VOID, index, length, SCK_RNGCHK_FAIL);
 
             // Element access
-            GenTree*             indexIntPtr = impImplicitIorI4Cast(indexClone, TYP_I_IMPL);
+            GenTree*             indexIntPtr = impImplicitIorI4Cast(indexClone, TYP_U_IMPL);
             GenTree*             sizeofNode  = gtNewIconNode(elemSize);
             GenTree*             mulNode     = gtNewOperNode(GT_MUL, TYP_I_IMPL, indexIntPtr, sizeofNode);
             CORINFO_FIELD_HANDLE ptrHnd      = info.compCompHnd->getFieldInClass(clsHnd, 0);

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -5726,7 +5726,7 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
         }
         else
         {
-            index = gtNewCastNode(TYP_I_IMPL, index, false, TYP_I_IMPL);
+            index = gtNewCastNode(TYP_I_IMPL, index, true, TYP_U_IMPL);
         }
     }
 #endif // _TARGET_64BIT_


### PR DESCRIPTION
Array bounds check guarantees that the index is non-negative, so there is no need for sign extension.

I tried to get the correct casting, but for the array/string case, I'm only getting half of the gains (`movsxd` replaced with `mov`) and while the `Span` case looks more promising (`movsxd` is eliminated entirely), it's also a bit too eager and does this for non-normalized registers (parameters/function return values), so it's not entirely correct.

@dotnet/jit-contrib What would be the correct solution here?

Code size reduction is up to 15% in some methods and `int.Parse` for example is about 2-4% faster.

Typical diffs look like this:
```diff
        cmp      r10d, 103
        jae      G_M36150_IG23
-       movsxd   rax, r10d
-       mov      r11, 0xD1FFAB1E
-       cmp      byte  ptr [rax+r11], 255
+       mov      rax, 0xD1FFAB1E
+       cmp      byte  ptr [r10+rax], 255

        cmp      eax, dword ptr [rsi+8]
        jae      SHORT G_M26958_IG04
-       movsxd   rax, eax
+       mov      eax, eax
        mov      eax, dword ptr [rsi+4*rax+16]
```