### PR TITLE
Fix warning causing error in warning as error (Windows)

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -2704,7 +2704,7 @@ void Compiler::lvaUpdateClass(unsigned varNum, CORINFO_CLASS_HANDLE clsHnd, bool
     // updating exact classes.
     if (!varDsc->lvClassIsExact && isNewClass)
     {
-        shouldUpdate = info.compCompHnd->isMoreSpecificType(varDsc->lvClassHnd, clsHnd);
+        shouldUpdate = !!info.compCompHnd->isMoreSpecificType(varDsc->lvClassHnd, clsHnd);
     }
     // Else are we attempting to update exactness?
     else if (isExact && !varDsc->lvClassIsExact && !isNewClass)


### PR DESCRIPTION
BOOL -> bool conversion
```
warning C4800: 'BOOL': forcing value to bool 'true' or 'false' (performance warning)
error C2220: warning treated as error - no 'object' file generated
```

/cc @AndyAyersMS @jkotas 