### PR TITLE
Fix ArrayStack's call to default constructor for <T>.

### DIFF
--- a/src/jit/arraystack.h
+++ b/src/jit/arraystack.h
@@ -146,6 +146,13 @@ public:
         return data[indx];
     }
 
+    // return a reference to the i'th from the bottom
+    T BottomRef(int indx)
+    {
+        assert(tosIndex > indx);
+        return data[indx];
+    }
+
     void Reset()
     {
         tosIndex = 0;

--- a/src/jit/arraystack.h
+++ b/src/jit/arraystack.h
@@ -11,17 +11,17 @@ class ArrayStack
     static const int builtinSize = 8;
 
 public:
-    ArrayStack(CompAllocator alloc, int initialSize = builtinSize) : m_alloc(alloc)
+    ArrayStack(CompAllocator alloc, int initialCapacity = builtinSize) : m_alloc(alloc)
     {
-        if (initialSize > builtinSize)
+        if (initialCapacity > builtinSize)
         {
-            maxIndex = initialSize;
-            data     = new (alloc) T[initialSize];
+            maxIndex = initialCapacity;
+            data     = m_alloc.allocate<T>(initialCapacity);
         }
         else
         {
             maxIndex = builtinSize;
-            data     = builtinData;
+            data     = reinterpret_cast<T*>(builtinData);
         }
 
         tosIndex = 0;
@@ -56,7 +56,7 @@ public:
         // and copy over
         T* oldData = data;
         noway_assert(maxIndex * 2 > maxIndex);
-        data = new (m_alloc) T[maxIndex * 2];
+        data = m_alloc.allocate<T>(maxIndex * 2);
         for (int i = 0; i < maxIndex; i++)
         {
             data[i] = oldData[i];
@@ -139,5 +139,5 @@ private:
     int           maxIndex;
     T*            data;
     // initial allocation
-    T builtinData[builtinSize];
+    char builtinData[builtinSize * sizeof(T)];
 };

--- a/src/jit/arraystack.h
+++ b/src/jit/arraystack.h
@@ -64,31 +64,6 @@ public:
         maxIndex *= 2;
     }
 
-    // reverse the top N in the stack
-    void ReverseTop(int number)
-    {
-        if (number < 2)
-        {
-            return;
-        }
-
-        assert(number <= tosIndex);
-
-        int start  = tosIndex - number;
-        int offset = 0;
-        while (offset < number / 2)
-        {
-            T   temp;
-            int index        = start + offset;
-            int otherIndex   = tosIndex - 1 - offset;
-            temp             = data[index];
-            data[index]      = data[otherIndex];
-            data[otherIndex] = temp;
-
-            offset++;
-        }
-    }
-
     T Pop()
     {
         assert(tosIndex > 0);

--- a/src/jit/arraystack.h
+++ b/src/jit/arraystack.h
@@ -127,6 +127,11 @@ public:
         return tosIndex;
     }
 
+    bool Empty()
+    {
+        return tosIndex == 0;
+    }
+
     // return the bottom of the stack
     T Bottom()
     {

--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -1295,10 +1295,6 @@ struct DfsBlockEntry
     DfsStackState dfsStackState; // The pre/post traversal action for this entry
     BasicBlock*   dfsBlock;      // The corresponding block for the action
 
-    DfsBlockEntry() : dfsStackState(DSS_Invalid), dfsBlock(nullptr)
-    {
-    }
-
     DfsBlockEntry(DfsStackState state, BasicBlock* basicBlock) : dfsStackState(state), dfsBlock(basicBlock)
     {
     }
@@ -1388,12 +1384,6 @@ class AllSuccessorEnumerator
     AllSuccessorIterPosition m_pos;
 
 public:
-    // Needed only because ArrayStack is broken - its built-in storage is such
-    // that it default constructs elements that do not actually exist.
-    AllSuccessorEnumerator() : m_block(nullptr), m_pos()
-    {
-    }
-
     // Constructs an enumerator of all `block`'s successors.
     AllSuccessorEnumerator(Compiler* comp, BasicBlock* block) : m_block(block), m_pos(comp, block)
     {

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -308,10 +308,6 @@ protected:
         regNumber reg1;
         regNumber reg2;
 
-        RegPair() : reg1(REG_NA), reg2(REG_NA)
-        {
-        }
-
         RegPair(regNumber reg1) : reg1(reg1), reg2(REG_NA)
         {
         }

--- a/src/jit/copyprop.cpp
+++ b/src/jit/copyprop.cpp
@@ -47,7 +47,7 @@ void Compiler::optBlockCopyPropPopStacks(BasicBlock* block, LclNumToGenTreePtrSt
                 GenTreePtrStack* stack = nullptr;
                 curSsaName->Lookup(lclNum, &stack);
                 stack->Pop();
-                if (stack->Height() == 0)
+                if (stack->Empty())
                 {
                     curSsaName->Remove(lclNum);
                 }

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -2341,7 +2341,7 @@ void Compiler::fgDfsInvPostOrderHelper(BasicBlock* block, BlockSet& visited, uns
     BlockSetOps::AddElemD(this, visited, block->bbNum);
 
     // The search is terminated once all the actions have been processed.
-    while (stack.Height() != 0)
+    while (!stack.Empty())
     {
         DfsBlockEntry current      = stack.Pop();
         BasicBlock*   currentBlock = current.dfsBlock;
@@ -2780,7 +2780,7 @@ void Compiler::fgTraverseDomTree(unsigned bbNum, BasicBlockList** domTree, unsig
         stack.Push(DfsNumEntry(DSS_Pre, bbNum));
 
         // The search is terminated once all the actions have been processed.
-        while (stack.Height() != 0)
+        while (!stack.Empty())
         {
             DfsNumEntry current    = stack.Pop();
             unsigned    currentNum = current.dfsNum;
@@ -21140,7 +21140,7 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
 
                     fgDebugCheckFlags(tree);
 
-                    while (stack.Height() > 0)
+                    while (!stack.Empty())
                     {
                         tree = stack.Pop();
                         assert((tree->gtFlags & GTF_REVERSE_OPS) == 0);

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -2397,7 +2397,7 @@ unsigned Compiler::gtSetListOrder(GenTree* list, bool isListCallArgs, bool callA
     } while ((list != nullptr) && (list->OperIsAnyList()));
 
     unsigned nxtlvl = (list == nullptr) ? 0 : gtSetEvalOrder(list);
-    while (listNodes.Height() > 0)
+    while (!listNodes.Empty())
     {
         list = listNodes.Pop();
         assert(list && list->OperIsAnyList());
@@ -15039,7 +15039,7 @@ void Compiler::gtExtractSideEffList(GenTree*  expr,
     // This is also why the list cannot be built while traversing the tree.
     // The number of side effects is usually small (<= 4), less than the ArrayStack's
     // built-in size, so memory allocation is avoided.
-    while (extractor.m_sideEffects.Height() > 0)
+    while (!extractor.m_sideEffects.Empty())
     {
         list = gtBuildCommaList(list, extractor.m_sideEffects.Pop());
     }

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1969,7 +1969,7 @@ void Lowering::LowerFastTailCall(GenTreeCall* call)
         }
     }
 
-    if (putargs.Height() > 0)
+    if (!putargs.Empty())
     {
         firstPutArgStk = putargs.Bottom();
     }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -4969,7 +4969,7 @@ GenTree* Compiler::fgMorphMultiregStructArg(GenTree* arg, fgArgTabEntry* fgEntry
     unsigned propFlags = (tree->gtOp.gtOp1->gtFlags & GTF_ALL_EFFECT);
     tree->gtFlags |= propFlags;
 
-    while (stack.Height() > 0)
+    while (!stack.Empty())
     {
         tree = stack.Pop();
         propFlags |= (tree->gtOp.gtOp1->gtFlags & GTF_ALL_EFFECT);
@@ -9681,7 +9681,7 @@ GenTree* Compiler::fgMorphBlkNode(GenTree* tree, bool isDest)
 #endif
         lastComma->gtOp.gtOp2 = effectiveValAddr;
 
-        while (commas.Height() > 0)
+        while (!commas.Empty())
         {
             GenTree* comma = commas.Pop();
             comma->gtType  = TYP_BYREF;
@@ -13512,7 +13512,7 @@ DONE_MORPHING_CHILDREN:
                 // For example, if we made the ADDR(IND(x)) == x transformation, we may be able to
                 // get rid of some of the the IND flags on the COMMA nodes (e.g., GTF_GLOB_REF).
 
-                while (commas.Height() > 0)
+                while (!commas.Empty())
                 {
                     GenTree* comma = commas.Pop();
                     comma->gtType  = op1->gtType;
@@ -18096,7 +18096,7 @@ public:
         }
 
         PopValue();
-        assert(m_valueStack.Height() == 0);
+        assert(m_valueStack.Empty());
 
 #ifdef DEBUG
         if (m_compiler->verbose)

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17849,18 +17849,6 @@ class LocalAddressVisitor final : public GenTreeVisitor<LocalAddressVisitor>
         INDEBUG(bool m_consumed;)
 
     public:
-        // TODO-Cleanup: This is only needed because ArrayStack initializes its storage incorrectly.
-        Value()
-            : m_node(nullptr)
-            , m_lclNum(BAD_VAR_NUM)
-            , m_offset(0)
-            , m_address(false)
-#ifdef DEBUG
-            , m_consumed(false)
-#endif // DEBUG
-        {
-        }
-
         // Produce an unknown value associated with the specified node.
         Value(GenTree* node)
             : m_node(node)

--- a/src/jit/ssabuilder.cpp
+++ b/src/jit/ssabuilder.cpp
@@ -197,7 +197,7 @@ int SsaBuilder::TopologicalSort(BasicBlock** postOrder, int count)
     blocks.Emplace(comp, block);
     DumpBlockAndSuccessors(comp, block);
 
-    while (blocks.Height() > 0)
+    while (!blocks.Empty())
     {
         BasicBlock* block = blocks.TopRef().Block();
         BasicBlock* succ  = blocks.TopRef().NextSuccessor(comp);


### PR DESCRIPTION
The first commit add `IsEmpty()`, the second adds `BottomRef()`, the third fixes the old issue that template argument for `ArrayStack` had to have a default constructor.

I hit the last issue again in #21395 so decided to fix it.

@mikedn  I think you also requested this change, could you please review it?
PTAL @dotnet/jit-contrib 