### PR TITLE
Use correct resolution scope when checking default implementations

### DIFF
--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -10787,6 +10787,8 @@ BOOL MethodTableBuilder::HasDefaultInterfaceImplementation(bmtRTType *pDeclType,
     {
         bmtRTType * pCurItf = bmtInterface->pInterfaceMap[i].GetInterfaceType();
 
+        Module * pCurIntfModule = pCurItf->GetMethodTable()->GetModule();
+
         // Go over the methods on the interface
         MethodTable::IntroducedMethodIterator methIt(pCurItf->GetMethodTable());
         for (; methIt.IsValid(); methIt.Next())
@@ -10810,11 +10812,11 @@ BOOL MethodTableBuilder::HasDefaultInterfaceImplementation(bmtRTType *pDeclType,
 
                 // Find out what interface this default implementation is implementing
                 mdToken tkParent;
-                IfFailThrow(GetModule()->GetMDImport()->GetParentToken(it.GetToken(), &tkParent));
+                IfFailThrow(pCurIntfModule->GetMDImport()->GetParentToken(it.GetToken(), &tkParent));
 
                 // We can only load the approximate interface at this point
                 MethodTable * pPotentialInterfaceMT = ClassLoader::LoadTypeDefOrRefOrSpecThrowing(
-                    GetModule(),
+                    pCurIntfModule,
                     tkParent,
                     &bmtGenerics->typeContext,
                     ClassLoader::ThrowIfNotFound,
@@ -10831,7 +10833,7 @@ BOOL MethodTableBuilder::HasDefaultInterfaceImplementation(bmtRTType *pDeclType,
                         return TRUE;
 
                     // If this is generic, we need to compare under substitutions
-                    Substitution curItfSubs(tkParent, GetModule(), &pCurItf->GetSubstitution());
+                    Substitution curItfSubs(tkParent, pCurIntfModule, &pCurItf->GetSubstitution());
 
                     // Type Equivalence is not respected for this comparision as you can have multiple type equivalent interfaces on a class
                     TokenPairList newVisited = TokenPairList::AdjustForTypeEquivalenceForbiddenScope(NULL);

--- a/tests/src/Regressions/coreclr/22021/consumer.il
+++ b/tests/src/Regressions/coreclr/22021/consumer.il
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern System.Runtime { }
+
+.assembly extern provider { }
+
+.assembly consumer { }
+
+.class private auto ansi beforefieldinit Test1
+       extends [System.Runtime]System.Object
+       implements [provider]I1,
+                  [provider]I2,
+                  [provider]I4,
+                  class [provider]IGen2`1<class [System.Runtime]System.ValueType>,
+                  class [provider]IGen2`1<class [System.Runtime]System.Object>,
+                  class [provider]IGen1`1<class [System.Runtime]System.Object>
+{
+  .method private hidebysig static int32 Main()
+  {
+    .entrypoint
+    .locals init (class Test1)
+    newobj instance void Test1::.ctor()
+    stloc.0
+
+    ldloc.0
+    callvirt   instance int32 [provider]I2::M1()
+    ldloc.0
+    callvirt   instance int32 [provider]I4::M1()
+    add
+
+    ldloc.0
+    callvirt   instance int32 class [provider]IGen2`1<class [System.Runtime]System.ValueType>::M1()
+    ldloc.0
+    callvirt   instance int32 class [provider]IGen2`1<class [System.Runtime]System.Object>::M1()
+    add
+
+    add
+
+    ldc.i4 90
+    add
+
+    ret
+  }
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    ldarg.0
+    call instance void [System.Runtime]System.Object::.ctor()
+    ret
+  }
+}

--- a/tests/src/Regressions/coreclr/22021/consumer.ilproj
+++ b/tests/src/Regressions/coreclr/22021/consumer.ilproj
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{85DFC527-4DB1-595E-A7D7-E94EE1F8140D}</ProjectGuid>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="consumer.il" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="provider.ilproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/tests/src/Regressions/coreclr/22021/provider.il
+++ b/tests/src/Regressions/coreclr/22021/provider.il
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern System.Runtime { }
+
+.assembly provider { }
+
+.class interface public abstract auto ansi I2
+{
+  .method public hidebysig newslot abstract virtual instance int32 M1()
+  {
+  }
+}
+
+.class interface public abstract auto ansi I4
+{
+  .method public hidebysig newslot abstract virtual instance int32 M1()
+  {
+  }
+}
+
+.class interface public abstract auto ansi I1
+       implements I2,
+                  I4
+{
+  .method private hidebysig virtual final instance int32 I2.M1()
+  {
+    .override I2::M1
+    ldc.i4.1
+    ret
+  }
+
+  .method private hidebysig virtual final instance int32 I4.M1()
+  {
+    .override I4::M1
+    ldc.i4.2
+    ret
+  }
+}
+
+.class interface public abstract auto ansi IGen2`1<T>
+{
+  .method public hidebysig newslot abstract virtual instance int32 M1()
+  {
+  }
+}
+
+.class interface public abstract auto ansi IGen1`1<T>
+       implements class IGen2`1<class [System.Runtime]System.ValueType>,
+                  class IGen2`1<!T>
+{
+  .method private hidebysig virtual final instance int32 Foo()
+  {
+    .override class IGen2`1<class [System.Runtime]System.ValueType>::M1
+    ldc.i4.3
+    ret
+  }
+
+  .method private hidebysig virtual final instance int32 Bar()
+  {
+    .override class IGen2`1<!T>::M1
+    ldc.i4.4
+    ret
+  }
+}

--- a/tests/src/Regressions/coreclr/22021/provider.ilproj
+++ b/tests/src/Regressions/coreclr/22021/provider.ilproj
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="provider.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
We need to use the module of the interface.

Fixes #22021.