### PR TITLE
Generate non-null assertion for byrefs if we can't find corresponding refs

### DIFF
--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -923,7 +923,8 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
 
         //
         // We only perform null-checks on GC refs
-        // so only make non-null assertions about GC refs
+        // so only make non-null assertions about GC refs or byrefs if we can't determine
+        // the corresponding ref.
         //
         if (lclVar->TypeGet() != TYP_REF)
         {
@@ -957,7 +958,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
                 }
             }
 
-            if (fgIsBigOffset(offset) || (vnStore->TypeOfVN(vn) != TYP_REF))
+            if (fgIsBigOffset(offset))
             {
                 goto DONE_ASSERTION; // Don't make an assertion
             }


### PR DESCRIPTION
When we have a non-null fact about a byref, we try to find the corresponding
ref and generate an assertion about the ref. Then it can be used on byrefs if the offset is not too big.
We use both trees and value numbers to find the ref. When the ref wasn't found we bailed on generating
the assertion.

I found that we get a number of good diffs if we generate assertions for byrefs when refs can't be found
so this change enables that.