### PR TITLE
Ensure method is active in PrepareMethod

### DIFF
--- a/src/vm/reflectioninvocation.cpp
+++ b/src/vm/reflectioninvocation.cpp
@@ -1944,6 +1944,8 @@ static void PrepareMethodHelper(MethodDesc * pMD)
 
     GCX_PREEMP();
 
+    pMD->EnsureActive();
+
     if (pMD->IsPointingToPrestub())
         pMD->DoPrestub(NULL);
 


### PR DESCRIPTION
Fixes an assert when first call to PrepareMethod for an assembly
is an interop method.