### PR TITLE
Use Windows.10.Arm64.Open with Jenkins ONLY

### DIFF
--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -135,7 +135,7 @@ jobs:
     archType: arm
     osGroup: Windows_NT
     osIdentifier: Windows_NT
-    helixQueuesPublic: 'Windows.10.Arm64.Open'
+    # TODO: return back Windows.10.Arm64.Open
     helixQueuesInternal: 'Windows.10.Arm64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 
@@ -145,6 +145,6 @@ jobs:
     archType: arm64
     osGroup: Windows_NT
     osIdentifier: Windows_NT
-    helixQueuesPublic: 'Windows.10.Arm64.Open'
+    # TODO: return back Windows.10.Arm64.Open
     helixQueuesInternal: 'Windows.10.Arm64'
     ${{ insert }}: ${{ parameters.jobParameters }}

--- a/netci.groovy
+++ b/netci.groovy
@@ -1944,6 +1944,7 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                     switch (scenario) {
                         case 'innerloop':
                             if (configuration == 'Checked') {
+                                isDefaultTrigger = true
                                 isArm64PrivateJob = true
                             }
                             break


### PR DESCRIPTION
Windows arm and Windows arm64 jobs are the only ones that block **coreclr-ci** badge from getting green (e.g. https://dev.azure.com/dnceng/public/_build/results?buildId=76471)

I propose to disable submitting to those queues from Azure DevOps jobs and enabling back the Jenkins default triggers for them. 