### PR TITLE
Clean-up of build.sh build-test.sh related to PortableBuild

### DIFF
--- a/build-test.sh
+++ b/build-test.sh
@@ -3,12 +3,6 @@
 initHostDistroRid()
 {
     __HostDistroRid=""
-
-    # Some OS groups should default to use the portable packages
-    if [ "$__BuildOS" == "OSX" ]; then
-        __PortableBuild=1
-    fi
-
     if [ "$__HostOS" == "Linux" ]; then
         if [ -e /etc/redhat-release ]; then
             local redhatRelease=$(</etc/redhat-release)
@@ -71,6 +65,10 @@ initTargetDistroRid()
 
     if [ "$ID.$VERSION_ID" == "ubuntu.16.04" ]; then
      export __DistroRid="ubuntu.14.04-$__BuildArch"
+    fi
+
+    if [ "$__BuildOS" == "OSX" ]; then
+        __PortableBuild=1
     fi
 
     # Portable builds target the base RID

--- a/build-test.sh
+++ b/build-test.sh
@@ -16,22 +16,12 @@ initHostDistroRid()
             if [[ $ID == "alpine" ]]; then
                 __HostDistroRid="linux-musl-$__HostArch"
             else
-                __PortableBuild=1
                 __HostDistroRid="$ID.$VERSION_ID-$__HostArch"
             fi
         fi
     elif [ "$__HostOS" == "FreeBSD" ]; then
         __freebsd_version=`sysctl -n kern.osrelease | cut -f1 -d'.'`
         __HostDistroRid="freebsd.$__freebsd_version-$__HostArch"
-    fi
-
-    # Portable builds target the base RID
-    if [ "$__PortableBuild" == 1 ]; then
-        if [ "$__BuildOS" == "OSX" ]; then
-            export __HostDistroRid="osx-$__BuildArch"
-        elif [ "$__BuildOS" == "Linux" ]; then
-            export __HostDistroRid="linux-$__BuildArch"
-        fi
     fi
 
     if [ "$__HostDistroRid" == "" ]; then

--- a/build-test.sh
+++ b/build-test.sh
@@ -62,7 +62,7 @@ initTargetDistroRid()
     fi
 
     # Portable builds target the base RID
-    if [ "$__PortableBuild" == 1 ]; then
+    if [ $__PortableBuild == 1 ]; then
         if [ "$__BuildOS" == "Linux" ]; then
             export __DistroRid="linux-$__BuildArch"
             export __RuntimeId="linux-$__BuildArch"

--- a/build-test.sh
+++ b/build-test.sh
@@ -75,7 +75,7 @@ initTargetDistroRid()
         fi
     fi
 
-    echo "__DistroRid: " $__DistroRid
+    echo "Setting __DistroRid to $__DistroRid"
 }
 
 isMSBuildOnNETCoreSupported()

--- a/build-test.sh
+++ b/build-test.sh
@@ -26,9 +26,9 @@ initHostDistroRid()
 
     if [ "$__HostDistroRid" == "" ]; then
         echo "WARNING: Cannot determine runtime id for current distro."
+    else
+        echo "Setting __HostDistroRid to $__HostDistroRid"
     fi
-
-    echo "Setting __HostDistroRid to $__HostDistroRid"
 }
 
 initTargetDistroRid()

--- a/build-test.sh
+++ b/build-test.sh
@@ -69,6 +69,9 @@ initTargetDistroRid()
         elif [ "$__BuildOS" == "OSX" ]; then
             export __DistroRid="osx-$__BuildArch"
             export __RuntimeId="osx-$__BuildArch"
+        elif [ "$__BuildOS" == "FreeBSD" ]; then
+            export __DistroRid="freebsd-$__BuildArch"
+            export __RuntimeId="freebsd-$__BuildArch"
         fi
     fi
 

--- a/build-test.sh
+++ b/build-test.sh
@@ -529,7 +529,6 @@ usage()
     echo "clangx.y - optional argument to build using clang version x.y - supported version 3.5 - 6.0"
     echo "cross - optional argument to signify cross compilation,"
     echo "      - will use ROOTFS_DIR environment variable if set."
-    echo "portableLinux - build for Portable Linux Distribution"
     echo "portablebuild - Use portable build."
     echo "verbose - optional argument to enable verbose build output."
     echo "rebuild - if tests have already been built - rebuild them"
@@ -659,7 +658,6 @@ __HostDistroRid=""
 __SkipRestorePackages=0
 __DistroRid=""
 __cmakeargs=""
-__PortableLinux=0
 __msbuildonunsupportedplatform=0
 __ZipTests=0
 __NativeTestIntermediatesDir=
@@ -726,15 +724,6 @@ while :; do
 
         portableBuild)
             __PortableBuild=1
-            ;;
-
-        portablelinux)
-            if [ "$__BuildOS" == "Linux" ]; then
-                __PortableLinux=1
-            else
-                echo "ERROR: portableLinux not supported for non-Linux platforms."
-                exit 1
-            fi
             ;;
 
         verbose)

--- a/build-test.sh
+++ b/build-test.sh
@@ -529,7 +529,6 @@ usage()
     echo "clangx.y - optional argument to build using clang version x.y - supported version 3.5 - 6.0"
     echo "cross - optional argument to signify cross compilation,"
     echo "      - will use ROOTFS_DIR environment variable if set."
-    echo "portablebuild - Use portable build."
     echo "verbose - optional argument to enable verbose build output."
     echo "rebuild - if tests have already been built - rebuild them"
     echo "skipnative: skip the native tests build"

--- a/build-test.sh
+++ b/build-test.sh
@@ -648,6 +648,7 @@ __HostDistroRid=""
 __SkipRestorePackages=0
 __DistroRid=""
 __cmakeargs=""
+__PortableBuild=1
 __msbuildonunsupportedplatform=0
 __ZipTests=0
 __NativeTestIntermediatesDir=
@@ -712,8 +713,8 @@ while :; do
             __CrossBuild=1
             ;;
 
-        portableBuild)
-            __PortableBuild=1
+        -portablebuild=false)
+            __PortableBuild=0
             ;;
 
         verbose)

--- a/build-test.sh
+++ b/build-test.sh
@@ -11,7 +11,12 @@ initHostDistroRid()
 
     if [ "$__HostOS" == "Linux" ]; then
         if [ -e /etc/redhat-release ]; then
-            __PortableBuild=1
+            local redhatRelease=$(</etc/redhat-release)
+            if [[ $redhatRelease == "CentOS release 6."* || $redhatRelease == "Red Hat Enterprise Linux Server release 6."* ]]; then
+               __HostDistroRid="rhel.6-$__HostArch"
+            elif [[ $redhatRelease == "CentOS Linux release 7."* || $redhatRelease == "Red Hat Enterprise Linux Server release 7."* ]]; then
+               __HostDistroRid="rhel.7-$__HostArch"
+            fi
         elif [ -e /etc/os-release ]; then
             source /etc/os-release
             if [[ $ID == "alpine" ]]; then

--- a/build.sh
+++ b/build.sh
@@ -125,6 +125,8 @@ initTargetDistroRid()
             export __DistroRid="freebsd-$__BuildArch"
         fi
     fi
+
+    echo "Setting __DistroRid to $__DistroRid"
 }
 
 setup_dirs()

--- a/build.sh
+++ b/build.sh
@@ -87,7 +87,7 @@ initHostDistroRid()
     fi
 
     if [ "$__HostDistroRid" == "" ]; then
-        echo "WARNING: Can not determine runtime id for current distro."
+        echo "WARNING: Cannot determine runtime id for current distro."
     fi
 }
 
@@ -100,7 +100,7 @@ initTargetDistroRid()
                     source $ROOTFS_DIR/android_platform
                     export __DistroRid="$RID"
                 else
-                    echo "WARNING: Can not determine runtime id for current distro."
+                    echo "WARNING: Cannot determine runtime id for current distro."
                     export __DistroRid=""
                 fi
             else

--- a/build.sh
+++ b/build.sh
@@ -74,9 +74,10 @@ initHostDistroRid()
             fi
         elif [ -e /etc/os-release ]; then
             source /etc/os-release
-            __HostDistroRid="$ID.$VERSION_ID-$__HostArch"
             if [[ $ID == "alpine" ]]; then
                 __HostDistroRid="linux-musl-$__HostArch"
+            else
+                __HostDistroRid="$ID.$VERSION_ID-$__HostArch"
             fi
         fi
     fi

--- a/build.sh
+++ b/build.sh
@@ -80,8 +80,7 @@ initHostDistroRid()
                 __HostDistroRid="$ID.$VERSION_ID-$__HostArch"
             fi
         fi
-    fi
-    if [ "$__HostOS" == "FreeBSD" ]; then
+    elif [ "$__HostOS" == "FreeBSD" ]; then
         __freebsd_version=`sysctl -n kern.osrelease | cut -f1 -d'.'`
         __HostDistroRid="freebsd.$__freebsd_version-$__HostArch"
     fi

--- a/build.sh
+++ b/build.sh
@@ -87,6 +87,8 @@ initHostDistroRid()
 
     if [ "$__HostDistroRid" == "" ]; then
         echo "WARNING: Cannot determine runtime id for current distro."
+    else
+        echo "Setting __HostDistroRid to $__HostDistroRid"
     fi
 }
 

--- a/build.sh
+++ b/build.sh
@@ -65,23 +65,18 @@ initHostDistroRid()
 {
     __HostDistroRid=""
     if [ "$__HostOS" == "Linux" ]; then
-        if [ -e /etc/os-release ]; then
-            source /etc/os-release
-            if [[ $ID == "rhel" ]]; then
-                # remove the last version digit
-                VERSION_ID=${VERSION_ID%.*}
-            fi
-            __HostDistroRid="$ID.$VERSION_ID-$__HostArch"
-            if [[ $ID == "alpine" ]]; then
-                __HostDistroRid="linux-musl-$__HostArch"
-            fi
-        elif [ -e /etc/redhat-release ]; then
+        if [ -e /etc/redhat-release ]; then
             local redhatRelease=$(</etc/redhat-release)
             if [[ $redhatRelease == "CentOS release 6."* || $redhatRelease == "Red Hat Enterprise Linux Server release 6."* ]]; then
                __HostDistroRid="rhel.6-$__HostArch"
+            elif [[ $redhatRelease == "CentOS Linux release 7."* || $redhatRelease == "Red Hat Enterprise Linux Server release 7."* ]]; then
+               __HostDistroRid="rhel.7-$__HostArch"
             fi
-            if [[ $redhatRelease == "CentOS Linux release 7."* ]]; then
-                __HostDistroRid="rhel.7-$__Arch"
+        elif [ -e /etc/os-release ]; then
+            source /etc/os-release
+            __HostDistroRid="$ID.$VERSION_ID-$__HostArch"
+            if [[ $ID == "alpine" ]]; then
+                __HostDistroRid="linux-musl-$__HostArch"
             fi
         fi
     fi

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -5,6 +5,7 @@ parameters:
   osIdentifier: ''
   containerName: ''
   crossrootfsDir: ''
+  portableBuild: ''
   timeoutInMinutes: ''
 
 ### Product build
@@ -34,16 +35,12 @@ jobs:
 
     crossrootfsDir: ${{ parameters.crossrootfsDir }}
 
+    portableBuild: ${{ parameters.portableBuild }}
+
     gatherAssetManifests: true
     variables:
     - name: osIdentifier
       value: ${{ parameters.osIdentifier }}
-    - name: portableBuildArg
-      value: ''
-    # Ensure that we produce os-specific packages for the following distros:
-    - ${{ if in(parameters.osIdentifier, 'Linux_rhel6', 'Linux_musl') }}:
-      - name: portableBuildArg
-        value: '-portablebuild=false'
     - name: clangArg
       value: ''
     # Our FreeBSD doesn't yet detect available clang versions, so pass it explicitly.

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -48,6 +48,7 @@ jobs:
     osIdentifier: Linux_musl
     containerName: musl_x64_build_image
     # TODO: add Alpine.Amd64 queues
+    portableBuild: false
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # RHEL 6
@@ -61,6 +62,7 @@ jobs:
     containerName: centos6_x64_build_image
     helixQueuesPublic: 'RedHat.6.Amd64.Open'
     helixQueuesInternal: 'RedHat.6.Amd64'
+    portableBuild: false
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux x64

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -10,6 +10,7 @@ parameters:
   helixQueuesInternal: ''
   timeoutInMinutes: ''
   crossrootfsDir: ''
+  portableBuild: ''
 
 ### Test job
 
@@ -79,6 +80,8 @@ jobs:
 
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
 
+    portableBuild: ${{ parameters.portableBuild }}
+
     steps:
 
     # Install test build dependencies
@@ -105,7 +108,7 @@ jobs:
     # Build tests
     # TODO: enable crossgen in build-test.sh
     - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-      - script: ./build-test.sh $(buildConfig) $(archType) $(crossArg) $(priorityArg) $(crossgenArg)
+      - script: ./build-test.sh $(buildConfig) $(archType) $(crossArg) $(priorityArg) $(crossgenArg) $(portableBuildArg)
         displayName: Build tests
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
       - script: build-test.cmd $(buildConfig) $(archType) $(priorityArg) $(crossgenArg)

--- a/eng/xplat-job.yml
+++ b/eng/xplat-job.yml
@@ -11,6 +11,7 @@ parameters:
   timeoutInMinutes: ''
   helixType: ''
   crossrootfsDir: ''
+  portableBuild: ''
   enableMicrobuild: ''
 
   # arcade-specific parameters
@@ -108,6 +109,13 @@ jobs:
       - name: crossArg
         value: ''
       - name: crossPackagesArg
+        value: ''
+
+    - ${{ if eq(parameters.portableBuild, 'false') }}:
+      - name: portableBuildArg
+        value: '-portablebuild=false'
+    - ${{ if ne(parameters.portableBuild, 'false') }}:
+      - name: portableBuildArg
         value: ''
 
     - ${{ each variable in parameters.variables }}:


### PR DESCRIPTION
1. Makes `initHostDistroRid()` to be identical in build.sh build-test.sh build-packages.sh
2. Switch portableBuild to opt-out mechanism in build-test.sh 
3. Refactor the way we define whether a build is portable in *.yml files

This fixes currently failing tests in AzDO on Linux_musl and Linux_rhel6


