### PR TITLE
Work around OSX native dependency install issue

### DIFF
--- a/eng/install-native-dependencies.sh
+++ b/eng/install-native-dependencies.sh
@@ -10,6 +10,10 @@ if [ "$1" = "Linux" ]; then
         exit 1;
     fi
 elif [ "$1" = "OSX" ]; then
+    brew update
+    if [ "$?" != "0" ]; then
+        exit 1;
+    fi
     brew install icu4c openssl
     if [ "$?" != "0" ]; then
         exit 1;

--- a/eng/install-native-dependencies.sh
+++ b/eng/install-native-dependencies.sh
@@ -19,7 +19,7 @@ elif [ "$1" = "OSX" ]; then
         exit 1;
     fi
     brew link --force icu4c
-    if [ "$?" != "0"]; then
+    if [ "$?" != "0" ]; then
         exit 1;
     fi
 else


### PR DESCRIPTION
This works around https://github.com/dotnet/coreclr/issues/21910 by running `brew update`.
@chcosta @jashook @echesakov 