### PR TITLE
Fix for JIT\Directed\arglist\vararg test case.

### DIFF
--- a/tests/src/JIT/Directed/arglist/vararg.cs
+++ b/tests/src/JIT/Directed/arglist/vararg.cs
@@ -134,6 +134,12 @@ namespace NativeVarargTest
         [DllImport("varargnative", CallingConvention = CallingConvention.Cdecl)]
         extern static FourDoubleStruct echo_four_double_struct(FourDoubleStruct arg, __arglist);
 
+        [DllImport("varargnative", CallingConvention = CallingConvention.Cdecl)]
+        extern static byte short_in_byte_out(short arg, __arglist);
+
+        [DllImport("varargnative", CallingConvention = CallingConvention.Cdecl)]
+        extern static short byte_in_short_out(byte arg, __arglist);
+
         ////////////////////////////////////////////////////////////////////////////
         // Test PInvoke, native vararg calls.
         ////////////////////////////////////////////////////////////////////////////
@@ -4410,6 +4416,22 @@ namespace NativeVarargTest
             return equal;
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static bool TestShortInByteOutNoVararg(short arg)
+        {
+            byte returnValue = short_in_byte_out(arg, __arglist());
+
+            return returnValue == (byte)arg;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static bool TestByteInShortOutNoVararg(byte arg)
+        {
+            short returnValue = byte_in_short_out(arg, __arglist());
+
+            return returnValue == (short)arg;
+        }
+
         ////////////////////////////////////////////////////////////////////////
         // Report Failure
         ////////////////////////////////////////////////////////////////////////
@@ -5006,8 +5028,7 @@ namespace NativeVarargTest
             // Echo types.
             success = ReportFailure(TestEchoByteNoVararg(1), "TestEchoByteNoVararg(1)", success, 85);
             success = ReportFailure(TestEchoCharNoVararg('c'), "TestEchoCharNoVararg(1)", success, 86);
-            // Issue: https://github.com/dotnet/coreclr/issues/19705
-            // success = ReportFailure(TestEchoShortNoVararg(2), "TestEchoShortNoVararg(2)", success, 87);
+            success = ReportFailure(TestEchoShortNoVararg(2), "TestEchoShortNoVararg(2)", success, 87);
             success = ReportFailure(TestEchoIntNoVararg(3), "TestEchoIntNoVararg(3)", success, 88);
             success = ReportFailure(TestEchoLongNoVararg(4), "TestEchoLongNoVararg(4)", success, 89);
             success = ReportFailure(TestEchoFloatNoVararg(5.0f), "TestEchoFloatNoVararg(5.0f)", success, 90);
@@ -5028,6 +5049,9 @@ namespace NativeVarargTest
             success = ReportFailure(TestEchoThreeDoubleStructNoVararg(), "TestEchoThreeDoubleStructNoVararg()", success, 105);
             success = ReportFailure(TestEchoFourFloatStructNoVararg(), "TestEchoFourFloatStructNoVararg()", success, 106);
             success = ReportFailure(TestEchoFourDoubleStructNoVararg(), "TestEchoFourDoubleStructNoVararg()", success, 107);
+
+            success = ReportFailure(TestShortInByteOutNoVararg(7), "TestShortInByteOutNoVararg(7)", success, 108);
+            success = ReportFailure(TestByteInShortOutNoVararg(8), "TestByteInShortOutNoVararg(8)", success, 109);
 
             printf("\n", __arglist());
             printf("%d Tests run. %d Passed, %d Failed.\n", __arglist(m_testCount, m_passCount, m_failCount));

--- a/tests/src/JIT/Directed/arglist/varargnative.c
+++ b/tests/src/JIT/Directed/arglist/varargnative.c
@@ -653,7 +653,7 @@ DLLEXPORT char _cdecl echo_char(char arg, ...)
     return arg;
 }
 
-DLLEXPORT __int8 _cdecl echo_short(__int8 arg, ...)
+DLLEXPORT __int16 _cdecl echo_short(__int16 arg, ...)
 {
     return arg;
 }
@@ -756,4 +756,14 @@ DLLEXPORT four_float_struct _cdecl echo_four_float_struct(four_float_struct arg,
 DLLEXPORT four_double_struct _cdecl echo_four_double_struct(four_double_struct arg, ...)
 {
     return arg;
+}
+
+DLLEXPORT __int8 _cdecl short_in_byte_out(__int16 arg, ...)
+{
+    return (__int8)arg;
+}
+
+DLLEXPORT __int16 _cdecl byte_in_short_out(__int8 arg, ...)
+{
+    return (__int16)arg;
 }


### PR DESCRIPTION
TestEchoShortNoVararg was failing and disabled. The reason it was
failing was a mismatch between DllImport declaration for echo_short and
the native function: the former specified 2-byte arg and return while
the latter specified 1-byte arg and return. I fixed that and also added
a couple of test cases with 1-byte arg and 2-byte return and
vice versa.

Fixes #19705.