### PR TITLE
JIT: handle preference miss two register xmm return case

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -2053,29 +2053,27 @@ void CodeGen::genMultiRegCallStoreToLocal(GenTree* treeNode)
 
         if (targetReg != reg0 && targetReg != reg1)
         {
-            // Copy reg0 into targetReg and let it to be handled by one
-            // of the cases below.
+            // targetReg = reg0;
+            // targetReg[127:64] = reg1[127:64]
             inst_RV_RV(ins_Copy(TYP_DOUBLE), targetReg, reg0, TYP_DOUBLE);
-            targetReg = reg0;
+            inst_RV_RV_IV(INS_shufpd, EA_16BYTE, targetReg, reg1, 0x00);
         }
-
-        if (targetReg == reg0)
+        else if (targetReg == reg0)
         {
-            // targeReg[63:0] = targetReg[63:0]
+            // (elided) targetReg = reg0
             // targetReg[127:64] = reg1[127:64]
             inst_RV_RV_IV(INS_shufpd, EA_16BYTE, targetReg, reg1, 0x00);
         }
         else
         {
             assert(targetReg == reg1);
-
             // We need two shuffles to achieve this
             // First:
-            // targeReg[63:0] = targetReg[63:0]
+            // targetReg[63:0] = targetReg[63:0]
             // targetReg[127:64] = reg0[63:0]
             //
             // Second:
-            // targeReg[63:0] = targetReg[127:64]
+            // targetReg[63:0] = targetReg[127:64]
             // targetReg[127:64] = targetReg[63:0]
             //
             // Essentially copy low 8-bytes from reg0 to high 8-bytes of targetReg

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -506,9 +506,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/GitHub_19601/Github_19601/*">
             <Issue>Needs Triage</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/SIMD/Vector3Interop_ro/*">
-            <Issue>22401</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- Unix arm64 specific -->


### PR DESCRIPTION
Fix a bug in codegen when returning a Vector3 result where the target
register is not one of the two return registers.

Re-enable the associated test.

Closes #22401.