### PR TITLE
Shrink Task.Delay when used without Cancellation (2)

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/Task.cs
@@ -5446,6 +5446,10 @@ namespace System.Threading.Tasks
                 if (Token.IsCancellationRequested)
                 {
                     setSucceeded = TrySetCanceled(Token);
+                    if (setSucceeded)
+                    {
+                        Timer?.Close();
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Follow up to https://github.com/dotnet/coreclr/pull/22233

`Task.Delay` is commonly used without cancellation:

`Task Delay(int)` - API Port 22.6%
`Task Delay(TimeSpan)` - API Port 9.8%

`Task Delay(int, CancellationToken)` - API Port 5.6%
`Task Delay(TimeSpan, CancellationToken)` - API Port 9.3%

This shaves 24 bytes of allocation off that common path.

Using @SergeyTeplyakov's [ObjectLayoutInspector](https://github.com/SergeyTeplyakov/ObjectLayoutInspector) and local copies of the internal objects to make it easier to inspect.
```csharp
ObjectLayoutInspector.TypeLayout.PrintLayout<DelayPromiseWithCancellation>(recursively: true);
ObjectLayoutInspector.TypeLayout.PrintLayout<DelayPromise>(recursively: true);
```
```
Type layout for 'DelayPromiseWithCancellation'
Size: 88 bytes. Paddings: 7 bytes (%7 of empty space)
|==============================================================|
| Object Header (8 bytes)                                      |
|--------------------------------------------------------------|
| Method Table Ptr (8 bytes)                                   |
|==============================================================|
|   0-7: Delegate m_action (8 bytes)                           |
|--------------------------------------------------------------|
|  8-15: Object m_stateObject (8 bytes)                        |
|--------------------------------------------------------------|
| 16-23: TaskScheduler m_taskScheduler (8 bytes)               |
|--------------------------------------------------------------|
| 24-31: Object m_continuationObject (8 bytes)                 |
|--------------------------------------------------------------|
| 32-39: ContingentProperties m_contingentProperties (8 bytes) |
|--------------------------------------------------------------|
| 40-43: Int32 m_taskId (4 bytes)                              |
|--------------------------------------------------------------|
| 44-47: Int32 m_stateFlags (4 bytes)                          |
|--------------------------------------------------------------|
|    48: VoidTaskResult m_result (1 byte)                      |
|--------------------------------------------------------------|
| 49-55: padding (7 bytes)                                     |
|--------------------------------------------------------------|
| 56-63: TimerQueueTimer Timer (8 bytes)                       |
|--------------------------------------------------------------|
| 64-71: CancellationToken Token (8 bytes)                     |
|--------------------------------------------------------------|
| 72-87: CancellationTokenRegistration Registration (16 bytes) |
| |=====================================|                      |
| |   0-7: CallbackNode _node (8 bytes) |                      |
| |-------------------------------------|                      |
| |  8-15: Int64 _id (8 bytes)          |                      |
| |=====================================|                      |
|==============================================================|
```
To
```
Type layout for 'DelayPromise'
Size: 64 bytes. Paddings: 7 bytes (%10 of empty space)
|==============================================================|
| Object Header (8 bytes)                                      |
|--------------------------------------------------------------|
| Method Table Ptr (8 bytes)                                   |
|==============================================================|
|   0-7: Delegate m_action (8 bytes)                           |
|--------------------------------------------------------------|
|  8-15: Object m_stateObject (8 bytes)                        |
|--------------------------------------------------------------|
| 16-23: TaskScheduler m_taskScheduler (8 bytes)               |
|--------------------------------------------------------------|
| 24-31: Object m_continuationObject (8 bytes)                 |
|--------------------------------------------------------------|
| 32-39: ContingentProperties m_contingentProperties (8 bytes) |
|--------------------------------------------------------------|
| 40-43: Int32 m_taskId (4 bytes)                              |
|--------------------------------------------------------------|
| 44-47: Int32 m_stateFlags (4 bytes)                          |
|--------------------------------------------------------------|
|    48: VoidTaskResult m_result (1 byte)                      |
|--------------------------------------------------------------|
| 49-55: padding (7 bytes)                                     |
|--------------------------------------------------------------|
| 56-63: TimerQueueTimer Timer (8 bytes)                       |
|==============================================================|
```

/cc @stephentoub 