### PR TITLE
Disable JIT/superpmi/superpmicollect test in r2r jobs

### DIFF
--- a/tests/src/JIT/superpmi/superpmicollect.csproj
+++ b/tests/src/JIT/superpmi/superpmicollect.csproj
@@ -11,6 +11,7 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <CrossGenTest>false</CrossGenTest>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
Enable back when https://github.com/dotnet/coreclr/issues/22027 is fixed