### PR TITLE
Fix ARM64 GS with localloc

### DIFF
--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -279,10 +279,6 @@ protected:
 
     void genEpilogRestoreReg(regNumber reg1, int spOffset, int spDelta, regNumber tmpReg, bool* pTmpRegIsZero);
 
-#ifdef DEBUG
-    static void genCheckSPOffset(bool isRegsCountOdd, int spOffset, int slotSize);
-#endif // DEBUG
-
     // A simple struct to keep register pairs for prolog and epilog.
     struct RegPair
     {
@@ -305,12 +301,8 @@ protected:
 
     static int genGetSlotSizeForRegsInMask(regMaskTP regsMask);
 
-    void genSaveCalleeSavedRegisterGroup(regMaskTP regsMask,
-                                         int       spDelta,
-                                         int spOffset DEBUGARG(bool isRegsToSaveCountOdd));
-    void genRestoreCalleeSavedRegisterGroup(regMaskTP regsMask,
-                                            int       spDelta,
-                                            int spOffset DEBUGARG(bool isRegsToRestoreCountOdd));
+    void genSaveCalleeSavedRegisterGroup(regMaskTP regsMask, int spDelta, int spOffset);
+    void genRestoreCalleeSavedRegisterGroup(regMaskTP regsMask, int spDelta, int spOffset);
 
     void genSaveCalleeSavedRegistersHelp(regMaskTP regsToSaveMask, int lowestCalleeSavedOffset, int spDelta);
     void genRestoreCalleeSavedRegistersHelp(regMaskTP regsToRestoreMask, int lowestCalleeSavedOffset, int spDelta);
@@ -514,6 +506,12 @@ protected:
 #if defined(DEBUG) && defined(LATE_DISASM) && defined(_TARGET_AMD64_)
     void genAmd64EmitterUnitTests();
 #endif
+
+#ifdef _TARGET_ARM64_
+    virtual void SetSaveFpLrWithAllCalleeSavedRegisters(bool value);
+    virtual bool IsSaveFpLrWithAllCalleeSavedRegisters();
+    bool         genSaveFpLrWithAllCalleeSavedRegisters;
+#endif // _TARGET_ARM64_
 
     //-------------------------------------------------------------------------
     //

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -176,6 +176,11 @@ public:
     int genSPtoFPdelta();
     int genTotalFrameSize();
 
+#ifdef _TARGET_ARM64_
+    virtual void SetSaveFpLrWithAllCalleeSavedRegisters(bool value) = 0;
+    virtual bool IsSaveFpLrWithAllCalleeSavedRegisters()            = 0;
+#endif // _TARGET_ARM64_
+
     regNumber genGetThisArgReg(GenTreeCall* call) const;
 
 #ifdef _TARGET_XARCH_

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -8486,6 +8486,12 @@ public:
         bool compTailCallLoopOpt;
 #endif
 
+#if defined(_TARGET_ARM64_)
+        // Decision about whether to save FP/LR registers with callee-saved registers (see
+        // COMPlus_JitSaveFpLrWithCalleSavedRegisters).
+        int compJitSaveFpLrWithCalleeSavedRegisters;
+#endif // defined(_TARGET_ARM64_)
+
 #ifdef ARM_SOFTFP
         static const bool compUseSoftFP = true;
 #else // !ARM_SOFTFP
@@ -8503,6 +8509,9 @@ public:
 #ifdef DEBUG
     static bool                s_pJitDisasmIncludeAssembliesListInitialized;
     static AssemblyNamesList2* s_pJitDisasmIncludeAssembliesList;
+
+    static bool       s_pJitFunctionFileInitialized;
+    static MethodSet* s_pJitMethodSet;
 #endif // DEBUG
 
 #ifdef DEBUG

--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -371,6 +371,37 @@ CONFIG_INTEGER(JitGuardedDevirtualizationGuessUniqueInterface, W("JitGuardedDevi
 CONFIG_INTEGER(JitGuardedDevirtualizationGuessBestClass, W("JitGuardedDevirtualizationGuessBestClass"), 1)
 #endif // DEBUG
 
+#if defined(DEBUG)
+// JitFunctionFile: Name of a file that contains a list of functions. If the currently compiled function is in the
+// file, certain other JIT config variables will be active. If the currently compiled function is not in the file,
+// the specific JIT config variables will not be active.
+//
+// Functions are approximately in the format output by JitFunctionTrace, e.g.:
+//
+// System.CLRConfig:GetBoolValue(ref,byref):bool (MethodHash=3c54d35e)
+//   -- use the MethodHash, not the function name
+//
+// System.CLRConfig:GetBoolValue(ref,byref):bool
+//   -- use just the name
+//
+// Lines with leading ";" "#" or "//" are ignored.
+//
+// If this is unset, then the JIT config values have their normal behavior.
+//
+CONFIG_STRING(JitFunctionFile, W("JitFunctionFile"))
+#endif // DEBUG
+
+#if defined(DEBUG)
+#if defined(_TARGET_ARM64_)
+// JitSaveFpLrWithCalleeSavedRegisters:
+//    0: use default frame type decision
+//    1: disable frames that save FP/LR registers with the callee-saved registers (at the top of the frame)
+//    2: force all frames to use the frame types that save FP/LR registers with the callee-saved registers (at the top
+//    of the frame)
+CONFIG_INTEGER(JitSaveFpLrWithCalleeSavedRegisters, W("JitSaveFpLrWithCalleeSavedRegisters"), 0)
+#endif // defined(_TARGET_ARM64_)
+#endif // DEBUG
+
 #undef CONFIG_INTEGER
 #undef CONFIG_STRING
 #undef CONFIG_METHODSET

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -4319,28 +4319,28 @@ unsigned Compiler::lvaGetMaxSpillTempSize()
  *
  *  The frame is laid out as follows for x86:
  *
- *              ESP frames                
+ *              ESP frames
  *
- *      |                       |         
- *      |-----------------------|         
- *      |       incoming        |         
- *      |       arguments       |         
- *      |-----------------------| <---- Virtual '0'         
- *      |    return address     |         
+ *      |                       |
+ *      |-----------------------|
+ *      |       incoming        |
+ *      |       arguments       |
+ *      |-----------------------| <---- Virtual '0'
+ *      |    return address     |
  *      +=======================+
- *      |Callee saved registers |         
- *      |-----------------------|         
- *      |       Temps           |         
- *      |-----------------------|         
- *      |       Variables       |         
+ *      |Callee saved registers |
+ *      |-----------------------|
+ *      |       Temps           |
+ *      |-----------------------|
+ *      |       Variables       |
  *      |-----------------------| <---- Ambient ESP
- *      |   Arguments for the   |         
- *      ~    next function      ~ 
- *      |                       |         
- *      |       |               |         
- *      |       | Stack grows   |         
- *              | downward                
- *              V                         
+ *      |   Arguments for the   |
+ *      ~    next function      ~
+ *      |                       |
+ *      |       |               |
+ *      |       | Stack grows   |
+ *              | downward
+ *              V
  *
  *
  *              EBP frames
@@ -4349,13 +4349,13 @@ unsigned Compiler::lvaGetMaxSpillTempSize()
  *      |-----------------------|
  *      |       incoming        |
  *      |       arguments       |
- *      |-----------------------| <---- Virtual '0'         
- *      |    return address     |         
+ *      |-----------------------| <---- Virtual '0'
+ *      |    return address     |
  *      +=======================+
  *      |    incoming EBP       |
  *      |-----------------------| <---- EBP
- *      |Callee saved registers |         
- *      |-----------------------|         
+ *      |Callee saved registers |
+ *      |-----------------------|
  *      |   security object     |
  *      |-----------------------|
  *      |     ParamTypeArg      |
@@ -4385,39 +4385,39 @@ unsigned Compiler::lvaGetMaxSpillTempSize()
  *
  *  The frame is laid out as follows for x64:
  *
- *              RSP frames                
- *      |                       |         
- *      |-----------------------|         
- *      |       incoming        |         
- *      |       arguments       |         
- *      |-----------------------|         
- *      |   4 fixed incoming    |         
- *      |    argument slots     |         
+ *              RSP frames
+ *      |                       |
+ *      |-----------------------|
+ *      |       incoming        |
+ *      |       arguments       |
+ *      |-----------------------|
+ *      |   4 fixed incoming    |
+ *      |    argument slots     |
  *      |-----------------------| <---- Caller's SP & Virtual '0'
- *      |    return address     |         
+ *      |    return address     |
  *      +=======================+
- *      | Callee saved Int regs |  
+ *      | Callee saved Int regs |
  *      -------------------------
  *      |        Padding        | <---- this padding (0 or 8 bytes) is to ensure flt registers are saved at a mem location aligned at 16-bytes
  *      |                       |       so that we can save 128-bit callee saved xmm regs using performant "movaps" instruction instead of "movups"
  *      -------------------------
  *      | Callee saved Flt regs | <----- entire 128-bits of callee saved xmm registers are stored here
- *      |-----------------------|         
- *      |         Temps         |         
- *      |-----------------------|         
- *      |       Variables       |         
  *      |-----------------------|
- *      |   Arguments for the   |         
- *      ~    next function      ~ 
- *      |                       |         
- *      |-----------------------|         
- *      |   4 fixed outgoing    |         
- *      |    argument slots     |         
+ *      |         Temps         |
+ *      |-----------------------|
+ *      |       Variables       |
+ *      |-----------------------|
+ *      |   Arguments for the   |
+ *      ~    next function      ~
+ *      |                       |
+ *      |-----------------------|
+ *      |   4 fixed outgoing    |
+ *      |    argument slots     |
  *      |-----------------------| <---- Ambient RSP
- *      |       |               |         
- *      ~       | Stack grows   ~         
- *      |       | downward      |         
- *              V                         
+ *      |       |               |
+ *      ~       | Stack grows   ~
+ *      |       | downward      |
+ *              V
  *
  *
  *              RBP frames
@@ -4425,30 +4425,30 @@ unsigned Compiler::lvaGetMaxSpillTempSize()
  *      |-----------------------|
  *      |       incoming        |
  *      |       arguments       |
- *      |-----------------------|         
- *      |   4 fixed incoming    |         
- *      |    argument slots     |         
+ *      |-----------------------|
+ *      |   4 fixed incoming    |
+ *      |    argument slots     |
  *      |-----------------------| <---- Caller's SP & Virtual '0'
- *      |    return address     |         
+ *      |    return address     |
  *      +=======================+
- *      | Callee saved Int regs |         
+ *      | Callee saved Int regs |
  *      -------------------------
- *      |        Padding        | 
+ *      |        Padding        |
  *      -------------------------
- *      | Callee saved Flt regs | 
- *      |-----------------------|         
+ *      | Callee saved Flt regs |
+ *      |-----------------------|
  *      |   security object     |
  *      |-----------------------|
  *      |     ParamTypeArg      |
  *      |-----------------------|
  *      |                       |
- *      |                       | 
+ *      |                       |
  *      ~       Variables       ~
- *      |                       | 
+ *      |                       |
  *      |                       |
  *      |-----------------------|
  *      |        Temps          |
- *      |-----------------------| 
+ *      |-----------------------|
  *      |                       |
  *      ~       localloc        ~   // not in frames with EH
  *      |                       |
@@ -4456,31 +4456,31 @@ unsigned Compiler::lvaGetMaxSpillTempSize()
  *      |        PSPSym         |   // only in frames with EH (thus no localloc)
  *      |                       |
  *      |-----------------------| <---- RBP in localloc frames (max 240 bytes from Initial-SP)
- *      |   Arguments for the   |         
- *      ~    next function      ~ 
- *      |                       |         
- *      |-----------------------| 
- *      |   4 fixed outgoing    |         
- *      |    argument slots     |         
+ *      |   Arguments for the   |
+ *      ~    next function      ~
+ *      |                       |
+ *      |-----------------------|
+ *      |   4 fixed outgoing    |
+ *      |    argument slots     |
  *      |-----------------------| <---- Ambient RSP (before localloc, this is Initial-SP)
- *      |       |               |         
- *      ~       | Stack grows   ~         
- *      |       | downward      |         
+ *      |       |               |
+ *      ~       | Stack grows   ~
+ *      |       | downward      |
  *              V
  *
  *
  *  The frame is laid out as follows for ARM (this is a general picture; details may differ for different conditions):
  *
- *              SP frames                
- *      |                       |         
- *      |-----------------------|         
- *      |       incoming        |         
- *      |       arguments       |         
+ *              SP frames
+ *      |                       |
+ *      |-----------------------|
+ *      |       incoming        |
+ *      |       arguments       |
  *      +=======================+ <---- Caller's SP
- *      |  Pre-spill registers  |         
+ *      |  Pre-spill registers  |
  *      |-----------------------| <---- Virtual '0'
- *      |Callee saved registers |         
- *      |-----------------------|         
+ *      |Callee saved registers |
+ *      |-----------------------|
  *      ~ possible double align ~
  *      |-----------------------|
  *      |   security object     |
@@ -4501,13 +4501,13 @@ unsigned Compiler::lvaGetMaxSpillTempSize()
  *      |-----------------------|
  *      ~ possible double align ~
  *      |-----------------------|
- *      |   Arguments for the   |         
- *      ~    next function      ~ 
- *      |                       |         
+ *      |   Arguments for the   |
+ *      ~    next function      ~
+ *      |                       |
  *      |-----------------------| <---- Ambient SP
- *      |       |               |         
- *      ~       | Stack grows   ~         
- *      |       | downward      |         
+ *      |       |               |
+ *      ~       | Stack grows   ~
+ *      |       | downward      |
  *              V
  *
  *
@@ -4517,10 +4517,10 @@ unsigned Compiler::lvaGetMaxSpillTempSize()
  *      |       incoming        |
  *      |       arguments       |
  *      +=======================+ <---- Caller's SP
- *      |  Pre-spill registers  |         
+ *      |  Pre-spill registers  |
  *      |-----------------------| <---- Virtual '0'
- *      |Callee saved registers |         
- *      |-----------------------|         
+ *      |Callee saved registers |
+ *      |-----------------------|
  *      |        PSPSym         |   // Only for frames with EH, which means FP-based frames
  *      |-----------------------|
  *      ~ possible double align ~
@@ -4545,13 +4545,13 @@ unsigned Compiler::lvaGetMaxSpillTempSize()
  *      |-----------------------|
  *      |       localloc        |
  *      |-----------------------|
- *      |   Arguments for the   |         
- *      ~    next function      ~ 
- *      |                       |         
+ *      |   Arguments for the   |
+ *      ~    next function      ~
+ *      |                       |
  *      |-----------------------| <---- Ambient SP
- *      |       |               |         
- *      ~       | Stack grows   ~         
- *      |       | downward      |         
+ *      |       |               |
+ *      ~       | Stack grows   ~
+ *      |       | downward      |
  *              V
  *
  *
@@ -4560,17 +4560,17 @@ unsigned Compiler::lvaGetMaxSpillTempSize()
  *  NOTE: SP must be 16-byte aligned, so there may be alignment slots in the frame.
  *  We will often save and establish a frame pointer to create better ETW stack walks.
  *
- *              SP frames                
- *      |                       |         
- *      |-----------------------|         
- *      |       incoming        |         
- *      |       arguments       |         
+ *              SP frames
+ *      |                       |
+ *      |-----------------------|
+ *      |       incoming        |
+ *      |       arguments       |
  *      +=======================+ <---- Caller's SP
  *      |         homed         | // this is only needed if reg argument need to be homed, e.g., for varargs
- *      |   register arguments  |         
+ *      |   register arguments  |
  *      |-----------------------| <---- Virtual '0'
  *      |Callee saved registers |
- *      |   except fp/lr        |         
+ *      |   except fp/lr        |
  *      |-----------------------|
  *      |   security object     |
  *      |-----------------------|
@@ -4591,13 +4591,13 @@ unsigned Compiler::lvaGetMaxSpillTempSize()
  *      |      Saved LR         |
  *      |-----------------------|
  *      |      Saved FP         | <---- Frame pointer
- *      |-----------------------|         
+ *      |-----------------------|
  *      |  Stack arguments for  |
  *      |   the next function   |
  *      |-----------------------| <---- SP
- *      |       |               |         
- *      ~       | Stack grows   ~         
- *      |       | downward      |         
+ *      |       |               |
+ *      ~       | Stack grows   ~
+ *      |       | downward      |
  *              V
  *
  *
@@ -4608,10 +4608,10 @@ unsigned Compiler::lvaGetMaxSpillTempSize()
  *      |       arguments       |
  *      +=======================+ <---- Caller's SP
  *      |     optional homed    | // this is only needed if reg argument need to be homed, e.g., for varargs
- *      |   register arguments  |         
- *      |-----------------------| <---- Virtual '0'         
+ *      |   register arguments  |
+ *      |-----------------------| <---- Virtual '0'
  *      |Callee saved registers |
- *      |   except fp/lr        |         
+ *      |   except fp/lr        |
  *      |-----------------------|
  *      |        PSPSym         | // Only for frames with EH, which requires FP-based frames
  *      |-----------------------|
@@ -4640,9 +4640,53 @@ unsigned Compiler::lvaGetMaxSpillTempSize()
  *      |  Stack arguments for  |
  *      |   the next function   |
  *      |-----------------------| <---- Ambient SP
- *      |       |               |         
- *      ~       | Stack grows   ~         
- *      |       | downward      |         
+ *      |       |               |
+ *      ~       | Stack grows   ~
+ *      |       | downward      |
+ *              V
+ *
+ *
+ *              FP (R29 / x29) frames where FP/LR are stored at the top of the frame (frames requiring GS that have localloc)
+ *      |                       |
+ *      |-----------------------|
+ *      |       incoming        |
+ *      |       arguments       |
+ *      +=======================+ <---- Caller's SP
+ *      |     optional homed    | // this is only needed if reg argument need to be homed, e.g., for varargs
+ *      |   register arguments  |
+ *      |-----------------------| <---- Virtual '0'
+ *      |      Saved LR         |
+ *      |-----------------------|
+ *      |      Saved FP         | <---- Frame pointer
+ *      |-----------------------|
+ *      |Callee saved registers |
+ *      |-----------------------|
+ *      |        PSPSym         | // Only for frames with EH, which requires FP-based frames
+ *      |-----------------------|
+ *      |   security object     |
+ *      |-----------------------|
+ *      |     ParamTypeArg      |
+ *      |-----------------------|
+ *      |  possible GS cookie   |
+ *      |-----------------------|
+ *      |       Variables       |
+ *      |-----------------------|
+ *      |  possible GS cookie   |
+ *      |-----------------------|
+ *      |        Temps          |
+ *      |-----------------------|
+ *      |   Stub Argument Var   |
+ *      |-----------------------|
+ *      |Inlined PInvoke Frame V|
+ *      |-----------------------|
+ *      ~       localloc        ~
+ *      |-----------------------|
+ *      |  Stack arguments for  |
+ *      |   the next function   |
+ *      |-----------------------| <---- Ambient SP
+ *      |       |               |
+ *      ~       | Stack grows   ~
+ *      |       | downward      |
  *              V
  *
  *
@@ -5576,6 +5620,30 @@ void Compiler::lvaAssignVirtualFrameOffsetsToLocals()
         codeGen->setFramePointerUsed(codeGen->isFramePointerRequired());
     }
 
+#ifdef _TARGET_ARM64_
+    // Decide where to save FP and LR registers. We store FP/LR registers at the bottom of the frame if there is
+    // a frame pointer used (so we get positive offsets from the frame pointer to access locals), but not if we
+    // need a GS cookie AND localloc is used, since we need the GS cookie to protect the saved return value,
+    // and also the saved frame pointer. See CodeGen::genPushCalleeSavedRegisters() for more details about the
+    // frame types. Since saving FP/LR at high addresses is a relatively rare case, force using it during stress.
+    // (It should be legal to use these frame types for every frame).
+
+    if (opts.compJitSaveFpLrWithCalleeSavedRegisters == 0)
+    {
+        // Default configuration
+        codeGen->SetSaveFpLrWithAllCalleeSavedRegisters((getNeedsGSSecurityCookie() && compLocallocUsed) ||
+                                                        compStressCompile(STRESS_GENERIC_VARN, 20));
+    }
+    else if (opts.compJitSaveFpLrWithCalleeSavedRegisters == 1)
+    {
+        codeGen->SetSaveFpLrWithAllCalleeSavedRegisters(false); // Disable using new frames
+    }
+    else if (opts.compJitSaveFpLrWithCalleeSavedRegisters == 2)
+    {
+        codeGen->SetSaveFpLrWithAllCalleeSavedRegisters(true); // Force using new frames
+    }
+#endif // _TARGET_ARM64_
+
 #ifdef _TARGET_XARCH_
     // On x86/amd64, the return address has already been pushed by the call instruction in the caller.
     stkOffs -= TARGET_POINTER_SIZE; // return address;
@@ -5618,15 +5686,16 @@ void Compiler::lvaAssignVirtualFrameOffsetsToLocals()
         stkOffs -= initialStkOffs;
     }
 
-    if (isFramePointerUsed())
+    if (codeGen->IsSaveFpLrWithAllCalleeSavedRegisters() ||
+        !isFramePointerUsed()) // Note that currently we always have a frame pointer
+    {
+        stkOffs -= compCalleeRegsPushed * REGSIZE_BYTES;
+    }
+    else
     {
         // Subtract off FP and LR.
         assert(compCalleeRegsPushed >= 2);
         stkOffs -= (compCalleeRegsPushed - 2) * REGSIZE_BYTES;
-    }
-    else
-    {
-        stkOffs -= compCalleeRegsPushed * REGSIZE_BYTES;
     }
 
 #else  // !_TARGET_ARM64_
@@ -6207,7 +6276,8 @@ void Compiler::lvaAssignVirtualFrameOffsetsToLocals()
 #endif // FEATURE_EH_FUNCLETS && defined(_TARGET_AMD64_)
 
 #ifdef _TARGET_ARM64_
-    if (isFramePointerUsed())
+    if (!codeGen->IsSaveFpLrWithAllCalleeSavedRegisters() &&
+        isFramePointerUsed()) // Note that currently we always have a frame pointer
     {
         // Create space for saving FP and LR.
         stkOffs -= 2 * REGSIZE_BYTES;

--- a/src/jit/utils.cpp
+++ b/src/jit/utils.cpp
@@ -1557,6 +1557,194 @@ bool AssemblyNamesList2::IsInList(const char* assemblyName)
     return false;
 }
 
+//=============================================================================
+// MethodSet
+//=============================================================================
+
+MethodSet::MethodSet(const wchar_t* filename, HostAllocator alloc) : m_pInfos(nullptr), m_alloc(alloc)
+{
+    FILE* methodSetFile = _wfopen(filename, W("r"));
+    if (methodSetFile == nullptr)
+    {
+        return;
+    }
+
+    MethodInfo* lastInfo = m_pInfos;
+    char        buffer[1024];
+
+    while (true)
+    {
+        // Get next line
+        if (fgets(buffer, sizeof(buffer), methodSetFile) == nullptr)
+        {
+            break;
+        }
+
+        // Ignore lines starting with leading ";" "#" "//".
+        if ((0 == _strnicmp(buffer, ";", 1)) || (0 == _strnicmp(buffer, "#", 1)) || (0 == _strnicmp(buffer, "//", 2)))
+        {
+            continue;
+        }
+
+        // Remove trailing newline, if any.
+        char* p = strpbrk(buffer, "\r\n");
+        if (p != nullptr)
+        {
+            *p = '\0';
+        }
+
+        char*    methodName;
+        unsigned methodHash = 0;
+
+        // Parse the line. Very simple. One of:
+        //
+        //    <method-name>
+        //    <method-name><whitespace>(MethodHash=<hash>)
+
+        const char methodHashPattern[] = " (MethodHash=";
+        p                              = strstr(buffer, methodHashPattern);
+        if (p == nullptr)
+        {
+            // Just use it without the hash.
+            methodName = _strdup(buffer);
+        }
+        else
+        {
+            // There's a method hash; use that.
+
+            // First, get the method name.
+            char* p2 = p;
+            *p       = '\0';
+
+            // Null terminate method at first whitespace. (Don't have any leading whitespace!)
+            p = strpbrk(buffer, " \t");
+            if (p != nullptr)
+            {
+                *p = '\0';
+            }
+            methodName = _strdup(buffer);
+
+            // Now get the method hash.
+            p2 += strlen(methodHashPattern);
+            char* p3 = strchr(p2, ')');
+            if (p3 == nullptr)
+            {
+                // Malformed line: no trailing slash.
+                JITDUMP("Couldn't parse: %s\n", p2);
+                // We can still just use the method name.
+            }
+            else
+            {
+                // Convert the slash to null.
+                *p3 = '\0';
+
+                // Now parse it as hex.
+                int count = sscanf_s(p2, "%x", &methodHash);
+                if (count != 1)
+                {
+                    JITDUMP("Couldn't parse: %s\n", p2);
+                    // Still, use the method name.
+                }
+            }
+        }
+
+        MethodInfo* newInfo = new (m_alloc) MethodInfo(methodName, methodHash);
+        if (m_pInfos == nullptr)
+        {
+            m_pInfos = lastInfo = newInfo;
+        }
+        else
+        {
+            lastInfo->m_next = newInfo;
+            lastInfo         = newInfo;
+        }
+    }
+
+    if (m_pInfos == nullptr)
+    {
+        JITDUMP("No methods read from %ws\n", filename);
+    }
+    else
+    {
+        JITDUMP("Methods read from %ws:\n", filename);
+
+        int methodCount = 0;
+        for (MethodInfo* pInfo = m_pInfos; pInfo != nullptr; pInfo = pInfo->m_next)
+        {
+            JITDUMP("  %s (MethodHash: %x)\n", pInfo->m_MethodName, pInfo->m_MethodHash);
+            ++methodCount;
+        }
+
+        if (methodCount > 100)
+        {
+            JITDUMP("Warning: high method count (%d) for MethodSet with linear search lookups might be slow\n",
+                    methodCount);
+        }
+    }
+}
+
+MethodSet::~MethodSet()
+{
+    for (MethodInfo* pInfo = m_pInfos; pInfo != nullptr; /**/)
+    {
+        MethodInfo* cur = pInfo;
+        pInfo           = pInfo->m_next;
+
+        m_alloc.deallocate(cur->m_MethodName);
+        m_alloc.deallocate(cur);
+    }
+}
+
+// TODO: make this more like JitConfigValues::MethodSet::contains()?
+bool MethodSet::IsInSet(const char* methodName)
+{
+    for (MethodInfo* pInfo = m_pInfos; pInfo != nullptr; pInfo = pInfo->m_next)
+    {
+        if (_stricmp(pInfo->m_MethodName, methodName) == 0)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool MethodSet::IsInSet(int methodHash)
+{
+    for (MethodInfo* pInfo = m_pInfos; pInfo != nullptr; pInfo = pInfo->m_next)
+    {
+        if (pInfo->m_MethodHash == methodHash)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool MethodSet::IsActiveMethod(const char* methodName, int methodHash)
+{
+    if (methodHash != 0)
+    {
+        // Use the method hash.
+        if (IsInSet(methodHash))
+        {
+            JITDUMP("Method active in MethodSet (hash match): %s Hash: %x\n", methodName, methodHash);
+            return true;
+        }
+    }
+
+    // Else, fall back and use the method name.
+    assert(methodName != nullptr);
+    if (IsInSet(methodName))
+    {
+        JITDUMP("Method active in MethodSet (name match): %s Hash: %x\n", methodName, methodHash);
+        return true;
+    }
+
+    return false;
+}
+
 #ifdef FEATURE_JIT_METHOD_PERF
 CycleCount::CycleCount() : cps(CycleTimer::CyclesPerSecond())
 {


### PR DESCRIPTION
Currently, all frame types place saved FP/LR (frame pointer / return address)
at low addresses on the frame, below the GS cookie. If a function has localloc,
the dynamically allocated and unsafe buffer will be lower than the saved FP/LR and
the GS cookie won't properly protect the saved FP/LR.

This change introduces new frame types, used only for functions needing
a GS cookie and using localloc, saving FP/LR along with the rest of
the callee-saved registers at the top (highest addresses) of the frame,
above the GS cookie.

There is a new `COMPlus_JitSaveFpLrWithCalleeSavedRegisters` to allow forcing using the new frame types, or preventing using them. By default, only the frames that actually need them will get them.
In addition, there is a new `COMPlus_JitFunctionFile` variable. It takes the name/path of a file
that contains a list of the functions for which certain other COMPlus variables should apply (currently, only `COMPlus_JitSaveFpLrWithCalleeSavedRegisters`). This allows for easy binary searching of
compiled functions with a particular setting applied.
