### PR TITLE
Reserve fast dictionary slots for Tier1 code

### DIFF
--- a/src/vm/genericdict.cpp
+++ b/src/vm/genericdict.cpp
@@ -132,6 +132,15 @@ DictionaryLayout::FindTokenWorker(LoaderAllocator *                 pAllocator,
     }
     CONTRACTL_END
 
+#ifndef FEATURE_NATIVE_IMAGE_GENERATION
+    // If the tiered compilation is on, save the fast dictionary slots for the hot Tier1 code
+    if (g_pConfig->TieredCompilation() && signatureSource == FromReadyToRunImage)
+    {
+        pResult->signature = pSig;
+        return FALSE;
+    }
+#endif
+
     BOOL isFirstBucket = TRUE;
 
     // First bucket also contains type parameters


### PR DESCRIPTION
Disable use of fast dictionary slots for R2R images when tiered JITing is enabled.

Fixes #22400