### PR TITLE
Disable tests consistently failing in AzDO CI

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -585,6 +585,12 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/v2.1/b152292/b152292/*">
             <Issue>20358</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/interlocked/compareexchange/CompareExchangeTClass/*">
+            <Issue>22303</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/interlocked/compareexchange/CompareExchangeTClass_1/*">
+            <Issue>22303</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- Unix arm32 specific -->

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -613,6 +613,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/doublearray/dblarray3_cs_r/*">
             <Issue>22015</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/opt/cse/hugeexpr1/*">
+            <Issue>22260</Issue>
+        </ExcludeList>
     </ItemGroup>
     
 


### PR DESCRIPTION
For example in both https://dev.azure.com/dnceng/public/_build/results?buildId=83004 https://dev.azure.com/dnceng/public/_build/results?buildId=83095
these are #22260 and #22303:
* hugeexpr1 on Linux/arm32
* CompareExchangeTClass on Linux/arm64

/cc @dotnet/jit-contrib 