### PR TITLE
Revert signing to fixed version (#22609)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,12 +36,6 @@ resources:
   - container: centos6_x64_build_image
     image: microsoft/dotnet-buildtools-prereqs:centos-6-376e1a3-20174311014331
 
-trigger:
-- master
-
-pr:
-- master
-
 jobs:
 
 ##   The following is the matrix of test runs that we have. This is

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -18,4 +18,9 @@
     <MicrosoftNETCorePlatformsPackage>Microsoft.NETCore.Platforms</MicrosoftNETCorePlatformsPackage>
     <MicrosoftNETCoreAppPackage>Microsoft.NETCore.App</MicrosoftNETCoreAppPackage>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- Override signing package version. Current version breaks signing SPC, remove
+         this property group once SignTool supports the scenario. -->
+    <MicrosoftDotNetSignToolVersion>1.0.0-beta.19067.6</MicrosoftDotNetSignToolVersion>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Ports the signing fix to 3.0. CC @mmitche @hoyosjs @jashook 