### PR TITLE
Add an exclusion for hugeexpr1 on arm32 under `JitOptSensitive`.

### DIFF
--- a/tests/src/JIT/jit64/opt/cse/hugeexpr1.csproj
+++ b/tests/src/JIT/jit64/opt/cse/hugeexpr1.csproj
@@ -24,8 +24,9 @@
   <PropertyGroup>
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
-    <!-- This test is very resource heavy and doesn't play well with some JitStress modes, especially when memory is limited -->
-    <JitOptimizationSensitive Condition="'$(Platform)' == 'x86'">true</JitOptimizationSensitive>
+    <!-- This test is very resource heavy and doesn't play well with some JitStress modes, especially when memory is limited  (x86),
+         on arm the test fails to crossgen with stress mode because of an relocation offset size limit, see #16587 -->
+    <JitOptimizationSensitive Condition="'$(Platform)' == 'x86' Or '$(Platform)' == 'arm'">true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="hugeexpr1.cs" />


### PR DESCRIPTION
Fixes #21842 

PTAL @BruceForstall, @echesakovMSFT.
cc @dotnet/jit-contrib.