### PR TITLE
Cleanup LLVM assumption

### DIFF
--- a/src/debug/daccess/daccess.cpp
+++ b/src/debug/daccess/daccess.cpp
@@ -7504,9 +7504,9 @@ STDAPI CLRDataAccessCreateInstance(ICLRDataTarget * pLegacyTarget,
 // This is the legacy entrypoint to DAC, used by dbgeng/dbghelp (windbg, SOS, watson, etc).
 //
 //----------------------------------------------------------------------------
-#ifdef __llvm__
+#ifdef __GNUC__
 __attribute__((used))
-#endif // __llvm__
+#endif // __GNUC__
 STDAPI
 CLRDataCreateInstance(REFIID iid,
                       ICLRDataTarget * pLegacyTarget,

--- a/src/dlls/mscordac/mscordac.cpp
+++ b/src/dlls/mscordac/mscordac.cpp
@@ -9,9 +9,9 @@
 //
 // This dummy reference to CLRDataCreateInstance prevents the LLVM toolchain from optimizing this important export out.
 //
-#ifdef __llvm__
+#ifdef __GNUC__
 __attribute__((used))
-#endif // __llvm__
+#endif // __GNUC__
 void
 DummyReferenceToExportedAPI()
 {

--- a/src/inc/corhlprpriv.h
+++ b/src/inc/corhlprpriv.h
@@ -183,11 +183,11 @@ public:
         _Alloc<TRUE /*bGrow*/, TRUE /*bThrow*/>(iItems);
     }
 
-#ifdef __llvm__
+#ifdef __GNUC__
     // This makes sure that we will not get an undefined symbol
-    // when building a release version of libcoreclr using LLVM.
+    // when building a release version of libcoreclr using LLVM/GCC.
     __attribute__((used))
-#endif // __llvm__
+#endif // __GNUC__
     HRESULT ReSizeNoThrow(SIZE_T iItems);
 
     void Shrink(SIZE_T iItems)

--- a/src/vm/corhost.cpp
+++ b/src/vm/corhost.cpp
@@ -51,11 +51,11 @@
 
 GVAL_IMPL_INIT(DWORD, g_fHostConfig, 0);
 
-#ifndef __llvm__
+#ifndef __GNUC__
 EXTERN_C __declspec(thread) ThreadLocalInfo gCurrentThreadInfo;
-#else // !__llvm__
+#else // !__GNUC__
 EXTERN_C __thread ThreadLocalInfo gCurrentThreadInfo;
-#endif // !__llvm__
+#endif // !__GNUC__
 #ifndef FEATURE_PAL
 EXTERN_C UINT32 _tls_index;
 #else // FEATURE_PAL

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -299,11 +299,11 @@ bool Thread::DetectHandleILStubsForDebugger()
 }
 
 extern "C" {
-#ifndef __llvm__
+#ifndef __GNUC__
 __declspec(thread)
-#else // !__llvm__
+#else // !__GNUC__
 __thread 
-#endif // !__llvm__
+#endif // !__GNUC__
 ThreadLocalInfo gCurrentThreadInfo = 
                                               {
                                                   NULL,    // m_pThread

--- a/src/vm/threads.inl
+++ b/src/vm/threads.inl
@@ -23,11 +23,11 @@
 
 #ifndef DACCESS_COMPILE
 
-#ifndef __llvm__
+#ifndef __GNUC__
 EXTERN_C __declspec(thread) ThreadLocalInfo gCurrentThreadInfo;
-#else // !__llvm__
+#else // !__GNUC__
 EXTERN_C __thread ThreadLocalInfo gCurrentThreadInfo;
-#endif // !__llvm__
+#endif // !__GNUC__
 
 EXTERN_C inline Thread* STDCALL GetThread()
 {


### PR DESCRIPTION
We want to support GNU compilation for CoreCLR. Luckily both LLVM
and GNU compilers define __GNUC__ and there are a lot of things
they can share.