### PR TITLE
Fixed potential memory leak in Cordb

### DIFF
--- a/src/debug/di/rsmain.cpp
+++ b/src/debug/di/rsmain.cpp
@@ -2118,6 +2118,7 @@ HRESULT Cordb::CreateObject(CorDebugInterfaceVersion iDebuggerVersion, DWORD pid
         cbMultiByte = WideCharToMultiByte(CP_ACP, 0, lpApplicationGroupId, -1, applicationGroupId, cbMultiByte, NULL, NULL);
         if (cbMultiByte == 0)
         {
+            delete [] applicationGroupId;
             return E_FAIL;
         }
     }


### PR DESCRIPTION
In the case that the conversion from wide char to multibyte of the application group ID fails, we never release the memory for the application group ID buffer.