### PR TITLE
Add GC.KeepAlive to keep collectible ALC alive across usage in ICustomMarshaler tests

### DIFF
--- a/tests/src/Interop/ICustomMarshaler/ConflictingNames/RunInALC.cs
+++ b/tests/src/Interop/ICustomMarshaler/ConflictingNames/RunInALC.cs
@@ -46,6 +46,7 @@ public class RunInALC
         object instance = Activator.CreateInstance(inContextType);
         MethodInfo parseIntMethod = inContextType.GetMethod("ParseInt", BindingFlags.Instance | BindingFlags.Public);
         Assert.AreEqual(1234, (int)parseIntMethod.Invoke(instance, new object[]{"1234"}));
+        GC.KeepAlive(context);
     }
 }
 


### PR DESCRIPTION
Fixes #22109.

cc: @BruceForstall @sandreenko 