### PR TITLE
[XUnit] Use ParallelRun==Collections on all platforms.

### DIFF
--- a/tests/tests.targets
+++ b/tests/tests.targets
@@ -31,11 +31,8 @@
 
     <PropertyGroup>
       <ExcludeTraits Condition="'$(ExcludeTraits)'==''">category=outerloop;category=failing</ExcludeTraits>
-      <!-- Run one assembly at a time on Linux/arm to avoid OutOfMemory (see https://github.com/dotnet/coreclr/issues/20328) -->
-      <ParallelRun Condition="'$(ParallelRun)'=='' and '$(__BuildOS)'=='Linux' and '$(__BuildArch)'=='arm'">collections</ParallelRun>
-      <!-- Run one assembly at a time on arm64 to avoid excessive parallelism leading to test timeouts (see https://github.com/dotnet/coreclr/issues/22419) -->
-      <ParallelRun Condition="'$(ParallelRun)'=='' and '$(__BuildArch)'=='arm64'">collections</ParallelRun>
-      <ParallelRun Condition="'$(ParallelRun)'==''">all</ParallelRun>
+	  <!-- Run one assembly at a time to avoid excessive parallelism leading to test timeouts -->
+      <ParallelRun Condition="'$(ParallelRun)'==''">collections</ParallelRun>
     </PropertyGroup>
     <ItemGroup>
       <IncludeTraitsItems Include="$(IncludeTraits)" />

--- a/tests/tests.targets
+++ b/tests/tests.targets
@@ -31,7 +31,7 @@
 
     <PropertyGroup>
       <ExcludeTraits Condition="'$(ExcludeTraits)'==''">category=outerloop;category=failing</ExcludeTraits>
-	  <!-- Run one assembly at a time to avoid excessive parallelism leading to test timeouts -->
+      <!-- Run one assembly at a time to avoid excessive parallelism leading to test timeouts -->
       <ParallelRun Condition="'$(ParallelRun)'==''">collections</ParallelRun>
     </PropertyGroup>
     <ItemGroup>


### PR DESCRIPTION
There is an old issue about unstable failures of chaos65204782cs and SuperPMI collect (that uses chaos65204782cs) #11921. I made a stress test for it #22474 with ~300 instances of this test and saw that the difference between the slowest and the fastest result during one run on my machine was 13x (~280s against 20s). With `ParallelRun==none` the test takes ~9s, with `ParallelRun=collections` it is the same ~9s.

My local measurements for the master branch (Windows x64, 4 cores, 8 threads) shows these results for pri0 tests:
```
collections: 25m;
all: 64m;
none: 71m.
```

with my stress chaos testing:
```
collections: 38m;
all: 68m;
none: 128m.

```
I was told that `ParallelRun==collections` is ~10-20% slower then `ParallelRun==all` but I got opposite results in my local runs. Lets see what ci shows us.

However, even if `ParallelRun==collections`  is slower we want to use it to get rid of these issues in Jenkins CI (ADO is running each assembly on a separate machine, so it has `ParallelRun==collections` by default).

FIxes #22419, fixes #11921.