### PR TITLE
Updating ScopeInfo::siUpdate comments/documentation

### DIFF
--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -592,7 +592,7 @@ public:
     void siBeginBlock(BasicBlock* block);
 
     void siEndBlock(BasicBlock* block);
-
+    // Closes the "ScopeInfo" of the tracked variables that has become dead.
     virtual void siUpdate();
 
     void siCheckVarScope(unsigned varNum, IL_OFFSET offs);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7187,11 +7187,6 @@ public:
     template <bool ForCodeGen>
     void compChangeLife(VARSET_VALARG_TP newLife);
 
-    void genChangeLife(VARSET_VALARG_TP newLife)
-    {
-        compChangeLife</*ForCodeGen*/ true>(newLife);
-    }
-
     template <bool ForCodeGen>
     inline void compUpdateLife(VARSET_VALARG_TP newLife);
 

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -44,7 +44,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
  *  Also,
  *  o At every assignment to a variable, siCheckVarScope() adds an open scope
  *    for the variable being assigned to.
- *  o genChangeLife() calls siUpdate() which closes scopes for variables which
+ *  o UpdateLifeVar() calls siUpdate() which closes scopes for variables which
  *    are not live anymore.
  *
  ******************************************************************************
@@ -918,15 +918,15 @@ void CodeGen::siEndBlock(BasicBlock* block)
 #endif
 }
 
-/*****************************************************************************
- *                          siUpdate
- *
- * Called at the start of basic blocks, and during code-gen of a block,
- * for non-debuggable code, whenever the life of any tracked variable changes
- * and the appropriate code has been generated. For debuggable code, variables are
- * live over their entire scope, and so they go live or dead only on
- * block boundaries.
- */
+//------------------------------------------------------------------------
+// siUpdate: Closes the "ScopeInfo" of the tracked variables that has become dead.
+//
+// Notes:
+//    Called at the start of basic blocks, and during code-gen of a block,
+//    for non-debuggable code, whenever the life of any tracked variable changes
+//    and the appropriate code has been generated. For debuggable code, variables are
+//    live over their entire scope, and so they go live or dead only on
+//    block boundaries.
 void CodeGen::siUpdate()
 {
     if (!compiler->opts.compScopeInfo)


### PR DESCRIPTION
- genChangeLife is not been called any more.
- update comments which says who calls siUpdate and siUpdates header documentation