### PR TITLE
Use Build.DefinitionName as a Creator value when submitting tests to Helix

### DIFF
--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -136,7 +136,7 @@ jobs:
         osGroup: ${{ parameters.osGroup }}
 
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          creator: 'coreclr'
+          creator: $(Build.DefinitionName)
 
         helixBuild: $(Build.BuildNumber)
 


### PR DESCRIPTION
This is needed to distinguish Helix jobs submitted by different Azure Pipelines build definitions but under the same Build.BuildNumber and Build.SourceBranch (resulting in HelixBuild and HelixSource being the same).

