### PR TITLE
Switch to dnceng-linux-external-temp pool

### DIFF
--- a/eng/xplat-job.yml
+++ b/eng/xplat-job.yml
@@ -36,7 +36,7 @@ jobs:
 
     pool:
       ${{ if and(eq(parameters.osGroup, 'Linux'), eq(variables['System.TeamProject'], 'public')) }}:
-        name: Hosted Ubuntu 1604
+        name: dnceng-linux-external-temp
       ${{ if and(eq(parameters.osGroup, 'Linux'), ne(variables['System.TeamProject'], 'public')) }}:
         name: dnceng-linux-internal-temp
       # FreeBSD builds only in the internal project


### PR DESCRIPTION
This should save us from the issues like this in AzDO Linux Docker builds:
```
2019-01-25T21:23:03.7271056Z /__w/1/s/Tools/IL.targets(49,5): error MSB6003: The specified task executable "sh" could not be run. Cannot allocate memory [/__w/1/s/tests/src/readytorun/tests/fieldgetter.ilproj]
2019-01-25T21:23:03.7271363Z /__w/1/s/Tools/IL.targets(49,5): error MSB6003: The specified task executable "sh" could not be run. Cannot allocate memory [/__w/1/s/tests/src/reflection/DefaultInterfaceMethods/GetInterfaceMapProvider.ilproj]
2019-01-25T21:23:03.7271805Z /__w/1/s/Tools/IL.targets(49,5): error MSB6003: The specified task executable "sh" could not be run. Cannot allocate memory [/__w/1/s/tests/src/reflection/DefaultInterfaceMethods/InvokeProvider.ilproj]
2019-01-25T21:23:03.7272224Z /__w/1/s/Tools/IL.targets(49,5): error MSB6003: The specified task executable "sh" could not be run. Cannot allocate memory [/__w/1/s/tests/src/reflection/Modifiers/modifiersdata.ilproj]
2019-01-25T21:23:03.7272604Z /__w/1/s/tests/dir.traversal.targets(25,5): error : (No message specified) [/__w/1/s/tests/src/dirs.proj]
```

https://dnceng.visualstudio.com/public/_build/results?buildId=80595

/cc @MattGal 