### PR TITLE
Makes CultureInfo.get_Parent thread safe.

### DIFF
--- a/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
@@ -495,23 +495,26 @@ namespace System.Globalization
             {
                 if (null == _parent)
                 {
+                    CultureInfo culture = null;
                     string parentName = _cultureData.SPARENT;
 
                     if (string.IsNullOrEmpty(parentName))
                     {
-                        _parent = InvariantCulture;
+                        culture = InvariantCulture;
                     }
                     else
                     {
-                        _parent = CreateCultureInfoNoThrow(parentName, _cultureData.UseUserOverride);
-                        if (_parent == null)
+                        culture = CreateCultureInfoNoThrow(parentName, _cultureData.UseUserOverride);
+                        if (culture == null)
                         {
                             // For whatever reason our IPARENT or SPARENT wasn't correct, so use invariant
                             // We can't allow ourselves to fail.  In case of custom cultures the parent of the
                             // current custom culture isn't installed.
-                            _parent = InvariantCulture;
+                            culture = InvariantCulture;
                         }
                     }
+
+                    Interlocked.CompareExchange<CultureInfo>(ref _parent, culture, null);
                 }
                 return _parent;
             }


### PR DESCRIPTION
This is reintroduction of #8656, a fix for #4105. At some point the bug was reintroduced by PR #9835. I noticed it when comparing the CoreRT and CoreCLR code.