### PR TITLE
Delete CoreLib.FixupCoreLibName

### DIFF
--- a/src/System.Private.CoreLib/shared/System/CoreLib.cs
+++ b/src/System.Private.CoreLib/shared/System/CoreLib.cs
@@ -8,15 +8,5 @@ namespace System
     internal static class CoreLib
     {
         public const string Name = "System.Private.CoreLib";
-
-        public static string FixupCoreLibName(string strToFixup)
-        {
-            if (!string.IsNullOrEmpty(strToFixup))
-            {
-                strToFixup = strToFixup.Replace("mscorlib", System.CoreLib.Name);
-            }
-
-            return strToFixup;
-        }
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Resources/ResourceReader.cs
+++ b/src/System.Private.CoreLib/shared/System/Resources/ResourceReader.cs
@@ -863,10 +863,8 @@ namespace System.Resources
                 // Read in type name for a suitable ResourceReader
                 // Note ResourceWriter & InternalResGen use different Strings.
                 string readerType = _store.ReadString();
-                readerType = System.CoreLib.FixupCoreLibName(readerType);
-                AssemblyName mscorlib = new AssemblyName(ResourceManager.MscorlibName);
 
-                if (!ResourceManager.CompareNames(readerType, ResourceManager.ResReaderTypeName, mscorlib))
+                if (!ResourceManager.IsDefaultType(readerType, ResourceManager.ResReaderTypeName))
                     throw new NotSupportedException(SR.Format(SR.NotSupported_WrongResourceReader_Type, readerType));
 
                 // Skip over type name for a suitable ResourceSet

--- a/src/System.Private.CoreLib/src/System/Resources/ManifestBasedResourceGroveler.cs
+++ b/src/System.Private.CoreLib/src/System/Resources/ManifestBasedResourceGroveler.cs
@@ -206,8 +206,8 @@ namespace System.Resources
                     if (resMgrHeaderVersion == ResourceManager.HeaderVersionNumber)
                     {
                         br.ReadInt32();  // We don't want the number of bytes to skip.
-                        readerTypeName = System.CoreLib.FixupCoreLibName(br.ReadString());
-                        resSetTypeName = System.CoreLib.FixupCoreLibName(br.ReadString());
+                        readerTypeName = br.ReadString();
+                        resSetTypeName = br.ReadString();
                     }
                     else if (resMgrHeaderVersion > ResourceManager.HeaderVersionNumber)
                     {
@@ -218,8 +218,8 @@ namespace System.Resources
                         int numBytesToSkip = br.ReadInt32();
                         long endPosition = br.BaseStream.Position + numBytesToSkip;
 
-                        readerTypeName = System.CoreLib.FixupCoreLibName(br.ReadString());
-                        resSetTypeName = System.CoreLib.FixupCoreLibName(br.ReadString());
+                        readerTypeName = br.ReadString();
+                        resSetTypeName = br.ReadString();
 
                         br.BaseStream.Seek(endPosition, SeekOrigin.Begin);
                     }
@@ -242,8 +242,7 @@ namespace System.Resources
                     }
                     else
                     {
-                        // we do not want to use partial binding here.
-                        Type readerType = Type.GetType(readerTypeName, true);
+                        Type readerType = Type.GetType(readerTypeName, throwOnError: true);
                         object[] args = new object[1];
                         args[0] = store;
                         IResourceReader reader = (IResourceReader)Activator.CreateInstance(readerType, args);
@@ -439,17 +438,16 @@ namespace System.Resources
             // Ignore the actual version of the ResourceReader and 
             // RuntimeResourceSet classes.  Let those classes deal with
             // versioning themselves.
-            AssemblyName mscorlib = new AssemblyName(ResourceManager.MscorlibName);
 
             if (readerTypeName != null)
             {
-                if (!ResourceManager.CompareNames(readerTypeName, ResourceManager.ResReaderTypeName, mscorlib))
+                if (!ResourceManager.IsDefaultType(readerTypeName, ResourceManager.ResReaderTypeName))
                     return false;
             }
 
             if (resSetTypeName != null)
             {
-                if (!ResourceManager.CompareNames(resSetTypeName, ResourceManager.ResSetTypeName, mscorlib))
+                if (!ResourceManager.IsDefaultType(resSetTypeName, ResourceManager.ResSetTypeName))
                     return false;
             }
 


### PR DESCRIPTION
This method doing blind find&replace of "mscorlib" with "System.Private.CoreLib". It is both incorrect (e.g. if the typename happened to contain "mscorlib" string) and inefficient (unnecessary allocations and use of reflection).