### PR TITLE
Fix accidental assignment inside an assert

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -3787,7 +3787,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
         argSlots += argEntry->getSlotCount();
 
         // lclVar address should have been retyped to TYP_I_IMPL.
-        assert(!argx->IsVarAddr() || (argx->gtType = TYP_I_IMPL));
+        assert(!argx->IsVarAddr() || (argx->gtType == TYP_I_IMPL));
 
         // Get information about this argument.
         var_types hfaType            = argEntry->hfaType;


### PR DESCRIPTION
Fixed a small problem found by [lgtm.com](https://lgtm.com/projects/g/dotnet/coreclr/snapshot/dist-1505965926042-1548102289075/files/src/jit/morph.cpp#x202d60abc530dc82:1).