### PR TITLE
Finding Standalone GC and CoreDisTools in non-standard host testing

### DIFF
--- a/src/vm/gcheaputilities.cpp
+++ b/src/vm/gcheaputilities.cpp
@@ -152,6 +152,69 @@ void StashKeywordAndLevel(bool isPublicProvider, GCEventKeyword keywords, GCEven
     }
 }
 
+#ifdef FEATURE_STANDALONE_GC
+HMODULE LoadStandaloneGc(LPCWSTR libFileName)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    //
+    // Look for the standalone GC module next to the hosting binary
+    //
+
+    PathString libPath;
+    DWORD result = WszGetModuleFileName(nullptr, libPath);
+    if (result == 0)
+    {
+        LOG((LF_GC, LL_FATALERROR, "GetModuleFileName failed, function 'LoadStandaloneGc': error %u\n", GetLastError()));
+        return nullptr;
+    }
+
+    assert(libFileName);
+    PathString::Iterator iter = libPath.End();
+    if (libPath.FindBack(iter, DIRECTORY_SEPARATOR_CHAR_W))
+    {
+        libPath.Truncate(++iter);
+        libPath.Append(libFileName);
+    }
+    else
+    {
+        assert(false && "unreachable");
+    }
+
+    LPCWSTR libraryName = libPath.GetUnicode();
+    LOG((LF_GC, LL_INFO100, "Loading standalone GC from path %S\n", libraryName));
+    HMODULE libraryHandle = CLRLoadLibrary(libraryName);
+    if (libraryHandle != nullptr)
+        return libraryHandle;
+
+    LOG((LF_GC, LL_INFO100, "Failed to load standalone GC. Attempting fallback\n"));
+
+    //
+    // Fallback to the CORE_ROOT path
+    //
+
+    DWORD pathLen = GetEnvironmentVariableW(W("CORE_ROOT"), nullptr, 0);
+    if (pathLen == 0) // not set
+        return nullptr;
+
+    pathLen += 1; // Add 1 for null
+    PathString coreRoot;
+    WCHAR *coreRootRaw = coreRoot.OpenUnicodeBuffer(pathLen);
+    GetEnvironmentVariableW(W("CORE_ROOT"), coreRootRaw, pathLen);
+
+    libPath.Clear();
+    libPath.AppendPrintf(W("%s%s%s"), coreRootRaw, DIRECTORY_SEPARATOR_STR_W, libFileName);
+
+    libraryName = libPath.GetUnicode();
+    LOG((LF_GC, LL_INFO100, "Loading standalone GC from path %S\n", libraryName));
+    libraryHandle = CLRLoadLibrary(libraryName);
+    if (libraryHandle != nullptr)
+        return libraryHandle;
+
+    return nullptr;
+}
+#endif // FEATURE_STANDALONE_GC
+
 // Loads and initializes a standalone GC, given the path to the GC
 // that we should load. Returns S_OK on success and the failed HRESULT
 // on failure.
@@ -166,13 +229,12 @@ HRESULT LoadAndInitializeGC(LPWSTR standaloneGcLocation)
     LOG((LF_GC, LL_FATALERROR, "EE not built with the ability to load standalone GCs"));
     return E_FAIL;
 #else
-    LOG((LF_GC, LL_INFO100, "Loading standalone GC from path %S\n", standaloneGcLocation));
-    HMODULE hMod = CLRLoadLibrary(standaloneGcLocation);
+    HMODULE hMod = LoadStandaloneGc(standaloneGcLocation);
     if (!hMod)
     {
         HRESULT err = GetLastError();
         LOG((LF_GC, LL_FATALERROR, "Load of %S failed\n", standaloneGcLocation));
-        return err;
+        return __HRESULT_FROM_WIN32(err);
     }
 
     // a standalone GC dispatches virtually on GCToEEInterface, so we must instantiate
@@ -189,7 +251,7 @@ HRESULT LoadAndInitializeGC(LPWSTR standaloneGcLocation)
     {
         HRESULT err = GetLastError();
         LOG((LF_GC, LL_FATALERROR, "Load of `GC_VersionInfo` from standalone GC failed\n"));
-        return err;
+        return __HRESULT_FROM_WIN32(err);
     }
 
     g_gc_load_status = GC_LOAD_STATUS_GET_VERSIONINFO;
@@ -216,7 +278,7 @@ HRESULT LoadAndInitializeGC(LPWSTR standaloneGcLocation)
     {
         HRESULT err = GetLastError();
         LOG((LF_GC, LL_FATALERROR, "Load of `GC_Initialize` from standalone GC failed\n"));
-        return err;
+        return __HRESULT_FROM_WIN32(err);
     }
 
     g_gc_load_status = GC_LOAD_STATUS_GET_INITIALIZE;


### PR DESCRIPTION
~~Update standalone GC search path to include probing the `CORE_ROOT` environment variable. This is done to ensure native COM tests that aren't hosted by `CoreRun.exe` can find the standalone GC.~~

~~See https://github.com/dotnet/coreclr/pull/21261 for prior art.~~

Also look in the "internal system directory" (i.e. location of `coreclr.dll`) for standalone GC and coredistools.

cc @jkoritzinsky 