### PR TITLE
Speedup SpanHelpers.IndexOf{Any}(byte, ...)

### DIFF
--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -47,6 +47,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\AttributeUsageAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\BadImageFormatException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\BitConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\BitOps.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Boolean.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\ArrayPool.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\ArrayPoolEventSource.cs" />

--- a/src/System.Private.CoreLib/shared/System/BitOps.cs
+++ b/src/System.Private.CoreLib/shared/System/BitOps.cs
@@ -3,7 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
+
+using Internal.Runtime.CompilerServices;
 
 namespace System
 {
@@ -16,11 +19,13 @@ namespace System
             {
                 return (int)Bmi1.TrailingZeroCount((uint)matches);
             }
-            else
+            else // Software fallback
             {
-                // Fallback
                 // https://graphics.stanford.edu/~seander/bithacks.html#ZerosOnRightMultLookup
-                return TrailingCountMultiplyDeBruijn[(int)(((uint)((matches & -matches) * 0x077CB531U)) >> 27)];
+                // uint.MaxValue >> 27 is always in range [0 - 31] so we use Unsafe.AddByteOffset to avoid bounds check
+                return Unsafe.AddByteOffset(
+                    ref MemoryMarshal.GetReference(TrailingCountMultiplyDeBruijn),
+                    ((uint)((matches & -matches) * 0x077CB531U)) >> 27);
             }
         }
 

--- a/src/System.Private.CoreLib/shared/System/BitOps.cs
+++ b/src/System.Private.CoreLib/shared/System/BitOps.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics.X86;
 
@@ -19,24 +18,10 @@ namespace System
             }
             else
             {
-                if (BitConverter.IsLittleEndian)
-                {
-                    return TrailingZeroCountFallback(matches);
-                }
-                else
-                {
-                    // Not sure the above failback will work on BigEndian
-                    Debug.Fail("TrailingZeroCount not implemented for BigEndian");
-                    return 0;
-                }
+                // Fallback
+                // https://graphics.stanford.edu/~seander/bithacks.html#ZerosOnRightMultLookup
+                return TrailingCountMultiplyDeBruijn[(int)(((uint)((matches & -matches) * 0x077CB531U)) >> 27)];
             }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int TrailingZeroCountFallback(int matches)
-        {
-            // https://graphics.stanford.edu/~seander/bithacks.html#ZerosOnRightMultLookup
-            return TrailingCountMultiplyDeBruijn[(int)(((uint)((matches & -matches) * 0x077CB531U)) >> 27)];
         }
 
         private static ReadOnlySpan<byte> TrailingCountMultiplyDeBruijn => new byte[32]

--- a/src/System.Private.CoreLib/shared/System/BitOps.cs
+++ b/src/System.Private.CoreLib/shared/System/BitOps.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics.X86;
+
+namespace System
+{
+    internal static class BitOps
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int TrailingZeroCount(int matches)
+        {
+            if (Bmi1.IsSupported)
+            {
+                return (int)Bmi1.TrailingZeroCount((uint)matches);
+            }
+            else
+            {
+                if (BitConverter.IsLittleEndian)
+                {
+                    return TrailingZeroCountFallback(matches);
+                }
+                else
+                {
+                    // Not sure the above failback will work on BigEndian
+                    Debug.Fail("TrailingZeroCount not implemented for BigEndian");
+                    return 0;
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int TrailingZeroCountFallback(int matches)
+        {
+            // https://graphics.stanford.edu/~seander/bithacks.html#ZerosOnRightMultLookup
+            return TrailingCountMultiplyDeBruijn[(int)(((uint)((matches & -matches) * 0x077CB531U)) >> 27)];
+        }
+
+        private static ReadOnlySpan<byte> TrailingCountMultiplyDeBruijn => new byte[32]
+        {
+            0, 1, 28, 2, 29, 14, 24, 3, 30, 22, 20, 15, 25, 17, 4, 8,
+            31, 27, 13, 23, 21, 19, 16, 7, 26, 12, 18, 6, 11, 5, 10, 9
+        };
+    }
+}

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
@@ -33,26 +33,26 @@ namespace System
             int valueTailLength = valueLength - 1;
             int remainingSearchSpaceLength = searchSpaceLength - valueTailLength;
 
-            int index = 0;
+            int offset = 0;
             while (remainingSearchSpaceLength > 0)
             {
                 // Do a quick search for the first element of "value".
-                int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, index), valueHead, remainingSearchSpaceLength);
+                int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, offset), valueHead, remainingSearchSpaceLength);
                 if (relativeIndex == -1)
                     break;
 
                 remainingSearchSpaceLength -= relativeIndex;
-                index += relativeIndex;
+                offset += relativeIndex;
 
                 if (remainingSearchSpaceLength <= 0)
                     break;  // The unsearched portion is now shorter than the sequence we're looking for. So it can't be there.
 
                 // Found the first element of "value". See if the tail matches.
-                if (SequenceEqual(ref Unsafe.Add(ref searchSpace, index + 1), ref valueTail, valueTailLength))
-                    return index;  // The tail matched. Return a successful find.
+                if (SequenceEqual(ref Unsafe.Add(ref searchSpace, offset + 1), ref valueTail, valueTailLength))
+                    return offset;  // The tail matched. Return a successful find.
 
                 remainingSearchSpaceLength--;
-                index++;
+                offset++;
             }
             return -1;
         }
@@ -65,21 +65,21 @@ namespace System
             if (valueLength == 0)
                 return 0;  // A zero-length sequence is always treated as "found" at the start of the search space.
 
-            int index = -1;
+            int offset = -1;
             for (int i = 0; i < valueLength; i++)
             {
                 var tempIndex = IndexOf(ref searchSpace, Unsafe.Add(ref value, i), searchSpaceLength);
-                if ((uint)tempIndex < (uint)index)
+                if ((uint)tempIndex < (uint)offset)
                 {
-                    index = tempIndex;
+                    offset = tempIndex;
                     // Reduce space for search, cause we don't care if we find the search value after the index of a previously found value
                     searchSpaceLength = tempIndex;
 
-                    if (index == 0)
+                    if (offset == 0)
                         break;
                 }
             }
-            return index;
+            return offset;
         }
 
         public static int LastIndexOfAny(ref byte searchSpace, int searchSpaceLength, ref byte value, int valueLength)
@@ -90,14 +90,14 @@ namespace System
             if (valueLength == 0)
                 return 0;  // A zero-length sequence is always treated as "found" at the start of the search space.
 
-            int index = -1;
+            int offset = -1;
             for (int i = 0; i < valueLength; i++)
             {
                 var tempIndex = LastIndexOf(ref searchSpace, Unsafe.Add(ref value, i), searchSpaceLength);
-                if (tempIndex > index)
-                    index = tempIndex;
+                if (tempIndex > offset)
+                    offset = tempIndex;
             }
-            return index;
+            return offset;
         }
 
         // Adapted from IndexOf(...)
@@ -106,13 +106,12 @@ namespace System
             Debug.Assert(length >= 0);
             
             uint uValue = value; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr offset = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
             IntPtr nLength = (IntPtr)length;
 
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
-                int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
-                nLength = (IntPtr)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
+                nLength = UnalignedByteCountVector(ref searchSpace);
             }
 
         SequentialScan:
@@ -120,68 +119,68 @@ namespace System
             {
                 nLength -= 8;
 
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 0) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 1) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 2) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 3) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 4) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 5) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 6) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 7))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 0) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 1) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 2) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 3) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 4) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 5) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 6) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 7))
                 {
                     goto Found;
                 }
 
-                index += 8;
+                offset += 8;
             }
 
             if ((byte*)nLength >= (byte*)4)
             {
                 nLength -= 4;
 
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 0) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 1) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 2) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, index + 3))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 0) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 1) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 2) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 3))
                 {
                     goto Found;
                 }
 
-                index += 4;
+                offset += 4;
             }
 
             while ((byte*)nLength > (byte*)0)
             {
                 nLength -= 1;
 
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
                     goto Found;
 
-                index += 1;
+                offset += 1;
             }
 
-            if (Vector.IsHardwareAccelerated && ((int)(byte*)index < length))
+            if (Vector.IsHardwareAccelerated && ((int)(byte*)offset < length))
             {
-                nLength = (IntPtr)((length - (int)(byte*)index) & ~(Vector<byte>.Count - 1));
+                nLength = (IntPtr)((length - (int)(byte*)offset) & ~(Vector<byte>.Count - 1));
 
                 // Get comparison Vector
                 Vector<byte> vComparison = new Vector<byte>(value);
 
-                while ((byte*)nLength > (byte*)index)
+                while ((byte*)nLength > (byte*)offset)
                 {
-                    var vMatches = Vector.Equals(vComparison, Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index)));
+                    var vMatches = Vector.Equals(vComparison, LoadVector(ref searchSpace, offset));
                     if (Vector<byte>.Zero.Equals(vMatches))
                     {
-                        index += Vector<byte>.Count;
+                        offset += Vector<byte>.Count;
                         continue;
                     }
 
                     goto Found;
                 }
 
-                if ((int)(byte*)index < length)
+                if ((int)(byte*)offset < length)
                 {
-                    nLength = (IntPtr)(length - (int)(byte*)index);
+                    nLength = (IntPtr)(length - (int)(byte*)offset);
                     goto SequentialScan;
                 }
             }
@@ -197,7 +196,7 @@ namespace System
             Debug.Assert(length >= 0);
 
             uint uValue = value; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr offset = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
             IntPtr nLength = (IntPtr)length;
 
             if (Avx2.IsSupported || Sse2.IsSupported)
@@ -219,177 +218,174 @@ namespace System
             {
                 nLength -= 8;
 
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
                     goto Found;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 1))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 1))
                     goto Found1;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 2))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 2))
                     goto Found2;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 3))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 3))
                     goto Found3;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 4))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 4))
                     goto Found4;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 5))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 5))
                     goto Found5;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 6))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 6))
                     goto Found6;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 7))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 7))
                     goto Found7;
 
-                index += 8;
+                offset += 8;
             }
 
             if ((byte*)nLength >= (byte*)4)
             {
                 nLength -= 4;
 
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
                     goto Found;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 1))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 1))
                     goto Found1;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 2))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 2))
                     goto Found2;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 3))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 3))
                     goto Found3;
 
-                index += 4;
+                offset += 4;
             }
 
             while ((byte*)nLength > (byte*)0)
             {
                 nLength -= 1;
 
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
                     goto Found;
 
-                index += 1;
+                offset += 1;
             }
 
             if (Avx2.IsSupported)
             {
-                if ((int)(byte*)index < length)
+                if ((int)(byte*)offset < length)
                 {
-                    nLength = GetByteVector256SpanLength(index, length);
-                    if ((byte*)nLength > (byte*)index)
+                    nLength = GetByteVector256SpanLength(offset, length);
+                    if ((byte*)nLength > (byte*)offset)
                     {
                         Vector256<byte> comparison = Vector256.Create(value);
                         do
                         {
-                            Vector256<byte> search = Unsafe.ReadUnaligned<Vector256<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
+                            Vector256<byte> search = LoadVector256(ref searchSpace, offset);
                             int matches = Avx2.MoveMask(Avx2.CompareEqual(comparison, search));
                             if (matches == 0)
                             {
-                                index += Vector256<byte>.Count;
+                                offset += Vector256<byte>.Count;
                                 continue;
                             }
-                            else
-                            {
-                                // Find offset of first match
-                                return ((int)(byte*)index) + BitOps.TrailingZeroCount(matches);
-                            }
-                        } while ((byte*)nLength > (byte*)index);
+
+                            // Find offset of first match
+                            return ((int)(byte*)offset) + BitOps.TrailingZeroCount(matches);
+                        } while ((byte*)nLength > (byte*)offset);
                     }
 
-                    nLength = GetByteVector128SpanLength(index, length);
-                    if ((byte*)nLength > (byte*)index)
+                    nLength = GetByteVector128SpanLength(offset, length);
+                    if ((byte*)nLength > (byte*)offset)
                     {
                         Vector128<byte> comparison = Vector128.Create(value);
 
-                        Vector128<byte> search = Unsafe.ReadUnaligned<Vector128<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
+                        Vector128<byte> search = LoadVector128(ref searchSpace, offset);
                         int matches = Sse2.MoveMask(Sse2.CompareEqual(comparison, search));
                         if (matches == 0)
                         {
-                            index += Vector128<byte>.Count;
+                            offset += Vector128<byte>.Count;
                         }
                         else
                         {
                             // Find offset of first match
-                            return ((int)(byte*)index) + BitOps.TrailingZeroCount(matches);
+                            return ((int)(byte*)offset) + BitOps.TrailingZeroCount(matches);
                         }
                     }
 
-                    if ((int)(byte*)index < length)
+                    if ((int)(byte*)offset < length)
                     {
-                        nLength = (IntPtr)(length - (int)(byte*)index);
+                        nLength = (IntPtr)(length - (int)(byte*)offset);
                         goto SequentialScan;
                     }
                 }
             }
             else if (Sse2.IsSupported)
             {
-                if ((int)(byte*)index < length)
+                if ((int)(byte*)offset < length)
                 {
-                    nLength = GetByteVector128SpanLength(index, length);
+                    nLength = GetByteVector128SpanLength(offset, length);
 
-                    Vector128<byte> comparison = Vector128.Create(value);
-                    while ((byte*)nLength > (byte*)index)
+                    Vector128<byte> values = Vector128.Create(value);
+                    while ((byte*)nLength > (byte*)offset)
                     {
-                        Vector128<byte> search = Unsafe.ReadUnaligned<Vector128<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
-                        int matches = Sse2.MoveMask(Sse2.CompareEqual(comparison, search));
+                        Vector128<byte> search = LoadVector128(ref searchSpace, offset);
+                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values, search));
                         if (matches == 0)
                         {
-                            index += Vector128<byte>.Count;
+                            offset += Vector128<byte>.Count;
                             continue;
                         }
+
                         // Find offset of first match
-                        else
-                        {
-                            return ((int)(byte*)index) + BitOps.TrailingZeroCount(matches);
-                        }
+                        return ((int)(byte*)offset) + BitOps.TrailingZeroCount(matches);
                     }
 
-                    if ((int)(byte*)index < length)
+                    if ((int)(byte*)offset < length)
                     {
-                        nLength = (IntPtr)(length - (int)(byte*)index);
+                        nLength = (IntPtr)(length - (int)(byte*)offset);
                         goto SequentialScan;
                     }
                 }
             }
             else if (Vector.IsHardwareAccelerated)
             {
-                if ((int)(byte*)index < length)
+                if ((int)(byte*)offset < length)
                 {
-                    nLength = GetByteVectorSpanLength(index, length);
+                    nLength = GetByteVectorSpanLength(offset, length);
 
                     // Get comparison Vector
-                    Vector<byte> vComparison = new Vector<byte>(value);
+                    Vector<byte> values = new Vector<byte>(value);
 
-                    while ((byte*)nLength > (byte*)index)
+                    while ((byte*)nLength > (byte*)offset)
                     {
-                        var vMatches = Vector.Equals(vComparison, Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index)));
-                        if (Vector<byte>.Zero.Equals(vMatches))
+                        var matches = Vector.Equals(values, LoadVector(ref searchSpace, offset));
+                        if (Vector<byte>.Zero.Equals(matches))
                         {
-                            index += Vector<byte>.Count;
+                            offset += Vector<byte>.Count;
                             continue;
                         }
+
                         // Find offset of first match
-                        return (int)(byte*)index + LocateFirstFoundByte(vMatches);
+                        return (int)(byte*)offset + LocateFirstFoundByte(matches);
                     }
 
-                    if ((int)(byte*)index < length)
+                    if ((int)(byte*)offset < length)
                     {
-                        nLength = (IntPtr)(length - (int)(byte*)index);
+                        nLength = (IntPtr)(length - (int)(byte*)offset);
                         goto SequentialScan;
                     }
                 }
             }
             return -1;
         Found: // Workaround for https://github.com/dotnet/coreclr/issues/13549
-            return (int)(byte*)index;
+            return (int)(byte*)offset;
         Found1:
-            return (int)(byte*)(index + 1);
+            return (int)(byte*)(offset + 1);
         Found2:
-            return (int)(byte*)(index + 2);
+            return (int)(byte*)(offset + 2);
         Found3:
-            return (int)(byte*)(index + 3);
+            return (int)(byte*)(offset + 3);
         Found4:
-            return (int)(byte*)(index + 4);
+            return (int)(byte*)(offset + 4);
         Found5:
-            return (int)(byte*)(index + 5);
+            return (int)(byte*)(offset + 5);
         Found6:
-            return (int)(byte*)(index + 6);
+            return (int)(byte*)(offset + 6);
         Found7:
-            return (int)(byte*)(index + 7);
+            return (int)(byte*)(offset + 7);
         }
 
         public static int LastIndexOf(ref byte searchSpace, int searchSpaceLength, ref byte value, int valueLength)
@@ -404,11 +400,11 @@ namespace System
             ref byte valueTail = ref Unsafe.Add(ref value, 1);
             int valueTailLength = valueLength - 1;
 
-            int index = 0;
+            int offset = 0;
             for (; ; )
             {
-                Debug.Assert(0 <= index && index <= searchSpaceLength); // Ensures no deceptive underflows in the computation of "remainingSearchSpaceLength".
-                int remainingSearchSpaceLength = searchSpaceLength - index - valueTailLength;
+                Debug.Assert(0 <= offset && offset <= searchSpaceLength); // Ensures no deceptive underflows in the computation of "remainingSearchSpaceLength".
+                int remainingSearchSpaceLength = searchSpaceLength - offset - valueTailLength;
                 if (remainingSearchSpaceLength <= 0)
                     break;  // The unsearched portion is now shorter than the sequence we're looking for. So it can't be there.
 
@@ -421,7 +417,7 @@ namespace System
                 if (SequenceEqual(ref Unsafe.Add(ref searchSpace, relativeIndex + 1), ref valueTail, valueTailLength))
                     return relativeIndex;  // The tail matched. Return a successful find.
 
-                index += remainingSearchSpaceLength - relativeIndex;
+                offset += remainingSearchSpaceLength - relativeIndex;
             }
             return -1;
         }
@@ -431,7 +427,7 @@ namespace System
             Debug.Assert(length >= 0);
 
             uint uValue = value; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            IntPtr index = (IntPtr)length; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr offset = (IntPtr)length; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
             IntPtr nLength = (IntPtr)length;
 
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
@@ -443,92 +439,93 @@ namespace System
             while ((byte*)nLength >= (byte*)8)
             {
                 nLength -= 8;
-                index -= 8;
+                offset -= 8;
 
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 7))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 7))
                     goto Found7;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 6))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 6))
                     goto Found6;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 5))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 5))
                     goto Found5;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 4))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 4))
                     goto Found4;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 3))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 3))
                     goto Found3;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 2))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 2))
                     goto Found2;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 1))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 1))
                     goto Found1;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
                     goto Found;
             }
 
             if ((byte*)nLength >= (byte*)4)
             {
                 nLength -= 4;
-                index -= 4;
+                offset -= 4;
 
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 3))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 3))
                     goto Found3;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 2))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 2))
                     goto Found2;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index + 1))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 1))
                     goto Found1;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
                     goto Found;
             }
 
             while ((byte*)nLength > (byte*)0)
             {
                 nLength -= 1;
-                index -= 1;
+                offset -= 1;
 
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, index))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
                     goto Found;
             }
 
-            if (Vector.IsHardwareAccelerated && ((byte*)index > (byte*)0))
+            if (Vector.IsHardwareAccelerated && ((byte*)offset > (byte*)0))
             {
-                nLength = (IntPtr)((int)(byte*)index & ~(Vector<byte>.Count - 1));
+                nLength = (IntPtr)((int)(byte*)offset & ~(Vector<byte>.Count - 1));
 
                 // Get comparison Vector
-                Vector<byte> vComparison = new Vector<byte>(value);
+                Vector<byte> values = new Vector<byte>(value);
 
                 while ((byte*)nLength > (byte*)(Vector<byte>.Count - 1))
                 {
-                    var vMatches = Vector.Equals(vComparison, Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index - Vector<byte>.Count)));
-                    if (Vector<byte>.Zero.Equals(vMatches))
+                    var matches = Vector.Equals(values, LoadVector(ref searchSpace, offset - Vector<byte>.Count));
+                    if (Vector<byte>.Zero.Equals(matches))
                     {
-                        index -= Vector<byte>.Count;
+                        offset -= Vector<byte>.Count;
                         nLength -= Vector<byte>.Count;
                         continue;
                     }
+
                     // Find offset of first match
-                    return (int)(index) - Vector<byte>.Count + LocateLastFoundByte(vMatches);
+                    return (int)(offset) - Vector<byte>.Count + LocateLastFoundByte(matches);
                 }
-                if ((byte*)index > (byte*)0)
+                if ((byte*)offset > (byte*)0)
                 {
-                    nLength = index;
+                    nLength = offset;
                     goto SequentialScan;
                 }
             }
             return -1;
         Found: // Workaround for https://github.com/dotnet/coreclr/issues/13549
-            return (int)(byte*)index;
+            return (int)(byte*)offset;
         Found1:
-            return (int)(byte*)(index + 1);
+            return (int)(byte*)(offset + 1);
         Found2:
-            return (int)(byte*)(index + 2);
+            return (int)(byte*)(offset + 2);
         Found3:
-            return (int)(byte*)(index + 3);
+            return (int)(byte*)(offset + 3);
         Found4:
-            return (int)(byte*)(index + 4);
+            return (int)(byte*)(offset + 4);
         Found5:
-            return (int)(byte*)(index + 5);
+            return (int)(byte*)(offset + 5);
         Found6:
-            return (int)(byte*)(index + 6);
+            return (int)(byte*)(offset + 6);
         Found7:
-            return (int)(byte*)(index + 7);
+            return (int)(byte*)(offset + 7);
         }
 
         public static unsafe int IndexOfAny(ref byte searchSpace, byte value0, byte value1, int length)
@@ -537,7 +534,7 @@ namespace System
 
             uint uValue0 = value0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue1 = value1; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr offset = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
             IntPtr nLength = (IntPtr)length;
 
             if (Avx2.IsSupported || Sse2.IsSupported)
@@ -560,201 +557,198 @@ namespace System
             {
                 nLength -= 8;
 
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found3;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 4);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 4);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found4;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 5);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 5);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found5;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 6);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 6);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found6;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 7);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 7);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found7;
 
-                index += 8;
+                offset += 8;
             }
 
             if ((byte*)nLength >= (byte*)4)
             {
                 nLength -= 4;
 
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found3;
 
-                index += 4;
+                offset += 4;
             }
 
             while ((byte*)nLength > (byte*)0)
             {
                 nLength -= 1;
 
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
 
-                index += 1;
+                offset += 1;
             }
 
             if (Avx2.IsSupported)
             {
-                if ((int)(byte*)index < length)
+                if ((int)(byte*)offset < length)
                 {
-                    nLength = GetByteVector256SpanLength(index, length);
-                    if ((byte*)nLength > (byte*)index)
+                    nLength = GetByteVector256SpanLength(offset, length);
+                    if ((byte*)nLength > (byte*)offset)
                     {
-                        Vector256<byte> comp0 = Vector256.Create(value0);
-                        Vector256<byte> comp1 = Vector256.Create(value1);
+                        Vector256<byte> values0 = Vector256.Create(value0);
+                        Vector256<byte> values1 = Vector256.Create(value1);
                         do
                         {
-                            Vector256<byte> search = Unsafe.ReadUnaligned<Vector256<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
-                            int matches = Avx2.MoveMask(Avx2.CompareEqual(comp0, search));
-                            matches |= Avx2.MoveMask(Avx2.CompareEqual(comp1, search));
+                            Vector256<byte> search = LoadVector256(ref searchSpace, offset);
+                            int matches = Avx2.MoveMask(Avx2.CompareEqual(values0, search));
+                            matches |= Avx2.MoveMask(Avx2.CompareEqual(values1, search));
                             if (matches == 0)
                             {
-                                index += Vector256<byte>.Count;
+                                offset += Vector256<byte>.Count;
                                 continue;
                             }
+
                             // Find offset of first match
-                            else
-                            {
-                                return ((int)(byte*)index) + BitOps.TrailingZeroCount(matches);
-                            }
-                        } while ((byte*)nLength > (byte*)index);
+                            return ((int)(byte*)offset) + BitOps.TrailingZeroCount(matches);
+                        } while ((byte*)nLength > (byte*)offset);
                     }
 
-                    nLength = GetByteVector128SpanLength(index, length);
-                    if ((byte*)nLength > (byte*)index)
+                    nLength = GetByteVector128SpanLength(offset, length);
+                    if ((byte*)nLength > (byte*)offset)
                     {
-                        Vector128<byte> comp0 = Vector128.Create(value0);
-                        Vector128<byte> comp1 = Vector128.Create(value1);
+                        Vector128<byte> values0 = Vector128.Create(value0);
+                        Vector128<byte> values1 = Vector128.Create(value1);
 
-                        Vector128<byte> search = Unsafe.ReadUnaligned<Vector128<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
-                        int matches = Sse2.MoveMask(Sse2.CompareEqual(comp0, search));
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(comp1, search));
+                        Vector128<byte> search = LoadVector128(ref searchSpace, offset);
+                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values0, search));
+                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values1, search));
                         if (matches == 0)
                         {
-                            index += Vector128<byte>.Count;
+                            offset += Vector128<byte>.Count;
                         }
-                        // Find offset of first match
                         else
                         {
-                            return ((int)(byte*)index) + BitOps.TrailingZeroCount(matches);
+                            // Find offset of first match
+                            return ((int)(byte*)offset) + BitOps.TrailingZeroCount(matches);
                         }
                     }
 
-                    if ((int)(byte*)index < length)
+                    if ((int)(byte*)offset < length)
                     {
-                        nLength = (IntPtr)(length - (int)(byte*)index);
+                        nLength = (IntPtr)(length - (int)(byte*)offset);
                         goto SequentialScan;
                     }
                 }
             }
             else if (Sse2.IsSupported)
             {
-                if ((int)(byte*)index < length)
+                if ((int)(byte*)offset < length)
                 {
-                    nLength = GetByteVector128SpanLength(index, length);
+                    nLength = GetByteVector128SpanLength(offset, length);
 
-                    Vector128<byte> comp0 = Vector128.Create(value0);
-                    Vector128<byte> comp1 = Vector128.Create(value1);
+                    Vector128<byte> values0 = Vector128.Create(value0);
+                    Vector128<byte> values1 = Vector128.Create(value1);
 
-                    while ((byte*)nLength > (byte*)index)
+                    while ((byte*)nLength > (byte*)offset)
                     {
-                        Vector128<byte> search = Unsafe.ReadUnaligned<Vector128<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
-                        int matches = Sse2.MoveMask(Sse2.CompareEqual(comp0, search));
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(comp1, search));
+                        Vector128<byte> search = LoadVector128(ref searchSpace, offset);
+                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values0, search));
+                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values1, search));
                         if (matches == 0)
                         {
-                            index += Vector128<byte>.Count;
+                            offset += Vector128<byte>.Count;
                             continue;
                         }
+
                         // Find offset of first match
-                        else
-                        {
-                            return ((int)(byte*)index) + BitOps.TrailingZeroCount(matches);
-                        }
+                        return ((int)(byte*)offset) + BitOps.TrailingZeroCount(matches);
                     }
 
-                    if ((int)(byte*)index < length)
+                    if ((int)(byte*)offset < length)
                     {
-                        nLength = (IntPtr)(length - (int)(byte*)index);
+                        nLength = (IntPtr)(length - (int)(byte*)offset);
                         goto SequentialScan;
                     }
                 }
             }
             else if (Vector.IsHardwareAccelerated)
             {
-                if ((int)(byte*)index < length)
+                if ((int)(byte*)offset < length)
                 {
-                    nLength = GetByteVectorSpanLength(index, length);
+                    nLength = GetByteVectorSpanLength(offset, length);
 
                     // Get comparison Vector
                     Vector<byte> values0 = new Vector<byte>(value0);
                     Vector<byte> values1 = new Vector<byte>(value1);
 
-                    while ((byte*)nLength > (byte*)index)
+                    while ((byte*)nLength > (byte*)offset)
                     {
-                        Vector<byte> vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
-                        var vMatches = Vector.BitwiseOr(
-                                        Vector.Equals(vData, values0),
-                                        Vector.Equals(vData, values1));
-                        if (Vector<byte>.Zero.Equals(vMatches))
+                        Vector<byte> search = LoadVector(ref searchSpace, offset);
+                        var matches = Vector.BitwiseOr(
+                                        Vector.Equals(search, values0),
+                                        Vector.Equals(search, values1));
+                        if (Vector<byte>.Zero.Equals(matches))
                         {
-                            index += Vector<byte>.Count;
+                            offset += Vector<byte>.Count;
                             continue;
                         }
+
                         // Find offset of first match
-                        return (int)(byte*)index + LocateFirstFoundByte(vMatches);
+                        return (int)(byte*)offset + LocateFirstFoundByte(matches);
                     }
 
-                    if ((int)(byte*)index < length)
+                    if ((int)(byte*)offset < length)
                     {
-                        nLength = (IntPtr)(length - (int)(byte*)index);
+                        nLength = (IntPtr)(length - (int)(byte*)offset);
                         goto SequentialScan;
                     }
                 }
             }
             return -1;
         Found: // Workaround for https://github.com/dotnet/coreclr/issues/13549
-            return (int)(byte*)index;
+            return (int)(byte*)offset;
         Found1:
-            return (int)(byte*)(index + 1);
+            return (int)(byte*)(offset + 1);
         Found2:
-            return (int)(byte*)(index + 2);
+            return (int)(byte*)(offset + 2);
         Found3:
-            return (int)(byte*)(index + 3);
+            return (int)(byte*)(offset + 3);
         Found4:
-            return (int)(byte*)(index + 4);
+            return (int)(byte*)(offset + 4);
         Found5:
-            return (int)(byte*)(index + 5);
+            return (int)(byte*)(offset + 5);
         Found6:
-            return (int)(byte*)(index + 6);
+            return (int)(byte*)(offset + 6);
         Found7:
-            return (int)(byte*)(index + 7);
+            return (int)(byte*)(offset + 7);
         }
 
         public static unsafe int IndexOfAny(ref byte searchSpace, byte value0, byte value1, byte value2, int length)
@@ -764,7 +758,7 @@ namespace System
             uint uValue0 = value0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue1 = value1; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue2 = value2; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr offset = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
             IntPtr nLength = (IntPtr)length;
 
             if (Avx2.IsSupported || Sse2.IsSupported)
@@ -787,212 +781,209 @@ namespace System
             {
                 nLength -= 8;
 
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found3;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 4);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 4);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found4;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 5);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 5);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found5;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 6);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 6);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found6;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 7);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 7);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found7;
 
-                index += 8;
+                offset += 8;
             }
 
             if ((byte*)nLength >= (byte*)4)
             {
                 nLength -= 4;
 
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found3;
 
-                index += 4;
+                offset += 4;
             }
 
             while ((byte*)nLength > (byte*)0)
             {
                 nLength -= 1;
 
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
 
-                index += 1;
+                offset += 1;
             }
 
             if (Avx2.IsSupported)
             {
-                if ((int)(byte*)index < length)
+                if ((int)(byte*)offset < length)
                 {
-                    nLength = GetByteVector256SpanLength(index, length);
-                    if ((byte*)nLength > (byte*)index)
+                    nLength = GetByteVector256SpanLength(offset, length);
+                    if ((byte*)nLength > (byte*)offset)
                     {
-                        Vector256<byte> comp0 = Vector256.Create(value0);
-                        Vector256<byte> comp1 = Vector256.Create(value1);
-                        Vector256<byte> comp2 = Vector256.Create(value2);
+                        Vector256<byte> values0 = Vector256.Create(value0);
+                        Vector256<byte> values1 = Vector256.Create(value1);
+                        Vector256<byte> values2 = Vector256.Create(value2);
                         do
                         {
-                            Vector256<byte> search = Unsafe.ReadUnaligned<Vector256<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
-                            int matches = Avx2.MoveMask(Avx2.CompareEqual(comp0, search));
-                            matches |= Avx2.MoveMask(Avx2.CompareEqual(comp1, search));
-                            matches |= Avx2.MoveMask(Avx2.CompareEqual(comp2, search));
+                            Vector256<byte> search = LoadVector256(ref searchSpace, offset);
+                            int matches = Avx2.MoveMask(Avx2.CompareEqual(values0, search));
+                            matches |= Avx2.MoveMask(Avx2.CompareEqual(values1, search));
+                            matches |= Avx2.MoveMask(Avx2.CompareEqual(values2, search));
                             if (matches == 0)
                             {
-                                index += Vector256<byte>.Count;
+                                offset += Vector256<byte>.Count;
                                 continue;
                             }
+
                             // Find offset of first match
-                            else
-                            {
-                                return ((int)(byte*)index) + BitOps.TrailingZeroCount(matches);
-                            }
-                        } while ((byte*)nLength > (byte*)index);
+                            return ((int)(byte*)offset) + BitOps.TrailingZeroCount(matches);
+                        } while ((byte*)nLength > (byte*)offset);
                     }
 
-                    nLength = GetByteVector128SpanLength(index, length);
-                    if ((byte*)nLength > (byte*)index)
+                    nLength = GetByteVector128SpanLength(offset, length);
+                    if ((byte*)nLength > (byte*)offset)
                     {
-                        Vector128<byte> comp0 = Vector128.Create(value0);
-                        Vector128<byte> comp1 = Vector128.Create(value1);
-                        Vector128<byte> comp2 = Vector128.Create(value2);
+                        Vector128<byte> values0 = Vector128.Create(value0);
+                        Vector128<byte> values1 = Vector128.Create(value1);
+                        Vector128<byte> values2 = Vector128.Create(value2);
 
-                        Vector128<byte> search = Unsafe.ReadUnaligned<Vector128<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
-                        int matches = Sse2.MoveMask(Sse2.CompareEqual(comp0, search));
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(comp1, search));
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(comp2, search));
+                        Vector128<byte> search = LoadVector128(ref searchSpace, offset);
+                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values0, search));
+                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values1, search));
+                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values2, search));
                         if (matches == 0)
                         {
-                            index += Vector128<byte>.Count;
+                            offset += Vector128<byte>.Count;
                         }
-                        // Find offset of first match
                         else
                         {
-                            return ((int)(byte*)index) + BitOps.TrailingZeroCount(matches);
+                            // Find offset of first match
+                            return ((int)(byte*)offset) + BitOps.TrailingZeroCount(matches);
                         }
                     }
 
-                    if ((int)(byte*)index < length)
+                    if ((int)(byte*)offset < length)
                     {
-                        nLength = (IntPtr)(length - (int)(byte*)index);
+                        nLength = (IntPtr)(length - (int)(byte*)offset);
                         goto SequentialScan;
                     }
                 }
             }
             else if (Sse2.IsSupported)
             {
-                if ((int)(byte*)index < length)
+                if ((int)(byte*)offset < length)
                 {
-                    nLength = GetByteVector128SpanLength(index, length);
+                    nLength = GetByteVector128SpanLength(offset, length);
 
-                    Vector128<byte> comp0 = Vector128.Create(value0);
-                    Vector128<byte> comp1 = Vector128.Create(value1);
-                    Vector128<byte> comp2 = Vector128.Create(value2);
+                    Vector128<byte> values0 = Vector128.Create(value0);
+                    Vector128<byte> values1 = Vector128.Create(value1);
+                    Vector128<byte> values2 = Vector128.Create(value2);
 
-                    while ((byte*)nLength > (byte*)index)
+                    while ((byte*)nLength > (byte*)offset)
                     {
-                        Vector128<byte> search = Unsafe.ReadUnaligned<Vector128<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
-                        int matches = Sse2.MoveMask(Sse2.CompareEqual(comp0, search));
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(comp1, search));
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(comp2, search));
+                        Vector128<byte> search = LoadVector128(ref searchSpace, offset);
+                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values0, search));
+                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values1, search));
+                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values2, search));
                         if (matches == 0)
                         {
-                            index += Vector128<byte>.Count;
+                            offset += Vector128<byte>.Count;
                             continue;
                         }
+
                         // Find offset of first match
-                        else
-                        {
-                            return ((int)(byte*)index) + BitOps.TrailingZeroCount(matches);
-                        }
+                        return ((int)(byte*)offset) + BitOps.TrailingZeroCount(matches);
                     }
 
-                    if ((int)(byte*)index < length)
+                    if ((int)(byte*)offset < length)
                     {
-                        nLength = (IntPtr)(length - (int)(byte*)index);
+                        nLength = (IntPtr)(length - (int)(byte*)offset);
                         goto SequentialScan;
                     }
                 }
             }
             else if (Vector.IsHardwareAccelerated)
             {
-                if ((int)(byte*)index < length)
+                if ((int)(byte*)offset < length)
                 {
-                    nLength = GetByteVectorSpanLength(index, length);
+                    nLength = GetByteVectorSpanLength(offset, length);
 
                     // Get comparison Vector
                     Vector<byte> values0 = new Vector<byte>(value0);
                     Vector<byte> values1 = new Vector<byte>(value1);
                     Vector<byte> values2 = new Vector<byte>(value2);
 
-                    while ((byte*)nLength > (byte*)index)
+                    while ((byte*)nLength > (byte*)offset)
                     {
-                        Vector<byte> vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
+                        Vector<byte> search = LoadVector(ref searchSpace, offset);
 
-                        var vMatches = Vector.BitwiseOr(
+                        var matches = Vector.BitwiseOr(
                                         Vector.BitwiseOr(
-                                            Vector.Equals(vData, values0),
-                                            Vector.Equals(vData, values1)),
-                                        Vector.Equals(vData, values2));
+                                            Vector.Equals(search, values0),
+                                            Vector.Equals(search, values1)),
+                                        Vector.Equals(search, values2));
 
-                        if (Vector<byte>.Zero.Equals(vMatches))
+                        if (Vector<byte>.Zero.Equals(matches))
                         {
-                            index += Vector<byte>.Count;
+                            offset += Vector<byte>.Count;
                             continue;
                         }
+
                         // Find offset of first match
-                        return (int)(byte*)index + LocateFirstFoundByte(vMatches);
+                        return (int)(byte*)offset + LocateFirstFoundByte(matches);
                     }
 
-                    if ((int)(byte*)index < length)
+                    if ((int)(byte*)offset < length)
                     {
-                        nLength = (IntPtr)(length - (int)(byte*)index);
+                        nLength = (IntPtr)(length - (int)(byte*)offset);
                         goto SequentialScan;
                     }
                 }
             }
             return -1;
         Found: // Workaround for https://github.com/dotnet/coreclr/issues/13549
-            return (int)(byte*)index;
+            return (int)(byte*)offset;
         Found1:
-            return (int)(byte*)(index + 1);
+            return (int)(byte*)(offset + 1);
         Found2:
-            return (int)(byte*)(index + 2);
+            return (int)(byte*)(offset + 2);
         Found3:
-            return (int)(byte*)(index + 3);
+            return (int)(byte*)(offset + 3);
         Found4:
-            return (int)(byte*)(index + 4);
+            return (int)(byte*)(offset + 4);
         Found5:
-            return (int)(byte*)(index + 5);
+            return (int)(byte*)(offset + 5);
         Found6:
-            return (int)(byte*)(index + 6);
+            return (int)(byte*)(offset + 6);
         Found7:
-            return (int)(byte*)(index + 7);
+            return (int)(byte*)(offset + 7);
         }
 
         public static unsafe int LastIndexOfAny(ref byte searchSpace, byte value0, byte value1, int length)
@@ -1001,7 +992,7 @@ namespace System
 
             uint uValue0 = value0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue1 = value1; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            IntPtr index = (IntPtr)length; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr offset = (IntPtr)length; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
             IntPtr nLength = (IntPtr)length;
 
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
@@ -1014,30 +1005,30 @@ namespace System
             while ((byte*)nLength >= (byte*)8)
             {
                 nLength -= 8;
-                index -= 8;
+                offset -= 8;
 
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 7);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 7);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found7;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 6);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 6);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found6;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 5);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 5);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found5;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 4);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 4);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found4;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found3;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
             }
@@ -1045,18 +1036,18 @@ namespace System
             if ((byte*)nLength >= (byte*)4)
             {
                 nLength -= 4;
-                index -= 4;
+                offset -= 4;
 
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found3;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
             }
@@ -1064,16 +1055,16 @@ namespace System
             while ((byte*)nLength > (byte*)0)
             {
                 nLength -= 1;
-                index -= 1;
+                offset -= 1;
 
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
             }
 
-            if (Vector.IsHardwareAccelerated && ((byte*)index > (byte*)0))
+            if (Vector.IsHardwareAccelerated && ((byte*)offset > (byte*)0))
             {
-                nLength = (IntPtr)((int)(byte*)index & ~(Vector<byte>.Count - 1));
+                nLength = (IntPtr)((int)(byte*)offset & ~(Vector<byte>.Count - 1));
 
                 // Get comparison Vector
                 Vector<byte> values0 = new Vector<byte>(value0);
@@ -1081,43 +1072,44 @@ namespace System
 
                 while ((byte*)nLength > (byte*)(Vector<byte>.Count - 1))
                 {
-                    Vector<byte> vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index - Vector<byte>.Count));
-                    var vMatches = Vector.BitwiseOr(
-                                    Vector.Equals(vData, values0),
-                                    Vector.Equals(vData, values1));
-                    if (Vector<byte>.Zero.Equals(vMatches))
+                    Vector<byte> search = LoadVector(ref searchSpace, offset - Vector<byte>.Count);
+                    var matches = Vector.BitwiseOr(
+                                    Vector.Equals(search, values0),
+                                    Vector.Equals(search, values1));
+                    if (Vector<byte>.Zero.Equals(matches))
                     {
-                        index -= Vector<byte>.Count;
+                        offset -= Vector<byte>.Count;
                         nLength -= Vector<byte>.Count;
                         continue;
                     }
+
                     // Find offset of first match
-                    return (int)(index) - Vector<byte>.Count + LocateLastFoundByte(vMatches);
+                    return (int)(offset) - Vector<byte>.Count + LocateLastFoundByte(matches);
                 }
 
-                if ((byte*)index > (byte*)0)
+                if ((byte*)offset > (byte*)0)
                 {
-                    nLength = index;
+                    nLength = offset;
                     goto SequentialScan;
                 }
             }
             return -1;
         Found: // Workaround for https://github.com/dotnet/coreclr/issues/13549
-            return (int)(byte*)index;
+            return (int)(byte*)offset;
         Found1:
-            return (int)(byte*)(index + 1);
+            return (int)(byte*)(offset + 1);
         Found2:
-            return (int)(byte*)(index + 2);
+            return (int)(byte*)(offset + 2);
         Found3:
-            return (int)(byte*)(index + 3);
+            return (int)(byte*)(offset + 3);
         Found4:
-            return (int)(byte*)(index + 4);
+            return (int)(byte*)(offset + 4);
         Found5:
-            return (int)(byte*)(index + 5);
+            return (int)(byte*)(offset + 5);
         Found6:
-            return (int)(byte*)(index + 6);
+            return (int)(byte*)(offset + 6);
         Found7:
-            return (int)(byte*)(index + 7);
+            return (int)(byte*)(offset + 7);
         }
 
         public static unsafe int LastIndexOfAny(ref byte searchSpace, byte value0, byte value1, byte value2, int length)
@@ -1127,7 +1119,7 @@ namespace System
             uint uValue0 = value0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue1 = value1; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue2 = value2; // Use uint for comparisons to avoid unnecessary 8->32 extensions
-            IntPtr index = (IntPtr)length; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr offset = (IntPtr)length; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
             IntPtr nLength = (IntPtr)length;
 
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
@@ -1140,30 +1132,30 @@ namespace System
             while ((byte*)nLength >= (byte*)8)
             {
                 nLength -= 8;
-                index -= 8;
+                offset -= 8;
 
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 7);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 7);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found7;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 6);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 6);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found6;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 5);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 5);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found5;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 4);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 4);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found4;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found3;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
             }
@@ -1171,18 +1163,18 @@ namespace System
             if ((byte*)nLength >= (byte*)4)
             {
                 nLength -= 4;
-                index -= 4;
+                offset -= 4;
 
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found3;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
             }
@@ -1190,16 +1182,16 @@ namespace System
             while ((byte*)nLength > (byte*)0)
             {
                 nLength -= 1;
-                index -= 1;
+                offset -= 1;
 
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, index);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
             }
 
-            if (Vector.IsHardwareAccelerated && ((byte*)index > (byte*)0))
+            if (Vector.IsHardwareAccelerated && ((byte*)offset > (byte*)0))
             {
-                nLength = (IntPtr)((int)(byte*)index & ~(Vector<byte>.Count - 1));
+                nLength = (IntPtr)((int)(byte*)offset & ~(Vector<byte>.Count - 1));
 
                 // Get comparison Vector
                 Vector<byte> values0 = new Vector<byte>(value0);
@@ -1208,47 +1200,48 @@ namespace System
 
                 while ((byte*)nLength > (byte*)(Vector<byte>.Count - 1))
                 {
-                    Vector<byte> vData = Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index - Vector<byte>.Count));
+                    Vector<byte> search = LoadVector(ref searchSpace, offset - Vector<byte>.Count);
 
-                    var vMatches = Vector.BitwiseOr(
+                    var matches = Vector.BitwiseOr(
                                     Vector.BitwiseOr(
-                                        Vector.Equals(vData, values0),
-                                        Vector.Equals(vData, values1)),
-                                    Vector.Equals(vData, values2));
+                                        Vector.Equals(search, values0),
+                                        Vector.Equals(search, values1)),
+                                    Vector.Equals(search, values2));
 
-                    if (Vector<byte>.Zero.Equals(vMatches))
+                    if (Vector<byte>.Zero.Equals(matches))
                     {
-                        index -= Vector<byte>.Count;
+                        offset -= Vector<byte>.Count;
                         nLength -= Vector<byte>.Count;
                         continue;
                     }
+
                     // Find offset of first match
-                    return (int)(index) - Vector<byte>.Count + LocateLastFoundByte(vMatches);
+                    return (int)(offset) - Vector<byte>.Count + LocateLastFoundByte(matches);
                 }
 
-                if ((byte*)index > (byte*)0)
+                if ((byte*)offset > (byte*)0)
                 {
-                    nLength = index;
+                    nLength = offset;
                     goto SequentialScan;
                 }
             }
             return -1;
         Found: // Workaround for https://github.com/dotnet/coreclr/issues/13549
-            return (int)(byte*)index;
+            return (int)(byte*)offset;
         Found1:
-            return (int)(byte*)(index + 1);
+            return (int)(byte*)(offset + 1);
         Found2:
-            return (int)(byte*)(index + 2);
+            return (int)(byte*)(offset + 2);
         Found3:
-            return (int)(byte*)(index + 3);
+            return (int)(byte*)(offset + 3);
         Found4:
-            return (int)(byte*)(index + 4);
+            return (int)(byte*)(offset + 4);
         Found5:
-            return (int)(byte*)(index + 5);
+            return (int)(byte*)(offset + 5);
         Found6:
-            return (int)(byte*)(index + 6);
+            return (int)(byte*)(offset + 6);
         Found7:
-            return (int)(byte*)(index + 7);
+            return (int)(byte*)(offset + 7);
         }
 
         // Optimized byte-based SequenceEquals. The "length" parameter for this one is declared a nuint rather than int as we also use it for types other than byte
@@ -1258,51 +1251,46 @@ namespace System
             if (Unsafe.AreSame(ref first, ref second))
                 goto Equal;
 
-            IntPtr i = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
-            IntPtr n = (IntPtr)(void*)length;
+            IntPtr offset = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr nLength = (IntPtr)(void*)length;
 
-            if (Vector.IsHardwareAccelerated && (byte*)n >= (byte*)Vector<byte>.Count)
+            if (Vector.IsHardwareAccelerated && (byte*)nLength >= (byte*)Vector<byte>.Count)
             {
-                n -= Vector<byte>.Count;
-                while ((byte*)n > (byte*)i)
+                nLength -= Vector<byte>.Count;
+                while ((byte*)nLength > (byte*)offset)
                 {
-                    if (Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref first, i)) !=
-                        Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref second, i)))
+                    if (LoadVector(ref first, offset) != LoadVector(ref second, offset))
                     {
                         goto NotEqual;
                     }
-                    i += Vector<byte>.Count;
+                    offset += Vector<byte>.Count;
                 }
-                return Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref first, n)) ==
-                       Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref second, n));
+                return LoadVector(ref first, nLength) == LoadVector(ref second, nLength);
             }
 
-            if ((byte*)n >= (byte*)sizeof(UIntPtr))
+            if ((byte*)nLength >= (byte*)sizeof(UIntPtr))
             {
-                n -= sizeof(UIntPtr);
-                while ((byte*)n > (byte*)i)
+                nLength -= sizeof(UIntPtr);
+                while ((byte*)nLength > (byte*)offset)
                 {
-                    if (Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref first, i)) !=
-                        Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref second, i)))
+                    if (LoadUIntPtr(ref first, offset) != LoadUIntPtr(ref second, offset))
                     {
                         goto NotEqual;
                     }
-                    i += sizeof(UIntPtr);
+                    offset += sizeof(UIntPtr);
                 }
-                return Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref first, n)) ==
-                       Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref second, n));
+                return LoadUIntPtr(ref first, nLength) == LoadUIntPtr(ref second, nLength);
             }
 
-            while ((byte*)n > (byte*)i)
+            while ((byte*)nLength > (byte*)offset)
             {
-                if (Unsafe.AddByteOffset(ref first, i) != Unsafe.AddByteOffset(ref second, i))
+                if (Unsafe.AddByteOffset(ref first, offset) != Unsafe.AddByteOffset(ref second, offset))
                     goto NotEqual;
-                i += 1;
+                offset += 1;
             }
 
         Equal:
             return true;
-
         NotEqual: // Workaround for https://github.com/dotnet/coreclr/issues/13549
             return false;
         }
@@ -1338,45 +1326,43 @@ namespace System
 
             IntPtr minLength = (IntPtr)((firstLength < secondLength) ? firstLength : secondLength);
 
-            IntPtr i = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
-            IntPtr n = (IntPtr)(void*)minLength;
+            IntPtr offset = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
+            IntPtr nLength = (IntPtr)(void*)minLength;
 
-            if (Vector.IsHardwareAccelerated && (byte*)n > (byte*)Vector<byte>.Count)
+            if (Vector.IsHardwareAccelerated && (byte*)nLength > (byte*)Vector<byte>.Count)
             {
-                n -= Vector<byte>.Count;
-                while ((byte*)n > (byte*)i)
+                nLength -= Vector<byte>.Count;
+                while ((byte*)nLength > (byte*)offset)
                 {
-                    if (Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref first, i)) !=
-                        Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref second, i)))
+                    if (LoadVector(ref first, offset) != LoadVector(ref second, offset))
                     {
                         goto NotEqual;
                     }
-                    i += Vector<byte>.Count;
+                    offset += Vector<byte>.Count;
                 }
                 goto NotEqual;
             }
 
-            if ((byte*)n > (byte*)sizeof(UIntPtr))
+            if ((byte*)nLength > (byte*)sizeof(UIntPtr))
             {
-                n -= sizeof(UIntPtr);
-                while ((byte*)n > (byte*)i)
+                nLength -= sizeof(UIntPtr);
+                while ((byte*)nLength > (byte*)offset)
                 {
-                    if (Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref first, i)) !=
-                        Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref second, i)))
+                    if (LoadUIntPtr(ref first, offset) != LoadUIntPtr(ref second, offset))
                     {
                         goto NotEqual;
                     }
-                    i += sizeof(UIntPtr);
+                    offset += sizeof(UIntPtr);
                 }
             }
 
         NotEqual:  // Workaround for https://github.com/dotnet/coreclr/issues/13549
-            while ((byte*)minLength > (byte*)i)
+            while ((byte*)minLength > (byte*)offset)
             {
-                int result = Unsafe.AddByteOffset(ref first, i).CompareTo(Unsafe.AddByteOffset(ref second, i));
+                int result = Unsafe.AddByteOffset(ref first, offset).CompareTo(Unsafe.AddByteOffset(ref second, offset));
                 if (result != 0)
                     return result;
-                i += 1;
+                offset += 1;
             }
 
         Equal:
@@ -1449,6 +1435,23 @@ namespace System
                                                        0x03ul << 32 |
                                                        0x02ul << 40 |
                                                        0x01ul << 48) + 1;
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe UIntPtr LoadUIntPtr(ref byte start, IntPtr offset)
+            => Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref start, offset));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe Vector<byte> LoadVector(ref byte start, IntPtr offset)
+            => Unsafe.ReadUnaligned<Vector<byte>>(ref Unsafe.AddByteOffset(ref start, offset));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe Vector128<byte> LoadVector128(ref byte start, IntPtr offset)
+            => Unsafe.ReadUnaligned<Vector128<byte>>(ref Unsafe.AddByteOffset(ref start, offset));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe Vector256<byte> LoadVector256(ref byte start, IntPtr offset)
+            => Unsafe.ReadUnaligned<Vector256<byte>>(ref Unsafe.AddByteOffset(ref start, offset));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe IntPtr GetByteVectorSpanLength(IntPtr offset, int length)

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
@@ -119,14 +119,14 @@ namespace System
             {
                 nLength -= 8;
 
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 0) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 1) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 2) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 3) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 4) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 5) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 6) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 7))
+                if (uValue == LoadByte(ref searchSpace, offset + 0) ||
+                    uValue == LoadByte(ref searchSpace, offset + 1) ||
+                    uValue == LoadByte(ref searchSpace, offset + 2) ||
+                    uValue == LoadByte(ref searchSpace, offset + 3) ||
+                    uValue == LoadByte(ref searchSpace, offset + 4) ||
+                    uValue == LoadByte(ref searchSpace, offset + 5) ||
+                    uValue == LoadByte(ref searchSpace, offset + 6) ||
+                    uValue == LoadByte(ref searchSpace, offset + 7))
                 {
                     goto Found;
                 }
@@ -138,10 +138,10 @@ namespace System
             {
                 nLength -= 4;
 
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 0) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 1) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 2) ||
-                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 3))
+                if (uValue == LoadByte(ref searchSpace, offset + 0) ||
+                    uValue == LoadByte(ref searchSpace, offset + 1) ||
+                    uValue == LoadByte(ref searchSpace, offset + 2) ||
+                    uValue == LoadByte(ref searchSpace, offset + 3))
                 {
                     goto Found;
                 }
@@ -153,7 +153,7 @@ namespace System
             {
                 nLength -= 1;
 
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
+                if (uValue == LoadByte(ref searchSpace, offset))
                     goto Found;
 
                 offset += 1;
@@ -218,21 +218,21 @@ namespace System
             {
                 nLength -= 8;
 
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
+                if (uValue == LoadByte(ref searchSpace, offset))
                     goto Found;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 1))
+                if (uValue == LoadByte(ref searchSpace, offset + 1))
                     goto Found1;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 2))
+                if (uValue == LoadByte(ref searchSpace, offset + 2))
                     goto Found2;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 3))
+                if (uValue == LoadByte(ref searchSpace, offset + 3))
                     goto Found3;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 4))
+                if (uValue == LoadByte(ref searchSpace, offset + 4))
                     goto Found4;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 5))
+                if (uValue == LoadByte(ref searchSpace, offset + 5))
                     goto Found5;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 6))
+                if (uValue == LoadByte(ref searchSpace, offset + 6))
                     goto Found6;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 7))
+                if (uValue == LoadByte(ref searchSpace, offset + 7))
                     goto Found7;
 
                 offset += 8;
@@ -242,13 +242,13 @@ namespace System
             {
                 nLength -= 4;
 
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
+                if (uValue == LoadByte(ref searchSpace, offset))
                     goto Found;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 1))
+                if (uValue == LoadByte(ref searchSpace, offset + 1))
                     goto Found1;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 2))
+                if (uValue == LoadByte(ref searchSpace, offset + 2))
                     goto Found2;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 3))
+                if (uValue == LoadByte(ref searchSpace, offset + 3))
                     goto Found3;
 
                 offset += 4;
@@ -258,7 +258,7 @@ namespace System
             {
                 nLength -= 1;
 
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
+                if (uValue == LoadByte(ref searchSpace, offset))
                     goto Found;
 
                 offset += 1;
@@ -441,21 +441,21 @@ namespace System
                 nLength -= 8;
                 offset -= 8;
 
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 7))
+                if (uValue == LoadByte(ref searchSpace, offset + 7))
                     goto Found7;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 6))
+                if (uValue == LoadByte(ref searchSpace, offset + 6))
                     goto Found6;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 5))
+                if (uValue == LoadByte(ref searchSpace, offset + 5))
                     goto Found5;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 4))
+                if (uValue == LoadByte(ref searchSpace, offset + 4))
                     goto Found4;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 3))
+                if (uValue == LoadByte(ref searchSpace, offset + 3))
                     goto Found3;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 2))
+                if (uValue == LoadByte(ref searchSpace, offset + 2))
                     goto Found2;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 1))
+                if (uValue == LoadByte(ref searchSpace, offset + 1))
                     goto Found1;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
+                if (uValue == LoadByte(ref searchSpace, offset))
                     goto Found;
             }
 
@@ -464,13 +464,13 @@ namespace System
                 nLength -= 4;
                 offset -= 4;
 
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 3))
+                if (uValue == LoadByte(ref searchSpace, offset + 3))
                     goto Found3;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 2))
+                if (uValue == LoadByte(ref searchSpace, offset + 2))
                     goto Found2;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 1))
+                if (uValue == LoadByte(ref searchSpace, offset + 1))
                     goto Found1;
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
+                if (uValue == LoadByte(ref searchSpace, offset))
                     goto Found;
             }
 
@@ -479,7 +479,7 @@ namespace System
                 nLength -= 1;
                 offset -= 1;
 
-                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
+                if (uValue == LoadByte(ref searchSpace, offset))
                     goto Found;
             }
 
@@ -557,28 +557,28 @@ namespace System
             {
                 nLength -= 8;
 
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
+                lookUp = LoadByte(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
+                lookUp = LoadByte(ref searchSpace, offset + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
+                lookUp = LoadByte(ref searchSpace, offset + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
+                lookUp = LoadByte(ref searchSpace, offset + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found3;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 4);
+                lookUp = LoadByte(ref searchSpace, offset + 4);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found4;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 5);
+                lookUp = LoadByte(ref searchSpace, offset + 5);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found5;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 6);
+                lookUp = LoadByte(ref searchSpace, offset + 6);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found6;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 7);
+                lookUp = LoadByte(ref searchSpace, offset + 7);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found7;
 
@@ -589,16 +589,16 @@ namespace System
             {
                 nLength -= 4;
 
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
+                lookUp = LoadByte(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
+                lookUp = LoadByte(ref searchSpace, offset + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
+                lookUp = LoadByte(ref searchSpace, offset + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
+                lookUp = LoadByte(ref searchSpace, offset + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found3;
 
@@ -609,7 +609,7 @@ namespace System
             {
                 nLength -= 1;
 
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
+                lookUp = LoadByte(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
 
@@ -781,28 +781,28 @@ namespace System
             {
                 nLength -= 8;
 
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
+                lookUp = LoadByte(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
+                lookUp = LoadByte(ref searchSpace, offset + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
+                lookUp = LoadByte(ref searchSpace, offset + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
+                lookUp = LoadByte(ref searchSpace, offset + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found3;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 4);
+                lookUp = LoadByte(ref searchSpace, offset + 4);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found4;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 5);
+                lookUp = LoadByte(ref searchSpace, offset + 5);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found5;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 6);
+                lookUp = LoadByte(ref searchSpace, offset + 6);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found6;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 7);
+                lookUp = LoadByte(ref searchSpace, offset + 7);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found7;
 
@@ -813,16 +813,16 @@ namespace System
             {
                 nLength -= 4;
 
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
+                lookUp = LoadByte(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
+                lookUp = LoadByte(ref searchSpace, offset + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
+                lookUp = LoadByte(ref searchSpace, offset + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
+                lookUp = LoadByte(ref searchSpace, offset + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found3;
 
@@ -833,7 +833,7 @@ namespace System
             {
                 nLength -= 1;
 
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
+                lookUp = LoadByte(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
 
@@ -1007,28 +1007,28 @@ namespace System
                 nLength -= 8;
                 offset -= 8;
 
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 7);
+                lookUp = LoadByte(ref searchSpace, offset + 7);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found7;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 6);
+                lookUp = LoadByte(ref searchSpace, offset + 6);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found6;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 5);
+                lookUp = LoadByte(ref searchSpace, offset + 5);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found5;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 4);
+                lookUp = LoadByte(ref searchSpace, offset + 4);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found4;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
+                lookUp = LoadByte(ref searchSpace, offset + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found3;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
+                lookUp = LoadByte(ref searchSpace, offset + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
+                lookUp = LoadByte(ref searchSpace, offset + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
+                lookUp = LoadByte(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
             }
@@ -1038,16 +1038,16 @@ namespace System
                 nLength -= 4;
                 offset -= 4;
 
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
+                lookUp = LoadByte(ref searchSpace, offset + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found3;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
+                lookUp = LoadByte(ref searchSpace, offset + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
+                lookUp = LoadByte(ref searchSpace, offset + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
+                lookUp = LoadByte(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
             }
@@ -1057,7 +1057,7 @@ namespace System
                 nLength -= 1;
                 offset -= 1;
 
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
+                lookUp = LoadByte(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
             }
@@ -1134,28 +1134,28 @@ namespace System
                 nLength -= 8;
                 offset -= 8;
 
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 7);
+                lookUp = LoadByte(ref searchSpace, offset + 7);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found7;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 6);
+                lookUp = LoadByte(ref searchSpace, offset + 6);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found6;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 5);
+                lookUp = LoadByte(ref searchSpace, offset + 5);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found5;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 4);
+                lookUp = LoadByte(ref searchSpace, offset + 4);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found4;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
+                lookUp = LoadByte(ref searchSpace, offset + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found3;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
+                lookUp = LoadByte(ref searchSpace, offset + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
+                lookUp = LoadByte(ref searchSpace, offset + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
+                lookUp = LoadByte(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
             }
@@ -1165,16 +1165,16 @@ namespace System
                 nLength -= 4;
                 offset -= 4;
 
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
+                lookUp = LoadByte(ref searchSpace, offset + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found3;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
+                lookUp = LoadByte(ref searchSpace, offset + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found2;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
+                lookUp = LoadByte(ref searchSpace, offset + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found1;
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
+                lookUp = LoadByte(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
             }
@@ -1184,7 +1184,7 @@ namespace System
                 nLength -= 1;
                 offset -= 1;
 
-                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
+                lookUp = LoadByte(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
             }
@@ -1284,7 +1284,7 @@ namespace System
 
             while ((byte*)nLength > (byte*)offset)
             {
-                if (Unsafe.AddByteOffset(ref first, offset) != Unsafe.AddByteOffset(ref second, offset))
+                if (LoadByte(ref first, offset) != LoadByte(ref second, offset))
                     goto NotEqual;
                 offset += 1;
             }
@@ -1359,7 +1359,7 @@ namespace System
         NotEqual:  // Workaround for https://github.com/dotnet/coreclr/issues/13549
             while ((byte*)minLength > (byte*)offset)
             {
-                int result = Unsafe.AddByteOffset(ref first, offset).CompareTo(Unsafe.AddByteOffset(ref second, offset));
+                int result = LoadByte(ref first, offset).CompareTo(LoadByte(ref second, offset));
                 if (result != 0)
                     return result;
                 offset += 1;
@@ -1436,6 +1436,10 @@ namespace System
                                                        0x02ul << 40 |
                                                        0x01ul << 48) + 1;
 
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe byte LoadByte(ref byte start, IntPtr offset)
+            => Unsafe.AddByteOffset(ref start, offset);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe UIntPtr LoadUIntPtr(ref byte start, IntPtr offset)

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
@@ -119,14 +119,14 @@ namespace System
             {
                 nLength -= 8;
 
-                if (uValue == LoadByte(ref searchSpace, offset + 0) ||
-                    uValue == LoadByte(ref searchSpace, offset + 1) ||
-                    uValue == LoadByte(ref searchSpace, offset + 2) ||
-                    uValue == LoadByte(ref searchSpace, offset + 3) ||
-                    uValue == LoadByte(ref searchSpace, offset + 4) ||
-                    uValue == LoadByte(ref searchSpace, offset + 5) ||
-                    uValue == LoadByte(ref searchSpace, offset + 6) ||
-                    uValue == LoadByte(ref searchSpace, offset + 7))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 0) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 1) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 2) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 3) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 4) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 5) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 6) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 7))
                 {
                     goto Found;
                 }
@@ -138,10 +138,10 @@ namespace System
             {
                 nLength -= 4;
 
-                if (uValue == LoadByte(ref searchSpace, offset + 0) ||
-                    uValue == LoadByte(ref searchSpace, offset + 1) ||
-                    uValue == LoadByte(ref searchSpace, offset + 2) ||
-                    uValue == LoadByte(ref searchSpace, offset + 3))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 0) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 1) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 2) ||
+                    uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 3))
                 {
                     goto Found;
                 }
@@ -153,7 +153,7 @@ namespace System
             {
                 nLength -= 1;
 
-                if (uValue == LoadByte(ref searchSpace, offset))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
                     goto Found;
 
                 offset += 1;
@@ -217,21 +217,21 @@ namespace System
             {
                 nLength -= 8;
 
-                if (uValue == LoadByte(ref searchSpace, offset))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
                     goto Found;
-                if (uValue == LoadByte(ref searchSpace, offset + 1))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 1))
                     goto Found1;
-                if (uValue == LoadByte(ref searchSpace, offset + 2))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 2))
                     goto Found2;
-                if (uValue == LoadByte(ref searchSpace, offset + 3))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 3))
                     goto Found3;
-                if (uValue == LoadByte(ref searchSpace, offset + 4))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 4))
                     goto Found4;
-                if (uValue == LoadByte(ref searchSpace, offset + 5))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 5))
                     goto Found5;
-                if (uValue == LoadByte(ref searchSpace, offset + 6))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 6))
                     goto Found6;
-                if (uValue == LoadByte(ref searchSpace, offset + 7))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 7))
                     goto Found7;
 
                 offset += 8;
@@ -241,13 +241,13 @@ namespace System
             {
                 nLength -= 4;
 
-                if (uValue == LoadByte(ref searchSpace, offset))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
                     goto Found;
-                if (uValue == LoadByte(ref searchSpace, offset + 1))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 1))
                     goto Found1;
-                if (uValue == LoadByte(ref searchSpace, offset + 2))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 2))
                     goto Found2;
-                if (uValue == LoadByte(ref searchSpace, offset + 3))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 3))
                     goto Found3;
 
                 offset += 4;
@@ -257,7 +257,7 @@ namespace System
             {
                 nLength -= 1;
 
-                if (uValue == LoadByte(ref searchSpace, offset))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
                     goto Found;
 
                 offset += 1;
@@ -440,21 +440,21 @@ namespace System
                 nLength -= 8;
                 offset -= 8;
 
-                if (uValue == LoadByte(ref searchSpace, offset + 7))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 7))
                     goto Found7;
-                if (uValue == LoadByte(ref searchSpace, offset + 6))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 6))
                     goto Found6;
-                if (uValue == LoadByte(ref searchSpace, offset + 5))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 5))
                     goto Found5;
-                if (uValue == LoadByte(ref searchSpace, offset + 4))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 4))
                     goto Found4;
-                if (uValue == LoadByte(ref searchSpace, offset + 3))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 3))
                     goto Found3;
-                if (uValue == LoadByte(ref searchSpace, offset + 2))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 2))
                     goto Found2;
-                if (uValue == LoadByte(ref searchSpace, offset + 1))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 1))
                     goto Found1;
-                if (uValue == LoadByte(ref searchSpace, offset))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
                     goto Found;
             }
 
@@ -463,13 +463,13 @@ namespace System
                 nLength -= 4;
                 offset -= 4;
 
-                if (uValue == LoadByte(ref searchSpace, offset + 3))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 3))
                     goto Found3;
-                if (uValue == LoadByte(ref searchSpace, offset + 2))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 2))
                     goto Found2;
-                if (uValue == LoadByte(ref searchSpace, offset + 1))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 1))
                     goto Found1;
-                if (uValue == LoadByte(ref searchSpace, offset))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
                     goto Found;
             }
 
@@ -478,7 +478,7 @@ namespace System
                 nLength -= 1;
                 offset -= 1;
 
-                if (uValue == LoadByte(ref searchSpace, offset))
+                if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
                     goto Found;
             }
 
@@ -555,28 +555,28 @@ namespace System
             {
                 nLength -= 8;
 
-                lookUp = LoadByte(ref searchSpace, offset);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
-                lookUp = LoadByte(ref searchSpace, offset + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found1;
-                lookUp = LoadByte(ref searchSpace, offset + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found2;
-                lookUp = LoadByte(ref searchSpace, offset + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found3;
-                lookUp = LoadByte(ref searchSpace, offset + 4);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 4);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found4;
-                lookUp = LoadByte(ref searchSpace, offset + 5);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 5);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found5;
-                lookUp = LoadByte(ref searchSpace, offset + 6);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 6);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found6;
-                lookUp = LoadByte(ref searchSpace, offset + 7);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 7);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found7;
 
@@ -587,16 +587,16 @@ namespace System
             {
                 nLength -= 4;
 
-                lookUp = LoadByte(ref searchSpace, offset);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
-                lookUp = LoadByte(ref searchSpace, offset + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found1;
-                lookUp = LoadByte(ref searchSpace, offset + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found2;
-                lookUp = LoadByte(ref searchSpace, offset + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found3;
 
@@ -607,7 +607,7 @@ namespace System
             {
                 nLength -= 1;
 
-                lookUp = LoadByte(ref searchSpace, offset);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
 
@@ -778,28 +778,28 @@ namespace System
             {
                 nLength -= 8;
 
-                lookUp = LoadByte(ref searchSpace, offset);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
-                lookUp = LoadByte(ref searchSpace, offset + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found1;
-                lookUp = LoadByte(ref searchSpace, offset + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found2;
-                lookUp = LoadByte(ref searchSpace, offset + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found3;
-                lookUp = LoadByte(ref searchSpace, offset + 4);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 4);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found4;
-                lookUp = LoadByte(ref searchSpace, offset + 5);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 5);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found5;
-                lookUp = LoadByte(ref searchSpace, offset + 6);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 6);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found6;
-                lookUp = LoadByte(ref searchSpace, offset + 7);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 7);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found7;
 
@@ -810,16 +810,16 @@ namespace System
             {
                 nLength -= 4;
 
-                lookUp = LoadByte(ref searchSpace, offset);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
-                lookUp = LoadByte(ref searchSpace, offset + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found1;
-                lookUp = LoadByte(ref searchSpace, offset + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found2;
-                lookUp = LoadByte(ref searchSpace, offset + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found3;
 
@@ -830,7 +830,7 @@ namespace System
             {
                 nLength -= 1;
 
-                lookUp = LoadByte(ref searchSpace, offset);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
 
@@ -1002,28 +1002,28 @@ namespace System
                 nLength -= 8;
                 offset -= 8;
 
-                lookUp = LoadByte(ref searchSpace, offset + 7);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 7);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found7;
-                lookUp = LoadByte(ref searchSpace, offset + 6);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 6);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found6;
-                lookUp = LoadByte(ref searchSpace, offset + 5);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 5);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found5;
-                lookUp = LoadByte(ref searchSpace, offset + 4);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 4);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found4;
-                lookUp = LoadByte(ref searchSpace, offset + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found3;
-                lookUp = LoadByte(ref searchSpace, offset + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found2;
-                lookUp = LoadByte(ref searchSpace, offset + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found1;
-                lookUp = LoadByte(ref searchSpace, offset);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
             }
@@ -1033,16 +1033,16 @@ namespace System
                 nLength -= 4;
                 offset -= 4;
 
-                lookUp = LoadByte(ref searchSpace, offset + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found3;
-                lookUp = LoadByte(ref searchSpace, offset + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found2;
-                lookUp = LoadByte(ref searchSpace, offset + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found1;
-                lookUp = LoadByte(ref searchSpace, offset);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
             }
@@ -1052,7 +1052,7 @@ namespace System
                 nLength -= 1;
                 offset -= 1;
 
-                lookUp = LoadByte(ref searchSpace, offset);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp)
                     goto Found;
             }
@@ -1127,28 +1127,28 @@ namespace System
                 nLength -= 8;
                 offset -= 8;
 
-                lookUp = LoadByte(ref searchSpace, offset + 7);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 7);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found7;
-                lookUp = LoadByte(ref searchSpace, offset + 6);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 6);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found6;
-                lookUp = LoadByte(ref searchSpace, offset + 5);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 5);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found5;
-                lookUp = LoadByte(ref searchSpace, offset + 4);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 4);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found4;
-                lookUp = LoadByte(ref searchSpace, offset + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found3;
-                lookUp = LoadByte(ref searchSpace, offset + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found2;
-                lookUp = LoadByte(ref searchSpace, offset + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found1;
-                lookUp = LoadByte(ref searchSpace, offset);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
             }
@@ -1158,16 +1158,16 @@ namespace System
                 nLength -= 4;
                 offset -= 4;
 
-                lookUp = LoadByte(ref searchSpace, offset + 3);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found3;
-                lookUp = LoadByte(ref searchSpace, offset + 2);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 2);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found2;
-                lookUp = LoadByte(ref searchSpace, offset + 1);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 1);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found1;
-                lookUp = LoadByte(ref searchSpace, offset);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
             }
@@ -1177,7 +1177,7 @@ namespace System
                 nLength -= 1;
                 offset -= 1;
 
-                lookUp = LoadByte(ref searchSpace, offset);
+                lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
                     goto Found;
             }
@@ -1276,7 +1276,7 @@ namespace System
 
             while ((byte*)nLength > (byte*)offset)
             {
-                if (LoadByte(ref first, offset) != LoadByte(ref second, offset))
+                if (Unsafe.AddByteOffset(ref  first, offset) != Unsafe.AddByteOffset(ref  second, offset))
                     goto NotEqual;
                 offset += 1;
             }
@@ -1351,7 +1351,7 @@ namespace System
         NotEqual:  // Workaround for https://github.com/dotnet/coreclr/issues/13549
             while ((byte*)minLength > (byte*)offset)
             {
-                int result = LoadByte(ref first, offset).CompareTo(LoadByte(ref second, offset));
+                int result = Unsafe.AddByteOffset(ref  first, offset).CompareTo(Unsafe.AddByteOffset(ref  second, offset));
                 if (result != 0)
                     return result;
                 offset += 1;
@@ -1427,11 +1427,6 @@ namespace System
                                                        0x03ul << 32 |
                                                        0x02ul << 40 |
                                                        0x01ul << 48) + 1;
-
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe byte LoadByte(ref byte start, IntPtr offset)
-            => Unsafe.AddByteOffset(ref start, offset);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe UIntPtr LoadUIntPtr(ref byte start, IntPtr offset)

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
@@ -1244,18 +1244,5 @@ namespace System
                                                        0x03ul << 32 |
                                                        0x02ul << 40 |
                                                        0x01ul << 48) + 1;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int TrailingZeroCountFallback(int matches)
-        {
-            // https://graphics.stanford.edu/~seander/bithacks.html#ZerosOnRightMultLookup
-            return TrailingCountMultiplyDeBruijn[(int)(((uint)((matches & -matches) * 0x077CB531U)) >> 27)];
-        }
-
-        private static ReadOnlySpan<byte> TrailingCountMultiplyDeBruijn => new byte[32]
-        {
-            0, 1, 28, 2, 29, 14, 24, 3, 30, 22, 20, 15, 25, 17, 4, 8,
-            31, 27, 13, 23, 21, 19, 16, 7, 26, 12, 18, 6, 11, 5, 10, 9
-        };
     }
 }

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
@@ -200,12 +200,7 @@ namespace System
             IntPtr index = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
             IntPtr nLength = (IntPtr)length;
 
-            if (Avx2.IsSupported && length >= Vector256<byte>.Count * 2)
-            {
-                int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector256<byte>.Count - 1);
-                nLength = (IntPtr)((Vector256<byte>.Count - unaligned) & (Vector256<byte>.Count - 1));
-            }
-            else if (!Avx2.IsSupported && Sse2.IsSupported && length >= Vector128<byte>.Count * 2)
+            if ((Avx2.IsSupported || Sse2.IsSupported) && length >= Vector128<byte>.Count * 2)
             {
                 int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector128<byte>.Count - 1);
                 nLength = (IntPtr)((Vector128<byte>.Count - unaligned) & (Vector128<byte>.Count - 1));
@@ -269,26 +264,28 @@ namespace System
             if (Avx2.IsSupported && ((int)(byte*)index < length))
             {
                 nLength = (IntPtr)((length - (int)(byte*)index) & ~(Vector256<byte>.Count - 1));
-
-                Vector256<byte> comparison256 = Vector256.Create(value);
-                while ((byte*)nLength > (byte*)index)
+                if ((byte*)nLength > (byte*)index)
                 {
-                    Vector256<byte> vSearch = Unsafe.ReadUnaligned<Vector256<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
-                    int matches = Avx2.MoveMask(Avx2.CompareEqual(comparison256, vSearch));
-                    if (matches == 0)
+                    Vector256<byte> comparison256 = Vector256.Create(value);
+                    do
                     {
-                        index += Vector256<byte>.Count;
-                        continue;
-                    }
-                    // Find offset of first match
-                    else if (Bmi1.IsSupported)
-                    {
-                        return ((int)(byte*)index) + (int)Bmi1.TrailingZeroCount((uint)matches);
-                    }
-                    else
-                    {
-                        return (int)(byte*)index + TrailingZeroCountFallback(matches);
-                    }
+                        Vector256<byte> vSearch = Unsafe.ReadUnaligned<Vector256<byte>>(ref Unsafe.AddByteOffset(ref searchSpace, index));
+                        int matches = Avx2.MoveMask(Avx2.CompareEqual(comparison256, vSearch));
+                        if (matches == 0)
+                        {
+                            index += Vector256<byte>.Count;
+                            continue;
+                        }
+                        // Find offset of first match
+                        else if (Bmi1.IsSupported)
+                        {
+                            return ((int)(byte*)index) + (int)Bmi1.TrailingZeroCount((uint)matches);
+                        }
+                        else
+                        {
+                            return (int)(byte*)index + TrailingZeroCountFallback(matches);
+                        }
+                    } while ((byte*)nLength > (byte*)index);
                 }
 
                 nLength = (IntPtr)((length - (int)(byte*)index) & ~(Vector128<byte>.Count - 1));

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
@@ -204,17 +204,14 @@ namespace System
             {
                 if (length >= Vector128<byte>.Count * 2)
                 {
-                    int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector128<byte>.Count - 1);
-                    nLength = (IntPtr)((Vector128<byte>.Count - unaligned) & (Vector128<byte>.Count - 1));
+                    nLength = UnalignedByteCountVector128(ref searchSpace);
                 }
-                
             }
             else if (Vector.IsHardwareAccelerated)
             {
                 if (length >= Vector<byte>.Count * 2)
                 {
-                    int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
-                    nLength = (IntPtr)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
+                    nLength = UnalignedByteCountVector(ref searchSpace);
                 }
             }
         SequentialScan:
@@ -272,7 +269,7 @@ namespace System
             {
                 if ((int)(byte*)index < length)
                 {
-                    nLength = (IntPtr)((length - (int)(byte*)index) & ~(Vector256<byte>.Count - 1));
+                    nLength = GetByteVector256SpanLength(index, length);
                     if ((byte*)nLength > (byte*)index)
                     {
                         Vector256<byte> comparison = Vector256.Create(value);
@@ -285,19 +282,15 @@ namespace System
                                 index += Vector256<byte>.Count;
                                 continue;
                             }
-                            // Find offset of first match
-                            else if (Bmi1.IsSupported)
-                            {
-                                return ((int)(byte*)index) + (int)Bmi1.TrailingZeroCount((uint)matches);
-                            }
                             else
                             {
-                                return (int)(byte*)index + TrailingZeroCountFallback(matches);
+                                // Find offset of first match
+                                return ((int)(byte*)index) + BitOps.TrailingZeroCount(matches);
                             }
                         } while ((byte*)nLength > (byte*)index);
                     }
 
-                    nLength = (IntPtr)((length - (int)(byte*)index) & ~(Vector128<byte>.Count - 1));
+                    nLength = GetByteVector128SpanLength(index, length);
                     if ((byte*)nLength > (byte*)index)
                     {
                         Vector128<byte> comparison = Vector128.Create(value);
@@ -308,14 +301,10 @@ namespace System
                         {
                             index += Vector128<byte>.Count;
                         }
-                        // Find offset of first match
-                        else if (Bmi1.IsSupported)
-                        {
-                            return ((int)(byte*)index) + (int)Bmi1.TrailingZeroCount((uint)matches);
-                        }
                         else
                         {
-                            return (int)(byte*)index + TrailingZeroCountFallback(matches);
+                            // Find offset of first match
+                            return ((int)(byte*)index) + BitOps.TrailingZeroCount(matches);
                         }
                     }
 
@@ -330,7 +319,7 @@ namespace System
             {
                 if ((int)(byte*)index < length)
                 {
-                    nLength = (IntPtr)((length - (int)(byte*)index) & ~(Vector128<byte>.Count - 1));
+                    nLength = GetByteVector128SpanLength(index, length);
 
                     Vector128<byte> comparison = Vector128.Create(value);
                     while ((byte*)nLength > (byte*)index)
@@ -343,13 +332,9 @@ namespace System
                             continue;
                         }
                         // Find offset of first match
-                        else if (Bmi1.IsSupported)
-                        {
-                            return ((int)(byte*)index) + (int)Bmi1.TrailingZeroCount((uint)matches);
-                        }
                         else
                         {
-                            return (int)(byte*)index + TrailingZeroCountFallback(matches);
+                            return ((int)(byte*)index) + BitOps.TrailingZeroCount(matches);
                         }
                     }
 
@@ -364,7 +349,7 @@ namespace System
             {
                 if ((int)(byte*)index < length)
                 {
-                    nLength = (IntPtr)((length - (int)(byte*)index) & ~(Vector<byte>.Count - 1));
+                    nLength = GetByteVectorSpanLength(index, length);
 
                     // Get comparison Vector
                     Vector<byte> vComparison = new Vector<byte>(value);
@@ -559,16 +544,14 @@ namespace System
             {
                 if (length >= Vector128<byte>.Count * 2)
                 {
-                    int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector128<byte>.Count - 1);
-                    nLength = (IntPtr)((Vector128<byte>.Count - unaligned) & (Vector128<byte>.Count - 1));
+                    nLength = UnalignedByteCountVector128(ref searchSpace);
                 }
             }
             else if (Vector.IsHardwareAccelerated)
             {
                 if (length >= Vector<byte>.Count * 2)
                 {
-                    int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
-                    nLength = (IntPtr)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
+                    nLength = UnalignedByteCountVector(ref searchSpace);
                 }
             }
         SequentialScan:
@@ -640,7 +623,7 @@ namespace System
             {
                 if ((int)(byte*)index < length)
                 {
-                    nLength = (IntPtr)((length - (int)(byte*)index) & ~(Vector256<byte>.Count - 1));
+                    nLength = GetByteVector256SpanLength(index, length);
                     if ((byte*)nLength > (byte*)index)
                     {
                         Vector256<byte> comp0 = Vector256.Create(value0);
@@ -656,18 +639,14 @@ namespace System
                                 continue;
                             }
                             // Find offset of first match
-                            else if (Bmi1.IsSupported)
-                            {
-                                return ((int)(byte*)index) + (int)Bmi1.TrailingZeroCount((uint)matches);
-                            }
                             else
                             {
-                                return (int)(byte*)index + TrailingZeroCountFallback(matches);
+                                return ((int)(byte*)index) + BitOps.TrailingZeroCount(matches);
                             }
                         } while ((byte*)nLength > (byte*)index);
                     }
 
-                    nLength = (IntPtr)((length - (int)(byte*)index) & ~(Vector128<byte>.Count - 1));
+                    nLength = GetByteVector128SpanLength(index, length);
                     if ((byte*)nLength > (byte*)index)
                     {
                         Vector128<byte> comp0 = Vector128.Create(value0);
@@ -681,13 +660,9 @@ namespace System
                             index += Vector128<byte>.Count;
                         }
                         // Find offset of first match
-                        else if (Bmi1.IsSupported)
-                        {
-                            return ((int)(byte*)index) + (int)Bmi1.TrailingZeroCount((uint)matches);
-                        }
                         else
                         {
-                            return (int)(byte*)index + TrailingZeroCountFallback(matches);
+                            return ((int)(byte*)index) + BitOps.TrailingZeroCount(matches);
                         }
                     }
 
@@ -702,7 +677,7 @@ namespace System
             {
                 if ((int)(byte*)index < length)
                 {
-                    nLength = (IntPtr)((length - (int)(byte*)index) & ~(Vector128<byte>.Count - 1));
+                    nLength = GetByteVector128SpanLength(index, length);
 
                     Vector128<byte> comp0 = Vector128.Create(value0);
                     Vector128<byte> comp1 = Vector128.Create(value1);
@@ -718,13 +693,9 @@ namespace System
                             continue;
                         }
                         // Find offset of first match
-                        else if (Bmi1.IsSupported)
-                        {
-                            return ((int)(byte*)index) + (int)Bmi1.TrailingZeroCount((uint)matches);
-                        }
                         else
                         {
-                            return (int)(byte*)index + TrailingZeroCountFallback(matches);
+                            return ((int)(byte*)index) + BitOps.TrailingZeroCount(matches);
                         }
                     }
 
@@ -739,7 +710,7 @@ namespace System
             {
                 if ((int)(byte*)index < length)
                 {
-                    nLength = (IntPtr)((length - (int)(byte*)index) & ~(Vector<byte>.Count - 1));
+                    nLength = GetByteVectorSpanLength(index, length);
 
                     // Get comparison Vector
                     Vector<byte> values0 = new Vector<byte>(value0);
@@ -800,16 +771,14 @@ namespace System
             {
                 if (length >= Vector128<byte>.Count * 2)
                 {
-                    int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector128<byte>.Count - 1);
-                    nLength = (IntPtr)((Vector128<byte>.Count - unaligned) & (Vector128<byte>.Count - 1));
+                    nLength = UnalignedByteCountVector128(ref searchSpace);
                 }
             }
             else if (Vector.IsHardwareAccelerated)
             {
                 if (length >= Vector<byte>.Count * 2)
                 {
-                    int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
-                    nLength = (IntPtr)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
+                    nLength = UnalignedByteCountVector(ref searchSpace);
                 }
             }
         SequentialScan:
@@ -881,7 +850,7 @@ namespace System
             {
                 if ((int)(byte*)index < length)
                 {
-                    nLength = (IntPtr)((length - (int)(byte*)index) & ~(Vector256<byte>.Count - 1));
+                    nLength = GetByteVector256SpanLength(index, length);
                     if ((byte*)nLength > (byte*)index)
                     {
                         Vector256<byte> comp0 = Vector256.Create(value0);
@@ -899,18 +868,14 @@ namespace System
                                 continue;
                             }
                             // Find offset of first match
-                            else if (Bmi1.IsSupported)
-                            {
-                                return ((int)(byte*)index) + (int)Bmi1.TrailingZeroCount((uint)matches);
-                            }
                             else
                             {
-                                return (int)(byte*)index + TrailingZeroCountFallback(matches);
+                                return ((int)(byte*)index) + BitOps.TrailingZeroCount(matches);
                             }
                         } while ((byte*)nLength > (byte*)index);
                     }
 
-                    nLength = (IntPtr)((length - (int)(byte*)index) & ~(Vector128<byte>.Count - 1));
+                    nLength = GetByteVector128SpanLength(index, length);
                     if ((byte*)nLength > (byte*)index)
                     {
                         Vector128<byte> comp0 = Vector128.Create(value0);
@@ -926,13 +891,9 @@ namespace System
                             index += Vector128<byte>.Count;
                         }
                         // Find offset of first match
-                        else if (Bmi1.IsSupported)
-                        {
-                            return ((int)(byte*)index) + (int)Bmi1.TrailingZeroCount((uint)matches);
-                        }
                         else
                         {
-                            return (int)(byte*)index + TrailingZeroCountFallback(matches);
+                            return ((int)(byte*)index) + BitOps.TrailingZeroCount(matches);
                         }
                     }
 
@@ -947,7 +908,7 @@ namespace System
             {
                 if ((int)(byte*)index < length)
                 {
-                    nLength = (IntPtr)((length - (int)(byte*)index) & ~(Vector128<byte>.Count - 1));
+                    nLength = GetByteVector128SpanLength(index, length);
 
                     Vector128<byte> comp0 = Vector128.Create(value0);
                     Vector128<byte> comp1 = Vector128.Create(value1);
@@ -965,13 +926,9 @@ namespace System
                             continue;
                         }
                         // Find offset of first match
-                        else if (Bmi1.IsSupported)
-                        {
-                            return ((int)(byte*)index) + (int)Bmi1.TrailingZeroCount((uint)matches);
-                        }
                         else
                         {
-                            return (int)(byte*)index + TrailingZeroCountFallback(matches);
+                            return ((int)(byte*)index) + BitOps.TrailingZeroCount(matches);
                         }
                     }
 
@@ -986,7 +943,7 @@ namespace System
             {
                 if ((int)(byte*)index < length)
                 {
-                    nLength = (IntPtr)((length - (int)(byte*)index) & ~(Vector<byte>.Count - 1));
+                    nLength = GetByteVectorSpanLength(index, length);
 
                     // Get comparison Vector
                     Vector<byte> values0 = new Vector<byte>(value0);
@@ -1492,5 +1449,31 @@ namespace System
                                                        0x03ul << 32 |
                                                        0x02ul << 40 |
                                                        0x01ul << 48) + 1;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe IntPtr GetByteVectorSpanLength(IntPtr offset, int length)
+            => (IntPtr)((length - (int)(byte*)offset) & ~(Vector<byte>.Count - 1));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe IntPtr GetByteVector128SpanLength(IntPtr offset, int length)
+            => (IntPtr)((length - (int)(byte*)offset) & ~(Vector128<byte>.Count - 1));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe IntPtr GetByteVector256SpanLength(IntPtr offset, int length)
+            => (IntPtr)((length - (int)(byte*)offset) & ~(Vector256<byte>.Count - 1));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe IntPtr UnalignedByteCountVector(ref byte searchSpace)
+        {
+            int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
+            return (IntPtr)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe IntPtr UnalignedByteCountVector128(ref byte searchSpace)
+        {
+            int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector128<byte>.Count - 1);
+            return (IntPtr)((Vector128<byte>.Count - unaligned) & (Vector128<byte>.Count - 1));
+        }
     }
 }

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
@@ -200,6 +200,7 @@ namespace System
 
             if (Avx2.IsSupported || Sse2.IsSupported)
             {
+                // Avx2 branch also operates on Sse2 sizes, so check is combined.
                 if (length >= Vector128<byte>.Count * 2)
                 {
                     nLength = UnalignedByteCountVector128(ref searchSpace);
@@ -537,6 +538,7 @@ namespace System
 
             if (Avx2.IsSupported || Sse2.IsSupported)
             {
+                // Avx2 branch also operates on Sse2 sizes, so check is combined.
                 if (length >= Vector128<byte>.Count * 2)
                 {
                     nLength = UnalignedByteCountVector128(ref searchSpace);
@@ -760,6 +762,7 @@ namespace System
 
             if (Avx2.IsSupported || Sse2.IsSupported)
             {
+                // Avx2 branch also operates on Sse2 sizes, so check is combined.
                 if (length >= Vector128<byte>.Count * 2)
                 {
                     nLength = UnalignedByteCountVector128(ref searchSpace);
@@ -1276,7 +1279,7 @@ namespace System
 
             while ((byte*)nLength > (byte*)offset)
             {
-                if (Unsafe.AddByteOffset(ref  first, offset) != Unsafe.AddByteOffset(ref  second, offset))
+                if (Unsafe.AddByteOffset(ref first, offset) != Unsafe.AddByteOffset(ref second, offset))
                     goto NotEqual;
                 offset += 1;
             }
@@ -1351,7 +1354,7 @@ namespace System
         NotEqual:  // Workaround for https://github.com/dotnet/coreclr/issues/13549
             while ((byte*)minLength > (byte*)offset)
             {
-                int result = Unsafe.AddByteOffset(ref  first, offset).CompareTo(Unsafe.AddByteOffset(ref  second, offset));
+                int result = Unsafe.AddByteOffset(ref first, offset).CompareTo(Unsafe.AddByteOffset(ref second, offset));
                 if (result != 0)
                     return result;
                 offset += 1;

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.cs
@@ -3,10 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using System.Globalization;
 using System.Runtime;
-using System.Runtime.CompilerServices;
-using System.Runtime.Intrinsics.X86;
 
 using Internal.Runtime.CompilerServices;
 

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Runtime;
 using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics.X86;
 
 using Internal.Runtime.CompilerServices;
 
@@ -412,18 +413,5 @@ namespace System
             // Write only element.
             ip = default;
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int TrailingZeroCountFallback(int matches)
-        {
-            // https://graphics.stanford.edu/~seander/bithacks.html#ZerosOnRightMultLookup
-            return TrailingCountMultiplyDeBruijn[(int)(((uint)((matches & -matches) * 0x077CB531U)) >> 27)];
-        }
-
-        private static ReadOnlySpan<byte> TrailingCountMultiplyDeBruijn => new byte[32]
-        {
-            0, 1, 28, 2, 29, 14, 24, 3, 30, 22, 20, 15, 25, 17, 4, 8,
-            31, 27, 13, 23, 21, 19, 16, 7, 26, 12, 18, 6, 11, 5, 10, 9
-        };
     }
 }

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime;
+using System.Runtime.CompilerServices;
 
 using Internal.Runtime.CompilerServices;
 
@@ -411,5 +412,18 @@ namespace System
             // Write only element.
             ip = default;
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int TrailingZeroCountFallback(int matches)
+        {
+            // https://graphics.stanford.edu/~seander/bithacks.html#ZerosOnRightMultLookup
+            return TrailingCountMultiplyDeBruijn[(int)(((uint)((matches & -matches) * 0x077CB531U)) >> 27)];
+        }
+
+        private static ReadOnlySpan<byte> TrailingCountMultiplyDeBruijn => new byte[32]
+        {
+            0, 1, 28, 2, 29, 14, 24, 3, 30, 22, 20, 15, 25, 17, 4, 8,
+            31, 27, 13, 23, 21, 19, 16, 7, 26, 12, 18, 6, 11, 5, 10, 9
+        };
     }
 }


### PR DESCRIPTION
Learnings from https://github.com/dotnet/coreclr/pull/22019; improvement on https://github.com/dotnet/coreclr/pull/21073

Applied to
```csharp
internal static partial class SpanHelpers
{
    static int IndexOf(ref byte searchSpace, byte value, int length);
    static int IndexOfAny(ref byte searchSpace, byte value0, byte value1, int length);
    static int IndexOfAny(ref byte searchSpace, byte value0, byte value1, byte value2, int length);
}
```


`MoveMask`/`vpmovmskb` used for equality in the vectorized path already has flagged the bits that match; so if we use the specific intrinsics rather than generic Vector, we just need to determine the bit set, rather than do further processing to determine the element offset.

```diff
-; Total bytes of code 597, prolog size 5 for method SpanHelpers:IndexOf(byref,ubyte,int):int
+; Total bytes of code 549, prolog size 5 for method SpanHelpers:IndexOf(byref,ubyte,int):int
```

Performance measurements:

Array length 512 significant improvements (up to more than double) for found item in any position. https://github.com/dotnet/coreclr/pull/22118#issuecomment-456199510 

Array lengths >= 32 with item in last position significant improvements  (up to more than double)  https://github.com/dotnet/coreclr/pull/22118#issuecomment-456223461

/cc @CarolEidt @fiigii @tannergooding @ahsonkhan