### PR TITLE
NativeLibraryTests: Platform restriction on some tests

### DIFF
--- a/tests/src/Interop/NativeLibrary/NativeLibraryTests.cs
+++ b/tests/src/Interop/NativeLibrary/NativeLibraryTests.cs
@@ -7,8 +7,6 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using TestLibrary;
 
-using Console = Internal.Console;
-
 enum TestResult {
     Success,
     ReturnFailure,

--- a/tests/src/Interop/NativeLibrary/NativeLibraryTests.cs
+++ b/tests/src/Interop/NativeLibrary/NativeLibraryTests.cs
@@ -105,7 +105,9 @@ public class NativeLibraryTest
             success &= EXPECT(TryLoadLibraryAdvanced(libName, assembly, null),
                 (TestLibrary.Utilities.IsWindows) ? TestResult.Success : TestResult.ReturnFailure);
 
-            if (TestLibrary.Utilities.IsWindows)
+            if (TestLibrary.Utilities.IsWindows && 
+                !TestLibrary.Utilities.IsWindowsIoTCore && 
+                !TestLibrary.Utilities.IsWindowsNanoServer)
             {
                 libName = GetWin32LibName();
 
@@ -144,7 +146,13 @@ public class NativeLibraryTest
             success &= EXPECT(FreeLibrary(handle));
 
             // Double Free
-            success &= EXPECT(FreeLibrary(handle), TestResult.InvalidOperation);
+            if (TestLibrary.Utilities.IsWindows)
+            {
+                // The FreeLibrary() implementation simply calls the appropriate OS API
+                // with the supplied handle. Not all OSes consistently return an error 
+                // when a library is double-freed.
+                success &= EXPECT(FreeLibrary(handle), TestResult.InvalidOperation);
+            }
 
             // Null Free
             success &= EXPECT(FreeLibrary(IntPtr.Zero));

--- a/tests/src/Interop/NativeLibrary/NativeLibraryTests.cs
+++ b/tests/src/Interop/NativeLibrary/NativeLibraryTests.cs
@@ -105,12 +105,13 @@ public class NativeLibraryTest
             success &= EXPECT(TryLoadLibraryAdvanced(libName, assembly, null),
                 (TestLibrary.Utilities.IsWindows) ? TestResult.Success : TestResult.ReturnFailure);
 
+            // Check for loading a native binary in the system32 directory.
+            // The choice of the binary is arbitrary, and may not be available on
+            // all Windows platforms (ex: Nano server)
+            libName = "url.dll";
             if (TestLibrary.Utilities.IsWindows && 
-                !TestLibrary.Utilities.IsWindowsIoTCore && 
-                !TestLibrary.Utilities.IsWindowsNanoServer)
+                File.Exists(Path.Combine(Environment.SystemDirectory, libName)))
             {
-                libName = GetWin32LibName();
-
                 // Calls on a valid library from System32 directory
                 success &= EXPECT(LoadLibraryAdvanced(libName, assembly, DllImportSearchPath.System32));
                 success &= EXPECT(TryLoadLibraryAdvanced(libName, assembly, DllImportSearchPath.System32));
@@ -196,11 +197,6 @@ public class NativeLibraryTest
     static string GetNativeLibraryPlainName()
     {
         return "NativeLibrary";
-    }
-
-    static string GetWin32LibName()
-    {
-        return "msi.dll";
     }
 
     static string GetNativeLibraryName()

--- a/tests/src/Interop/NativeLibrary/NativeLibraryTests.csproj
+++ b/tests/src/Interop/NativeLibrary/NativeLibraryTests.csproj
@@ -11,7 +11,6 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <ReferenceSystemPrivateCoreLib>true</ReferenceSystemPrivateCoreLib>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">


### PR DESCRIPTION
This change adds platform restrictions on two API tests:
* Disable the test for `msi.dll` on Nano, because the file seems to be not available in the system directory.
* Disable double-free tests on Linux, because the OS call doesn't reliably fail.

Fixes #22726