### PR TITLE
Enable portable fast alloc helpers on ARM64 Windows

### DIFF
--- a/src/vm/arm64/stubs.cpp
+++ b/src/vm/arm64/stubs.cpp
@@ -1084,7 +1084,6 @@ void JIT_TailCall()
 #if !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
 void InitJITHelpers1()
 {
-#ifdef FEATURE_PAL // TODO
     STANDARD_VM_CONTRACT;
 
     _ASSERTE(g_SystemInfo.dwNumberOfProcessors != 0);
@@ -1107,7 +1106,6 @@ void InitJITHelpers1()
             ECall::DynamicallyAssignFCallImpl(GetEEFuncEntryPoint(AllocateString_MP_FastPortable), ECall::FastAllocateString);
         }
     }
-#endif
 
     JIT_UpdateWriteBarrierState(GCHeapUtilities::IsServerHeap());
 }

--- a/src/vm/object.cpp
+++ b/src/vm/object.cpp
@@ -779,6 +779,8 @@ void ArrayBase::AssertArrayTypeDescLoaded()
 {
     _ASSERTE (m_pMethTab->IsArray());
 
+    ENABLE_FORBID_GC_LOADER_USE_IN_THIS_SCOPE();
+
     // The type should already be loaded
     // See also: MethodTable::DoFullyLoad
     TypeHandle th = ClassLoader::LoadArrayTypeThrowing(m_pMethTab->GetApproxArrayElementTypeHandle(),


### PR DESCRIPTION
Address https://github.com/dotnet/coreclr/issues/13053

See https://github.com/dotnet/coreclr/issues/13053#issuecomment-462595248 for more details.