### PR TITLE
Updating some local functions to be 'static' (captureless).

### DIFF
--- a/src/System.Private.CoreLib/shared/System/BitOps.cs
+++ b/src/System.Private.CoreLib/shared/System/BitOps.cs
@@ -306,18 +306,18 @@ namespace System
 
             return SoftwareFallback(value);
 
-            int SoftwareFallback(uint v)
+            static int SoftwareFallback(uint value)
             {
                 const uint c1 = 0x_55555555u;
                 const uint c2 = 0x_33333333u;
                 const uint c3 = 0x_0F0F0F0Fu;
                 const uint c4 = 0x_01010101u;
 
-                v = v - ((v >> 1) & c1);
-                v = (v & c2) + ((v >> 2) & c2);
-                v = (((v + (v >> 4)) & c3) * c4) >> 24;
+                value = value - ((value >> 1) & c1);
+                value = (value & c2) + ((value >> 2) & c2);
+                value = (((value + (value >> 4)) & c3) * c4) >> 24;
 
-                return (int)v;
+                return (int)value;
             }
         }
 
@@ -340,18 +340,18 @@ namespace System
 #else
             return SoftwareFallback(value);
 
-            int SoftwareFallback(ulong v) 
+            static int SoftwareFallback(ulong value) 
             {
                 const ulong c1 = 0x_55555555_55555555ul;
                 const ulong c2 = 0x_33333333_33333333ul;
                 const ulong c3 = 0x_0F0F0F0F_0F0F0F0Ful;
                 const ulong c4 = 0x_01010101_01010101ul;
 
-                v = v - ((v >> 1) & c1);
-                v = (v & c2) + ((v >> 2) & c2);
-                v = (((v + (v >> 4)) & c3) * c4) >> 56;
+                value = value - ((value >> 1) & c1);
+                value = (value & c2) + ((value >> 2) & c2);
+                value = (((value + (value >> 4)) & c3) * c4) >> 56;
 
-                return (int)v;
+                return (int)value;
             }
 #endif
         }

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128.cs
@@ -202,26 +202,26 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector128<byte> SoftwareFallback(byte x)
+            static Vector128<byte> SoftwareFallback(byte value)
             {
                 var pResult = stackalloc byte[16]
                 {
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
                 };
 
                 return Unsafe.AsRef<Vector128<byte>>(pResult);
@@ -251,12 +251,12 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector128<double> SoftwareFallback(double x)
+            static Vector128<double> SoftwareFallback(double value)
             {
                 var pResult = stackalloc double[2]
                 {
-                    x,
-                    x,
+                    value,
+                    value,
                 };
 
                 return Unsafe.AsRef<Vector128<double>>(pResult);
@@ -287,18 +287,18 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector128<short> SoftwareFallback(short x)
+            static Vector128<short> SoftwareFallback(short value)
             {
                 var pResult = stackalloc short[8]
                 {
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
                 };
 
                 return Unsafe.AsRef<Vector128<short>>(pResult);
@@ -325,14 +325,14 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector128<int> SoftwareFallback(int x)
+            static Vector128<int> SoftwareFallback(int value)
             {
                 var pResult = stackalloc int[4]
                 {
-                    x,
-                    x,
-                    x,
-                    x,
+                    value,
+                    value,
+                    value,
+                    value,
                 };
 
                 return Unsafe.AsRef<Vector128<int>>(pResult);
@@ -361,12 +361,12 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector128<long> SoftwareFallback(long x)
+            static Vector128<long> SoftwareFallback(long value)
             {
                 var pResult = stackalloc long[2]
                 {
-                    x,
-                    x,
+                    value,
+                    value,
                 };
 
                 return Unsafe.AsRef<Vector128<long>>(pResult);
@@ -405,26 +405,26 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector128<sbyte> SoftwareFallback(sbyte x)
+            static Vector128<sbyte> SoftwareFallback(sbyte value)
             {
                 var pResult = stackalloc sbyte[16]
                 {
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
                 };
 
                 return Unsafe.AsRef<Vector128<sbyte>>(pResult);
@@ -457,14 +457,14 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector128<float> SoftwareFallback(float x)
+            static Vector128<float> SoftwareFallback(float value)
             {
                 var pResult = stackalloc float[4]
                 {
-                    x,
-                    x,
-                    x,
-                    x,
+                    value,
+                    value,
+                    value,
+                    value,
                 };
 
                 return Unsafe.AsRef<Vector128<float>>(pResult);
@@ -496,18 +496,18 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector128<ushort> SoftwareFallback(ushort x)
+            static Vector128<ushort> SoftwareFallback(ushort value)
             {
                 var pResult = stackalloc ushort[8]
                 {
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
                 };
 
                 return Unsafe.AsRef<Vector128<ushort>>(pResult);
@@ -535,14 +535,14 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector128<uint> SoftwareFallback(uint x)
+            static Vector128<uint> SoftwareFallback(uint value)
             {
                 var pResult = stackalloc uint[4]
                 {
-                    x,
-                    x,
-                    x,
-                    x,
+                    value,
+                    value,
+                    value,
+                    value,
                 };
 
                 return Unsafe.AsRef<Vector128<uint>>(pResult);
@@ -572,12 +572,12 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector128<ulong> SoftwareFallback(ulong x)
+            static Vector128<ulong> SoftwareFallback(ulong value)
             {
                 var pResult = stackalloc ulong[2]
                 {
-                    x,
-                    x,
+                    value,
+                    value,
                 };
 
                 return Unsafe.AsRef<Vector128<ulong>>(pResult);
@@ -660,26 +660,26 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(e0, e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14, e15);
 
-            Vector128<byte> SoftwareFallback(byte i0, byte i1, byte i2, byte i3, byte i4, byte i5, byte i6, byte i7, byte i8, byte i9, byte i10, byte i11, byte i12, byte i13, byte i14, byte i15)
+            static Vector128<byte> SoftwareFallback(byte e0, byte e1, byte e2, byte e3, byte e4, byte e5, byte e6, byte e7, byte e8, byte e9, byte e10, byte e11, byte e12, byte e13, byte e14, byte e15)
             {
                 var pResult = stackalloc byte[16]
                 {
-                    i0,
-                    i1,
-                    i2,
-                    i3,
-                    i4,
-                    i5,
-                    i6,
-                    i7,
-                    i8,
-                    i9,
-                    i10,
-                    i11,
-                    i12,
-                    i13,
-                    i14,
-                    i15,
+                    e0,
+                    e1,
+                    e2,
+                    e3,
+                    e4,
+                    e5,
+                    e6,
+                    e7,
+                    e8,
+                    e9,
+                    e10,
+                    e11,
+                    e12,
+                    e13,
+                    e14,
+                    e15,
                 };
 
                 return Unsafe.AsRef<Vector128<byte>>(pResult);
@@ -703,12 +703,12 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(e0, e1);
 
-            Vector128<double> SoftwareFallback(double i0, double i1)
+            static Vector128<double> SoftwareFallback(double e0, double e1)
             {
                 var pResult = stackalloc double[2]
                 {
-                    i0,
-                    i1,
+                    e0,
+                    e1,
                 };
 
                 return Unsafe.AsRef<Vector128<double>>(pResult);
@@ -742,18 +742,18 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(e0, e1, e2, e3, e4, e5, e6, e7);
 
-            Vector128<short> SoftwareFallback(short i0, short i1, short i2, short i3, short i4, short i5, short i6, short i7)
+            static Vector128<short> SoftwareFallback(short e0, short e1, short e2, short e3, short e4, short e5, short e6, short e7)
             {
                 var pResult = stackalloc short[8]
                 {
-                    i0,
-                    i1,
-                    i2,
-                    i3,
-                    i4,
-                    i5,
-                    i6,
-                    i7,
+                    e0,
+                    e1,
+                    e2,
+                    e3,
+                    e4,
+                    e5,
+                    e6,
+                    e7,
                 };
 
                 return Unsafe.AsRef<Vector128<short>>(pResult);
@@ -790,14 +790,14 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(e0, e1, e2, e3);
 
-            Vector128<int> SoftwareFallback(int i0, int i1, int i2, int i3)
+            static Vector128<int> SoftwareFallback(int e0, int e1, int e2, int e3)
             {
                 var pResult = stackalloc int[4]
                 {
-                    i0,
-                    i1,
-                    i2,
-                    i3,
+                    e0,
+                    e1,
+                    e2,
+                    e3,
                 };
 
                 return Unsafe.AsRef<Vector128<int>>(pResult);
@@ -824,12 +824,12 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(e0, e1);
 
-            Vector128<long> SoftwareFallback(long i0, long i1)
+            static Vector128<long> SoftwareFallback(long e0, long e1)
             {
                 var pResult = stackalloc long[2]
                 {
-                    i0,
-                    i1,
+                    e0,
+                    e1,
                 };
 
                 return Unsafe.AsRef<Vector128<long>>(pResult);
@@ -913,26 +913,26 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(e0, e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14, e15);
 
-            Vector128<sbyte> SoftwareFallback(sbyte i0, sbyte i1, sbyte i2, sbyte i3, sbyte i4, sbyte i5, sbyte i6, sbyte i7, sbyte i8, sbyte i9, sbyte i10, sbyte i11, sbyte i12, sbyte i13, sbyte i14, sbyte i15)
+            static Vector128<sbyte> SoftwareFallback(sbyte e0, sbyte e1, sbyte e2, sbyte e3, sbyte e4, sbyte e5, sbyte e6, sbyte e7, sbyte e8, sbyte e9, sbyte e10, sbyte e11, sbyte e12, sbyte e13, sbyte e14, sbyte e15)
             {
                 var pResult = stackalloc sbyte[16]
                 {
-                    i0,
-                    i1,
-                    i2,
-                    i3,
-                    i4,
-                    i5,
-                    i6,
-                    i7,
-                    i8,
-                    i9,
-                    i10,
-                    i11,
-                    i12,
-                    i13,
-                    i14,
-                    i15,
+                    e0,
+                    e1,
+                    e2,
+                    e3,
+                    e4,
+                    e5,
+                    e6,
+                    e7,
+                    e8,
+                    e9,
+                    e10,
+                    e11,
+                    e12,
+                    e13,
+                    e14,
+                    e15,
                 };
 
                 return Unsafe.AsRef<Vector128<sbyte>>(pResult);
@@ -966,14 +966,14 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(e0, e1, e2, e3);
 
-            Vector128<float> SoftwareFallback(float i0, float i1, float i2, float i3)
+            static Vector128<float> SoftwareFallback(float e0, float e1, float e2, float e3)
             {
                 var pResult = stackalloc float[4]
                 {
-                    i0,
-                    i1,
-                    i2,
-                    i3,
+                    e0,
+                    e1,
+                    e2,
+                    e3,
                 };
 
                 return Unsafe.AsRef<Vector128<float>>(pResult);
@@ -1008,18 +1008,18 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(e0, e1, e2, e3, e4, e5, e6, e7);
 
-            Vector128<ushort> SoftwareFallback(ushort i0, ushort i1, ushort i2, ushort i3, ushort i4, ushort i5, ushort i6, ushort i7)
+            static Vector128<ushort> SoftwareFallback(ushort e0, ushort e1, ushort e2, ushort e3, ushort e4, ushort e5, ushort e6, ushort e7)
             {
                 var pResult = stackalloc ushort[8]
                 {
-                    i0,
-                    i1,
-                    i2,
-                    i3,
-                    i4,
-                    i5,
-                    i6,
-                    i7,
+                    e0,
+                    e1,
+                    e2,
+                    e3,
+                    e4,
+                    e5,
+                    e6,
+                    e7,
                 };
 
                 return Unsafe.AsRef<Vector128<ushort>>(pResult);
@@ -1057,14 +1057,14 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(e0, e1, e2, e3);
 
-            Vector128<uint> SoftwareFallback(uint i0, uint i1, uint i2, uint i3)
+            static Vector128<uint> SoftwareFallback(uint e0, uint e1, uint e2, uint e3)
             {
                 var pResult = stackalloc uint[4]
                 {
-                    i0,
-                    i1,
-                    i2,
-                    i3,
+                    e0,
+                    e1,
+                    e2,
+                    e3,
                 };
 
                 return Unsafe.AsRef<Vector128<uint>>(pResult);
@@ -1092,12 +1092,12 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(e0, e1);
 
-            Vector128<ulong> SoftwareFallback(ulong i0, ulong i1)
+            static Vector128<ulong> SoftwareFallback(ulong e0, ulong e1)
             {
                 var pResult = stackalloc ulong[2]
                 {
-                    i0,
-                    i1,
+                    e0,
+                    e1,
                 };
 
                 return Unsafe.AsRef<Vector128<ulong>>(pResult);
@@ -1273,10 +1273,10 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector128<byte> SoftwareFallback(byte x)
+            static Vector128<byte> SoftwareFallback(byte value)
             {
                 var result = Vector128<byte>.Zero;
-                Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<byte>, byte>(ref result), x);
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<byte>, byte>(ref result), value);
                 return result;
             }
         }
@@ -1294,10 +1294,10 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector128<double> SoftwareFallback(double x)
+            static Vector128<double> SoftwareFallback(double value)
             {
                 var result = Vector128<double>.Zero;
-                Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<double>, byte>(ref result), x);
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<double>, byte>(ref result), value);
                 return result;
             }
         }
@@ -1317,10 +1317,10 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector128<short> SoftwareFallback(short x)
+            static Vector128<short> SoftwareFallback(short value)
             {
                 var result = Vector128<short>.Zero;
-                Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<short>, byte>(ref result), x);
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<short>, byte>(ref result), value);
                 return result;
             }
         }
@@ -1338,10 +1338,10 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector128<int> SoftwareFallback(int x)
+            static Vector128<int> SoftwareFallback(int value)
             {
                 var result = Vector128<int>.Zero;
-                Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<int>, byte>(ref result), x);
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<int>, byte>(ref result), value);
                 return result;
             }
         }
@@ -1358,10 +1358,10 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector128<long> SoftwareFallback(long x)
+            static Vector128<long> SoftwareFallback(long value)
             {
                 var result = Vector128<long>.Zero;
-                Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<long>, byte>(ref result), x);
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<long>, byte>(ref result), value);
                 return result;
             }
         }
@@ -1382,10 +1382,10 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector128<sbyte> SoftwareFallback(sbyte x)
+            static Vector128<sbyte> SoftwareFallback(sbyte value)
             {
                 var result = Vector128<sbyte>.Zero;
-                Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<sbyte>, byte>(ref result), x);
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<sbyte>, byte>(ref result), value);
                 return result;
             }
         }
@@ -1403,10 +1403,10 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector128<float> SoftwareFallback(float x)
+            static Vector128<float> SoftwareFallback(float value)
             {
                 var result = Vector128<float>.Zero;
-                Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<float>, byte>(ref result), x);
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<float>, byte>(ref result), value);
                 return result;
             }
         }
@@ -1427,10 +1427,10 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector128<ushort> SoftwareFallback(ushort x)
+            static Vector128<ushort> SoftwareFallback(ushort value)
             {
                 var result = Vector128<ushort>.Zero;
-                Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<ushort>, byte>(ref result), x);
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<ushort>, byte>(ref result), value);
                 return result;
             }
         }
@@ -1449,10 +1449,10 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector128<uint> SoftwareFallback(uint x)
+            static Vector128<uint> SoftwareFallback(uint value)
             {
                 var result = Vector128<uint>.Zero;
-                Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<uint>, byte>(ref result), x);
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<uint>, byte>(ref result), value);
                 return result;
             }
         }
@@ -1471,10 +1471,10 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector128<ulong> SoftwareFallback(ulong x)
+            static Vector128<ulong> SoftwareFallback(ulong value)
             {
                 var result = Vector128<ulong>.Zero;
-                Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<ulong>, byte>(ref result), x);
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<ulong>, byte>(ref result), value);
                 return result;
             }
         }

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128_1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector128_1.cs
@@ -204,11 +204,11 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(in this, other);
 
-            bool SoftwareFallback(in Vector128<T> x, Vector128<T> y)
+            static bool SoftwareFallback(in Vector128<T> vector, Vector128<T> other)
             {
                 for (int i = 0; i < Count; i++)
                 {
-                    if (!((IEquatable<T>)(x.GetElement(i))).Equals(y.GetElement(i)))
+                    if (!((IEquatable<T>)(vector.GetElement(i))).Equals(other.GetElement(i)))
                     {
                         return false;
                     }

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256.cs
@@ -191,42 +191,42 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector256<byte> SoftwareFallback(byte x)
+            static Vector256<byte> SoftwareFallback(byte value)
             {
                 var pResult = stackalloc byte[32]
                 {
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
                 };
 
                 return Unsafe.AsRef<Vector256<byte>>(pResult);
@@ -253,14 +253,14 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector256<double> SoftwareFallback(double x)
+            static Vector256<double> SoftwareFallback(double value)
             {
                 var pResult = stackalloc double[4]
                 {
-                    x,
-                    x,
-                    x,
-                    x,
+                    value,
+                    value,
+                    value,
+                    value,
                 };
 
                 return Unsafe.AsRef<Vector256<double>>(pResult);
@@ -287,26 +287,26 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector256<short> SoftwareFallback(short x)
+            static Vector256<short> SoftwareFallback(short value)
             {
                 var pResult = stackalloc short[16]
                 {
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
                 };
 
                 return Unsafe.AsRef<Vector256<short>>(pResult);
@@ -333,18 +333,18 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector256<int> SoftwareFallback(int x)
+            static Vector256<int> SoftwareFallback(int value)
             {
                 var pResult = stackalloc int[8]
                 {
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
                 };
 
                 return Unsafe.AsRef<Vector256<int>>(pResult);
@@ -373,14 +373,14 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector256<long> SoftwareFallback(long x)
+            static Vector256<long> SoftwareFallback(long value)
             {
                 var pResult = stackalloc long[4]
                 {
-                    x,
-                    x,
-                    x,
-                    x,
+                    value,
+                    value,
+                    value,
+                    value,
                 };
 
                 return Unsafe.AsRef<Vector256<long>>(pResult);
@@ -408,42 +408,42 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector256<sbyte> SoftwareFallback(sbyte x)
+            static Vector256<sbyte> SoftwareFallback(sbyte value)
             {
                 var pResult = stackalloc sbyte[32]
                 {
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
                 };
 
                 return Unsafe.AsRef<Vector256<sbyte>>(pResult);
@@ -470,18 +470,18 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector256<float> SoftwareFallback(float x)
+            static Vector256<float> SoftwareFallback(float value)
             {
                 var pResult = stackalloc float[8]
                 {
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
                 };
 
                 return Unsafe.AsRef<Vector256<float>>(pResult);
@@ -509,26 +509,26 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector256<ushort> SoftwareFallback(ushort x)
+            static Vector256<ushort> SoftwareFallback(ushort value)
             {
                 var pResult = stackalloc ushort[16]
                 {
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
                 };
 
                 return Unsafe.AsRef<Vector256<ushort>>(pResult);
@@ -556,18 +556,18 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector256<uint> SoftwareFallback(uint x)
+            static Vector256<uint> SoftwareFallback(uint value)
             {
                 var pResult = stackalloc uint[8]
                 {
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
-                    x,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
+                    value,
                 };
 
                 return Unsafe.AsRef<Vector256<uint>>(pResult);
@@ -597,14 +597,14 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector256<ulong> SoftwareFallback(ulong x)
+            static Vector256<ulong> SoftwareFallback(ulong value)
             {
                 var pResult = stackalloc ulong[4]
             {
-                    x,
-                    x,
-                    x,
-                    x,
+                    value,
+                    value,
+                    value,
+                    value,
                 };
 
                 return Unsafe.AsRef<Vector256<ulong>>(pResult);
@@ -657,42 +657,42 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(e0, e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14, e15, e16, e17, e18, e19, e20, e21, e22, e23, e24, e25, e26, e27, e28, e29, e30, e31);
 
-            Vector256<byte> SoftwareFallback(byte i0, byte i1, byte i2, byte i3, byte i4, byte i5, byte i6, byte i7, byte i8, byte i9, byte i10, byte i11, byte i12, byte i13, byte i14, byte i15, byte i16, byte i17, byte i18, byte i19, byte i20, byte i21, byte i22, byte i23, byte i24, byte i25, byte i26, byte i27, byte i28, byte i29, byte i30, byte i31)
+            static Vector256<byte> SoftwareFallback(byte e0, byte e1, byte e2, byte e3, byte e4, byte e5, byte e6, byte e7, byte e8, byte e9, byte e10, byte e11, byte e12, byte e13, byte e14, byte e15, byte e16, byte e17, byte e18, byte e19, byte e20, byte e21, byte e22, byte e23, byte e24, byte e25, byte e26, byte e27, byte e28, byte e29, byte e30, byte e31)
             {
                 var pResult = stackalloc byte[32]
                 {
-                    i0,
-                    i1,
-                    i2,
-                    i3,
-                    i4,
-                    i5,
-                    i6,
-                    i7,
-                    i8,
-                    i9,
-                    i10,
-                    i11,
-                    i12,
-                    i13,
-                    i14,
-                    i15,
-                    i16,
-                    i17,
-                    i18,
-                    i19,
-                    i20,
-                    i21,
-                    i22,
-                    i23,
-                    i24,
-                    i25,
-                    i26,
-                    i27,
-                    i28,
-                    i29,
-                    i30,
-                    i31,
+                    e0,
+                    e1,
+                    e2,
+                    e3,
+                    e4,
+                    e5,
+                    e6,
+                    e7,
+                    e8,
+                    e9,
+                    e10,
+                    e11,
+                    e12,
+                    e13,
+                    e14,
+                    e15,
+                    e16,
+                    e17,
+                    e18,
+                    e19,
+                    e20,
+                    e21,
+                    e22,
+                    e23,
+                    e24,
+                    e25,
+                    e26,
+                    e27,
+                    e28,
+                    e29,
+                    e30,
+                    e31,
                 };
 
                 return Unsafe.AsRef<Vector256<byte>>(pResult);
@@ -717,14 +717,14 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(e0, e1, e2, e3);
 
-            Vector256<double> SoftwareFallback(double i0, double i1, double i2, double i3)
+            static Vector256<double> SoftwareFallback(double e0, double e1, double e2, double e3)
             {
                 var pResult = stackalloc double[4]
                 {
-                    i0,
-                    i1,
-                    i2,
-                    i3,
+                    e0,
+                    e1,
+                    e2,
+                    e3,
                 };
 
                 return Unsafe.AsRef<Vector256<double>>(pResult);
@@ -761,26 +761,26 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(e0, e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14, e15);
 
-            Vector256<short> SoftwareFallback(short i0, short i1, short i2, short i3, short i4, short i5, short i6, short i7, short i8, short i9, short i10, short i11, short i12, short i13, short i14, short i15)
+            static Vector256<short> SoftwareFallback(short e0, short e1, short e2, short e3, short e4, short e5, short e6, short e7, short e8, short e9, short e10, short e11, short e12, short e13, short e14, short e15)
             {
                 var pResult = stackalloc short[16]
                 {
-                    i0,
-                    i1,
-                    i2,
-                    i3,
-                    i4,
-                    i5,
-                    i6,
-                    i7,
-                    i8,
-                    i9,
-                    i10,
-                    i11,
-                    i12,
-                    i13,
-                    i14,
-                    i15,
+                    e0,
+                    e1,
+                    e2,
+                    e3,
+                    e4,
+                    e5,
+                    e6,
+                    e7,
+                    e8,
+                    e9,
+                    e10,
+                    e11,
+                    e12,
+                    e13,
+                    e14,
+                    e15,
                 };
 
                 return Unsafe.AsRef<Vector256<short>>(pResult);
@@ -809,18 +809,18 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(e0, e1, e2, e3, e4, e5, e6, e7);
 
-            Vector256<int> SoftwareFallback(int i0, int i1, int i2, int i3, int i4, int i5, int i6, int i7)
+            static Vector256<int> SoftwareFallback(int e0, int e1, int e2, int e3, int e4, int e5, int e6, int e7)
             {
                 var pResult = stackalloc int[8]
                 {
-                    i0,
-                    i1,
-                    i2,
-                    i3,
-                    i4,
-                    i5,
-                    i6,
-                    i7,
+                    e0,
+                    e1,
+                    e2,
+                    e3,
+                    e4,
+                    e5,
+                    e6,
+                    e7,
                 };
 
                 return Unsafe.AsRef<Vector256<int>>(pResult);
@@ -845,14 +845,14 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(e0, e1, e2, e3);
 
-            Vector256<long> SoftwareFallback(long i0, long i1, long i2, long i3)
+            static Vector256<long> SoftwareFallback(long e0, long e1, long e2, long e3)
             {
                 var pResult = stackalloc long[4]
                 {
-                    i0,
-                    i1,
-                    i2,
-                    i3,
+                    e0,
+                    e1,
+                    e2,
+                    e3,
                 };
 
                 return Unsafe.AsRef<Vector256<long>>(pResult);
@@ -906,42 +906,42 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(e0, e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14, e15, e16, e17, e18, e19, e20, e21, e22, e23, e24, e25, e26, e27, e28, e29, e30, e31);
 
-            Vector256<sbyte> SoftwareFallback(sbyte i0, sbyte i1, sbyte i2, sbyte i3, sbyte i4, sbyte i5, sbyte i6, sbyte i7, sbyte i8, sbyte i9, sbyte i10, sbyte i11, sbyte i12, sbyte i13, sbyte i14, sbyte i15, sbyte i16, sbyte i17, sbyte i18, sbyte i19, sbyte i20, sbyte i21, sbyte i22, sbyte i23, sbyte i24, sbyte i25, sbyte i26, sbyte i27, sbyte i28, sbyte i29, sbyte i30, sbyte i31)
+            static Vector256<sbyte> SoftwareFallback(sbyte e0, sbyte e1, sbyte e2, sbyte e3, sbyte e4, sbyte e5, sbyte e6, sbyte e7, sbyte e8, sbyte e9, sbyte e10, sbyte e11, sbyte e12, sbyte e13, sbyte e14, sbyte e15, sbyte e16, sbyte e17, sbyte e18, sbyte e19, sbyte e20, sbyte e21, sbyte e22, sbyte e23, sbyte e24, sbyte e25, sbyte e26, sbyte e27, sbyte e28, sbyte e29, sbyte e30, sbyte e31)
             {
                 var pResult = stackalloc sbyte[32]
                 {
-                    i0,
-                    i1,
-                    i2,
-                    i3,
-                    i4,
-                    i5,
-                    i6,
-                    i7,
-                    i8,
-                    i9,
-                    i10,
-                    i11,
-                    i12,
-                    i13,
-                    i14,
-                    i15,
-                    i16,
-                    i17,
-                    i18,
-                    i19,
-                    i20,
-                    i21,
-                    i22,
-                    i23,
-                    i24,
-                    i25,
-                    i26,
-                    i27,
-                    i28,
-                    i29,
-                    i30,
-                    i31,
+                    e0,
+                    e1,
+                    e2,
+                    e3,
+                    e4,
+                    e5,
+                    e6,
+                    e7,
+                    e8,
+                    e9,
+                    e10,
+                    e11,
+                    e12,
+                    e13,
+                    e14,
+                    e15,
+                    e16,
+                    e17,
+                    e18,
+                    e19,
+                    e20,
+                    e21,
+                    e22,
+                    e23,
+                    e24,
+                    e25,
+                    e26,
+                    e27,
+                    e28,
+                    e29,
+                    e30,
+                    e31,
                 };
 
                 return Unsafe.AsRef<Vector256<sbyte>>(pResult);
@@ -970,18 +970,18 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(e0, e1, e2, e3, e4, e5, e6, e7);
 
-            Vector256<float> SoftwareFallback(float i0, float i1, float i2, float i3, float i4, float i5, float i6, float i7)
+            static Vector256<float> SoftwareFallback(float e0, float e1, float e2, float e3, float e4, float e5, float e6, float e7)
             {
                 var pResult = stackalloc float[8]
                 {
-                    i0,
-                    i1,
-                    i2,
-                    i3,
-                    i4,
-                    i5,
-                    i6,
-                    i7,
+                    e0,
+                    e1,
+                    e2,
+                    e3,
+                    e4,
+                    e5,
+                    e6,
+                    e7,
                 };
 
                 return Unsafe.AsRef<Vector256<float>>(pResult);
@@ -1019,26 +1019,26 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(e0, e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12, e13, e14, e15);
 
-            Vector256<ushort> SoftwareFallback(ushort i0, ushort i1, ushort i2, ushort i3, ushort i4, ushort i5, ushort i6, ushort i7, ushort i8, ushort i9, ushort i10, ushort i11, ushort i12, ushort i13, ushort i14, ushort i15)
+            static Vector256<ushort> SoftwareFallback(ushort e0, ushort e1, ushort e2, ushort e3, ushort e4, ushort e5, ushort e6, ushort e7, ushort e8, ushort e9, ushort e10, ushort e11, ushort e12, ushort e13, ushort e14, ushort e15)
             {
                 var pResult = stackalloc ushort[16]
                 {
-                    i0,
-                    i1,
-                    i2,
-                    i3,
-                    i4,
-                    i5,
-                    i6,
-                    i7,
-                    i8,
-                    i9,
-                    i10,
-                    i11,
-                    i12,
-                    i13,
-                    i14,
-                    i15,
+                    e0,
+                    e1,
+                    e2,
+                    e3,
+                    e4,
+                    e5,
+                    e6,
+                    e7,
+                    e8,
+                    e9,
+                    e10,
+                    e11,
+                    e12,
+                    e13,
+                    e14,
+                    e15,
                 };
 
                 return Unsafe.AsRef<Vector256<ushort>>(pResult);
@@ -1068,18 +1068,18 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(e0, e1, e2, e3, e4, e5, e6, e7);
 
-            Vector256<uint> SoftwareFallback(uint i0, uint i1, uint i2, uint i3, uint i4, uint i5, uint i6, uint i7)
+            static Vector256<uint> SoftwareFallback(uint e0, uint e1, uint e2, uint e3, uint e4, uint e5, uint e6, uint e7)
             {
                 var pResult = stackalloc uint[8]
                 {
-                    i0,
-                    i1,
-                    i2,
-                    i3,
-                    i4,
-                    i5,
-                    i6,
-                    i7,
+                    e0,
+                    e1,
+                    e2,
+                    e3,
+                    e4,
+                    e5,
+                    e6,
+                    e7,
                 };
 
                 return Unsafe.AsRef<Vector256<uint>>(pResult);
@@ -1105,14 +1105,14 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(e0, e1, e2, e3);
 
-            Vector256<ulong> SoftwareFallback(ulong i0, ulong i1, ulong i2, ulong i3)
+            static Vector256<ulong> SoftwareFallback(ulong e0, ulong e1, ulong e2, ulong e3)
             {
                 var pResult = stackalloc ulong[4]
                 {
-                    i0,
-                    i1,
-                    i2,
-                    i3,
+                    e0,
+                    e1,
+                    e2,
+                    e3,
                 };
 
                 return Unsafe.AsRef<Vector256<ulong>>(pResult);
@@ -1134,13 +1134,13 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(lower, upper);
 
-            Vector256<byte> SoftwareFallback(Vector128<byte> x, Vector128<byte> y)
+            static Vector256<byte> SoftwareFallback(Vector128<byte> lower, Vector128<byte> upper)
             {
                 Vector256<byte> result256 = Vector256<byte>.Zero;
 
                 ref Vector128<byte> result128 = ref Unsafe.As<Vector256<byte>, Vector128<byte>>(ref result256);
-                result128 = x;
-                Unsafe.Add(ref result128, 1) = y;
+                result128 = lower;
+                Unsafe.Add(ref result128, 1) = upper;
 
                 return result256;
             }
@@ -1161,13 +1161,13 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(lower, upper);
 
-            Vector256<double> SoftwareFallback(Vector128<double> x, Vector128<double> y)
+            static Vector256<double> SoftwareFallback(Vector128<double> lower, Vector128<double> upper)
             {
                 Vector256<double> result256 = Vector256<double>.Zero;
 
                 ref Vector128<double> result128 = ref Unsafe.As<Vector256<double>, Vector128<double>>(ref result256);
-                result128 = x;
-                Unsafe.Add(ref result128, 1) = y;
+                result128 = lower;
+                Unsafe.Add(ref result128, 1) = upper;
 
                 return result256;
             }
@@ -1188,13 +1188,13 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(lower, upper);
 
-            Vector256<short> SoftwareFallback(Vector128<short> x, Vector128<short> y)
+            static Vector256<short> SoftwareFallback(Vector128<short> lower, Vector128<short> upper)
             {
                 Vector256<short> result256 = Vector256<short>.Zero;
 
                 ref Vector128<short> result128 = ref Unsafe.As<Vector256<short>, Vector128<short>>(ref result256);
-                result128 = x;
-                Unsafe.Add(ref result128, 1) = y;
+                result128 = lower;
+                Unsafe.Add(ref result128, 1) = upper;
 
                 return result256;
             }
@@ -1215,13 +1215,13 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(lower, upper);
 
-            Vector256<int> SoftwareFallback(Vector128<int> x, Vector128<int> y)
+            static Vector256<int> SoftwareFallback(Vector128<int> lower, Vector128<int> upper)
             {
                 Vector256<int> result256 = Vector256<int>.Zero;
 
                 ref Vector128<int> result128 = ref Unsafe.As<Vector256<int>, Vector128<int>>(ref result256);
-                result128 = x;
-                Unsafe.Add(ref result128, 1) = y;
+                result128 = lower;
+                Unsafe.Add(ref result128, 1) = upper;
 
                 return result256;
             }
@@ -1242,13 +1242,13 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(lower, upper);
 
-            Vector256<long> SoftwareFallback(Vector128<long> x, Vector128<long> y)
+            static Vector256<long> SoftwareFallback(Vector128<long> lower, Vector128<long> upper)
             {
                 Vector256<long> result256 = Vector256<long>.Zero;
 
                 ref Vector128<long> result128 = ref Unsafe.As<Vector256<long>, Vector128<long>>(ref result256);
-                result128 = x;
-                Unsafe.Add(ref result128, 1) = y;
+                result128 = lower;
+                Unsafe.Add(ref result128, 1) = upper;
 
                 return result256;
             }
@@ -1270,13 +1270,13 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(lower, upper);
 
-            Vector256<sbyte> SoftwareFallback(Vector128<sbyte> x, Vector128<sbyte> y)
+            static Vector256<sbyte> SoftwareFallback(Vector128<sbyte> lower, Vector128<sbyte> upper)
             {
                 Vector256<sbyte> result256 = Vector256<sbyte>.Zero;
 
                 ref Vector128<sbyte> result128 = ref Unsafe.As<Vector256<sbyte>, Vector128<sbyte>>(ref result256);
-                result128 = x;
-                Unsafe.Add(ref result128, 1) = y;
+                result128 = lower;
+                Unsafe.Add(ref result128, 1) = upper;
 
                 return result256;
             }
@@ -1297,13 +1297,13 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(lower, upper);
 
-            Vector256<float> SoftwareFallback(Vector128<float> x, Vector128<float> y)
+            static Vector256<float> SoftwareFallback(Vector128<float> lower, Vector128<float> upper)
             {
                 Vector256<float> result256 = Vector256<float>.Zero;
 
                 ref Vector128<float> result128 = ref Unsafe.As<Vector256<float>, Vector128<float>>(ref result256);
-                result128 = x;
-                Unsafe.Add(ref result128, 1) = y;
+                result128 = lower;
+                Unsafe.Add(ref result128, 1) = upper;
 
                 return result256;
             }
@@ -1325,13 +1325,13 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(lower, upper);
 
-            Vector256<ushort> SoftwareFallback(Vector128<ushort> x, Vector128<ushort> y)
+            static Vector256<ushort> SoftwareFallback(Vector128<ushort> lower, Vector128<ushort> upper)
             {
                 Vector256<ushort> result256 = Vector256<ushort>.Zero;
 
                 ref Vector128<ushort> result128 = ref Unsafe.As<Vector256<ushort>, Vector128<ushort>>(ref result256);
-                result128 = x;
-                Unsafe.Add(ref result128, 1) = y;
+                result128 = lower;
+                Unsafe.Add(ref result128, 1) = upper;
 
                 return result256;
             }
@@ -1353,13 +1353,13 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(lower, upper);
 
-            Vector256<uint> SoftwareFallback(Vector128<uint> x, Vector128<uint> y)
+            static Vector256<uint> SoftwareFallback(Vector128<uint> lower, Vector128<uint> upper)
             {
                 Vector256<uint> result256 = Vector256<uint>.Zero;
 
                 ref Vector128<uint> result128 = ref Unsafe.As<Vector256<uint>, Vector128<uint>>(ref result256);
-                result128 = x;
-                Unsafe.Add(ref result128, 1) = y;
+                result128 = lower;
+                Unsafe.Add(ref result128, 1) = upper;
 
                 return result256;
             }
@@ -1381,13 +1381,13 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(lower, upper);
 
-            Vector256<ulong> SoftwareFallback(Vector128<ulong> x, Vector128<ulong> y)
+            static Vector256<ulong> SoftwareFallback(Vector128<ulong> lower, Vector128<ulong> upper)
             {
                 Vector256<ulong> result256 = Vector256<ulong>.Zero;
 
                 ref Vector128<ulong> result128 = ref Unsafe.As<Vector256<ulong>, Vector128<ulong>>(ref result256);
-                result128 = x;
-                Unsafe.Add(ref result128, 1) = y;
+                result128 = lower;
+                Unsafe.Add(ref result128, 1) = upper;
 
                 return result256;
             }
@@ -1406,10 +1406,10 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector256<byte> SoftwareFallback(byte x)
+            static Vector256<byte> SoftwareFallback(byte value)
             {
                 var result = Vector256<byte>.Zero;
-                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<byte>, byte>(ref result), x);
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<byte>, byte>(ref result), value);
                 return result;
             }
         }
@@ -1427,10 +1427,10 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector256<double> SoftwareFallback(double x)
+            static Vector256<double> SoftwareFallback(double value)
             {
                 var result = Vector256<double>.Zero;
-                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<double>, byte>(ref result), x);
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<double>, byte>(ref result), value);
                 return result;
             }
         }
@@ -1448,10 +1448,10 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector256<short> SoftwareFallback(short x)
+            static Vector256<short> SoftwareFallback(short value)
             {
                 var result = Vector256<short>.Zero;
-                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<short>, byte>(ref result), x);
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<short>, byte>(ref result), value);
                 return result;
             }
         }
@@ -1469,10 +1469,10 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector256<int> SoftwareFallback(int x)
+            static Vector256<int> SoftwareFallback(int value)
             {
                 var result = Vector256<int>.Zero;
-                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<int>, byte>(ref result), x);
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<int>, byte>(ref result), value);
                 return result;
             }
         }
@@ -1490,10 +1490,10 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector256<long> SoftwareFallback(long x)
+            static Vector256<long> SoftwareFallback(long value)
             {
                 var result = Vector256<long>.Zero;
-                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<long>, byte>(ref result), x);
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<long>, byte>(ref result), value);
                 return result;
             }
         }
@@ -1512,10 +1512,10 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector256<sbyte> SoftwareFallback(sbyte x)
+            static Vector256<sbyte> SoftwareFallback(sbyte value)
             {
                 var result = Vector256<sbyte>.Zero;
-                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<sbyte>, byte>(ref result), x);
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<sbyte>, byte>(ref result), value);
                 return result;
             }
         }
@@ -1533,10 +1533,10 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector256<float> SoftwareFallback(float x)
+            static Vector256<float> SoftwareFallback(float value)
             {
                 var result = Vector256<float>.Zero;
-                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<float>, byte>(ref result), x);
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<float>, byte>(ref result), value);
                 return result;
             }
         }
@@ -1555,10 +1555,10 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector256<ushort> SoftwareFallback(ushort x)
+            static Vector256<ushort> SoftwareFallback(ushort value)
             {
                 var result = Vector256<ushort>.Zero;
-                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<ushort>, byte>(ref result), x);
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<ushort>, byte>(ref result), value);
                 return result;
             }
         }
@@ -1577,10 +1577,10 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector256<uint> SoftwareFallback(uint x)
+            static Vector256<uint> SoftwareFallback(uint value)
             {
                 var result = Vector256<uint>.Zero;
-                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<uint>, byte>(ref result), x);
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<uint>, byte>(ref result), value);
                 return result;
             }
         }
@@ -1599,10 +1599,10 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(value);
 
-            Vector256<ulong> SoftwareFallback(ulong x)
+            static Vector256<ulong> SoftwareFallback(ulong value)
             {
                 var result = Vector256<ulong>.Zero;
-                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<ulong>, byte>(ref result), x);
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<ulong>, byte>(ref result), value);
                 return result;
             }
         }

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256_1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256_1.cs
@@ -205,11 +205,11 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(in this, other);
 
-            bool SoftwareFallback(in Vector256<T> x, Vector256<T> y)
+            static bool SoftwareFallback(in Vector256<T> vector, Vector256<T> other)
             {
                 for (int i = 0; i < Count; i++)
                 {
-                    if (!((IEquatable<T>)(x.GetElement(i))).Equals(y.GetElement(i)))
+                    if (!((IEquatable<T>)(vector.GetElement(i))).Equals(other.GetElement(i)))
                     {
                         return false;
                     }
@@ -318,10 +318,10 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(in this, value);
 
-            Vector256<T> SoftwareFallback(in Vector256<T> t, Vector128<T> x)
+            static Vector256<T> SoftwareFallback(in Vector256<T> vector, Vector128<T> value)
             {
-                Vector256<T> result = t;
-                Unsafe.As<Vector256<T>, Vector128<T>>(ref result) = x;
+                Vector256<T> result = vector;
+                Unsafe.As<Vector256<T>, Vector128<T>>(ref result) = value;
                 return result;
             }
         }
@@ -349,9 +349,9 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(in this);
 
-            Vector128<T> SoftwareFallback(in Vector256<T> t)
+            static Vector128<T> SoftwareFallback(in Vector256<T> vector)
             {
-                ref Vector128<T> lower = ref Unsafe.As<Vector256<T>, Vector128<T>>(ref Unsafe.AsRef(in t));
+                ref Vector128<T> lower = ref Unsafe.As<Vector256<T>, Vector128<T>>(ref Unsafe.AsRef(in vector));
                 return Unsafe.Add(ref lower, 1);
             }
         }
@@ -380,11 +380,11 @@ namespace System.Runtime.Intrinsics
 
             return SoftwareFallback(in this, value);
 
-            Vector256<T> SoftwareFallback(in Vector256<T> t, Vector128<T> x)
+            static Vector256<T> SoftwareFallback(in Vector256<T> vector, Vector128<T> value)
             {
-                Vector256<T> result = t;
+                Vector256<T> result = vector;
                 ref Vector128<T> lower = ref Unsafe.As<Vector256<T>, Vector128<T>>(ref result);
-                Unsafe.Add(ref lower, 1) = x;
+                Unsafe.Add(ref lower, 1) = value;
                 return result;
             }
         }


### PR DESCRIPTION
Now that CoreCLR, CoreFX, and CoreRT are all dogfooding the C# 8 compilers, we can use some of the new language features where they make sense.

This updates several local functions to be `static`, which enforces that they are captureless. It also allows us to "shadow" the existing variable names, which improves code clarity.