### PR TITLE
this test should not be run under gcstress

### DIFF
--- a/tests/src/GC/API/GC/Collect1.csproj
+++ b/tests/src/GC/API/GC/Collect1.csproj
@@ -27,6 +27,7 @@
     <DebugType>PdbOnly</DebugType>
     <NoLogo>True</NoLogo>
     <DefineConstants>$(DefineConstants);DESKTOP</DefineConstants>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Collect1.cs" />


### PR DESCRIPTION
See disscusion in #22170.

Fixes jobs like https://ci.dot.net/job/dotnet_coreclr/job/master/job/jitstress/job/x86_checked_windows_nt_gcstress0xc_zapdisable_heapverify1/lastFailedBuild/testReport/junit/GC_API/_GC_Collect1_Collect1_/_GC_Collect1_Collect1_cmd/

Fixes #22170 