### PR TITLE
Don't use $(_HelixSource) and $(_HelixType) in test-job.yml

### DIFF
--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -35,11 +35,6 @@ jobs:
 
     crossrootfsDir: ${{ parameters.crossrootfsDir }}
 
-    ${{ if eq(parameters.readyToRun, false) }}:
-      helixType: ${{ format('test/functional/cli/pri{0}', parameters.priority) }}
-    ${{ if eq(parameters.readyToRun, true) }}:
-      helixType: ${{ format('test/functional/r2r/cli/pri{0}', parameters.priority) }}
-
     variables:
     - group: DotNet-HelixApi-Access
     # Map template parameters to command line arguments
@@ -131,9 +126,23 @@ jobs:
         archType: ${{ parameters.archType }}
         osGroup: ${{ parameters.osGroup }}
 
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          creator: 'coreclr'
+
         helixBuild: $(Build.BuildNumber)
-        helixSource: $(_HelixSource)
-        helixType: $(_HelixType)
+
+        ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+          helixSource: official/dotnet/coreclr/$(Build.SourceBranch)
+        ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+          helixSource: pr/dotnet/coreclr/$(Build.SourceBranch)
+        ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+          helixSource: ci/dotnet/coreclr/$(Build.SourceBranch)
+
+        ${{ if eq(parameters.readyToRun, false) }}:
+          helixType: ${{ format('test/functional/cli/pri{0}', parameters.priority) }}
+        ${{ if eq(parameters.readyToRun, true) }}:
+          helixType: ${{ format('test/functional/r2r/cli/pri{0}', parameters.priority) }}
+
         helixQueues: ${{ parameters.helixQueues.asString }}
 
         ${{ if eq(parameters.helixQueues.asString, '') }}:
@@ -149,8 +158,5 @@ jobs:
           # Access token variable for internal project from the
           # DotNet-HelixApi-Access variable group
           helixAccessToken: $(HelixApiAccessToken)
-
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          creator: coreclr-pulls
 
         scenarios: ${{ parameters.scenarios.asString }}

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -135,7 +135,7 @@ jobs:
           helixSource: official/dotnet/coreclr/$(Build.SourceBranch)
         ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
           helixSource: pr/dotnet/coreclr/$(Build.SourceBranch)
-        ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+        ${{ if and(eq(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
           helixSource: ci/dotnet/coreclr/$(Build.SourceBranch)
 
         ${{ if eq(parameters.readyToRun, false) }}:

--- a/eng/xplat-job.yml
+++ b/eng/xplat-job.yml
@@ -9,7 +9,6 @@ parameters:
   dependsOn: ''
   containerName: ''
   timeoutInMinutes: ''
-  helixType: ''
   crossrootfsDir: ''
   enableMicrobuild: ''
 
@@ -30,7 +29,6 @@ jobs:
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
 
     helixRepo: 'dotnet/coreclr'
-    helixType: ${{ parameters.helixType }}
 
     enableMicrobuild: ${{ parameters.enableMicrobuild }}
 


### PR DESCRIPTION
https://github.com/dotnet/coreclr/commit/f2937685095844e37c0319d940ca54f3cb414cea removed code in arcade that was setting $(_HelixSource) and $(_HelixType). As a consequence, links to mc.dot.net are invalid in PRs. 

Define helixSource and helixType in test-job.yml instead of relying on eng/common/templates/job/job.yml