### PR TITLE
Replace several Nullable<T>.Value with .GetValueOrDefault()

### DIFF
--- a/src/System.Private.CoreLib/shared/System/IO/FileStream.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileStream.Unix.cs
@@ -209,7 +209,7 @@ namespace System.IO
                 _canSeek = Interop.Sys.LSeek(fileHandle, 0, Interop.Sys.SeekWhence.SEEK_CUR) >= 0;
             }
 
-            return _canSeek.Value;
+            return _canSeek.GetValueOrDefault();
         }
 
         private long GetLengthInternal()

--- a/src/System.Private.CoreLib/shared/System/IO/FileStream.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileStream.cs
@@ -135,7 +135,7 @@ namespace System.IO
 
             if (handle.IsClosed)
                 throw new ObjectDisposedException(SR.ObjectDisposed_FileClosed);
-            if (handle.IsAsync.HasValue && isAsync != handle.IsAsync.Value)
+            if (handle.IsAsync.HasValue && isAsync != handle.IsAsync.GetValueOrDefault())
                 throw new ArgumentException(SR.Arg_HandleNotAsync, nameof(handle));
 
             _exposedHandle = true;

--- a/src/System.Private.CoreLib/shared/System/TimeZoneInfo.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/TimeZoneInfo.Unix.cs
@@ -1095,7 +1095,7 @@ namespace System
                 TimeSpan? parsedBaseOffset = TZif_ParseOffsetString(standardOffset);
                 if (parsedBaseOffset.HasValue)
                 {
-                    TimeSpan baseOffset = parsedBaseOffset.Value.Negate(); // offsets are backwards in POSIX notation
+                    TimeSpan baseOffset = parsedBaseOffset.GetValueOrDefault().Negate(); // offsets are backwards in POSIX notation
                     baseOffset = TZif_CalculateTransitionOffsetFromBase(baseOffset, timeZoneBaseUtcOffset);
 
                     // having a daylightSavingsName means there is a DST rule
@@ -1110,7 +1110,7 @@ namespace System
                         }
                         else
                         {
-                            daylightSavingsTimeSpan = parsedDaylightSavings.Value.Negate(); // offsets are backwards in POSIX notation
+                            daylightSavingsTimeSpan = parsedDaylightSavings.GetValueOrDefault().Negate(); // offsets are backwards in POSIX notation
                             daylightSavingsTimeSpan = TZif_CalculateTransitionOffsetFromBase(daylightSavingsTimeSpan, timeZoneBaseUtcOffset);
                             daylightSavingsTimeSpan = TZif_CalculateTransitionOffsetFromBase(daylightSavingsTimeSpan, baseOffset);
                         }
@@ -1176,7 +1176,7 @@ namespace System
 
                 if (result.HasValue && negative)
                 {
-                    result = result.Value.Negate();
+                    result = result.GetValueOrDefault().Negate();
                 }
             }
 
@@ -1193,8 +1193,8 @@ namespace System
                 // Some time zones use time values like, "26", "144", or "-2".
                 // This allows the week to sometimes be week 4 and sometimes week 5 in the month.
                 // For now, strip off any 'days' in the offset, and just get the time of day correct
-                timeOffset = new TimeSpan(timeOffset.Value.Hours, timeOffset.Value.Minutes, timeOffset.Value.Seconds);
-                if (timeOffset.Value < TimeSpan.Zero)
+                timeOffset = new TimeSpan(timeOffset.GetValueOrDefault().Hours, timeOffset.GetValueOrDefault().Minutes, timeOffset.GetValueOrDefault().Seconds);
+                if (timeOffset.GetValueOrDefault() < TimeSpan.Zero)
                 {
                     timeOfDay = new DateTime(1, 1, 2, 0, 0, 0);
                 }
@@ -1203,7 +1203,7 @@ namespace System
                     timeOfDay = new DateTime(1, 1, 1, 0, 0, 0);
                 }
 
-                timeOfDay += timeOffset.Value;
+                timeOfDay += timeOffset.GetValueOrDefault();
             }
             else
             {

--- a/src/System.Private.CoreLib/shared/System/TimeZoneInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/TimeZoneInfo.cs
@@ -286,9 +286,9 @@ namespace System
         {
             Debug.Assert(rule.NoDaylightTransitions, "GetPreviousAdjustmentRule should only be used with NoDaylightTransitions rules.");
 
-            if (ruleIndex.HasValue && 0 < ruleIndex.Value && ruleIndex.Value < _adjustmentRules.Length)
+            if (ruleIndex.HasValue && 0 < ruleIndex.GetValueOrDefault() && ruleIndex.GetValueOrDefault() < _adjustmentRules.Length)
             {
-                return _adjustmentRules[ruleIndex.Value - 1];
+                return _adjustmentRules[ruleIndex.GetValueOrDefault() - 1];
             }
 
             AdjustmentRule result = rule;

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/CLRIReferenceImpl.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/CLRIReferenceImpl.cs
@@ -296,7 +296,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (propType.HasValue)
             {
                 Type specificType = typeof(CLRIReferenceImpl<>).MakeGenericType(type);
-                return Activator.CreateInstance(specificType, new object[] { propType.Value, obj });
+                return Activator.CreateInstance(specificType, new object[] { propType.GetValueOrDefault(), obj });
             }
 
             Debug.Fail("We should not see non-WinRT type here");
@@ -389,7 +389,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             {
                 // All WinRT value type will be Property.Other
                 Type specificType = typeof(CLRIReferenceArrayImpl<>).MakeGenericType(type);
-                return Activator.CreateInstance(specificType, new object[] { propType.Value, obj });
+                return Activator.CreateInstance(specificType, new object[] { propType.GetValueOrDefault(), obj });
             }
             else
             {


### PR DESCRIPTION
The former does extra work that the latter doesn't do, and they're equivalent when we know it contains a value, such as immediately after a HasValue check.

@AndyAyersMS, I was a little surprised in some of these cases that the JIT isn't able to compile down to the same code for Value as it does for GetValueOrDefault.  As an example, for this:
```C#
using System;
using System.Runtime.CompilerServices;

class Program
{
    static void Main() { Positive1(42); Positive2(42); }

    [MethodImpl(MethodImplOptions.NoInlining)]
    private static bool Positive1(int? i) => i.HasValue && i.Value > 0;

    [MethodImpl(MethodImplOptions.NoInlining)]
    private static bool Positive2(int? i) => i.HasValue && i.GetValueOrDefault() > 0;
}
```
I get this for Positive1 that uses Value:
```
G_M60389_IG01:
       4883EC28             sub      rsp, 40
       90                   nop
       48894C2430           mov      qword ptr [rsp+30H], rcx

G_M60389_IG02:
       0FB6442430           movzx    rax, byte  ptr [rsp+30H]
       85C0                 test     eax, eax
       7414                 je       SHORT G_M60389_IG05
       85C0                 test     eax, eax
       7417                 je       SHORT G_M60389_IG07

G_M60389_IG03:
       837C243400           cmp      dword ptr [rsp+34H], 0
       0F9FC0               setg     al
       0FB6C0               movzx    rax, al

G_M60389_IG04:
       4883C428             add      rsp, 40
       C3                   ret

G_M60389_IG05:
       33C0                 xor      eax, eax

G_M60389_IG06:
       4883C428             add      rsp, 40
       C3                   ret

G_M60389_IG07:
       E815FFFFFF           call     ThrowHelper:ThrowInvalidOperationException_InvalidOperation_NoValue()
       CC                   int3
```
and this for Positive2 that uses GetValueOrDefault:
```
G_M60387_IG01:
       0F1F440000           nop
       48894C2408           mov      qword ptr [rsp+08H], rcx

G_M60387_IG02:
       807C240800           cmp      byte  ptr [rsp+08H], 0
       740C                 je       SHORT G_M60387_IG04
       837C240C00           cmp      dword ptr [rsp+0CH], 0
       0F9FC0               setg     al
       0FB6C0               movzx    rax, al

G_M60387_IG03:
       C3                   ret

G_M60387_IG04:
       33C0                 xor      eax, eax

G_M60387_IG05:
       C3                   ret
```
The former ends up doing the HasValue check twice, even though they happen one right after the other as part of Value getting inlined, and then I'd have expected it to be able to eliminate the dead branch that includes the ThrowHelper call.

Is it expected that it can't get this?