### PR TITLE
Gnuport cleanup 3

### DIFF
--- a/src/ToolBox/SOS/Strike/ExpressionNode.h
+++ b/src/ToolBox/SOS/Strike/ExpressionNode.h
@@ -7,7 +7,7 @@
 #define _EXPRESSION_NODE_
 
 #ifdef FEATURE_PAL
-#error This file isn't designed to build in PAL
+#error "This file isn't designed to build in PAL"
 #endif
 
 #include "strike.h"

--- a/src/gc/unix/events.cpp
+++ b/src/gc/unix/events.cpp
@@ -146,7 +146,7 @@ public:
             TimeSpecAdd(&endTime, milliseconds);
         }
 #else
-#error Don't know how to perfom timed wait on this platform
+#error "Don't know how to perfom timed wait on this platform"
 #endif
 
         int st = 0;

--- a/src/inc/contract.h
+++ b/src/inc/contract.h
@@ -989,10 +989,10 @@ class BaseContract
     };
 
 
-    __declspec(nothrow) BaseContract() : m_pClrDebugState(NULL),  m_testmask(0)
+    NOTHROW_DECL BaseContract() : m_pClrDebugState(NULL),  m_testmask(0)
     {
     }
-    __declspec(nothrow) void Restore()
+    NOTHROW_DECL void Restore()
     {
         // m_pClrDebugState is setup in BaseContract::DoChecks. If an SO happens after the
         // BaseContract object is constructed but before DoChecks is invoked, m_pClrDebugState
@@ -1160,7 +1160,7 @@ class Contract: public BaseContract
    virtual void DestructorDefinedThatCallsRestore(){}
 
    public:
-    __declspec(nothrow) ~Contract()
+    NOTHROW_DECL ~Contract()
     {
         Restore();
     }

--- a/src/inc/cor.h
+++ b/src/inc/cor.h
@@ -2032,14 +2032,6 @@ typedef enum
 #endif
 #endif
 
-#ifndef DBG_NOINLINE_X86__RET_INLINE
-#if defined(_DEBUG) && defined(_X86_)
-#define DBG_NOINLINE_X86__RET_INLINE NOINLINE
-#else
-#define DBG_NOINLINE_X86__RET_INLINE FORCEINLINE
-#endif
-#endif
-
 #ifndef NOINLINE
 #ifdef _MSC_VER
 #define NOINLINE __declspec(noinline)

--- a/src/inc/cor.h
+++ b/src/inc/cor.h
@@ -2026,7 +2026,7 @@ typedef enum
 
 #ifndef DEBUG_NOINLINE
 #if defined(_DEBUG)
-#define DEBUG_NOINLINE __declspec(noinline)
+#define DEBUG_NOINLINE NOINLINE
 #else
 #define DEBUG_NOINLINE
 #endif
@@ -2034,7 +2034,7 @@ typedef enum
 
 #ifndef DBG_NOINLINE_X86__RET_INLINE
 #if defined(_DEBUG) && defined(_X86_)
-#define DBG_NOINLINE_X86__RET_INLINE __declspec(noinline)
+#define DBG_NOINLINE_X86__RET_INLINE NOINLINE
 #else
 #define DBG_NOINLINE_X86__RET_INLINE FORCEINLINE
 #endif

--- a/src/inc/metadatatracker.h
+++ b/src/inc/metadatatracker.h
@@ -182,7 +182,7 @@ public:
         return NoteAccessWorker(address);
     }
 
-    __declspec(noinline) static void* NoteAccessWorker(void *address)
+    NOINLINE static void* NoteAccessWorker(void *address)
     {
         STATIC_CONTRACT_NOTHROW;
         STATIC_CONTRACT_GC_NOTRIGGER;
@@ -204,7 +204,7 @@ public:
         NoteSearchWorker(result);
     }
 
-    __declspec(noinline) static void NoteSearchWorker(void *result)
+    NOINLINE static void NoteSearchWorker(void *result)
     {
         STATIC_CONTRACT_NOTHROW;
         STATIC_CONTRACT_GC_NOTRIGGER;

--- a/src/inc/palclr.h
+++ b/src/inc/palclr.h
@@ -37,6 +37,14 @@
 #endif
 #endif
 
+#ifndef NOINLINE
+#ifdef _MSC_VER
+#define NOINLINE __declspec(noinline)
+#else
+#define NOINLINE __attribute__((noinline))
+#endif // !_MSC_VER
+#endif // !NOINLINE
+
 //
 // CPP_ASSERT() can be used within a class definition, to perform a
 // compile-time assertion involving private names within the class.

--- a/src/inc/palclr.h
+++ b/src/inc/palclr.h
@@ -37,6 +37,14 @@
 #endif
 #endif
 
+#ifndef NOTHROW_DECL
+#ifdef _MSC_VER
+#define NOTHROW_DECL __declspec(nothrow)
+#else
+#define NOTHROW_DECL __attribute__((nothrow))
+#endif // !_MSC_VER
+#endif // !NOTHROW_DECL
+
 #ifndef NOINLINE
 #ifdef _MSC_VER
 #define NOINLINE __declspec(noinline)

--- a/src/inc/slist.h
+++ b/src/inc/slist.h
@@ -20,7 +20,7 @@
 //-----------------------------------------------------------------------------
 
 //#ifndef _H_UTIL
-//#error I am a part of util.hpp Please don't include me alone !
+//#error "I am a part of util.hpp Please don't include me alone !"
 //#endif
 
 

--- a/src/inc/utilcode.h
+++ b/src/inc/utilcode.h
@@ -150,15 +150,6 @@ typedef LPSTR   LPUTF8;
 #endif
 #endif
 
-#ifndef DBG_NOINLINE_X86__RET_INLINE
-#if defined(_DEBUG) && defined(_TARGET_X86_)
-// this exists to make scan work on x86. 
-#define DBG_NOINLINE_X86__RET_INLINE NOINLINE
-#else
-#define DBG_NOINLINE_X86__RET_INLINE FORCEINLINE
-#endif
-#endif
-
 #include <stddef.h> // for offsetof
 
 #ifndef NumItems

--- a/src/inc/utilcode.h
+++ b/src/inc/utilcode.h
@@ -144,7 +144,7 @@ typedef LPSTR   LPUTF8;
 
 #ifndef DEBUG_NOINLINE
 #if defined(_DEBUG)
-#define DEBUG_NOINLINE __declspec(noinline)
+#define DEBUG_NOINLINE NOINLINE
 #else
 #define DEBUG_NOINLINE
 #endif
@@ -153,7 +153,7 @@ typedef LPSTR   LPUTF8;
 #ifndef DBG_NOINLINE_X86__RET_INLINE
 #if defined(_DEBUG) && defined(_TARGET_X86_)
 // this exists to make scan work on x86. 
-#define DBG_NOINLINE_X86__RET_INLINE __declspec(noinline)
+#define DBG_NOINLINE_X86__RET_INLINE NOINLINE
 #else
 #define DBG_NOINLINE_X86__RET_INLINE FORCEINLINE
 #endif

--- a/src/inc/winrt/paraminstanceapi.h
+++ b/src/inc/winrt/paraminstanceapi.h
@@ -79,7 +79,7 @@ namespace Ro { namespace detail {
     //  to see HRESULT propagation.
     // 
     #ifdef DEBUG
-    inline HRESULT __declspec(noinline) _FailedHR(HRESULT hr) { static HRESULT _hr = hr; return hr; }
+    inline HRESULT NOINLINE _FailedHR(HRESULT hr) { static HRESULT _hr = hr; return hr; }
     #else
     inline HRESULT _FailedHR(HRESULT hr) { return hr; }
     #endif

--- a/src/pal/inc/rt/palrt.h
+++ b/src/pal/inc/rt/palrt.h
@@ -214,6 +214,7 @@ inline void *__cdecl operator new(size_t, void *_P)
 
 #define STDAPI               EXTERN_C HRESULT STDAPICALLTYPE
 #define STDAPI_(type)        EXTERN_C type STDAPICALLTYPE
+#define STDAPI_VIS(vis,type) EXTERN_C vis type STDAPICALLTYPE
 
 #define STDAPIV              EXTERN_C HRESULT STDAPIVCALLTYPE
 #define STDAPIV_(type)       EXTERN_C type STDAPIVCALLTYPE
@@ -372,9 +373,9 @@ typedef union _ULARGE_INTEGER {
 
 /******************* OLE, BSTR, VARIANT *************************/
 
-DLLEXPORT STDAPI_(LPVOID) CoTaskMemAlloc(SIZE_T cb);
-DLLEXPORT STDAPI_(LPVOID) CoTaskMemRealloc(LPVOID pv, SIZE_T cb);
-DLLEXPORT STDAPI_(void) CoTaskMemFree(LPVOID pv);
+STDAPI_VIS(DLLEXPORT, LPVOID) CoTaskMemAlloc(SIZE_T cb);
+STDAPI_VIS(DLLEXPORT, LPVOID) CoTaskMemRealloc(LPVOID pv, SIZE_T cb);
+STDAPI_VIS(DLLEXPORT, void) CoTaskMemFree(LPVOID pv);
 
 typedef SHORT VARIANT_BOOL;
 #define VARIANT_TRUE ((VARIANT_BOOL)-1)
@@ -386,12 +387,12 @@ typedef const OLECHAR* LPCOLESTR;
 
 typedef WCHAR *BSTR;
 
-DLLEXPORT STDAPI_(BSTR) SysAllocString(const OLECHAR*);
-DLLEXPORT STDAPI_(BSTR) SysAllocStringLen(const OLECHAR*, UINT);
-DLLEXPORT STDAPI_(BSTR) SysAllocStringByteLen(const char *, UINT);
-DLLEXPORT STDAPI_(void) SysFreeString(BSTR);
-DLLEXPORT STDAPI_(UINT) SysStringLen(BSTR);
-DLLEXPORT STDAPI_(UINT) SysStringByteLen(BSTR);
+STDAPI_VIS(DLLEXPORT, BSTR) SysAllocString(const OLECHAR*);
+STDAPI_VIS(DLLEXPORT, BSTR) SysAllocStringLen(const OLECHAR*, UINT);
+STDAPI_VIS(DLLEXPORT, BSTR) SysAllocStringByteLen(const char *, UINT);
+STDAPI_VIS(DLLEXPORT, void) SysFreeString(BSTR);
+STDAPI_VIS(DLLEXPORT, UINT) SysStringLen(BSTR);
+STDAPI_VIS(DLLEXPORT, UINT) SysStringByteLen(BSTR);
 
 typedef double DATE;
 

--- a/src/pal/inc/rt/sal.h
+++ b/src/pal/inc/rt/sal.h
@@ -2363,7 +2363,7 @@ typedef struct __F_ __F_;
 
 #ifdef  __cplusplus // [
 #ifndef __nothrow // [
-# define __nothrow __declspec(nothrow)
+# define __nothrow NOTHROW_DECL
 #endif // ]
 extern "C" {
 #else // ][

--- a/src/vm/callhelpers.h
+++ b/src/vm/callhelpers.h
@@ -89,7 +89,7 @@ private:
     ArgIterator m_argIt;
 
 #ifdef _DEBUG 
-    __declspec(noinline) void LogWeakAssert()
+    NOINLINE void LogWeakAssert()
     {
         LIMITED_METHOD_CONTRACT;
         LOG((LF_ASSERT, LL_WARNING, "%s::%s\n", m_pMD->m_pszDebugClassName, m_pMD->m_pszDebugMethodName));

--- a/src/vm/class.h
+++ b/src/vm/class.h
@@ -410,7 +410,7 @@ class EEClassLayoutInfo
             e_HAS_EXPLICIT_SIZE         = 0x08,
 #ifdef UNIX_AMD64_ABI
 #ifdef FEATURE_HFA
-#error Can't have FEATURE_HFA and UNIX_AMD64_ABI defined at the same time.
+#error "Can't have FEATURE_HFA and UNIX_AMD64_ABI defined at the same time."
 #endif // FEATURE_HFA
             e_NATIVE_PASS_IN_REGISTERS  = 0x10, // Flag wheter a native struct is passed in registers.
 #endif // UNIX_AMD64_ABI

--- a/src/vm/crst.h
+++ b/src/vm/crst.h
@@ -265,7 +265,7 @@ public:
     CrstBase *GetThreadsOwnedCrsts();
     void SetThreadsOwnedCrsts(CrstBase *pCrst);
 
-    __declspec(noinline) EEThreadId GetHolderThreadId()
+    NOINLINE EEThreadId GetHolderThreadId()
     {
         LIMITED_METHOD_CONTRACT;
         return m_holderthreadid;

--- a/src/vm/eecontract.h
+++ b/src/vm/eecontract.h
@@ -35,7 +35,7 @@ class EEContract : public BaseContract
     virtual void DestructorDefinedThatCallsRestore(){}
 
   public:
-    __declspec(nothrow) ~EEContract()
+    NOTHROW_DECL ~EEContract()
     {
         Restore();
     }

--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -43,7 +43,7 @@
 #endif // _TARGET_ARM_ || _TARGET_ARM64_ || _TARGET_X86_
 
 #ifndef FEATURE_PAL
-void __declspec(noinline)
+void NOINLINE
 ClrUnwindEx(EXCEPTION_RECORD* pExceptionRecord,
                  UINT_PTR          ReturnValue,
                  UINT_PTR          TargetIP,

--- a/src/vm/finalizerthread.cpp
+++ b/src/vm/finalizerthread.cpp
@@ -59,7 +59,7 @@ BOOL FinalizerThread::HaveExtraWorkForFinalizer()
 
 // This helper is here to avoid EH goo associated with DefineFullyQualifiedNameForStack being 
 // invoked when logging is off.
-__declspec(noinline)
+NOINLINE
 void LogFinalization(Object* obj)
 {
     STATIC_CONTRACT_NOTHROW;

--- a/src/vm/ibclogger.h
+++ b/src/vm/ibclogger.h
@@ -422,7 +422,7 @@ public:                                                 \
     }                                                   \
                                                         \
 private:                                                \
-    __declspec(noinline) static void Log##name##AccessStatic(const void * p) \
+    NOINLINE static void Log##name##AccessStatic(const void * p) \
     {                                                   \
         WRAPPER_NO_CONTRACT;                               \
         /* To make the logging callsite as small as */  \

--- a/src/vm/methodtable.h
+++ b/src/vm/methodtable.h
@@ -3666,14 +3666,14 @@ private:
 
 #if defined(FEATURE_HFA)
 #if defined(UNIX_AMD64_ABI)
-#error Can't define both FEATURE_HFA and UNIX_AMD64_ABI
+#error "Can't define both FEATURE_HFA and UNIX_AMD64_ABI"
 #endif
         enum_flag_IsHFA                     = 0x00000800,   // This type is an HFA (Homogenous Floating-point Aggregate)
 #endif // FEATURE_HFA
 
 #if defined(UNIX_AMD64_ABI)
 #if defined(FEATURE_HFA)
-#error Can't define both FEATURE_HFA and UNIX_AMD64_ABI
+#error "Can't define both FEATURE_HFA and UNIX_AMD64_ABI"
 #endif
         enum_flag_IsRegStructPassed         = 0x00000800,   // This type is a System V register passed struct.
 #endif // UNIX_AMD64_ABI

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -1864,7 +1864,7 @@ MethodTableBuilder::BuildMethodTableThrowing(
 #endif
 #ifdef UNIX_AMD64_ABI
 #ifdef FEATURE_HFA
-#error Can't have FEATURE_HFA and UNIX_AMD64_ABI defined at the same time.
+#error "Can't have FEATURE_HFA and UNIX_AMD64_ABI defined at the same time."
 #endif // FEATURE_HFA
         SystemVAmd64CheckForPassStructInRegister();
 #endif // UNIX_AMD64_ABI
@@ -1872,7 +1872,7 @@ MethodTableBuilder::BuildMethodTableThrowing(
 
 #ifdef UNIX_AMD64_ABI
 #ifdef FEATURE_HFA
-#error Can't have FEATURE_HFA and UNIX_AMD64_ABI defined at the same time.
+#error "Can't have FEATURE_HFA and UNIX_AMD64_ABI defined at the same time."
 #endif // FEATURE_HFA
     if (HasLayout())
     {

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -6821,7 +6821,7 @@ BOOL Thread::IsSPBeyondLimit()
     return FALSE;
 }
 
-__declspec(noinline) void AllocateSomeStack(){
+NOINLINE void AllocateSomeStack(){
     LIMITED_METHOD_CONTRACT;
 #ifdef _TARGET_X86_
     const size_t size = 0x200;


### PR DESCRIPTION
- Abstract __declspec(noinline)
- Abstract __declspec(nothrow)
- Need double quotes around single quotes in error statements
- Reorder extern "C" and visibility statements
