### PR TITLE
Update CoreFX Windows Arm32 exclusion list.

### DIFF
--- a/tests/arm/corefx_test_exclusions.txt
+++ b/tests/arm/corefx_test_exclusions.txt
@@ -1,14 +1,12 @@
-Microsoft.Win32.Registry.Tests       # https://github.com/dotnet/corefx/issues/28856
 Microsoft.Win32.SystemEvents.Tests   # https://github.com/dotnet/corefx/issues/29166
 System.Console.Tests
 System.Data.SqlClient.Tests          # https://github.com/dotnet/coreclr/issues/16001
 System.Diagnostics.Process.Tests     # https://github.com/dotnet/coreclr/issues/16001
-System.Diagnostics.PerformanceCounter.Tests # https://github.com/dotnet/coreclr/issues/17799
-System.Diagnostics.StackTrace.Tests  # https://github.com/dotnet/coreclr/issues/17557 -- JitStress=1; https://github.com/dotnet/coreclr/issues/17558 -- JitStress=2
+System.Diagnostics.PerformanceCounter.Tests # https://github.com/dotnet/corefx/issues/29377
 System.Drawing.Common.Tests          # https://github.com/dotnet/coreclr/issues/16001
 System.IO.FileSystem.Tests           # https://github.com/dotnet/coreclr/issues/16001
 System.IO.Ports.Tests                # https://github.com/dotnet/coreclr/issues/16001
 System.Management.Tests              # https://github.com/dotnet/coreclr/issues/16001
 System.Net.HttpListener.Tests        # https://github.com/dotnet/coreclr/issues/17584
-System.Runtime.Numerics.Tests        # https://github.com/dotnet/coreclr/issues/18362 -- JitStress=1 JitStress=2
+System.Runtime.Tests                 # https://github.com/dotnet/coreclr/issues/22379
 System.Text.RegularExpressions.Tests # https://github.com/dotnet/coreclr/issues/17754 -- timeout -- JitMinOpts only

--- a/tests/arm/corefx_test_exclusions.txt
+++ b/tests/arm/corefx_test_exclusions.txt
@@ -4,6 +4,7 @@ System.Data.SqlClient.Tests          # https://github.com/dotnet/coreclr/issues/
 System.Diagnostics.Process.Tests     # https://github.com/dotnet/coreclr/issues/16001
 System.Diagnostics.PerformanceCounter.Tests # https://github.com/dotnet/corefx/issues/29377
 System.Drawing.Common.Tests          # https://github.com/dotnet/coreclr/issues/16001
+System.Globalization.Calendars.Tests # https://github.com/dotnet/coreclr/issues/22719
 System.IO.FileSystem.Tests           # https://github.com/dotnet/coreclr/issues/16001
 System.IO.Ports.Tests                # https://github.com/dotnet/coreclr/issues/16001
 System.Management.Tests              # https://github.com/dotnet/coreclr/issues/16001

--- a/tests/arm/corefx_test_exclusions.txt
+++ b/tests/arm/corefx_test_exclusions.txt
@@ -9,5 +9,6 @@ System.IO.FileSystem.Tests           # https://github.com/dotnet/coreclr/issues/
 System.IO.Ports.Tests                # https://github.com/dotnet/coreclr/issues/16001
 System.Management.Tests              # https://github.com/dotnet/coreclr/issues/16001
 System.Net.HttpListener.Tests        # https://github.com/dotnet/coreclr/issues/17584
+System.Net.Sockets.Tests             # flaky test
 System.Runtime.Tests                 # https://github.com/dotnet/coreclr/issues/22379
 System.Text.RegularExpressions.Tests # https://github.com/dotnet/coreclr/issues/17754 -- timeout -- JitMinOpts only


### PR DESCRIPTION
It is part of #22358 that can be merged now.