### PR TITLE
Reverting Fixing up the UTF8Formatter and some tests to properly handle -0.0

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Decimal.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Decimal.cs
@@ -47,6 +47,10 @@ namespace System.Buffers.Text
                         Number.NumberBuffer number = new Number.NumberBuffer(Number.NumberBufferKind.Decimal, pDigits, Number.DecimalNumberBufferLength);
 
                         Number.DecimalToNumber(ref value, ref number);
+                        if (number.Digits[0] == 0)	
+                        {	
+                            number.IsNegative = false; // For Decimals, -0 must print as normal 0.	
+                        }
                         bool success = TryFormatDecimalG(ref number, destination, out bytesWritten);
 #if DEBUG
                         // This DEBUG segment exists to close a code coverage hole inside TryFormatDecimalG(). Because we don't call RoundNumber() on this path, we have no way to feed
@@ -91,6 +95,7 @@ namespace System.Buffers.Text
                         Number.DecimalToNumber(ref value, ref number);
                         byte precision = (format.Precision == StandardFormat.NoPrecision) ? (byte)2 : format.Precision;
                         Number.RoundNumber(ref number, number.Scale + precision);
+                        Debug.Assert((number.Digits[0] != 0) || !number.IsNegative);   // For Decimals, -0 must print as normal 0. As it happens, Number.RoundNumber already ensures this invariant.
                         return TryFormatDecimalF(ref number, destination, out bytesWritten, precision);
                     }
 
@@ -103,6 +108,7 @@ namespace System.Buffers.Text
                         Number.DecimalToNumber(ref value, ref number);
                         byte precision = (format.Precision == StandardFormat.NoPrecision) ? (byte)6 : format.Precision;
                         Number.RoundNumber(ref number, precision + 1);
+                        Debug.Assert((number.Digits[0] != 0) || !number.IsNegative);   // For Decimals, -0 must print as normal 0. As it happens, Number.RoundNumber already ensures this invariant.
                         return TryFormatDecimalE(ref number, destination, out bytesWritten, precision, exponentSymbol: (byte)format.Symbol);
                     }
 


### PR DESCRIPTION
CC. @jkotas, @pentp 

This was missed in https://github.com/dotnet/coreclr/pull/22070 and fixes the UTF8Formatter