### PR TITLE
Skip rangecheck in string.EndsWith(char)

### DIFF
--- a/src/System.Private.CoreLib/shared/System/String.Comparison.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Comparison.cs
@@ -594,8 +594,13 @@ namespace System
 
         public bool EndsWith(char value)
         {
-            int thisLen = Length;
-            return thisLen != 0 && this[thisLen - 1] == value;
+            int lastPos = Length - 1;
+            if ((uint)lastPos < (uint)Length && this[lastPos] == value)
+            {
+                return true;
+            }
+
+            return false;
         }
 
         // Determines whether two strings match.

--- a/src/System.Private.CoreLib/shared/System/String.Comparison.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Comparison.cs
@@ -595,12 +595,7 @@ namespace System
         public bool EndsWith(char value)
         {
             int lastPos = Length - 1;
-            if ((uint)lastPos < (uint)Length && this[lastPos] == value)
-            {
-                return true;
-            }
-
-            return false;
+            return ((uint)lastPos < (uint)Length) && this[lastPos] == value;
         }
 
         // Determines whether two strings match.


### PR DESCRIPTION
```diff
 G_M23653_IG01:
-      sub      rsp, 40
       nop      
 G_M23653_IG02:
       mov      eax, dword ptr [rcx+8]
-      mov      r8d, eax
-      test     r8d, r8d
-      je       SHORT G_M23653_IG04
+      mov      eax, dword ptr [rcx+8]
+      lea      r8d, [rax-1]
+      cmp      eax, r8d
+      jbe      SHORT G_M23653_IG04
-      dec      r8d
-      cmp      r8d, eax
-      jae      SHORT G_M23653_IG06
       movsxd   rax, r8d
       movzx    rax, word  ptr [rcx+2*rax+12]
       movzx    rdx, dx
       cmp      eax, edx
-      sete     al
-      movzx    rax, al
+      jne      SHORT G_M23653_IG04
+      mov      eax, 1
 G_M23653_IG03:
-      add      rsp, 40
       ret      
 G_M23653_IG04:
       xor      eax, eax
 G_M23653_IG05:
-      add      rsp, 40
       ret      
-G_M23653_IG06:
-      call     CORINFO_HELP_RNGCHKFAIL
-      int3     
-; Total bytes of code 61, prolog size 5 for method String:EndsWith(ushort):bool:this
+; Total bytes of code 41, prolog size 5 for method String:EndsWith(ushort):bool:this
```

/cc @jkotas @stephentoub 