### PR TITLE
Avoid pulling in Lazy<T> during startup

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Environment.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Environment.Unix.cs
@@ -298,10 +298,10 @@ namespace System
 
         public static string NewLine => "\n";
 
-        private static readonly Lazy<OperatingSystem> s_osVersion = new Lazy<OperatingSystem>(() => GetOperatingSystem(Interop.Sys.GetUnixRelease()));
-
-        private static OperatingSystem GetOperatingSystem(string release)
+        private static OperatingSystem GetOperatingSystem()
         {
+            string release = Interop.Sys.GetUnixRelease();
+
             int major = 0, minor = 0, build = 0, revision = 0;
 
             // Parse the uname's utsname.release for the first four numbers found.

--- a/src/System.Private.CoreLib/shared/System/Environment.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Environment.Unix.cs
@@ -298,10 +298,11 @@ namespace System
 
         public static string NewLine => "\n";
 
-        private static OperatingSystem GetOperatingSystem()
-        {
-            string release = Interop.Sys.GetUnixRelease();
+        private static OperatingSystem GetOSVersion() => GetOperatingSystem(Interop.Sys.GetUnixRelease());
 
+        // Tests exercise this method for corner cases via private reflection
+        private static OperatingSystem GetOperatingSystem(string release)
+        {
             int major = 0, minor = 0, build = 0, revision = 0;
 
             // Parse the uname's utsname.release for the first four numbers found.

--- a/src/System.Private.CoreLib/shared/System/Environment.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Environment.Windows.cs
@@ -86,7 +86,7 @@ namespace System
             Interop.Kernel32.GetComputerName() ??
             throw new InvalidOperationException(SR.InvalidOperation_ComputerName);
 
-        private static unsafe OperatingSystem GetOperatingSystem()
+        private static unsafe OperatingSystem GetOSVersion()
         {
             var version = new Interop.Kernel32.OSVERSIONINFOEX { dwOSVersionInfoSize = sizeof(Interop.Kernel32.OSVERSIONINFOEX) };
             if (!Interop.Kernel32.GetVersionExW(ref version))

--- a/src/System.Private.CoreLib/shared/System/Environment.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Environment.Windows.cs
@@ -86,7 +86,7 @@ namespace System
             Interop.Kernel32.GetComputerName() ??
             throw new InvalidOperationException(SR.InvalidOperation_ComputerName);
 
-        private static readonly unsafe Lazy<OperatingSystem> s_osVersion = new Lazy<OperatingSystem>(() =>
+        private static unsafe OperatingSystem GetOperatingSystem()
         {
             var version = new Interop.Kernel32.OSVERSIONINFOEX { dwOSVersionInfoSize = sizeof(Interop.Kernel32.OSVERSIONINFOEX) };
             if (!Interop.Kernel32.GetVersionExW(ref version))
@@ -98,7 +98,7 @@ namespace System
                 PlatformID.Win32NT,
                 new Version(version.dwMajorVersion, version.dwMinorVersion, version.dwBuildNumber, (version.wServicePackMajor << 16) | version.wServicePackMinor),
                 Marshal.PtrToStringUni((IntPtr)version.szCSDVersion));
-        });
+        }
 
         public static string SystemDirectory
         {

--- a/src/System.Private.CoreLib/shared/System/Environment.cs
+++ b/src/System.Private.CoreLib/shared/System/Environment.cs
@@ -121,7 +121,7 @@ namespace System
             {
                 if (s_osVersion == null)
                 {
-                    Interlocked.CompareExchange(ref s_osVersion, GetOperatingSystem(), null);
+                    Interlocked.CompareExchange(ref s_osVersion, GetOSVersion(), null);
                 }
                 return s_osVersion;
             }

--- a/src/System.Private.CoreLib/shared/System/Environment.cs
+++ b/src/System.Private.CoreLib/shared/System/Environment.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
+using System.Threading;
 
 namespace System
 {
@@ -112,7 +113,19 @@ namespace System
 
         public static bool Is64BitOperatingSystem => Is64BitProcess || Is64BitOperatingSystemWhen32BitProcess;
 
-        public static OperatingSystem OSVersion => s_osVersion.Value;
+        private static OperatingSystem s_osVersion;
+
+        public static OperatingSystem OSVersion
+        {
+            get
+            {
+                if (s_osVersion == null)
+                {
+                    Interlocked.CompareExchange(ref s_osVersion, GetOperatingSystem(), null);
+                }
+                return s_osVersion;
+            }
+        }
 
         public static bool UserInteractive => true;
 


### PR DESCRIPTION
Environment constructor runs on every startup path. Remove dependency on Lazy<T> from it.