### PR TITLE
Bring Debug CRT DLLs when build IJW tests

### DIFF
--- a/tests/src/Interop/IJW/ManagedCallingNative/ManagedCallingNative.csproj
+++ b/tests/src/Interop/IJW/ManagedCallingNative/ManagedCallingNative.csproj
@@ -24,6 +24,9 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
   </PropertyGroup>
+  <PropertyGroup>
+    <CopyDebugRuntimeDllsToOutputDirectory Condition="('$(Configuration)' == 'Debug') Or ('$(Configuration)' == 'Checked')">true</CopyDebugRuntimeDllsToOutputDirectory>
+  </PropertyGroup>
   <ItemGroup>
     <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
       <Visible>False</Visible>

--- a/tests/src/Interop/IJW/ManagedCallingNative/ManagedCallingNative.csproj
+++ b/tests/src/Interop/IJW/ManagedCallingNative/ManagedCallingNative.csproj
@@ -38,4 +38,5 @@
     <ProjectReference Include="../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Interop.settings.targets))\Interop.settings.targets" />
 </Project>

--- a/tests/src/Interop/IJW/NativeCallingManaged/NativeCallingManaged.csproj
+++ b/tests/src/Interop/IJW/NativeCallingManaged/NativeCallingManaged.csproj
@@ -24,6 +24,9 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
   </PropertyGroup>
+  <PropertyGroup>
+    <CopyDebugRuntimeDllsToOutputDirectory Condition="('$(Configuration)' == 'Debug') Or ('$(Configuration)' == 'Checked')">true</CopyDebugRuntimeDllsToOutputDirectory>
+  </PropertyGroup>
   <ItemGroup>
     <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
       <Visible>False</Visible>

--- a/tests/src/Interop/IJW/NativeCallingManaged/NativeCallingManaged.csproj
+++ b/tests/src/Interop/IJW/NativeCallingManaged/NativeCallingManaged.csproj
@@ -38,4 +38,5 @@
     <ProjectReference Include="../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Interop.settings.targets))\Interop.settings.targets" />
 </Project>

--- a/tests/src/Interop/Interop.settings.targets
+++ b/tests/src/Interop/Interop.settings.targets
@@ -17,4 +17,10 @@
       Condition="('$(IgnoreCoreCLRTestLibraryDependency)' != 'true') And ('$(ReferenceSystemPrivateCoreLib)' == 'true')"
       Include="$(MSBuildThisFileDirectory)\..\Common\CoreCLRTestLibrary\Assertion.cs" />
   </ItemGroup>
+
+  <!-- Required debug vcruntime and UCRT dlls -->
+  <ItemGroup Condition="('$(TargetsWindows)' == 'true') And ('$(CopyDebugRuntimeDllsToOutputDirectory)' == 'true')" >
+    <None Include="$(VCToolsRedistDir)onecore/debug_nonredist/$(Platform)/Microsoft.VC*.DebugCRT/vcruntime*d.dll" CopyToOutputDirectory="Always" />
+    <None Include="$(UniversalCRTSdkDir)bin/$(Platform)/ucrt/ucrtbased.dll" CopyToOutputDirectory="Always" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
IJW tests must be dynamically linked against UCRT and vcruntime.
When submitted to a Helix machine the tests would fail since there are no debug libraries installed in there.

This PR adds an ability to specify whether a Interop test needs Debug runtime libraries to be placed next to the test assembly by setting property `$(CopyDebugRuntimeDllsToOutputDirectory)`.