### PR TITLE
Fail loading types with default interface methods for fragile ngen

### DIFF
--- a/src/vm/classcompat.cpp
+++ b/src/vm/classcompat.cpp
@@ -2597,10 +2597,11 @@ VOID    MethodTableBuilder::EnumerateClassMethods()
         }
 
         // Some interface checks.
-        // Ngen wasn't upgraded to deal with default interface methods.
+        // We only need them if default interface method support is disabled or if this is fragile crossgen
+#if !FEATURE_DEFAULT_INTERFACES || FEATURE_NATIVE_IMAGE_GENERATION
         if (fIsClassInterface
-            && IsCompilationProcess()
-#if FEATURE_READYTORUN
+#if FEATURE_DEFAULT_INTERFACES
+            // Only fragile crossgen wasn't upgraded to deal with default interface methods.
             && !IsReadyToRunCompilation()
 #endif
             )
@@ -2611,16 +2612,17 @@ VOID    MethodTableBuilder::EnumerateClassMethods()
                 {
                     BuildMethodTableThrowException(BFA_VIRTUAL_NONAB_INT_METHOD);
                 }
-            } 
+            }
             else
             {
-                // Instance field/method
+                // Instance method
                 if (!IsMdStatic(dwMemberAttrs))
                 {
                     BuildMethodTableThrowException(BFA_NONVIRT_INST_INT_METHOD);
                 }
             }
         }
+#endif // !FEATURE_DEFAULT_INTERFACES || FEATURE_NATIVE_IMAGE_GENERATION
 
         // No synchronized methods in ValueTypes
         if(fIsClassValueType && IsMiSynchronized(dwImplFlags))

--- a/src/vm/classcompat.cpp
+++ b/src/vm/classcompat.cpp
@@ -2596,9 +2596,14 @@ VOID    MethodTableBuilder::EnumerateClassMethods()
             }
         }
 
-#ifndef FEATURE_DEFAULT_INTERFACES
         // Some interface checks.
-        if (fIsClassInterface)
+        // Ngen wasn't upgraded to deal with default interface methods.
+        if (fIsClassInterface
+            && IsCompilationProcess()
+#if FEATURE_READYTORUN
+            && !IsReadyToRunCompilation()
+#endif
+            )
         {
             if (IsMdVirtual(dwMemberAttrs))
             {
@@ -2616,7 +2621,6 @@ VOID    MethodTableBuilder::EnumerateClassMethods()
                 }
             }
         }
-#endif
 
         // No synchronized methods in ValueTypes
         if(fIsClassValueType && IsMiSynchronized(dwImplFlags))

--- a/src/vm/classcompat.cpp
+++ b/src/vm/classcompat.cpp
@@ -2598,9 +2598,9 @@ VOID    MethodTableBuilder::EnumerateClassMethods()
 
         // Some interface checks.
         // We only need them if default interface method support is disabled or if this is fragile crossgen
-#if !FEATURE_DEFAULT_INTERFACES || FEATURE_NATIVE_IMAGE_GENERATION
+#if !defined(FEATURE_DEFAULT_INTERFACES) || defined(FEATURE_NATIVE_IMAGE_GENERATION)
         if (fIsClassInterface
-#if FEATURE_DEFAULT_INTERFACES
+#if defined(FEATURE_DEFAULT_INTERFACES)
             // Only fragile crossgen wasn't upgraded to deal with default interface methods.
             && !IsReadyToRunCompilation()
 #endif
@@ -2622,7 +2622,7 @@ VOID    MethodTableBuilder::EnumerateClassMethods()
                 }
             }
         }
-#endif // !FEATURE_DEFAULT_INTERFACES || FEATURE_NATIVE_IMAGE_GENERATION
+#endif // !defined(FEATURE_DEFAULT_INTERFACES) || defined(FEATURE_NATIVE_IMAGE_GENERATION)
 
         // No synchronized methods in ValueTypes
         if(fIsClassValueType && IsMiSynchronized(dwImplFlags))

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -2910,9 +2910,9 @@ MethodTableBuilder::EnumerateClassMethods()
 
         // Some interface checks.
         // We only need them if default interface method support is disabled or if this is fragile crossgen
-#if !FEATURE_DEFAULT_INTERFACES || FEATURE_NATIVE_IMAGE_GENERATION
+#if !defined(FEATURE_DEFAULT_INTERFACES) || defined(FEATURE_NATIVE_IMAGE_GENERATION)
         if (fIsClassInterface
-#if FEATURE_DEFAULT_INTERFACES
+#if defined(FEATURE_DEFAULT_INTERFACES)
             // Only fragile crossgen wasn't upgraded to deal with default interface methods.
             && !IsReadyToRunCompilation()
 #endif
@@ -2934,7 +2934,7 @@ MethodTableBuilder::EnumerateClassMethods()
                 }
             }
         }
-#endif // !FEATURE_DEFAULT_INTERFACES || FEATURE_NATIVE_IMAGE_GENERATION
+#endif // !defined(FEATURE_DEFAULT_INTERFACES) || defined(FEATURE_NATIVE_IMAGE_GENERATION)
 
         // No synchronized methods in ValueTypes
         if(fIsClassValueType && IsMiSynchronized(dwImplFlags))

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -2908,9 +2908,14 @@ MethodTableBuilder::EnumerateClassMethods()
             }
         }
 
-#ifndef FEATURE_DEFAULT_INTERFACES
         // Some interface checks.
-        if (fIsClassInterface)
+        // Ngen wasn't upgraded to deal with default interface methods.
+        if (fIsClassInterface
+            && IsCompilationProcess()
+#if FEATURE_READYTORUN
+            && !IsReadyToRunCompilation()
+#endif
+            )
         {
             if (IsMdVirtual(dwMemberAttrs))
             {
@@ -2928,7 +2933,6 @@ MethodTableBuilder::EnumerateClassMethods()
                 }
             }
         }
-#endif
 
         // No synchronized methods in ValueTypes
         if(fIsClassValueType && IsMiSynchronized(dwImplFlags))

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -2909,10 +2909,11 @@ MethodTableBuilder::EnumerateClassMethods()
         }
 
         // Some interface checks.
-        // Ngen wasn't upgraded to deal with default interface methods.
+        // We only need them if default interface method support is disabled or if this is fragile crossgen
+#if !FEATURE_DEFAULT_INTERFACES || FEATURE_NATIVE_IMAGE_GENERATION
         if (fIsClassInterface
-            && IsCompilationProcess()
-#if FEATURE_READYTORUN
+#if FEATURE_DEFAULT_INTERFACES
+            // Only fragile crossgen wasn't upgraded to deal with default interface methods.
             && !IsReadyToRunCompilation()
 #endif
             )
@@ -2926,13 +2927,14 @@ MethodTableBuilder::EnumerateClassMethods()
             }
             else
             {
-                // Instance field/method
+                // Instance method
                 if (!IsMdStatic(dwMemberAttrs))
                 {
                     BuildMethodTableThrowException(BFA_NONVIRT_INST_INT_METHOD);
                 }
             }
         }
+#endif // !FEATURE_DEFAULT_INTERFACES || FEATURE_NATIVE_IMAGE_GENERATION
 
         // No synchronized methods in ValueTypes
         if(fIsClassValueType && IsMiSynchronized(dwImplFlags))


### PR DESCRIPTION
We are not generating the right data structures for this. Since fragile crossgen is no longer a mainstream scenario, it's not worth the effort to add default interface methods support for it.

This avoids `!"Precode::GetPrecodeFromEntryPoint: Unexpected code in precode"` and similar issues.

Fixes #15682.