### PR TITLE
[WIP] Intrinsicify SpanHelpers.Char

### DIFF
--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
@@ -108,17 +108,17 @@ namespace System
             
             uint uValue = value; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             IntPtr offset = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
-            IntPtr nLength = (IntPtr)length;
+            IntPtr lengthToExamine = (IntPtr)length;
 
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
-                nLength = UnalignedByteCountVector(ref searchSpace);
+                lengthToExamine = UnalignedCountVector(ref searchSpace);
             }
 
         SequentialScan:
-            while ((byte*)nLength >= (byte*)8)
+            while ((byte*)lengthToExamine >= (byte*)8)
             {
-                nLength -= 8;
+                lengthToExamine -= 8;
 
                 if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 0) ||
                     uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 1) ||
@@ -135,9 +135,9 @@ namespace System
                 offset += 8;
             }
 
-            if ((byte*)nLength >= (byte*)4)
+            if ((byte*)lengthToExamine >= (byte*)4)
             {
-                nLength -= 4;
+                lengthToExamine -= 4;
 
                 if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 0) ||
                     uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 1) ||
@@ -150,9 +150,9 @@ namespace System
                 offset += 4;
             }
 
-            while ((byte*)nLength > (byte*)0)
+            while ((byte*)lengthToExamine > (byte*)0)
             {
-                nLength -= 1;
+                lengthToExamine -= 1;
 
                 if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
                     goto Found;
@@ -162,11 +162,11 @@ namespace System
 
             if (Vector.IsHardwareAccelerated && ((int)(byte*)offset < length))
             {
-                nLength = (IntPtr)((length - (int)(byte*)offset) & ~(Vector<byte>.Count - 1));
+                lengthToExamine = (IntPtr)((length - (int)(byte*)offset) & ~(Vector<byte>.Count - 1));
 
                 Vector<byte> values = new Vector<byte>(value);
 
-                while ((byte*)nLength > (byte*)offset)
+                while ((byte*)lengthToExamine > (byte*)offset)
                 {
                     var matches = Vector.Equals(values, LoadVector(ref searchSpace, offset));
                     if (Vector<byte>.Zero.Equals(matches))
@@ -180,7 +180,7 @@ namespace System
 
                 if ((int)(byte*)offset < length)
                 {
-                    nLength = (IntPtr)(length - (int)(byte*)offset);
+                    lengthToExamine = (IntPtr)(length - (int)(byte*)offset);
                     goto SequentialScan;
                 }
             }
@@ -198,27 +198,27 @@ namespace System
 
             uint uValue = value; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             IntPtr offset = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
-            IntPtr nLength = (IntPtr)length;
+            IntPtr lengthToExamine = (IntPtr)length;
 
             if (Avx2.IsSupported || Sse2.IsSupported)
             {
                 // Avx2 branch also operates on Sse2 sizes, so check is combined.
                 if (length >= Vector128<byte>.Count * 2)
                 {
-                    nLength = UnalignedByteCountVector128(ref searchSpace);
+                    lengthToExamine = UnalignedCountVector128(ref searchSpace);
                 }
             }
             else if (Vector.IsHardwareAccelerated)
             {
                 if (length >= Vector<byte>.Count * 2)
                 {
-                    nLength = UnalignedByteCountVector(ref searchSpace);
+                    lengthToExamine = UnalignedCountVector(ref searchSpace);
                 }
             }
         SequentialScan:
-            while ((byte*)nLength >= (byte*)8)
+            while ((byte*)lengthToExamine >= (byte*)8)
             {
-                nLength -= 8;
+                lengthToExamine -= 8;
 
                 if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
                     goto Found;
@@ -240,9 +240,9 @@ namespace System
                 offset += 8;
             }
 
-            if ((byte*)nLength >= (byte*)4)
+            if ((byte*)lengthToExamine >= (byte*)4)
             {
-                nLength -= 4;
+                lengthToExamine -= 4;
 
                 if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
                     goto Found;
@@ -256,9 +256,9 @@ namespace System
                 offset += 4;
             }
 
-            while ((byte*)nLength > (byte*)0)
+            while ((byte*)lengthToExamine > (byte*)0)
             {
-                nLength -= 1;
+                lengthToExamine -= 1;
 
                 if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
                     goto Found;
@@ -296,8 +296,8 @@ namespace System
                         }
                     }
 
-                    nLength = GetByteVector256SpanLength(offset, length);
-                    if ((byte*)nLength > (byte*)offset)
+                    lengthToExamine = GetByteVector256SpanLength(offset, length);
+                    if ((byte*)lengthToExamine > (byte*)offset)
                     {
                         Vector256<byte> values = Vector256.Create(value);
                         do
@@ -315,11 +315,11 @@ namespace System
 
                             // Find bitflag offset of first match and add to current offset
                             return ((int)(byte*)offset) + BitOps.TrailingZeroCount(matches);
-                        } while ((byte*)nLength > (byte*)offset);
+                        } while ((byte*)lengthToExamine > (byte*)offset);
                     }
 
-                    nLength = GetByteVector128SpanLength(offset, length);
-                    if ((byte*)nLength > (byte*)offset)
+                    lengthToExamine = GetByteVector128SpanLength(offset, length);
+                    if ((byte*)lengthToExamine > (byte*)offset)
                     {
                         Vector128<byte> values = Vector128.Create(value);
                         Vector128<byte> search = LoadVector128(ref searchSpace, offset);
@@ -340,7 +340,7 @@ namespace System
 
                     if ((int)(byte*)offset < length)
                     {
-                        nLength = (IntPtr)(length - (int)(byte*)offset);
+                        lengthToExamine = (IntPtr)(length - (int)(byte*)offset);
                         goto SequentialScan;
                     }
                 }
@@ -349,10 +349,10 @@ namespace System
             {
                 if ((int)(byte*)offset < length)
                 {
-                    nLength = GetByteVector128SpanLength(offset, length);
+                    lengthToExamine = GetByteVector128SpanLength(offset, length);
 
                     Vector128<byte> values = Vector128.Create(value);
-                    while ((byte*)nLength > (byte*)offset)
+                    while ((byte*)lengthToExamine > (byte*)offset)
                     {
                         Vector128<byte> search = LoadVector128(ref searchSpace, offset);
 
@@ -371,7 +371,7 @@ namespace System
 
                     if ((int)(byte*)offset < length)
                     {
-                        nLength = (IntPtr)(length - (int)(byte*)offset);
+                        lengthToExamine = (IntPtr)(length - (int)(byte*)offset);
                         goto SequentialScan;
                     }
                 }
@@ -380,11 +380,11 @@ namespace System
             {
                 if ((int)(byte*)offset < length)
                 {
-                    nLength = GetByteVectorSpanLength(offset, length);
+                    lengthToExamine = GetByteVectorSpanLength(offset, length);
 
                     Vector<byte> values = new Vector<byte>(value);
 
-                    while ((byte*)nLength > (byte*)offset)
+                    while ((byte*)lengthToExamine > (byte*)offset)
                     {
                         var matches = Vector.Equals(values, LoadVector(ref searchSpace, offset));
                         if (Vector<byte>.Zero.Equals(matches))
@@ -399,7 +399,7 @@ namespace System
 
                     if ((int)(byte*)offset < length)
                     {
-                        nLength = (IntPtr)(length - (int)(byte*)offset);
+                        lengthToExamine = (IntPtr)(length - (int)(byte*)offset);
                         goto SequentialScan;
                     }
                 }
@@ -465,16 +465,16 @@ namespace System
 
             uint uValue = value; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             IntPtr offset = (IntPtr)length; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
-            IntPtr nLength = (IntPtr)length;
+            IntPtr lengthToExamine = (IntPtr)length;
 
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
-                nLength = UnalignedByteCountVectorFromEnd(ref searchSpace, length);
+                lengthToExamine = UnalignedCountVectorFromEnd(ref searchSpace, length);
             }
         SequentialScan:
-            while ((byte*)nLength >= (byte*)8)
+            while ((byte*)lengthToExamine >= (byte*)8)
             {
-                nLength -= 8;
+                lengthToExamine -= 8;
                 offset -= 8;
 
                 if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 7))
@@ -495,9 +495,9 @@ namespace System
                     goto Found;
             }
 
-            if ((byte*)nLength >= (byte*)4)
+            if ((byte*)lengthToExamine >= (byte*)4)
             {
-                nLength -= 4;
+                lengthToExamine -= 4;
                 offset -= 4;
 
                 if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset + 3))
@@ -510,9 +510,9 @@ namespace System
                     goto Found;
             }
 
-            while ((byte*)nLength > (byte*)0)
+            while ((byte*)lengthToExamine > (byte*)0)
             {
-                nLength -= 1;
+                lengthToExamine -= 1;
                 offset -= 1;
 
                 if (uValue == Unsafe.AddByteOffset(ref searchSpace, offset))
@@ -521,17 +521,17 @@ namespace System
 
             if (Vector.IsHardwareAccelerated && ((byte*)offset > (byte*)0))
             {
-                nLength = (IntPtr)((int)(byte*)offset & ~(Vector<byte>.Count - 1));
+                lengthToExamine = (IntPtr)((int)(byte*)offset & ~(Vector<byte>.Count - 1));
 
                 Vector<byte> values = new Vector<byte>(value);
 
-                while ((byte*)nLength > (byte*)(Vector<byte>.Count - 1))
+                while ((byte*)lengthToExamine > (byte*)(Vector<byte>.Count - 1))
                 {
                     var matches = Vector.Equals(values, LoadVector(ref searchSpace, offset - Vector<byte>.Count));
                     if (Vector<byte>.Zero.Equals(matches))
                     {
                         offset -= Vector<byte>.Count;
-                        nLength -= Vector<byte>.Count;
+                        lengthToExamine -= Vector<byte>.Count;
                         continue;
                     }
 
@@ -540,7 +540,7 @@ namespace System
                 }
                 if ((byte*)offset > (byte*)0)
                 {
-                    nLength = offset;
+                    lengthToExamine = offset;
                     goto SequentialScan;
                 }
             }
@@ -571,28 +571,28 @@ namespace System
             uint uValue0 = value0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue1 = value1; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             IntPtr offset = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
-            IntPtr nLength = (IntPtr)length;
+            IntPtr lengthToExamine = (IntPtr)length;
 
             if (Avx2.IsSupported || Sse2.IsSupported)
             {
                 // Avx2 branch also operates on Sse2 sizes, so check is combined.
                 if (length >= Vector128<byte>.Count * 2)
                 {
-                    nLength = UnalignedByteCountVector128(ref searchSpace);
+                    lengthToExamine = UnalignedCountVector128(ref searchSpace);
                 }
             }
             else if (Vector.IsHardwareAccelerated)
             {
                 if (length >= Vector<byte>.Count * 2)
                 {
-                    nLength = UnalignedByteCountVector(ref searchSpace);
+                    lengthToExamine = UnalignedCountVector(ref searchSpace);
                 }
             }
         SequentialScan:
             uint lookUp;
-            while ((byte*)nLength >= (byte*)8)
+            while ((byte*)lengthToExamine >= (byte*)8)
             {
-                nLength -= 8;
+                lengthToExamine -= 8;
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp)
@@ -622,9 +622,9 @@ namespace System
                 offset += 8;
             }
 
-            if ((byte*)nLength >= (byte*)4)
+            if ((byte*)lengthToExamine >= (byte*)4)
             {
-                nLength -= 4;
+                lengthToExamine -= 4;
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp)
@@ -642,9 +642,9 @@ namespace System
                 offset += 4;
             }
 
-            while ((byte*)nLength > (byte*)0)
+            while ((byte*)lengthToExamine > (byte*)0)
             {
-                nLength -= 1;
+                lengthToExamine -= 1;
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp)
@@ -657,8 +657,8 @@ namespace System
             {
                 if ((int)(byte*)offset < length)
                 {
-                    nLength = GetByteVector256SpanLength(offset, length);
-                    if ((byte*)nLength > (byte*)offset)
+                    lengthToExamine = GetByteVector256SpanLength(offset, length);
+                    if ((byte*)lengthToExamine > (byte*)offset)
                     {
                         Vector256<byte> values0 = Vector256.Create(value0);
                         Vector256<byte> values1 = Vector256.Create(value1);
@@ -679,11 +679,11 @@ namespace System
 
                             // Find bitflag offset of first match and add to current offset
                             return ((int)(byte*)offset) + BitOps.TrailingZeroCount(matches);
-                        } while ((byte*)nLength > (byte*)offset);
+                        } while ((byte*)lengthToExamine > (byte*)offset);
                     }
 
-                    nLength = GetByteVector128SpanLength(offset, length);
-                    if ((byte*)nLength > (byte*)offset)
+                    lengthToExamine = GetByteVector128SpanLength(offset, length);
+                    if ((byte*)lengthToExamine > (byte*)offset)
                     {
                         Vector128<byte> values0 = Vector128.Create(value0);
                         Vector128<byte> values1 = Vector128.Create(value1);
@@ -706,7 +706,7 @@ namespace System
 
                     if ((int)(byte*)offset < length)
                     {
-                        nLength = (IntPtr)(length - (int)(byte*)offset);
+                        lengthToExamine = (IntPtr)(length - (int)(byte*)offset);
                         goto SequentialScan;
                     }
                 }
@@ -715,12 +715,12 @@ namespace System
             {
                 if ((int)(byte*)offset < length)
                 {
-                    nLength = GetByteVector128SpanLength(offset, length);
+                    lengthToExamine = GetByteVector128SpanLength(offset, length);
 
                     Vector128<byte> values0 = Vector128.Create(value0);
                     Vector128<byte> values1 = Vector128.Create(value1);
 
-                    while ((byte*)nLength > (byte*)offset)
+                    while ((byte*)lengthToExamine > (byte*)offset)
                     {
                         Vector128<byte> search = LoadVector128(ref searchSpace, offset);
                         // Same method as above
@@ -739,7 +739,7 @@ namespace System
 
                     if ((int)(byte*)offset < length)
                     {
-                        nLength = (IntPtr)(length - (int)(byte*)offset);
+                        lengthToExamine = (IntPtr)(length - (int)(byte*)offset);
                         goto SequentialScan;
                     }
                 }
@@ -748,12 +748,12 @@ namespace System
             {
                 if ((int)(byte*)offset < length)
                 {
-                    nLength = GetByteVectorSpanLength(offset, length);
+                    lengthToExamine = GetByteVectorSpanLength(offset, length);
 
                     Vector<byte> values0 = new Vector<byte>(value0);
                     Vector<byte> values1 = new Vector<byte>(value1);
 
-                    while ((byte*)nLength > (byte*)offset)
+                    while ((byte*)lengthToExamine > (byte*)offset)
                     {
                         Vector<byte> search = LoadVector(ref searchSpace, offset);
                         var matches = Vector.BitwiseOr(
@@ -771,7 +771,7 @@ namespace System
 
                     if ((int)(byte*)offset < length)
                     {
-                        nLength = (IntPtr)(length - (int)(byte*)offset);
+                        lengthToExamine = (IntPtr)(length - (int)(byte*)offset);
                         goto SequentialScan;
                     }
                 }
@@ -804,28 +804,28 @@ namespace System
             uint uValue1 = value1;
             uint uValue2 = value2;
             IntPtr offset = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
-            IntPtr nLength = (IntPtr)length;
+            IntPtr lengthToExamine = (IntPtr)length;
 
             if (Avx2.IsSupported || Sse2.IsSupported)
             {
                 // Avx2 branch also operates on Sse2 sizes, so check is combined.
                 if (length >= Vector128<byte>.Count * 2)
                 {
-                    nLength = UnalignedByteCountVector128(ref searchSpace);
+                    lengthToExamine = UnalignedCountVector128(ref searchSpace);
                 }
             }
             else if (Vector.IsHardwareAccelerated)
             {
                 if (length >= Vector<byte>.Count * 2)
                 {
-                    nLength = UnalignedByteCountVector(ref searchSpace);
+                    lengthToExamine = UnalignedCountVector(ref searchSpace);
                 }
             }
         SequentialScan:
             uint lookUp;
-            while ((byte*)nLength >= (byte*)8)
+            while ((byte*)lengthToExamine >= (byte*)8)
             {
-                nLength -= 8;
+                lengthToExamine -= 8;
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
@@ -855,9 +855,9 @@ namespace System
                 offset += 8;
             }
 
-            if ((byte*)nLength >= (byte*)4)
+            if ((byte*)lengthToExamine >= (byte*)4)
             {
-                nLength -= 4;
+                lengthToExamine -= 4;
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
@@ -875,9 +875,9 @@ namespace System
                 offset += 4;
             }
 
-            while ((byte*)nLength > (byte*)0)
+            while ((byte*)lengthToExamine > (byte*)0)
             {
-                nLength -= 1;
+                lengthToExamine -= 1;
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
                 if (uValue0 == lookUp || uValue1 == lookUp || uValue2 == lookUp)
@@ -890,8 +890,8 @@ namespace System
             {
                 if ((int)(byte*)offset < length)
                 {
-                    nLength = GetByteVector256SpanLength(offset, length);
-                    if ((byte*)nLength > (byte*)offset)
+                    lengthToExamine = GetByteVector256SpanLength(offset, length);
+                    if ((byte*)lengthToExamine > (byte*)offset)
                     {
                         Vector256<byte> values0 = Vector256.Create(value0);
                         Vector256<byte> values1 = Vector256.Create(value1);
@@ -915,11 +915,11 @@ namespace System
 
                             // Find bitflag offset of first match and add to current offset
                             return ((int)(byte*)offset) + BitOps.TrailingZeroCount(matches);
-                        } while ((byte*)nLength > (byte*)offset);
+                        } while ((byte*)lengthToExamine > (byte*)offset);
                     }
 
-                    nLength = GetByteVector128SpanLength(offset, length);
-                    if ((byte*)nLength > (byte*)offset)
+                    lengthToExamine = GetByteVector128SpanLength(offset, length);
+                    if ((byte*)lengthToExamine > (byte*)offset)
                     {
                         Vector128<byte> values0 = Vector128.Create(value0);
                         Vector128<byte> values1 = Vector128.Create(value1);
@@ -944,7 +944,7 @@ namespace System
 
                     if ((int)(byte*)offset < length)
                     {
-                        nLength = (IntPtr)(length - (int)(byte*)offset);
+                        lengthToExamine = (IntPtr)(length - (int)(byte*)offset);
                         goto SequentialScan;
                     }
                 }
@@ -953,13 +953,13 @@ namespace System
             {
                 if ((int)(byte*)offset < length)
                 {
-                    nLength = GetByteVector128SpanLength(offset, length);
+                    lengthToExamine = GetByteVector128SpanLength(offset, length);
 
                     Vector128<byte> values0 = Vector128.Create(value0);
                     Vector128<byte> values1 = Vector128.Create(value1);
                     Vector128<byte> values2 = Vector128.Create(value2);
 
-                    while ((byte*)nLength > (byte*)offset)
+                    while ((byte*)lengthToExamine > (byte*)offset)
                     {
                         Vector128<byte> search = LoadVector128(ref searchSpace, offset);
                         // Same method as above
@@ -979,7 +979,7 @@ namespace System
 
                     if ((int)(byte*)offset < length)
                     {
-                        nLength = (IntPtr)(length - (int)(byte*)offset);
+                        lengthToExamine = (IntPtr)(length - (int)(byte*)offset);
                         goto SequentialScan;
                     }
                 }
@@ -988,13 +988,13 @@ namespace System
             {
                 if ((int)(byte*)offset < length)
                 {
-                    nLength = GetByteVectorSpanLength(offset, length);
+                    lengthToExamine = GetByteVectorSpanLength(offset, length);
 
                     Vector<byte> values0 = new Vector<byte>(value0);
                     Vector<byte> values1 = new Vector<byte>(value1);
                     Vector<byte> values2 = new Vector<byte>(value2);
 
-                    while ((byte*)nLength > (byte*)offset)
+                    while ((byte*)lengthToExamine > (byte*)offset)
                     {
                         Vector<byte> search = LoadVector(ref searchSpace, offset);
 
@@ -1016,7 +1016,7 @@ namespace System
 
                     if ((int)(byte*)offset < length)
                     {
-                        nLength = (IntPtr)(length - (int)(byte*)offset);
+                        lengthToExamine = (IntPtr)(length - (int)(byte*)offset);
                         goto SequentialScan;
                     }
                 }
@@ -1047,17 +1047,17 @@ namespace System
             uint uValue0 = value0; // Use uint for comparisons to avoid unnecessary 8->32 extensions
             uint uValue1 = value1;
             IntPtr offset = (IntPtr)length; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
-            IntPtr nLength = (IntPtr)length;
+            IntPtr lengthToExamine = (IntPtr)length;
 
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
-                nLength = UnalignedByteCountVectorFromEnd(ref searchSpace, length);
+                lengthToExamine = UnalignedCountVectorFromEnd(ref searchSpace, length);
             }
         SequentialScan:
             uint lookUp;
-            while ((byte*)nLength >= (byte*)8)
+            while ((byte*)lengthToExamine >= (byte*)8)
             {
-                nLength -= 8;
+                lengthToExamine -= 8;
                 offset -= 8;
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 7);
@@ -1086,9 +1086,9 @@ namespace System
                     goto Found;
             }
 
-            if ((byte*)nLength >= (byte*)4)
+            if ((byte*)lengthToExamine >= (byte*)4)
             {
-                nLength -= 4;
+                lengthToExamine -= 4;
                 offset -= 4;
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
@@ -1105,9 +1105,9 @@ namespace System
                     goto Found;
             }
 
-            while ((byte*)nLength > (byte*)0)
+            while ((byte*)lengthToExamine > (byte*)0)
             {
-                nLength -= 1;
+                lengthToExamine -= 1;
                 offset -= 1;
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
@@ -1117,12 +1117,12 @@ namespace System
 
             if (Vector.IsHardwareAccelerated && ((byte*)offset > (byte*)0))
             {
-                nLength = (IntPtr)((int)(byte*)offset & ~(Vector<byte>.Count - 1));
+                lengthToExamine = (IntPtr)((int)(byte*)offset & ~(Vector<byte>.Count - 1));
 
                 Vector<byte> values0 = new Vector<byte>(value0);
                 Vector<byte> values1 = new Vector<byte>(value1);
 
-                while ((byte*)nLength > (byte*)(Vector<byte>.Count - 1))
+                while ((byte*)lengthToExamine > (byte*)(Vector<byte>.Count - 1))
                 {
                     Vector<byte> search = LoadVector(ref searchSpace, offset - Vector<byte>.Count);
                     var matches = Vector.BitwiseOr(
@@ -1131,7 +1131,7 @@ namespace System
                     if (Vector<byte>.Zero.Equals(matches))
                     {
                         offset -= Vector<byte>.Count;
-                        nLength -= Vector<byte>.Count;
+                        lengthToExamine -= Vector<byte>.Count;
                         continue;
                     }
 
@@ -1141,7 +1141,7 @@ namespace System
 
                 if ((byte*)offset > (byte*)0)
                 {
-                    nLength = offset;
+                    lengthToExamine = offset;
                     goto SequentialScan;
                 }
             }
@@ -1172,17 +1172,17 @@ namespace System
             uint uValue1 = value1;
             uint uValue2 = value2;
             IntPtr offset = (IntPtr)length; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
-            IntPtr nLength = (IntPtr)length;
+            IntPtr lengthToExamine = (IntPtr)length;
 
             if (Vector.IsHardwareAccelerated && length >= Vector<byte>.Count * 2)
             {
-                nLength = UnalignedByteCountVectorFromEnd(ref searchSpace, length);
+                lengthToExamine = UnalignedCountVectorFromEnd(ref searchSpace, length);
             }
         SequentialScan:
             uint lookUp;
-            while ((byte*)nLength >= (byte*)8)
+            while ((byte*)lengthToExamine >= (byte*)8)
             {
-                nLength -= 8;
+                lengthToExamine -= 8;
                 offset -= 8;
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 7);
@@ -1211,9 +1211,9 @@ namespace System
                     goto Found;
             }
 
-            if ((byte*)nLength >= (byte*)4)
+            if ((byte*)lengthToExamine >= (byte*)4)
             {
-                nLength -= 4;
+                lengthToExamine -= 4;
                 offset -= 4;
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset + 3);
@@ -1230,9 +1230,9 @@ namespace System
                     goto Found;
             }
 
-            while ((byte*)nLength > (byte*)0)
+            while ((byte*)lengthToExamine > (byte*)0)
             {
-                nLength -= 1;
+                lengthToExamine -= 1;
                 offset -= 1;
 
                 lookUp = Unsafe.AddByteOffset(ref searchSpace, offset);
@@ -1242,13 +1242,13 @@ namespace System
 
             if (Vector.IsHardwareAccelerated && ((byte*)offset > (byte*)0))
             {
-                nLength = (IntPtr)((int)(byte*)offset & ~(Vector<byte>.Count - 1));
+                lengthToExamine = (IntPtr)((int)(byte*)offset & ~(Vector<byte>.Count - 1));
 
                 Vector<byte> values0 = new Vector<byte>(value0);
                 Vector<byte> values1 = new Vector<byte>(value1);
                 Vector<byte> values2 = new Vector<byte>(value2);
 
-                while ((byte*)nLength > (byte*)(Vector<byte>.Count - 1))
+                while ((byte*)lengthToExamine > (byte*)(Vector<byte>.Count - 1))
                 {
                     Vector<byte> search = LoadVector(ref searchSpace, offset - Vector<byte>.Count);
 
@@ -1261,7 +1261,7 @@ namespace System
                     if (Vector<byte>.Zero.Equals(matches))
                     {
                         offset -= Vector<byte>.Count;
-                        nLength -= Vector<byte>.Count;
+                        lengthToExamine -= Vector<byte>.Count;
                         continue;
                     }
 
@@ -1271,7 +1271,7 @@ namespace System
 
                 if ((byte*)offset > (byte*)0)
                 {
-                    nLength = offset;
+                    lengthToExamine = offset;
                     goto SequentialScan;
                 }
             }
@@ -1303,12 +1303,12 @@ namespace System
                 goto Equal;
 
             IntPtr offset = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
-            IntPtr nLength = (IntPtr)(void*)length;
+            IntPtr lengthToExamine = (IntPtr)(void*)length;
 
-            if (Vector.IsHardwareAccelerated && (byte*)nLength >= (byte*)Vector<byte>.Count)
+            if (Vector.IsHardwareAccelerated && (byte*)lengthToExamine >= (byte*)Vector<byte>.Count)
             {
-                nLength -= Vector<byte>.Count;
-                while ((byte*)nLength > (byte*)offset)
+                lengthToExamine -= Vector<byte>.Count;
+                while ((byte*)lengthToExamine > (byte*)offset)
                 {
                     if (LoadVector(ref first, offset) != LoadVector(ref second, offset))
                     {
@@ -1316,13 +1316,13 @@ namespace System
                     }
                     offset += Vector<byte>.Count;
                 }
-                return LoadVector(ref first, nLength) == LoadVector(ref second, nLength);
+                return LoadVector(ref first, lengthToExamine) == LoadVector(ref second, lengthToExamine);
             }
 
-            if ((byte*)nLength >= (byte*)sizeof(UIntPtr))
+            if ((byte*)lengthToExamine >= (byte*)sizeof(UIntPtr))
             {
-                nLength -= sizeof(UIntPtr);
-                while ((byte*)nLength > (byte*)offset)
+                lengthToExamine -= sizeof(UIntPtr);
+                while ((byte*)lengthToExamine > (byte*)offset)
                 {
                     if (LoadUIntPtr(ref first, offset) != LoadUIntPtr(ref second, offset))
                     {
@@ -1330,10 +1330,10 @@ namespace System
                     }
                     offset += sizeof(UIntPtr);
                 }
-                return LoadUIntPtr(ref first, nLength) == LoadUIntPtr(ref second, nLength);
+                return LoadUIntPtr(ref first, lengthToExamine) == LoadUIntPtr(ref second, lengthToExamine);
             }
 
-            while ((byte*)nLength > (byte*)offset)
+            while ((byte*)lengthToExamine > (byte*)offset)
             {
                 if (Unsafe.AddByteOffset(ref first, offset) != Unsafe.AddByteOffset(ref second, offset))
                     goto NotEqual;
@@ -1379,15 +1379,15 @@ namespace System
             IntPtr minLength = (IntPtr)((firstLength < secondLength) ? firstLength : secondLength);
 
             IntPtr offset = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
-            IntPtr nLength = (IntPtr)(void*)minLength;
+            IntPtr lengthToExamine = (IntPtr)(void*)minLength;
 
             if (Avx2.IsSupported)
             {
-                if ((byte*)nLength >= (byte*)Vector256<byte>.Count)
+                if ((byte*)lengthToExamine >= (byte*)Vector256<byte>.Count)
                 {
-                    nLength -= Vector256<byte>.Count;
+                    lengthToExamine -= Vector256<byte>.Count;
                     uint matches;
-                    while ((byte*)nLength > (byte*)offset)
+                    while ((byte*)lengthToExamine > (byte*)offset)
                     {
                         matches = (uint)Avx2.MoveMask(Avx2.CompareEqual(LoadVector256(ref first, offset), LoadVector256(ref second, offset)));
                         // Note that MoveMask has converted the equal vector elements into a set of bit flags,
@@ -1404,7 +1404,7 @@ namespace System
                         goto Difference;
                     }
                     // Move to Vector length from end for final compare
-                    offset = nLength;
+                    offset = lengthToExamine;
                     // Same as method as above
                     matches = (uint)Avx2.MoveMask(Avx2.CompareEqual(LoadVector256(ref first, offset), LoadVector256(ref second, offset)));
                     if (matches == uint.MaxValue)
@@ -1424,11 +1424,11 @@ namespace System
                     return result;
                 }
 
-                if ((byte*)nLength >= (byte*)Vector128<byte>.Count)
+                if ((byte*)lengthToExamine >= (byte*)Vector128<byte>.Count)
                 {
-                    nLength -= Vector128<byte>.Count;
+                    lengthToExamine -= Vector128<byte>.Count;
                     uint matches;
-                    if ((byte*)nLength > (byte*)offset)
+                    if ((byte*)lengthToExamine > (byte*)offset)
                     {
                         matches = (uint)Sse2.MoveMask(Sse2.CompareEqual(LoadVector128(ref first, offset), LoadVector128(ref second, offset)));
                         // Note that MoveMask has converted the equal vector elements into a set of bit flags,
@@ -1446,7 +1446,7 @@ namespace System
                         }
                     }
                     // Move to Vector length from end for final compare
-                    offset = nLength;
+                    offset = lengthToExamine;
                     // Same as method as above
                     matches = (uint)Sse2.MoveMask(Sse2.CompareEqual(LoadVector128(ref first, offset), LoadVector128(ref second, offset)));
                     if (matches == ushort.MaxValue)
@@ -1468,11 +1468,11 @@ namespace System
             }
             else if (Sse2.IsSupported)
             {
-                if ((byte*)nLength >= (byte*)Vector128<byte>.Count)
+                if ((byte*)lengthToExamine >= (byte*)Vector128<byte>.Count)
                 {
-                    nLength -= Vector128<byte>.Count;
+                    lengthToExamine -= Vector128<byte>.Count;
                     uint matches;
-                    while ((byte*)nLength > (byte*)offset)
+                    while ((byte*)lengthToExamine > (byte*)offset)
                     {
                         matches = (uint)Sse2.MoveMask(Sse2.CompareEqual(LoadVector128(ref first, offset), LoadVector128(ref second, offset)));
                         // Note that MoveMask has converted the equal vector elements into a set of bit flags,
@@ -1489,7 +1489,7 @@ namespace System
                         goto Difference;
                     }
                     // Move to Vector length from end for final compare
-                    offset = nLength;
+                    offset = lengthToExamine;
                     // Same as method as above
                     matches = (uint)Sse2.MoveMask(Sse2.CompareEqual(LoadVector128(ref first, offset), LoadVector128(ref second, offset)));
                     if (matches == ushort.MaxValue)
@@ -1511,10 +1511,10 @@ namespace System
             }
             else if (Vector.IsHardwareAccelerated)
             {
-                if ((byte*)nLength > (byte*)Vector<byte>.Count)
+                if ((byte*)lengthToExamine > (byte*)Vector<byte>.Count)
                 {
-                    nLength -= Vector<byte>.Count;
-                    while ((byte*)nLength > (byte*)offset)
+                    lengthToExamine -= Vector<byte>.Count;
+                    while ((byte*)lengthToExamine > (byte*)offset)
                     {
                         if (LoadVector(ref first, offset) != LoadVector(ref second, offset))
                         {
@@ -1526,10 +1526,10 @@ namespace System
                 }
             }
 
-            if ((byte*)nLength > (byte*)sizeof(UIntPtr))
+            if ((byte*)lengthToExamine > (byte*)sizeof(UIntPtr))
             {
-                nLength -= sizeof(UIntPtr);
-                while ((byte*)nLength > (byte*)offset)
+                lengthToExamine -= sizeof(UIntPtr);
+                while ((byte*)lengthToExamine > (byte*)offset)
                 {
                     if (LoadUIntPtr(ref first, offset) != LoadUIntPtr(ref second, offset))
                     {
@@ -1648,21 +1648,21 @@ namespace System
             => (IntPtr)((length - (int)(byte*)offset) & ~(Vector256<byte>.Count - 1));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe IntPtr UnalignedByteCountVector(ref byte searchSpace)
+        private static unsafe IntPtr UnalignedCountVector(ref byte searchSpace)
         {
             int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
             return (IntPtr)((Vector<byte>.Count - unaligned) & (Vector<byte>.Count - 1));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe IntPtr UnalignedByteCountVector128(ref byte searchSpace)
+        private static unsafe IntPtr UnalignedCountVector128(ref byte searchSpace)
         {
             int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector128<byte>.Count - 1);
             return (IntPtr)((Vector128<byte>.Count - unaligned) & (Vector128<byte>.Count - 1));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe IntPtr UnalignedByteCountVectorFromEnd(ref byte searchSpace, int length)
+        private static unsafe IntPtr UnalignedCountVectorFromEnd(ref byte searchSpace, int length)
         {
             int unaligned = (int)Unsafe.AsPointer(ref searchSpace) & (Vector<byte>.Count - 1);
             return (IntPtr)(((length & (Vector<byte>.Count - 1)) + unaligned) & (Vector<byte>.Count - 1));

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
@@ -653,6 +653,8 @@ namespace System
                 offset += 1;
             }
 
+            // We get past SequentialScan only if IsHardwareAccelerated or intrinsic .IsSupported is true. However, we still have the redundant check to allow
+            // the JIT to see that the code is unreachable and eliminate it when the platform does not have hardware accelerated.
             if (Avx2.IsSupported)
             {
                 if ((int)(byte*)offset < length)

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
@@ -667,11 +667,13 @@ namespace System
                         do
                         {
                             Vector256<byte> search = LoadVector256(ref searchSpace, offset);
+                            // Bitwise Or to combine the matches and MoveMask to convert them to bitflags
+                            int matches = Avx2.MoveMask(
+                                Avx2.Or(
+                                    Avx2.CompareEqual(values0, search), 
+                                    Avx2.CompareEqual(values1, search)));
                             // Note that MoveMask has converted the equal vector elements into a set of bit flags,
                             // So the bit position in 'matches' corresponds to the element offset.
-                            int matches = Avx2.MoveMask(Avx2.CompareEqual(values0, search));
-                            // Bitwise Or to combine the flagged matches for the second value to our match flags
-                            matches |= Avx2.MoveMask(Avx2.CompareEqual(values1, search));
                             if (matches == 0)
                             {
                                 // Zero flags set so no matches
@@ -692,8 +694,10 @@ namespace System
 
                         Vector128<byte> search = LoadVector128(ref searchSpace, offset);
                         // Same method as above
-                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values0, search));
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values1, search));
+                        int matches = Sse2.MoveMask(
+                            Sse2.Or(
+                                Sse2.CompareEqual(values0, search),
+                                Sse2.CompareEqual(values1, search)));
                         if (matches == 0)
                         {
                             // Zero flags set so no matches
@@ -726,8 +730,10 @@ namespace System
                     {
                         Vector128<byte> search = LoadVector128(ref searchSpace, offset);
                         // Same method as above
-                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values0, search));
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values1, search));
+                        int matches = Sse2.MoveMask(
+                            Sse2.Or(
+                                Sse2.CompareEqual(values0, search),
+                                Sse2.CompareEqual(values1, search)));
                         if (matches == 0)
                         {
                             // Zero flags set so no matches
@@ -901,13 +907,14 @@ namespace System
                         do
                         {
                             Vector256<byte> search = LoadVector256(ref searchSpace, offset);
+
+                            Vector256<byte> matches0 = Avx2.CompareEqual(values0, search);
+                            Vector256<byte> matches1 = Avx2.CompareEqual(values1, search);
+                            Vector256<byte> matches2 = Avx2.CompareEqual(values2, search);
+                            // Bitwise Or to combine the matches and MoveMask to convert them to bitflags
+                            int matches = Avx2.MoveMask(Avx2.Or(Avx2.Or(matches0, matches1), matches2));
                             // Note that MoveMask has converted the equal vector elements into a set of bit flags,
                             // So the bit position in 'matches' corresponds to the element offset.
-                            int matches = Avx2.MoveMask(Avx2.CompareEqual(values0, search));
-                            // Bitwise Or to combine the flagged matches for the second value to our match flags
-                            matches |= Avx2.MoveMask(Avx2.CompareEqual(values1, search));
-                            // Bitwise Or to combine the flagged matches for the third value to our match flags
-                            matches |= Avx2.MoveMask(Avx2.CompareEqual(values2, search));
                             if (matches == 0)
                             {
                                 // Zero flags set so no matches
@@ -928,10 +935,12 @@ namespace System
                         Vector128<byte> values2 = Vector128.Create(value2);
 
                         Vector128<byte> search = LoadVector128(ref searchSpace, offset);
+
+                        Vector128<byte> matches0 = Sse2.CompareEqual(values0, search);
+                        Vector128<byte> matches1 = Sse2.CompareEqual(values1, search);
+                        Vector128<byte> matches2 = Sse2.CompareEqual(values2, search);
                         // Same method as above
-                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values0, search));
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values1, search));
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values2, search));
+                        int matches = Sse2.MoveMask(Sse2.Or(Sse2.Or(matches0, matches1), matches2));
                         if (matches == 0)
                         {
                             // Zero flags set so no matches
@@ -964,10 +973,12 @@ namespace System
                     while ((byte*)lengthToExamine > (byte*)offset)
                     {
                         Vector128<byte> search = LoadVector128(ref searchSpace, offset);
+
+                        Vector128<byte> matches0 = Sse2.CompareEqual(values0, search);
+                        Vector128<byte> matches1 = Sse2.CompareEqual(values1, search);
+                        Vector128<byte> matches2 = Sse2.CompareEqual(values2, search);
                         // Same method as above
-                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values0, search));
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values1, search));
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values2, search));
+                        int matches = Sse2.MoveMask(Sse2.Or(Sse2.Or(matches0, matches1), matches2));
                         if (matches == 0)
                         {
                             // Zero flags set so no matches

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
@@ -1024,13 +1024,20 @@ namespace System
                         Vector128<ushort> values1 = Vector128.Create(value1);
                         Vector128<ushort> values2 = Vector128.Create(value2);
                         Vector128<ushort> values3 = Vector128.Create(value3);
+
                         Vector128<ushort> search = LoadVector128(ref searchSpace, offset);
 
+                        // We can do the ORs in vectors here as we don't need to keep the values as we are not looping
+                        Vector128<ushort> matches0 = Sse2.CompareEqual(values0, search);
+                        Vector128<ushort> matches1 = Sse2.CompareEqual(values1, search);
+                        Vector128<ushort> matches2 = Sse2.CompareEqual(values2, search);
+                        Vector128<ushort> matches3 = Sse2.CompareEqual(values3, search);
+
+                        Vector128<ushort> matches01 = Sse2.Or(matches0, matches1);
+                        Vector128<ushort> matches23 = Sse2.Or(matches2, matches3);
+
                         // Same method as above
-                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values0, search).AsByte());
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values1, search).AsByte());
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values2, search).AsByte());
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values3, search).AsByte());
+                        int matches = Sse2.MoveMask(Sse2.Or(matches01, matches23).AsByte());
                         if (matches == 0)
                         {
                             // Zero flags set so no matches
@@ -1241,14 +1248,21 @@ namespace System
                         Vector128<ushort> values2 = Vector128.Create(value2);
                         Vector128<ushort> values3 = Vector128.Create(value3);
                         Vector128<ushort> values4 = Vector128.Create(value4);
+
                         Vector128<ushort> search = LoadVector128(ref searchSpace, offset);
 
+                        // We can do the ORs in vectors here as we don't need to keep the values as we are not looping
+                        Vector128<ushort> matches0 = Sse2.CompareEqual(values0, search);
+                        Vector128<ushort> matches1 = Sse2.CompareEqual(values1, search);
+                        Vector128<ushort> matches2 = Sse2.CompareEqual(values2, search);
+                        Vector128<ushort> matches3 = Sse2.CompareEqual(values3, search);
+                        Vector128<ushort> matches4 = Sse2.CompareEqual(values4, search);
+
+                        Vector128<ushort> matches01 = Sse2.Or(matches0, matches1);
+                        Vector128<ushort> matches23 = Sse2.Or(matches2, matches3);
+
                         // Same method as above
-                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values0, search).AsByte());
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values1, search).AsByte());
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values2, search).AsByte());
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values3, search).AsByte());
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values4, search).AsByte());
+                        int matches = Sse2.MoveMask(Sse2.Or(Sse2.Or(matches01, matches4), matches23).AsByte());
                         if (matches == 0)
                         {
                             // Zero flags set so no matches

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
@@ -570,11 +570,14 @@ namespace System
                         do
                         {
                             Vector256<ushort> search = LoadVector256(ref searchSpace, offset);
+                            // Bitwise Or to combine the flagged matches for the second value to our match flags
+                            int matches = Avx2.MoveMask(
+                                            Avx2.Or(
+                                                Avx2.CompareEqual(values0, search),
+                                                Avx2.CompareEqual(values1, search))
+                                            .AsByte());
                             // Note that MoveMask has converted the equal vector elements into a set of bit flags,
                             // So the bit position in 'matches' corresponds to the element offset.
-                            int matches = Avx2.MoveMask(Avx2.CompareEqual(values0, search).AsByte());
-                            // Bitwise Or to combine the flagged matches for the second value to our match flags
-                            matches |= Avx2.MoveMask(Avx2.CompareEqual(values1, search).AsByte());
                             if (matches == 0)
                             {
                                 // Zero flags set so no matches
@@ -596,8 +599,11 @@ namespace System
                         Vector128<ushort> search = LoadVector128(ref searchSpace, offset);
 
                         // Same method as above
-                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values0, search).AsByte());
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values1, search).AsByte());
+                        int matches = Sse2.MoveMask(
+                                        Sse2.Or(
+                                            Sse2.CompareEqual(values0, search),
+                                            Sse2.CompareEqual(values1, search))
+                                        .AsByte());
                         if (matches == 0)
                         {
                             // Zero flags set so no matches
@@ -631,8 +637,11 @@ namespace System
                         Vector128<ushort> search = LoadVector128(ref searchSpace, offset);
 
                         // Same method as above
-                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values0, search).AsByte());
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values1, search).AsByte());
+                        int matches = Sse2.MoveMask(
+                                        Sse2.Or(
+                                            Sse2.CompareEqual(values0, search),
+                                            Sse2.CompareEqual(values1, search))
+                                        .AsByte());
                         if (matches == 0)
                         {
                             // Zero flags set so no matches
@@ -767,12 +776,16 @@ namespace System
                         do
                         {
                             Vector256<ushort> search = LoadVector256(ref searchSpace, offset);
+
+                            Vector256<ushort> matches0 = Avx2.CompareEqual(values0, search);
+                            Vector256<ushort> matches1 = Avx2.CompareEqual(values1, search);
+                            Vector256<ushort> matches2 = Avx2.CompareEqual(values2, search);
+                            // Bitwise Or to combine the flagged matches for the second and third values to our match flags
+                            int matches = Avx2.MoveMask(
+                                            Avx2.Or(Avx2.Or(matches0, matches1), matches2)
+                                            .AsByte());
                             // Note that MoveMask has converted the equal vector elements into a set of bit flags,
                             // So the bit position in 'matches' corresponds to the element offset.
-                            int matches = Avx2.MoveMask(Avx2.CompareEqual(values0, search).AsByte());
-                            // Bitwise Or to combine the flagged matches for the second and third values to our match flags
-                            matches |= Avx2.MoveMask(Avx2.CompareEqual(values1, search).AsByte());
-                            matches |= Avx2.MoveMask(Avx2.CompareEqual(values2, search).AsByte());
                             if (matches == 0)
                             {
                                 // Zero flags set so no matches
@@ -792,12 +805,17 @@ namespace System
                         Vector128<ushort> values0 = Vector128.Create(value0);
                         Vector128<ushort> values1 = Vector128.Create(value1);
                         Vector128<ushort> values2 = Vector128.Create(value2);
+
                         Vector128<ushort> search = LoadVector128(ref searchSpace, offset);
 
+                        Vector128<ushort> matches0 = Sse2.CompareEqual(values0, search);
+                        Vector128<ushort> matches1 = Sse2.CompareEqual(values1, search);
+                        Vector128<ushort> matches2 = Sse2.CompareEqual(values2, search);
+
                         // Same method as above
-                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values0, search).AsByte());
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values1, search).AsByte());
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values2, search).AsByte());
+                        int matches = Sse2.MoveMask(
+                                        Sse2.Or(Sse2.Or(matches0, matches1), matches2)
+                                        .AsByte());
                         if (matches == 0)
                         {
                             // Zero flags set so no matches
@@ -831,10 +849,14 @@ namespace System
                     {
                         Vector128<ushort> search = LoadVector128(ref searchSpace, offset);
 
+                        Vector128<ushort> matches0 = Sse2.CompareEqual(values0, search);
+                        Vector128<ushort> matches1 = Sse2.CompareEqual(values1, search);
+                        Vector128<ushort> matches2 = Sse2.CompareEqual(values2, search);
+
                         // Same method as above
-                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values0, search).AsByte());
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values1, search).AsByte());
-                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values2, search).AsByte());
+                        int matches = Sse2.MoveMask(
+                                        Sse2.Or(Sse2.Or(matches0, matches1), matches2)
+                                        .AsByte());
                         if (matches == 0)
                         {
                             // Zero flags set so no matches
@@ -973,13 +995,15 @@ namespace System
                         do
                         {
                             Vector256<ushort> search = LoadVector256(ref searchSpace, offset);
-                            // Note that MoveMask has converted the equal vector elements into a set of bit flags,
-                            // So the bit position in 'matches' corresponds to the element offset.
+                            // We preform the Or at non-Vector level as we are using the maximum number of non-preserved registers,
+                            // and more causes them first to be pushed to stack and then popped on exit to preseve their values.
                             int matches = Avx2.MoveMask(Avx2.CompareEqual(values0, search).AsByte());
                             // Bitwise Or to combine the flagged matches for the second, third and fourth values to our match flags
                             matches |= Avx2.MoveMask(Avx2.CompareEqual(values1, search).AsByte());
                             matches |= Avx2.MoveMask(Avx2.CompareEqual(values2, search).AsByte());
                             matches |= Avx2.MoveMask(Avx2.CompareEqual(values3, search).AsByte());
+                            // Note that MoveMask has converted the equal vector elements into a set of bit flags,
+                            // So the bit position in 'matches' corresponds to the element offset.
                             if (matches == 0)
                             {
                                 // Zero flags set so no matches
@@ -1186,14 +1210,16 @@ namespace System
                         do
                         {
                             Vector256<ushort> search = LoadVector256(ref searchSpace, offset);
-                            // Note that MoveMask has converted the equal vector elements into a set of bit flags,
-                            // So the bit position in 'matches' corresponds to the element offset.
+                            // We preform the Or at non-Vector level as we are using the maximum number of non-preserved registers (+ 1),
+                            // and more causes them first to be pushed to stack and then popped on exit to preseve their values.
                             int matches = Avx2.MoveMask(Avx2.CompareEqual(values0, search).AsByte());
                             // Bitwise Or to combine the flagged matches for the second, third, fourth and fifth values to our match flags
                             matches |= Avx2.MoveMask(Avx2.CompareEqual(values1, search).AsByte());
                             matches |= Avx2.MoveMask(Avx2.CompareEqual(values2, search).AsByte());
                             matches |= Avx2.MoveMask(Avx2.CompareEqual(values3, search).AsByte());
                             matches |= Avx2.MoveMask(Avx2.CompareEqual(values4, search).AsByte());
+                            // Note that MoveMask has converted the equal vector elements into a set of bit flags,
+                            // So the bit position in 'matches' corresponds to the element offset.
                             if (matches == 0)
                             {
                                 // Zero flags set so no matches

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
@@ -908,7 +908,15 @@ namespace System
             int offset = 0; // Use nint for arithmetic to avoid unnecessary 64->32->64 truncations
             int lengthToExamine = length;
 
-            if (Vector.IsHardwareAccelerated)
+            if (Avx2.IsSupported || Sse2.IsSupported)
+            {
+                // Avx2 branch also operates on Sse2 sizes, so check is combined.
+                if (length >= Vector128<byte>.Count * 2)
+                {
+                    lengthToExamine = UnalignedCountVector128(ref searchSpace);
+                }
+            }
+            else if (Vector.IsHardwareAccelerated)
             {
                 if (length >= Vector<ushort>.Count * 2)
                 {
@@ -949,9 +957,115 @@ namespace System
                 offset += 1;
             }
 
-            // We get past SequentialScan only if IsHardwareAccelerated is true. However, we still have the redundant check to allow
+            // We get past SequentialScan only if IsHardwareAccelerated or intrinsic .IsSupported is true. However, we still have the redundant check to allow
             // the JIT to see that the code is unreachable and eliminate it when the platform does not have hardware accelerated.
-            if (Vector.IsHardwareAccelerated)
+            if (Avx2.IsSupported)
+            {
+                if (offset < length)
+                {
+                    lengthToExamine = GetCharVector256SpanLength(offset, length);
+                    if (lengthToExamine > offset)
+                    {
+                        Vector256<ushort> values0 = Vector256.Create(value0);
+                        Vector256<ushort> values1 = Vector256.Create(value1);
+                        Vector256<ushort> values2 = Vector256.Create(value2);
+                        Vector256<ushort> values3 = Vector256.Create(value3);
+                        do
+                        {
+                            Vector256<ushort> search = LoadVector256(ref searchSpace, offset);
+                            // Note that MoveMask has converted the equal vector elements into a set of bit flags,
+                            // So the bit position in 'matches' corresponds to the element offset.
+                            int matches = Avx2.MoveMask(Avx2.CompareEqual(values0, search).AsByte());
+                            // Bitwise Or to combine the flagged matches for the second, third and fourth values to our match flags
+                            matches |= Avx2.MoveMask(Avx2.CompareEqual(values1, search).AsByte());
+                            matches |= Avx2.MoveMask(Avx2.CompareEqual(values2, search).AsByte());
+                            matches |= Avx2.MoveMask(Avx2.CompareEqual(values3, search).AsByte());
+                            if (matches == 0)
+                            {
+                                // Zero flags set so no matches
+                                offset += Vector256<ushort>.Count;
+                                continue;
+                            }
+
+                            // Find bitflag offset of first match and add to current offset, 
+                            // flags are in bytes so divide for chars
+                            return offset + (BitOps.TrailingZeroCount(matches) / sizeof(char));
+                        } while (lengthToExamine > offset);
+                    }
+
+                    lengthToExamine = GetCharVector128SpanLength(offset, length);
+                    if (lengthToExamine > offset)
+                    {
+                        Vector128<ushort> values0 = Vector128.Create(value0);
+                        Vector128<ushort> values1 = Vector128.Create(value1);
+                        Vector128<ushort> values2 = Vector128.Create(value2);
+                        Vector128<ushort> values3 = Vector128.Create(value3);
+                        Vector128<ushort> search = LoadVector128(ref searchSpace, offset);
+
+                        // Same method as above
+                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values0, search).AsByte());
+                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values1, search).AsByte());
+                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values2, search).AsByte());
+                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values3, search).AsByte());
+                        if (matches == 0)
+                        {
+                            // Zero flags set so no matches
+                            offset += Vector128<ushort>.Count;
+                        }
+                        else
+                        {
+                            // Find bitflag offset of first match and add to current offset, 
+                            // flags are in bytes so divide for chars
+                            return offset + (BitOps.TrailingZeroCount(matches) / sizeof(char));
+                        }
+                    }
+
+                    if (offset < length)
+                    {
+                        lengthToExamine = length - offset;
+                        goto SequentialScan;
+                    }
+                }
+            }
+            else if (Sse2.IsSupported)
+            {
+                if (offset < length)
+                {
+                    lengthToExamine = GetCharVector128SpanLength(offset, length);
+
+                    Vector128<ushort> values0 = Vector128.Create(value0);
+                    Vector128<ushort> values1 = Vector128.Create(value1);
+                    Vector128<ushort> values2 = Vector128.Create(value2);
+                    Vector128<ushort> values3 = Vector128.Create(value3);
+                    while (lengthToExamine > offset)
+                    {
+                        Vector128<ushort> search = LoadVector128(ref searchSpace, offset);
+
+                        // Same method as above
+                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values0, search).AsByte());
+                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values1, search).AsByte());
+                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values2, search).AsByte());
+                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values3, search).AsByte());
+                        if (matches == 0)
+                        {
+                            // Zero flags set so no matches
+                            offset += Vector128<ushort>.Count;
+                            continue;
+                        }
+
+                        // Find bitflag offset of first match and add to current offset, 
+                        // flags are in bytes so divide for chars
+                        return offset + (BitOps.TrailingZeroCount(matches) / sizeof(char));
+                    }
+
+                    if (offset < length)
+                    {
+                        lengthToExamine = length - offset;
+                        goto SequentialScan;
+                    }
+                }
+            }
+            else if (Vector.IsHardwareAccelerated)
             {
                 if (offset < length)
                 {

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
@@ -1120,7 +1120,15 @@ namespace System
             int offset = 0; // Use nint for arithmetic to avoid unnecessary 64->32->64 truncations
             int lengthToExamine = length;
 
-            if (Vector.IsHardwareAccelerated)
+            if (Avx2.IsSupported || Sse2.IsSupported)
+            {
+                // Avx2 branch also operates on Sse2 sizes, so check is combined.
+                if (length >= Vector128<byte>.Count * 2)
+                {
+                    lengthToExamine = UnalignedCountVector128(ref searchSpace);
+                }
+            }
+            else if (Vector.IsHardwareAccelerated)
             {
                 if (length >= Vector<ushort>.Count * 2)
                 {
@@ -1161,9 +1169,121 @@ namespace System
                 offset += 1;
             }
 
-            // We get past SequentialScan only if IsHardwareAccelerated is true. However, we still have the redundant check to allow
+            // We get past SequentialScan only if IsHardwareAccelerated or intrinsic .IsSupported is true. However, we still have the redundant check to allow
             // the JIT to see that the code is unreachable and eliminate it when the platform does not have hardware accelerated.
-            if (Vector.IsHardwareAccelerated)
+            if (Avx2.IsSupported)
+            {
+                if (offset < length)
+                {
+                    lengthToExamine = GetCharVector256SpanLength(offset, length);
+                    if (lengthToExamine > offset)
+                    {
+                        Vector256<ushort> values0 = Vector256.Create(value0);
+                        Vector256<ushort> values1 = Vector256.Create(value1);
+                        Vector256<ushort> values2 = Vector256.Create(value2);
+                        Vector256<ushort> values3 = Vector256.Create(value3);
+                        Vector256<ushort> values4 = Vector256.Create(value4);
+                        do
+                        {
+                            Vector256<ushort> search = LoadVector256(ref searchSpace, offset);
+                            // Note that MoveMask has converted the equal vector elements into a set of bit flags,
+                            // So the bit position in 'matches' corresponds to the element offset.
+                            int matches = Avx2.MoveMask(Avx2.CompareEqual(values0, search).AsByte());
+                            // Bitwise Or to combine the flagged matches for the second, third, fourth and fifth values to our match flags
+                            matches |= Avx2.MoveMask(Avx2.CompareEqual(values1, search).AsByte());
+                            matches |= Avx2.MoveMask(Avx2.CompareEqual(values2, search).AsByte());
+                            matches |= Avx2.MoveMask(Avx2.CompareEqual(values3, search).AsByte());
+                            matches |= Avx2.MoveMask(Avx2.CompareEqual(values4, search).AsByte());
+                            if (matches == 0)
+                            {
+                                // Zero flags set so no matches
+                                offset += Vector256<ushort>.Count;
+                                continue;
+                            }
+
+                            // Find bitflag offset of first match and add to current offset, 
+                            // flags are in bytes so divide for chars
+                            return offset + (BitOps.TrailingZeroCount(matches) / sizeof(char));
+                        } while (lengthToExamine > offset);
+                    }
+
+                    lengthToExamine = GetCharVector128SpanLength(offset, length);
+                    if (lengthToExamine > offset)
+                    {
+                        Vector128<ushort> values0 = Vector128.Create(value0);
+                        Vector128<ushort> values1 = Vector128.Create(value1);
+                        Vector128<ushort> values2 = Vector128.Create(value2);
+                        Vector128<ushort> values3 = Vector128.Create(value3);
+                        Vector128<ushort> values4 = Vector128.Create(value4);
+                        Vector128<ushort> search = LoadVector128(ref searchSpace, offset);
+
+                        // Same method as above
+                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values0, search).AsByte());
+                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values1, search).AsByte());
+                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values2, search).AsByte());
+                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values3, search).AsByte());
+                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values4, search).AsByte());
+                        if (matches == 0)
+                        {
+                            // Zero flags set so no matches
+                            offset += Vector128<ushort>.Count;
+                        }
+                        else
+                        {
+                            // Find bitflag offset of first match and add to current offset, 
+                            // flags are in bytes so divide for chars
+                            return offset + (BitOps.TrailingZeroCount(matches) / sizeof(char));
+                        }
+                    }
+
+                    if (offset < length)
+                    {
+                        lengthToExamine = length - offset;
+                        goto SequentialScan;
+                    }
+                }
+            }
+            else if (Sse2.IsSupported)
+            {
+                if (offset < length)
+                {
+                    lengthToExamine = GetCharVector128SpanLength(offset, length);
+
+                    Vector128<ushort> values0 = Vector128.Create(value0);
+                    Vector128<ushort> values1 = Vector128.Create(value1);
+                    Vector128<ushort> values2 = Vector128.Create(value2);
+                    Vector128<ushort> values3 = Vector128.Create(value3);
+                    Vector128<ushort> values4 = Vector128.Create(value4);
+                    while (lengthToExamine > offset)
+                    {
+                        Vector128<ushort> search = LoadVector128(ref searchSpace, offset);
+
+                        // Same method as above
+                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values0, search).AsByte());
+                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values1, search).AsByte());
+                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values2, search).AsByte());
+                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values3, search).AsByte());
+                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values4, search).AsByte());
+                        if (matches == 0)
+                        {
+                            // Zero flags set so no matches
+                            offset += Vector128<ushort>.Count;
+                            continue;
+                        }
+
+                        // Find bitflag offset of first match and add to current offset, 
+                        // flags are in bytes so divide for chars
+                        return offset + (BitOps.TrailingZeroCount(matches) / sizeof(char));
+                    }
+
+                    if (offset < length)
+                    {
+                        lengthToExamine = length - offset;
+                        goto SequentialScan;
+                    }
+                }
+            }
+            else if (Vector.IsHardwareAccelerated)
             {
                 if (offset < length)
                 {

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
@@ -70,7 +70,138 @@ namespace System
             int offset = 0;
             int lengthToExamine = minLength;
 
-            if (Vector.IsHardwareAccelerated)
+            if (Avx2.IsSupported)
+            {
+                if (lengthToExamine >= Vector256<ushort>.Count)
+                {
+                    lengthToExamine -= Vector256<ushort>.Count;
+                    uint matches;
+                    while (lengthToExamine > offset)
+                    {
+                        matches = (uint)Avx2.MoveMask(Avx2.CompareEqual(LoadVector256(ref first, offset), LoadVector256(ref second, offset)).AsByte());
+                        // Note that MoveMask has converted the equal vector elements into a set of bit flags,
+                        // So the bit position in 'matches' corresponds to the element offset.
+
+                        // 32 elements in Vector256<byte> so we compare to uint.MaxValue to check if everything matched
+                        if (matches == uint.MaxValue)
+                        {
+                            // All matched
+                            offset += Vector256<ushort>.Count;
+                            continue;
+                        }
+
+                        goto Difference;
+                    }
+                    // Move to Vector length from end for final compare
+                    offset = lengthToExamine;
+                    // Same as method as above
+                    matches = (uint)Avx2.MoveMask(Avx2.CompareEqual(LoadVector256(ref first, offset), LoadVector256(ref second, offset)).AsByte());
+                    if (matches == uint.MaxValue)
+                    {
+                        // All matched
+                        goto Equal;
+                    }
+                Difference:
+                    // Invert matches to find differences
+                    uint differences = ~matches;
+                    // Find bitflag offset of first difference and add to current offset, 
+                    // flags are in bytes so divide for chars
+                    offset = offset + BitOps.TrailingZeroCount((int)differences) / sizeof(char);
+
+                    int result = Unsafe.Add(ref first, offset).CompareTo(Unsafe.Add(ref second, offset));
+                    Debug.Assert(result != 0);
+
+                    return result;
+                }
+
+                if (lengthToExamine >= Vector128<ushort>.Count)
+                {
+                    lengthToExamine -= Vector128<ushort>.Count;
+                    uint matches;
+                    if (lengthToExamine > offset)
+                    {
+                        matches = (uint)Sse2.MoveMask(Sse2.CompareEqual(LoadVector128(ref first, offset), LoadVector128(ref second, offset)).AsByte());
+                        // Note that MoveMask has converted the equal vector elements into a set of bit flags,
+                        // So the bit position in 'matches' corresponds to the element offset.
+
+                        // 16 elements in Vector128<byte> so we compare to ushort.MaxValue to check if everything matched
+                        if (matches == ushort.MaxValue)
+                        {
+                            // All matched
+                            offset += Vector128<ushort>.Count;
+                        }
+                        else
+                        {
+                            goto Difference;
+                        }
+                    }
+                    // Move to Vector length from end for final compare
+                    offset = lengthToExamine;
+                    // Same as method as above
+                    matches = (uint)Sse2.MoveMask(Sse2.CompareEqual(LoadVector128(ref first, offset), LoadVector128(ref second, offset)).AsByte());
+                    if (matches == ushort.MaxValue)
+                    {
+                        // All matched
+                        goto Equal;
+                    }
+                Difference:
+                    // Invert matches to find differences
+                    uint differences = ~matches;
+                    // Find bitflag offset of first difference and add to current offset, 
+                    // flags are in bytes so divide for chars
+                    offset = offset + BitOps.TrailingZeroCount((int)differences) / sizeof(char);
+
+                    int result = Unsafe.Add(ref first, offset).CompareTo(Unsafe.Add(ref second, offset));
+                    Debug.Assert(result != 0);
+
+                    return result;
+                }
+            }
+            else if (Sse2.IsSupported)
+            {
+                if (lengthToExamine >= Vector128<ushort>.Count)
+                {
+                    lengthToExamine -= Vector128<ushort>.Count;
+                    uint matches;
+                    while (lengthToExamine > offset)
+                    {
+                        matches = (uint)Sse2.MoveMask(Sse2.CompareEqual(LoadVector128(ref first, offset), LoadVector128(ref second, offset)).AsByte());
+                        // Note that MoveMask has converted the equal vector elements into a set of bit flags,
+                        // So the bit position in 'matches' corresponds to the element offset.
+
+                        // 16 elements in Vector128<byte> so we compare to ushort.MaxValue to check if everything matched
+                        if (matches == ushort.MaxValue)
+                        {
+                            // All matched
+                            offset += Vector128<ushort>.Count;
+                            continue;
+                        }
+
+                        goto Difference;
+                    }
+                    // Move to Vector length from end for final compare
+                    offset = lengthToExamine;
+                    // Same as method as above
+                    matches = (uint)Sse2.MoveMask(Sse2.CompareEqual(LoadVector128(ref first, offset), LoadVector128(ref second, offset)).AsByte());
+                    if (matches == ushort.MaxValue)
+                    {
+                        // All matched
+                        goto Equal;
+                    }
+                Difference:
+                    // Invert matches to find differences
+                    uint differences = ~matches;
+                    // Find bitflag offset of first difference and add to current offset, 
+                    // flags are in bytes so divide for chars
+                    offset = offset + BitOps.TrailingZeroCount((int)differences) / sizeof(char);
+
+                    int result = Unsafe.Add(ref first, offset).CompareTo(Unsafe.Add(ref second, offset));
+                    Debug.Assert(result != 0);
+
+                    return result;
+                }
+            }
+            else if (Vector.IsHardwareAccelerated)
             {
                 if (lengthToExamine > Vector<ushort>.Count)
                 {

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
@@ -703,7 +703,15 @@ namespace System
             int offset = 0;
             int lengthToExamine = length;
 
-            if (Vector.IsHardwareAccelerated)
+            if (Avx2.IsSupported || Sse2.IsSupported)
+            {
+                // Avx2 branch also operates on Sse2 sizes, so check is combined.
+                if (length >= Vector128<byte>.Count * 2)
+                {
+                    lengthToExamine = UnalignedCountVector128(ref searchSpace);
+                }
+            }
+            else if (Vector.IsHardwareAccelerated)
             {
                 if (length >= Vector<ushort>.Count * 2)
                 {
@@ -744,9 +752,109 @@ namespace System
                 offset += 1;
             }
 
-            // We get past SequentialScan only if IsHardwareAccelerated is true. However, we still have the redundant check to allow
+            // We get past SequentialScan only if IsHardwareAccelerated or intrinsic .IsSupported is true. However, we still have the redundant check to allow
             // the JIT to see that the code is unreachable and eliminate it when the platform does not have hardware accelerated.
-            if (Vector.IsHardwareAccelerated)
+            if (Avx2.IsSupported)
+            {
+                if (offset < length)
+                {
+                    lengthToExamine = GetCharVector256SpanLength(offset, length);
+                    if (lengthToExamine > offset)
+                    {
+                        Vector256<ushort> values0 = Vector256.Create(value0);
+                        Vector256<ushort> values1 = Vector256.Create(value1);
+                        Vector256<ushort> values2 = Vector256.Create(value2);
+                        do
+                        {
+                            Vector256<ushort> search = LoadVector256(ref searchSpace, offset);
+                            // Note that MoveMask has converted the equal vector elements into a set of bit flags,
+                            // So the bit position in 'matches' corresponds to the element offset.
+                            int matches = Avx2.MoveMask(Avx2.CompareEqual(values0, search).AsByte());
+                            // Bitwise Or to combine the flagged matches for the second and third values to our match flags
+                            matches |= Avx2.MoveMask(Avx2.CompareEqual(values1, search).AsByte());
+                            matches |= Avx2.MoveMask(Avx2.CompareEqual(values2, search).AsByte());
+                            if (matches == 0)
+                            {
+                                // Zero flags set so no matches
+                                offset += Vector256<ushort>.Count;
+                                continue;
+                            }
+
+                            // Find bitflag offset of first match and add to current offset, 
+                            // flags are in bytes so divide for chars
+                            return offset + (BitOps.TrailingZeroCount(matches) / sizeof(char));
+                        } while (lengthToExamine > offset);
+                    }
+
+                    lengthToExamine = GetCharVector128SpanLength(offset, length);
+                    if (lengthToExamine > offset)
+                    {
+                        Vector128<ushort> values0 = Vector128.Create(value0);
+                        Vector128<ushort> values1 = Vector128.Create(value1);
+                        Vector128<ushort> values2 = Vector128.Create(value2);
+                        Vector128<ushort> search = LoadVector128(ref searchSpace, offset);
+
+                        // Same method as above
+                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values0, search).AsByte());
+                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values1, search).AsByte());
+                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values2, search).AsByte());
+                        if (matches == 0)
+                        {
+                            // Zero flags set so no matches
+                            offset += Vector128<ushort>.Count;
+                        }
+                        else
+                        {
+                            // Find bitflag offset of first match and add to current offset, 
+                            // flags are in bytes so divide for chars
+                            return offset + (BitOps.TrailingZeroCount(matches) / sizeof(char));
+                        }
+                    }
+
+                    if (offset < length)
+                    {
+                        lengthToExamine = length - offset;
+                        goto SequentialScan;
+                    }
+                }
+            }
+            else if (Sse2.IsSupported)
+            {
+                if (offset < length)
+                {
+                    lengthToExamine = GetCharVector128SpanLength(offset, length);
+
+                    Vector128<ushort> values0 = Vector128.Create(value0);
+                    Vector128<ushort> values1 = Vector128.Create(value1);
+                    Vector128<ushort> values2 = Vector128.Create(value2);
+                    while (lengthToExamine > offset)
+                    {
+                        Vector128<ushort> search = LoadVector128(ref searchSpace, offset);
+
+                        // Same method as above
+                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values0, search).AsByte());
+                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values1, search).AsByte());
+                        matches |= Sse2.MoveMask(Sse2.CompareEqual(values2, search).AsByte());
+                        if (matches == 0)
+                        {
+                            // Zero flags set so no matches
+                            offset += Vector128<ushort>.Count;
+                            continue;
+                        }
+
+                        // Find bitflag offset of first match and add to current offset, 
+                        // flags are in bytes so divide for chars
+                        return offset + (BitOps.TrailingZeroCount(matches) / sizeof(char));
+                    }
+
+                    if (offset < length)
+                    {
+                        lengthToExamine = length - offset;
+                        goto SequentialScan;
+                    }
+                }
+            }
+            else if (Vector.IsHardwareAccelerated)
             {
                 if (offset < length)
                 {

--- a/src/System.Private.CoreLib/shared/System/String.cs
+++ b/src/System.Private.CoreLib/shared/System/String.cs
@@ -561,109 +561,18 @@ namespace System
             return new StringRuneEnumerator(this);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe int wcslen(char* ptr)
         {
-            char* end = ptr;
-
-            // First make sure our pointer is aligned on a word boundary
-            int alignment = IntPtr.Size - 1;
-
-            // If ptr is at an odd address (e.g. 0x5), this loop will simply iterate all the way
-            while (((uint)end & (uint)alignment) != 0)
+            // IndexOf processes memory in aligned chunks, and thus it won't crash even if it accesses memory beyond the null terminator.
+            int length = SpanHelpers.IndexOf(ref *ptr, '\0', int.MaxValue);
+            if (length < 0)
             {
-                if (*end == 0) goto FoundZero;
-                end++;
+                ThrowMustBeNullTerminatedString();
             }
 
-#if !BIT64
-            // The following code is (somewhat surprisingly!) significantly faster than a naive loop,
-            // at least on x86 and the current jit.
-
-            // The loop condition below works because if "end[0] & end[1]" is non-zero, that means
-            // neither operand can have been zero. If is zero, we have to look at the operands individually,
-            // but we hope this going to fairly rare.
-
-            // In general, it would be incorrect to access end[1] if we haven't made sure
-            // end[0] is non-zero. However, we know the ptr has been aligned by the loop above
-            // so end[0] and end[1] must be in the same word (and therefore page), so they're either both accessible, or both not.
-
-            while ((end[0] & end[1]) != 0 || (end[0] != 0 && end[1] != 0))
-            {
-                end += 2;
-            }
-
-            Debug.Assert(end[0] == 0 || end[1] == 0);
-            if (end[0] != 0) end++;
-#else // !BIT64
-            // Based on https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord
-
-            // 64-bit implementation: process 1 ulong (word) at a time
-
-            // What we do here is add 0x7fff from each of the
-            // 4 individual chars within the ulong, using MagicMask.
-            // If the char > 0 and < 0x8001, it will have its high bit set.
-            // We then OR with MagicMask, to set all the other bits.
-            // This will result in all bits set (ulong.MaxValue) for any
-            // char that fits the above criteria, and something else otherwise.
-
-            // Note that for any char > 0x8000, this will be a false
-            // positive and we will fallback to the slow path and
-            // check each char individually. This is OK though, since
-            // we optimize for the common case (ASCII chars, which are < 0x80).
-
-            // NOTE: We can access a ulong a time since the ptr is aligned,
-            // and therefore we're only accessing the same word/page. (See notes
-            // for the 32-bit version above.)
-
-            const ulong MagicMask = 0x7fff7fff7fff7fff;
-
-            while (true)
-            {
-                ulong word = *(ulong*)end;
-                word += MagicMask; // cause high bit to be set if not zero, and <= 0x8000
-                word |= MagicMask; // set everything besides the high bits
-
-                if (word == ulong.MaxValue) // 0xffff...
-                {
-                    // all of the chars have their bits set (and therefore none can be 0)
-                    end += 4;
-                    continue;
-                }
-
-                // at least one of them didn't have their high bit set!
-                // go through each char and check for 0.
-
-                if (end[0] == 0) goto EndAt0;
-                if (end[1] == 0) goto EndAt1;
-                if (end[2] == 0) goto EndAt2;
-                if (end[3] == 0) goto EndAt3;
-
-                // if we reached here, it was a false positive-- just continue
-                end += 4;
-            }
-
-            EndAt3: end++;
-            EndAt2: end++;
-            EndAt1: end++;
-            EndAt0:
-#endif // !BIT64
-
-            FoundZero:
-            Debug.Assert(*end == 0);
-
-            int count = (int)(end - ptr);
-
-#if BIT64
-            // Check for overflow
-            if (ptr + count != end)
-                throw new ArgumentException(SR.Arg_MustBeNullTerminatedString);
-#else
-            Debug.Assert(ptr + count == end);
-#endif
-
-            return count;
+            return length;
         }
-
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe int strlen(byte* ptr)


### PR DESCRIPTION
Use `System.Runtime.Intrinsics.X86` in addition to `System.Numerics.Vector` and apply the learnings of `byte` https://github.com/dotnet/coreclr/pull/22118 and https://github.com/dotnet/coreclr/pull/22127 to `char`.

Split this into separate commits so its easier to follow; thought the first one is kinda messy.

1. Prepare SpanHelpers.Char for intrinsics https://github.com/dotnet/coreclr/pull/22187/commits/6bb19c37bd1cefd72e6073f2a1f272e8ab5d83c8
* Mirror SpanHelpers.Byte methods and remove pinning; so its easier to use the same intrinsic patterns as used for byte. (Also rename `nLength` to `lengthToExamine` as it was confusing me)
2. Intrinsicify SpanHelpers.IndexOf(char) https://github.com/dotnet/coreclr/pull/22187/commits/aa80e6cbfefcda07eb5f1383e501beffc4399b68
3. Intrinsicify SpanHelpers.SequenceCompareTo(char) https://github.com/dotnet/coreclr/pull/22187/commits/88a25d285638558696dfbcefa5c93b3f14d5215b
4. Intrinsicify SpanHelpers.IndexOfAny(char,char) https://github.com/dotnet/coreclr/pull/22187/commits/981cc45d2b5a75c5eac48a52ab7b6316c84c0741
5. Intrinsicify SpanHelpers.IndexOfAny(char,char,char) https://github.com/dotnet/coreclr/pull/22187/commits/e02e9abaecace159944d887df4e707929b7694b1
6. Intrinsicify SpanHelpers.IndexOfAny(char,char,char,char) https://github.com/dotnet/coreclr/pull/22187/commits/733a1379d489ca640406cd2ba0132eef02b2b520
7. Intrinsicify SpanHelpers.IndexOfAny(char,char,char,char,char) https://github.com/dotnet/coreclr/pull/22187/commits/991ced66fcaf1fc9f46304eb8280f6daf3c84aae
8. Optimize IndexOfAny(2, 3) https://github.com/dotnet/coreclr/pull/22187/commits/6ac7daf807b6b0433be6ea455965e71f44dbeb1b
9. Optimize .IndexOfAny(4,5) for short lengths https://github.com/dotnet/coreclr/pull/22187/commits/eebbd2f3ea1f1ded0d77fb9ab6210519956e3712
10. Reduce sign extensions https://github.com/dotnet/coreclr/pull/22187/commits/07a282a9a44be0d9447fb7732b2003a84dde3484
11. Align IndexOf  buffers so String.wcslen can use it (Vectorize wcslen https://github.com/dotnet/coreclr/pull/21730) https://github.com/dotnet/coreclr/pull/22187/commits/c7836d50011109537bb93911efb6183ed2969d88

Methods improved
```csharp
internal partial class SpanHelpers
{
    int IndexOfAny(ref byte, byte, byte, int);

    int IndexOf(ref char, char, int);
    int IndexOfAny(ref char, char, char, int);
    int IndexOfAny(ref char, char, char, char, int);
    int IndexOfAny(ref char, char, char, char, char, int);
    int IndexOfAny(ref char, char, char, char, char, char, int);
    int SequenceCompareTo(ref char, int, ref char, int) 
}
```

Perf numbers https://github.com/dotnet/coreclr/pull/22187#issuecomment-460068120

/cc @CarolEidt @fiigii @tannergooding @jkotas 