### PR TITLE
Add LZCNT-based CountDigits implementation

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/FormattingHelpers.CountDigits.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/FormattingHelpers.CountDigits.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+using Internal.Runtime.CompilerServices;
 
 namespace System.Buffers.Text
 {
@@ -36,106 +38,21 @@ namespace System.Buffers.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int CountDigits(ulong value)
         {
-            if (Lzcnt.X64.IsSupported)
-            {
-                int y = UInt64MaxLog10GivenLzCount[(int)Lzcnt.X64.LeadingZeroCount(value)];
-                int d = unchecked((int)((value - s_uInt64PowersOf10[y]) >> 63));
-                return y - d;
-            }
-
-            int digits = 1;
-            uint part;
-            if (value >= 10000000)
-            {
-                if (value >= 100000000000000)
-                {
-                    part = (uint)(value / 100000000000000);
-                    digits += 14;
-                }
-                else
-                {
-                    part = (uint)(value / 10000000);
-                    digits += 7;
-                }
-            }
-            else
-            {
-                part = (uint)value;
-            }
-
-            if (part < 10)
-            {
-                // no-op
-            }
-            else if (part < 100)
-            {
-                digits += 1;
-            }
-            else if (part < 1000)
-            {
-                digits += 2;
-            }
-            else if (part < 10000)
-            {
-                digits += 3;
-            }
-            else if (part < 100000)
-            {
-                digits += 4;
-            }
-            else if (part < 1000000)
-            {
-                digits += 5;
-            }
-            else
-            {
-                Debug.Assert(part < 10000000);
-                digits += 6;
-            }
-
-            return digits;
+            int y = Unsafe.AddByteOffset(
+                ref MemoryMarshal.GetReference(UInt64MaxLog10GivenLzCount),
+                (IntPtr)BitOps.LeadingZeroCount(value));
+            int d = unchecked((int)((value - s_uInt64PowersOf10[y]) >> 63));
+            return y - d;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int CountDigits(uint value)
         {
-            if (Lzcnt.IsSupported)
-            {
-                int y = UInt32MaxLog10GivenLzCount[(int)Lzcnt.LeadingZeroCount(value)];
-                int d = unchecked((int)((value - s_uInt32PowersOf10[y]) >> 31));
-                return y - d;
-            }
-
-            int digits = 1;
-            if (value >= 100000)
-            {
-                value = value / 100000;
-                digits += 5;
-            }
-
-            if (value < 10)
-            {
-                // no-op
-            }
-            else if (value < 100)
-            {
-                digits += 1;
-            }
-            else if (value < 1000)
-            {
-                digits += 2;
-            }
-            else if (value < 10000)
-            {
-                digits += 3;
-            }
-            else
-            {
-                Debug.Assert(value < 100000);
-                digits += 4;
-            }
-
-            return digits;
+            int y = Unsafe.AddByteOffset(
+                ref MemoryMarshal.GetReference(UInt32MaxLog10GivenLzCount),
+                (IntPtr)BitOps.LeadingZeroCount(value));
+            int d = unchecked((int)((value - s_uInt32PowersOf10[y]) >> 31));
+            return y - d;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/FormattingHelpers.CountDigits.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/FormattingHelpers.CountDigits.cs
@@ -13,7 +13,7 @@ namespace System.Buffers.Text
         {
             19, 18, 18, 18, 18, 17, 17, 17, 16, 16, 16, 15, 15, 15, 15, 14, 14, 14, 13, 13, 13, 12, 12, 12, 12, 11, 11,
             11, 10, 10, 10, 9, 9, 9, 9, 8, 8, 8, 7, 7, 7, 6, 6, 6, 6, 5, 5, 5, 4, 4, 4, 3, 3, 3, 3, 2, 2, 2, 1, 1, 1, 0,
-            0, 0
+            0, 0, 1
         };
 
         private static readonly ulong[] s_uInt64PowersOf10 = 
@@ -25,7 +25,7 @@ namespace System.Buffers.Text
 
 		private static readonly byte[] s_uInt32MaxLog10GivenLzCount = 
         {
-            10, 9, 9, 8, 8, 8, 7, 7, 7, 6, 6, 6, 6, 5, 5, 5, 4, 4, 4, 3, 3, 3, 3, 2, 2, 2, 1, 1, 1, 0, 0, 0, 0
+            10, 9, 9, 8, 8, 8, 7, 7, 7, 6, 6, 6, 6, 5, 5, 5, 4, 4, 4, 3, 3, 3, 3, 2, 2, 2, 1, 1, 1, 0, 0, 0, 1
         };
 
         private static readonly uint[] s_uInt32PowersOf10 = 

--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/FormattingHelpers.CountDigits.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/FormattingHelpers.CountDigits.cs
@@ -11,26 +11,26 @@ namespace System.Buffers.Text
     {
         private static ReadOnlySpan<byte> UInt64MaxLog10GivenLzCount => new byte[]
         {
-            19, 18, 18, 18, 18, 17, 17, 17, 16, 16, 16, 15, 15, 15, 15, 14, 14, 14, 13, 13, 13, 12, 12, 12, 12, 11, 11,
-            11, 10, 10, 10, 9, 9, 9, 9, 8, 8, 8, 7, 7, 7, 6, 6, 6, 6, 5, 5, 5, 4, 4, 4, 3, 3, 3, 3, 2, 2, 2, 1, 1, 1, 0,
-            0, 0, 1
+            20, 19, 19, 19, 19, 18, 18, 18, 17, 17, 17, 16, 16, 16, 16, 15, 15, 15, 14, 14, 14, 13, 13, 13, 13, 12, 12,
+            12, 11, 11, 11, 10, 10, 10, 10, 9, 9, 9, 8, 8, 8, 7, 7, 7, 7, 6, 6, 6, 5, 5, 5, 4, 4, 4, 4, 3, 3, 3, 2, 2, 
+            2, 1, 1, 1, 2
         };
 
-        private static readonly ulong[] s_uInt64PowersOf10 = 
+        private static readonly ulong[] s_uInt64PowersOf10 =
         {
-            1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000, 10000000000, 100000000000, 
+            0, 1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000, 10000000000, 100000000000, 
             1000000000000, 10000000000000, 100000000000000, 1000000000000000, 10000000000000000, 100000000000000000, 
             1000000000000000000, 10000000000000000000
         };
 
         private static ReadOnlySpan<byte> UInt32MaxLog10GivenLzCount => new byte[]
         {
-            10, 9, 9, 8, 8, 8, 7, 7, 7, 6, 6, 6, 6, 5, 5, 5, 4, 4, 4, 3, 3, 3, 3, 2, 2, 2, 1, 1, 1, 0, 0, 0, 1
+            11, 10, 10, 9, 9, 9, 8, 8, 8, 7, 7, 7, 7, 6, 6, 6, 5, 5, 5, 4, 4, 4, 4, 3, 3, 3, 2, 2, 2, 1, 1, 1, 2
         };
 
-        private static readonly uint[] s_uInt32PowersOf10 = 
+        private static readonly uint[] s_uInt32PowersOf10 =
         {
-            1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000, 0
+            0, 1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000, 0
         };
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -40,7 +40,7 @@ namespace System.Buffers.Text
             {
                 int y = UInt64MaxLog10GivenLzCount[(int)Lzcnt.X64.LeadingZeroCount(value)];
                 int d = unchecked((int)((value - s_uInt64PowersOf10[y]) >> 63));
-                return y - d + 1;
+                return y - d;
             }
 
             int digits = 1;
@@ -103,7 +103,7 @@ namespace System.Buffers.Text
             {
                 int y = UInt32MaxLog10GivenLzCount[(int)Lzcnt.LeadingZeroCount(value)];
                 int d = unchecked((int)((value - s_uInt32PowersOf10[y]) >> 31));
-                return y - d + 1;
+                return y - d;
             }
 
             int digits = 1;

--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/FormattingHelpers.CountDigits.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/FormattingHelpers.CountDigits.cs
@@ -9,9 +9,39 @@ namespace System.Buffers.Text
 {
     internal static partial class FormattingHelpers
     {
+        private static readonly byte[] s_uInt64MaxLog10GivenLzCount = 
+        {
+            19, 18, 18, 18, 18, 17, 17, 17, 16, 16, 16, 15, 15, 15, 15, 14, 14, 14, 13, 13, 13, 12, 12, 12, 12, 11, 11,
+            11, 10, 10, 10, 9, 9, 9, 9, 8, 8, 8, 7, 7, 7, 6, 6, 6, 6, 5, 5, 5, 4, 4, 4, 3, 3, 3, 3, 2, 2, 2, 1, 1, 1, 0,
+            0, 0
+        };
+
+        private static readonly ulong[] s_uInt64PowersOf10 = 
+        {
+            1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000, 10000000000, 100000000000, 
+            1000000000000, 10000000000000, 100000000000000, 1000000000000000, 10000000000000000, 100000000000000000, 
+            1000000000000000000, 10000000000000000000
+        };
+
+		private static readonly byte[] s_uInt32MaxLog10GivenLzCount = 
+        {
+            10, 9, 9, 8, 8, 8, 7, 7, 7, 6, 6, 6, 6, 5, 5, 5, 4, 4, 4, 3, 3, 3, 3, 2, 2, 2, 1, 1, 1, 0, 0, 0, 0
+        };
+
+        private static readonly uint[] s_uInt32PowersOf10 = 
+        {
+            1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000, 0
+        };
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int CountDigits(ulong value)
         {
+			if (Lzcnt.X64.IsSupported)
+            {
+                int y = s_uInt64MaxLog10GivenLzCount[Lzcnt.X64.LeadingZeroCount(value)];
+                return y - (int)((value - s_uInt64PowersOf10[y]) >> 63) + 1;
+            }
+
             int digits = 1;
             uint part;
             if (value >= 10000000)
@@ -68,6 +98,12 @@ namespace System.Buffers.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int CountDigits(uint value)
         {
+			if (Lzcnt.IsSupported)
+            {
+                int y = s_uInt32MaxLog10GivenLzCount[Lzcnt.LeadingZeroCount(value)];
+                return y - (int)((value - s_uInt32PowersOf10[y]) >> 31) + 1;
+            }
+
             int digits = 1;
             if (value >= 100000)
             {

--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/FormattingHelpers.CountDigits.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/FormattingHelpers.CountDigits.cs
@@ -39,7 +39,8 @@ namespace System.Buffers.Text
 			if (Lzcnt.X64.IsSupported)
             {
                 int y = s_uInt64MaxLog10GivenLzCount[Lzcnt.X64.LeadingZeroCount(value)];
-                return y - (int)((value - s_uInt64PowersOf10[y]) >> 63) + 1;
+				int d = unchecked((int)((value - s_uInt64PowersOf10[y]) >> 63));
+                return y - d + 1;
             }
 
             int digits = 1;
@@ -101,7 +102,8 @@ namespace System.Buffers.Text
 			if (Lzcnt.IsSupported)
             {
                 int y = s_uInt32MaxLog10GivenLzCount[Lzcnt.LeadingZeroCount(value)];
-                return y - (int)((value - s_uInt32PowersOf10[y]) >> 31) + 1;
+				int d = unchecked((int)((value - s_uInt32PowersOf10[y]) >> 31));
+                return y - d + 1;
             }
 
             int digits = 1;

--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/FormattingHelpers.CountDigits.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/FormattingHelpers.CountDigits.cs
@@ -23,7 +23,7 @@ namespace System.Buffers.Text
             1000000000000000000, 10000000000000000000
         };
 
-		private static readonly byte[] s_uInt32MaxLog10GivenLzCount = 
+        private static readonly byte[] s_uInt32MaxLog10GivenLzCount = 
         {
             10, 9, 9, 8, 8, 8, 7, 7, 7, 6, 6, 6, 6, 5, 5, 5, 4, 4, 4, 3, 3, 3, 3, 2, 2, 2, 1, 1, 1, 0, 0, 0, 1
         };
@@ -36,10 +36,10 @@ namespace System.Buffers.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int CountDigits(ulong value)
         {
-			if (Lzcnt.X64.IsSupported)
+            if (Lzcnt.X64.IsSupported)
             {
                 int y = s_uInt64MaxLog10GivenLzCount[Lzcnt.X64.LeadingZeroCount(value)];
-				int d = unchecked((int)((value - s_uInt64PowersOf10[y]) >> 63));
+                int d = unchecked((int)((value - s_uInt64PowersOf10[y]) >> 63));
                 return y - d + 1;
             }
 
@@ -99,10 +99,10 @@ namespace System.Buffers.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int CountDigits(uint value)
         {
-			if (Lzcnt.IsSupported)
+            if (Lzcnt.IsSupported)
             {
                 int y = s_uInt32MaxLog10GivenLzCount[Lzcnt.LeadingZeroCount(value)];
-				int d = unchecked((int)((value - s_uInt32PowersOf10[y]) >> 31));
+                int d = unchecked((int)((value - s_uInt32PowersOf10[y]) >> 31));
                 return y - d + 1;
             }
 

--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/FormattingHelpers.CountDigits.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/FormattingHelpers.CountDigits.cs
@@ -9,7 +9,7 @@ namespace System.Buffers.Text
 {
     internal static partial class FormattingHelpers
     {
-        private static readonly byte[] s_uInt64MaxLog10GivenLzCount = 
+        private static ReadOnlySpan<byte> UInt64MaxLog10GivenLzCount => new byte[]
         {
             19, 18, 18, 18, 18, 17, 17, 17, 16, 16, 16, 15, 15, 15, 15, 14, 14, 14, 13, 13, 13, 12, 12, 12, 12, 11, 11,
             11, 10, 10, 10, 9, 9, 9, 9, 8, 8, 8, 7, 7, 7, 6, 6, 6, 6, 5, 5, 5, 4, 4, 4, 3, 3, 3, 3, 2, 2, 2, 1, 1, 1, 0,
@@ -23,7 +23,7 @@ namespace System.Buffers.Text
             1000000000000000000, 10000000000000000000
         };
 
-        private static readonly byte[] s_uInt32MaxLog10GivenLzCount = 
+        private static ReadOnlySpan<byte> UInt32MaxLog10GivenLzCount => new byte[]
         {
             10, 9, 9, 8, 8, 8, 7, 7, 7, 6, 6, 6, 6, 5, 5, 5, 4, 4, 4, 3, 3, 3, 3, 2, 2, 2, 1, 1, 1, 0, 0, 0, 1
         };
@@ -38,7 +38,7 @@ namespace System.Buffers.Text
         {
             if (Lzcnt.X64.IsSupported)
             {
-                int y = s_uInt64MaxLog10GivenLzCount[Lzcnt.X64.LeadingZeroCount(value)];
+                int y = UInt64MaxLog10GivenLzCount[(int)Lzcnt.X64.LeadingZeroCount(value)];
                 int d = unchecked((int)((value - s_uInt64PowersOf10[y]) >> 63));
                 return y - d + 1;
             }
@@ -101,7 +101,7 @@ namespace System.Buffers.Text
         {
             if (Lzcnt.IsSupported)
             {
-                int y = s_uInt32MaxLog10GivenLzCount[Lzcnt.LeadingZeroCount(value)];
+                int y = UInt32MaxLog10GivenLzCount[(int)Lzcnt.LeadingZeroCount(value)];
                 int d = unchecked((int)((value - s_uInt32PowersOf10[y]) >> 31));
                 return y - d + 1;
             }


### PR DESCRIPTION
Adds a LZCNT-based CountDigits implementation to the `FormattingHelpers`. The general idea behind the implemetnation is that the number of digits in an unsiged number equals to `floor(log_10(x)) + 1`. This specific implementation is based on "Hacker's Delight, Second Edition by Henry S. Warren Jr.; Figure 11-11" - a branch free implementation of log base 10 with a two table lookup.

The following table shows the performance difference between the current implementation and the LZCNT based implementation when calculating the number of digits for 1'000'000 numbers.

|                     Method |     Mean |     Error |    StdDev |
|--------------------------- |---------:|----------:|----------:|
|         CountDigits (uint) | 4.780 ms | 0.0143 ms | 0.0134 ms |
|  CountDigits (uint, lzcnt) | 2.314 ms | 0.0071 ms | 0.0063 ms |
|        CountDigits (ulong) | 7.310 ms | 0.0260 ms | 0.0230 ms |
| CountDigits (ulong, lzcnt) | 2.401 ms | 0.0057 ms | 0.0053 ms |