### PR TITLE
Reduce allocation in Index/Range.ToString

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Index.cs
+++ b/src/System.Private.CoreLib/shared/System/Index.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+
 namespace System
 {
     public readonly struct Index : IEquatable<Index>
@@ -33,7 +35,8 @@ namespace System
         private string ToStringFromEnd()
         {
             Span<char> span = stackalloc char[11]; // 1 for ^ and 10 for longest possible uint value
-            ((uint)Value).TryFormat(span.Slice(1), out int charsWritten);
+            bool formatted = ((uint)Value).TryFormat(span.Slice(1), out int charsWritten);
+            Debug.Assert(formatted);
             span[0] = '^';
             return new string(span.Slice(0, charsWritten + 1));
         }

--- a/src/System.Private.CoreLib/shared/System/Index.cs
+++ b/src/System.Private.CoreLib/shared/System/Index.cs
@@ -28,10 +28,14 @@ namespace System
             return _value;
         }
 
-        public override string ToString()
+        public override string ToString() => FromEnd ? ToStringFromEnd() : ((uint)Value).ToString();
+
+        private string ToStringFromEnd()
         {
-            string str = Value.ToString();
-            return FromEnd ? "^" + str : str;
+            Span<char> span = stackalloc char[11]; // 1 for ^ and 10 for longest possible uint value
+            ((uint)Value).TryFormat(span.Slice(1), out int charsWritten);
+            span[0] = '^';
+            return new string(span.Slice(0, charsWritten + 1));
         }
 
         public static implicit operator Index(int value)

--- a/src/System.Private.CoreLib/shared/System/Range.cs
+++ b/src/System.Private.CoreLib/shared/System/Range.cs
@@ -35,7 +35,29 @@ namespace System
 
         public override string ToString()
         {
-            return Start + ".." + End;
+            Span<char> span = stackalloc char[2 + (2 * 11)]; // 2 for "..", then for each index 1 for '^' and 10 for longest possible uint
+            int charsWritten;
+            int pos = 0;
+
+            if (Start.FromEnd)
+            {
+                span[0] = '^';
+                pos = 1;
+            }
+            ((uint)Start.Value).TryFormat(span.Slice(pos), out charsWritten);
+            pos += charsWritten;
+
+            span[pos++] = '.';
+            span[pos++] = '.';
+
+            if (End.FromEnd)
+            {
+                span[pos++] = '^';
+            }
+            ((uint)End.Value).TryFormat(span.Slice(pos), out charsWritten);
+            pos += charsWritten;
+
+            return new string(span.Slice(0, pos));
         }
 
         public static Range Create(Index start, Index end) => new Range(start, end);

--- a/src/System.Private.CoreLib/shared/System/Range.cs
+++ b/src/System.Private.CoreLib/shared/System/Range.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+
 namespace System
 {
     public readonly struct Range : IEquatable<Range>
@@ -44,7 +46,8 @@ namespace System
                 span[0] = '^';
                 pos = 1;
             }
-            ((uint)Start.Value).TryFormat(span.Slice(pos), out charsWritten);
+            bool formatted = ((uint)Start.Value).TryFormat(span.Slice(pos), out charsWritten);
+            Debug.Assert(formatted);
             pos += charsWritten;
 
             span[pos++] = '.';
@@ -54,7 +57,8 @@ namespace System
             {
                 span[pos++] = '^';
             }
-            ((uint)End.Value).TryFormat(span.Slice(pos), out charsWritten);
+            formatted = ((uint)End.Value).TryFormat(span.Slice(pos), out charsWritten);
+            Debug.Assert(formatted);
             pos += charsWritten;
 
             return new string(span.Slice(0, pos));


### PR DESCRIPTION
Index.ToString first calls ToString on the integer value, and then if it's FromEnd, concatenates with "^", resulting in an extra string allocation in the FromEnd case. Range.ToString then builds on that, not only generating the intermediate Index strings, but boxing those Index structs to call string.Concat(object, object, object).

This change removes the extra allocation, so there's at most one allocation for Index/Range.ToString, the resulting string itself.  For Index, there might still be zero allocations in the case where it just delegates to Value.ToString(), and it's able to return a cached string for a single-digit integer value.

```C#
private Index _indexCached = new Index(1, false);
private Index _indexFromStart = new Index(42, false);
private Index _indexFromEnd = new Index(42, true);
private Range _rangeFromStart = Range.Create(new Index(42, false), new Index(43, false));
private Range _rangeFromEnd = Range.Create(new Index(43, true), new Index(42, true));

[Benchmark] public string IndexCached() => _indexCached.ToString();
[Benchmark] public string IndexFromStartToString() => _indexFromStart.ToString();
[Benchmark] public string IndexFromEndToString() => _indexFromEnd.ToString();
[Benchmark] public string RangeFromStartToString() => _rangeFromStart.ToString();
[Benchmark] public string RangeFromEndToString() => _rangeFromEnd.ToString();
```

Before:
```
                 Method |      Mean |     Error |    StdDev |  Gen 0 | Allocated |
----------------------- |----------:|----------:|----------:|-------:|----------:|
            IndexCached |  14.41 ns | 0.3629 ns | 0.3883 ns |      - |       0 B |
 IndexFromStartToString |  21.62 ns | 0.5399 ns | 1.5750 ns | 0.0076 |      32 B |
   IndexFromEndToString |  35.04 ns | 0.7046 ns | 0.6591 ns | 0.0153 |      64 B |
 RangeFromStartToString |  73.13 ns | 1.7092 ns | 2.2224 ns | 0.0362 |     152 B |
   RangeFromEndToString | 108.04 ns | 2.0858 ns | 1.8490 ns | 0.0516 |     216 B |
```

After:
```
                 Method |     Mean |     Error |    StdDev |  Gen 0 | Allocated |
----------------------- |---------:|----------:|----------:|-------:|----------:|
            IndexCached | 14.19 ns | 0.0979 ns | 0.0818 ns |      - |       0 B |
 IndexFromStartToString | 22.70 ns | 0.1632 ns | 0.1363 ns | 0.0076 |      32 B |
   IndexFromEndToString | 34.87 ns | 0.6725 ns | 0.5962 ns | 0.0076 |      32 B |
 RangeFromStartToString | 55.33 ns | 0.3032 ns | 0.2192 ns | 0.0095 |      40 B |
   RangeFromEndToString | 55.92 ns | 0.3618 ns | 0.3021 ns | 0.0095 |      40 B |
```

cc: @tarekgh, @jkotas