### PR TITLE
Reduce struct copies in ValueTask.GetAwaiter

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
@@ -28,7 +28,15 @@ namespace System.Runtime.CompilerServices
 
         /// <summary>Returns an awaiter for this <see cref="ConfiguredValueTaskAwaitable"/> instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ConfiguredValueTaskAwaiter GetAwaiter() => new ConfiguredValueTaskAwaiter(_value);
+        public ConfiguredValueTaskAwaiter GetAwaiter()
+        {
+            // Unsafe casting to work around https://github.com/dotnet/coreclr/issues/18542
+
+            // NOTE: This only works because ConfiguredValueTaskAwaiter and ConfiguredValueTaskAwaitable are structs, 
+            // exactly the same data layout and ConfiguredValueTaskAwaitable.ctor does no real initalization.
+
+            return Unsafe.As<ConfiguredValueTaskAwaitable, ConfiguredValueTaskAwaiter>(ref Unsafe.AsRef(in this));
+        }
 
         /// <summary>Provides an awaiter for a <see cref="ConfiguredValueTaskAwaitable"/>.</summary>
         [StructLayout(LayoutKind.Auto)]
@@ -134,7 +142,15 @@ namespace System.Runtime.CompilerServices
 
         /// <summary>Returns an awaiter for this <see cref="ConfiguredValueTaskAwaitable{TResult}"/> instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ConfiguredValueTaskAwaiter GetAwaiter() => new ConfiguredValueTaskAwaiter(_value);
+        public ConfiguredValueTaskAwaiter GetAwaiter()
+        {
+            // Unsafe casting to work around https://github.com/dotnet/coreclr/issues/18542
+
+            // NOTE: This only works because ConfiguredValueTaskAwaiter and ConfiguredValueTaskAwaitable are structs, 
+            // exactly the same data layout and ConfiguredValueTaskAwaitable.ctor does no real initalization.
+
+            return Unsafe.As<ConfiguredValueTaskAwaitable<TResult>, ConfiguredValueTaskAwaiter>(ref Unsafe.AsRef(in this));
+        }
 
         /// <summary>Provides an awaiter for a <see cref="ConfiguredValueTaskAwaitable{TResult}"/>.</summary>
         [StructLayout(LayoutKind.Auto)]

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
@@ -30,10 +30,18 @@ namespace System.Runtime.CompilerServices
         /// <summary>The value being awaited.</summary>
         private readonly ValueTask _value;
 
+        // NOTE: If any extra fields are added ValueTask.GetAwaiter 
+        // must be updated to call the constructor.
+
         /// <summary>Initializes the awaiter.</summary>
         /// <param name="value">The value to be awaited.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal ValueTaskAwaiter(ValueTask value) => _value = value;
+        internal ValueTaskAwaiter(ValueTask value)
+        {
+            // NOTE: If this method is ever updated to perform more initialization,
+            //       ValueTask<TResult>.GetAwaiter must be updated to call this.
+            _value = value;
+        }
 
         /// <summary>Gets whether the <see cref="ValueTask"/> has completed.</summary>
         public bool IsCompleted
@@ -113,10 +121,18 @@ namespace System.Runtime.CompilerServices
         /// <summary>The value being awaited.</summary>
         private readonly ValueTask<TResult> _value;
 
+        // NOTE: If any extra fields are added ValueTask<TResult>.GetAwaiter 
+        // must be updated to call the constructor.
+
         /// <summary>Initializes the awaiter.</summary>
         /// <param name="value">The value to be awaited.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal ValueTaskAwaiter(ValueTask<TResult> value) => _value = value;
+        internal ValueTaskAwaiter(ValueTask<TResult> value)
+        {
+            // NOTE: If this method is ever updated to perform more initialization,
+            //       ValueTask<TResult>.GetAwaiter must be updated to call this.
+            _value = value;
+        }
 
         /// <summary>Gets whether the <see cref="ValueTask{TResult}"/> has completed.</summary>
         public bool IsCompleted

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/ValueTask.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/ValueTask.cs
@@ -369,7 +369,16 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>Gets an awaiter for this <see cref="ValueTask"/>.</summary>
-        public ValueTaskAwaiter GetAwaiter() => new ValueTaskAwaiter(this);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ValueTaskAwaiter GetAwaiter()
+        {
+            // Unsafe casting to work around https://github.com/dotnet/coreclr/issues/18542
+
+            // NOTE: This only works because ValueTaskAwaiter and ValueTask are structs, 
+            // exactly the same data layout and ValueTaskAwaiter does no real initalization.
+
+            return Unsafe.As<ValueTask, ValueTaskAwaiter>(ref Unsafe.AsRef(in this));
+        }
 
         /// <summary>Configures an awaiter for this <see cref="ValueTask"/>.</summary>
         /// <param name="continueOnCapturedContext">
@@ -765,7 +774,15 @@ namespace System.Threading.Tasks
 
         /// <summary>Gets an awaiter for this <see cref="ValueTask{TResult}"/>.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ValueTaskAwaiter<TResult> GetAwaiter() => new ValueTaskAwaiter<TResult>(this);
+        public ValueTaskAwaiter<TResult> GetAwaiter()
+        {
+            // Unsafe casting to work around https://github.com/dotnet/coreclr/issues/18542
+
+            // NOTE: This only works because ValueTaskAwaiter<TResult> and ValueTask<TResult> are structs, 
+            // exactly the same data layout and ValueTaskAwaiter.ctor does no real initalization.
+
+            return Unsafe.As<ValueTask<TResult>, ValueTaskAwaiter<TResult>>(ref Unsafe.AsRef(in this));
+        }
 
         /// <summary>Configures an awaiter for this <see cref="ValueTask{TResult}"/>.</summary>
         /// <param name="continueOnCapturedContext">


### PR DESCRIPTION
Work around for part of https://github.com/dotnet/coreclr/issues/18542#issuecomment-465621796

Using Unsafe casting rather than .ctors

Cuts
```asm
; Lcl frame size = 408
G_M43654_IG04:
       mov      rdx, bword ptr [rbp+10H]
       mov      rcx, gword ptr [rdx+8]
       lea      rdx, bword ptr [rbp-E0H]
       xor      r8, r8
       mov      rax, qword ptr [rcx]
       mov      rax, qword ptr [rax+64]
       call     qword ptr [rax+40]PipeReader:ReadAsync(struct):struct:this

G_M43654_IG05:
       vmovdqu  xmm0, qword ptr [rbp-E0H]
       vmovdqu  qword ptr [rbp-158H], xmm0
       vmovdqu  xmm0, qword ptr [rbp-D0H]
       vmovdqu  qword ptr [rbp-148H], xmm0
       vmovdqu  xmm0, qword ptr [rbp-C0H]
       vmovdqu  qword ptr [rbp-138H], xmm0
       mov      rdx, qword ptr [rbp-B0H]
       mov      qword ptr [rbp-128H], rdx

G_M43654_IG06:
       vmovdqu  xmm0, qword ptr [rbp-158H]
       vmovdqu  qword ptr [rbp-120H], xmm0
       vmovdqu  xmm0, qword ptr [rbp-148H]
       vmovdqu  qword ptr [rbp-110H], xmm0
       vmovdqu  xmm0, qword ptr [rbp-138H]
       vmovdqu  qword ptr [rbp-100H], xmm0
       mov      rdx, qword ptr [rbp-128H]
       mov      qword ptr [rbp-F0H], rdx

G_M43661_IG07:
       vmovdqu  xmm0, qword ptr [rbp-120H]
       vmovdqu  qword ptr [rbp-A8H], xmm0
       vmovdqu  xmm0, qword ptr [rbp-110H]
       vmovdqu  qword ptr [rbp-98H], xmm0
       vmovdqu  xmm0, qword ptr [rbp-100H]
       vmovdqu  qword ptr [rbp-88H], xmm0
       mov      rdx, qword ptr [rbp-F0H]
       mov      qword ptr [rbp-78H], rdx

G_M43663_IG08:
       mov      rsi, gword ptr [rbp-A8H]
       test     rsi, rsi
       jne      SHORT G_M43663_IG09
       mov      edi, 1
       jmp      SHORT G_M43663_IG11

; Total bytes of code 1525, prolog size 59 for method <ProcessSends>d__26:MoveNext():this
```
To
```asm
; Lcl frame size = 296
G_M43654_IG04:
       mov      rdx, bword ptr [rbp+10H]
       mov      rcx, gword ptr [rdx+8]
       lea      rdx, bword ptr [rbp-E0H]
       xor      r8, r8
       mov      rax, qword ptr [rcx]
       mov      rax, qword ptr [rax+64]
       call     qword ptr [rax+40]PipeReader:ReadAsync(struct):struct:this

G_M43664_IG05:
       vmovdqu  xmm0, qword ptr [rbp-E0H]
       vmovdqu  qword ptr [rbp-A8H], xmm0
       vmovdqu  xmm0, qword ptr [rbp-D0H]
       vmovdqu  qword ptr [rbp-98H], xmm0
       vmovdqu  xmm0, qword ptr [rbp-C0H]
       vmovdqu  qword ptr [rbp-88H], xmm0
       mov      rdx, qword ptr [rbp-B0H]
       mov      qword ptr [rbp-78H], rdx

G_M43664_IG06:
       mov      rsi, gword ptr [rbp-A8H]
       test     rsi, rsi
       jne      SHORT G_M43664_IG07
       mov      edi, 1
       jmp      SHORT G_M43664_IG09

; Total bytes of code 1401, prolog size 59 for method <ProcessSends>d__26:MoveNext():this
```

Acceptable workaround?

/cc @stephentoub @jkotas @CarolEidt @AndyAyersMS @mikedn 