### PR TITLE
Fix various fgMorphInitBlock issues

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2324,7 +2324,7 @@ public:
 
     GenTree* gtNewLconNode(__int64 value);
 
-    GenTree* gtNewDconNode(double value);
+    GenTree* gtNewDconNode(double value, var_types type = TYP_DOUBLE);
 
     GenTree* gtNewSconNode(int CPX, CORINFO_MODULE_HANDLE scpHandle);
 
@@ -5246,6 +5246,7 @@ private:
     void fgAssignSetVarDef(GenTree* tree);
     GenTree* fgMorphOneAsgBlockOp(GenTree* tree);
     GenTree* fgMorphInitBlock(GenTree* tree);
+    GenTree* fgMorphPromoteLocalInitBlock(GenTreeLclVar* destLclNode, GenTree* initVal, unsigned blockSize);
     GenTree* fgMorphBlkToInd(GenTreeBlk* tree, var_types type);
     GenTree* fgMorphGetStructAddr(GenTree** pTree, CORINFO_CLASS_HANDLE clsHnd, bool isRValue = false);
     GenTree* fgMorphBlkNode(GenTree* tree, bool isDest);

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -5668,9 +5668,9 @@ GenTree* Compiler::gtNewLconNode(__int64 value)
     return node;
 }
 
-GenTree* Compiler::gtNewDconNode(double value)
+GenTree* Compiler::gtNewDconNode(double value, var_types type)
 {
-    GenTree* node = new (this, GT_CNS_DBL) GenTreeDblCon(value);
+    GenTree* node = new (this, GT_CNS_DBL) GenTreeDblCon(value, type);
 
     return node;
 }

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -2680,8 +2680,9 @@ struct GenTreeDblCon : public GenTree
         return (bits == otherBits);
     }
 
-    GenTreeDblCon(double val) : GenTree(GT_CNS_DBL, TYP_DOUBLE), gtDconVal(val)
+    GenTreeDblCon(double val, var_types type = TYP_DOUBLE) : GenTree(GT_CNS_DBL, type), gtDconVal(val)
     {
+        assert(varTypeIsFloating(type));
     }
 #if DEBUGGABLE_GENTREE
     GenTreeDblCon() : GenTree()

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -9329,8 +9329,6 @@ GenTree* Compiler::fgMorphInitBlock(GenTree* tree)
         }
         else
         {
-            GenTree* destAddr = dest->AsIndir()->Addr();
-
             if (dest->OperIs(GT_IND))
             {
                 assert(dest->TypeGet() == TYP_STRUCT);
@@ -9348,7 +9346,7 @@ GenTree* Compiler::fgMorphInitBlock(GenTree* tree)
             }
 
             FieldSeqNode* destFldSeq = nullptr;
-            if (destAddr->IsLocalAddrExpr(this, &destLclNode, &destFldSeq))
+            if (dest->AsIndir()->Addr()->IsLocalAddrExpr(this, &destLclNode, &destFldSeq))
             {
                 destLclNum = destLclNode->GetLclNum();
                 destLclVar = lvaGetDesc(destLclNum);

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -9289,7 +9289,6 @@ GenTree* Compiler::fgMorphInitBlock(GenTree* tree)
     bool morphed = false;
 #endif // DEBUG
 
-    GenTree* asg      = tree;
     GenTree* src      = tree->gtGetOp2();
     GenTree* origDest = tree->gtGetOp1();
 
@@ -9315,217 +9314,92 @@ GenTree* Compiler::fgMorphInitBlock(GenTree* tree)
     }
     else
     {
-        GenTree*             destAddr          = nullptr;
-        GenTree*             initVal           = src->OperIsInitVal() ? src->gtGetOp1() : src;
-        GenTree*             blockSize         = nullptr;
-        unsigned             blockWidth        = 0;
-        FieldSeqNode*        destFldSeq        = nullptr;
-        LclVarDsc*           destLclVar        = nullptr;
-        bool                 destDoFldAsg      = false;
-        unsigned             destLclNum        = BAD_VAR_NUM;
-        bool                 blockWidthIsConst = false;
-        GenTreeLclVarCommon* lclVarTree        = nullptr;
+        GenTreeLclVarCommon* destLclNode = nullptr;
+        unsigned             destLclNum  = BAD_VAR_NUM;
+        LclVarDsc*           destLclVar  = nullptr;
+        GenTree*             initVal     = src->OperIsInitVal() ? src->gtGetOp1() : src;
+        unsigned             blockSize   = 0;
+
         if (dest->IsLocal())
         {
-            lclVarTree = dest->AsLclVarCommon();
+            destLclNode = dest->AsLclVarCommon();
+            destLclNum  = destLclNode->GetLclNum();
+            destLclVar  = lvaGetDesc(destLclNum);
+            blockSize   = varTypeIsStruct(destLclVar) ? destLclVar->lvExactSize : genTypeSize(destLclVar->TypeGet());
         }
         else
         {
-            if (dest->OperIsBlk())
+            GenTree* destAddr = dest->AsIndir()->Addr();
+
+            if (dest->OperIs(GT_IND))
             {
-                destAddr   = dest->AsBlk()->Addr();
-                blockWidth = dest->AsBlk()->gtBlkSize;
+                assert(dest->TypeGet() == TYP_STRUCT);
+                blockSize = genTypeSize(dest->TypeGet());
+            }
+            else if (dest->OperIs(GT_DYN_BLK))
+            {
+                blockSize = 0;
             }
             else
             {
-                assert((dest->gtOper == GT_IND) && (dest->TypeGet() != TYP_STRUCT));
-                destAddr   = dest->gtGetOp1();
-                blockWidth = genTypeSize(dest->TypeGet());
-            }
-        }
-        if (lclVarTree != nullptr)
-        {
-            destLclNum        = lclVarTree->gtLclNum;
-            destLclVar        = &lvaTable[destLclNum];
-            blockWidth        = varTypeIsStruct(destLclVar) ? destLclVar->lvExactSize : genTypeSize(destLclVar);
-            blockWidthIsConst = true;
-        }
-        else
-        {
-            if (dest->gtOper == GT_DYN_BLK)
-            {
-                // The size must be an integer type
-                blockSize = dest->AsBlk()->gtDynBlk.gtDynamicSize;
-                assert(varTypeIsIntegral(blockSize->gtType));
-            }
-            else
-            {
-                assert(blockWidth != 0);
-                blockWidthIsConst = true;
+                assert(dest->OperIs(GT_BLK, GT_OBJ));
+                blockSize = dest->AsBlk()->Size();
+                assert(blockSize != 0);
             }
 
-            if ((destAddr != nullptr) && destAddr->IsLocalAddrExpr(this, &lclVarTree, &destFldSeq))
+            FieldSeqNode* destFldSeq = nullptr;
+            if (destAddr->IsLocalAddrExpr(this, &destLclNode, &destFldSeq))
             {
-                destLclNum = lclVarTree->gtLclNum;
-                destLclVar = &lvaTable[destLclNum];
+                destLclNum = destLclNode->GetLclNum();
+                destLclVar = lvaGetDesc(destLclNum);
             }
         }
+
+        bool destDoFldAsg = false;
+
         if (destLclNum != BAD_VAR_NUM)
         {
 #if LOCAL_ASSERTION_PROP
             // Kill everything about destLclNum (and its field locals)
-            if (optLocalAssertionProp)
+            if (optLocalAssertionProp && (optAssertionCount > 0))
             {
-                if (optAssertionCount > 0)
-                {
-                    fgKillDependentAssertions(destLclNum DEBUGARG(tree));
-                }
+                fgKillDependentAssertions(destLclNum DEBUGARG(tree));
             }
 #endif // LOCAL_ASSERTION_PROP
 
-            if (destLclVar->lvPromoted && blockWidthIsConst)
+            if (destLclVar->lvPromoted)
             {
-                assert(initVal->OperGet() == GT_CNS_INT);
-                noway_assert(varTypeIsStruct(destLclVar));
-                noway_assert(!opts.MinOpts());
-                if (destLclVar->lvAddrExposed & destLclVar->lvContainsHoles)
+                GenTree* newTree = fgMorphPromoteLocalInitBlock(destLclNode->AsLclVar(), initVal, blockSize);
+
+                if (newTree != nullptr)
                 {
-                    JITDUMP(" dest is address exposed");
-                }
-                else
-                {
-                    if (blockWidth == destLclVar->lvExactSize)
-                    {
-                        JITDUMP(" (destDoFldAsg=true)");
-                        // We may decide later that a copyblk is required when this struct has holes
-                        destDoFldAsg = true;
-                    }
-                    else
-                    {
-                        JITDUMP(" with mismatched size");
-                    }
+                    tree         = newTree;
+                    destDoFldAsg = true;
+                    INDEBUG(morphed = true);
                 }
             }
-        }
 
-        // Can we use field by field assignment for the dest?
-        if (destDoFldAsg && destLclVar->lvCustomLayout && destLclVar->lvContainsHoles)
-        {
-            JITDUMP(" dest contains holes");
-            destDoFldAsg = false;
-        }
-
-        JITDUMP(destDoFldAsg ? " using field by field initialization.\n" : " this requires an InitBlock.\n");
-
-        // If we're doing an InitBlock and we've transformed the dest to a non-Blk
-        // we need to change it back.
-        if (!destDoFldAsg && !dest->OperIsBlk())
-        {
-            noway_assert(blockWidth != 0);
-            tree->gtOp.gtOp1 = origDest;
-            tree->gtType     = origDest->gtType;
-        }
-
-        if (!destDoFldAsg && (destLclVar != nullptr))
-        {
             // If destLclVar is not a reg-sized non-field-addressed struct, set it as DoNotEnregister.
-            if (!destLclVar->lvRegStruct)
+            if (!destDoFldAsg && !destLclVar->lvRegStruct)
             {
-                // Mark it as DoNotEnregister.
                 lvaSetVarDoNotEnregister(destLclNum DEBUGARG(DNER_BlockOp));
             }
         }
 
-        // Mark the dest struct as DoNotEnreg
-        // when they are LclVar structs and we are using a CopyBlock
-        // or the struct is not promoted
-        //
         if (!destDoFldAsg)
         {
-            dest             = fgMorphBlockOperand(dest, dest->TypeGet(), blockWidth, true);
+            // If we're doing an InitBlock and we've transformed the dest to a non-Blk
+            // we need to change it back.
+            if (!dest->OperIsBlk())
+            {
+                noway_assert(blockSize != 0);
+                tree->gtOp.gtOp1 = origDest;
+                tree->gtType     = origDest->gtType;
+            }
+
+            dest             = fgMorphBlockOperand(dest, dest->TypeGet(), blockSize, true);
             tree->gtOp.gtOp1 = dest;
             tree->gtFlags |= (dest->gtFlags & GTF_ALL_EFFECT);
-        }
-        else
-        {
-            // The initVal must be a constant of TYP_INT
-            noway_assert(initVal->OperGet() == GT_CNS_INT);
-            noway_assert(genActualType(initVal->gtType) == TYP_INT);
-
-            // The dest must be of a struct type.
-            noway_assert(varTypeIsStruct(destLclVar));
-
-            //
-            // Now, convert InitBlock to individual assignments
-            //
-
-            tree = nullptr;
-            INDEBUG(morphed = true);
-
-            GenTree* dest;
-            GenTree* srcCopy;
-            unsigned fieldLclNum;
-            unsigned fieldCnt = destLclVar->lvFieldCnt;
-
-            for (unsigned i = 0; i < fieldCnt; ++i)
-            {
-                fieldLclNum = destLclVar->lvFieldLclStart + i;
-                dest        = gtNewLclvNode(fieldLclNum, lvaTable[fieldLclNum].TypeGet());
-
-                noway_assert(lclVarTree->gtOper == GT_LCL_VAR);
-                // If it had been labeled a "USEASG", assignments to the the individual promoted fields are not.
-                dest->gtFlags |= (lclVarTree->gtFlags & ~(GTF_NODE_MASK | GTF_VAR_USEASG));
-
-                srcCopy = gtCloneExpr(initVal);
-                noway_assert(srcCopy != nullptr);
-
-                // need type of oper to be same as tree
-                if (dest->gtType == TYP_LONG)
-                {
-                    srcCopy->ChangeOperConst(GT_CNS_NATIVELONG);
-                    // copy and extend the value
-                    srcCopy->gtIntConCommon.SetLngValue(initVal->gtIntConCommon.IconValue());
-                    /* Change the types of srcCopy to TYP_LONG */
-                    srcCopy->gtType = TYP_LONG;
-                }
-                else if (varTypeIsFloating(dest->gtType))
-                {
-                    srcCopy->ChangeOperConst(GT_CNS_DBL);
-                    // setup the bit pattern
-                    memset(&srcCopy->gtDblCon.gtDconVal, (int)initVal->gtIntCon.gtIconVal,
-                           sizeof(srcCopy->gtDblCon.gtDconVal));
-                    /* Change the types of srcCopy to TYP_DOUBLE */
-                    srcCopy->gtType = TYP_DOUBLE;
-                }
-                else
-                {
-                    noway_assert(srcCopy->gtOper == GT_CNS_INT);
-                    noway_assert(srcCopy->TypeGet() == TYP_INT);
-                    // setup the bit pattern
-                    memset(&srcCopy->gtIntCon.gtIconVal, (int)initVal->gtIntCon.gtIconVal,
-                           sizeof(srcCopy->gtIntCon.gtIconVal));
-                }
-
-                srcCopy->gtType = dest->TypeGet();
-
-                asg = gtNewAssignNode(dest, srcCopy);
-
-#if LOCAL_ASSERTION_PROP
-                if (optLocalAssertionProp)
-                {
-                    optAssertionGen(asg);
-                }
-#endif // LOCAL_ASSERTION_PROP
-
-                if (tree)
-                {
-                    tree = gtNewOperNode(GT_COMMA, TYP_VOID, tree, asg);
-                }
-                else
-                {
-                    tree = asg;
-                }
-            }
         }
     }
 
@@ -9541,6 +9415,159 @@ GenTree* Compiler::fgMorphInitBlock(GenTree* tree)
         }
     }
 #endif
+
+    return tree;
+}
+
+//------------------------------------------------------------------------
+// fgMorphPromoteLocalInitBlock: Attempts to promote a local block init tree
+// to a tree of promoted field initialization assignments.
+//
+// Arguments:
+//    destLclNode - The destination LclVar node
+//    initVal - The initialization value
+//    blockSize - The amount of bytes to initialize
+//
+// Return Value:
+//    A tree that performs field by field initialization of the destination
+//    struct variable if various conditions are met, nullptr otherwise.
+//
+GenTree* Compiler::fgMorphPromoteLocalInitBlock(GenTreeLclVar* destLclNode, GenTree* initVal, unsigned blockSize)
+{
+    assert(destLclNode->OperIs(GT_LCL_VAR));
+
+    LclVarDsc* destLclVar = lvaGetDesc(destLclNode);
+    assert(varTypeIsStruct(destLclVar->TypeGet()));
+    assert(destLclVar->lvPromoted);
+
+    if (blockSize == 0)
+    {
+        JITDUMP(" size is not known.\n");
+        return nullptr;
+    }
+
+    if (destLclVar->lvAddrExposed && destLclVar->lvContainsHoles)
+    {
+        JITDUMP(" dest is address exposed and contains holes.\n");
+        return nullptr;
+    }
+
+    if (destLclVar->lvCustomLayout && destLclVar->lvContainsHoles)
+    {
+        JITDUMP(" dest has custom layout and contains holes.\n");
+        return nullptr;
+    }
+
+    if (destLclVar->lvExactSize != blockSize)
+    {
+        JITDUMP(" dest size mismatch.\n");
+        return nullptr;
+    }
+
+    if (!initVal->OperIs(GT_CNS_INT))
+    {
+        JITDUMP(" source is not constant.\n");
+        return nullptr;
+    }
+
+    const int64_t initPattern = (initVal->AsIntCon()->IconValue() & 0xFF) * 0x0101010101010101LL;
+
+    if (initPattern != 0)
+    {
+        for (unsigned i = 0; i < destLclVar->lvFieldCnt; ++i)
+        {
+            LclVarDsc* fieldDesc = lvaGetDesc(destLclVar->lvFieldLclStart + i);
+
+            if (varTypeIsSIMD(fieldDesc->TypeGet()) || varTypeIsGC(fieldDesc->TypeGet()))
+            {
+                // Cannot initialize GC or SIMD types with a non-zero constant.
+                // The former is completly bogus. The later restriction could be
+                // lifted by supporting non-zero SIMD constants or by generating
+                // field initialization code that converts an integer constant to
+                // the appropiate SIMD value. Unlikely to be very useful, though.
+                JITDUMP(" dest contains GC and/or SIMD fields and source constant is not 0.\n");
+                return nullptr;
+            }
+        }
+    }
+
+    JITDUMP(" using field by field initialization.\n");
+
+    GenTree* tree = nullptr;
+
+    for (unsigned i = 0; i < destLclVar->lvFieldCnt; ++i)
+    {
+        unsigned   fieldLclNum = destLclVar->lvFieldLclStart + i;
+        LclVarDsc* fieldDesc   = lvaGetDesc(fieldLclNum);
+        GenTree*   dest        = gtNewLclvNode(fieldLclNum, fieldDesc->TypeGet());
+        // If it had been labeled a "USEASG", assignments to the the individual promoted fields are not.
+        dest->gtFlags |= (destLclNode->gtFlags & ~(GTF_NODE_MASK | GTF_VAR_USEASG));
+
+        GenTree* src;
+
+        switch (dest->TypeGet())
+        {
+            case TYP_BOOL:
+            case TYP_BYTE:
+            case TYP_UBYTE:
+            case TYP_SHORT:
+            case TYP_USHORT:
+                // Promoted fields are expected to be "normalize on load". If that changes then
+                // we may need to adjust this code to widen the constant correctly.
+                assert(fieldDesc->lvNormalizeOnLoad());
+                __fallthrough;
+            case TYP_INT:
+            {
+                int64_t mask = (int64_t(1) << (genTypeSize(dest->TypeGet()) * 8)) - 1;
+                src          = gtNewIconNode(static_cast<int32_t>(initPattern & mask));
+                break;
+            }
+            case TYP_LONG:
+                src = gtNewLconNode(initPattern);
+                break;
+            case TYP_FLOAT:
+                float floatPattern;
+                memcpy(&floatPattern, &initPattern, sizeof(floatPattern));
+                src = gtNewDconNode(floatPattern, dest->TypeGet());
+                break;
+            case TYP_DOUBLE:
+                double doublePattern;
+                memcpy(&doublePattern, &initPattern, sizeof(doublePattern));
+                src = gtNewDconNode(doublePattern, dest->TypeGet());
+                break;
+            case TYP_REF:
+            case TYP_BYREF:
+#ifdef FEATURE_SIMD
+            case TYP_SIMD8:
+            case TYP_SIMD12:
+            case TYP_SIMD16:
+            case TYP_SIMD32:
+#endif // FEATURE_SIMD
+                assert(initPattern == 0);
+                src = gtNewIconNode(0, dest->TypeGet());
+                break;
+            default:
+                unreached();
+        }
+
+        GenTree* asg = gtNewAssignNode(dest, src);
+
+#if LOCAL_ASSERTION_PROP
+        if (optLocalAssertionProp)
+        {
+            optAssertionGen(asg);
+        }
+#endif // LOCAL_ASSERTION_PROP
+
+        if (tree != nullptr)
+        {
+            tree = gtNewOperNode(GT_COMMA, TYP_VOID, tree, asg);
+        }
+        else
+        {
+            tree = asg;
+        }
+    }
 
     return tree;
 }

--- a/tests/src/JIT/Regression/JitBlue/GitHub_21761/GitHub_21761.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_21761/GitHub_21761.il
@@ -1,0 +1,318 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern System.Runtime { }
+.assembly GitHub_21761 { }
+
+// Some basic tests to ensure that the JIT handles non-zero
+// initialization correctly.
+
+.class sequential sealed Point extends [System.Runtime]System.ValueType
+{
+    .field public int32 X
+    .field public int32 Y
+}
+
+.method static bool ConstFixedSizeInitBlk() cil managed noinlining
+{
+    .locals init (valuetype Point a)
+
+    ldloca a
+    ldc.i4 42
+    sizeof Point
+    initblk
+
+    ldloca a
+    ldind.i4
+    ldc.i4 0x2a2a2a2a
+    ceq
+    ret
+}
+
+.method static bool NonConstFixedSizeInitBlk() cil managed noinlining
+{
+    .locals init (valuetype Point a, int32 s)
+
+    ldloca a
+    ldloc s
+    sizeof Point
+    initblk
+
+    ldloca a
+    ldfld int32 Point::X
+    ldc.i4 0
+    ceq
+    ret
+}
+
+.class sequential sealed Point64 extends [System.Runtime]System.ValueType
+{
+    .field public int64 X
+    .field public int64 Y
+}
+
+.method static bool ConstFixedSizeInitBlk64() cil managed noinlining
+{
+    .locals init (valuetype Point64 a)
+
+    ldloca a
+    ldc.i4 42
+    sizeof Point64
+    initblk
+
+    ldloca a
+    ldind.i8
+    ldc.i8 0x2a2a2a2a2a2a2a2a
+    ceq
+    ret
+}
+
+.method static bool NonConstFixedSizeInitBlk64() cil managed noinlining
+{
+    .locals init (valuetype Point64 a, int32 s)
+
+    ldloca a
+    ldloc s
+    sizeof Point64
+    initblk
+
+    ldloca a
+    ldfld int64 Point64::X
+    ldc.i8 0
+    ceq
+    ret
+}
+
+// Small int promoted fields are supposed to be "normalize on load" so
+// no special care is needed when initializing them. Still, make sure
+// that field by field initialization handles small ints correctly.
+
+.class sequential sealed SmallInts extends [System.Runtime]System.ValueType
+{
+    .field public int8 I8;
+    .field public uint8 U8;
+    .field public int16 I16;
+}
+
+.method static bool SmallIntsInitBlk() cil managed noinlining
+{
+    .locals init (valuetype SmallInts a)
+
+    ldloca a
+    ldc.i4 42
+    sizeof SmallInts
+    initblk
+
+    ldloca a
+    ldind.i1
+    ldc.i4 0x2a
+    bne.un FAIL
+
+    ldloca a
+    ldind.u1
+    ldc.i4 0x2a
+    bne.un FAIL
+
+    ldloca a
+    ldind.i2
+    ldc.i4 0x2a2a
+    bne.un FAIL
+
+    ldc.i4 1
+    ret
+
+FAIL:
+    ldc.i4 0
+    ret
+}
+
+.method static bool SmallIntsSignedInitBlk() cil managed noinlining
+{
+    .locals init (valuetype SmallInts a)
+
+    ldloca a
+    ldc.i4 0x8a
+    sizeof SmallInts
+    initblk
+
+    ldloca a
+    ldind.i1
+    ldc.i4 0xFFFFFF8a
+    bne.un FAIL
+
+    ldloca a
+    ldind.u1
+    ldc.i4 0x8a
+    bne.un FAIL
+
+    ldloca a
+    ldind.i2
+    ldc.i4 0xFFFF8a8a
+    bne.un FAIL
+
+    ldc.i4 1
+    ret
+
+FAIL:
+    ldc.i4 0
+    ret
+}
+
+// If floating point fields are involved, special care is needed
+// since floating point constants having a required bit pattern
+// have to be generated.
+
+.class sequential sealed F32Vec3 extends [System.Runtime]System.ValueType
+{
+    .field public float32 X
+    .field public float32 Y
+    .field public float32 Z
+}
+
+// Make sure that the JIT produces an appropiate floating point constant.
+// JIT's internal representation uses doubles to store constants, even
+// when constants are float-typed. This means that the JIT should first
+// create a float value having the required bit pattern and then convert
+// it double. Directly creating a double having the required bit pattern
+// is not valid.
+
+.method static bool Float32InitBlk() cil managed noinlining
+{
+    .locals init (valuetype F32Vec3 a)
+
+    ldloca a
+    ldc.i4 42
+    sizeof F32Vec3
+    initblk
+
+    ldloca a
+    ldind.i4
+    ldc.i4 0x2a2a2a2a
+    ceq
+    ret
+}
+
+// Initializing a float value with 255, 255, 255... is a special case
+// because the result is a NaN. And since the JIT uses double to store
+// float constants, this means that the JIT may end up producing a float
+// NaN value, convert it to double and then convert it back to float
+// during codegen. Will the NaN payload be preserved through conversions?
+// This may depend on the host's floating point implementation.
+
+.method static bool Float32NaNInitBlk() cil managed noinlining
+{
+    .locals init (valuetype F32Vec3 a)
+
+    ldloca a
+    ldc.i4 255
+    sizeof F32Vec3
+    initblk
+
+    ldloca a
+    ldind.i4
+    ldc.i4 0xFFFFFFFF
+    ceq
+    ret
+}
+
+// Non-zero initialization of a GC reference is not exactly a valid scenario.
+// Still, the JIT shouldn't end up generating invalid IR (non-zero GC typed
+// constant nodes).
+
+.class sequential sealed Pair extends [System.Runtime]System.ValueType
+{
+    .field public int64 Key
+    .field public class [System.Runtime]System.Object Value
+}
+
+.method static bool ObjRefInitBlk() cil managed noinlining
+{
+    .locals init (valuetype Pair a)
+
+    ldloca a
+    ldc.i4 1
+    sizeof Pair
+    initblk
+
+    ldloca a
+    ldind.i8
+    ldc.i8 0x0101010101010101
+    ceq
+    ret
+}
+
+// Non-zero SIMD constants are not supported so field by field initialization
+// should not be attempted.
+
+.class sequential sealed Wrapper extends [System.Runtime]System.ValueType
+{
+    .field public valuetype [System.Numerics.Vectors]System.Numerics.Vector4 Value
+}
+
+.method static bool SimdInitBlk() cil managed noinlining
+{
+    .locals init (valuetype Wrapper a, valuetype [System.Numerics.Vectors]System.Numerics.Vector4 v, float32 len)
+
+    ldloca a
+    ldc.i4 42
+    ldc.i4 16
+    initblk
+
+    ldloca a
+    ldflda valuetype [System.Numerics.Vectors]System.Numerics.Vector4 Wrapper::Value
+    call instance float32 [System.Numerics.Vectors]System.Numerics.Vector4::Length()
+    stloc len
+
+    ldloca a
+    ldfld valuetype [System.Numerics.Vectors]System.Numerics.Vector4 Wrapper::Value
+    stloc v
+
+    ldloca v
+    ldind.i4
+    ldc.i4 0x2a2a2a2a
+    ceq
+    ret
+}
+
+.method hidebysig static int32 Main() cil managed
+{
+    .entrypoint
+    .locals init (valuetype Point a)
+
+    call bool ConstFixedSizeInitBlk()
+    brfalse FAIL
+
+    call bool NonConstFixedSizeInitBlk()
+    brfalse FAIL
+
+    call bool ConstFixedSizeInitBlk64()
+    brfalse FAIL
+
+    call bool NonConstFixedSizeInitBlk64()
+    brfalse FAIL
+
+    call bool SmallIntsInitBlk()
+    brfalse FAIL
+
+    call bool SmallIntsSignedInitBlk()
+    brfalse FAIL
+
+    call bool Float32InitBlk()
+    brfalse FAIL
+
+    call bool Float32NaNInitBlk()
+    brfalse FAIL
+
+    call bool ObjRefInitBlk()
+    brfalse FAIL
+    
+    call bool SimdInitBlk()
+    brfalse FAIL
+
+    ldc.i4 100
+    ret
+ FAIL:
+    ldc.i4 1
+    ret
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_21761/GitHub_21761.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_21761/GitHub_21761.ilproj
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_21761.il" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
fgMorphInitBlock fails left and right if you use anything other than 0 for initialization. Not exactly a common scenario I'd guess, but since I started to get my hands dirty with struct related issues I decided to just fix the whole thing, rather than attempt to disable field by field initialization for non 0 init values.

More details in test code comments.

Fixes #21761

No FX diffs.

There are all kinds of further improvements that could be made but I've node idea who would need this. For example, there's no reason to not do field by field initialization with a non-const value - you just add `MUL(initValue, 0x01010101)` and use it to initialize the fields. Nor there's any reason to require that the block size be equal to the struct size, if the block is smaller then initialize only the affected fields. But who needs that? We'll have to wait and see.