### PR TITLE
Unblock Azure DevOps-as-CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,7 +126,7 @@ jobs:
       jobParameters:
         priority: 0
         scenarios: 'normal,no_tiered_compilation'
-        timeoutInMinutes: 120
+        timeoutInMinutes: 240
 
 # Pri1 (CI)
 - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
@@ -137,7 +137,7 @@ jobs:
       jobParameters:
         priority: 1
         scenarios: 'normal,no_tiered_compilation'
-        timeoutInMinutes: 240
+        timeoutInMinutes: 360
 
 # Pri1 crossgen (CI)
 - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
@@ -149,7 +149,7 @@ jobs:
         priority: 1
         crossgen: true
         scenarios: 'normal,no_tiered_compilation'
-        timeoutInMinutes: 240
+        timeoutInMinutes: 360
 
 # Pri1 (Manual)
 - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'Manual')) }}:
@@ -160,7 +160,7 @@ jobs:
       jobParameters:
         priority: 1
         scenarios: 'normal,no_tiered_compilation,jitstress1,jitstress2,jitstress1_tiered,jitstress2_tiered'
-        timeoutInMinutes: 300
+        timeoutInMinutes: 480
 
 #
 # Release test builds (Official Build)
@@ -174,8 +174,8 @@ jobs:
       buildConfig: release
       jobParameters:
         priority: 1
-        timeoutInMinutes: 240
         scenarios: 'normal,no_tiered_compilation'
+        timeoutInMinutes: 360
 
 # Pri1 crossgen (Official Build)
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
@@ -186,8 +186,8 @@ jobs:
       jobParameters:
         priority: 1
         crossgen: true
-        timeoutInMinutes: 240
         scenarios: 'normal,no_tiered_compilation'
+        timeoutInMinutes: 360
 
 
 # Publish build information to Build Assets Registry

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -59,7 +59,8 @@ jobs:
     osGroup: Linux
     osIdentifier: Linux_rhel6
     containerName: centos6_x64_build_image
-    helixQueuesPublic: 'RedHat.6.Amd64.Open'
+    # TODO: enable RedHat.6.Amd64.Open
+    # when https://github.com/dotnet/core-eng/issues/4100 is resolved
     helixQueuesInternal: 'RedHat.6.Amd64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 

--- a/eng/send-to-helix-step.yml
+++ b/eng/send-to-helix-step.yml
@@ -4,7 +4,6 @@ parameters:
   archType: ''
   osGroup: ''
   buildConfig: ''
-  isExternal: ''
   creator: ''
   publishTestResults: ''
   helixAccessToken: ''
@@ -25,7 +24,6 @@ steps:
       __BuildArch: ${{ parameters.archType }}
       __BuildOS: ${{ parameters.osGroup }}
       __BuildType: ${{ parameters.buildConfig }}
-      _IsExternal: ${{ parameters.isExternal }}
       _Creator: ${{ parameters.creator }}
       _PublishTestResults: ${{ parameters.publishTestResults }}
       _HelixAccessToken: ${{ parameters.helixAccessToken }}
@@ -47,7 +45,6 @@ steps:
       __BuildArch: ${{ parameters.archType }}
       __BuildOS: ${{ parameters.osGroup }}
       __BuildType: ${{ parameters.buildConfig }}
-      _IsExternal: ${{ parameters.isExternal }}
       _Creator: ${{ parameters.creator }}
       _PublishTestResults: ${{ parameters.publishTestResults }}
       _HelixAccessToken: ${{ parameters.helixAccessToken }}

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -130,15 +130,14 @@ jobs:
         timeoutInMinutes: 30
 
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          isExternal: false
           # Access token variable for internal project from the
           # DotNet-HelixApi-Access variable group
           helixAccessToken: $(HelixApiAccessToken)
           helixQueues: ${{ parameters.helixQueuesInternal }}
           ${{ if eq(parameters.helixQueuesInternal, '') }}:
             condition: false
+
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          isExternal: true
           creator: coreclr-pulls
           helixQueues: ${{ parameters.helixQueuesPublic }}
           ${{ if eq(parameters.helixQueuesPublic, '') }}:

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -139,7 +139,7 @@ jobs:
             condition: false
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           isExternal: true
-          creator: coreclr/pulls
+          creator: coreclr-pulls
           helixQueues: ${{ parameters.helixQueuesPublic }}
           ${{ if eq(parameters.helixQueuesPublic, '') }}:
             condition: false

--- a/tests/helixpublishwitharcade.proj
+++ b/tests/helixpublishwitharcade.proj
@@ -11,11 +11,8 @@
     <HelixConfiguration Condition=" '$(Scenario)' == 'normal' ">$(BuildType)</HelixConfiguration>
     <HelixConfiguration Condition=" '$(Scenario)' != 'normal' ">$(BuildType)-$(Scenario)</HelixConfiguration>
 
-    <IsExternal>$(_IsExternal)</IsExternal>
-    <IsExternal Condition=" '$(IsExternal)' == '' ">true</IsExternal>
-
-    <Creator Condition=" '$(IsExternal)' == 'true' ">$(_Creator)</Creator>
-    <HelixAccessToken Condition=" '$(IsExternal)' != 'true' ">$(_HelixAccessToken)</HelixAccessToken>
+    <Creator>$(_Creator)</Creator>
+    <HelixAccessToken>$(_HelixAccessToken)</HelixAccessToken>
     <HelixTargetQueues>$(_HelixTargetQueues)</HelixTargetQueues>
 
     <EnableAzurePipelinesReporter>$(_PublishTestResults)</EnableAzurePipelinesReporter>

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -50,6 +50,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/StackTracePreserve/StackTracePreserveTests/*">
             <Issue>20322</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/readytorun/r2rdump/R2RDumpTest/*">
+            <Issue>19441;22020</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- All Unix targets -->
@@ -125,9 +128,6 @@
             <Issue>needs triage</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/GC/Regressions/dev10bugs/536168/536168/*">
-            <Issue>needs triage</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/readytorun/r2rdump/R2RDumpTest/*">
             <Issue>needs triage</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/GC/API/GC/GetAllocatedBytesForCurrentThread/*">
@@ -232,9 +232,6 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/DevDiv_590771/DevDiv_590771/*">
             <Issue>needs triage</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/readytorun/r2rdump/R2RDumpTest/*">
-            <Issue>19441</Issue>
         </ExcludeList>
     </ItemGroup>
 

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -601,6 +601,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/GC/Scenarios/Dynamo/dynamo/*">
             <Issue>17129</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/doublearray/dblarray3_cs_do/*">
+            <Issue>22015</Issue>
+        </ExcludeList>
     </ItemGroup>
     
 


### PR DESCRIPTION
* Disable **JIT.Methodical/doublearray/dblarray3_cs_do** (#22015)
* Disable **readytorun.r2rdump/R2RDumpTest** (#22020)
* Disable RedHat.6.Amd64.Open (https://github.com/dotnet/core-eng/issues/4100)
* Rename Creator coreclr/pulls -> coreclr-pulls (https://github.com/dotnet/arcade/issues/1755)
* Remove usages of deprecated IsExternal (as of #22007)
* Increase timeout for all test jobs (to mitigate timeout failures during submission jobs to Helix when it takes hours to get an available machine)
