### PR TITLE
Reduce struct copy by 1 in ValueTask.GetAwaiter

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
@@ -24,7 +24,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>Initializes the awaitable.</summary>
         /// <param name="value">The wrapped <see cref="ValueTask"/>.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal ConfiguredValueTaskAwaitable(ValueTask value) => _value = value;
+        internal ConfiguredValueTaskAwaitable(in ValueTask value) => _value = value;
 
         /// <summary>Returns an awaiter for this <see cref="ConfiguredValueTaskAwaitable"/> instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -40,7 +40,7 @@ namespace System.Runtime.CompilerServices
             /// <summary>Initializes the awaiter.</summary>
             /// <param name="value">The value to be awaited.</param>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            internal ConfiguredValueTaskAwaiter(ValueTask value) => _value = value;
+            internal ConfiguredValueTaskAwaiter(in ValueTask value) => _value = value;
 
             /// <summary>Gets whether the <see cref="ConfiguredValueTaskAwaitable"/> has completed.</summary>
             public bool IsCompleted
@@ -130,7 +130,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>Initializes the awaitable.</summary>
         /// <param name="value">The wrapped <see cref="ValueTask{TResult}"/>.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal ConfiguredValueTaskAwaitable(ValueTask<TResult> value) => _value = value;
+        internal ConfiguredValueTaskAwaitable(in ValueTask<TResult> value) => _value = value;
 
         /// <summary>Returns an awaiter for this <see cref="ConfiguredValueTaskAwaitable{TResult}"/> instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -146,7 +146,7 @@ namespace System.Runtime.CompilerServices
             /// <summary>Initializes the awaiter.</summary>
             /// <param name="value">The value to be awaited.</param>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            internal ConfiguredValueTaskAwaiter(ValueTask<TResult> value) => _value = value;
+            internal ConfiguredValueTaskAwaiter(in ValueTask<TResult> value) => _value = value;
 
             /// <summary>Gets whether the <see cref="ConfiguredValueTaskAwaitable{TResult}"/> has completed.</summary>
             public bool IsCompleted

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
@@ -28,7 +28,7 @@ namespace System.Runtime.CompilerServices
 
         /// <summary>Returns an awaiter for this <see cref="ConfiguredValueTaskAwaitable"/> instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ConfiguredValueTaskAwaiter GetAwaiter() => new ConfiguredValueTaskAwaiter(_value);
+        public ConfiguredValueTaskAwaiter GetAwaiter() => new ConfiguredValueTaskAwaiter(in _value);
 
         /// <summary>Provides an awaiter for a <see cref="ConfiguredValueTaskAwaitable"/>.</summary>
         [StructLayout(LayoutKind.Auto)]
@@ -134,7 +134,7 @@ namespace System.Runtime.CompilerServices
 
         /// <summary>Returns an awaiter for this <see cref="ConfiguredValueTaskAwaitable{TResult}"/> instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ConfiguredValueTaskAwaiter GetAwaiter() => new ConfiguredValueTaskAwaiter(_value);
+        public ConfiguredValueTaskAwaiter GetAwaiter() => new ConfiguredValueTaskAwaiter(in _value);
 
         /// <summary>Provides an awaiter for a <see cref="ConfiguredValueTaskAwaitable{TResult}"/>.</summary>
         [StructLayout(LayoutKind.Auto)]

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
@@ -33,7 +33,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>Initializes the awaiter.</summary>
         /// <param name="value">The value to be awaited.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal ValueTaskAwaiter(ValueTask value) => _value = value;
+        internal ValueTaskAwaiter(in ValueTask value) => _value = value;
 
         /// <summary>Gets whether the <see cref="ValueTask"/> has completed.</summary>
         public bool IsCompleted
@@ -116,7 +116,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>Initializes the awaiter.</summary>
         /// <param name="value">The value to be awaited.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal ValueTaskAwaiter(ValueTask<TResult> value) => _value = value;
+        internal ValueTaskAwaiter(in ValueTask<TResult> value) => _value = value;
 
         /// <summary>Gets whether the <see cref="ValueTask{TResult}"/> has completed.</summary>
         public bool IsCompleted

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/ValueTask.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/ValueTask.cs
@@ -369,7 +369,7 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>Gets an awaiter for this <see cref="ValueTask"/>.</summary>
-        public ValueTaskAwaiter GetAwaiter() => new ValueTaskAwaiter(this);
+        public ValueTaskAwaiter GetAwaiter() => new ValueTaskAwaiter(in this);
 
         /// <summary>Configures an awaiter for this <see cref="ValueTask"/>.</summary>
         /// <param name="continueOnCapturedContext">
@@ -765,7 +765,7 @@ namespace System.Threading.Tasks
 
         /// <summary>Gets an awaiter for this <see cref="ValueTask{TResult}"/>.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ValueTaskAwaiter<TResult> GetAwaiter() => new ValueTaskAwaiter<TResult>(this);
+        public ValueTaskAwaiter<TResult> GetAwaiter() => new ValueTaskAwaiter<TResult>(in this);
 
         /// <summary>Configures an awaiter for this <see cref="ValueTask{TResult}"/>.</summary>
         /// <param name="continueOnCapturedContext">


### PR DESCRIPTION
Non-Unsafe version of  https://github.com/dotnet/coreclr/pull/22735 (which cut it by 2)

Cuts
```asm
; Lcl frame size = 408
       call     qword ptr [rax+40]PipeReader:ReadAsync(struct):struct:this

G_M43654_IG05:
       vmovdqu  xmm0, qword ptr [rbp-E0H]
       vmovdqu  qword ptr [rbp-158H], xmm0
       vmovdqu  xmm0, qword ptr [rbp-D0H]
       vmovdqu  qword ptr [rbp-148H], xmm0
       vmovdqu  xmm0, qword ptr [rbp-C0H]
       vmovdqu  qword ptr [rbp-138H], xmm0
       mov      rdx, qword ptr [rbp-B0H]
       mov      qword ptr [rbp-128H], rdx

G_M43654_IG06:
       vmovdqu  xmm0, qword ptr [rbp-158H]
       vmovdqu  qword ptr [rbp-120H], xmm0
       vmovdqu  xmm0, qword ptr [rbp-148H]
       vmovdqu  qword ptr [rbp-110H], xmm0
       vmovdqu  xmm0, qword ptr [rbp-138H]
       vmovdqu  qword ptr [rbp-100H], xmm0
       mov      rdx, qword ptr [rbp-128H]
       mov      qword ptr [rbp-F0H], rdx

G_M43661_IG07:
       vmovdqu  xmm0, qword ptr [rbp-120H]
       vmovdqu  qword ptr [rbp-A8H], xmm0
       vmovdqu  xmm0, qword ptr [rbp-110H]
       vmovdqu  qword ptr [rbp-98H], xmm0
       vmovdqu  xmm0, qword ptr [rbp-100H]
       vmovdqu  qword ptr [rbp-88H], xmm0
       mov      rdx, qword ptr [rbp-F0H]
       mov      qword ptr [rbp-78H], rdx

G_M43663_IG08:
       mov      rsi, gword ptr [rbp-A8H]
       test     rsi, rsi
       jne      SHORT G_M43663_IG09
       mov      edi, 1
       jmp      SHORT G_M43663_IG11

; Total bytes of code 1525, prolog size 59 for method <ProcessSends>d__26:MoveNext():this
```
To
```asm
; Lcl frame size = 360
       call     qword ptr [rax+40]PipeReader:ReadAsync(struct):struct:this

G_M43655_IG05:
       vmovdqu  xmm0, qword ptr [rbp-E0H]
       vmovdqu  qword ptr [rbp-120H], xmm0
       vmovdqu  xmm0, qword ptr [rbp-D0H]
       vmovdqu  qword ptr [rbp-110H], xmm0
       vmovdqu  xmm0, qword ptr [rbp-C0H]
       vmovdqu  qword ptr [rbp-100H], xmm0
       mov      rdx, qword ptr [rbp-B0H]
       mov      qword ptr [rbp-F0H], rdx

G_M43661_IG06:
       vmovdqu  xmm0, qword ptr [rbp-120H]
       vmovdqu  qword ptr [rbp-A8H], xmm0
       vmovdqu  xmm0, qword ptr [rbp-110H]
       vmovdqu  qword ptr [rbp-98H], xmm0
       vmovdqu  xmm0, qword ptr [rbp-100H]
       vmovdqu  qword ptr [rbp-88H], xmm0
       mov      rdx, qword ptr [rbp-F0H]
       mov      qword ptr [rbp-78H], rdx

G_M43663_IG07:
       mov      rsi, gword ptr [rbp-A8H]
       test     rsi, rsi
       jne      SHORT G_M43663_IG08
       mov      edi, 1
       jmp      SHORT G_M43663_IG10
       
; Total bytes of code 1463, prolog size 59 for method <ProcessSends>d__26:MoveNext():this
```

/cc @stephentoub @jkotas 