### PR TITLE
Change a couple string.Replace("a", "b") to string.Replace('a', 'b')

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -5183,7 +5183,7 @@ namespace System.Diagnostics.Tracing
             if (dllName != null)
                 sb.Append("\" resourceFileName=\"").Append(dllName).Append("\" messageFileName=\"").Append(dllName);
 
-            var symbolsName = providerName.Replace("-", "").Replace(".", "_");  // Period and - are illegal replace them.
+            var symbolsName = providerName.Replace("-", "").Replace('.', '_');  // Period and - are illegal replace them.
             sb.Append("\" symbol=\"").Append(symbolsName);
             sb.Append("\">").AppendLine();
         }

--- a/src/System.Private.CoreLib/shared/System/Reflection/Emit/Opcode.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Emit/Opcode.cs
@@ -149,7 +149,7 @@ namespace System.Reflection.Emit
                     return name;
 
                 // Create ilasm style name from the enum value name.
-                name = Enum.GetName(typeof(OpCodeValues), opCodeValue).ToLowerInvariant().Replace("_", ".");
+                name = Enum.GetName(typeof(OpCodeValues), opCodeValue).ToLowerInvariant().Replace('_', '.');
                 Volatile.Write(ref nameCache[idx], name);
                 return name;
             }


### PR DESCRIPTION
The latter is functionally the same but less overhead. Just minor cleanup happened to notice while looking at other things; the other uses of Replace in Corelib have at least one argument that's not just one char.