### PR TITLE
Adjust gc stress compatibility settings for two tests

### DIFF
--- a/tests/src/Regressions/coreclr/GitHub_12224/Test12224.csproj
+++ b/tests/src/Regressions/coreclr/GitHub_12224/Test12224.csproj
@@ -12,6 +12,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/tracing/eventsource/eventsourcetrace/eventsourcetrace.csproj
+++ b/tests/src/tracing/eventsource/eventsourcetrace/eventsourcetrace.csproj
@@ -14,7 +14,6 @@
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
-    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'"></PropertyGroup>


### PR DESCRIPTION
* enable eventsourcetrace for gc stress. Closes #17188.
* disable GitHub_12224 for gc stress (relies on timeout). Closes #19086.