### PR TITLE
Use macOS 10.12 agent pool and new Helix queues in Azure DevOps

### DIFF
--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -92,9 +92,8 @@ jobs:
     archType: x64
     osGroup: OSX
     osIdentifier: OSX
-    # TODO: add OSX.1012.Amd64.Open and OSX.1012.Amd64 when https://github.com/dotnet/core-eng/issues/4856 is resolved
-    helixQueuesPublic: 'OSX.1013.Amd64.Open'
-    helixQueuesInternal: 'OSX.1013.Amd64'
+    helixQueuesPublic: 'OSX.1012.Amd64.Open,OSX.1013.Amd64.Open'
+    helixQueuesInternal: 'OSX.1012.Amd64,OSX.1013.Amd64,OSX.1014.Amd64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Windows x64/x86/arm/arm64

--- a/eng/xplat-job.yml
+++ b/eng/xplat-job.yml
@@ -40,9 +40,9 @@ jobs:
       ${{ if and(eq(parameters.osGroup, 'Linux'), ne(variables['System.TeamProject'], 'public')) }}:
         name: dnceng-linux-internal-temp
       ${{ if and(eq(parameters.osGroup, 'OSX'), ne(variables['System.TeamProject'], 'public')) }}:
-        name: Hosted Mac Internal
+        name: Hosted Mac Internal Sierra
       ${{ if and(eq(parameters.osGroup, 'OSX'), eq(variables['System.TeamProject'], 'public')) }}:
-        name: Hosted MacOS
+        name: Hosted Mac Internal Sierra
       ${{ if and(eq(parameters.osGroup, 'Windows_NT'), ne(variables['System.TeamProject'], 'public')) }}:
         name: dotnet-internal-temp
       ${{ if and(eq(parameters.osGroup, 'Windows_NT'), eq(variables['System.TeamProject'], 'public')) }}:


### PR DESCRIPTION
* As suggested in https://github.com/dotnet/core-eng/issues/4856#issuecomment-451295212 switch to Hosted Mac Internal Sierra for both internal and external projects.

* Enable back OSX.1012.Amd64.Open and OSX.1012.Amd64 Helix queues.

* Add new OSX.1014.Amd64 for internal project.