### PR TITLE
Use StringBuilderCache in PathInternal.NormalizeDirectorySeparators

### DIFF
--- a/src/System.Private.CoreLib/shared/System/IO/PathInternal.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/PathInternal.Windows.cs
@@ -375,7 +375,7 @@ namespace System.IO
             if (normalized)
                 return path;
 
-            StringBuilder builder = new StringBuilder(path.Length);
+            StringBuilder builder = StringBuilderCache.Acquire(path.Length);
 
             int start = 0;
             if (IsDirectorySeparator(path[start]))
@@ -404,7 +404,7 @@ namespace System.IO
                 builder.Append(current);
             }
 
-            return builder.ToString();
+            return StringBuilderCache.GetStringAndRelease(builder);
         }
 
         /// <summary>


### PR DESCRIPTION
When we do need to normalize, we're currently allocating the StringBuilder/char[] for the full path length.  As long as the path length is less than the max cacheable size (360), we'll now use a cached builder.

cc: @JeremyKuhne 