### PR TITLE
Fix missing project error in official build

### DIFF
--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -53,6 +53,17 @@ jobs:
 
     steps:
 
+    # Build packages and publish official build
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+      - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
+        - script: ./eng/common/build.sh /p:DotNetPublishToBlobFeed=true --ci --restore --projects $(Build.SourcesDirectory)/eng/empty.proj
+          displayName: Restore blob feed tasks
+      - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+        # TODO: pass publish feed url and access token in from the internal pipeline
+        - powershell: eng\common\build.ps1 /p:DotNetPublishToBlobFeed=true -ci -restore -projects $(Build.SourcesDirectory)\eng\empty.proj
+          displayName: Restore blob feed tasks
+
+
     # Install native dependencies
     #
     # This is only required for non-docker builds.

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -53,17 +53,6 @@ jobs:
 
     steps:
 
-    # Build packages and publish official build
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
-      - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-        - script: ./eng/common/build.sh /p:DotNetPublishToBlobFeed=true --ci --restore --projects $(Build.SourcesDirectory)/eng/empty.proj
-          displayName: Restore blob feed tasks
-      - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-        # TODO: pass publish feed url and access token in from the internal pipeline
-        - powershell: eng\common\build.ps1 /p:DotNetPublishToBlobFeed=true -ci -restore -projects $(Build.SourcesDirectory)\eng\empty.proj
-          displayName: Restore blob feed tasks
-
-
     # Install native dependencies
     #
     # This is only required for non-docker builds.

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -115,7 +115,7 @@ jobs:
       - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
         - script: ./build-packages.sh -BuildArch=$(archType) -BuildType=$(buildConfigUpper) $(crossPackagesArg) -OfficialBuildId=$(Build.BuildNumber) $(portableBuildArg)
           displayName: Build packages
-        - script: ./eng/common/build.sh /p:DotNetPublishToBlobFeed=true --ci --restore
+        - script: ./eng/common/build.sh /p:DotNetPublishToBlobFeed=true --ci --restore --projects $(Build.SourcesDirectory)/eng/empty.proj
           displayName: Restore blob feed tasks
         - script: ./eng/common/msbuild.sh --ci src/publishwitharcade.proj /p:__BuildType=$(buildConfigUpper) /p:__BuildArch=$(archType) /p:OSIdentifier=$(osIdentifier) /p:AzureFeedUrl=$(dotnetfeedUrl) /p:AzureAccountKey=$(dotnetfeedPAT)
           displayName: Publish packages to blob feed
@@ -126,7 +126,7 @@ jobs:
         # TODO: pass publish feed url and access token in from the internal pipeline
         - script: build-packages.cmd -BuildArch=$(archType) -BuildType=$(buildConfigUpper) -OfficialBuildId=$(Build.BuildNumber)
           displayName: Build packages
-        - powershell: eng\common\build.ps1 /p:DotNetPublishToBlobFeed=true -ci -restore
+        - powershell: eng\common\build.ps1 /p:DotNetPublishToBlobFeed=true -ci -restore -projects $(Build.SourcesDirectory)\eng\empty.proj
           displayName: Restore blob feed tasks
         - powershell: eng\common\msbuild.ps1 -ci src\publishwitharcade.proj /p:__BuildType=$(buildConfigUpper) /p:__BuildArch=$(archType) /p:OSIdentifier=$(osIdentifier) /p:AzureFeedUrl=$(dotnetfeedUrl) /p:AzureAccountKey=$(dotnetfeedPAT)
           displayName: Publish packages to blob feed

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -75,7 +75,7 @@ jobs:
 
     # Sign on Windows
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest'), eq(parameters.osGroup, 'Windows_NT')) }}:
-      - script: powershell eng\common\build.ps1 -ci -sign -restore -configuration:$(buildConfig) -warnaserror:0 /p:ArcadeBuild=true /p:OfficialBuild=true /p:BuildOS=$(osGroup) /p:BuildArch=$(archType) /p:BuildType=$(buildConfig) /p:DotNetSignType=%_SignType%
+      - script: powershell eng\common\build.ps1 -ci -sign -restore -configuration:$(buildConfig) -warnaserror:0 /p:ArcadeBuild=true /p:OfficialBuild=true /p:BuildOS=$(osGroup) /p:BuildArch=$(archType) /p:BuildType=$(buildConfig) /p:DotNetSignType=%_SignType% -projects $(Build.SourcesDirectory)\eng\empty.proj
         displayName: Sign Binaries
 
       - task: PublishBuildArtifacts@1

--- a/eng/empty.proj
+++ b/eng/empty.proj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/eng/empty.proj
+++ b/eng/empty.proj
@@ -1,5 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- This project exists purely to work around Arcade
+       behavior. Arcade knows how to restore tasks needed for
+       publishing to blob feeds, but it requires a project file that
+       imports nuget restore targets to be specified for this to
+       work. See details in
+       https://github.com/dotnet/arcade/commit/f657be5cb7cd4920334dd9162173b131211a1e17#r31728598.
+  -->
+
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
+
 </Project>

--- a/tests/helixpublishwitharcade.proj
+++ b/tests/helixpublishwitharcade.proj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.DotNet.Helix.Sdk" DefaultTargets="SubmitTestsToHelix">
 
-  <!-- This project uses the helix SDK ,documented at
+  <!-- This project uses the helix SDK, documented at
        https://github.com/dotnet/arcade/tree/master/src/Microsoft.DotNet.Helix/Sdk,
        to send test jobs to helix. -->
 


### PR DESCRIPTION
Since picking up https://github.com/dotnet/arcade/pull/1567, our official builds have been broken because they use arcade to restore some tasks and sign in cases where we don't specify a project to build. From https://dnceng.visualstudio.com/internal/_build/results?buildId=64720:
```
2019-01-02T13:08:11.9115670Z ./eng/common/build.sh /p:DotNetPublishToBlobFeed=true --ci --restore
2019-01-02T13:08:11.9158940Z [command]/bin/bash --noprofile --norc /Users/vsts/agent/2.144.0/work/_temp/0d24fa91-087e-4035-ac08-2b2f050d222a.sh
2019-01-02T13:08:13.3110000Z /Users/vsts/.dotnet/sdk/2.2.101/MSBuild.dll /noconsolelogger /nologo -maxcpucount /m -verbosity:m /v:minimal /bl:/Users/vsts/agent/2.144.0/work/1/s/artifacts/log/Debug/ToolsetRestore.binlog /clp:Summary /nr:false /p:TreatWarningsAsErrors=true /p:__ToolsetLocationOutputFile=/Users/vsts/agent/2.144.0/work/1/s/artifacts/toolset/1.0.0-beta.18629.1.txt /t:__WriteToolsetLocation /warnaserror /Users/vsts/agent/2.144.0/work/1/s/artifacts/toolset/restore.proj
2019-01-02T13:08:17.1799150Z /Users/vsts/.dotnet/sdk/2.2.101/MSBuild.dll /nologo -maxcpucount /m -verbosity:m /v:minimal /bl:/Users/vsts/agent/2.144.0/work/1/s/artifacts/log/Debug/Build.binlog /clp:Summary /nr:false /p:TreatWarningsAsErrors=true /p:Configuration=Debug /p:RepoRoot=/Users/vsts/agent/2.144.0/work/1/s /p:Restore=true /p:Build=false /p:Rebuild=false /p:Test=false /p:Pack=false /p:IntegrationTest=false /p:PerformanceTest=false /p:Sign=false /p:Publish=false /p:ContinuousIntegrationBuild=true /p:DotNetPublishToBlobFeed=true /warnaserror /Users/vsts/agent/2.144.0/work/1/s/.packages/microsoft.dotnet.arcade.sdk/1.0.0-beta.18629.1/tools/Build.proj
2019-01-02T13:08:17.5106090Z /Users/vsts/agent/2.144.0/work/1/s/.packages/microsoft.dotnet.arcade.sdk/1.0.0-beta.18629.1/tools/Build.proj(100,5): error : No projects were found to build. Either the 'Projects' property or 'ProjectToBuild' item group must be specified.
2019-01-02T13:08:17.5293110Z 
```

The arcade change now requires a project to be specified, so empty.proj will serve this purpose until we set up an actual project as the arcade entry point.