### PR TITLE
Set GTF_ADDR_ONSTACK in LocalAddressVisitor.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -18179,6 +18179,11 @@ public:
                 assert(TopValue(1).Node() == node);
                 assert(TopValue(0).Node() == node->gtGetOp1());
 
+                if (node->gtGetOp1()->OperGet() == GT_LCL_VAR)
+                {
+                    node->gtFlags |= GTF_ADDR_ONSTACK;
+                }
+
                 TopValue(1).Address(TopValue(0));
                 PopValue();
                 break;


### PR DESCRIPTION
`GTF_ADDR_ONSTACK`  indicates that the address points to the stack.
It's set for all new `GT_ADDR` nodes when the child is `GT_LCL_VAR`.
This flag is used in morph. One of the uses is to change the type
from `TYP_BYREF` to `TYP_I_IMPL`.

`LocalAddressVisitor` runs before morph and calls `fgMorphStructField`,
which may result in a child of `GT_ADDR` to be simplified to `GT_LCL_VAR`.
This change recognizes this case and sets `GTF_ADDR_ONSTACK`
on `GT_ADDR` node.

Fixes #22190.