### PR TITLE
Avoid boxing, object[], and string[] allocations in BuildTraceFileName

### DIFF
--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeController.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeController.cs
@@ -290,7 +290,7 @@ namespace System.Diagnostics.Tracing
 
         private static string BuildTraceFileName()
         {
-            return GetAppName() + "." + Win32Native.GetCurrentProcessId() + NetPerfFileExtension;
+            return GetAppName() + "." + Win32Native.GetCurrentProcessId().ToString() + NetPerfFileExtension;
         }
 
         private static string GetAppName()


### PR DESCRIPTION
This was calling the string.Concat(object[]) overload, which entailed boxing the process ID and allocating an object[]; then string.Concat would allocate a string[] to store the ToString results of all arguments.  By calling ToString on the process ID ourselves, we avoid the boxing, the object[], and the string[] (there's a four-string Concat overload).