### PR TITLE
Fix marshalling UTF8 string struct member from native to managed.

### DIFF
--- a/src/vm/fieldmarshaler.cpp
+++ b/src/vm/fieldmarshaler.cpp
@@ -3300,7 +3300,7 @@ VOID FieldMarshaler_StringUtf8::UpdateCLRImpl(const VOID *pNativeValue, OBJECTRE
         MethodDescCallSite convertToManaged(METHOD__CUTF8MARSHALER__CONVERT_TO_MANAGED);
         ARG_SLOT args[] =
         {
-            PtrToArgSlot(pNativeValue),
+            PtrToArgSlot(sz),
         };
         pString = convertToManaged.Call_RetSTRINGREF(args);
     }

--- a/src/vm/fieldmarshaler.cpp
+++ b/src/vm/fieldmarshaler.cpp
@@ -3291,11 +3291,7 @@ VOID FieldMarshaler_StringUtf8::UpdateCLRImpl(const VOID *pNativeValue, OBJECTRE
 
     STRINGREF pString = NULL;
     LPCUTF8  sz = (LPCUTF8)MAYBE_UNALIGNED_READ(pNativeValue, _PTR);
-    if (!sz)
-    {
-        pString = NULL;
-    }
-    else
+    if (sz)
     {
         MethodDescCallSite convertToManaged(METHOD__CUTF8MARSHALER__CONVERT_TO_MANAGED);
         ARG_SLOT args[] =

--- a/tests/src/Interop/StringMarshalling/UTF8/UTF8Test.cs
+++ b/tests/src/Interop/StringMarshalling/UTF8/UTF8Test.cs
@@ -156,9 +156,11 @@ class UTF8StructMarshalling
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
          CompareWithUTF8Encoding();
 
-        SetStringInStruct(ref utf8Struct, "StructTestString");
+        string testString = "StructTestString\uD83D\uDE00";
 
-        if (utf8Struct.FirstName != "StructTestString")
+        SetStringInStruct(ref utf8Struct, testString);
+
+        if (utf8Struct.FirstName != testString)
         {
             throw new Exception("Incorrect UTF8 string marshalled back from native to managed.");
         }

--- a/tests/src/Interop/StringMarshalling/UTF8/UTF8Test.cs
+++ b/tests/src/Interop/StringMarshalling/UTF8/UTF8Test.cs
@@ -141,6 +141,9 @@ class UTF8StructMarshalling
     [DllImport("UTF8TestNative", CallingConvention = CallingConvention.Cdecl)]
     public static extern void TestStructWithUtf8Field(Utf8Struct utfStruct);
 
+    [DllImport("UTF8TestNative", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void SetStringInStruct(ref Utf8Struct utfStruct, [MarshalAs(UnmanagedType.LPUTF8Str)] string str);
+
     public static void TestUTF8StructMarshalling(string[] utf8Strings)
     {
         Utf8Struct utf8Struct = new Utf8Struct();
@@ -152,6 +155,13 @@ class UTF8StructMarshalling
         }
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
          CompareWithUTF8Encoding();
+
+        SetStringInStruct(ref utf8Struct, "StructTestString");
+
+        if (utf8Struct.FirstName != "StructTestString")
+        {
+            throw new Exception("Incorrect UTF8 string marshalled back from native to managed.");
+        }
    }
    
    unsafe static void CompareWithUTF8Encoding()

--- a/tests/src/Interop/StringMarshalling/UTF8/UTF8TestNative.cpp
+++ b/tests/src/Interop/StringMarshalling/UTF8/UTF8TestNative.cpp
@@ -234,6 +234,16 @@ extern "C" DLL_EXPORT void __cdecl TestStructWithUtf8Field(struct FieldWithUtf8 
     free_utf8_string(pszNative);
 }
 
+extern "C" DLL_EXPORT void __cdecl SetStringInStruct(FieldWithUtf8* fieldStruct, char* str)
+{
+    size_t strLength = strlen(str);
+    char* strCopy = (char*)CoreClrAlloc(sizeof(char) * strlen(str) + 1);
+
+    memcpy(strCopy, str, strLength + 1);
+    fieldStruct->pFirst = strCopy;
+    fieldStruct->index = 0;
+}
+
 // test c# out keyword
 extern "C" DLL_EXPORT void __cdecl StringParameterRefOut(/*out*/ char **s, int index)
 {


### PR DESCRIPTION
Fixes #22394