### PR TITLE
Replace Array.Copy(src, dst, int) calls with Array.Copy(src, 0, dst, 0, int)

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Globalization/CultureData.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CultureData.cs
@@ -1852,7 +1852,7 @@ namespace System.Globalization
 
                         // It worked, remember the list
                         CalendarId[] temp = new CalendarId[count];
-                        Array.Copy(calendars, temp, count);
+                        Array.Copy(calendars, 0, temp, 0, count);
 
                         // Want 1st calendar to be default
                         // Prior to Vista the enumeration didn't have default calendar first

--- a/src/System.Private.CoreLib/shared/System/Globalization/StringInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/StringInfo.cs
@@ -341,7 +341,7 @@ namespace System.Globalization
             if (resultCount < len)
             {
                 int[] returnArray = new int[resultCount];
-                Array.Copy(result, returnArray, resultCount);
+                Array.Copy(result, 0, returnArray, 0, resultCount);
                 return (returnArray);
             }
             return (result);

--- a/src/System.Private.CoreLib/shared/System/Runtime/Serialization/SerializationInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Serialization/SerializationInfo.cs
@@ -134,9 +134,9 @@ namespace System.Runtime.Serialization
             object[] newData = new object[newSize];
             Type[] newTypes = new Type[newSize];
 
-            Array.Copy(_names, newMembers, _count);
-            Array.Copy(_values, newData, _count);
-            Array.Copy(_types, newTypes, _count);
+            Array.Copy(_names, 0, newMembers, 0, _count);
+            Array.Copy(_values, 0, newData, 0, _count);
+            Array.Copy(_types, 0, newTypes, 0, _count);
 
             // Assign the new arrays back to the member vars.
             _names = newMembers;

--- a/src/System.Private.CoreLib/shared/System/Text/EncodingProvider.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/EncodingProvider.cs
@@ -60,7 +60,7 @@ namespace System.Text
                 }
 
                 EncodingProvider[] providers = new EncodingProvider[s_providers.Length + 1];
-                Array.Copy(s_providers, providers, s_providers.Length);
+                Array.Copy(s_providers, 0, providers, 0, s_providers.Length);
                 providers[providers.Length - 1] = provider;
                 s_providers = providers;
             }

--- a/src/System.Private.CoreLib/src/System/Attribute.cs
+++ b/src/System.Private.CoreLib/src/System/Attribute.cs
@@ -310,7 +310,7 @@ namespace System
 
                 Attribute[] temp = ret;
                 ret = CreateAttributeArrayHelper(type, temp.Length + count);
-                Array.Copy(temp, ret, temp.Length);
+                Array.Copy(temp, 0, ret, 0, temp.Length);
 
                 int offset = temp.Length;
 

--- a/src/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
@@ -365,13 +365,13 @@ namespace System.Reflection
             if (publicKey != null)
             {
                 _publicKey = new byte[publicKey.Length];
-                Array.Copy(publicKey, _publicKey, publicKey.Length);
+                Array.Copy(publicKey, 0, _publicKey, 0, publicKey.Length);
             }
 
             if (publicKeyToken != null)
             {
                 _publicKeyToken = new byte[publicKeyToken.Length];
-                Array.Copy(publicKeyToken, _publicKeyToken, publicKeyToken.Length);
+                Array.Copy(publicKeyToken, 0, _publicKeyToken, 0, publicKeyToken.Length);
             }
 
             if (version != null)

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
@@ -260,7 +260,7 @@ namespace System.Reflection
                 return parameters;
 
             ParameterInfo[] ret = new ParameterInfo[parameters.Length];
-            Array.Copy(parameters, ret, parameters.Length);
+            Array.Copy(parameters, 0, ret, 0, parameters.Length);
             return ret;
         }
 

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
@@ -365,7 +365,7 @@ namespace System.Reflection
 
             ParameterInfo[] ret = new ParameterInfo[m_parameters.Length];
 
-            Array.Copy(m_parameters, ret, m_parameters.Length);
+            Array.Copy(m_parameters, 0, ret, 0, m_parameters.Length);
 
             return ret;
         }

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
@@ -305,7 +305,7 @@ namespace System.Reflection
 
             ParameterInfo[] ret = new ParameterInfo[numParams];
 
-            Array.Copy(indexParams, ret, numParams);
+            Array.Copy(indexParams, 0, ret, 0, numParams);
 
             return ret;
         }

--- a/src/System.Private.CoreLib/src/System/RtType.cs
+++ b/src/System.Private.CoreLib/src/System/RtType.cs
@@ -3416,7 +3416,7 @@ namespace System
             // Make a copy since we can't hand out the same array since users can modify them
             string[] retVal = new string[ret.Length];
 
-            Array.Copy(ret, retVal, ret.Length);
+            Array.Copy(ret, 0, retVal, 0, ret.Length);
 
             return retVal;
         }

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -1505,7 +1505,7 @@ namespace System.Runtime.InteropServices
             if (objects != null)
             {
                 result = new T[objects.Length];
-                Array.Copy(objects, result, objects.Length);
+                Array.Copy(objects, 0, result, 0, objects.Length);
             }
 
             return result;


### PR DESCRIPTION
The former calls GetLowerBound(0) on both src and dst, which is unnecessary when the arrays are T[] and thus always have a lower bound of 0.