### PR TITLE
Avoid some unnecessary allocation in MethodBuilder.ToString

### DIFF
--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.cs
@@ -497,9 +497,9 @@ namespace System.Reflection.Emit
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder(1000);
-            sb.Append("Name: " + m_strName + " " + Environment.NewLine);
-            sb.Append("Attributes: " + (int)m_iAttributes + Environment.NewLine);
-            sb.Append("Method Signature: " + GetMethodSignature() + Environment.NewLine);
+            sb.Append("Name: ").Append(m_strName).AppendLine(" ");
+            sb.Append("Attributes: ").Append((int)m_iAttributes).AppendLine();
+            sb.Append("Method Signature: ").Append(GetMethodSignature()).AppendLine();
             sb.Append(Environment.NewLine);
             return sb.ToString();
         }


### PR DESCRIPTION
This method already allocates a ton, and it's not going to be hot-path, but it's annoying me showing up in queries for string.Concat usage, so I'm fixing it :)