### PR TITLE
Shorter ExecutionContext.Capture

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
@@ -57,10 +57,16 @@ namespace System.Threading
         public static ExecutionContext Capture()
         {
             ExecutionContext executionContext = Thread.CurrentThread.ExecutionContext;
-            return
-                executionContext == null ? Default :
-                executionContext.m_isFlowSuppressed ? null :
-                executionContext;
+            if (executionContext == null)
+            {
+                executionContext = Default;
+            }
+            else if (executionContext.m_isFlowSuppressed)
+            {
+                executionContext = null;
+            }
+
+            return executionContext;
         }
 
         private ExecutionContext ShallowClone(bool isFlowSuppressed)


### PR DESCRIPTION
Isn't hugely exciting, just shaves 12 bytes off the asm size.
```diff
 G_M58377_IG01:
        57                   push     rdi
        56                   push     rsi
        4883EC28             sub      rsp, 40
 
 G_M58377_IG02:
        488B3500000000       mov      rsi, qword ptr [(reloc)]
        488BCE               mov      rcx, rsi
        BABB010000           mov      edx, 443
        E800000000           call     CORINFO_HELP_GETSHARED_GCTHREADSTATIC_BASE_NOCTOR
        488B7808             mov      rdi, gword ptr [rax+8]
        4885FF               test     rdi, rdi
        7508                 jne      SHORT G_M58377_IG03
        E800000000           call     Thread:InitializeCurrentThread():ref
        488BF8               mov      rdi, rax
 
 G_M58377_IG03:
        488B4708             mov      rax, gword ptr [rdi+8]
-       7416                 je       SHORT G_M58377_IG07
-       80781800             cmp      byte  ptr [rax+24], 0
-       7507                 jne      SHORT G_M58377_IG05
-
-G_M58377_IG04:
-       4883C428             add      rsp, 40
-       5E                   pop      rsi
-       5F                   pop      rdi
-       C3                   ret      
-
-G_M58377_IG05:
-       33C0                 xor      rax, rax
-
-G_M58377_IG06:
-       4883C428             add      rsp, 40
-       5E                   pop      rsi
-       5F                   pop      rdi
-       C3                   ret      
-
-G_M58377_IG07:
-       488BCE               mov      rcx, rsi
-       BAFE010000           mov      edx, 510
-       E800000000           call     CORINFO_HELP_GETSHARED_GCSTATIC_BASE
-       488B8050050000       mov      rax, gword ptr [rax+0550H]
+       4885C0               test     rax, rax
+       7516                 jne      SHORT G_M58377_IG04
+       488BCE               mov      rcx, rsi
+       BAFE010000           mov      edx, 510
+       E800000000           call     CORINFO_HELP_GETSHARED_GCSTATIC_BASE
+       488B8050050000       mov      rax, gword ptr [rax+0550H]
+       EB08                 jmp      SHORT G_M58377_IG05
+
+G_M58377_IG04:
+       80781800             cmp      byte  ptr [rax+24], 0
+       7402                 je       SHORT G_M58377_IG05
+       33C0                 xor      rax, rax
 
-G_M58377_IG08:
+G_M58377_IG05:
        4883C428             add      rsp, 40
        5E                   pop      rsi
        5F                   pop      rdi
        C3                   ret      
 
-; Total bytes of code 101, prolog size 6 for method ExecutionContext:Capture():ref
+; Total bytes of code 89, prolog size 6 for method ExecutionContext:Capture():ref
```
Was hoping to get it down to something I could justify inlining as it both "looks" simple (C#) and is very heavily used; however it is kinda busy when compiled to asm so don't think I can.

/cc @stephentoub 