### PR TITLE
Correct assert to add R8 as a potential valid register.

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -2717,7 +2717,7 @@ void CodeGen::genJmpMethod(GenTree* jmp)
         if (compiler->info.compIsVarArgs)
         {
             // In case of a jmp call to a vararg method ensure only integer registers are passed.
-            assert(((genRegMask(argReg) & RBM_ARG_REGS) & REG_ARG_RET_BUFF) != RBM_NONE);
+            assert(((genRegMask(argReg) & (RBM_ARG_REGS | REG_ARG_RET_BUFF)) != RBM_NONE);
 
             fixedIntArgMask |= genRegMask(argReg);
 

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -2714,9 +2714,9 @@ void CodeGen::genJmpMethod(GenTree* jmp)
             }
         }
 
-        // In case of a jmp call to a vararg method ensure only integer registers are passed.
         if (compiler->info.compIsVarArgs)
         {
+            // In case of a jmp call to a vararg method ensure only integer registers are passed.
             assert(((genRegMask(argReg) & RBM_ARG_REGS) & REG_ARG_RET_BUFF) != RBM_NONE);
 
             fixedIntArgMask |= genRegMask(argReg);

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -2717,8 +2717,6 @@ void CodeGen::genJmpMethod(GenTree* jmp)
         // In case of a jmp call to a vararg method ensure only integer registers are passed.
         if (compiler->info.compIsVarArgs)
         {
-            assert((genRegMask(argReg) & RBM_ARG_REGS) != RBM_NONE);
-
             fixedIntArgMask |= genRegMask(argReg);
 
             if (compiler->lvaIsMultiregStruct(varDsc, compiler->info.compIsVarArgs))

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -2717,6 +2717,8 @@ void CodeGen::genJmpMethod(GenTree* jmp)
         // In case of a jmp call to a vararg method ensure only integer registers are passed.
         if (compiler->info.compIsVarArgs)
         {
+            assert(((genRegMask(argReg) & RBM_ARG_REGS) & REG_ARG_RET_BUFF) != RBM_NONE);
+
             fixedIntArgMask |= genRegMask(argReg);
 
             if (compiler->lvaIsMultiregStruct(varDsc, compiler->info.compIsVarArgs))

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -2717,7 +2717,7 @@ void CodeGen::genJmpMethod(GenTree* jmp)
         if (compiler->info.compIsVarArgs)
         {
             // In case of a jmp call to a vararg method ensure only integer registers are passed.
-            assert(((genRegMask(argReg) & (RBM_ARG_REGS | REG_ARG_RET_BUFF)) != RBM_NONE);
+            assert((genRegMask(argReg) & (RBM_ARG_REGS | REG_ARG_RET_BUFF)) != RBM_NONE);
 
             fixedIntArgMask |= genRegMask(argReg);
 

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -414,24 +414,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/opt/rngchk/RngchkStress3/*">
             <Issue>Needs Triage</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/mcc/interop/mcc_i53/*">
-            <Issue>Needs Triage</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/mcc/interop/mcc_i13/*">
-            <Issue>Needs Triage</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/mcc/interop/mcc_i03/*">
-            <Issue>Needs Triage</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/mcc/interop/mcc_i33/*">
-            <Issue>Needs Triage</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/mcc/interop/mcc_i63/*">
-            <Issue>Needs Triage</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/mcc/interop/mcc_i73/*">
-            <Issue>Needs Triage</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- arm32 All OS specific excludes -->


### PR DESCRIPTION
This fixes asserts that use JMP and varargs on Arm64.