### PR TITLE
Perf: Consolidate implementation of LeadingZeroCount

### DIFF
--- a/src/System.Private.CoreLib/shared/System/BitOps.cs
+++ b/src/System.Private.CoreLib/shared/System/BitOps.cs
@@ -189,14 +189,15 @@ namespace System
         #region Log2
 
         /// <summary>
-        /// Returns the integer (floor) log of the specified value, base 2, without branching.
+        /// Returns the integer (floor) log of the specified value, base 2.
         /// Note that by convention, input value 0 returns 0 since Log(0) is undefined.
+        /// Does not incur branching.
         /// </summary>
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint Log2(uint value)
         {
-            FoldTrailingOnes(ref value);
+            value = FoldTrailingOnes(value);
 
             // uint.MaxValue >> 27 is always in range [0 - 31] so we use Unsafe.AddByteOffset to avoid bounds check
             return Unsafe.AddByteOffset(
@@ -206,7 +207,7 @@ namespace System
         }
 
         /// <summary>
-        /// Returns the integer (floor) log of the specified value, base 2, without branching.
+        /// Returns the integer (floor) log of the specified value, base 2.
         /// Note that by convention, input value 0 returns 0 since Log(0) is undefined.
         /// </summary>
         /// <param name="value">The value.</param>
@@ -234,7 +235,7 @@ namespace System
         /// </summary>
         /// <param name="value">The value to mutate.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void FoldTrailingOnes(ref uint value)
+        private static uint FoldTrailingOnes(uint value)
         {
             // byte#                         4          3   2  1
             //                       1000 0000  0000 0000  00 00
@@ -243,6 +244,8 @@ namespace System
             value |= value >> 04; // 1111 1111  0000 0000  00 00
             value |= value >> 08; // 1111 1111  1111 1111  00 00
             value |= value >> 16; // 1111 1111  1111 1111  FF FF
+
+            return value;
         }
 
         #endregion

--- a/src/System.Private.CoreLib/shared/System/BitOps.cs
+++ b/src/System.Private.CoreLib/shared/System/BitOps.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
 
-using Internal.Runtime.CompilerServices;
+using Internal.Runtime.CompilerServices; // Unsafe.AddByteOffset
 
 // Some routines inspired by the Stanford Bit Twiddling Hacks by Sean Eron Anderson:
 // http://graphics.stanford.edu/~seander/bithacks.html
@@ -67,7 +67,7 @@ namespace System
             return Unsafe.AddByteOffset(
                 ref MemoryMarshal.GetReference(s_TrailingZeroCountDeBruijn),
                 // Using deBruijn sequence, k=2, n=5 (2^5=32) : 0b_0000_0111_0111_1100_1011_0101_0011_0001u
-                ((uint)((value & -value) * 0x077CB531u)) >> 27);
+                (IntPtr)(((value & -value) * 0x077CB531u) >> 27));
         }
 
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/BitOps.cs
+++ b/src/System.Private.CoreLib/shared/System/BitOps.cs
@@ -160,7 +160,7 @@ namespace System
         /// </summary>
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint Log2(uint value)
+        public static int Log2(uint value)
         {
             value = FoldTrailingOnes(value);
 
@@ -177,13 +177,13 @@ namespace System
         /// </summary>
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint Log2(ulong value)
+        public static int Log2(ulong value)
         {
             uint hi = (uint)(value >> 32);
 
             if (hi != 0)
             {
-                return 32u + Log2(hi);
+                return 32 + Log2(hi);
             }
 
             return Log2((uint)value);

--- a/src/System.Private.CoreLib/shared/System/BitOps.cs
+++ b/src/System.Private.CoreLib/shared/System/BitOps.cs
@@ -93,30 +93,14 @@ namespace System
                 return (int)Bmi1.X64.TrailingZeroCount(value);
             }
 
-            // Main code has behavior 0->0, so special-case to match intrinsic path 0->64
-            if (value == 0u)
-                return 64;
+            uint lo = (uint)value;
 
-            // Use the 32-bit function twice
-            uint tz = (uint)value; // lo
-            if (Bmi1.IsSupported)
+            if (lo == 0)
             {
-                tz = Bmi1.TrailingZeroCount(tz); // lo
-
-                // Use hi iff lo is 32 zeros
-                if (tz == 32u)
-                    tz += Bmi1.TrailingZeroCount((uint)(value >> 32)); // hi
-            }
-            else
-            {
-                tz = (uint)TrailingZeroCount(tz); // lo
-
-                // Use hi iff lo is 32 zeros
-                if (tz == 32u)
-                    tz += (uint)TrailingZeroCount((uint)(value >> 32)); // hi
+                return 32 + TrailingZeroCount((uint)(value >> 32));
             }
 
-            return (int)tz;
+            return TrailingZeroCount(lo);
         }
 
         #endregion

--- a/src/System.Private.CoreLib/shared/System/BitOps.cs
+++ b/src/System.Private.CoreLib/shared/System/BitOps.cs
@@ -140,11 +140,12 @@ namespace System
                 return (int)Lzcnt.X64.LeadingZeroCount(value);
             }
 
-            // Main code has behavior 0->0, so special-case to match intrinsic path 0->64
-            if (value == 0u)
-                return 64;
+            uint hi = (uint)(value >> 32);
 
-            return 63 - Log2(value);
+            if (hi == 0)
+                return 32 + LeadingZeroCount((uint)value);
+
+            return LeadingZeroCount(hi);
         }
 
         #endregion

--- a/src/System.Private.CoreLib/shared/System/BitOps.cs
+++ b/src/System.Private.CoreLib/shared/System/BitOps.cs
@@ -34,8 +34,6 @@ namespace System
             19, 27, 23, 06, 26, 05, 04, 31
         };
 
-        #region TrailingZeroCount
-
         /// <summary>
         /// Count the number of trailing zero bits in an integer value.
         /// Similar in behavior to the x86 instruction TZCNT.
@@ -61,7 +59,9 @@ namespace System
 
             // Main code has behavior 0->0, so special-case to match intrinsic path 0->32
             if (value == 0u)
+            {
                 return 32;
+            }
 
             // uint.MaxValue >> 27 is always in range [0 - 31] so we use Unsafe.AddByteOffset to avoid bounds check
             return Unsafe.AddByteOffset(
@@ -96,14 +96,12 @@ namespace System
             uint lo = (uint)value;
 
             if (lo == 0)
+            {
                 return 32 + TrailingZeroCount((uint)(value >> 32));
+            }
 
             return TrailingZeroCount(lo);
         }
-
-        #endregion
-
-        #region LeadingZeroCount
 
         /// <summary>
         /// Count the number of leading zero bits in a mask.
@@ -120,8 +118,10 @@ namespace System
             }
 
             // Main code has behavior 0->0, so special-case to match intrinsic path 0->32
-            if (value == 0u)
+            if (value == 0)
+            {
                 return 32;
+            }
 
             return 31 - Log2(value);
         }
@@ -143,14 +143,12 @@ namespace System
             uint hi = (uint)(value >> 32);
 
             if (hi == 0)
+            {
                 return 32 + LeadingZeroCount((uint)value);
+            }
 
             return LeadingZeroCount(hi);
         }
-
-        #endregion
-
-        #region Log2
 
         /// <summary>
         /// Returns the integer (floor) log of the specified value, base 2.
@@ -180,15 +178,13 @@ namespace System
         {
             uint hi = (uint)(value >> 32);
 
-            if (hi != 0)
-                return 32 + Log2(hi);
+            if (hi == 0)
+            {
+                return Log2((uint)value);
+            }
 
-            return Log2((uint)value);
+            return 32 + Log2(hi);
         }
-
-        #endregion
-
-        #region Helpers
 
         /// <summary>
         /// Fills the trailing zeros in a mask with ones.
@@ -209,7 +205,5 @@ namespace System
 
             return value;
         }
-
-        #endregion
     }
 }

--- a/src/System.Private.CoreLib/shared/System/BitOps.cs
+++ b/src/System.Private.CoreLib/shared/System/BitOps.cs
@@ -96,9 +96,7 @@ namespace System
             uint lo = (uint)value;
 
             if (lo == 0)
-            {
                 return 32 + TrailingZeroCount((uint)(value >> 32));
-            }
 
             return TrailingZeroCount(lo);
         }
@@ -125,7 +123,7 @@ namespace System
             if (value == 0u)
                 return 32;
 
-            return (int)(31u - Log2(value));
+            return 31 - Log2(value);
         }
 
         /// <summary>
@@ -146,7 +144,7 @@ namespace System
             if (value == 0u)
                 return 64;
 
-            return (int)(63u - Log2(value));
+            return 63 - Log2(value);
         }
 
         #endregion
@@ -182,9 +180,7 @@ namespace System
             uint hi = (uint)(value >> 32);
 
             if (hi != 0)
-            {
                 return 32 + Log2(hi);
-            }
 
             return Log2((uint)value);
         }

--- a/src/System.Private.CoreLib/shared/System/BitOps.cs
+++ b/src/System.Private.CoreLib/shared/System/BitOps.cs
@@ -162,26 +162,7 @@ namespace System
             if (value == 0u)
                 return 64;
 
-            // Use the 32-bit function twice
-            uint lz = (uint)(value >> 32); // hi
-            if (Lzcnt.IsSupported)
-            {
-                lz = Lzcnt.LeadingZeroCount(lz); // hi
-
-                // Use lo iff hi is 32 zeros
-                if (lz == 32u)
-                    lz += Lzcnt.LeadingZeroCount((uint)value); // lo
-            }
-            else
-            {
-                lz = (uint)LeadingZeroCount(lz); // hi
-
-                // Use lo iff hi is 32 zeros
-                if (lz == 32u)
-                    lz += (uint)LeadingZeroCount((uint)value); // lo
-            }
-
-            return (int)lz;
+            return (int)(63u - Log2(value));
         }
 
         #endregion

--- a/src/System.Private.CoreLib/shared/System/BitOps.cs
+++ b/src/System.Private.CoreLib/shared/System/BitOps.cs
@@ -178,7 +178,7 @@ namespace System
                 return 31 - (int)Lzcnt.LeadingZeroCount(value);
             }
 
-            // Already has contract 0->0
+            // Already has contract 0->0, without branching
             return Log2SoftwareFallback(value);
         }
 
@@ -192,13 +192,11 @@ namespace System
         {
             // No AggressiveInlining due to large method size
 
-            // byte#                         4          3   2  1
-            //                       1000 0000  0000 0000  00 00
-            value |= value >> 01; // 1100 0000  0000 0000  00 00
-            value |= value >> 02; // 1111 0000  0000 0000  00 00
-            value |= value >> 04; // 1111 1111  0000 0000  00 00
-            value |= value >> 08; // 1111 1111  1111 1111  00 00
-            value |= value >> 16; // 1111 1111  1111 1111  FF FF
+            value |= value >> 01;
+            value |= value >> 02;
+            value |= value >> 04;
+            value |= value >> 08;
+            value |= value >> 16;
 
             // uint.MaxValue >> 27 is always in range [0 - 31] so we use Unsafe.AddByteOffset to avoid bounds check
             return Unsafe.AddByteOffset(

--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/FormattingHelpers.CountDigits.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/FormattingHelpers.CountDigits.cs
@@ -4,7 +4,6 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Runtime.Intrinsics.X86;
 
 namespace System.Buffers.Text
 {
@@ -104,36 +103,11 @@ namespace System.Buffers.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int CountHexDigits(ulong value)
         {
-            if (Lzcnt.X64.IsSupported)
-            {
-                int right = 64 - (int)Lzcnt.X64.LeadingZeroCount(value | 1);
-                return (right + 3) >> 2;
-            }
-
-            int digits = 1;
-
-            if (value > 0xFFFFFFFF)
-            {
-                digits += 8;
-                value >>= 0x20;
-            }
-            if (value > 0xFFFF)
-            {
-                digits += 4;
-                value >>= 0x10;
-            }
-            if (value > 0xFF)
-            {
-                digits += 2;
-                value >>= 0x8;
-            }
-            if (value > 0xF)
-                digits++;
-
-            return digits;
+            int right = 64 - BitOps.LeadingZeroCount(value | 1);
+            return (right + 3) >> 2;
         }
 
-        
+
         // Counts the number of trailing '0' digits in a decimal number.
         // e.g., value =      0 => retVal = 0, valueWithoutTrailingZeros = 0
         //       value =   1234 => retVal = 0, valueWithoutTrailingZeros = 1234

--- a/src/System.Private.CoreLib/shared/System/Buffers/Utilities.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Utilities.cs
@@ -4,7 +4,6 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Runtime.Intrinsics.X86;
 
 namespace System.Buffers
 {
@@ -14,25 +13,8 @@ namespace System.Buffers
         internal static int SelectBucketIndex(int bufferSize)
         {
             Debug.Assert(bufferSize >= 0);
-            if (Lzcnt.IsSupported)
-            {
-                uint bits = ((uint)bufferSize - 1) >> 4;
-                return 32 - (int)Lzcnt.LeadingZeroCount(bits);
-            }
-
-            // bufferSize of 0 will underflow here, causing a huge
-            // index which the caller will discard because it is not
-            // within the bounds of the bucket array.
-            uint bitsRemaining = ((uint)bufferSize - 1) >> 4;
-
-            int poolIndex = 0;
-            if (bitsRemaining > 0xFFFF) { bitsRemaining >>= 16; poolIndex = 16; }
-            if (bitsRemaining > 0xFF)   { bitsRemaining >>= 8;  poolIndex += 8; }
-            if (bitsRemaining > 0xF)    { bitsRemaining >>= 4;  poolIndex += 4; }
-            if (bitsRemaining > 0x3)    { bitsRemaining >>= 2;  poolIndex += 2; }
-            if (bitsRemaining > 0x1)    { bitsRemaining >>= 1;  poolIndex += 1; }
-
-            return poolIndex + (int)bitsRemaining;
+            uint bits = ((uint)bufferSize - 1) >> 4;
+            return 32 - BitOps.LeadingZeroCount(bits);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/System.Private.CoreLib/shared/System/Decimal.DecCalc.cs
+++ b/src/System.Private.CoreLib/shared/System/Decimal.DecCalc.cs
@@ -547,7 +547,7 @@ PosRem:
                 if (hiRes > 2)
                 {
                     newScale = (int)hiRes * 32 - 64 - 1;
-                    newScale -= X86.Lzcnt.IsSupported ? (int)X86.Lzcnt.LeadingZeroCount(result[hiRes]) : LeadingZeroCount(result[hiRes]);
+                    newScale -= BitOps.LeadingZeroCount(result[hiRes]);
 
                     // Multiply bit position by log10(2) to figure it's power of 10.
                     // We scale the log by 256.  log(2) = .30103, * 256 = 77.  Doing this
@@ -722,34 +722,6 @@ ThrowOverflow:
 #endif
                 }
                 return power;
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private static int LeadingZeroCount(uint value)
-            {
-                Debug.Assert(value > 0);
-                int c = 1;
-                if ((value & 0xFFFF0000) == 0)
-                {
-                    value <<= 16;
-                    c += 16;
-                }
-                if ((value & 0xFF000000) == 0)
-                {
-                    value <<= 8;
-                    c += 8;
-                }
-                if ((value & 0xF0000000) == 0)
-                {
-                    value <<= 4;
-                    c += 4;
-                }
-                if ((value & 0xC0000000) == 0)
-                {
-                    value <<= 2;
-                    c += 2;
-                }
-                return c + ((int)value >> 31);
             }
 
             /// <summary>
@@ -2047,7 +2019,7 @@ ReturnZero:
                     if (tmp == 0)
                         tmp = d2.Mid;
 
-                    curScale = X86.Lzcnt.IsSupported ? (int)X86.Lzcnt.LeadingZeroCount(tmp) : LeadingZeroCount(tmp);
+                    curScale = BitOps.LeadingZeroCount(tmp);
 
                     // Shift both dividend and divisor left by curScale.
                     //
@@ -2328,7 +2300,7 @@ ThrowOverflow:
                 uint tmp = d2.High;
                 if (tmp == 0)
                     tmp = d2.Mid;
-                int shift = X86.Lzcnt.IsSupported ? (int)X86.Lzcnt.LeadingZeroCount(tmp) : LeadingZeroCount(tmp);
+                int shift = BitOps.LeadingZeroCount(tmp);
 
                 Buf28 b;
                 _ = &b; // workaround for CS0165

--- a/src/System.Private.CoreLib/shared/System/Number.BigInteger.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.BigInteger.cs
@@ -311,12 +311,6 @@ namespace System
                 0x00000000,
             };
 
-            private static readonly uint[] s_MultiplyDeBruijnBitPosition = new uint[]
-            {
-                0, 9, 1, 10, 13, 21, 2, 29, 11, 14, 16, 18, 22, 25, 3, 30,
-                8, 12, 20, 28, 15, 17, 24, 7, 19, 27, 23, 6, 26, 5, 4, 31
-            };
-
             private int _length;
             private fixed uint _blocks[MaxBlockCount];
 
@@ -461,19 +455,25 @@ namespace System
 
             public static uint CountSignificantBits(uint value)
             {
-                return (value != 0) ? (1 + LogBase2(value)) : 0;
+                // TODO: Check that this is the correct substitution
+                //return (value != 0) ? (1 + LogBase2(value)) : 0;
+
+                return 32u - (uint)BitOps.LeadingZeroCount(value);
             }
 
             public static uint CountSignificantBits(ulong value)
             {
-                uint upper = (uint)(value >> 32);
+                // TODO: Check that this is the correct substitution
+                //uint upper = (uint)(value >> 32);
 
-                if (upper != 0)
-                {
-                    return 32 + CountSignificantBits(upper);
-                }
+                //if (upper != 0)
+                //{
+                //    return 32 + CountSignificantBits(upper);
+                //}
 
-                return CountSignificantBits((uint)(value));
+                //return CountSignificantBits((uint)(value));
+
+                return 64u - (uint)BitOps.LeadingZeroCount(value);
             }
 
             public static uint CountSignificantBits(ref BigInteger value)
@@ -752,43 +752,24 @@ namespace System
 
             public static uint LeadingZeroCount(uint value)
             {
-                return 32 - CountSignificantBits(value);
+                return (uint)BitOps.LeadingZeroCount(value);
             }
 
             public static uint LeadingZeroCount(ulong value)
             {
-                return 64 - CountSignificantBits(value);
+                return (uint)BitOps.LeadingZeroCount(value);
             }
 
             public static uint LogBase2(uint value)
             {
                 Debug.Assert(value != 0);
-
-                // This comes from the Stanford Bit Widdling Hacks by Sean Eron Anderson:
-                // http://graphics.stanford.edu/~seander/bithacks.html#IntegerLogDeBruijn
-
-                value |= (value >> 1); // first round down to one less than a power of 2 
-                value |= (value >> 2);
-                value |= (value >> 4);
-                value |= (value >> 8);
-                value |= (value >> 16);
-
-                uint index = (value * 0x07C4ACDD) >> 27;
-                return s_MultiplyDeBruijnBitPosition[(int)(index)];
+                return BitOps.Log2(value);
             }
 
             public static uint LogBase2(ulong value)
             {
                 Debug.Assert(value != 0);
-
-                uint upper = (uint)(value >> 32);
-
-                if (upper != 0)
-                {
-                    return 32 + LogBase2(upper);
-                }
-
-                return LogBase2((uint)(value));
+                return BitOps.Log2(value);
             }
 
             public static void Multiply(ref BigInteger lhs, uint value, ref BigInteger result)

--- a/src/System.Private.CoreLib/shared/System/Number.BigInteger.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.BigInteger.cs
@@ -757,13 +757,13 @@ namespace System
             public static uint LogBase2(uint value)
             {
                 Debug.Assert(value != 0);
-                return BitOps.Log2(value);
+                return (uint)BitOps.Log2(value);
             }
 
             public static uint LogBase2(ulong value)
             {
                 Debug.Assert(value != 0);
-                return BitOps.Log2(value);
+                return (uint)BitOps.Log2(value);
             }
 
             public static void Multiply(ref BigInteger lhs, uint value, ref BigInteger result)

--- a/src/System.Private.CoreLib/shared/System/Number.BigInteger.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.BigInteger.cs
@@ -455,7 +455,7 @@ namespace System
 
             public static uint CountSignificantBits(uint value)
             {
-                return 32u - (uint)BitOps.LeadingZeroCount(value);
+                return 32 - (uint)BitOps.LeadingZeroCount(value);
             }
 
             public static uint CountSignificantBits(ulong value)
@@ -464,7 +464,7 @@ namespace System
 
                 if (upper != 0)
                 {
-                    return 32u + CountSignificantBits(upper);
+                    return 32 + CountSignificantBits(upper);
                 }
 
                 return CountSignificantBits((uint)value);
@@ -742,18 +742,6 @@ namespace System
                 }
 
                 return quotient;
-            }
-
-            public static uint LogBase2(uint value)
-            {
-                Debug.Assert(value != 0);
-                return (uint)BitOps.Log2(value);
-            }
-
-            public static uint LogBase2(ulong value)
-            {
-                Debug.Assert(value != 0);
-                return (uint)BitOps.Log2(value);
             }
 
             public static void Multiply(ref BigInteger lhs, uint value, ref BigInteger result)

--- a/src/System.Private.CoreLib/shared/System/Number.BigInteger.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.BigInteger.cs
@@ -463,17 +463,14 @@ namespace System
 
             public static uint CountSignificantBits(ulong value)
             {
-                // TODO: Check that this is the correct substitution
-                //uint upper = (uint)(value >> 32);
+                uint upper = (uint)(value >> 32);
 
-                //if (upper != 0)
-                //{
-                //    return 32 + CountSignificantBits(upper);
-                //}
+                if (upper != 0)
+                {
+                    return 32u + CountSignificantBits(upper);
+                }
 
-                //return CountSignificantBits((uint)(value));
-
-                return 64u - (uint)BitOps.LeadingZeroCount(value);
+                return CountSignificantBits((uint)value);
             }
 
             public static uint CountSignificantBits(ref BigInteger value)

--- a/src/System.Private.CoreLib/shared/System/Number.BigInteger.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.BigInteger.cs
@@ -455,9 +455,6 @@ namespace System
 
             public static uint CountSignificantBits(uint value)
             {
-                // TODO: Check that this is the correct substitution
-                //return (value != 0) ? (1 + LogBase2(value)) : 0;
-
                 return 32u - (uint)BitOps.LeadingZeroCount(value);
             }
 

--- a/src/System.Private.CoreLib/shared/System/Number.BigInteger.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.BigInteger.cs
@@ -560,7 +560,7 @@ namespace System
                     uint divLo = rhs._blocks[rhsLength - 2];
 
                     // We measure the leading zeros of the divisor
-                    int shiftLeft = (int)(LeadingZeroCount(divHi));
+                    int shiftLeft = BitOps.LeadingZeroCount(divHi);
                     int shiftRight = 32 - shiftLeft;
 
                     // And, we make sure the most significant bit is set
@@ -742,16 +742,6 @@ namespace System
                 }
 
                 return quotient;
-            }
-
-            public static uint LeadingZeroCount(uint value)
-            {
-                return (uint)BitOps.LeadingZeroCount(value);
-            }
-
-            public static uint LeadingZeroCount(ulong value)
-            {
-                return (uint)BitOps.LeadingZeroCount(value);
             }
 
             public static uint LogBase2(uint value)

--- a/src/System.Private.CoreLib/shared/System/Number.DiyFp.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.DiyFp.cs
@@ -111,7 +111,7 @@ namespace System
                 // and subtract once.
 
                 Debug.Assert(f != 0);
-                int lzcnt = (int)(BigInteger.LeadingZeroCount(f));
+                int lzcnt = BitOps.LeadingZeroCount(f);
                 return new DiyFp((f << lzcnt), (e - lzcnt));
             }
 

--- a/src/System.Private.CoreLib/shared/System/Number.Dragon4.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Dragon4.cs
@@ -30,7 +30,8 @@ namespace System
             }
             else
             {
-                mantissaHighBitIdx = BigInteger.LogBase2(mantissa);
+                Debug.Assert(mantissa != 0);
+                mantissaHighBitIdx = (uint)BitOps.Log2(mantissa);
             }
 
             int length = (int)(Dragon4(mantissa, exponent, mantissaHighBitIdx, hasUnequalMargins, cutoffNumber, isSignificantDigits, number.Digits, out int decimalExponent));
@@ -59,7 +60,8 @@ namespace System
             }
             else
             {
-                mantissaHighBitIdx = BigInteger.LogBase2(mantissa);
+                Debug.Assert(mantissa != 0);
+                mantissaHighBitIdx = (uint)BitOps.Log2(mantissa);
             }
 
             int length = (int)(Dragon4(mantissa, exponent, mantissaHighBitIdx, hasUnequalMargins, cutoffNumber, isSignificantDigits, number.Digits, out int decimalExponent));
@@ -289,7 +291,8 @@ namespace System
                 // We are more likely to make accurate quotient estimations in BigInteger.HeuristicDivide() with higher denominator values so we shift the denominator to place the highest bit at index 27 of the highest block.
                 // This is safe because (2^28 - 1) = 268435455 which is less than 429496729.
                 // This means that all values with a highest bit at index 27 are within range.
-                uint hiBlockLog2 = BigInteger.LogBase2(hiBlock);
+                Debug.Assert(hiBlock != 0);
+                uint hiBlockLog2 = (uint)BitOps.Log2(hiBlock);
                 Debug.Assert((hiBlockLog2 < 3) || (hiBlockLog2 > 27));
                 uint shift = (32 + 27 - hiBlockLog2) % 32;
 

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
@@ -1587,14 +1587,6 @@ namespace System
             return 7 - (BitOps.LeadingZeroCount(match) >> 3);
         }
 
-        private const ulong XorPowerOfTwoToHighByte = (0x07ul |
-                                                       0x06ul << 8 |
-                                                       0x05ul << 16 |
-                                                       0x04ul << 24 |
-                                                       0x03ul << 32 |
-                                                       0x02ul << 40 |
-                                                       0x01ul << 48) + 1;
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe UIntPtr LoadUIntPtr(ref byte start, IntPtr offset)
             => Unsafe.ReadUnaligned<UIntPtr>(ref Unsafe.AddByteOffset(ref start, offset));

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
@@ -1577,38 +1577,14 @@ namespace System
         private static int LocateFirstFoundByte(ulong match)
         {
             // TODO: Arm variants
-            if (Bmi1.X64.IsSupported)
-            {
-                return (int)(Bmi1.X64.TrailingZeroCount(match) >> 3);
-            }
-            else
-            {
-                // Flag least significant power of two bit
-                var powerOfTwoFlag = match ^ (match - 1);
-                // Shift all powers of two into the high byte and extract
-                return (int)((powerOfTwoFlag * XorPowerOfTwoToHighByte) >> 57);
-            }
+            return BitOps.TrailingZeroCount(match) >> 3;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int LocateLastFoundByte(ulong match)
         {
             // TODO: Arm variants
-            if (Lzcnt.X64.IsSupported)
-            {
-                return 7 - (int)(Lzcnt.X64.LeadingZeroCount(match) >> 3);
-            }
-            else
-            {
-                // Find the most significant byte that has its highest bit set
-                int index = 7;
-                while ((long)match > 0)
-                {
-                    match = match << 8;
-                    index--;
-                }
-                return index;
-            }
+            return 7 - (BitOps.LeadingZeroCount(match) >> 3);
         }
 
         private const ulong XorPowerOfTwoToHighByte = (0x07ul |

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
@@ -874,7 +874,6 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int LocateLastFoundChar(ulong match)
         {
-            // TODO: Arm variants
             return 3 - (BitOps.LeadingZeroCount(match) >> 4);
         }
     }

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
@@ -875,21 +875,7 @@ namespace System
         private static int LocateLastFoundChar(ulong match)
         {
             // TODO: Arm variants
-            if (Lzcnt.X64.IsSupported)
-            {
-                return 3 - (int)(Lzcnt.X64.LeadingZeroCount(match) >> 4);
-            }
-            else
-            {
-                // Find the most significant char that has its highest bit set
-                int index = 3;
-                while ((long)match > 0)
-                {
-                    match = match << 16;
-                    index--;
-                }
-                return index;
-            }
+            return 3 - (BitOps.LeadingZeroCount(match) >> 4);
         }
     }
 }


### PR DESCRIPTION
There are several implementations of `LeadingZeroCount ` in the stack, with differing or branch-heavy implementations.
* This PR consolidates them into a central implementation that uses intrinsics & optimized software fallbacks.
* Also fixes an issue in a related [PR](https://github.com/dotnet/coreclr/pull/22333) where explicit conversions to `(IntPtr)` was missing, causing some [units](https://github.com/dotnet/corefx/pull/35193) to fail. Note the idiom to convert from `long` to `IntPtr` inexpensively.
* All `BitOps` methods pass units (said units will be added to `CoreFx`).

cc @tannergooding 