### PR TITLE
Remove stale warning 420 pragmas

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Lazy.cs
+++ b/src/System.Private.CoreLib/shared/System/Lazy.cs
@@ -10,8 +10,6 @@
 //
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-#pragma warning disable 0420
-
 using System.Diagnostics;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/Future.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/Future.cs
@@ -15,9 +15,6 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 
-// Disable the "reference to volatile field not treated as volatile" error.
-#pragma warning disable 0420
-
 namespace System.Threading.Tasks
 {
     /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/Task.cs
@@ -23,9 +23,6 @@ using Internal.Runtime.CompilerServices;
 using Thread = Internal.Runtime.Augments.RuntimeThread;
 #endif
 
-// Disable the "reference to volatile field not treated as volatile" error.
-#pragma warning disable 0420
-
 namespace System.Threading.Tasks
 {
     /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskCompletionSource.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskCompletionSource.cs
@@ -18,9 +18,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 
-// Disable the "reference to volatile field not treated as volatile" error.
-#pragma warning disable 0420
-
 namespace System.Threading.Tasks
 {
     /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskExceptionHolder.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskExceptionHolder.cs
@@ -10,9 +10,6 @@
 //
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-// Disable the "reference to volatile field not treated as volatile" error.
-#pragma warning disable 0420
-
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskScheduler.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskScheduler.cs
@@ -9,8 +9,6 @@
 // This file contains the primary interface and management of tasks and queues.  
 //
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-// Disable the "reference to volatile field not treated as volatile" error.
-#pragma warning disable 0420
 
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/System.Private.CoreLib/shared/System/TimeZoneInfo.Win32.cs
+++ b/src/System.Private.CoreLib/shared/System/TimeZoneInfo.Win32.cs
@@ -38,7 +38,6 @@ namespace System
 
         private const int MaxKeyLength = 255;
 
-#pragma warning disable 0420
         private sealed partial class CachedData
         {
             private static TimeZoneInfo GetCurrentOneYearLocal()
@@ -66,7 +65,6 @@ namespace System
                 return oneYearLocFromUtc;
             }
         }
-#pragma warning restore 0420
 
         private sealed class OffsetAndRule
         {

--- a/src/System.Private.CoreLib/shared/System/TimeZoneInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/TimeZoneInfo.cs
@@ -61,7 +61,6 @@ namespace System
         // For example, TimeZoneInfo.Local can be cleared by another thread calling TimeZoneInfo.ClearCachedData. Without the consistent snapshot,
         // there is a chance that the internal ConvertTime calls will throw since 'source' won't be reference equal to the new TimeZoneInfo.Local.
         //
-#pragma warning disable 0420
         private sealed partial class CachedData
         {
             private volatile TimeZoneInfo _localTimeZone;
@@ -139,7 +138,6 @@ namespace System
             public ReadOnlyCollection<TimeZoneInfo> _readOnlySystemTimeZones;
             public bool _allSystemTimeZonesRead;
         };
-#pragma warning restore 0420
 
         // used by GetUtcOffsetFromUtc (DateTime.Now, DateTime.ToLocalTime) for max/min whole-day range checks
         private static readonly DateTime s_maxDateOnly = new DateTime(9999, 12, 31);


### PR DESCRIPTION
It used to be that the CS0420 warning ("a reference to a volatile field will not be treated as volatile") would fire when a volatile was used with an Interlocked.* operation.  That warning was unnecessary, as Interlocked.* would itself provide the relevant barriers, and these functions were special cased in Roslyn a long time ago.  But there are still lots of places where pragmas disabling the warning have stuck around.  I'm deleting them all.