### PR TITLE
Support faster null checks

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Globalization/SortVersion.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/SortVersion.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.CompilerServices;
+
 namespace System.Globalization
 {
     [Serializable]
@@ -75,20 +77,19 @@ namespace System.Globalization
             return m_NlsVersion * 7 | m_SortId.GetHashCode();
         }
 
+        // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(SortVersion left, SortVersion right)
         {
-            if (((object)left) != null)
+            // Test "right" first to allow branch elimination when inlined for null checks (== null)
+            // so it can become a simple test
+            if (right is null)
             {
-                return left.Equals(right);
+                // return true/false not the test result https://github.com/dotnet/coreclr/issues/914
+                return (left is null) ? true : false;
             }
 
-            if (((object)right) != null)
-            {
-                return right.Equals(left);
-            }
-
-            // Both null.
-            return true;
+            return right.Equals(left);
         }
 
         public static bool operator !=(SortVersion left, SortVersion right)

--- a/src/System.Private.CoreLib/shared/System/Reflection/Assembly.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Assembly.cs
@@ -148,11 +148,6 @@ namespace System.Reflection
         public override bool Equals(object o) => base.Equals(o);
         public override int GetHashCode() => base.GetHashCode();
 
-        // Non-inline call to the virtual Equals so operator== only inlines to the ReferenceEquals 
-        // and doesn't include the virtual Equals preamble as well as part of the inline.
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private bool Equals(Assembly o) => Equals((object)o);
-
         // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(Assembly left, Assembly right)

--- a/src/System.Private.CoreLib/shared/System/Reflection/Assembly.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Assembly.cs
@@ -148,6 +148,11 @@ namespace System.Reflection
         public override bool Equals(object o) => base.Equals(o);
         public override int GetHashCode() => base.GetHashCode();
 
+        // Non-inline call to the virtual Equals so operator== only inlines to the ReferenceEquals 
+        // and doesn't include the virtual Equals preamble as well as part of the inline.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private bool Equals(Assembly o) => Equals((object)o);
+
         // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(Assembly left, Assembly right)

--- a/src/System.Private.CoreLib/shared/System/Reflection/ConstructorInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/ConstructorInfo.cs
@@ -22,6 +22,11 @@ namespace System.Reflection
         public override bool Equals(object obj) => base.Equals(obj);
         public override int GetHashCode() => base.GetHashCode();
 
+        // Non-inline call to the virtual Equals so operator== only inlines to the ReferenceEquals 
+        // and doesn't include the virtual Equals preamble as well as part of the inline.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private bool Equals(ConstructorInfo o) => Equals((object)o);
+
         // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(ConstructorInfo left, ConstructorInfo right)

--- a/src/System.Private.CoreLib/shared/System/Reflection/ConstructorInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/ConstructorInfo.cs
@@ -22,11 +22,6 @@ namespace System.Reflection
         public override bool Equals(object obj) => base.Equals(obj);
         public override int GetHashCode() => base.GetHashCode();
 
-        // Non-inline call to the virtual Equals so operator== only inlines to the ReferenceEquals 
-        // and doesn't include the virtual Equals preamble as well as part of the inline.
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private bool Equals(ConstructorInfo o) => Equals((object)o);
-
         // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(ConstructorInfo left, ConstructorInfo right)

--- a/src/System.Private.CoreLib/shared/System/Reflection/EventInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/EventInfo.cs
@@ -100,6 +100,11 @@ namespace System.Reflection
         public override bool Equals(object obj) => base.Equals(obj);
         public override int GetHashCode() => base.GetHashCode();
 
+        // Non-inline call to the virtual Equals so operator== only inlines to the ReferenceEquals 
+        // and doesn't include the virtual Equals preamble as well as part of the inline.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private bool Equals(EventInfo o) => Equals((object)o);
+
         // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(EventInfo left, EventInfo right)

--- a/src/System.Private.CoreLib/shared/System/Reflection/EventInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/EventInfo.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 #if FEATURE_COMINTEROP
 using EventRegistrationToken = System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken;
@@ -99,15 +100,20 @@ namespace System.Reflection
         public override bool Equals(object obj) => base.Equals(obj);
         public override int GetHashCode() => base.GetHashCode();
 
+        // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(EventInfo left, EventInfo right)
         {
-            if (object.ReferenceEquals(left, right))
-                return true;
+            // Test "right" first to allow branch elimination when inlined for null checks (== null)
+            // so it can become a simple test
+            if (right is null)
+            {
+                // return true/false not the test result https://github.com/dotnet/coreclr/issues/914
+                return (left is null) ? true : false;
+            }
 
-            if ((object)left == null || (object)right == null)
-                return false;
-
-            return left.Equals(right);
+            // Quick reference equality test prior to calling the virtual Equality
+            return ReferenceEquals(right, left) ? true : right.Equals(left);
         }
 
         public static bool operator !=(EventInfo left, EventInfo right) => !(left == right);

--- a/src/System.Private.CoreLib/shared/System/Reflection/EventInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/EventInfo.cs
@@ -100,11 +100,6 @@ namespace System.Reflection
         public override bool Equals(object obj) => base.Equals(obj);
         public override int GetHashCode() => base.GetHashCode();
 
-        // Non-inline call to the virtual Equals so operator== only inlines to the ReferenceEquals 
-        // and doesn't include the virtual Equals preamble as well as part of the inline.
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private bool Equals(EventInfo o) => Equals((object)o);
-
         // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(EventInfo left, EventInfo right)

--- a/src/System.Private.CoreLib/shared/System/Reflection/FieldInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/FieldInfo.cs
@@ -40,6 +40,11 @@ namespace System.Reflection
         public override bool Equals(object obj) => base.Equals(obj);
         public override int GetHashCode() => base.GetHashCode();
 
+        // Non-inline call to the virtual Equals so operator== only inlines to the ReferenceEquals 
+        // and doesn't include the virtual Equals preamble as well as part of the inline.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private bool Equals(FieldInfo o) => Equals((object)o);
+
         // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(FieldInfo left, FieldInfo right)

--- a/src/System.Private.CoreLib/shared/System/Reflection/FieldInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/FieldInfo.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 
 namespace System.Reflection
 {
@@ -39,15 +40,20 @@ namespace System.Reflection
         public override bool Equals(object obj) => base.Equals(obj);
         public override int GetHashCode() => base.GetHashCode();
 
+        // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(FieldInfo left, FieldInfo right)
         {
-            if (object.ReferenceEquals(left, right))
-                return true;
+            // Test "right" first to allow branch elimination when inlined for null checks (== null)
+            // so it can become a simple test
+            if (right is null)
+            {
+                // return true/false not the test result https://github.com/dotnet/coreclr/issues/914
+                return (left is null) ? true : false;
+            }
 
-            if ((object)left == null || (object)right == null)
-                return false;
-
-            return left.Equals(right);
+            // Quick reference equality test prior to calling the virtual Equality
+            return ReferenceEquals(right, left) ? true : right.Equals(left);
         }
 
         public static bool operator !=(FieldInfo left, FieldInfo right) => !(left == right);

--- a/src/System.Private.CoreLib/shared/System/Reflection/FieldInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/FieldInfo.cs
@@ -40,11 +40,6 @@ namespace System.Reflection
         public override bool Equals(object obj) => base.Equals(obj);
         public override int GetHashCode() => base.GetHashCode();
 
-        // Non-inline call to the virtual Equals so operator== only inlines to the ReferenceEquals 
-        // and doesn't include the virtual Equals preamble as well as part of the inline.
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private bool Equals(FieldInfo o) => Equals((object)o);
-
         // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(FieldInfo left, FieldInfo right)

--- a/src/System.Private.CoreLib/shared/System/Reflection/MemberInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/MemberInfo.cs
@@ -45,6 +45,11 @@ namespace System.Reflection
         public override bool Equals(object obj) => base.Equals(obj);
         public override int GetHashCode() => base.GetHashCode();
 
+        // Non-inline call to the virtual Equals so operator== only inlines to the ReferenceEquals 
+        // and doesn't include the virtual Equals preamble as well as part of the inline.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private bool Equals(MemberInfo o) => Equals((object)o);
+
         // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(MemberInfo left, MemberInfo right)

--- a/src/System.Private.CoreLib/shared/System/Reflection/MemberInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/MemberInfo.cs
@@ -45,11 +45,6 @@ namespace System.Reflection
         public override bool Equals(object obj) => base.Equals(obj);
         public override int GetHashCode() => base.GetHashCode();
 
-        // Non-inline call to the virtual Equals so operator== only inlines to the ReferenceEquals 
-        // and doesn't include the virtual Equals preamble as well as part of the inline.
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private bool Equals(MemberInfo o) => Equals((object)o);
-
         // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(MemberInfo left, MemberInfo right)

--- a/src/System.Private.CoreLib/shared/System/Reflection/MethodBase.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/MethodBase.cs
@@ -63,11 +63,6 @@ namespace System.Reflection
         public override bool Equals(object obj) => base.Equals(obj);
         public override int GetHashCode() => base.GetHashCode();
 
-        // Non-inline call to the virtual Equals so operator== only inlines to the ReferenceEquals
-        // and doesn't include the virtual Equals preamble as well as part of the inline.
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private bool Equals(MethodBase o) => Equals((object)o);
-
         // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(MethodBase left, MethodBase right)

--- a/src/System.Private.CoreLib/shared/System/Reflection/MethodBase.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/MethodBase.cs
@@ -63,6 +63,11 @@ namespace System.Reflection
         public override bool Equals(object obj) => base.Equals(obj);
         public override int GetHashCode() => base.GetHashCode();
 
+        // Non-inline call to the virtual Equals so operator== only inlines to the ReferenceEquals
+        // and doesn't include the virtual Equals preamble as well as part of the inline.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private bool Equals(MethodBase o) => Equals((object)o);
+
         // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(MethodBase left, MethodBase right)

--- a/src/System.Private.CoreLib/shared/System/Reflection/MethodInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/MethodInfo.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.CompilerServices;
+
 namespace System.Reflection
 {
     public abstract partial class MethodInfo : MethodBase
@@ -27,15 +29,20 @@ namespace System.Reflection
         public override bool Equals(object obj) => base.Equals(obj);
         public override int GetHashCode() => base.GetHashCode();
 
+        // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(MethodInfo left, MethodInfo right)
         {
-            if (object.ReferenceEquals(left, right))
-                return true;
+            // Test "right" first to allow branch elimination when inlined for null checks (== null)
+            // so it can become a simple test
+            if (right is null)
+            {
+                // return true/false not the test result https://github.com/dotnet/coreclr/issues/914
+                return (left is null) ? true : false;
+            }
 
-            if ((object)left == null || (object)right == null)
-                return false;
-
-            return left.Equals(right);
+            // Quick reference equality test prior to calling the virtual Equality
+            return ReferenceEquals(right, left) ? true : right.Equals(left);
         }
 
         public static bool operator !=(MethodInfo left, MethodInfo right) => !(left == right);

--- a/src/System.Private.CoreLib/shared/System/Reflection/MethodInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/MethodInfo.cs
@@ -29,11 +29,6 @@ namespace System.Reflection
         public override bool Equals(object obj) => base.Equals(obj);
         public override int GetHashCode() => base.GetHashCode();
 
-        // Non-inline call to the virtual Equals so operator== only inlines to the ReferenceEquals 
-        // and doesn't include the virtual Equals preamble as well as part of the inline.
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private bool Equals(MethodInfo o) => Equals((object)o);
-
         // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(MethodInfo left, MethodInfo right)

--- a/src/System.Private.CoreLib/shared/System/Reflection/MethodInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/MethodInfo.cs
@@ -29,6 +29,11 @@ namespace System.Reflection
         public override bool Equals(object obj) => base.Equals(obj);
         public override int GetHashCode() => base.GetHashCode();
 
+        // Non-inline call to the virtual Equals so operator== only inlines to the ReferenceEquals 
+        // and doesn't include the virtual Equals preamble as well as part of the inline.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private bool Equals(MethodInfo o) => Equals((object)o);
+
         // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(MethodInfo left, MethodInfo right)

--- a/src/System.Private.CoreLib/shared/System/Reflection/Module.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Module.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
 namespace System.Reflection
@@ -115,15 +116,20 @@ namespace System.Reflection
         public override bool Equals(object o) => base.Equals(o);
         public override int GetHashCode() => base.GetHashCode();
 
+        // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(Module left, Module right)
         {
-            if (object.ReferenceEquals(left, right))
-                return true;
+            // Test "right" first to allow branch elimination when inlined for null checks (== null)
+            // so it can become a simple test
+            if (right is null)
+            {
+                // return true/false not the test result https://github.com/dotnet/coreclr/issues/914
+                return (left is null) ? true : false;
+            }
 
-            if ((object)left == null || (object)right == null)
-                return false;
-
-            return left.Equals(right);
+            // Quick reference equality test prior to calling the virtual Equality
+            return ReferenceEquals(right, left) ? true : right.Equals(left);
         }
 
         public static bool operator !=(Module left, Module right) => !(left == right);

--- a/src/System.Private.CoreLib/shared/System/Reflection/Module.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Module.cs
@@ -116,6 +116,11 @@ namespace System.Reflection
         public override bool Equals(object o) => base.Equals(o);
         public override int GetHashCode() => base.GetHashCode();
 
+        // Non-inline call to the virtual Equals so operator== only inlines to the ReferenceEquals 
+        // and doesn't include the virtual Equals preamble as well as part of the inline.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private bool Equals(Module o) => Equals((object)o);
+        
         // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(Module left, Module right)

--- a/src/System.Private.CoreLib/shared/System/Reflection/Module.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Module.cs
@@ -115,11 +115,6 @@ namespace System.Reflection
 
         public override bool Equals(object o) => base.Equals(o);
         public override int GetHashCode() => base.GetHashCode();
-
-        // Non-inline call to the virtual Equals so operator== only inlines to the ReferenceEquals 
-        // and doesn't include the virtual Equals preamble as well as part of the inline.
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private bool Equals(Module o) => Equals((object)o);
         
         // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/System.Private.CoreLib/shared/System/Reflection/PropertyInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/PropertyInfo.cs
@@ -59,11 +59,6 @@ namespace System.Reflection
         public override bool Equals(object obj) => base.Equals(obj);
         public override int GetHashCode() => base.GetHashCode();
 
-        // Non-inline call to the virtual Equals so operator== only inlines to the ReferenceEquals 
-        // and doesn't include the virtual Equals preamble as well as part of the inline.
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private bool Equals(PropertyInfo o) => Equals((object)o);
-
         // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(PropertyInfo left, PropertyInfo right)

--- a/src/System.Private.CoreLib/shared/System/Reflection/PropertyInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/PropertyInfo.cs
@@ -59,6 +59,11 @@ namespace System.Reflection
         public override bool Equals(object obj) => base.Equals(obj);
         public override int GetHashCode() => base.GetHashCode();
 
+        // Non-inline call to the virtual Equals so operator== only inlines to the ReferenceEquals 
+        // and doesn't include the virtual Equals preamble as well as part of the inline.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private bool Equals(PropertyInfo o) => Equals((object)o);
+
         // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(PropertyInfo left, PropertyInfo right)

--- a/src/System.Private.CoreLib/shared/System/Reflection/PropertyInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/PropertyInfo.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 
 namespace System.Reflection
 {
@@ -58,15 +59,20 @@ namespace System.Reflection
         public override bool Equals(object obj) => base.Equals(obj);
         public override int GetHashCode() => base.GetHashCode();
 
+        // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(PropertyInfo left, PropertyInfo right)
         {
-            if (object.ReferenceEquals(left, right))
-                return true;
+            // Test "right" first to allow branch elimination when inlined for null checks (== null)
+            // so it can become a simple test
+            if (right is null)
+            {
+                // return true/false not the test result https://github.com/dotnet/coreclr/issues/914
+                return (left is null) ? true : false;
+            }
 
-            if ((object)left == null || (object)right == null)
-                return false;
-
-            return left.Equals(right);
+            // Quick reference equality test prior to calling the virtual Equality
+            return ReferenceEquals(right, left) ? true : right.Equals(left);
         }
 
         public static bool operator !=(PropertyInfo left, PropertyInfo right) => !(left == right);

--- a/src/System.Private.CoreLib/src/System/Delegate.cs
+++ b/src/System.Private.CoreLib/src/System/Delegate.cs
@@ -505,20 +505,32 @@ namespace System
             return d;
         }
 
+        // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(Delegate d1, Delegate d2)
         {
-            if ((object)d1 == null)
-                return (object)d2 == null;
+            // Test d2 first to allow branch elimination when inlined for null checks (== null)
+            // so it can become a simple test
+            if (d2 is null)
+            {
+                // return true/false not the test result https://github.com/dotnet/coreclr/issues/914
+                return (d1 is null) ? true : false;
+            }
 
-            return d1.Equals(d2);
+            return ReferenceEquals(d2, d1) ? true : d2.Equals(d1);
         }
 
         public static bool operator !=(Delegate d1, Delegate d2)
         {
-            if ((object)d1 == null)
-                return (object)d2 != null;
+            // Test d2 first to allow branch elimination when inlined for not null checks (!= null)
+            // so it can become a simple test
+            if (d2 is null)
+            {
+                // return true/false not the test result https://github.com/dotnet/coreclr/issues/914
+                return (d1 is null) ? false : true;
+            }
 
-            return !d1.Equals(d2);
+            return ReferenceEquals(d2, d1) ? false : !d2.Equals(d1);
         }
 
         //

--- a/src/System.Private.CoreLib/src/System/Delegate.cs
+++ b/src/System.Private.CoreLib/src/System/Delegate.cs
@@ -505,11 +505,6 @@ namespace System
             return d;
         }
 
-        // Non-inline call to the virtual Equals so operator== only inlines to the ReferenceEquals 
-        // and doesn't include the virtual Equals preamble as well as part of the inline.
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private bool Equals(Delegate o) => Equals((object)o);
-
         // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(Delegate d1, Delegate d2)
@@ -522,7 +517,7 @@ namespace System
                 return (d1 is null) ? true : false;
             }
 
-            return ReferenceEquals(d2, d1) ? true : d2.Equals(d1);
+            return ReferenceEquals(d2, d1) ? true : d2.Equals((object)d1);
         }
 
         public static bool operator !=(Delegate d1, Delegate d2)

--- a/src/System.Private.CoreLib/src/System/Delegate.cs
+++ b/src/System.Private.CoreLib/src/System/Delegate.cs
@@ -505,6 +505,11 @@ namespace System
             return d;
         }
 
+        // Non-inline call to the virtual Equals so operator== only inlines to the ReferenceEquals 
+        // and doesn't include the virtual Equals preamble as well as part of the inline.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private bool Equals(Delegate o) => Equals((object)o);
+
         // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(Delegate d1, Delegate d2)

--- a/src/System.Private.CoreLib/src/System/MulticastDelegate.cs
+++ b/src/System.Private.CoreLib/src/System/MulticastDelegate.cs
@@ -429,6 +429,11 @@ namespace System
             return del;
         }
 
+        // Non-inline call to the virtual Equals so operator== only inlines to the ReferenceEquals 
+        // and doesn't include the virtual Equals preamble as well as part of the inline.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private bool Equals(MulticastDelegate o) => Equals((object)o);
+
         // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(MulticastDelegate d1, MulticastDelegate d2)

--- a/src/System.Private.CoreLib/src/System/MulticastDelegate.cs
+++ b/src/System.Private.CoreLib/src/System/MulticastDelegate.cs
@@ -429,11 +429,6 @@ namespace System
             return del;
         }
 
-        // Non-inline call to the virtual Equals so operator== only inlines to the ReferenceEquals 
-        // and doesn't include the virtual Equals preamble as well as part of the inline.
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private bool Equals(MulticastDelegate o) => Equals((object)o);
-
         // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(MulticastDelegate d1, MulticastDelegate d2)
@@ -446,7 +441,7 @@ namespace System
                 return (d1 is null) ? true : false;
             }
 
-            return ReferenceEquals(d2, d1) ? true : d2.Equals(d1);
+            return ReferenceEquals(d2, d1) ? true : d2.Equals((object)d1);
         }
 
         // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller

--- a/src/System.Private.CoreLib/src/System/MulticastDelegate.cs
+++ b/src/System.Private.CoreLib/src/System/MulticastDelegate.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 
@@ -428,24 +429,36 @@ namespace System
             return del;
         }
 
+        // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(MulticastDelegate d1, MulticastDelegate d2)
         {
-            if (ReferenceEquals(d1, d2))
+            // Test d2 first to allow branch elimination when inlined for null checks (== null)
+            // so it can become a simple test
+            if (d2 is null)
             {
-                return true;
+                // return true/false not the test result https://github.com/dotnet/coreclr/issues/914
+                return (d1 is null) ? true : false;
             }
 
-            return d1 is null ? false : d1.Equals(d2);
+            return ReferenceEquals(d2, d1) ? true : d2.Equals(d1);
         }
 
+        // Force inline as the true/false ternary takes it above ALWAYS_INLINE size even though the asm ends up smaller
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator !=(MulticastDelegate d1, MulticastDelegate d2)
         {
-            if (ReferenceEquals(d1, d2))
+            // Can't call the == operator as it will call object==
+
+            // Test d2 first to allow branch elimination when inlined for not null checks (!= null)
+            // so it can become a simple test
+            if (d2 is null)
             {
-                return false;
+                // return true/false not the test result https://github.com/dotnet/coreclr/issues/914
+                return (d1 is null) ? false : true;
             }
 
-            return d1 is null ? true : !d1.Equals(d2);
+            return ReferenceEquals(d2, d1) ? false : !d2.Equals(d1);
         }
 
         public override sealed int GetHashCode()


### PR DESCRIPTION
To improve the common use of right-sided null `x == null` upstream. 

If we trim most of the class `operator==` methods to only null check (some also ReferenceEquals and check either arg for `null`) then switch the common order of the params used for `.Equals` (which is normally `left.Equals(right)`; so:
```csharp
public static bool operator== (MyClass left, MyClass right)
    => (right is null) ? (left is null) : right.Equals(left);
```
Then it drops under the ` [below ALWAYS_INLINE size]` inlining threshold; after inlining the Jit can remove the branch (as right is constant `null`) so it becomes just `left is null`

A fast-path `.Equals` that does `ReferenceEquals` is then added so it doesn't inline for the `is null` check; but does inline for a vs variable check (as `base.Equals(object)` method is virtual and can't inline).

Current

![image](https://user-images.githubusercontent.com/1142958/50612373-aa528800-0ed1-11e9-8ec6-6cea0d860e86.png)

Previous PR https://github.com/dotnet/coreclr/pull/21736 (faster null checks)

![image](https://user-images.githubusercontent.com/1142958/50612452-03222080-0ed2-11e9-9eb0-a36af6352b8f.png)

This PR with both commits (operator== change + `ReferenceEquals` fast path in strongly typed `Equals`)

![image](https://user-images.githubusercontent.com/1142958/50612487-16cd8700-0ed2-11e9-9fcc-b15ce537a216.png)

/cc @jkotas @stephentoub better?