### PR TITLE
[WIP] NO-MERGE Test re-enabling Windows arm64 corefx tests

### DIFF
--- a/tests/arm64/corefx_test_exclusions.txt
+++ b/tests/arm64/corefx_test_exclusions.txt
@@ -1,13 +1,5 @@
-Invariant.Tests
 System.ComponentModel.Composition.Tests                 # https://github.com/dotnet/coreclr/issues/18913
 System.Diagnostics.Process.Tests                        # https://github.com/dotnet/coreclr/issues/16001
-System.Drawing.Common.Tests                             # https://github.com/dotnet/coreclr/issues/18886
-System.Linq.Expressions.Tests                           # JitStress=1 JitStress=2 https://github.com/dotnet/coreclr/issues/18886
-System.Management.Tests                                 # https://github.com/dotnet/coreclr/issues/18886
 System.Net.HttpListener.Tests                           # https://github.com/dotnet/coreclr/issues/17584
-System.Numerics.Vectors.Tests                           # https://github.com/dotnet/coreclr/issues/18886
-System.Runtime.InteropServices.RuntimeInformation.Tests # VM assert -- https://github.com/dotnet/coreclr/issues/18886
-System.Runtime.Serialization.Formatters.Tests           # long running? https://github.com/dotnet/coreclr/issues/18886
 System.Runtime.Tests                                    # https://github.com/dotnet/coreclr/issues/18914
 System.Text.RegularExpressions.Tests                    # https://github.com/dotnet/coreclr/issues/18912 -- timeout -- JitMinOpts only
-System.ValueTuple.Tests


### PR DESCRIPTION
The ones that haven't been investigated, and don't have
individual issues. See if any pass. Note that these are not
disabled for Linux/arm64.