### PR TITLE
Disable OSX.1012.Amd64.Open in Azure DevOps

### DIFF
--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -97,7 +97,8 @@ jobs:
     archType: x64
     osGroup: OSX
     osIdentifier: OSX
-    helixQueuesPublic: 'OSX.1012.Amd64.Open,OSX.1013.Amd64.Open'
+    # TODO: return back OSX.1012.Amd64.Open once Jenkins has been shutdown
+    helixQueuesPublic: 'OSX.1013.Amd64.Open'
     helixQueuesInternal: 'OSX.1012.Amd64,OSX.1013.Amd64,OSX.1014.Amd64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 
@@ -135,7 +136,7 @@ jobs:
     archType: arm
     osGroup: Windows_NT
     osIdentifier: Windows_NT
-    # TODO: return back Windows.10.Arm64.Open
+    # TODO: return back Windows.10.Arm64.Open once Jenkins has been shutdown
     helixQueuesInternal: 'Windows.10.Arm64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 
@@ -145,6 +146,6 @@ jobs:
     archType: arm64
     osGroup: Windows_NT
     osIdentifier: Windows_NT
-    # TODO: return back Windows.10.Arm64.Open
+    # TODO: return back Windows.10.Arm64.Open once Jenkins has been shutdown
     helixQueuesInternal: 'Windows.10.Arm64'
     ${{ insert }}: ${{ parameters.jobParameters }}


### PR DESCRIPTION
Keep the queue exclusively for Jenkins jobs