### PR TITLE
Stop collecting source line information during a stacktrace for the E…

### DIFF
--- a/src/System.Private.CoreLib/src/System/Exception.cs
+++ b/src/System.Private.CoreLib/src/System/Exception.cs
@@ -337,7 +337,7 @@ namespace System
             {
                 if (_source == null)
                 {
-                    StackTrace st = new StackTrace(this, true);
+                    StackTrace st = new StackTrace(this, false);
                     if (st.FrameCount > 0)
                     {
                         StackFrame sf = st.GetFrame(0);

--- a/src/System.Private.CoreLib/src/System/Exception.cs
+++ b/src/System.Private.CoreLib/src/System/Exception.cs
@@ -337,7 +337,7 @@ namespace System
             {
                 if (_source == null)
                 {
-                    StackTrace st = new StackTrace(this, false);
+                    StackTrace st = new StackTrace(this, fNeedFileInfo: false);
                     if (st.FrameCount > 0)
                     {
                         StackFrame sf = st.GetFrame(0);


### PR DESCRIPTION
…xception.Source property.

Rough statistics when computed with and without the change. Note the callstack was only 2 deep so for deeper stacks this would be even more profound.

```
Scenario: get_Source - source file query [n = 4000] [values in ticks]
    Mean: 228
     Min: 63
     Max: 500755

Scenario: get_Source - NO source file query [n = 4000] [values in ticks]
    Mean: 52
     Min: 29
     Max: 10540
```
