### PR TITLE
Reduce steps for string.Contains(string value)

### DIFF
--- a/src/System.Private.CoreLib/shared/System/String.Searching.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Searching.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
-using System.Numerics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Internal.Runtime.CompilerServices;
 
@@ -14,7 +12,14 @@ namespace System
     {
         public bool Contains(string value)
         {
-            return (IndexOf(value, StringComparison.Ordinal) >= 0);
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+
+            return SpanHelpers.IndexOf(
+                ref _firstChar,
+                Length,
+                ref value._firstChar,
+                value.Length) >= 0;
         }
 
         public bool Contains(string value, StringComparison comparisonType)

--- a/src/System.Private.CoreLib/shared/System/String.Searching.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Searching.cs
@@ -13,7 +13,7 @@ namespace System
         public bool Contains(string value)
         {
             if (value == null)
-                throw new ArgumentNullException(nameof(value));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
 
             return SpanHelpers.IndexOf(
                 ref _firstChar,


### PR DESCRIPTION
Validate `value` is not null and go straight to `SpanHelpers.IndexOf` rather than

```
.Contains(string)
-> .IndexOf(string, StringComparison)
-> .IndexOf(string, int, int, StringComparison)

`value` is not null (as earlier)

Validate introduced values startIndex (`0`), count (`s.Length`) against `s.Length`
Check comparisonType == StringComparison.Ordinal

`SpanHelpers.IndexOf`
```

a nit 

/cc @jkotas