### PR TITLE
[Official Build] Disable FreeBSD builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -273,7 +273,6 @@ jobs:
       - build_Linux_musl_x64_release
       - build_Linux_rhel6_x64_release
       - build_Linux_x64_release
-      - build_FreeBSD_x64_release
       - build_OSX_x64_release
       - build_Windows_NT_x64_release
       - build_Windows_NT_x86_release

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -136,17 +136,20 @@ jobs:
 
 # FreeBSD
 
-- template: ${{ parameters.jobTemplate }}
-  parameters:
-    buildConfig: ${{ parameters.buildConfig }}
-    archType: x64
-    osGroup: FreeBSD
-    osIdentifier: FreeBSD
-    # There are no FreeBSD helix queues, so we don't run tests at the moment.
-    helixQueues:
-      asString: ''
-      asArray: []
-    ${{ insert }}: ${{ parameters.jobParameters }}
+# FreeBSD machines are currenrly offline. Re-enable in the official build when
+# the machines are healthy.
+
+# - template: ${{ parameters.jobTemplate }}
+#   parameters:
+#     buildConfig: ${{ parameters.buildConfig }}
+#     archType: x64
+#     osGroup: FreeBSD
+#     osIdentifier: FreeBSD
+#     # There are no FreeBSD helix queues, so we don't run tests at the moment.
+#     helixQueues:
+#       asString: ''
+#       asArray: []
+#     ${{ insert }}: ${{ parameters.jobParameters }}
 
 # macOS x64
 


### PR DESCRIPTION
Currently all the FreeBSD machines are offline or in an unclean state
which blocks official builds from finishing.