### PR TITLE
Updating gtGetSIMDZero to only return the NI_Base_VectorXXX_Zero node if they are supported by the compiler

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -16449,9 +16449,23 @@ GenTree* Compiler::gtGetSIMDZero(var_types simdType, var_types baseType, CORINFO
         switch (simdType)
         {
             case TYP_SIMD16:
-                return gtNewSimdHWIntrinsicNode(simdType, NI_Base_Vector128_Zero, baseType, size);
+                if (compSupports(InstructionSet_SSE))
+                {
+                    // We only return the HWIntrinsicNode if SSE is supported, since it is possible for
+                    // the user to disable the SSE HWIntrinsic support via the COMPlus configuration knobs
+                    // even though the hardware vector types are still available.
+                    return gtNewSimdHWIntrinsicNode(simdType, NI_Base_Vector128_Zero, baseType, size);
+                }
+                return nullptr;
             case TYP_SIMD32:
-                return gtNewSimdHWIntrinsicNode(simdType, NI_Base_Vector256_Zero, baseType, size);
+                if (compSupports(InstructionSet_AVX))
+                {
+                    // We only return the HWIntrinsicNode if AVX is supported, since it is possible for
+                    // the user to disable the AVX HWIntrinsic support via the COMPlus configuration knobs
+                    // even though the hardware vector types are still available.
+                    return gtNewSimdHWIntrinsicNode(simdType, NI_Base_Vector256_Zero, baseType, size);
+                }
+                return nullptr;
             default:
                 break;
         }


### PR DESCRIPTION
This resolves https://github.com/dotnet/coreclr/issues/21596

As per https://github.com/dotnet/coreclr/issues/21596#issuecomment-448773792, the assert exists because users are able to disable the HWIntrinsic codegen support via `COMPlus_EnableHWIntrinsic=0` (in which case we shouldn't be hitting any code in `hwintrinsiccodegenxarch.cpp` and we should end up emitting the software fallback code instead).