### PR TITLE
Treat CLRTestExecutionArguments as an array in generated Bash scripts

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -60,9 +60,6 @@
 
     <!-- All Unix targets -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TargetsWindows)' != 'true'">
-        <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/paramthreadstart/ThreadStartString_1/*">
-            <Issue>3627</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutExp/*">
             <Issue>Issue building native components for the test.</Issue>
         </ExcludeList>
@@ -1779,9 +1776,6 @@
             <Issue>needs triage</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/mutex/openexisting/openmutexpos4/*">
-            <Issue>needs triage</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/paramthreadstart/ThreadStartString_1/*">
             <Issue>needs triage</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/readerwriterlockslim/ensurelockordering/*">

--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -122,7 +122,7 @@ echo BEGIN EXECUTION]]>
       </BashCLRTestExitCodePrep>
     
       <BashCLRTestArgPrep Condition=" '$(CLRTestExecutionArguments)'!='' ">
-<![CDATA[if [ -z ${CLRTestExecutionArguments+x} ]%3B then export CLRTestExecutionArguments='$(CLRTestExecutionArguments)'%3B fi]]>
+<![CDATA[if [ -z ${CLRTestExecutionArguments+x} ]%3B then CLRTestExecutionArguments=($(CLRTestExecutionArguments))%3B fi]]>
       </BashCLRTestArgPrep>
     
       <!-- By default, be prepared to do a full check -->
@@ -271,8 +271,8 @@ else
     LAUNCHER="$_DebuggerFullPath $(_CLRTestRunFile)"
 fi
 
-echo $LAUNCHER $ExePath $CLRTestExecutionArguments
-$LAUNCHER $ExePath $CLRTestExecutionArguments
+echo $LAUNCHER $ExePath %24(printf "'%s' " "${CLRTestExecutionArguments[@]}")
+$LAUNCHER $ExePath "${CLRTestExecutionArguments[@]}"
 
 CLRTestExitCode=$?
 if [ ! -z ${RunCrossGen+x} ]%3B then
@@ -284,8 +284,8 @@ $(BashLinkerTestCleanupCmds)
 $(BashCLRTestLaunchCmds)
 echo export CDPATH="$%28dirname "$0")"
 export CDPATH="$%28dirname "$0")"
-echo /bin/sh $(InputAssemblyName) 
-/bin/sh $(InputAssemblyName)
+echo /usr/bin/env bash $(InputAssemblyName) %24(printf "'%s' " "${CLRTestExecutionArguments[@]}")
+/usr/bin/env bash $(InputAssemblyName) "${CLRTestExecutionArguments[@]}"
 CLRTestExitCode=$?
 CLRTestExpectedExitCode=0
       ]]></BashCLRTestLaunchCmds>
@@ -341,7 +341,7 @@ for i in "$@"
 %(Command)
         %3B%3B')
         *)
-        CLRTestExecutionArguments="$CLRTestExecutionArguments $i"
+        CLRTestExecutionArguments+=("${i}")
     esac
 done
 

--- a/tests/src/CLRTest.Jit.targets
+++ b/tests/src/CLRTest.Jit.targets
@@ -115,8 +115,8 @@ fi
         <![CDATA[
 if [ -z "$DoLink" -a ! -z "$RunningIlasmRoundTrip" ];
 then
-  echo $(_CLRTestRunFile) $(TargetAssemblyName) $CLRTestExecutionArguments
-  $(_CLRTestRunFile) $(TargetAssemblyName) $CLRTestExecutionArguments
+  echo $(_CLRTestRunFile) $(TargetAssemblyName) %24(printf "'%s' " "${CLRTestExecutionArguments[@]}")
+  $(_CLRTestRunFile) $(TargetAssemblyName) "${CLRTestExecutionArguments[@]}"
   if [  $? -ne $CLRTestExpectedExitCode ]
   then
     echo END EXECUTION OF IL{D}ASM BINARY - FAILED $? vs $CLRTestExpectedExitCode


### PR DESCRIPTION
This fixes the following issues with generated test runners (Bash scripts):
1. When a test project has `CLRTestKind="RunOnly"` during the test run another script got called here
https://github.com/dotnet/coreclr/blob/a3073f2e280c8ad767d1f5b4f566cac07b3fec38/tests/src/CLRTest.Execute.Bash.targets#L266-L274
Since calling /bin/sh directly does not obey a shebang this produces the following error 
```
../ThreadStartChar/ThreadStartChar.sh: 167: ../ThreadStartChar/ThreadStartChar.sh: shopt: not found
```
since shopt is Bash builtin.

Instead we should call with /usr/bin/env bash.

2. **ThreadStartString_1** was failing in https://github.com/dotnet/coreclr/issues/3627 with the following error:
```
BEGIN EXECUTION
export CDPATH=.
/bin/sh ../ThreadStartString/ThreadStartString.sh
BEGIN EXECUTION
../ThreadStartString/ThreadStartString.sh: 167: ../ThreadStartString/ThreadStartString.sh: shopt: not found
/home/echesako/git/coreclr/bin/tests/Linux.x64.Checked/Tests/Core_Root/corerun ThreadStartString.exe " "
USAGE: ThreadStartString <string>|null

Expected: 100
Actual: 255
END EXECUTION - FAILED
Expected: 0
Actual: 1
END EXECUTION - FAILED
```
It turns out that this is due to $(CLRTestExecutionArguments) being treated as a string inside the Bash script:
https://github.com/dotnet/coreclr/blob/a3073f2e280c8ad767d1f5b4f566cac07b3fec38/tests/src/CLRTest.Execute.Bash.targets#L117
 And in this example, since $CLRTestExecutionArguments contains only one space character was simply ignored during the call:
https://github.com/dotnet/coreclr/blob/a3073f2e280c8ad767d1f5b4f566cac07b3fec38/tests/src/CLRTest.Execute.Bash.targets#L258-L259

On Windows the tests passes with the following output:
```
BEGIN EXECUTION
 cmd /c ..\ThreadStartString\ThreadStartString.cmd
BEGIN EXECUTION
 "D:\AfterSystemPrivateCoreLibR2R\Windows_NT.x64.Checked\Tests\Core_Root\corerun.exe" ThreadStartString.exe " " 
 
Test Passed
Expected: 100
Actual: 100
END EXECUTION - PASSED
PASSED
Expected: 0
Actual: 0
END EXECUTION - PASSED
PASSED
Test Harness Exitcode is : 0
```

3.  **ThreadStartString_2** was not failing, but `<CLRTestExecutionArguments>""</CLRTestExecutionArguments>` was treated as a string containing two double-quote characters:
```
BEGIN EXECUTION
export CDPATH=/home/echesako/git/coreclr/bin/tests/Linux.x64.Checked/baseservices/threading/paramthreadstart/ThreadStartString_2
/bin/sh ../ThreadStartString/ThreadStartString.sh
BEGIN EXECUTION
/home/echesako/git/coreclr/bin/tests/Linux.x64.Checked/Tests/Core_Root/corerun ThreadStartString.exe ""
""
Test Passed
Expected: 100
Actual: 100
END EXECUTION - PASSED
Expected: 0
Actual: 0
END EXECUTION - PASSED
Test Harness Exitcode is : 0
```
while on Windows the test runs with an empty string as an argument:
```
BEGIN EXECUTION
 cmd /c ..\ThreadStartString\ThreadStartString.cmd
BEGIN EXECUTION
 "D:\AfterSystemPrivateCoreLibR2R\Windows_NT.x64.Checked\Tests\Core_Root\corerun.exe" ThreadStartString.exe "" 

Test Passed
Expected: 100
Actual: 100
END EXECUTION - PASSED
PASSED
Expected: 0
Actual: 0
END EXECUTION - PASSED
PASSED
Test Harness Exitcode is : 0
```

I propose a solution to treat $(CLRTestExecutionArguments) as an array to fix both 2) and 3).
The only problem here that there is no elegant way to pass an array variable $CLRTestExecutionArguments between two scripts. Instead I decided to pass these values to the parent script via command line.

**After the change:**
**ThreadStartString_1**  passes
```
BEGIN EXECUTION
export CDPATH=/opt/code/bin/tests/Linux.x64.Checked/baseservices/threading/paramthreadstart/ThreadStartString_1
/usr/bin/env bash ../ThreadStartString/ThreadStartString.sh ' '
BEGIN EXECUTION
/opt/code/bin/tests/Linux.x64.Checked/Tests/Core_Root/corerun ThreadStartString.exe ' '
 
Test Passed
Expected: 100
Actual: 100
END EXECUTION - PASSED
Expected: 0
Actual: 0
END EXECUTION - PASSED
Test Harness Exitcode is : 0
```

**ThreadStartString_2** behaves as a Windows counterpart
```
BEGIN EXECUTION
export CDPATH=/opt/code/bin/tests/Linux.x64.Checked/baseservices/threading/paramthreadstart/ThreadStartString_2
/usr/bin/env bash ../ThreadStartString/ThreadStartString.sh ''
BEGIN EXECUTION
/opt/code/bin/tests/Linux.x64.Checked/Tests/Core_Root/corerun ThreadStartString.exe ''

Test Passed
Expected: 100
Actual: 100
END EXECUTION - PASSED
Expected: 0
Actual: 0
END EXECUTION - PASSED
Test Harness Exitcode is : 0
```


Closes https://github.com/dotnet/coreclr/issues/3627