### PR TITLE
Use `saveNext` unwind opcode on arm64.

### DIFF
--- a/src/jit/arraystack.h
+++ b/src/jit/arraystack.h
@@ -122,7 +122,7 @@ public:
     }
 
     // return a reference to the i'th from the bottom
-    T BottomRef(int indx)
+    T& BottomRef(int indx)
     {
         assert(tosIndex > indx);
         return data[indx];

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -330,12 +330,12 @@ protected:
 
     static int genGetSlotSizeForRegsInMask(regMaskTP regsMask);
 
-    int genSaveCalleeSavedRegisterGroup(regMaskTP regsMask,
-                                        int       spDelta,
-                                        int spOffset DEBUGARG(bool isRegsToSaveCountOdd));
-    int genRestoreCalleeSavedRegisterGroup(regMaskTP regsMask,
-                                           int       spDelta,
-                                           int spOffset DEBUGARG(bool isRegsToRestoreCountOdd));
+    void genSaveCalleeSavedRegisterGroup(regMaskTP regsMask,
+                                         int       spDelta,
+                                         int spOffset DEBUGARG(bool isRegsToSaveCountOdd));
+    void genRestoreCalleeSavedRegisterGroup(regMaskTP regsMask,
+                                            int       spDelta,
+                                            int spOffset DEBUGARG(bool isRegsToRestoreCountOdd));
 
     void genSaveCalleeSavedRegistersHelp(regMaskTP regsToSaveMask, int lowestCalleeSavedOffset, int spDelta);
     void genRestoreCalleeSavedRegistersHelp(regMaskTP regsToRestoreMask, int lowestCalleeSavedOffset, int spDelta);

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -326,7 +326,6 @@ protected:
 
     static void genBuildRegPairsStack(regMaskTP regsMask, ArrayStack<RegPair>* regStack);
     static void genSetUseSaveNextPairs(ArrayStack<RegPair>* regStack);
-    static bool genCanUseSaveNextPair(RegPair curr, RegPair next);
 
     static int genGetSlotSizeForRegsInMask(regMaskTP regsMask);
 

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -287,14 +287,19 @@ protected:
                               regNumber reg2,
                               int       spOffset,
                               int       spDelta,
-                              bool      lastSavedWasPreviousPair,
+                              bool      useSaveNextPair,
                               regNumber tmpReg,
                               bool*     pTmpRegIsZero);
 
     void genPrologSaveReg(regNumber reg1, int spOffset, int spDelta, regNumber tmpReg, bool* pTmpRegIsZero);
 
-    void genEpilogRestoreRegPair(
-        regNumber reg1, regNumber reg2, int spOffset, int spDelta, regNumber tmpReg, bool* pTmpRegIsZero);
+    void genEpilogRestoreRegPair(regNumber reg1,
+                                 regNumber reg2,
+                                 int       spOffset,
+                                 int       spDelta,
+                                 bool      useSaveNextPair,
+                                 regNumber tmpReg,
+                                 bool*     pTmpRegIsZero);
 
     void genEpilogRestoreReg(regNumber reg1, int spOffset, int spDelta, regNumber tmpReg, bool* pTmpRegIsZero);
 
@@ -307,18 +312,21 @@ protected:
     {
         regNumber reg1;
         regNumber reg2;
+        bool      useSaveNextPair;
 
-        RegPair(regNumber reg1) : reg1(reg1), reg2(REG_NA)
+        RegPair(regNumber reg1) : reg1(reg1), reg2(REG_NA), useSaveNextPair(false)
         {
         }
 
-        RegPair(regNumber reg1, regNumber reg2) : reg1(reg1), reg2(reg2)
+        RegPair(regNumber reg1, regNumber reg2) : reg1(reg1), reg2(reg2), useSaveNextPair(false)
         {
             assert(reg2 == REG_NEXT(reg1));
         }
     };
 
     static void genBuildRegPairsStack(regMaskTP regsMask, ArrayStack<RegPair>* regStack);
+    static void genSetUseSaveNextPairs(ArrayStack<RegPair>* regStack);
+    static bool genCanUseSaveNextPair(RegPair curr, RegPair next);
 
     static int genGetSlotSizeForRegsInMask(regMaskTP regsMask);
 

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -490,25 +490,25 @@ void CodeGen::genBuildRegPairsStack(regMaskTP regsMask, ArrayStack<RegPair>* reg
 //   regStack - a regStack instance to set useSaveNextPair.
 //
 // Notes:
-// We can use save_next for RegPair(N, N+1) only when we have sequence like (N-2, N-1), (N, N+1), (N+2, N+3).
-// In this case in the prolog save_next for (N, N+1) refers to save_pair(N-2, N-1),
-// in the epilog it refers to save_pair(N+2, N+3).
+// We can use save_next for RegPair(N, N+1) only when we have sequence like (N-2, N-1), (N, N+1).
+// In this case in the prolog save_next for (N, N+1) refers to save_pair(N-2, N-1);
+// in the epilog the unwinder will search for the first save_pair (N-2, N-1)
+// and then go back to the first save_next (N, N+1) to restore it first.
 //
 // static
 void CodeGen::genSetUseSaveNextPairs(ArrayStack<RegPair>* regStack)
 {
-    for (int i = 1; i < regStack->Height() - 1; ++i)
+    for (int i = 1; i < regStack->Height(); ++i)
     {
         RegPair& curr = regStack->BottomRef(i);
         RegPair  prev = regStack->Bottom(i - 1);
-        RegPair  next = regStack->Bottom(i + 1);
 
-        if (prev.reg2 == REG_NA || curr.reg2 == REG_NA || next.reg2 == REG_NA)
+        if (prev.reg2 == REG_NA || curr.reg2 == REG_NA)
         {
             continue;
         }
 
-        if (genCanUseSaveNextPair(prev, curr) && genCanUseSaveNextPair(curr, next))
+        if (genCanUseSaveNextPair(prev, curr))
         {
             curr.useSaveNextPair = true;
         }

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -5746,7 +5746,7 @@ void CodeGen::genPopCalleeSavedRegistersAndFreeLclFrame(bool jmpEpilog)
                 // Generate:
                 //      ldp fp,lr,[sp]
                 //      add sp,sp,#remainingFrameSz
-                genEpilogRestoreRegPair(REG_FP, REG_LR, alignmentAdjustment2, spAdjustment2, REG_IP1, nullptr);
+                genEpilogRestoreRegPair(REG_FP, REG_LR, alignmentAdjustment2, spAdjustment2, false, REG_IP1, nullptr);
             }
             else
             {
@@ -5764,8 +5764,8 @@ void CodeGen::genPopCalleeSavedRegistersAndFreeLclFrame(bool jmpEpilog)
                 //      add sp,sp,#remainingFrameSz     ; might need to load this constant in a scratch register if
                 //                                      ; it's large
 
-                genEpilogRestoreRegPair(REG_FP, REG_LR, compiler->lvaOutgoingArgSpaceSize, remainingFrameSz, REG_IP1,
-                                        nullptr);
+                genEpilogRestoreRegPair(REG_FP, REG_LR, compiler->lvaOutgoingArgSpaceSize, remainingFrameSz, false,
+                                        REG_IP1, nullptr);
             }
 
             // Unlike frameType=1 or frameType=2 that restore SP at the end,


### PR DESCRIPTION
According to [Microsoft ARM64 exception handling doc](https://docs.microsoft.com/en-us/cpp/build/arm64-exception-handling?view=vs-2017) we can use `save_next` as unwind code.

And we have had part of it implemented in `genPrologSaveRegPair` but before the cleaning in #21395 it was tricky to support it in the epilog generation and keep prolog/epilog unwind infos matched.

This PR adds `genSetUseSaveNextPairs` that marks register pairs that we can save/restore with `save_next` and teaches `genEpilogRestoreRegPair` to use `save_next` (`genPrologSaveRegPair` has already known how to do that).

Asm diffs for System.Private.CoreLib (arm64 checked, altjit):
```
1 files had text diffs but not size diffs.
System.Private.CoreLib.dasm had 65544 diffs
```
that look like:
```
***** F:\DIFFS\DIFFOUT\DASMSET_86\BASE\System.Private.CoreLib.dasm
    C9 8A       save_regp X#6 Z#10 (0x0A); stp x25, x26, [sp, #80]
    C9 08       save_regp X#4 Z#8 (0x08); stp x23, x24, [sp, #64]
    C8 86       save_regp X#2 Z#6 (0x06); stp x21, x22, [sp, #48]
    C8 04       save_regp X#0 Z#4 (0x04); stp x19, x20, [sp, #32]
***** F:\DIFFS\DIFFOUT\DASMSET_86\DIFF\SYSTEM.PRIVATE.CORELIB.DASM
    C9 8A       save_regp X#6 Z#10 (0x0A); stp x25, x26, [sp, #80]
    E6          save_next
    E6          save_next
    C8 04       save_regp X#0 Z#4 (0x04); stp x19, x20, [sp, #32]
*****
```
and there is a tiny improvement in the native image `System.Private.CoreLib.dll` size.


Tested with GC_Stress=0xc and forced holes on arm64.