### PR TITLE
Run on one Helix queue on pull requests and CI builds. Add CI trigger for master branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,9 +88,9 @@ jobs:
 # https://github.com/Microsoft/azure-pipelines-yaml/pull/46 for more information
 
 #
-# Debug build (CI)
+# Debug build (Pull Request)
 #
-- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+- ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: build-job.yml
@@ -106,17 +106,18 @@ jobs:
       buildConfig: checked
 
 #
-# Release build (Official Build)
+# Release build (Official Build, Pull Request)
 #
-- template: eng/platform-matrix.yml
-  parameters:
-    jobTemplate: build-job.yml
-    buildConfig: release
-    jobParameters:
-      # Publishing packages to blob feeds sometimes takes a long time
-      # due to waiting for an exclusive lock on the feed.
-      # See https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/AsyncPublishing.md
-      timeoutInMinutes: 120
+- ${{ if xor(eq(variables['System.TeamProject'], 'internal'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+  - template: eng/platform-matrix.yml
+    parameters:
+      jobTemplate: build-job.yml
+      buildConfig: release
+      jobParameters:
+        # Publishing packages to blob feeds sometimes takes a long time
+        # due to waiting for an exclusive lock on the feed.
+        # See https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/AsyncPublishing.md
+        timeoutInMinutes: 120
 
 #
 # Checked test builds

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,8 @@ resources:
   - container: centos6_x64_build_image
     image: microsoft/dotnet-buildtools-prereqs:centos-6-376e1a3-20174311014331
 
-trigger: none
+trigger:
+- master
 
 pr:
 - master

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,7 +97,7 @@ jobs:
       buildConfig: debug
 
 #
-# Checked build (CI)
+# Checked build
 #
 - ${{ if eq(variables['System.TeamProject'], 'public') }}:
   - template: eng/platform-matrix.yml
@@ -123,7 +123,7 @@ jobs:
 # Checked test builds
 #
 
-# Pri0 (PullRequest)
+# Pri0 (Pull Request)
 - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng/platform-matrix.yml
     parameters:
@@ -169,8 +169,8 @@ jobs:
           - no_tiered_compilation
         timeoutInMinutes: 360
 
-# Pri1 (Manual)
-- ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'Manual')) }}:
+# Pri1 (Schedule, Manual)
+- ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule', 'Manual')) }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: test-job.yml
@@ -189,11 +189,11 @@ jobs:
         timeoutInMinutes: 480
 
 #
-# Release test builds (Official Build)
+# Release test builds
 #
 
-# Pri1
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+# Pri1 (Official Build)
+- ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: test-job.yml
@@ -208,7 +208,7 @@ jobs:
         timeoutInMinutes: 360
 
 # Pri1 crossgen (Official Build)
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+- ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: test-job.yml
@@ -231,7 +231,7 @@ jobs:
 # registry. Its dependencies should be updated to include all of the
 # official builds if we add more platform/arch combinations.
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+- ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - template: /eng/common/templates/job/publish-build-assets.yml
     parameters:
       configuration: Release

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -39,16 +39,20 @@ jobs:
     osIdentifier: Linux
     containerName: ubuntu_1604_arm64_cross_build_image
     helixQueues:
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        # TODO: enable Debian.9.Arm64.Open and Debian.9.Arm64 queues
-        # when https://github.com/dotnet/core-eng/issues/4805 is resolved
-        # Don't use Ubuntu.1604.Arm64.Open here - the queue should be exclusively used by Jenkins
+      ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
         asString: 'Ubuntu.1804.Arm64.Open'
         asArray:
         - Ubuntu.1804.Arm64.Open
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        asString: 'Ubuntu.1604.Arm64,Ubuntu.1804.Arm64'
+      ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+        # TODO: add Ubuntu.1604.Arm64.Open once Jenkins has been shutdown
+        asString: 'Debian.9.Arm64.Open,Ubuntu.1804.Arm64.Open'
         asArray:
+        - Debian.9.Arm64.Open
+        - Ubuntu.1804.Arm64.Open
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        asString: 'Debian.9.Arm64,Ubuntu.1604.Arm64,Ubuntu.1804.Arm64'
+        asArray:
+        - Debian.9.Arm64
         - Ubuntu.1604.Arm64
         - Ubuntu.1804.Arm64
     crossrootfsDir: '/crossrootfs/arm64'
@@ -100,7 +104,11 @@ jobs:
     osIdentifier: Linux
     containerName: centos7_x64_build_image
     helixQueues:
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+        asString: 'Ubuntu.1804.Amd64.Open'
+        asArray:
+        - Ubuntu.1804.Amd64.Open
+      ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
         asString: 'Debian.9.Amd64.Open,Ubuntu.1604.Amd64.Open,Ubuntu.1804.Amd64.Open,Centos.7.Amd64.Open,Fedora.28.Amd64.Open,RedHat.7.Amd64.Open'
         asArray:
         - Debian.9.Amd64.Open
@@ -143,11 +151,16 @@ jobs:
     osGroup: OSX
     osIdentifier: OSX
     helixQueues:
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        # TODO: return back OSX.1012.Amd64.Open once Jenkins has been shutdown
+      ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
         asString: 'OSX.1013.Amd64.Open'
         asArray:
         - OSX.1013.Amd64.Open
+      ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+        # TODO: add OSX.1012.Amd64.Open once Jenkins has been shutdown
+        asString: 'OSX.1013.Amd64.Open,OSX.1014.Amd64.Open'
+        asArray:
+        - OSX.1013.Amd64.Open
+        - OSX.1014.Amd64.Open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         asString: 'OSX.1012.Amd64,OSX.1013.Amd64,OSX.1014.Amd64'
         asArray:
@@ -165,9 +178,13 @@ jobs:
     osGroup: Windows_NT
     osIdentifier: Windows_NT
     helixQueues:
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        # TODO: add Windows.10.Nano.Amd64.Open when https://github.com/dotnet/coreclr/issues/21693 is resolved
-        # TODO: add Windows.7.Amd64.Open when https://github.com/dotnet/coreclr/issues/21796 is resolved
+      ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+        asString: 'Windows.10.Amd64.Open'
+        asArray:
+        - Windows.10.Amd64.Open
+      ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+        # TODO: add Windows.10.Nano.Amd64.Open once https://github.com/dotnet/coreclr/issues/21693 has been resolved
+        # TODO: add Windows.7.Amd64.Open once https://github.com/dotnet/coreclr/issues/21796 has been resolved
         asString: 'Windows.10.Amd64.Open,Windows.81.Amd64.Open'
         asArray:
         - Windows.10.Amd64.Open
@@ -189,8 +206,12 @@ jobs:
     osGroup: Windows_NT
     osIdentifier: Windows_NT
     helixQueues:
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        # TODO: add Windows.7.Amd64.Open when https://github.com/dotnet/coreclr/issues/21796 is resolved
+      ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+        asString: 'Windows.10.Amd64.Open'
+        asArray:
+        - Windows.10.Amd64.Open
+      ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+        # TODO: add Windows.7.Amd64.Open once https://github.com/dotnet/coreclr/issues/21796 has been resolved
         asString: 'Windows.10.Amd64.Open,Windows.81.Amd64.Open'
         asArray:
         - Windows.10.Amd64.Open
@@ -214,7 +235,7 @@ jobs:
     osIdentifier: Windows_NT
     helixQueues:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        # TODO: return back Windows.10.Arm64.Open once Jenkins has been shutdown
+        # TODO: add Windows.10.Arm64.Open once Jenkins has been shutdown
         asString: ''
         asArray: []
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
@@ -231,7 +252,7 @@ jobs:
     osIdentifier: Windows_NT
     helixQueues:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        # TODO: return back Windows.10.Arm64.Open once Jenkins has been shutdown
+        # TODO: add Windows.10.Arm64.Open once Jenkins has been shutdown
         asString: ''
         asArray: []
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -67,10 +67,16 @@ jobs:
     osGroup: Linux
     osIdentifier: Linux_musl
     containerName: musl_x64_build_image
-    # TODO: add Alpine.Amd64 queues
     helixQueues:
-      asString: ''
-      asArray: []
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        # TODO: there are no open Alpine queues https://github.com/dotnet/core-eng/issues/4958
+        asString: ''
+        asArray: []
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        asString: 'Alpine.36.Amd64,Alpine.38.Amd64'
+        asArray:
+        - Alpine.36.Amd64
+        - Alpine.38.Amd64
     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # RHEL 6

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -604,6 +604,15 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/doublearray/dblarray3_cs_do/*">
             <Issue>22015</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/doublearray/dblarray3_cs_d/*">
+            <Issue>22015</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/doublearray/dblarray3_cs_ro/*">
+            <Issue>22015</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/doublearray/dblarray3_cs_r/*">
+            <Issue>22015</Issue>
+        </ExcludeList>
     </ItemGroup>
     
 


### PR DESCRIPTION
This limits pull request and CI (push) triggered jobs to running only on one *default* Helix queue:

Linux arm32 - Ubuntu.1404.Arm32.Open
Linux arm64 - Ubuntu.1804.Arm64.Open
Linux x64 - Ubuntu.1804.Amd64.Open

Windows_NT x86/x64 - Windows.10.Amd64.Open
Windows_NT arm32/arm64 - we don't run these in AzDO

OSX - OSX.1013.Amd64.Open

Scheduled and manually triggered jobs will use more than one Helix queues for more comprehensive checking. 

These open queues should NOT be used - we keep them for Jenkins CI:
- Ubuntu.1604.Arm64.Open
- OSX.1012.Amd64.Open
- Windows.10.Arm64.Open 

This enables CI (push) trigger for master branch. During CI build the following scenarios for Pri1 tests are going to run:
- normal
- no_tiered_compilation
