### PR TITLE
[Back Port] of PR #21771 Issue #21461 Added opt-out of runtime polling

### DIFF
--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventPipeController.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventPipeController.cs
@@ -35,7 +35,7 @@ namespace System.Diagnostics.Tracing
         private const string NetPerfFileExtension = ".netperf";
         private const string ConfigFileSuffix = ".eventpipeconfig";
         private const int EnabledPollingIntervalMilliseconds = 1000; // 1 second
-        private const int DisabledPollingIntervalMilliseconds = 20000; // 20 seconds
+        private const int DisabledPollingIntervalMilliseconds = 5000; // 5 seconds
         private const uint DefaultCircularBufferMB = 1024; // 1 GB
         private static readonly char[] ProviderConfigDelimiter = new char[] { ',' };
         private static readonly char[] ConfigComponentDelimiter = new char[] { ':' };

--- a/tests/src/tracing/tracecontrol/TraceControl.cs
+++ b/tests/src/tracing/tracecontrol/TraceControl.cs
@@ -22,8 +22,6 @@ CircularMB=2048
 Providers=*:0xFFFFFFFFFFFFFFFF:5
 ";
 
-        private static readonly TimeSpan TimeIntervalToReadConfigFile = new TimeSpan(0, 0, 25);
-
         private const int BytesInOneMB = 1024 * 1024;
 
         /// <summary>
@@ -40,9 +38,9 @@ Providers=*:0xFFFFFFFFFFFFFFFF:5
             File.WriteAllText(configFilePath, ConfigFileContents);
             Console.WriteLine("Wrote contents of config file.");
 
-            // Wait few seconds to ensure that tracing has started.
-            Console.WriteLine($"Waiting {TimeIntervalToReadConfigFile.TotalSeconds} seconds for the config file to be picked up by the next poll operation.");
-            Thread.Sleep(TimeIntervalToReadConfigFile);
+            // Wait 5 seconds to ensure that tracing has started.
+            Console.WriteLine("Waiting 5 seconds for the config file to be picked up by the next poll operation.");
+            Thread.Sleep(TimeSpan.FromSeconds(5));
 
             // Do some work that we can look for in the trace.
             Console.WriteLine("Do some work that will be captured by the trace.");
@@ -64,9 +62,8 @@ Providers=*:0xFFFFFFFFFFFFFFFF:5
             // Wait for 1 second, which is the poll time when tracing is enabled.
             Thread.Sleep(TimeSpan.FromSeconds(1));
 
-            // Poll for file size changes to the trace file itself.
-            // When the size of the trace file hasn't changed for few seconds, consider it fully written out.
-            Console.WriteLine($"Waiting for the trace file to be written. Poll every second to watch for {TimeIntervalToReadConfigFile.TotalSeconds} seconds of no file size changes.");
+            // Poll for file size changes to the trace file itself.  When the size of the trace file hasn't changed for 5 seconds, consider it fully written out.
+            Console.WriteLine("Waiting for the trace file to be written.  Poll every second to watch for 5 seconds of no file size changes.");
             long lastSizeInBytes = 0;
             DateTime timeOfLastChangeUTC = DateTime.UtcNow;
             do
@@ -83,7 +80,7 @@ Providers=*:0xFFFFFFFFFFFFFFFF:5
 
                 Thread.Sleep(TimeSpan.FromSeconds(1));
 
-            } while (DateTime.UtcNow.Subtract(timeOfLastChangeUTC) < TimeIntervalToReadConfigFile);
+            } while (DateTime.UtcNow.Subtract(timeOfLastChangeUTC) < TimeSpan.FromSeconds(5));
 
             int retVal = 0;
 

--- a/tests/src/tracing/tracecontrol/TraceControl.cs
+++ b/tests/src/tracing/tracecontrol/TraceControl.cs
@@ -22,6 +22,8 @@ CircularMB=2048
 Providers=*:0xFFFFFFFFFFFFFFFF:5
 ";
 
+        private static readonly TimeSpan TimeIntervalToReadConfigFile = new TimeSpan(0, 0, 25);
+
         private const int BytesInOneMB = 1024 * 1024;
 
         /// <summary>
@@ -38,9 +40,9 @@ Providers=*:0xFFFFFFFFFFFFFFFF:5
             File.WriteAllText(configFilePath, ConfigFileContents);
             Console.WriteLine("Wrote contents of config file.");
 
-            // Wait 5 seconds to ensure that tracing has started.
-            Console.WriteLine("Waiting 5 seconds for the config file to be picked up by the next poll operation.");
-            Thread.Sleep(TimeSpan.FromSeconds(5));
+            // Wait few seconds to ensure that tracing has started.
+            Console.WriteLine($"Waiting {TimeIntervalToReadConfigFile.TotalSeconds} seconds for the config file to be picked up by the next poll operation.");
+            Thread.Sleep(TimeIntervalToReadConfigFile);
 
             // Do some work that we can look for in the trace.
             Console.WriteLine("Do some work that will be captured by the trace.");
@@ -62,8 +64,9 @@ Providers=*:0xFFFFFFFFFFFFFFFF:5
             // Wait for 1 second, which is the poll time when tracing is enabled.
             Thread.Sleep(TimeSpan.FromSeconds(1));
 
-            // Poll for file size changes to the trace file itself.  When the size of the trace file hasn't changed for 5 seconds, consider it fully written out.
-            Console.WriteLine("Waiting for the trace file to be written.  Poll every second to watch for 5 seconds of no file size changes.");
+            // Poll for file size changes to the trace file itself.
+            // When the size of the trace file hasn't changed for few seconds, consider it fully written out.
+            Console.WriteLine($"Waiting for the trace file to be written. Poll every second to watch for {TimeIntervalToReadConfigFile.TotalSeconds} seconds of no file size changes.");
             long lastSizeInBytes = 0;
             DateTime timeOfLastChangeUTC = DateTime.UtcNow;
             do
@@ -80,7 +83,7 @@ Providers=*:0xFFFFFFFFFFFFFFFF:5
 
                 Thread.Sleep(TimeSpan.FromSeconds(1));
 
-            } while (DateTime.UtcNow.Subtract(timeOfLastChangeUTC) < TimeSpan.FromSeconds(5));
+            } while (DateTime.UtcNow.Subtract(timeOfLastChangeUTC) < TimeIntervalToReadConfigFile);
 
             int retVal = 0;
 


### PR DESCRIPTION
#### Description
In V2.2 to support starting and stopping of EventPipe profiling on already started processes, the runtime wakes up every 5 seconds to check for profiling commands.    V2.1 did not have this behavior.  

For the vast majority of use cases, this polling is not an issue, as it is on its own thread and does very little (check for the existence of a file) each time.   

However it is possible that if users have 
    1. A large number of processes (e.g. hundreds or more) and 
    2. Expect that these processes will stay asleep for long periods (minutes to hours).  

Then this polling could have a noticeable negative effect on their performance (since waking up the process requires things to be paged back in).   

To insure that this polling does not block adoption of V2.2 it is prudent to have the ability to opt-out.   

This change address #21461 by:
- Increasing the polling interval to 20 seconds (thus making it less likely to even have impact)
- Add an option to opt-out from polling of EventPipe commands.   (Setting COMPLUS_EventPipeEnabled=0 will stop polling).  

#### Customer Impact

Most customers are not affected, but some high profile internal teams such as Bing, AzureWebSites and AzureFunctions may see an impact (they are still on 2.1 so have not run into the issue one way or the other).    We have contacted these teams, and while it is not clear how much they would be affected, having the opt-out is good 'insurance' (the alternative is take the risk that they would be prevented from upgrading to 2.2. because of this issue).  

#### Regression?
V2.2 behavior is different than V2.1 and in this sense it is a regression, however we are actually not changing the behavior, just providing an opt-out.   

#### Risk

Very small.   Consumers wishing to control the EventPipe after startup will  wait longer (before 5 sec, after 20 sec).  The code path that is changed is executed on every startup and thus is well tested.   

#### Issue
https://github.com/dotnet/coreclr/issues/21461  Also see PR #21771. 