### PR TITLE
Disable what fails and blocks transitioning to Azure DevOps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,9 +14,6 @@ resources:
   - container: ubuntu_1604_arm64_cross_build_image
     image: microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-cross-arm64-a3ae44b-20180315221921
 
-  - container: ubuntu_1604_x64_build_image
-    image: microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-c103199-20180628134544
-
   - container: musl_x64_build_image
     image: microsoft/dotnet-buildtools-prereqs:alpine-3.6-WithNode-f4d3fe3-20181220200247
 
@@ -204,7 +201,6 @@ jobs:
       - build_Linux_arm64_release
       - build_Linux_musl_x64_release
       - build_Linux_rhel6_x64_release
-      - build_Linux_rhel7_x64_release
       - build_Linux_x64_release
       - build_OSX_x64_release
       - build_Windows_NT_x64_release

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -171,6 +171,7 @@ jobs:
       buildConfig: release
       jobParameters:
         priority: 1
+        timeoutInMinutes: 240
 
 # Pri1 crossgen (Official Build)
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
@@ -181,6 +182,7 @@ jobs:
       jobParameters:
         priority: 1
         crossgen: true
+        timeoutInMinutes: 240
 
 
 # Publish build information to Build Assets Registry

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -36,7 +36,7 @@ jobs:
     - name: portableBuildArg
       value: ''
     # Ensure that we produce os-specific packages for the following distros:
-    - ${{ if in(parameters.osIdentifier, 'Linux_rhel6', 'Linux_rhel7', 'Linux_musl') }}:
+    - ${{ if in(parameters.osIdentifier, 'Linux_rhel6', 'Linux_musl') }}:
       - name: portableBuildArg
         value: '-portablebuild=false'
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -105,7 +105,8 @@ jobs:
     archType: x64
     osGroup: Windows_NT
     osIdentifier: Windows_NT
-    helixQueuesPublic: 'Windows.10.Amd64.Open,Windows.10.Nano.Amd64.Open,Windows.7.Amd64.Open,Windows.81.Amd64.Open'
+    # TODO: add Windows.10.Nano.Amd64.Open when https://github.com/dotnet/coreclr/issues/21693 is resolved
+    helixQueuesPublic: 'Windows.10.Amd64.Open,Windows.7.Amd64.Open,Windows.81.Amd64.Open'
     helixQueuesInternal: 'Windows.10.Amd64,Windows.10.Nano.Amd64,Windows.10.Amd64.Core,Windows.7.Amd64,Windows.81.Amd64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 
@@ -115,7 +116,8 @@ jobs:
     archType: x86
     osGroup: Windows_NT
     osIdentifier: Windows_NT
-    helixQueuesPublic: 'Windows.10.Amd64.Open,Windows.10.Nano.Amd64.Open,Windows.7.Amd64.Open,Windows.81.Amd64.Open'
+    # TODO: add Windows.10.Nano.Amd64.Open when https://github.com/dotnet/coreclr/issues/21693 is resolved
+    helixQueuesPublic: 'Windows.10.Amd64.Open,Windows.7.Amd64.Open,Windows.81.Amd64.Open'
     helixQueuesInternal: 'Windows.10.Amd64,Windows.10.Nano.Amd64,Windows.10.Amd64.Core,Windows.7.Amd64,Windows.81.Amd64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -9,6 +9,7 @@ jobs:
 # https://github.com/Microsoft/azure-pipelines-yaml/pull/46 for more information
 
 # Linux arm
+
 - template: ${{ parameters.jobTemplate }}
   parameters:
     buildConfig: ${{ parameters.buildConfig }}
@@ -22,6 +23,7 @@ jobs:
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux arm64
+
 - template: ${{ parameters.jobTemplate }}
   parameters:
     buildConfig: ${{ parameters.buildConfig }}
@@ -37,6 +39,7 @@ jobs:
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux musl
+
 - template: ${{ parameters.jobTemplate }}
   parameters:
     buildConfig: ${{ parameters.buildConfig }}
@@ -48,6 +51,7 @@ jobs:
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # RHEL 6
+
 - template: ${{ parameters.jobTemplate }}
   parameters:
     buildConfig: ${{ parameters.buildConfig }}
@@ -59,18 +63,6 @@ jobs:
     helixQueuesInternal: 'RedHat.6.Amd64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 
-# RHEL 7
-- template: ${{ parameters.jobTemplate }}
-  parameters:
-    buildConfig: ${{ parameters.buildConfig }}
-    archType: x64
-    osGroup: Linux
-    osIdentifier: Linux_rhel7
-    containerName: centos7_x64_build_image
-    helixQueuesPublic: 'Centos.7.Amd64.Open,Fedora.28.Amd64.Open,RedHat.7.Amd64.Open'
-    helixQueuesInternal: 'Centos.7.Amd64,Fedora.28.Amd64,RedHat.7.Amd64'
-    ${{ insert }}: ${{ parameters.jobParameters }}
-
 # Linux x64
 
 - template: ${{ parameters.jobTemplate }}
@@ -79,9 +71,9 @@ jobs:
     archType: x64
     osGroup: Linux
     osIdentifier: Linux
-    containerName: ubuntu_1604_x64_build_image
-    helixQueuesPublic: 'Debian.9.Amd64.Open,Ubuntu.1604.Amd64.Open,Ubuntu.1804.Amd64.Open'
-    helixQueuesInternal: 'Debian.9.Amd64,Ubuntu.1604.Amd64,Ubuntu.1804.Amd64'
+    containerName: centos7_x64_build_image
+    helixQueuesPublic: 'Debian.9.Amd64.Open,Ubuntu.1604.Amd64.Open,Ubuntu.1804.Amd64.Open,Centos.7.Amd64.Open,Fedora.28.Amd64.Open,RedHat.7.Amd64.Open'
+    helixQueuesInternal: 'Debian.9.Amd64,Ubuntu.1604.Amd64,Ubuntu.1804.Amd64,Centos.7.Amd64,Fedora.28.Amd64,RedHat.7.Amd64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # macOS x64
@@ -97,7 +89,7 @@ jobs:
     helixQueuesInternal: 'OSX.1013.Amd64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Windows x64/x86/arm/arm64
+# Windows x64/x86
 
 - template: ${{ parameters.jobTemplate }}
   parameters:
@@ -122,6 +114,8 @@ jobs:
     helixQueuesPublic: 'Windows.10.Amd64.Open,Windows.81.Amd64.Open'
     helixQueuesInternal: 'Windows.10.Amd64,Windows.10.Nano.Amd64,Windows.10.Amd64.Core,Windows.7.Amd64,Windows.81.Amd64'
     ${{ insert }}: ${{ parameters.jobParameters }}
+
+# Windows arm/arm64
 
 - template: ${{ parameters.jobTemplate }}
   parameters:

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -106,7 +106,8 @@ jobs:
     osGroup: Windows_NT
     osIdentifier: Windows_NT
     # TODO: add Windows.10.Nano.Amd64.Open when https://github.com/dotnet/coreclr/issues/21693 is resolved
-    helixQueuesPublic: 'Windows.10.Amd64.Open,Windows.7.Amd64.Open,Windows.81.Amd64.Open'
+    # TODO: add Windows.7.Amd64.Open when https://github.com/dotnet/coreclr/issues/21796 is resolved
+    helixQueuesPublic: 'Windows.10.Amd64.Open,Windows.81.Amd64.Open'
     helixQueuesInternal: 'Windows.10.Amd64,Windows.10.Nano.Amd64,Windows.10.Amd64.Core,Windows.7.Amd64,Windows.81.Amd64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 
@@ -117,7 +118,8 @@ jobs:
     osGroup: Windows_NT
     osIdentifier: Windows_NT
     # TODO: add Windows.10.Nano.Amd64.Open when https://github.com/dotnet/coreclr/issues/21693 is resolved
-    helixQueuesPublic: 'Windows.10.Amd64.Open,Windows.7.Amd64.Open,Windows.81.Amd64.Open'
+    # TODO: add Windows.7.Amd64.Open when https://github.com/dotnet/coreclr/issues/21796 is resolved
+    helixQueuesPublic: 'Windows.10.Amd64.Open,Windows.81.Amd64.Open'
     helixQueuesInternal: 'Windows.10.Amd64,Windows.10.Nano.Amd64,Windows.10.Amd64.Core,Windows.7.Amd64,Windows.81.Amd64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -80,8 +80,8 @@ jobs:
     osGroup: Linux
     osIdentifier: Linux
     containerName: ubuntu_1604_x64_build_image
-    helixQueuesPublic: 'Debian.8.Amd64.Open,Ubuntu.1604.Amd64.Open,Ubuntu.1804.Amd64.Open'
-    helixQueuesInternal: 'Debian.8.Amd64,Ubuntu.1604.Amd64,Ubuntu.1804.Amd64'
+    helixQueuesPublic: 'Debian.9.Amd64.Open,Ubuntu.1604.Amd64.Open,Ubuntu.1804.Amd64.Open'
+    helixQueuesInternal: 'Debian.9.Amd64,Ubuntu.1604.Amd64,Ubuntu.1804.Amd64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # macOS x64

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -129,9 +129,13 @@ jobs:
           # Access token variable for internal project
           helixAccessToken: $(DotNet-HelixApi-Access)
           helixQueues: ${{ parameters.helixQueuesInternal }}
+          ${{ if eq(parameters.helixQueuesInternal, '') }}:
+            condition: false
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           isExternal: true
           creator: $(Build.RequestedForId)
           helixQueues: ${{ parameters.helixQueuesPublic }}
+          ${{ if eq(parameters.helixQueuesPublic, '') }}:
+            condition: false
 
         scenarios: ${{ parameters.scenarios }}

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -133,7 +133,7 @@ jobs:
             condition: false
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           isExternal: true
-          creator: $(Build.RequestedForId)
+          creator: coreclr/pulls
           helixQueues: ${{ parameters.helixQueuesPublic }}
           ${{ if eq(parameters.helixQueuesPublic, '') }}:
             condition: false

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -52,13 +52,6 @@
         </ExcludeList>
     </ItemGroup>
 
-    <!-- All Windows targets -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TargetsWindows)' == 'true'">
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/superpmi/superpmicollect/*">
-            <Issue>21698</Issue>
-        </ExcludeList>
-    </ItemGroup>
-
     <!-- All Unix targets -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TargetsWindows)' != 'true'">
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/paramthreadstart/ThreadStartString_1/*">

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -52,6 +52,13 @@
         </ExcludeList>
     </ItemGroup>
 
+    <!-- All Windows targets -->
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TargetsWindows)' == 'true'">
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/superpmi/superpmicollect/*">
+            <Issue>21698</Issue>
+        </ExcludeList>
+    </ItemGroup>
+
     <!-- All Unix targets -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TargetsWindows)' != 'true'">
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/paramthreadstart/ThreadStartString_1/*">


### PR DESCRIPTION
1. Use CentOS 7 image for building Linux x64 coreclr (the same way it's done in buildpipeline). As a consequence, we don't need Linux_rhel7 build and test jobs.
2. Use Debian.9.Amd64 queue instead of Debian.8.Amd64
3. Don't run on Windows.10.Nano.Amd64.Open and Windows.7.Amd64.Open due to these blocking issues: #21693 #21796 
4. Conditionalize submission to Helix step and skip the step if there are no queues (Alpine.*.Amd64.Open)
5. Temporary disable JIT/superpmi/superpmicollect due to #21698 
6. Increase timeout for Release test jobs - currently failing in official build