### PR TITLE
[release/2.2] Update Helix queues used for testing

### DIFF
--- a/buildpipeline/tests/Dotnet-CoreClr-Trusted-BuildTests.json
+++ b/buildpipeline/tests/Dotnet-CoreClr-Trusted-BuildTests.json
@@ -303,7 +303,7 @@
       "value": "linux-x64"
     },
     "TargetQueues": {
-      "value": "debian.82.amd64,fedora.26.amd64,fedora.27.amd64,redhat.73.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1710.amd64,ubuntu.1804.amd64,opensuse.423.amd64,sles.12.amd64"
+      "value": "Debian.8.Amd64,Fedora.27.Amd64,Redhat.7.amd64,Ubuntu.1404.Amd64,Ubuntu.1604.Amd64,Ubuntu.1804.Amd64,Opensuse.423.Amd64,Sles.12.Amd64"
     },
     "TestProduct": {
       "value": "coreclr"

--- a/buildpipeline/tests/test_pipelines.json
+++ b/buildpipeline/tests/test_pipelines.json
@@ -56,7 +56,7 @@
                 "HelixJobType": "test/functional/cli/",
                 "TargetsWindows": "true",
                 "Rid": "win-arm",
-                "TargetQueues": "windows.10.arm64",
+                "TargetQueues": "Windows.10.Arm64",
                 "TestContainerSuffix": "windows",
                 },
                 "ReportingParameters": {
@@ -74,7 +74,7 @@
                 "HelixJobType": "test/functional/r2r/cli/",
                 "TargetsWindows": "true",
                 "Rid": "win-arm",
-                "TargetQueues": "windows.10.arm64",
+                "TargetQueues": "Windows.10.Arm64",
                 "TestContainerSuffix": "windows-r2r",
                 "CrossgenArg": "Crossgen "
                 },
@@ -92,7 +92,7 @@
                 "HelixJobType": "test/functional/cli/",
                 "TargetsWindows": "false",
                 "Rid": "osx-x64",
-                "TargetQueues": "osx.1012.amd64,osx.1013.amd64",
+                "TargetQueues": "OSX.1012.Amd64,OSX.1013.Amd64",
                 "TestContainerSuffix": "osx",
                 "TargetsNonWindowsArg": "TargetsNonWindows "
                 },
@@ -109,7 +109,7 @@
                 "HelixJobType": "test/functional/r2r/cli/",
                 "TargetsWindows": "false",
                 "Rid": "osx-x64",
-                "TargetQueues": "osx.1012.amd64,osx.1013.amd64",
+                "TargetQueues": "OSX.1012.Amd64,OSX.1013.Amd64",
                 "TestContainerSuffix": "osx-r2r",
                 "CrossgenArg": "Crossgen ",
                 "TargetsNonWindowsArg": "TargetsNonWindows "
@@ -127,7 +127,7 @@
                 "HelixJobType": "test/functional/cli/",
                 "TargetsWindows": "false",
                 "Rid": "linux-x64",
-                "TargetQueues": "debian.82.amd64,fedora.26.amd64,fedora.27.amd64,redhat.73.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1710.amd64,ubuntu.1804.amd64,opensuse.423.amd64,sles.12.amd64",
+                "TargetQueues": "Debian.8.Amd64,Fedora.27.Amd64,Redhat.7.Amd64,Ubuntu.1404.Amd64,Ubuntu.1604.Amd64,Ubuntu.1804.Amd64,Opensuse.423.Amd64,SLES.12.Amd64",
                 "TestContainerSuffix": "linux",
                 "TargetsNonWindowsArg": "TargetsNonWindows "
                 },
@@ -144,7 +144,7 @@
                 "HelixJobType": "test/functional/r2r/cli/",
                 "TargetsWindows": "false",
                 "Rid": "linux-x64",
-                "TargetQueues": "debian.82.amd64,fedora.26.amd64,fedora.27.amd64,redhat.73.amd64,ubuntu.1404.amd64,ubuntu.1604.amd64,ubuntu.1710.amd64,ubuntu.1804.amd64,opensuse.423.amd64,sles.12.amd64",
+                "TargetQueues": "Debian.8.Amd64,Fedora.27.Amd64,Redhat.7.Amd64,Ubuntu.1404.Amd64,Ubuntu.1604.Amd64,Ubuntu.1804.Amd64,Opensuse.423.Amd64,SLES.12.Amd64",
                 "TestContainerSuffix": "linux-r2r",
                 "CrossgenArg": "Crossgen ",
                 "TargetsNonWindowsArg": "TargetsNonWindows "
@@ -162,7 +162,7 @@
                 "HelixJobType": "test/functional/cli/",
                 "TargetsWindows": "false",
                 "Rid": "rhel.6-x64",
-                "TargetQueues": "redhat.69.amd64",
+                "TargetQueues": "Redhat.6.Amd64",
                 "TestContainerSuffix": "rhel6",
                 "TargetsNonWindowsArg": "TargetsNonWindows "
                 },
@@ -179,7 +179,7 @@
                 "HelixJobType": "test/functional/r2r/cli/",
                 "TargetsWindows": "false",
                 "Rid": "rhel.6-x64",
-                "TargetQueues": "redhat.69.amd64",
+                "TargetQueues": "Redhat.6.Amd64",
                 "TestContainerSuffix": "rhel6-r2r",
                 "CrossgenArg": "Crossgen ",
                 "TargetsNonWindowsArg": "TargetsNonWindows "
@@ -196,7 +196,7 @@
                 "Parameters": {
                 "HelixJobType": "test/functional/cli/",
                 "TargetsWindows": "false",
-                "Rid": "alpine.3.6",
+                "Rid": "linux-musl-x64",
                 "TargetQueues": "Alpine.36.Amd64",
                 "TestContainerSuffix": "alpine36",
                 "TargetsNonWindowsArg": "TargetsNonWindows "
@@ -213,7 +213,7 @@
                 "Parameters": {
                 "HelixJobType": "test/functional/r2r/cli/",
                 "TargetsWindows": "false",
-                "Rid": "alpine.3.6",
+                "Rid": "linux-musl-x64",
                 "TargetQueues": "Alpine.36.Amd64",
                 "TestContainerSuffix": "alpine36-r2r",
                 "CrossgenArg": "Crossgen ",


### PR DESCRIPTION
Also port fecf57a0bfc8267e7ca50e9a532a83fa29ebec87