### PR TITLE
Fix the build of Loader/NativeLib test

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -509,9 +509,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b37646/*">
             <Issue>Varargs not supported on this platform</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Loader/NativeLibs/FromNativePaths/*">
-            <Issue>Issue building native components for the test.</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/pinning/object-pin/*">
             <Issue>Issue building native components for the test.</Issue>
         </ExcludeList>
@@ -1695,7 +1692,7 @@
             <Issue>needs triage</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Loader/NativeLibs/FromNativePaths/*">
-            <Issue>needs triage</Issue>
+            <Issue>This requires the native assets to be in the test folder, which is currently not the case when building against packages.</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest612/Generated612/*">
             <Issue>needs triage</Issue>

--- a/tests/src/Loader/NativeLibs/CMakeLists.txt
+++ b/tests/src/Loader/NativeLibs/CMakeLists.txt
@@ -3,7 +3,7 @@ project(FromNativePaths_lib)
 
 set(CMAKE_SHARED_LIBRARY_PREFIX "")
 
-set(SOURCES FromNativePaths_lib.cpp FromNativePaths_lib.def)
+set(SOURCES FromNativePaths_lib.cpp)
 add_library(FromNativePaths_lib SHARED ${SOURCES})
 
 install(TARGETS FromNativePaths_lib DESTINATION Loader/NativeLibs)

--- a/tests/src/Loader/NativeLibs/FromNativePaths_lib.cpp
+++ b/tests/src/Loader/NativeLibs/FromNativePaths_lib.cpp
@@ -1,7 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-extern "C" bool NativeFunc()
+#if defined(__clang__)
+#define EXPORT_API extern "C" __attribute__((visibility("default")))
+#elif defined(_MSC_VER)
+#define EXPORT_API extern "C" __declspec(dllexport)
+#endif 
+
+EXPORT_API bool NativeFunc()
 {
     return true;
 }

--- a/tests/src/Loader/NativeLibs/FromNativePaths_lib.def
+++ b/tests/src/Loader/NativeLibs/FromNativePaths_lib.def
@@ -1,2 +1,0 @@
-EXPORTS
-    NativeFunc


### PR DESCRIPTION
The native test assets were not build correctly on Unix platforms.
The native library exports were generated as private symbols by clang.

This change fixes the export declaration so that the global symbols are
correctly generated for exported symbols.

Fixes #22549