### PR TITLE
Remove unnecessary ThrowIfUnsupportedType calls and definitions

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128_1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128_1.cs
@@ -41,7 +41,7 @@ namespace System.Runtime.Intrinsics
         {
             get
             {
-                ThrowIfUnsupportedType();
+                ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
                 return Vector128.Size / Unsafe.SizeOf<T>();
             }
         }
@@ -53,7 +53,7 @@ namespace System.Runtime.Intrinsics
             [Intrinsic]
             get
             {
-                ThrowIfUnsupportedType();
+                ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
                 return default;
             }
         }
@@ -91,15 +91,6 @@ namespace System.Runtime.Intrinsics
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void ThrowIfUnsupportedType()
-        {
-            if (!IsSupported)
-            {
-                throw new NotSupportedException(SR.Arg_TypeNotSupported);
-            }
-        }
-
         /// <summary>Reinterprets the current instance as a new <see cref="Vector128{U}" />.</summary>
         /// <typeparam name="U">The type of the vector the current instance should be reinterpreted as.</typeparam>
         /// <returns>The current instance reinterpreted as a new <see cref="Vector128{U}" />.</returns>
@@ -108,8 +99,8 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Vector128<U> As<U>() where U : struct
         {
-            ThrowIfUnsupportedType();
-            Vector128<U>.ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<U>();
             return Unsafe.As<Vector128<T>, Vector128<U>>(ref Unsafe.AsRef(in this));
         }
 
@@ -184,7 +175,7 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(Vector128<T> other)
         {
-            ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
             if (Sse.IsSupported && (typeof(T) == typeof(float)))
             {
@@ -243,11 +234,11 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> was less than zero or greater than the number of elements.</exception>
         public T GetElement(int index)
         {
-            ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
             if ((uint)(index) >= (uint)(Count))
             {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
             }
 
             ref T e0 = ref Unsafe.As<Vector128<T>, T>(ref Unsafe.AsRef(in this));
@@ -262,11 +253,11 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> was less than zero or greater than the number of elements.</exception>
         public Vector128<T> WithElement(int index, T value)
         {
-            ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
             if ((uint)(index) >= (uint)(Count))
             {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
             }
 
             Vector128<T> result = this;
@@ -280,7 +271,7 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         public override int GetHashCode()
         {
-            ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
             int hashCode = 0;
 
@@ -297,8 +288,8 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         public Vector64<T> GetLower()
         {
-            ThrowIfUnsupportedType();
-            Vector64<T>.ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
+
             return Unsafe.As<Vector128<T>, Vector64<T>>(ref Unsafe.AsRef(in this));
         }
 
@@ -308,8 +299,7 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         public Vector128<T> WithLower(Vector64<T> value)
         {
-            ThrowIfUnsupportedType();
-            Vector64<T>.ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
             Vector128<T> result = this;
             Unsafe.As<Vector128<T>, Vector64<T>>(ref result) = value;
@@ -321,8 +311,7 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         public Vector64<T> GetUpper()
         {
-            ThrowIfUnsupportedType();
-            Vector64<T>.ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
             ref Vector64<T> lower = ref Unsafe.As<Vector128<T>, Vector64<T>>(ref Unsafe.AsRef(in this));
             return Unsafe.Add(ref lower, 1);
@@ -334,8 +323,7 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         public Vector128<T> WithUpper(Vector64<T> value)
         {
-            ThrowIfUnsupportedType();
-            Vector64<T>.ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
             Vector128<T> result = this;
             ref Vector64<T> lower = ref Unsafe.As<Vector128<T>, Vector64<T>>(ref result);
@@ -349,7 +337,7 @@ namespace System.Runtime.Intrinsics
         [Intrinsic]
         public T ToScalar()
         {
-            ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
             return Unsafe.As<Vector128<T>, T>(ref Unsafe.AsRef(in this));
         }
 
@@ -377,7 +365,7 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         public string ToString(string format, IFormatProvider formatProvider)
         {
-            ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
             string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;
             int lastElement = Count - 1;
@@ -403,8 +391,7 @@ namespace System.Runtime.Intrinsics
         [Intrinsic]
         public Vector256<T> ToVector256()
         {
-            ThrowIfUnsupportedType();
-            Vector256<T>.ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
             Vector256<T> result = Vector256<T>.Zero;
             Unsafe.As<Vector256<T>, Vector128<T>>(ref result) = this;
@@ -417,8 +404,7 @@ namespace System.Runtime.Intrinsics
         [Intrinsic]
         public unsafe Vector256<T> ToVector256Unsafe()
         {
-            ThrowIfUnsupportedType();
-            Vector256<T>.ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
             // This relies on us stripping the "init" flag from the ".locals"
             // declaration to let the upper bits be uninitialized.

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256_1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256_1.cs
@@ -43,7 +43,7 @@ namespace System.Runtime.Intrinsics
         {
             get
             {
-                ThrowIfUnsupportedType();
+                ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
                 return Vector256.Size / Unsafe.SizeOf<T>();
             }
         }
@@ -55,7 +55,7 @@ namespace System.Runtime.Intrinsics
             [Intrinsic]
             get
             {
-                ThrowIfUnsupportedType();
+                ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
                 return default;
             }
         }
@@ -93,15 +93,6 @@ namespace System.Runtime.Intrinsics
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void ThrowIfUnsupportedType()
-        {
-            if (!IsSupported)
-            {
-                throw new NotSupportedException(SR.Arg_TypeNotSupported);
-            }
-        }
-
         /// <summary>Reinterprets the current instance as a new <see cref="Vector256{U}" />.</summary>
         /// <typeparam name="U">The type of the vector the current instance should be reinterpreted as.</typeparam>
         /// <returns>The current instance reinterpreted as a new <see cref="Vector256{U}" />.</returns>
@@ -110,8 +101,8 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Vector256<U> As<U>() where U : struct
         {
-            ThrowIfUnsupportedType();
-            Vector256<U>.ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<U>();
             return Unsafe.As<Vector256<T>, Vector256<U>>(ref Unsafe.AsRef(in this));
         }
 
@@ -183,6 +174,7 @@ namespace System.Runtime.Intrinsics
         /// <param name="other">The <see cref="Vector256{T}" /> to compare with the current instance.</param>
         /// <returns><c>true</c> if <paramref name="other" /> is equal to the current instance; otherwise, <c>false</c>.</returns>
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(Vector256<T> other)
         {
             if (Avx.IsSupported)
@@ -243,11 +235,11 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> was less than zero or greater than the number of elements.</exception>
         public T GetElement(int index)
         {
-            ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
             if ((uint)(index) >= (uint)(Count))
             {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
             }
 
             ref T e0 = ref Unsafe.As<Vector256<T>, T>(ref Unsafe.AsRef(in this));
@@ -262,11 +254,11 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> was less than zero or greater than the number of elements.</exception>
         public Vector256<T> WithElement(int index, T value)
         {
-            ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
             if ((uint)(index) >= (uint)(Count))
             {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
             }
 
             Vector256<T> result = this;
@@ -280,7 +272,7 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         public override int GetHashCode()
         {
-            ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
             int hashCode = 0;
 
@@ -298,8 +290,7 @@ namespace System.Runtime.Intrinsics
         [Intrinsic]
         public Vector128<T> GetLower()
         {
-            ThrowIfUnsupportedType();
-            Vector128<T>.ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
             return Unsafe.As<Vector256<T>, Vector128<T>>(ref Unsafe.AsRef(in this));
         }
 
@@ -310,8 +301,7 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Vector256<T> WithLower(Vector128<T> value)
         {
-            ThrowIfUnsupportedType();
-            Vector128<T>.ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
             if (Avx2.IsSupported && ((typeof(T) != typeof(float)) && (typeof(T) != typeof(double))))
             {
@@ -342,8 +332,7 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Vector128<T> GetUpper()
         {
-            ThrowIfUnsupportedType();
-            Vector128<T>.ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
             if (Avx2.IsSupported && ((typeof(T) != typeof(float)) && (typeof(T) != typeof(double))))
             {
@@ -374,8 +363,7 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Vector256<T> WithUpper(Vector128<T> value)
         {
-            ThrowIfUnsupportedType();
-            Vector128<T>.ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
             if (Avx2.IsSupported && ((typeof(T) != typeof(float)) && (typeof(T) != typeof(double))))
             {
@@ -407,7 +395,7 @@ namespace System.Runtime.Intrinsics
         [Intrinsic]
         public T ToScalar()
         {
-            ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
             return Unsafe.As<Vector256<T>, T>(ref Unsafe.AsRef(in this));
         }
 
@@ -435,7 +423,7 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         public string ToString(string format, IFormatProvider formatProvider)
         {
-            ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
             string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;
             int lastElement = Count - 1;

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector64_1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector64_1.cs
@@ -28,7 +28,7 @@ namespace System.Runtime.Intrinsics
         {
             get
             {
-                ThrowIfUnsupportedType();
+                ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
                 return Vector64.Size / Unsafe.SizeOf<T>();
             }
         }
@@ -39,7 +39,7 @@ namespace System.Runtime.Intrinsics
         {
             get
             {
-                ThrowIfUnsupportedType();
+                ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
                 return default;
             }
         }
@@ -77,15 +77,6 @@ namespace System.Runtime.Intrinsics
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void ThrowIfUnsupportedType()
-        {
-            if (!IsSupported)
-            {
-                throw new NotSupportedException(SR.Arg_TypeNotSupported);
-            }
-        }
-
         /// <summary>Reinterprets the current instance as a new <see cref="Vector64{U}" />.</summary>
         /// <typeparam name="U">The type of the vector the current instance should be reinterpreted as.</typeparam>
         /// <returns>The current instance reinterpreted as a new <see cref="Vector64{U}" />.</returns>
@@ -94,8 +85,8 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Vector64<U> As<U>() where U : struct
         {
-            ThrowIfUnsupportedType();
-            Vector64<U>.ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<U>();
             return Unsafe.As<Vector64<T>, Vector64<U>>(ref Unsafe.AsRef(in this));
         }
 
@@ -169,7 +160,7 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         public bool Equals(Vector64<T> other)
         {
-            ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
             for (int i = 0; i < Count; i++)
             {
@@ -198,11 +189,11 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> was less than zero or greater than the number of elements.</exception>
         public T GetElement(int index)
         {
-            ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
             if ((uint)(index) >= (uint)(Count))
             {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
             }
 
             ref T e0 = ref Unsafe.As<Vector64<T>, T>(ref Unsafe.AsRef(in this));
@@ -217,7 +208,7 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="index" /> was less than zero or greater than the number of elements.</exception>
         public Vector64<T> WithElement(int index, T value)
         {
-            ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
             if ((uint)(index) >= (uint)(Count))
             {
@@ -235,7 +226,7 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         public override int GetHashCode()
         {
-            ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
             int hashCode = 0;
 
@@ -252,7 +243,7 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         public T ToScalar()
         {
-            ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
             return Unsafe.As<Vector64<T>, T>(ref Unsafe.AsRef(in this));
         }
 
@@ -280,7 +271,7 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         public string ToString(string format, IFormatProvider formatProvider)
         {
-            ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
             string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;
             int lastElement = Count - 1;
@@ -305,8 +296,7 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         public Vector128<T> ToVector128()
         {
-            ThrowIfUnsupportedType();
-            Vector128<T>.ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
             Vector128<T> result = Vector128<T>.Zero;
             Unsafe.As<Vector128<T>, Vector64<T>>(ref result) = this;
@@ -318,8 +308,7 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of the current instance (<typeparamref name="T" />) is not supported.</exception>
         public unsafe Vector128<T> ToVector128Unsafe()
         {
-            ThrowIfUnsupportedType();
-            Vector128<T>.ThrowIfUnsupportedType();
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
 
             // This relies on us stripping the "init" flag from the ".locals"
             // declaration to let the upper bits be uninitialized.

--- a/src/System.Private.CoreLib/shared/System/ThrowHelper.cs
+++ b/src/System.Private.CoreLib/shared/System/ThrowHelper.cs
@@ -399,7 +399,8 @@ namespace System
                 ThrowHelper.ThrowArgumentNullException(argName);
         }
 
-        internal static void ThrowNotSupportedExceptionIfNonNumericType<T>()
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void ThrowForUnsupportedVectorBaseType<T>() where T : struct
         {
             if (typeof(T) != typeof(byte) && typeof(T) != typeof(sbyte) &&
                 typeof(T) != typeof(short) && typeof(T) != typeof(ushort) &&
@@ -407,7 +408,7 @@ namespace System
                 typeof(T) != typeof(long) && typeof(T) != typeof(ulong) &&
                 typeof(T) != typeof(float) && typeof(T) != typeof(double))
             {
-                throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                ThrowNotSupportedException(ExceptionResource.Arg_TypeNotSupported);
             }
         }
 
@@ -723,6 +724,8 @@ namespace System
                     return SR.NotSupported_FixedSizeCollection;
                 case ExceptionResource.Rank_MultiDimNotSupported:
                     return SR.Rank_MultiDimNotSupported;
+                case ExceptionResource.Arg_TypeNotSupported:
+                    return SR.Arg_TypeNotSupported;
                 default:
                     Debug.Assert(false,
                         "The enum value is not defined, please check the ExceptionResource Enum.");
@@ -880,5 +883,6 @@ namespace System
         InvalidOperation_IComparerFailed,
         NotSupported_FixedSizeCollection,
         Rank_MultiDimNotSupported,
+        Arg_TypeNotSupported,
     }
 }


### PR DESCRIPTION
Contribute to https://github.com/dotnet/coreclr/issues/21794

`ThrowIfUnsupportedType` just checks the base-type and not related to vector types, so we can eliminate these call-sites.

@CarolEidt @tannergooding 