### PR TITLE
Disable more baseservices/threading/interlocked tests on Ubuntu.Arm64

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -570,6 +570,18 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/interlocked/compareexchange/CompareExchangeTClass_1/*">
             <Issue>22303</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/interlocked/exchange/ExchangeTClass/*">
+            <Issue>22303</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/interlocked/exchange/ExchangeTString/*">
+            <Issue>22303</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/interlocked/exchange/ExchangeTString_1/*">
+            <Issue>22303</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/interlocked/exchange/ExchangeTString_2/*">
+            <Issue>22303</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- Unix arm32 specific -->


### PR DESCRIPTION
In the last two weeks the following tests have failed:
* baseservices/threading/interlocked/exchange/ExchangeTClass - 5 times
* baseservices/threading/interlocked/exchange/ExchangeTString - 13 times
* baseservices/threading/interlocked/exchange/ExchangeTString_1 - 12 times
* baseservices/threading/interlocked/exchange/ExchangeTString_2 - 20 times

In addition to the previously disabled tests (in #22304):
* baseservices/threading/interlocked/compareexchange/CompareExchangeTClass - 9 times
* baseservices/threading/interlocked/compareexchange/CompareExchangeTClass_1 - 32 times

All the failures happened on Ubuntu.1804.Arm64 in AzDO Pri1 jobs

**Related issue:** #22303