### PR TITLE
Remove several uses of VoidTaskResult 

### DIFF
--- a/src/System.Private.CoreLib/shared/System/IO/MemoryStream.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/MemoryStream.cs
@@ -414,7 +414,7 @@ namespace System.IO
             }
             catch (OperationCanceledException oce)
             {
-                return Task.FromCancellation<int>(oce);
+                return Task.FromCanceled<int>(oce);
             }
             catch (Exception exception)
             {
@@ -450,7 +450,7 @@ namespace System.IO
             }
             catch (OperationCanceledException oce)
             {
-                return new ValueTask<int>(Task.FromCancellation<int>(oce));
+                return new ValueTask<int>(Task.FromCanceled<int>(oce));
             }
             catch (Exception exception)
             {
@@ -739,7 +739,7 @@ namespace System.IO
             }
             catch (OperationCanceledException oce)
             {
-                return Task.FromCancellation<VoidTaskResult>(oce);
+                return Task.FromCanceled(oce);
             }
             catch (Exception exception)
             {
@@ -770,7 +770,7 @@ namespace System.IO
             }
             catch (OperationCanceledException oce)
             {
-                return new ValueTask(Task.FromCancellation<VoidTaskResult>(oce));
+                return new ValueTask(Task.FromCanceled(oce));
             }
             catch (Exception exception)
             {

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -190,7 +190,7 @@ namespace System.Runtime.CompilerServices
 #if PROJECTN
         private static readonly Task<VoidTaskResult> s_cachedCompleted = AsyncTaskCache.CreateCacheableTask<VoidTaskResult>(default(VoidTaskResult));
 #else
-        private readonly static Task<VoidTaskResult> s_cachedCompleted = AsyncTaskMethodBuilder<VoidTaskResult>.s_defaultResultTask;
+        private static readonly Task<VoidTaskResult> s_cachedCompleted = AsyncTaskMethodBuilder<VoidTaskResult>.s_defaultResultTask;
 #endif
 
         /// <summary>The generic builder object to which this non-generic instance delegates.</summary>

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncValueTaskMethodBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncValueTaskMethodBuilder.cs
@@ -38,11 +38,7 @@ namespace System.Runtime.CompilerServices
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine =>
             // will provide the right ExecutionContext semantics
-#if netstandard
-            _methodBuilder.Start(ref stateMachine);
-#else
             AsyncMethodBuilderCore.Start(ref stateMachine);
-#endif
 
         /// <summary>Associates the builder with the specified state machine.</summary>
         /// <param name="stateMachine">The state machine instance to associate with the builder.</param>
@@ -143,11 +139,7 @@ namespace System.Runtime.CompilerServices
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine =>
             // will provide the right ExecutionContext semantics
-#if netstandard
-            _methodBuilder.Start(ref stateMachine);
-#else
             AsyncMethodBuilderCore.Start(ref stateMachine);
-#endif
 
         /// <summary>Associates the builder with the specified state machine.</summary>
         /// <param name="stateMachine">The state machine instance to associate with the builder.</param>

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/Future.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/Future.cs
@@ -386,6 +386,8 @@ namespace System.Threading.Tasks
         {
             Debug.Assert(m_action == null, "Task<T>.TrySetResult(): non-null m_action");
 
+            bool returnValue = false;
+
             // "Reserve" the completion for this task, while making sure that: (1) No prior reservation
             // has been made, (2) The result has not already been set, (3) An exception has not previously 
             // been recorded, and (4) Cancellation has not been requested.
@@ -411,10 +413,10 @@ namespace System.Threading.Tasks
                     props.SetCompleted();
                 }
                 FinishContinuations();
-                return true;
+                returnValue = true;
             }
 
-            return false;
+            return returnValue;
         }
 
         // Transitions the promise task into a successfully completed state with the specified result.
@@ -489,95 +491,6 @@ namespace System.Threading.Tasks
             Debug.Assert(IsCompletedSuccessfully, "Task<T>.Result getter: Expected result to have been set.");
 
             return m_result;
-        }
-
-        // Allow multiple exceptions to be assigned to a promise-style task.
-        // This is useful when a TaskCompletionSource<T> stands in as a proxy
-        // for a "real" task (as we do in Unwrap(), ContinueWhenAny() and ContinueWhenAll())
-        // and the "real" task ends up with multiple exceptions, which is possible when
-        // a task has children.
-        //
-        // Called from TaskCompletionSource<T>.SetException(IEnumerable<Exception>).
-        internal bool TrySetException(object exceptionObject)
-        {
-            Debug.Assert(m_action == null, "Task<T>.TrySetException(): non-null m_action");
-
-            // TCS.{Try}SetException() should have checked for this
-            Debug.Assert(exceptionObject != null, "Expected non-null exceptionObject argument");
-
-            // Only accept these types.
-            Debug.Assert(
-                (exceptionObject is Exception) || (exceptionObject is IEnumerable<Exception>) ||
-                (exceptionObject is ExceptionDispatchInfo) || (exceptionObject is IEnumerable<ExceptionDispatchInfo>),
-                "Expected exceptionObject to be either Exception, ExceptionDispatchInfo, or IEnumerable<> of one of those");
-
-            bool returnValue = false;
-
-            // "Reserve" the completion for this task, while making sure that: (1) No prior reservation
-            // has been made, (2) The result has not already been set, (3) An exception has not previously 
-            // been recorded, and (4) Cancellation has not been requested.
-            //
-            // If the reservation is successful, then add the exception(s) and finish completion processing.
-            //
-            // The lazy initialization may not be strictly necessary, but I'd like to keep it here
-            // anyway.  Some downstream logic may depend upon an inflated m_contingentProperties.
-            EnsureContingentPropertiesInitialized();
-            if (AtomicStateUpdate(TASK_STATE_COMPLETION_RESERVED,
-                TASK_STATE_COMPLETION_RESERVED | TASK_STATE_RAN_TO_COMPLETION | TASK_STATE_FAULTED | TASK_STATE_CANCELED))
-            {
-                AddException(exceptionObject); // handles singleton exception or exception collection
-                Finish(false);
-                returnValue = true;
-            }
-
-            return returnValue;
-        }
-
-        // internal helper function breaks out logic used by TaskCompletionSource and AsyncMethodBuilder
-        // If the tokenToRecord is not None, it will be stored onto the task.
-        // This method is only valid for promise tasks.
-        internal bool TrySetCanceled(CancellationToken tokenToRecord)
-        {
-            return TrySetCanceled(tokenToRecord, null);
-        }
-
-        // internal helper function breaks out logic used by TaskCompletionSource and AsyncMethodBuilder
-        // If the tokenToRecord is not None, it will be stored onto the task.
-        // If the OperationCanceledException is not null, it will be stored into the task's exception holder.
-        // This method is only valid for promise tasks.
-        internal bool TrySetCanceled(CancellationToken tokenToRecord, object cancellationException)
-        {
-            Debug.Assert(m_action == null, "Task<T>.TrySetCanceled(): non-null m_action");
-#if DEBUG
-            var ceAsEdi = cancellationException as ExceptionDispatchInfo;
-            Debug.Assert(
-                cancellationException == null ||
-                cancellationException is OperationCanceledException ||
-                (ceAsEdi != null && ceAsEdi.SourceException is OperationCanceledException),
-                "Expected null or an OperationCanceledException");
-#endif
-
-            bool returnValue = false;
-
-            // "Reserve" the completion for this task, while making sure that: (1) No prior reservation
-            // has been made, (2) The result has not already been set, (3) An exception has not previously 
-            // been recorded, and (4) Cancellation has not been requested.
-            //
-            // If the reservation is successful, then record the cancellation and finish completion processing.
-            //
-            // Note: I had to access static Task variables through Task<object>
-            // instead of Task, because I have a property named Task and that
-            // was confusing the compiler.  
-            if (AtomicStateUpdate(Task<object>.TASK_STATE_COMPLETION_RESERVED,
-                Task<object>.TASK_STATE_COMPLETION_RESERVED | Task<object>.TASK_STATE_CANCELED |
-                Task<object>.TASK_STATE_FAULTED | Task<object>.TASK_STATE_RAN_TO_COMPLETION))
-            {
-                RecordInternalCancellationRequest(tokenToRecord, cancellationException);
-                CancellationCleanupLogic(); // perform cancellation cleanup actions
-                returnValue = true;
-            }
-
-            return returnValue;
         }
 
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/FutureFactory.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/FutureFactory.cs
@@ -800,7 +800,7 @@ namespace System.Threading.Tasks
                     Task.RemoveFromActiveTasks(promise);
 
                 // Make sure we don't leave promise "dangling".
-                promise.TrySetResult(default);
+                promise.TrySetResult();
                 throw;
             }
 
@@ -917,7 +917,7 @@ namespace System.Threading.Tasks
                     Task.RemoveFromActiveTasks(promise);
 
                 // Make sure we don't leave promise "dangling".
-                promise.TrySetResult(default);
+                promise.TrySetResult();
                 throw;
             }
 
@@ -1042,7 +1042,7 @@ namespace System.Threading.Tasks
                     Task.RemoveFromActiveTasks(promise);
 
                 // Make sure we don't leave promise "dangling".
-                promise.TrySetResult(default);
+                promise.TrySetResult();
                 throw;
             }
 
@@ -1175,7 +1175,7 @@ namespace System.Threading.Tasks
                     Task.RemoveFromActiveTasks(promise);
 
                 // Make sure we don't leave the promise "dangling".
-                promise.TrySetResult(default);
+                promise.TrySetResult();
                 throw;
             }
 

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/ValueTask.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/ValueTask.cs
@@ -7,10 +7,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks.Sources;
-
-#if !netstandard
 using Internal.Runtime.CompilerServices;
-#endif
 
 namespace System.Threading.Tasks
 {
@@ -60,19 +57,10 @@ namespace System.Threading.Tasks
     public readonly struct ValueTask : IEquatable<ValueTask>
     {
         /// <summary>A task canceled using `new CancellationToken(true)`.</summary>
-        private static readonly Task s_canceledTask =
-#if netstandard
-            Task.Delay(Timeout.Infinite, new CancellationToken(canceled: true));
-#else
-            Task.FromCanceled(new CancellationToken(canceled: true));
-#endif
+        private static readonly Task s_canceledTask = Task.FromCanceled(new CancellationToken(canceled: true));
+
         /// <summary>A successfully completed task.</summary>
-        internal static Task CompletedTask
-#if netstandard
-            { get; } = Task.Delay(0);
-#else
-            => Task.CompletedTask;
-#endif
+        internal static Task CompletedTask => Task.CompletedTask;
 
         /// <summary>null if representing a successful synchronous completion, otherwise a <see cref="Task"/> or a <see cref="IValueTaskSource"/>.</summary>
         internal readonly object _obj;
@@ -190,45 +178,27 @@ namespace System.Threading.Tasks
                 {
                     if (status == ValueTaskSourceStatus.Canceled)
                     {
-#if !netstandard
                         if (exc is OperationCanceledException oce)
                         {
                             var task = new Task<VoidTaskResult>();
                             task.TrySetCanceled(oce.CancellationToken, oce);
                             return task;
                         }
-#endif
+
                         return s_canceledTask;
                     }
                     else
                     {
-#if netstandard
-                        var tcs = new TaskCompletionSource<bool>();
-                        tcs.TrySetException(exc);
-                        return tcs.Task;
-#else
                         return Task.FromException(exc);
-#endif
                     }
                 }
             }
 
-            var m = new ValueTaskSourceAsTask(t, _token);
-            return
-#if netstandard
-                m.Task;
-#else
-                m;
-#endif
+            return new ValueTaskSourceAsTask(t, _token);
         }
 
         /// <summary>Type used to create a <see cref="Task"/> to represent a <see cref="IValueTaskSource"/>.</summary>
-        private sealed class ValueTaskSourceAsTask :
-#if netstandard
-            TaskCompletionSource<bool>
-#else
-            Task<VoidTaskResult>
-#endif
+        private sealed class ValueTaskSourceAsTask : Task<VoidTaskResult>
         {
             private static readonly Action<object> s_completionAction = state =>
             {
@@ -253,9 +223,6 @@ namespace System.Threading.Tasks
                 {
                     if (status == ValueTaskSourceStatus.Canceled)
                     {
-#if netstandard
-                        vtst.TrySetCanceled();
-#else
                         if (exc is OperationCanceledException oce)
                         {
                             vtst.TrySetCanceled(oce.CancellationToken, oce);
@@ -264,7 +231,6 @@ namespace System.Threading.Tasks
                         {
                             vtst.TrySetCanceled(new CancellationToken(true));
                         }
-#endif
                     }
                     else
                     {
@@ -325,12 +291,7 @@ namespace System.Threading.Tasks
 
                 if (obj is Task t)
                 {
-                    return
-#if netstandard
-                        t.Status == TaskStatus.RanToCompletion;
-#else
-                        t.IsCompletedSuccessfully;
-#endif
+                    return t.IsCompletedSuccessfully;
                 }
 
                 return Unsafe.As<IValueTaskSource>(obj).GetStatus(_token) == ValueTaskSourceStatus.Succeeded;
@@ -398,11 +359,7 @@ namespace System.Threading.Tasks
             {
                 if (obj is Task t)
                 {
-#if netstandard
-                    t.GetAwaiter().GetResult();
-#else
                     TaskAwaiter.ValidateEnd(t);
-#endif
                 }
                 else
                 {
@@ -569,12 +526,7 @@ namespace System.Threading.Tasks
 
             if (obj == null)
             {
-                return
-#if netstandard
-                    Task.FromResult(_result);
-#else
-                    AsyncTaskMethodBuilder<TResult>.GetTaskForResult(_result);
-#endif
+                return AsyncTaskMethodBuilder<TResult>.GetTaskForResult(_result);
             }
 
             if (obj is Task<TResult> t)
@@ -602,12 +554,7 @@ namespace System.Threading.Tasks
                 {
                     // Get the result of the operation and return a task for it.
                     // If any exception occurred, propagate it
-                    return
-#if netstandard
-                        Task.FromResult(t.GetResult(_token));
-#else
-                        AsyncTaskMethodBuilder<TResult>.GetTaskForResult(t.GetResult(_token));
-#endif
+                    return AsyncTaskMethodBuilder<TResult>.GetTaskForResult(t.GetResult(_token));
 
                     // If status is Faulted or Canceled, GetResult should throw.  But
                     // we can't guarantee every implementation will do the "right thing".
@@ -618,59 +565,33 @@ namespace System.Threading.Tasks
                 {
                     if (status == ValueTaskSourceStatus.Canceled)
                     {
-#if !netstandard
                         if (exc is OperationCanceledException oce)
                         {
                             var task = new Task<TResult>();
                             task.TrySetCanceled(oce.CancellationToken, oce);
                             return task;
                         }
-#endif
 
                         Task<TResult> canceledTask = s_canceledTask;
                         if (canceledTask == null)
                         {
-#if netstandard
-                            var tcs = new TaskCompletionSource<TResult>();
-                            tcs.TrySetCanceled();
-                            canceledTask = tcs.Task;
-#else
-                            canceledTask = Task.FromCanceled<TResult>(new CancellationToken(true));
-#endif
                             // Benign race condition to initialize cached task, as identity doesn't matter.
-                            s_canceledTask = canceledTask;
+                            s_canceledTask = Task.FromCanceled<TResult>(new CancellationToken(true));
                         }
                         return canceledTask;
                     }
                     else
                     {
-#if netstandard
-                        var tcs = new TaskCompletionSource<TResult>();
-                        tcs.TrySetException(exc);
-                        return tcs.Task;
-#else
                         return Task.FromException<TResult>(exc);
-#endif
                     }
                 }
             }
 
-            var m = new ValueTaskSourceAsTask(t, _token);
-            return
-#if netstandard
-                m.Task;
-#else
-                m;
-#endif
+            return new ValueTaskSourceAsTask(t, _token);
         }
 
         /// <summary>Type used to create a <see cref="Task{TResult}"/> to represent a <see cref="IValueTaskSource{TResult}"/>.</summary>
-        private sealed class ValueTaskSourceAsTask :
-#if netstandard
-            TaskCompletionSource<TResult>
-#else
-            Task<TResult>
-#endif
+        private sealed class ValueTaskSourceAsTask : Task<TResult>
         {
             private static readonly Action<object> s_completionAction = state =>
             {
@@ -694,9 +615,6 @@ namespace System.Threading.Tasks
                 {
                     if (status == ValueTaskSourceStatus.Canceled)
                     {
-#if netstandard
-                        vtst.TrySetCanceled();
-#else
                         if (exc is OperationCanceledException oce)
                         {
                             vtst.TrySetCanceled(oce.CancellationToken, oce);
@@ -705,7 +623,6 @@ namespace System.Threading.Tasks
                         {
                             vtst.TrySetCanceled(new CancellationToken(true));
                         }
-#endif
                     }
                     else
                     {
@@ -766,12 +683,7 @@ namespace System.Threading.Tasks
 
                 if (obj is Task<TResult> t)
                 {
-                    return
-#if netstandard
-                        t.Status == TaskStatus.RanToCompletion;
-#else
-                        t.IsCompletedSuccessfully;
-#endif
+                    return t.IsCompletedSuccessfully;
                 }
 
                 return Unsafe.As<IValueTaskSource<TResult>>(obj).GetStatus(_token) == ValueTaskSourceStatus.Succeeded;
@@ -843,12 +755,8 @@ namespace System.Threading.Tasks
 
                 if (obj is Task<TResult> t)
                 {
-#if netstandard
-                    return t.GetAwaiter().GetResult();
-#else
                     TaskAwaiter.ValidateEnd(t);
                     return t.ResultOnSuccess;
-#endif
                 }
 
                 return Unsafe.As<IValueTaskSource<TResult>>(obj).GetResult(_token);

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/ValueTask.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/ValueTask.cs
@@ -180,7 +180,7 @@ namespace System.Threading.Tasks
                     {
                         if (exc is OperationCanceledException oce)
                         {
-                            var task = new Task<VoidTaskResult>();
+                            var task = new Task();
                             task.TrySetCanceled(oce.CancellationToken, oce);
                             return task;
                         }
@@ -198,7 +198,7 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>Type used to create a <see cref="Task"/> to represent a <see cref="IValueTaskSource"/>.</summary>
-        private sealed class ValueTaskSourceAsTask : Task<VoidTaskResult>
+        private sealed class ValueTaskSourceAsTask : Task
         {
             private static readonly Action<object> s_completionAction = state =>
             {
@@ -217,7 +217,7 @@ namespace System.Threading.Tasks
                 try
                 {
                     source.GetResult(vtst._token);
-                    vtst.TrySetResult(default);
+                    vtst.TrySetResult();
                 }
                 catch (Exception exc)
                 {


### PR DESCRIPTION
Currently TrySetResult/Canceled/Exception live on `Task<T>`.  There's no reason `TrySetCanceled` and `TrySetException` need to live there, as they only access state from the base `Task`, and so can be moved down.  `TrySetResult` needs the `TResult`, however in a variety of cases `Task<T>` is used with a `VoidTaskResult`, and for such cases we can just have a parameterless `TrySetResult()` on the base class as well, which can be used any time there is no `TResult` or when `default(TResult)` is the desired result.  This lets us switch several cases where we were using `Task<VoidTaskResult>` to just be `Task`, which saves 8 bytes on the task instance on 64-bit.  It also avoids an Interlocked.Exchange as part of the TrySetResult call.

This primarily affects Task.Delay and the non-generic variants of Task.WhenAll, ValueTask.AsTask(), Task.FromCanceled, and Task.FromException.

cc: @kouvel, @tarekgh, @benaadams, @jkotas