### PR TITLE
Avoid boxing allocation in CodePageDataItem.DisplayNameResourceKey

### DIFF
--- a/src/System.Private.CoreLib/src/System/Text/CodePageDataItem.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Text/CodePageDataItem.Unix.cs
@@ -58,7 +58,7 @@ namespace System.Text
             {
                 if (_displayNameResourceKey == null)
                 {
-                    _displayNameResourceKey = "Globalization_cp_" + CodePage;
+                    _displayNameResourceKey = "Globalization_cp_" + CodePage.ToString();
                 }
 
                 return _displayNameResourceKey;


### PR DESCRIPTION
Use string.Concat(string, string) instead of string.Concat(object, object), which then calls ToString on each object.