### PR TITLE
Spill tree temp large vectors around calls

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -6689,9 +6689,9 @@ void LinearScan::resolveRegisters()
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
             if (currentRefPosition->refType == RefTypeUpperVectorSaveDef)
             {
-                // The treeNode must be a call.
+                // The treeNode must be non-null. It is a call or an instruction that becomes a call.
                 noway_assert(treeNode != nullptr);
-                assert(treeNode->OperIs(GT_CALL));
+
                 // If the associated interval is internal, this must be a RefPosition for a LargeVectorType LocalVar.
                 // Otherwise, this  is a non-lclVar interval that has been spilled, and we don't need to do anything.
                 if (currentRefPosition->getInterval()->isInternal)

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -1678,8 +1678,9 @@ void LinearScan::identifyCandidates()
             CLANG_FORMAT_COMMENT_ANCHOR;
 
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
-            // Additionally, when we are generating AVX on non-UNIX amd64, we keep a separate set of the LargeVectorType
-            // vars.
+            // Additionally, when we are generating code for a target with partial SIMD callee-save
+            // (AVX on non-UNIX amd64 and 16-byte vectors on arm64), we keep a separate set of the
+            // LargeVectorType vars.
             if (varTypeNeedsPartialCalleeSave(varDsc->lvType))
             {
                 largeVectorVarCount++;
@@ -5237,10 +5238,28 @@ void LinearScan::allocateRegisters()
 #ifdef FEATURE_SIMD
             else if (refType == RefTypeUpperVectorSaveDef || refType == RefTypeUpperVectorSaveUse)
             {
-                Interval* lclVarInterval = currentInterval->relatedInterval;
-                if (lclVarInterval->physReg == REG_NA)
+                if (currentInterval->isInternal)
                 {
-                    allocate = false;
+                    // This is the lclVar case. This internal interval is what will hold the upper half.
+                    Interval* lclVarInterval = currentInterval->relatedInterval;
+                    assert(lclVarInterval->isLocalVar);
+                    if (lclVarInterval->physReg == REG_NA)
+                    {
+                        allocate = false;
+                    }
+                }
+                else
+                {
+                    assert(!currentInterval->isLocalVar);
+                    // Note that this case looks a lot like the case below, but in this case we need to spill
+                    // at the previous RefPosition.
+                    if (assignedRegister != REG_NA)
+                    {
+                        unassignPhysReg(getRegisterRecord(assignedRegister), currentInterval->firstRefPosition);
+                        INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_NO_REG_ALLOCATED, currentInterval));
+                    }
+                    currentRefPosition->registerAssignment = RBM_NONE;
+                    continue;
                 }
             }
 #endif // FEATURE_SIMD
@@ -6670,13 +6689,26 @@ void LinearScan::resolveRegisters()
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
             if (currentRefPosition->refType == RefTypeUpperVectorSaveDef)
             {
-                // The treeNode must be a call, and this must be a RefPosition for a LargeVectorType LocalVar.
-                // If the LocalVar is in a callee-save register, we are going to spill its upper half around the call.
-                // If we have allocated a register to spill it to, we will use that; otherwise, we will spill it
-                // to the stack.  We can use as a temp register any non-arg caller-save register.
+                // The treeNode must be a call.
                 noway_assert(treeNode != nullptr);
-                currentRefPosition->referent->recentRefPosition = currentRefPosition;
-                insertUpperVectorSaveAndReload(treeNode, currentRefPosition, block);
+                assert(treeNode->OperIs(GT_CALL));
+                // If the associated interval is internal, this must be a RefPosition for a LargeVectorType LocalVar.
+                // Otherwise, this  is a non-lclVar interval that has been spilled, and we don't need to do anything.
+                if (currentRefPosition->getInterval()->isInternal)
+                {
+                    // If the LocalVar is in a callee-save register, we are going to spill its upper half around the
+                    // call.
+                    // If we have allocated a register to spill it to, we will use that; otherwise, we will spill it
+                    // to the stack.  We can use as a temp register any non-arg caller-save register.
+                    currentRefPosition->referent->recentRefPosition = currentRefPosition;
+                    insertUpperVectorSaveAndReload(treeNode, currentRefPosition, block);
+                }
+                else
+                {
+                    // This is a non-lclVar interval that must have been spilled.
+                    assert(!currentRefPosition->getInterval()->isLocalVar);
+                    assert(currentRefPosition->getInterval()->firstRefPosition->spillAfter);
+                }
             }
             else if (currentRefPosition->refType == RefTypeUpperVectorSaveUse)
             {
@@ -6776,6 +6808,15 @@ void LinearScan::resolveRegisters()
                         if (INDEBUG(alwaysInsertReload() ||)
                                 nextRefPosition->assignedReg() != currentRefPosition->assignedReg())
                         {
+                            if (!currentRefPosition->getInterval()->isLocalVar)
+                            {
+                                while ((nextRefPosition != nullptr) &&
+                                       (nextRefPosition->refType == RefTypeUpperVectorSaveDef))
+                                {
+                                    nextRefPosition = nextRefPosition->nextRefPosition;
+                                }
+                            }
+                            noway_assert(nextRefPosition != nullptr);
                             if (nextRefPosition->assignedReg() != REG_NA)
                             {
                                 insertCopyOrReload(block, treeNode, currentRefPosition->getMultiRegIdx(),

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -1840,8 +1840,7 @@ public:
     // A RefPosition refers to either an Interval or a RegRecord. 'referent' points to one
     // of these types. If it refers to a RegRecord, then 'isPhysRegRef' is true. If it
     // refers to an Interval, then 'isPhysRegRef' is false.
-    //
-    // Q: can 'referent' be NULL?
+    // referent can never be null.
 
     Referenceable* referent;
 

--- a/src/jit/lsrabuild.cpp
+++ b/src/jit/lsrabuild.cpp
@@ -1311,11 +1311,18 @@ void LinearScan::buildInternalRegisterUses()
 // Arguments:
 //    tree       - The current node being handled
 //    currentLoc - The location of the current node
+//    fpCalleeKillSet - The set of registers killed by this node.
 //
 // Return Value: Returns the set of lclVars that are killed by this node, and therefore
 //               required RefTypeUpperVectorSaveDef RefPositions.
 //
-// Notes: The returned set is used by buildUpperVectorRestoreRefPositions.
+// Notes: The returned set contains any lclVars that were partially spilled, and is
+//        used by buildUpperVectorRestoreRefPositions.
+//        This is called by BuildDefsWithKills for any node that kills registers in the
+//        RBM_FLT_CALLEE_TRASH set. We actually need to find any calls that kill the upper-half
+//        of the callee-save vector registers.
+//        But we will use as a proxy any node that kills floating point registers.
+//        (Note that some calls are masquerading as other nodes at this point so we can't just check for calls.)
 //
 VARSET_VALRET_TP
 LinearScan::buildUpperVectorSaveRefPositions(GenTree* tree, LsraLocation currentLoc, regMaskTP fpCalleeKillSet)
@@ -1324,29 +1331,37 @@ LinearScan::buildUpperVectorSaveRefPositions(GenTree* tree, LsraLocation current
     VARSET_TP liveLargeVectors(VarSetOps::MakeEmpty(compiler));
     if (!VarSetOps::IsEmpty(compiler, largeVectorVars))
     {
-        // We actually need to find any calls that kill the upper-half of the callee-save vector registers.
-        // But we will use as a proxy any node that kills floating point registers.
-        // (Note that some calls are masquerading as other nodes at this point so we can't just check for calls.)
-        // This check should have been done by the caller.
-        if ((fpCalleeKillSet & RBM_FLT_CALLEE_TRASH) != RBM_NONE)
+        assert((fpCalleeKillSet & RBM_FLT_CALLEE_TRASH) != RBM_NONE);
+        VarSetOps::AssignNoCopy(compiler, liveLargeVectors,
+                                VarSetOps::Intersection(compiler, currentLiveVars, largeVectorVars));
+        VarSetOps::Iter iter(compiler, liveLargeVectors);
+        unsigned        varIndex = 0;
+        while (iter.NextElem(&varIndex))
         {
-            VarSetOps::AssignNoCopy(compiler, liveLargeVectors,
-                                    VarSetOps::Intersection(compiler, currentLiveVars, largeVectorVars));
-            VarSetOps::Iter iter(compiler, liveLargeVectors);
-            unsigned        varIndex = 0;
-            while (iter.NextElem(&varIndex))
+            Interval* varInterval    = getIntervalForLocalVar(varIndex);
+            Interval* tempInterval   = newInterval(varInterval->registerType);
+            tempInterval->isInternal = true;
+            RefPosition* pos =
+                newRefPosition(tempInterval, currentLoc, RefTypeUpperVectorSaveDef, tree, RBM_FLT_CALLEE_SAVED);
+            // We are going to save the existing relatedInterval of varInterval on tempInterval, so that we can set
+            // the tempInterval as the relatedInterval of varInterval, so that we can build the corresponding
+            // RefTypeUpperVectorSaveUse RefPosition.  We will then restore the relatedInterval onto varInterval,
+            // and set varInterval as the relatedInterval of tempInterval.
+            tempInterval->relatedInterval = varInterval->relatedInterval;
+            varInterval->relatedInterval  = tempInterval;
+        }
+        // For any non-lclVar intervals that are live at this point (i.e. in the DefList), we will also create
+        // a RefTypeUpperVectorSaveDef. For now these will all be spilled at this point, as we don't currently
+        // have a mechanism to communicate any non-lclVar intervals that need to be restored.
+        // TODO-CQ: Consider reworking this as part of addressing GitHub Issues #18144 and #17481.
+        for (RefInfoListNode *listNode = defList.Begin(), *end = defList.End(); listNode != end;
+             listNode = listNode->Next())
+        {
+            var_types treeType = listNode->treeNode->TypeGet();
+            if (varTypeIsSIMD(treeType) && varTypeNeedsPartialCalleeSave(treeType))
             {
-                Interval* varInterval    = getIntervalForLocalVar(varIndex);
-                Interval* tempInterval   = newInterval(varInterval->registerType);
-                tempInterval->isInternal = true;
-                RefPosition* pos =
-                    newRefPosition(tempInterval, currentLoc, RefTypeUpperVectorSaveDef, tree, RBM_FLT_CALLEE_SAVED);
-                // We are going to save the existing relatedInterval of varInterval on tempInterval, so that we can set
-                // the tempInterval as the relatedInterval of varInterval, so that we can build the corresponding
-                // RefTypeUpperVectorSaveUse RefPosition.  We will then restore the relatedInterval onto varInterval,
-                // and set varInterval as the relatedInterval of tempInterval.
-                tempInterval->relatedInterval = varInterval->relatedInterval;
-                varInterval->relatedInterval  = tempInterval;
+                RefPosition* pos = newRefPosition(listNode->ref->getInterval(), currentLoc, RefTypeUpperVectorSaveDef,
+                                                  tree, RBM_FLT_CALLEE_SAVED);
             }
         }
     }
@@ -2513,7 +2528,7 @@ void LinearScan::BuildDefsWithKills(GenTree* tree, int dstCount, regMaskTP dstCa
     {
         buildKillPositionsForNode(tree, currentLoc + 1, killMask);
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
-        if (enregisterLocalVars && (RBM_FLT_CALLEE_SAVED != RBM_NONE))
+        if (enregisterLocalVars && ((killMask & RBM_FLT_CALLEE_TRASH) != RBM_NONE))
         {
             // Build RefPositions for saving any live large vectors.
             // This must be done after the kills, so that we know which large vectors are still live.


### PR DESCRIPTION
The code was there to handle lclVars, but there was an implicit assumption that non-lclVar large vector tree temps would never be live across a call.

Fixes the GitHub_20657 failure in #22253