### PR TITLE
Fix SIMD12 GT_STORE_LCL_FLD

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -4855,7 +4855,7 @@ void CodeGen::genStoreLclTypeSIMD12(GenTree* treeNode)
     unsigned varNum = treeNode->gtLclVarCommon.gtLclNum;
     assert(varNum < compiler->lvaCount);
 
-    if (treeNode->OperGet() == GT_LCL_FLD)
+    if (treeNode->OperGet() == GT_STORE_LCL_FLD)
     {
         offs = treeNode->gtLclFld.gtLclOffs;
     }

--- a/src/jit/simdcodegenxarch.cpp
+++ b/src/jit/simdcodegenxarch.cpp
@@ -2895,7 +2895,7 @@ void CodeGen::genStoreLclTypeSIMD12(GenTree* treeNode)
     unsigned varNum = treeNode->gtLclVarCommon.gtLclNum;
     assert(varNum < compiler->lvaCount);
 
-    if (treeNode->OperGet() == GT_LCL_FLD)
+    if (treeNode->OperGet() == GT_STORE_LCL_FLD)
     {
         offs = treeNode->gtLclFld.gtLclOffs;
     }


### PR DESCRIPTION
It was ignoring the local field offset, by checking for the wrong
operator.

This appeared as a recent regression, but I couldn't find any code
(including test) change that would have caused this.

The failure only happens for JitStress with remorphing stress. This
creates the STORE_LCL_FLD. Otherwise, it looks like we normally
end up with IND(LCL_FLD_ADDR). Maybe we should be morphing these
somewhere?

No x64 PMI asm diffs in corelib or the JIT\SIMD tree. With JitStress=1
there are exactly 6 asm diffs in the Vector3Interop test, which was the
one failing.

Fixes #21935