### PR TITLE
Fix dblarray tests and reenable for arm32

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -592,18 +592,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/GC/Scenarios/Dynamo/dynamo/*">
             <Issue>17129</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/doublearray/dblarray3_cs_do/*">
-            <Issue>22015</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/doublearray/dblarray3_cs_d/*">
-            <Issue>22015</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/doublearray/dblarray3_cs_ro/*">
-            <Issue>22015</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/doublearray/dblarray3_cs_r/*">
-            <Issue>22015</Issue>
-        </ExcludeList>
     </ItemGroup>
 
 

--- a/tests/src/JIT/Methodical/doublearray/dblarray1.cs
+++ b/tests/src/JIT/Methodical/doublearray/dblarray1.cs
@@ -77,20 +77,34 @@ internal class DblArray1
         }
     }
 
+    public static void Run(Action f)
+    {
+        try
+        {
+            GC.TryStartNoGCRegion(500_000);
+            f();
+        }
+        finally
+        {
+            GC.EndNoGCRegion();
+        }
+    }
+
     public static int Main()
     {
         if (Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE") == "x86")
         {
             s_LOH_GEN = 2;
         }
+
         try
         {
-            f0();
-            f1();
-            f2();
-            f3();
-            f4();
-            f5();
+            Run(f0);
+            Run(f1);
+            Run(f2);
+            Run(f3);
+            Run(f4);
+            Run(f5);
         }
         catch (Exception e)
         {

--- a/tests/src/JIT/Methodical/doublearray/dblarray2.cs
+++ b/tests/src/JIT/Methodical/doublearray/dblarray2.cs
@@ -266,39 +266,53 @@ internal class DblArray
         }
     }
 
+    public static void Run(Action f)
+    {
+        try
+        {
+            GC.TryStartNoGCRegion(500_000);
+            f();
+        }
+        finally
+        {
+            GC.EndNoGCRegion();
+        }
+    }
+
     public static int Main()
     {
         if (Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE") == "x86")
         {
             s_LOH_GEN = 2;
         }
+
         try
         {
-            f0();
-            f1a();
-            f2a();
-            f3a();
-            f4a();
-            f5a();
-            f6a();
-            f7a();
-            f8a();
-            f9a();
-            f10a();
-            f11a();
-            f12a();
-            f1b();
-            f2b();
-            f3b();
-            f4b();
-            f5b();
-            f6b();
-            f7b();
-            f8b();
-            f9b();
-            f10b();
-            f11b();
-            f12b();
+            Run(f0);
+            Run(f1a);
+            Run(f2a);
+            Run(f3a);
+            Run(f4a);
+            Run(f5a);
+            Run(f6a);
+            Run(f7a);
+            Run(f8a);
+            Run(f9a);
+            Run(f10a);
+            Run(f11a);
+            Run(f12a);
+            Run(f1b);
+            Run(f2b);
+            Run(f3b);
+            Run(f4b);
+            Run(f5b);
+            Run(f6b);
+            Run(f7b);
+            Run(f8b);
+            Run(f9b);
+            Run(f10b);
+            Run(f11b);
+            Run(f12b);
         }
         catch (Exception e)
         {

--- a/tests/src/JIT/Methodical/doublearray/dblarray3.cs
+++ b/tests/src/JIT/Methodical/doublearray/dblarray3.cs
@@ -126,6 +126,19 @@ internal class DblArray3
         }
     }
 
+    public static void Run(Action f)
+    {
+        try
+        {
+            GC.TryStartNoGCRegion(500_000);
+            f();
+        }
+        finally
+        {
+            GC.EndNoGCRegion();
+        }
+    }
+
     public static int Main()
     {
         Console.WriteLine(Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE"));
@@ -133,18 +146,19 @@ internal class DblArray3
         {
             s_LOH_GEN = 2;
         }
+
         try
         {
-            f0();
-            f1a();
-            f1b();
-            f1c();
-            f1d();
-            f2a();
-            f2b();
-            f3();
-            f4();
-            f5();
+            Run(f0);
+            Run(f1a);
+            Run(f1b);
+            Run(f1c);
+            Run(f1d);
+            Run(f2a);
+            Run(f2b);
+            Run(f3);
+            Run(f4);
+            Run(f5);
         }
         catch (Exception e)
         {

--- a/tests/src/JIT/Methodical/doublearray/dblarray4.cs
+++ b/tests/src/JIT/Methodical/doublearray/dblarray4.cs
@@ -27,14 +27,23 @@ internal class DblArray4
 
         Console.WriteLine("DoubleArrayToLargeObjectHeap is {0}", Environment.GetEnvironmentVariable("complus_DoubleArrayToLargeObjectHeap"));
 
-        double[] arr = new double[101];
-        if (GC.GetGeneration(arr) != s_LOH_GEN)
+        try
         {
-            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
-            Console.WriteLine("FAILED");
-            return 1;
+            GC.TryStartNoGCRegion(500_000);
+            double[] arr = new double[101];
+            if (GC.GetGeneration(arr) != s_LOH_GEN)
+            {
+                Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+                Console.WriteLine("FAILED");
+                return 1;
+            }
+
+            Console.WriteLine("PASSED");
+            return 100;
         }
-        Console.WriteLine("PASSED");
-        return 100;
+        finally
+        {
+            GC.EndNoGCRegion();
+        }
     }
 }


### PR DESCRIPTION
Run the allocate/gen-check sequence under a forbid GC region, and enable the
tests for arm32.

Closes #22015.