### PR TITLE
Replace more of JitHelpers with S.R.CS.Unsafe

### DIFF
--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/FrameworkEventSource.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/FrameworkEventSource.cs
@@ -15,6 +15,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Text;
 using System.Runtime.CompilerServices;
+using Internal.Runtime.CompilerServices;
 
 namespace System.Diagnostics.Tracing
 {
@@ -572,7 +573,7 @@ namespace System.Diagnostics.Tracing
         public unsafe void ThreadPoolEnqueueWorkObject(object workID)
         {
             // convert the Object Id to a long
-            ThreadPoolEnqueueWork((long)*((void**)JitHelpers.UnsafeCastToStackPointer(ref workID)));
+            ThreadPoolEnqueueWork((long)*((void**)Unsafe.AsPointer(ref workID)));
         }
 
         [Event(31, Level = EventLevel.Verbose, Keywords = Keywords.ThreadPool | Keywords.ThreadTransfer)]
@@ -588,7 +589,7 @@ namespace System.Diagnostics.Tracing
         public unsafe void ThreadPoolDequeueWorkObject(object workID)
         {
             // convert the Object Id to a long
-            ThreadPoolDequeueWork((long)*((void**)JitHelpers.UnsafeCastToStackPointer(ref workID)));
+            ThreadPoolDequeueWork((long)*((void**)Unsafe.AsPointer(ref workID)));
         }
 
         // In the desktop runtime they don't use Tasks for the point at which the response happens, which means that the
@@ -686,7 +687,7 @@ namespace System.Diagnostics.Tracing
 #endif // !CORECLR
         public unsafe void ThreadTransferSendObj(object id, int kind, string info, bool multiDequeues, int intInfo1, int intInfo2)
         {
-            ThreadTransferSend((long)*((void**)JitHelpers.UnsafeCastToStackPointer(ref id)), kind, info, multiDequeues, intInfo1, intInfo2);
+            ThreadTransferSend((long)*((void**)Unsafe.AsPointer(ref id)), kind, info, multiDequeues, intInfo1, intInfo2);
         }
 
         // id -   represents a correlation ID that allows correlation of two activities, one stamped by 
@@ -711,7 +712,7 @@ namespace System.Diagnostics.Tracing
 #endif // !CORECLR
         public unsafe void ThreadTransferReceiveObj(object id, int kind, string info)
         {
-            ThreadTransferReceive((long)*((void**)JitHelpers.UnsafeCastToStackPointer(ref id)), kind, info);
+            ThreadTransferReceive((long)*((void**)Unsafe.AsPointer(ref id)), kind, info);
         }
 
         // id -   represents a correlation ID that allows correlation of two activities, one stamped by 
@@ -736,7 +737,7 @@ namespace System.Diagnostics.Tracing
 #endif // !CORECLR
         public unsafe void ThreadTransferReceiveHandledObj(object id, int kind, string info)
         {
-            ThreadTransferReceive((long)*((void**)JitHelpers.UnsafeCastToStackPointer(ref id)), kind, info);
+            ThreadTransferReceive((long)*((void**)Unsafe.AsPointer(ref id)), kind, info);
         }
 
         // return a stable ID for a an object.  We use the hash code which is not truely unique but is 

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/CLRIPropertyValueImpl.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/CLRIPropertyValueImpl.cs
@@ -9,6 +9,8 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Security;
 
+using Internal.Runtime.CompilerServices;
+
 namespace System.Runtime.InteropServices.WindowsRuntime
 {
     internal class CLRIPropertyValueImpl : IPropertyValue
@@ -492,7 +494,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
             fixed (byte* pData = &_data.GetRawData())
             {
-                byte* pUnboxed = (byte*)JitHelpers.UnsafeCastToStackPointer(ref unboxed);
+                byte* pUnboxed = (byte*)Unsafe.AsPointer(ref unboxed);
                 Buffer.Memcpy(pUnboxed, pData, Marshal.SizeOf(unboxed));
             }
 

--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/TPLETWProvider.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/TPLETWProvider.cs
@@ -15,8 +15,9 @@ using System.Collections.Generic;
 using System.Text;
 using System.Security;
 using System.Runtime.CompilerServices;
-
 using System.Diagnostics.Tracing;
+
+using Internal.Runtime.CompilerServices;
 
 namespace System.Threading.Tasks
 {
@@ -514,7 +515,7 @@ namespace System.Threading.Tasks
         }
 
         [NonEvent]
-        public unsafe void RunningContinuation(int TaskID, object Object) { RunningContinuation(TaskID, (long)*((void**)JitHelpers.UnsafeCastToStackPointer(ref Object))); }
+        public unsafe void RunningContinuation(int TaskID, object Object) { RunningContinuation(TaskID, (long)*((void**)Unsafe.AsPointer(ref Object))); }
         [Event(20, Keywords = Keywords.Debug)]
         private void RunningContinuation(int TaskID, long Object)
         {
@@ -523,7 +524,7 @@ namespace System.Threading.Tasks
         }
 
         [NonEvent]
-        public unsafe void RunningContinuationList(int TaskID, int Index, object Object) { RunningContinuationList(TaskID, Index, (long)*((void**)JitHelpers.UnsafeCastToStackPointer(ref Object))); }
+        public unsafe void RunningContinuationList(int TaskID, int Index, object Object) { RunningContinuationList(TaskID, Index, (long)*((void**)Unsafe.AsPointer(ref Object))); }
 
         [Event(21, Keywords = Keywords.Debug)]
         public void RunningContinuationList(int TaskID, int Index, long Object)

--- a/src/vm/array.cpp
+++ b/src/vm/array.cpp
@@ -781,7 +781,7 @@ public:
         DWORD dwFactorLocalNum = NewLocal(ELEMENT_TYPE_I4);
         DWORD dwLengthLocalNum = NewLocal(ELEMENT_TYPE_I4);
 
-        mdToken tokPinningHelper = GetToken(MscorlibBinder::GetField(FIELD__PINNING_HELPER__M_DATA));
+        mdToken tokRawData = GetToken(MscorlibBinder::GetField(FIELD__RAW_DATA__DATA));
 
         ILCodeLabel * pRangeExceptionLabel = NewCodeLabel();
         ILCodeLabel * pRangeExceptionLabel1 = NewCodeLabel();
@@ -817,13 +817,13 @@ public:
                 m_pCode->EmitBRFALSE(pTypeCheckOK); //Storing NULL is OK
                 
                 m_pCode->EmitLDARG(rank); // return param
-                m_pCode->EmitLDFLDA(tokPinningHelper);
+                m_pCode->EmitLDFLDA(tokRawData);
                 m_pCode->EmitLDC(Object::GetOffsetOfFirstField());
                 m_pCode->EmitSUB();
                 m_pCode->EmitLDIND_I(); // TypeHandle
 
                 m_pCode->EmitLoadThis();
-                m_pCode->EmitLDFLDA(tokPinningHelper);
+                m_pCode->EmitLDFLDA(tokRawData);
                 m_pCode->EmitLDC(Object::GetOffsetOfFirstField());
                 m_pCode->EmitSUB();
                 m_pCode->EmitLDIND_I(); // Array MT
@@ -851,13 +851,13 @@ public:
                 m_pCode->EmitLDARG(hiddenArgIdx); // hidden param
                 m_pCode->EmitBRFALSE(pTypeCheckPassed);
                 m_pCode->EmitLDARG(hiddenArgIdx);
-                m_pCode->EmitLDFLDA(tokPinningHelper);          
+                m_pCode->EmitLDFLDA(tokRawData);          
                 m_pCode->EmitLDC(offsetof(ParamTypeDesc, m_Arg) - (Object::GetOffsetOfFirstField()+2));
                 m_pCode->EmitADD();
                 m_pCode->EmitLDIND_I();
                 
                 m_pCode->EmitLoadThis();
-                m_pCode->EmitLDFLDA(tokPinningHelper);
+                m_pCode->EmitLDFLDA(tokRawData);
                 m_pCode->EmitLDC(Object::GetOffsetOfFirstField());
                 m_pCode->EmitSUB();
                 m_pCode->EmitLDIND_I(); // Array MT
@@ -875,7 +875,7 @@ public:
         {
             // check if the array is SZArray.
             m_pCode->EmitLoadThis();
-            m_pCode->EmitLDFLDA(tokPinningHelper);
+            m_pCode->EmitLDFLDA(tokRawData);
             m_pCode->EmitLDC(Object::GetOffsetOfFirstField());
             m_pCode->EmitSUB();
             m_pCode->EmitLDIND_I();
@@ -889,7 +889,7 @@ public:
             // it is SZArray
             // bounds check
             m_pCode->EmitLoadThis();
-            m_pCode->EmitLDFLDA(tokPinningHelper);
+            m_pCode->EmitLDFLDA(tokRawData);
             m_pCode->EmitLDC(ArrayBase::GetOffsetOfNumComponents() - Object::GetOffsetOfFirstField());
             m_pCode->EmitADD();
             m_pCode->EmitLDIND_I4();
@@ -897,7 +897,7 @@ public:
             m_pCode->EmitBLE_UN(pRangeExceptionLabel);
 
             m_pCode->EmitLoadThis();
-            m_pCode->EmitLDFLDA(tokPinningHelper);
+            m_pCode->EmitLDFLDA(tokRawData);
             m_pCode->EmitLDC(ArrayBase::GetBoundsOffset(pMT) - Object::GetOffsetOfFirstField());
             m_pCode->EmitADD();
             m_pCode->EmitLDARG(firstIdx);          
@@ -909,7 +909,7 @@ public:
         {
             // Cache length
             m_pCode->EmitLoadThis();
-            m_pCode->EmitLDFLDA(tokPinningHelper);
+            m_pCode->EmitLDFLDA(tokRawData);
             m_pCode->EmitLDC((ArrayBase::GetBoundsOffset(pMT) - Object::GetOffsetOfFirstField()) + (idx-firstIdx)*sizeof(DWORD));
             m_pCode->EmitADD();
             m_pCode->EmitLDIND_I4();
@@ -922,7 +922,7 @@ public:
             {
                 // Load lower bound
                 m_pCode->EmitLoadThis();
-                m_pCode->EmitLDFLDA(tokPinningHelper);
+                m_pCode->EmitLDFLDA(tokRawData);
                 m_pCode->EmitLDC((ArrayBase::GetLowerBoundsOffset(pMT) - Object::GetOffsetOfFirstField()) + (idx-firstIdx)*sizeof(DWORD));
                 m_pCode->EmitADD();
                 m_pCode->EmitLDIND_I4();
@@ -961,7 +961,7 @@ public:
 
         // Compute element address
         m_pCode->EmitLoadThis();
-        m_pCode->EmitLDFLDA(tokPinningHelper);
+        m_pCode->EmitLDFLDA(tokRawData);
         m_pCode->EmitLDC(ArrayBase::GetDataPtrOffset(pMT) - Object::GetOffsetOfFirstField());
         m_pCode->EmitADD();
         m_pCode->EmitLDLOC(dwTotalLocalNum);

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -222,9 +222,6 @@ FCFuncEnd()
 
 FCFuncStart(gJitHelpers)
     FCFuncElement("UnsafeSetArrayElement", JitHelpers::UnsafeSetArrayElement)
-#ifdef _DEBUG
-    FCFuncElement("IsAddressInStack", ReflectionInvocation::IsAddressInStack)
-#endif
 FCFuncEnd()
 
 FCFuncStart(gCOMTypeHandleFuncs)

--- a/src/vm/ilmarshalers.cpp
+++ b/src/vm/ilmarshalers.cpp
@@ -2448,7 +2448,7 @@ void ILBlittablePtrMarshaler::EmitConvertContentsCLRToNative(ILCodeStream* pslIL
 
     ILCodeLabel* pNullRefLabel = pslILEmit->NewCodeLabel();
     UINT uNativeSize = m_pargs->m_pMT->GetNativeSize();
-    int fieldDef = pslILEmit->GetToken(MscorlibBinder::GetField(FIELD__PINNING_HELPER__M_DATA));
+    int fieldDef = pslILEmit->GetToken(MscorlibBinder::GetField(FIELD__RAW_DATA__DATA));
 
     EmitLoadNativeValue(pslILEmit);
     pslILEmit->EmitBRFALSE(pNullRefLabel);
@@ -2470,7 +2470,7 @@ void ILBlittablePtrMarshaler::EmitConvertContentsNativeToCLR(ILCodeStream* pslIL
     
     ILCodeLabel* pNullRefLabel = pslILEmit->NewCodeLabel();
     UINT uNativeSize = m_pargs->m_pMT->GetNativeSize();
-    int fieldDef = pslILEmit->GetToken(MscorlibBinder::GetField(FIELD__PINNING_HELPER__M_DATA));
+    int fieldDef = pslILEmit->GetToken(MscorlibBinder::GetField(FIELD__RAW_DATA__DATA));
     
     EmitLoadManagedValue(pslILEmit);
     pslILEmit->EmitBRFALSE(pNullRefLabel);

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -12506,8 +12506,8 @@ CorJitResult CallCompileMethodWithSEHWrapper(EEJitManager *jitMgr,
         flags.Set(CORJIT_FLAGS::CORJIT_FLAG_FRAMED);
     if (g_pConfig->JitAlignLoops())
         flags.Set(CORJIT_FLAGS::CORJIT_FLAG_ALIGN_LOOPS);
-//    if (ftn->IsVersionableWithJumpStamp() || g_pConfig->AddRejitNops())
-//        flags.Set(CORJIT_FLAGS::CORJIT_FLAG_PROF_REJIT_NOPS);
+    if (ftn->IsVersionableWithJumpStamp() || g_pConfig->AddRejitNops())
+        flags.Set(CORJIT_FLAGS::CORJIT_FLAG_PROF_REJIT_NOPS);
 #ifdef _TARGET_X86_
     if (g_pConfig->PInvokeRestoreEsp(ftn->GetModule()->IsPreV4Assembly()))
         flags.Set(CORJIT_FLAGS::CORJIT_FLAG_PINVOKE_RESTORE_ESP);

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -6973,18 +6973,7 @@ bool getILIntrinsicImplementation(MethodDesc * ftn,
     // Compare tokens to cover all generic instantiations
     // The body of the first method is simply ret Arg0. The second one first casts the arg to I4.
 
-    if (tk == MscorlibBinder::GetMethod(METHOD__JIT_HELPERS__UNSAFE_CAST_TO_STACKPTR)->GetMemberDef())
-    {
-        // Return the argument that was passed in converted to IntPtr
-        static const BYTE ilcode[] = { CEE_LDARG_0, CEE_CONV_I, CEE_RET };
-        methInfo->ILCode = const_cast<BYTE*>(ilcode);
-        methInfo->ILCodeSize = sizeof(ilcode);
-        methInfo->maxStack = 1;
-        methInfo->EHcount = 0;
-        methInfo->options = (CorInfoOptions)0;
-        return true;
-    }
-    else if (tk == MscorlibBinder::GetMethod(METHOD__JIT_HELPERS__UNSAFE_ENUM_CAST)->GetMemberDef()) 
+    if (tk == MscorlibBinder::GetMethod(METHOD__JIT_HELPERS__UNSAFE_ENUM_CAST)->GetMemberDef()) 
     {
         // Normally we would follow the above pattern and unconditionally replace the IL,
         // relying on generic type constraints to guarantee that it will only ever be instantiated
@@ -7048,16 +7037,16 @@ bool getILIntrinsicImplementation(MethodDesc * ftn,
     }
     else if (tk == MscorlibBinder::GetMethod(METHOD__JIT_HELPERS__GET_RAW_SZ_ARRAY_DATA)->GetMemberDef())
     {
-        mdToken tokArrayPinningHelper = MscorlibBinder::GetField(FIELD__ARRAY_PINNING_HELPER__M_ARRAY_DATA)->GetMemberDef();
+        mdToken tokRawSzArrayData = MscorlibBinder::GetField(FIELD__RAW_SZARRAY_DATA__DATA)->GetMemberDef();
 
         static BYTE ilcode[] = { CEE_LDARG_0,
                                  CEE_LDFLDA,0,0,0,0,
                                  CEE_RET };
 
-        ilcode[2] = (BYTE)(tokArrayPinningHelper);
-        ilcode[3] = (BYTE)(tokArrayPinningHelper >> 8);
-        ilcode[4] = (BYTE)(tokArrayPinningHelper >> 16);
-        ilcode[5] = (BYTE)(tokArrayPinningHelper >> 24);
+        ilcode[2] = (BYTE)(tokRawSzArrayData);
+        ilcode[3] = (BYTE)(tokRawSzArrayData >> 8);
+        ilcode[4] = (BYTE)(tokRawSzArrayData >> 16);
+        ilcode[5] = (BYTE)(tokRawSzArrayData >> 24);
 
         methInfo->ILCode = const_cast<BYTE*>(ilcode);
         methInfo->ILCodeSize = sizeof(ilcode);
@@ -12517,8 +12506,8 @@ CorJitResult CallCompileMethodWithSEHWrapper(EEJitManager *jitMgr,
         flags.Set(CORJIT_FLAGS::CORJIT_FLAG_FRAMED);
     if (g_pConfig->JitAlignLoops())
         flags.Set(CORJIT_FLAGS::CORJIT_FLAG_ALIGN_LOOPS);
-    if (ftn->IsVersionableWithJumpStamp() || g_pConfig->AddRejitNops())
-        flags.Set(CORJIT_FLAGS::CORJIT_FLAG_PROF_REJIT_NOPS);
+//    if (ftn->IsVersionableWithJumpStamp() || g_pConfig->AddRejitNops())
+//        flags.Set(CORJIT_FLAGS::CORJIT_FLAG_PROF_REJIT_NOPS);
 #ifdef _TARGET_X86_
     if (g_pConfig->PInvokeRestoreEsp(ftn->GetModule()->IsPreV4Assembly()))
         flags.Set(CORJIT_FLAGS::CORJIT_FLAG_PINVOKE_RESTORE_ESP);

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -717,6 +717,7 @@ DEFINE_CLASS(RAW_DATA,              CompilerServices,       RawData)
 DEFINE_FIELD(RAW_DATA,              DATA,                   Data)
 
 DEFINE_CLASS(RAW_SZARRAY_DATA,      CompilerServices,       RawSzArrayData)
+DEFINE_FIELD(RAW_SZARRAY_DATA,      COUNT,                  Count)
 DEFINE_FIELD(RAW_SZARRAY_DATA,      DATA,                   Data)
 
 DEFINE_CLASS(RUNTIME_WRAPPED_EXCEPTION, CompilerServices,   RuntimeWrappedException)

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -682,11 +682,9 @@ DEFINE_CLASS(JIT_HELPERS,           CompilerServices,       JitHelpers)
 #ifdef _DEBUG
 DEFINE_METHOD(JIT_HELPERS,          UNSAFE_ENUM_CAST,       UnsafeEnumCastInternal, NoSig)
 DEFINE_METHOD(JIT_HELPERS,          UNSAFE_ENUM_CAST_LONG,  UnsafeEnumCastLongInternal, NoSig)
-DEFINE_METHOD(JIT_HELPERS,          UNSAFE_CAST_TO_STACKPTR,UnsafeCastToStackPointerInternal, NoSig)
 #else // _DEBUG
 DEFINE_METHOD(JIT_HELPERS,          UNSAFE_ENUM_CAST,       UnsafeEnumCast, NoSig)
 DEFINE_METHOD(JIT_HELPERS,          UNSAFE_ENUM_CAST_LONG,  UnsafeEnumCastLong, NoSig)
-DEFINE_METHOD(JIT_HELPERS,          UNSAFE_CAST_TO_STACKPTR,UnsafeCastToStackPointer, NoSig)
 #endif // _DEBUG
 DEFINE_METHOD(JIT_HELPERS,          GET_RAW_SZ_ARRAY_DATA,  GetRawSzArrayData, NoSig)
 
@@ -715,12 +713,11 @@ DEFINE_CLASS(INTERLOCKED,           Threading,              Interlocked)
 DEFINE_METHOD(INTERLOCKED,          COMPARE_EXCHANGE_T,     CompareExchange, GM_RefT_T_T_RetT)
 DEFINE_METHOD(INTERLOCKED,          COMPARE_EXCHANGE_OBJECT,CompareExchange, SM_RefObject_Object_Object_RetObject)
 
-DEFINE_CLASS(PINNING_HELPER,        CompilerServices,       PinningHelper)
-DEFINE_FIELD(PINNING_HELPER,        M_DATA,                 m_data)
+DEFINE_CLASS(RAW_DATA,              CompilerServices,       RawData)
+DEFINE_FIELD(RAW_DATA,              DATA,                   Data)
 
-DEFINE_CLASS(ARRAY_PINNING_HELPER,  CompilerServices,                     ArrayPinningHelper)
-DEFINE_FIELD(ARRAY_PINNING_HELPER,  M_ARRAY_DATA,                         m_arrayData)
-DEFINE_FIELD(ARRAY_PINNING_HELPER,  M_ARRAY_LENGTH_AND_PADDING,           m_lengthAndPadding)
+DEFINE_CLASS(RAW_SZARRAY_DATA,      CompilerServices,       RawSzArrayData)
+DEFINE_FIELD(RAW_SZARRAY_DATA,      DATA,                   Data)
 
 DEFINE_CLASS(RUNTIME_WRAPPED_EXCEPTION, CompilerServices,   RuntimeWrappedException)
 DEFINE_METHOD(RUNTIME_WRAPPED_EXCEPTION, OBJ_CTOR,          .ctor,                      IM_Obj_RetVoid)

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -1206,13 +1206,13 @@ Stub * CreateUnboxingILStubForSharedGenericValueTypeMethods(MethodDesc* pTargetM
     CreateInstantiatingILStubTargetSig(pTargetMD, typeContext, &stubSigBuilder);
 
     // 2. Emit the method body
-    mdToken tokPinningHelper = pCode->GetToken(MscorlibBinder::GetField(FIELD__PINNING_HELPER__M_DATA));
+    mdToken tokRawData = pCode->GetToken(MscorlibBinder::GetField(FIELD__RAW_DATA__DATA));
 
     // 2.1 Push the thisptr
     // We need to skip over the MethodTable*
     // The trick below will do that.
     pCode->EmitLoadThis();
-    pCode->EmitLDFLDA(tokPinningHelper);
+    pCode->EmitLDFLDA(tokRawData);
 
 #if defined(_TARGET_X86_)
     // 2.2 Push the rest of the arguments for x86
@@ -1225,7 +1225,7 @@ Stub * CreateUnboxingILStubForSharedGenericValueTypeMethods(MethodDesc* pTargetM
     // 2.3 Push the hidden context param
     // The context is going to be captured from the thisptr
     pCode->EmitLoadThis();
-    pCode->EmitLDFLDA(tokPinningHelper);
+    pCode->EmitLDFLDA(tokRawData);
     pCode->EmitLDC(Object::GetOffsetOfFirstField());
     pCode->EmitSUB();
     pCode->EmitLDIND_I();

--- a/src/vm/reflectioninvocation.cpp
+++ b/src/vm/reflectioninvocation.cpp
@@ -2375,15 +2375,6 @@ FCIMPL1(Object*, ReflectionInvocation::TypedReferenceToObject, TypedByRef * valu
 }
 FCIMPLEND
 
-#ifdef _DEBUG
-FCIMPL1(FC_BOOL_RET, ReflectionInvocation::IsAddressInStack, void * ptr)
-{
-    FCALL_CONTRACT;
-    FC_RETURN_BOOL(Thread::IsAddressInCurrentStack(ptr));
-}
-FCIMPLEND
-#endif
-
 FCIMPL2_IV(Object*, ReflectionInvocation::CreateEnum, ReflectClassBaseObject *pTypeUNSAFE, INT64 value) {
     FCALL_CONTRACT;
     

--- a/src/vm/reflectioninvocation.h
+++ b/src/vm/reflectioninvocation.h
@@ -63,9 +63,6 @@ public:
     static FCDECL4(void, MakeTypedReference, TypedByRef * value, Object* targetUNSAFE, ArrayBase* fldsUNSAFE, ReflectClassBaseObject *pFieldType);
     static FCDECL2(void, SetTypedReference, TypedByRef * target, Object* objUNSAFE);
     static FCDECL1(Object*, TypedReferenceToObject, TypedByRef * value);
-#ifdef _DEBUG
-    static FCDECL1(FC_BOOL_RET, IsAddressInStack, void * ptr);
-#endif
 
 #ifdef FEATURE_COMINTEROP
     static FCDECL3(Object*, GetClassFromProgID, StringObject* classNameUNSAFE, StringObject* serverUNSAFE, CLR_BOOL bThrowOnError);


### PR DESCRIPTION
- Replace JitHelpers.UnsafeCastToStackPtr with Unsafe.AsPointer
- Delete PinningHelper that was duplicate of RawData helper class