### PR TITLE
Fix delegate creation for default interface methods on structs

### DIFF
--- a/src/vm/comdelegate.cpp
+++ b/src/vm/comdelegate.cpp
@@ -1657,7 +1657,7 @@ FCIMPL3(PCODE, COMDelegate::AdjustTarget, Object* refThisUNSAFE, Object* targetU
 
     // Use the Unboxing stub for value class methods, since the value
     // class is constructed using the boxed instance.
-    if (pMTTarg->IsValueType() && !pCorrectedMethod->IsUnboxingStub())
+    if (pCorrectedMethod->GetMethodTable()->IsValueType() && !pCorrectedMethod->IsUnboxingStub())
     {
         // those should have been ruled out at jit time (code:COMDelegate::GetDelegateCtor)
         _ASSERTE((pMTMeth != g_pValueTypeClass) && (pMTMeth != g_pObjectClass));

--- a/tests/src/Regressions/coreclr/22386/debug3.il
+++ b/tests/src/Regressions/coreclr/22386/debug3.il
@@ -1,0 +1,180 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+.assembly extern System.Runtime { }
+.assembly extern System.Console { }
+
+.assembly debug3 { }
+
+.class interface public abstract auto ansi I1
+{
+  .method public hidebysig newslot virtual abstract
+          instance int32 AddImpl(int32 x) cil managed
+  {
+  }
+
+  .method public hidebysig newslot virtual 
+          instance int32  Add(int32 x) cil managed
+  {
+    ldarg.0
+    ldarg.1
+    ldc.i4.1
+    add
+    callvirt instance int32 class I1::AddImpl(int32 x)
+    ret
+  }
+}
+
+.class private sequential ansi sealed beforefieldinit Test1
+       extends [System.Runtime]System.ValueType
+       implements I1
+{
+  .field public int32 Value
+
+  .method public hidebysig newslot virtual
+          instance int32 AddImpl(int32 x) cil managed
+  {
+      ldarg.0
+      ldfld int32 Test1::Value
+      ldarg.1
+      add
+      ret
+  }
+}
+
+.class interface public abstract auto ansi I2`1<T>
+{
+  .method public hidebysig newslot virtual abstract
+          instance int32 AddImpl(int32 x) cil managed
+  {
+  }
+
+  .method public hidebysig newslot virtual 
+          instance int32  Add(int32 x) cil managed
+  {
+    ldarg.0
+
+    ldtoken !T
+    call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    callvirt instance string [System.Runtime]System.Object::ToString()
+    call instance int32 [System.Runtime]System.String::get_Length()
+    ldarg.1
+    add
+
+    ldc.i4.1
+    add
+
+    callvirt instance int32 class I2`1<!T>::AddImpl(int32 x)
+    ret
+  }
+}
+
+.class private sequential ansi sealed beforefieldinit Test2`1<T>
+       extends [System.Runtime]System.ValueType
+       implements class I2`1<!T>
+{
+  .field public int32 Value
+
+  .method public hidebysig newslot virtual
+          instance int32 AddImpl(int32 x) cil managed
+  {
+      ldarg.0
+      ldfld int32 Test1::Value
+      ldarg.1
+      add
+
+      ldtoken !T[]
+      call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+      callvirt instance string [System.Runtime]System.Object::ToString()
+      call instance int32 [System.Runtime]System.String::get_Length()
+      add
+
+      ret
+  }
+}
+
+
+.method private hidebysig static int32 Main() cil managed
+{
+  .entrypoint
+  .locals init (class I1 V_0,
+             valuetype Test1 V_1,
+             class [System.Runtime]System.Func`2<int32, int32> V_2,
+             class I2`1<class [System.Runtime]System.String> V_3,
+             valuetype Test2`1<class [System.Runtime]System.String> V_4)
+
+  //
+  // Nongeneric case
+  //
+
+  ldloca.s   V_1
+  initobj    Test1
+
+  // V_1.Value = 30
+  ldloca.s   V_1
+  ldc.i4 30
+  stfld int32 Test1::Value
+
+  // V_0 = (I1)V_1;
+  ldloc.1
+  box        Test1
+  stloc.0
+
+  // V_2 = V_0.Add
+  ldloc.0
+  dup
+  ldvirtftn  instance int32 I1::Add(int32)
+  newobj     instance void class [System.Runtime]System.Func`2<int32, int32>::.ctor(object, native int)
+  stloc.2
+
+  // V_2(2)
+  ldloc.2
+  ldc.i4.2
+  callvirt   instance !1 class [System.Runtime]System.Func`2<int32, int32>::Invoke(!0)
+
+  //
+  // We expect 33 on the stack now
+  //
+
+  //
+  // Generic case
+  //
+
+  ldloca.s   V_4
+  initobj    valuetype Test2`1<class [System.Runtime]System.String>
+
+  // V_4.Value = 36
+  ldloca.s   V_4
+  ldc.i4 36
+  stfld int32 valuetype Test2`1<class [System.Runtime]System.String>::Value
+
+  // V_3 = (I1)V_4;
+  ldloc.s    4
+  box        valuetype Test2`1<class [System.Runtime]System.String>
+  stloc.3
+
+  // V_2 = V_3.Add
+  ldloc.3
+  dup
+  ldvirtftn  instance int32 class I2`1<class [System.Runtime]System.String>::Add(int32)
+  newobj     instance void class [System.Runtime]System.Func`2<int32, int32>::.ctor(object, native int)
+  stloc.2
+
+  ldloc.2
+  ldc.i4.2
+  callvirt   instance !1 class [System.Runtime]System.Func`2<int32, int32>::Invoke(!0)
+
+  //
+  // We expect this return 67
+  //
+
+  //
+  // Add the two results - sum should be 100
+  //
+
+  add
+
+  ret
+}

--- a/tests/src/Regressions/coreclr/22386/debug3.ilproj
+++ b/tests/src/Regressions/coreclr/22386/debug3.ilproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{85DFC527-4DB1-595E-A7D7-E94EE1F8140D}</ProjectGuid>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="debug3.il" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
We only need to find an unboxing stub if we resolved the interface to a valuetype method. If we resolved to a default interface method implementation, unboxing is not necessary.

Fixes #22386.