### PR TITLE
Force results of rejected multi-reg-returning tail-call candidates to temp.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8258,21 +8258,32 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
                 // Create a new temp.
                 unsigned tmpNum =
                     lvaGrabTemp(false DEBUGARG("Return value temp for multi-reg return (rejected tail call)."));
-                const bool unsafeValueClsCheck = false;
-                lvaSetStruct(tmpNum, call->gtRetClsHnd, unsafeValueClsCheck);
                 lvaTable[tmpNum].lvIsMultiRegRet = true;
 
-                // Create the assignment tree and morph it.
-                var_types structType = lvaTable[tmpNum].lvType;
-                GenTree*  dst        = gtNewLclvNode(tmpNum, structType);
-                GenTree*  assg       = fgMorphTree(gtNewAssignNode(dst, call));
+                GenTree* assg = nullptr;
+                if (varTypeIsStruct(callType))
+                {
+                    CORINFO_CLASS_HANDLE structHandle = call->gtRetClsHnd;
+                    assert(structHandle != NO_CLASS_HANDLE);
+                    const bool unsafeValueClsCheck = false;
+                    lvaSetStruct(tmpNum, structHandle, unsafeValueClsCheck);
+                    var_types structType = lvaTable[tmpNum].lvType;
+                    GenTree*  dst        = gtNewLclvNode(tmpNum, structType);
+                    assg                 = gtNewAssignNode(dst, call);
+                }
+                else
+                {
+                    assg = gtNewTempAssign(tmpNum, call);
+                }
+
+                assg = fgMorphTree(assg);
 
                 // Create the assignment statement and insert it before the current statement.
                 GenTree* assgStmt = gtNewStmt(assg, compCurStmt->AsStmt()->gtStmtILoffsx);
                 fgInsertStmtBefore(compCurBB, compCurStmt, assgStmt);
 
                 // Return the temp.
-                GenTree* result = gtNewLclvNode(tmpNum, structType);
+                GenTree* result = gtNewLclvNode(tmpNum, lvaTable[tmpNum].lvType);
                 result->gtFlags |= GTF_DONT_CSE;
 
 #ifdef DEBUG

--- a/tests/src/JIT/Regression/JitBlue/GitHub_20269/GitHub_20269.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_20269/GitHub_20269.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Numerics;
+
+namespace GitHub_20269
+{
+    // This tests a case where 
+    // 1) We merge returns.
+    // 2) One of the returns has an operand that is a call to a multi-reg returning method.
+    // 3) The call is marked as a tail-call candidate in the importer.
+    // 3) The tail call is rejected late in morph.
+    // 
+
+    class Program
+    {
+        static int i;
+        static int Main(string[] args)
+        {
+            i = 1;
+            return (int)new Program().GetVector()[0] + 99;
+        }
+
+        public virtual Vector<float> GetVector()
+        {
+            // Address-taken local prevents tail-calling
+            // GetVectorHelper.
+            int x = 0;
+            DoNothing(ref x);
+
+            // 5 returns are needed to trigger merge of returns
+            switch(i)
+            {
+                case 1:
+                    // This call is a tail-call candidate rejected late.
+                    return GetVectorHelper();
+
+                case 2:
+                    return new Vector<float>(2.0f);
+
+                case 3:
+                    return new Vector<float>(3.0f);
+
+                case 4:
+                    return new Vector<float>(4.0f);
+
+                default:
+                    return new Vector<float>(100.0f);
+
+            }
+        }
+
+        // This is a multi-reg return method on ARM64
+        public virtual Vector<float> GetVectorHelper()
+        {
+            return new Vector<float>(1.0f);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void DoNothing(ref int i)
+        {
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_20269/GitHub_20269.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_20269/GitHub_20269.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Issue #20269 ran into an assert when trying to merge returns, one of which
is a call to a multi-reg-returning method. The repro in the bug is a pmi
of `System.Reflection.Metadata`. I added a simple repro test case.

Results of calls to multi-reg-returning methods are expected to
be saved to temps. Normally it's ensured by `impFixupCallStructReturn`;
however, it doesn't do that for tail-call candidates.

This change forces results of calls to multi-reg-returning methods
to temps if the tail call is rejected late in morph.

Fixes #20269.