### PR TITLE
Fix for missing GC ref map record on ARM64 for the X8 register

### DIFF
--- a/src/vm/callingconvention.h
+++ b/src/vm/callingconvention.h
@@ -142,6 +142,16 @@ struct TransitionBlock
         LIMITED_METHOD_CONTRACT;
         return offsetof(TransitionBlock, m_x8RetBuffReg);
     }
+    
+    static int GetOffsetOfFirstGCRefMapSlot()
+    {
+        return GetOffsetOfRetBuffArgReg();
+    }
+#else
+    static int GetOffsetOfFirstGCRefMapSlot()
+    {
+        return GetOffsetOfArgumentRegisters();
+    }
 #endif
 
     static BYTE GetOffsetOfArgs()

--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -1007,19 +1007,13 @@ void CEECompileInfo::GetCallRefMap(CORINFO_METHOD_HANDLE hMethod, GCRefMapBuilde
 
     UINT nStackSlots;
 
-#ifdef _TARGET_ARM64_
-    static const int ReturnBuffPtrExtraSlot = 1;
-#else
-    static const int ReturnBuffPtrExtraSlot = 0;
-#endif
-
 #ifdef _TARGET_X86_
     UINT cbStackPop = argit.CbStackPop();
     pBuilder->WriteStackPop(cbStackPop / sizeof(TADDR));
 
     nStackSlots = nStackBytes / sizeof(TADDR) + NUM_ARGUMENT_REGISTERS;
 #else
-    nStackSlots = (sizeof(TransitionBlock) + nStackBytes - TransitionBlock::GetOffsetOfArgumentRegisters()) / TARGET_POINTER_SIZE + ReturnBuffPtrExtraSlot;
+    nStackSlots = (sizeof(TransitionBlock) + nStackBytes - TransitionBlock::GetOffsetOfFirstGCRefMapSlot()) / TARGET_POINTER_SIZE;
 #endif
 
     for (UINT pos = 0; pos < nStackSlots; pos++)
@@ -1031,7 +1025,7 @@ void CEECompileInfo::GetCallRefMap(CORINFO_METHOD_HANDLE hMethod, GCRefMapBuilde
             (TransitionBlock::GetOffsetOfArgumentRegisters() + ARGUMENTREGISTERS_SIZE - (pos + 1) * sizeof(TADDR)) :
             (TransitionBlock::GetOffsetOfArgs() + (pos - NUM_ARGUMENT_REGISTERS) * sizeof(TADDR));
 #else
-        ofs = TransitionBlock::GetOffsetOfArgumentRegisters() - ReturnBuffPtrExtraSlot * TARGET_POINTER_SIZE + pos * TARGET_POINTER_SIZE;
+        ofs = TransitionBlock::GetOffsetOfFirstGCRefMapSlot() + pos * TARGET_POINTER_SIZE;
 #endif
 
         CORCOMPILE_GCREFMAP_TOKENS token = *(CORCOMPILE_GCREFMAP_TOKENS *)(pFrame + ofs);
@@ -1074,7 +1068,7 @@ void CEECompileInfo::GetCallRefMap(CORINFO_METHOD_HANDLE hMethod, GCRefMapBuilde
             (TransitionBlock::GetOffsetOfArgumentRegisters() + ARGUMENTREGISTERS_SIZE - (pos + 1) * sizeof(TADDR)) :
             (TransitionBlock::GetOffsetOfArgs() + (pos - NUM_ARGUMENT_REGISTERS) * sizeof(TADDR));
 #else
-        ofs = TransitionBlock::GetOffsetOfArgumentRegisters() - ReturnBuffPtrExtraSlot * TARGET_POINTER_SIZE + pos * TARGET_POINTER_SIZE;
+        ofs = TransitionBlock::GetOffsetOfFirstGCRefMapSlot() + pos * TARGET_POINTER_SIZE;
 #endif
 
         if (token != 0)

--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -1330,7 +1330,7 @@ void TransitionFrame::PromoteCallerStackUsingGCRefMap(promote_func* fn, ScanCont
             (TransitionBlock::GetOffsetOfArgumentRegisters() + ARGUMENTREGISTERS_SIZE - (pos + 1) * sizeof(TADDR)) :
             (TransitionBlock::GetOffsetOfArgs() + (pos - NUM_ARGUMENT_REGISTERS) * sizeof(TADDR));
 #else
-        ofs = TransitionBlock::GetOffsetOfArgumentRegisters() + pos * sizeof(TADDR);
+        ofs = TransitionBlock::GetOffsetOfFirstGCRefMapSlot() + pos * sizeof(TADDR);
 #endif
 
         PTR_TADDR ppObj = dac_cast<PTR_TADDR>(pTransitionBlock + ofs);


### PR DESCRIPTION
This is a simple hotfix for the generator only that works for me locally.
I suspect a similar adjustment needs to be done to the GC ref map parser.
We also need to bump up the ARM64 R2R PE format version as the images
emitted with this change will have an incompatible GC ref map compared
to the older ones.

Based on my offline chat with JanV I have decided to publish the WIP PR.
I'm looking forward to CoreCLR architects' suggestions on how to clean up
and finalize this change. One possibility for cleanup is to introduce a new
TransitionBlock function "OffsetOfFirstGCRefMapEntry" that will resolve to
OffsetOfArgumentRegisters on all architectures except for ARM64 where
it will be the offset of the X8 register (i.e. OffsetOfArgumentRegisters - 8).

Thanks

Tomas