### PR TITLE
[WIP] Prototype using IPC to enable/disable EventPipe.

### DIFF
--- a/build-lite.cmd
+++ b/build-lite.cmd
@@ -1,0 +1,36 @@
+@if not defined _echo echo off
+
+setlocal
+
+    set "ERRORLEVEL="
+
+    set "ARCHITECTURE=x64"
+    REM set "ARCHITECTURE=x86"
+
+    REM set "CONFIGURATIONS=Debug Checked Release"
+    REM set "CONFIGURATIONS=Debug"
+    REM set "CONFIGURATIONS=Checked"
+    set "CONFIGURATIONS=Release"
+
+    cls
+    for %%c in (%CONFIGURATIONS%) do (
+        call :run_cmd .\build.cmd %ARCHITECTURE% %%c skiptests skipbuildpackages                                                || exit /b 1
+        REM Deprecated: .\run.cmd build -Project="tests\build.proj" -BuildOS=Windows_NT -BuildType=%%c -BuildArch=%ARCHITECTURE% -BatchRestorePackages
+        call :run_cmd MSBuild.exe .\tests\build.proj /p:Configuration=%%c /p:Platform=%ARCHITECTURE% /t:BatchRestorePackages    || exit /b 1
+        call :run_cmd .\tests\runtest.cmd %ARCHITECTURE% %%c generatelayoutonly                                                 || exit /b 1
+    )
+
+endlocal& exit /b 0
+
+
+:run_cmd
+    if "%~1" == "" exit /b 1
+
+    echo/
+    echo/-------------------------------------------------------------------------------
+    echo/ %USERNAME%@%COMPUTERNAME% "%CD%"
+    echo/ [%DATE% %TIME%] $ %*
+    echo/-------------------------------------------------------------------------------
+    echo/
+    call %*
+    exit /b %ERRORLEVEL%

--- a/src/debug/debug-pal/CMakeLists.txt
+++ b/src/debug/debug-pal/CMakeLists.txt
@@ -11,6 +11,7 @@ if(WIN32)
     include_directories(../../inc) #needed for warning control
 
     set(TWO_WAY_PIPE_SOURCES 
+        win/diagnosticsipc.cpp
         win/twowaypipe.cpp
         win/processdescriptor.cpp
     )
@@ -24,6 +25,7 @@ if(CLR_CMAKE_PLATFORM_UNIX)
     add_definitions(-D_POSIX_C_SOURCE=200809L)
 
     set(TWO_WAY_PIPE_SOURCES
+      unix/diagnosticsipc.cpp
       unix/twowaypipe.cpp
       unix/processdescriptor.cpp
     )

--- a/src/debug/debug-pal/unix/diagnosticsipc.cpp
+++ b/src/debug/debug-pal/unix/diagnosticsipc.cpp
@@ -1,0 +1,143 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include <pal.h>
+#include <pal_assert.h>
+#include "diagnosticsipc.h"
+#include <new>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <type_traits>
+
+DiagnosticsIpc::DiagnosticsIpc(const char *const pIpcName, const uint32_t pid)
+    : _pServerAddress(new (std::nothrow) sockaddr_un)
+{
+    _ASSERTE(_pServerAddress != nullptr);
+    _ASSERTE(pIpcName != nullptr);
+
+    _serverSocket = ::socket(PF_UNIX, SOCK_STREAM, 0);
+    _ASSERTE(_serverSocket != -1); // TODO: Add error handling.
+
+    memset(_pServerAddress, 0, sizeof(sockaddr_un));
+    _pServerAddress->sun_family = AF_UNIX;
+    const int nCharactersWritten = sprintf_s(
+        _pServerAddress->sun_path,
+        sizeof(_pServerAddress->sun_path),
+        "/tmp/%s-%d.socket",
+        pIpcName,
+        pid);
+    _ASSERTE(nCharactersWritten > 0);
+
+    const int fSuccessBind = ::bind(_serverSocket, (sockaddr *)_pServerAddress, sizeof(*_pServerAddress));
+    _ASSERTE(fSuccessBind != -1);
+}
+
+DiagnosticsIpc::~DiagnosticsIpc()
+{
+    if (IsValidStatus())
+    {
+        bool fSuccess = Close();
+        if (!fSuccess)
+        {
+            // TODO: Add error handling.
+        }
+
+        const int fSuccessClose = ::close(_serverSocket);
+        _ASSERTE(fSuccessClose != -1); // TODO: Add error handling.
+
+        const int fSuccessUnlink = ::unlink(_pServerAddress->sun_path);
+        _ASSERTE(fSuccessUnlink != -1); // TODO: Add error handling.
+
+        delete _pServerAddress;
+    }
+}
+
+bool DiagnosticsIpc::Open()
+{
+    return true;
+}
+
+bool DiagnosticsIpc::Close()
+{
+    if (_clientSocket != -1)
+    {
+        const int fSuccessClose = ::close(_clientSocket);
+        _clientSocket = -1;
+        _ASSERTE(fSuccessClose != -1);
+        if (fSuccessClose == -1)
+        {
+            // TODO: Add error handling.
+            return false;
+        }
+        return true;
+    }
+    return false;
+}
+
+bool DiagnosticsIpc::IsValidStatus() const
+{
+    return _serverSocket != -1;
+}
+
+bool DiagnosticsIpc::Accept()
+{
+    const int fSuccessListen = ::listen(_serverSocket, /* backlog */ 255); // TODO: Unlimited here?
+    _ASSERTE(fSuccessListen != -1);
+    if (fSuccessListen == -1)
+    {
+        // TODO: Add error handling.
+        return false;
+    }
+
+    sockaddr_un from;
+    socklen_t fromlen = sizeof(from);
+    _clientSocket = ::accept(_serverSocket, (sockaddr *)&from, &fromlen);
+    _ASSERTE(_clientSocket != -1);
+    if (_clientSocket == -1)
+    {
+        // TODO: Add error handling.
+        return false;
+    }
+    return true;
+}
+
+bool DiagnosticsIpc::Read(void *lpBuffer, const uint32_t nBytesToRead, uint32_t &nBytesRead) const
+{
+    _ASSERTE(lpBuffer != nullptr);
+
+    const ssize_t ssize = ::recv(_clientSocket, lpBuffer, nBytesToRead, 0);
+    const bool fSuccess = ssize != -1;
+
+    if (!fSuccess)
+    {
+        // TODO: Add error handling.
+    }
+
+    nBytesRead = fSuccess ? static_cast<std::remove_reference<decltype(nBytesRead)>::type>(ssize) : 0;
+    return fSuccess;
+}
+
+bool DiagnosticsIpc::Write(const void *lpBuffer, const uint32_t nBytesToWrite, uint32_t &nBytesWritten) const
+{
+    _ASSERTE(lpBuffer != nullptr);
+
+    const ssize_t ssize = ::send(_clientSocket, lpBuffer, nBytesToWrite, 0);
+    const bool fSuccess = ssize != -1;
+
+    if (!fSuccess)
+    {
+        // TODO: Add error handling.
+    }
+
+    nBytesWritten = fSuccess ? static_cast<std::remove_reference<decltype(nBytesWritten)>::type>(ssize) : 0;
+    return fSuccess;
+}
+
+bool DiagnosticsIpc::Flush() const
+{
+    return true;
+}

--- a/src/debug/debug-pal/win/diagnosticsipc.cpp
+++ b/src/debug/debug-pal/win/diagnosticsipc.cpp
@@ -1,0 +1,136 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include <assert.h>
+#include <stdio.h>
+#include <type_traits>
+#include "diagnosticsipc.h"
+
+#define _ASSERTE assert
+
+DiagnosticsIpc::DiagnosticsIpc(const char *const pIpcName, const uint32_t pid)
+{
+    _ASSERTE(pIpcName != nullptr);
+
+    memset(_pNamedPipeName, 0, sizeof(_pNamedPipeName));
+    const int nCharactersWritten = sprintf_s(
+        _pNamedPipeName,
+        sizeof(_pNamedPipeName),
+        "\\\\.\\pipe\\%s-%d",
+        pIpcName,
+        pid);
+    _ASSERTE(nCharactersWritten > 0);
+}
+
+DiagnosticsIpc::~DiagnosticsIpc()
+{
+    if (IsValidStatus())
+    {
+        bool fSuccess = Close();
+        if (!fSuccess)
+        {
+            // TODO: Add error handling.
+        }
+    }
+}
+
+bool DiagnosticsIpc::Open()
+{
+    const uint32_t BufferSize = 8192;
+    _hPipe = ::CreateNamedPipeA(
+        _pNamedPipeName,                                            // pipe name
+        PIPE_ACCESS_DUPLEX,                                         // read/write access
+        PIPE_TYPE_BYTE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,    // message type pipe, message-read and blocking mode
+        PIPE_UNLIMITED_INSTANCES,                                   // max. instances
+        BufferSize,                                                 // output buffer size
+        BufferSize,                                                 // input buffer size
+        0,                                                          // default client time-out
+        NULL);                                                      // default security attribute
+
+    return (_hPipe != INVALID_HANDLE_VALUE);
+}
+
+bool DiagnosticsIpc::Close()
+{
+    if (IsValidStatus())
+    {
+        HANDLE hPipe = _hPipe;
+        _hPipe = INVALID_HANDLE_VALUE;
+
+        BOOL fSuccess;
+        fSuccess = ::DisconnectNamedPipe(hPipe);
+        if (fSuccess == 0)
+            return false;
+
+        fSuccess = ::CloseHandle(hPipe);
+        if (fSuccess == 0)
+            return false;
+        return true;
+    }
+
+    return false;
+}
+
+bool DiagnosticsIpc::IsValidStatus() const
+{
+    return _hPipe != INVALID_HANDLE_VALUE;
+}
+
+bool DiagnosticsIpc::Accept()
+{
+    const BOOL fSuccess = ::ConnectNamedPipe(_hPipe, NULL);
+    return fSuccess != 0 ? true : (GetLastError() == ERROR_PIPE_CONNECTED);
+}
+
+bool DiagnosticsIpc::Read(void *lpBuffer, const uint32_t nBytesToRead, uint32_t &nBytesRead) const
+{
+    _ASSERTE(lpBuffer != nullptr);
+
+    DWORD nNumberOfBytesRead = 0;
+    const bool fSuccess = ::ReadFile(
+        _hPipe,                 // handle to pipe
+        lpBuffer,               // buffer to receive data
+        nBytesToRead,           // size of buffer
+        &nNumberOfBytesRead,    // number of bytes read
+        NULL) != 0;             // not overlapped I/O
+
+    if (!fSuccess)
+    {
+        // TODO: Add error handling.
+    }
+
+    nBytesRead = fSuccess ? static_cast<std::remove_reference<decltype(nBytesRead)>::type>(nNumberOfBytesRead) : 0;
+    return fSuccess;
+}
+
+bool DiagnosticsIpc::Write(const void *lpBuffer, const uint32_t nBytesToWrite, uint32_t &nBytesWritten) const
+{
+    _ASSERTE(lpBuffer != nullptr);
+
+    DWORD nNumberOfBytesWritten = 0;
+    const bool fSuccess = ::WriteFile(
+        _hPipe,                 // handle to pipe
+        lpBuffer,               // buffer to write from
+        nBytesToWrite,          // number of bytes to write
+        &nNumberOfBytesWritten, // number of bytes written
+        NULL) != 0;             // not overlapped I/O
+
+    if (!fSuccess)
+    {
+        // TODO: Add error handling.
+    }
+
+    nBytesWritten = fSuccess ? static_cast<std::remove_reference<decltype(nBytesWritten)>::type>(nNumberOfBytesWritten) : 0;
+    return fSuccess;
+}
+
+bool DiagnosticsIpc::Flush() const
+{
+    const bool fSuccess = ::FlushFileBuffers(_hPipe) != 0;
+    if (!fSuccess)
+    {
+        // TODO: Add error handling.
+    }
+    return fSuccess;
+}

--- a/src/debug/inc/diagnosticsipc.h
+++ b/src/debug/inc/diagnosticsipc.h
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef __DIAGNOSTICS_IPC_H__
+#define __DIAGNOSTICS_IPC_H__
+
+
+#ifdef FEATURE_PAL
+  struct sockaddr_un;
+#else
+  #include <stdint.h>
+  #include <Windows.h>
+#endif /* FEATURE_PAL */
+
+class DiagnosticsIpc final
+{
+public:
+    DiagnosticsIpc(const char *const pIpcName, const uint32_t pid);
+    ~DiagnosticsIpc();
+
+    bool IsValidStatus() const;
+
+    bool Open();
+    bool Close();
+
+    bool Accept();
+    bool Read(void *lpBuffer, const uint32_t nBytesToRead, uint32_t &nBytesRead) const;
+    bool Write(const void *lpBuffer, const uint32_t nBytesToWrite, uint32_t &nBytesWritten) const;
+    bool Flush() const;
+
+    /*
+     * Bind -> bool
+     * (Listen/Accept)(Server)/Connect(Client) -> bool
+     * Send/Receive -> bool
+     */
+
+    DiagnosticsIpc() = delete;
+    DiagnosticsIpc(const DiagnosticsIpc &src) = delete;
+    DiagnosticsIpc(DiagnosticsIpc &&src) = delete;
+    DiagnosticsIpc &operator=(const DiagnosticsIpc &rhs) = delete;
+    DiagnosticsIpc &&operator=(DiagnosticsIpc &&rhs) = delete;
+
+private:
+#ifdef FEATURE_PAL
+    int _serverSocket = -1;
+    int _clientSocket = -1;
+    sockaddr_un *const _pServerAddress;
+#else
+    char _pNamedPipeName[256]; // https://docs.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-createnamedpipea
+    HANDLE _hPipe = INVALID_HANDLE_VALUE;
+#endif /* FEATURE_PAL */
+};
+
+#endif // __DIAGNOSTICS_IPC_H__

--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -319,6 +319,7 @@ set(VM_SOURCES_WKS
     eventpipeeventsource.cpp
     eventpipeblock.cpp
     eventpipefile.cpp
+    eventpipeinternal.cpp
     eventpipejsonfile.cpp
     eventpipemetadatagenerator.cpp
     eventpipeprovider.cpp
@@ -439,6 +440,7 @@ set(VM_HEADERS_WKS
     eventpipeeventinstance.h
     eventpipeeventsource.h
     eventpipefile.h
+    eventpipeinternal.h
     eventpipejsonfile.h
     eventpipemetadatagenerator.h
     eventpipeprovider.h

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -216,6 +216,7 @@
 #endif
 
 #include "eventpipe.h"
+#include "eventpipeinternal.h"
 
 #ifndef FEATURE_PAL
 // Included for referencing __security_cookie
@@ -671,6 +672,7 @@ void EEStartupHelper(COINITIEE fFlags)
 
 #ifdef FEATURE_PERFTRACING
         // Initialize the event pipe.
+        EventPipeInternal::Initialize();
         EventPipe::Initialize();
 #endif // FEATURE_PERFTRACING
 
@@ -1466,6 +1468,7 @@ void STDMETHODCALLTYPE EEShutDownHelper(BOOL fIsDllUnloading)
 #ifdef FEATURE_PERFTRACING
     // Shutdown the event pipe.
     EventPipe::Shutdown();
+    EventPipeInternal::Shutdown();
 #endif // FEATURE_PERFTRACING
 
 #if defined(FEATURE_COMINTEROP)

--- a/src/vm/common.h
+++ b/src/vm/common.h
@@ -75,7 +75,6 @@
 #include <stdlib.h>
 #include <wchar.h>
 #include <objbase.h>
-#include <stddef.h>
 #include <float.h>
 #include <math.h>
 #include <time.h>

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -4,6 +4,7 @@
 
 #include "common.h"
 #include "clrtypes.h"
+#include "processdescriptor.h"
 #include "safemath.h"
 #include "eventpipe.h"
 #include "eventpipebuffermanager.h"
@@ -26,12 +27,12 @@
 
 CrstStatic EventPipe::s_configCrst;
 bool EventPipe::s_tracingInitialized = false;
-EventPipeConfiguration* EventPipe::s_pConfig = NULL;
-EventPipeSession* EventPipe::s_pSession = NULL;
-EventPipeBufferManager* EventPipe::s_pBufferManager = NULL;
+EventPipeConfiguration *EventPipe::s_pConfig = NULL;
+EventPipeSession *EventPipe::s_pSession = NULL;
+EventPipeBufferManager *EventPipe::s_pBufferManager = NULL;
 LPCWSTR EventPipe::s_pOutputPath = NULL;
-EventPipeFile* EventPipe::s_pFile = NULL;
-EventPipeEventSource* EventPipe::s_pEventSource = NULL;
+EventPipeFile *EventPipe::s_pFile = NULL;
+EventPipeEventSource *EventPipe::s_pEventSource = NULL;
 LPCWSTR EventPipe::s_pCommandLine = NULL;
 unsigned long EventPipe::s_nextFileIndex;
 HANDLE EventPipe::s_fileSwitchTimerHandle = NULL;
@@ -78,7 +79,7 @@ EventPipeEventPayload::EventPipeEventPayload(EventData *pEventData, unsigned int
     m_allocatedData = false;
 
     S_UINT32 tmp_size = S_UINT32(0);
-    for (unsigned int i=0; i<m_eventDataCount; i++)
+    for (unsigned int i = 0; i < m_eventDataCount; i++)
     {
         tmp_size += S_UINT32(m_pEventData[i].Size);
     }
@@ -106,7 +107,7 @@ EventPipeEventPayload::~EventPipeEventPayload()
     }
     CONTRACTL_END;
 
-    if(m_allocatedData && m_pData != NULL)
+    if (m_allocatedData && m_pData != NULL)
     {
         delete[] m_pData;
         m_pData = NULL;
@@ -123,11 +124,11 @@ void EventPipeEventPayload::Flatten()
     }
     CONTRACTL_END;
 
-    if(m_size > 0)
+    if (m_size > 0)
     {
         if (!IsFlattened())
         {
-            BYTE* tmp_pData = new (nothrow) BYTE[m_size];
+            BYTE *tmp_pData = new (nothrow) BYTE[m_size];
             if (tmp_pData != NULL)
             {
                 m_allocatedData = true;
@@ -148,26 +149,26 @@ void EventPipeEventPayload::CopyData(BYTE *pDst)
     }
     CONTRACTL_END;
 
-    if(m_size > 0)
+    if (m_size > 0)
     {
-        if(IsFlattened())
+        if (IsFlattened())
         {
             memcpy(pDst, m_pData, m_size);
         }
 
-        else if(m_pEventData != NULL)
+        else if (m_pEventData != NULL)
         {
             unsigned int offset = 0;
-            for(unsigned int i=0; i<m_eventDataCount; i++)
+            for (unsigned int i = 0; i < m_eventDataCount; i++)
             {
-                memcpy(pDst + offset, (BYTE*) m_pEventData[i].Ptr, m_pEventData[i].Size);
+                memcpy(pDst + offset, (BYTE *)m_pEventData[i].Ptr, m_pEventData[i].Size);
                 offset += m_pEventData[i].Size;
             }
         }
     }
 }
 
-BYTE* EventPipeEventPayload::GetFlatData()
+BYTE *EventPipeEventPayload::GetFlatData()
 {
     CONTRACTL
     {
@@ -222,7 +223,7 @@ void EventPipe::Shutdown()
     {
         Disable((EventPipeSessionID)s_pSession);
     }
-    EX_CATCH { }
+    EX_CATCH {}
     EX_END_CATCH(SwallowAllExceptions);
 
     // Save pointers to the configuration and buffer manager.
@@ -236,17 +237,17 @@ void EventPipe::Shutdown()
     FlushProcessWriteBuffers();
 
     // Free resources.
-    delete(pConfig);
-    delete(pBufferManager);
-    delete(s_pEventSource);
+    delete pConfig;
+    delete pBufferManager;
+    delete s_pEventSource;
     s_pEventSource = NULL;
-    delete(s_pOutputPath);
+    delete[] s_pOutputPath; // This is an array! Maybe it should be of SString type!
     s_pOutputPath = NULL;
 
     // On Windows, this is just a pointer to the return value from
     // GetCommandLineW(), so don't attempt to free it.
 #ifdef FEATURE_PAL
-    delete[](s_pCommandLine);
+    delete[] s_pCommandLine;
     s_pCommandLine = NULL;
 #endif
 }
@@ -290,13 +291,13 @@ EventPipeSessionID EventPipe::Enable(LPCWSTR strOutputPath, EventPipeSession *pS
     CONTRACTL_END;
 
     // If tracing is not initialized or is already enabled, bail here.
-    if(!s_tracingInitialized || s_pConfig == NULL || s_pConfig->Enabled())
+    if (!s_tracingInitialized || s_pConfig == NULL || s_pConfig->Enabled())
     {
         return 0;
     }
 
     // If the state or arguments are invalid, bail here.
-    if(pSession == NULL || !pSession->IsValid())
+    if (pSession == NULL || !pSession->IsValid())
     {
         return 0;
     }
@@ -342,7 +343,7 @@ EventPipeSessionID EventPipe::Enable(LPCWSTR strOutputPath, EventPipeSession *pS
     SampleProfiler::Enable();
 
     // Enable the file switch timer if needed.
-    if(s_pSession->GetMultiFileTraceLengthInSeconds() > 0)
+    if (s_pSession->GetMultiFileTraceLengthInSeconds() > 0)
     {
         CreateFileSwitchTimer();
     }
@@ -363,7 +364,7 @@ void EventPipe::Disable(EventPipeSessionID id)
 
     // Only perform the disable operation if the session ID
     // matches the current active session.
-    if(id != (EventPipeSessionID)s_pSession)
+    if (id != (EventPipeSessionID)s_pSession)
     {
         return;
     }
@@ -374,7 +375,7 @@ void EventPipe::Disable(EventPipeSessionID id)
     // Take the lock before disabling tracing.
     CrstHolder _crst(GetLock());
 
-    if(s_pConfig != NULL && s_pConfig->Enabled())
+    if (s_pConfig != NULL && s_pConfig->Enabled())
     {
         // Disable the profiler.
         SampleProfiler::Disable();
@@ -399,27 +400,26 @@ void EventPipe::Disable(EventPipeSessionID id)
         FlushProcessWriteBuffers();
 
         // Write to the file.
-        if(s_pFile != NULL)
+        if (s_pFile != NULL)
         {
             LARGE_INTEGER disableTimeStamp;
             QueryPerformanceCounter(&disableTimeStamp);
             s_pBufferManager->WriteAllBuffersToFile(s_pFile, disableTimeStamp);
 
-            if(CLRConfig::GetConfigValue(CLRConfig::INTERNAL_EventPipeRundown) > 0)
+            if (CLRConfig::GetConfigValue(CLRConfig::INTERNAL_EventPipeRundown) > 0)
             {
                 // Before closing the file, do rundown.
                 const unsigned int numRundownProviders = 2;
-                EventPipeProviderConfiguration rundownProviders[] =
-                {
-                    { W("Microsoft-Windows-DotNETRuntime"), 0x80020138, static_cast<unsigned int>(EventPipeEventLevel::Verbose), NULL }, // Public provider.
-                    { W("Microsoft-Windows-DotNETRuntimeRundown"), 0x80020138, static_cast<unsigned int>(EventPipeEventLevel::Verbose), NULL } // Rundown provider.
+                EventPipeProviderConfiguration rundownProviders[] = {
+                    {W("Microsoft-Windows-DotNETRuntime"), 0x80020138, static_cast<unsigned int>(EventPipeEventLevel::Verbose), NULL},       // Public provider.
+                    {W("Microsoft-Windows-DotNETRuntimeRundown"), 0x80020138, static_cast<unsigned int>(EventPipeEventLevel::Verbose), NULL} // Rundown provider.
                 };
                 // The circular buffer size doesn't matter because all events are written synchronously during rundown.
                 s_pSession = s_pConfig->CreateSession(EventPipeSessionType::File, 1 /* circularBufferSizeInMB */, rundownProviders, numRundownProviders);
                 s_pConfig->EnableRundown(s_pSession);
 
                 // Ask the runtime to emit rundown events.
-                if(g_fEEStarted && !g_fEEShutDown)
+                if (g_fEEStarted && !g_fEEShutDown)
                 {
                     ETW::EnumerationLog::EndRundown();
                 }
@@ -432,7 +432,7 @@ void EventPipe::Disable(EventPipeSessionID id)
                 s_pSession = NULL;
             }
 
-            delete(s_pFile);
+            delete s_pFile;
             s_pFile = NULL;
         }
 
@@ -456,7 +456,7 @@ void EventPipe::CreateFileSwitchTimer()
     }
     CONTRACTL_END
 
-    NewHolder<ThreadpoolMgr::TimerInfoContext> timerContextHolder = new(nothrow) ThreadpoolMgr::TimerInfoContext();
+    NewHolder<ThreadpoolMgr::TimerInfoContext> timerContextHolder = new (nothrow) ThreadpoolMgr::TimerInfoContext();
     if (timerContextHolder == NULL)
     {
         return;
@@ -503,7 +503,7 @@ void EventPipe::DeleteFileSwitchTimer()
     }
     CONTRACTL_END
 
-    if((s_fileSwitchTimerHandle != NULL) && (ThreadpoolMgr::DeleteTimerQueueTimer(s_fileSwitchTimerHandle, NULL)))
+    if ((s_fileSwitchTimerHandle != NULL) && (ThreadpoolMgr::DeleteTimerQueueTimer(s_fileSwitchTimerHandle, NULL)))
     {
         s_fileSwitchTimerHandle = NULL;
     }
@@ -520,25 +520,23 @@ void WINAPI EventPipe::SwitchToNextFileTimerCallback(PVOID parameter, BOOLEAN ti
     }
     CONTRACTL_END;
 
-    
     // Take the lock control lock to make sure that tracing isn't disabled during this operation.
     CrstHolder _crst(GetLock());
 
     // Make sure that we should actually switch files.
     UINT64 multiFileTraceLengthInSeconds = s_pSession->GetMultiFileTraceLengthInSeconds();
-    if(!Enabled() || s_pSession->GetSessionType() != EventPipeSessionType::File || multiFileTraceLengthInSeconds == 0)
+    if (!Enabled() || s_pSession->GetSessionType() != EventPipeSessionType::File || multiFileTraceLengthInSeconds == 0)
     {
         return;
     }
 
     GCX_PREEMP();
 
-    if(CLRGetTickCount64() > (s_lastFileSwitchTime + (multiFileTraceLengthInSeconds * 1000)))
+    if (CLRGetTickCount64() > (s_lastFileSwitchTime + (multiFileTraceLengthInSeconds * 1000)))
     {
         SwitchToNextFile();
         s_lastFileSwitchTime = CLRGetTickCount64();
     }
-
 }
 
 void EventPipe::SwitchToNextFile()
@@ -562,14 +560,14 @@ void EventPipe::SwitchToNextFile()
     // Open the new file.
     SString nextTraceFilePath;
     GetNextFilePath(s_pSession, nextTraceFilePath);
-    EventPipeFile* pFile = new (nothrow) EventPipeFile(nextTraceFilePath);
-    if(pFile == NULL)
+    EventPipeFile *pFile = new (nothrow) EventPipeFile(nextTraceFilePath);
+    if (pFile == NULL)
     {
         return;
     }
 
     // Close the previous file.
-    delete(s_pFile);
+    delete s_pFile;
 
     // Swap in the new file.
     s_pFile = pFile;
@@ -592,11 +590,11 @@ void EventPipe::GetNextFilePath(EventPipeSession *pSession, SString &nextTraceFi
 
     // If multiple files have been requested, then add a sequence number to the trace file name.
     UINT64 multiFileTraceLengthInSeconds = pSession->GetMultiFileTraceLengthInSeconds();
-    if(multiFileTraceLengthInSeconds > 0)
+    if (multiFileTraceLengthInSeconds > 0)
     {
         // Remove the ".netperf" file extension if it exists.
         SString::Iterator netPerfExtension = nextTraceFilePath.End();
-        if(nextTraceFilePath.FindBack(netPerfExtension, W(".netperf")))
+        if (nextTraceFilePath.FindBack(netPerfExtension, W(".netperf")))
         {
             nextTraceFilePath.Truncate(netPerfExtension);
         }
@@ -608,12 +606,12 @@ void EventPipe::GetNextFilePath(EventPipeSession *pSession, SString &nextTraceFi
     }
 }
 
-EventPipeSession* EventPipe::GetSession(EventPipeSessionID id)
+EventPipeSession *EventPipe::GetSession(EventPipeSessionID id)
 {
     LIMITED_METHOD_CONTRACT;
 
     EventPipeSession *pSession = NULL;
-    if((EventPipeSessionID)s_pSession == id)
+    if ((EventPipeSessionID)s_pSession == id)
     {
         pSession = s_pSession;
     }
@@ -625,7 +623,7 @@ bool EventPipe::Enabled()
     LIMITED_METHOD_CONTRACT;
 
     bool enabled = false;
-    if(s_pConfig != NULL)
+    if (s_pConfig != NULL)
     {
         enabled = s_pConfig->Enabled();
     }
@@ -633,7 +631,7 @@ bool EventPipe::Enabled()
     return enabled;
 }
 
-EventPipeProvider* EventPipe::CreateProvider(const SString &providerName, EventPipeCallback pCallbackFunction, void *pCallbackData)
+EventPipeProvider *EventPipe::CreateProvider(const SString &providerName, EventPipeCallback pCallbackFunction, void *pCallbackData)
 {
     CONTRACTL
     {
@@ -650,10 +648,9 @@ EventPipeProvider* EventPipe::CreateProvider(const SString &providerName, EventP
     }
 
     return pProvider;
-
 }
 
-EventPipeProvider* EventPipe::GetProvider(const SString &providerName)
+EventPipeProvider *EventPipe::GetProvider(const SString &providerName)
 {
     CONTRACTL
     {
@@ -687,9 +684,9 @@ void EventPipe::DeleteProvider(EventPipeProvider *pProvider)
     // where we hold a provider after tracing has been disabled.
     CrstHolder _crst(GetLock());
 
-    if(pProvider != NULL)
+    if (pProvider != NULL)
     {
-        if(Enabled())
+        if (Enabled())
         {
             // Save the provider until the end of the tracing session.
             pProvider->SetDeleteDeferred();
@@ -744,7 +741,7 @@ void EventPipe::WriteEventInternal(EventPipeEvent &event, EventPipeEventPayload 
     CONTRACTL_END;
 
     // Exit early if the event is not enabled.
-    if(!event.IsEnabled())
+    if (!event.IsEnabled())
     {
         return;
     }
@@ -752,7 +749,7 @@ void EventPipe::WriteEventInternal(EventPipeEvent &event, EventPipeEventPayload 
     // Get the current thread;
     Thread *pThread = GetThread();
 
-    if(s_pConfig == NULL)
+    if (s_pConfig == NULL)
     {
         // We can't procede without a configuration
         return;
@@ -760,23 +757,23 @@ void EventPipe::WriteEventInternal(EventPipeEvent &event, EventPipeEventPayload 
     _ASSERTE(s_pSession != NULL);
 
     // If the activity id isn't specified AND we are in a managed thread, pull it from the current thread.
-    // If pThread is NULL (we aren't in writing from a managed thread) then pActivityId can be NULL 
-    if(pActivityId == NULL && pThread != NULL)
+    // If pThread is NULL (we aren't in writing from a managed thread) then pActivityId can be NULL
+    if (pActivityId == NULL && pThread != NULL)
     {
         pActivityId = pThread->GetActivityId();
     }
 
-    if(!s_pConfig->RundownEnabled() && s_pBufferManager != NULL)
+    if (!s_pConfig->RundownEnabled() && s_pBufferManager != NULL)
     {
         s_pBufferManager->WriteEvent(pThread, *s_pSession, event, payload, pActivityId, pRelatedActivityId);
     }
-    else if(s_pConfig->RundownEnabled())
+    else if (s_pConfig->RundownEnabled())
     {
         // It is possible that some events that are enabled on rundown can be emitted from other threads.
         // We're not interested in these events and they can cause corrupted trace files because rundown
         // events are written synchronously and not under lock.
         // If we encounter an event that did not originate on the thread that is doing rundown, ignore it.
-        if(pThread == NULL || !s_pConfig->IsRundownThread(pThread))
+        if (pThread == NULL || !s_pConfig->IsRundownThread(pThread))
         {
             return;
         }
@@ -799,7 +796,7 @@ void EventPipe::WriteEventInternal(EventPipeEvent &event, EventPipeEventPayload 
                 pActivityId,
                 pRelatedActivityId);
 
-            if(s_pFile != NULL)
+            if (s_pFile != NULL)
             {
                 // EventPipeFile::WriteEvent needs to allocate a metadata event
                 // and can therefore throw. In this context we will silently
@@ -808,7 +805,7 @@ void EventPipe::WriteEventInternal(EventPipeEvent &event, EventPipeEventPayload 
                 {
                     s_pFile->WriteEvent(instance);
                 }
-                EX_CATCH { }
+                EX_CATCH {}
                 EX_END_CATCH(SwallowAllExceptions);
             }
         }
@@ -828,7 +825,7 @@ void EventPipe::WriteSampleProfileEvent(Thread *pSamplingThread, EventPipeEvent 
     EventPipeEventPayload payload(pData, length);
 
     // Write the event to the thread's buffer.
-    if(s_pBufferManager != NULL)
+    if (s_pBufferManager != NULL)
     {
         // Specify the sampling thread as the "current thread", so that we select the right buffer.
         // Specify the target thread so that the event gets properly attributed.
@@ -847,7 +844,7 @@ bool EventPipe::WalkManagedStackForCurrentThread(StackContents &stackContents)
     CONTRACTL_END;
 
     Thread *pThread = GetThread();
-    if(pThread != NULL)
+    if (pThread != NULL)
     {
         return WalkManagedStackForThread(pThread, stackContents);
     }
@@ -868,12 +865,12 @@ bool EventPipe::WalkManagedStackForThread(Thread *pThread, StackContents &stackC
 
     // Calling into StackWalkFrames in preemptive mode violates the host contract,
     // but this contract is not used on CoreCLR.
-    CONTRACT_VIOLATION( HostViolation );
+    CONTRACT_VIOLATION(HostViolation);
 
     stackContents.Reset();
 
     StackWalkAction swaRet = pThread->StackWalkFrames(
-        (PSTACKWALKFRAMESCALLBACK) &StackWalkCallback,
+        (PSTACKWALKFRAMESCALLBACK)&StackWalkCallback,
         &stackContents,
         ALLOW_ASYNC_STACK_WALK | FUNCTIONSONLY | HANDLESKIPPEDFRAMES | ALLOW_INVALID_OBJECTS);
 
@@ -894,9 +891,9 @@ StackWalkAction EventPipe::StackWalkCallback(CrawlFrame *pCf, StackContents *pDa
 
     // Get the IP.
     UINT_PTR controlPC = (UINT_PTR)pCf->GetRegisterSet()->ControlPC;
-    if(controlPC == 0)
+    if (controlPC == 0)
     {
-        if(pData->GetLength() == 0)
+        if (pData->GetLength() == 0)
         {
             // This happens for pinvoke stubs on the top of the stack.
             return SWA_CONTINUE;
@@ -908,21 +905,20 @@ StackWalkAction EventPipe::StackWalkCallback(CrawlFrame *pCf, StackContents *pDa
     // Add the IP to the captured stack.
     pData->Append(
         controlPC,
-        pCf->GetFunction()
-        );
+        pCf->GetFunction());
 
     // Continue the stack walk.
     return SWA_CONTINUE;
 }
 
-EventPipeConfiguration* EventPipe::GetConfiguration()
+EventPipeConfiguration *EventPipe::GetConfiguration()
 {
     LIMITED_METHOD_CONTRACT;
 
     return s_pConfig;
 }
 
-CrstStatic* EventPipe::GetLock()
+CrstStatic *EventPipe::GetLock()
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -954,7 +950,7 @@ void EventPipe::SaveCommandLine(LPCWSTR pwzAssemblyPath, int argc, LPCWSTR *argv
     commandLine.Append((WCHAR)' ');
     commandLine.Append(pwzAssemblyPath);
 
-    for(int i=0; i<argc; i++)
+    for (int i = 0; i < argc; i++)
     {
         commandLine.Append((WCHAR)' ');
         commandLine.Append(argv[i]);
@@ -970,7 +966,7 @@ void EventPipe::SaveCommandLine(LPCWSTR pwzAssemblyPath, int argc, LPCWSTR *argv
 #endif
 }
 
-EventPipeEventInstance* EventPipe::GetNextEvent()
+EventPipeEventInstance *EventPipe::GetNextEvent()
 {
     CONTRACTL
     {
@@ -990,255 +986,6 @@ EventPipeEventInstance* EventPipe::GetNextEvent()
     }
 
     return pInstance;
-}
-
-UINT64 QCALLTYPE EventPipeInternal::Enable(
-        __in_z LPCWSTR outputFile,
-        UINT32 circularBufferSizeInMB,
-        INT64 profilerSamplingRateInNanoseconds,
-        EventPipeProviderConfiguration *pProviders,
-        INT32 numProviders,
-        UINT64 multiFileTraceLengthInSeconds)
-{
-    QCALL_CONTRACT;
-
-    UINT64 sessionID = 0;
-
-    BEGIN_QCALL;
-    SampleProfiler::SetSamplingRate((unsigned long)profilerSamplingRateInNanoseconds);
-    sessionID = EventPipe::Enable(outputFile, circularBufferSizeInMB, pProviders, numProviders, multiFileTraceLengthInSeconds);
-    END_QCALL;
-
-    return sessionID;
-}
-
-void QCALLTYPE EventPipeInternal::Disable(UINT64 sessionID)
-{
-    QCALL_CONTRACT;
-
-    BEGIN_QCALL;
-    EventPipe::Disable(sessionID);
-    END_QCALL;
-}
-
-bool QCALLTYPE EventPipeInternal::GetSessionInfo(UINT64 sessionID, EventPipeSessionInfo *pSessionInfo)
-{
-    QCALL_CONTRACT;
-
-    bool retVal = false;
-    BEGIN_QCALL;
-
-    if(pSessionInfo != NULL)
-    {
-        EventPipeSession *pSession = EventPipe::GetSession(sessionID);
-        if(pSession != NULL)
-        {
-            pSessionInfo->StartTimeAsUTCFileTime = pSession->GetStartTime();
-            pSessionInfo->StartTimeStamp.QuadPart = pSession->GetStartTimeStamp().QuadPart;
-            QueryPerformanceFrequency(&pSessionInfo->TimeStampFrequency);
-            retVal = true;
-        }
-    }
-
-    END_QCALL;
-    return retVal;
-}
-
-INT_PTR QCALLTYPE EventPipeInternal::CreateProvider(
-    __in_z LPCWSTR providerName,
-    EventPipeCallback pCallbackFunc)
-{
-    QCALL_CONTRACT;
-
-    EventPipeProvider *pProvider = NULL;
-
-    BEGIN_QCALL;
-
-    pProvider = EventPipe::CreateProvider(providerName, pCallbackFunc, NULL);
-
-    END_QCALL;
-
-    return reinterpret_cast<INT_PTR>(pProvider);
-}
-
-INT_PTR QCALLTYPE EventPipeInternal::DefineEvent(
-    INT_PTR provHandle,
-    UINT32 eventID,
-    __int64 keywords,
-    UINT32 eventVersion,
-    UINT32 level,
-    void *pMetadata,
-    UINT32 metadataLength)
-{
-    QCALL_CONTRACT;
-
-    EventPipeEvent *pEvent = NULL;
-
-    BEGIN_QCALL;
-
-    _ASSERTE(provHandle != NULL);
-    EventPipeProvider *pProvider = reinterpret_cast<EventPipeProvider *>(provHandle);
-    pEvent = pProvider->AddEvent(eventID, keywords, eventVersion, (EventPipeEventLevel)level, (BYTE *)pMetadata, metadataLength);
-    _ASSERTE(pEvent != NULL);
-
-    END_QCALL;
-
-    return reinterpret_cast<INT_PTR>(pEvent);
-}
-
-INT_PTR QCALLTYPE EventPipeInternal::GetProvider(
-    __in_z LPCWSTR providerName)
-{
-    QCALL_CONTRACT;
-
-    EventPipeProvider *pProvider = NULL;
-
-    BEGIN_QCALL;
-
-    pProvider = EventPipe::GetProvider(providerName);
-
-    END_QCALL;
-
-    return reinterpret_cast<INT_PTR>(pProvider);
-}
-
-void QCALLTYPE EventPipeInternal::DeleteProvider(
-    INT_PTR provHandle)
-{
-    QCALL_CONTRACT;
-    BEGIN_QCALL;
-
-    if(provHandle != NULL)
-    {
-        EventPipeProvider *pProvider = reinterpret_cast<EventPipeProvider*>(provHandle);
-        EventPipe::DeleteProvider(pProvider);
-    }
-
-    END_QCALL;
-}
-
-int QCALLTYPE EventPipeInternal::EventActivityIdControl(
-    uint controlCode,
-    GUID *pActivityId)
-{
-
-    QCALL_CONTRACT;
-
-    int retVal = 0;
-
-    BEGIN_QCALL;
-
-    Thread *pThread = GetThread();
-    if(pThread == NULL || pActivityId == NULL)
-    {
-        retVal = 1;
-    }
-    else
-    {
-        ActivityControlCode activityControlCode = (ActivityControlCode)controlCode;
-        GUID currentActivityId;
-        switch(activityControlCode)
-        {
-            case ActivityControlCode::EVENT_ACTIVITY_CONTROL_GET_ID:
-
-                *pActivityId = *pThread->GetActivityId();
-                break;
-
-            case ActivityControlCode::EVENT_ACTIVITY_CONTROL_SET_ID:
-
-                pThread->SetActivityId(pActivityId);
-                break;
-
-            case ActivityControlCode::EVENT_ACTIVITY_CONTROL_CREATE_ID:
-
-                CoCreateGuid(pActivityId);
-                break;
-
-            case ActivityControlCode::EVENT_ACTIVITY_CONTROL_GET_SET_ID:
-
-                currentActivityId = *pThread->GetActivityId();
-                pThread->SetActivityId(pActivityId);
-                *pActivityId = currentActivityId;
-
-                break;
-
-            case ActivityControlCode::EVENT_ACTIVITY_CONTROL_CREATE_SET_ID:
-
-                *pActivityId = *pThread->GetActivityId();
-                CoCreateGuid(&currentActivityId);
-                pThread->SetActivityId(&currentActivityId);
-                break;
-
-            default:
-                retVal = 1;
-        };
-    }
-
-    END_QCALL;
-    return retVal;
-}
-
-void QCALLTYPE EventPipeInternal::WriteEvent(
-    INT_PTR eventHandle,
-    UINT32 eventID,
-    void *pData,
-    UINT32 length,
-    LPCGUID pActivityId,
-    LPCGUID pRelatedActivityId)
-{
-    QCALL_CONTRACT;
-    BEGIN_QCALL;
-
-    _ASSERTE(eventHandle != NULL);
-    EventPipeEvent *pEvent = reinterpret_cast<EventPipeEvent *>(eventHandle);
-    EventPipe::WriteEvent(*pEvent, (BYTE *)pData, length, pActivityId, pRelatedActivityId);
-
-    END_QCALL;
-}
-
-void QCALLTYPE EventPipeInternal::WriteEventData(
-    INT_PTR eventHandle,
-    UINT32 eventID,
-    EventData *pEventData,
-    UINT32 eventDataCount,
-    LPCGUID pActivityId,
-    LPCGUID pRelatedActivityId)
-{
-    QCALL_CONTRACT;
-    BEGIN_QCALL;
-
-    _ASSERTE(eventHandle != NULL);
-    EventPipeEvent *pEvent = reinterpret_cast<EventPipeEvent *>(eventHandle);
-    EventPipe::WriteEvent(*pEvent, pEventData, eventDataCount, pActivityId, pRelatedActivityId);
-
-    END_QCALL;
-}
-
-bool QCALLTYPE EventPipeInternal::GetNextEvent(
-    EventPipeEventInstanceData *pInstance)
-{
-    QCALL_CONTRACT;
-
-    EventPipeEventInstance *pNextInstance = NULL;
-    BEGIN_QCALL;
-
-    _ASSERTE(pInstance != NULL);
-
-    pNextInstance = EventPipe::GetNextEvent();
-    if (pNextInstance)
-    {
-        pInstance->ProviderID = pNextInstance->GetEvent()->GetProvider();
-        pInstance->EventID = pNextInstance->GetEvent()->GetEventID();
-        pInstance->ThreadID = pNextInstance->GetThreadId();
-        pInstance->TimeStamp.QuadPart = pNextInstance->GetTimeStamp()->QuadPart;
-        pInstance->ActivityId = *pNextInstance->GetActivityId();
-        pInstance->RelatedActivityId = *pNextInstance->GetRelatedActivityId();
-        pInstance->Payload = pNextInstance->GetData();
-        pInstance->PayloadLength = pNextInstance->GetDataLength();
-    }
-
-    END_QCALL;
-    return pNextInstance != NULL;
 }
 
 #endif // FEATURE_PERFTRACING

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -14,13 +14,10 @@ class EventPipeConfiguration;
 class EventPipeEvent;
 class EventPipeEventInstance;
 class EventPipeFile;
-class EventPipeJsonFile;
-class EventPipeBuffer;
 class EventPipeBufferManager;
 class EventPipeEventSource;
 class EventPipeProvider;
 class MethodDesc;
-class SampleProfilerEventInstance;
 struct EventPipeProviderConfiguration;
 class EventPipeSession;
 
@@ -36,13 +33,13 @@ struct EventFilterDescriptor
     ULONGLONG Ptr;
 
     // The size of the filter data, in bytes. The maximum size is 1024 bytes.
-    ULONG     Size;
+    ULONG Size;
 
     // The type of filter data. The type is application-defined. An event
     // controller that knows about the provider and knows details about the
     // provider's events can use the Type field to send the provider an
     // arbitrary set of data for use as enhancements to the filtering of events.
-    ULONG     Type;
+    ULONG Type;
 };
 
 // Define the event pipe callback to match the ETW callback signature.
@@ -57,7 +54,6 @@ typedef void (*EventPipeCallback)(
 
 struct EventData
 {
-public:
     UINT64 Ptr;
     unsigned int Size;
     unsigned int Reserved;
@@ -92,7 +88,7 @@ public:
     // Get the flat formatted data in this payload
     // This method will allocate a buffer if it does not already contain flattened data
     // This method will return NULL on OOM if a buffer needed to be allocated
-    BYTE* GetFlatData();
+    BYTE *GetFlatData();
 
     // Return true is the data is stored in a flat buffer
     bool IsFlattened() const
@@ -110,7 +106,7 @@ public:
         return m_size;
     }
 
-    EventData* GetEventDataArray() const
+    EventData *GetEventDataArray() const
     {
         LIMITED_METHOD_CONTRACT;
 
@@ -121,7 +117,6 @@ public:
 class StackContents
 {
 private:
-
     const static unsigned int MAX_STACK_DEPTH = 100;
 
     // Array of IP values from a stack crawl.
@@ -131,14 +126,13 @@ private:
 #ifdef _DEBUG
     // Parallel array of MethodDesc pointers.
     // Used for debug-only stack printing.
-    MethodDesc* m_methods[MAX_STACK_DEPTH];
+    MethodDesc *m_methods[MAX_STACK_DEPTH];
 #endif // _DEBUG
 
     // The next available slot in StackFrames.
     unsigned int m_nextAvailableFrame;
 
 public:
-
     StackContents()
     {
         LIMITED_METHOD_CONTRACT;
@@ -153,7 +147,7 @@ public:
 
         memcpy_s(pDest->m_stackFrames, MAX_STACK_DEPTH * sizeof(UINT_PTR), m_stackFrames, sizeof(UINT_PTR) * m_nextAvailableFrame);
 #ifdef _DEBUG
-        memcpy_s(pDest->m_methods, MAX_STACK_DEPTH * sizeof(MethodDesc*), m_methods, sizeof(MethodDesc*) * m_nextAvailableFrame);
+        memcpy_s(pDest->m_methods, MAX_STACK_DEPTH * sizeof(MethodDesc *), m_methods, sizeof(MethodDesc *) * m_nextAvailableFrame);
 #endif
         pDest->m_nextAvailableFrame = m_nextAvailableFrame;
     }
@@ -193,7 +187,7 @@ public:
     }
 
 #ifdef _DEBUG
-    MethodDesc* GetMethod(unsigned int frameIndex)
+    MethodDesc *GetMethod(unsigned int frameIndex)
     {
         LIMITED_METHOD_CONTRACT;
         _ASSERTE(frameIndex < MAX_STACK_DEPTH);
@@ -211,7 +205,7 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
 
-        if(m_nextAvailableFrame < MAX_STACK_DEPTH)
+        if (m_nextAvailableFrame < MAX_STACK_DEPTH)
         {
             m_stackFrames[m_nextAvailableFrame] = controlPC;
 #ifdef _DEBUG
@@ -221,11 +215,11 @@ public:
         }
     }
 
-    BYTE* GetPointer() const
+    BYTE *GetPointer() const
     {
         LIMITED_METHOD_CONTRACT;
 
-        return (BYTE*)m_stackFrames;
+        return (BYTE *)m_stackFrames;
     }
 
     unsigned int GetSize() const
@@ -247,146 +241,149 @@ class EventPipe
     friend class EventPipeBufferManager;
     friend class SampleProfiler;
 
-    public:
+public:
+    // Initialize the event pipe.
+    static void Initialize();
 
-        // Initialize the event pipe.
-        static void Initialize();
+    // Shutdown the event pipe.
+    static void Shutdown();
 
-        // Shutdown the event pipe.
-        static void Shutdown();
+    // Enable tracing via the event pipe.
+    static EventPipeSessionID Enable(
+        LPCWSTR strOutputPath,
+        unsigned int circularBufferSizeInMB,
+        EventPipeProviderConfiguration *pProviders,
+        int numProviders,
+        UINT64 multiFileTraceLengthInSeconds);
 
-        // Enable tracing via the event pipe.
-        static EventPipeSessionID Enable(
-            LPCWSTR strOutputPath,
-            unsigned int circularBufferSizeInMB,
-            EventPipeProviderConfiguration *pProviders,
-            int numProviders,
-            UINT64 multiFileTraceLengthInSeconds);
+    // Disable tracing via the event pipe.
+    static void Disable(EventPipeSessionID id);
 
-        // Disable tracing via the event pipe.
-        static void Disable(EventPipeSessionID id);
+    // Get the session for the specified session ID.
+    static EventPipeSession *GetSession(EventPipeSessionID id);
 
-        // Get the session for the specified session ID.
-        static EventPipeSession* GetSession(EventPipeSessionID id);
+    // Specifies whether or not the event pipe is enabled.
+    static bool Enabled();
 
-        // Specifies whether or not the event pipe is enabled.
-        static bool Enabled();
+    // Create a provider.
+    static EventPipeProvider *CreateProvider(const SString &providerName, EventPipeCallback pCallbackFunction = NULL, void *pCallbackData = NULL);
 
-        // Create a provider.
-        static EventPipeProvider* CreateProvider(const SString &providerName, EventPipeCallback pCallbackFunction = NULL, void *pCallbackData = NULL);
+    // Get a provider.
+    static EventPipeProvider *GetProvider(const SString &providerName);
 
-        // Get a provider.
-        static EventPipeProvider* GetProvider(const SString &providerName);
+    // Delete a provider.
+    static void DeleteProvider(EventPipeProvider *pProvider);
 
-        // Delete a provider.
-        static void DeleteProvider(EventPipeProvider *pProvider);
+    // Write out an event from a flat buffer.
+    // Data is written as a serialized blob matching the ETW serialization conventions.
+    static void WriteEvent(EventPipeEvent &event, BYTE *pData, unsigned int length, LPCGUID pActivityId = NULL, LPCGUID pRelatedActivityId = NULL);
 
-        // Write out an event from a flat buffer.
-        // Data is written as a serialized blob matching the ETW serialization conventions.
-        static void WriteEvent(EventPipeEvent &event, BYTE *pData, unsigned int length, LPCGUID pActivityId = NULL, LPCGUID pRelatedActivityId = NULL);
+    // Write out an event from an EventData array.
+    // Data is written as a serialized blob matching the ETW serialization conventions.
+    static void WriteEvent(EventPipeEvent &event, EventData *pEventData, unsigned int eventDataCount, LPCGUID pActivityId = NULL, LPCGUID pRelatedActivityId = NULL);
 
-        // Write out an event from an EventData array.
-        // Data is written as a serialized blob matching the ETW serialization conventions.
-        static void WriteEvent(EventPipeEvent &event, EventData *pEventData, unsigned int eventDataCount, LPCGUID pActivityId = NULL, LPCGUID pRelatedActivityId = NULL);
+    // Write out a sample profile event.
+    static void WriteSampleProfileEvent(Thread *pSamplingThread, EventPipeEvent *pEvent, Thread *pTargetThread, StackContents &stackContents, BYTE *pData = NULL, unsigned int length = 0);
 
-        // Write out a sample profile event.
-        static void WriteSampleProfileEvent(Thread *pSamplingThread, EventPipeEvent *pEvent, Thread *pTargetThread, StackContents &stackContents, BYTE *pData = NULL, unsigned int length = 0);
+    // Get the managed call stack for the current thread.
+    static bool WalkManagedStackForCurrentThread(StackContents &stackContents);
 
-        // Get the managed call stack for the current thread.
-        static bool WalkManagedStackForCurrentThread(StackContents &stackContents);
+    // Get the managed call stack for the specified thread.
+    static bool WalkManagedStackForThread(Thread *pThread, StackContents &stackContents);
 
-        // Get the managed call stack for the specified thread.
-        static bool WalkManagedStackForThread(Thread *pThread, StackContents &stackContents);
+    // Save the command line for the current process.
+    static void SaveCommandLine(LPCWSTR pwzAssemblyPath, int argc, LPCWSTR *argv);
 
-        // Save the command line for the current process.
-        static void SaveCommandLine(LPCWSTR pwzAssemblyPath, int argc, LPCWSTR *argv);
+    // Get next event.
+    static EventPipeEventInstance *GetNextEvent();
 
-        // Get next event.
-        static EventPipeEventInstance* GetNextEvent();
+private:
+    // The counterpart to WriteEvent which after the payload is constructed
+    static void WriteEventInternal(EventPipeEvent &event, EventPipeEventPayload &payload, LPCGUID pActivityId = NULL, LPCGUID pRelatedActivityId = NULL);
 
-    protected:
+    // Enable the specified EventPipe session.
+    static EventPipeSessionID Enable(LPCWSTR strOutputPath, EventPipeSession *pSession);
 
-        // The counterpart to WriteEvent which after the payload is constructed
-        static void WriteEventInternal(EventPipeEvent &event, EventPipeEventPayload &payload, LPCGUID pActivityId = NULL, LPCGUID pRelatedActivityId = NULL);
+    static void CreateFileSwitchTimer();
 
-    private:
+    static void DeleteFileSwitchTimer();
 
-        // Enable the specified EventPipe session.
-        static EventPipeSessionID Enable(LPCWSTR strOutputPath, EventPipeSession *pSession);
+    // Performs one polling operation to determine if it is necessary to switch to a new file.
+    // If the polling operation decides it is time, it will perform the switch.
+    // Called directly from the timer when the timer is triggered.
+    static void WINAPI SwitchToNextFileTimerCallback(PVOID parameter, BOOLEAN timerFired);
 
-        static void CreateFileSwitchTimer();
+    // If event pipe has been configured to write multiple files, switch to the next file.
+    static void SwitchToNextFile();
 
-        static void DeleteFileSwitchTimer();
+    // Generate the file path for the next trace file.
+    // This is used when event pipe has been configured to create multiple trace files with a specified maximum length of time.
+    static void GetNextFilePath(EventPipeSession *pSession, SString &nextTraceFilePath);
 
-        // Performs one polling operation to determine if it is necessary to switch to a new file.
-        // If the polling operation decides it is time, it will perform the switch.
-        // Called directly from the timer when the timer is triggered.
-        static void WINAPI SwitchToNextFileTimerCallback(PVOID parameter, BOOLEAN timerFired);
+    // Callback function for the stack walker.  For each frame walked, this callback is invoked.
+    static StackWalkAction StackWalkCallback(CrawlFrame *pCf, StackContents *pData);
 
-        // If event pipe has been configured to write multiple files, switch to the next file.
-        static void SwitchToNextFile();
+    // Get the configuration object.
+    // This is called directly by the EventPipeProvider constructor to register the new provider.
+    static EventPipeConfiguration *GetConfiguration();
 
-        // Generate the file path for the next trace file.
-        // This is used when event pipe has been configured to create multiple trace files with a specified maximum length of time.
-        static void GetNextFilePath(EventPipeSession *pSession, SString &nextTraceFilePath);
+    // Get the event pipe configuration lock.
+    static CrstStatic *GetLock();
 
-        // Callback function for the stack walker.  For each frame walked, this callback is invoked.
-        static StackWalkAction StackWalkCallback(CrawlFrame *pCf, StackContents *pData);
-
-        // Get the configuration object.
-        // This is called directly by the EventPipeProvider constructor to register the new provider.
-        static EventPipeConfiguration* GetConfiguration();
-
-        // Get the event pipe configuration lock.
-        static CrstStatic* GetLock();
-
-        static CrstStatic s_configCrst;
-        static bool s_tracingInitialized;
-        static EventPipeConfiguration *s_pConfig;
-        static EventPipeSession *s_pSession;
-        static EventPipeBufferManager *s_pBufferManager;
-        static LPCWSTR s_pOutputPath;
-        static unsigned long s_nextFileIndex;
-        static EventPipeFile *s_pFile;
-        static EventPipeEventSource *s_pEventSource;
-        static LPCWSTR s_pCommandLine;
-        const static DWORD FileSwitchTimerPeriodMS = 1000;
-        static HANDLE s_fileSwitchTimerHandle;
-        static ULONGLONG s_lastFileSwitchTime;
+    static CrstStatic s_configCrst;
+    static bool s_tracingInitialized;
+    static EventPipeConfiguration *s_pConfig;
+    static EventPipeSession *s_pSession;
+    static EventPipeBufferManager *s_pBufferManager;
+    static LPCWSTR s_pOutputPath;
+    static unsigned long s_nextFileIndex;
+    static EventPipeFile *s_pFile;
+    static EventPipeEventSource *s_pEventSource;
+    static LPCWSTR s_pCommandLine;
+    const static DWORD FileSwitchTimerPeriodMS = 1000;
+    static HANDLE s_fileSwitchTimerHandle;
+    static ULONGLONG s_lastFileSwitchTime;
 };
 
 struct EventPipeProviderConfiguration
 {
-
 private:
-
-    LPCWSTR m_pProviderName;
-    UINT64 m_keywords;
-    UINT32 m_loggingLevel;
-    LPCWSTR m_pFilterData;
+    LPCWSTR m_pProviderName = nullptr;
+    UINT64 m_keywords = 0;
+    UINT32 m_loggingLevel = 0;
+    LPCWSTR m_pFilterData = nullptr;
 
 public:
+    EventPipeProviderConfiguration() = default;
 
-    EventPipeProviderConfiguration()
+    EventPipeProviderConfiguration(LPCWSTR pProviderName, UINT64 keywords, UINT32 loggingLevel, LPCWSTR pFilterData) :
+        m_keywords(keywords),
+        m_loggingLevel(loggingLevel)
     {
         LIMITED_METHOD_CONTRACT;
-        m_pProviderName = NULL;
-        m_keywords = NULL;
-        m_loggingLevel = 0;
-        m_pFilterData = NULL;
-    }
+        _ASSERTE(pProviderName != nullptr); // Do we need this here?
 
-    EventPipeProviderConfiguration(
-        LPCWSTR pProviderName,
-        UINT64 keywords,
-        UINT32 loggingLevel,
-        LPCWSTR pFilterData)
-    {
-        LIMITED_METHOD_CONTRACT;
-        m_pProviderName = pProviderName;
-        m_keywords = keywords;
-        m_loggingLevel = loggingLevel;
-        m_pFilterData = pFilterData;
+        // Provider name is required.
+        auto ProviderNameLength = wcslen(pProviderName);
+        NewArrayHolder<WCHAR> hProviderName = new (nothrow) WCHAR[ProviderNameLength + 1];
+        if (hProviderName.IsNull())
+            return;
+        wcsncpy(hProviderName.GetValue(), pProviderName, ProviderNameLength);
+        hProviderName.GetValue()[ProviderNameLength] = 0;
+
+        // Filter data is optional.
+        if (pFilterData != nullptr)
+        {
+            const size_t FilterDataLength = wcslen(pFilterData);
+            NewArrayHolder<WCHAR> hFilterData = new (nothrow) WCHAR[FilterDataLength + 1];
+            if (hFilterData.IsNull())
+                return;
+            wcsncpy(hFilterData.GetValue(), pFilterData, FilterDataLength);
+            hFilterData.GetValue()[FilterDataLength] = 0;
+            m_pFilterData = hFilterData.Extract();
+        }
+
+        m_pProviderName = hProviderName.Extract();
     }
 
     LPCWSTR GetProviderName() const
@@ -412,97 +409,13 @@ public:
         LIMITED_METHOD_CONTRACT;
         return m_pFilterData;
     }
+
+    ~EventPipeProviderConfiguration()
+    {
+        delete[] m_pProviderName;
+        delete[] m_pFilterData;
+    }
 };
-
-class EventPipeInternal
-{
-private:
-
-    enum class ActivityControlCode
-    {
-        EVENT_ACTIVITY_CONTROL_GET_ID = 1,
-        EVENT_ACTIVITY_CONTROL_SET_ID = 2,
-        EVENT_ACTIVITY_CONTROL_CREATE_ID = 3,
-        EVENT_ACTIVITY_CONTROL_GET_SET_ID = 4,
-        EVENT_ACTIVITY_CONTROL_CREATE_SET_ID = 5
-    };
-
-    struct EventPipeEventInstanceData
-    {
-    public:
-        void *ProviderID;
-        unsigned int EventID;
-        unsigned int ThreadID;
-        LARGE_INTEGER TimeStamp;
-        GUID ActivityId;
-        GUID RelatedActivityId;
-        const BYTE *Payload;
-        unsigned int PayloadLength;
-    };
-
-    struct EventPipeSessionInfo
-    {
-    public:
-        FILETIME StartTimeAsUTCFileTime;
-        LARGE_INTEGER StartTimeStamp;
-        LARGE_INTEGER TimeStampFrequency;
-    };
-
-public:
-
-    static UINT64 QCALLTYPE Enable(
-        __in_z LPCWSTR outputFile,
-        UINT32 circularBufferSizeInMB,
-        INT64 profilerSamplingRateInNanoseconds,
-        EventPipeProviderConfiguration *pProviders,
-        INT32 numProviders,
-        UINT64 multiFileTraceLengthInSeconds);
-
-    static void QCALLTYPE Disable(UINT64 sessionID);
-
-    static bool QCALLTYPE GetSessionInfo(UINT64 sessionID, EventPipeSessionInfo *pSessionInfo);
-
-    static INT_PTR QCALLTYPE CreateProvider(
-        __in_z LPCWSTR providerName,
-        EventPipeCallback pCallbackFunc);
-
-    static INT_PTR QCALLTYPE DefineEvent(
-        INT_PTR provHandle,
-        UINT32 eventID,
-        __int64 keywords,
-        UINT32 eventVersion,
-        UINT32 level,
-        void *pMetadata,
-        UINT32 metadataLength);
-
-    static INT_PTR QCALLTYPE GetProvider(
-        __in_z LPCWSTR providerName);
-
-    static void QCALLTYPE DeleteProvider(
-        INT_PTR provHandle);
-
-    static int QCALLTYPE EventActivityIdControl(
-        uint controlCode,
-        GUID *pActivityId);
-
-    static void QCALLTYPE WriteEvent(
-        INT_PTR eventHandle,
-        UINT32 eventID,
-        void *pData,
-        UINT32 length,
-        LPCGUID pActivityId, LPCGUID pRelatedActivityId);
-
-    static void QCALLTYPE WriteEventData(
-        INT_PTR eventHandle,
-        UINT32 eventID,
-        EventData *pEventData,
-        UINT32 eventDataCount,
-        LPCGUID pActivityId, LPCGUID pRelatedActivityId);
-
-    static bool QCALLTYPE GetNextEvent(
-        EventPipeEventInstanceData *pInstance);
-};
-
 #endif // FEATURE_PERFTRACING
 
 #endif // __EVENTPIPE_H__

--- a/src/vm/eventpipeconfiguration.cpp
+++ b/src/vm/eventpipeconfiguration.cpp
@@ -134,15 +134,13 @@ void EventPipeConfiguration::DeleteProvider(EventPipeProvider *pProvider)
     CONTRACTL_END;
 
     if (pProvider == NULL)
-    {
         return;
-    }
 
     // Unregister the provider.
     UnregisterProvider(*pProvider);
 
     // Free the provider itself.
-    delete(pProvider);
+    delete pProvider;
 }
 
 

--- a/src/vm/eventpipeeventinstance.h
+++ b/src/vm/eventpipeeventinstance.h
@@ -14,6 +14,8 @@
 #include "fastserializableobject.h"
 #include "fastserializer.h"
 
+class EventPipeJsonFile;
+
 class EventPipeEventInstance
 {
     // Declare friends.

--- a/src/vm/eventpipeinternal.cpp
+++ b/src/vm/eventpipeinternal.cpp
@@ -1,0 +1,720 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// #include <algorithm>
+// #include <string>
+#include <type_traits>
+#include "common.h"
+#include "diagnosticsipc.h"
+#include "eventpipe.h"
+#include "eventpipeconfiguration.h"
+#include "eventpipeeventinstance.h"
+#include "eventpipeinternal.h"
+#include "eventpipeprovider.h"
+#include "eventpipesession.h"
+#include "processdescriptor.h"
+#include "sampleprofiler.h"
+
+#ifdef FEATURE_PAL
+#include "pal.h"
+#endif // FEATURE_PAL
+
+#ifdef FEATURE_PERFTRACING
+
+//! x is clamped to the range [Minimum , Maximum]
+//! Returns Minimum if x is less than Minimum.
+//! Returns Maximum if x is greater than Maximum.
+//! Returns x otherwise.
+template <typename T>
+constexpr const typename std::enable_if<std::is_integral<T>::value, T>::type Clamp(const T x, const T Minimum, const T Maximum)
+{
+    _ASSERTE(Minimum < Maximum);
+    return (x < Minimum) ? Minimum : (Maximum < x) ? Maximum : x;
+}
+
+template <class InputIt, class T>
+constexpr InputIt &Find(InputIt &first, InputIt &last, const T &value)
+{
+    for (; first != last; ++first)
+        if (*first == value)
+            return first;
+    return last;
+}
+
+typedef SList<SListElem<EventPipeProviderConfiguration *>> Providers;
+
+void ProviderParser(const char *first, const char *last, Providers &providers)
+{
+    // Provider:        "(GUID|KnownProviderName)[:Flags[:Level][:KeyValueArgs]]"
+    // KeyValueArgs:    "[key1=value1][;key2=value2]"
+
+    // TODO: Should these be read from a config file?
+    const uint64_t DefaultKeywords = UINT64_MAX;
+    const uint32_t DefaultLevel = static_cast<uint32_t>(EventPipeEventLevel::Verbose);
+
+    SString providerName;
+    uint64_t keywords = DefaultKeywords;
+    uint32_t loggingLevel = DefaultLevel;
+    SString filterData;
+
+    for (; first != last; ++first)
+    {
+        StackScratchBuffer scratchBuffer;
+
+        // Split on : <- (Provider:Flags:Level - or - Provider:Flags:Level:KeyValueArgs)
+        const char *begin = first;
+        const char *end = Find(first, last, ':'); // Provider name.
+
+        if (begin == end)
+            break; // Ignore undefined provider.
+
+        COUNT_T count = static_cast<COUNT_T>(end - begin);
+        if (count > 0)
+        {
+            SString tmpProviderName;
+            tmpProviderName.SetANSI(begin, count);
+            tmpProviderName.ConvertToUnicode(providerName);
+        }
+
+        if (first == last)
+            break; // There is nothing after the separator ':'
+        ++first;   // Move on to the next string.
+
+        begin = first;
+        end = Find(first, last, ':'); // Keyword.
+
+        if (begin != end)
+        {
+            // There is something to parse.
+            count = static_cast<COUNT_T>(end - begin);
+            if (count > 0)
+            {
+                SString value;
+                value.SetANSI(begin, count);
+                keywords = static_cast<uint64_t>(strtoull(value.GetANSI(scratchBuffer), nullptr, 0));
+            }
+        }
+
+        if (first == last)
+            break; // There is nothing after the separator ':'
+        ++first;   // Move on to the next string.
+
+        begin = first;
+        end = Find(first, last, ':'); // Logging level.
+
+        if (begin != end)
+        {
+            count = static_cast<COUNT_T>(end - begin);
+            if (count > 0)
+            {
+                SString value;
+                value.SetANSI(begin, count);
+                loggingLevel = Clamp(
+                    static_cast<uint32_t>(strtoul(value.GetANSI(scratchBuffer), nullptr, 0)),
+                    static_cast<uint32_t>(EventPipeEventLevel::LogAlways),
+                    static_cast<uint32_t>(EventPipeEventLevel::Verbose));
+            }
+        }
+
+        if (first == last)
+            break; // There is nothing after the separator ':'
+        ++first;   // Move on to the next string.
+
+        count = static_cast<COUNT_T>(last - first);
+        if (count > 0)
+        {
+            SString tmpProviderName;
+            tmpProviderName.SetANSI(first, count);
+            tmpProviderName.ConvertToUnicode(filterData);
+        }
+
+        break;
+    }
+
+    // TODO: Move to a different function?
+    if (providerName.GetCount() > 0)
+    {
+        NewHolder<EventPipeProviderConfiguration> hEventPipeProviderConfiguration = new (nothrow) EventPipeProviderConfiguration(
+            providerName.GetUnicode(), // TODO: Make sure we do not end up with a dangling reference.
+            keywords,
+            loggingLevel,
+            filterData.GetCount() > 0 ? filterData.GetUnicode() : nullptr);
+        if (hEventPipeProviderConfiguration.IsNull())
+            return;
+
+        NewHolder<SListElem<EventPipeProviderConfiguration *>> hSListElem = new (nothrow) SListElem<EventPipeProviderConfiguration *>(
+            hEventPipeProviderConfiguration.Extract());
+        if (hSListElem.IsNull())
+            return;
+        providers.InsertTail(hSListElem.Extract());
+    }
+}
+
+void ProvidersParser(const char *first, const char *last, Providers &providers)
+{
+    // Providers:       "Provider[,Provider]"
+
+    for (; first != last; ++first)
+    {
+        const char *begin = first;
+        const char *end = Find(first, last, ',');
+
+        // TODO: Parse provider.
+        ProviderParser(begin, end, providers);
+        if (end == last)
+            break;
+    }
+}
+
+void ConfigurationParser(
+    const char *first,
+    const char *last,
+    SString &strOutputPath,
+    unsigned int &circularBufferSizeInMB,
+    Providers &providers,
+    UINT64 &multiFileTraceLengthInSeconds)
+{
+    // Matching Config file keys in EventPipeController.cs
+    SString Providers;
+    Providers.SetANSI("Providers");
+    SString CircularMB;
+    CircularMB.SetANSI("CircularMB");
+    SString OutputPath;
+    OutputPath.SetANSI("OutputPath");
+    SString ProcessID;
+    ProcessID.SetANSI("ProcessID");
+    SString MultiFileSec;
+    MultiFileSec.SetANSI("MultiFileSec");
+
+    // TODO: Set defaults?
+    const unsigned int DefaultCircularBufferMB = 1024; // 1 GB // TODO: Do we need this much as default?
+    circularBufferSizeInMB = DefaultCircularBufferMB;
+
+    const char *begin;
+    const char *end;
+    SString key;
+    SString value;
+    for (; first != last; ++first)
+    {
+        begin = first;
+        end = Find(first, last, '=');
+        key.SetANSI(reinterpret_cast<const ANSI *>(begin), static_cast<COUNT_T>(end - begin));
+        if (end == last)
+            break; // Only found a key (no value).
+
+        if (first == last)
+            break; // There is nothing after the separator '='
+        ++first;   // Move on to the next string.
+
+        begin = first;
+        end = Find(first, last, '\n');
+        value.SetANSI(reinterpret_cast<const ANSI *>(begin), static_cast<COUNT_T>(end - begin));
+        if (value.GetCount() > 0 && value[value.GetCount() - 1] == '\r')
+            value.Truncate(value.End() - 1);
+
+        if (key.GetCount() > 0 && value.GetCount() > 0)
+        {
+            // TODO: Maybe trim white spaces, for an user friendlier experience?
+            // TODO: Case insensitive comparison.
+
+            StackScratchBuffer scratchBuffer;
+            if (key.Compare(Providers) == 0)
+            {
+                // TODO: Parse into an array of providers?
+                ProvidersParser(
+                    reinterpret_cast<const char *>(value.GetANSI(scratchBuffer)),
+                    reinterpret_cast<const char *>(value.GetANSI(scratchBuffer)) + value.GetCount(),
+                    providers);
+            }
+            else if (key.Compare(CircularMB) == 0)
+            {
+                circularBufferSizeInMB = static_cast<uint32_t>(strtoul(value.GetANSI(scratchBuffer), nullptr, 0));
+            }
+            else if (key.Compare(OutputPath) == 0)
+            {
+                // TODO: Generate output file name (This is just the "Directory").
+                //  Expected file name should be: "<AppName>.<Pid>.netperf"
+                strOutputPath = value; // TODO: Expected type is LPCWSTR.
+            }
+            else if (key.Compare(ProcessID) == 0)
+            {
+                // TODO: Add error handling (overflow?).
+                const uint32_t processId = static_cast<uint32_t>(strtoul(value.GetANSI(scratchBuffer), nullptr, 0));
+                const DWORD pid = ProcessDescriptor::FromCurrentProcess().m_Pid;
+
+                // TODO: If set, bail out early if the specified process does not match the current process.
+                //  Do we need this anymore?
+            }
+            else if (key.Compare(MultiFileSec) == 0)
+            {
+                // TODO: Add error handling (overflow?).
+                multiFileTraceLengthInSeconds = static_cast<UINT64>(strtoull(value.GetANSI(scratchBuffer), nullptr, 0));
+            }
+        }
+
+        if (end == last)
+            break; // Already reached EOL.
+    }
+
+    // TODO: Clamp values where applicable?
+}
+
+//! TODO: Temp func.
+static uint64_t EventPipeEnableDispatcher(const char *string, uint32_t nBytes)
+{
+    CONTRACTL
+    {
+        THROWS;
+        GC_TRIGGERS;
+        MODE_ANY;
+        PRECONDITION(string != nullptr);
+    }
+    CONTRACTL_END;
+
+    // TODO: Parse and get the following data:
+    SString strOutputPath;
+    unsigned int circularBufferSizeInMB = 0;  // What should be the default minimum?
+    UINT64 multiFileTraceLengthInSeconds = 0; // What should be the default minimum?
+    Providers providers;
+
+    ConfigurationParser(
+        string,
+        string + nBytes,
+        strOutputPath,
+        circularBufferSizeInMB,
+        providers,
+        multiFileTraceLengthInSeconds);
+
+    uint32_t nElements = 0;
+    for (auto pElem = providers.GetHead(); pElem != nullptr; pElem = providers.GetNext(pElem))
+        ++nElements;
+
+    if (nElements == 0)
+        return (EventPipeSessionID) nullptr;
+
+    NewArrayHolder<EventPipeProviderConfiguration> hRundownProviders = new (nothrow) EventPipeProviderConfiguration[nElements];
+    if (hRundownProviders.IsNull())
+        return (EventPipeSessionID) nullptr;
+
+    uint32_t i = 0;
+    for (auto pElem = providers.GetHead(); pElem != nullptr; pElem = providers.GetNext(pElem))
+        hRundownProviders.GetValue()[i++] = *pElem->GetValue();
+
+    const uint32_t profilerSamplingRateInNanoseconds = 1000000; // TODO: Read from user input.
+    SampleProfiler::SetSamplingRate(profilerSamplingRateInNanoseconds);
+    auto sessionId = EventPipe::Enable(
+        strOutputPath.GetUnicode(),     // outputFile
+        circularBufferSizeInMB,         // circularBufferSizeInMB
+        hRundownProviders.Extract(),    // pProviders
+        nElements,                      // numProviders
+        multiFileTraceLengthInSeconds); // multiFileTraceLengthInSeconds
+
+    // Clear the providers
+    auto pIterElement = providers.GetHead();
+    while (pIterElement != nullptr)
+    {
+        auto pCurrentElement = pIterElement;
+        pIterElement = providers.GetNext(pIterElement);
+
+        auto pEventPipeProviderConfiguration = pCurrentElement->GetValue();
+        delete pEventPipeProviderConfiguration;
+        delete pCurrentElement;
+    }
+
+    return sessionId;
+}
+
+static uint64_t EventPipeDisableDispatcher(const char *buffer, uint32_t nBytes)
+{
+    CONTRACTL
+    {
+        THROWS;
+        GC_TRIGGERS;
+        MODE_ANY;
+        PRECONDITION(buffer != nullptr);
+    }
+    CONTRACTL_END;
+
+    if (nBytes != sizeof(uint64_t))
+        return 0;
+
+    // TODO:
+    const EventPipeSessionID sessionId = *(reinterpret_cast<const uint64_t *>(buffer));
+    EventPipe::Disable(sessionId);
+    return nBytes;
+}
+
+static DWORD WINAPI EventPipeMainThread(LPVOID lpThreadParameter)
+{
+    const ProcessDescriptor pd = ProcessDescriptor::FromCurrentProcess();
+    DiagnosticsIpc ipc("dotnetcore-eventpipe", pd.m_Pid);
+
+    while (true)
+    {
+        bool fSuccess = ipc.Open();
+        if (!fSuccess)
+        {
+            // TODO: Add error handling.
+            return 1;
+        }
+
+        fSuccess = ipc.Accept();
+        if (!fSuccess)
+        {
+            // TODO: Add error handling.
+            ipc.Close();
+            continue;
+        }
+
+        uint32_t nNumberOfBytesRead = 0;
+        IpcHeader header;
+        fSuccess = ipc.Read(&header, sizeof(header), nNumberOfBytesRead);
+
+        if (!fSuccess || nNumberOfBytesRead != sizeof(header))
+        {
+            // TODO: Add error handling.
+            ipc.Close();
+            continue;
+        }
+        else
+        {
+            // TODO: Read within a loop.
+            const uint32_t BufferSize = 8192;
+            char buffer[BufferSize]{};
+            fSuccess = ipc.Read(buffer, sizeof(buffer), nNumberOfBytesRead);
+            if (!fSuccess)
+            {
+                // TODO: Add error handing.
+                ipc.Close();
+                continue;
+            }
+
+            switch (header.requestType)
+            {
+            case EventPipeMessageType::Enable:
+            {
+                auto response = EventPipeEnableDispatcher(buffer, nNumberOfBytesRead);
+                uint32_t nNumberOfBytesWritten = 0;
+                fSuccess = ipc.Write(&response, sizeof(response), nNumberOfBytesWritten);
+                if (nNumberOfBytesWritten != sizeof(response))
+                {
+                    // TODO: Add error handling.
+                    ipc.Close();
+                    continue;
+                }
+
+                if (!ipc.Flush())
+                {
+                    // TODO: Add error handling.
+                    ipc.Close();
+                    continue;
+                }
+            }
+            break;
+
+            case EventPipeMessageType::Disable:
+                EventPipeDisableDispatcher(buffer, nNumberOfBytesRead);
+                break;
+
+            // case EventPipeMessageType::GetSessionInfo:
+            // case EventPipeMessageType::CreateProvider:
+            // case EventPipeMessageType::DefineEvent:
+            // case EventPipeMessageType::GetProvider:
+            // case EventPipeMessageType::DeleteProvider:
+            // case EventPipeMessageType::EventActivityIdControl:
+            // case EventPipeMessageType::WriteEvent:
+            // case EventPipeMessageType::WriteEventData:
+            // case EventPipeMessageType::GetNextEvent:
+            //     break;
+
+            default:
+                // TODO: Add error handling?
+                break;
+            }
+        }
+
+        fSuccess = ipc.Close();
+        if (!fSuccess)
+        {
+            // TODO: Add error handing.
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+void EventPipeInternal::Initialize()
+{
+    DWORD dwThreadId = 0;
+    HANDLE hThread = CreateThread(
+        nullptr,             // no security attribute
+        0,                   // default stack size
+        EventPipeMainThread, // thread proc
+        nullptr,             // thread parameter
+        0,                   // not suspended
+        &dwThreadId);        // returns thread ID
+    if (hThread == nullptr)
+    {
+        // TODO: Failed to create IPC thread. What should we do here?
+    }
+    else
+    {
+        CloseHandle(hThread); // Maybe hold on to the thread to abort/cleanup atexit?
+    }
+}
+
+void EventPipeInternal::Shutdown()
+{
+    // TODO: Close IPC server thread?
+}
+
+UINT64 QCALLTYPE EventPipeInternal::Enable(
+    __in_z LPCWSTR outputFile,
+    UINT32 circularBufferSizeInMB,
+    INT64 profilerSamplingRateInNanoseconds,
+    EventPipeProviderConfiguration *pProviders,
+    INT32 numProviders,
+    UINT64 multiFileTraceLengthInSeconds)
+{
+    QCALL_CONTRACT;
+
+    UINT64 sessionID = 0;
+
+    BEGIN_QCALL;
+    SampleProfiler::SetSamplingRate((unsigned long)profilerSamplingRateInNanoseconds);
+    sessionID = EventPipe::Enable(outputFile, circularBufferSizeInMB, pProviders, numProviders, multiFileTraceLengthInSeconds);
+    END_QCALL;
+
+    return sessionID;
+}
+
+void QCALLTYPE EventPipeInternal::Disable(UINT64 sessionID)
+{
+    QCALL_CONTRACT;
+
+    BEGIN_QCALL;
+    EventPipe::Disable(sessionID);
+    END_QCALL;
+}
+
+bool QCALLTYPE EventPipeInternal::GetSessionInfo(UINT64 sessionID, EventPipeSessionInfo *pSessionInfo)
+{
+    QCALL_CONTRACT;
+
+    bool retVal = false;
+    BEGIN_QCALL;
+
+    if (pSessionInfo != NULL)
+    {
+        EventPipeSession *pSession = EventPipe::GetSession(sessionID);
+        if (pSession != NULL)
+        {
+            pSessionInfo->StartTimeAsUTCFileTime = pSession->GetStartTime();
+            pSessionInfo->StartTimeStamp.QuadPart = pSession->GetStartTimeStamp().QuadPart;
+            QueryPerformanceFrequency(&pSessionInfo->TimeStampFrequency);
+            retVal = true;
+        }
+    }
+
+    END_QCALL;
+    return retVal;
+}
+
+INT_PTR QCALLTYPE EventPipeInternal::CreateProvider(
+    __in_z LPCWSTR providerName,
+    EventPipeCallback pCallbackFunc)
+{
+    QCALL_CONTRACT;
+
+    EventPipeProvider *pProvider = NULL;
+
+    BEGIN_QCALL;
+
+    pProvider = EventPipe::CreateProvider(providerName, pCallbackFunc, NULL);
+
+    END_QCALL;
+
+    return reinterpret_cast<INT_PTR>(pProvider);
+}
+
+INT_PTR QCALLTYPE EventPipeInternal::DefineEvent(
+    INT_PTR provHandle,
+    UINT32 eventID,
+    __int64 keywords,
+    UINT32 eventVersion,
+    UINT32 level,
+    void *pMetadata,
+    UINT32 metadataLength)
+{
+    QCALL_CONTRACT;
+
+    EventPipeEvent *pEvent = NULL;
+
+    BEGIN_QCALL;
+
+    _ASSERTE(provHandle != NULL);
+    EventPipeProvider *pProvider = reinterpret_cast<EventPipeProvider *>(provHandle);
+    pEvent = pProvider->AddEvent(eventID, keywords, eventVersion, (EventPipeEventLevel)level, (BYTE *)pMetadata, metadataLength);
+    _ASSERTE(pEvent != NULL);
+
+    END_QCALL;
+
+    return reinterpret_cast<INT_PTR>(pEvent);
+}
+
+INT_PTR QCALLTYPE EventPipeInternal::GetProvider(
+    __in_z LPCWSTR providerName)
+{
+    QCALL_CONTRACT;
+
+    EventPipeProvider *pProvider = NULL;
+
+    BEGIN_QCALL;
+
+    pProvider = EventPipe::GetProvider(providerName);
+
+    END_QCALL;
+
+    return reinterpret_cast<INT_PTR>(pProvider);
+}
+
+void QCALLTYPE EventPipeInternal::DeleteProvider(INT_PTR provHandle)
+{
+    QCALL_CONTRACT;
+    BEGIN_QCALL;
+
+    if (provHandle != NULL)
+    {
+        EventPipeProvider *pProvider = reinterpret_cast<EventPipeProvider *>(provHandle);
+        EventPipe::DeleteProvider(pProvider);
+    }
+
+    END_QCALL;
+}
+
+int QCALLTYPE EventPipeInternal::EventActivityIdControl(
+    uint32_t controlCode,
+    GUID *pActivityId)
+{
+
+    QCALL_CONTRACT;
+
+    int retVal = 0;
+
+    BEGIN_QCALL;
+
+    Thread *pThread = GetThread();
+    if (pThread == NULL || pActivityId == NULL)
+    {
+        retVal = 1;
+    }
+    else
+    {
+        ActivityControlCode activityControlCode = (ActivityControlCode)controlCode;
+        GUID currentActivityId;
+        switch (activityControlCode)
+        {
+        case ActivityControlCode::EVENT_ACTIVITY_CONTROL_GET_ID:
+
+            *pActivityId = *pThread->GetActivityId();
+            break;
+
+        case ActivityControlCode::EVENT_ACTIVITY_CONTROL_SET_ID:
+
+            pThread->SetActivityId(pActivityId);
+            break;
+
+        case ActivityControlCode::EVENT_ACTIVITY_CONTROL_CREATE_ID:
+
+            CoCreateGuid(pActivityId);
+            break;
+
+        case ActivityControlCode::EVENT_ACTIVITY_CONTROL_GET_SET_ID:
+
+            currentActivityId = *pThread->GetActivityId();
+            pThread->SetActivityId(pActivityId);
+            *pActivityId = currentActivityId;
+            break;
+
+        case ActivityControlCode::EVENT_ACTIVITY_CONTROL_CREATE_SET_ID:
+
+            *pActivityId = *pThread->GetActivityId();
+            CoCreateGuid(&currentActivityId);
+            pThread->SetActivityId(&currentActivityId);
+            break;
+
+        default:
+            retVal = 1;
+        }
+    }
+
+    END_QCALL;
+    return retVal;
+}
+
+void QCALLTYPE EventPipeInternal::WriteEvent(
+    INT_PTR eventHandle,
+    UINT32 eventID,
+    void *pData,
+    UINT32 length,
+    LPCGUID pActivityId,
+    LPCGUID pRelatedActivityId)
+{
+    QCALL_CONTRACT;
+    BEGIN_QCALL;
+
+    _ASSERTE(eventHandle != NULL);
+    EventPipeEvent *pEvent = reinterpret_cast<EventPipeEvent *>(eventHandle);
+    EventPipe::WriteEvent(*pEvent, (BYTE *)pData, length, pActivityId, pRelatedActivityId);
+
+    END_QCALL;
+}
+
+void QCALLTYPE EventPipeInternal::WriteEventData(
+    INT_PTR eventHandle,
+    UINT32 eventID,
+    EventData *pEventData,
+    UINT32 eventDataCount,
+    LPCGUID pActivityId,
+    LPCGUID pRelatedActivityId)
+{
+    QCALL_CONTRACT;
+    BEGIN_QCALL;
+
+    _ASSERTE(eventHandle != NULL);
+    EventPipeEvent *pEvent = reinterpret_cast<EventPipeEvent *>(eventHandle);
+    EventPipe::WriteEvent(*pEvent, pEventData, eventDataCount, pActivityId, pRelatedActivityId);
+
+    END_QCALL;
+}
+
+bool QCALLTYPE EventPipeInternal::GetNextEvent(
+    EventPipeEventInstanceData *pInstance)
+{
+    QCALL_CONTRACT;
+
+    EventPipeEventInstance *pNextInstance = NULL;
+    BEGIN_QCALL;
+
+    _ASSERTE(pInstance != NULL);
+
+    pNextInstance = EventPipe::GetNextEvent();
+    if (pNextInstance)
+    {
+        pInstance->ProviderID = pNextInstance->GetEvent()->GetProvider();
+        pInstance->EventID = pNextInstance->GetEvent()->GetEventID();
+        pInstance->ThreadID = pNextInstance->GetThreadId();
+        pInstance->TimeStamp.QuadPart = pNextInstance->GetTimeStamp()->QuadPart;
+        pInstance->ActivityId = *pNextInstance->GetActivityId();
+        pInstance->RelatedActivityId = *pNextInstance->GetRelatedActivityId();
+        pInstance->Payload = pNextInstance->GetData();
+        pInstance->PayloadLength = pNextInstance->GetDataLength();
+    }
+
+    END_QCALL;
+    return pNextInstance != NULL;
+}
+
+#endif // FEATURE_PERFTRACING

--- a/src/vm/eventpipeinternal.h
+++ b/src/vm/eventpipeinternal.h
@@ -1,0 +1,140 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef __EVENTPIPEINTERNAL_H__
+#define __EVENTPIPEINTERNAL_H__
+
+#ifdef FEATURE_PERFTRACING
+
+//! TODO: Temp class.
+enum class EventPipeMessageType : uint32_t
+{
+    Enable = 0,
+    Disable,
+
+    // TODO: Define what else is available on the out-of-proc interface?
+    // GetSessionInfo,
+    // CreateProvider,
+    // DefineEvent,
+    // GetProvider,
+    // DeleteProvider,
+    // EventActivityIdControl,
+    // WriteEvent,
+    // WriteEventData,
+    // GetNextEvent,
+
+    // Add new events before this line.
+    TotalNumberOfEvents,
+};
+
+//! TODO: Temp class.
+struct IpcHeader
+{
+    uint32_t pid;
+    EventPipeMessageType requestType;
+};
+
+class EventPipeInternal
+{
+private:
+    enum class ActivityControlCode
+    {
+        EVENT_ACTIVITY_CONTROL_GET_ID = 1,
+        EVENT_ACTIVITY_CONTROL_SET_ID = 2,
+        EVENT_ACTIVITY_CONTROL_CREATE_ID = 3,
+        EVENT_ACTIVITY_CONTROL_GET_SET_ID = 4,
+        EVENT_ACTIVITY_CONTROL_CREATE_SET_ID = 5
+    };
+
+    struct EventPipeEventInstanceData
+    {
+        void *ProviderID;
+        unsigned int EventID;
+        unsigned int ThreadID;
+        LARGE_INTEGER TimeStamp;
+        GUID ActivityId;
+        GUID RelatedActivityId;
+        const BYTE *Payload;
+        unsigned int PayloadLength;
+    };
+
+    struct EventPipeSessionInfo
+    {
+        FILETIME StartTimeAsUTCFileTime;
+        LARGE_INTEGER StartTimeStamp;
+        LARGE_INTEGER TimeStampFrequency;
+    };
+
+public:
+    //! Initialize the event pipe (Creates the EventPipe IPC server).
+    static void Initialize();
+
+    //! Shutdown the event pipe.
+    // TODO: Shutdown the EventPipe IPC server.
+    static void Shutdown();
+
+    //!
+    //! Sets the sampling rate and enables the event pipe for the specified configuration.
+    //!
+    static UINT64 QCALLTYPE Enable(
+        __in_z LPCWSTR outputFile,
+        UINT32 circularBufferSizeInMB,
+        INT64 profilerSamplingRateInNanoseconds,
+        EventPipeProviderConfiguration *pProviders,
+        INT32 numProviders,
+        UINT64 multiFileTraceLengthInSeconds);
+
+    //! TODO: Add a ListActiveSessions to get the live SessionID in order to Disable?
+
+    //!
+    //! Disables the specified session Id.
+    //!
+    static void QCALLTYPE Disable(UINT64 sessionID);
+
+    static bool QCALLTYPE GetSessionInfo(UINT64 sessionID, EventPipeSessionInfo *pSessionInfo);
+
+    static INT_PTR QCALLTYPE CreateProvider(
+        __in_z LPCWSTR providerName,
+        EventPipeCallback pCallbackFunc);
+
+    static INT_PTR QCALLTYPE DefineEvent(
+        INT_PTR provHandle,
+        UINT32 eventID,
+        __int64 keywords,
+        UINT32 eventVersion,
+        UINT32 level,
+        void *pMetadata,
+        UINT32 metadataLength);
+
+    static INT_PTR QCALLTYPE GetProvider(
+        __in_z LPCWSTR providerName);
+
+    static void QCALLTYPE DeleteProvider(
+        INT_PTR provHandle);
+
+    static int QCALLTYPE EventActivityIdControl(
+        uint32_t controlCode,
+        GUID *pActivityId);
+
+    static void QCALLTYPE WriteEvent(
+        INT_PTR eventHandle,
+        UINT32 eventID,
+        void *pData,
+        UINT32 length,
+        LPCGUID pActivityId, LPCGUID pRelatedActivityId);
+
+    static void QCALLTYPE WriteEventData(
+        INT_PTR eventHandle,
+        UINT32 eventID,
+        EventData *pEventData,
+        UINT32 eventDataCount,
+        LPCGUID pActivityId, LPCGUID pRelatedActivityId);
+
+    static bool QCALLTYPE GetNextEvent(
+        EventPipeEventInstanceData *pInstance);
+};
+
+#endif // FEATURE_PERFTRACING
+
+#endif // __EVENTPIPEINTERNAL_H__

--- a/src/vm/eventpipeprovider.h
+++ b/src/vm/eventpipeprovider.h
@@ -72,7 +72,7 @@ public:
     // Create a new event.
     EventPipeEvent* AddEvent(unsigned int eventID, INT64 keywords, unsigned int eventVersion, EventPipeEventLevel level, BYTE *pMetadata = NULL, unsigned int metadataLength = 0);
 
-  private:
+private:
 
     // Create a new event, but allow needStack to be specified.
     // In general, we want stack walking to be controlled by the consumer and not the producer of events.

--- a/src/vm/mscorlib.cpp
+++ b/src/vm/mscorlib.cpp
@@ -85,10 +85,12 @@
 #if defined(FEATURE_EVENTSOURCE_XPLAT)
 #include "nativeeventsource.h"
 #include "eventpipe.h"
+#include "eventpipeinternal.h"
 #endif //defined(FEATURE_EVENTSOURCE_XPLAT)
 
 #ifdef FEATURE_PERFTRACING
 #include "eventpipe.h"
+#include "eventpipeinternal.h"
 #endif //FEATURE_PERFTRACING
 
 #endif // CROSSGEN_MSCORLIB


### PR DESCRIPTION
# What's here
- Moved `EventPipeInternal` to their own cpp/h files (This is a façade used to interface with the runtime from in-Proc and out-of-Proc, so I felt it was clear this way).
- EventPipe uses IPC (named pipe on Windows, and sockets on Linux)
- The EventPipe server gets created on `ceemain` during initialization, and it currently handles a single client at a time

# What I have tested so far
- Enabling/disabling EventPipe from out-of-proc with a "hello world" style test, and a more robust gc stress/perf test (With and without event counters).

# What's missing here?
- I have not added tests yet.
- I have not removed the `EventPipeController.cs` yet, but it will be in the final PR
- EventPipe is still a static class ("Singleton"). Enabling multiple sessions would be in a different PR.
- I have not created a proper NamedPipe/Socket server/thread shutdown yet.
- Streaming events out-of-proc (I'm looking into it, but I would like to know more on the main scenario).

# What am I looking for?
- Mainly feedback on error handling.
- What should we do if we fail to initialize the IPC? retry? If so, how many times before giving up? etc.
- I am only enabling and disabling EventPipe, but there are other functions (EventPipeInternal interface that I could add though I'm not clear on what is relevant to add here).

# What should be ignored?
- Please ignore my `build-lite.cmd` script
- Please ignore the parsing at the moment as I will be cleaning it up shortly.