### PR TITLE
Fix issue #20585 createdump explicitly uses /tmp.

### DIFF
--- a/src/dlls/mscordac/mscordac_unixexports.src
+++ b/src/dlls/mscordac/mscordac_unixexports.src
@@ -131,6 +131,7 @@ nativeStringResourceTable_mscorrc_debug
 #GetSystemTime
 #GetSystemTimeAsFileTime
 #GetTempFileNameW
+#GetTempPathA
 #GetTempPathW
 #HeapAlloc
 #HeapFree

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -1103,6 +1103,14 @@ GetTempPathW(
          IN DWORD nBufferLength,
          OUT LPWSTR lpBuffer);
 
+PALIMPORT
+DWORD
+PALAPI
+GetTempPathA(
+         IN DWORD nBufferLength,
+         OUT LPSTR lpBuffer);
+
+
 #ifdef UNICODE
 #define GetTempPath GetTempPathW
 #else


### PR DESCRIPTION
Changed to PAL's GetTempPathA to get the temp path.