### PR TITLE
Fix Issue 22436 - noway_assert  'expTyp == cseLclVarTyp' in optcse.cpp

### DIFF
--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -1976,7 +1976,7 @@ public:
     //
     bool IsCompatibleType(var_types cseLclVarTyp, var_types expTyp)
     {
-        // Excat type match is the expected case
+        // Exact type match is the expected case
         if (cseLclVarTyp == expTyp)
         {
             return true;

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -1978,14 +1978,20 @@ public:
     {
         // Excat type match is the expected case
         if (cseLclVarTyp == expTyp)
+        {
             return true;
+        }
 
         // We also allow TYP_BYREF and TYP_I_IMPL as compatible types
         //
         if ((cseLclVarTyp == TYP_BYREF) && (expTyp == TYP_I_IMPL))
+        {
             return true;
+        }
         if ((cseLclVarTyp == TYP_I_IMPL) && (expTyp == TYP_BYREF))
+        {
             return true;
+        }
 
         // Otherwise we have incompatible types
         return false;

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -1971,6 +1971,26 @@ public:
         return result;
     }
 
+    // IsCompatibleType() takes two var_types and returns true if they
+    // are compatible types for CSE substitution
+    //
+    bool IsCompatibleType(var_types cseLclVarTyp, var_types expTyp)
+    {
+        // Excat type match is the expected case
+        if (cseLclVarTyp == expTyp)
+            return true;
+
+        // We also allow TYP_BYREF and TYP_I_IMPL as compatible types
+        //
+        if ((cseLclVarTyp == TYP_BYREF) && (expTyp == TYP_I_IMPL))
+            return true;
+        if ((cseLclVarTyp == TYP_I_IMPL) && (expTyp == TYP_BYREF))
+            return true;
+
+        // Otherwise we have incompatible types
+        return false;
+    }
+
     // PerformCSE() takes a successful candidate and performs  the appropriate replacements:
     //
     // It will replace all of the CSE defs with assignments to a new "cse0" LclVar
@@ -2105,7 +2125,10 @@ public:
 
             /* Figure out the actual type of the value */
             var_types expTyp = genActualType(exp->TypeGet());
-            noway_assert(expTyp == cseLclVarTyp);
+
+            // The cseLclVarType must be a compatible with expTyp
+            //
+            noway_assert(IsCompatibleType(cseLclVarTyp, expTyp));
 
             // This will contain the replacement tree for exp
             // It will either be the CSE def or CSE ref

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -255,18 +255,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/varargs/varargsupport_r/*">
             <Issue>Varargs supported on this platform</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/BestFitMapping/Char/AFT_PFT/AFT_PFT/*">
-            <Issue>22436</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/BestFitMapping/Char/Assembly_False_False/Assembly_False_False/*">
-            <Issue>22436</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/BestFitMapping/LPStr/AFT_PFT/AFT_PFT/*">
-            <Issue>22436</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/BestFitMapping/LPStr/Assembly_False_False/Assembly_False_False/*">
-            <Issue>22436</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- Windows x86 specific excludes -->
@@ -294,12 +282,6 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/varargs/varargsupport_r/*">
             <Issue>Varargs supported on this platform</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/BestFitMapping/Char/AFT_PFT/AFT_PFT/*">
-            <Issue>22436</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/BestFitMapping/LPStr/AFT_PFT/AFT_PFT/*">
-            <Issue>22436</Issue>
         </ExcludeList>
     </ItemGroup>
 


### PR DESCRIPTION
We now allow TYP_BYREF to be compatible with TYP_I_IMPL when performing CSE substitutions.
Re-enable the failing BestFitMapping interop tests