### PR TITLE
Fix incorrect assignment of READYTORUN_HELPER_[Dbl|Flt][Rem/Round]

### DIFF
--- a/src/inc/readytorunhelpers.h
+++ b/src/inc/readytorunhelpers.h
@@ -84,10 +84,10 @@ HELPER(READYTORUN_HELPER_Dbl2UIntOvf,               CORINFO_HELP_DBL2UINT_OVF,  
 HELPER(READYTORUN_HELPER_Dbl2ULng,                  CORINFO_HELP_DBL2ULNG,                          )
 HELPER(READYTORUN_HELPER_Dbl2ULngOvf,               CORINFO_HELP_DBL2ULNG_OVF,                      )
 
-HELPER(READYTORUN_HELPER_DblRem,                    CORINFO_HELP_FLTREM,                            )
-HELPER(READYTORUN_HELPER_FltRem,                    CORINFO_HELP_DBLREM,                            )
-HELPER(READYTORUN_HELPER_DblRound,                  CORINFO_HELP_FLTROUND,                          )
-HELPER(READYTORUN_HELPER_FltRound,                  CORINFO_HELP_DBLROUND,                          )
+HELPER(READYTORUN_HELPER_FltRem,                    CORINFO_HELP_FLTREM,                            )
+HELPER(READYTORUN_HELPER_DblRem,                    CORINFO_HELP_DBLREM,                            )
+HELPER(READYTORUN_HELPER_FltRound,                  CORINFO_HELP_FLTROUND,                          )
+HELPER(READYTORUN_HELPER_DblRound,                  CORINFO_HELP_DBLROUND,                          )
 
 #ifndef _TARGET_X86_
 HELPER(READYTORUN_HELPER_PersonalityRoutine,        CORINFO_HELP_EE_PERSONALITY_ROUTINE,            OPTIMIZEFORSIZE)

--- a/src/tools/r2rdump/R2RConstants.cs
+++ b/src/tools/r2rdump/R2RConstants.cs
@@ -231,10 +231,10 @@ namespace R2RDump
         READYTORUN_HELPER_Dbl2ULngOvf = 0xD7,
 
         // Floating point ops
-        READYTORUN_HELPER_DblRem = 0xE0,
-        READYTORUN_HELPER_FltRem = 0xE1,
-        READYTORUN_HELPER_DblRound = 0xE2,
-        READYTORUN_HELPER_FltRound = 0xE3,
+        READYTORUN_HELPER_FltRem = 0xE0,
+        READYTORUN_HELPER_DblRem = 0xE1,
+        READYTORUN_HELPER_FltRound = 0xE2,
+        READYTORUN_HELPER_DblRound = 0xE3,
 
         // Personality rountines
         READYTORUN_HELPER_PersonalityRoutine = 0xF0,


### PR DESCRIPTION
Turns out there's a long-standing typo in CoreCLR that reverses
the helper enumeration values for DBL and FLT. This doesn't seem
to be a problem in the CoreCLR repo as such because it solely
uses the legacy identifiers CORINFO_HELP_DBLREM et al. We have
however ported the incorrect helper enumeration values into R2RDump
and ILCompiler. This change immediately fixes R2RDump as it resides
in the same repo, I'll send out the ILCompiler change in
a separate PR.

Thanks

Tomas