### PR TITLE
In CLRLifoSemaphore, start the underlying semaphore with 0 for the initial signal count

### DIFF
--- a/src/vm/synch.cpp
+++ b/src/vm/synch.cpp
@@ -589,7 +589,7 @@ void CLRLifoSemaphore::Create(INT32 initialSignalCount, INT32 maximumSignalCount
     _ASSERTE(m_handle == nullptr);
 
 #ifdef FEATURE_PAL
-    HANDLE h = UnsafeCreateSemaphore(nullptr, initialSignalCount, maximumSignalCount, nullptr);
+    HANDLE h = UnsafeCreateSemaphore(nullptr, 0, maximumSignalCount, nullptr);
 #else // !FEATURE_PAL
     HANDLE h = CreateIoCompletionPort(INVALID_HANDLE_VALUE, nullptr, 0, maximumSignalCount);
 #endif // FEATURE_PAL


### PR DESCRIPTION
- Port of a fix from https://github.com/dotnet/corert/pull/6955
- The underlying semaphore is only used to wake up waiters, initially there are no waiters and the signal count should be zero. This was already the case on Windows, this fixes the Unix side. The actual initial signal count is tracked in the upper layer counts.
- The initial signal count passed in is zero anyway in the places where it's used, so it makes no difference for now, just some cleanup