### PR TITLE
Branchless TextInfo.ToLowerAsciiInvariant / ToUpperAsciiInvariant

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Globalization/TextInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/TextInfo.cs
@@ -565,11 +565,14 @@ namespace System.Globalization
 
         private static char ToLowerAsciiInvariant(char c)
         {
-            if ((uint)(c - 'A') <= (uint)('Z' - 'A'))
-            {
-                c = (char)(c | 0x20);
-            }
-            return c;
+            const int offset = 'a' - 'A';
+            const int bitsPerChar = sizeof(char) * 8;
+
+            int maskA = 'A' - c - 1;
+            int maskZ = c - 'Z' - 1;
+            int mask = (maskA & maskZ) >> bitsPerChar;
+
+            return (char)(c + (mask & offset));
         }
 
         ////////////////////////////////////////////////////////////////////////
@@ -604,11 +607,14 @@ namespace System.Globalization
 
         internal static char ToUpperAsciiInvariant(char c)
         {
-            if ((uint)(c - 'a') <= (uint)('z' - 'a'))
-            {
-                c = (char)(c & ~0x20);
-            }
-            return c;
+            const int offset = 'A' - 'a';
+            const int bitsPerChar = sizeof(char) * 8;
+
+            int maskA = 'a' - c - 1;
+            int maskB = c - 'z' - 1;
+            int mask = (maskA & maskB) >> bitsPerChar;
+
+            return (char)(c + (mask & offset));
         }
 
         private static bool IsAscii(char c)

--- a/src/System.Private.CoreLib/shared/System/Globalization/TextInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/TextInfo.cs
@@ -565,14 +565,13 @@ namespace System.Globalization
 
         private static char ToLowerAsciiInvariant(char c)
         {
-            const int offset = 'a' - 'A';
             const int bitsPerChar = sizeof(char) * 8;
 
             int maskA = 'A' - c - 1;
             int maskZ = c - 'Z' - 1;
             int mask = (maskA & maskZ) >> bitsPerChar;
 
-            return (char)(c + (mask & offset));
+            return (char)(c ^ (mask & 0x20));
         }
 
         ////////////////////////////////////////////////////////////////////////
@@ -607,14 +606,13 @@ namespace System.Globalization
 
         internal static char ToUpperAsciiInvariant(char c)
         {
-            const int offset = 'A' - 'a';
             const int bitsPerChar = sizeof(char) * 8;
 
             int maskA = 'a' - c - 1;
             int maskB = c - 'z' - 1;
             int mask = (maskA & maskB) >> bitsPerChar;
 
-            return (char)(c + (mask & offset));
+            return (char)(c ^ (mask & 0x20));
         }
 
         private static bool IsAscii(char c)


### PR DESCRIPTION
When the char-input is random it is quite a lot faster.
If the char-input is [predictable](https://github.com/dotnet/coreclr/blob/c0c51f83e56eb37bb5a257c0e82ca6676894d6c1/src/System.Private.CoreLib/shared/System/Globalization/TextInfo.cs#L568) (and the branch predictor does a good job) it regresses.


|     Method | AlwaysWithinRange |     Mean |     Error |    StdDev | Ratio |
|----------- |------------------ |---------:|----------:|----------:|------:|
|       **Base** |             **False** | **3.361 us** | **1.0209 us** | **0.0560 us** |  **1.00** |
| Branchless |             False | 2.139 us | 0.3716 us | 0.0204 us |  0.64 |
|            |                   |          |           |           |       |
|       **Base** |              **True** | **1.791 us** | **0.1942 us** | **0.0106 us** |  **1.00** |
| Branchless |              True | 2.115 us | 0.3156 us | 0.0173 us |  1.18 |

(Results for ToLowerAsciiInvariant / ToUpperAsciiInvariant  are quite similar, thus showed only ToLowerAsciiInvariant.)

[Benchmark-Source](https://github.com/gfoidl/Benchmarks/tree/50bdbd238287e84213c82c3f647dddde6b84a68f/coreclr/TextInfo_ToLowerUpper/source/TextInfo_ToLowerUpper/Benchmarks)

Do we have more realistic test-data for the benchmarks?