### PR TITLE
Disable failing BestFitMapping tests

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -252,6 +252,18 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/varargs/varargsupport_r/*">
             <Issue>Varargs supported on this platform</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/BestFitMapping/Char/AFT_PFT/AFT_PFT/*">
+            <Issue>22436</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/BestFitMapping/Char/Assembly_False_False/Assembly_False_False/*">
+            <Issue>22436</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/BestFitMapping/LPStr/AFT_PFT/AFT_PFT/*">
+            <Issue>22436</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/BestFitMapping/LPStr/Assembly_False_False/Assembly_False_False/*">
+            <Issue>22436</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- Windows x86 specific excludes -->
@@ -279,6 +291,12 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/varargs/varargsupport_r/*">
             <Issue>Varargs supported on this platform</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/BestFitMapping/Char/AFT_PFT/AFT_PFT/*">
+            <Issue>22436</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/BestFitMapping/LPStr/AFT_PFT/AFT_PFT/*">
+            <Issue>22436</Issue>
         </ExcludeList>
     </ItemGroup>
 


### PR DESCRIPTION
Tests:
```
Interop\PInvoke\BestFitMapping\Char\AFT_PFT\AFT_PFT\AFT_PFT.cmd
Interop\PInvoke\BestFitMapping\Char\Assembly_False_False\Assembly_False_False\Assembly_False_False.cmd
Interop\PInvoke\BestFitMapping\LPStr\AFT_PFT\AFT_PFT\AFT_PFT.cmd
Interop\PInvoke\BestFitMapping\LPStr\Assembly_False_False\Assembly_False_False\Assembly_False_False.cmd
```

Tracked by https://github.com/dotnet/coreclr/issues/22436