### PR TITLE
Fix warning causing error in warning as error (Windows)

### DIFF
--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -4429,7 +4429,7 @@ extern "C"
 
         GCEventKeyword keywords = static_cast<GCEventKeyword>(MatchAnyKeyword);
         GCEventLevel level = static_cast<GCEventLevel>(Level);
-        GCHeapUtilities::RecordEventStateChange(bIsPublicTraceHandle, keywords, level);
+        GCHeapUtilities::RecordEventStateChange(!!bIsPublicTraceHandle, keywords, level);
 
         // EventPipeEtwCallback contains some GC eventing functionality shared between EventPipe and ETW.
         // Eventually, we'll want to merge these two codepaths whenever we can.


### PR DESCRIPTION
```
LINK : warning LNK4266: missing load config symbol for image built with /GUARD 
[C:\GitHub\coreclr\bin\obj\Windows_NT.x64.Checked\src\dlls\clretwrc\clretwrc.vcxproj]

c:\github\coreclr\src\vm\eventtrace.cpp(4432): warning C4800:
 'BOOLEAN': forcing value to bool 'true' or 'false' (performance warning) 
[C:\GitHub\coreclr\bin\obj\Windows_NT.x64.Checked\src\vm\wks\cee_wks.vcxproj]

LINK : warning LNK4266: missing load config symbol for image built with /GUARD 
[C:\GitHub\coreclr\bin\obj\Windows_NT.x64.Checked\src\dlls\mscorrc\small\mscorrc.vcxproj]
LINK : warning LNK4266: missing load config symbol for image built with /GUARD 
[C:\GitHub\coreclr\bin\obj\Windows_NT.x64.Checked\src\dlls\mscorrc\full\mscorrc.debug.vcxproj]

c:\github\coreclr\src\vm\eventtrace.cpp(4432): error C2220: warning treated as error - no 'object' file generated [C:\GitHub\coreclr\bin\obj\Windows_NT.x64.Checked\src\vm\wks\cee_wks.vcxproj]
Command execution failed with exit code 1.
```

Not sure why I get these in local builds but CI doesn't get them?

/cc @jkotas 