### PR TITLE
Remove System.Runtime.Tests exclusions on arm and arm64.

### DIFF
--- a/tests/arm/corefx_linux_test_exclusions.txt
+++ b/tests/arm/corefx_linux_test_exclusions.txt
@@ -11,7 +11,6 @@ System.Memory.Tests                  # https://github.com/dotnet/coreclr/issues/
 System.Net.Http.Functional.Tests     # https://github.com/dotnet/coreclr/issues/17739
 System.Net.NameResolution.Functional.Tests # https://github.com/dotnet/coreclr/issues/21224 -- JitStressRegs=1
 System.Net.NameResolution.Pal.Tests  # https://github.com/dotnet/coreclr/issues/17740
-System.Runtime.Tests                 # https://github.com/dotnet/coreclr/issues/21223 -- JitStress=2
 System.Text.Encodings.Web.Tests      # https://github.com/dotnet/coreclr/issues/21113 -- minopts
 System.Text.Json.Tests               # https://github.com/dotnet/coreclr/issues/21112
 System.Text.RegularExpressions.Tests # https://github.com/dotnet/coreclr/issues/17754 -- timeout -- JitMinOpts only

--- a/tests/arm64/corefx_linux_test_exclusions.txt
+++ b/tests/arm64/corefx_linux_test_exclusions.txt
@@ -2,7 +2,6 @@ System.Buffers.Tests                          # https://github.com/dotnet/corecl
 System.Collections.Immutable.Tests            # https://github.com/dotnet/coreclr/issues/20209 -- JitStress=2 TieredCompilation=0
 System.Memory.Tests                           # https://github.com/dotnet/coreclr/issues/20958
 System.Net.NameResolution.Functional.Tests    # https://github.com/dotnet/coreclr/issues/20924 https://github.com/dotnet/corefx/issues/24355
-System.Runtime.Tests                          # https://github.com/dotnet/coreclr/issues/21223 -- JitStress=2
 System.Runtime.Serialization.Formatters.Tests # https://github.com/dotnet/coreclr/issues/20246 -- timeout
 System.Text.RegularExpressions.Tests          # https://github.com/dotnet/coreclr/issues/17754 -- timeout -- JitMinOpts + Tiered only
 System.Threading.Tests                        # https://github.com/dotnet/coreclr/issues/20215


### PR DESCRIPTION
#21223 was fixed by https://github.com/dotnet/corefx/pull/34653
so the exclusions can be removed.
