### PR TITLE
Fix DynamicMethodDesc memory leak

### DIFF
--- a/src/vm/dynamicmethod.h
+++ b/src/vm/dynamicmethod.h
@@ -110,7 +110,7 @@ class LCGMethodResolver : public DynamicResolver
     friend struct ExecutionManager::JumpStubCache;
 
 public:
-    void Destroy(BOOL fDomainUnload = FALSE);
+    void Destroy();
 
     void FreeCompileTimeState();
     void GetJitContext(SecurityControlFlags * securityControlFlags,

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -226,14 +226,7 @@ BaseDomain *MethodDesc::GetDomain()
 //*******************************************************************************
 LoaderAllocator * MethodDesc::GetLoaderAllocatorForCode()
 {
-    if (IsLCGMethod())
-    {
-        return ::GetAppDomain()->GetLoaderAllocator();
-    }
-    else
-    {
-        return GetLoaderAllocator();
-    }
+    return GetLoaderAllocator();
 }
 
 

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -2423,7 +2423,7 @@ public:
     //
     // following implementations defined in DynamicMethod.cpp
     //
-    void Destroy(BOOL fDomainUnload = FALSE);
+    void Destroy();
 };
 
 


### PR DESCRIPTION
The DynamicMethodTable::AddMethodsToList was incorrectly allocating the
MethodDescChunk from the domain's LoaderAllocator instead of the context
specific one. Thus the allocated memory was leaking after a collectible
AssemblyLoadContext was collected.

There was also a problem with the DynamicMethodDesc::Destroy being
called twice for collectible classes - once by
RuntimeMethodHandle::Destroy() and once when the DomainFile destructor
was called. Due to the primary issue, this problem was not visible,
since the domain's LoaderAllocator is never unmapped. But it started to
cause AV after the primary issue was fixed.