### PR TITLE
Use AggressiveOptimization for intrinsics-based SpanHelpers

### DIFF
--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
@@ -990,7 +990,6 @@ namespace System
             return (int)(byte*)(offset + 7);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe int LastIndexOfAny(ref byte searchSpace, byte value0, byte value1, int length)
         {
             Debug.Assert(length >= 0);
@@ -1115,7 +1114,6 @@ namespace System
             return (int)(byte*)(offset + 7);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe int LastIndexOfAny(ref byte searchSpace, byte value0, byte value1, byte value2, int length)
         {
             Debug.Assert(length >= 0);

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
@@ -101,6 +101,7 @@ namespace System
         }
 
         // Adapted from IndexOf(...)
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe bool Contains(ref byte searchSpace, byte value, int length)
         {
             Debug.Assert(length >= 0);
@@ -190,6 +191,7 @@ namespace System
             return true;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe int IndexOf(ref byte searchSpace, byte value, int length)
         {
             Debug.Assert(length >= 0);
@@ -423,6 +425,7 @@ namespace System
             return -1;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe int LastIndexOf(ref byte searchSpace, byte value, int length)
         {
             Debug.Assert(length >= 0);
@@ -527,6 +530,7 @@ namespace System
             return (int)(byte*)(offset + 7);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe int IndexOfAny(ref byte searchSpace, byte value0, byte value1, int length)
         {
             Debug.Assert(length >= 0);
@@ -750,6 +754,7 @@ namespace System
             return (int)(byte*)(offset + 7);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe int IndexOfAny(ref byte searchSpace, byte value0, byte value1, byte value2, int length)
         {
             Debug.Assert(length >= 0);
@@ -985,6 +990,7 @@ namespace System
             return (int)(byte*)(offset + 7);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe int LastIndexOfAny(ref byte searchSpace, byte value0, byte value1, int length)
         {
             Debug.Assert(length >= 0);
@@ -1109,6 +1115,7 @@ namespace System
             return (int)(byte*)(offset + 7);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe int LastIndexOfAny(ref byte searchSpace, byte value0, byte value1, byte value2, int length)
         {
             Debug.Assert(length >= 0);
@@ -1241,6 +1248,7 @@ namespace System
 
         // Optimized byte-based SequenceEquals. The "length" parameter for this one is declared a nuint rather than int as we also use it for types other than byte
         // where the length can exceed 2Gb once scaled by sizeof(T).
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe bool SequenceEqual(ref byte first, ref byte second, nuint length)
         {
             if (Unsafe.AreSame(ref first, ref second))
@@ -1311,6 +1319,7 @@ namespace System
             return i * 8 + LocateFirstFoundByte(candidate);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe int SequenceCompareTo(ref byte first, int firstLength, ref byte second, int secondLength)
         {
             Debug.Assert(firstLength >= 0);

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
@@ -61,6 +61,7 @@ namespace System
             return -1;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe int SequenceCompareTo(ref char first, int firstLength, ref char second, int secondLength)
         {
             Debug.Assert(firstLength >= 0);
@@ -124,6 +125,7 @@ namespace System
         }
 
         // Adapted from IndexOf(...)
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe bool Contains(ref char searchSpace, char value, int length)
         {
             Debug.Assert(length >= 0);
@@ -211,6 +213,7 @@ namespace System
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe int IndexOf(ref char searchSpace, char value, int length)
         {
             Debug.Assert(length >= 0);
@@ -304,6 +307,7 @@ namespace System
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe int IndexOfAny(ref char searchSpace, char value0, char value1, int length)
         {
             Debug.Assert(length >= 0);
@@ -401,6 +405,7 @@ namespace System
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe int IndexOfAny(ref char searchSpace, char value0, char value1, char value2, int length)
         {
             Debug.Assert(length >= 0);
@@ -501,6 +506,7 @@ namespace System
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe int IndexOfAny(ref char searchSpace, char value0, char value1, char value2, char value3, int length)
         {
             Debug.Assert(length >= 0);
@@ -603,6 +609,7 @@ namespace System
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe int IndexOfAny(ref char searchSpace, char value0, char value1, char value2, char value3, char value4, int length)
         {
             Debug.Assert(length >= 0);
@@ -708,6 +715,7 @@ namespace System
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static unsafe int LastIndexOf(ref char searchSpace, char value, int length)
         {
             Debug.Assert(length >= 0);


### PR DESCRIPTION
They are very commonly used as the heavy lifting functions of many other methods and their performance is heavily dependant on their inlines working; and code size heavily dependant on branch elimination based on supported architecture.

From: https://github.com/dotnet/coreclr/pull/22127#issuecomment-457339121

/cc @AndyAyersMS @jkotas @fiigii @kouvel @tannergooding 