### PR TITLE
Fix finding entry point unwind record for a method with fragmented un…

### DIFF
--- a/src/vm/codeman.cpp
+++ b/src/vm/codeman.cpp
@@ -3920,11 +3920,13 @@ PTR_RUNTIME_FUNCTION EEJitManager::LazyGetFunctionEntry(EECodeInfo * pCodeInfo)
 
         if (RUNTIME_FUNCTION__BeginAddress(pFunctionEntry) <= address && address < RUNTIME_FUNCTION__EndAddress(pFunctionEntry, baseAddress))
         {
+
 #if defined(EXCEPTION_DATA_SUPPORTS_FUNCTION_FRAGMENTS)
             // If we may have fragmented unwind make sure we're returning the root record
             pFunctionEntry = FindRootEntry(pFunctionEntry, baseAddress);
 #endif
-            break;
+
+            return pFunctionEntry;
         }
     }
 

--- a/src/vm/codeman.cpp
+++ b/src/vm/codeman.cpp
@@ -894,6 +894,32 @@ BOOL IsFunctionFragment(TADDR baseAddress, PTR_RUNTIME_FUNCTION pFunctionEntry)
 #endif
 }
 
+// When we have fragmented unwind we usually want to refer to the
+// unwind record that includes the prolog. We can find it by searching
+// back in the sequence of unwind records.
+PTR_RUNTIME_FUNCTION FindRootEntry(PTR_RUNTIME_FUNCTION pFunctionEntry, TADDR baseAddress)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+
+    PTR_RUNTIME_FUNCTION pRootEntry = pFunctionEntry;
+
+    if (pRootEntry != NULL)
+    {
+        for (;;)
+        {
+            if (!IsFunctionFragment(baseAddress, pRootEntry))
+            {
+                // This is not a fragment; we're done
+                break;
+            }
+
+            --pRootEntry;
+        }
+    }
+
+    return pRootEntry;
+}
+
 #endif // EXCEPTION_DATA_SUPPORTS_FUNCTION_FRAGMENTS
 
 
@@ -1078,30 +1104,12 @@ TADDR IJitManager::GetFuncletStartAddress(EECodeInfo * pCodeInfo)
 #endif
 
     TADDR baseAddress = pCodeInfo->GetModuleBase();
-    TADDR funcletStartAddress = baseAddress + RUNTIME_FUNCTION__BeginAddress(pFunctionEntry);
 
 #if defined(EXCEPTION_DATA_SUPPORTS_FUNCTION_FRAGMENTS)
-    // Is the RUNTIME_FUNCTION a fragment? If so, we need to walk backwards until we find the first
-    // non-fragment RUNTIME_FUNCTION, and use that one. This happens when we have very large functions
-    // and multiple RUNTIME_FUNCTION entries per function or funclet. However, all but the first will
-    // have the "F" bit set in the unwind data, indicating a fragment (with phantom prolog unwind codes).
-
-    for (;;)
-    {
-        if (!IsFunctionFragment(baseAddress, pFunctionEntry))
-        {
-            // This is not a fragment; we're done
-            break;
-        }
-
-        // We found a fragment. Walk backwards in the RUNTIME_FUNCTION array until we find a non-fragment.
-        // We're guaranteed to find one, because we require that a fragment live in a function or funclet
-        // that has a prolog, which will have non-fragment .xdata.
-        --pFunctionEntry;
-
-        funcletStartAddress = baseAddress + RUNTIME_FUNCTION__BeginAddress(pFunctionEntry);
-    }
+    pFunctionEntry = FindRootEntry(pFunctionEntry, baseAddress);
 #endif // EXCEPTION_DATA_SUPPORTS_FUNCTION_FRAGMENTS
+
+    TADDR funcletStartAddress = baseAddress + RUNTIME_FUNCTION__BeginAddress(pFunctionEntry);
 
     return funcletStartAddress;
 }
@@ -3899,19 +3907,24 @@ PTR_RUNTIME_FUNCTION EEJitManager::LazyGetFunctionEntry(EECodeInfo * pCodeInfo)
     // We need the module base address to calculate the end address of a function from the functionEntry.
     // Thus, save it off right now.
     TADDR baseAddress = pCodeInfo->GetModuleBase();
+    PTR_RUNTIME_FUNCTION pFunctionEntry = NULL;
 
     // NOTE: We could binary search here, if it would be helpful (e.g., large number of funclets)
     for (UINT iUnwindInfo = 0; iUnwindInfo < pHeader->GetNumberOfUnwindInfos(); iUnwindInfo++)
     {
-        PTR_RUNTIME_FUNCTION pFunctionEntry = pHeader->GetUnwindInfo(iUnwindInfo);
+        pFunctionEntry = pHeader->GetUnwindInfo(iUnwindInfo);
 
         if (RUNTIME_FUNCTION__BeginAddress(pFunctionEntry) <= address && address < RUNTIME_FUNCTION__EndAddress(pFunctionEntry, baseAddress))
         {
-            return pFunctionEntry;
+            break;
         }
     }
 
-    return NULL;
+#if defined(EXCEPTION_DATA_SUPPORTS_FUNCTION_FRAGMENTS)
+    pFunctionEntry = FindRootEntry(pFunctionEntry, baseAddress);
+#endif
+
+    return pFunctionEntry;
 }
 
 DWORD EEJitManager::GetFuncletStartOffsets(const METHODTOKEN& MethodToken, DWORD* pStartFuncletOffsets, DWORD dwLength)


### PR DESCRIPTION
…wind

On Arm and Arm64 unwind records can only cover a limited range of code
(512K and 1MB respectively). So for methods larger than this the jit
will emit multiple "fragment" unwind records to cover the full method code
range. Only the first of these describes the behavior of the method prolog.

When mapping an offset back to a method's entry point unwind, make sure to
find this "root" unwind record instead of one of the internal fragments.

Fixes #19209.