### PR TITLE
Add AzDO outerloop jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,7 @@ jobs:
 #
 # Debug build (Pull Request)
 #
-- ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+- ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: build-job.yml
@@ -110,9 +110,18 @@ jobs:
       buildConfig: checked
 
 #
-# Release build (Official Build, Pull Request)
+# Release build (Pull Request)
 #
-- ${{ if xor(eq(variables['System.TeamProject'], 'internal'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+- ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
+  - template: eng/platform-matrix.yml
+    parameters:
+      jobTemplate: build-job.yml
+      buildConfig: release
+
+#
+# Release build (Official Build)
+#
+- ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: build-job.yml
@@ -128,7 +137,7 @@ jobs:
 #
 
 # Pri0 (Pull Request)
-- ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+- ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: test-job.yml
@@ -148,6 +157,23 @@ jobs:
         # In case xUnit test wrappers get refactored this number should also be adjusted.
         timeoutPerTestCollectionInMinutes: 30
         # "PerTest" corresponds to individual test running time (i.e. __TestTimeout).
+        timeoutPerTestInMinutes: 10
+
+# Pri1 (Pull Request, Outerloop)
+- ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-outerloop')) }}:
+  - template: eng/platform-matrix.yml
+    parameters:
+      jobTemplate: test-job.yml
+      buildConfig: checked
+      jobParameters:
+        priority: 1
+        scenarios:
+          asString: 'normal,no_tiered_compilation'
+          asArray:
+          - normal
+          - no_tiered_compilation
+        timeoutTotalInMinutes: 360
+        timeoutPerTestCollectionInMinutes: 60
         timeoutPerTestInMinutes: 10
 
 # Pri1 (CI)


### PR DESCRIPTION
PR workload selection feature seems working.

I have created **coreclr-outerloop** build definition and this PR adds priority1 jobs to be run when this build definition is triggered.