### PR TITLE
Fix AssemblyDependencyResolver tests on Windows x86 test runs

### DIFF
--- a/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyDependencyResolver.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyDependencyResolver.cs
@@ -64,6 +64,7 @@ namespace System.Runtime.Loader
                 {
                     // Reset the error write to the one used before
                     corehost_set_error_writer(previousErrorWriterPtr);
+                    GC.KeepAlive(errorWriter);
                 }
             }
             catch (EntryPointNotFoundException entryPointNotFoundException)
@@ -289,13 +290,13 @@ namespace System.Runtime.Loader
         }
 #endif
 
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = HostpolicyCharSet)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi, CharSet = HostpolicyCharSet)]
         internal delegate void corehost_resolve_component_dependencies_result_fn(
             string assembly_paths,
             string native_search_paths,
             string resource_search_paths);
 
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = HostpolicyCharSet)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi, CharSet = HostpolicyCharSet)]
         internal delegate void corehost_error_writer_fn(
             string message);
 

--- a/tests/src/Loader/AssemblyDependencyResolverTests/HostPolicyMock.cs
+++ b/tests/src/Loader/AssemblyDependencyResolverTests/HostPolicyMock.cs
@@ -28,7 +28,7 @@ namespace AssemblyDependencyResolverTests
         [DllImport("hostpolicy", CharSet = HostpolicyCharSet)]
         private static extern IntPtr Get_corehost_set_error_writer_lastSet_error_writer();
 
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = HostpolicyCharSet)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi, CharSet = HostpolicyCharSet)]
         internal delegate void Callback_corehost_resolve_component_dependencies(
             string component_main_assembly_path);
 
@@ -39,7 +39,7 @@ namespace AssemblyDependencyResolverTests
         private static Type _assemblyDependencyResolverType;
         private static Type _corehost_error_writer_fnType;
 
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = HostpolicyCharSet)]
+        [UnmanagedFunctionPointer(CallingConvention.Winapi, CharSet = HostpolicyCharSet)]
         public delegate void ErrorWriterDelegate(string message);
 
         public static string DeleteExistingHostpolicy(string coreRoot)
@@ -88,11 +88,13 @@ namespace AssemblyDependencyResolverTests
 
         internal class MockValues_corehost_resolve_componet_dependencies : IDisposable
         {
+            private Callback_corehost_resolve_component_dependencies callback;
+
             public Action<string> Callback
             {
                 set
                 {
-                    var callback = new Callback_corehost_resolve_component_dependencies(value);
+                    callback = new Callback_corehost_resolve_component_dependencies(value);
                     if (callback != null)
                     {
                         Set_corehost_resolve_component_dependencies_Callback(
@@ -113,6 +115,8 @@ namespace AssemblyDependencyResolverTests
                     string.Empty,
                     string.Empty);
                 Set_corehost_resolve_component_dependencies_Callback(IntPtr.Zero);
+                GC.KeepAlive(callback);
+                callback = null;
             }
         }
 


### PR DESCRIPTION
Fix calling conventions on reverse PInvoke callbacks in AssemblyDependencyResolver and tests. Fixes the AssemblyDependencyResolver tests on Windows x86.

cc: @sandreenko 
