### PR TITLE
Fix GC for collectible array of pure value types

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -18023,6 +18023,11 @@ void gc_heap::mark_object_simple1 (uint8_t* oo, uint8_t* start THREAD_NUMBER_DCL
                             *mark_stack_tos = oo;
                         }
                     }
+
+                    if (!contain_pointers (oo))
+                    {
+                        goto next_level;
+                    }
                 }
 #endif //COLLECTIBLE_CLASS
 
@@ -18630,6 +18635,11 @@ void gc_heap::background_mark_simple1 (uint8_t* oo THREAD_NUMBER_DCL)
                             *(background_mark_stack_tos++) = class_obj;
                         }
                     }
+
+                    if (!contain_pointers (oo))
+                    {
+                        goto next_level;
+                    }                    
                 }
 #endif //COLLECTIBLE_CLASS
 
@@ -18714,6 +18724,9 @@ void gc_heap::background_mark_simple1 (uint8_t* oo THREAD_NUMBER_DCL)
         }
 #endif //SORT_MARK_STACK
 
+#ifdef COLLECTIBLE_CLASS
+next_level:
+#endif // COLLECTIBLE_CLASS
         allow_fgc();
 
         if (!(background_mark_stack_tos == background_mark_stack_array))


### PR DESCRIPTION
For collectible arrays, we enter the mark_object_simple1 method even if
the array contains no pointers so that the reference to LoaderAllocator
can be walked. But we were missing skipping the call to go_through_object
which is both not necessary and it also doesn't work correctly for
objects without pointers (the loop over the fields reports the first 8
bytes of each array element as if it was a pointer).
The fix is to skip the call to go_through_object for objects without
pointers in the mark_object_simple1 and background_mark_simple1.