### PR TITLE
Don't use Ubuntu.1604.Arm64.Open queue in Azure DevOps

### DIFF
--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -33,7 +33,8 @@ jobs:
     containerName: ubuntu_1604_arm64_cross_build_image
     # TODO: enable Debian.9.Arm64.Open and Debian.9.Arm64 queues
     # when https://github.com/dotnet/core-eng/issues/4805 is resolved
-    helixQueuesPublic: 'Ubuntu.1604.Arm64.Open,Ubuntu.1804.Arm64.Open'
+    # Don't use Ubuntu.1604.Arm64.Open here - the queue should be exclusively used by Jenkins
+    helixQueuesPublic: 'Ubuntu.1804.Arm64.Open'
     helixQueuesInternal: 'Ubuntu.1604.Arm64,Ubuntu.1804.Arm64'
     crossrootfsDir: '/crossrootfs/arm64'
     ${{ insert }}: ${{ parameters.jobParameters }}


### PR DESCRIPTION
Keep the queue exclusively for running tests in Jenkins 