### PR TITLE
Remove resetting of unmanaged thread locale from thread pool APIs

### DIFF
--- a/src/vm/finalizerthread.cpp
+++ b/src/vm/finalizerthread.cpp
@@ -168,12 +168,8 @@ Object * FinalizerThread::DoOneFinalization(Object* fobj, Thread* pThread,int bi
             }
         };
         {
-            ThreadLocaleHolder localeHolder;
-
-            {
-                ResetFinalizerStartTime resetTime;
-                CallFinalizer(fobj);
-            }
+            ResetFinalizerStartTime resetTime;
+            CallFinalizer(fobj);
         }
         pThread->InternalReset();
     } 
@@ -194,8 +190,6 @@ Object * FinalizerThread::DoOneFinalization(Object* fobj, Thread* pThread,int bi
             args.bitToCheck = bitToCheck;
             GCPROTECT_BEGIN(args.fobj);
             {
-                ThreadLocaleHolder localeHolder;
-
                 _ASSERTE(pThreadTurnAround != NULL);
                 ManagedThreadBase::FinalizerAppDomain(targetAppDomain,
                                                       FinalizeAllObjects_Wrapper,

--- a/src/vm/util.cpp
+++ b/src/vm/util.cpp
@@ -2043,11 +2043,6 @@ size_t GetCacheSizePerLogicalCpu(BOOL bTrueSize)
 //---------------------------------------------------------------------
 
 #ifndef FEATURE_PAL
-ThreadLocaleHolder::~ThreadLocaleHolder()
-{
-    SetThreadLocale(m_locale);
-}
-
 HMODULE CLRGetModuleHandle(LPCWSTR lpModuleFileName)
 {
     // Don't use dynamic contract: will override GetLastError value
@@ -2058,20 +2053,6 @@ HMODULE CLRGetModuleHandle(LPCWSTR lpModuleFileName)
     HMODULE hMod = WszGetModuleHandle(lpModuleFileName);
     return hMod;
 }
-
-
-HMODULE CLRGetCurrentModuleHandle()
-{
-    // Don't use dynamic contract: will override GetLastError value
-    STATIC_CONTRACT_NOTHROW;
-    STATIC_CONTRACT_GC_NOTRIGGER;
-    STATIC_CONTRACT_FORBID_FAULT;
-
-    HMODULE hMod = WszGetModuleHandle(NULL);
-    return hMod;
-}
-
-
 #endif // !FEATURE_PAL
 
 LPVOID EEHeapAllocInProcessHeap(DWORD dwFlags, SIZE_T dwBytes);

--- a/src/vm/util.hpp
+++ b/src/vm/util.hpp
@@ -681,10 +681,6 @@ inline BOOL CLRHosted()
 #ifndef FEATURE_PAL
 HMODULE CLRGetModuleHandle(LPCWSTR lpModuleFileName);
 
-// Equivalent to CLRGetModuleHandle(NULL) but doesn't have the INJECT_FAULT contract associated
-// with CLRGetModuleHandle.
-HMODULE CLRGetCurrentModuleHandle();
-
 HMODULE CLRLoadLibraryEx(LPCWSTR lpLibFileName, HANDLE hFile, DWORD dwFlags);
 #endif // !FEATURE_PAL
 
@@ -875,29 +871,8 @@ inline bool IsInCantStopRegion()
 }
 #endif // _DEBUG
 
-
-// PAL does not support per-thread locales. The holder is no-op for FEATURE_PALs
-class ThreadLocaleHolder
-{
-#ifndef FEATURE_PAL
-public:
-
-    ThreadLocaleHolder()
-    {
-        m_locale = GetThreadLocale();
-    }
-
-    ~ThreadLocaleHolder();
-
-private:
-    LCID m_locale;
-#endif // !FEATURE_PAL
-};
-
-
-
 BOOL IsValidMethodCodeNotification(USHORT Notification);
-    
+
 typedef DPTR(struct JITNotification) PTR_JITNotification;
 struct JITNotification
 {

--- a/src/vm/win32threadpool.cpp
+++ b/src/vm/win32threadpool.cpp
@@ -831,8 +831,6 @@ BOOL ThreadpoolMgr::QueueUserWorkItem(LPTHREAD_START_ROUTINE Function,
         ThreadCounter::Counts counts = CPThreadCounter.GetCleanCounts();
         if ((MaxLimitTotalCPThreads - counts.NumActive) >= MinimumAvailableCPThreads )
         {
-            ThreadLocaleHolder localeHolder;
-
             QueueUserWorkItemHelp(Function, Context);
             return TRUE;
         }
@@ -1507,8 +1505,6 @@ DWORD WINAPI ThreadpoolMgr::ExecuteHostRequest(PVOID pArg)
     }
     CONTRACTL_END;
 
-    ThreadLocaleHolder localeHolder;
-
     bool foundWork, wasNotRecalled;
     ExecuteWorkRequest(&foundWork, &wasNotRecalled);
     return ERROR_SUCCESS;
@@ -2005,8 +2001,6 @@ Work:
     }
 
     {
-        ThreadLocaleHolder localeHolder;
-
         ThreadpoolMgr::UpdateLastDequeueTime();
         ThreadpoolMgr::ExecuteWorkRequest(&foundWork, &wasNotRecalled);
     }
@@ -3620,8 +3614,6 @@ Top:
 
                 {
                     CONTRACT_VIOLATION(ThrowsViolation);
-
-                    ThreadLocaleHolder localeHolder;
 
                     ((LPOVERLAPPED_COMPLETION_ROUTINE) key)(errorCode, numBytes, pOverlapped);
                 }


### PR DESCRIPTION
The cost of doing this is showing up in the TechEmpower profiles. There is a lot of thread locale state in unmanaged libraries and OS APIs that the threadpool friendly code has to be aware off. It does not make sense to keep reseting just the Locale.