### PR TITLE
Rename private GetEntryAssembly QCall overload

### DIFF
--- a/src/System.Private.CoreLib/src/System/Reflection/Assembly.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Assembly.CoreCLR.cs
@@ -211,12 +211,12 @@ namespace System.Reflection
         }
 
         [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
-        private static extern void GetExecutingAssembly(StackCrawlMarkHandle stackMark, ObjectHandleOnStack retAssembly);
+        private static extern void GetExecutingAssemblyNative(StackCrawlMarkHandle stackMark, ObjectHandleOnStack retAssembly);
 
         internal static RuntimeAssembly GetExecutingAssembly(ref StackCrawlMark stackMark)
         {
             RuntimeAssembly retAssembly = null;
-            GetExecutingAssembly(JitHelpers.GetStackCrawlMarkHandle(ref stackMark), JitHelpers.GetObjectHandleOnStack(ref retAssembly));
+            GetExecutingAssemblyNative(JitHelpers.GetStackCrawlMarkHandle(ref stackMark), JitHelpers.GetObjectHandleOnStack(ref retAssembly));
             return retAssembly;
         }
 
@@ -239,7 +239,7 @@ namespace System.Reflection
         }
 
         [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
-        private static extern void GetEntryAssembly(ObjectHandleOnStack retAssembly);
+        private static extern void GetEntryAssemblyNative(ObjectHandleOnStack retAssembly);
 
         // internal test hook
         private static bool s_forceNullEntryPoint = false;
@@ -250,7 +250,7 @@ namespace System.Reflection
                 return null;
 
             RuntimeAssembly entryAssembly = null;
-            GetEntryAssembly(JitHelpers.GetObjectHandleOnStack(ref entryAssembly));
+            GetEntryAssemblyNative(JitHelpers.GetObjectHandleOnStack(ref entryAssembly));
             return entryAssembly;
         }
 

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -540,8 +540,8 @@ FCFuncStart(gLoaderAllocatorFuncs)
 FCFuncEnd()
 
 FCFuncStart(gAssemblyFuncs)
-    QCFuncElement("GetEntryAssembly", AssemblyNative::GetEntryAssembly)
-    QCFuncElement("GetExecutingAssembly", AssemblyNative::GetExecutingAssembly)
+    QCFuncElement("GetEntryAssemblyNative", AssemblyNative::GetEntryAssembly)
+    QCFuncElement("GetExecutingAssemblyNative", AssemblyNative::GetExecutingAssembly)
 FCFuncEnd()
 
 FCFuncStart(gAssemblyBuilderFuncs)


### PR DESCRIPTION
To avoid issues with existing private reflection-based code that now gets a parameter count mismatch exception.

Fixes https://github.com/dotnet/corefx/issues/35068
cc: @jkotas