### PR TITLE
Add Rune creation API from UTF-16 surrogate pair

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Text/Rune.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/Rune.cs
@@ -59,6 +59,18 @@ namespace System.Text
         }
 
         /// <summary>
+        /// Creates a <see cref="Rune"/> from the provided UTF-16 surrogate pair.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// If <paramref name="highSurrogate"/> does not represent a UTF-16 high surrogate code point
+        /// or <paramref name="lowSurrogate"/> does not represent a UTF-16 low surrogate code point.
+        /// </exception>
+        public Rune(char highSurrogate, char lowSurrogate)
+            : this((uint)char.ConvertToUtf32(highSurrogate, lowSurrogate), false)
+        {
+        }
+
+        /// <summary>
         /// Creates a <see cref="Rune"/> from the provided Unicode scalar value.
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException">
@@ -359,6 +371,36 @@ namespace System.Text
             }
             else
             {
+                result = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Attempts to create a <see cref="Rune"/> from the provided UTF-16 surrogate pair.
+        /// Returns <see langword="false"/> if the input values don't represent a well-formed UTF-16surrogate pair.
+        /// </summary>
+        public static bool TryCreate(char highSurrogate, char lowSurrogate, out Rune result)
+        {
+            // First, extend both to 32 bits, then calculate the offset of
+            // each candidate surrogate char from the start of its range.
+
+            uint highSurrogateOffset = (uint)highSurrogate - CharUnicodeInfo.HIGH_SURROGATE_START;
+            uint lowSurrogateOffset = (uint)lowSurrogate - CharUnicodeInfo.LOW_SURROGATE_START;
+
+            // This is a single comparison which allows us to check both for validity at once since
+            // both the high surrogate range and the low surrogate range are the same length.
+            // If the comparison fails, we call to a helper method to throw the correct exception message.
+
+            if ((highSurrogateOffset | lowSurrogateOffset) <= CharUnicodeInfo.HIGH_SURROGATE_RANGE)
+            {
+                // The 0x40u << 10 below is to account for uuuuu = wwww + 1 in the surrogate encoding.
+                result = UnsafeCreate((highSurrogateOffset << 10) + ((uint)lowSurrogate - CharUnicodeInfo.LOW_SURROGATE_START) + (0x40u << 10));
+                return true;
+            }
+            else
+            {
+                // Didn't have a high surrogate followed by a low surrogate.
                 result = default;
                 return false;
             }


### PR DESCRIPTION
This is the implementation of the API proposed at https://github.com/dotnet/corefx/issues/34683.

I also rolled into this a small perf tweak to `UnicodeUtility` and some substantial perf tweaks to `char`.

__`char.ConvertToInt32(char, char)` before:__

```asm
00007ffa`82d43970 57              push    rdi
00007ffa`82d43971 56              push    rsi
00007ffa`82d43972 4883ec28        sub     rsp,28h
00007ffa`82d43976 0fb7c1          movzx   eax,cx
00007ffa`82d43979 050028ffff      add     eax,0FFFF2800h
00007ffa`82d4397e 3dff030000      cmp     eax,3FFh
00007ffa`82d43983 7722            ja      System_Private_CoreLib!System.Char.ConvertToUtf32(Char, Char)+0xffffffff`a1bdc757 (00007ffa`82d439a7)
00007ffa`82d43985 0fb7ca          movzx   ecx,dx
00007ffa`82d43988 8d910024ffff    lea     edx,[rcx-0DC00h]
00007ffa`82d4398e 81faff030000    cmp     edx,3FFh
00007ffa`82d43994 776e            ja      System_Private_CoreLib!System.Char.ConvertToUtf32(Char, Char)+0xffffffff`a1bdc7b4 (00007ffa`82d43a04)
00007ffa`82d43996 c1e00a          shl     eax,0Ah
00007ffa`82d43999 8d840800240000  lea     eax,[rax+rcx+2400h]
00007ffa`82d439a0 4883c428        add     rsp,28h
00007ffa`82d439a4 5e              pop     rsi
00007ffa`82d439a5 5f              pop     rdi
00007ffa`82d439a6 c3              ret
00007ffa`82d439a7 48b93825bc82fa7f0000 mov rcx,7FFA82BC2538h
00007ffa`82d439b1 e80a7c8c5f      call    coreclr!JIT_TrialAllocSFastMP_InlineGetThread (00007ffa`e260b5c0)
00007ffa`82d439b6 488bf0          mov     rsi,rax
00007ffa`82d439b9 b919fd0000      mov     ecx,0FD19h
00007ffa`82d439be 48ba20609f82fa7f0000 mov rdx,7FFA829F6020h
00007ffa`82d439c8 e823c18b5f      call    coreclr!JIT_StrCns (00007ffa`e25ffaf0)
00007ffa`82d439cd 488bf8          mov     rdi,rax
00007ffa`82d439d0 b9157a0000      mov     ecx,7A15h
00007ffa`82d439d5 48ba20609f82fa7f0000 mov rdx,7FFA829F6020h
00007ffa`82d439df e80cc18b5f      call    coreclr!JIT_StrCns (00007ffa`e25ffaf0)
00007ffa`82d439e4 488bc8          mov     rcx,rax
00007ffa`82d439e7 33d2            xor     edx,edx
00007ffa`82d439e9 e82a3effff      call    System.SR.GetResourceString(System.String, System.String) (00007ffa`82d37818)
00007ffa`82d439ee 4c8bc0          mov     r8,rax
00007ffa`82d439f1 488bd7          mov     rdx,rdi
00007ffa`82d439f4 488bce          mov     rcx,rsi
00007ffa`82d439f7 e8dc72dcff      call    System.ArgumentOutOfRangeException..ctor(System.String, System.String) (00007ffa`82b0acd8)
00007ffa`82d439fc 488bce          mov     rcx,rsi
00007ffa`82d439ff e8cc4c845f      call    coreclr!IL_Throw (00007ffa`e25886d0)
00007ffa`82d43a04 48b93825bc82fa7f0000 mov rcx,7FFA82BC2538h
00007ffa`82d43a0e e8ad7b8c5f      call    coreclr!JIT_TrialAllocSFastMP_InlineGetThread (00007ffa`e260b5c0)
00007ffa`82d43a13 488bf0          mov     rsi,rax
00007ffa`82d43a16 b935fd0000      mov     ecx,0FD35h
00007ffa`82d43a1b 48ba20609f82fa7f0000 mov rdx,7FFA829F6020h
00007ffa`82d43a25 e8c6c08b5f      call    coreclr!JIT_StrCns (00007ffa`e25ffaf0)
00007ffa`82d43a2a 488bf8          mov     rdi,rax
00007ffa`82d43a2d b9657a0000      mov     ecx,7A65h
00007ffa`82d43a32 48ba20609f82fa7f0000 mov rdx,7FFA829F6020h
00007ffa`82d43a3c e8afc08b5f      call    coreclr!JIT_StrCns (00007ffa`e25ffaf0)
00007ffa`82d43a41 488bc8          mov     rcx,rax
00007ffa`82d43a44 33d2            xor     edx,edx
00007ffa`82d43a46 e8cd3dffff      call    System.SR.GetResourceString(System.String, System.String) (00007ffa`82d37818)
00007ffa`82d43a4b 4c8bc0          mov     r8,rax
00007ffa`82d43a4e 488bd7          mov     rdx,rdi
00007ffa`82d43a51 488bce          mov     rcx,rsi
00007ffa`82d43a54 e87f72dcff      call    System.ArgumentOutOfRangeException..ctor(System.String, System.String) (00007ffa`82b0acd8)
00007ffa`82d43a59 488bce          mov     rcx,rsi
00007ffa`82d43a5c e86f4c845f      call    coreclr!IL_Throw (00007ffa`e25886d0)
```

__`char.ConvertToInt32(char, char)` after:__

```asm
00007ffa`83b9930e 448bc2          mov     r8d,edx
00007ffa`83b99311 448bc9          mov     r9d,ecx
00007ffa`83b99314 4181c00028ffff  add     r8d,0FFFF2800h
00007ffa`83b9931b 458d910024ffff  lea     r10d,[r9-0DC00h]
00007ffa`83b99322 450bd0          or      r10d,r8d
00007ffa`83b99325 4181fa00040000  cmp     r10d,400h
00007ffa`83b9932c 731d            jae     <error_handler>   ; jumps to a call instruction
00007ffa`83b9932e 41c1e00a        shl     r8d,0Ah
00007ffa`83b99332 478d840800240000 lea     r8d,[r8+r9+2400h]
```

(The implementation is now small enough that the JIT automatically inlines it into the caller.)