### PR TITLE
Fix ThreadPool.cs warning

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
@@ -650,7 +650,7 @@ namespace System.Threading
                 // If we get here, it's because our quantum expired.  Tell the VM we're returning normally.
                 return true;
             }
-            catch (ThreadAbortException tae)
+            catch (ThreadAbortException)
             {
                 //
                 // In this case, the VM is going to request another thread on our behalf.  No need to do it twice.


### PR DESCRIPTION
Fixes:
```
src\System\Threading\ThreadPool.cs(653,41): warning CS0168: The variable 'tae' is declared but never used [d:\repos\coreclr\src\System.Private.CoreLib\System.Private.CoreLib.csproj]
```