### PR TITLE
WIP: Peephole optimize redundant and shuffle moves

### DIFF
--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -1067,6 +1067,8 @@ protected:
 #ifdef _TARGET_XARCH_
     void genCodeForShiftRMW(GenTreeStoreInd* storeInd);
     void genCodeForBT(GenTreeOp* bt);
+    bool isRedundantMove(emitter::instrDesc* id, instruction ins, emitAttr size, regNumber srcReg, regNumber targetReg);
+    bool interferesWithMove(emitter::instrDesc* id, regNumber srcReg, regNumber targetReg);
 #endif // _TARGET_XARCH_
 
     void genCodeForCast(GenTreeOp* tree);

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -4613,46 +4613,54 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
             {
                 assert(op1->gtRegNum != REG_NA);
 
-                instruction         ins       = ins_Move_Extend(targetType, true);
-                bool                canSkip   = false;
-                emitter::instrDesc* prevInstr = emit->emitLastIns;
+                instruction ins     = ins_Move_Extend(targetType, true);
+                bool        canSkip = false;
 
-                // TODO: make sure prevInstr is always null if there is control flow or we
-                // are at the start of a new IG.
+                // Check for skippable if we're optimizing, we're within an IG, and we have a simple mov.
                 //
-                // Do we need any other checks? Maybe same gcness?
-                //
-                // Sure would be nice to just provisionally emit the new instruction and compare
-                // instrDescs, but....
-                //
-                // We could also think about handling reg-mem moves in a similar manner,
-                // especially when mem is a stack access. This could give us writethrough like
-                // codegen for EH methods and (if we dared) for minopts or debug codegen.
-                //
-                // eg    mov [rbp + 40], rax
-                //       mov rax, [rbp + 40]  -- can omit the "reload"
-                //
-                if (compiler->opts.OptimizationEnabled() && (ins == INS_mov) && (prevInstr != nullptr) &&
-                    (ins == prevInstr->idIns()) && prevInstr->idSimpleRegReg() &&
-                    (prevInstr->idOpSize() == EA_SIZE(emitTypeSize(tree))))
+                if (compiler->opts.OptimizationEnabled() && (emit->emitCurIGinsCnt > 0) && (ins == INS_mov))
                 {
-                    // Look for back to back identical moves
+                    emitter::instrDesc* prevInstr = emit->emitLastIns;
+                    assert(prevInstr != nullptr);
+
+                    // See if we're about to emit the same or similar kind of mov.
                     //
-                    // mov... rax, rcx
-                    // mov... rax, rcx -- can omit
-                    if ((prevInstr->idReg1() == targetReg) && (prevInstr->idReg2() == op1->gtRegNum))
-                    {
-                        JITDUMP("\n-- skipping emission -- previous instr is makes this redundant\n");
-                        canSkip = true;
-                    }
-                    // Look for a shuffle move
+                    // Sure would be nice to just provisionally emit the new instruction and compare
+                    // instrDescs, but that's not possible just yet.
                     //
-                    // mov rax, rcx
-                    // mov rcx, rax -- can omit
-                    else if ((prevInstr->idReg1() == op1->gtRegNum) && (prevInstr->idReg2() == targetReg))
+                    // Do we need any other safety checks here? Maybe same gcness?
+                    //
+                    // We could also think about handling reg-mem moves in a similar manner,
+                    // especially when mem is a stack access. This could give us writethrough like
+                    // codegen for EH methods and (perhaps, if we dared) simpler code for minopts
+                    // or debug codegen.
+                    //
+                    // eg    mov [rbp + 40], rax
+                    //       mov rax, [rbp + 40]  -- can omit the "reload"
+                    //
+                    if ((ins == prevInstr->idIns()) && prevInstr->idSimpleRegReg() &&
+                        (prevInstr->idOpSize() == EA_SIZE(emitTypeSize(tree))))
                     {
-                        JITDUMP("\n-- skipping emission -- previous instr makes this a shuffle\n");
-                        canSkip = true;
+                        // Look for back to back identical moves
+                        //
+                        // mov... rax, rcx
+                        // mov... rax, rcx -- can omit
+                        //
+                        if ((prevInstr->idReg1() == targetReg) && (prevInstr->idReg2() == op1->gtRegNum))
+                        {
+                            JITDUMP("\n-- skipping emission -- previous instr is makes this redundant\n");
+                            canSkip = true;
+                        }
+                        // Look for a shuffle move
+                        //
+                        // mov rax, rcx
+                        // mov rcx, rax -- can omit
+                        //
+                        else if ((prevInstr->idReg1() == op1->gtRegNum) && (prevInstr->idReg2() == targetReg))
+                        {
+                            JITDUMP("\n-- skipping emission -- previous instr makes this a shuffle\n");
+                            canSkip = true;
+                        }
                     }
                 }
 

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -917,7 +917,8 @@ insGroup* emitter::emitSavIG(bool emitAdd)
         assert(emitLastIns != nullptr);
         assert(emitCurIGfreeBase <= (BYTE*)emitLastIns);
         assert((BYTE*)emitLastIns < emitCurIGfreeBase + sz);
-        emitLastIns = (instrDesc*)((BYTE*)id + ((BYTE*)emitLastIns - (BYTE*)emitCurIGfreeBase));
+        emitLastIns       = (instrDesc*)((BYTE*)id + ((BYTE*)emitLastIns - (BYTE*)emitCurIGfreeBase));
+        emitNextToLastIns = nullptr;
     }
 
     /* Reset the buffer free pointers */
@@ -1054,7 +1055,8 @@ void emitter::emitBegFN(bool hasFramePtr
 
     emitPrologIG = emitIGlist = emitIGlast = emitCurIG = ig = emitAllocIG();
 
-    emitLastIns = nullptr;
+    emitLastIns       = nullptr;
+    emitNextToLastIns = nullptr;
 
     ig->igNext = nullptr;
 
@@ -1244,6 +1246,7 @@ void* emitter::emitAllocInstr(size_t sz, emitAttr opsz)
 
     /* Grab the space for the instruction */
 
+    emitNextToLastIns = emitLastIns;
     emitLastIns = id = (instrDesc*)emitCurIGfreeNext;
     emitCurIGfreeNext += sz;
 

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -878,6 +878,11 @@ protected:
             assert(sz == _idCodeSize);
         }
 
+        bool idSimpleRegReg() const
+        {
+            return (idInsFmt() == IF_RWR_RRD);
+        }
+
 #elif defined(_TARGET_ARM64_)
         unsigned idCodeSize() const
         {

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -1728,6 +1728,7 @@ private:
         return (emitCurIG && emitCurIGfreeNext > emitCurIGfreeBase);
     }
 
+    instrDesc* emitNextToLastIns;
     instrDesc* emitLastIns;
 
 #ifdef DEBUG


### PR DESCRIPTION
Proof of concept for a late peephole optimization.

Take advantage of the fact that the emitter tracks the last emitted instruction and that IGs do not span basic blocks to do a simple peephole optimization that can suppress redundant (`mov rax, rdx; mov rax rdx`) and shuffle (`mov rax, rdx; mov rdx, rax`) moves.

In combination these two address simple the cases of shuffle move chains like
```
mov rax, rdx
mov rdx, rax      ==>     mov rax, rdx
mov rax, rdx
```
The second mov is supressed as shuffle and so the third move becomes redundant.

@dotnet/jit-contrib curious to hear your thoughts on this approach. It would serve as a complementary piece and is not intended as the primary solution to various CQ issues. And it could give us a template for doing other simple-minded peephole opts.

We could also look back further (with some extra work) to catch the two-register variant which we sometimes see from promoted `Span<T>` copies.

```
PMI Diffs for System.Private.CoreLib.dll, framework assemblies for x64 default jit
Summary:
(Lower is better)
Total bytes of diff: -20032 (-0.05% of base)
    diff is an improvement.
Top file improvements by size (bytes):
       -4359 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.08% of base)
       -2809 : System.Private.CoreLib.dasm (-0.07% of base)
       -2497 : Microsoft.CodeAnalysis.CSharp.dasm (-0.06% of base)
       -1474 : System.Private.Xml.dasm (-0.04% of base)
        -834 : System.Memory.dasm (-0.51% of base)
90 total files with size differences (90 improved, 0 regressed), 39 unchanged.
Top method improvements by size (bytes):
        -135 (-2.61% of base) : System.IO.FileSystem.dasm - FileSystemEnumerator`1:MoveNext():bool:this (5 methods)
         -90 (-2.29% of base) : System.Private.CoreLib.dasm - TextInfo:ChangeCaseCommon(ref):ref:this (6 methods)
         -90 (-4.27% of base) : System.Private.CoreLib.dasm - EventPipePayloadDecoder:DecodePayload(byref,struct):ref
         -73 (-1.25% of base) : System.Security.Cryptography.Algorithms.dasm - KeyFormatHelper:ReadEncryptedPkcs8(ref,struct,struct,struct,ref,byref,byref) (5 methods)
         -66 (-2.12% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Scanner:ScanXmlString(ushort,ushort,bool):ref:this
Top method improvements by size (percentage):
          -6 (-15.79% of base) : Microsoft.CodeAnalysis.dasm - ModuleMetadata:CreateFromFile(ref):ref
          -6 (-12.77% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - CustomEventAccessorSymbol:GetAttributeDeclarations():struct:this
          -6 (-12.77% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceMethodSymbol:GetAttributeDeclarations():struct:this
          -6 (-12.77% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - SourceMethodSymbol:GetReturnTypeAttributeDeclarations():struct:this
         -22 (-11.40% of base) : System.Private.Xml.dasm - NameTable:ComputeHash32(ref,int,int):int
3138 total methods with size differences (3138 improved, 0 regressed), 190301 unchanged.
```

Sample cherry-picked diff:
```diff
;; System.Private.Xml      
;; NameTable:ComputeHash32(ref,int,int):int

 G_M17318_IG06:
        mov      rcx, rax
-       mov      rax, rcx
        imul     ecx, r9d, 2
        jo       SHORT G_M17318_IG08
        mov      rdx, rax               // this is also now dead....
-       mov      rax, rdx
-       mov      rdx, rax
-       mov      rax, rdx
-       mov      rdx, rax
-       mov      rax, rdx
        mov      rsi, rax
        mov      edi, ecx
        mov      rcx, 0xD1FFAB1E
        mov      edx, 100
        call     CORINFO_HELP_GETSHARED_NONGCSTATIC_BASE
```


