### PR TITLE
JIT: fix byte range used by RangeCheck

### DIFF
--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -1151,7 +1151,7 @@ Range RangeCheck::ComputeRange(BasicBlock* block, GenTree* expr, bool monotonic 
                 range = Range(Limit(Limit::keConstant, 0), Limit(Limit::keConstant, 255));
                 break;
             case TYP_BYTE:
-                range = Range(Limit(Limit::keConstant, -127), Limit(Limit::keConstant, 128));
+                range = Range(Limit(Limit::keConstant, -128), Limit(Limit::keConstant, 127));
                 break;
             case TYP_USHORT:
                 range = Range(Limit(Limit::keConstant, 0), Limit(Limit::keConstant, 65535));

--- a/tests/src/JIT/Regression/JitBlue/GitHub_21915/Github_21915.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_21915/Github_21915.cs
@@ -1,0 +1,109 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+// Some tests for removing bounds checks based
+// on byte and sbyte-based indices
+
+class GitHub_21915
+{
+    private static ReadOnlySpan<byte> A => new byte[256] {
+    0, 0, 0, 7, 8, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    1, 1, 0, 1, 1, 1, 0, 0, 1, 1, 1, 0, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1,
+    0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static byte NeedsEscapingByte256(int value) => A[value];
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static byte NeedsEscapingByte255(int value) => A.Slice(0, 255)[value];
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static byte ByteRemoveBoundsCheck(ReadOnlySpan<byte> data, int i)
+    {
+        return NeedsEscapingByte256(data[i]);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static byte ByteKeepBoundsCheck1(ReadOnlySpan<byte> data, int i)
+    {
+        return NeedsEscapingByte255(data[i]);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static byte ByteKeepBoundsCheck2(ReadOnlySpan<byte> data, int i)
+    {
+        return NeedsEscapingByte256(data[i] + 1);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static byte SByteRemoveBoundsCheck(ReadOnlySpan<sbyte> data, int i)
+    {
+        return NeedsEscapingByte256(data[i] + 128);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static byte SByteKeepBoundsCheck1(ReadOnlySpan<sbyte> data, int i)
+    {
+        return NeedsEscapingByte255(data[i] + 128);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static byte SByteKeepBoundsCheck2(ReadOnlySpan<sbyte> data, int i)
+    {
+        return NeedsEscapingByte256(data[i] + 127);
+    }
+
+    public static int Main()
+    {
+        ReadOnlySpan<byte> bytes = new byte[] { 2, 3 };
+
+        byte brbc = ByteRemoveBoundsCheck(bytes, 1);
+        byte bkbc1 = ByteKeepBoundsCheck1(bytes, 1);
+        byte bkbc2 = ByteKeepBoundsCheck2(bytes, 0);
+
+        Console.WriteLine($"byte cases: {brbc} {bkbc1} {bkbc2} (expected 7 7 7)");
+
+        ReadOnlySpan<sbyte> sbytes = new sbyte[] { -124, -125, -128 };
+
+        byte sbrbc = SByteRemoveBoundsCheck(sbytes, 1);
+        byte sbkbc1 = SByteKeepBoundsCheck1(sbytes, 1);
+        byte sbkbc2 = SByteKeepBoundsCheck2(sbytes, 0);
+
+        Console.WriteLine($"sbyte cases: {sbrbc} {sbkbc1} {sbkbc2} (expected 7 7 7)");
+
+        bool ok = (brbc == 7) && (bkbc1 == 7) && (bkbc2 == 7) && (sbrbc == 7) && (sbkbc1 == 7) && (sbkbc2 == 7);
+
+        try
+        {
+            // Check for buggy case in initial PR 21857
+            // -128 + 127 should index with -1 and throw.
+            SByteKeepBoundsCheck2(sbytes, 2);
+            Console.WriteLine($"error: did not throw as expected");
+            ok = false;
+        }
+        catch (IndexOutOfRangeException)
+        {
+            Console.WriteLine($"threw exception, as expected");
+        }
+
+        return ok ? 100 : -1;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_21915/Github_21915.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_21915/Github_21915.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{2649FAFE-07BF-4F93-8120-BA9A69285ABB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Fix wrong byte range introduced in #21857.

Thanks to @jakobbotsch for spotting this.