### PR TITLE
Disable flaky Linux/arm64 corefx System.Net.Sockets.Tests

### DIFF
--- a/tests/arm64/corefx_linux_test_exclusions.txt
+++ b/tests/arm64/corefx_linux_test_exclusions.txt
@@ -4,6 +4,7 @@ System.Diagnostics.Process.Tests              # https://github.com/dotnet/corecl
 System.Memory.Tests                           # https://github.com/dotnet/coreclr/issues/20958
 System.Net.NameResolution.Pal.Tests           # https://github.com/dotnet/corefx/issues/32797
 System.Net.NameResolution.Functional.Tests    # https://github.com/dotnet/coreclr/issues/20924 https://github.com/dotnet/corefx/issues/24355
+System.Net.Sockets.Tests                      # https://github.com/dotnet/coreclr/issues/21576 -- continuing flakiness
 System.Runtime.Tests                          # https://github.com/dotnet/coreclr/issues/21223 -- JitStress=2
 System.Runtime.Serialization.Formatters.Tests # https://github.com/dotnet/coreclr/issues/20246 -- timeout
 System.Text.RegularExpressions.Tests          # https://github.com/dotnet/coreclr/issues/17754 -- timeout -- JitMinOpts + Tiered only


### PR DESCRIPTION
Tracking: https://github.com/dotnet/coreclr/issues/21576

In general, any System.Net test that exhibits flakiness should be
disabled; we pay more in flakiness than we gain in coverage.