### PR TITLE
Correctly error out gracefully on setup-stress-dependencies when libcoredistools isn't available.

### DIFF
--- a/tests/setup-stress-dependencies.sh
+++ b/tests/setup-stress-dependencies.sh
@@ -117,7 +117,7 @@ fi
 
 # Get library path
 libPath=`find $packageDir | grep $rid | grep -m 1 libcoredistools`
-if [ ! -e $libPath ]; then
+if [ ! -e $libPath ] || [ -z "$libpath" ]; then
     exit_with_error 1 'Failed to locate the downloaded library'
 fi
 


### PR DESCRIPTION
Right now `setup-stress-dependencies.sh` only errors out if the retrieved path doesn't exist. However, it doesn't error out if the path is empty. This change enables it to error out gracefully on an empty path.