### PR TITLE
Remove tizen jobs as valid pr jobs

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -221,11 +221,6 @@ class Constants {
             'x64': [
                 'Checked'
             ]
-        ],
-        'Tizen': [
-            'armem': [
-                'Checked'
-            ]
         ]
     ]
 


### PR DESCRIPTION
Related to https://github.com/dotnet/coreclr/issues/21422.

Note that with the corefx job no longer working our armel jobs now will fail.