### PR TITLE
Disable baseservices\threading\mutex\misc\waitone2 test

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -47,6 +47,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/StackTracePreserve/StackTracePreserveTests/*">
             <Issue>20322</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/mutex/misc/waitone2/*">
+            <Issue>6397</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/readytorun/r2rdump/R2RDumpTest/*">
             <Issue>19441;22020</Issue>
         </ExcludeList>


### PR DESCRIPTION
This test has been failing randomly in the CI on all architectures
for a long, long time.

Tracking issue: https://github.com/dotnet/coreclr/issues/6397