### PR TITLE
Streamline RuntimeMethodInfo.Invoke

### DIFF
--- a/src/System.Private.CoreLib/src/System/Reflection/MethodBase.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/MethodBase.CoreCLR.cs
@@ -121,12 +121,13 @@ namespace System.Reflection
                         p = GetParametersNoCopy();
                     }
 
-                    if (p[i].DefaultValue == DBNull.Value)
+                    object defaultValue = p[i].DefaultValue;
+                    if (defaultValue == DBNull.Value)
                     {
                         throw new ArgumentException(SR.Arg_VarMissNull, nameof(parameters));
                     }
 
-                    arg = p[i].DefaultValue;
+                    arg = defaultValue;
                 }
 
                 copyOfParameters[i] = argRT.CheckValue(arg, binder, culture, invokeAttr);

--- a/src/System.Private.CoreLib/src/System/Reflection/MethodBase.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/MethodBase.CoreCLR.cs
@@ -108,24 +108,33 @@ namespace System.Reflection
             object[] copyOfParameters = new object[parameters.Length];
 
             ParameterInfo[] p = null;
+            RuntimeType[] runtimeTypes = sig.Arguments;
             for (int i = 0; i < parameters.Length; i++)
             {
                 object arg = parameters[i];
-                RuntimeType argRT = sig.Arguments[i];
+                RuntimeType argRT = runtimeTypes[i];
 
                 if (arg == Type.Missing)
                 {
-                    if (p == null)
+                    if (p is null)
+                    {
                         p = GetParametersNoCopy();
-                    if (p[i].DefaultValue == System.DBNull.Value)
+                    }
+
+                    if (p[i].DefaultValue == DBNull.Value)
+                    {
                         throw new ArgumentException(SR.Arg_VarMissNull, nameof(parameters));
+                    }
+
                     arg = p[i].DefaultValue;
                 }
+
                 copyOfParameters[i] = argRT.CheckValue(arg, binder, culture, invokeAttr);
             }
 
             return copyOfParameters;
         }
+
         #endregion
     }
 }


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/34283#issuecomment-451015598

Shaves a little off `RuntimeMethodInfo.Invoke` for startup (used when looking up `CustomAttributes` for `EventSource`s that don't use the Guid .ctor)

![image](https://user-images.githubusercontent.com/1142958/50763326-67910700-1267-11e9-9cc8-ad01dee95cd8.png)

There's not a lot to do here, assuming the defensive copy of params in `CheckArguments` is required (checked set of params, used to invoke method detached from user modification between the call to invoke and the invoke)

Could introduce an `UnsafeInvoke` that doesn't do a defensive copy for the runtime; however not sure there are that many paths that would call it; and since its only a single element `object[]` being created probably wouldn't save much (method is 21% of `.Invoke`).

![image](https://user-images.githubusercontent.com/1142958/50764158-c9527080-1269-11e9-878b-969ef5346c0e.png)
