### PR TITLE
Fixing Utf8Formatter.Float to support all the same format specifiers as the utf16 formatter.

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Float.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Float.cs
@@ -61,29 +61,6 @@ namespace System.Buffers.Text
 
         private static bool TryFormatFloatingPoint<T>(T value, Span<byte> destination, out int bytesWritten, StandardFormat format) where T : IFormattable, ISpanFormattable
         {
-            if (format.IsDefault)
-            {
-                format = 'G';
-            }
-
-            switch (format.Symbol)
-            {
-                case 'g':
-                case 'G':
-                    if (format.Precision != StandardFormat.NoPrecision)
-                        throw new NotSupportedException(SR.Argument_GWithPrecisionNotSupported);
-                    break;
-
-                case 'f':
-                case 'F':
-                case 'e':
-                case 'E':
-                    break;
-
-                default:
-                    return FormattingHelpers.TryFormatThrowFormatException(out bytesWritten);
-            }
-            
             Span<char> formatText = stackalloc char[StandardFormat.FormatStringLength];
             int formattedLength = format.Format(formatText);
             formatText = formatText.Slice(0, formattedLength);

--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Float.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Float.cs
@@ -61,9 +61,14 @@ namespace System.Buffers.Text
 
         private static bool TryFormatFloatingPoint<T>(T value, Span<byte> destination, out int bytesWritten, StandardFormat format) where T : IFormattable, ISpanFormattable
         {
-            Span<char> formatText = stackalloc char[StandardFormat.FormatStringLength];
-            int formattedLength = format.Format(formatText);
-            formatText = formatText.Slice(0, formattedLength);
+            Span<char> formatText = stackalloc char[0];
+
+            if (!format.IsDefault)
+            {
+                formatText = stackalloc char[StandardFormat.FormatStringLength];
+                int formatTextLength = format.Format(formatText);
+                formatText = formatText.Slice(0, formatTextLength);
+            }
 
             // We first try to format into a stack-allocated buffer, and if it succeeds, we can avoid
             // all allocation.  If that fails, we fall back to allocating strings.  If it proves impactful,
@@ -75,7 +80,7 @@ namespace System.Buffers.Text
             ReadOnlySpan<char> utf16Text = stackalloc char[0];
 
             // Try to format into the stack buffer.  If we're successful, we can avoid all allocations.
-            if (value.TryFormat(stackBuffer, out formattedLength, formatText, CultureInfo.InvariantCulture))
+            if (value.TryFormat(stackBuffer, out int formattedLength, formatText, CultureInfo.InvariantCulture))
             {
                 utf16Text = stackBuffer.Slice(0, formattedLength);
             }

--- a/tests/CoreFX/CoreFX.issues.json
+++ b/tests/CoreFX/CoreFX.issues.json
@@ -751,6 +751,14 @@
                     "name": "System.Buffers.Text.Tests.ParserTests.TestParserDouble",
                     "reason": "https://github.com/dotnet/coreclr/pull/20707"
                 },
+                {
+                    "name": "System.Buffers.Text.Tests.FormatterTests.TestGFormatWithPrecisionNotSupported",
+                    "reason": "https://github.com/dotnet/coreclr/pull/22434"
+                },
+                {
+                    "name": "System.Buffers.Text.Tests.FormatterTests.TestBadFormat",
+                    "reason": "https://github.com/dotnet/coreclr/pull/22434"
+                },
             ]
         }
     },


### PR DESCRIPTION
Given that the Utf8Formatter for float/double currently just forwards to the Utf16 implementation, this just removes the checks around the given `StandardFormat` and just forwards it down as well. It allows us to support all the same format specifiers that the Utf16 implementation supports.
It would be nice to have similar fixes for the other types Utf8Formatter supports, but those (for the most part) don't forward and are instead reimplemented on the Utf8 side, so the fix is not as trivial.

This resolves https://github.com/dotnet/coreclr/issues/21273