### PR TITLE
Re-enable publishing of transport packages

### DIFF
--- a/src/publishwitharcade.proj
+++ b/src/publishwitharcade.proj
@@ -18,6 +18,7 @@
 
     <ItemGroup>
       <PackagesToPublish Include="$(PackagesBinDir)pkg\*.nupkg" IsShipping="true" />
+      <PackagesToPublish Update="$(PackagesBinDir)pkg\transport*.nupkg" IsShipping="false" />
       <SymbolPackagesToPublish Include="$(PackagesBinDir)symbolpkg\*.nupkg" IsShipping="true" />
     </ItemGroup>
 
@@ -25,18 +26,10 @@
          only want to upload them once. Let's arbitrarily upload these
          only from the x64 leg. -->
     <ItemGroup Condition=" '$(BuildArch)' != 'x64' ">
-      <PackagesToPublish Remove="$(PackagesBinDir)pkg\Microsoft.NET.Sdk.IL*.nupkg" />
-      <PackagesToPublish Remove="$(PackagesBinDir)pkg\Microsoft.TargetingPack.Private.CoreCLR*.nupkg" />
-
+      <PackagesToPublish Remove="$(PackagesBinDir)pkg\*Microsoft.NET.Sdk.IL*.nupkg" />
+      <PackagesToPublish Remove="$(PackagesBinDir)pkg\*Microsoft.TargetingPack.Private.CoreCLR*.nupkg" />
       <SymbolPackagesToPublish Remove="$(PackagesBinDir)symbolpkg\Microsoft.NET.Sdk.IL*.nupkg" />
       <SymbolPackagesToPublish Remove="$(PackagesBinDir)symbolpkg\Microsoft.TargetingPack.Private.CoreCLR*.nupkg" />
-    </ItemGroup>
-
-    <!-- TODO: Investigate whether we can get rid of the transport
-         packages entirely. For now, just exclude them from
-         publishing. -->
-    <ItemGroup>
-      <PackagesToPublish Remove="$(PackagesBinDir)pkg\transport*.nupkg" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Core-setup currently uses nuget restore to download transport packages containing coreclr symbols to redistribute. This re-enables publishing of transport packages in our new official builds. Fixes https://github.com/dotnet/coreclr/issues/21897.

@rakeshsinghranchi @echesakov @jashook 