### PR TITLE
Use Kernel32 instead of api-ms-win-core-* in SafeHandlesTests

### DIFF
--- a/tests/src/Interop/PInvoke/SafeHandles/SafeFileHandle.cs
+++ b/tests/src/Interop/PInvoke/SafeHandles/SafeFileHandle.cs
@@ -21,7 +21,7 @@ namespace SafeHandlesTests{
         }
 
         //each SafeHandle subclass will expose a static method for instance creation
-        [DllImport("api-ms-win-core-file-l1-2-1", EntryPoint = "CreateFileW", SetLastError = true)]
+        [DllImport("Kernel32", EntryPoint = "CreateFileW", SetLastError = true)]
         public static extern ChildSFH_NoCloseHandle CreateChildSafeFileHandle(String lpFileName,
             DesiredAccess dwDesiredAccess, ShareMode dwShareMode,
             IntPtr lpSecurityAttributes, CreationDisposition dwCreationDisposition,
@@ -49,7 +49,7 @@ namespace SafeHandlesTests{
     public class ChildSafeFileHandle : SafeFileHandle
     {
         //each SafeHandle subclass will expose a static method for instance creation
-        [DllImport("api-ms-win-core-file-l1-2-1", EntryPoint = "CreateFileW", SetLastError = true)]
+        [DllImport("Kernel32", EntryPoint = "CreateFileW", SetLastError = true)]
         public static extern ChildSafeFileHandle CreateChildSafeFileHandle(String lpFileName,
             DesiredAccess dwDesiredAccess, ShareMode dwShareMode,
             IntPtr lpSecurityAttributes, CreationDisposition dwCreationDisposition,
@@ -77,7 +77,7 @@ namespace SafeHandlesTests{
         }
 
         //each SafeHandle subclass will expose a static method for instance creation
-        [DllImport("api-ms-win-core-file-l1-2-1", EntryPoint = "CreateFileW", SetLastError = true)]
+        [DllImport("Kernel32", EntryPoint = "CreateFileW", SetLastError = true)]
         public static extern SFH_NoCloseHandle CreateFile(String lpFileName,
                                                 DesiredAccess dwDesiredAccess, ShareMode dwShareMode,
                                                 IntPtr lpSecurityAttributes, CreationDisposition dwCreationDisposition,
@@ -126,12 +126,12 @@ namespace SafeHandlesTests{
         }
 
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-        [DllImport("api-ms-win-core-handle-l1-1-0", SetLastError = true)]
+        [DllImport("Kernel32", SetLastError = true)]
         private static extern bool CloseHandle(IntPtr handle);
 
 
         //each SafeHandle subclass will expose a static method for instance creation
-        [DllImport("api-ms-win-core-file-l1-2-1", EntryPoint = "CreateFileW", SetLastError = true)]
+        [DllImport("Kernel32", EntryPoint = "CreateFileW", SetLastError = true)]
         public static extern SafeFileHandle CreateFile(String lpFileName,
                                                 DesiredAccess dwDesiredAccess, ShareMode dwShareMode,
                                                 IntPtr lpSecurityAttributes, CreationDisposition dwCreationDisposition,


### PR DESCRIPTION
Fix **SafeHandlesTests** failures on Windows 7 x64/x86

An example of such failure:
```
xUnit.net Console Runner v2.4.1 (64-bit .NET Core 4.6.27303.0)
  Discovering: Interop.PInvoke.XUnitWrapper
  Discovered:  Interop.PInvoke.XUnitWrapper
  Starting:    Interop.PInvoke.XUnitWrapper
    Interop_PInvoke._SafeHandles_InvalidMarshalAs_InvalidMarshalAsTest_InvalidMarshalAsTest_._SafeHandles_InvalidMarshalAs_InvalidMarshalAsTest_InvalidMarshalAsTest_cmd [FAIL]
      

Return code:      1
Raw output file:      C:\dotnetbuild\work\d0bbea5e-181f-468b-ad47-e70059b15b5c\Work\a89d7721-b91e-4982-851a-1893ecb2e030\Unzip\Reports\Interop.PInvoke\SafeHandles\InvalidMarshalAs\InvalidMarshalAsTest\InvalidMarshalAsTest.output.txt
Raw output:
BEGIN EXECUTION
       "C:\dotnetbuild\work\d0bbea5e-181f-468b-ad47-e70059b15b5c\Payload\corerun.exe" InvalidMarshalAsTest.exe 
      
RunSHInvalidMATests():
      Test Failure: System.EntryPointNotFoundException: Unable to find an entry point named 'CreateFileW' in DLL 'api-ms-win-core-file-l1-2-1'.
         at SafeHandlesTests.SafeFileHandle.CreateFile(String lpFileName, DesiredAccess dwDesiredAccess, ShareMode dwShareMode, IntPtr lpSecurityAttributes, CreationDisposition dwCreationDisposition, FlagsAndAttributes dwFlagsAndAttributes, IntPtr hTemplateFile)
         at SafeHandlesTests.Helper.NewSFH()
         at SHTester_MA.RunSHInvalidMATests()
         at SHTester_MA.Main()
      Expected: 100
      Actual: 101
      END EXECUTION - FAILED
      FAILED
      Test Harness Exitcode is : 1
```

**Official build:** https://mc.dot.net/#/product/netcore/30/source/official~2Fcoreclr~2Fmaster~2F/type/test~2Ffunctional~2Fcli~2F/build/20190103.03/workItem/Interop.PInvoke.XUnitWrapper