### PR TITLE
Remove GTF_REVERSE_OPS checks from LSRA

### DIFF
--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -687,20 +687,16 @@ int LinearScan::BuildBlockStore(GenTreeBlk* blkNode)
         buildInternalIntRegisterDefForNode(blkNode, blkSizeRegMask);
     }
 
-    if (!dstAddr->isContained() && !blkNode->IsReverseOp())
+    if (!dstAddr->isContained())
     {
         srcCount++;
         BuildUse(dstAddr, dstAddrRegMask);
     }
+
     if ((srcAddrOrFill != nullptr) && !srcAddrOrFill->isContained())
     {
         srcCount++;
         BuildUse(srcAddrOrFill, sourceRegMask);
-    }
-    if (!dstAddr->isContained() && blkNode->IsReverseOp())
-    {
-        srcCount++;
-        BuildUse(dstAddr, dstAddrRegMask);
     }
 
     if (size == 0)

--- a/src/jit/lsrabuild.cpp
+++ b/src/jit/lsrabuild.cpp
@@ -2812,11 +2812,6 @@ int LinearScan::BuildBinaryUses(GenTreeOp* node, regMaskTP candidates)
     int      srcCount = 0;
     GenTree* op1      = node->gtOp1;
     GenTree* op2      = node->gtGetOp2IfPresent();
-    if (node->IsReverseOp() && (op2 != nullptr))
-    {
-        srcCount += BuildOperandUses(op2, candidates);
-        op2 = nullptr;
-    }
     if (op1 != nullptr)
     {
         srcCount += BuildOperandUses(op1, candidates);

--- a/src/jit/lsraxarch.cpp
+++ b/src/jit/lsraxarch.cpp
@@ -796,7 +796,6 @@ int LinearScan::BuildRMWUses(GenTreeOp* node, regMaskTP candidates)
     int       srcCount      = 0;
     GenTree*  op1           = node->gtOp1;
     GenTree*  op2           = node->gtGetOp2IfPresent();
-    bool      isReverseOp   = node->IsReverseOp();
     regMaskTP op1Candidates = candidates;
     regMaskTP op2Candidates = candidates;
 
@@ -821,7 +820,6 @@ int LinearScan::BuildRMWUses(GenTreeOp* node, regMaskTP candidates)
     bool prefOp2 = false;
     getTgtPrefOperands(node, prefOp1, prefOp2);
     assert(!prefOp2 || node->OperIsCommutative());
-    assert(!isReverseOp || node->OperIsCommutative());
 
     // Determine which operand, if any, should be delayRegFree. Normally, this would be op2,
     // but if we have a commutative operator and op1 is a contained memory op, it would be op1.
@@ -857,12 +855,6 @@ int LinearScan::BuildRMWUses(GenTreeOp* node, regMaskTP candidates)
     {
         assert(!prefOp1 || delayUseOperand != op1);
         assert(!prefOp2 || delayUseOperand != op2);
-    }
-
-    if (isReverseOp)
-    {
-        op1 = op2;
-        op2 = node->gtOp1;
     }
 
     // Build first use
@@ -1437,20 +1429,16 @@ int LinearScan::BuildBlockStore(GenTreeBlk* blkNode)
         buildInternalIntRegisterDefForNode(blkNode, blkSizeRegMask);
     }
 
-    if (!dstAddr->isContained() && !blkNode->IsReverseOp())
+    if (!dstAddr->isContained())
     {
         srcCount++;
         BuildUse(dstAddr, dstAddrRegMask);
     }
+
     if ((srcAddrOrFill != nullptr) && !srcAddrOrFill->isContained())
     {
         srcCount++;
         BuildUse(srcAddrOrFill, sourceRegMask);
-    }
-    if (!dstAddr->isContained() && blkNode->IsReverseOp())
-    {
-        srcCount++;
-        BuildUse(dstAddr, dstAddrRegMask);
     }
 
     if (size == 0)


### PR DESCRIPTION
GTF_REVERSE_OPS is cleared during rationalization.

Pulled out of #21711 as that's way too large.