### PR TITLE
Add tests for marshalling a System.Drawing.Color.

### DIFF
--- a/tests/src/Common/test_dependencies/test_dependencies.csproj
+++ b/tests/src/Common/test_dependencies/test_dependencies.csproj
@@ -25,6 +25,9 @@
     <PackageReference Include="System.Diagnostics.EventLog">
       <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
     </PackageReference>
+    <PackageReference Include="System.Drawing.Common">
+      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
+    </PackageReference>
   </ItemGroup>
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/tests/src/Interop/COM/NETClients/Primitives/ColorTests.cs
+++ b/tests/src/Interop/COM/NETClients/Primitives/ColorTests.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace NetClient
+{
+    using System;
+    using System.Drawing;
+    using System.Runtime.InteropServices;
+    using TestLibrary;
+
+    class ColorTests
+    {
+        private readonly Server.Contract.Servers.ColorTesting server;
+        public ColorTests()
+        {
+            this.server = (Server.Contract.Servers.ColorTesting)new Server.Contract.Servers.ColorTestingClass();
+        }
+
+        public void Run()
+        {
+            this.VerifyColorMarshalling();
+            this.VerifyGetRed();
+        }
+
+        private void VerifyColorMarshalling()
+        {
+            Assert.IsTrue(server.AreColorsEqual(Color.Green, ColorTranslator.ToOle(Color.Green)));
+        }
+
+        private void VerifyGetRed()
+        {
+            Assert.AreEqual(Color.Red, server.GetRed());
+        }
+    }
+}

--- a/tests/src/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
+++ b/tests/src/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
@@ -32,6 +32,7 @@
     <Compile Include="ErrorTests.cs" />
     <Compile Include="NumericTests.cs" />
     <Compile Include="StringTests.cs" />
+    <Compile Include="ColorTests.cs" />
     <Compile Include="../../ServerContracts/NativeServers.cs" />
     <Compile Include="../../ServerContracts/Server.Contracts.cs" />
     <Compile Include="../../ServerContracts/ServerGuids.cs" />
@@ -39,6 +40,9 @@
   <ItemGroup>
     <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
     <ProjectReference Include="../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <PackageReference Include="System.Drawing.Common">
+      <Version>$(MicrosoftPrivateCoreFxNETCoreAppPackageVersion)</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/tests/src/Interop/COM/NETClients/Primitives/Program.cs
+++ b/tests/src/Interop/COM/NETClients/Primitives/Program.cs
@@ -22,6 +22,7 @@ namespace NetClient
                 new ArrayTests().Run();
                 new StringTests().Run();
                 new ErrorTests().Run();
+                new ColorTests().Run();
             }
             catch (Exception e)
             {

--- a/tests/src/Interop/COM/NETServer/ColorTesting.cs
+++ b/tests/src/Interop/COM/NETServer/ColorTesting.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Drawing;
+using System.Runtime.InteropServices;
+
+[ComVisible(true)]
+[Guid(Server.Contract.Guids.ColorTesting)]
+public class ColorTesting : Server.Contract.IColorTesting
+{
+    public bool AreColorsEqual(Color managed, int native) => ColorTranslator.ToOle(managed) == native;
+
+    public Color GetRed() => Color.Red;
+}

--- a/tests/src/Interop/COM/NETServer/NETServer.csproj
+++ b/tests/src/Interop/COM/NETServer/NETServer.csproj
@@ -22,6 +22,7 @@
     <Compile Include="ArrayTesting.cs" />
     <Compile Include="StringTesting.cs" />
     <Compile Include="ErrorMarshalTesting.cs" />
+    <Compile Include="ColorTesting.cs" />
     <Compile Include="../ServerContracts/Server.Contracts.cs" />
     <Compile Include="../ServerContracts/ServerGuids.cs" />
   </ItemGroup>

--- a/tests/src/Interop/COM/NativeClients/Primitives/CMakeLists.txt
+++ b/tests/src/Interop/COM/NativeClients/Primitives/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCES
     ArrayTests.cpp
     StringTests.cpp
     ErrorTests.cpp
+    ColorTests.cpp
     App.manifest)
 
 # add the executable

--- a/tests/src/Interop/COM/NativeClients/Primitives/Client.cpp
+++ b/tests/src/Interop/COM/NativeClients/Primitives/Client.cpp
@@ -34,6 +34,7 @@ int __cdecl main()
         Run_ArrayTests();
         Run_StringTests();
         Run_ErrorTests();
+        Run_ColorTests();
     }
     catch (HRESULT hr)
     {

--- a/tests/src/Interop/COM/NativeClients/Primitives/ClientTests.h
+++ b/tests/src/Interop/COM/NativeClients/Primitives/ClientTests.h
@@ -68,3 +68,4 @@ void Run_NumericTests();
 void Run_ArrayTests();
 void Run_StringTests();
 void Run_ErrorTests();
+void Run_ColorTests();

--- a/tests/src/Interop/COM/NativeClients/Primitives/ColorTests.cpp
+++ b/tests/src/Interop/COM/NativeClients/Primitives/ColorTests.cpp
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "ClientTests.h"
+
+#define RED RGB(0xFF, 0x00, 0x00)
+#define GREEN RGB(0x00, 0xFF, 0x00)
+
+namespace
+{
+    void VerifyColorMarshalling(IColorTesting* color)
+    {
+        HRESULT hr;
+        BOOL match;
+
+        THROW_IF_FAILED(color->AreColorsEqual(GREEN, GREEN, &match));
+
+        THROW_FAIL_IF_FALSE(match);
+    }
+
+    void VerifyGetRed(IColorTesting* color)
+    {
+        HRESULT hr;
+        OLE_COLOR red;
+        
+        THROW_IF_FAILED(color->GetRed(&red));
+        
+        THROW_FAIL_IF_FALSE(red == RED);
+    }
+}
+
+void Run_ColorTests()
+{
+    HRESULT hr;
+
+    CoreShimComActivation csact{ W("NETServer.dll"), W("ColorTesting") };
+
+    ComSmartPtr<IColorTesting> color;
+    THROW_IF_FAILED(::CoCreateInstance(CLSID_ColorTesting, nullptr, CLSCTX_INPROC, IID_IColorTesting, (void**)&color));
+
+    VerifyColorMarshalling(color);
+    VerifyGetRed(color);
+}

--- a/tests/src/Interop/COM/NativeClients/Primitives/CoreShim.X.manifest
+++ b/tests/src/Interop/COM/NativeClients/Primitives/CoreShim.X.manifest
@@ -23,6 +23,10 @@
   <comClass
     clsid="{71CF5C45-106C-4B32-B418-43A463C6041F}"
     threadingModel="Both" />
+  <!-- ColorTesting -->
+  <comClass
+    clsid="{C222F472-DA5A-4FC6-9321-92F4F7053A65}"
+    threadingModel="Both" />
 </file>
 
 </assembly>

--- a/tests/src/Interop/COM/NativeServer/COMNativeServer.X.manifest
+++ b/tests/src/Interop/COM/NativeServer/COMNativeServer.X.manifest
@@ -36,6 +36,11 @@
   <comClass
     clsid="{4CEFE36D-F377-4B6E-8C34-819A8BB9CB04}"
     threadingModel="Both" />
+
+  <!-- ColorTesting -->
+  <comClass
+    clsid="{C222F472-DA5A-4FC6-9321-92F4F7053A65}"
+    threadingModel="Both" />
 </file>
 
 </assembly>

--- a/tests/src/Interop/COM/NativeServer/ColorTesting.h
+++ b/tests/src/Interop/COM/NativeServer/ColorTesting.h
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include "Servers.h"
+
+#define RED RGB(0xFF, 0x00, 0x00)
+
+class ColorTesting : public UnknownImpl, public IColorTesting
+{
+public: // IColorTesting
+    DEF_FUNC(AreColorsEqual)(
+        _In_ OLE_COLOR managed,
+        _In_ OLE_COLOR native,
+        _Out_ BOOL* areEqual
+    )
+    {
+        *areEqual = (managed == native ? TRUE : FALSE);
+        return S_OK;
+    }
+
+    DEF_FUNC(GetRed)(
+        _Out_ OLE_COLOR* color
+    )
+    {
+        *color = RED;
+        return S_OK;
+    }
+
+public: // IUnknown
+    STDMETHOD(QueryInterface)(
+        /* [in] */ REFIID riid,
+        /* [iid_is][out] */ _COM_Outptr_ void __RPC_FAR *__RPC_FAR *ppvObject)
+    {
+        return DoQueryInterface<ColorTesting, IColorTesting>(this, riid, ppvObject);
+    }
+
+    DEFINE_REF_COUNTING();
+};

--- a/tests/src/Interop/COM/NativeServer/Servers.cpp
+++ b/tests/src/Interop/COM/NativeServer/Servers.cpp
@@ -166,6 +166,7 @@ STDAPI DllRegisterServer(void)
     RETURN_IF_FAILED(RegisterClsid(__uuidof(ErrorMarshalTesting), L"Both"));
     RETURN_IF_FAILED(RegisterClsid(__uuidof(DispatchTesting), L"Both"));
     RETURN_IF_FAILED(RegisterClsid(__uuidof(AggregationTesting), L"Both"));
+    RETURN_IF_FAILED(RegisterClsid(__uuidof(ColorTesting), L"Both"));
 
     return S_OK;
 }
@@ -180,6 +181,7 @@ STDAPI DllUnregisterServer(void)
     RETURN_IF_FAILED(RemoveClsid(__uuidof(ErrorMarshalTesting)));
     RETURN_IF_FAILED(RemoveClsid(__uuidof(DispatchTesting)));
     RETURN_IF_FAILED(RemoveClsid(__uuidof(AggregationTesting)));
+    RETURN_IF_FAILED(RemoveClsid(__uuidof(ColorTesting)));
 
     return S_OK;
 }
@@ -203,6 +205,9 @@ STDAPI DllGetClassObject(_In_ REFCLSID rclsid, _In_ REFIID riid, _Out_ LPVOID FA
 
     if (rclsid == __uuidof(AggregationTesting))
         return ClassFactoryAggregate<AggregationTesting>::Create(riid, ppv);
+
+    if (rclsid == __uuidof(ColorTesting))
+        return ClassFactoryBasic<ColorTesting>::Create(riid, ppv);
 
     return CLASS_E_CLASSNOTAVAILABLE;
 }

--- a/tests/src/Interop/COM/NativeServer/Servers.h
+++ b/tests/src/Interop/COM/NativeServer/Servers.h
@@ -16,6 +16,7 @@ class DECLSPEC_UUID("C73C83E8-51A2-47F8-9B5C-4284458E47A6") StringTesting;
 class DECLSPEC_UUID("71CF5C45-106C-4B32-B418-43A463C6041F") ErrorMarshalTesting;
 class DECLSPEC_UUID("0F8ACD0C-ECE0-4F2A-BD1B-6BFCA93A0726") DispatchTesting;
 class DECLSPEC_UUID("4CEFE36D-F377-4B6E-8C34-819A8BB9CB04") AggregationTesting;
+class DECLSPEC_UUID("C222F472-DA5A-4FC6-9321-92F4F7053A65") ColorTesting;
 
 #define CLSID_NumericTesting __uuidof(NumericTesting)
 #define CLSID_ArrayTesting __uuidof(ArrayTesting)
@@ -23,6 +24,7 @@ class DECLSPEC_UUID("4CEFE36D-F377-4B6E-8C34-819A8BB9CB04") AggregationTesting;
 #define CLSID_ErrorMarshalTesting __uuidof(ErrorMarshalTesting)
 #define CLSID_DispatchTesting __uuidof(DispatchTesting)
 #define CLSID_AggregationTesting __uuidof(AggregationTesting)
+#define CLSID_ColorTesting __uuidof(ColorTesting)
 
 #define IID_INumericTesting __uuidof(INumericTesting)
 #define IID_IArrayTesting __uuidof(IArrayTesting)
@@ -30,6 +32,7 @@ class DECLSPEC_UUID("4CEFE36D-F377-4B6E-8C34-819A8BB9CB04") AggregationTesting;
 #define IID_IErrorMarshalTesting __uuidof(IErrorMarshalTesting)
 #define IID_IDispatchTesting __uuidof(IDispatchTesting)
 #define IID_IAggregationTesting __uuidof(IAggregationTesting)
+#define IID_IColorTesting __uuidof(IColorTesting)
 
 // Class used for COM activation when using CoreShim
 struct CoreShimComActivation
@@ -65,4 +68,5 @@ private:
     #include "ErrorMarshalTesting.h"
     #include "DispatchTesting.h"
     #include "AggregationTesting.h"
+    #include "ColorTesting.h"
 #endif

--- a/tests/src/Interop/COM/ServerContracts/NativeServers.cs
+++ b/tests/src/Interop/COM/ServerContracts/NativeServers.cs
@@ -122,6 +122,25 @@ namespace Server.Contract.Servers
     internal class AggregationTestingClass
     {
     }
+
+    /// <summary>
+    /// Managed definition of CoClass 
+    /// </summary>
+    [ComImport]
+    [CoClass(typeof(ColorTestingClass))]
+    [Guid("E6D72BA7-0936-4396-8A69-3B76DA1108DA")]
+    internal interface ColorTesting : Server.Contract.IColorTesting
+    {
+    }
+
+    /// <summary>
+    /// Managed activation for CoClass
+    /// </summary>
+    [ComImport]
+    [Guid(Server.Contract.Guids.ColorTesting)]
+    internal class ColorTestingClass
+    {
+    }
 }
 
 #pragma warning restore IDE1006 // Naming Styles

--- a/tests/src/Interop/COM/ServerContracts/Server.Contracts.cs
+++ b/tests/src/Interop/COM/ServerContracts/Server.Contracts.cs
@@ -7,6 +7,7 @@
 namespace Server.Contract
 {
     using System;
+    using System.Drawing;
     using System.Runtime.InteropServices;
     using System.Text;
 
@@ -245,6 +246,15 @@ namespace Server.Contract
         [return: MarshalAs(UnmanagedType.VariantBool)]
         bool AreAggregated([MarshalAs(UnmanagedType.IUnknown)] object aggregateMaybe1, [MarshalAs(UnmanagedType.IUnknown)] object aggregateMaybe2);
     };
+
+    [ComVisible(true)]
+    [Guid("E6D72BA7-0936-4396-8A69-3B76DA1108DA")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IColorTesting
+    {
+        bool AreColorsEqual(Color managed, int native);
+        Color GetRed();
+    }
 }
 
 #pragma warning restore 618 // Must test deprecated features

--- a/tests/src/Interop/COM/ServerContracts/Server.Contracts.h
+++ b/tests/src/Interop/COM/ServerContracts/Server.Contracts.h
@@ -21,6 +21,8 @@ struct __declspec(uuid("a5e04c1c-474e-46d2-bbc0-769d04e12b54"))
 /* interface */ IDispatchTesting;
 struct __declspec(uuid("98cc27f0-d521-4f79-8b63-e980e3a92974"))
 /* interface */ IAggregationTesting;
+struct __declspec(uuid("E6D72BA7-0936-4396-8A69-3B76DA1108DA"))
+/* interface */ IColorTesting;
 
 //
 // Smart pointer typedef declarations
@@ -32,6 +34,7 @@ _COM_SMARTPTR_TYPEDEF(IStringTesting, __uuidof(IStringTesting));
 _COM_SMARTPTR_TYPEDEF(IErrorMarshalTesting, __uuidof(IErrorMarshalTesting));
 _COM_SMARTPTR_TYPEDEF(IDispatchTesting, __uuidof(IDispatchTesting));
 _COM_SMARTPTR_TYPEDEF(IAggregationTesting, __uuidof(IAggregationTesting));
+_COM_SMARTPTR_TYPEDEF(IColorTesting, __uuidof(IColorTesting));
 
 //
 // Type library items
@@ -453,6 +456,18 @@ IAggregationTesting : IUnknown
         _In_ IUnknown *aggregateMaybe1,
         _In_ IUnknown *aggregateMaybe2,
         _Out_ VARIANT_BOOL *areAggregated) = 0;
+};
+
+struct __declspec(uuid("E6D72BA7-0936-4396-8A69-3B76DA1108DA"))
+IColorTesting : public IUnknown
+{
+    virtual HRESULT STDMETHODCALLTYPE AreColorsEqual(
+        _In_ OLE_COLOR managed,
+        _In_ OLE_COLOR native,
+        _Out_ _Ret_ BOOL* areEqual) = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE GetRed(
+        _Out_ _Ret_ OLE_COLOR* color) = 0;
 };
 
 #pragma pack(pop)

--- a/tests/src/Interop/COM/ServerContracts/ServerGuids.cs
+++ b/tests/src/Interop/COM/ServerContracts/ServerGuids.cs
@@ -15,5 +15,6 @@ namespace Server.Contract
         public const string ErrorMarshalTesting = "71CF5C45-106C-4B32-B418-43A463C6041F";
         public const string DispatchTesting = "0F8ACD0C-ECE0-4F2A-BD1B-6BFCA93A0726";
         public const string AggregationTesting = "4CEFE36D-F377-4B6E-8C34-819A8BB9CB04";
+        public const string ColorTesting = "C222F472-DA5A-4FC6-9321-92F4F7053A65";
     }
 }


### PR DESCRIPTION
Add tests for marshalling a `System.Drawing.Color` object to an `OLE_COLOR` value in COM marshalling scenarios.