### PR TITLE
[WIP] Tail call stress needs to check more conditions

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -9599,9 +9599,9 @@ int cTreeFlagsIR(Compiler* comp, GenTree* tree)
                     {
                         chars += printf("[CALL_M_PINVOKE]");
                     }
-                    if (call->gtCallMoreFlags & GTF_CALL_M_TAILCALL_STRESS)
+                    if (call->gtCallMoreFlags & GTF_CALL_M_STRESS_TAILCALL)
                     {
-                        chars += printf("[CALL_M_TAILCALL_STRESS]");
+                        chars += printf("[CALL_M_STRESS_TAILCALL]");
                     }
                 }
                 break;

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -9599,6 +9599,10 @@ int cTreeFlagsIR(Compiler* comp, GenTree* tree)
                     {
                         chars += printf("[CALL_M_PINVOKE]");
                     }
+                    if (call->gtCallMoreFlags & GTF_CALL_M_TAILCALL_STRESS)
+                    {
+                        chars += printf("[CALL_M_TAILCALL_STRESS]");
+                    }
                 }
                 break;
 

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -3556,7 +3556,7 @@ struct GenTreeCall final : public GenTree
         return (gtCallMoreFlags & GTF_CALL_M_EXPLICIT_TAILCALL) != 0;
     }
 
-    bool IsTailCallStress() const
+    bool IsStressTailCall() const
     {
         return (gtCallMoreFlags & GTF_CALL_M_STRESS_TAILCALL) != 0;
     }
@@ -3572,7 +3572,7 @@ struct GenTreeCall final : public GenTree
     // and providing a hint that this can be converted to a tail call.
     bool CanTailCall() const
     {
-        return IsTailPrefixedCall() || IsTailCallStress() || IsImplicitTailCall();
+        return IsTailPrefixedCall() || IsStressTailCall() || IsImplicitTailCall();
     }
 
     bool IsTailCallViaHelper() const

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -3459,7 +3459,7 @@ struct GenTreeCall final : public GenTree
 #define GTF_CALL_M_GUARDED_DEVIRT        0x00100000 // GT_CALL -- this call is a candidate for guarded devirtualization
 #define GTF_CALL_M_GUARDED               0x00200000 // GT_CALL -- this call was transformed by guarded devirtualization
 #define GTF_CALL_M_ALLOC_SIDE_EFFECTS    0x00400000 // GT_CALL -- this is a call to an allocator with side effects
-#define GTF_CALL_M_TAILCALL_STRESS       0x00800000 // GT_CALL -- this is a call under tail call stress
+#define GTF_CALL_M_STRESS_TAILCALL       0x00800000 // GT_CALL -- this is a call under tail call stress
 
     // clang-format on
 
@@ -3553,12 +3553,12 @@ struct GenTreeCall final : public GenTree
     // either a tail call (i.e. IsTailCall() is true) or a non-tail call.
     bool IsTailPrefixedCall() const
     {
-        return (gtCallMoreFlags & (GTF_CALL_M_EXPLICIT_TAILCALL | GTF_CALL_M_TAILCALL_STRESS)) != 0;
+        return (gtCallMoreFlags & (GTF_CALL_M_EXPLICIT_TAILCALL | GTF_CALL_M_STRESS_TAILCALL)) != 0;
     }
 
     bool IsTailCallStress() const
     {
-        return (gtCallMoreFlags & GTF_CALL_M_TAILCALL_STRESS) != 0;
+        return (gtCallMoreFlags & GTF_CALL_M_STRESS_TAILCALL) != 0;
     }
 
     // This method returning "true" implies that tail call flowgraph morhphing has

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -3459,7 +3459,7 @@ struct GenTreeCall final : public GenTree
 #define GTF_CALL_M_GUARDED_DEVIRT        0x00100000 // GT_CALL -- this call is a candidate for guarded devirtualization
 #define GTF_CALL_M_GUARDED               0x00200000 // GT_CALL -- this call was transformed by guarded devirtualization
 #define GTF_CALL_M_ALLOC_SIDE_EFFECTS    0x00400000 // GT_CALL -- this is a call to an allocator with side effects
-#define GTF_CALL_M_STRESS_TAILCALL       0x00800000 // GT_CALL -- this is a call under tail call stress
+#define GTF_CALL_M_STRESS_TAILCALL       0x00800000 // GT_CALL -- this is a call under stress tail call
 
     // clang-format on
 

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -3459,6 +3459,7 @@ struct GenTreeCall final : public GenTree
 #define GTF_CALL_M_GUARDED_DEVIRT        0x00100000 // GT_CALL -- this call is a candidate for guarded devirtualization
 #define GTF_CALL_M_GUARDED               0x00200000 // GT_CALL -- this call was transformed by guarded devirtualization
 #define GTF_CALL_M_ALLOC_SIDE_EFFECTS    0x00400000 // GT_CALL -- this is a call to an allocator with side effects
+#define GTF_CALL_M_TAILCALL_STRESS       0x00800000 // GT_CALL -- this is a call under tail call stress
 
     // clang-format on
 
@@ -3552,7 +3553,12 @@ struct GenTreeCall final : public GenTree
     // either a tail call (i.e. IsTailCall() is true) or a non-tail call.
     bool IsTailPrefixedCall() const
     {
-        return (gtCallMoreFlags & GTF_CALL_M_EXPLICIT_TAILCALL) != 0;
+        return (gtCallMoreFlags & (GTF_CALL_M_EXPLICIT_TAILCALL | GTF_CALL_M_TAILCALL_STRESS)) != 0;
+    }
+
+    bool IsTailCallStress() const
+    {
+        return (gtCallMoreFlags & GTF_CALL_M_TAILCALL_STRESS) != 0;
     }
 
     // This method returning "true" implies that tail call flowgraph morhphing has

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -3553,7 +3553,7 @@ struct GenTreeCall final : public GenTree
     // either a tail call (i.e. IsTailCall() is true) or a non-tail call.
     bool IsTailPrefixedCall() const
     {
-        return (gtCallMoreFlags & (GTF_CALL_M_EXPLICIT_TAILCALL | GTF_CALL_M_STRESS_TAILCALL)) != 0;
+        return (gtCallMoreFlags & GTF_CALL_M_EXPLICIT_TAILCALL) != 0;
     }
 
     bool IsTailCallStress() const
@@ -3572,7 +3572,7 @@ struct GenTreeCall final : public GenTree
     // and providing a hint that this can be converted to a tail call.
     bool CanTailCall() const
     {
-        return IsTailPrefixedCall() || IsImplicitTailCall();
+        return IsTailPrefixedCall() || IsTailCallStress() || IsImplicitTailCall();
     }
 
     bool IsTailCallViaHelper() const

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -7394,10 +7394,10 @@ bool Compiler::impTailCallRetTypeCompatible(var_types            callerRetType,
 enum
 {
     PREFIX_TAILCALL_EXPLICIT = 0x00000001, // call has "tail" IL prefix
-    PREFIX_TAILCALL_STRESS = 0x00000002, // call is under "tail call" stress mode
+    PREFIX_STRESS_TAILCALL = 0x00000002, // call is under "tail call" stress mode
     PREFIX_TAILCALL_IMPLICIT =
         0x00000010, // call is treated as having "tail" prefix even though there is no "tail" IL prefix
-    PREFIX_TAILCALL    = (PREFIX_TAILCALL_EXPLICIT | PREFIX_TAILCALL_STRESS | PREFIX_TAILCALL_IMPLICIT),
+    PREFIX_TAILCALL    = (PREFIX_TAILCALL_EXPLICIT | PREFIX_STRESS_TAILCALL | PREFIX_TAILCALL_IMPLICIT),
     PREFIX_VOLATILE    = 0x00000100,
     PREFIX_UNALIGNED   = 0x00001000,
     PREFIX_CONSTRAINED = 0x00010000,
@@ -7518,7 +7518,7 @@ bool Compiler::impIsImplicitTailCallCandidate(
     }
 
     // must not be under "tail call" stress mode
-    if (prefixFlags & PREFIX_TAILCALL_STRESS)
+    if (prefixFlags & PREFIX_STRESS_TAILCALL)
     {
         return false;
     }
@@ -8739,7 +8739,7 @@ DONE:
 
         // Check for permission to tailcall
         bool explicitTailCall = (tailCall & PREFIX_TAILCALL_EXPLICIT) != 0;
-        bool tailCallStress = (tailCall & PREFIX_TAILCALL_STRESS) != 0;
+        bool tailCallStress = (tailCall & PREFIX_STRESS_TAILCALL) != 0;
         bool isTailPrefixed = explicitTailCall || tailCallStress;
 
         assert(!isTailPrefixed || compCurBB->bbJumpKind == BBJ_RETURN);
@@ -14148,8 +14148,8 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                                                               hasTailPrefix)) // Is it legal to do tailcall?
                             {
                                 // Stress the tailcall.
-                                JITDUMP(" (Tailcall stress: prefixFlags |= PREFIX_TAILCALL_STRESS)");
-                                prefixFlags |= PREFIX_TAILCALL_STRESS;
+                                JITDUMP(" (Tailcall stress: prefixFlags |= PREFIX_STRESS_TAILCALL)");
+                                prefixFlags |= PREFIX_STRESS_TAILCALL;
                             }
                         }
                     }
@@ -14186,7 +14186,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
                 // Treat this call as tail call for verification only if "tail" prefixed (i.e. explicit tail call).
                 explicitTailCall = (prefixFlags & PREFIX_TAILCALL_EXPLICIT) != 0;
-                tailCallStress = (prefixFlags & PREFIX_TAILCALL_STRESS) != 0;
+                tailCallStress = (prefixFlags & PREFIX_STRESS_TAILCALL) != 0;
                 readonlyCall     = (prefixFlags & PREFIX_READONLY) != 0;
 
                 if (opcode != CEE_CALLI && opcode != CEE_NEWOBJ)

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -8769,12 +8769,12 @@ DONE:
                 }
                 else if (tailCallStress)
                 {
-                    call->gtCall.gtCallMoreFlags |= GTF_CALL_M_TAILCALL_STRESS;
+                    call->gtCall.gtCallMoreFlags |= GTF_CALL_M_STRESS_TAILCALL;
 
 #ifdef DEBUG
                     if (verbose)
                     {
-                        printf("\nGTF_CALL_M_TAILCALL_STRESS bit set for call ");
+                        printf("\nGTF_CALL_M_STRESS_TAILCALL bit set for call ");
                         printTreeID(call);
                         printf("\n");
                     }
@@ -9367,7 +9367,7 @@ GenTree* Compiler::impFixupStructReturnType(GenTree* op, CORINFO_CLASS_HANDLE re
                 // convention for result return.
                 op->gtCall.gtCallMoreFlags &= ~GTF_CALL_M_TAILCALL;
                 op->gtCall.gtCallMoreFlags &= ~GTF_CALL_M_EXPLICIT_TAILCALL;
-                op->gtCall.gtCallMoreFlags &= ~GTF_CALL_M_TAILCALL_STRESS;
+                op->gtCall.gtCallMoreFlags &= ~GTF_CALL_M_STRESS_TAILCALL;
             }
             else
             {
@@ -9404,7 +9404,7 @@ GenTree* Compiler::impFixupStructReturnType(GenTree* op, CORINFO_CLASS_HANDLE re
                 // convention for result return.
                 op->gtCall.gtCallMoreFlags &= ~GTF_CALL_M_TAILCALL;
                 op->gtCall.gtCallMoreFlags &= ~GTF_CALL_M_EXPLICIT_TAILCALL;
-                op->gtCall.gtCallMoreFlags &= ~GTF_CALL_M_TAILCALL_STRESS;
+                op->gtCall.gtCallMoreFlags &= ~GTF_CALL_M_STRESS_TAILCALL;
             }
             else
             {

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -14200,7 +14200,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 if (tiVerificationNeeded)
                 {
                     verVerifyCall(opcode, &resolvedToken, constraintCall ? &constrainedResolvedToken : nullptr,
-                                  explicitTailCall || stressTailCall, readonlyCall, delegateCreateStart, codeAddr - 1,
+                                  explicitTailCall, readonlyCall, delegateCreateStart, codeAddr - 1,
                                   &callInfo DEBUGARG(info.compFullName));
                 }
 

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -19897,6 +19897,12 @@ void Compiler::impMarkInlineCandidateHelper(GenTreeCall*           call,
         return;
     }
 
+    if (call->IsStressTailCall())
+    {
+        inlineResult.NoteFatal(InlineObservation::CALLSITE_STRESS_TAIL_CALL);
+        return;
+    }
+
     // Tail recursion elimination takes precedence over inlining.
     // TODO: We may want to do some of the additional checks from fgMorphCall
     // here to reduce the chance we don't inline a call that won't be optimized

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -19897,12 +19897,6 @@ void Compiler::impMarkInlineCandidateHelper(GenTreeCall*           call,
         return;
     }
 
-    if (call->IsStressTailCall())
-    {
-        inlineResult.NoteFatal(InlineObservation::CALLSITE_STRESS_TAIL_CALL);
-        return;
-    }
-
     // Tail recursion elimination takes precedence over inlining.
     // TODO: We may want to do some of the additional checks from fgMorphCall
     // here to reduce the chance we don't inline a call that won't be optimized

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -7394,10 +7394,10 @@ bool Compiler::impTailCallRetTypeCompatible(var_types            callerRetType,
 enum
 {
     PREFIX_TAILCALL_EXPLICIT = 0x00000001, // call has "tail" IL prefix
-    PREFIX_STRESS_TAILCALL = 0x00000002, // call is under "tail call" stress mode
+    PREFIX_TAILCALL_STRESS = 0x00000002, // call is under "tail call" stress mode
     PREFIX_TAILCALL_IMPLICIT =
         0x00000010, // call is treated as having "tail" prefix even though there is no "tail" IL prefix
-    PREFIX_TAILCALL    = (PREFIX_TAILCALL_EXPLICIT | PREFIX_STRESS_TAILCALL | PREFIX_TAILCALL_IMPLICIT),
+    PREFIX_TAILCALL    = (PREFIX_TAILCALL_EXPLICIT | PREFIX_TAILCALL_STRESS | PREFIX_TAILCALL_IMPLICIT),
     PREFIX_VOLATILE    = 0x00000100,
     PREFIX_UNALIGNED   = 0x00001000,
     PREFIX_CONSTRAINED = 0x00010000,
@@ -7518,7 +7518,7 @@ bool Compiler::impIsImplicitTailCallCandidate(
     }
 
     // must not be under "tail call" stress mode
-    if (prefixFlags & PREFIX_STRESS_TAILCALL)
+    if (prefixFlags & PREFIX_TAILCALL_STRESS)
     {
         return false;
     }
@@ -8692,7 +8692,7 @@ DONE:
     if (tailCall)
     {
         const bool explicitTailCall = (tailCall & PREFIX_TAILCALL_EXPLICIT) != 0;
-        const bool stressTailCall = (tailCall & PREFIX_STRESS_TAILCALL) != 0;
+        const bool stressTailCall = (tailCall & PREFIX_TAILCALL_STRESS) != 0;
         const bool implicitTailCall = (tailCall & PREFIX_TAILCALL_IMPLICIT) != 0;
 
         // This check cannot be performed for implicit tail calls for the reason
@@ -14148,8 +14148,8 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                                                               hasTailPrefix)) // Is it legal to do tailcall?
                             {
                                 // Stress the tailcall.
-                                JITDUMP(" (Tailcall stress: prefixFlags |= PREFIX_STRESS_TAILCALL)");
-                                prefixFlags |= PREFIX_STRESS_TAILCALL;
+                                JITDUMP(" (Tailcall stress: prefixFlags |= PREFIX_TAILCALL_STRESS)");
+                                prefixFlags |= PREFIX_TAILCALL_STRESS;
                             }
                         }
                     }
@@ -14186,7 +14186,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
                 // Treat this call as tail call for verification only if "tail" prefixed (i.e. explicit tail call).
                 explicitTailCall = (prefixFlags & PREFIX_TAILCALL_EXPLICIT) != 0;
-                stressTailCall = (prefixFlags & PREFIX_STRESS_TAILCALL) != 0;
+                stressTailCall = (prefixFlags & PREFIX_TAILCALL_STRESS) != 0;
                 readonlyCall     = (prefixFlags & PREFIX_READONLY) != 0;
 
                 if (opcode != CEE_CALLI && opcode != CEE_NEWOBJ)

--- a/src/jit/inline.def
+++ b/src/jit/inline.def
@@ -129,7 +129,6 @@ INLINE_OBSERVATION(CROSS_BOUNDARY_CALLI,      bool,   "cross-boundary calli",   
 INLINE_OBSERVATION(CROSS_BOUNDARY_SECURITY,   bool,   "cross-boundary security check", FATAL,       CALLSITE)
 INLINE_OBSERVATION(EXCEEDS_THRESHOLD,         bool,   "exceeds profit threshold",      FATAL,       CALLSITE)
 INLINE_OBSERVATION(EXPLICIT_TAIL_PREFIX,      bool,   "explicit tail prefix",          FATAL,       CALLSITE)
-INLINE_OBSERVATION(STRESS_TAIL_CALL,          bool,   "stress tail call",              FATAL,       CALLSITE)
 INLINE_OBSERVATION(GENERIC_DICTIONARY_LOOKUP, bool,   "runtime dictionary lookup",     FATAL,       CALLSITE)
 INLINE_OBSERVATION(HAS_CALL_VIA_LDVIRTFTN,    bool,   "call via ldvirtftn",            FATAL,       CALLSITE)
 INLINE_OBSERVATION(HAS_COMPLEX_HANDLE,        bool,   "complex handle access",         FATAL,       CALLSITE)

--- a/src/jit/inline.def
+++ b/src/jit/inline.def
@@ -129,6 +129,7 @@ INLINE_OBSERVATION(CROSS_BOUNDARY_CALLI,      bool,   "cross-boundary calli",   
 INLINE_OBSERVATION(CROSS_BOUNDARY_SECURITY,   bool,   "cross-boundary security check", FATAL,       CALLSITE)
 INLINE_OBSERVATION(EXCEEDS_THRESHOLD,         bool,   "exceeds profit threshold",      FATAL,       CALLSITE)
 INLINE_OBSERVATION(EXPLICIT_TAIL_PREFIX,      bool,   "explicit tail prefix",          FATAL,       CALLSITE)
+INLINE_OBSERVATION(STRESS_TAIL_CALL,          bool,   "stress tail call",              FATAL,       CALLSITE)
 INLINE_OBSERVATION(GENERIC_DICTIONARY_LOOKUP, bool,   "runtime dictionary lookup",     FATAL,       CALLSITE)
 INLINE_OBSERVATION(HAS_CALL_VIA_LDVIRTFTN,    bool,   "call via ldvirtftn",            FATAL,       CALLSITE)
 INLINE_OBSERVATION(HAS_COMPLEX_HANDLE,        bool,   "complex handle access",         FATAL,       CALLSITE)

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7985,8 +7985,8 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
     }
     if (call->CanTailCall())
     {
-        // It should either be a tail prefixed call (i.e either explicit or tail call stress) or an implicit tail call
-        assert(call->IsTailPrefixedCall() != call->IsImplicitTailCall());
+        // It should be an explicit (i.e. tail prefixed) tail call or a stress tail call or an implicit tail call
+        assert(call->IsTailPrefixedCall() || (!call->IsTailPrefixedCall() && (call->IsStressTailCall() != call->IsImplicitTailCall())));
 
         // It cannot be an inline candidate
         assert(!call->IsInlineCandidate());

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -6741,7 +6741,6 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result)
     // impMarkInlineCandidate() is expected not to mark tail prefixed calls
     // and recursive tail calls as inline candidates.
     noway_assert(!call->IsTailPrefixedCall());
-    noway_assert(!call->IsStressTailCall());
     noway_assert(!call->IsImplicitTailCall() || !gtIsRecursiveCall(call));
 
     /* If the caller's stack frame is marked, then we can't do any inlining. Period.

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7986,14 +7986,13 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
     if (call->CanTailCall())
     {
         // It should be an explicit (i.e. tail prefixed) tail call or a stress tail call or an implicit tail call
-        assert(call->IsTailPrefixedCall() || (!call->IsTailPrefixedCall() && (call->IsStressTailCall() != call->IsImplicitTailCall())));
+        assert(call->IsTailPrefixedCall() ? !call->IsStressTailCall() && !call->IsImplicitTailCall() : (call->IsStressTailCall() != call->IsImplicitTailCall()));
 
         // It cannot be an inline candidate
         assert(!call->IsInlineCandidate());
 
         const char* szFailReason   = nullptr;
         bool        hasStructParam = false;
-
         if (call->gtCallMoreFlags & GTF_CALL_M_SPECIAL_INTRINSIC)
         {
             szFailReason = "Might turn into an intrinsic";

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -6741,6 +6741,7 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result)
     // impMarkInlineCandidate() is expected not to mark tail prefixed calls
     // and recursive tail calls as inline candidates.
     noway_assert(!call->IsTailPrefixedCall());
+    noway_assert(!call->IsStressTailCall());
     noway_assert(!call->IsImplicitTailCall() || !gtIsRecursiveCall(call));
 
     /* If the caller's stack frame is marked, then we can't do any inlining. Period.

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8102,7 +8102,6 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
                         break;
                     }
                 }
-#if FEATURE_TAILCALL_OPT
                 if (varTypeIsStruct(varDsc->TypeGet()) && varDsc->lvIsParam)
                 {
                     hasStructParam = true;
@@ -8111,7 +8110,6 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
                     // look at the rest of parameters.
                     continue;
                 }
-#endif // FEATURE_TAILCALL_OPT
             }
 
             if (hasAddrExposedVars)

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8023,7 +8023,7 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
             szFailReason = "GcChecks";
         }
 #endif
-        else if (FEATURE_TAILCALL_OPT || call->IsTailCallStress())
+        else if (FEATURE_TAILCALL_OPT || call->IsStressTailCall())
         {
             // We are still not sure whether it can be a tail call. Because, when converting
             // a call to an implicit tail call, we must check that there are no locals with
@@ -8057,7 +8057,7 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
                 // We still must check for any struct parameters and set 'hasStructParam'
                 // so that we won't transform the recursive tail call into a loop.
                 //
-                if (call->IsImplicitTailCall() || call->IsTailCallStress())
+                if (call->IsImplicitTailCall() || call->IsStressTailCall())
                 {
                     if (varDsc->lvHasLdAddrOp)
                     {

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8194,7 +8194,7 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
         // Clear these flags before calling fgMorphCall() to avoid recursion.
         bool isTailPrefixed = call->IsTailPrefixedCall();
         call->gtCallMoreFlags &= ~GTF_CALL_M_EXPLICIT_TAILCALL;
-        call->gtCallMoreFlags &= ~GTF_CALL_M_TAILCALL_STRESS;
+        call->gtCallMoreFlags &= ~GTF_CALL_M_STRESS_TAILCALL;
 
 #if FEATURE_TAILCALL_OPT
         call->gtCallMoreFlags &= ~GTF_CALL_M_IMPLICIT_TAILCALL;

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7984,8 +7984,8 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
     }
     if (call->CanTailCall())
     {
-        // It should either be an explicit (i.e. tail prefixed) or an implicit tail call
-        assert(call->IsTailPrefixedCall() ^ call->IsImplicitTailCall());
+        // It should either be a tail prefixed call (i.e either explicit or tail call stress) or an implicit tail call
+        assert(call->IsTailPrefixedCall() != call->IsImplicitTailCall());
 
         // It cannot be an inline candidate
         assert(!call->IsInlineCandidate());
@@ -8193,6 +8193,7 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
         // Clear these flags before calling fgMorphCall() to avoid recursion.
         bool isTailPrefixed = call->IsTailPrefixedCall();
         call->gtCallMoreFlags &= ~GTF_CALL_M_EXPLICIT_TAILCALL;
+        call->gtCallMoreFlags &= ~GTF_CALL_M_TAILCALL_STRESS;
 
 #if FEATURE_TAILCALL_OPT
         call->gtCallMoreFlags &= ~GTF_CALL_M_IMPLICIT_TAILCALL;


### PR DESCRIPTION
This is an attempt to fix https://github.com/dotnet/coreclr/issues/11408 (and as a result of the aggressive tail call stressing https://github.com/dotnet/coreclr/issues/17584 also)

The idea is to move stress tail calls out of explicit tail call category and do hazard checks for the former (similar to what it's done for implicit tail calls).

@dotnet/jit-contrib Does anyone have any suggestions how to validate that we are not loosing TailCallStress power due to adding those checks? 