### PR TITLE
Fix warning causing error in warning as error (Windows)

### DIFF
--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -6033,8 +6033,8 @@ CorInfoHelpFunc CEEInfo::getNewHelperStatic(MethodTable * pMT, bool * pHasSideEf
 
     // Slow helper is the default
     CorInfoHelpFunc helper = CORINFO_HELP_NEWFAST;
-    bool hasFinalizer = pMT->HasFinalizer();
-    bool isComObjectType = pMT->IsComObjectType();
+    bool hasFinalizer = pMT->HasFinalizer() != 0;
+    BOOL isComObjectType = pMT->IsComObjectType();
 
     if (pHasSideEffects != nullptr)
     {

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -6051,7 +6051,7 @@ CorInfoHelpFunc CEEInfo::getNewHelperStatic(MethodTable * pMT, bool * pHasSideEf
         else
 #endif
         {
-            *pHasSideEffects = (hasFinalizer != 0);
+            *pHasSideEffects = !!hasFinalizer;
         }
     }
 

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -6033,7 +6033,7 @@ CorInfoHelpFunc CEEInfo::getNewHelperStatic(MethodTable * pMT, bool * pHasSideEf
 
     // Slow helper is the default
     CorInfoHelpFunc helper = CORINFO_HELP_NEWFAST;
-    bool hasFinalizer = pMT->HasFinalizer() != 0;
+    BOOL hasFinalizer = pMT->HasFinalizer();
     BOOL isComObjectType = pMT->IsComObjectType();
 
     if (pHasSideEffects != nullptr)
@@ -6051,7 +6051,7 @@ CorInfoHelpFunc CEEInfo::getNewHelperStatic(MethodTable * pMT, bool * pHasSideEf
         else
 #endif
         {
-            *pHasSideEffects = hasFinalizer;
+            *pHasSideEffects = (hasFinalizer != 0);
         }
     }
 


### PR DESCRIPTION
```
 warning C4800: 'DWORD': forcing value to bool 'true' or 'false' (performance warning)
 warning C4800: 'BOOL': forcing value to bool 'true' or 'false' (performance warning)
```

```
error C2220: warning treated as error - no 'object' file generated
```
/cc @jkotas @erozenfeld