### PR TITLE
Move new extension methods into different type

### DIFF
--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -809,6 +809,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\ThreadLocal.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Volatile.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\AsyncCausalityTracerConstants.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\AsyncExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\ConcurrentExclusiveSchedulerPair.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\Future.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\FutureFactory.cs" />

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/AsyncExtensions.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/AsyncExtensions.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace System.Threading.Tasks
+{
+    /// <summary>Provides a set of static methods for working with specific kinds of <see cref="IAsyncEnumerable{IAsyncEnumerable}"/> instances.</summary>
+    public static class AsyncExtensions
+    {        
+        /// <summary>Configures how awaits on the tasks returned from an async disposable will be performed.</summary>
+        /// <param name="source">The source async disposable.</param>
+        /// <param name="continueOnCapturedContext">Whether to capture and marshal back to the current context.</param>
+        /// <returns>The configured async disposable.</returns>
+        public static ConfiguredAsyncDisposable ConfigureAwait(this IAsyncDisposable source, bool continueOnCapturedContext) =>
+            new ConfiguredAsyncDisposable(source, continueOnCapturedContext);
+
+        /// <summary>Configures how awaits on the tasks returned from an async iteration will be performed.</summary>
+        /// <typeparam name="T">The type of the objects being iterated.</typeparam>
+        /// <param name="source">The source enumerable being iterated.</param>
+        /// <param name="continueOnCapturedContext">Whether to capture and marshal back to the current context.</param>
+        /// <returns>The configured enumerable.</returns>
+        public static ConfiguredCancelableAsyncEnumerable<T> ConfigureAwait<T>(
+            this IAsyncEnumerable<T> source, bool continueOnCapturedContext) =>
+            new ConfiguredCancelableAsyncEnumerable<T>(source, continueOnCapturedContext, cancellationToken: default);
+
+        /// <summary>Sets the <see cref="CancellationToken"/> to be passed to <see cref="IAsyncEnumerable{T}.GetAsyncEnumerator(CancellationToken)"/> when iterating.</summary>
+        /// <typeparam name="T">The type of the objects being iterated.</typeparam>
+        /// <param name="source">The source enumerable being iterated.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
+        /// <returns>The configured enumerable.</returns>
+        public static ConfiguredCancelableAsyncEnumerable<T> WithCancellation<T>(
+            this IAsyncEnumerable<T> source, CancellationToken cancellationToken) =>
+            new ConfiguredCancelableAsyncEnumerable<T>(source, continueOnCapturedContext: true, cancellationToken);
+    }
+}

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskExtensions.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskExtensions.cs
@@ -47,30 +47,5 @@ namespace System.Threading.Tasks
                 task.Result ??
                 Task.FromCanceled<TResult>(new CancellationToken(true));
         }
-
-        /// <summary>Configures how awaits on the tasks returned from an async disposable will be performed.</summary>
-        /// <param name="source">The source async disposable.</param>
-        /// <param name="continueOnCapturedContext">Whether to capture and marshal back to the current context.</param>
-        /// <returns>The configured async disposable.</returns>
-        public static ConfiguredAsyncDisposable ConfigureAwait(this IAsyncDisposable source, bool continueOnCapturedContext) =>
-            new ConfiguredAsyncDisposable(source, continueOnCapturedContext);
-
-        /// <summary>Configures how awaits on the tasks returned from an async iteration will be performed.</summary>
-        /// <typeparam name="T">The type of the objects being iterated.</typeparam>
-        /// <param name="source">The source enumerable being iterated.</param>
-        /// <param name="continueOnCapturedContext">Whether to capture and marshal back to the current context.</param>
-        /// <returns>The configured enumerable.</returns>
-        public static ConfiguredCancelableAsyncEnumerable<T> ConfigureAwait<T>(
-            this IAsyncEnumerable<T> source, bool continueOnCapturedContext) =>
-            new ConfiguredCancelableAsyncEnumerable<T>(source, continueOnCapturedContext, cancellationToken: default);
-
-        /// <summary>Sets the <see cref="CancellationToken"/> to be passed to <see cref="IAsyncEnumerable{T}.GetAsyncEnumerator(CancellationToken)"/> when iterating.</summary>
-        /// <typeparam name="T">The type of the objects being iterated.</typeparam>
-        /// <param name="source">The source enumerable being iterated.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
-        /// <returns>The configured enumerable.</returns>
-        public static ConfiguredCancelableAsyncEnumerable<T> WithCancellation<T>(
-            this IAsyncEnumerable<T> source, CancellationToken cancellationToken) =>
-            new ConfiguredCancelableAsyncEnumerable<T>(source, continueOnCapturedContext: true, cancellationToken);
     }
 }


### PR DESCRIPTION
See: 
https://github.com/dotnet/coreclr/pull/21939#issuecomment-464786494

/cc @terrajobst @stephentoub @jcouv @bartdesmet 

The core scenario is enabling a library to copy the core interfaces and types if they want to support pre netstandard2.1/netcoreapp3.0 targets. That part works fine today but the problem is unification once they have a 2.1/3.0 target. The types need to be TypeForwardable to the corelib versions. 

The added types are okay with this, but adding these helper methods to an existing type breaks this scenario. If these methods are added to a discreet type, it's easy to copy that as well and then typeforward the static class. It's not possible to type forward individual methods. 

If the method bodies need to be kept to move forwards, then the internal ctor's on the configured awaitables become the next issue. I believe that can be avoided by enabling entire types to be forwarded so method bodies don't need to be carried forward. The build system also does not presently support library aliases, so tricks like forwarding an impl to the library is also much harder.