### PR TITLE
Reduce ExecutionContext register handling code size

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
@@ -180,14 +180,7 @@ namespace System.Threading
             ExecutionContext currentExecutionCtx = currentThread.ExecutionContext;
             if (currentExecutionCtx != previousExecutionCtx)
             {
-                // Restore changed ExecutionContext back to previous
-                currentThread.ExecutionContext = previousExecutionCtx;
-                if ((currentExecutionCtx != null && currentExecutionCtx.HasChangeNotifications) ||
-                    (previousExecutionCtx != null && previousExecutionCtx.HasChangeNotifications))
-                {
-                    // There are change notifications; trigger any affected
-                    OnValuesChanged(currentExecutionCtx, previousExecutionCtx);
-                }
+                RestoreChangedContextToThread(currentThread, previousExecutionCtx, currentExecutionCtx);
             }
 
             // If exception was thrown by callback, rethrow it now original contexts are restored
@@ -244,18 +237,27 @@ namespace System.Threading
             ExecutionContext currentExecutionCtx = currentThread.ExecutionContext;
             if (currentExecutionCtx != previousExecutionCtx)
             {
-                // Restore changed ExecutionContext back to previous
-                currentThread.ExecutionContext = previousExecutionCtx;
-                if ((currentExecutionCtx != null && currentExecutionCtx.HasChangeNotifications) ||
-                    (previousExecutionCtx != null && previousExecutionCtx.HasChangeNotifications))
-                {
-                    // There are change notifications; trigger any affected
-                    OnValuesChanged(currentExecutionCtx, previousExecutionCtx);
-                }
+                RestoreChangedContextToThread(currentThread, previousExecutionCtx, currentExecutionCtx);
             }
 
             // If exception was thrown by callback, rethrow it now original contexts are restored
             edi?.Throw();
+        }
+
+
+        internal static void RestoreChangedContextToThread(Thread currentThread, ExecutionContext previousExecutionCtx, ExecutionContext currentExecutionCtx)
+        {
+            Debug.Assert(currentThread == Thread.CurrentThread);
+            Debug.Assert(previousExecutionCtx != currentExecutionCtx);
+
+            // Restore changed ExecutionContext back to previous
+            currentThread.ExecutionContext = previousExecutionCtx;
+            if ((currentExecutionCtx != null && currentExecutionCtx.HasChangeNotifications) ||
+                (previousExecutionCtx != null && previousExecutionCtx.HasChangeNotifications))
+            {
+                // There are change notifications; trigger any affected
+                OnValuesChanged(currentExecutionCtx, previousExecutionCtx);
+            }
         }
 
         internal static void RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, object state)

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -965,14 +965,7 @@ namespace System.Runtime.CompilerServices
             ExecutionContext currentExecutionCtx = currentThread.ExecutionContext;
             if (previousExecutionCtx != currentExecutionCtx)
             {
-                // Restore changed ExecutionContext back to previous
-                currentThread.ExecutionContext = previousExecutionCtx;
-                if ((currentExecutionCtx != null && currentExecutionCtx.HasChangeNotifications) ||
-                    (previousExecutionCtx != null && previousExecutionCtx.HasChangeNotifications))
-                {
-                    // There are change notifications; trigger any affected
-                    ExecutionContext.OnValuesChanged(currentExecutionCtx, previousExecutionCtx);
-                }
+                ExecutionContext.RestoreChangedContextToThread(currentThread, previousExecutionCtx, currentExecutionCtx);
             }
 
             // If exception was thrown by callback, rethrow it now original contexts are restored


### PR DESCRIPTION
Brought up in https://github.com/dotnet/coreclr/pull/21875#issuecomment-452363722

Remove executing on the ExecutionContext with error handling out of flow to `RunReturningAnyException` methods; away from setting and restoring ExecutionContext to reduce the need for manual enregistering workarounds.

```
Total bytes of diff: -1955 (-0.05% of base)
    diff is an improvement.

Total byte diff includes 2397 bytes from reconciling methods
        Base had    0 unique methods,        0 unique bytes
        Diff had    4 unique methods,     2397 unique bytes

Top file improvements by size (bytes):
       -1955 : System.Private.CoreLib.dasm (-0.05% of base)

1 total files with size differences (1 improved, 0 regressed), 0 unchanged.

Top method regessions by size (bytes):
        2074 : System.Private.CoreLib.dasm - AsyncMethodBuilderCore:RunReturningAnyException(byref):ref (0/25 methods)
         174 : System.Private.CoreLib.dasm - ExecutionContext:RunReturningAnyException(ref,byref):ref (0/2 methods)
          84 : System.Private.CoreLib.dasm - ExecutionContext:RunReturningAnyException(ref,ref):ref (0/1 methods)
          65 : System.Private.CoreLib.dasm - ExecutionContext:RestoreChangedContextToThread(ref,ref,ref) (0/1 methods)

Top method improvements by size (bytes):
       -3974 : System.Private.CoreLib.dasm - AsyncMethodBuilderCore:Start(byref) (25 methods)
        -168 : System.Private.CoreLib.dasm - ExecutionContext:RunInternal(ref,ref,byref) (2 methods)
        -129 : System.Private.CoreLib.dasm - ExecutionContext:RunInternal(ref,ref,ref)
         -81 : System.Private.CoreLib.dasm - ExecutionContext:RunFromThreadPoolDispatchLoop(ref,ref,ref,ref)

8 total methods with size differences (4 improved, 4 regressed), 17548 unchanged.
```

https://github.com/dotnet/coreclr/pull/21908/files?w=1

/cc @stephentoub @jkotas not sure if this is a help or hindrance?