### PR TITLE
Locally define DLLEXPORT in ee_il_dll.cpp

### DIFF
--- a/src/jit/ee_il_dll.cpp
+++ b/src/jit/ee_il_dll.cpp
@@ -26,6 +26,10 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #include <errno.h> // For EINVAL
 #endif
 
+#ifndef DLLEXPORT
+#define DLLEXPORT
+#endif // !DLLEXPORT
+
 /*****************************************************************************/
 
 FILE* jitstdout = nullptr;


### PR DESCRIPTION
This prevents a desktop build break due to DLLEXPORT being undefined.  If
you know of a better place to put this, I'm happy to try it.  Otherwise,
this should unblock the desktop build.