### PR TITLE
Temporary remove OSX.1012.Amd64.Open and OSX.1012.Amd64 Helix queues

### DIFF
--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -92,8 +92,9 @@ jobs:
     archType: x64
     osGroup: OSX
     osIdentifier: OSX
-    helixQueuesPublic: 'OSX.1012.Amd64.Open,OSX.1013.Amd64.Open'
-    helixQueuesInternal: 'OSX.1012.Amd64,OSX.1013.Amd64'
+    # TODO: add OSX.1012.Amd64.Open and OSX.1012.Amd64 when https://github.com/dotnet/core-eng/issues/4856 is resolved
+    helixQueuesPublic: 'OSX.1013.Amd64.Open'
+    helixQueuesInternal: 'OSX.1013.Amd64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Windows x64/x86/arm/arm64


### PR DESCRIPTION
Currently, the build agents in Azure DevOps run on OSX 10.13. This causes the following failures when a test job submitted to OSX 10.12 queue.
```
dlopen failed to open the libcoreclr.so with error dlopen(/Users/dotnet-bot/dotnetbuild/work/955a3b93-78a6-41fb-8696-8e73e9be05b2/Payload/libcoreclr.dylib, 6): Symbol not found: _syslog$DARWIN_EXTSN
  Referenced from: /Users/dotnet-bot/dotnetbuild/work/955a3b93-78a6-41fb-8696-8e73e9be05b2/Payload/libcoreclr.dylib (which was built for Mac OS X 10.13)
  Expected in: /usr/lib/libSystem.B.dylib
 in /Users/dotnet-bot/dotnetbuild/work/955a3b93-78a6-41fb-8696-8e73e9be05b2/Payload/libcoreclr.dylib
```

This PR temporary removes OSX.1012.Amd64.Open and OSX.1012.Amd64 from Helix target queues.

**Related issue**: https://github.com/dotnet/core-eng/issues/4856