### PR TITLE
Comparing code and debug info sizes

### DIFF
--- a/src/inc/corcompile.h
+++ b/src/inc/corcompile.h
@@ -1724,8 +1724,10 @@ class ICorCompileInfo
             IN ULONG            iOffsetMapping,
             IN ICorDebugInfo::NativeVarInfo  * pNativeVarInfo,
             IN ULONG            iNativeVarInfo,
-            IN OUT SBuffer    * pDebugInfoBuffer,
-            IN ULONG            codeSize
+            IN OUT SBuffer    * pDebugInfoBuffer
+#ifdef DEBUG
+            ,IN ULONG            codeSize
+#endif
             ) = 0;
 
 

--- a/src/inc/corcompile.h
+++ b/src/inc/corcompile.h
@@ -1724,7 +1724,8 @@ class ICorCompileInfo
             IN ULONG            iOffsetMapping,
             IN ICorDebugInfo::NativeVarInfo  * pNativeVarInfo,
             IN ULONG            iNativeVarInfo,
-            IN OUT SBuffer    * pDebugInfoBuffer
+            IN OUT SBuffer    * pDebugInfoBuffer,
+            IN ULONG            codeSize
             ) = 0;
 
 

--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -1088,12 +1088,13 @@ void CEECompileInfo::CompressDebugInfo(
     IN ULONG            iOffsetMapping,
     IN ICorDebugInfo::NativeVarInfo * pNativeVarInfo,
     IN ULONG            iNativeVarInfo,
-    IN OUT SBuffer    * pDebugInfoBuffer
+    IN OUT SBuffer    * pDebugInfoBuffer,
+    ULONG               codeSize
     )
 {
     STANDARD_VM_CONTRACT;
 
-    CompressDebugInfo::CompressBoundariesAndVars(pOffsetMapping, iOffsetMapping, pNativeVarInfo, iNativeVarInfo, pDebugInfoBuffer, NULL);
+    CompressDebugInfo::CompressBoundariesAndVars(pOffsetMapping, iOffsetMapping, pNativeVarInfo, iNativeVarInfo, pDebugInfoBuffer, NULL, codeSize);
 }
 
 ICorJitHost* CEECompileInfo::GetJitHost()

--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -1088,13 +1088,19 @@ void CEECompileInfo::CompressDebugInfo(
     IN ULONG            iOffsetMapping,
     IN ICorDebugInfo::NativeVarInfo * pNativeVarInfo,
     IN ULONG            iNativeVarInfo,
-    IN OUT SBuffer    * pDebugInfoBuffer,
-    ULONG               codeSize
+    IN OUT SBuffer    * pDebugInfoBuffer
+#ifdef DEBUG
+    ,ULONG               codeSize
+#endif
     )
 {
     STANDARD_VM_CONTRACT;
 
-    CompressDebugInfo::CompressBoundariesAndVars(pOffsetMapping, iOffsetMapping, pNativeVarInfo, iNativeVarInfo, pDebugInfoBuffer, NULL, codeSize);
+    CompressDebugInfo::CompressBoundariesAndVars(pOffsetMapping, iOffsetMapping, pNativeVarInfo, iNativeVarInfo, pDebugInfoBuffer, NULL
+#ifdef DEBUG
+        , codeSize
+#endif
+    );
 }
 
 ICorJitHost* CEECompileInfo::GetJitHost()

--- a/src/vm/compile.h
+++ b/src/vm/compile.h
@@ -346,7 +346,8 @@ class CEECompileInfo : public ICorCompileInfo
                                     IN ULONG            iOffsetMapping,
                                     IN ICorDebugInfo::NativeVarInfo * pNativeVarInfo,
                                     IN ULONG            iNativeVarInfo,
-                                    IN OUT SBuffer    * pDebugInfoBuffer);
+                                    IN OUT SBuffer    * pDebugInfoBuffer,
+                                    IN ULONG            codeSize);
 
     HRESULT SetVerboseLevel(
                                     IN  VerboseLevel        level);

--- a/src/vm/compile.h
+++ b/src/vm/compile.h
@@ -346,8 +346,11 @@ class CEECompileInfo : public ICorCompileInfo
                                     IN ULONG            iOffsetMapping,
                                     IN ICorDebugInfo::NativeVarInfo * pNativeVarInfo,
                                     IN ULONG            iNativeVarInfo,
-                                    IN OUT SBuffer    * pDebugInfoBuffer,
-                                    IN ULONG            codeSize);
+                                    IN OUT SBuffer    * pDebugInfoBuffer
+#ifdef DEBUG
+                                    ,IN ULONG            codeSize
+#endif
+                                    );
 
     HRESULT SetVerboseLevel(
                                     IN  VerboseLevel        level);

--- a/src/vm/debuginfostore.cpp
+++ b/src/vm/debuginfostore.cpp
@@ -441,8 +441,10 @@ PTR_BYTE CompressDebugInfo::CompressBoundariesAndVars(
     IN ICorDebugInfo::NativeVarInfo * pNativeVarInfo,
     IN ULONG            iNativeVarInfo,
     IN OUT SBuffer    * pDebugInfoBuffer,
-    IN LoaderHeap     * pLoaderHeap,
-    IN ULONG            codeSize
+    IN LoaderHeap     * pLoaderHeap
+#ifdef DEBUG
+    ,IN ULONG            codeSize
+#endif
     )
 {
     CONTRACTL {

--- a/src/vm/debuginfostore.cpp
+++ b/src/vm/debuginfostore.cpp
@@ -441,7 +441,8 @@ PTR_BYTE CompressDebugInfo::CompressBoundariesAndVars(
     IN ICorDebugInfo::NativeVarInfo * pNativeVarInfo,
     IN ULONG            iNativeVarInfo,
     IN OUT SBuffer    * pDebugInfoBuffer,
-    IN LoaderHeap     * pLoaderHeap
+    IN LoaderHeap     * pLoaderHeap,
+    IN ULONG            codeSize
     )
 {
     CONTRACTL {
@@ -494,6 +495,8 @@ PTR_BYTE CompressDebugInfo::CompressBoundariesAndVars(
         ptrStart = pDebugInfoBuffer->OpenRawBuffer(cbFinalSize.Value());
     }
     _ASSERTE(ptrStart != NULL); // throws on oom.
+
+    LOG((LF_CORDB, LL_EVERYTHING, "Code/Debug %d/%d.\n", codeSize, cbFinalSize.Value()));
 
     BYTE *ptr = ptrStart;
 

--- a/src/vm/debuginfostore.h
+++ b/src/vm/debuginfostore.h
@@ -84,7 +84,8 @@ public:
         IN ICorDebugInfo::NativeVarInfo * pNativeVarInfo,
         IN ULONG            iNativeVarInfo,
         IN OUT SBuffer    * pDebugInfoBuffer,
-        IN LoaderHeap     * pLoaderHeap
+        IN LoaderHeap     * pLoaderHeap,
+        IN ULONG            codeSize
     );
 
 public:

--- a/src/vm/debuginfostore.h
+++ b/src/vm/debuginfostore.h
@@ -84,8 +84,10 @@ public:
         IN ICorDebugInfo::NativeVarInfo * pNativeVarInfo,
         IN ULONG            iNativeVarInfo,
         IN OUT SBuffer    * pDebugInfoBuffer,
-        IN LoaderHeap     * pLoaderHeap,
-        IN ULONG            codeSize
+        IN LoaderHeap     * pLoaderHeap
+#ifdef DEBUG
+        ,IN ULONG            codeSize
+#endif
     );
 
 public:

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -11037,7 +11037,7 @@ void CEEJitInfo::setVars(CORINFO_METHOD_HANDLE ftn, ULONG32 cVars, ICorDebugInfo
     EE_TO_JIT_TRANSITION();
 }
 
-void CEEJitInfo::CompressDebugInfo()
+void CEEJitInfo::CompressDebugInfo(ULONG codeSize)
 {
     CONTRACTL {
         THROWS;
@@ -11060,7 +11060,8 @@ void CEEJitInfo::CompressDebugInfo()
             m_pOffsetMapping, m_iOffsetMapping,
             m_pNativeVarInfo, m_iNativeVarInfo,
             NULL, 
-            m_pMethodBeingCompiled->GetLoaderAllocator()->GetLowFrequencyHeap());
+            m_pMethodBeingCompiled->GetLoaderAllocator()->GetLowFrequencyHeap(),
+            codeSize);
 
         GetCodeHeader()->SetDebugInfo(pDebugInfo);
     }
@@ -12280,7 +12281,7 @@ CorJitResult invokeCompileMethodHelper(EEJitManager *jitMgr,
     //
     if (SUCCEEDED(ret) && !jitFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_IMPORT_ONLY) && !((CEEJitInfo*)comp)->JitAgain())
     {
-        ((CEEJitInfo*)comp)->CompressDebugInfo();
+        ((CEEJitInfo*)comp)->CompressDebugInfo(*nativeSizeOfCode);
 
 #ifdef FEATURE_INTERPRETER
         // We do this cleanup in the prestub, where we know whether the method

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -11037,7 +11037,11 @@ void CEEJitInfo::setVars(CORINFO_METHOD_HANDLE ftn, ULONG32 cVars, ICorDebugInfo
     EE_TO_JIT_TRANSITION();
 }
 
-void CEEJitInfo::CompressDebugInfo(ULONG codeSize)
+void CEEJitInfo::CompressDebugInfo(
+#ifdef DEBUG
+    ULONG codeSize
+#endif
+    )
 {
     CONTRACTL {
         THROWS;
@@ -11060,8 +11064,11 @@ void CEEJitInfo::CompressDebugInfo(ULONG codeSize)
             m_pOffsetMapping, m_iOffsetMapping,
             m_pNativeVarInfo, m_iNativeVarInfo,
             NULL, 
-            m_pMethodBeingCompiled->GetLoaderAllocator()->GetLowFrequencyHeap(),
-            codeSize);
+            m_pMethodBeingCompiled->GetLoaderAllocator()->GetLowFrequencyHeap()
+#ifdef DEBUG
+            ,codeSize
+#endif
+            );
 
         GetCodeHeader()->SetDebugInfo(pDebugInfo);
     }
@@ -12281,7 +12288,11 @@ CorJitResult invokeCompileMethodHelper(EEJitManager *jitMgr,
     //
     if (SUCCEEDED(ret) && !jitFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_IMPORT_ONLY) && !((CEEJitInfo*)comp)->JitAgain())
     {
-        ((CEEJitInfo*)comp)->CompressDebugInfo(*nativeSizeOfCode);
+        ((CEEJitInfo*)comp)->CompressDebugInfo(
+#ifdef DEBUG
+            *nativeSizeOfCode
+#endif
+            );
 
 #ifdef FEATURE_INTERPRETER
         // We do this cleanup in the prestub, where we know whether the method

--- a/src/vm/jitinterface.h
+++ b/src/vm/jitinterface.h
@@ -1479,7 +1479,11 @@ public:
                        ULONG32 cMap, ICorDebugInfo::OffsetMapping *pMap);
     void setVars(CORINFO_METHOD_HANDLE ftn, ULONG32 cVars,
                  ICorDebugInfo::NativeVarInfo *vars);
-    void CompressDebugInfo(ULONG codeSize);
+    void CompressDebugInfo(
+#ifdef DEBUG
+        ULONG codeSize
+#endif
+        );
 
     void* getHelperFtn(CorInfoHelpFunc    ftnNum,                 /* IN  */
                        void **            ppIndirection);         /* OUT */

--- a/src/vm/jitinterface.h
+++ b/src/vm/jitinterface.h
@@ -1479,7 +1479,7 @@ public:
                        ULONG32 cMap, ICorDebugInfo::OffsetMapping *pMap);
     void setVars(CORINFO_METHOD_HANDLE ftn, ULONG32 cVars,
                  ICorDebugInfo::NativeVarInfo *vars);
-    void CompressDebugInfo();
+    void CompressDebugInfo(ULONG codeSize);
 
     void* getHelperFtn(CorInfoHelpFunc    ftnNum,                 /* IN  */
                        void **            ppIndirection);         /* OUT */

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -211,7 +211,7 @@ CORJIT_FLAGS ZapInfo::ComputeJitFlags(CORINFO_METHOD_HANDLE handle)
     return jitFlags;
 }
 
-ZapDebugInfo * ZapInfo::EmitDebugInfo()
+ZapDebugInfo * ZapInfo::EmitDebugInfo(ULONG codeSize)
 {
     if (m_iNativeVarInfo == 0 && m_iOffsetMapping == 0)
     {
@@ -225,7 +225,8 @@ ZapDebugInfo * ZapInfo::EmitDebugInfo()
     m_pEECompileInfo->CompressDebugInfo( 
             m_pOffsetMapping, m_iOffsetMapping,
             m_pNativeVarInfo, m_iNativeVarInfo,
-            &debugInfoBuffer);
+            &debugInfoBuffer,
+            codeSize);
 
     if (IsReadyToRunCompilation())
         return ZapBlob::NewBlob(m_pImage, &debugInfoBuffer[0], debugInfoBuffer.GetSize());
@@ -516,7 +517,7 @@ void ZapInfo::CompileMethod()
     }
 #endif
 
-    PublishCompiledMethod();
+    PublishCompiledMethod(cCode);
 }
 
 #ifndef FEATURE_FULL_NGEN
@@ -748,7 +749,7 @@ COUNT_T ZapImage::MethodCodeTraits::Hash(key_t k)
 }
 #endif
 
-void ZapInfo::PublishCompiledMethod()
+void ZapInfo::PublishCompiledMethod(ULONG codeSize)
 {
     EmitCodeRelocations();
 
@@ -777,7 +778,7 @@ void ZapInfo::PublishCompiledMethod()
 
     pMethod->m_pFixupList = EmitFixupList();
 
-    pMethod->m_pDebugInfo = EmitDebugInfo();
+    pMethod->m_pDebugInfo = EmitDebugInfo(codeSize);
     pMethod->m_pGCInfo = EmitGCInfo();
 
 #ifdef WIN64EXCEPTIONS

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -211,7 +211,11 @@ CORJIT_FLAGS ZapInfo::ComputeJitFlags(CORINFO_METHOD_HANDLE handle)
     return jitFlags;
 }
 
-ZapDebugInfo * ZapInfo::EmitDebugInfo(ULONG codeSize)
+ZapDebugInfo * ZapInfo::EmitDebugInfo(
+#ifdef DEBUG
+    ULONG codeSize
+#endif
+    )
 {
     if (m_iNativeVarInfo == 0 && m_iOffsetMapping == 0)
     {
@@ -225,8 +229,11 @@ ZapDebugInfo * ZapInfo::EmitDebugInfo(ULONG codeSize)
     m_pEECompileInfo->CompressDebugInfo( 
             m_pOffsetMapping, m_iOffsetMapping,
             m_pNativeVarInfo, m_iNativeVarInfo,
-            &debugInfoBuffer,
-            codeSize);
+            &debugInfoBuffer
+#ifdef DEBUG
+            ,codeSize
+#endif
+            );
 
     if (IsReadyToRunCompilation())
         return ZapBlob::NewBlob(m_pImage, &debugInfoBuffer[0], debugInfoBuffer.GetSize());
@@ -517,7 +524,11 @@ void ZapInfo::CompileMethod()
     }
 #endif
 
-    PublishCompiledMethod(cCode);
+    PublishCompiledMethod(
+#ifdef DEBUG
+        cCode
+#endif
+        );
 }
 
 #ifndef FEATURE_FULL_NGEN
@@ -749,7 +760,11 @@ COUNT_T ZapImage::MethodCodeTraits::Hash(key_t k)
 }
 #endif
 
-void ZapInfo::PublishCompiledMethod(ULONG codeSize)
+void ZapInfo::PublishCompiledMethod(
+#ifdef DEBUG
+    ULONG codeSize
+#endif
+    )
 {
     EmitCodeRelocations();
 
@@ -778,7 +793,11 @@ void ZapInfo::PublishCompiledMethod(ULONG codeSize)
 
     pMethod->m_pFixupList = EmitFixupList();
 
-    pMethod->m_pDebugInfo = EmitDebugInfo(codeSize);
+    pMethod->m_pDebugInfo = EmitDebugInfo(
+#ifdef DEBUG
+        codeSize
+#endif
+        );
     pMethod->m_pGCInfo = EmitGCInfo();
 
 #ifdef WIN64EXCEPTIONS

--- a/src/zap/zapinfo.h
+++ b/src/zap/zapinfo.h
@@ -233,11 +233,19 @@ class ZapInfo
 
     CORJIT_FLAGS ComputeJitFlags(CORINFO_METHOD_HANDLE handle);
 
-    ZapDebugInfo * EmitDebugInfo(ULONG codeSize);
+    ZapDebugInfo * EmitDebugInfo(
+#ifdef DEBUG
+        ULONG codeSize
+#endif
+        );
     ZapGCInfo * EmitGCInfo();
     ZapImport ** EmitFixupList();
 
-    void PublishCompiledMethod(ULONG codeSize);
+    void PublishCompiledMethod(
+#ifdef DEBUG
+        ULONG codeSize
+#endif
+        );
 
     void EmitCodeRelocations();
 

--- a/src/zap/zapinfo.h
+++ b/src/zap/zapinfo.h
@@ -233,11 +233,11 @@ class ZapInfo
 
     CORJIT_FLAGS ComputeJitFlags(CORINFO_METHOD_HANDLE handle);
 
-    ZapDebugInfo * EmitDebugInfo();
+    ZapDebugInfo * EmitDebugInfo(ULONG codeSize);
     ZapGCInfo * EmitGCInfo();
     ZapImport ** EmitFixupList();
 
-    void PublishCompiledMethod();
+    void PublishCompiledMethod(ULONG codeSize);
 
     void EmitCodeRelocations();
 


### PR DESCRIPTION
The code passes the size of the code down all the way to the point where the compressed debug info is computed. For now, a simple log statement is used to report the sizes 