### PR TITLE
Fix collectible AssemblyLoadContext weak handle

### DIFF
--- a/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -72,8 +72,8 @@ namespace System.Runtime.Loader
                     throw new InvalidOperationException(SR.GetResourceString("AssemblyLoadContext_Constructor_CannotInstantiateWhileUnloading"));
                 }
 
-                // If this is a collectible ALC, we are creating a weak handle otherwise we use a strong handle
-                var thisHandle = GCHandle.Alloc(this, IsCollectible ? GCHandleType.Weak : GCHandleType.Normal);
+                // If this is a collectible ALC, we are creating a weak handle tracking resurrection otherwise we use a strong handle
+                var thisHandle = GCHandle.Alloc(this, IsCollectible ? GCHandleType.WeakTrackResurrection : GCHandleType.Normal);
                 var thisHandlePtr = GCHandle.ToIntPtr(thisHandle);
                 m_pNativeAssemblyLoadContext = InitializeAssemblyLoadContext(thisHandlePtr, fRepresentsTPALoadContext, isCollectible);
 

--- a/src/binder/clrprivbinderassemblyloadcontext.cpp
+++ b/src/binder/clrprivbinderassemblyloadcontext.cpp
@@ -267,7 +267,7 @@ void CLRPrivBinderAssemblyLoadContext::PrepareForLoadContextRelease(INT_PTR ptrM
     // CLRPrivBinderAssemblyLoadContext::ReleaseLoadContext is called.
     OBJECTHANDLE handle = reinterpret_cast<OBJECTHANDLE>(m_ptrManagedAssemblyLoadContext);
     OBJECTHANDLE strongHandle = reinterpret_cast<OBJECTHANDLE>(ptrManagedStrongAssemblyLoadContext);
-    DestroyShortWeakHandle(handle);
+    DestroyLongWeakHandle(handle);
     m_ptrManagedAssemblyLoadContext = reinterpret_cast<INT_PTR>(strongHandle);
 
     _ASSERTE(m_pAssemblyLoaderAllocator != NULL);


### PR DESCRIPTION
Native runtime keeps short weak handle for collectible AssemblyLoadContext
until the unload time when it gets converted to a strong one. A test
running with gc stress has recently hit a problem caused by the fact
that the weak handle is "short weak" and thus doesn't track
resurrection. Here is what happened:
* The test code has lost reference to the AssemblyLoadContext
* Finalizer of that AssemblyLoadContext was just invoked due to that and
  so the weak short handle was destroyed.
* Native runtime called AssemblyLoadContext.Resolve with the now dead
  handle, the function tried to get the managed object and failed.

The fix is to change the handle type to long weak so that it doesn't get
destroyed before the finalization.

Closes #22174