### PR TITLE
Use .asArray/.asString syntax for scenarios and helixQueues

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,7 +130,11 @@ jobs:
       buildConfig: checked
       jobParameters:
         priority: 0
-        scenarios: 'normal,no_tiered_compilation'
+        scenarios:
+          asString: 'normal,no_tiered_compilation'
+          asArray:
+          - normal
+          - no_tiered_compilation
         timeoutInMinutes: 240
 
 # Pri1 (CI)
@@ -141,7 +145,11 @@ jobs:
       buildConfig: checked
       jobParameters:
         priority: 1
-        scenarios: 'normal,no_tiered_compilation'
+        scenarios:
+          asString: 'normal,no_tiered_compilation'
+          asArray:
+          - normal
+          - no_tiered_compilation
         timeoutInMinutes: 360
 
 # Pri1 crossgen (CI)
@@ -153,7 +161,11 @@ jobs:
       jobParameters:
         priority: 1
         crossgen: true
-        scenarios: 'normal,no_tiered_compilation'
+        scenarios:
+          asString: 'normal,no_tiered_compilation'
+          asArray:
+          - normal
+          - no_tiered_compilation
         timeoutInMinutes: 360
 
 # Pri1 (Manual)
@@ -164,7 +176,15 @@ jobs:
       buildConfig: checked
       jobParameters:
         priority: 1
-        scenarios: 'normal,no_tiered_compilation,jitstress1,jitstress2,jitstress1_tiered,jitstress2_tiered'
+        scenarios:
+          asString: 'normal,no_tiered_compilation,jitstress1,jitstress2,jitstress1_tiered,jitstress2_tiered'
+          asArray:
+          - normal
+          - no_tiered_compilation
+          - jitstress1
+          - jitstress2
+          - jitstress1_tiered
+          - jitstress2_tiered
         timeoutInMinutes: 480
 
 #
@@ -179,7 +199,11 @@ jobs:
       buildConfig: release
       jobParameters:
         priority: 1
-        scenarios: 'normal,no_tiered_compilation'
+        scenarios:
+          asString: 'normal,no_tiered_compilation'
+          asArray:
+          - normal
+          - no_tiered_compilation
         timeoutInMinutes: 360
 
 # Pri1 crossgen (Official Build)
@@ -191,7 +215,11 @@ jobs:
       jobParameters:
         priority: 1
         crossgen: true
-        scenarios: 'normal,no_tiered_compilation'
+        scenarios:
+          asString: 'normal,no_tiered_compilation'
+          asArray:
+          - normal
+          - no_tiered_compilation
         timeoutInMinutes: 360
 
 

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -17,9 +17,16 @@ jobs:
     osGroup: Linux
     osIdentifier: Linux
     containerName: ubuntu_1404_arm_cross_build_image
-    helixQueuesPublic: 'Ubuntu.1404.Arm32.Open'
+    helixQueues:
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        asString: 'Ubuntu.1404.Arm32.Open'
+        asArray:
+        - Ubuntu.1404.Arm32.Open
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        # We don't have any Linux/arm32 internal Helix queues
+        asString: ''
+        asArray: []
     crossrootfsDir: '/crossrootfs/arm'
-    # Currently we don't have Linux/arm32 internal Helix queues
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux arm64
@@ -31,11 +38,19 @@ jobs:
     osGroup: Linux
     osIdentifier: Linux
     containerName: ubuntu_1604_arm64_cross_build_image
-    # TODO: enable Debian.9.Arm64.Open and Debian.9.Arm64 queues
-    # when https://github.com/dotnet/core-eng/issues/4805 is resolved
-    # Don't use Ubuntu.1604.Arm64.Open here - the queue should be exclusively used by Jenkins
-    helixQueuesPublic: 'Ubuntu.1804.Arm64.Open'
-    helixQueuesInternal: 'Ubuntu.1604.Arm64,Ubuntu.1804.Arm64'
+    helixQueues:
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        # TODO: enable Debian.9.Arm64.Open and Debian.9.Arm64 queues
+        # when https://github.com/dotnet/core-eng/issues/4805 is resolved
+        # Don't use Ubuntu.1604.Arm64.Open here - the queue should be exclusively used by Jenkins
+        asString: 'Ubuntu.1804.Arm64.Open'
+        asArray:
+        - Ubuntu.1804.Arm64.Open
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        asString: 'Ubuntu.1604.Arm64,Ubuntu.1804.Arm64'
+        asArray:
+        - Ubuntu.1604.Arm64
+        - Ubuntu.1804.Arm64
     crossrootfsDir: '/crossrootfs/arm64'
     ${{ insert }}: ${{ parameters.jobParameters }}
 
@@ -49,6 +64,9 @@ jobs:
     osIdentifier: Linux_musl
     containerName: musl_x64_build_image
     # TODO: add Alpine.Amd64 queues
+    helixQueues:
+      asString: ''
+      asArray: []
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # RHEL 6
@@ -60,9 +78,16 @@ jobs:
     osGroup: Linux
     osIdentifier: Linux_rhel6
     containerName: centos6_x64_build_image
-    # TODO: enable RedHat.6.Amd64.Open
-    # when https://github.com/dotnet/core-eng/issues/4100 is resolved
-    helixQueuesInternal: 'RedHat.6.Amd64'
+    helixQueues:
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        # TODO: enable RedHat.6.Amd64.Open
+        # when https://github.com/dotnet/core-eng/issues/4100 is resolved
+        asString: ''
+        asArray: []
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        asString: 'RedHat.6.Amd64'
+        asArray:
+        - RedHat.6.Amd64
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux x64
@@ -74,8 +99,25 @@ jobs:
     osGroup: Linux
     osIdentifier: Linux
     containerName: centos7_x64_build_image
-    helixQueuesPublic: 'Debian.9.Amd64.Open,Ubuntu.1604.Amd64.Open,Ubuntu.1804.Amd64.Open,Centos.7.Amd64.Open,Fedora.28.Amd64.Open,RedHat.7.Amd64.Open'
-    helixQueuesInternal: 'Debian.9.Amd64,Ubuntu.1604.Amd64,Ubuntu.1804.Amd64,Centos.7.Amd64,Fedora.28.Amd64,RedHat.7.Amd64'
+    helixQueues:
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        asString: 'Debian.9.Amd64.Open,Ubuntu.1604.Amd64.Open,Ubuntu.1804.Amd64.Open,Centos.7.Amd64.Open,Fedora.28.Amd64.Open,RedHat.7.Amd64.Open'
+        asArray:
+        - Debian.9.Amd64.Open
+        - Ubuntu.1604.Amd64.Open
+        - Ubuntu.1804.Amd64.Open
+        - Centos.7.Amd64.Open
+        - Fedora.28.Amd64.Open
+        - RedHat.7.Amd64.Open
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        asString: 'Debian.9.Amd64,Ubuntu.1604.Amd64,Ubuntu.1804.Amd64,Centos.7.Amd64,Fedora.28.Amd64,RedHat.7.Amd64'
+        asArray:
+        - Debian.9.Amd64
+        - Ubuntu.1604.Amd64
+        - Ubuntu.1804.Amd64
+        - Centos.7.Amd64
+        - Fedora.28.Amd64
+        - RedHat.7.Amd64
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # FreeBSD
@@ -87,6 +129,9 @@ jobs:
     osGroup: FreeBSD
     osIdentifier: FreeBSD
     # There are no FreeBSD helix queues, so we don't run tests at the moment.
+    helixQueues:
+      asString: ''
+      asArray: []
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # macOS x64
@@ -97,9 +142,18 @@ jobs:
     archType: x64
     osGroup: OSX
     osIdentifier: OSX
-    # TODO: return back OSX.1012.Amd64.Open once Jenkins has been shutdown
-    helixQueuesPublic: 'OSX.1013.Amd64.Open'
-    helixQueuesInternal: 'OSX.1012.Amd64,OSX.1013.Amd64,OSX.1014.Amd64'
+    helixQueues:
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        # TODO: return back OSX.1012.Amd64.Open once Jenkins has been shutdown
+        asString: 'OSX.1013.Amd64.Open'
+        asArray:
+        - OSX.1013.Amd64.Open
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        asString: 'OSX.1012.Amd64,OSX.1013.Amd64,OSX.1014.Amd64'
+        asArray:
+        - OSX.1012.Amd64
+        - OSX.1013.Amd64
+        - OSX.1014.Amd64
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Windows x64/x86
@@ -110,10 +164,22 @@ jobs:
     archType: x64
     osGroup: Windows_NT
     osIdentifier: Windows_NT
-    # TODO: add Windows.10.Nano.Amd64.Open when https://github.com/dotnet/coreclr/issues/21693 is resolved
-    # TODO: add Windows.7.Amd64.Open when https://github.com/dotnet/coreclr/issues/21796 is resolved
-    helixQueuesPublic: 'Windows.10.Amd64.Open,Windows.81.Amd64.Open'
-    helixQueuesInternal: 'Windows.10.Amd64,Windows.10.Nano.Amd64,Windows.10.Amd64.Core,Windows.7.Amd64,Windows.81.Amd64'
+    helixQueues:
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        # TODO: add Windows.10.Nano.Amd64.Open when https://github.com/dotnet/coreclr/issues/21693 is resolved
+        # TODO: add Windows.7.Amd64.Open when https://github.com/dotnet/coreclr/issues/21796 is resolved
+        asString: 'Windows.10.Amd64.Open,Windows.81.Amd64.Open'
+        asArray:
+        - Windows.10.Amd64.Open
+        - Windows.81.Amd64.Open
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        asString: 'Windows.10.Amd64,Windows.10.Nano.Amd64,Windows.10.Amd64.Core,Windows.7.Amd64,Windows.81.Amd64'
+        asArray:
+        - Windows.10.Amd64
+        - Windows.10.Nano.Amd64
+        - Windows.10.Amd64.Core
+        - Windows.7.Amd64
+        - Windows.81.Amd64
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 - template: ${{ parameters.jobTemplate }}
@@ -122,10 +188,20 @@ jobs:
     archType: x86
     osGroup: Windows_NT
     osIdentifier: Windows_NT
-    # TODO: add Windows.10.Nano.Amd64.Open when https://github.com/dotnet/coreclr/issues/21693 is resolved
-    # TODO: add Windows.7.Amd64.Open when https://github.com/dotnet/coreclr/issues/21796 is resolved
-    helixQueuesPublic: 'Windows.10.Amd64.Open,Windows.81.Amd64.Open'
-    helixQueuesInternal: 'Windows.10.Amd64,Windows.10.Nano.Amd64,Windows.10.Amd64.Core,Windows.7.Amd64,Windows.81.Amd64'
+    helixQueues:
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        # TODO: add Windows.7.Amd64.Open when https://github.com/dotnet/coreclr/issues/21796 is resolved
+        asString: 'Windows.10.Amd64.Open,Windows.81.Amd64.Open'
+        asArray:
+        - Windows.10.Amd64.Open
+        - Windows.81.Amd64.Open
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        asString: 'Windows.10.Amd64,Windows.10.Nano.Amd64,Windows.10.Amd64.Core,Windows.7.Amd64,Windows.81.Amd64'
+        asArray:
+        - Windows.10.Amd64
+        - Windows.10.Amd64.Core
+        - Windows.7.Amd64
+        - Windows.81.Amd64
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Windows arm/arm64
@@ -136,8 +212,15 @@ jobs:
     archType: arm
     osGroup: Windows_NT
     osIdentifier: Windows_NT
-    # TODO: return back Windows.10.Arm64.Open once Jenkins has been shutdown
-    helixQueuesInternal: 'Windows.10.Arm64'
+    helixQueues:
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        # TODO: return back Windows.10.Arm64.Open once Jenkins has been shutdown
+        asString: ''
+        asArray: []
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        asString: 'Windows.10.Arm64'
+        asArray:
+        - Windows.10.Arm64
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 - template: ${{ parameters.jobTemplate }}
@@ -146,6 +229,13 @@ jobs:
     archType: arm64
     osGroup: Windows_NT
     osIdentifier: Windows_NT
-    # TODO: return back Windows.10.Arm64.Open once Jenkins has been shutdown
-    helixQueuesInternal: 'Windows.10.Arm64'
+    helixQueues:
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        # TODO: return back Windows.10.Arm64.Open once Jenkins has been shutdown
+        asString: ''
+        asArray: []
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        asString: 'Windows.10.Arm64'
+        asArray:
+        - Windows.10.Arm64
     ${{ insert }}: ${{ parameters.jobParameters }}

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -6,8 +6,7 @@ parameters:
   priority: 0
   crossgen: false
   scenarios: ''
-  helixQueuesPublic: ''
-  helixQueuesInternal: ''
+  helixQueues: ''
   timeoutInMinutes: ''
   crossrootfsDir: ''
 
@@ -123,6 +122,10 @@ jobs:
         helixBuild: $(Build.BuildNumber)
         helixSource: $(_HelixSource)
         helixType: $(_HelixType)
+        helixQueues: ${{ parameters.helixQueues.asString }}
+
+        ${{ if eq(parameters.helixQueues.asString, '') }}:
+          condition: false
 
         publishTestResults: true
         # TODO: see if this amount is enough for all individual jobs to finish
@@ -133,14 +136,8 @@ jobs:
           # Access token variable for internal project from the
           # DotNet-HelixApi-Access variable group
           helixAccessToken: $(HelixApiAccessToken)
-          helixQueues: ${{ parameters.helixQueuesInternal }}
-          ${{ if eq(parameters.helixQueuesInternal, '') }}:
-            condition: false
 
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           creator: coreclr-pulls
-          helixQueues: ${{ parameters.helixQueuesPublic }}
-          ${{ if eq(parameters.helixQueuesPublic, '') }}:
-            condition: false
 
-        scenarios: ${{ parameters.scenarios }}
+        scenarios: ${{ parameters.scenarios.asString }}


### PR DESCRIPTION
As far as I know, there is no way in Yaml to convert between comma-separated strings and arrays (i.e. neither `String.Join(", ", items)` nor `str.Split(',')` are available). As an unfortunate workaround, I propose to use .asString/.asArray syntax for properties that needed in both formats. 

As an example, right now we are using scenarios and helixQueues* properties only as an MSBuild input (i.e. comma-separated string passed as MSBuild properties).

For the purpose of enabling test publishing to Azure DevOps using officially supported task we would need to iterate over Helix queues and scenarios to call the task multiple times so we would those to be array values. 

