### PR TITLE
WIP: Remove stack crawl marks and CAS residue from resource file loading.

### DIFF
--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
@@ -523,21 +523,17 @@ namespace System.Reflection.Emit
             return InternalAssembly.GetLoadedModules(getResourceModules);
         }
         
-        [DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod.
         public override Assembly GetSatelliteAssembly(CultureInfo culture)
         {
-            StackCrawlMark stackMark = StackCrawlMark.LookForMyCaller;
-            return InternalAssembly.InternalGetSatelliteAssembly(culture, null, ref stackMark);
+            return InternalAssembly.InternalGetSatelliteAssembly(culture, null);
         }
 
         /// <sumary> 
         /// Useful for binding to a very specific version of a satellite assembly
         /// </sumary>
-        [DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod.
         public override Assembly GetSatelliteAssembly(CultureInfo culture, Version version)
         {
-            StackCrawlMark stackMark = StackCrawlMark.LookForMyCaller;
-            return InternalAssembly.InternalGetSatelliteAssembly(culture, version, ref stackMark);
+            return InternalAssembly.InternalGetSatelliteAssembly(culture, version);
         }
 
         public override bool IsDynamic => true;

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -383,7 +383,12 @@ namespace System.Reflection
 
             string codeBase = VerifyCodeBase(assemblyRef.CodeBase);
 
-            return nLoad(assemblyRef, codeBase, reqAssembly, ref stackMark,
+            if (reqAssembly == null)
+            {
+                reqAssembly = Assembly.GetExecutingAssembly(ref stackMark);
+            }
+
+            return nLoad(assemblyRef, codeBase, reqAssembly,
                 pPrivHostBinder,
                 throwOnFileNotFound, ptrLoadContextBinder);
         }
@@ -392,7 +397,6 @@ namespace System.Reflection
         private static extern RuntimeAssembly nLoad(AssemblyName fileName,
                                                     string codeBase,
                                                     RuntimeAssembly locationHint,
-                                                    ref StackCrawlMark stackMark,
                                                     IntPtr pPrivHostBinder,
                                                     bool throwOnFileNotFound,
                                                     IntPtr ptrLoadContextBinder = default);
@@ -670,7 +674,6 @@ namespace System.Reflection
             return InternalGetSatelliteAssembly(name, culture, version, true);
         }
 
-        [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
         internal RuntimeAssembly InternalGetSatelliteAssembly(string name,
                                                               CultureInfo culture,
                                                               Version version,
@@ -689,11 +692,7 @@ namespace System.Reflection
             an.CultureInfo = culture;
             an.Name = name;
 
-            // This stack crawl mark is never used in the native code sinde we specify the assembly
-            // explicitly.
-            StackCrawlMark stackMark = StackCrawlMark.LookForMe;
-
-            RuntimeAssembly retAssembly = nLoad(an, null, this, ref stackMark, IntPtr.Zero, throwOnFileNotFound);
+            RuntimeAssembly retAssembly = nLoad(an, null, this, IntPtr.Zero, throwOnFileNotFound);
 
             if (retAssembly == this || (retAssembly == null && throwOnFileNotFound))
             {

--- a/src/System.Private.CoreLib/src/System/Resources/FileBasedResourceGroveler.cs
+++ b/src/System.Private.CoreLib/src/System/Resources/FileBasedResourceGroveler.cs
@@ -34,7 +34,7 @@ namespace System.Resources
         // Consider modifying IResourceGroveler interface (hence this method signature) when we figure out 
         // serialization compat story for moving ResourceManager members to either file-based or 
         // manifest-based classes. Want to continue tightening the design to get rid of unused params.
-        public ResourceSet GrovelForResourceSet(CultureInfo culture, Dictionary<string, ResourceSet> localResourceSets, bool tryParents, bool createIfNotExists, ref StackCrawlMark stackMark)
+        public ResourceSet GrovelForResourceSet(CultureInfo culture, Dictionary<string, ResourceSet> localResourceSets, bool tryParents, bool createIfNotExists)
         {
             Debug.Assert(culture != null, "culture shouldn't be null; check caller");
 

--- a/src/System.Private.CoreLib/src/System/Resources/IResourceGroveler.cs
+++ b/src/System.Private.CoreLib/src/System/Resources/IResourceGroveler.cs
@@ -24,6 +24,6 @@ namespace System.Resources
     internal interface IResourceGroveler
     {
         ResourceSet GrovelForResourceSet(CultureInfo culture, Dictionary<string, ResourceSet> localResourceSets, bool tryParents,
-            bool createIfNotExists, ref StackCrawlMark stackMark);
+            bool createIfNotExists);
     }
 }

--- a/src/System.Private.CoreLib/src/System/Resources/ManifestBasedResourceGroveler.cs
+++ b/src/System.Private.CoreLib/src/System/Resources/ManifestBasedResourceGroveler.cs
@@ -51,7 +51,7 @@ namespace System.Resources
             _mediator = mediator;
         }
 
-        public ResourceSet GrovelForResourceSet(CultureInfo culture, Dictionary<string, ResourceSet> localResourceSets, bool tryParents, bool createIfNotExists, ref StackCrawlMark stackMark)
+        public ResourceSet GrovelForResourceSet(CultureInfo culture, Dictionary<string, ResourceSet> localResourceSets, bool tryParents, bool createIfNotExists)
         {
             Debug.Assert(culture != null, "culture shouldn't be null; check caller");
             Debug.Assert(localResourceSets != null, "localResourceSets shouldn't be null; check caller");
@@ -71,7 +71,7 @@ namespace System.Resources
             }
             else
             {
-                satellite = GetSatelliteAssembly(lookForCulture, ref stackMark);
+                satellite = GetSatelliteAssembly(lookForCulture);
 
                 if (satellite == null)
                 {
@@ -100,7 +100,7 @@ namespace System.Resources
                     localResourceSets.TryGetValue(culture.Name, out rs);
                 }
 
-                stream = GetManifestResourceStream(satellite, fileName, ref stackMark);
+                stream = GetManifestResourceStream(satellite, fileName);
             }
 
             // 4a. Found a stream; create a ResourceSet if possible
@@ -306,17 +306,12 @@ namespace System.Resources
             }
         }
 
-        private Stream GetManifestResourceStream(RuntimeAssembly satellite, string fileName, ref StackCrawlMark stackMark)
+        private Stream GetManifestResourceStream(RuntimeAssembly satellite, string fileName)
         {
             Debug.Assert(satellite != null, "satellite shouldn't be null; check caller");
             Debug.Assert(fileName != null, "fileName shouldn't be null; check caller");
 
-            // If we're looking in the main assembly AND if the main assembly was the person who
-            // created the ResourceManager, skip a security check for private manifest resources.
-            bool canSkipSecurityCheck = (_mediator.MainAssembly == satellite)
-                                        && (_mediator.CallingAssembly == _mediator.MainAssembly);
-
-            Stream stream = satellite.GetManifestResourceStream(_mediator.LocationInfo, fileName, canSkipSecurityCheck, ref stackMark);
+            Stream stream = satellite.GetManifestResourceStream(_mediator.LocationInfo, fileName);
             if (stream == null)
             {
                 stream = CaseInsensitiveManifestResourceStreamLookup(satellite, fileName);
@@ -370,15 +365,10 @@ namespace System.Resources
                 return null;
             }
 
-            // If we're looking in the main assembly AND if the main
-            // assembly was the person who created the ResourceManager,
-            // skip a security check for private manifest resources.
-            bool canSkipSecurityCheck = _mediator.MainAssembly == satellite && _mediator.CallingAssembly == _mediator.MainAssembly;
-            StackCrawlMark stackMark = StackCrawlMark.LookForMyCaller;
-            return satellite.GetManifestResourceStream(canonicalName, ref stackMark, canSkipSecurityCheck);
+            return satellite.GetManifestResourceStream(canonicalName);
         }
 
-        private RuntimeAssembly GetSatelliteAssembly(CultureInfo lookForCulture, ref StackCrawlMark stackMark)
+        private RuntimeAssembly GetSatelliteAssembly(CultureInfo lookForCulture)
         {
             if (!_mediator.LookedForSatelliteContractVersion)
             {
@@ -395,7 +385,7 @@ namespace System.Resources
             // Yet also somehow log this error for a developer.
             try
             {
-                satellite = _mediator.MainAssembly.InternalGetSatelliteAssembly(satAssemblyName, lookForCulture, _mediator.SatelliteContractVersion, false, ref stackMark);
+                satellite = _mediator.MainAssembly.InternalGetSatelliteAssembly(satAssemblyName, lookForCulture, _mediator.SatelliteContractVersion, false);
             }
 
             // Jun 08: for cases other than ACCESS_DENIED, we'll assert instead of throw to give release builds more opportunity to fallback.

--- a/src/System.Private.CoreLib/src/System/Resources/ResourceManager.cs
+++ b/src/System.Private.CoreLib/src/System/Resources/ResourceManager.cs
@@ -148,8 +148,6 @@ namespace System.Resources
         private Version _satelliteContractVersion;
         private bool _lookedForSatelliteContractVersion;
 
-        private RuntimeAssembly _callingAssembly;  // Assembly who created the ResMgr.
-
         private IResourceGroveler resourceGroveler;
 
         public static readonly int MagicNumber = unchecked((int)0xBEEFCACE);  // If only hex had a K...
@@ -180,16 +178,8 @@ namespace System.Resources
         internal const string ResFileExtension = ".resources";
         internal const int ResFileExtensionLength = 10;
 
-        [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
-        private void Init()
-        {
-            _callingAssembly = (RuntimeAssembly)Assembly.GetCallingAssembly();
-        }
-
         protected ResourceManager()
         {
-            Init();
-
             _lastUsedResourceCache = new CultureNameResourceSetPair();
             ResourceManagerMediator mediator = new ResourceManagerMediator(this);
             resourceGroveler = new ManifestBasedResourceGroveler(mediator);
@@ -227,7 +217,6 @@ namespace System.Resources
             resourceGroveler = new FileBasedResourceGroveler(mediator);
         }
 
-        [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
         public ResourceManager(string baseName, Assembly assembly)
         {
             if (null == baseName)
@@ -245,19 +234,8 @@ namespace System.Resources
             SetAppXConfiguration();
 
             CommonAssemblyInit();
-
-            _callingAssembly = (RuntimeAssembly)Assembly.GetCallingAssembly();
-            // Special case for mscorlib - protect mscorlib's private resources.
-            // This isn't for security reasons, but to ensure we can make
-            // breaking changes to mscorlib's internal resources without 
-            // assuming users may have taken a dependency on them.
-            if (assembly == typeof(object).Assembly && _callingAssembly != assembly)
-            {
-                _callingAssembly = null;
-            }
         }
 
-        [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
         public ResourceManager(string baseName, Assembly assembly, Type usingResourceSet)
         {
             if (null == baseName)
@@ -276,16 +254,8 @@ namespace System.Resources
             _userResourceSet = usingResourceSet;
 
             CommonAssemblyInit();
-            _callingAssembly = (RuntimeAssembly)Assembly.GetCallingAssembly();
-            // Special case for mscorlib - protect mscorlib's private resources.
-            // This isn't for security reasons, but to ensure we can make
-            // breaking changes to mscorlib's internal resources without 
-            // assuming users may have taken a dependency on them.
-            if (assembly == typeof(object).Assembly && _callingAssembly != assembly)
-                _callingAssembly = null;
         }
 
-        [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
         public ResourceManager(Type resourceSource)
         {
             if (null == resourceSource)
@@ -301,13 +271,6 @@ namespace System.Resources
             SetAppXConfiguration();
 
             CommonAssemblyInit();
-
-            _callingAssembly = (RuntimeAssembly)Assembly.GetCallingAssembly();
-            // Special case for mscorlib - protect mscorlib's private resources.
-            if (MainAssembly == typeof(object).Assembly && _callingAssembly != MainAssembly)
-            {
-                _callingAssembly = null;
-            }
         }
 
         // Trying to unify code as much as possible, even though having to do a
@@ -466,7 +429,6 @@ namespace System.Resources
         // if it hasn't yet been loaded and if parent CultureInfos should be 
         // loaded as well for resource inheritance.
         //         
-        [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
         public virtual ResourceSet GetResourceSet(CultureInfo culture, bool createIfNotExists, bool tryParents)
         {
             if (null == culture)
@@ -483,13 +445,11 @@ namespace System.Resources
                 }
             }
 
-            StackCrawlMark stackMark = StackCrawlMark.LookForMyCaller;
-
             if (UseManifest && culture.HasInvariantCultureName)
             {
                 string fileName = GetResourceFileName(culture);
                 RuntimeAssembly mainAssembly = (RuntimeAssembly)MainAssembly;
-                Stream stream = mainAssembly.GetManifestResourceStream(_locationInfo, fileName, _callingAssembly == MainAssembly, ref stackMark);
+                Stream stream = mainAssembly.GetManifestResourceStream(_locationInfo, fileName);
                 if (createIfNotExists && stream != null)
                 {
                     rs = ((ManifestBasedResourceGroveler)resourceGroveler).CreateResourceSet(stream, MainAssembly);
@@ -513,33 +473,22 @@ namespace System.Resources
         // for getting a resource set lives.  Access to it is controlled by
         // threadsafe methods such as GetResourceSet, GetString, & GetObject.  
         // This will take a minimal number of locks.
-        [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
         protected virtual ResourceSet InternalGetResourceSet(CultureInfo culture, bool createIfNotExists, bool tryParents)
         {
             Debug.Assert(culture != null, "culture != null");
 
-            StackCrawlMark stackMark = StackCrawlMark.LookForMyCaller;
-            return InternalGetResourceSet(culture, createIfNotExists, tryParents, ref stackMark);
-        }
-
-        // InternalGetResourceSet is a non-threadsafe method where all the logic
-        // for getting a resource set lives.  Access to it is controlled by
-        // threadsafe methods such as GetResourceSet, GetString, & GetObject.  
-        // This will take a minimal number of locks.
-        private ResourceSet InternalGetResourceSet(CultureInfo requestedCulture, bool createIfNotExists, bool tryParents, ref StackCrawlMark stackMark)
-        {
             Dictionary<string, ResourceSet> localResourceSets = _resourceSets;
             ResourceSet rs = null;
             CultureInfo foundCulture = null;
             lock (localResourceSets)
             {
-                if (localResourceSets.TryGetValue(requestedCulture.Name, out rs))
+                if (localResourceSets.TryGetValue(culture.Name, out rs))
                 {
                     return rs;
                 }
             }
 
-            ResourceFallbackManager mgr = new ResourceFallbackManager(requestedCulture, _neutralResourcesCulture, tryParents);
+            ResourceFallbackManager mgr = new ResourceFallbackManager(culture, _neutralResourcesCulture, tryParents);
 
             foreach (CultureInfo currentCultureInfo in mgr)
             {
@@ -548,7 +497,7 @@ namespace System.Resources
                     if (localResourceSets.TryGetValue(currentCultureInfo.Name, out rs))
                     {
                         // we need to update the cache if we fellback
-                        if (requestedCulture != currentCultureInfo) foundCulture = currentCultureInfo;
+                        if (culture != currentCultureInfo) foundCulture = currentCultureInfo;
                         break;
                     }
                 }
@@ -560,7 +509,7 @@ namespace System.Resources
                 // ResourceManager).  It's happened.
 
                 rs = resourceGroveler.GrovelForResourceSet(currentCultureInfo, localResourceSets,
-                                                           tryParents, createIfNotExists, ref stackMark);
+                                                           tryParents, createIfNotExists);
 
                 // found a ResourceSet; we're done
                 if (rs != null)
@@ -767,9 +716,6 @@ namespace System.Resources
             bool bUsingSatelliteAssembliesUnderAppX = false;
 
             RuntimeAssembly resourcesAssembly = (RuntimeAssembly)MainAssembly;
-
-            if (resourcesAssembly == null)
-                resourcesAssembly = _callingAssembly;
 
             if (resourcesAssembly != null)
             {
@@ -1137,11 +1083,6 @@ namespace System.Resources
             {
                 get { return _rm.FallbackLocation; }
                 set { _rm._fallbackLoc = value; }
-            }
-
-            internal RuntimeAssembly CallingAssembly
-            {
-                get { return _rm._callingAssembly; }
             }
 
             internal RuntimeAssembly MainAssembly

--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -6068,7 +6068,6 @@ AppDomain::BindHostedPrivAssembly(
 PEAssembly * AppDomain::BindAssemblySpec(
     AssemblySpec *         pSpec, 
     BOOL                   fThrowOnFileNotFound, 
-    StackCrawlMark *       pCallerStackMark, 
     BOOL                   fUseHostBinderIfAvailable)
 {
     STATIC_CONTRACT_THROWS;
@@ -6169,7 +6168,7 @@ EndTry2:;
                     // Use CoreClr's fusion alternative
                     CoreBindResult bindResult;
 
-                    pSpec->Bind(this, fThrowOnFileNotFound, &bindResult, FALSE /* fNgenExplicitBind */, FALSE /* fExplicitBindToNativeImage */, pCallerStackMark);
+                    pSpec->Bind(this, fThrowOnFileNotFound, &bindResult, FALSE /* fNgenExplicitBind */, FALSE /* fExplicitBindToNativeImage */);
                     hrBindResult = bindResult.GetHRBindResult();
 
                     if (bindResult.Found()) 

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -2263,7 +2263,6 @@ public:
     virtual PEAssembly * BindAssemblySpec(
         AssemblySpec *pSpec,
         BOOL fThrowOnFileNotFound,
-        StackCrawlMark *pCallerStackMark = NULL,
         BOOL fUseHostBinderIfAvailable = TRUE) DAC_EMPTY_RET(NULL);
 
     HRESULT BindAssemblySpecForHostedBinder(

--- a/src/vm/assembly.cpp
+++ b/src/vm/assembly.cpp
@@ -1855,7 +1855,6 @@ BOOL Assembly::FileNotFound(HRESULT hr)
 BOOL Assembly::GetResource(LPCSTR szName, DWORD *cbResource,
                               PBYTE *pbInMemoryResource, Assembly** pAssemblyRef,
                               LPCSTR *szFileName, DWORD *dwLocation,
-                              StackCrawlMark *pStackMark, BOOL fSkipSecurityCheck,
                               BOOL fSkipRaiseResolveEvent)
 {
     CONTRACTL
@@ -1869,7 +1868,7 @@ BOOL Assembly::GetResource(LPCSTR szName, DWORD *cbResource,
     DomainAssembly *pAssembly = NULL;
     BOOL result = GetDomainAssembly()->GetResource(szName, cbResource,
                                                    pbInMemoryResource, &pAssembly,
-                                                   szFileName, dwLocation, pStackMark, fSkipSecurityCheck,
+                                                   szFileName, dwLocation,
                                                    fSkipRaiseResolveEvent);
     if (result && pAssemblyRef != NULL && pAssembly!=NULL)
         *pAssemblyRef = pAssembly->GetAssembly();

--- a/src/vm/assembly.hpp
+++ b/src/vm/assembly.hpp
@@ -413,7 +413,6 @@ public:
     BOOL GetResource(LPCSTR szName, DWORD *cbResource,
                      PBYTE *pbInMemoryResource, Assembly **pAssemblyRef,
                      LPCSTR *szFileName, DWORD *dwLocation,
-                     StackCrawlMark *pStackMark = NULL, BOOL fSkipSecurityCheck = FALSE,
                      BOOL fSkipRaiseResolveEvent = FALSE);
 
     //****************************************************************************************

--- a/src/vm/assemblynative.cpp
+++ b/src/vm/assemblynative.cpp
@@ -34,10 +34,9 @@
 
 
 
-FCIMPL7(Object*, AssemblyNative::Load, AssemblyNameBaseObject* assemblyNameUNSAFE, 
+FCIMPL6(Object*, AssemblyNative::Load, AssemblyNameBaseObject* assemblyNameUNSAFE, 
         StringObject* codeBaseUNSAFE, 
         AssemblyBaseObject* requestingAssemblyUNSAFE,
-        StackCrawlMark* stackMark,
         ICLRPrivBinder * pPrivHostBinder,
         CLR_BOOL fThrowOnFileNotFound,
         INT_PTR ptrLoadContextBinder)
@@ -59,6 +58,8 @@ FCIMPL7(Object*, AssemblyNative::Load, AssemblyNameBaseObject* assemblyNameUNSAF
 
     HELPER_METHOD_FRAME_BEGIN_RET_PROTECT(gc);
 
+    _ASSERTE(gc.requestingAssembly != NULL);
+
     if (gc.assemblyName == NULL)
         COMPlusThrow(kArgumentNullException, W("ArgumentNull_AssemblyName"));
 
@@ -76,14 +77,7 @@ FCIMPL7(Object*, AssemblyNative::Load, AssemblyNameBaseObject* assemblyNameUNSAF
     else
     {
         // Compute parent assembly
-        if (gc.requestingAssembly == NULL)
-        {
-            pRefAssembly = SystemDomain::GetCallersAssembly(stackMark);
-        }
-        else
-        {
-            pRefAssembly = gc.requestingAssembly->GetAssembly();
-        }
+        pRefAssembly = gc.requestingAssembly->GetAssembly();
 
         // Shared or collectible assemblies should not be used for the parent in the
         // late-bound case.

--- a/src/vm/assemblynative.cpp
+++ b/src/vm/assemblynative.cpp
@@ -84,7 +84,7 @@ FCIMPL7(Object*, AssemblyNative::Load, AssemblyNameBaseObject* assemblyNameUNSAF
         {
             pRefAssembly = gc.requestingAssembly->GetAssembly();
         }
-        
+
         // Shared or collectible assemblies should not be used for the parent in the
         // late-bound case.
         if (pRefAssembly && (!pRefAssembly->IsCollectible()))
@@ -135,7 +135,7 @@ FCIMPL7(Object*, AssemblyNative::Load, AssemblyNameBaseObject* assemblyNameUNSAF
     
     {
         GCX_PREEMP();
-        pAssembly = spec.LoadAssembly(FILE_LOADED, fThrowOnFileNotFound, stackMark);
+        pAssembly = spec.LoadAssembly(FILE_LOADED, fThrowOnFileNotFound);
     }
 
     if (pAssembly != NULL)
@@ -558,7 +558,7 @@ INT32 QCALLTYPE AssemblyNative::GetFlags(QCall::AssemblyHandle pAssembly)
     return retVal;
 }
 
-BYTE * QCALLTYPE AssemblyNative::GetResource(QCall::AssemblyHandle pAssembly, LPCWSTR wszName, UINT64 * length, QCall::StackCrawlMarkHandle stackMark, BOOL skipSecurityCheck)
+BYTE * QCALLTYPE AssemblyNative::GetResource(QCall::AssemblyHandle pAssembly, LPCWSTR wszName, UINT64 * length)
 {
     QCALL_CONTRACT;
 
@@ -581,7 +581,7 @@ BYTE * QCALLTYPE AssemblyNative::GetResource(QCall::AssemblyHandle pAssembly, LP
     DWORD  cbResource;
     if (pAssembly->GetResource(pNameUTF8, &cbResource,
                                &pbInMemoryResource, NULL, NULL,
-                               NULL, stackMark, skipSecurityCheck, FALSE))
+                               NULL, FALSE))
     {
         *length = cbResource;
     }
@@ -592,7 +592,7 @@ BYTE * QCALLTYPE AssemblyNative::GetResource(QCall::AssemblyHandle pAssembly, LP
     return pbInMemoryResource;
 }
 
-INT32 QCALLTYPE AssemblyNative::GetManifestResourceInfo(QCall::AssemblyHandle pAssembly, LPCWSTR wszName, QCall::ObjectHandleOnStack retAssembly, QCall::StringHandleOnStack retFileName, QCall::StackCrawlMarkHandle stackMark)
+INT32 QCALLTYPE AssemblyNative::GetManifestResourceInfo(QCall::AssemblyHandle pAssembly, LPCWSTR wszName, QCall::ObjectHandleOnStack retAssembly, QCall::StringHandleOnStack retFileName)
 {
     QCALL_CONTRACT;
 
@@ -617,7 +617,7 @@ INT32 QCALLTYPE AssemblyNative::GetManifestResourceInfo(QCall::AssemblyHandle pA
     DWORD dwLocation = 0;
 
     if (pAssembly->GetResource(pNameUTF8, NULL, NULL, &pReferencedAssembly, &pFileName,
-                              &dwLocation, stackMark, FALSE, FALSE))
+                              &dwLocation, FALSE))
     {
         if (pFileName)
             retFileName.Set(pFileName);

--- a/src/vm/assemblynative.hpp
+++ b/src/vm/assemblynative.hpp
@@ -70,7 +70,7 @@ public:
     void QCALLTYPE GetCodeBase(QCall::AssemblyHandle pAssembly, BOOL fCopiedName, QCall::StringHandleOnStack retString);
 
     static 
-    BYTE * QCALLTYPE GetResource(QCall::AssemblyHandle pAssembly, LPCWSTR wszName, UINT64 * length, QCall::StackCrawlMarkHandle stackMark, BOOL skipSecurityCheck);
+    BYTE * QCALLTYPE GetResource(QCall::AssemblyHandle pAssembly, LPCWSTR wszName, UINT64 * length);
 
     static 
     BOOL QCALLTYPE GetNeutralResourcesLanguageAttribute(QCall::AssemblyHandle pAssembly, QCall::StringHandleOnStack cultureName, INT16& outFallbackLocation);
@@ -88,7 +88,7 @@ public:
     void QCALLTYPE GetForwardedType(QCall::AssemblyHandle pAssembly, mdToken mdtExternalType, QCall::ObjectHandleOnStack retType);
 
     static 
-    INT32 QCALLTYPE GetManifestResourceInfo(QCall::AssemblyHandle pAssembly, LPCWSTR wszName, QCall::ObjectHandleOnStack retAssembly, QCall::StringHandleOnStack retFileName, QCall::StackCrawlMarkHandle stackMark);
+    INT32 QCALLTYPE GetManifestResourceInfo(QCall::AssemblyHandle pAssembly, LPCWSTR wszName, QCall::ObjectHandleOnStack retAssembly, QCall::StringHandleOnStack retFileName);
 
     static
     void QCALLTYPE GetModules(QCall::AssemblyHandle pAssembly, BOOL fLoadIfNotFound, BOOL fGetResourceModules, QCall::ObjectHandleOnStack retModules);

--- a/src/vm/assemblynative.hpp
+++ b/src/vm/assemblynative.hpp
@@ -32,10 +32,9 @@ public:
     static
     void QCALLTYPE GetExecutingAssembly(QCall::StackCrawlMarkHandle stackMark, QCall::ObjectHandleOnStack retAssembly);
 
-    static FCDECL7(Object*,         Load,                       AssemblyNameBaseObject* assemblyNameUNSAFE, 
+    static FCDECL6(Object*,         Load,                       AssemblyNameBaseObject* assemblyNameUNSAFE, 
                                                                 StringObject* codeBaseUNSAFE, 
                                                                 AssemblyBaseObject* requestingAssemblyUNSAFE,
-                                                                StackCrawlMark* stackMark,
                                                                 ICLRPrivBinder * pPrivHostBinder,
                                                                 CLR_BOOL fThrowOnFileNotFound,
                                                                 INT_PTR ptrLoadContextBinder);

--- a/src/vm/assemblyspec.cpp
+++ b/src/vm/assemblyspec.cpp
@@ -753,7 +753,7 @@ PEAssembly *AssemblySpec::ResolveAssemblyFile(AppDomain *pDomain)
 }
 
 
-Assembly *AssemblySpec::LoadAssembly(FileLoadLevel targetLevel, BOOL fThrowOnFileNotFound, StackCrawlMark *pCallerStackMark)
+Assembly *AssemblySpec::LoadAssembly(FileLoadLevel targetLevel, BOOL fThrowOnFileNotFound)
 {
     CONTRACTL
     {
@@ -763,7 +763,7 @@ Assembly *AssemblySpec::LoadAssembly(FileLoadLevel targetLevel, BOOL fThrowOnFil
     }
     CONTRACTL_END;
  
-    DomainAssembly * pDomainAssembly = LoadDomainAssembly(targetLevel, fThrowOnFileNotFound, pCallerStackMark);
+    DomainAssembly * pDomainAssembly = LoadDomainAssembly(targetLevel, fThrowOnFileNotFound);
     if (pDomainAssembly == NULL) {
         _ASSERTE(!fThrowOnFileNotFound);
         return NULL;
@@ -891,8 +891,7 @@ ICLRPrivBinder* AssemblySpec::GetBindingContextFromParentAssembly(AppDomain *pDo
 }
 
 DomainAssembly *AssemblySpec::LoadDomainAssembly(FileLoadLevel targetLevel,
-                                                 BOOL fThrowOnFileNotFound,
-                                                 StackCrawlMark *pCallerStackMark)
+                                                 BOOL fThrowOnFileNotFound)
 {
     CONTRACT(DomainAssembly *)
     {
@@ -932,7 +931,7 @@ DomainAssembly *AssemblySpec::LoadDomainAssembly(FileLoadLevel targetLevel,
     }
 
 
-    PEAssemblyHolder pFile(pDomain->BindAssemblySpec(this, fThrowOnFileNotFound, pCallerStackMark));
+    PEAssemblyHolder pFile(pDomain->BindAssemblySpec(this, fThrowOnFileNotFound));
     if (pFile == NULL)
         RETURN NULL;
 

--- a/src/vm/assemblyspec.hpp
+++ b/src/vm/assemblyspec.hpp
@@ -216,15 +216,12 @@ class AssemblySpec  : public BaseAssemblySpec
         BOOL fThrowOnFileNotFound,
         CoreBindResult* pBindResult,
         BOOL fNgenExplicitBind = FALSE, 
-        BOOL fExplicitBindToNativeImage = FALSE,
-        StackCrawlMark *pCallerStackMark  = NULL );
+        BOOL fExplicitBindToNativeImage = FALSE );
 
     Assembly *LoadAssembly(FileLoadLevel targetLevel, 
-                           BOOL fThrowOnFileNotFound = TRUE,
-                           StackCrawlMark *pCallerStackMark = NULL);
+                           BOOL fThrowOnFileNotFound = TRUE);
     DomainAssembly *LoadDomainAssembly(FileLoadLevel targetLevel,
-                                       BOOL fThrowOnFileNotFound = TRUE,
-                                       StackCrawlMark *pCallerStackMark = NULL);
+                                       BOOL fThrowOnFileNotFound = TRUE);
 
     //****************************************************************************************
     //

--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -7221,7 +7221,6 @@ void ReportMissingDependency(Exception * e)
 PEAssembly *CompilationDomain::BindAssemblySpec(
     AssemblySpec *pSpec,
     BOOL fThrowOnFileNotFound,
-    StackCrawlMark *pCallerStackMark,
     BOOL fUseHostBinderIfAvailable)
 {
     PEAssembly *pFile = NULL;
@@ -7238,7 +7237,6 @@ PEAssembly *CompilationDomain::BindAssemblySpec(
         pFile = AppDomain::BindAssemblySpec(
             pSpec,
             fThrowOnFileNotFound,
-            pCallerStackMark,
             fUseHostBinderIfAvailable);
     }
     EX_HOOK

--- a/src/vm/compile.h
+++ b/src/vm/compile.h
@@ -791,7 +791,6 @@ class CompilationDomain : public AppDomain,
     PEAssembly *BindAssemblySpec(
         AssemblySpec *pSpec,
         BOOL fThrowOnFileNotFound,
-        StackCrawlMark *pCallerStackMark = NULL,
         BOOL fUseHostBinderIfAvailable = TRUE) DAC_EMPTY_RET(NULL);
 
     BOOL CanEagerBindToZapFile(Module *targetModule, BOOL limitToHardBindList = TRUE);

--- a/src/vm/coreassemblyspec.cpp
+++ b/src/vm/coreassemblyspec.cpp
@@ -107,8 +107,7 @@ VOID  AssemblySpec::Bind(AppDomain      *pAppDomain,
                          BOOL            fThrowOnFileNotFound,
                          CoreBindResult *pResult,
                          BOOL fNgenExplicitBind /* = FALSE */,
-                         BOOL fExplicitBindToNativeImage /* = FALSE */,
-                         StackCrawlMark *pCallerStackMark /* = NULL */)
+                         BOOL fExplicitBindToNativeImage /* = FALSE */)
 {
     CONTRACTL
     {

--- a/src/vm/domainfile.cpp
+++ b/src/vm/domainfile.cpp
@@ -1714,7 +1714,6 @@ void DomainAssembly::DeliverSyncEvents()
 BOOL DomainAssembly::GetResource(LPCSTR szName, DWORD *cbResource,
                                  PBYTE *pbInMemoryResource, DomainAssembly** pAssemblyRef,
                                  LPCSTR *szFileName, DWORD *dwLocation,
-                                 StackCrawlMark *pStackMark, BOOL fSkipSecurityCheck,
                                  BOOL fSkipRaiseResolveEvent)
 {
     CONTRACTL
@@ -1732,8 +1731,6 @@ BOOL DomainAssembly::GetResource(LPCSTR szName, DWORD *cbResource,
                                    pAssemblyRef,
                                    szFileName,
                                    dwLocation,
-                                   pStackMark,
-                                   fSkipSecurityCheck,
                                    fSkipRaiseResolveEvent,
                                    this,
                                    this->m_pDomain );

--- a/src/vm/domainfile.h
+++ b/src/vm/domainfile.h
@@ -641,7 +641,6 @@ public:
     BOOL GetResource(LPCSTR szName, DWORD *cbResource,
                      PBYTE *pbInMemoryResource, DomainAssembly** pAssemblyRef,
                      LPCSTR *szFileName, DWORD *dwLocation,
-                     StackCrawlMark *pStackMark, BOOL fSkipSecurityCheck,
                      BOOL fSkipRaiseResolveEvent);
 
 #ifdef FEATURE_PREJIT

--- a/src/vm/pefile.h
+++ b/src/vm/pefile.h
@@ -282,8 +282,7 @@ public:
 
     BOOL GetResource(LPCSTR szName, DWORD *cbResource,
                      PBYTE *pbInMemoryResource, DomainAssembly** pAssemblyRef,
-                     LPCSTR *szFileName, DWORD *dwLocation, 
-                     StackCrawlMark *pStackMark, BOOL fSkipSecurityCheck,
+                     LPCSTR *szFileName, DWORD *dwLocation,
                      BOOL fSkipRaiseResolveEvent, DomainAssembly* pDomainAssembly,
                      AppDomain* pAppDomain);
 #ifndef DACCESS_COMPILE


### PR DESCRIPTION
Reference: #21629

This is prerequisite for moving remaining System.Resources code to shared CoreLib. In case of `GetSatelliteAssembly` and related code the native code never used the stack crawl mark. The other code path discussed in the issue above ended up in `pefile.cpp` and it's not clear to me whether the `kMemberAccess` check is still useful or not.