### PR TITLE
Add AmbiguousImplementationException

### DIFF
--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -166,6 +166,9 @@
   <data name="AppDomain_AppBaseNotSet" xml:space="preserve">
     <value>The ApplicationBase must be set before retrieving this property.</value>
   </data>
+  <data name="AmbiguousImplementationException_NullMessage" xml:space="preserve">
+    <value>Ambiguous implementation found.</value>
+  </data>
   <data name="Arg_AccessException" xml:space="preserve">
     <value>Cannot access member.</value>
   </data>

--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -675,6 +675,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Serialization\StreamingContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Versioning\NonVersionableAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Versioning\TargetFrameworkAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\AmbiguousImplementationException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\MemoryFailPoint.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\SByte.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Security\AllowPartiallyTrustedCallersAttribute.cs" />

--- a/src/System.Private.CoreLib/shared/System/Runtime/AmbiguousImplementationException.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/AmbiguousImplementationException.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime;
+using System.Globalization;
+
+namespace System.Runtime.Serialization
+{
+    [Serializable]
+    public sealed class AmbiguousImplementationException : Exception
+    {
+        public AmbiguousImplementationException()
+            : base(SR.AmbiguousImplementationException_NullMessage)
+        {
+        }
+
+        public AmbiguousImplementationException(string message)
+            : base(message)
+        {
+        }
+
+        public AmbiguousImplementationException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        private AmbiguousImplementationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}


### PR DESCRIPTION
For dotnet/corefx#34124 (Exception to throw when interface dispatch is ambiguous)

I based the new exception on `SerializationException`. I also added a constructor that takes parameters for string formatting for the proposed error string, and a default error string for use in the parameterless constructor. (I've never messed with resx files before, so hopefully I did this right.)

I didn't try to compile it or anything, so someone else might want to test it before merging.