### PR TITLE
Fix TaskCompletionSource to avoid capturing ExecutionContext

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -520,6 +520,10 @@ namespace System.Threading.Tasks
             }
 
             TaskConstructorCore(action, state, cancellationToken, creationOptions, internalOptions, scheduler);
+
+            Debug.Assert(m_contingentProperties == null || m_contingentProperties.m_capturedContext == null,
+                "Captured an ExecutionContext when one was already captured.");
+            CapturedContext = ExecutionContext.Capture();
         }
 
         /// <summary>
@@ -596,10 +600,6 @@ namespace System.Threading.Tasks
 
                 AssignCancellationToken(cancellationToken, null, null);
             }
-
-            Debug.Assert(m_contingentProperties == null || m_contingentProperties.m_capturedContext == null,
-                "Captured an ExecutionContext when one was already captured.");
-            CapturedContext = ExecutionContext.Capture();
         }
 
         /// <summary>


### PR DESCRIPTION
When a TaskCompletionSource is constructed without any arguments, it simply creates a Task using a simple Task constructor that sets a few fields and is done.  When it's constructed with options, though, those options are validated, and then it calls into a shared routine that configures based on those options.  A previous set of changes resulted in erroneously doing the ExecutionContext.Capture for the task inside of that shared routine, rather than only doing it for tasks that actually have a delegate to be executed.  The net effect of this is that, while TaskCompletionSources created with the parameterless constructor correctly did not capture ExecutionContext, TaskCompletionSources created with options erroneously did; this doesn't have a functional impact, because that ExecutionContext isn't used for anything, but it can have a performance impact, in particular for memory, if the resulting Task is cached, and if the captured ExecutionContext holds onto some expensive object from an AsyncLocal, such that the cached Task then does so, too.

The fix is simply to move the capture from the shared routine that's invoked in two places to instead be done only in the one caller that's for tasks with delegates.

Fixes https://github.com/dotnet/coreclr/issues/21662
cc: @kouvel, @tarekgh, @davidfowl 