### PR TITLE
Don't Sleep(1) in some spin-wait loops

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Collections/Concurrent/ConcurrentQueueSegment.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Concurrent/ConcurrentQueueSegment.cs
@@ -193,7 +193,7 @@ namespace System.Collections.Concurrent
                 }
 
                 // Lost a race. Spin a bit, then try again.
-                spinner.SpinOnce();
+                spinner.SpinOnce(sleep1Threshold: -1);
             }
         }
 
@@ -254,7 +254,7 @@ namespace System.Collections.Concurrent
                 }
 
                 // Lost a race. Spin a bit, then try again.
-                spinner.SpinOnce();
+                spinner.SpinOnce(sleep1Threshold: -1);
             }
         }
 
@@ -311,7 +311,7 @@ namespace System.Collections.Concurrent
                 }
 
                 // Lost a race. Spin a bit, then try again.
-                spinner.SpinOnce();
+                spinner.SpinOnce(sleep1Threshold: -1);
             }
         }
 

--- a/src/System.Private.CoreLib/shared/System/Threading/ManualResetEventSlim.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ManualResetEventSlim.cs
@@ -551,7 +551,7 @@ namespace System.Threading
                 var spinner = new SpinWait();
                 while (spinner.Count < spinCount)
                 {
-                    spinner.SpinOnce(SpinWait.Sleep1ThresholdForLongSpinBeforeWait);
+                    spinner.SpinOnce(sleep1Threshold: -1);
 
                     if (IsSet)
                     {
@@ -720,7 +720,7 @@ namespace System.Threading
                     return;
                 }
 
-                sw.SpinOnce();
+                sw.SpinOnce(sleep1Threshold: -1);
             } while (true);
         }
 

--- a/src/System.Private.CoreLib/shared/System/Threading/SpinWait.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/SpinWait.cs
@@ -89,16 +89,6 @@ namespace System.Threading
         /// </remarks>
         internal static readonly int SpinCountforSpinBeforeWait = PlatformHelper.IsSingleProcessor ? 1 : 35;
 
-        /// <summary>
-        /// Typically, Sleep(1) should not be issued for a spin-wait before a proper wait because it is usually more beneficial
-        /// to just issue the proper wait. For longer spin-waits (when the spin count is configurable), this value may be used as
-        /// a threshold for issuing Sleep(1).
-        /// </summary>
-        /// <remarks>
-        /// Should be greater than <see cref="SpinCountforSpinBeforeWait"/> so that Sleep(1) would not be used by default.
-        /// </remarks>
-        internal const int Sleep1ThresholdForLongSpinBeforeWait = 40;
-
         // The number of times we've spun already.
         private int _count;
 


### PR DESCRIPTION
- In spin-wait loops that are not expected to last too long, Sleep(1) significantly delays threads from completing the operation
- From eliminating Sleep(1) in such spin-wait loops, there can be a tradeoff, better fairness vs worse throughput, because Sleep(1) removes threads from contention and in some cases fewer threads can make faster progress at the cost of delaying the Sleep(1) threads relatively significantly. Eliminating the Sleep(1) in such spin-wait loops seems to be a good tradeoff.
- Fixes https://github.com/dotnet/corefx/issues/29595