### PR TITLE
Pin StringBuilders with only one chunk when marshalling.

### DIFF
--- a/src/System.Private.CoreLib/src/System/Text/StringBuilder.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Text/StringBuilder.CoreCLR.cs
@@ -142,10 +142,27 @@ namespace System.Text
         /// </summary>
         /// <param name="chunk">A reference to the internal chunk.</param>
         /// <returns>Returns <c>true</c> if this StringBuilder only has one chunk; otherwise false.</returns>
+        /// <remarks>
+        /// This method is used by the marshalling system to determine if this StringBuilder can be passed to native
+        /// by only having its buffer pinned.
+        /// </remarks>
         internal bool IsSingleChunk(out char[] chunk)
         {
             chunk = m_ChunkChars;
             return m_ChunkPrevious == null;
+        }
+
+        /// <summary>
+        /// Updates the length of this StringBuilder with the assumption that this is the only chunk.
+        /// </summary>
+        /// <param name="length">The length of the string in the chunk.</param>
+        /// <remarks>
+        /// This method is used by the marshalling system when the StringBuilder is pinned to update the length.
+        /// </remarks>
+        internal void UpdateLengthOfSingleChunk(int length)
+        {
+            System.Diagnostics.Debug.Assert(m_ChunkPrevious == null);
+            m_ChunkLength = length;
         }
     }
 }

--- a/src/System.Private.CoreLib/src/System/Text/StringBuilder.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Text/StringBuilder.CoreCLR.cs
@@ -138,18 +138,16 @@ namespace System.Text
         }
 
         /// <summary>
-        /// Checks if this StringBuilder contains only one chunk (char buffer).
+        /// Checks if this StringBuilder contains only one chunk (char buffer). If it is only one chunk, get that chunk.
         /// </summary>
-        /// <param name="chunk">A reference to the internal chunk.</param>
-        /// <returns>Returns <c>true</c> if this StringBuilder only has one chunk; otherwise false.</returns>
+        /// <returns>Returns the chunk if it is the only chunk. If it is not the only chunk, returns <c>null</c>.</returns>
         /// <remarks>
         /// This method is used by the marshalling system to determine if this StringBuilder can be passed to native
         /// by only having its buffer pinned.
         /// </remarks>
-        internal bool IsSingleChunk(out char[] chunk)
+        internal char[] TryGetSingleChunk()
         {
-            chunk = m_ChunkChars;
-            return m_ChunkPrevious == null;
+            return m_ChunkPrevious == null ? m_ChunkChars : null;
         }
 
         /// <summary>
@@ -161,7 +159,7 @@ namespace System.Text
         /// </remarks>
         internal void UpdateLengthOfSingleChunk(int length)
         {
-            System.Diagnostics.Debug.Assert(m_ChunkPrevious == null);
+            System.Diagnostics.Debug.Assert(TryGetSingleChunk() != null);
             m_ChunkLength = length;
         }
     }

--- a/src/System.Private.CoreLib/src/System/Text/StringBuilder.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Text/StringBuilder.CoreCLR.cs
@@ -136,5 +136,16 @@ namespace System.Text
             }
             while (currentSrc != null);
         }
+
+        /// <summary>
+        /// Checks if this StringBuilder contains only one chunk (char buffer).
+        /// </summary>
+        /// <param name="chunk">A reference to the internal chunk.</param>
+        /// <returns>Returns <c>true</c> if this StringBuilder only has one chunk; otherwise false.</returns>
+        internal bool IsSingleChunk(out char[] chunk)
+        {
+            chunk = m_ChunkChars;
+            return m_ChunkPrevious == null;
+        }
     }
 }

--- a/src/vm/ilmarshalers.cpp
+++ b/src/vm/ilmarshalers.cpp
@@ -921,6 +921,12 @@ void ILWSTRBufferMarshaler::EmitConvertContentsNativeToCLR(ILCodeStream* pslILEm
     {
         pslILEmit->EmitLDLOC(m_dwPinnedBuffer);
         pslILEmit->EmitBRTRUE(marshalFinishedLabel);
+        
+        EmitLoadManagedValue(pslILEmit);
+        EmitLoadNativeValue(pslILEmit);
+        // static int System.String.wcslen(char *ptr)
+        pslILEmit->EmitCALL(METHOD__STRING__WCSLEN, 1, 1);
+        pslILEmit->EmitCALL(METHOD__STRING_BUILDER__UPDATE_LENGTH_OF_SINGLE_CHUNK, 2, 0);
     }
 
     EmitLoadNativeValue(pslILEmit);

--- a/src/vm/ilmarshalers.cpp
+++ b/src/vm/ilmarshalers.cpp
@@ -916,18 +916,22 @@ void ILWSTRBufferMarshaler::EmitConvertContentsNativeToCLR(ILCodeStream* pslILEm
     STANDARD_VM_CONTRACT;
 
     ILCodeLabel* marshalFinishedLabel = pslILEmit->NewCodeLabel();
+    ILCodeLabel* replaceBufferLabel = pslILEmit->NewCodeLabel();
 
     if (m_dwPinnedBuffer != LOCAL_NUM_UNUSED)
     {
         pslILEmit->EmitLDLOC(m_dwPinnedBuffer);
-        pslILEmit->EmitBRTRUE(marshalFinishedLabel);
+        pslILEmit->EmitBRFALSE(replaceBufferLabel);
         
         EmitLoadManagedValue(pslILEmit);
         EmitLoadNativeValue(pslILEmit);
         // static int System.String.wcslen(char *ptr)
         pslILEmit->EmitCALL(METHOD__STRING__WCSLEN, 1, 1);
         pslILEmit->EmitCALL(METHOD__STRING_BUILDER__UPDATE_LENGTH_OF_SINGLE_CHUNK, 2, 0);
+        pslILEmit->EmitBR(marshalFinishedLabel);
     }
+
+    pslILEmit->EmitLabel(replaceBufferLabel);
 
     EmitLoadNativeValue(pslILEmit);
     pslILEmit->EmitBRFALSE(marshalFinishedLabel);

--- a/src/vm/ilmarshalers.h
+++ b/src/vm/ilmarshalers.h
@@ -2057,15 +2057,16 @@ public:
     }
 
     virtual LocalDesc GetManagedType();
-	void EmitTryPinBuffer(ILCodeStream * pslILEmit, ILCodeLabel * marshalledLabel);
 	virtual void EmitConvertSpaceAndContentsCLRToNativeTemp(ILCodeStream* pslILEmit);
     virtual void EmitConvertSpaceCLRToNativeTemp(ILCodeStream* pslILEmit);
     virtual void EmitConvertSpaceCLRToNative(ILCodeStream* pslILEmit);
     virtual void EmitConvertContentsCLRToNative(ILCodeStream* pslILEmit);
     virtual void EmitConvertSpaceNativeToCLR(ILCodeStream* pslILEmit);
     virtual void EmitConvertContentsNativeToCLR(ILCodeStream* pslILEmit);
+    virtual void EmitClearNative(ILCodeStream* pslILEmit);
 
 private:
+	void EmitTryPinBuffer(ILCodeStream * pslILEmit, ILCodeLabel * marshalledLabel);
     static bool CanTryUsePinnedBuffer(DWORD dwMarshalFlags)
     {
         return IsCLRToNative(dwMarshalFlags) && !IsByref(dwMarshalFlags);

--- a/src/vm/ilmarshalers.h
+++ b/src/vm/ilmarshalers.h
@@ -2057,10 +2057,21 @@ public:
     }
 
     virtual LocalDesc GetManagedType();
+	void EmitTryPinBuffer(ILCodeStream * pslILEmit, ILCodeLabel * marshalledLabel);
+	virtual void EmitConvertSpaceAndContentsCLRToNativeTemp(ILCodeStream* pslILEmit);
+    virtual void EmitConvertSpaceCLRToNativeTemp(ILCodeStream* pslILEmit);
     virtual void EmitConvertSpaceCLRToNative(ILCodeStream* pslILEmit);
     virtual void EmitConvertContentsCLRToNative(ILCodeStream* pslILEmit);
     virtual void EmitConvertSpaceNativeToCLR(ILCodeStream* pslILEmit);
     virtual void EmitConvertContentsNativeToCLR(ILCodeStream* pslILEmit);
+
+private:
+    static bool CanTryUsePinnedBuffer(DWORD dwMarshalFlags)
+    {
+        return IsCLRToNative(dwMarshalFlags) && !IsByref(dwMarshalFlags);
+    }
+
+    DWORD m_dwPinnedBuffer = LOCAL_NUM_UNUSED;
 };
 
 class ILCSTRBufferMarshaler : public ILOptimizedAllocMarshaler

--- a/src/vm/ilmarshalers.h
+++ b/src/vm/ilmarshalers.h
@@ -2067,9 +2067,9 @@ public:
 
 private:
 	void EmitTryPinBuffer(ILCodeStream * pslILEmit, ILCodeLabel * marshalledLabel);
-    static bool CanTryUsePinnedBuffer(DWORD dwMarshalFlags)
+    bool CanTryUsePinnedBuffer()
     {
-        return IsCLRToNative(dwMarshalFlags) && !IsByref(dwMarshalFlags);
+        return IsCLRToNative(m_dwMarshalFlags) && !IsByref(m_dwMarshalFlags);
     }
 
     DWORD m_dwPinnedBuffer = LOCAL_NUM_UNUSED;

--- a/src/vm/ilmarshalers.h
+++ b/src/vm/ilmarshalers.h
@@ -2057,7 +2057,7 @@ public:
     }
 
     virtual LocalDesc GetManagedType();
-	virtual void EmitConvertSpaceAndContentsCLRToNativeTemp(ILCodeStream* pslILEmit);
+    virtual void EmitConvertSpaceAndContentsCLRToNativeTemp(ILCodeStream* pslILEmit);
     virtual void EmitConvertSpaceCLRToNativeTemp(ILCodeStream* pslILEmit);
     virtual void EmitConvertSpaceCLRToNative(ILCodeStream* pslILEmit);
     virtual void EmitConvertContentsCLRToNative(ILCodeStream* pslILEmit);
@@ -2066,7 +2066,7 @@ public:
     virtual void EmitClearNative(ILCodeStream* pslILEmit);
 
 private:
-	void EmitTryPinBuffer(ILCodeStream * pslILEmit, ILCodeLabel * marshalledLabel);
+    void EmitTryPinBuffer(ILCodeStream * pslILEmit, ILCodeLabel * marshalledLabel);
     bool CanTryUsePinnedBuffer()
     {
         return IsCLRToNative(m_dwMarshalFlags) && !IsByref(m_dwMarshalFlags);

--- a/src/vm/metasig.h
+++ b/src/vm/metasig.h
@@ -371,7 +371,7 @@ DEFINE_METASIG_T(SM(UInt_UInt_PtrNativeOverlapped_RetVoid, K K P(g(NATIVEOVERLAP
 DEFINE_METASIG(IM(Long_RetVoid, l, v))
 DEFINE_METASIG(IM(IntPtr_Int_RetVoid, I i, v))
 DEFINE_METASIG(IM(IntInt_RetArrByte, i i, a(b)))
-DEFINE_METASIG(IM(RefArrChar_RetBool, r(a(u)), F))
+DEFINE_METASIG(IM(RetArrChar, _, a(u)))
 DEFINE_METASIG(IM(RetIntPtr, _, I))
 DEFINE_METASIG(IM(RetInt, _, i))
 DEFINE_METASIG_T(IM(RetAssemblyName, _, C(ASSEMBLY_NAME)))

--- a/src/vm/metasig.h
+++ b/src/vm/metasig.h
@@ -371,6 +371,7 @@ DEFINE_METASIG_T(SM(UInt_UInt_PtrNativeOverlapped_RetVoid, K K P(g(NATIVEOVERLAP
 DEFINE_METASIG(IM(Long_RetVoid, l, v))
 DEFINE_METASIG(IM(IntPtr_Int_RetVoid, I i, v))
 DEFINE_METASIG(IM(IntInt_RetArrByte, i i, a(b)))
+DEFINE_METASIG(IM(RefArrChar_RetBool, r(a(u)), F))
 DEFINE_METASIG(IM(RetIntPtr, _, I))
 DEFINE_METASIG(IM(RetInt, _, i))
 DEFINE_METASIG_T(IM(RetAssemblyName, _, C(ASSEMBLY_NAME)))

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -795,6 +795,8 @@ DEFINE_METHOD(STRING,               STRLEN,                 strlen,             
 DEFINE_PROPERTY(STRING,             LENGTH,                 Length,                     Int)
 
 DEFINE_CLASS(STRING_BUILDER,        Text,                   StringBuilder)
+DEFINE_FIELD(STRING_BUILDER,        M_CHUNK_CHARS,          m_ChunkChars)
+DEFINE_FIELD(STRING_BUILDER,        M_CHUNK_PREVIOUS,       m_ChunkPrevious)
 DEFINE_PROPERTY(STRING_BUILDER,     LENGTH,                 Length,                     Int)
 DEFINE_PROPERTY(STRING_BUILDER,     CAPACITY,               Capacity,                   Int)
 DEFINE_METHOD(STRING_BUILDER,       CTOR_INT,               .ctor,                      IM_Int_RetVoid)

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -802,7 +802,7 @@ DEFINE_METHOD(STRING_BUILDER,       TO_STRING,              ToString,           
 DEFINE_METHOD(STRING_BUILDER,       INTERNAL_COPY,          InternalCopy,               IM_IntPtr_Int_RetVoid)
 DEFINE_METHOD(STRING_BUILDER,       REPLACE_BUFFER_INTERNAL,ReplaceBufferInternal,      IM_PtrChar_Int_RetVoid)
 DEFINE_METHOD(STRING_BUILDER,       REPLACE_BUFFER_ANSI_INTERNAL,ReplaceBufferAnsiInternal, IM_PtrSByt_Int_RetVoid)
-DEFINE_METHOD(STRING_BUILDER,       IS_SINGLE_CHUNK,         IsSingleChunk,              IM_RefArrChar_RetBool)
+DEFINE_METHOD(STRING_BUILDER,       TRY_GET_SINGLE_CHUNK,   TryGetSingleChunk,          IM_RetArrChar)
 DEFINE_METHOD(STRING_BUILDER,       UPDATE_LENGTH_OF_SINGLE_CHUNK, UpdateLengthOfSingleChunk, IM_Int_RetVoid)
 
 DEFINE_CLASS(STRONG_NAME_KEY_PAIR,  Reflection,             StrongNameKeyPair)

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -795,8 +795,6 @@ DEFINE_METHOD(STRING,               STRLEN,                 strlen,             
 DEFINE_PROPERTY(STRING,             LENGTH,                 Length,                     Int)
 
 DEFINE_CLASS(STRING_BUILDER,        Text,                   StringBuilder)
-DEFINE_FIELD(STRING_BUILDER,        M_CHUNK_CHARS,          m_ChunkChars)
-DEFINE_FIELD(STRING_BUILDER,        M_CHUNK_PREVIOUS,       m_ChunkPrevious)
 DEFINE_PROPERTY(STRING_BUILDER,     LENGTH,                 Length,                     Int)
 DEFINE_PROPERTY(STRING_BUILDER,     CAPACITY,               Capacity,                   Int)
 DEFINE_METHOD(STRING_BUILDER,       CTOR_INT,               .ctor,                      IM_Int_RetVoid)
@@ -804,6 +802,7 @@ DEFINE_METHOD(STRING_BUILDER,       TO_STRING,              ToString,           
 DEFINE_METHOD(STRING_BUILDER,       INTERNAL_COPY,          InternalCopy,               IM_IntPtr_Int_RetVoid)
 DEFINE_METHOD(STRING_BUILDER,       REPLACE_BUFFER_INTERNAL,ReplaceBufferInternal,      IM_PtrChar_Int_RetVoid)
 DEFINE_METHOD(STRING_BUILDER,       REPLACE_BUFFER_ANSI_INTERNAL,ReplaceBufferAnsiInternal, IM_PtrSByt_Int_RetVoid)
+DEFINE_METHOD(STRING_BUILDER,       IS_SINGLE_CHUNK,         IsSingleChunk,              IM_RefArrChar_RetBool)
 
 DEFINE_CLASS(STRONG_NAME_KEY_PAIR,  Reflection,             StrongNameKeyPair)
 

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -803,6 +803,7 @@ DEFINE_METHOD(STRING_BUILDER,       INTERNAL_COPY,          InternalCopy,       
 DEFINE_METHOD(STRING_BUILDER,       REPLACE_BUFFER_INTERNAL,ReplaceBufferInternal,      IM_PtrChar_Int_RetVoid)
 DEFINE_METHOD(STRING_BUILDER,       REPLACE_BUFFER_ANSI_INTERNAL,ReplaceBufferAnsiInternal, IM_PtrSByt_Int_RetVoid)
 DEFINE_METHOD(STRING_BUILDER,       IS_SINGLE_CHUNK,         IsSingleChunk,              IM_RefArrChar_RetBool)
+DEFINE_METHOD(STRING_BUILDER,       UPDATE_LENGTH_OF_SINGLE_CHUNK, UpdateLengthOfSingleChunk, IM_Int_RetVoid)
 
 DEFINE_CLASS(STRONG_NAME_KEY_PAIR,  Reflection,             StrongNameKeyPair)
 

--- a/src/vm/stubgen.cpp
+++ b/src/vm/stubgen.cpp
@@ -1314,6 +1314,11 @@ void ILCodeStream::EmitLDC_R8(UINT64 uConst)
 #endif // _WIN64
     Emit(CEE_LDC_R8, 1, (UINT_PTR)uConst);
 }
+void ILCodeStream::EmitLDELEMA(int token)
+{
+    WRAPPER_NO_CONTRACT;
+    Emit(CEE_LDELEMA, -1, token);
+}
 void ILCodeStream::EmitLDELEM_REF()
 {
     WRAPPER_NO_CONTRACT;

--- a/src/vm/stubgen.h
+++ b/src/vm/stubgen.h
@@ -75,6 +75,11 @@ struct LocalDesc
         bIsCopyConstructed = TRUE;
     }
 
+    void MakeArray()
+    {
+        ChangeType(ELEMENT_TYPE_SZARRAY);
+    }
+
     void ChangeType(CorElementType elemType)
     {
         LIMITED_METHOD_CONTRACT;

--- a/src/vm/stubgen.h
+++ b/src/vm/stubgen.h
@@ -600,6 +600,7 @@ public:
     void EmitLDC        (DWORD_PTR uConst);
     void EmitLDC_R4     (UINT32 uConst);
     void EmitLDC_R8     (UINT64 uConst);
+    void EmitLDELEMA   (int token);
     void EmitLDELEM_REF ();
     void EmitLDFLD      (int token);
     void EmitLDFLDA     (int token);

--- a/src/vm/stubgen.h
+++ b/src/vm/stubgen.h
@@ -60,23 +60,27 @@ struct LocalDesc
 
     void MakeByRef()
     {
+        LIMITED_METHOD_CONTRACT;
         ChangeType(ELEMENT_TYPE_BYREF);
     }
 
     void MakePinned()
     {
+        LIMITED_METHOD_CONTRACT;
         ChangeType(ELEMENT_TYPE_PINNED);
     }
 
     // makes the LocalDesc semantically equivalent to ET_TYPE_CMOD_REQD<IsCopyConstructed>/ET_TYPE_CMOD_REQD<NeedsCopyConstructorModifier>
     void MakeCopyConstructedPointer()
     {
+        LIMITED_METHOD_CONTRACT;
         ChangeType(ELEMENT_TYPE_PTR);
         bIsCopyConstructed = TRUE;
     }
 
     void MakeArray()
     {
+        LIMITED_METHOD_CONTRACT;
         ChangeType(ELEMENT_TYPE_SZARRAY);
     }
 
@@ -600,7 +604,7 @@ public:
     void EmitLDC        (DWORD_PTR uConst);
     void EmitLDC_R4     (UINT32 uConst);
     void EmitLDC_R8     (UINT64 uConst);
-    void EmitLDELEMA   (int token);
+    void EmitLDELEMA    (int token);
     void EmitLDELEM_REF ();
     void EmitLDFLD      (int token);
     void EmitLDFLDA     (int token);

--- a/tests/src/Interop/COM/NETClients/Primitives/StringTests.cs
+++ b/tests/src/Interop/COM/NETClients/Primitives/StringTests.cs
@@ -230,6 +230,13 @@ namespace NetClient
                 this.server.Reverse_SB_LPWStr_OutAttr(local, actual);
                 Assert.AreEqual(expected, actual.ToString());
                 Assert.AreEqual(expected, local.ToString());
+
+                local = new StringBuilder(s.Length / 2);
+                actual = new StringBuilder(s.Length);
+                local.Append(s);
+                this.server.Reverse_SB_LPWStr_OutAttr(local, actual);
+                Assert.AreEqual(expected, actual.ToString());
+                Assert.AreEqual(expected, local.ToString());
             }
         }
 


### PR DESCRIPTION
If we are marshalling a `StringBuilder`, we currently always copy into a buffer of some sort. If we are marshalling to a `LPWSTR` and our `StringBuilder` has only one chunk, we can pin the underlying buffer and pass that to the native code. This PR adds the codegen paths in the ILStubs to pin when the buffer is only one chunk.

Fixes #1842
