### PR TITLE
Less work for OptimalMaxSpinWaitsPerSpinIteration fast-path

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -468,18 +468,20 @@ namespace System.Threading
         {
             get
             {
-                if (s_optimalMaxSpinWaitsPerSpinIteration != 0)
-                {
-                    return s_optimalMaxSpinWaitsPerSpinIteration;
-                }
-
-                // This is done lazily because the first call to the function below in the process triggers a measurement that
-                // takes a nontrivial amount of time if the measurement has not already been done in the backgorund.
-                // See Thread::InitializeYieldProcessorNormalized(), which describes and calculates this value.
-                s_optimalMaxSpinWaitsPerSpinIteration = GetOptimalMaxSpinWaitsPerSpinIterationInternal();
-                Debug.Assert(s_optimalMaxSpinWaitsPerSpinIteration > 0);
-                return s_optimalMaxSpinWaitsPerSpinIteration;
+                int optimalMaxSpinWaitsPerSpinIteration = s_optimalMaxSpinWaitsPerSpinIteration;
+                return optimalMaxSpinWaitsPerSpinIteration != 0 ? optimalMaxSpinWaitsPerSpinIteration : CalculateOptimalMaxSpinWaitsPerSpinIteration();
             }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static int CalculateOptimalMaxSpinWaitsPerSpinIteration()
+        {
+            // This is done lazily because the first call to the function below in the process triggers a measurement that
+            // takes a nontrivial amount of time if the measurement has not already been done in the backgorund.
+            // See Thread::InitializeYieldProcessorNormalized(), which describes and calculates this value.
+            s_optimalMaxSpinWaitsPerSpinIteration = GetOptimalMaxSpinWaitsPerSpinIterationInternal();
+            Debug.Assert(s_optimalMaxSpinWaitsPerSpinIteration > 0);
+            return s_optimalMaxSpinWaitsPerSpinIteration;
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]


### PR DESCRIPTION
Split `RuntimeThread.OptimalMaxSpinWaitsPerSpinIteration` into fast and initalization paths to allow the fast path to be a small inline. 

Currently it doesn't inline:
```
Marking RuntimeThread:get_OptimalMaxSpinWaitsPerSpinIteration():int
 as NOINLINE because of unprofitable inline
```

![image](https://user-images.githubusercontent.com/1142958/50537402-eba40a00-0b56-11e9-9af4-fbd684f553a4.png)

as it is a deceptively chunky method:

```asm
; Assembly listing for method RuntimeThread:get_OptimalMaxSpinWaitsPerSpinIteration():int
; Lcl frame size = 104

G_M3979_IG01:
       55                   push     rbp
       4157                 push     r15
       4156                 push     r14
       4155                 push     r13
       4154                 push     r12
       57                   push     rdi
       56                   push     rsi
       53                   push     rbx
       4883EC68             sub      rsp, 104
       488DAC24A0000000     lea      rbp, [rsp+A0H]

G_M3979_IG02:
       488D4D90             lea      rcx, bword ptr [rbp-70H]
       498BD2               mov      rdx, r10
       E800000000           call     CORINFO_HELP_INIT_PINVOKE_FRAME
       488BF0               mov      rsi, rax
       488BCC               mov      rcx, rsp
       48894DB0             mov      qword ptr [rbp-50H], rcx
       488BCD               mov      rcx, rbp
       48894DC0             mov      qword ptr [rbp-40H], rcx
       488B0D00000000       mov      rcx, qword ptr [(reloc)]
       E800000000           call     CORINFO_HELP_GETSHARED_NONGCSTATIC_BASE_NOCTOR
       488BF8               mov      rdi, rax
       448B9F78090000       mov      r11d, dword ptr [rdi+0978H]
       4585DB               test     r11d, r11d
       7405                 je       SHORT G_M3979_IG03
       418BC3               mov      eax, r11d
       EB55                 jmp      SHORT G_M3979_IG07

G_M3979_IG03:
       4533DB               xor      r11, r11
       488D0500000000       lea      rax, [(reloc)]
       488945A0             mov      qword ptr [rbp-60H], rax
       488D0580000000       lea      rax, G_M3979_IG05
       488945B8             mov      qword ptr [rbp-48H], rax
       488D4590             lea      rax, bword ptr [rbp-70H]
       48894610             mov      qword ptr [rsi+16], rax
       C6460C00             mov      byte  ptr [rsi+12], 0

G_M3979_IG04:
       FF1500000000         call     [RuntimeThread:GetOptimalMaxSpinWaitsPerSpinIterationInternal():int]

G_M3979_IG05:
       C6460C01             mov      byte  ptr [rsi+12], 1
       488B1500000000       mov      rdx, qword ptr [(reloc)]
       833A00               cmp      dword ptr [rdx], 0
       7406                 je       SHORT G_M3979_IG06
       FF1500000000         call     [CORINFO_HELP_STOP_FOR_GC]

G_M3979_IG06:
       488B5598             mov      rdx, bword ptr [rbp-68H]
       48895610             mov      qword ptr [rsi+16], rdx
       898778090000         mov      dword ptr [rdi+0978H], eax
       8B8778090000         mov      eax, dword ptr [rdi+0978H]

G_M3979_IG07:
       C6460C01             mov      byte  ptr [rsi+12], 1

G_M3979_IG08:
       488D65C8             lea      rsp, [rbp-38H]
       5B                   pop      rbx
       5E                   pop      rsi
       5F                   pop      rdi
       415C                 pop      r12
       415D                 pop      r13
       415E                 pop      r14
       415F                 pop      r15
       5D                   pop      rbp
       C3                   ret      

; Total bytes of code 191, prolog size 24 for method RuntimeThread:get_OptimalMaxSpinWaitsPerSpinIteration():int
```
This shrinks the non-initalization fast-path to be much smaller and without 8 register push and pops:
```asm
; Assembly listing for method RuntimeThread:get_OptimalMaxSpinWaitsPerSpinIteration():int
; Lcl frame size = 40

G_M3979_IG01:
       4883EC28             sub      rsp, 40
       90                   nop      

G_M3979_IG02:
       488B0D00000000       mov      rcx, qword ptr [(reloc)]
       E800000000           call     CORINFO_HELP_GETSHARED_NONGCSTATIC_BASE_NOCTOR
       8B8078090000         mov      eax, dword ptr [rax+0978H]
       85C0                 test     eax, eax
       750E                 jne      SHORT G_M3979_IG04
       488D0500000000       lea      rax, [(reloc)]

G_M3979_IG03:
       4883C428             add      rsp, 40
       48FFE0               rex.jmp  rax

G_M3979_IG04:
       4883C428             add      rsp, 40
       C3                   ret      

; Total bytes of code 46, prolog size 5 for method RuntimeThread:get_OptimalMaxSpinWaitsPerSpinIteration():int
```

/cc @kouvel @jkotas @stephentoub 