### PR TITLE
JIT: In morph, only call DefinesLocal on assignments

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -15400,24 +15400,6 @@ bool GenTree::IsPartialLclFld(Compiler* comp)
             (comp->lvaTable[this->gtLclVarCommon.gtLclNum].lvExactSize != genTypeSize(gtType)));
 }
 
-//------------------------------------------------------------------------
-// DefinesLocal: Determine if this tree defines a local, and if so,
-//    provide additional info about the definition in the two out parameters.
-//
-// Arguments:
-//    comp        - The Compiler instance
-//    pLclVarTree - A required "out" argument that is set to the LclVarCommon
-//                  subtree, if this tree is indeed a local definition
-//    pIsEntire   - An optional "out" argument that is set to true if the
-//                  tree defines the entire local.
-//
-// Return Value:
-//    Returns true, and sets the out arguments accordingly, if this is
-//    the definition of a local.
-//
-// Notes:
-//    Will only return true for GT_ASG nodes.
-
 bool GenTree::DefinesLocal(Compiler* comp, GenTreeLclVarCommon** pLclVarTree, bool* pIsEntire)
 {
     GenTreeBlk* blkNode = nullptr;
@@ -15450,7 +15432,10 @@ bool GenTree::DefinesLocal(Compiler* comp, GenTreeLclVarCommon** pLclVarTree, bo
             blkNode = gtOp.gtOp1->AsBlk();
         }
     }
-
+    else if (OperIsBlk())
+    {
+        blkNode = this->AsBlk();
+    }
     if (blkNode != nullptr)
     {
         GenTree* destAddr = blkNode->Addr();

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -15400,6 +15400,24 @@ bool GenTree::IsPartialLclFld(Compiler* comp)
             (comp->lvaTable[this->gtLclVarCommon.gtLclNum].lvExactSize != genTypeSize(gtType)));
 }
 
+//------------------------------------------------------------------------
+// DefinesLocal: Determine if this tree defines a local, and if so,
+//    provide additional info about the definition in the two out parameters.
+//
+// Arguments:
+//    comp        - The Compiler instance
+//    pLclVarTree - A required "out" argument that is set to the LclVarCommon
+//                  subtree, if this tree is indeed a local definition
+//    pIsEntire   - An optional "out" argument that is set to true if the
+//                  tree defines the entire local.
+//
+// Return Value:
+//    Returns true, and sets the out arguments accordingly, if this is
+//    the definition of a local.
+//
+// Notes:
+//    Will only return true for GT_ASG nodes.
+
 bool GenTree::DefinesLocal(Compiler* comp, GenTreeLclVarCommon** pLclVarTree, bool* pIsEntire)
 {
     GenTreeBlk* blkNode = nullptr;
@@ -15432,10 +15450,7 @@ bool GenTree::DefinesLocal(Compiler* comp, GenTreeLclVarCommon** pLclVarTree, bo
             blkNode = gtOp.gtOp1->AsBlk();
         }
     }
-    else if (OperIsBlk())
-    {
-        blkNode = this->AsBlk();
-    }
+
     if (blkNode != nullptr)
     {
         GenTree* destAddr = blkNode->Addr();

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -15184,6 +15184,15 @@ void Compiler::fgMorphTreeDone(GenTree* tree,
     {
         /* Is this an assignment to a local variable */
         GenTreeLclVarCommon* lclVarTree = nullptr;
+
+        // The check below will miss LIR-style assignments.
+        //
+        // But we shouldn't be running local assertion prop on these,
+        // as local prop gets disabled when we run global prop.
+        assert(!tree->OperIs(GT_STORE_LCL_VAR, GT_STORE_LCL_FLD));
+
+        // DefinesLocal can return true for some BLK op uses, so
+        // check what gets assigned only when we're at an assignment.
         if (tree->OperIs(GT_ASG) && tree->DefinesLocal(this, &lclVarTree))
         {
             unsigned lclNum = lclVarTree->gtLclNum;

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -15184,7 +15184,7 @@ void Compiler::fgMorphTreeDone(GenTree* tree,
     {
         /* Is this an assignment to a local variable */
         GenTreeLclVarCommon* lclVarTree = nullptr;
-        if (tree->DefinesLocal(this, &lclVarTree))
+        if (tree->OperIs(GT_ASG) && tree->DefinesLocal(this, &lclVarTree))
         {
             unsigned lclNum = lclVarTree->gtLclNum;
             noway_assert(lclNum < lvaCount);


### PR DESCRIPTION
~~Only return true for actual assignments.~~

Only call `DefinesLocal` for `GT_ASG` nodes, so we're sure we are looking at a def, not a use.

Resolves #22747.