### PR TITLE
Remove parsing from GUID constants

### DIFF
--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/ComEventsSink.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/ComEventsSink.cs
@@ -122,7 +122,7 @@ namespace System.Runtime.InteropServices
 
         #endregion
 
-        private static Guid IID_IManagedObject = new Guid("{C3FCC19E-A970-11D2-8B5A-00A0C9B7C9C4}");
+        private static Guid IID_IManagedObject = new Guid(0xC3FCC19E, 0xA970, 0x11D2, 0x8B, 0x5A, 0, 0xA0, 0xC9, 0xB7, 0xC9, 0xC4);
 
         CustomQueryInterfaceResult ICustomQueryInterface.GetInterface(ref Guid iid, out IntPtr ppv)
         {

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/ComEventsSink.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/ComEventsSink.cs
@@ -122,8 +122,6 @@ namespace System.Runtime.InteropServices
 
         #endregion
 
-        private static Guid IID_IManagedObject = new Guid(0xC3FCC19E, 0xA970, 0x11D2, 0x8B, 0x5A, 0, 0xA0, 0xC9, 0xB7, 0xC9, 0xC4);
-
         CustomQueryInterfaceResult ICustomQueryInterface.GetInterface(ref Guid iid, out IntPtr ppv)
         {
             ppv = IntPtr.Zero;
@@ -131,10 +129,6 @@ namespace System.Runtime.InteropServices
             {
                 ppv = Marshal.GetComInterfaceForObject(this, typeof(IDispatch), CustomQueryInterfaceMode.Ignore);
                 return CustomQueryInterfaceResult.Handled;
-            }
-            else if (iid == IID_IManagedObject)
-            {
-                return CustomQueryInterfaceResult.Failed;
             }
 
             return CustomQueryInterfaceResult.NotHandled;

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -29,7 +29,7 @@ namespace System.Runtime.InteropServices
     public static partial class Marshal
     {
 #if FEATURE_COMINTEROP
-        internal static Guid IID_IUnknown = new Guid("00000000-0000-0000-C000-000000000046");
+        internal static Guid IID_IUnknown = new Guid(0, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0x46);
 #endif //FEATURE_COMINTEROP
 
         private const int LMEM_FIXED = 0;

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -29,6 +29,9 @@ namespace System.Runtime.InteropServices
     public static partial class Marshal
     {
 #if FEATURE_COMINTEROP
+        /// <summary>
+        /// IUnknown is {00000000-0000-0000-C000-000000000046}
+        /// </summary>
         internal static Guid IID_IUnknown = new Guid(0, 0, 0, 0xC0, 0, 0, 0, 0, 0, 0, 0x46);
 #endif //FEATURE_COMINTEROP
 


### PR DESCRIPTION
In #21555 test failures I noticed that `Marshal..cctor` pulls in quite a lot of code just to parse a constant GUID.