### PR TITLE
[Arm64/arm32] GCStress failure in tracing/eventsourcetrace/eventsourcetrace

### DIFF
--- a/tests/src/tracing/eventsource/eventsourcetrace/eventsourcetrace.csproj
+++ b/tests/src/tracing/eventsource/eventsourcetrace/eventsourcetrace.csproj
@@ -14,6 +14,7 @@
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'"></PropertyGroup>


### PR DESCRIPTION
Marking this test `GCStressIncompatible` = **True**.
Fixes https://github.com/dotnet/coreclr/issues/17188