### PR TITLE
Add option to run tests in unloadable context

### DIFF
--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -51,6 +51,7 @@ set __CoreFXTestsRunAllAvailable=
 set __SkipGenerateLayout=
 set __BuildXUnitWrappers=
 set __PrintLastResultsOnly=
+set __RunInUnloadableContext=
 
 :Arg_Loop
 if "%1" == "" goto ArgsDone
@@ -108,6 +109,8 @@ if /i "%1" == "altjitarch"                              (set __AltJitArch=%2&shi
 REM change it to COMPlus_GCStress when we stop using xunit harness
 if /i "%1" == "gcstresslevel"                           (set COMPlus_GCStress=%2&set __TestTimeout=1800000&shift&shift&goto Arg_Loop)
 if /i "%1" == "collectdumps"                            (set __CollectDumps=true&shift&goto Arg_Loop)
+
+if /i "%1" == "runincontext"                            (set __RunInUnloadableContext=1&shift&goto Arg_Loop)
 
 if /i not "%1" == "msbuildargs" goto SkipMsbuildArgs
 :: All the rest of the args will be collected and passed directly to msbuild.
@@ -220,6 +223,10 @@ if defined __PrintLastResultsOnly (
 
 if defined __AltJitArch (
     set __RuntestPyArgs=%__RuntestPyArgs% -altjit_arch %__AltJitArch%
+)
+
+if defined __RunInUnloadableContext (
+    set __RuntestPyArgs=%__RuntestPyArgs% --run_in_context
 )
 
 REM __ProjectDir is poorly named, it is actually <projectDir>/tests
@@ -744,6 +751,7 @@ echo gcname ^<name^>             - Runs the tests with COMPlus_GCName=name
 echo timeout ^<n^>               - Sets the per-test timeout in milliseconds ^(default is 10 minutes = 10 * 60 * 1000 = 600000^).
 echo                             Note: some options override this ^(gcstresslevel, longgc, gcsimulator^).
 echo printlastresultsonly      - Print the last test results without running tests.
+echo runincontext              - Run each tests in an unloadable AssemblyLoadContext
 echo msbuildargs ^<args...^>     - Pass all subsequent args directly to msbuild invocations.
 echo ^<CORE_ROOT^>               - Path to the runtime to test ^(if specified^).
 echo.

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -131,6 +131,7 @@ parser.add_argument("--generate_layout_only", dest="generate_layout_only", actio
 parser.add_argument("--analyze_results_only", dest="analyze_results_only", action="store_true", default=False)
 parser.add_argument("--verbose", dest="verbose", action="store_true", default=False)
 parser.add_argument("--limited_core_dumps", dest="limited_core_dumps", action="store_true", default=False)
+parser.add_argument("--run_in_context", dest="run_in_context", action="store_true", default=False)
 
 # Only used on Unix
 parser.add_argument("-test_native_bin_location", dest="test_native_bin_location", nargs='?', default=None)
@@ -995,7 +996,8 @@ def run_tests(host_os,
               run_crossgen_tests=False,
               large_version_bubble=False,
               run_sequential=False,
-              limited_core_dumps=False):
+              limited_core_dumps=False,
+              run_in_context=False):
     """ Run the coreclr tests
     
     Args:
@@ -1015,6 +1017,7 @@ def run_tests(host_os,
         run_crossgen_tests(bool)    :
         run_sequential(bool)        :
         limited_core_dumps(bool)    :
+        run_in_context(bool)        : run the tests in an unloadable AssemblyLoadContext
     """
 
     # Setup the dotnetcli location
@@ -1061,6 +1064,12 @@ def run_tests(host_os,
 
     if limited_core_dumps:
         setup_coredump_generation(host_os)
+
+    if run_in_context:
+        print("Running test in an unloadable AssemblyLoadContext")
+        os.environ["CLRCustomTestLauncher"] = os.path.join(coreclr_repo_location, "tests", "scripts", "runincontext%s" % (".cmd" if host_os == "Windows_NT" else ".sh"))
+        os.environ["__RunInUnloadableContext"] = "1";
+        per_test_timeout = 20*60*1000
 
     # Set __TestTimeout environment variable, which is the per-test timeout in milliseconds.
     # This is read by the test wrapper invoker, in tests\src\Common\Coreclr.TestWrapper\CoreclrTestWrapperLib.cs.
@@ -1313,6 +1322,11 @@ def setup_args(args):
                               "test_native_bin_location",
                               lambda arg: True,
                               "Error setting test_native_bin_location")
+
+    coreclr_setup_args.verify(args,
+                              "run_in_context",
+                              lambda arg: True,
+                              "Error setting run_in_context")
 
     is_same_os = False
     is_same_arch = False
@@ -2379,7 +2393,8 @@ def do_setup(host_os,
                      run_crossgen_tests=unprocessed_args.run_crossgen_tests,
                      large_version_bubble=unprocessed_args.large_version_bubble,
                      run_sequential=unprocessed_args.sequential,
-                     limited_core_dumps=unprocessed_args.limited_core_dumps)
+                     limited_core_dumps=unprocessed_args.limited_core_dumps,
+                     run_in_context=unprocessed_args.run_in_context)
 
 ################################################################################
 # Main

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -42,6 +42,7 @@ function print_usage {
     echo '  --xunitOutputPath=<path>         : Create xUnit XML report at the specifed path (default: <test root>/coreclrtests.xml)'
     echo '  --buildXUnitWrappers             : Force creating the xunit wrappers, this is useful if there have been changes to issues.targets'
     echo '  --printLastResultsOnly           : Print the results of the last run'
+    echo '  --runincontext                   : Run each tests in an unloadable AssemblyLoadContext'
     echo ''
     echo 'CoreFX Test Options '
     echo '  --corefxtests                    : Runs CoreFX tests'
@@ -225,6 +226,7 @@ printLastResultsOnly=
 generateLayoutOnly=
 generateLayout=
 runSequential=0
+runincontext=0
 
 for i in "$@"
 do
@@ -398,6 +400,9 @@ do
         --xunitOutputPath=*)
             xunitOutputPath=${i#*=}
             ;;
+        --runincontext)
+            runincontext=1
+            ;;
         *)
             echo "Unknown switch: $i"
             print_usage
@@ -556,6 +561,11 @@ fi
 
 if [ "$limitedCoreDumps" == "ON" ]; then
     runtestPyArguments+=("--limited_core_dumps")
+fi
+
+if [[ ! "$runincontext" -eq 0 ]]; then
+    echo "Running in an unloadable AssemblyLoadContext"
+    runtestPyArguments+=("--run_in_context")
 fi
 
 # Default to python3 if it is installed

--- a/tests/scripts/runincontext.sh
+++ b/tests/scripts/runincontext.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# This script is a bridge that allows .cmd files of individual tests to run the respective test executables
+# in an unloadable AssemblyLoadContext.
+#
+# To use this script, set the CLRCustomTestLauncher environment variable to the full path of this script.
+#
+# Additional command line arguments can be passed to the runincontext tool by setting the RunInContextExtraArgs
+# environment variable
+#
+# The .cmd files of the individual tests will call this script to launch the test.
+# This script gets the following arguments
+# 1. Full path to the directory of the test binaries (the test .sh file is in there)
+# 2. Filename of the test executable
+# 3. - n. Additional arguments that were passed to the test .sh
+
+export CORE_LIBRARIES=$1
+$_DebuggerFullPath "$CORE_ROOT/corerun" "$CORE_ROOT/../../runincontext/runincontext/runincontext.exe" $RunInContextExtraArgs /referencespath:$CORE_ROOT/ $1$2 $3 $4 $5 $6 $7 $8 $9

--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -79,6 +79,14 @@ then
   exit $(GCBashScriptExitCode)
 fi
       ]]></BashCLRTestEnvironmentCompatibilityCheck>
+      <BashCLRTestEnvironmentCompatibilityCheck Condition="'$(UnloadabilityIncompatible)' == 'true'"><![CDATA[
+$(BashCLRTestEnvironmentCompatibilityCheck)
+if [ ! -z "$__RunInUnloadableContext" ]
+then
+  echo SKIPPING EXECUTION BECAUSE the test is incompatible with unloadability
+  exit $(GCBashScriptExitCode)
+fi
+      ]]></BashCLRTestEnvironmentCompatibilityCheck>
       <BashCLRTestEnvironmentCompatibilityCheck Condition="'$(JitOptimizationSensitive)' == 'true'">
     <![CDATA[
 $(BashCLRTestEnvironmentCompatibilityCheck)
@@ -152,7 +160,7 @@ fi
         <HasParam>true</HasParam>
         <ParamText>=*</ParamText> <!-- Bash specific -->
         <ParamName>coreRootFullPath</ParamName>
-        <Command><![CDATA[        CORE_ROOT="${i#*=}"]]></Command>
+        <Command><![CDATA[        export CORE_ROOT="${i#*=}"]]></Command>
         <Description>Set CORE_ROOT to the specified value before running the test.</Description>
       </BashCLRTestExecutionScriptArgument>
     </ItemGroup>
@@ -255,8 +263,17 @@ $(BashCLRTestLaunchCmds)
 if [ ! -z ${RunCrossGen+x} ]%3B then
   TakeLock
 fi
-echo $_DebuggerFullPath $(_CLRTestRunFile) $ExePath $CLRTestExecutionArguments 
-$_DebuggerFullPath $(_CLRTestRunFile) $ExePath $CLRTestExecutionArguments 
+
+if [ ! -z "$CLRCustomTestLauncher" ];
+then
+    LAUNCHER="$CLRCustomTestLauncher $PWD/"
+else
+    LAUNCHER="$_DebuggerFullPath $(_CLRTestRunFile)"
+fi
+
+echo $LAUNCHER $ExePath $CLRTestExecutionArguments
+$LAUNCHER $ExePath $CLRTestExecutionArguments
+
 CLRTestExitCode=$?
 if [ ! -z ${RunCrossGen+x} ]%3B then
   ReleaseLock

--- a/tests/src/CLRTest.Execute.Batch.targets
+++ b/tests/src/CLRTest.Execute.Batch.targets
@@ -76,6 +76,14 @@ IF NOT "%COMPlus_GCStress%"=="" (
   Exit /b 0
 )
       ]]></BatchCLRTestEnvironmentCompatibilityCheck>
+      <BatchCLRTestEnvironmentCompatibilityCheck Condition="'$(UnloadabilityIncompatible)' == 'true'"><![CDATA[
+$(BatchCLRTestEnvironmentCompatibilityCheck)
+IF NOT "%__RunInUnloadableContext%"=="" (
+  ECHO SKIPPING EXECUTION BECAUSE the test is incompatible with unloadability
+  popd
+  Exit /b 0
+)
+      ]]></BatchCLRTestEnvironmentCompatibilityCheck>
       <BatchCLRTestEnvironmentCompatibilityCheck Condition="'$(JitOptimizationSensitive)' == 'true'">
     <![CDATA[
 $(BatchCLRTestEnvironmentCompatibilityCheck)
@@ -162,6 +170,7 @@ Exit /b 0
         <Command><![CDATA[
     IF EXIST "%2" (
         set _DebuggerFullPath=%2
+        shift
     ) ELSE (
         ECHO The Debugger FullPath "%2" doesn't exist
         GOTO :USAGE
@@ -246,7 +255,7 @@ IF defined DoLink (
     copy *.txt %LinkBin% > nul 2> nul
 
     set ExePath=%LinkBin%\$(InputAssemblyName)
-    set CORE_ROOT=%~dp0%LinkBin%
+    set CORE_ROOT=%scriptPath%LinkBin%
 )
 ]]>
           </BatchLinkerTestLaunchCmds>
@@ -272,7 +281,7 @@ COPY /y %CORE_ROOT%\CoreShim.dll .
       ]]></BatchCopyCoreShimLocalCmds>
       <BatchCLRTestLaunchCmds><![CDATA[
 IF NOT "%CLRCustomTestLauncher%"=="" (
-  set LAUNCHER=call %CLRCustomTestLauncher% %~dp0
+  set LAUNCHER=call %CLRCustomTestLauncher% %scriptPath%
 ) ELSE (
   set LAUNCHER=%_DebuggerFullPath% $(_CLRTestRunFile)
 )
@@ -377,6 +386,7 @@ $(BatchCLRTestArgPrep)
 setlocal ENABLEDELAYEDEXPANSION
 set "lockFolder=%~dp0\lock"
 pushd %~dp0
+set "scriptPath=%~dp0"
 
 $(BatchCLRTestArgPrep)
 $(BatchCLRTestExitCodePrep)

--- a/tests/src/CoreMangLib/system/span/RefStructWithSpan.csproj
+++ b/tests/src/CoreMangLib/system/span/RefStructWithSpan.csproj
@@ -14,6 +14,8 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- Secondary threads with infinite loop prevent unloading -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>

--- a/tests/src/GC/Features/HeapExpansion/bestfit-finalize.csproj
+++ b/tests/src/GC/Features/HeapExpansion/bestfit-finalize.csproj
@@ -10,6 +10,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- The test timeouts when running tests in parallel -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Features/HeapExpansion/pluggaps.csproj
+++ b/tests/src/GC/Features/HeapExpansion/pluggaps.csproj
@@ -11,6 +11,8 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <GCStressIncompatible>true</GCStressIncompatible>
     <HeapVerifyIncompatible>true</HeapVerifyIncompatible>
+    <!-- This test timeouts (but completes if given a long time) if running with other tests in parallel -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Regressions/v2.0-beta1/149926/149926.csproj
+++ b/tests/src/GC/Regressions/v2.0-beta1/149926/149926.csproj
@@ -10,6 +10,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- The test sometimes timeouts when running in parallel with other tests -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/GC/Scenarios/BinTree/thdtree.csproj
+++ b/tests/src/GC/Scenarios/BinTree/thdtree.csproj
@@ -10,6 +10,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- The test leaves threads running at exit -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/BinTree/thdtreegrowingobj.csproj
+++ b/tests/src/GC/Scenarios/BinTree/thdtreegrowingobj.csproj
@@ -10,6 +10,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- The test leaves threads running at exit -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/BinTree/thdtreelivingobj.csproj
+++ b/tests/src/GC/Scenarios/BinTree/thdtreelivingobj.csproj
@@ -10,6 +10,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- The test leaves threads running at exit -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/GC/Scenarios/FinalizeTimeout/FinalizeTimeout.csproj
+++ b/tests/src/GC/Scenarios/FinalizeTimeout/FinalizeTimeout.csproj
@@ -8,6 +8,7 @@
     <ProjectGuid>{3B0E8096-79D4-413F-9010-F68DF90073B5}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">

--- a/tests/src/GC/Scenarios/LeakGen/leakgenthrd.csproj
+++ b/tests/src/GC/Scenarios/LeakGen/leakgenthrd.csproj
@@ -10,6 +10,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- The test leaves secondary threads running at exit -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/GC/Scenarios/THDList/thdlist.csproj
+++ b/tests/src/GC/Scenarios/THDList/thdlist.csproj
@@ -10,6 +10,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- This test leaves threads running at exit -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/Interop/COM/NETClients/Aggregation/NETClientAggregation.csproj
+++ b/tests/src/Interop/COM/NETClients/Aggregation/NETClientAggregation.csproj
@@ -20,6 +20,8 @@
     <!-- Test unsupported outside of windows -->
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>
+    <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">

--- a/tests/src/Interop/COM/NETClients/IDispatch/NETClientIDispatch.csproj
+++ b/tests/src/Interop/COM/NETClients/IDispatch/NETClientIDispatch.csproj
@@ -20,6 +20,8 @@
     <!-- Test unsupported outside of windows -->
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>
+    <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">

--- a/tests/src/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
+++ b/tests/src/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
@@ -19,6 +19,8 @@
 
     <!-- Test unsupported outside of windows -->
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
+    <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/Interop/COM/NETClients/Primitives/NETClientPrimitivesInALC.csproj
+++ b/tests/src/Interop/COM/NETClients/Primitives/NETClientPrimitivesInALC.csproj
@@ -20,6 +20,8 @@
     <!-- Test unsupported outside of windows -->
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>
+    <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">

--- a/tests/src/Interop/ICustomMarshaler/ConflictingNames/MultipleALCs.csproj
+++ b/tests/src/Interop/ICustomMarshaler/ConflictingNames/MultipleALCs.csproj
@@ -11,6 +11,7 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>

--- a/tests/src/Interop/ICustomMarshaler/ConflictingNames/SameNameDifferentAssembly.csproj
+++ b/tests/src/Interop/ICustomMarshaler/ConflictingNames/SameNameDifferentAssembly.csproj
@@ -11,6 +11,7 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>

--- a/tests/src/Interop/ICustomMarshaler/Primitives/ICustomMarshaler.csproj
+++ b/tests/src/Interop/ICustomMarshaler/Primitives/ICustomMarshaler.csproj
@@ -11,6 +11,8 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants Condition="'$(TargetsWindows)' == 'true'">$(DefineConstants);Windows</DefineConstants>
+    <!-- The test uses xunit directly and it fails to find the test assembly for some reason -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>

--- a/tests/src/Interop/NativeLibraryResolveEvent/ResolveEventTests.csproj
+++ b/tests/src/Interop/NativeLibraryResolveEvent/ResolveEventTests.csproj
@@ -12,6 +12,8 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceSystemPrivateCoreLib>true</ReferenceSystemPrivateCoreLib>
+    <!-- The test leaves AssemblyLoadContext.Default.ResolvingUnmanagedDll event registered to a method in the test at exit -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">

--- a/tests/src/Interop/PInvoke/Delegate/MarshalDelegateAsParam/AsInterface/AsInterfaceTest.csproj
+++ b/tests/src/Interop/PInvoke/Delegate/MarshalDelegateAsParam/AsInterface/AsInterfaceTest.csproj
@@ -15,6 +15,8 @@
     <!-- Test unsupported outside of windows -->
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>
+    <!-- RefCounted handle holding a delegate in the test alive at exit -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'"></PropertyGroup>

--- a/tests/src/Interop/PInvoke/DllImportPath/DllImportPathTest.csproj
+++ b/tests/src/Interop/PInvoke/DllImportPath/DllImportPathTest.csproj
@@ -11,6 +11,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
+    <!-- The test cannot be run twice in the same process since it moves a native dll that it uses for pinvoke later -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'"></PropertyGroup>

--- a/tests/src/Interop/PInvoke/IEnumerator/IEnumeratorTest.csproj
+++ b/tests/src/Interop/PInvoke/IEnumerator/IEnumeratorTest.csproj
@@ -17,6 +17,8 @@
     <!-- IEnumerator/IEnumerable marshalling unsupported outside of windows -->
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>
+    <!-- RefCounted handle to System.Runtime.InteropServices.CustomMarshalers.EnumVariantViewOfEnumerator holds the LoaderAllocator alive via System.Linq.Enumerable+RangeIterator -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'"></PropertyGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/Avx2_r.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/Avx2_r.csproj
@@ -10,6 +10,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- It takes a long time to complete (on a non-AVX machine) -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>

--- a/tests/src/JIT/HardwareIntrinsics/X86/Avx2/Avx2_ro.csproj
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Avx2/Avx2_ro.csproj
@@ -10,6 +10,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- It takes a long time to complete (on a non-AVX machine) -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>

--- a/tests/src/JIT/Methodical/Boxing/misc/_dbgconcurgc_il.ilproj
+++ b/tests/src/JIT/Methodical/Boxing/misc/_dbgconcurgc_il.ilproj
@@ -11,6 +11,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <!-- The test leaves a secondary thread running -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/JIT/Methodical/Boxing/misc/_relconcurgc_il.ilproj
+++ b/tests/src/JIT/Methodical/Boxing/misc/_relconcurgc_il.ilproj
@@ -11,6 +11,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <!-- The test leaves a secondary thread running -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/JIT/Methodical/cctor/misc/threads2_cs_do.csproj
+++ b/tests/src/JIT/Methodical/cctor/misc/threads2_cs_do.csproj
@@ -10,6 +10,7 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/JIT/Methodical/explicit/basic/_dbgrefarg_i1.csproj
+++ b/tests/src/JIT/Methodical/explicit/basic/_dbgrefarg_i1.csproj
@@ -10,6 +10,8 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <!-- TestAssemblyLoadContext.Load called from the finalizer -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/JIT/Methodical/explicit/basic/_relrefarg_i1.csproj
+++ b/tests/src/JIT/Methodical/explicit/basic/_relrefarg_i1.csproj
@@ -10,6 +10,8 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <!-- TestAssemblyLoadContext.Load called from the finalizer -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/JIT/Performance/CodeQuality/Bytemark/Bytemark.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/Bytemark/Bytemark.csproj
@@ -12,6 +12,8 @@
     <NuGetTargetMoniker>.NETStandard,Version=v1.4</NuGetTargetMoniker>
     <NuGetTargetMonikerShort>netstandard1.4</NuGetTargetMonikerShort>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- This test takes a very long time when run with runincontext -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13621/b13621.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13621/b13621.csproj
@@ -10,6 +10,7 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-QFE/b151440/static-none.ilproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-QFE/b151440/static-none.ilproj
@@ -10,6 +10,8 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <!-- This is failing due to the fact that it compares main arguments with the GetCommandLineArgs function result -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1.1-M1-Beta1/b143840/b143840.ilproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1.1-M1-Beta1/b143840/b143840.ilproj
@@ -11,6 +11,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- This test leaves threads running at exit -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>

--- a/tests/src/JIT/Regression/VS-ia64-JIT/M00/b113493/b113493.csproj
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/M00/b113493/b113493.csproj
@@ -10,6 +10,8 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <!-- This test leaves threads running at exit -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/superpmi/superpmicollect.csproj
+++ b/tests/src/JIT/superpmi/superpmicollect.csproj
@@ -12,6 +12,8 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <GCStressIncompatible>true</GCStressIncompatible>
     <CrossGenTest>false</CrossGenTest>
+    <!-- This test takes a long time to complete -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/Loader/AssemblyDependencyResolverTests/AssemblyDependencyResolverTests.csproj
+++ b/tests/src/Loader/AssemblyDependencyResolverTests/AssemblyDependencyResolverTests.csproj
@@ -8,6 +8,8 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <!-- The test fails if ran twice in the same process. In one of the test cases, it expects a hostpolicy to not to be found, but it actually is found in the second pass -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DefineConstants Condition="$(OSGroup) == 'Windows_NT'">WINDOWS</DefineConstants>

--- a/tests/src/Loader/NativeLibs/FromNativePaths.csproj
+++ b/tests/src/Loader/NativeLibs/FromNativePaths.csproj
@@ -7,6 +7,8 @@
     <AssemblyName>FromNativePaths</AssemblyName>
     <ProjectGuid>{649A239B-AB4B-4E20-BDCA-3BA736E8B790}</ProjectGuid>
     <OutputType>Exe</OutputType>
+    <!-- The test cannot be run twice in the same process since it moves a native dll that it uses for pinvoke later -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/Loader/regressions/polyrec/Polyrec.csproj
+++ b/tests/src/Loader/regressions/polyrec/Polyrec.csproj
@@ -13,6 +13,8 @@
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
     <CLRTestExecutionArguments>4 50</CLRTestExecutionArguments>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- This test leaves threads running at exit -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'"></PropertyGroup>

--- a/tests/src/baseservices/compilerservices/FixedAddressValueType/FixedAddressValueType.csproj
+++ b/tests/src/baseservices/compilerservices/FixedAddressValueType/FixedAddressValueType.csproj
@@ -13,6 +13,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GCStressIncompatible>true</GCStressIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- FixedAddressValueTypeAttribute is not supported on collectible types -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>

--- a/tests/src/baseservices/compilerservices/dynamicobjectproperties/test448035.csproj
+++ b/tests/src/baseservices/compilerservices/dynamicobjectproperties/test448035.csproj
@@ -11,6 +11,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>BuildAndRun</CLRTestKind>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/baseservices/compilerservices/modulector/runmoduleconstructor.cs
+++ b/tests/src/baseservices/compilerservices/modulector/runmoduleconstructor.cs
@@ -13,7 +13,7 @@ class RuntimeHelperTest
 {
     public static int Main(string[] args)
     {
-        AssemblyLoadContext resolver0 = AssemblyLoadContext.Default;
+        AssemblyLoadContext resolver0 = AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly());
         Assembly asm0 = resolver0.LoadFromAssemblyName(new AssemblyName("moduleCctor"));
         Module mod = asm0.ManifestModule;
         

--- a/tests/src/baseservices/exceptions/WindowsEventLog/WindowsEventLog.csproj
+++ b/tests/src/baseservices/exceptions/WindowsEventLog/WindowsEventLog.csproj
@@ -13,6 +13,7 @@
 
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
     <DefineConstants Condition="$(OSGroup) == 'Windows_NT'">WINDOWS</DefineConstants>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">

--- a/tests/src/baseservices/exceptions/regressions/V1/SEH/VJ/ExternalException.csproj
+++ b/tests/src/baseservices/exceptions/regressions/V1/SEH/VJ/ExternalException.csproj
@@ -13,6 +13,8 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- This test leaves secondary threads running at exit -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/exceptions/regressions/V1/SEH/VJ/UserExceptionThread.csproj
+++ b/tests/src/baseservices/exceptions/regressions/V1/SEH/VJ/UserExceptionThread.csproj
@@ -11,6 +11,8 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>BuildAndRun</CLRTestKind>
+    <!-- This test leaves secondary threads running at exit -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/baseservices/exceptions/stacktrace/Tier1StackTrace.csproj
+++ b/tests/src/baseservices/exceptions/stacktrace/Tier1StackTrace.csproj
@@ -10,6 +10,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- The stack trace of the two tiers sometimes differ (one is missing System.Reflection.MethodBase.Invoke between 
+    TestRunner.ExecuteAssemblyEntryPoint and System.Reflection.RuntimeMethodInfo.Invoke -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">

--- a/tests/src/baseservices/threading/monitor/enter/monitorenter.csproj
+++ b/tests/src/baseservices/threading/monitor/enter/monitorenter.csproj
@@ -9,6 +9,8 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <!-- The ThreadIdPosTests test fails when run multiple times in the same process as thread ids get recycled -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/baseservices/threading/mutex/abandonedmutex/am05waitanymutex.csproj
+++ b/tests/src/baseservices/threading/mutex/abandonedmutex/am05waitanymutex.csproj
@@ -12,6 +12,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <CLRTestExecutionArguments>/size:64 /pos:63</CLRTestExecutionArguments>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- The test leaves secondary thread running at exit -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
 
     <!-- Test unsupported outside of windows -->
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>

--- a/tests/src/baseservices/threading/mutex/abandonedmutex/am07abandonmultiplemutex.csproj
+++ b/tests/src/baseservices/threading/mutex/abandonedmutex/am07abandonmultiplemutex.csproj
@@ -11,6 +11,8 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <CLRTestPriority>1</CLRTestPriority>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- The test leaves secondary thread running at exit -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
 
     <!-- Test unsupported outside of windows -->
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>

--- a/tests/src/baseservices/threading/mutex/abandonedmutex/am08mixedarray.csproj
+++ b/tests/src/baseservices/threading/mutex/abandonedmutex/am08mixedarray.csproj
@@ -11,6 +11,8 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <CLRTestPriority>1</CLRTestPriority>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- The test leaves secondary thread running at exit -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
 
     <!-- Test unsupported outside of windows -->
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>

--- a/tests/src/baseservices/threading/regressions/13662/13662-a.csproj
+++ b/tests/src/baseservices/threading/regressions/13662/13662-a.csproj
@@ -9,6 +9,8 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <!-- Under heavy load, some of the TimerCallback functions don't complete before the test exits, preventing unload -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/baseservices/threading/regressions/13662/13662-b.csproj
+++ b/tests/src/baseservices/threading/regressions/13662/13662-b.csproj
@@ -9,6 +9,8 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <!-- Under heavy load, some of the TimerCallback functions don't complete before the test exits, preventing unload -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/baseservices/threading/regressions/13662/13662-simple.csproj
+++ b/tests/src/baseservices/threading/regressions/13662/13662-simple.csproj
@@ -9,6 +9,8 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <!-- Under heavy load, some of the TimerCallback functions don't complete before the test exits, preventing unload -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/baseservices/threading/regressions/beta2/437017.csproj
+++ b/tests/src/baseservices/threading/regressions/beta2/437017.csproj
@@ -9,6 +9,8 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <!-- This test leaves random number of WaitOrTimerCallbacks registered at the exit, which prevents unloading -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/baseservices/threading/waithandle/waitall/waitallex8.csproj
+++ b/tests/src/baseservices/threading/waithandle/waitall/waitallex8.csproj
@@ -11,6 +11,8 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <CLRTestPriority>1</CLRTestPriority>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- This test leaves threads running at exit -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
 
     <!-- Test unsupported outside of windows -->
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>

--- a/tests/src/baseservices/threading/waithandle/waitall/waitallex8a.csproj
+++ b/tests/src/baseservices/threading/waithandle/waitall/waitallex8a.csproj
@@ -11,6 +11,8 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <CLRTestPriority>1</CLRTestPriority>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- This test leaves threads running at exit -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
 
     <!-- Test unsupported outside of windows -->
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>

--- a/tests/src/baseservices/threading/waithandle/waitany/waitanyex10.csproj
+++ b/tests/src/baseservices/threading/waithandle/waitany/waitanyex10.csproj
@@ -12,6 +12,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <CLRTestExecutionArguments>/size:2 /pos:1</CLRTestExecutionArguments>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- This test leaves threads running at exit -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
 
     <!-- Test unsupported outside of windows -->
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>

--- a/tests/src/baseservices/threading/waithandle/waitany/waitanyex10a.csproj
+++ b/tests/src/baseservices/threading/waithandle/waitany/waitanyex10a.csproj
@@ -12,6 +12,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <CLRTestExecutionArguments>/size:2 /pos:1</CLRTestExecutionArguments>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- This test leaves threads running at exit -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/readytorun/DynamicMethodGCStress/DynamicMethodGCStress.csproj
+++ b/tests/src/readytorun/DynamicMethodGCStress/DynamicMethodGCStress.csproj
@@ -9,6 +9,8 @@
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
+    <!-- This test has a secondary thread with an infinite loop -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">

--- a/tests/src/readytorun/tests/main.cs
+++ b/tests/src/readytorun/tests/main.cs
@@ -331,7 +331,9 @@ class Program
 #if CORECLR
     class MyLoadContext : AssemblyLoadContext
     {
-        public MyLoadContext()
+        // If running in a collectible context, make the MyLoadContext collectible too so that it doesn't prevent
+        // unloading.
+        public MyLoadContext() : base(AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly()).IsCollectible)
         {
         }
 

--- a/tests/src/tracing/runtimeeventsource/runtimeeventsource.csproj
+++ b/tests/src/tracing/runtimeeventsource/runtimeeventsource.csproj
@@ -14,6 +14,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- This test has a secondary thread with an infinite loop -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">

--- a/tests/src/tracing/tracevalidation/inducedgc/inducedgc.csproj
+++ b/tests/src/tracing/tracevalidation/inducedgc/inducedgc.csproj
@@ -13,6 +13,8 @@
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
     <CLRTestPriority>0</CLRTestPriority>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- Due to https://github.com/dotnet/coreclr/issues/22247 -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'"></PropertyGroup>

--- a/tests/src/tracing/tracevalidation/jittingstarted/JittingStarted.csproj
+++ b/tests/src/tracing/tracevalidation/jittingstarted/JittingStarted.csproj
@@ -13,6 +13,8 @@
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
     <CLRTestPriority>0</CLRTestPriority>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- Due to https://github.com/dotnet/coreclr/issues/22247 -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'"></PropertyGroup>

--- a/tests/src/tracing/tracevalidation/rundown/rundown.csproj
+++ b/tests/src/tracing/tracevalidation/rundown/rundown.csproj
@@ -13,6 +13,8 @@
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
     <CLRTestPriority>0</CLRTestPriority>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- Due to https://github.com/dotnet/coreclr/issues/22247 -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'"></PropertyGroup>


### PR DESCRIPTION
This change adds new "runincontext" option to the tests/runtest.cmd/sh that
allows running tests inside of an unloadable AssemblyLoadContext.
It also adds new property that allows tests to be marked as incompatible
with running this way. All known tests that have such issue are marked
in this PR too.
The Unix generated test .sh were missing support for external test launcher that was 
present in the generated windows .cmd files and that I am using, so I've added that
to those too.
It also fixes couple of bugs in the generated test .cmd fil