### PR TITLE
Remove Environment static constructor

### DIFF
--- a/src/System.Private.CoreLib/src/System/Environment.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.cs
@@ -275,7 +275,7 @@ namespace System
         internal static bool IsWindows8OrAbove => WindowsVersion.IsWindows8OrAbove;
 
         // Seperate type so a .cctor is not created for Enviroment which then would be triggered during startup
-        internal static class WindowsVersion
+        private static class WindowsVersion
         {
             // Cache the value in readonly static that can be optimized out by the JIT
             internal readonly static bool IsWindows8OrAbove = GetIsWindows8OrAbove();
@@ -310,7 +310,7 @@ namespace System
 
 #if FEATURE_COMINTEROP
         // Seperate type so a .cctor is not created for Enviroment which then would be triggered during startup
-        internal static class WinRT
+        private static class WinRT
         {
             // Cache the value in readonly static that can be optimized out by the JIT
             public readonly static bool IsSupported = WinRTSupported();


### PR DESCRIPTION
Runs a bunch of stuff at startup when calling `SetCommandLineArgs` 

![image](https://user-images.githubusercontent.com/1142958/50547197-414ae600-0c2d-11e9-9c93-9c6cba8dd4dc.png)


```
.method private hidebysig specialname rtspecialname static 
	void .cctor () cil managed 
{
	// Method begins at RVA 0x3f25d3
	// Code size 59 (0x3b)
	.maxstack 8

	IL_0000: ldnull
	IL_0001: stsfld string[] System.Environment::s_CommandLineArgs
	IL_0006: ldsfld class System.Environment/'<>c' System.Environment/'<>c'::'<>9'
	IL_000b: ldftn instance bool System.Environment/'<>c'::'<.cctor>b__59_0'()
	IL_0011: newobj instance void class System.Func`1<bool>::.ctor(object, native int)
	IL_0016: newobj instance void class System.Lazy`1<bool>::.ctor(class System.Func`1<!0>)
	IL_001b: stsfld class System.Lazy`1<bool> System.Environment::s_IsWindows8OrAbove
	IL_0020: ldsfld class System.Environment/'<>c' System.Environment/'<>c'::'<>9'
	IL_0025: ldftn instance bool System.Environment/'<>c'::'<.cctor>b__59_1'()
	IL_002b: newobj instance void class System.Func`1<bool>::.ctor(object, native int)
	IL_0030: newobj instance void class System.Lazy`1<bool>::.ctor(class System.Func`1<!0>)
	IL_0035: stsfld class System.Lazy`1<bool> System.Environment::s_IsWinRTSupported
	IL_003a: ret
} // end of method Environment::.cctor
```
After

![image](https://user-images.githubusercontent.com/1142958/50547202-7ce5b000-0c2d-11e9-9d2a-306a385e2ff2.png)

/cc @jkotas 