### PR TITLE
Improve init/copy block codegen

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -1931,8 +1931,33 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
 {
     assert(node->OperIs(GT_STORE_BLK));
 
-    regNumber dstAddrBaseReg = genConsumeReg(node->Addr());
-    unsigned  dstOffset      = 0;
+    unsigned  dstLclNum      = BAD_VAR_NUM;
+    regNumber dstAddrBaseReg = REG_NA;
+    int       dstOffset      = 0;
+    GenTree*  dstAddr        = node->Addr();
+
+    if (!dstAddr->isContained())
+    {
+        dstAddrBaseReg = genConsumeReg(dstAddr);
+    }
+    else if (dstAddr->OperIsAddrMode())
+    {
+        assert(!dstAddr->AsAddrMode()->HasIndex());
+
+        dstAddrBaseReg = genConsumeReg(dstAddr->AsAddrMode()->Base());
+        dstOffset      = dstAddr->AsAddrMode()->Offset();
+    }
+    else
+    {
+        assert(dstAddr->OperIsLocalAddr());
+        dstLclNum = dstAddr->AsLclVarCommon()->GetLclNum();
+
+        if (dstAddr->OperIs(GT_LCL_FLD_ADDR))
+        {
+            assert(dstAddr->AsLclFld()->gtLclOffs <= INT32_MAX);
+            dstOffset = dstAddr->AsLclFld()->gtLclOffs;
+        }
+    }
 
     regNumber srcReg;
     GenTree*  src = node->Data();
@@ -1965,10 +1990,20 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
     emitter* emit = GetEmitter();
     unsigned size = node->GetLayout()->GetSize();
 
+    assert(size <= INT32_MAX);
+    assert(dstOffset < INT32_MAX - static_cast<int>(size));
+
 #ifdef _TARGET_ARM64_
     for (unsigned regSize = 2 * REGSIZE_BYTES; size >= regSize; size -= regSize, dstOffset += regSize)
     {
-        emit->emitIns_R_R_R_I(INS_stp, EA_8BYTE, srcReg, srcReg, dstAddrBaseReg, dstOffset);
+        if (dstLclNum != BAD_VAR_NUM)
+        {
+            emit->emitIns_S_S_R_R(INS_stp, EA_8BYTE, EA_8BYTE, srcReg, srcReg, dstLclNum, dstOffset);
+        }
+        else
+        {
+            emit->emitIns_R_R_R_I(INS_stp, EA_8BYTE, srcReg, srcReg, dstAddrBaseReg, dstOffset);
+        }
     }
 #endif
 
@@ -1986,22 +2021,16 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
         {
             case 1:
                 storeIns = INS_strb;
-#ifdef _TARGET_ARM64_
-                attr = EA_1BYTE;
-#else
-                attr = EA_4BYTE;
-#endif
+                attr     = EA_4BYTE;
                 break;
             case 2:
                 storeIns = INS_strh;
-#ifdef _TARGET_ARM64_
-                attr = EA_2BYTE;
-#else
-                attr = EA_4BYTE;
-#endif
+                attr     = EA_4BYTE;
                 break;
             case 4:
+#ifdef _TARGET_ARM64_
             case 8:
+#endif
                 storeIns = INS_str;
                 attr     = EA_ATTR(regSize);
                 break;
@@ -2009,7 +2038,14 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
                 unreached();
         }
 
-        emit->emitIns_R_R_I(storeIns, attr, srcReg, dstAddrBaseReg, dstOffset);
+        if (dstLclNum != BAD_VAR_NUM)
+        {
+            emit->emitIns_S_R(storeIns, attr, srcReg, dstLclNum, dstOffset);
+        }
+        else
+        {
+            emit->emitIns_R_R_I(storeIns, attr, srcReg, dstAddrBaseReg, dstOffset);
+        }
     }
 }
 
@@ -2025,12 +2061,19 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
 
     unsigned  dstLclNum      = BAD_VAR_NUM;
     regNumber dstAddrBaseReg = REG_NA;
-    unsigned  dstOffset      = 0;
+    int       dstOffset      = 0;
     GenTree*  dstAddr        = node->Addr();
 
     if (!dstAddr->isContained())
     {
         dstAddrBaseReg = genConsumeReg(dstAddr);
+    }
+    else if (dstAddr->OperIsAddrMode())
+    {
+        assert(!dstAddr->AsAddrMode()->HasIndex());
+
+        dstAddrBaseReg = genConsumeReg(dstAddr->AsAddrMode()->Base());
+        dstOffset      = dstAddr->AsAddrMode()->Offset();
     }
     else
     {
@@ -2045,12 +2088,17 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
 
         assert(dstAddr->OperIsLocalAddr());
         dstLclNum = dstAddr->AsLclVarCommon()->GetLclNum();
-        dstOffset = dstAddr->OperIs(GT_LCL_FLD_ADDR) ? dstAddr->AsLclFld()->gtLclOffs : 0;
+
+        if (dstAddr->OperIs(GT_LCL_FLD_ADDR))
+        {
+            assert(dstAddr->AsLclFld()->gtLclOffs <= INT32_MAX);
+            dstOffset = dstAddr->AsLclFld()->gtLclOffs;
+        }
     }
 
     unsigned  srcLclNum      = BAD_VAR_NUM;
     regNumber srcAddrBaseReg = REG_NA;
-    unsigned  srcOffset      = 0;
+    int       srcOffset      = 0;
     GenTree*  src            = node->Data();
 
     assert(src->isContained());
@@ -2058,7 +2106,12 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
     if (src->OperIs(GT_LCL_VAR, GT_LCL_FLD))
     {
         srcLclNum = src->AsLclVarCommon()->GetLclNum();
-        srcOffset = src->OperIs(GT_LCL_FLD) ? src->AsLclFld()->gtLclOffs : 0;
+
+        if (src->OperIs(GT_LCL_FLD))
+        {
+            assert(src->AsLclFld()->gtLclOffs <= INT32_MAX);
+            srcOffset = static_cast<int>(src->AsLclFld()->gtLclOffs);
+        }
     }
     else
     {
@@ -2069,11 +2122,21 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
         {
             srcAddrBaseReg = genConsumeReg(srcAddr);
         }
+        else if (srcAddr->OperIsAddrMode())
+        {
+            srcAddrBaseReg = genConsumeReg(srcAddr->AsAddrMode()->Base());
+            srcOffset      = srcAddr->AsAddrMode()->Offset();
+        }
         else
         {
             assert(srcAddr->OperIsLocalAddr());
             srcLclNum = srcAddr->AsLclVarCommon()->GetLclNum();
-            srcOffset = srcAddr->OperIs(GT_LCL_FLD_ADDR) ? srcAddr->AsLclFld()->gtLclOffs : 0;
+
+            if (srcAddr->OperIs(GT_LCL_FLD_ADDR))
+            {
+                assert(srcAddr->AsLclFld()->gtLclOffs <= INT32_MAX);
+                srcOffset = static_cast<int>(srcAddr->AsLclFld()->gtLclOffs);
+            }
         }
     }
 
@@ -2084,6 +2147,10 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
 
     emitter* emit = GetEmitter();
     unsigned size = node->GetLayout()->GetSize();
+
+    assert(size <= INT32_MAX);
+    assert(srcOffset < INT32_MAX - static_cast<int>(size));
+    assert(dstOffset < INT32_MAX - static_cast<int>(size));
 
     regNumber tempReg = node->ExtractTempReg(RBM_ALLINT);
 
@@ -2132,20 +2199,12 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
             case 1:
                 loadIns  = INS_ldrb;
                 storeIns = INS_strb;
-#ifdef _TARGET_ARM64_
-                attr = EA_1BYTE;
-#else
-                attr = EA_4BYTE;
-#endif
+                attr     = EA_4BYTE;
                 break;
             case 2:
                 loadIns  = INS_ldrh;
                 storeIns = INS_strh;
-#ifdef _TARGET_ARM64_
-                attr = EA_2BYTE;
-#else
-                attr = EA_4BYTE;
-#endif
+                attr     = EA_4BYTE;
                 break;
             case 4:
 #ifdef _TARGET_ARM64_

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -282,6 +282,7 @@ private:
     GenTree* LowerConstIntDivOrMod(GenTree* node);
     GenTree* LowerSignedDivOrMod(GenTree* node);
     void LowerBlockStore(GenTreeBlk* blkNode);
+    void ContainBlockStoreAddress(GenTreeBlk* blkNode, unsigned size, GenTree* addr);
     void LowerPutArgStk(GenTreePutArgStk* tree);
 
     bool TryCreateAddrMode(GenTree* addr, bool isContainable);

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -679,11 +679,22 @@ int LinearScan::BuildBlockStore(GenTreeBlk* blkNode)
         useCount++;
         BuildUse(dstAddr, dstAddrRegMask);
     }
-
-    if ((srcAddrOrFill != nullptr) && !srcAddrOrFill->isContained())
+    else if (dstAddr->OperIsAddrMode())
     {
-        useCount++;
-        BuildUse(srcAddrOrFill, srcRegMask);
+        useCount += BuildAddrUses(dstAddr->AsAddrMode()->Base());
+    }
+
+    if (srcAddrOrFill != nullptr)
+    {
+        if (!srcAddrOrFill->isContained())
+        {
+            useCount++;
+            BuildUse(srcAddrOrFill, srcRegMask);
+        }
+        else if (srcAddrOrFill->OperIsAddrMode())
+        {
+            useCount += BuildAddrUses(srcAddrOrFill->AsAddrMode()->Base());
+        }
     }
 
     if (blkNode->OperIs(GT_STORE_DYN_BLK))

--- a/src/jit/lsraxarch.cpp
+++ b/src/jit/lsraxarch.cpp
@@ -1408,11 +1408,22 @@ int LinearScan::BuildBlockStore(GenTreeBlk* blkNode)
         useCount++;
         BuildUse(dstAddr, dstAddrRegMask);
     }
-
-    if ((srcAddrOrFill != nullptr) && !srcAddrOrFill->isContained())
+    else if (dstAddr->OperIsAddrMode())
     {
-        useCount++;
-        BuildUse(srcAddrOrFill, srcRegMask);
+        useCount += BuildAddrUses(dstAddr);
+    }
+
+    if (srcAddrOrFill != nullptr)
+    {
+        if (!srcAddrOrFill->isContained())
+        {
+            useCount++;
+            BuildUse(srcAddrOrFill, srcRegMask);
+        }
+        else if (srcAddrOrFill->OperIsAddrMode())
+        {
+            useCount += BuildAddrUses(srcAddrOrFill);
+        }
     }
 
     if (blkNode->OperIs(GT_STORE_DYN_BLK))


### PR DESCRIPTION
This improved block op codegen by better containment of the source/destination address in the unrolled case:
* Contain a local destination address on block init. This was already done for block copy.
* ~~Enable block init unroll on ARM32 (it was already enabled on ARM64 and the differences between the 2 architectures are trivial).~~ (Done in #27450)
* ~~Fix block copy local address containment on ARM. Block store lowering didn't mark local addresses as contained yet the codegen did containment on its own by ignoring the address computed in a register and instead emitting load/stores using the frame pointer register directly.~~ (Done in #27338)
* Form and contain address modes (on both XARCH and ARM). 

Examples:
```asm
; obj1.val = obj2.val
       4983C018             add      r8, 24
       4883C218             add      rdx, 24
       C4C17A6F00           vmovdqu  xmm0, qword ptr [r8]
       C5FA7F02             vmovdqu  qword ptr [rdx], xmm0
       418B4010             mov      eax, dword ptr [r8+16]
       894210               mov      dword ptr [rdx+16], eax
```
With this change the following code is generated instead:
```asm
       C4C17A6F4018         vmovdqu  xmm0, xmmword ptr [r8+24]
       C5FA7F4218           vmovdqu  xmmword ptr [rdx+24], xmm0
       418B4028             mov      eax, dword ptr [r8+40]
       894228               mov      dword ptr [rdx+40], eax
```
This also applies to array elements and local variables. For example, initializing a struct local var may currently generate:
```asm
       33C9                 xor      rcx, rcx
       488D442420           lea      rax, bword ptr [rsp+20H]
       C5F857C0             vxorps   xmm0, xmm0
       C5FA7F00             vmovdqu  qword ptr [rax], xmm0
       894810               mov      dword ptr [rax+16], ecx
```
After this change the generated code is:
```asm
       33C9                 xor      ecx, ecx
       C5F857C0             vxorps   xmm0, xmm0
       C5FA7F442420         vmovdqu  xmmword ptr [rsp+20H], xmm0
       894C2430             mov      dword ptr [rsp+30H], ecx
```

