### PR TITLE
Removed erroneous use of 'PROCESSOR_ARCHITECTURE' Enviroment variable

### DIFF
--- a/tests/src/GC/Performance/Tests/Allocation.cs
+++ b/tests/src/GC/Performance/Tests/Allocation.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.InteropServices;
 
 //Measure allocation time when allocating objects on a single thread.
 //Should be run with server GC
@@ -17,11 +18,10 @@ class Allocation
             return;
         }
 
-        string processor = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
-        Console.WriteLine("Running on {0}", processor);
+        Console.WriteLine("Running on {0}", RuntimeInformation.ProcessArchitecture);
 
         UInt64 MaxBytes = 1500000000;
-        if (processor.ToLower() == "amd64")
+        if (RuntimeInformation.ProcessArchitecture == Architecture.X64)
         {
             MaxBytes = 5000000000;
         }

--- a/tests/src/JIT/Directed/intrinsic/pow/pow1.cs
+++ b/tests/src/JIT/Directed/intrinsic/pow/pow1.cs
@@ -6,6 +6,7 @@
 //Testing the special values
 
 using System;
+using System.Runtime.InteropServices;
 
 internal class pow1
 {
@@ -15,18 +16,8 @@ internal class pow1
         bool pass = true;
 
         //Check if the test is being executed on ARMARCH
-        bool isProcessorArmArch = false;
-
-        string processorArchEnvVar = null;
-
-        processorArchEnvVar = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
-
-        if ((processorArchEnvVar != null)
-            && (processorArchEnvVar.Equals("ARM", StringComparison.CurrentCultureIgnoreCase)
-                || processorArchEnvVar.Equals("ARM64", StringComparison.CurrentCultureIgnoreCase)))
-        {
-            isProcessorArmArch = true;
-        }
+        bool isProcessorArmArch = RuntimeInformation.ProcessArchitecture == Architecture.Arm
+                                || RuntimeInformation.ProcessArchitecture == Architecture.Arm64;
 
         x = 0;
         y = 0;

--- a/tests/src/JIT/Methodical/doublearray/dblarray1.cs
+++ b/tests/src/JIT/Methodical/doublearray/dblarray1.cs
@@ -13,6 +13,7 @@
 
 // Variation on array length
 
+using System.Runtime.InteropServices;
 using System;
 internal class DblArray1
 {
@@ -92,7 +93,7 @@ internal class DblArray1
 
     public static int Main()
     {
-        if (Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE") == "x86")
+        if (RuntimeInformation.ProcessArchitecture == Architecture.X86)
         {
             s_LOH_GEN = 2;
         }

--- a/tests/src/JIT/Methodical/doublearray/dblarray2.cs
+++ b/tests/src/JIT/Methodical/doublearray/dblarray2.cs
@@ -12,6 +12,7 @@
 // 6) the threshold can be set by registry key DoubleArrayToLargeObjectHeap
 
 
+using System.Runtime.InteropServices;
 using System;
 internal class DblArray
 {
@@ -281,7 +282,7 @@ internal class DblArray
 
     public static int Main()
     {
-        if (Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE") == "x86")
+        if (RuntimeInformation.ProcessArchitecture == Architecture.X86)
         {
             s_LOH_GEN = 2;
         }

--- a/tests/src/JIT/Methodical/doublearray/dblarray3.cs
+++ b/tests/src/JIT/Methodical/doublearray/dblarray3.cs
@@ -5,6 +5,7 @@
 
 
 using System;
+using System.Runtime.InteropServices;
 
 internal struct VT
 {
@@ -141,8 +142,8 @@ internal class DblArray3
 
     public static int Main()
     {
-        Console.WriteLine(Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE"));
-        if (Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE") == "x86")
+        Console.WriteLine(RuntimeInformation.ProcessArchitecture);
+        if (RuntimeInformation.ProcessArchitecture == Architecture.X86)
         {
             s_LOH_GEN = 2;
         }

--- a/tests/src/JIT/Methodical/doublearray/dblarray4.cs
+++ b/tests/src/JIT/Methodical/doublearray/dblarray4.cs
@@ -14,13 +14,14 @@
 // Test DoubleArrayToLargeObjectHeap - need to set the key to <= 100
 
 using System;
+using System.Runtime.InteropServices;
 
 internal class DblArray4
 {
     private static int s_LOH_GEN = 0;
     public static int Main()
     {
-        if (Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE") == "x86")
+        if (RuntimeInformation.ProcessArchitecture == Architecture.X86)
         {
             s_LOH_GEN = 2;
         }


### PR DESCRIPTION
Removed erroneous use of `PROCESSOR_ARCHITECTURE` Enviroment variable

Changed all uses of `Enviroment.GetEnviromentVariable("PROCESSOR_ARCHITECTURE")`
to usage of `System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture`
and `enum System.Runtime.InteropServices.Architecture`

Fix #22694