### PR TITLE
Delete useless ArgumentNullException message

### DIFF
--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -1609,9 +1609,6 @@
   <data name="ArgumentNull_Key" xml:space="preserve">
     <value>Key cannot be null.</value>
   </data>
-  <data name="ArgumentNull_Obj" xml:space="preserve">
-    <value>Object cannot be null.</value>
-  </data>
   <data name="ArgumentNull_Path" xml:space="preserve">
     <value>Path cannot be null.</value>
   </data>

--- a/src/System.Private.CoreLib/shared/System/Globalization/CultureInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CultureInfo.cs
@@ -983,7 +983,7 @@ namespace System.Globalization
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException(nameof(value), SR.ArgumentNull_Obj);
+                    throw new ArgumentNullException(nameof(value));
                 }
                 VerifyWritable();
                 _numInfo = value;
@@ -1016,7 +1016,7 @@ namespace System.Globalization
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException(nameof(value), SR.ArgumentNull_Obj);
+                    throw new ArgumentNullException(nameof(value));
                 }
                 VerifyWritable();
                 _dateTimeInfo = value;
@@ -1097,7 +1097,6 @@ namespace System.Globalization
         **Returns:
         **Arguments:
         **Exceptions:
-        **  ArgumentNull_Obj if the set value is null.
         ============================================================================*/
         public virtual Calendar Calendar
         {

--- a/src/System.Private.CoreLib/shared/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/DateTimeFormatInfo.cs
@@ -444,7 +444,7 @@ namespace System.Globalization
                     throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
                 if (value == null)
                 {
-                    throw new ArgumentNullException(nameof(value), SR.ArgumentNull_Obj);
+                    throw new ArgumentNullException(nameof(value));
                 }
                 if (value == calendar)
                 {
@@ -1842,8 +1842,7 @@ namespace System.Globalization
         {
             if (dtfi == null)
             {
-                throw new ArgumentNullException(nameof(dtfi),
-                    SR.ArgumentNull_Obj);
+                throw new ArgumentNullException(nameof(dtfi));
             }
             if (dtfi.IsReadOnly)
             {

--- a/src/System.Private.CoreLib/shared/System/Globalization/NumberFormatInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/NumberFormatInfo.cs
@@ -316,8 +316,7 @@ namespace System.Globalization
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException(nameof(CurrencyGroupSizes),
-                        SR.ArgumentNull_Obj);
+                    throw new ArgumentNullException(nameof(CurrencyGroupSizes));
                 }
                 VerifyWritable();
 
@@ -339,8 +338,7 @@ namespace System.Globalization
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException(nameof(NumberGroupSizes),
-                        SR.ArgumentNull_Obj);
+                    throw new ArgumentNullException(nameof(NumberGroupSizes));
                 }
                 VerifyWritable();
 
@@ -361,8 +359,7 @@ namespace System.Globalization
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException(nameof(PercentGroupSizes),
-                        SR.ArgumentNull_Obj);
+                    throw new ArgumentNullException(nameof(PercentGroupSizes));
                 }
                 VerifyWritable();
                 int[] inputSizes = (int[])value.Clone();


### PR DESCRIPTION
"Object cannot be null" does not add anything over the default "Value cannot be null"