### PR TITLE
Changed Math field constant values

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Math.cs
+++ b/src/System.Private.CoreLib/shared/System/Math.cs
@@ -22,9 +22,9 @@ namespace System
 {
     public static partial class Math
     {
-        public const double E = 2.7182818284590452354;
+        public const double E = 2.7182818284590451;
 
-        public const double PI = 3.14159265358979323846;
+        public const double PI = 3.1415926535897931;
 
         private const int maxRoundingDigits = 15;
 

--- a/src/System.Private.CoreLib/shared/System/MathF.cs
+++ b/src/System.Private.CoreLib/shared/System/MathF.cs
@@ -17,9 +17,9 @@ namespace System
 {
     public static partial class MathF
     {
-        public const float E = 2.71828183f;
+        public const float E = 2.71828175f;
 
-        public const float PI = 3.14159265f;
+        public const float PI = 3.14159274f;
 
         private const int maxRoundingDigits = 6;
 


### PR DESCRIPTION
## Changed Math field constant values

Currently, there are disparities between:

- The declared value (2.7182818284590452354) and round-trippable value (2.7182818284590451) of Math.E.
- The declared value (3.14159265358979323846) and round-trippable value (3.1415926535897931) of MathF.E.
- The declared value (2.71828183) and round-trippable value (2.71828175) of Math.PI.
- The declared value (3.14159265) and round-trippable value (3.14159274) of MathF.PI.

This PR modifies the declared value to correspond to the value produced by the "G17" format string for Double values (which displays a Double in full precision) and the "G9" format string for Single values (which displays a Single in full precision).

//cc @tannergooding @nguerrera @stephentoub  

Related to dotnet/corefx#35141
