### PR TITLE
Fix "harmless" bug in ZapImport - use AppendByte to emit fixup type

### DIFF
--- a/src/zap/zapimport.cpp
+++ b/src/zap/zapimport.cpp
@@ -2289,7 +2289,7 @@ ZapImport * ZapImportTable::GetHelperImport(ReadyToRunHelper helperNum)
     {
         SigBuilder sigBuilder;
 
-        sigBuilder.AppendData(ENCODE_READYTORUN_HELPER);
+        sigBuilder.AppendByte(ENCODE_READYTORUN_HELPER);
         sigBuilder.AppendData(helperNum);
 
         pImport->SetBlob(GetBlob(&sigBuilder));


### PR DESCRIPTION
During my work on the CPAOT compiler I found out that in the past
I had believed we should use the compressed uint signature encoding
for emitting fixup types. This place may have contributed to my
mistake. I have audited all places in CoreCLR where signatures are
decoded and in all cases the fixup type is assumed to be a byte,
not a signature-compressed uint.

As I said, the bug is harmless (after all, Crossgen works) because
the enum code of READYTORUN_FIXUP_Helper is less than 128 and for
values 0-127 the compressed uint encoding is identical with the
byte value; I however believe it's useful to make this change
nonetheless for the sake of code clarity and to help avoid future
confusions similar to mine.

Thanks

Tomas