### PR TITLE
Make JIT\superpmi\superpmicollect compatible with Helix

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -787,9 +787,6 @@
     <!-- The following are tests that fail when building tests against packages -->
 
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(BuildTestsAgainstPackages)' == 'true'">
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/superpmi/superpmicollect/*">
-            <Issue>needs triage</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Performance/CodeQuality/BenchmarksGame/k-nucleotide/k-nucleotide-1/k-nucleotide-1*">
             <Issue>9314</Issue>
         </ExcludeList>
@@ -2116,5 +2113,15 @@
             <Issue>Bug</Issue>
         </ExcludeList>
     </ItemGroup>
-    
+
+    <!-- runtest.proj finds all the *.cmd/*.sh scripts in a test folder and creates corresponding test methods.
+         Exclude these scripts to avoid creating such methods for the superpmicollect dependent test projects
+         and running them separately from superpmicollect test. -->
+
+    <ItemGroup Condition="'$(XunitTestBinBase)' != ''">
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/superpmi/superpmicollect/*" Exclude="$(XunitTestBinBase)/JIT/superpmi/superpmicollect/superpmicollect.*">
+            <Issue>Do not run these scripts separately from superpmicollect test</Issue>
+        </ExcludeList>
+    </ItemGroup>
+
 </Project>

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -787,24 +787,6 @@
     <!-- The following are tests that fail when building tests against packages -->
 
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(BuildTestsAgainstPackages)' == 'true'">
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Performance/CodeQuality/BenchmarksGame/k-nucleotide/k-nucleotide-1/k-nucleotide-1*">
-            <Issue>9314</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Performance/CodeQuality/BenchmarksGame/k-nucleotide/k-nucleotide-9/k-nucleotide-9*">
-            <Issue>9314</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Performance/CodeQuality/BenchmarksGame/regex-redux/regex-redux-1/regex-redux-1*">
-            <Issue>9314</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Performance/CodeQuality/BenchmarksGame/regex-redux/regex-redux-5/regex-redux-5*">
-            <Issue>9314</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Performance/CodeQuality/BenchmarksGame/reverse-complement/reverse-complement-1/reverse-complement-1*">
-            <Issue>9314</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Performance/CodeQuality/BenchmarksGame/reverse-complement/reverse-complement-6/reverse-complement-6*">
-            <Issue>9314</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/varargs/varargsupport_r/*">
             <Issue>Varargs supported on this platform</Issue>
         </ExcludeList>

--- a/tests/src/JIT/superpmi/TestProjects.txt
+++ b/tests/src/JIT/superpmi/TestProjects.txt
@@ -1,0 +1,3 @@
+..\Performance\CodeQuality\Bytemark\Bytemark.csproj
+..\Methodical\fp\exgen\10w5d_cs_do.csproj
+..\Generics\Coverage\chaos65204782cs.csproj

--- a/tests/src/JIT/superpmi/superpmicollect.csproj
+++ b/tests/src/JIT/superpmi/superpmicollect.csproj
@@ -29,17 +29,27 @@
   <ItemGroup>
     <Compile Include="superpmicollect.cs" />
   </ItemGroup>
-
-    <!-- Add project references to those tests that we run as part of the test -->
-    <!-- Don't do this now; it simply builds and copies these EXE/PDB, but not the .cmd/.sh, which we use.
-    <ProjectReference Include="..\Performance\CodeQuality\Roslyn\CscBench.csproj" />
-    <ProjectReference Include="..\Methodical\fp\exgen\10w5d_cs_do.csproj" />
-    <ProjectReference Include="..\Generics\Coverage\chaos65204782cs.csproj" />
-    -->
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
-  </PropertyGroup> 
+  </PropertyGroup>
+  <!-- TestProjects file contains the relative paths to the test projects that are used by superpmicollect test. -->
+  <PropertyGroup>
+    <_TestProjectsFileName>TestProjects.txt</_TestProjectsFileName>
+  </PropertyGroup>
+  <!-- In order to avoid hard-coding of those paths in C# file we embed the file as an assembly resource. -->
+  <ItemGroup>
+    <EmbeddedResource Include="$(_TestProjectsFileName)">
+      <LogicalName>TestProjects</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+  <!-- This target builds the executables and test running scripts for the TestProjects to output directory of the current project. -->
+  <Target Name="_BuildTestProjects" AfterTargets="Build">
+    <ReadLinesFromFile File="$(_TestProjectsFileName)">
+      <Output TaskParameter="Lines" ItemName="_TestProjectsToBuild" />
+    </ReadLinesFromFile>
+    <MSBuild Projects="@(_TestProjectsToBuild)" Properties="OutputPath=$(OutputPath)" />
+  </Target>
 </Project>


### PR DESCRIPTION
Two changes here:
1. Build dependent projects as a part of superpmicollect - this ensures that their executables and running scripts are copied to superpmicollect folder
2. Keep names of the dependent projects in a separate file - this allows embedding the file as an assembly resource (instead of hard-coding) and using the same file from MSBuild

Fixes #21698

Shouldn't break current testing with Jenkins