### PR TITLE
Fix BSWAP16 Intrinsic handling of signed values

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -4122,7 +4122,8 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 {
                     case CorInfoType::CORINFO_TYPE_SHORT:
                     case CorInfoType::CORINFO_TYPE_USHORT:
-                        retNode = gtNewOperNode(GT_BSWAP16, callType, impPopStack().val);
+                        retNode = gtNewCastNode(TYP_INT, gtNewOperNode(GT_BSWAP16, TYP_INT, impPopStack().val), false,
+                                                callType);
                         break;
 
                     case CorInfoType::CORINFO_TYPE_INT:


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/22667

The BSWAP16 JIT intrisic uses a `ror` on the low word of the target register but fails to sign extend the result.  If the byte swap results in a change in sign, this leaves the high bits set incorrectly.

~~This changes the Intrinsic implementation to emit a `movsx` following the `ror` for signed types.~~ This change adds an `int` cast to get the register sign/zero extended after the `ror`.

I also fixed up the tests, which never returned a `Fail` value and added new tests to cover signed arguments that change sign on swap.
