### PR TITLE
Fix arm32 unwind for large methods

### DIFF
--- a/src/vm/codeman.cpp
+++ b/src/vm/codeman.cpp
@@ -3914,8 +3914,10 @@ PTR_RUNTIME_FUNCTION EEJitManager::LazyGetFunctionEntry(EECodeInfo * pCodeInfo)
         if (RUNTIME_FUNCTION__BeginAddress(pFunctionEntry) <= address && address < RUNTIME_FUNCTION__EndAddress(pFunctionEntry, baseAddress))
         {
 
-#if defined(EXCEPTION_DATA_SUPPORTS_FUNCTION_FRAGMENTS)
-            // If we may have fragmented unwind make sure we're returning the root record
+#if defined(EXCEPTION_DATA_SUPPORTS_FUNCTION_FRAGMENTS) && defined(_TARGET_ARM64_)
+            // If we might have fragmented unwind, and we're on ARM64, make sure
+            // to returning the root record, as the trailing records don't have
+            // prolog unwind codes.
             pFunctionEntry = FindRootEntry(pFunctionEntry, baseAddress);
 #endif
 

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -619,9 +619,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/doublearray/dblarray3_cs_r/*">
             <Issue>22015</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/opt/cse/hugeexpr1/*">
-            <Issue>22260</Issue>
-        </ExcludeList>
     </ItemGroup>
     
 


### PR DESCRIPTION
For arm32, the unwinder bails out with an error if the method offset is not
within the fragment range. And the jit copies prolog unwind codes to all
fragments, so there's no need to walk back and find the root unwind record.

Closes #22260.