### PR TITLE
Enable arm64 linux musl builds

### DIFF
--- a/Documentation/building/linux-instructions.md
+++ b/Documentation/building/linux-instructions.md
@@ -45,14 +45,15 @@ Note that instructions on building the crossrootfs location can be found at http
 Docker Images
 =============
 
-| OS             | Target Arch | Image location | crossrootfs location |
-| -------------- | ----------- | -------------- | -------------------- |
-| Ubuntu 16.04   | x64         | `microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-c103199-20180628134544` | - |
-| Alpine         | x64         | `microsoft/dotnet-buildtools-prereqs:alpine-3.6-e2521f8-20180716231200` | - |
-| CentOS 6 (build for RHEL 6) | x64 | `microsoft/dotnet-buildtools-prereqs:centos-6-376e1a3-20174311014331` | - |
-| CentOS 7 (build for RHEL 7) | x64 | `microsoft/dotnet-buildtools-prereqs:centos-7-d485f41-20173404063424` | - | 
-| Ubuntu 14.04   | arm32(armhf) | `microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-e435274-20180426002420` | `/crossrootfs/arm` |
-| Ubuntu 16.04   | arm64 (aarch64) | `microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-cross-arm64-a3ae44b-20180315221921` | `/crossrootfs/arm64` |
+| OS             | Target Arch | Image location | crossrootfs location | Clang Version |
+| -------------- | ----------- | -------------- | -------------------- | ------------- |
+| Ubuntu 16.04   | x64         | `microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-c103199-20180628134544` | - | - |
+| Alpine         | x64         | `microsoft/dotnet-buildtools-prereqs:alpine-3.6-e2521f8-20180716231200` | - | - |
+| CentOS 6 (build for RHEL 6) | x64 | `microsoft/dotnet-buildtools-prereqs:centos-6-376e1a3-20174311014331` | - | - |
+| CentOS 7 (build for RHEL 7) | x64 | `microsoft/dotnet-buildtools-prereqs:centos-7-d485f41-20173404063424` | - | - |
+| Ubuntu 14.04   | arm32(armhf) | `microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-e435274-20180426002420` | `/crossrootfs/arm` | - |
+| Ubuntu 16.04   | arm64 (arm64v8) | `microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-cross-arm64-a3ae44b-20180315221921` | `/crossrootfs/arm64` | - |
+| Alpine | arm64 (arm64v8) | `microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-cross-arm64-alpine10fcdcf-20190208200917` | `/crossrootfs/arm64` | -clang5.0 |
 
 Environment
 ===========

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,9 @@ resources:
   - container: musl_x64_build_image
     image: microsoft/dotnet-buildtools-prereqs:alpine-3.6-WithNode-f4d3fe3-20181220200247
 
+  - container: musl_arm64_build_image
+    image: microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-cross-arm64-alpine10fcdcf-20190208200917
+
   - container: centos7_x64_build_image
     image: microsoft/dotnet-buildtools-prereqs:centos-7-d485f41-20173404063424
 
@@ -271,6 +274,7 @@ jobs:
       - build_Linux_arm_release
       - build_Linux_arm64_release
       - build_Linux_musl_x64_release
+      - build_Linux_musl_arm64_release
       - build_Linux_rhel6_x64_release
       - build_Linux_x64_release
       - build_FreeBSD_x64_release

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -56,6 +56,9 @@ jobs:
     - ${{ if eq(parameters.osGroup, 'FreeBSD') }}:
       - name: clangArg
         value: '-clang6.0'
+    - ${{ if and(eq(parameters.osIdentifier, 'Linux_musl'), eq(parameters.archType, "arm64")) }}:
+      - name: clangArg
+        value: '-clang5.0'
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
       # Variables used to publish packages to blob feed
       - name: dotnetfeedUrl

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -56,7 +56,7 @@ jobs:
     - ${{ if eq(parameters.osGroup, 'FreeBSD') }}:
       - name: clangArg
         value: '-clang6.0'
-    - ${{ if and(eq(parameters.osIdentifier, 'Linux_musl'), eq(parameters.archType, "arm64")) }}:
+    - ${{ if and(eq(parameters.osIdentifier, 'Linux_musl'), eq(parameters.archType, 'arm64')) }}:
       - name: clangArg
         value: '-clang5.0'
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -79,6 +79,27 @@ jobs:
         - Alpine.38.Amd64
     ${{ insert }}: ${{ parameters.jobParameters }}
 
+# Linux musl arm64
+
+- template: ${{ parameters.jobTemplate }}
+  parameters:
+    buildConfig: ${{ parameters.buildConfig }}
+    archType: arm64
+    osGroup: Linux
+    osIdentifier: Linux_musl
+    containerName: musl_arm64_build_image
+    helixQueues:
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        # TODO: there are no Alpine arm64 queues https://github.com/dotnet/core-eng/issues/5206
+        asString: ''
+        asArray: []
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        # TODO: there are no Alpine arm64 queues https://github.com/dotnet/core-eng/issues/5206
+        asString: ''
+        asArray: []
+    crossrootfsDir: '/crossrootfs/arm64'
+    ${{ insert }}: ${{ parameters.jobParameters }}
+
 # RHEL 6
 
 - template: ${{ parameters.jobTemplate }}

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -61,6 +61,16 @@ jobs:
       - name: crossgenArg
         value: ''
 
+    - name: clangArg
+      value: ''
+    # Our FreeBSD doesn't yet detect available clang versions, so pass it explicitly.
+    - ${{ if eq(parameters.osGroup, 'FreeBSD') }}:
+      - name: clangArg
+        value: '-clang6.0'
+    - ${{ if and(eq(parameters.osIdentifier, 'Linux_musl'), eq(parameters.archType, 'arm64')) }}:
+      - name: clangArg
+        value: '-clang5.0'
+
     # TODO: Enable crossgen in build-test.sh. It currently doesn't
     # accept a crossgen arg, so disable the macos/linux crossgen test
     # build jobs.
@@ -106,7 +116,7 @@ jobs:
     # Build tests
     # TODO: enable crossgen in build-test.sh
     - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-      - script: ./build-test.sh $(buildConfig) $(archType) $(crossArg) $(priorityArg) $(crossgenArg)
+      - script: ./build-test.sh $(buildConfig) $(archType) $(crossArg) $(priorityArg) $(crossgenArg) $(clangArg)
         displayName: Build tests
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
       - script: build-test.cmd $(buildConfig) $(archType) $(priorityArg) $(crossgenArg)


### PR DESCRIPTION
Note that -clang5.0 is required to be passed.