### PR TITLE
Remove EventPipeController static constructor

### DIFF
--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeController.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeController.cs
@@ -49,18 +49,12 @@ namespace System.Diagnostics.Tracing
         private const string ConfigKey_MultiFileSec = "MultiFileSec";
 
         // The default set of providers/keywords/levels.  Used if an alternative configuration is not specified.
-        private static EventPipeProviderConfiguration[] DefaultProviderConfiguration => Defaults.ProviderConfiguration;
-
-        // Inner static type to hold static initalization to avoid creating a static .cctor that's activated in the startup path
-        private static class Defaults
+        private static EventPipeProviderConfiguration[] DefaultProviderConfiguration => new EventPipeProviderConfiguration[]
         {
-            internal static readonly EventPipeProviderConfiguration[] ProviderConfiguration = new EventPipeProviderConfiguration[]
-            {
-                new EventPipeProviderConfiguration("Microsoft-Windows-DotNETRuntime", 0x4c14fccbd, 5, null),
-                new EventPipeProviderConfiguration("Microsoft-Windows-DotNETRuntimePrivate", 0x4002000b, 5, null),
-                new EventPipeProviderConfiguration("Microsoft-DotNETCore-SampleProfiler", 0x0, 5, null),
-            };
-        }
+            new EventPipeProviderConfiguration("Microsoft-Windows-DotNETRuntime", 0x4c14fccbd, 5, null),
+            new EventPipeProviderConfiguration("Microsoft-Windows-DotNETRuntimePrivate", 0x4002000b, 5, null),
+            new EventPipeProviderConfiguration("Microsoft-DotNETCore-SampleProfiler", 0x0, 5, null),
+        };
 
         // Singleton controller instance.
         private static EventPipeController s_controllerInstance;

--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeController.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeController.cs
@@ -38,17 +38,15 @@ namespace System.Diagnostics.Tracing
         private const int DisabledPollingIntervalMilliseconds = 5000; // 5 seconds
         private const uint DefaultCircularBufferMB = 1024; // 1 GB
         private const char ConfigEntryDelimiter = '=';
-
-        private static char[] ProviderConfigDelimiter => Defaults.ProviderConfigDelimiter;
-        private static char[] ConfigComponentDelimiter => Defaults.ConfigComponentDelimiter;
-        private static string[] ConfigFileLineDelimiters => Defaults.ConfigFileLineDelimiters;
+        private const char ProviderConfigDelimiter = ',';
+        private const char ConfigComponentDelimiter = ':';
 
         // Config file keys.
-        private static string ConfigKey_Providers => Defaults.ConfigKey_Providers;
-        private static string ConfigKey_CircularMB => Defaults.ConfigKey_CircularMB;
-        private static string ConfigKey_OutputPath => Defaults.ConfigKey_OutputPath;
-        private static string ConfigKey_ProcessID => Defaults.ConfigKey_ProcessID;
-        private static string ConfigKey_MultiFileSec => Defaults.ConfigKey_MultiFileSec;
+        private const string ConfigKey_Providers = "Providers";
+        private const string ConfigKey_CircularMB = "CircularMB";
+        private const string ConfigKey_OutputPath = "OutputPath";
+        private const string ConfigKey_ProcessID = "ProcessID";
+        private const string ConfigKey_MultiFileSec = "MultiFileSec";
 
         // The default set of providers/keywords/levels.  Used if an alternative configuration is not specified.
         private static EventPipeProviderConfiguration[] DefaultProviderConfiguration => Defaults.ProviderConfiguration;
@@ -62,17 +60,6 @@ namespace System.Diagnostics.Tracing
                 new EventPipeProviderConfiguration("Microsoft-Windows-DotNETRuntimePrivate", 0x4002000b, 5, null),
                 new EventPipeProviderConfiguration("Microsoft-DotNETCore-SampleProfiler", 0x0, 5, null),
             };
-
-            internal static readonly char[] ProviderConfigDelimiter = new char[] { ',' };
-            internal static readonly char[] ConfigComponentDelimiter = new char[] { ':' };
-            internal static readonly string[] ConfigFileLineDelimiters = new string[] { "\r\n", "\n" };
-
-            // Config file keys.
-            internal const string ConfigKey_Providers = "Providers";
-            internal const string ConfigKey_CircularMB = "CircularMB";
-            internal const string ConfigKey_OutputPath = "OutputPath";
-            internal const string ConfigKey_ProcessID = "ProcessID";
-            internal const string ConfigKey_MultiFileSec = "MultiFileSec";
         }
 
         // Singleton controller instance.
@@ -195,7 +182,7 @@ namespace System.Diagnostics.Tracing
             string strMultiFileSec = null;
 
             // Split the configuration entries by line.
-            string[] configEntries = strConfigContents.Split(ConfigFileLineDelimiters, StringSplitOptions.RemoveEmptyEntries);
+            string[] configEntries = strConfigContents.Split(new string[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
             foreach (string configEntry in configEntries)
             {
                 //`Split the key and value by '='.


### PR DESCRIPTION
Is unnecessary work in the startup path (and doesn't get used until EventPipe is enabled)

Pre

![image](https://user-images.githubusercontent.com/1142958/50549997-6fe1b480-0c5f-11e9-9b98-8831a6b7e990.png)

Previous .cctor
```
.method private hidebysig specialname rtspecialname static 
	void .cctor () cil managed 
{
	// Method begins at RVA 0x472c8c
	// Code size 181 (0xb5)
	.maxstack 7

	IL_0000: ldc.i4.1
	IL_0001: newarr System.Char
	IL_0006: dup
	IL_0007: ldc.i4.0
	IL_0008: ldc.i4.s 44
	IL_000a: stelem.i2
	IL_000b: stsfld char[] System.Diagnostics.Tracing.EventPipeController::ProviderConfigDelimiter
	IL_0010: ldc.i4.1
	IL_0011: newarr System.Char
	IL_0016: dup
	IL_0017: ldc.i4.0
	IL_0018: ldc.i4.s 58
	IL_001a: stelem.i2
	IL_001b: stsfld char[] System.Diagnostics.Tracing.EventPipeController::ConfigComponentDelimiter
	IL_0020: ldc.i4.2
	IL_0021: newarr System.String
	IL_0026: dup
	IL_0027: ldc.i4.0
	IL_0028: ldstr "\r\n"
	IL_002d: stelem.ref
	IL_002e: dup
	IL_002f: ldc.i4.1
	IL_0030: ldstr "\n"
	IL_0035: stelem.ref
	IL_0036: stsfld string[] System.Diagnostics.Tracing.EventPipeController::ConfigFileLineDelimiters
	IL_003b: ldc.i4.3
	IL_003c: newarr System.Diagnostics.Tracing.EventPipeProviderConfiguration
	IL_0041: dup
	IL_0042: ldc.i4.0
	IL_0043: ldstr "Microsoft-Windows-DotNETRuntime"
	IL_0048: ldc.i8 20423101629
	IL_0051: ldc.i4.5
	IL_0052: ldnull
	IL_0053: newobj instance void System.Diagnostics.Tracing.EventPipeProviderConfiguration::.ctor(string, uint64, uint32, string)
	IL_0058: stelem System.Diagnostics.Tracing.EventPipeProviderConfiguration
	IL_005d: dup
	IL_005e: ldc.i4.1
	IL_005f: ldstr "Microsoft-Windows-DotNETRuntimePrivate"
	IL_0064: ldc.i4 1073872907
	IL_0069: conv.i8
	IL_006a: ldc.i4.5
	IL_006b: ldnull
	IL_006c: newobj instance void System.Diagnostics.Tracing.EventPipeProviderConfiguration::.ctor(string, uint64, uint32, string)
	IL_0071: stelem System.Diagnostics.Tracing.EventPipeProviderConfiguration
	IL_0076: dup
	IL_0077: ldc.i4.2
	IL_0078: ldstr "Microsoft-DotNETCore-SampleProfiler"
	IL_007d: ldc.i4.0
	IL_007e: conv.i8
	IL_007f: ldc.i4.5
	IL_0080: ldnull
	IL_0081: newobj instance void System.Diagnostics.Tracing.EventPipeProviderConfiguration::.ctor(string, uint64, uint32, string)
	IL_0086: stelem System.Diagnostics.Tracing.EventPipeProviderConfiguration
	IL_008b: stsfld valuetype System.Diagnostics.Tracing.EventPipeProviderConfiguration[] System.Diagnostics.Tracing.EventPipeController::DefaultProviderConfiguration
	IL_0090: ldnull
	IL_0091: stsfld class System.Diagnostics.Tracing.EventPipeController System.Diagnostics.Tracing.EventPipeController::s_controllerInstance
	IL_0096: ldc.i4.0
	IL_0097: stsfld bool System.Diagnostics.Tracing.EventPipeController::s_initializing
	IL_009c: ldc.i4.m1
	IL_009d: stsfld int32 System.Diagnostics.Tracing.EventPipeController::s_Config_EnableEventPipe
	IL_00a2: ldnull
	IL_00a3: stsfld string System.Diagnostics.Tracing.EventPipeController::s_Config_EventPipeConfig
	IL_00a8: ldc.i4.0
	IL_00a9: stsfld uint32 System.Diagnostics.Tracing.EventPipeController::s_Config_EventPipeCircularMB
	IL_00ae: ldnull
	IL_00af: stsfld string System.Diagnostics.Tracing.EventPipeController::s_Config_EventPipeOutputPath
	IL_00b4: ret
} // end of method EventPipeController::.cctor
```

Post

![image](https://user-images.githubusercontent.com/1142958/50550093-7d983980-0c61-11e9-82b7-b07c1d931a8c.png)

/cc @jkotas @vancem @brianrob