### PR TITLE
R2RDump - Gracefully handle inability to parse GC Info

### DIFF
--- a/src/tools/r2rdump/R2RReader.cs
+++ b/src/tools/r2rdump/R2RReader.cs
@@ -456,7 +456,15 @@ namespace R2RDump
                         unwindInfo = new Amd64.UnwindInfo(Image, unwindOffset);
                         if (isEntryPoint[runtimeFunctionId])
                         {
-                            gcInfo = new Amd64.GcInfo(Image, unwindOffset + unwindInfo.Size, Machine, R2RHeader.MajorVersion);
+                            try
+                            {
+                                gcInfo = new Amd64.GcInfo(Image, unwindOffset + unwindInfo.Size, Machine, R2RHeader.MajorVersion);
+                            }
+                            catch (IndexOutOfRangeException)
+                            {
+                                Console.WriteLine($"Warning: Could not parse GC Info for method: {method.SignatureString}");
+                            }
+                            
                         }
                     }
                     else if (Machine == Machine.I386)


### PR DESCRIPTION
The Amd64 GC Info parser is not complete in its implementation and
sometimes will index to a location beyond the size of the image.

If we fail to parse the GC info for a method, continue dumping the rest
of the image.

Emit a warning when this happens so we don't forget about this.