### PR TITLE
Pass official build id to build

### DIFF
--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -67,6 +67,11 @@ jobs:
         value: true
       - name: _BuildConfig
         value: $(buildConfigUpper)
+    - name: officialBuildIdArg
+      value: ''
+    - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+      - name: officialBuildIdArg
+        value: '-officialbuildid=$(Build.BuildNumber)'
 
     steps:
 
@@ -84,7 +89,7 @@ jobs:
 
     # Build
     - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-      - script: ./build.sh $(buildConfig) $(archType) $(crossArg) -skiptests -skipnuget $(clangArg) $(stripSymbolsArg)
+      - script: ./build.sh $(buildConfig) $(archType) $(crossArg) -skiptests -skipnuget $(clangArg) $(stripSymbolsArg) $(officialBuildIdArg)
         displayName: Build product
         ${{ if eq(parameters.osGroup, 'FreeBSD') }}:
           env:
@@ -92,8 +97,8 @@ jobs:
             # Once we are using Arcade, use DotNetCoreSdkDir instead, as we do below.
             DotNetBootstrapCliTarPath: /dotnet-sdk-freebsd-x64.tar
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-      # TODO: IBCOptimize? EnforcePGO? pass an OfficialBuildId? SignType? file logging parameters?
-      - script: set __TestIntermediateDir=int&&build.cmd $(buildConfig) $(archType) -skiptests -skipbuildpackages
+      # TODO: IBCOptimize? EnforcePGO? file logging parameters?
+      - script: set __TestIntermediateDir=int&&build.cmd $(buildConfig) $(archType) -skiptests -skipbuildpackages $(officialBuildIdArg)
         displayName: Build product
 
     # Sign on Windows


### PR DESCRIPTION
This ensures that coreclr gets a version number based on the build id. I don't know if this has any effect on unix, but the argument is passed either way for consistency.

I've confirmed that this produces a coreclr.dll with a version that has a revision number matching a build id. Fixes https://github.com/dotnet/coreclr/issues/22323.

Looking at the comment in the change reminded me that we really should figure out what to do about IBC - opened an issue for that here: https://github.com/dotnet/coreclr/issues/22467.