### PR TITLE
JIT: modify inline budget update to use estimated imported IL size

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -5800,8 +5800,9 @@ int Compiler::compCompileHelper(CORINFO_MODULE_HANDLE            classPtr,
 {
     CORINFO_METHOD_HANDLE methodHnd = info.compMethodHnd;
 
-    info.compCode       = methodInfo->ILCode;
-    info.compILCodeSize = methodInfo->ILCodeSize;
+    info.compCode         = methodInfo->ILCode;
+    info.compILCodeSize   = methodInfo->ILCodeSize;
+    info.compILImportSize = 0;
 
     if (info.compILCodeSize == 0)
     {

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -8695,6 +8695,7 @@ public:
 
         const BYTE*    compCode;
         IL_OFFSET      compILCodeSize;     // The IL code size
+        IL_OFFSET      compILImportSize;   // Estimated amount of IL actually imported
         UNATIVE_OFFSET compNativeCodeSize; // The native code size, after instructions are issued. This
                                            // is less than (compTotalHotCodeSize + compTotalColdCodeSize) only if:
         // (1) the code is not hot/cold split, and we issued less code than we expected, or

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -6822,6 +6822,42 @@ void Compiler::fgImport()
         verFlag = tiIsVerifiableCode ? CORINFO_FLG_VERIFIABLE : CORINFO_FLG_UNVERIFIABLE;
         info.compCompHnd->setMethodAttribs(info.compMethodHnd, verFlag);
     }
+
+    // Estimate how much of method IL was actually imported.
+    //
+    // Note this includes (to some extent) the impact of importer folded
+    // branches, provided the folded tree covered the entire block's IL.
+    unsigned importedILSize = 0;
+    for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->bbNext)
+    {
+        if ((block->bbFlags & BBF_IMPORTED) != 0)
+        {
+            // Assume if we generate any IR for the block we generate IR for the entire block.
+            if (!block->isEmpty())
+            {
+                unsigned blockILSize = blockILSize = block->bbCodeOffsEnd - block->bbCodeOffs;
+                importedILSize += blockILSize;
+            }
+        }
+    }
+
+    // Could be tripped up if we ever duplicate blocks
+    assert(importedILSize <= info.compILCodeSize);
+
+    // Leave a note if we only did a partial import.
+    if (importedILSize != info.compILCodeSize)
+    {
+        JITDUMP("\n** Note: %s IL was partially imported -- imported %u of %u bytes of method IL\n",
+                compIsForInlining() ? "inlinee" : "root method", importedILSize, info.compILCodeSize);
+    }
+
+    // Record this for diagnostics and for the inliner's budget computations
+    info.compILImportSize = importedILSize;
+
+    if (compIsForInlining())
+    {
+        compInlineResult->SetImportedILSize(info.compILImportSize);
+    }
 }
 
 /*****************************************************************************

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -6835,8 +6835,14 @@ void Compiler::fgImport()
             // Assume if we generate any IR for the block we generate IR for the entire block.
             if (!block->isEmpty())
             {
-                unsigned blockILSize = blockILSize = block->bbCodeOffsEnd - block->bbCodeOffs;
-                importedILSize += blockILSize;
+                IL_OFFSET beginOffset = block->bbCodeOffs;
+                IL_OFFSET endOffset   = block->bbCodeOffsEnd;
+
+                if ((beginOffset != BAD_IL_OFFSET) && (endOffset != BAD_IL_OFFSET) && (endOffset > beginOffset))
+                {
+                    unsigned blockILSize = endOffset - beginOffset;
+                    importedILSize += blockILSize;
+                }
             }
         }
     }

--- a/src/jit/inline.h
+++ b/src/jit/inline.h
@@ -470,10 +470,20 @@ public:
         m_Reported = true;
     }
 
-    // Get the InlineContext for this inline
+    // Get the InlineContext for this inline.
     InlineContext* GetInlineContext() const
     {
         return m_InlineContext;
+    }
+
+    unsigned GetImportedILSize() const
+    {
+        return m_ImportedILSize;
+    }
+
+    void SetImportedILSize(unsigned x)
+    {
+        m_ImportedILSize = x;
     }
 
 private:
@@ -490,6 +500,7 @@ private:
     InlineContext*        m_InlineContext;
     CORINFO_METHOD_HANDLE m_Caller; // immediate caller's handle
     CORINFO_METHOD_HANDLE m_Callee;
+    unsigned              m_ImportedILSize; // estimated size of imported IL
     const char*           m_Description;
     bool                  m_Reported;
 };
@@ -707,6 +718,11 @@ public:
         return m_Unboxed;
     }
 
+    unsigned GetImportedILSize() const
+    {
+        return m_ImportedILSize;
+    }
+
 private:
     InlineContext(InlineStrategy* strategy);
 
@@ -717,6 +733,7 @@ private:
     InlineContext*    m_Sibling;           // next child of the parent
     BYTE*             m_Code;              // address of IL buffer for the method
     unsigned          m_ILSize;            // size of IL buffer for the method
+    unsigned          m_ImportedILSize;    // estimated size of imported IL
     IL_OFFSETX        m_Offset;            // call site location within parent
     InlineObservation m_Observation;       // what lead to this inline
     int               m_CodeSizeEstimate;  // in bytes * 10


### PR DESCRIPTION
The inliner keeps a time budget to try and avoid pathological runaway inline
behavior (see #4375). The jit estimates the time impact of an inline using a
simple projection based on IL size. If an prospective inline would put the jit
over the time budget, the inline is blocked -- and note even aggressive inlines
can be blocked this way.

We now have a fair number of aggressive inline methods like
`Vector256<T>.IsSupported` where the IL is optimized early on by the jit and the
actual impact on the calling method is much less than the initial IL size would
suggest. For instance `IsSupported` is 286 bytes of IL, but the net contribution
of this method at jit time is either a constant 0 or 1, and so the effective size
is more like 2 bytes of IL.

This set of changes updates the jit to estimate the imported IL size of a method
when updating the budget.

Closes #21794.