### PR TITLE
Use Jenkins for Linux/arm32 testing

### DIFF
--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -19,9 +19,9 @@ jobs:
     containerName: ubuntu_1404_arm_cross_build_image
     helixQueues:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        asString: 'Ubuntu.1404.Arm32.Open'
-        asArray:
-        - Ubuntu.1404.Arm32.Open
+        # TODO: add Ubuntu.1404.Arm32.Open once Jenkins has been shutdown
+        asString: ''
+        asArray: []
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         # We don't have any Linux/arm32 internal Helix queues
         asString: ''

--- a/netci.groovy
+++ b/netci.groovy
@@ -1928,10 +1928,19 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                         needsTrigger = false
                         break
                     }
-
-                    if (scenario == 'crossgen_comparison') {
-                        if (os == 'Ubuntu' && architecture == 'arm' && (configuration == 'Checked' || configuration == 'Release')) {
-                            isDefaultTrigger = true
+                    if (os == 'Ubuntu' && architecture == 'arm') {
+                        switch (scenario) {
+                            case 'innerloop':
+                            case 'no_tiered_compilation_innerloop':
+                                if (configuration == 'Checked') {
+                                    isDefaultTrigger = true
+                                }
+                                break
+                             case 'crossgen_comparison':
+                                if (configuration == 'Checked' || configuration == 'Release') {
+                                    isDefaultTrigger = true
+                                }
+                                break
                         }
                     }
                     break


### PR DESCRIPTION
As discussed in https://github.com/dotnet/core-eng/issues/5150 to unblock running stress testing on Linux/arm32