### PR TITLE
Move OperationStatus into shared source

### DIFF
--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -54,6 +54,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\IPinnable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\MemoryHandle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\MemoryManager.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\OperationStatus.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\StandardFormat.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\TlsOverPerCoreLockedStacksArrayPool.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Utilities.cs" />

--- a/src/System.Private.CoreLib/shared/System/Buffers/OperationStatus.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/OperationStatus.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Buffers
+{
+    /// <summary>
+    /// This enum defines the various potential status that can be returned from Span-based operations
+    /// that support processing of input contained in multiple discontiguous buffers.
+    /// </summary>
+    public enum OperationStatus
+    {
+        /// <summary>
+        /// The entire input buffer has been processed and the operation is complete.
+        /// </summary>
+        Done,
+        /// <summary>
+        /// The input is partially processed, up to what could fit into the destination buffer.
+        /// The caller can enlarge the destination buffer, slice the buffers appropriately, and retry.
+        /// </summary>
+        DestinationTooSmall,
+        /// <summary>
+        /// The input is partially processed, up to the last valid chunk of the input that could be consumed.
+        /// The caller can stitch the remaining unprocessed input with more data, slice the buffers appropriately, and retry.
+        /// </summary>
+        NeedMoreData,
+        /// <summary>
+        /// The input contained invalid bytes which could not be processed. If the input is partially processed,
+        /// the destination contains the partial result. This guarantees that no additional data appended to the input
+        /// will make the invalid sequence valid.
+        /// </summary>
+        InvalidData,
+    }
+}


### PR DESCRIPTION
This is the first step to moving OperationStatus from corefx into coreclr. It'll be used by the transcoding APIs which live in System.Private.CoreLib.