### PR TITLE
Fixes the desktop build

### DIFF
--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -5625,8 +5625,10 @@ void emitter::emitDispDataSec(dataSecDsc* section)
                         printf("dd\t%08Xh", ig->igOffs - igFirst->igOffs);
                     }
                 }
-                else if (TARGET_POINTER_SIZE == 4)
+                else
                 {
+#ifndef _TARGET_64BIT_
+                    // We have a 32-BIT target
                     if (emitComp->opts.disDiffable)
                     {
                         printf("dd\t%s\n", blockLabel);
@@ -5635,9 +5637,8 @@ void emitter::emitDispDataSec(dataSecDsc* section)
                     {
                         printf("dd\t%08Xh", reinterpret_cast<uint32_t>(emitOffsetToPtr(ig->igOffs)));
                     }
-                }
-                else
-                {
+#else // _TARGET_64BIT_
+                    // We have a 64-BIT target
                     if (emitComp->opts.disDiffable)
                     {
                         printf("dq\t%s\n", blockLabel);
@@ -5646,6 +5647,7 @@ void emitter::emitDispDataSec(dataSecDsc* section)
                     {
                         printf("dq\t%016llXh", reinterpret_cast<uint64_t>(emitOffsetToPtr(ig->igOffs)));
                     }
+#endif  // _TARGET_64BIT_
                 }
 
                 if (!emitComp->opts.disDiffable)

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -5637,7 +5637,7 @@ void emitter::emitDispDataSec(dataSecDsc* section)
                     {
                         printf("dd\t%08Xh", reinterpret_cast<uint32_t>(emitOffsetToPtr(ig->igOffs)));
                     }
-#else // _TARGET_64BIT_
+#else  // _TARGET_64BIT_
                     // We have a 64-BIT target
                     if (emitComp->opts.disDiffable)
                     {
@@ -5647,7 +5647,7 @@ void emitter::emitDispDataSec(dataSecDsc* section)
                     {
                         printf("dq\t%016llXh", reinterpret_cast<uint64_t>(emitOffsetToPtr(ig->igOffs)));
                     }
-#endif  // _TARGET_64BIT_
+#endif // _TARGET_64BIT_
                 }
 
                 if (!emitComp->opts.disDiffable)


### PR DESCRIPTION
A 64-bit build on the desktop CLR build would fail due to this warning:
This code is unreachable but still causes the warning to be issued.

warning C4311: 'reinterpret_cast': pointer truncation from 'BYTE *' to 'uint32_t'  f:\j6\codegenmirror\src\ndp\clr\src\jit\emit.cpp(5636): warning C4302: 'reinterpret_cast': truncation from 'BYTE *' to 'uint32_t'