### PR TITLE
disabling the Collect0 test for gcstress

### DIFF
--- a/tests/src/GC/API/GC/Collect0.csproj
+++ b/tests/src/GC/API/GC/Collect0.csproj
@@ -27,6 +27,7 @@
     <DebugType>PdbOnly</DebugType>
     <NoLogo>True</NoLogo>
     <DefineConstants>$(DefineConstants);DESKTOP</DefineConstants>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Collect0.cs" />


### PR DESCRIPTION
this test can rightfully fail during GC stress 0xc where a GC could be triggered between these 2 lines:
```csharp
		int agen2 = GC.GetGeneration(array);
		int ogen2 = GC.GetGeneration(obj);
```
in which case both objects could be promoted to gen2. agen2 could still say 1 because at that point both objects were in gen1. disabling for gcstress