### PR TITLE
Fixing the number formatting code to only recognize 'R' for double/float.

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
@@ -1723,6 +1723,11 @@ namespace System
                 case 'R':
                 case 'r':
                 {
+                    if (number.Kind != NumberBufferKind.FloatingPoint)
+                    {
+                        goto default;
+                    }
+
                     format = (char)(format - ('R' - 'G'));
                     Debug.Assert((format == 'G') || (format == 'g'));
                     goto case 'G';


### PR DESCRIPTION
@davidwrighton found this impacting a negative test for ushort.

CC. @stephentoub, @jkotas