### PR TITLE
Switch to Debian.9.Amd64.Open

### DIFF
--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -111,9 +111,9 @@ jobs:
     containerName: centos7_x64_build_image
     helixQueues:
       ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-        asString: 'Ubuntu.1804.Amd64.Open'
+        asString: 'Debian.9.Amd64.Open'
         asArray:
-        - Ubuntu.1804.Amd64.Open
+        - Debian.9.Amd64.Open
       ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
         asString: 'Debian.9.Amd64.Open,Ubuntu.1604.Amd64.Open,Ubuntu.1804.Amd64.Open,Centos.7.Amd64.Open,Fedora.28.Amd64.Open,RedHat.7.Amd64.Open'
         asArray:


### PR DESCRIPTION
As per https://github.com/dotnet/core-eng/issues/5209 Ubuntu.16.04.Amd64 and Ubuntu.18.04.Amd64 are completely not-functional:
* Ubuntu.16.04.Amd64.Open has 28497 items in a queue
* Ubuntu.18.04.Amd64.Open has 29306 items in a queue

It is also not clear when the issue is going to be resolved. Therefore, switch to Debian.9.Amd64.Open to unblock currently failing coreclr-ci Linux/x64 test jobs.