### PR TITLE
Add build timeout

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,6 +110,11 @@ jobs:
   parameters:
     jobTemplate: build-job.yml
     buildConfig: release
+    jobParameters:
+      # Publishing packages to blob feeds sometimes takes a long time
+      # due to waiting for an exclusive lock on the feed.
+      # See https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/AsyncPublishing.md
+      timeoutInMinutes: 120
 
 #
 # Checked test builds

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -5,6 +5,7 @@ parameters:
   osIdentifier: ''
   containerName: ''
   crossrootfsDir: ''
+  timeoutInMinutes: ''
 
 ### Product build
 jobs:
@@ -23,6 +24,9 @@ jobs:
     # Run all steps in the container.
     # Note that the containers are resources defined in azure-pipelines.yml
     containerName: ${{ parameters.containerName }}
+
+    timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+
     crossrootfsDir: ${{ parameters.crossrootfsDir }}
 
     gatherAssetManifests: true


### PR DESCRIPTION
This should fix official build failures that are timing out because
the jobs are waiting to obtain an exclusive lock on the blob
feed.