### PR TITLE
Check result of call to TestEnv script

### DIFF
--- a/tests/src/CLRTest.Execute.Batch.targets
+++ b/tests/src/CLRTest.Execute.Batch.targets
@@ -382,7 +382,14 @@ $(BatchCLRTestArgPrep)
 $(BatchCLRTestExitCodePrep)
 
 REM The __TestEnv variable may be used to specify something to run before the test.
-IF NOT "%__TestEnv%"=="" call %__TestEnv%
+IF NOT "%__TestEnv%"=="" (
+    call %__TestEnv%
+    IF NOT "!ERRORLEVEL!"=="0" (
+        ECHO CALLING __TestEnv SCRIPT FAILED
+        popd
+        Exit /b 1
+    )
+)
 
 REM Environment Variables
 $(BatchEnvironmentVariables)


### PR DESCRIPTION
If you give an illegal, not executable TestEnv script, then this
will not fail silently.