### PR TITLE
Specify __RuntimeId for non-portable Linux test builds

### DIFF
--- a/build-test.sh
+++ b/build-test.sh
@@ -61,6 +61,7 @@ initTargetDistroRid()
         fi
     else
         export __DistroRid="$__HostDistroRid"
+        export __RuntimeId="$__HostDistroRid"
     fi
 
     if [ "$ID.$VERSION_ID" == "ubuntu.16.04" ]; then


### PR DESCRIPTION
This fixes the following failure during build-test.sh on Alpine in Azure DevOps

```
2018-12-20T22:19:56.6047791Z Building step 'Creating test overlay' via "/__w/1/s/run.sh" build -Project=/__w/1/s/tests/runtest.proj -MsBuildLog="/flp:Verbosity=normal;LogFile=/__w/1/s/bin/Logs/Tests_Overlay_Managed.Linux.x64.Checked.log" -MsBuildWrn="/flp1:WarningsOnly;LogFile=/__w/1/s/bin/Logs/Tests_Overlay_Managed.Linux.x64.Checked.wrn" -MsBuildErr="/flp2:ErrorsOnly;LogFile=/__w/1/s/bin/Logs/Tests_Overlay_Managed.Linux.x64.Checked.err" -MsBuildEventLogging="/l:BinClashLogger,Tools/Microsoft.DotNet.Build.Tasks.dll;LogFile=binclash.log" -testOverlay -BuildArch=x64 -BuildType=Checked -BuildOS=Linux 
2018-12-20T22:19:56.6081808Z Running init-tools.sh
2018-12-20T22:19:56.6138816Z Tools are already initialized
2018-12-20T22:19:56.6142321Z Running: /__w/1/s/Tools/dotnetcli/dotnet /__w/1/s/Tools/run.exe /__w/1/s/config.json build -Project=/__w/1/s/tests/runtest.proj -MsBuildLog=/flp:Verbosity=normal;LogFile=/__w/1/s/bin/Logs/Tests_Overlay_Managed.Linux.x64.Checked.log -MsBuildWrn=/flp1:WarningsOnly;LogFile=/__w/1/s/bin/Logs/Tests_Overlay_Managed.Linux.x64.Checked.wrn -MsBuildErr=/flp2:ErrorsOnly;LogFile=/__w/1/s/bin/Logs/Tests_Overlay_Managed.Linux.x64.Checked.err -MsBuildEventLogging=/l:BinClashLogger,Tools/Microsoft.DotNet.Build.Tasks.dll;LogFile=binclash.log -testOverlay -BuildArch=x64 -BuildType=Checked -BuildOS=Linux
2018-12-20T22:19:56.8017725Z Running: /__w/1/s/Tools/msbuild.sh /nologo /verbosity:minimal /clp:Summary  /l:BinClashLogger,Tools/Microsoft.DotNet.Build.Tasks.dll;LogFile=binclash.log  /__w/1/s/tests/runtest.proj /p:__BuildType=Checked /p:__BuildArch=x64 /p:__BuildOS=Linux  /maxcpucount /p:RestoreDefaultOptimizationDataPackage=false /p:UsePartialNGENOptimization=false /p:PortableBuild=true  /flp:Verbosity=normal;LogFile=/__w/1/s/bin/Logs/Tests_Overlay_Managed.Linux.x64.Checked.log  /flp1:WarningsOnly;LogFile=/__w/1/s/bin/Logs/Tests_Overlay_Managed.Linux.x64.Checked.wrn  /flp2:ErrorsOnly;LogFile=/__w/1/s/bin/Logs/Tests_Overlay_Managed.Linux.x64.Checked.err /t:CreateTestOverlay 
2018-12-20T22:19:57.6371177Z /__w/1/s/tests/publishdependency.targets(49,5): error : Your project.json doesn't have a runtimes section. You should add '"runtimes": { "ubuntu.14.04-x64": { } }' to your project.json and then re-run NuGet restore. [/__w/1/s/tests/runtest.proj]
2018-12-20T22:19:57.6720314Z 
2018-12-20T22:19:57.6720739Z Build FAILED.
2018-12-20T22:19:57.6720800Z 
2018-12-20T22:19:57.6727108Z /__w/1/s/tests/publishdependency.targets(49,5): error : Your project.json doesn't have a runtimes section. You should add '"runtimes": { "ubuntu.14.04-x64": { } }' to your project.json and then re-run NuGet restore. [/__w/1/s/tests/runtest.proj]
2018-12-20T22:19:57.6727436Z     0 Warning(s)
2018-12-20T22:19:57.6727567Z     1 Error(s)
2018-12-20T22:19:57.6727630Z 
```

The issue happens during CreateTestOverlay -> CopyDependecyToCoreRoot at https://github.com/dotnet/coreclr/blob/master/tests/publishdependency.targets#L115-L143
due to $(TargetRid) being set to default value (ubuntu.14.04-x64) (https://github.com/dotnet/coreclr/blob/master/tests/src/dir.props#L117-L120) instead of a proper value passed via __RuntimeId.