### PR TITLE
Clean up a few minor Span-related uses

### DIFF
--- a/src/System.Private.CoreLib/shared/System/IO/FileStream.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileStream.Unix.cs
@@ -597,13 +597,13 @@ namespace System.IO
                 int spaceRemaining = _bufferLength - _writePos;
                 if (spaceRemaining >= source.Length)
                 {
-                    source.CopyTo(new Span<byte>(GetBuffer()).Slice(_writePos));
+                    source.CopyTo(GetBuffer().AsSpan(_writePos));
                     _writePos += source.Length;
                     return;
                 }
                 else if (spaceRemaining > 0)
                 {
-                    source.Slice(0, spaceRemaining).CopyTo(new Span<byte>(GetBuffer()).Slice(_writePos));
+                    source.Slice(0, spaceRemaining).CopyTo(GetBuffer().AsSpan(_writePos));
                     _writePos += spaceRemaining;
                     source = source.Slice(spaceRemaining);
                 }

--- a/src/System.Private.CoreLib/shared/System/IO/FileStream.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileStream.Windows.cs
@@ -661,13 +661,13 @@ namespace System.IO
                 {
                     if (numBytes >= source.Length)
                     {
-                        source.CopyTo(new Span<byte>(GetBuffer()).Slice(_writePos));
+                        source.CopyTo(GetBuffer().AsSpan(_writePos));
                         _writePos += source.Length;
                         return;
                     }
                     else
                     {
-                        source.Slice(0, numBytes).CopyTo(new Span<byte>(GetBuffer()).Slice(_writePos));
+                        source.Slice(0, numBytes).CopyTo(GetBuffer().AsSpan(_writePos));
                         _writePos += numBytes;
                         source = source.Slice(numBytes);
                     }
@@ -692,7 +692,7 @@ namespace System.IO
             }
 
             // Copy remaining bytes into buffer, to write at a later date.
-            source.CopyTo(new Span<byte>(GetBuffer()).Slice(_writePos));
+            source.CopyTo(GetBuffer().AsSpan(_writePos));
             _writePos = source.Length;
             return;
         }

--- a/src/System.Private.CoreLib/shared/System/IO/UnmanagedMemoryStream.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/UnmanagedMemoryStream.cs
@@ -656,7 +656,7 @@ namespace System.IO
             if (buffer.Length - offset < count)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
 
-            WriteCore(new Span<byte>(buffer, offset, count));
+            WriteCore(new ReadOnlySpan<byte>(buffer, offset, count));
         }
 
         public override void Write(ReadOnlySpan<byte> buffer)

--- a/src/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/System.Private.CoreLib/src/System/Enum.cs
@@ -269,7 +269,7 @@ namespace System
             const int SeparatorStringLength = 2; // ", "
             string result = string.FastAllocateString(checked(resultLength + (SeparatorStringLength * (foundItemsCount - 1))));
 
-            Span<char> resultSpan = MemoryMarshal.CreateSpan(ref result.GetRawStringData(), result.Length);
+            Span<char> resultSpan = new Span<char>(ref result.GetRawStringData(), result.Length);
             string name = names[foundItems[--foundItemsCount]];
             name.AsSpan().CopyTo(resultSpan);
             resultSpan = resultSpan.Slice(name.Length);

--- a/src/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -45,7 +45,7 @@ namespace System.StubHelpers
 
         internal static char ConvertToManaged(byte nativeChar)
         {
-            Span<byte> bytes = new Span<byte>(ref nativeChar, 1);
+            var bytes = new ReadOnlySpan<byte>(ref nativeChar, 1);
             string str = Encoding.Default.GetString(bytes);
             return str[0];
         }
@@ -204,7 +204,7 @@ namespace System.StubHelpers
 
             byte* pBytes = (byte*)pNative;
             int nbBytes = string.strlen(pBytes);
-            sb.ReplaceBufferUtf8Internal(new Span<byte>(pBytes, nbBytes));
+            sb.ReplaceBufferUtf8Internal(new ReadOnlySpan<byte>(pBytes, nbBytes));
         }
     }
 

--- a/src/System.Private.CoreLib/src/System/Text/StringBuilder.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Text/StringBuilder.CoreCLR.cs
@@ -38,7 +38,7 @@ namespace System.Text
             m_ChunkOffset = 0;
         }
 
-        internal void ReplaceBufferUtf8Internal(Span<byte> source)
+        internal void ReplaceBufferUtf8Internal(ReadOnlySpan<byte> source)
         {
             if (source.Length > m_MaxCapacity)
                 throw new ArgumentOutOfRangeException("capacity", SR.ArgumentOutOfRange_Capacity);


### PR DESCRIPTION
Some unnecessary Span to ReadOnlySpan casts.
Some places where new Span(...).Slice(...) can be replaced with AsSpan(...).
Etc.

cc: @jkotas
Related to https://github.com/dotnet/corefx/pull/34646