### PR TITLE
Fix SOS GCInfo for Arm/Arm64

### DIFF
--- a/src/gcdump/gcdumpnonx86.cpp
+++ b/src/gcdump/gcdumpnonx86.cpp
@@ -285,7 +285,11 @@ size_t      GCDump::DumpGCTable(PTR_CBYTE      gcInfoBlock,
                                                   | DECODE_GENERICS_INST_CONTEXT
                                                   | DECODE_GC_LIFETIMES
                                                   | DECODE_PROLOG_LENGTH
-                                                  | DECODE_RETURN_KIND),
+                                                  | DECODE_RETURN_KIND
+#if defined(_TARGET_ARM_) || defined(_TARGET_ARM64_)
+                                                  | DECODE_HAS_TAILCALLS
+#endif
+                                                 ),
                              0);
 
     if (NO_SECURITY_OBJECT != hdrdecoder.GetSecurityObjectStackSlot() ||


### PR DESCRIPTION
Add missing DECODE_HAS_TAILCALLS flag.

Closes #22163