### PR TITLE
Fixing ContainCheckHWIntrinsic to ensure that scalar integer operands are the appropriate size

### DIFF
--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -2653,7 +2653,7 @@ bool Lowering::IsContainableHWIntrinsicOp(GenTreeHWIntrinsic* containingNode, Ge
 
                     const unsigned expectedSize = genTypeSize(genActualType(containingNode->gtSIMDBaseType));
                     const unsigned operandSize  = genTypeSize(node->TypeGet());
-                    
+
                     supportsGeneralLoads = (operandSize == expectedSize);
                     break;
                 }

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -2654,7 +2654,7 @@ bool Lowering::IsContainableHWIntrinsicOp(GenTreeHWIntrinsic* containingNode, Ge
                 case NI_Base_Vector256_CreateScalarUnsafe:
                 {
                     // These intrinsics require the contained operand to be the same size as the widened
-                    // baseType (genActualType(baseType) of the containing node. This is because codegen 
+                    // baseType (genActualType(baseType) of the containing node. This is because codegen
                     // uses `emitActualTypeSize(baseType)`.
                     //
                     // If it isn't, we can't mark the node as contained because:
@@ -2673,7 +2673,7 @@ bool Lowering::IsContainableHWIntrinsicOp(GenTreeHWIntrinsic* containingNode, Ge
                     assert(supportsSIMDScalarLoads == false);
 
                     const unsigned expectedSize = genTypeSize(genActualType(containingNode->gtSIMDBaseType));
-                    const unsigned operandSize = genTypeSize(node->TypeGet());
+                    const unsigned operandSize  = genTypeSize(node->TypeGet());
 
                     supportsGeneralLoads = (operandSize == expectedSize);
                     break;

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -2679,13 +2679,13 @@ bool Lowering::IsContainableHWIntrinsicOp(GenTreeHWIntrinsic* containingNode, Ge
             assert(supportsSIMDScalarLoads == false);
             assert(supportsUnalignedSIMDLoads == false);
 
-            if (genTypeSize(node->TypeGet()) != genTypeSize(containingNode->gtSIMDBaseType))
+            if (genTypeSize(node->TypeGet()) != genTypeSize(containingNode->TypeGet()))
             {
                 // We should only get here for integral nodes
                 assert(varTypeIsIntegral(node->TypeGet()));
 
                 // These intrinsics require the contained operand to be
-                // the same size as the baseType for the containing node.
+                // the same size as the type for the containing node.
                 //
                 // If it isn't the same size, we can't mark the node as
                 // contained because it might avoid a zero or sign-extension

--- a/tests/src/JIT/Regression/JitBlue/GitHub_21625/GitHub_21625.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_21625/GitHub_21625.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+namespace GitHub_21625
+{
+    public class test
+    {
+        public static Vector128<ushort> CreateScalar(ushort value)
+        {
+            if (Sse2.IsSupported)
+            {
+                return Sse2.ConvertScalarToVector128UInt32(value).AsUInt16();
+            }
+ 
+            return SoftwareFallback(value);
+ 
+            Vector128<ushort> SoftwareFallback(ushort x)
+            {
+                var result = Vector128<ushort>.Zero;
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<ushort>, byte>(ref result), value);
+                return result;
+            }
+        }
+
+        static int Main()
+        {
+            ushort value = TestLibrary.Generator.GetUInt16();
+            Vector128<ushort> result = CreateScalar(value);
+
+            if (result.GetElement(0) != value)
+            {
+                return 0;
+            }
+
+            for (int i = 1; i < Vector128<ushort>.Count; i++)
+            {
+                if (result.GetElement(i) != 0)
+                {
+                    return 0;
+                }
+            }
+
+            return 100;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_21625/GitHub_21625.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_21625/GitHub_21625.csproj
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{2649FAFE-07BF-4F93-8120-BA9A69285ABB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(SourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
This resolves https://github.com/dotnet/coreclr/issues/21625