### PR TITLE
Fix path length 255

### DIFF
--- a/src/System.Private.CoreLib/shared/Interop/Unix/System.Native/Interop.ReadDir.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Unix/System.Native/Interop.ReadDir.cs
@@ -46,8 +46,6 @@ internal static partial class Interop
                     : new ReadOnlySpan<byte>(Name, NameLength);
 
                 Debug.Assert(nameBytes.Length > 0, "we shouldn't have gotten a garbage value from the OS");
-                if (nameBytes.Length == 0)
-                    return buffer.Slice(0, 0);
 
                 int charCount = Encoding.UTF8.GetChars(nameBytes, buffer);
                 ReadOnlySpan<char> value = buffer.Slice(0, charCount);


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/34359
Tests https://github.com/dotnet/corefx/pull/34389

It's fortunate that the PAL did not need changing (SystemNative_ReadDirR) as well because then we would have a dependency in two directions.