### PR TITLE
JIT: Suppress emitting same-reg zero extending move

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -3112,7 +3112,7 @@ void CodeGen::genCodeForCpBlkRepMovs(GenTreeBlk* cpBlkNode)
     else
 #endif
     {
-#ifdef _TARGET_X64_
+#ifdef _TARGET_AMD64_
         assert(size > CPBLK_UNROLL_LIMIT && size < CPBLK_MOVS_LIMIT);
 #else
         assert(size > CPBLK_UNROLL_LIMIT);
@@ -6398,6 +6398,7 @@ void CodeGen::genIntToIntCast(GenTreeCast* cast)
 
     const regNumber srcReg = cast->gtGetOp1()->gtRegNum;
     const regNumber dstReg = cast->gtRegNum;
+    emitter*        emit   = getEmitter();
 
     assert(genIsValidIntReg(srcReg));
     assert(genIsValidIntReg(dstReg));
@@ -6413,6 +6414,7 @@ void CodeGen::genIntToIntCast(GenTreeCast* cast)
     {
         instruction ins;
         unsigned    insSize;
+        bool        canSkip = false;
 
         switch (desc.ExtendKind())
         {
@@ -6426,6 +6428,14 @@ void CodeGen::genIntToIntCast(GenTreeCast* cast)
                 break;
 #ifdef _TARGET_64BIT_
             case GenIntCastDesc::ZERO_EXTEND_INT:
+                // We can skip emitting this zero extending move if the previous instruction zero extended implicitly
+                if ((srcReg == dstReg) && (emit->emitCurIGinsCnt > 0) && compiler->opts.OptimizationEnabled())
+                {
+                    emitter::instrDesc* prevInstr = emit->emitLastIns;
+                    assert(prevInstr != nullptr);
+                    canSkip = emit->doesZeroExtendingWrite(prevInstr, srcReg);
+                }
+
                 ins     = INS_mov;
                 insSize = 4;
                 break;
@@ -6436,12 +6446,20 @@ void CodeGen::genIntToIntCast(GenTreeCast* cast)
 #endif
             default:
                 assert(desc.ExtendKind() == GenIntCastDesc::COPY);
+                assert(srcReg != dstReg);
                 ins     = INS_mov;
                 insSize = desc.ExtendSrcSize();
                 break;
         }
 
-        getEmitter()->emitIns_R_R(ins, EA_ATTR(insSize), dstReg, srcReg);
+        if (canSkip)
+        {
+            JITDUMP("\n -- suppressing emission as previous instruction already properly extends.\n");
+        }
+        else
+        {
+            emit->emitIns_R_R(ins, EA_ATTR(insSize), dstReg, srcReg);
+        }
     }
 
     genProduceReg(cast);

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -3112,7 +3112,7 @@ void CodeGen::genCodeForCpBlkRepMovs(GenTreeBlk* cpBlkNode)
     else
 #endif
     {
-#ifdef _TARGET_AMD64_
+#ifdef _TARGET_X64_
         assert(size > CPBLK_UNROLL_LIMIT && size < CPBLK_MOVS_LIMIT);
 #else
         assert(size > CPBLK_UNROLL_LIMIT);
@@ -6429,11 +6429,9 @@ void CodeGen::genIntToIntCast(GenTreeCast* cast)
 #ifdef _TARGET_64BIT_
             case GenIntCastDesc::ZERO_EXTEND_INT:
                 // We can skip emitting this zero extending move if the previous instruction zero extended implicitly
-                if ((srcReg == dstReg) && (emit->emitCurIGinsCnt > 0) && compiler->opts.OptimizationEnabled())
+                if ((srcReg == dstReg) && compiler->opts.OptimizationEnabled())
                 {
-                    emitter::instrDesc* prevInstr = emit->emitLastIns;
-                    assert(prevInstr != nullptr);
-                    canSkip = emit->doesZeroExtendingWrite(prevInstr, srcReg);
+                    canSkip = emit->AreUpper32BitsZero(srcReg);
                 }
 
                 ins     = INS_mov;

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -145,6 +145,31 @@ bool emitter::IsDstSrcSrcAVXInstruction(instruction ins)
     return ((CodeGenInterface::instInfo[ins] & INS_Flags_IsDstSrcSrcAVXInstruction) != 0) && IsAVXInstruction(ins);
 }
 
+bool emitter::doesZeroExtendingWrite(instrDesc* id, regNumber reg)
+{
+    insFormat fmt = id->idInsFmt();
+
+    switch (fmt)
+    {
+        case IF_RWR_CNS:
+        case IF_RRW_CNS:
+        case IF_RRW_SHF:
+        case IF_RWR_RRD:
+        case IF_RRW_RRD:
+        case IF_RWR_MRD:
+        case IF_RWR_SRD:
+        case IF_RWR_ARD:
+
+            // Can't rely on a "small" movsx as we will over-extend to 8 bytes
+            return (id->idIns() != INS_movsx) && (id->idReg1() == reg) && (id->idOpSize() != EA_8BYTE);
+
+        default:
+            break;
+    }
+
+    return false;
+}
+
 #ifdef FEATURE_HW_INTRINSICS
 //------------------------------------------------------------------------
 // IsDstSrcImmAvxInstruction: Checks if the instruction has a "reg, reg/mem, imm" or

--- a/src/jit/emitxarch.h
+++ b/src/jit/emitxarch.h
@@ -94,7 +94,7 @@ code_t AddRexPrefix(instruction ins, code_t code);
 bool EncodedBySSE38orSSE3A(instruction ins);
 bool Is4ByteSSEInstruction(instruction ins);
 
-bool doesZeroExtendingWrite(instrDesc* id, regNumber reg);
+bool AreUpper32BitsZero(regNumber reg);
 
 // Adjust code size for CRC32 that has 4-byte opcode
 // but does not use SSE38 or EES3A encoding.

--- a/src/jit/emitxarch.h
+++ b/src/jit/emitxarch.h
@@ -94,6 +94,8 @@ code_t AddRexPrefix(instruction ins, code_t code);
 bool EncodedBySSE38orSSE3A(instruction ins);
 bool Is4ByteSSEInstruction(instruction ins);
 
+bool doesZeroExtendingWrite(instrDesc* id, regNumber reg);
+
 // Adjust code size for CRC32 that has 4-byte opcode
 // but does not use SSE38 or EES3A encoding.
 UNATIVE_OFFSET emitAdjustSizeCrc32(instruction ins, emitAttr attr)


### PR DESCRIPTION
Add a peephole optimization to suppress emitting zero extending moves
if the previous instruction has already done a suitable zero extension.

Only implemented for x64 currently.

Closes #21923