### PR TITLE
Remove ToString from RuntimeAssembly.GetManifestResourceStream

### DIFF
--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -210,7 +210,7 @@ namespace System.Reflection
 
             char c = Type.Delimiter;
             string resourceName = nameSpace != null && name != null ?
-                string.Concat(nameSpace, new Span<char>(ref c, 1), name) :
+                string.Concat(nameSpace, new ReadOnlySpan<char>(ref c, 1), name) :
                 string.Concat(nameSpace, name);
 
             return GetManifestResourceStream(resourceName);

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -207,8 +207,11 @@ namespace System.Reflection
                 throw new ArgumentNullException(nameof(type));
 
             string nameSpace = type?.Namespace;
-            string delimiter = (nameSpace != null && name != null) ? Type.Delimiter.ToString() : null;
-            string resourceName = string.Concat(nameSpace, delimiter, name);
+
+            char c = Type.Delimiter;
+            string resourceName = nameSpace != null && name != null ?
+                string.Concat(nameSpace, new Span<char>(ref c, 1), name) :
+                string.Concat(nameSpace, name);
 
             return GetManifestResourceStream(resourceName);
         }

--- a/src/System.Private.CoreLib/src/System/Resources/ManifestBasedResourceGroveler.cs
+++ b/src/System.Private.CoreLib/src/System/Resources/ManifestBasedResourceGroveler.cs
@@ -330,8 +330,11 @@ namespace System.Resources
             Debug.Assert(name != null, "name shouldn't be null; check caller");
 
             string nameSpace = _mediator.LocationInfo?.Namespace;
-            string delimiter = (nameSpace != null && name != null) ? Type.Delimiter.ToString() : null;
-            string resourceName = string.Concat(nameSpace, delimiter, name);
+
+            char c = Type.Delimiter;
+            string resourceName = nameSpace != null && name != null ?
+                string.Concat(nameSpace, new ReadOnlySpan<char>(ref c, 1), name) :
+                string.Concat(nameSpace, name);
 
             string canonicalName = null;
             foreach (string existingName in satellite.GetManifestResourceNames())


### PR DESCRIPTION
A small allocation we can avoid with the span-based string.Concat.