### PR TITLE
prestub: fix ExternalMethodFixupWorker

### DIFF
--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -2378,7 +2378,11 @@ EXTERN_C PCODE STDCALL ExternalMethodFixupWorker(TransitionBlock * pTransitionBl
             DispatchToken token;
             if (pMT->IsInterface() || MethodTable::VTableIndir_t::isRelative)
             {
-                token = pMT->GetLoaderAllocator()->GetDispatchToken(pMT->GetTypeID(), slot);
+                if (pMT->IsInterface())
+                    token = pMT->GetLoaderAllocator()->GetDispatchToken(pMT->GetTypeID(), slot);
+                else
+                    token = DispatchToken::CreateDispatchToken(slot);
+
                 StubCallSite callSite(pIndirection, pEMFrame->GetReturnAddress());
                 pCode = pMgr->ResolveWorker(&callSite, protectedObj, token, VirtualCallStubManager::SK_LOOKUP);
             }


### PR DESCRIPTION
Use DispatchToken::CreateDispatchToken to get token to resolve virtual method in case of non interface MT. This patch fixes following assert (coreclr is compiled with `FEATURE_NGEN_RELOCS_OPTIMIZATIONS` defined):
```
SD: VCSM::Resolver: (start) looking up interface method in AppCommon.Tizen.Program

Assert failure(PID 1110 [0x00000456], Thread: 1110 [0x0456]): Consistency check failed: FAILED: pMT->IsInterface()
    File: /media/kbaladurin/data/dotnet/forked/coreclr/src/vm/appdomain.cpp Line: 7819
    Image: /usr/bin/dotnet-launcher

onSigabrt called
```