### PR TITLE
Restrict arm64 parallelism to collections

### DIFF
--- a/tests/tests.targets
+++ b/tests/tests.targets
@@ -33,6 +33,8 @@
       <ExcludeTraits Condition="'$(ExcludeTraits)'==''">category=outerloop;category=failing</ExcludeTraits>
       <!-- Run one assembly at a time on Linux/arm to avoid OutOfMemory (see https://github.com/dotnet/coreclr/issues/20328) -->
       <ParallelRun Condition="'$(ParallelRun)'=='' and '$(__BuildOS)'=='Linux' and '$(__BuildArch)'=='arm'">collections</ParallelRun>
+      <!-- Run one assembly at a time on arm64 to avoid excessive parallelism leading to test timeouts (see https://github.com/dotnet/coreclr/issues/22419) -->
+      <ParallelRun Condition="'$(ParallelRun)'=='' and '$(__BuildArch)'=='arm64'">collections</ParallelRun>
       <ParallelRun Condition="'$(ParallelRun)'==''">all</ParallelRun>
     </PropertyGroup>
     <ItemGroup>


### PR DESCRIPTION
Attempt to reduce test timeout failures by restricting test parallelism.

Attempts to address https://github.com/dotnet/coreclr/issues/22419