### PR TITLE
Fix batch script errors running JitOptimizationSensitive tests

### DIFF
--- a/tests/src/CLRTest.Execute.Batch.targets
+++ b/tests/src/CLRTest.Execute.Batch.targets
@@ -88,7 +88,7 @@ REM
 REM TieredCompilation will use minopts. Therefore it is also included in this
 REM set. Unlike the rest, TieredCompilation=0 should run the JitOptimizationSensitive
 REM tests. The following cannot run the test.
-REN
+REM
 REM     TieredCompilation=1
 REM     TieredCompilation=
 IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_JITMinOpts%"=="" IF "%COMPlus_TailcallStress%"=="" goto :Compatible


### PR DESCRIPTION
Simple typo: REN instead of REM, leading to:

"The syntax of the command is incorrect."