### PR TITLE
Intrinsicify SpanHelpers.IndexOf(char)

### DIFF
--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
@@ -284,7 +284,7 @@ namespace System
                 if (offset < length)
                 {
                     Debug.Assert(length - offset >= Vector128<ushort>.Count);
-                    if (((nint)Unsafe.AsPointer(ref Unsafe.Add(ref searchSpace, (IntPtr)offset)) & (nint)(Vector256<ushort>.Count - 1)) != 0)
+                    if (((nint)Unsafe.AsPointer(ref Unsafe.Add(ref searchSpace, (IntPtr)offset)) & (nint)(Vector256<byte>.Count - 1)) != 0)
                     {
                         // Not currently aligned to Vector256 (is aligned to Vector128); this can cause a problem for searches
                         // with no upper bound e.g. String.wcslen. Start with a check on Vector128 to align to Vector256, 

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
@@ -279,7 +279,7 @@ namespace System
             {
                 if (offset < length)
                 {
-                    Debug.Assert(offset - length >= Vector128<ushort>.Count);
+                    Debug.Assert(length - offset >= Vector128<ushort>.Count);
                     if ((((nint)Unsafe.AsPointer(ref searchSpace) + (nint)offset) & (nint)(Vector256<ushort>.Count - 1)) != 0)
                     {
                         // Not currently aligned to Vector256 (is aligned to Vector128); this can cause a problem for searches
@@ -369,6 +369,8 @@ namespace System
             {
                 if (offset < length)
                 {
+                    Debug.Assert(length - offset >= Vector128<ushort>.Count);
+
                     lengthToExamine = GetCharVector128SpanLength(offset, length);
                     if (lengthToExamine > 0)
                     {
@@ -406,6 +408,8 @@ namespace System
             {
                 if (offset < length)
                 {
+                    Debug.Assert(length - offset >= Vector<ushort>.Count);
+
                     lengthToExamine = GetCharVectorSpanLength(offset, length);
 
                     if (lengthToExamine > 0)

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
@@ -224,7 +224,11 @@ namespace System
             nint offset = 0;
             nint lengthToExamine = length;
 
-            if (Sse2.IsSupported)
+            if (((int)Unsafe.AsPointer(ref searchSpace) & 1) != 0)
+            {
+                // Input isn't char aligned, we won't be able to align it to a Vector
+            }
+            else if (Sse2.IsSupported)
             {
                 // Avx2 branch also operates on Sse2 sizes, so check is combined.
                 // Needs to be double length to allow us to align the data first.

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
@@ -285,8 +285,14 @@ namespace System
                         // Not currently aligned to Vector256 (is aligned to Vector128); this can cause a problem for searches
                         // with no upper bound e.g. String.wcslen. Start with a check on Vector128 to align to Vector256, 
                         // before moving to processing Vector256.
+
                         // If the input searchSpan has been fixed or pinned, this ensures we do not fault across memory pages 
-                        // while searching for an end of string.
+                        // while searching for an end of string. Specifically that this assumes that the length is either correct 
+                        // or that the data is pinned otherwise it may cause an AccessViolation from crossing a page boundary into an 
+                        // unowned page. If the search is unbounded (e.g. null terminator in wcslen) and the search value is not found,
+                        // again this will likely cause an AccessViolation. However, correctly bounded searches will return -1 rather 
+                        // than ever causing an AV.
+
                         // If the searchSpan has not been fixed or pinned the GC can relocate it during the execution of this 
                         // method, so the alignment only acts as best endeavour. The GC cost is likely to dominate over
                         // the misalignment that may occur after; to we default to giving the GC a free hand to relocate and 

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
@@ -228,7 +228,7 @@ namespace System
             {
                 // Avx2 branch also operates on Sse2 sizes, so check is combined.
                 // Needs to be double length to allow us to align the data first.
-                if (length >= Vector128<byte>.Count * 2)
+                if (length >= Vector128<ushort>.Count * 2)
                 {
                     lengthToExamine = UnalignedCountVector128(ref searchSpace);
                 }

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
@@ -370,7 +370,7 @@ namespace System
                 if (offset < length)
                 {
                     lengthToExamine = GetCharVector128SpanLength(offset, length);
-                    if (lengthToExamine >= 0)
+                    if (lengthToExamine > 0)
                     {
                         Vector128<ushort> values = Vector128.Create((ushort)value);
                         do

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
@@ -284,7 +284,7 @@ namespace System
                 if (offset < length)
                 {
                     Debug.Assert(length - offset >= Vector128<ushort>.Count);
-                    if ((((nint)Unsafe.AsPointer(ref searchSpace) + (nint)offset) & (nint)(Vector256<ushort>.Count - 1)) != 0)
+                    if (((nint)Unsafe.AsPointer(ref Unsafe.Add(ref searchSpace, (IntPtr)offset)) & (nint)(Vector256<ushort>.Count - 1)) != 0)
                     {
                         // Not currently aligned to Vector256 (is aligned to Vector128); this can cause a problem for searches
                         // with no upper bound e.g. String.wcslen. Start with a check on Vector128 to align to Vector256, 

--- a/src/System.Private.CoreLib/shared/System/String.cs
+++ b/src/System.Private.CoreLib/shared/System/String.cs
@@ -572,109 +572,18 @@ namespace System
             return new StringRuneEnumerator(this);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe int wcslen(char* ptr)
         {
-            char* end = ptr;
-
-            // First make sure our pointer is aligned on a word boundary
-            int alignment = IntPtr.Size - 1;
-
-            // If ptr is at an odd address (e.g. 0x5), this loop will simply iterate all the way
-            while (((uint)end & (uint)alignment) != 0)
+            // IndexOf processes memory in aligned chunks, and thus it won't crash even if it accesses memory beyond the null terminator.
+            int length = SpanHelpers.IndexOf(ref *ptr, '\0', int.MaxValue);
+            if (length < 0)
             {
-                if (*end == 0) goto FoundZero;
-                end++;
+                ThrowMustBeNullTerminatedString();
             }
 
-#if !BIT64
-            // The following code is (somewhat surprisingly!) significantly faster than a naive loop,
-            // at least on x86 and the current jit.
-
-            // The loop condition below works because if "end[0] & end[1]" is non-zero, that means
-            // neither operand can have been zero. If is zero, we have to look at the operands individually,
-            // but we hope this going to fairly rare.
-
-            // In general, it would be incorrect to access end[1] if we haven't made sure
-            // end[0] is non-zero. However, we know the ptr has been aligned by the loop above
-            // so end[0] and end[1] must be in the same word (and therefore page), so they're either both accessible, or both not.
-
-            while ((end[0] & end[1]) != 0 || (end[0] != 0 && end[1] != 0))
-            {
-                end += 2;
-            }
-
-            Debug.Assert(end[0] == 0 || end[1] == 0);
-            if (end[0] != 0) end++;
-#else // !BIT64
-            // Based on https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord
-
-            // 64-bit implementation: process 1 ulong (word) at a time
-
-            // What we do here is add 0x7fff from each of the
-            // 4 individual chars within the ulong, using MagicMask.
-            // If the char > 0 and < 0x8001, it will have its high bit set.
-            // We then OR with MagicMask, to set all the other bits.
-            // This will result in all bits set (ulong.MaxValue) for any
-            // char that fits the above criteria, and something else otherwise.
-
-            // Note that for any char > 0x8000, this will be a false
-            // positive and we will fallback to the slow path and
-            // check each char individually. This is OK though, since
-            // we optimize for the common case (ASCII chars, which are < 0x80).
-
-            // NOTE: We can access a ulong a time since the ptr is aligned,
-            // and therefore we're only accessing the same word/page. (See notes
-            // for the 32-bit version above.)
-
-            const ulong MagicMask = 0x7fff7fff7fff7fff;
-
-            while (true)
-            {
-                ulong word = *(ulong*)end;
-                word += MagicMask; // cause high bit to be set if not zero, and <= 0x8000
-                word |= MagicMask; // set everything besides the high bits
-
-                if (word == ulong.MaxValue) // 0xffff...
-                {
-                    // all of the chars have their bits set (and therefore none can be 0)
-                    end += 4;
-                    continue;
-                }
-
-                // at least one of them didn't have their high bit set!
-                // go through each char and check for 0.
-
-                if (end[0] == 0) goto EndAt0;
-                if (end[1] == 0) goto EndAt1;
-                if (end[2] == 0) goto EndAt2;
-                if (end[3] == 0) goto EndAt3;
-
-                // if we reached here, it was a false positive-- just continue
-                end += 4;
-            }
-
-            EndAt3: end++;
-            EndAt2: end++;
-            EndAt1: end++;
-            EndAt0:
-#endif // !BIT64
-
-            FoundZero:
-            Debug.Assert(*end == 0);
-
-            int count = (int)(end - ptr);
-
-#if BIT64
-            // Check for overflow
-            if (ptr + count != end)
-                throw new ArgumentException(SR.Arg_MustBeNullTerminatedString);
-#else
-            Debug.Assert(ptr + count == end);
-#endif
-
-            return count;
+            return length;
         }
-
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe int strlen(byte* ptr)


### PR DESCRIPTION
Based on https://github.com/dotnet/coreclr/pull/22875 which is first commit

and Vectorize wcslen

From #22187

```diff
 -------------------- |--------- |-----------:|
-      String_IndexOf |        7 |   5.031 ns |
+      String_IndexOf |        7 |   4.403 ns |
-      String_IndexOf |        8 |   5.053 ns |
+      String_IndexOf |        8 |   4.400 ns |
-      String_IndexOf |       15 |   8.817 ns |
+      String_IndexOf |       15 |   4.577 ns |
-      String_IndexOf |       16 |   8.223 ns |
+      String_IndexOf |       16 |   4.697 ns |
-      String_IndexOf |       31 |   9.292 ns |
+      String_IndexOf |       31 |   5.226 ns |
-      String_IndexOf |       32 |   9.276 ns |
+      String_IndexOf |       32 |   5.224 ns |
-      String_IndexOf |       63 |  11.307 ns |
+      String_IndexOf |       63 |   6.991 ns |
-      String_IndexOf |       64 |  11.196 ns |
+      String_IndexOf |       64 |   6.990 ns |
-      String_IndexOf |      127 |  14.386 ns |
+      String_IndexOf |      127 |   9.050 ns |
-      String_IndexOf |      128 |  14.643 ns |
+      String_IndexOf |      128 |   9.228 ns |
-      String_IndexOf |      255 |  21.395 ns |
+      String_IndexOf |      255 |  13.919 ns |
-      String_IndexOf |      256 |  21.452 ns |
+      String_IndexOf |      256 |  13.768 ns |
-      String_IndexOf |     1023 |  68.075 ns |
+      String_IndexOf |     1023 |  49.797 ns |
-      String_IndexOf |     1024 |  68.530 ns |
+      String_IndexOf |     1024 |  49.741 ns |
```

Will follow up after with the other methods as they depend on the helper methods at the bottom of this one.

/cc @CarolEidt @fiigii @tannergooding @jkotas 

Resolves #22762