### PR TITLE
Specify the minimum supported version of macOS

### DIFF
--- a/configurecompiler.cmake
+++ b/configurecompiler.cmake
@@ -475,6 +475,11 @@ if (CLR_CMAKE_PLATFORM_UNIX)
   # Some architectures (e.g., ARM) assume char type is unsigned while CoreCLR assumes char is signed
   # as x64 does. It has been causing issues in ARM (https://github.com/dotnet/coreclr/issues/4746)
   add_compile_options(-fsigned-char)
+
+  # Specify the minimum supported version of macOS
+  if(CLR_CMAKE_PLATFORM_DARWIN)
+    add_compile_options(-mmacosx-version-min=10.12)
+  endif(CLR_CMAKE_PLATFORM_DARWIN)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
 if(CLR_CMAKE_PLATFORM_UNIX_ARM)

--- a/configurecompiler.cmake
+++ b/configurecompiler.cmake
@@ -478,7 +478,10 @@ if (CLR_CMAKE_PLATFORM_UNIX)
 
   # Specify the minimum supported version of macOS
   if(CLR_CMAKE_PLATFORM_DARWIN)
-    add_compile_options(-mmacosx-version-min=10.12)
+    set(MACOS_VERSION_MIN_FLAGS "-mmacosx-version-min=10.12")
+    add_compile_options("${MACOS_VERSION_MIN_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${MACOS_VERSION_MIN_FLAGS}")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${MACOS_VERSION_MIN_FLAGS}")
   endif(CLR_CMAKE_PLATFORM_DARWIN)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -92,9 +92,8 @@ jobs:
     archType: x64
     osGroup: OSX
     osIdentifier: OSX
-    # TODO: add OSX.1012.Amd64.Open and OSX.1012.Amd64 when https://github.com/dotnet/core-eng/issues/4856 is resolved
-    helixQueuesPublic: 'OSX.1013.Amd64.Open'
-    helixQueuesInternal: 'OSX.1013.Amd64'
+    helixQueuesPublic: 'OSX.1012.Amd64.Open,OSX.1013.Amd64.Open'
+    helixQueuesInternal: 'OSX.1012.Amd64,OSX.1013.Amd64,OSX.1014.Amd64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Windows x64/x86/arm/arm64


### PR DESCRIPTION
As suggested in https://github.com/dotnet/coreclr/pull/21642#issuecomment-450670464 specify the minimum supported version of macOS to make coreclr built on macOS 10.13 work on macOS 10.12 and later

Tested in https://dnceng.visualstudio.com/public/_build/results?buildId=66785 and https://dnceng.visualstudio.com/public/_build/results?buildId=66781