### PR TITLE
Improvements for object stack allocation.

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -9269,6 +9269,10 @@ int cTreeFlagsIR(Compiler* comp, GenTree* tree)
                 {
                     chars += printf("[IND_TGTANYWHERE]");
                 }
+                if (tree->gtFlags & GTF_IND_TGT_NOT_HEAP)
+                {
+                    chars += printf("[IND_TGT_NOT_HEAP]");
+                }
                 if (tree->gtFlags & GTF_IND_TLS_REF)
                 {
                     chars += printf("[IND_TLS_REF]");

--- a/src/jit/gcencode.cpp
+++ b/src/jit/gcencode.cpp
@@ -4245,7 +4245,6 @@ void GCInfo::gcMakeRegPtrTable(
                 // Or in byref_OFFSET_FLAG for 'byref' pointer tracking
                 flags = (GcSlotFlags)(flags | GC_SLOT_INTERIOR);
             }
-            gcUpdateFlagForStackAllocatedObjects(flags);
 
             if (varDsc->lvPinned)
             {
@@ -4345,7 +4344,6 @@ void GCInfo::gcMakeRegPtrTable(
                 {
                     flags = (GcSlotFlags)(flags | GC_SLOT_INTERIOR);
                 }
-                gcUpdateFlagForStackAllocatedObjects(flags);
 
                 GcStackSlotBase stackSlotBase = GC_SP_REL;
                 if (compiler->isFramePointerUsed())
@@ -4730,7 +4728,6 @@ void GCInfo::gcInfoRecordGCRegStateChange(GcInfoEncoder* gcInfoEncoder,
         {
             regFlags = (GcSlotFlags)(regFlags | GC_SLOT_INTERIOR);
         }
-        gcUpdateFlagForStackAllocatedObjects(regFlags);
 
         RegSlotIdKey rskey(regNum, regFlags);
         GcSlotId     regSlotId;
@@ -4821,7 +4818,6 @@ void GCInfo::gcMakeVarPtrTable(GcInfoEncoder* gcInfoEncoder, MakeRegPtrMode mode
         {
             flags = (GcSlotFlags)(flags | GC_SLOT_INTERIOR);
         }
-        gcUpdateFlagForStackAllocatedObjects(flags);
 
         if ((lowBits & pinned_OFFSET_FLAG) != 0)
         {
@@ -4922,30 +4918,6 @@ void GCInfo::gcInfoRecordGCStackArgsDead(GcInfoEncoder* gcInfoEncoder,
         assert(b); // Should have been added in the first pass.
         // Live until the call.
         gcInfoEncoderWithLog->SetSlotState(instrOffset, varSlotId, GC_SLOT_DEAD);
-    }
-}
-
-//------------------------------------------------------------------------
-// gcUpdateFlagForStackAllocatedObjects: Update the flags to handle a possibly stack-allocated object.
-//                                       allocation.
-// Arguments:
-//    flags - flags to update
-//
-//
-// Notes:
-//    TODO-ObjectStackAllocation: This is a temporary conservative implementation.
-//    Currently variables pointing to heap and/or stack allocated objects have type TYP_REF so we
-//    conservatively report them as INTERIOR.
-//    Ideally we should have the following types for object pointers:
-//        1. TYP_I_IMPL for variables always pointing to stack-allocated objects (not reporting to GC)
-//        2. TYP_REF for variables always pointing to heap-allocated objects (reporting as normal objects to GC)
-//        3. TYP_BYREF for variables that may point to the stack or to the heap (reporting as interior objects to GC)
-
-void GCInfo::gcUpdateFlagForStackAllocatedObjects(GcSlotFlags& flags)
-{
-    if ((compiler->optMethodFlags & OMF_HAS_OBJSTACKALLOC) != 0)
-    {
-        flags = (GcSlotFlags)(flags | GC_SLOT_INTERIOR);
     }
 }
 

--- a/src/jit/gcinfo.cpp
+++ b/src/jit/gcinfo.cpp
@@ -267,6 +267,12 @@ GCInfo::WriteBarrierForm GCInfo::gcIsWriteBarrierCandidate(GenTree* tgt, GenTree
                 // This case occurs for Span<T>.
                 return WBF_NoBarrier;
             }
+            if (tgt->gtFlags & GTF_IND_TGT_NOT_HEAP)
+            {
+                // This indirection is not from to the heap.
+                // This case occurs for stack-allocated objects.
+                return WBF_NoBarrier;
+            }
             return gcWriteBarrierFormFromTargetAddress(tgt->gtOp.gtOp1);
 
         case GT_LEA:

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -9337,6 +9337,12 @@ void Compiler::gtDispNode(GenTree* tree, IndentStack* indentStack, __in __in_z _
                         --msgLength;
                         break;
                     }
+                    if (tree->gtFlags & GTF_IND_TGT_NOT_HEAP)
+                    {
+                        printf("s");
+                        --msgLength;
+                        break;
+                    }
                     if (tree->gtFlags & GTF_IND_INVARIANT)
                     {
                         printf("#");
@@ -14436,6 +14442,11 @@ GenTree* Compiler::gtNewTempAssign(
         }
         // 2) TYP_DOUBLE = TYP_FLOAT or TYP_FLOAT = TYP_DOUBLE
         else if (varTypeIsFloating(dstTyp) && varTypeIsFloating(valTyp))
+        {
+            ok = true;
+        }
+        // 3) TYP_BYREF = TYP_REF when object stack allocation is enabled
+        else if (JitConfig.JitObjectStackAllocation() && (dstTyp == TYP_BYREF) && (valTyp == TYP_REF))
         {
             ok = true;
         }

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -798,6 +798,7 @@ public:
 #define GTF_INX_REFARR_LAYOUT       0x20000000 // GT_INDEX
 #define GTF_INX_STRING_LAYOUT       0x40000000 // GT_INDEX -- this uses the special string array layout
 
+#define GTF_IND_TGT_NOT_HEAP        0x80000000 // GT_IND   -- the target is not on the heap
 #define GTF_IND_VOLATILE            0x40000000 // GT_IND   -- the load or store must use volatile sematics (this is a nop on X86)
 #define GTF_IND_NONFAULTING         0x20000000 // Operations for which OperIsIndir() is true  -- An indir that cannot fault.
                                                // Same as GTF_ARRLEN_NONFAULTING.
@@ -818,7 +819,7 @@ public:
 
 #define GTF_IND_FLAGS \
     (GTF_IND_VOLATILE | GTF_IND_TGTANYWHERE | GTF_IND_NONFAULTING | GTF_IND_TLS_REF |          \
-     GTF_IND_UNALIGNED | GTF_IND_INVARIANT | GTF_IND_ARR_INDEX)
+     GTF_IND_UNALIGNED | GTF_IND_INVARIANT | GTF_IND_ARR_INDEX | GTF_IND_TGT_NOT_HEAP)
 
 #define GTF_CLS_VAR_VOLATILE        0x40000000 // GT_FIELD/GT_CLS_VAR -- same as GTF_IND_VOLATILE
 #define GTF_CLS_VAR_INITCLASS       0x20000000 // GT_FIELD/GT_CLS_VAR -- same as GTF_FLD_INITCLASS
@@ -1807,8 +1808,11 @@ public:
         while (node->gtOper == GT_COMMA)
         {
             node = node->gtGetOp2();
-            assert(node->gtType == oldType);
-            node->gtType = newType;
+            if (node->gtType != newType)
+            {
+                assert(node->gtType == oldType);
+                node->gtType = newType;
+            }
         }
     }
 

--- a/src/jit/jitgcinfo.h
+++ b/src/jit/jitgcinfo.h
@@ -231,9 +231,6 @@ public:
                                      regPtrDsc*     genStackPtrFirst,
                                      regPtrDsc*     genStackPtrLast);
 
-    // Update the flags for a stack allocated object
-    void gcUpdateFlagForStackAllocatedObjects(GcSlotFlags& flags);
-
 #endif
 
 #if MEASURE_PTRTAB_SIZE

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -16857,14 +16857,10 @@ void Compiler::fgMorph()
     // local variable allocation on the stack.
     ObjectAllocator objectAllocator(this); // PHASE_ALLOCATE_OBJECTS
 
-// TODO-ObjectStackAllocation: Enable the optimization for architectures using
-// JIT32_GCENCODER (i.e., x86).
-#ifndef JIT32_GCENCODER
     if (JitConfig.JitObjectStackAllocation() && opts.OptimizationEnabled())
     {
         objectAllocator.EnableObjectStackAllocation();
     }
-#endif // JIT32_GCENCODER
 
     objectAllocator.Run();
 

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -309,13 +309,6 @@
         </ExcludeList>
     </ItemGroup>
 
-    <!-- x86 specific excludes -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(BuildArch)' == 'x86'">
-      <ExcludeList Include="$(XunitTestBinBase)/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests/*">
-        <Issue>Object stack allocation is not supported on x86 yet</Issue>
-      </ExcludeList>
-    </ItemGroup>
-
     <!-- Windows arm32 specific excludes -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(BuildArch)' == 'arm' or '$(AltJitArch)' == 'arm') and '$(TargetsWindows)' == 'true'">
         <ExcludeList Include="$(XunitTestBinBase)/Interop/COM/NETClients/Primitives/NETClientPrimitives/*">


### PR DESCRIPTION
This change enables object stack allocation for more cases:

1. Objects with gc fields can now be stack-allocated.
2. Object stack allocation is enabled for x86.

ObjectAllocator updates the types of trees containing references
to possibly-stack-allocated objects to TYP_BYREF or TYP_I_IMPL as appropriate.
That allows us to remove the hacks in gcencode.cpp and refine reporting of pointers:
the pointer is not reported when we can prove that it always points to a stack-allocated object or is null (typed as TYP_I_IMPL);
the pointer is reported as an interior pointer when it may point to either a stack-allocated object or a heap-allocated object (typed as TYP_BYREF);
the pointer is reported as a normal pointer when it points to a heap-allocated object (typed as TYP_REF).

ObjectAllocator also adds flags to indirections:
GTF_IND_TGTANYWHERE when the indirection may be the heap or the stack
(that results in checked write barriers used for writes)
or the new GTF_IND_TGT_NOT_HEAP when the indirection is null or stack memory
(that results in no barrier used for writes).