### PR TITLE
Add .NET Core version to EventLog

### DIFF
--- a/src/vm/eventreporter.cpp
+++ b/src/vm/eventreporter.cpp
@@ -18,6 +18,8 @@
 #include "typestring.h"
 #include "debugdebugger.h"
 
+#include <configuration.h>
+
 #include "../dlls/mscorrc/resource.h"
 
 #include "getproductversionnumber.h"
@@ -106,7 +108,16 @@ EventReporter::EventReporter(EventReporterType type)
         {
             m_Description.Append(ssMessage);
             m_Description.Append(W("\n"));
-        }        
+        }
+    }
+
+    // Log the .NET Core Version if we can get it
+    LPCWSTR fxProductVersion = Configuration::GetKnobStringValue(W("FX_PRODUCT_VERSION"));
+    if (fxProductVersion != nullptr)
+    {
+        m_Description.Append(W(".NET Core Version: "));
+        m_Description.Append(fxProductVersion);
+        m_Description.Append(W("\n"));
     }
 
     ssMessage.Clear();


### PR DESCRIPTION
Address https://github.com/dotnet/coreclr/issues/21563

Example output:
![eventlogfix](https://user-images.githubusercontent.com/30421794/50103493-94a84780-01dc-11e9-9a57-ee2e3a8b69d2.jpg)
