### PR TITLE
Add Module Override Recognition to R2RDump

### DIFF
--- a/src/tools/r2rdump/R2RConstants.cs
+++ b/src/tools/r2rdump/R2RConstants.cs
@@ -32,6 +32,14 @@ namespace R2RDump
     };
 
     /// <summary>
+    /// based on <a href="https://github.com/dotnet/coreclr/blob/master/src/inc/corcompile.h">src/inc/corcompile.h</a> CorCompileImportFlags
+    /// </summary>
+    public enum CORCOMPILE_FIXUP_BLOB_KIND
+    {
+        ENCODE_MODULE_OVERRIDE = 0x80,     /* When the high bit is set, override of the module immediately follows */
+    }
+
+    /// <summary>
     /// Constants for method and field encoding
     /// </summary>
     [Flags]

--- a/src/tools/r2rdump/R2RSignature.cs
+++ b/src/tools/r2rdump/R2RSignature.cs
@@ -344,14 +344,6 @@ namespace R2RDump
         }
 
         /// <summary>
-        /// Read a single byte from the signature stream without advancing the current offset.
-        /// </summary>
-        public byte PeekByte()
-        {
-            return _image[_offset];
-        }
-
-        /// <summary>
         /// Read a single unsigned 32-bit in from the signature stream. Adapted from CorSigUncompressData,
         /// <a href="">https://github.com/dotnet/coreclr/blob/master/src/inc/cor.h</a>.
         /// </summary>
@@ -468,21 +460,15 @@ namespace R2RDump
         /// <param name="builder"></param>
         private void ParseSignature(StringBuilder builder)
         {
-            uint fixupType = PeekByte();
-            bool moduleOverride = (fixupType & (uint)CORCOMPILE_FIXUP_BLOB_KIND.ENCODE_MODULE_OVERRIDE) != 0;
+            uint fixupType = ReadByte();
+            bool moduleOverride = (fixupType & (byte)CORCOMPILE_FIXUP_BLOB_KIND.ENCODE_MODULE_OVERRIDE) != 0;
             // Check first byte for a module override being encoded
             if (moduleOverride)
             {
                 builder.Append("ENCODE_MODULE_OVERRIDE @ ");
                 fixupType &= ~(uint)CORCOMPILE_FIXUP_BLOB_KIND.ENCODE_MODULE_OVERRIDE;
-                ReadByte();
-                uint moduleIndex = ReadByte();
+                uint moduleIndex = ReadUInt();
                 builder.Append(string.Format(" Index:  {0:X2}", moduleIndex));
-            }
-            // If the most significant bit has not been set, 
-            else
-            {
-                fixupType = ReadUInt();
             }
 
             switch ((ReadyToRunFixupKind)fixupType)


### PR DESCRIPTION
This was added to help debug work with large version bubbles. The changes should allow R2RDump to have some rudimentary understanding of `ENCODE_METHOD_OVERRIDE`. 

The big TODO here is allow loading of external dependency assemblies to be able to resolve the tokens coming after the override.