### PR TITLE
Fast-path GetStateMachineBox

### DIFF
--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -445,6 +445,18 @@ namespace System.Runtime.CompilerServices
                 return stronglyTypedBox;
             }
 
+            // We haven't created the IAsyncStateMachineBox yet, create it
+            return CreateStateMachineBox(ref stateMachine, currentContext);
+        }
+
+        /// <summary>Creates the "boxed" state machine object.</summary>
+        /// <typeparam name="TStateMachine">Specifies the type of the async state machine.</typeparam>
+        /// <param name="stateMachine">The state machine.</param>
+        /// <param name="currentContext">The current <see cref="ExecutionContext"/> to initialize the state machine with.</param>
+        /// <returns>The "boxed" state machine.</returns>
+        private IAsyncStateMachineBox CreateStateMachineBox<TStateMachine>(ref TStateMachine stateMachine,
+            ExecutionContext currentContext) where TStateMachine : IAsyncStateMachine
+        {
             // The least common case: we have a weakly-typed boxed.  This results if the debugger
             // or some other use of reflection accesses a property like ObjectIdForDebugger or a
             // method like SetNotificationForWaitCompletion prior to the first await happening.  In
@@ -479,7 +491,7 @@ namespace System.Runtime.CompilerServices
 
             // At this point, m_task should really be null, in which case we want to create the box.
             // However, in a variety of debugger-related (erroneous) situations, it might be non-null,
-            // e.g. if the Task property is examined in a Watch window, forcing it to be lazily-intialized
+            // e.g. if the Task property is examined in a Watch window, forcing it to be lazily-initialized
             // as a Task<TResult> rather than as an AsyncStateMachineBox.  The worst that happens in such
             // cases is we lose the ability to properly step in the debugger, as the debugger uses that
             // object's identity to track this specific builder/state machine.  As such, we proceed to

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -425,6 +425,7 @@ namespace System.Runtime.CompilerServices
         /// <typeparam name="TStateMachine">Specifies the type of the async state machine.</typeparam>
         /// <param name="stateMachine">The state machine.</param>
         /// <returns>The "boxed" state machine.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private IAsyncStateMachineBox GetStateMachineBox<TStateMachine>(
             ref TStateMachine stateMachine)
             where TStateMachine : IAsyncStateMachine
@@ -454,6 +455,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="stateMachine">The state machine.</param>
         /// <param name="currentContext">The current <see cref="ExecutionContext"/> to initialize the state machine with.</param>
         /// <returns>The "boxed" state machine.</returns>
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private IAsyncStateMachineBox CreateStateMachineBox<TStateMachine>(ref TStateMachine stateMachine,
             ExecutionContext currentContext) where TStateMachine : IAsyncStateMachine
         {


### PR DESCRIPTION
Split `CreateStateMachineBox` out from `GetStateMachineBox` for a fast-path in common scenario.

At Jit time `GetStateMachineBox` for a pre-"boxed" statemachine is generally considered a profitable inline (without forcing with AggressiveInlining), adding only 79 bytes of asm to XxOnCompleted; whereas with the creation in it is not (417 bytes of asm). 

At crossgen it it blocked due to `[FAILED: runtime dictionary lookup]` but that should be cleaned up by Tier1 Jit.

The `GetStateMachineBox` portion is the always called section for `AwaitUnsafeOnCompleted`

As per the comments the Get not Create path is the more common one (here's with Get inlined):

![image](https://user-images.githubusercontent.com/1142958/50831168-f2463480-1341-11e9-87ab-97a7d5b8c61f.png)


/cc @stephentoub 