### PR TITLE
Removing noisy R2R compilation outputs, and putting them under the /verbose switch

### DIFF
--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -5603,7 +5603,8 @@ mdTypeRef Module::LookupTypeRefByMethodTable(MethodTable *pMT)
     {
         if (pMT->GetClass()->IsEquivalentType())
         {
-            GetSvcLogger()->Log(W("ReadyToRun: Type reference to equivalent type cannot be encoded\n"));
+            if (g_CorCompileVerboseLevel >= CORCOMPILE_VERBOSE)
+                GetSvcLogger()->Log(W("ReadyToRun: Type reference to equivalent type cannot be encoded\n"));
             ThrowHR(E_NOTIMPL);
         }
 

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -454,7 +454,8 @@ void ZapInfo::CompileMethod()
 
         if (!(methodAttribs & CORINFO_FLG_NOSECURITYWRAP) || (methodAttribs & CORINFO_FLG_SECURITYCHECK))
         {
-            m_zapper->Warning(W("ReadyToRun: Methods with security checks not supported\n"));
+            if (m_zapper->m_pOpt->m_verbose)
+                m_zapper->Warning(W("ReadyToRun: Methods with security checks not supported\n"));
             ThrowHR(E_NOTIMPL);
         }
     }
@@ -1741,7 +1742,8 @@ void * ZapInfo::getHelperFtn (CorInfoHelpFunc ftnNum, void **ppIndirection)
 
         if (helperNum == READYTORUN_HELPER_Invalid)
         {
-            m_zapper->Warning(W("ReadyToRun: JIT helper not supported: %S\n"), m_pEEJitInfo->getHelperName(ftnNum));
+            if (m_zapper->m_pOpt->m_verbose)
+                m_zapper->Warning(W("ReadyToRun: JIT helper not supported: %S\n"), m_pEEJitInfo->getHelperName(ftnNum));
             ThrowHR(E_NOTIMPL);
         }
 
@@ -1899,7 +1901,8 @@ void ZapInfo::getFunctionEntryPoint(
     if (IsReadyToRunCompilation())
     {
         // READYTORUN: FUTURE: JIT still calls this for tail. and jmp instructions
-        m_zapper->Warning(W("ReadyToRun: Method entrypoint cannot be encoded\n"));
+        if (m_zapper->m_pOpt->m_verbose)
+            m_zapper->Warning(W("ReadyToRun: Method entrypoint cannot be encoded\n"));
         ThrowHR(E_NOTIMPL);
     }
 
@@ -2099,25 +2102,29 @@ void ZapInfo::getCallInfo(CORINFO_RESOLVED_TOKEN * pResolvedToken,
     {
         if (pResult->sig.isVarArg())
         {
-            m_zapper->Warning(W("ReadyToRun: VarArg methods not supported\n"));
+            if (m_zapper->m_pOpt->m_verbose)
+                m_zapper->Warning(W("ReadyToRun: VarArg methods not supported\n"));
             ThrowHR(E_NOTIMPL);
         }
 
         if (pResult->accessAllowed != CORINFO_ACCESS_ALLOWED)
         {
-            m_zapper->Warning(W("ReadyToRun: Runtime method access checks not supported\n"));
+            if (m_zapper->m_pOpt->m_verbose)
+                m_zapper->Warning(W("ReadyToRun: Runtime method access checks not supported\n"));
             ThrowHR(E_NOTIMPL);
         }
 
         if (pResult->methodFlags & CORINFO_FLG_SECURITYCHECK)
         {
-            m_zapper->Warning(W("ReadyToRun: Methods with security checks not supported\n"));
+            if (m_zapper->m_pOpt->m_verbose)
+                m_zapper->Warning(W("ReadyToRun: Methods with security checks not supported\n"));
             ThrowHR(E_NOTIMPL);
         }
 
         if (GetCompileInfo()->IsNativeCallableMethod(pResult->hMethod))
         {
-            m_zapper->Warning(W("ReadyToRun: References to methods with NativeCallableAttribute not supported\n"));
+            if (m_zapper->m_pOpt->m_verbose)
+                m_zapper->Warning(W("ReadyToRun: References to methods with NativeCallableAttribute not supported\n"));
             ThrowHR(E_NOTIMPL);
         }
     }
@@ -2866,7 +2873,8 @@ void ZapInfo::getFieldInfo (CORINFO_RESOLVED_TOKEN * pResolvedToken,
     {
         if (pResult->accessAllowed != CORINFO_ACCESS_ALLOWED)
         {
-            m_zapper->Warning(W("ReadyToRun: Runtime field access checks not supported\n"));
+            if (m_zapper->m_pOpt->m_verbose)
+                m_zapper->Warning(W("ReadyToRun: Runtime field access checks not supported\n"));
             ThrowHR(E_NOTIMPL);
         }
 
@@ -2887,7 +2895,8 @@ void ZapInfo::getFieldInfo (CORINFO_RESOLVED_TOKEN * pResolvedToken,
 
                         if (pResult->offset > eeInfo.maxUncheckedOffsetForNullObject / 2)
                         {
-                            m_zapper->Warning(W("ReadyToRun: Cross-module instance fields with large offsets not supported\n"));
+                            if (m_zapper->m_pOpt->m_verbose)
+                                m_zapper->Warning(W("ReadyToRun: Cross-module instance fields with large offsets not supported\n"));
                             ThrowHR(E_NOTIMPL);
                         }
                         pResult->offset = 0;
@@ -2914,7 +2923,8 @@ void ZapInfo::getFieldInfo (CORINFO_RESOLVED_TOKEN * pResolvedToken,
 
                         if (pResult->offset > eeInfo.maxUncheckedOffsetForNullObject / 2)
                         {
-                            m_zapper->Warning(W("ReadyToRun: Large objects crossing module boundaries not supported\n"));
+                            if (m_zapper->m_pOpt->m_verbose)
+                                m_zapper->Warning(W("ReadyToRun: Large objects crossing module boundaries not supported\n"));
                             ThrowHR(E_NOTIMPL);
                         }
                         _ASSERTE(pResult->offset >= dwBaseOffset);
@@ -2940,7 +2950,8 @@ void ZapInfo::getFieldInfo (CORINFO_RESOLVED_TOKEN * pResolvedToken,
 
         case CORINFO_FIELD_INSTANCE_HELPER:
         case CORINFO_FIELD_INSTANCE_ADDR_HELPER:
-            m_zapper->Warning(W("ReadyToRun: Special instance fields not supported\n"));
+            if (m_zapper->m_pOpt->m_verbose)
+                m_zapper->Warning(W("ReadyToRun: Special instance fields not supported\n"));
             ThrowHR(E_NOTIMPL);
             break;
 
@@ -3018,7 +3029,8 @@ void ZapInfo::getFieldInfo (CORINFO_RESOLVED_TOKEN * pResolvedToken,
         case CORINFO_FIELD_STATIC_RVA_ADDRESS:       // RVA field at given address
             if (m_pEEJitInfo->getClassModule(pResolvedToken->hClass) != m_pImage->m_hModule)
             {
-                m_zapper->Warning(W("ReadyToRun: Cross-module RVA static fields not supported\n"));
+                if (m_zapper->m_pOpt->m_verbose)
+                    m_zapper->Warning(W("ReadyToRun: Cross-module RVA static fields not supported\n"));
                 ThrowHR(E_NOTIMPL);
             }
             break;
@@ -3026,7 +3038,8 @@ void ZapInfo::getFieldInfo (CORINFO_RESOLVED_TOKEN * pResolvedToken,
         case CORINFO_FIELD_STATIC_ADDRESS:           // field at given address
         case CORINFO_FIELD_STATIC_ADDR_HELPER:       // static field accessed using address-of helper (argument is FieldDesc *)
         case CORINFO_FIELD_STATIC_TLS:
-            m_zapper->Warning(W("ReadyToRun: Rare kinds of static fields not supported\n"));
+            if (m_zapper->m_pOpt->m_verbose)
+                m_zapper->Warning(W("ReadyToRun: Rare kinds of static fields not supported\n"));
             ThrowHR(E_NOTIMPL);
             break;
 
@@ -3242,7 +3255,8 @@ CorInfoIsAccessAllowedResult ZapInfo::canAccessClass( CORINFO_RESOLVED_TOKEN * p
 #ifdef FEATURE_READYTORUN_COMPILER
     if (ret != CORINFO_ACCESS_ALLOWED)
     {
-        m_zapper->Warning(W("ReadyToRun: Runtime access checks not supported\n"));
+        if (m_zapper->m_pOpt->m_verbose)
+            m_zapper->Warning(W("ReadyToRun: Runtime access checks not supported\n"));
         ThrowHR(E_NOTIMPL);
     }
 #endif
@@ -3500,7 +3514,8 @@ bool ZapInfo::getReadyToRunHelper(CORINFO_RESOLVED_TOKEN * pResolvedToken,
         else
         {
             // READYTORUN: FUTURE: Cross-module static cctor triggers
-            m_zapper->Warning(W("ReadyToRun: Cross-module static cctor triggers not supported\n"));
+            if (m_zapper->m_pOpt->m_verbose)
+                m_zapper->Warning(W("ReadyToRun: Cross-module static cctor triggers not supported\n"));
             ThrowHR(E_NOTIMPL);
         }
         break;
@@ -3706,7 +3721,8 @@ bool ZapInfo::canTailCall(CORINFO_METHOD_HANDLE caller,
     {
         if (fIsTailPrefix)
         {
-            m_zapper->Warning(W("ReadyToRun: Explicit tailcalls not supported\n"));
+            if (m_zapper->m_pOpt->m_verbose)
+                m_zapper->Warning(W("ReadyToRun: Explicit tailcalls not supported\n"));
             ThrowHR(E_NOTIMPL);
         }
 


### PR DESCRIPTION
If we're going to ship crossgen as a public and widely used tool for building .NET core apps, we need to cleanup the noisy output (mostly about unsupported R2R scenarios), which based on feedback, is pretty confusing especially when compilation succeeds at the end.