### PR TITLE
Improve CustomAttribute

### DIFF
--- a/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -258,7 +258,7 @@ namespace System.Reflection
 
             for (int i = 0; i < records.Length; i++)
             {
-                scope.GetCustomAttributeRecord(tkCustomAttributeTokens[i], 
+                scope.GetCustomAttributeProps(tkCustomAttributeTokens[i], 
                     out records[i].tkCtor.Value, out records[i].blob);
             }
 

--- a/src/System.Private.CoreLib/src/System/Reflection/MdImport.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/MdImport.cs
@@ -2,20 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// 
-
 using System;
-using System.Reflection;
 using System.Globalization;
-using System.Threading;
 using System.Diagnostics;
-using System.Collections;
 using System.Runtime.CompilerServices;
-using System.Security;
-using System.Text;
 using System.Runtime.InteropServices;
-using System.Configuration.Assemblies;
-using System.Runtime.Versioning;
 
 namespace System.Reflection
 {
@@ -162,6 +153,10 @@ namespace System.Reflection
 
     internal readonly struct ConstArray
     {
+        // Keep the definition in sync with vm\ManagedMdImport.hpp
+        internal readonly int m_length;
+        internal readonly IntPtr m_constArray;
+
         public IntPtr Signature => m_constArray;
         public int Length => m_length;
 
@@ -179,13 +174,12 @@ namespace System.Reflection
             }
         }
 
-        // Keep the definition in sync with vm\ManagedMdImport.hpp
-        internal readonly int m_length;
-        internal readonly IntPtr m_constArray;
     }
 
-    internal readonly struct MetadataToken
+    internal struct MetadataToken
     {
+        public int Value;
+
         public static implicit operator int(MetadataToken token) => token.Value;
         public static implicit operator MetadataToken(int token) => new MetadataToken(token);
 
@@ -202,7 +196,6 @@ namespace System.Reflection
 
         public static bool IsNullToken(int token) => (token & 0x00FFFFFF) == 0;
 
-        public readonly int Value;
 
         public MetadataToken(int token) { Value = token; }
 
@@ -540,13 +533,12 @@ namespace System.Reflection
 
         public void GetCustomAttributeRecord(
             int customAttributeToken,
-            out CustomAttributeRecord record)
+            out int constructorToken,
+            out ConstArray signature)
         {
 
             _GetCustomAttributeProps(m_metadataImport2, customAttributeToken,
-                out int token, out ConstArray signature);
-
-            record = new CustomAttributeRecord(token, signature);
+                out constructorToken, out signature);
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]

--- a/src/System.Private.CoreLib/src/System/Reflection/MdImport.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/MdImport.cs
@@ -536,7 +536,6 @@ namespace System.Reflection
             out int constructorToken,
             out ConstArray signature)
         {
-
             _GetCustomAttributeProps(m_metadataImport2, customAttributeToken,
                 out constructorToken, out signature);
         }

--- a/src/System.Private.CoreLib/src/System/Reflection/MdImport.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/MdImport.cs
@@ -531,7 +531,7 @@ namespace System.Reflection
             out int constructorToken,
             out ConstArray signature);
 
-        public void GetCustomAttributeRecord(
+        public void GetCustomAttributeProps(
             int customAttributeToken,
             out int constructorToken,
             out ConstArray signature)

--- a/src/System.Private.CoreLib/src/System/Reflection/MdImport.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/MdImport.cs
@@ -160,10 +160,11 @@ namespace System.Reflection
         Invalid = 0x7FFFFFFF,
     }
 
-    internal struct ConstArray
+    internal readonly struct ConstArray
     {
-        public IntPtr Signature { get { return m_constArray; } }
-        public int Length { get { return m_length; } }
+        public IntPtr Signature => m_constArray;
+        public int Length => m_length;
+
         public byte this[int index]
         {
             get
@@ -179,18 +180,15 @@ namespace System.Reflection
         }
 
         // Keep the definition in sync with vm\ManagedMdImport.hpp
-        internal int m_length;
-        internal IntPtr m_constArray;
+        internal readonly int m_length;
+        internal readonly IntPtr m_constArray;
     }
 
-    internal struct MetadataToken
+    internal readonly struct MetadataToken
     {
-        #region Implicit Cast Operators
-        public static implicit operator int(MetadataToken token) { return token.Value; }
-        public static implicit operator MetadataToken(int token) { return new MetadataToken(token); }
-        #endregion
+        public static implicit operator int(MetadataToken token) => token.Value;
+        public static implicit operator MetadataToken(int token) => new MetadataToken(token);
 
-        #region Public Static Members
         public static bool IsTokenOfType(int token, params MetadataTokenType[] types)
         {
             for (int i = 0; i < types.Length; i++)
@@ -202,43 +200,31 @@ namespace System.Reflection
             return false;
         }
 
-        public static bool IsNullToken(int token)
-        {
-            return (token & 0x00FFFFFF) == 0;
-        }
-        #endregion
+        public static bool IsNullToken(int token) => (token & 0x00FFFFFF) == 0;
 
-        #region Public Data Members
-        public int Value;
-        #endregion
+        public readonly int Value;
 
-        #region Constructor
         public MetadataToken(int token) { Value = token; }
-        #endregion
 
-        #region Public Members
-        public bool IsGlobalTypeDefToken { get { return (Value == 0x02000001); } }
-        public MetadataTokenType TokenType { get { return (MetadataTokenType)(Value & 0xFF000000); } }
-        public bool IsTypeRef { get { return TokenType == MetadataTokenType.TypeRef; } }
-        public bool IsTypeDef { get { return TokenType == MetadataTokenType.TypeDef; } }
-        public bool IsFieldDef { get { return TokenType == MetadataTokenType.FieldDef; } }
-        public bool IsMethodDef { get { return TokenType == MetadataTokenType.MethodDef; } }
-        public bool IsMemberRef { get { return TokenType == MetadataTokenType.MemberRef; } }
-        public bool IsEvent { get { return TokenType == MetadataTokenType.Event; } }
-        public bool IsProperty { get { return TokenType == MetadataTokenType.Property; } }
-        public bool IsParamDef { get { return TokenType == MetadataTokenType.ParamDef; } }
-        public bool IsTypeSpec { get { return TokenType == MetadataTokenType.TypeSpec; } }
-        public bool IsMethodSpec { get { return TokenType == MetadataTokenType.MethodSpec; } }
-        public bool IsString { get { return TokenType == MetadataTokenType.String; } }
-        public bool IsSignature { get { return TokenType == MetadataTokenType.Signature; } }
-        public bool IsModule { get { return TokenType == MetadataTokenType.Module; } }
-        public bool IsAssembly { get { return TokenType == MetadataTokenType.Assembly; } }
-        public bool IsGenericPar { get { return TokenType == MetadataTokenType.GenericPar; } }
-        #endregion
+        public bool IsGlobalTypeDefToken => (Value == 0x02000001);
+        public MetadataTokenType TokenType => (MetadataTokenType)(Value & 0xFF000000);
+        public bool IsTypeRef => TokenType == MetadataTokenType.TypeRef;
+        public bool IsTypeDef => TokenType == MetadataTokenType.TypeDef;
+        public bool IsFieldDef => TokenType == MetadataTokenType.FieldDef;
+        public bool IsMethodDef => TokenType == MetadataTokenType.MethodDef;
+        public bool IsMemberRef => TokenType == MetadataTokenType.MemberRef;
+        public bool IsEvent => TokenType == MetadataTokenType.Event;
+        public bool IsProperty => TokenType == MetadataTokenType.Property;
+        public bool IsParamDef => TokenType == MetadataTokenType.ParamDef;
+        public bool IsTypeSpec => TokenType == MetadataTokenType.TypeSpec;
+        public bool IsMethodSpec => TokenType == MetadataTokenType.MethodSpec;
+        public bool IsString => TokenType == MetadataTokenType.String;
+        public bool IsSignature => TokenType == MetadataTokenType.Signature;
+        public bool IsModule => TokenType == MetadataTokenType.Module;
+        public bool IsAssembly => TokenType == MetadataTokenType.Assembly;
+        public bool IsGenericPar => TokenType == MetadataTokenType.GenericPar;
 
-        #region Object Overrides
-        public override string ToString() { return string.Format(CultureInfo.InvariantCulture, "0x{0:x8}", Value); }
-        #endregion
+        public override string ToString() => string.Format(CultureInfo.InvariantCulture, "0x{0:x8}", Value);
     }
 
     internal unsafe struct MetadataEnumResult
@@ -270,12 +256,10 @@ namespace System.Reflection
         }
     }
 
-    internal struct MetadataImport
+    internal readonly struct MetadataImport
     {
-        #region Private Data Members
-        private IntPtr m_metadataImport2;
-        private object m_keepalive;
-        #endregion
+        private readonly IntPtr m_metadataImport2;
+        private readonly object m_keepalive;
 
         #region Override methods from Object
         internal static readonly MetadataImport EmptyImport = new MetadataImport((IntPtr)0, null);
@@ -554,13 +538,15 @@ namespace System.Reflection
             out int constructorToken,
             out ConstArray signature);
 
-        public void GetCustomAttributeProps(
+        public void GetCustomAttributeRecord(
             int customAttributeToken,
-            out int constructorToken,
-            out ConstArray signature)
+            out CustomAttributeRecord record)
         {
+
             _GetCustomAttributeProps(m_metadataImport2, customAttributeToken,
-                out constructorToken, out signature);
+                out int token, out ConstArray signature);
+
+            record = new CustomAttributeRecord(token, signature);
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]


### PR DESCRIPTION
Contributes to https://github.com/dotnet/wpf/issues/94
Contributes to https://github.com/dotnet/corefx/issues/34283#issuecomment-451015598

Originally started as reducing local scopes in `AddCustomAttributes` (moving declaration and assignment closer to use; to decrease lifetime) (First commit https://github.com/dotnet/coreclr/commit/a43f3d21c16d6469c3a4d55da594c68e85f3c049)

Then tidied up the rest of the file while I was there (Second commit https://github.com/dotnet/coreclr/commit/996bed3cfc5c60ab3a3c3392149ffea3afb869a0)

Including making the following structs readonly `CustomAttributeNamedArgument`, `CustomAttributeTypedArgument`, `CustomAttributeEncodedArgument`, `CustomAttributeNamedParameter`, `CustomAttributeCtorParameter`, `CustomAttributeType`, 

Final commit

```
Total bytes of diff: -602 (-0.02% of base)
    diff is an improvement.

Total byte diff includes -13 bytes from reconciling methods
        Base had    3 unique methods,     2765 unique bytes
        Diff had    4 unique methods,     2752 unique bytes

Top file improvements by size (bytes):
        -602 : System.Private.CoreLib.dasm (-0.02% of base)

1 total files with size differences (1 improved, 0 regressed), 0 unchanged.

Top method regessions by size (bytes):
        1665 : System.Private.CoreLib.dasm - CustomAttributeData:.ctor(ref,struct,byref):this (0/1 methods)
        1048 : System.Private.CoreLib.dasm - CustomAttribute:FilterCustomAttributeRecord(struct,byref,ref,struct,ref,bool,byref,byref,byref,byref,byref):bool (0/1 methods)
          20 : System.Private.CoreLib.dasm - CustomAttributeRecord:.ctor(int,struct):this (0/1 methods)
          19 : System.Private.CoreLib.dasm - MetadataImport:GetCustomAttributeRecord(int,byref,byref):this (0/1 methods)
           6 : System.Private.CoreLib.dasm - CustomAttributeTypedArgument:ToString(bool):ref:this

Top method improvements by size (bytes):
       -1663 : System.Private.CoreLib.dasm - CustomAttributeData:.ctor(ref,struct):this (1/0 methods)
       -1083 : System.Private.CoreLib.dasm - CustomAttribute:FilterCustomAttributeRecord(struct,struct,ref,struct,ref,bool,byref,byref,byref,byref,byref):bool (1/0 methods)
        -218 : System.Private.CoreLib.dasm - CustomAttribute:AddCustomAttributes(byref,ref,int,ref,bool,byref)
        -148 : System.Private.CoreLib.dasm - CustomAttributeData:.ctor(ref):this
        -121 : System.Private.CoreLib.dasm - CustomAttribute:IsCustomAttributeDefined(ref,int,ref,int,bool):bool
         -23 : System.Private.CoreLib.dasm - CustomAttributeData:get_ConstructorArguments():ref:this
         -23 : System.Private.CoreLib.dasm - CustomAttribute:GetAttributeUsage(ref):ref
         -19 : System.Private.CoreLib.dasm - CustomAttributeData:GetCustomAttributes(ref,int):ref
         -19 : System.Private.CoreLib.dasm - MetadataImport:GetCustomAttributeProps(int,byref,byref):this (1/0 methods)
         -16 : System.Private.CoreLib.dasm - PseudoCustomAttribute:GetMarshalAsCustomAttribute(int,ref):ref
         -13 : System.Private.CoreLib.dasm - PseudoCustomAttribute:GetDllImportCustomAttribute(ref):ref
         -10 : System.Private.CoreLib.dasm - PseudoCustomAttribute:GetStructLayoutCustomAttribute(ref):ref
          -4 : System.Private.CoreLib.dasm - CustomAttributeNamedArgument:.ctor(ref,ref):this

18 total methods with size differences (13 improved, 5 regressed), 17539 unchanged.
```

----

Commit 2
```
Total bytes of diff: -305 (-0.01% of base)
    diff is an improvement.

Total byte diff includes 0 bytes from reconciling methods
        Base had    0 unique methods,        0 unique bytes
        Diff had    0 unique methods,        0 unique bytes

Top file improvements by size (bytes):
        -305 : System.Private.CoreLib.dasm (-0.01% of base)

1 total files with size differences (1 improved, 0 regressed), 0 unchanged.

Top method regessions by size (bytes):
           6 : System.Private.CoreLib.dasm - CustomAttributeTypedArgument:ToString(bool):ref:this

Top method improvements by size (bytes):
        -148 : System.Private.CoreLib.dasm - CustomAttributeData:.ctor(ref):this
         -97 : System.Private.CoreLib.dasm - CustomAttribute:AddCustomAttributes(byref,ref,int,ref,bool,byref)
         -23 : System.Private.CoreLib.dasm - CustomAttributeData:get_ConstructorArguments():ref:this
         -16 : System.Private.CoreLib.dasm - PseudoCustomAttribute:GetMarshalAsCustomAttribute(int,ref):ref
         -13 : System.Private.CoreLib.dasm - PseudoCustomAttribute:GetDllImportCustomAttribute(ref):ref
         -10 : System.Private.CoreLib.dasm - PseudoCustomAttribute:GetStructLayoutCustomAttribute(ref):ref
          -4 : System.Private.CoreLib.dasm - CustomAttributeNamedArgument:.ctor(ref,ref):this

8 total methods with size differences (7 improved, 1 regressed), 17552 unchanged.
```

Commit 3
```
Total bytes of diff: -410 (-0.01% of base)
    diff is an improvement.

Total byte diff includes 68 bytes from reconciling methods
        Base had    3 unique methods,     2765 unique bytes
        Diff had    4 unique methods,     2833 unique bytes

Top file improvements by size (bytes):
        -410 : System.Private.CoreLib.dasm (-0.01% of base)

1 total files with size differences (1 improved, 0 regressed), 0 unchanged.

Top method regessions by size (bytes):
        1663 : System.Private.CoreLib.dasm - CustomAttributeData:.ctor(ref,byref):this (0/1 methods)
        1048 : System.Private.CoreLib.dasm - CustomAttribute:FilterCustomAttributeRecord(struct,byref,ref,struct,ref,bool,byref,byref,byref,byref,byref):bool (0/1 methods)
         116 : System.Private.CoreLib.dasm - CustomAttributeData:GetCustomAttributeRecords(ref,int):ref
         102 : System.Private.CoreLib.dasm - MetadataImport:GetCustomAttributeRecord(int,byref):this (0/1 methods)
          20 : System.Private.CoreLib.dasm - CustomAttributeRecord:.ctor(int,struct):this (0/1 methods)
           6 : System.Private.CoreLib.dasm - CustomAttributeTypedArgument:ToString(bool):ref:this

Top method improvements by size (bytes):
       -1663 : System.Private.CoreLib.dasm - CustomAttributeData:.ctor(ref,struct):this (1/0 methods)
       -1083 : System.Private.CoreLib.dasm - CustomAttribute:FilterCustomAttributeRecord(struct,struct,ref,struct,ref,bool,byref,byref,byref,byref,byref):bool (1/0 methods)
        -218 : System.Private.CoreLib.dasm - CustomAttribute:AddCustomAttributes(byref,ref,int,ref,bool,byref)
        -148 : System.Private.CoreLib.dasm - CustomAttributeData:.ctor(ref):this
        -121 : System.Private.CoreLib.dasm - CustomAttribute:IsCustomAttributeDefined(ref,int,ref,int,bool):bool
         -24 : System.Private.CoreLib.dasm - CustomAttributeData:GetCustomAttributes(ref,int):ref
         -23 : System.Private.CoreLib.dasm - CustomAttributeData:get_ConstructorArguments():ref:this
         -23 : System.Private.CoreLib.dasm - CustomAttribute:GetAttributeUsage(ref):ref
         -19 : System.Private.CoreLib.dasm - MetadataImport:GetCustomAttributeProps(int,byref,byref):this (1/0 methods)
         -16 : System.Private.CoreLib.dasm - PseudoCustomAttribute:GetMarshalAsCustomAttribute(int,ref):ref
         -13 : System.Private.CoreLib.dasm - PseudoCustomAttribute:GetDllImportCustomAttribute(ref):ref
         -10 : System.Private.CoreLib.dasm - PseudoCustomAttribute:GetStructLayoutCustomAttribute(ref):ref
          -4 : System.Private.CoreLib.dasm - CustomAttributeNamedArgument:.ctor(ref,ref):this

19 total methods with size differences (13 improved, 6 regressed), 17538 unchanged.
```
Commit 4

```
Total bytes of diff: -602 (-0.02% of base)
    diff is an improvement.

Total byte diff includes -13 bytes from reconciling methods
        Base had    3 unique methods,     2765 unique bytes
        Diff had    4 unique methods,     2752 unique bytes

Top file improvements by size (bytes):
        -602 : System.Private.CoreLib.dasm (-0.02% of base)

1 total files with size differences (1 improved, 0 regressed), 0 unchanged.

Top method regessions by size (bytes):
        1665 : System.Private.CoreLib.dasm - CustomAttributeData:.ctor(ref,struct,byref):this (0/1 methods)
        1048 : System.Private.CoreLib.dasm - CustomAttribute:FilterCustomAttributeRecord(struct,byref,ref,struct,ref,bool,byref,byref,byref,byref,byref):bool (0/1 methods)
          20 : System.Private.CoreLib.dasm - CustomAttributeRecord:.ctor(int,struct):this (0/1 methods)
          19 : System.Private.CoreLib.dasm - MetadataImport:GetCustomAttributeRecord(int,byref,byref):this (0/1 methods)
           6 : System.Private.CoreLib.dasm - CustomAttributeTypedArgument:ToString(bool):ref:this

Top method improvements by size (bytes):
       -1663 : System.Private.CoreLib.dasm - CustomAttributeData:.ctor(ref,struct):this (1/0 methods)
       -1083 : System.Private.CoreLib.dasm - CustomAttribute:FilterCustomAttributeRecord(struct,struct,ref,struct,ref,bool,byref,byref,byref,byref,byref):bool (1/0 methods)
        -218 : System.Private.CoreLib.dasm - CustomAttribute:AddCustomAttributes(byref,ref,int,ref,bool,byref)
        -148 : System.Private.CoreLib.dasm - CustomAttributeData:.ctor(ref):this
        -121 : System.Private.CoreLib.dasm - CustomAttribute:IsCustomAttributeDefined(ref,int,ref,int,bool):bool
         -23 : System.Private.CoreLib.dasm - CustomAttributeData:get_ConstructorArguments():ref:this
         -23 : System.Private.CoreLib.dasm - CustomAttribute:GetAttributeUsage(ref):ref
         -19 : System.Private.CoreLib.dasm - CustomAttributeData:GetCustomAttributes(ref,int):ref
         -19 : System.Private.CoreLib.dasm - MetadataImport:GetCustomAttributeProps(int,byref,byref):this (1/0 methods)
         -16 : System.Private.CoreLib.dasm - PseudoCustomAttribute:GetMarshalAsCustomAttribute(int,ref):ref
         -13 : System.Private.CoreLib.dasm - PseudoCustomAttribute:GetDllImportCustomAttribute(ref):ref
         -10 : System.Private.CoreLib.dasm - PseudoCustomAttribute:GetStructLayoutCustomAttribute(ref):ref
          -4 : System.Private.CoreLib.dasm - CustomAttributeNamedArgument:.ctor(ref,ref):this

18 total methods with size differences (13 improved, 5 regressed), 17539 unchanged.
```