### PR TITLE
Fix warning causing error in warning as error (Windows)

### DIFF
--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -4467,9 +4467,9 @@ void DECLSPEC_NORETURN RaiseDeadLockException()
 //  Returns:
 //    true              If the exception is of a type that is always swallowed.
 //
-bool ExceptionIsAlwaysSwallowed(EXCEPTION_POINTERS *pExceptionInfo)
+BOOL ExceptionIsAlwaysSwallowed(EXCEPTION_POINTERS *pExceptionInfo)
 {
-    bool isSwallowed = false;
+    BOOL isSwallowed = false;
 
     // The exception code must be ours, if it is one of our Exceptions.
     if (IsComPlusException(pExceptionInfo->ExceptionRecord))


### PR DESCRIPTION
Causing local build errors as `IsExceptionOfType` returns `BOOL` not `bool`
```
[C:\GitHub\coreclr\bin\obj\Windows_NT.x64.Release\src\vm\wks\cee_wks.vcxproj]
c:\github\coreclr\src\vm\excep.cpp(4489):
warning C4800: 'BOOL': forcing value to bool 'true' or 'false'
(performance warning)
[C:\GitHub\coreclr\bin\obj\Windows_NT.x64.Release\src\vm\wks\cee_wks.vcxproj]

c:\github\coreclr\src\vm\excep.cpp(4489):
error C2220: warning treated as error - no 'object' file generated
```