### PR TITLE
 Updating `FusedMultiplyAdd` for `System.Math` and `System.MathF` to use intrinsics when available.

### DIFF
--- a/src/System.Private.CoreLib/src/System/Math.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Math.CoreCLR.cs
@@ -64,6 +64,7 @@ namespace System
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern double Floor(double d);
 
+        [Intrinsic]
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern double FusedMultiplyAdd(double x, double y, double z);
 

--- a/src/System.Private.CoreLib/src/System/MathF.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/MathF.CoreCLR.cs
@@ -55,6 +55,7 @@ namespace System
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern float Floor(float x);
 
+        [Intrinsic]
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern float FusedMultiplyAdd(float x, float y, float z);
 

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -4039,8 +4039,8 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 break;
             }
 
-            case NI_MathF_Round:
-            case NI_Math_Round:
+            case NI_System_Math_Round:
+            case NI_System_MathF_Round:
             {
                 // Math.Round and MathF.Round used to be a traditional JIT intrinsic. In order
                 // to simplify the transition, we will just treat it as if it was still the
@@ -4460,13 +4460,24 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
         {
             result = NI_System_Enum_HasFlag;
         }
-        else if ((strcmp(className, "MathF") == 0) && (strcmp(methodName, "Round") == 0))
+        else if (strncmp(methodName, "Math", 4) == 0)
         {
-            result = NI_MathF_Round;
-        }
-        else if ((strcmp(className, "Math") == 0) && (strcmp(methodName, "Round") == 0))
-        {
-            result = NI_Math_Round;
+            methodName += 4;
+
+            if (methodName[0] == '\0')
+            {
+                if (strcmp(methodName, "Round") == 0)
+                {
+                    result = NI_System_Math_Round;
+                }
+            }
+            else if (strcmp(methodName, "F") == 0)
+            {
+                if (strcmp(methodName, "Round") == 0)
+                {
+                    result = NI_System_MathF_Round;
+                }
+            }
         }
     }
 #if defined(_TARGET_XARCH_) // We currently only support BSWAP on x86

--- a/src/jit/namedintrinsiclist.h
+++ b/src/jit/namedintrinsiclist.h
@@ -11,7 +11,9 @@ enum NamedIntrinsic : unsigned short
 {
     NI_Illegal = 0,
     NI_System_Enum_HasFlag,
+    NI_System_Math_FusedMultiplyAdd,
     NI_System_Math_Round,
+    NI_System_MathF_FusedMultiplyAdd,
     NI_System_MathF_Round,
     NI_System_Collections_Generic_EqualityComparer_get_Default,
     NI_System_Buffers_Binary_BinaryPrimitives_ReverseEndianness,

--- a/src/jit/namedintrinsiclist.h
+++ b/src/jit/namedintrinsiclist.h
@@ -9,12 +9,12 @@
 
 enum NamedIntrinsic : unsigned short
 {
-    NI_Illegal                                                  = 0,
-    NI_System_Enum_HasFlag                                      = 1,
-    NI_MathF_Round                                              = 2,
-    NI_Math_Round                                               = 3,
-    NI_System_Collections_Generic_EqualityComparer_get_Default  = 4,
-    NI_System_Buffers_Binary_BinaryPrimitives_ReverseEndianness = 5,
+    NI_Illegal = 0,
+    NI_System_Enum_HasFlag,
+    NI_Math_Round,
+    NI_MathF_Round,
+    NI_System_Collections_Generic_EqualityComparer_get_Default,
+    NI_System_Buffers_Binary_BinaryPrimitives_ReverseEndianness,
 
 #ifdef FEATURE_HW_INTRINSICS
     NI_HW_INTRINSIC_START,

--- a/src/jit/namedintrinsiclist.h
+++ b/src/jit/namedintrinsiclist.h
@@ -11,8 +11,8 @@ enum NamedIntrinsic : unsigned short
 {
     NI_Illegal = 0,
     NI_System_Enum_HasFlag,
-    NI_Math_Round,
-    NI_MathF_Round,
+    NI_System_Math_Round,
+    NI_System_MathF_Round,
     NI_System_Collections_Generic_EqualityComparer_get_Default,
     NI_System_Buffers_Binary_BinaryPrimitives_ReverseEndianness,
 


### PR DESCRIPTION
This updates `System.Math.FusedMultiplyAdd` and `System.MathF.FusedMultiplyAdd` to be imported as the appropriate chain of HWIntrinsics when the underlying CPU supports the FMA instruction set.