### PR TITLE
Run Azure DevOps builds against pull requests in master

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,8 @@ resources:
   - container: centos6_x64_build_image
     image: microsoft/dotnet-buildtools-prereqs:centos-6-376e1a3-20174311014331
 
+trigger: none
+
 jobs:
 
 ##   The following is the matrix of test runs that we have. This is

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,6 +25,9 @@ resources:
 
 trigger: none
 
+pr:
+- master
+
 jobs:
 
 ##   The following is the matrix of test runs that we have. This is

--- a/netci.groovy
+++ b/netci.groovy
@@ -1927,7 +1927,7 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                         case 'innerloop':
                         case 'no_tiered_compilation_innerloop':
                             if (configuration == 'Checked') {
-                                isDefaultTrigger = true
+                                isDefaultTrigger = false
                             }
                             break
                          case 'crossgen_comparison':
@@ -1955,9 +1955,9 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                                 // Add default PR trigger for Windows arm64 Debug builds. This is a build only -- no tests are run --
                                 // so the private test hardware is not used. Thus, it can be run by all users, not just arm64Users.
                                 // People in arm64Users will get both this and the Checked Build and Test job.
-                                isDefaultTrigger = true
+                                isDefaultTrigger = false
                             } else if (configuration == 'Checked') {
-                                isDefaultTrigger = true
+                                isDefaultTrigger = false
                                 isArm64PrivateJob = true
                             }
                             break

--- a/netci.groovy
+++ b/netci.groovy
@@ -1923,15 +1923,10 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                         break
                     }
 
-                    switch (scenario) {
-                        case 'innerloop':
-                        case 'no_tiered_compilation_innerloop':
-                            break
-                         case 'crossgen_comparison':
-                            if (os == 'Ubuntu' && architecture == 'arm' && (configuration == 'Checked' || configuration == 'Release')) {
-                                isDefaultTrigger = true
-                            }
-                            break
+                    if (scenario == 'crossgen_comparison') {
+                        if (os == 'Ubuntu' && architecture == 'arm' && (configuration == 'Checked' || configuration == 'Release')) {
+                            isDefaultTrigger = true
+                        }
                     }
                     break
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -1926,8 +1926,6 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                     switch (scenario) {
                         case 'innerloop':
                         case 'no_tiered_compilation_innerloop':
-                            if (configuration == 'Checked') {
-                            }
                             break
                          case 'crossgen_comparison':
                             if (os == 'Ubuntu' && architecture == 'arm' && (configuration == 'Checked' || configuration == 'Release')) {

--- a/netci.groovy
+++ b/netci.groovy
@@ -1927,7 +1927,6 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                         case 'innerloop':
                         case 'no_tiered_compilation_innerloop':
                             if (configuration == 'Checked') {
-                                isDefaultTrigger = false
                             }
                             break
                          case 'crossgen_comparison':
@@ -1951,13 +1950,7 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
 
                     switch (scenario) {
                         case 'innerloop':
-                            if (configuration == 'Debug') {
-                                // Add default PR trigger for Windows arm64 Debug builds. This is a build only -- no tests are run --
-                                // so the private test hardware is not used. Thus, it can be run by all users, not just arm64Users.
-                                // People in arm64Users will get both this and the Checked Build and Test job.
-                                isDefaultTrigger = false
-                            } else if (configuration == 'Checked') {
-                                isDefaultTrigger = false
+                            if (configuration == 'Checked') {
                                 isArm64PrivateJob = true
                             }
                             break

--- a/tests/helixpublishwitharcade.proj
+++ b/tests/helixpublishwitharcade.proj
@@ -69,6 +69,8 @@
 
   <Target Name="BuildHelixWorkItem" BeforeTargets="Test">
     <PropertyGroup>
+      <EnableXUnitReporter>true</EnableXUnitReporter>
+      <FailOnMissionControlTestFailure>true</FailOnMissionControlTestFailure>
       <TestRunNamePrefix Condition=" '$(Scenario)' == 'normal' ">$(BuildOS) $(BuildArch) $(BuildType) @ </TestRunNamePrefix>
       <TestRunNamePrefix Condition=" '$(Scenario)' != 'normal' ">$(BuildOS) $(BuildArch) $(BuildType) $(Scenario) @ </TestRunNamePrefix>
       <_XUnitRunnerArgs>-parallel collections -nocolor -noshadow -xml testResults.xml -notrait category=outerloop -notrait category=failing</_XUnitRunnerArgs>


### PR DESCRIPTION
This would provide default branches for PR and CI triggers. 

As soon as this merged (and we ready to enable AzDO-as-CI), we can uncheck boxes "Override YAML Pull Request trigger" and "Override YAML Continuous Integration trigger" in the build definition and control the behavior only via YAML file. 

Opt-in to use Mission Control for visualizing tests results and fail a corresponding step (and the whole job) if there any failed tests 

Reduce a load on arm32/arm64 machines be disabling the corresponding jobs' default triggers.

Keep other legs enabled.