### PR TITLE
test/runtest.py: fix path construction in copy_tree

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -1590,7 +1590,7 @@ def setup_core_root(host_os,
 
                 if host_os != "Windows_NT":
                     # Set executable bit
-                    os.chmod(os.path.join(dest, item), 0o774)
+                    os.chmod(os.path.join(dest, os.path.basename(item)), 0o774)
             else:
                 new_dir = os.path.join(dest, os.path.basename(item))
                 if os.path.isdir(new_dir):


### PR DESCRIPTION
This patch fixes following errors:
```
$ tests/runtest.sh Release x64 --generateLayoutOnly --testRootDir='/home/kbaladurin/Downloads/tizen-5.0-m2-coreclr-2.1.4-test.Windows_NT.x86.Debug/bin/tests/Windows_NT.x86.Debug' --testNativeBinDir='/home/kbaladurin/Downloads/tizen-5.0-m2-coreclr-2.1.4-test.Windows_NT.x86.Debug/bin/tests/Windows_NT.x86.Debug/bin' --coreClrBinDir=bin/Product/Linux.x64.Release
...
Copying Product Bin to Core_Root:
cp -r bin/Product/Linux.x64.Release/* /home/kbaladurin/Downloads/tizen-5.0-m2-coreclr-2.1.4-test.Windows_NT.x86.Debug/bin/tests/Windows_NT.x86.Debug/Tests/Core_Root
Traceback (most recent call last):
  File "/media/kbaladurin/data/dotnet/forked/coreclr/tests/runtest.py", line 2310, in <module>
    sys.exit(main(args))
  File "/media/kbaladurin/data/dotnet/forked/coreclr/tests/runtest.py", line 2284, in main
    lambda path: do_setup(host_os,
  File "/media/kbaladurin/data/dotnet/forked/coreclr/tests/runtest.py", line 524, in create_and_use_test_env
    ret_code = func(test_env.name)
  File "/media/kbaladurin/data/dotnet/forked/coreclr/tests/runtest.py", line 2293, in <lambda>
    path))
  File "/media/kbaladurin/data/dotnet/forked/coreclr/tests/runtest.py", line 2188, in do_setup
    core_root)
  File "/media/kbaladurin/data/dotnet/forked/coreclr/tests/runtest.py", line 1605, in setup_core_root
    copy_tree(product_location, core_root)
  File "/media/kbaladurin/data/dotnet/forked/coreclr/tests/runtest.py", line 1593, in copy_tree
    os.chmod(os.path.join(dest, item), 0o774)
FileNotFoundError: [Errno 2] No such file or directory: '/home/kbaladurin/Downloads/tizen-5.0-m2-coreclr-2.1.4-test.Windows_NT.x86.Debug/bin/tests/Windows_NT.x86.Debug/Tests/Core_Root/bin/Product/Linux.x64.Release/System.Private.CoreLib.ni.{ab1c7773-f6cf-46ca-9baf-d9c2fec5aa2c}.map'
```