### PR TITLE
disable dynamo test on arm32/64

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -586,6 +586,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/GC/Scenarios/DoublinkList/dlstack/*">
             <Issue>Release only crash</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/GC/Scenarios/Dynamo/dynamo/*">
+            <Issue>17129</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/v2.1/b152292/b152292/*">
             <Issue>20358</Issue>
         </ExcludeList>
@@ -601,6 +604,9 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/GitHub_19361/GitHub_19361/*">
             <Issue>20232</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/GC/Scenarios/Dynamo/dynamo/*">
+            <Issue>17129</Issue>
         </ExcludeList>
     </ItemGroup>
     


### PR DESCRIPTION
Disabling this test on ARM32/64 on Linux to get the ARM legs to pass while the failure is being investigated. https://github.com/dotnet/coreclr/issues/17129