### PR TITLE
Refactor Send to Helix step in Azure DevOps

### DIFF
--- a/eng/send-to-helix-step.yml
+++ b/eng/send-to-helix-step.yml
@@ -1,0 +1,61 @@
+parameters:
+  displayName: ''
+  condition: ''
+  archType: ''
+  osGroup: ''
+  buildConfig: ''
+  isExternal: ''
+  creator: ''
+  publishTestResults: ''
+  helixAccessToken: ''
+  helixBuild: ''
+  helixSource: ''
+  helixTargetQueues: ''
+  helixType: ''
+  scenarios: ''
+  timeoutInMinutes: ''
+
+steps:
+- ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+  - powershell: eng\common\msbuild.ps1 -ci tests\helixpublishwitharcade.proj /maxcpucount
+    displayName: ${{ parameters.displayName }}
+    ${{ if ne(parameters.condition, '') }}:
+      condition: ${{ parameters.condition }}
+    env:
+      __BuildArch: ${{ parameters.archType }}
+      __BuildOS: ${{ parameters.osGroup }}
+      __BuildType: ${{ parameters.buildConfig }}
+      _IsExternal: ${{ parameters.isExternal }}
+      _Creator: ${{ parameters.creator }}
+      _PublishTestResults: ${{ parameters.publishTestResults }}
+      _HelixAccessToken: ${{ parameters.helixAccessToken }}
+      _HelixBuild: ${{ parameters.helixBuild }}
+      _HelixSource: ${{ parameters.helixSource }}
+      _HelixTargetQueues: ${{ parameters.helixTargetQueues }}
+      _HelixType: ${{ parameters.helixType }}
+      _Scenarios: ${{ parameters.scenarios }}
+      _TimeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+      ${{ if eq(parameters.publishTestResults, 'true') }}:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+- ${{ if or(eq(parameters.osGroup, 'Linux'), eq(parameters.osGroup, 'OSX')) }}:
+  - script: ./eng/common/msbuild.sh --ci tests/helixpublishwitharcade.proj /maxcpucount
+    displayName: ${{ parameters.displayName }}
+    ${{ if ne(parameters.condition, '') }}:
+      condition: ${{ parameters.condition }}
+    env:
+      __BuildArch: ${{ parameters.archType }}
+      __BuildOS: ${{ parameters.osGroup }}
+      __BuildType: ${{ parameters.buildConfig }}
+      _IsExternal: ${{ parameters.isExternal }}
+      _Creator: ${{ parameters.creator }}
+      _PublishTestResults: ${{ parameters.publishTestResults }}
+      _HelixAccessToken: ${{ parameters.helixAccessToken }}
+      _HelixBuild: ${{ parameters.helixBuild }}
+      _HelixSource: ${{ parameters.helixSource }}
+      _HelixTargetQueues: ${{ parameters.helixTargetQueues }}
+      _HelixType: ${{ parameters.helixType }}
+      _Scenarios: ${{ parameters.scenarios }}
+      _TimeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+      ${{ if eq(parameters.publishTestResults, 'true') }}:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/eng/send-to-helix-step.yml
+++ b/eng/send-to-helix-step.yml
@@ -10,7 +10,7 @@ parameters:
   helixAccessToken: ''
   helixBuild: ''
   helixSource: ''
-  helixTargetQueues: ''
+  helixQueues: ''
   helixType: ''
   scenarios: ''
   timeoutInMinutes: ''
@@ -31,7 +31,7 @@ steps:
       _HelixAccessToken: ${{ parameters.helixAccessToken }}
       _HelixBuild: ${{ parameters.helixBuild }}
       _HelixSource: ${{ parameters.helixSource }}
-      _HelixTargetQueues: ${{ parameters.helixTargetQueues }}
+      _HelixTargetQueues: ${{ parameters.helixQueues }}
       _HelixType: ${{ parameters.helixType }}
       _Scenarios: ${{ parameters.scenarios }}
       _TimeoutInMinutes: ${{ parameters.timeoutInMinutes }}
@@ -53,7 +53,7 @@ steps:
       _HelixAccessToken: ${{ parameters.helixAccessToken }}
       _HelixBuild: ${{ parameters.helixBuild }}
       _HelixSource: ${{ parameters.helixSource }}
-      _HelixTargetQueues: ${{ parameters.helixTargetQueues }}
+      _HelixTargetQueues: ${{ parameters.helixQueues }}
       _HelixType: ${{ parameters.helixType }}
       _Scenarios: ${{ parameters.scenarios }}
       _TimeoutInMinutes: ${{ parameters.timeoutInMinutes }}

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -53,12 +53,6 @@ jobs:
     - ${{ if eq(parameters.crossgen, 'false') }}:
       - name: crossgenArg
         value: ''
-    - ${{ if ne(parameters.scenarios, '') }}:
-      - name: scenariosArg
-        value: ${{ format('/p:Scenarios=\"{0}\"', parameters.scenarios) }}
-    - ${{ if eq(parameters.scenarios, '') }}:
-      - name: scenariosArg
-        value: ''
 
     # TODO: Enable crossgen in build-test.sh. It currently doesn't
     # accept a crossgen arg, so disable the macos/linux crossgen test

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -34,6 +34,11 @@ jobs:
 
     crossrootfsDir: ${{ parameters.crossrootfsDir }}
 
+    ${{ if eq(parameters.crossgen, 'false') }}:
+      helixType: ${{ format('test/functional/cli/pri{0}', parameters.priority) }}
+    ${{ if eq(parameters.crossgen, 'true') }}:
+      helixType: ${{ format('test/functional/r2r/cli/pri{0}', parameters.priority) }}
+
     variables:
     # Map template parameters to command line arguments
     - ${{ if eq(parameters.priority, '1') }}:
@@ -112,11 +117,7 @@ jobs:
 
         helixBuild: $(Build.BuildNumber)
         helixSource: $(_HelixSource)
-
-        ${{ if eq(parameters.crossgen, 'false') }}:
-          helixType: ${{ format('test/functional/cli/pri{0}', parameters.priority) }}
-        ${{ if eq(parameters.crossgen, 'true') }}:
-          helixType: ${{ format('test/functional/r2r/cli/pri{0}', parameters.priority) }}
+        helixType: $(_HelixType)
 
         publishTestResults: true
         # TODO: see if this amount is enough for all individual jobs to finish

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -133,8 +133,8 @@ jobs:
           isExternal: false
           # Access token variable for internal project
           helixAccessToken: $(DotNet-HelixApi-Access)
-          helixTargetQueues: ${{ parameters.helixQueuesInternal }}
+          helixQueues: ${{ parameters.helixQueuesInternal }}
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           isExternal: true
           creator: $(Build.RequestedForId)
-          helixTargetQueues: ${{ parameters.helixQueuesPublic }}
+          helixQueues: ${{ parameters.helixQueuesPublic }}

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -32,11 +32,6 @@ jobs:
       name: ${{ format('testbuild_pri{0}_r2r_{1}_{2}_{3}', parameters.priority, parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
       displayName: ${{ format('Test Pri{0} R2R {1} {2} {3}', parameters.priority, parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
 
-    ${{ if eq(parameters.crossgen, 'false') }}:
-      helixType: ${{ format('test/functional/cli/pri{0}', parameters.priority) }}
-    ${{ if eq(parameters.crossgen, 'true') }}:
-      helixType: ${{ format('test/functional/r2r/cli/pri{0}', parameters.priority) }}
-
     crossrootfsDir: ${{ parameters.crossrootfsDir }}
 
     variables:
@@ -64,14 +59,6 @@ jobs:
     - ${{ if eq(parameters.scenarios, '') }}:
       - name: scenariosArg
         value: ''
-    - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      - name: helixTargetQueuesArg
-        value: ${{ format('/p:HelixTargetQueues=\"{0}\"', parameters.helixQueuesPublic) }}
-    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - name: helixTargetQueuesArg
-        value: ${{ format('/p:HelixTargetQueues=\"{0}\"', parameters.helixQueuesInternal) }}
-    - name: commonMSBuildArgs
-      value: ${{ format('/maxcpucount /p:__BuildOS={0} /p:__BuildArch={1} /p:__BuildType={2}', parameters.osGroup, parameters.archType, parameters.buildConfig) }}
 
     # TODO: Enable crossgen in build-test.sh. It currently doesn't
     # accept a crossgen arg, so disable the macos/linux crossgen test
@@ -110,7 +97,7 @@ jobs:
           artifactName: ${{ format('{0}_{1}_{2}_build', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
           targetPath: $(Build.SourcesDirectory)\bin\Product\Windows_NT.$(archType).$(buildConfigUpper)
 
-      
+
     # Build tests
     # TODO: enable crossgen in build-test.sh
     - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
@@ -121,26 +108,33 @@ jobs:
         displayName: Build tests
 
 
-    # Send tests to helix
-    - ${{ if or(eq(parameters.osGroup, 'Linux'), eq(parameters.osGroup, 'OSX')) }}:
-      - script: ./Tools/dotnetcli/dotnet msbuild tests/helixpublishwitharcade.proj $(commonMSBuildArgs) $(scenariosArg) $(helixTargetQueuesArg)
-        displayName: Send test jobs to Helix
-        env:
-          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            # Access token variable for internal project
-            HelixAccessToken: $(DotNet-HelixApi-Access)
-          ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            # Access token variable for public project
-            HelixAccessToken: $(BotAccount-dotnet-github-anon-kaonashi-bot-helix-token)
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-      - script: .\Tools\dotnetcli\dotnet msbuild tests\helixpublishwitharcade.proj $(commonMSBuildArgs) $(scenariosArg) $(helixTargetQueuesArg)
-        displayName: Send test jobs to Helix
-        env:
-          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            # Access token variable for internal project
-            HelixAccessToken: $(DotNet-HelixApi-Access)
-          ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            # Access token variable for public project
-            HelixAccessToken: $(BotAccount-dotnet-github-anon-kaonashi-bot-helix-token)
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    # Send tests to Helix
+    - template: /eng/send-to-helix-step.yml
+      parameters:
+        displayName: Send tests to Helix
+        buildConfig: ${{ parameters.buildConfig }}
+        archType: ${{ parameters.archType }}
+        osGroup: ${{ parameters.osGroup }}
+
+        helixBuild: $(Build.BuildNumber)
+        helixSource: $(_HelixSource)
+
+        ${{ if eq(parameters.crossgen, 'false') }}:
+          helixType: ${{ format('test/functional/cli/pri{0}', parameters.priority) }}
+        ${{ if eq(parameters.crossgen, 'true') }}:
+          helixType: ${{ format('test/functional/r2r/cli/pri{0}', parameters.priority) }}
+
+        publishTestResults: true
+        # TODO: see if this amount is enough for all individual jobs to finish
+        # TODO: consider passing this value as a parameter to a test job
+        timeoutInMinutes: 30
+
+        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          isExternal: false
+          # Access token variable for internal project
+          helixAccessToken: $(DotNet-HelixApi-Access)
+          helixTargetQueues: ${{ parameters.helixQueuesInternal }}
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          isExternal: true
+          creator: $(Build.RequestedForId)
+          helixTargetQueues: ${{ parameters.helixQueuesPublic }}

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -138,3 +138,5 @@ jobs:
           isExternal: true
           creator: $(Build.RequestedForId)
           helixQueues: ${{ parameters.helixQueuesPublic }}
+
+        scenarios: ${{ parameters.scenarios }}

--- a/tests/helixpublishwitharcade.proj
+++ b/tests/helixpublishwitharcade.proj
@@ -7,13 +7,27 @@
   <Import Project="..\dir.props" />
 
   <PropertyGroup>
+    <HelixArchitecture>$(BuildArch)</HelixArchitecture>
+    <HelixConfiguration>$(BuildType)</HelixConfiguration>
+
+    <IsExternal>$(_IsExternal)</IsExternal>
+    <IsExternal Condition=" '$(IsExternal)' == '' ">true</IsExternal>
+
+    <Creator Condition=" '$(IsExternal)' == 'true' ">$(_Creator)</Creator>
+    <HelixAccessToken Condition=" '$(IsExternal)' != 'true' ">$(_HelixAccessToken)</HelixAccessToken>
+    <HelixTargetQueues>$(_HelixTargetQueues)</HelixTargetQueues>
+
+    <EnableAzurePipelinesReporter>$(_PublishTestResults)</EnableAzurePipelinesReporter>
+    <EnableAzurePipelinesReporter Condition=" '$(EnableAzurePipelinesReporter)' == '' ">false</EnableAzurePipelinesReporter>
+
+    <HelixBuild>$(_HelixBuild)</HelixBuild>
     <HelixSource>$(_HelixSource)</HelixSource>
     <HelixType>$(_HelixType)</HelixType>
-    <HelixBuild>$(BUILD_BUILDNUMBER)</HelixBuild>
 
-    <EnableAzurePipelinesReporter Condition=" '$(EnableAzurePipelinesReporter)' != 'false' ">true</EnableAzurePipelinesReporter>
+    <TimeoutInMinutes>$(_TimeoutInMinutes)</TimeoutInMinutes>
+    <TimeoutInMinutes Condition=" '$(TimeoutInMinutes)' == '' ">30</TimeoutInMinutes>
+
     <WaitForWorkItemCompletion>true</WaitForWorkItemCompletion>
-    <TimeoutInSeconds Condition=" '$(TimeoutInSeconds)' == '' ">1000</TimeoutInSeconds>
     <CoreRootDirectory>$(TestWorkingDir)\Tests\Core_Root</CoreRootDirectory>
   </PropertyGroup>
 
@@ -32,23 +46,21 @@
     <XUnitWrapperDlls Include="$(TestWorkingDir)\**\*.XUnitWrapper.dll" />
   </ItemGroup>
 
-  <Target Name="CopyRunnerScript" BeforeTargets="SubmitTestsToHelix">
+  <Target Name="CopyRunnerScriptToCoreRootDirectory" BeforeTargets="SubmitTestsToHelix">
     <Copy SourceFiles="$(MSBuildThisFileDirectory)\runtest_helix.py" DestinationFolder="$(CoreRootDirectory)" />
   </Target>
 
   <Target Name="SubmitTestsToHelix">
     <ItemGroup>
-      <Scenarios Include="$(Scenarios.Split(','))" />
+      <Scenarios Include="$(_Scenarios.Split(','))" />
       <ProjectsToBuild Include="$(MSBuildProjectFile)">
-        <Properties>Scenario=%(Scenarios.Identity)</Properties>
+        <Properties>Scenario=%(_Scenarios.Identity)</Properties>
       </ProjectsToBuild>
     </ItemGroup>
-
     <PropertyGroup>
       <BuildInParallel>false</BuildInParallel>
       <BuildInParallel Condition=" '@(ProjectsToBuild->Count())' > '1' ">true</BuildInParallel>
     </PropertyGroup>
-
     <MSBuild Projects="@(ProjectsToBuild)" Targets="Test" BuildInParallel="$(BuildInParallel)" StopOnFirstFailure="false" UnloadProjectsOnCompletion="true" />
   </Target>
 
@@ -64,11 +76,11 @@
       <TestRunNamePrefix Condition=" '$(Scenario)' != '' ">$(BuildOS) $(BuildArch) $(BuildType) $(Scenario) @ </TestRunNamePrefix>
     </PropertyGroup>
     <ItemGroup>
-      <HelixWorkItem Include="@(XUnitWrapperDlls->'%(FileName)'->Replace('.XUnitWrapper', ''))" >
+      <HelixWorkItem Include="@(XUnitWrapperDlls->'%(FileName)'->Replace('.XUnitWrapper', ''))">
         <PayloadDirectory>%(RootDir)%(Directory)</PayloadDirectory>
         <Command Condition=" '$(Scenario)' == '' ">$(HelixPythonPath) $(RunnerScript) -wrapper %(FileName)%(Extension)</Command>
         <Command Condition=" '$(Scenario)' != '' ">$(HelixPythonPath) $(RunnerScript) -wrapper %(FileName)%(Extension) -scenario $(Scenario)</Command>
-        <Timeout>$([System.TimeSpan]::FromSeconds($(TimeoutInSeconds)))</Timeout>
+        <Timeout>$([System.TimeSpan]::FromMinutes($(TimeoutInMinutes)))</Timeout>
       </HelixWorkItem>
     </ItemGroup>
   </Target>

--- a/tests/helixpublishwitharcade.proj
+++ b/tests/helixpublishwitharcade.proj
@@ -25,7 +25,7 @@
     <HelixType>$(_HelixType)</HelixType>
 
     <TimeoutInMinutes>$(_TimeoutInMinutes)</TimeoutInMinutes>
-    <TimeoutInMinutes Condition=" '$(TimeoutInMinutes)' == '' ">30</TimeoutInMinutes>
+    <TimeoutInMinutes Condition=" '$(TimeoutInMinutes)' == '' ">5</TimeoutInMinutes>
 
     <WaitForWorkItemCompletion>true</WaitForWorkItemCompletion>
     <CoreRootDirectory>$(TestWorkingDir)\Tests\Core_Root</CoreRootDirectory>


### PR DESCRIPTION
1. Move all the test job submission logic into separate file **eng/send-to-helix-step.yml**. The idea is to have one platform-independent YAML step template for sending tests to Helix and declutter test-job.yml from duplication of the logic for Windows vs. non-Windows platforms. 
2. Pass IsExternal=true and Creator for public submissions
3. Pass IsExternal=false and HelixAccessToken for internal submissions.
4. Pass the parameters to MSBuild via environment. 
5. Make all the properties names passed to MSBuild from outside starting with underscore.
6. Specify HelixArchitecture and HelixConfiguration properties