### PR TITLE
Fix bug in FindDispatchSlot usage

### DIFF
--- a/src/vm/comcallablewrapper.cpp
+++ b/src/vm/comcallablewrapper.cpp
@@ -3239,7 +3239,7 @@ IUnknown * ComCallWrapper::GetComIPFromCCW_HandleExtendsCOMObject(
                 MethodDesc *pClsMD = NULL;
 
                 // Find the implementation for the first slot of the interface
-                DispatchSlot impl(pMT->FindDispatchSlot(intIt.GetInterface()->GetTypeID(), 0));
+                DispatchSlot impl(pMT->FindDispatchSlot(intIt.GetInterface()->GetTypeID(), 0, FALSE /* throwOnConflict */));
                 CONSISTENCY_CHECK(!impl.IsNull());
 
                 // Get the MethodDesc for this slot in the class

--- a/src/vm/contractimpl.h
+++ b/src/vm/contractimpl.h
@@ -256,7 +256,7 @@ public:
         m_token = INVALID_TOKEN;
     }
 
-    DispatchToken(UINT_PTR token)
+    explicit DispatchToken(UINT_PTR token)
     {
         CONSISTENCY_CHECK(token != INVALID_TOKEN);
         m_token = token;

--- a/src/vm/gccover.cpp
+++ b/src/vm/gccover.cpp
@@ -59,7 +59,7 @@ static MethodDesc* getTargetMethodDesc(PCODE target)
     if (vsdStubKind != VirtualCallStubManager::SK_BREAKPOINT && vsdStubKind != VirtualCallStubManager::SK_UNKNOWN)
     {
         // It is a VSD stub manager.
-        DispatchToken token = VirtualCallStubManager::GetTokenFromStubQuick(pVSDStubManager, target, vsdStubKind);
+        DispatchToken token(VirtualCallStubManager::GetTokenFromStubQuick(pVSDStubManager, target, vsdStubKind));
         _ASSERTE(token.IsValid());
         return VirtualCallStubManager::GetInterfaceMethodDescFromToken(token);
     }

--- a/src/vm/memberload.cpp
+++ b/src/vm/memberload.cpp
@@ -1179,7 +1179,7 @@ MemberLoader::FindMethodForInterfaceSlot(MethodTable * pMT, MethodTable *pInterf
 
     MethodDesc *pMDRet = NULL;
 
-    DispatchSlot ds(pMT->FindDispatchSlot(pInterface->GetTypeID(), (UINT32)slotNum));
+    DispatchSlot ds(pMT->FindDispatchSlot(pInterface->GetTypeID(), (UINT32)slotNum, FALSE /* throwOnConflict */));
     if (!ds.IsNull()) {
         pMDRet = ds.GetMethodDesc();
     }

--- a/src/vm/methodtable.cpp
+++ b/src/vm/methodtable.cpp
@@ -7337,15 +7337,6 @@ BOOL MethodTable::FindDefaultInterfaceImplementation(
 //==========================================================================================
 DispatchSlot MethodTable::FindDispatchSlot(UINT32 typeID, UINT32 slotNumber, BOOL throwOnConflict)
 {
-    WRAPPER_NO_CONTRACT;
-    DispatchSlot implSlot(NULL);
-    FindDispatchImpl(typeID, slotNumber, &implSlot, throwOnConflict);
-    return implSlot;
-}
-
-//==========================================================================================
-DispatchSlot MethodTable::FindDispatchSlot(DispatchToken tok, BOOL throwOnConflict)
-{
     CONTRACTL
     {
         THROWS;
@@ -7353,7 +7344,10 @@ DispatchSlot MethodTable::FindDispatchSlot(DispatchToken tok, BOOL throwOnConfli
         MODE_ANY;
     }
     CONTRACTL_END;
-    return FindDispatchSlot(tok.GetTypeID(), tok.GetSlotNumber(), throwOnConflict);
+
+    DispatchSlot implSlot(NULL);
+    FindDispatchImpl(typeID, slotNumber, &implSlot, throwOnConflict);
+    return implSlot;
 }
 
 #ifndef DACCESS_COMPILE

--- a/src/vm/methodtable.h
+++ b/src/vm/methodtable.h
@@ -2442,14 +2442,14 @@ protected:
                            UINT32 slotNumber,
                            DispatchMapEntry *pEntry);
 
-public:
+private:
     BOOL FindDispatchImpl(
         UINT32         typeID, 
         UINT32         slotNumber, 
         DispatchSlot * pImplSlot,
         BOOL           throwOnConflict);
 
-
+public:
 #ifndef DACCESS_COMPILE
     BOOL FindDefaultInterfaceImplementation(
         MethodDesc *pInterfaceMD,
@@ -2460,8 +2460,6 @@ public:
 #endif // DACCESS_COMPILE
 
     DispatchSlot FindDispatchSlot(UINT32 typeID, UINT32 slotNumber, BOOL throwOnConflict);
-
-    DispatchSlot FindDispatchSlot(DispatchToken tok, BOOL throwOnConflict);
 
     // You must use the second of these two if there is any chance the pMD is a method
     // on a generic interface such as IComparable<T> (which it normally can be).  The 


### PR DESCRIPTION
PR https://github.com/dotnet/coreclr/pull/20458 introduced a subtle bug relating to how C++ coerces types. The issue here is an `INT` is coerced to an `UINT_PTR` which causes the non-explicit constructor for `DispatchToken` to be instantiated. This caused heck with some COM scenarios.

Made the `DispatchToken` constructor explicit and fixed usage throughout.