### PR TITLE
Improve performance of Path.ChangeExtension

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Globalization/CultureData.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CultureData.cs
@@ -956,9 +956,11 @@ namespace System.Globalization
                             if (this.SENGLISHLANGUAGE[this.SENGLISHLANGUAGE.Length - 1] == ')')
                             {
                                 // "Azeri (Latin)" + "Azerbaijan" -> "Azeri (Latin, Azerbaijan)"
-                                _sEnglishDisplayName =
-                                    this.SENGLISHLANGUAGE.Substring(0, _sEnglishLanguage.Length - 1) +
-                                    ", " + this.SENGCOUNTRY + ")";
+                                _sEnglishDisplayName = string.Concat(
+                                    this.SENGLISHLANGUAGE.AsSpan(0, _sEnglishLanguage.Length - 1),
+                                    ", ",
+                                    this.SENGCOUNTRY,
+                                    ")");
                             }
                             else
                             {
@@ -1645,7 +1647,7 @@ namespace System.Globalization
                             sep = "";
                         }
 
-                        time = time.Substring(0, j) + sep + time.Substring(endIndex);
+                        time = string.Concat(time.AsSpan(0, j), sep, time.AsSpan(endIndex));
                         break;
                     case 'm':
                     case 'H':

--- a/src/System.Private.CoreLib/shared/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/DateTimeFormatInfo.cs
@@ -2377,7 +2377,6 @@ namespace System.Globalization
                 // This is determined in DateTimeFormatInfoScanner.  Use this flag to determine if we should treat date separator as ignorable symbol.
                 bool useDateSepAsIgnorableSymbol = false;
 
-                string monthPostfix = null;
                 if (dateWords != null)
                 {
                     // There are DateWords.  It could be a real date word (such as "de"), or a monthPostfix.
@@ -2389,7 +2388,7 @@ namespace System.Globalization
                             // This is a month postfix
                             case DateTimeFormatInfoScanner.MonthPostfixChar:
                                 // Get the real month postfix.
-                                monthPostfix = dateWords[i].Substring(1);
+                                ReadOnlySpan<char> monthPostfix = dateWords[i].AsSpan(1);
                                 // Add the month name + postfix into the token.
                                 AddMonthNames(temp, monthPostfix);
                                 break;
@@ -2421,7 +2420,7 @@ namespace System.Globalization
                     InsertHash(temp, this.DateSeparator, TokenType.SEP_Date, 0);
                 }
                 // Add the regular month names.
-                AddMonthNames(temp, null);
+                AddMonthNames(temp);
 
                 // Add the abbreviated month names.
                 for (int i = 1; i <= 13; i++)
@@ -2548,22 +2547,21 @@ namespace System.Globalization
             return (temp);
         }
 
-        private void AddMonthNames(TokenHashValue[] temp, string monthPostfix)
+        private void AddMonthNames(TokenHashValue[] temp, ReadOnlySpan<char> monthPostfix = default)
         {
             for (int i = 1; i <= 13; i++)
             {
-                string str;
                 //str = internalGetMonthName(i, MonthNameStyles.Regular, false);
                 // We have to call public methods here to work with inherited DTFI.
                 // Insert the month name first, so that they are at the front of abbreviated
                 // month names.
-                str = GetMonthName(i);
+                string str = GetMonthName(i);
                 if (str.Length > 0)
                 {
-                    if (monthPostfix != null)
+                    if (!monthPostfix.IsEmpty)
                     {
                         // Insert the month name with the postfix first, so it can be matched first.
-                        InsertHash(temp, str + monthPostfix, TokenType.MonthToken, i);
+                        InsertHash(temp, string.Concat(str, monthPostfix), TokenType.MonthToken, i);
                     }
                     else
                     {

--- a/src/System.Private.CoreLib/shared/System/Globalization/DateTimeFormatInfoScanner.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/DateTimeFormatInfoScanner.cs
@@ -245,7 +245,7 @@ namespace System.Globalization
                         }
                         if (str[str.Length - 1] == '.')
                         {
-                            // Old version ignore the trialing dot in the date words. Support this as well.
+                            // Old version ignore the trailing dot in the date words. Support this as well.
                             string strWithoutDot = str.Substring(0, str.Length - 1);
                             if (!m_dateWords.Contains(strWithoutDot))
                             {

--- a/src/System.Private.CoreLib/shared/System/IO/Path.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/Path.cs
@@ -74,23 +74,11 @@ namespace System.IO
             {
                 return path.Substring(0, subLength);
             }
-            else if (extension.StartsWith('.'))
-            {
-                string result = string.FastAllocateString(subLength + extension.Length);
-                Span<char> resultSpan = new Span<char>(ref result.GetRawStringData(), result.Length);
-                path.AsSpan(0, subLength).CopyTo(resultSpan);
-                extension.AsSpan().CopyTo(resultSpan.Slice(subLength));
-                return result;
-            }
-            else
-            {
-                string result = string.FastAllocateString(subLength + 1 + extension.Length);
-                Span<char> resultSpan = new Span<char>(ref result.GetRawStringData(), result.Length);
-                path.AsSpan(0, subLength).CopyTo(resultSpan);
-                resultSpan[subLength] = '.';
-                extension.AsSpan().CopyTo(resultSpan.Slice(subLength + 1));
-                return result;
-            }
+
+            ReadOnlySpan<char> subpath = path.AsSpan(0, subLength);
+            return extension.StartsWith('.') ?
+                string.Concat(subpath, extension) :
+                string.Concat(subpath, ".", extension);
         }
 
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/String.Manipulation.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Manipulation.cs
@@ -341,6 +341,55 @@ namespace System
             return result;
         }
 
+        // TODO: Expose publicly: https://github.com/dotnet/corefx/issues/34330.
+        internal static string Concat(ReadOnlySpan<char> str0, ReadOnlySpan<char> str1)
+        {
+            string result = FastAllocateString(str0.Length + str1.Length);
+            Span<char> resultSpan = new Span<char>(ref result.GetRawStringData(), result.Length);
+
+            str0.CopyTo(resultSpan);
+            str1.CopyTo(resultSpan.Slice(str0.Length));
+
+            return result;
+        }
+
+        // TODO: Expose publicly: https://github.com/dotnet/corefx/issues/34330.
+        internal static string Concat(ReadOnlySpan<char> str0, ReadOnlySpan<char> str1, ReadOnlySpan<char> str2)
+        {
+            string result = FastAllocateString(str0.Length + str1.Length + str2.Length);
+            Span<char> resultSpan = new Span<char>(ref result.GetRawStringData(), result.Length);
+
+            str0.CopyTo(resultSpan);
+            resultSpan = resultSpan.Slice(str0.Length);
+
+            str1.CopyTo(resultSpan);
+            resultSpan = resultSpan.Slice(str1.Length);
+
+            str2.CopyTo(resultSpan);
+
+            return result;
+        }
+
+        // TODO: Expose publicly: https://github.com/dotnet/corefx/issues/34330.
+        internal static string Concat(ReadOnlySpan<char> str0, ReadOnlySpan<char> str1, ReadOnlySpan<char> str2, ReadOnlySpan<char> str3)
+        {
+            string result = FastAllocateString(str0.Length + str1.Length + str2.Length + str3.Length);
+            Span<char> resultSpan = new Span<char>(ref result.GetRawStringData(), result.Length);
+
+            str0.CopyTo(resultSpan);
+            resultSpan = resultSpan.Slice(str0.Length);
+
+            str1.CopyTo(resultSpan);
+            resultSpan = resultSpan.Slice(str1.Length);
+
+            str2.CopyTo(resultSpan);
+            resultSpan = resultSpan.Slice(str2.Length);
+
+            str3.CopyTo(resultSpan);
+
+            return result;
+        }
+
         public static string Concat(params string[] values)
         {
             if (values == null)

--- a/src/System.Private.CoreLib/shared/System/String.Manipulation.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Manipulation.cs
@@ -344,7 +344,7 @@ namespace System
         // TODO: Expose publicly: https://github.com/dotnet/corefx/issues/34330.
         internal static string Concat(ReadOnlySpan<char> str0, ReadOnlySpan<char> str1)
         {
-            string result = FastAllocateString(str0.Length + str1.Length);
+            string result = FastAllocateString(checked(str0.Length + str1.Length));
             Span<char> resultSpan = new Span<char>(ref result.GetRawStringData(), result.Length);
 
             str0.CopyTo(resultSpan);
@@ -356,7 +356,7 @@ namespace System
         // TODO: Expose publicly: https://github.com/dotnet/corefx/issues/34330.
         internal static string Concat(ReadOnlySpan<char> str0, ReadOnlySpan<char> str1, ReadOnlySpan<char> str2)
         {
-            string result = FastAllocateString(str0.Length + str1.Length + str2.Length);
+            string result = FastAllocateString(checked(str0.Length + str1.Length + str2.Length));
             Span<char> resultSpan = new Span<char>(ref result.GetRawStringData(), result.Length);
 
             str0.CopyTo(resultSpan);
@@ -373,7 +373,7 @@ namespace System
         // TODO: Expose publicly: https://github.com/dotnet/corefx/issues/34330.
         internal static string Concat(ReadOnlySpan<char> str0, ReadOnlySpan<char> str1, ReadOnlySpan<char> str2, ReadOnlySpan<char> str3)
         {
-            string result = FastAllocateString(str0.Length + str1.Length + str2.Length + str3.Length);
+            string result = FastAllocateString(checked(str0.Length + str1.Length + str2.Length + str3.Length));
             Span<char> resultSpan = new Span<char>(ref result.GetRawStringData(), result.Length);
 
             str0.CopyTo(resultSpan);


### PR DESCRIPTION
In the common case where it need to replace a non-empty extension with a non-empty extension, it currently incurs a substring without the original extension prior to then concatenating with the new extension.  This PR avoids that.

(As the `Path` implementation is in corelib, this uses `string.FastAllocateString` and then formats into it with a span; if we wanted to avoid that, `string.Create` could also be used.  That could also be addressed with new `String.Concat` overloads that accept `ReadOnlySpan<char>`s.)

Benchmark:
```C#
[Benchmark] public string ChangeExtensionReplace() => Path.ChangeExtension(@"c:\this\is\a\path\hello.txt", ".dat");
[Benchmark] public string ChangeExtensionRemove() => Path.ChangeExtension(@"c:\this\is\a\path\hello.txt", null);
```

Before:
```
                 Method |     Mean |     Error |    StdDev |  Gen 0 | Allocated |
----------------------- |---------:|----------:|----------:|-------:|----------:|
 ChangeExtensionReplace | 41.39 ns | 1.4013 ns | 2.7985 ns | 0.0363 |     152 B |
  ChangeExtensionRemove | 18.57 ns | 0.2763 ns | 0.2449 ns | 0.0172 |      72 B |
```

After:
```
                 Method |     Mean |     Error |    StdDev |  Gen 0 | Allocated |
----------------------- |---------:|----------:|----------:|-------:|----------:|
 ChangeExtensionReplace | 18.66 ns | 0.1989 ns | 0.1764 ns | 0.0191 |      80 B |
  ChangeExtensionRemove | 18.81 ns | 0.2678 ns | 0.2505 ns | 0.0172 |      72 B |
```

cc: @JeremyKuhne, @jkotas