### PR TITLE
Exclude RecursiveException and MultipleException from GCStress runs.

### DIFF
--- a/tests/src/baseservices/exceptions/regressions/V1/SEH/VJ/MultipleException.csproj
+++ b/tests/src/baseservices/exceptions/regressions/V1/SEH/VJ/MultipleException.csproj
@@ -12,6 +12,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- Issue #22339 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/exceptions/regressions/V1/SEH/VJ/RecursiveException.csproj
+++ b/tests/src/baseservices/exceptions/regressions/V1/SEH/VJ/RecursiveException.csproj
@@ -12,6 +12,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- Issue #22339 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
Fixes #20460.

Revert this PR if #22339 is fixed.