### PR TITLE
RunCrossGen in ReadyToRun tests, set TimeoutPerTest, set FailOnWorkItemFailure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -182,7 +182,7 @@ jobs:
       jobParameters:
         priority: 1
         scenarios:
-          asString: 'normal,no_tiered_compilation,jitstress1,jitstress2,jitstress1_tiered,jitstress2_tiered'
+          asString: 'normal,no_tiered_compilation,jitstress1,jitstress2,jitstress1_tiered,jitstress2_tiered,jitstressregs1,jitstressregs2,jitstressregs3,jitstressregs4,jitstressregs8,jitstressregs0x10,jitstressregs0x80,jitstressregs0x1000,jitminopts'
           asArray:
           - normal
           - no_tiered_compilation
@@ -190,6 +190,15 @@ jobs:
           - jitstress2
           - jitstress1_tiered
           - jitstress2_tiered
+          - jitstressregs1
+          - jitstressregs2
+          - jitstressregs3
+          - jitstressregs4
+          - jitstressregs8
+          - jitstressregs0x10
+          - jitstressregs0x80
+          - jitstressregs0x1000
+          - jitminopts
         timeoutInMinutes: 480
         timeoutPerTestInMinutes: 30
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -138,6 +138,7 @@ jobs:
           - normal
           - no_tiered_compilation
         timeoutInMinutes: 240
+        timeoutPerTestInMinutes: 10
 
 # Pri1 (CI)
 - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
@@ -153,6 +154,7 @@ jobs:
           - normal
           - no_tiered_compilation
         timeoutInMinutes: 360
+        timeoutPerTestInMinutes: 10
 
 # Pri1 ReadyToRun (CI)
 - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
@@ -169,6 +171,7 @@ jobs:
           - normal
           - no_tiered_compilation
         timeoutInMinutes: 360
+        timeoutPerTestInMinutes: 30
 
 # Pri1 (Schedule, Manual)
 - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule', 'Manual')) }}:
@@ -188,6 +191,8 @@ jobs:
           - jitstress1_tiered
           - jitstress2_tiered
         timeoutInMinutes: 480
+        timeoutPerTestInMinutes: 30
+
 
 #
 # Release test builds
@@ -207,6 +212,7 @@ jobs:
           - normal
           - no_tiered_compilation
         timeoutInMinutes: 360
+        timeoutPerTestInMinutes: 10
 
 # Pri1 ReadyToRun (Official Build)
 - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
@@ -223,6 +229,7 @@ jobs:
           - normal
           - no_tiered_compilation
         timeoutInMinutes: 360
+        timeoutPerTestInMinutes: 30
 
 
 # Publish build information to Build Assets Registry

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -154,7 +154,7 @@ jobs:
           - no_tiered_compilation
         timeoutInMinutes: 360
 
-# Pri1 crossgen (CI)
+# Pri1 ReadyToRun (CI)
 - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
   - template: eng/platform-matrix.yml
     parameters:
@@ -162,7 +162,7 @@ jobs:
       buildConfig: checked
       jobParameters:
         priority: 1
-        crossgen: true
+        readyToRun: true
         scenarios:
           asString: 'normal,no_tiered_compilation'
           asArray:
@@ -208,7 +208,7 @@ jobs:
           - no_tiered_compilation
         timeoutInMinutes: 360
 
-# Pri1 crossgen (Official Build)
+# Pri1 ReadyToRun (Official Build)
 - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng/platform-matrix.yml
     parameters:
@@ -216,7 +216,7 @@ jobs:
       buildConfig: release
       jobParameters:
         priority: 1
-        crossgen: true
+        readyToRun: true
         scenarios:
           asString: 'normal,no_tiered_compilation'
           asArray:

--- a/eng/send-to-helix-step.yml
+++ b/eng/send-to-helix-step.yml
@@ -13,6 +13,7 @@ parameters:
   helixType: ''
   scenarios: ''
   timeoutInMinutes: ''
+  timeoutPerTestInMinutes: ''
   readyToRun: ''
 
 steps:
@@ -34,6 +35,7 @@ steps:
       _HelixType: ${{ parameters.helixType }}
       _Scenarios: ${{ parameters.scenarios }}
       _TimeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+      _TimeoutPerTestInMinutes: ${{ parameters.timeoutPerTestInMinutes }}
       _ReadyToRun: ${{ parameters.readyToRun }}
       ${{ if eq(parameters.publishTestResults, 'true') }}:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -56,6 +58,7 @@ steps:
       _HelixType: ${{ parameters.helixType }}
       _Scenarios: ${{ parameters.scenarios }}
       _TimeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+      _TimeoutPerTestInMinutes: ${{ parameters.timeoutPerTestInMinutes }}
       _ReadyToRun: ${{ parameters.readyToRun }}
       ${{ if eq(parameters.publishTestResults, 'true') }}:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/eng/send-to-helix-step.yml
+++ b/eng/send-to-helix-step.yml
@@ -13,6 +13,7 @@ parameters:
   helixType: ''
   scenarios: ''
   timeoutInMinutes: ''
+  readyToRun: ''
 
 steps:
 - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
@@ -33,6 +34,7 @@ steps:
       _HelixType: ${{ parameters.helixType }}
       _Scenarios: ${{ parameters.scenarios }}
       _TimeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+      _ReadyToRun: ${{ parameters.readyToRun }}
       ${{ if eq(parameters.publishTestResults, 'true') }}:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
@@ -54,5 +56,6 @@ steps:
       _HelixType: ${{ parameters.helixType }}
       _Scenarios: ${{ parameters.scenarios }}
       _TimeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+      _ReadyToRun: ${{ parameters.readyToRun }}
       ${{ if eq(parameters.publishTestResults, 'true') }}:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -4,7 +4,7 @@ parameters:
   osGroup: ''
   osIdentifier: ''
   priority: 0
-  crossgen: false
+  readyToRun: false
   scenarios: ''
   helixQueues: ''
   timeoutInMinutes: ''
@@ -24,18 +24,18 @@ jobs:
     osIdentifier: ${{ parameters.osIdentifier }}
 
     # Compute job name from template parameters
-    ${{ if eq(parameters.crossgen, 'false') }}:
+    ${{ if eq(parameters.readyToRun, false) }}:
       name: ${{ format('testbuild_pri{0}_{1}_{2}_{3}', parameters.priority, parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
       displayName: ${{ format('Test Pri{0} {1} {2} {3}', parameters.priority, parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
-    ${{ if eq(parameters.crossgen, 'true') }}:
+    ${{ if eq(parameters.readyToRun, true) }}:
       name: ${{ format('testbuild_pri{0}_r2r_{1}_{2}_{3}', parameters.priority, parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
       displayName: ${{ format('Test Pri{0} R2R {1} {2} {3}', parameters.priority, parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
 
     crossrootfsDir: ${{ parameters.crossrootfsDir }}
 
-    ${{ if eq(parameters.crossgen, 'false') }}:
+    ${{ if eq(parameters.readyToRun, false) }}:
       helixType: ${{ format('test/functional/cli/pri{0}', parameters.priority) }}
-    ${{ if eq(parameters.crossgen, 'true') }}:
+    ${{ if eq(parameters.readyToRun, true) }}:
       helixType: ${{ format('test/functional/r2r/cli/pri{0}', parameters.priority) }}
 
     variables:
@@ -52,17 +52,17 @@ jobs:
       - name: priorityArg
         value: ''
 
-    - ${{ if eq(parameters.crossgen, 'true') }}:
+    - ${{ if eq(parameters.readyToRun, true) }}:
       - name: crossgenArg
         value: 'crossgen'
-    - ${{ if eq(parameters.crossgen, 'false') }}:
+    - ${{ if eq(parameters.readyToRun, false) }}:
       - name: crossgenArg
         value: ''
 
     # TODO: Enable crossgen in build-test.sh. It currently doesn't
     # accept a crossgen arg, so disable the macos/linux crossgen test
     # build jobs.
-    ${{ if and(eq(parameters.crossgen, 'true'), in(parameters.osGroup, 'Linux', 'OSX')) }}:
+    ${{ if and(eq(parameters.readyToRun, true), in(parameters.osGroup, 'Linux', 'OSX')) }}:
       condition: false
 
     # FreeBSD test jobs are disabled since we don't have any FreeBSD helix queues.
@@ -131,6 +131,8 @@ jobs:
         # TODO: see if this amount is enough for all individual jobs to finish
         # TODO: consider passing this value as a parameter to a test job
         timeoutInMinutes: 30
+
+        readyToRun: ${{ parameters.readyToRun }}
 
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           # Access token variable for internal project from the

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -8,6 +8,7 @@ parameters:
   scenarios: ''
   helixQueues: ''
   timeoutInMinutes: ''
+  timeoutPerTestInMinutes: ''
   crossrootfsDir: ''
 
 ### Test job
@@ -128,9 +129,8 @@ jobs:
           condition: false
 
         publishTestResults: true
-        # TODO: see if this amount is enough for all individual jobs to finish
-        # TODO: consider passing this value as a parameter to a test job
-        timeoutInMinutes: 30
+        timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+        timeoutPerTestInMinutes: ${{ parameters.timeoutPerTestInMinutes }}
 
         readyToRun: ${{ parameters.readyToRun }}
 

--- a/tests/helixpublishwitharcade.proj
+++ b/tests/helixpublishwitharcade.proj
@@ -25,6 +25,9 @@
     <TimeoutInMinutes>$(_TimeoutInMinutes)</TimeoutInMinutes>
     <TimeoutInMinutes Condition=" '$(TimeoutInMinutes)' == '' ">5</TimeoutInMinutes>
 
+    <ReadyToRun>$(_ReadyToRun)</ReadyToRun>
+    <ReadyToRun Condition=" '$(ReadyToRun)' == '' ">false</ReadyToRun>
+
     <WaitForWorkItemCompletion>true</WaitForWorkItemCompletion>
     <CoreRootDirectory>$(TestWorkingDir)\Tests\Core_Root</CoreRootDirectory>
     <TestEnvFileExtension Condition=" '$(TargetsWindows)' == 'true' ">.cmd</TestEnvFileExtension>
@@ -79,19 +82,31 @@
     <PropertyGroup Condition=" '$(TargetsWindows)' == 'true' ">
       <_CoreRun>%CORE_ROOT%\CoreRun.exe</_CoreRun>
       <_XUnitRunnerDll>%CORE_ROOT%\xunit.console.dll</_XUnitRunnerDll>
-      <_HelixPreCommands>set CORE_ROOT=%HELIX_CORRELATION_PAYLOAD%;set __TestEnv=%HELIX_WORKITEM_PAYLOAD%\SetStressModes_$(Scenario)$(TestEnvFileExtension);type %__TestEnv%</_HelixPreCommands>
     </PropertyGroup>
+
+    <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
+      <_HelixPreCommands Include="set CORE_ROOT=%HELIX_CORRELATION_PAYLOAD%" />
+      <_HelixPreCommands Include="set RunCrossGen=true" Condition=" '$(ReadyToRun)' == 'true' " />
+      <_HelixPreCommands Include="set __TestEnv=%HELIX_WORKITEM_PAYLOAD%\SetStressModes_$(Scenario)$(TestEnvFileExtension)" />
+      <_HelixPreCommands Include="type %__TestEnv%" />
+    </ItemGroup>
 
     <PropertyGroup Condition=" '$(TargetsWindows)' != 'true' ">
       <_CoreRun>$CORE_ROOT/corerun</_CoreRun>
       <_XUnitRunnerDll>$CORE_ROOT/xunit.console.dll</_XUnitRunnerDll>
-      <_HelixPreCommands>export CORE_ROOT=$HELIX_CORRELATION_PAYLOAD;export __TestEnv=$HELIX_WORKITEM_PAYLOAD/SetStressModes_$(Scenario)$(TestEnvFileExtension);cat $__TestEnv</_HelixPreCommands>
     </PropertyGroup>
+
+    <ItemGroup Condition=" '$(TargetsWindows)' != 'true' ">
+      <_HelixPreCommands Include="export CORE_ROOT=$HELIX_CORRELATION_PAYLOAD" />
+      <_HelixPreCommands Include="export RunCrossGen=true" Condition=" '$(ReadyToRun)' == 'true' " />
+      <_HelixPreCommands Include="export __TestEnv=$HELIX_WORKITEM_PAYLOAD/SetStressModes_$(Scenario)$(TestEnvFileExtension)" />
+      <_HelixPreCommands Include="cat $__TestEnv" />
+    </ItemGroup>
 
     <ItemGroup>
       <HelixWorkItem Include="@(XUnitWrapperDlls->'%(FileName)'->Replace('.XUnitWrapper', ''))">
         <PayloadDirectory>%(RootDir)%(Directory)</PayloadDirectory>
-        <PreCommands>$(_HelixPreCommands)</PreCommands>
+        <PreCommands>@(_HelixPreCommands)</PreCommands>
         <Command>$(_CoreRun) $(_XUnitRunnerDll) %(FileName)%(Extension) $(_XUnitRunnerArgs)</Command>
         <Timeout>$([System.TimeSpan]::FromMinutes($(TimeoutInMinutes)))</Timeout>
       </HelixWorkItem>

--- a/tests/helixpublishwitharcade.proj
+++ b/tests/helixpublishwitharcade.proj
@@ -23,7 +23,7 @@
     <HelixType>$(_HelixType)</HelixType>
 
     <TimeoutInMinutes>$(_TimeoutInMinutes)</TimeoutInMinutes>
-    <TimeoutInMinutes Condition=" '$(TimeoutInMinutes)' == '' ">5</TimeoutInMinutes>
+    <TimeoutPerTestInMilliseconds Condition=" '$(_TimeoutPerTestInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(_TimeoutPerTestInMinutes)).TotalMilliseconds)</TimeoutPerTestInMilliseconds>
 
     <ReadyToRun>$(_ReadyToRun)</ReadyToRun>
     <ReadyToRun Condition=" '$(ReadyToRun)' == '' ">false</ReadyToRun>
@@ -88,6 +88,7 @@
       <_HelixPreCommands Include="set CORE_ROOT=%HELIX_CORRELATION_PAYLOAD%" />
       <_HelixPreCommands Include="set RunCrossGen=true" Condition=" '$(ReadyToRun)' == 'true' " />
       <_HelixPreCommands Include="set __TestEnv=%HELIX_WORKITEM_PAYLOAD%\SetStressModes_$(Scenario)$(TestEnvFileExtension)" />
+      <_HelixPreCommands Include="set __TestTimeout=$(TimeoutPerTestInMilliseconds)" Condition=" '$(TimeoutPerTestInMilliseconds)' != '' " />
       <_HelixPreCommands Include="type %__TestEnv%" />
     </ItemGroup>
 
@@ -100,6 +101,7 @@
       <_HelixPreCommands Include="export CORE_ROOT=$HELIX_CORRELATION_PAYLOAD" />
       <_HelixPreCommands Include="export RunCrossGen=true" Condition=" '$(ReadyToRun)' == 'true' " />
       <_HelixPreCommands Include="export __TestEnv=$HELIX_WORKITEM_PAYLOAD/SetStressModes_$(Scenario)$(TestEnvFileExtension)" />
+      <_HelixPreCommands Include="export __TestTimeout=$(TimeoutPerTestInMilliseconds)" Condition=" '$(TimeoutPerTestInMilliseconds)' != '' " />
       <_HelixPreCommands Include="cat $__TestEnv" />
     </ItemGroup>
 
@@ -108,7 +110,7 @@
         <PayloadDirectory>%(RootDir)%(Directory)</PayloadDirectory>
         <PreCommands>@(_HelixPreCommands)</PreCommands>
         <Command>$(_CoreRun) $(_XUnitRunnerDll) %(FileName)%(Extension) $(_XUnitRunnerArgs)</Command>
-        <Timeout>$([System.TimeSpan]::FromMinutes($(TimeoutInMinutes)))</Timeout>
+        <Timeout Condition=" '$(TimeoutInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutInMinutes)))</Timeout>
       </HelixWorkItem>
     </ItemGroup>
   </Target>

--- a/tests/helixpublishwitharcade.proj
+++ b/tests/helixpublishwitharcade.proj
@@ -74,6 +74,7 @@
     <PropertyGroup>
       <EnableXUnitReporter>true</EnableXUnitReporter>
       <FailOnMissionControlTestFailure>true</FailOnMissionControlTestFailure>
+      <FailOnWorkItemFailure>true</FailOnWorkItemFailure>
       <TestRunNamePrefix Condition=" '$(Scenario)' == 'normal' ">$(BuildOS) $(BuildArch) $(BuildType) @ </TestRunNamePrefix>
       <TestRunNamePrefix Condition=" '$(Scenario)' != 'normal' ">$(BuildOS) $(BuildArch) $(BuildType) $(Scenario) @ </TestRunNamePrefix>
       <_XUnitRunnerArgs>-parallel collections -nocolor -noshadow -xml testResults.xml -notrait category=outerloop -notrait category=failing</_XUnitRunnerArgs>

--- a/tests/helixpublishwitharcade.proj
+++ b/tests/helixpublishwitharcade.proj
@@ -106,10 +106,14 @@
       <_HelixPreCommands Include="cat $__TestEnv" />
     </ItemGroup>
 
+    <PropertyGroup>
+      <_HelixPreCommands>@(_HelixPreCommands)</_HelixPreCommands>
+    </PropertyGroup>
+
     <ItemGroup>
       <HelixWorkItem Include="@(XUnitWrapperDlls->'%(FileName)'->Replace('.XUnitWrapper', ''))">
         <PayloadDirectory>%(RootDir)%(Directory)</PayloadDirectory>
-        <PreCommands>@(_HelixPreCommands)</PreCommands>
+        <PreCommands>$(_HelixPreCommands)</PreCommands>
         <Command>$(_CoreRun) $(_XUnitRunnerDll) %(FileName)%(Extension) $(_XUnitRunnerArgs)</Command>
         <Timeout Condition=" '$(TimeoutInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutInMinutes)))</Timeout>
       </HelixWorkItem>

--- a/tests/testenvironment.proj
+++ b/tests/testenvironment.proj
@@ -55,7 +55,7 @@
     <!-- "normal" scenario doesn't define any COMPlus_* variables and uses the coreclr runtime default values
          while other scenarios use the default values of COMPlus_* variables defined in ItemDefinitionGroup above -->
     <TestEnvironment Include="normal" TieredCompilation="" />
-    <TestEnvironment Include="minopts" JITMinOpts="1" />
+    <TestEnvironment Include="jitminopts" JITMinOpts="1" />
     <TestEnvironment Include="no_tiered_compilation" TieredCompilation="0" />
     <TestEnvironment Include="forcerelocs" ForceRelocs="1" />
     <TestEnvironment Include="jitstress1" JitStress="1" />
@@ -98,7 +98,7 @@
     <TestEnvironment Include="gcstress0xc_zapdisable_heapverify1" GCStress="0xC" ZapDisable="1" ReadyToRun="0" HeapVerify="1" />
     <TestEnvironment Include="gcstress0xc_jitstress1" GCStress="0xC" JitStress="1" />
     <TestEnvironment Include="gcstress0xc_jitstress2" GCStress="0xC" JitStress="2" />
-    <TestEnvironment Include="gcstress0xc_minopts_heapverify1" GCStress="0xC" JITMinOpts="1" HeapVerify="1" />
+    <TestEnvironment Include="gcstress0xc_jitminopts_heapverify1" GCStress="0xC" JITMinOpts="1" HeapVerify="1" />
   </ItemGroup>
 
   <!-- We use target batching on the COMPlusVariable items to iterate over the all COMPlus_* environment variables


### PR DESCRIPTION
1. For ReadyToRun tests in AzDO set RunCrossGen=true during Helix test running
2. Set __TestTimeout and introduce TimeoutPerTestInMinutes for test jobs
3. Set FailOnWorkItemFailure - fail the AzDO step on Helix work item "catastrophic failure"
