### PR TITLE
[Linux/ARM] Disable PSPSym in filter prolog for CoreRT

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -8935,6 +8935,12 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
     // This is the end of the OS-reported prolog for purposes of unwinding
     compiler->unwindEndProlog();
 
+    // If there is no PSPSym (CoreRT ABI), we are done.
+    if (compiler->lvaPSPSym == BAD_VAR_NUM)
+    {
+        return;
+    }
+
     if (isFilter)
     {
         // This is the first block of a filter


### PR DESCRIPTION
This patch disables generation of the code that sets up PSPSym in filter prolog for CoreRT ABI, similar to what's already done for x64. Related issue: https://github.com/dotnet/corert/issues/6831
CC @jkotas @alpencolt @iarischenko