### PR TITLE
Use CompareOrdinalHelper for SpanHelpers.SequenceCompareTo

### DIFF
--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.Globalization.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.Globalization.cs
@@ -45,7 +45,7 @@ namespace System
         /// </summary>
         public static bool Equals(this ReadOnlySpan<char> span, ReadOnlySpan<char> other, StringComparison comparisonType)
         {
-            string.CheckStringComparison(comparisonType);
+            string.ThrowIfStringComparisonInvalid(comparisonType);
 
             switch (comparisonType)
             {
@@ -101,7 +101,7 @@ namespace System
         /// </summary>
         public static int CompareTo(this ReadOnlySpan<char> span, ReadOnlySpan<char> other, StringComparison comparisonType)
         {
-            string.CheckStringComparison(comparisonType);
+            string.ThrowIfStringComparisonInvalid(comparisonType);
 
             switch (comparisonType)
             {
@@ -138,7 +138,7 @@ namespace System
         /// </summary>
         public static int IndexOf(this ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)
         {
-            string.CheckStringComparison(comparisonType);
+            string.ThrowIfStringComparisonInvalid(comparisonType);
 
             if (value.Length == 0)
             {
@@ -188,7 +188,7 @@ namespace System
         /// </summary>
         public static int LastIndexOf(this ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)
         {
-            string.CheckStringComparison(comparisonType);
+            string.ThrowIfStringComparisonInvalid(comparisonType);
 
             if (value.Length == 0)
             {
@@ -333,7 +333,7 @@ namespace System
         /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/> and <paramref name="value"/> are compared.</param>
         public static bool EndsWith(this ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)
         {
-            string.CheckStringComparison(comparisonType);
+            string.ThrowIfStringComparisonInvalid(comparisonType);
 
             if (value.Length == 0)
             {
@@ -366,7 +366,7 @@ namespace System
         /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/> and <paramref name="value"/> are compared.</param>
         public static bool StartsWith(this ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)
         {
-            string.CheckStringComparison(comparisonType);
+            string.ThrowIfStringComparisonInvalid(comparisonType);
 
             if (value.Length == 0)
             {

--- a/src/System.Private.CoreLib/shared/System/String.Comparison.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Comparison.cs
@@ -56,6 +56,8 @@ namespace System
 
             return CompareInfo.EqualsOrdinalIgnoreCase(ref strA.GetRawStringData(), ref strB.GetRawStringData(), strB.Length);
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe int CompareOrdinalHelper(string strA, string strB)
         {
             Debug.Assert(strA != null);
@@ -67,112 +69,8 @@ namespace System
                 "For performance reasons, callers of this method should " +
                 "check/short-circuit beforehand if the first char is the same.");
 
-            int length = Math.Min(strA.Length, strB.Length);
-
-            fixed (char* ap = &strA._firstChar) fixed (char* bp = &strB._firstChar)
-            {
-                char* a = ap;
-                char* b = bp;
-
-                // Check if the second chars are different here
-                // The reason we check if _firstChar is different is because
-                // it's the most common case and allows us to avoid a method call
-                // to here.
-                // The reason we check if the second char is different is because
-                // if the first two chars the same we can increment by 4 bytes,
-                // leaving us word-aligned on both 32-bit (12 bytes into the string)
-                // and 64-bit (16 bytes) platforms.
-
-                // For empty strings, the second char will be null due to padding.
-                // The start of the string is the type pointer + string length, which
-                // takes up 8 bytes on 32-bit, 12 on x64. For empty strings the null
-                // terminator immediately follows, leaving us with an object
-                // 10/14 bytes in size. Since everything needs to be a multiple
-                // of 4/8, this will get padded and zeroed out.
-
-                // For one-char strings the second char will be the null terminator.
-
-                // NOTE: If in the future there is a way to read the second char
-                // without pinning the string (e.g. System.Runtime.CompilerServices.Unsafe
-                // is exposed to mscorlib, or a future version of C# allows inline IL),
-                // then do that and short-circuit before the fixed.
-
-                if (*(a + 1) != *(b + 1)) goto DiffOffset1;
-
-                // Since we know that the first two chars are the same,
-                // we can increment by 2 here and skip 4 bytes.
-                // This leaves us 8-byte aligned, which results
-                // on better perf for 64-bit platforms.
-                length -= 2; a += 2; b += 2;
-
-                // unroll the loop
-#if BIT64
-                while (length >= 12)
-                {
-                    if (*(long*)a != *(long*)b) goto DiffOffset0;
-                    if (*(long*)(a + 4) != *(long*)(b + 4)) goto DiffOffset4;
-                    if (*(long*)(a + 8) != *(long*)(b + 8)) goto DiffOffset8;
-                    length -= 12; a += 12; b += 12;
-                }
-#else // BIT64
-                while (length >= 10)
-                {
-                    if (*(int*)a != *(int*)b) goto DiffOffset0;
-                    if (*(int*)(a + 2) != *(int*)(b + 2)) goto DiffOffset2;
-                    if (*(int*)(a + 4) != *(int*)(b + 4)) goto DiffOffset4;
-                    if (*(int*)(a + 6) != *(int*)(b + 6)) goto DiffOffset6;
-                    if (*(int*)(a + 8) != *(int*)(b + 8)) goto DiffOffset8;
-                    length -= 10; a += 10; b += 10;
-                }
-#endif // BIT64
-
-                // Fallback loop:
-                // go back to slower code path and do comparison on 4 bytes at a time.
-                // This depends on the fact that the String objects are
-                // always zero terminated and that the terminating zero is not included
-                // in the length. For odd string sizes, the last compare will include
-                // the zero terminator.
-                while (length > 0)
-                {
-                    if (*(int*)a != *(int*)b) goto DiffNextInt;
-                    length -= 2;
-                    a += 2;
-                    b += 2;
-                }
-
-                // At this point, we have compared all the characters in at least one string.
-                // The longer string will be larger.
-                return strA.Length - strB.Length;
-
-#if BIT64
-            DiffOffset8: a += 4; b += 4;
-            DiffOffset4: a += 4; b += 4;
-#else // BIT64
-                // Use jumps instead of falling through, since
-                // otherwise going to DiffOffset8 will involve
-                // 8 add instructions before getting to DiffNextInt
-                DiffOffset8: a += 8; b += 8; goto DiffOffset0;
-                DiffOffset6: a += 6; b += 6; goto DiffOffset0;
-                DiffOffset4: a += 2; b += 2;
-                DiffOffset2: a += 2; b += 2;
-#endif // BIT64
-
-            DiffOffset0:
-                // If we reached here, we already see a difference in the unrolled loop above
-#if BIT64
-                if (*(int*)a == *(int*)b)
-                {
-                    a += 2; b += 2;
-                }
-#endif // BIT64
-
-            DiffNextInt:
-                if (*a != *b) return *a - *b;
-
-                DiffOffset1:
-                Debug.Assert(*(a + 1) != *(b + 1), "This char must be different if we reach here!");
-                return *(a + 1) - *(b + 1);
-            }
+            // Already compared 1 char, so start 1 char in
+            return SpanHelpers.SequenceCompareTo(ref Unsafe.Add(ref strA.GetRawStringData(), 1), strA.Length - 1, ref Unsafe.Add(ref strB.GetRawStringData(), 1), strB.Length - 1);
         }
 
         // Provides a culture-correct string comparison. StrA is compared to StrB
@@ -199,21 +97,20 @@ namespace System
         // for meaning of different comparisonType.
         public static int Compare(string? strA, string? strB, StringComparison comparisonType)
         {
+            ThrowIfStringComparisonInvalid(comparisonType);
+
             if (object.ReferenceEquals(strA, strB))
             {
-                CheckStringComparison(comparisonType);
                 return 0;
             }
 
             // They can't both be null at this point.
             if (strA == null)
             {
-                CheckStringComparison(comparisonType);
                 return -1;
             }
             if (strB == null)
             {
-                CheckStringComparison(comparisonType);
                 return 1;
             }
 
@@ -237,11 +134,9 @@ namespace System
 
                     return CompareOrdinalHelper(strA, strB);
 
-                case StringComparison.OrdinalIgnoreCase:
+                default: // StringComparison.OrdinalIgnoreCase
+                    Debug.Assert(comparisonType == StringComparison.OrdinalIgnoreCase);
                     return CompareInfo.CompareOrdinalIgnoreCase(strA, strB);
-
-                default:
-                    throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
             }
         }
 
@@ -351,7 +246,7 @@ namespace System
 
         public static int Compare(string? strA, int indexA, string? strB, int indexB, int length, StringComparison comparisonType)
         {
-            CheckStringComparison(comparisonType);
+            ThrowIfStringComparisonInvalid(comparisonType);
 
             if (strA == null || strB == null)
             {
@@ -403,7 +298,7 @@ namespace System
                     return CompareOrdinalHelper(strA, indexA, lengthA, strB, indexB, lengthB);
 
                 default:
-                    Debug.Assert(comparisonType == StringComparison.OrdinalIgnoreCase); // CheckStringComparison validated these earlier
+                    Debug.Assert(comparisonType == StringComparison.OrdinalIgnoreCase); // ThrowIfStringComparisonInvalid validated these earlier
                     return CompareInfo.CompareOrdinalIgnoreCase(strA, indexA, lengthA, strB, indexB, lengthB);
             }
         }
@@ -530,15 +425,15 @@ namespace System
                 throw new ArgumentNullException(nameof(value));
             }
 
+            ThrowIfStringComparisonInvalid(comparisonType);
+
             if ((object)this == (object)value)
             {
-                CheckStringComparison(comparisonType);
                 return true;
             }
 
             if (value.Length == 0)
             {
-                CheckStringComparison(comparisonType);
                 return true;
             }
 
@@ -556,11 +451,9 @@ namespace System
                     int offset = this.Length - value.Length;
                     return (uint)offset <= (uint)this.Length && this.AsSpan(offset).SequenceEqual(value);
 
-                case StringComparison.OrdinalIgnoreCase:
+                default: // StringComparison.OrdinalIgnoreCase
+                    Debug.Assert(comparisonType == StringComparison.OrdinalIgnoreCase);
                     return this.Length < value.Length ? false : (CompareInfo.CompareOrdinalIgnoreCase(this, this.Length - value.Length, value.Length, value, 0, value.Length) == 0);
-
-                default:
-                    throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
             }
         }
 
@@ -622,15 +515,15 @@ namespace System
 
         public bool Equals(string? value, StringComparison comparisonType)
         {
+            ThrowIfStringComparisonInvalid(comparisonType);
+
             if (object.ReferenceEquals(this, value))
             {
-                CheckStringComparison(comparisonType);
                 return true;
             }
 
             if (value is null)
             {
-                CheckStringComparison(comparisonType);
                 return false;
             }
 
@@ -649,14 +542,12 @@ namespace System
                         return false;
                     return EqualsHelper(this, value);
 
-                case StringComparison.OrdinalIgnoreCase:
+                default: // StringComparison.OrdinalIgnoreCase
+                    Debug.Assert(comparisonType == StringComparison.OrdinalIgnoreCase);
                     if (this.Length != value.Length)
                         return false;
 
                     return EqualsOrdinalIgnoreCase(this, value);
-
-                default:
-                    throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
             }
         }
 
@@ -678,15 +569,15 @@ namespace System
 
         public static bool Equals(string? a, string? b, StringComparison comparisonType)
         {
+            ThrowIfStringComparisonInvalid(comparisonType);
+
             if (object.ReferenceEquals(a, b))
             {
-                CheckStringComparison(comparisonType);
                 return true;
             }
 
             if (a is null || b is null)
             {
-                CheckStringComparison(comparisonType);
                 return false;
             }
 
@@ -705,14 +596,12 @@ namespace System
                         return false;
                     return EqualsHelper(a, b);
 
-                case StringComparison.OrdinalIgnoreCase:
+                default: // StringComparison.OrdinalIgnoreCase
+                    Debug.Assert(comparisonType == StringComparison.OrdinalIgnoreCase);
                     if (a.Length != b.Length)
                         return false;
 
                     return EqualsOrdinalIgnoreCase(a, b);
-
-                default:
-                    throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
             }
         }
 
@@ -837,15 +726,15 @@ namespace System
                 throw new ArgumentNullException(nameof(value));
             }
 
+            ThrowIfStringComparisonInvalid(comparisonType);
+
             if ((object)this == (object)value)
             {
-                CheckStringComparison(comparisonType);
                 return true;
             }
 
             if (value.Length == 0)
             {
-                CheckStringComparison(comparisonType);
                 return true;
             }
 
@@ -871,15 +760,13 @@ namespace System
                                 ref Unsafe.As<char, byte>(ref value.GetRawStringData()),
                                 ((nuint)value.Length) * 2);
 
-                case StringComparison.OrdinalIgnoreCase:
+                default: // StringComparison.OrdinalIgnoreCase
+                    Debug.Assert(comparisonType == StringComparison.OrdinalIgnoreCase);
                     if (this.Length < value.Length)
                     {
                         return false;
                     }
                     return CompareInfo.EqualsOrdinalIgnoreCase(ref this.GetRawStringData(), ref value.GetRawStringData(), value.Length);
-
-                default:
-                    throw new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
             }
         }
 
@@ -901,7 +788,7 @@ namespace System
 
         public bool StartsWith(char value) => Length != 0 && _firstChar == value;
 
-        internal static void CheckStringComparison(StringComparison comparisonType)
+        internal static void ThrowIfStringComparisonInvalid(StringComparison comparisonType)
         {
             // Single comparison to check if comparisonType is within [CurrentCulture .. OrdinalIgnoreCase]
             if ((uint)comparisonType > (uint)StringComparison.OrdinalIgnoreCase)

--- a/src/System.Private.CoreLib/src/System/Text/Utf8Span.Searching.cs
+++ b/src/System.Private.CoreLib/src/System/Text/Utf8Span.Searching.cs
@@ -53,7 +53,7 @@ namespace System.Text
             }
             else
             {
-                string.CheckStringComparison(comparisonType);
+                string.ThrowIfStringComparisonInvalid(comparisonType);
 
                 // Surrogate chars can't exist in well-formed UTF-8 data - bail immediately.
 
@@ -185,7 +185,7 @@ namespace System.Text
 
         private unsafe bool TryFind(Utf8Span value, StringComparison comparisonType, out Range range, bool fromBeginning)
         {
-            string.CheckStringComparison(comparisonType);
+            string.ThrowIfStringComparisonInvalid(comparisonType);
 
             if (value.IsEmpty)
             {
@@ -367,7 +367,7 @@ namespace System.Text
             }
             else
             {
-                string.CheckStringComparison(comparisonType);
+                string.ThrowIfStringComparisonInvalid(comparisonType);
 
                 // Surrogate chars can't exist in well-formed UTF-8 data - bail immediately.
 


### PR DESCRIPTION
Rather than a custom implementation, use the Vectorized `SpanHelpers.SequenceCompareTo` for 
```csharp
int CompareOrdinalHelper(string strA, string strB)
```
As per (which already uses it)
```csharp
int CompareOrdinalHelper(string strA, int indexA, int countA, string strB, int indexB, int countB)
```
Performance should be additionally improved after https://github.com/dotnet/coreclr/pull/22187

/cc @jkotas @stephentoub 