### PR TITLE
Cleanup: Remove MethodDesc::GetLoaderAllocatorForCode

### DIFF
--- a/src/vm/amd64/cgenamd64.cpp
+++ b/src/vm/amd64/cgenamd64.cpp
@@ -634,7 +634,7 @@ INT32 rel32UsingJumpStub(INT32 UNALIGNED * pRel32, PCODE target, MethodDesc *pMe
         // If a domain is provided, the MethodDesc mustn't yet be set up to have one, or it must match the MethodDesc's domain,
         // unless we're in a compilation domain (NGen loads assemblies as domain-bound but compiles them as domain neutral).
         PRECONDITION(!pLoaderAllocator || !pMethod || pMethod->GetMethodDescChunk()->GetMethodTablePtr()->IsNull() || 
-            pLoaderAllocator == pMethod->GetMethodDescChunk()->GetFirstMethodDesc()->GetLoaderAllocatorForCode() || IsCompilationProcess());
+            pLoaderAllocator == pMethod->GetMethodDescChunk()->GetFirstMethodDesc()->GetLoaderAllocator() || IsCompilationProcess());
     }
     CONTRACTL_END;
 

--- a/src/vm/arm/stubs.cpp
+++ b/src/vm/arm/stubs.cpp
@@ -3334,7 +3334,7 @@ Stub * StubLinkerCPU::CreateTailCallCopyArgsThunk(CORINFO_SIG_INFO * pSig,
         pSl->ThumbEmitJumpRegister(thumbRegLr);
     }
 
-    LoaderHeap* pHeap = pMD->GetLoaderAllocatorForCode()->GetStubHeap();
+    LoaderHeap* pHeap = pMD->GetLoaderAllocator()->GetStubHeap();
     return pSl->Link(pHeap);
 }
 

--- a/src/vm/codeman.cpp
+++ b/src/vm/codeman.cpp
@@ -631,7 +631,7 @@ BOOL EEJitManager::CodeHeapIterator::Next()
             // LoaderAllocator filter
             if (m_pLoaderAllocator && m_pCurrent)
             {
-                LoaderAllocator *pCurrentLoaderAllocator = m_pCurrent->GetLoaderAllocatorForCode();
+                LoaderAllocator *pCurrentLoaderAllocator = m_pCurrent->GetLoaderAllocator();
                 if(pCurrentLoaderAllocator != m_pLoaderAllocator)
                     continue;
             }
@@ -2281,7 +2281,7 @@ void CodeHeapRequestInfo::Init()
     } CONTRACTL_END;
 
     if (m_pAllocator == NULL)
-        m_pAllocator = m_pMD->GetLoaderAllocatorForCode();
+        m_pAllocator = m_pMD->GetLoaderAllocator();
     m_isDynamicDomain = (m_pMD != NULL) ? m_pMD->IsLCGMethod() : false;
     m_isCollectible = m_pAllocator->IsCollectible() ? true : false;
     m_throwOnOutOfMemoryWithinRange = true;
@@ -4986,7 +4986,7 @@ PCODE ExecutionManager::jumpStub(MethodDesc* pMD, PCODE target,
 
     if (pLoaderAllocator == NULL)
     {
-        pLoaderAllocator = pMD->GetLoaderAllocatorForCode();
+        pLoaderAllocator = pMD->GetLoaderAllocator();
     }
     _ASSERTE(pLoaderAllocator != NULL);
 

--- a/src/vm/comdelegate.cpp
+++ b/src/vm/comdelegate.cpp
@@ -1018,7 +1018,7 @@ void COMDelegate::BindToMethod(DELEGATEREF   *pRefThis,
         else
 #ifdef HAS_THISPTR_RETBUF_PRECODE
         if (pTargetMethod->IsStatic() && pTargetMethod->HasRetBuffArg() && IsRetBuffPassedAsFirstArg())
-            pTargetCode = pTargetMethod->GetLoaderAllocatorForCode()->GetFuncPtrStubs()->GetFuncPtrStub(pTargetMethod, PRECODE_THISPTR_RETBUF);
+            pTargetCode = pTargetMethod->GetLoaderAllocator()->GetFuncPtrStubs()->GetFuncPtrStub(pTargetMethod, PRECODE_THISPTR_RETBUF);
         else
 #endif // HAS_THISPTR_RETBUF_PRECODE
             pTargetCode = pTargetMethod->GetMultiCallableAddrOfCode();
@@ -1882,7 +1882,7 @@ FCIMPL3(void, COMDelegate::DelegateConstruct, Object* refThisUNSAFE, Object* tar
         }
 #ifdef HAS_THISPTR_RETBUF_PRECODE
         else if (pMeth->HasRetBuffArg() && IsRetBuffPassedAsFirstArg())
-            method = pMeth->GetLoaderAllocatorForCode()->GetFuncPtrStubs()->GetFuncPtrStub(pMeth, PRECODE_THISPTR_RETBUF);
+            method = pMeth->GetLoaderAllocator()->GetFuncPtrStubs()->GetFuncPtrStub(pMeth, PRECODE_THISPTR_RETBUF);
 #endif // HAS_THISPTR_RETBUF_PRECODE
 
         gc.refThis->SetTarget(gc.target);

--- a/src/vm/dynamicmethod.cpp
+++ b/src/vm/dynamicmethod.cpp
@@ -848,7 +848,7 @@ void DynamicMethodDesc::Destroy()
     CONTRACTL_END;
 
     _ASSERTE(IsDynamicMethod());
-    LoaderAllocator *pLoaderAllocator = GetLoaderAllocatorForCode();
+    LoaderAllocator *pLoaderAllocator = GetLoaderAllocator();
 
     LOG((LF_BCL, LL_INFO1000, "Level3 - Destroying DynamicMethod {0x%p}\n", this));
     if (!m_pSig.IsNull())
@@ -924,8 +924,8 @@ void LCGMethodResolver::RecycleIndCells()
         }
 
         // Insert the linked list to the free list of the VirtualCallStubManager of the current domain.
-        // We should use GetLoaderAllocatorForCode because that is where the ind cell was allocated.
-        LoaderAllocator *pLoaderAllocator = GetDynamicMethod()->GetLoaderAllocatorForCode();
+        // We should use GetLoaderAllocator because that is where the ind cell was allocated.
+        LoaderAllocator *pLoaderAllocator = GetDynamicMethod()->GetLoaderAllocator();
         VirtualCallStubManager *pMgr = pLoaderAllocator->GetVirtualCallStubManager();
         pMgr->InsertIntoRecycledIndCellList_Locked(cellhead, cellcurr);
         m_UsedIndCellList = NULL;

--- a/src/vm/fptrstubs.cpp
+++ b/src/vm/fptrstubs.cpp
@@ -123,7 +123,7 @@ PCODE FuncPtrStubs::GetFuncPtrStub(MethodDesc * pMD, PrecodeType type)
     // 
     {
         AllocMemTracker amt;
-        Precode* pNewPrecode = Precode::Allocate(type, pMD, pMD->GetLoaderAllocatorForCode(), &amt);
+        Precode* pNewPrecode = Precode::Allocate(type, pMD, pMD->GetLoaderAllocator(), &amt);
    
         if (target != NULL)
         {

--- a/src/vm/gccover.cpp
+++ b/src/vm/gccover.cpp
@@ -82,7 +82,7 @@ void SetupAndSprinkleBreakpoints(
 {
     // Allocate room for the GCCoverageInfo and copy of the method instructions
     size_t memSize = sizeof(GCCoverageInfo) + methodRegionInfo.hotSize + methodRegionInfo.coldSize;
-    GCCoverageInfo* gcCover = (GCCoverageInfo*)(void*) pMD->GetLoaderAllocatorForCode()->GetHighFrequencyHeap()->AllocAlignedMem(memSize, CODE_SIZE_ALIGN);
+    GCCoverageInfo* gcCover = (GCCoverageInfo*)(void*) pMD->GetLoaderAllocator()->GetHighFrequencyHeap()->AllocAlignedMem(memSize, CODE_SIZE_ALIGN);
 
     memset(gcCover, 0, sizeof(GCCoverageInfo));
 

--- a/src/vm/i386/stublinkerx86.cpp
+++ b/src/vm/i386/stublinkerx86.cpp
@@ -6430,7 +6430,7 @@ Stub * StubLinkerCPU::CreateTailCallCopyArgsThunk(CORINFO_SIG_INFO * pSig,
         EncodeGCOffsets(pSl, gcLayout);
     }
 
-    LoaderHeap* pHeap = pMD->GetLoaderAllocatorForCode()->GetStubHeap();
+    LoaderHeap* pHeap = pMD->GetLoaderAllocator()->GetStubHeap();
     return pSl->Link(pHeap);
 }
 #endif // DACCESS_COMPILE
@@ -6805,7 +6805,7 @@ BOOL ThisPtrRetBufPrecode::SetTargetInterlocked(TADDR target, TADDR expected)
     _ASSERTE(m_rel32 == REL32_JMP_SELF);
 
     // Use pMD == NULL to allocate the jump stub in non-dynamic heap that has the same lifetime as the precode itself
-    INT32 newRel32 = rel32UsingJumpStub(&m_rel32, target, NULL /* pMD */, ((MethodDesc *)GetMethodDesc())->GetLoaderAllocatorForCode());
+    INT32 newRel32 = rel32UsingJumpStub(&m_rel32, target, NULL /* pMD */, ((MethodDesc *)GetMethodDesc())->GetLoaderAllocator());
 
     _ASSERTE(IS_ALIGNED(&m_rel32, sizeof(INT32)));
     FastInterlockExchange((LONG *)&m_rel32, (LONG)newRel32);

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -5554,7 +5554,7 @@ void CEEInfo::getCallInfo(
                 // We shouldn't be using GetLoaderAllocator here because for LCG, we need to get the 
                 // VirtualCallStubManager from where the stub will be used. 
                 // For normal methods there is no difference.
-                LoaderAllocator *pLoaderAllocator = m_pMethodBeingCompiled->GetLoaderAllocatorForCode();
+                LoaderAllocator *pLoaderAllocator = m_pMethodBeingCompiled->GetLoaderAllocator();
                 VirtualCallStubManager *pMgr = pLoaderAllocator->GetVirtualCallStubManager();
 
                 PCODE addr = pMgr->GetCallStub(exactType, pTargetMD);

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -224,13 +224,6 @@ BaseDomain *MethodDesc::GetDomain()
 #ifndef DACCESS_COMPILE
 
 //*******************************************************************************
-LoaderAllocator * MethodDesc::GetLoaderAllocatorForCode()
-{
-    return GetLoaderAllocator();
-}
-
-
-//*******************************************************************************
 LoaderAllocator * MethodDesc::GetDomainSpecificLoaderAllocator()
 {
     if (GetLoaderModule()->IsCollectible())

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -524,13 +524,6 @@ public:
 
     PTR_LoaderAllocator GetLoaderAllocator();
 
-    // GetLoaderAllocatorForCode returns the allocator with the responsibility for allocation.
-    // This is called from GetMulticallableAddrOfCode when allocating a small trampoline stub for the method.
-    // Normally a method in a shared domain will allocate memory for stubs in the shared domain.
-    // That has to be different for DynamicMethod as they need to be allocated always in the AppDomain
-    // that created the method.
-    LoaderAllocator * GetLoaderAllocatorForCode();
-
     // GetDomainSpecificLoaderAllocator returns the collectable loader allocator for collectable types
     // and the loader allocator in the current domain for non-collectable types
     LoaderAllocator * GetDomainSpecificLoaderAllocator();

--- a/src/vm/precode.cpp
+++ b/src/vm/precode.cpp
@@ -479,7 +479,7 @@ void Precode::Reset()
     WRAPPER_NO_CONTRACT;
 
     MethodDesc* pMD = GetMethodDesc();
-    Init(GetType(), pMD, pMD->GetLoaderAllocatorForCode());
+    Init(GetType(), pMD, pMD->GetLoaderAllocator());
     ClrFlushInstructionCache(this, SizeOf());
 }
 


### PR DESCRIPTION
This function was recently changed to just return the
MethodDesc::GetLoaderAllocator. This is a cleanup that removes the
function completely and replaces all of its usages.