### PR TITLE
Fix Assembly::Load context for collectible assemblies

### DIFF
--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -1176,27 +1176,6 @@ void AppDomain::ShutdownNativeDllSearchDirectories()
     m_NativeDllSearchDirectories.Clear();
 }
 
-void AppDomain::ReleaseDomainBoundInfo()
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_ANY;
-    }
-    CONTRACTL_END;;
-    // Shutdown assemblies
-    m_AssemblyCache.OnAppDomainUnload();
-
-    AssemblyIterator i = IterateAssembliesEx( (AssemblyIterationFlags)(kIncludeFailedToLoad) );
-    CollectibleAssemblyHolder<DomainAssembly *> pDomainAssembly;
-    
-    while (i.Next(pDomainAssembly.This()))
-    {
-       pDomainAssembly->ReleaseManagedData();
-    }
-}
-
 void AppDomain::ReleaseFiles()
 {
     STANDARD_VM_CONTRACT;

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -1823,7 +1823,6 @@ public:
     void ShutdownAssemblies();
     void ShutdownFreeLoaderAllocators(BOOL bFromManagedCode);
     
-    void ReleaseDomainBoundInfo();
     void ReleaseFiles();
     
 

--- a/src/vm/assemblynative.cpp
+++ b/src/vm/assemblynative.cpp
@@ -84,9 +84,7 @@ FCIMPL7(Object*, AssemblyNative::Load, AssemblyNameBaseObject* assemblyNameUNSAF
             pRefAssembly = gc.requestingAssembly->GetAssembly();
         }
         
-        // Shared or collectible assemblies should not be used for the parent in the
-        // late-bound case.
-        if (pRefAssembly && (!pRefAssembly->IsCollectible()))
+        if (pRefAssembly)
         {
             pParentAssembly= pRefAssembly->GetDomainAssembly();
         }

--- a/src/vm/assemblyspec.cpp
+++ b/src/vm/assemblyspec.cpp
@@ -1223,27 +1223,6 @@ void AssemblySpecBindingCache::Clear()
     m_map.Clear();
 }
 
-void AssemblySpecBindingCache::OnAppDomainUnload()
-{
-    CONTRACTL
-    {
-        DESTRUCTOR_CHECK;
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_ANY;
-    }
-    CONTRACTL_END;
-
-    PtrHashMap::PtrIterator i = m_map.begin();
-    while (!i.end())
-    {
-        AssemblyBinding *b = (AssemblyBinding*) i.GetValue();
-        b->OnAppDomainUnload();
-
-        ++i;
-    }
-}
-
 void AssemblySpecBindingCache::Init(CrstBase *pCrst, LoaderHeap *pHeap)
 {
     WRAPPER_NO_CONTRACT;
@@ -1776,7 +1755,7 @@ BOOL AssemblySpecBindingCache::RemoveAssembly(DomainAssembly* pAssembly)
     while (!i.end())
     {
         AssemblyBinding* entry = (AssemblyBinding*)i.GetValue();
-        if (entry->GetAssembly() == pAssembly)
+        if (entry->GetAssembly() == pAssembly || entry->GetParentAssembly() == pAssembly)
         {
             UPTR key = i.GetKey();
             m_map.DeleteValue(key, entry);

--- a/src/vm/assemblyspec.cpp
+++ b/src/vm/assemblyspec.cpp
@@ -1755,7 +1755,7 @@ BOOL AssemblySpecBindingCache::RemoveAssembly(DomainAssembly* pAssembly)
     while (!i.end())
     {
         AssemblyBinding* entry = (AssemblyBinding*)i.GetValue();
-        if (entry->GetAssembly() == pAssembly || entry->GetParentAssembly() == pAssembly)
+        if (entry->GetAssembly() == pAssembly)
         {
             UPTR key = i.GetKey();
             m_map.DeleteValue(key, entry);
@@ -1851,6 +1851,11 @@ VOID DomainAssemblyCache::InsertEntry(AssemblySpec* pSpec, LPVOID pData1, LPVOID
 
             pEntry->spec.CopyFrom(pSpec);
             pEntry->spec.CloneFieldsToLoaderHeap(AssemblySpec::ALL_OWNED, m_pDomain->GetLowFrequencyHeap(), pamTracker);
+
+            // Clear the parent assembly, it is not needed for the AssemblySpec in the cache entry and it could contain stale
+            // pointer when the parent was a collectible assembly that was collected.
+            pEntry->spec.SetParentAssembly(NULL);
+
             pEntry->pData[0] = pData1;
             pEntry->pData[1] = pData2;
             DWORD hashValue = pEntry->Hash();

--- a/src/vm/assemblyspec.hpp
+++ b/src/vm/assemblyspec.hpp
@@ -425,7 +425,6 @@ class AssemblySpecBindingCache
 
         inline DomainAssembly* GetAssembly(){ LIMITED_METHOD_CONTRACT; return m_pAssembly;};
         inline void SetAssembly(DomainAssembly* pAssembly){ LIMITED_METHOD_CONTRACT;  m_pAssembly=pAssembly;};
-        inline DomainAssembly* GetParentAssembly(){ LIMITED_METHOD_CONTRACT; return m_spec.GetParentAssembly();};
         inline PEAssembly* GetFile(){ LIMITED_METHOD_CONTRACT; return m_pFile;};
         inline BOOL IsError(){ LIMITED_METHOD_CONTRACT; return (m_exceptionType!=EXTYPE_NONE);};
 

--- a/src/vm/assemblyspec.hpp
+++ b/src/vm/assemblyspec.hpp
@@ -423,19 +423,9 @@ class AssemblySpecBindingCache
                 delete m_pException;
         };
 
-        void OnAppDomainUnload()
-        {
-            LIMITED_METHOD_CONTRACT;
-            if (m_exceptionType == EXTYPE_EE)
-            {
-                m_exceptionType = EXTYPE_NONE;
-                delete m_pException;
-                m_pException = NULL;
-            }
-        };
-
         inline DomainAssembly* GetAssembly(){ LIMITED_METHOD_CONTRACT; return m_pAssembly;};
-        inline void SetAssembly(DomainAssembly* pAssembly){ LIMITED_METHOD_CONTRACT;  m_pAssembly=pAssembly;};        
+        inline void SetAssembly(DomainAssembly* pAssembly){ LIMITED_METHOD_CONTRACT;  m_pAssembly=pAssembly;};
+        inline DomainAssembly* GetParentAssembly(){ LIMITED_METHOD_CONTRACT; return m_spec.GetParentAssembly();};
         inline PEAssembly* GetFile(){ LIMITED_METHOD_CONTRACT; return m_pFile;};
         inline BOOL IsError(){ LIMITED_METHOD_CONTRACT; return (m_exceptionType!=EXTYPE_NONE);};
 
@@ -578,8 +568,6 @@ class AssemblySpecBindingCache
 
     void Init(CrstBase *pCrst, LoaderHeap *pHeap = NULL);
     void Clear();
-
-    void OnAppDomainUnload();
 
     BOOL Contains(AssemblySpec *pSpec);
 

--- a/src/vm/loaderallocator.cpp
+++ b/src/vm/loaderallocator.cpp
@@ -501,13 +501,9 @@ LoaderAllocator * LoaderAllocator::GCLoaderAllocators_RemoveAssemblies(AppDomain
                 pAppDomain->RemoveFileFromCache(domainAssemblyToRemove->GetFile());
                 AssemblySpec spec;
                 spec.InitializeSpec(domainAssemblyToRemove->GetFile());
+                VERIFY(pAppDomain->RemoveAssemblyFromCache(domainAssemblyToRemove));
                 pAppDomain->RemoveNativeImageDependency(&spec);
             }
-
-            // We need to call RemoveAssemblyFromCache even for dynamic assemblies.
-            // Even though they don't have their own entries in the cache, they can
-            // be stored in the cache entries as parent assemblies.
-            VERIFY(pAppDomain->RemoveAssemblyFromCache(domainAssemblyToRemove));
 
             domainAssemblyIt++;
         }

--- a/src/vm/loaderallocator.cpp
+++ b/src/vm/loaderallocator.cpp
@@ -501,9 +501,13 @@ LoaderAllocator * LoaderAllocator::GCLoaderAllocators_RemoveAssemblies(AppDomain
                 pAppDomain->RemoveFileFromCache(domainAssemblyToRemove->GetFile());
                 AssemblySpec spec;
                 spec.InitializeSpec(domainAssemblyToRemove->GetFile());
-                VERIFY(pAppDomain->RemoveAssemblyFromCache(domainAssemblyToRemove));
                 pAppDomain->RemoveNativeImageDependency(&spec);
             }
+
+            // We need to call RemoveAssemblyFromCache even for dynamic assemblies.
+            // Even though they don't have their own entries in the cache, they can
+            // be stored in the cache entries as parent assemblies.
+            VERIFY(pAppDomain->RemoveAssemblyFromCache(domainAssemblyToRemove));
 
             domainAssemblyIt++;
         }


### PR DESCRIPTION
This change fixes a problem when Assembly::Load is called from an
assembly in a collectible AssemblyLoadContext. In that case, we ended up
loading it into the default context instead of the context of the
calling assembly.

I have also bumped into a couple of functions that are not used anymore, so I have removed them.