### PR TITLE
Separate ThreadPool...ThreadLocals get from initalization

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
@@ -408,6 +408,8 @@ namespace System.Threading
         [MethodImpl(MethodImplOptions.NoInlining)]
         private ThreadPoolWorkQueueThreadLocals CreateThreadLocals()
         {
+            Debug.Assert(ThreadPoolWorkQueueThreadLocals.threadLocals == null);
+
             return (ThreadPoolWorkQueueThreadLocals.threadLocals = new ThreadPoolWorkQueueThreadLocals(this));
         }
 

--- a/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
@@ -402,9 +402,14 @@ namespace System.Threading
             loggingEnabled = FrameworkEventSource.Log.IsEnabled(EventLevel.Verbose, FrameworkEventSource.Keywords.ThreadPool | FrameworkEventSource.Keywords.ThreadTransfer);
         }
 
-        public ThreadPoolWorkQueueThreadLocals EnsureCurrentThreadHasQueue() =>
-            ThreadPoolWorkQueueThreadLocals.threadLocals ??
-            (ThreadPoolWorkQueueThreadLocals.threadLocals = new ThreadPoolWorkQueueThreadLocals(this));
+        public ThreadPoolWorkQueueThreadLocals GetOrCreateThreadLocals() =>
+            ThreadPoolWorkQueueThreadLocals.threadLocals ?? CreateThreadLocals();
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private ThreadPoolWorkQueueThreadLocals CreateThreadLocals()
+        {
+            return (ThreadPoolWorkQueueThreadLocals.threadLocals = new ThreadPoolWorkQueueThreadLocals(this));
+        }
 
         internal void EnsureThreadRequested()
         {
@@ -545,7 +550,7 @@ namespace System.Threading
                 //
                 // Use operate on workQueue local to try block so it can be enregistered 
                 ThreadPoolWorkQueue workQueue = outerWorkQueue;
-                ThreadPoolWorkQueueThreadLocals tl = workQueue.EnsureCurrentThreadHasQueue();
+                ThreadPoolWorkQueueThreadLocals tl = workQueue.GetOrCreateThreadLocals();
                 Thread currentThread = tl.currentThread;
 
                 // Start on clean ExecutionContext and SynchronizationContext


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1142958/50539436-1b173e80-0b78-11e9-83f8-aae21045cf5b.png)


Changes the hot path in `ThreadPoolWorkQueue.Dispatch()` from
```
[FAILED: noinline per IL/cached result]
 ThreadPoolWorkQueue:EnsureCurrentThreadHasQueue():ref:this
```
```asm
E800000000           call     ThreadPoolWorkQueue:EnsureCurrentThreadHasQueue():ref:this
```
```asm
G_M49946_IG01:
       57                   push     rdi
       56                   push     rsi
       53                   push     rbx
       4883EC20             sub      rsp, 32
       488BF1               mov      rsi, rcx

G_M49946_IG02:
       488B0D00000000       mov      rcx, qword ptr [(reloc)]
       BAC3010000           mov      edx, 451
       E800000000           call     CORINFO_HELP_GETSHARED_GCTHREADSTATIC_BASE_NOCTOR
       488BF8               mov      rdi, rax
       488B4720             mov      rax, gword ptr [rdi+32]
       4885C0               test     rax, rax
       7529                 jne      SHORT G_M49946_IG03
;      488D0D00000000       lea      rcx, [(reloc)]
;      E800000000           call     CORINFO_HELP_NEWFAST
;      488BD8               mov      rbx, rax
;      488BCB               mov      rcx, rbx
;      488BD6               mov      rdx, rsi
;      E800000000           call     ThreadPoolWorkQueueThreadLocals:.ctor(ref):this
;      488D4F20             lea      rcx, bword ptr [rdi+32]
;      488BD3               mov      rdx, rbx
;      E800000000           call     CORINFO_HELP_ASSIGN_REF
;      488BC3               mov      rax, rbx

G_M49946_IG03:
       4883C420             add      rsp, 32
       5B                   pop      rbx
       5E                   pop      rsi
       5F                   pop      rdi
       C3                   ret      
```
To:
```
[below ALWAYS_INLINE size] ThreadPoolWorkQueue:GetOrCreateThreadLocals():ref:this
```
```asm
       BAC3010000           mov      edx, 451
       E800000000           call     CORINFO_HELP_GETSHARED_GCTHREADSTATIC_BASE_NOCTOR
       4C8B7820             mov      r15, gword ptr [rax+32]
       4D85FF               test     r15, r15
       750B                 jne      SHORT G_M60397_IG07
;      498BCE               mov      rcx, r14
;      E800000000           call     ThreadPoolWorkQueue:CreateThreadLocals():ref:this
```

Commented out lines `; assembly` are not taken part

/cc @stephentoub 