### PR TITLE
Do not cache error string in SerializationException

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/Serialization/SerializationException.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Serialization/SerializationException.cs
@@ -10,12 +10,10 @@ namespace System.Runtime.Serialization
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class SerializationException : SystemException
     {
-        private static string s_nullMessage = SR.SerializationException;
-
         // Creates a new SerializationException with its message 
         // string set to a default message.
         public SerializationException()
-            : base(s_nullMessage)
+            : base(SR.SerializationException)
         {
             HResult = HResults.COR_E_SERIALIZATION;
         }


### PR DESCRIPTION
`System.Runtime.Serialization.SerializationException` caches its error string. As discussed [here](https://github.com/dotnet/coreclr/pull/22280#discussion_r252049592), this is an outlier and does not offer any benefit.