### PR TITLE
Improving local variable debugging experience on optimized code

### DIFF
--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -623,7 +623,6 @@ protected:
     // Returns a "siVarLoc" instance representing the place where the variable lives base on
     // varDsc and scope description.
     CodeGenInterface::siVarLoc getSiVarLoc(const LclVarDsc* varDsc, const siScope* scope) const;
-    //CodeGenInterface::siVarLoc getSiVarLoc(const LclVarDsc* varDsc, unsigned int stackLevel) const;
 
     siScope siOpenScopeList, siScopeList, *siOpenScopeLast, *siScopeLast;
 

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -23,16 +23,6 @@
 #define FOREACH_REGISTER_FILE(file) (file) = &(this->intRegState);
 #endif
 
-// Enable these macros to get psiScopes info or either VariableLiveRange info
-// reporting variables' home location on the prolog and epilog of the method.
-// Both can be used at the same time but only one will be sent to the debugger.
-#if 1
-    #define USING_SCOPE_INFO
-#endif
-#if 1
-    #define USING_VARIABLE_LIVE_RANGE
-#endif
-
 class CodeGen : public CodeGenInterface
 {
     friend class emitter;

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -549,13 +549,13 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     //-------------------------------------------------------------------------
     // scope info for the variables
 
-    void genSetScopeInfo(unsigned       which,
-                         UNATIVE_OFFSET startOffs,
-                         UNATIVE_OFFSET length,
-                         unsigned       varNum,
-                         unsigned       LVnum,
-                         bool           avail,
-                         const siVarLoc*      varLoc);
+    void genSetScopeInfo(unsigned        which,
+                         UNATIVE_OFFSET  startOffs,
+                         UNATIVE_OFFSET  length,
+                         unsigned        varNum,
+                         unsigned        LVnum,
+                         bool            avail,
+                         const siVarLoc* varLoc);
 
     void genSetScopeInfo();
     void genSetScopeInfoUsingsiScope();

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -23,6 +23,16 @@
 #define FOREACH_REGISTER_FILE(file) (file) = &(this->intRegState);
 #endif
 
+// Enable these macros to get psiScopes info or either VariableLiveRange info
+// reporting variables' home location on the prolog and epilog of the method.
+// Both can be used at the same time but only one will be sent to the debugger.
+#if 1
+    #define USING_SCOPE_INFO
+#endif
+#if 1
+    #define USING_VARIABLE_LIVE_RANGE
+#endif
+
 class CodeGen : public CodeGenInterface
 {
     friend class emitter;

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -745,7 +745,9 @@ protected:
 
     void psiEndPrologScope(psiScope* scope);
 
-    void psSetScopeOffset(psiScope* newScope, LclVarDsc* lclVarDsc1);
+    void psiSetScopeOffset(psiScope* newScope, const LclVarDsc* lclVarDsc1) const;
+
+    NATIVE_OFFSET psiGetVarStackOffset(const LclVarDsc* lclVarDsc) const;
 
 /*****************************************************************************
  *                        TrnslLocalVarInfo

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -555,7 +555,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
                          unsigned       varNum,
                          unsigned       LVnum,
                          bool           avail,
-                         siVarLoc*      varLoc);
+                         const siVarLoc*      varLoc);
 
     void genSetScopeInfo();
     void genSetScopeInfoUsingsiScope();

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -683,12 +683,18 @@ public:
 public:
     void psiBegProlog();
 
-    void psiAdjustStackLevel(unsigned size);
+    // When ESP changes, all scopes relative to ESP have to be updated.
+    void psiAdjustStackLevel(unsigned stackLevelSizeChange);
 
+    // For EBP-frames, the parameters are accessed via ESP on entry to the function,
+    // but via EBP right after a "mov ebp,esp" instruction.
     void psiMoveESPtoEBP();
 
+    // Close previous psiScope and open a new one on the location described by the registers.
     void psiMoveToReg(unsigned varNum, regNumber reg = REG_NA, regNumber otherReg = REG_NA);
 
+    // Search the open "psiScope" of the "varNum" parameter, close it and open
+    // a new one using "LclVarDsc" fields.
     void psiMoveToStack(unsigned varNum);
 
     void psiEndProlog();

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -558,6 +558,8 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
                          siVarLoc*      varLoc);
 
     void genSetScopeInfo();
+    void genSetScopeInfoUsingsiScope();
+    void genSetScopeInfoUsingVariableRanges();
 
 protected:
     /*

--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -912,6 +912,7 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
     genConsumeReg(data);
     emit->emitIns_S_R(ins, attr, data->gtRegNum, varNum, offset);
 
+    // Updating variable liveness after instruction was emitted
     genUpdateLife(tree);
     varDsc->lvRegNum = REG_STK;
 }
@@ -964,6 +965,7 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
 
             emit->emitIns_S_R(ins, attr, dataReg, varNum, /* offset */ 0);
 
+            // Updating variable liveness after instruction was emitted
             genUpdateLife(tree);
 
             varDsc->lvRegNum = REG_STK;

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -2177,8 +2177,10 @@ void CodeGen::genRegCopy(GenTree* treeNode)
 
                 genUpdateVarReg(varDsc, treeNode);
 
+#ifdef USING_VARIABLE_LIVE_RANGE
                 // Report the home change for this variable
                 compiler->siUpdateVariableLiveRange(varDsc);
+#endif
 
                 // The new location is going live
                 genUpdateRegLife(varDsc, /*isBorn*/ true, /*isDying*/ false DEBUGARG(treeNode));

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -2176,9 +2176,9 @@ void CodeGen::genRegCopy(GenTree* treeNode)
                 gcInfo.gcMarkRegSetNpt(genRegMask(op1->gtRegNum));
 
                 genUpdateVarReg(varDsc, treeNode);
-                // Build the location of the variable
-                siVarLoc siVarLoc = CodeGenInterface::getSiVarLoc(varDsc, genStackLevel);
-                varDsc->UpdateRegisterHome(varDsc->lvRegNum, siVarLoc, getEmitter());
+                
+                // Report the home change for this variable
+                compiler->updateVariableLiveRange(varDsc);
 
                 // The new location is going live
                 genUpdateRegLife(varDsc, /*isBorn*/ true, /*isDying*/ false DEBUGARG(treeNode));

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -2176,7 +2176,7 @@ void CodeGen::genRegCopy(GenTree* treeNode)
                 gcInfo.gcMarkRegSetNpt(genRegMask(op1->gtRegNum));
 
                 genUpdateVarReg(varDsc, treeNode);
-                
+
                 // Report the home change for this variable
                 compiler->updateVariableLiveRange(varDsc);
 

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -2179,7 +2179,8 @@ void CodeGen::genRegCopy(GenTree* treeNode)
 
 #ifdef USING_VARIABLE_LIVE_RANGE
                 // Report the home change for this variable
-                compiler->siUpdateVariableLiveRange(varDsc);
+                VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
+                varLvKeeper->siUpdateVariableLiveRange(varDsc);
 #endif
 
                 // The new location is going live

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -2181,7 +2181,7 @@ void CodeGen::genRegCopy(GenTree* treeNode)
                 // Report the home change for this variable
                 VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
                 varLvKeeper->siUpdateVariableLiveRange(varDsc);
-#endif
+#endif // USING_VARIABLE_LIVE_RANGE
 
                 // The new location is going live
                 genUpdateRegLife(varDsc, /*isBorn*/ true, /*isDying*/ false DEBUGARG(treeNode));

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -2178,7 +2178,7 @@ void CodeGen::genRegCopy(GenTree* treeNode)
                 genUpdateVarReg(varDsc, treeNode);
 
                 // Report the home change for this variable
-                compiler->updateVariableLiveRange(varDsc);
+                compiler->siUpdateVariableLiveRange(varDsc);
 
                 // The new location is going live
                 genUpdateRegLife(varDsc, /*isBorn*/ true, /*isDying*/ false DEBUGARG(treeNode));

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -1305,6 +1305,7 @@ void CodeGen::genMultiRegCallStoreToLocal(GenTree* treeNode)
             offset += genTypeSize(type);
         }
 
+        // Updating variable liveness after instruction was emitted
         genUpdateLife(treeNode);
         varDsc->lvRegNum = REG_STK;
     }

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -712,7 +712,7 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
 #ifdef USING_VARIABLE_LIVE_RANGE
         VariableLiveKeeper* varLiveKeeper = getVariableLiveKeeper();
         varLiveKeeper->siEndVariableLiveRange(varNum);
-#endif
+#endif // USING_VARIABLE_LIVE_RANGE
     }
 
     VarSetOps::Iter bornIter(this, bornSet);
@@ -754,7 +754,7 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
 #ifdef USING_VARIABLE_LIVE_RANGE
         VariableLiveKeeper* varLiveKeeper = getVariableLiveKeeper();
         varLiveKeeper->siStartVariableLiveRange(varDsc);
-#endif
+#endif // USING_VARIABLE_LIVE_RANGE
     }
 
     codeGen->siUpdate();
@@ -2314,8 +2314,8 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
         VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
         varLiveKeeper->dumpLvaVariableLiveRanges();
     }
-#endif
-#endif
+#endif // DEBUG
+#endif // USING_VARIABLE_LIVE_RANGE
 
 #ifdef LATE_DISASM
     unsigned finalHotCodeSize;

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2311,7 +2311,7 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
         printf("\n\n\n////////////////////////////////////////\n");
         printf("////////////////////////////////////////\n\n\n");
         printf("PRINTING REGISTER LIVE RANGES:\n");
-        for (varNum = 0, varDsc = compiler->lvaTable; varNum < compiler->lvaCount; varNum++, varDsc++)
+        for (varNum = 0, varDsc = compiler->lvaTable; varNum < compiler->info.compLocalsCount; varNum++, varDsc++)
         {
             printf("IL Var Num %d:\n", compiler->compMap2ILvarNum(varNum));
             varDsc->dumpAllRegisterLiveRangesForBlock(getEmitter(), this);

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -10608,7 +10608,7 @@ void CodeGen::genSetScopeInfo()
     LclVarDsc*   varDsc;
     unsigned int liveRangeIndex = 0;
 
-    for (varDsc = compiler->lvaTable, varNum = 0; varNum < compiler->lvaCount; varNum++, varDsc++)
+    for (varDsc = compiler->lvaTable, varNum = 0; varNum < compiler->info.compLocalsCount; varNum++, varDsc++)
     {
         LiveRangeList* liveRanges = varDsc->getLiveRanges();
 

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -10818,7 +10818,7 @@ const char* CodeGen::siStackVarName(size_t offs, size_t size, unsigned reg, unsi
 
     for (unsigned i = 0; i < genTrnslLocalVarCount; i++)
     {
-        if ((genTrnslLocalVarInfo[i].tlviVarLoc.vlIsOnStk((regNumber)reg, stkOffs)) &&
+        if ((genTrnslLocalVarInfo[i].tlviVarLoc.vlIsOnStack((regNumber)reg, stkOffs)) &&
             (genTrnslLocalVarInfo[i].tlviAvailable == true) && (genTrnslLocalVarInfo[i].tlviStartPC <= offs + size) &&
             (genTrnslLocalVarInfo[i].tlviStartPC + genTrnslLocalVarInfo[i].tlviLength > offs))
         {

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -710,7 +710,8 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
             JITDUMP("\t\t\t\t\t\t\tV%02u becoming dead\n", varNum);
         }
 #ifdef USING_VARIABLE_LIVE_RANGE
-        siEndVariableLiveRange(varDsc);
+        VariableLiveKeeper* varLiveKeeper = getVariableLiveKeeper();
+        varLiveKeeper->siEndVariableLiveRange(varNum);
 #endif
     }
 
@@ -751,7 +752,8 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
         }
 
 #ifdef USING_VARIABLE_LIVE_RANGE
-        siStartVariableLiveRange(varDsc);
+        VariableLiveKeeper* varLiveKeeper = getVariableLiveKeeper();
+        varLiveKeeper->siStartVariableLiveRange(varDsc);
 #endif
     }
 
@@ -2309,7 +2311,8 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
 #ifdef DEBUG
     if (compiler->verbose)
     {
-        compiler->dumpLvaVariableLiveRanges();
+        VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
+        varLiveKeeper->dumpLvaVariableLiveRanges();
     }
 #endif
 #endif
@@ -10514,7 +10517,8 @@ void CodeGen::genSetScopeInfo()
 #ifdef USING_SCOPE_INFO
     lvCount = siScopeCnt + psiScopeCnt;
 #else
-    lvCount = compiler->getLiveRangesCount();
+    const VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
+    lvCount = varLiveKeeper->getLiveRangesCount();
 #endif
 
 #ifdef USING_SCOPE_INFO

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2305,19 +2305,7 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
 #if DEBUG
     if (compiler->verbose)
     {
-        unsigned   varNum;
-        LclVarDsc* varDsc;
-        // Printing information of variable change lifetime
-        printf("\n\n\n////////////////////////////////////////\n");
-        printf("////////////////////////////////////////\n\n\n");
-        printf("PRINTING REGISTER LIVE RANGES:\n");
-        for (varNum = 0, varDsc = compiler->lvaTable; varNum < compiler->info.compLocalsCount; varNum++, varDsc++)
-        {
-            printf("IL Var Num %d:\n", compiler->compMap2ILvarNum(varNum));
-            varDsc->dumpAllRegisterLiveRangesForBlock(getEmitter(), this);
-        }
-        printf("\n\n\n////////////////////////////////////////\n");
-        printf("////////////////////////////////////////\n\n\n");
+        compiler->dumpLvaVariableLiveRanges();
     }
 #endif
 

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -628,7 +628,7 @@ regMaskTP Compiler::compHelperCallKillSet(CorInfoHelpFunc helper)
 // Assumptions:
 //    The set of live variables reflects the result of only emitted code, it should not be considering the becoming
 //    live/dead of instructions that has not been emitted yet. This is used to ensure [) "VariableLiveRange"
-//    intervals when calling "startVariableLiveRange" and "endVariableLiveRange".
+//    intervals when calling "siStartVariableLiveRange" and "siEndVariableLiveRange".
 //
 // Notes:
 //    If "ForCodeGen" is false, only "compCurLife" set (and no mask) will be setted.
@@ -710,7 +710,7 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
             JITDUMP("\t\t\t\t\t\t\tV%02u becoming dead\n", varNum);
         }
 
-        endVariableLiveRange(varDsc);
+        siEndVariableLiveRange(varDsc);
     }
 
     VarSetOps::Iter bornIter(this, bornSet);
@@ -749,7 +749,7 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
             JITDUMP("\t\t\t\t\t\t\tV%02u becoming live\n", varNum);
         }
 
-        startVariableLiveRange(varDsc);
+        siStartVariableLiveRange(varDsc);
     }
 
     codeGen->siUpdate();

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2315,7 +2315,6 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
         {
             printf("IL Var Num %d:\n", compiler->compMap2ILvarNum(varNum));
             varDsc->dumpAllRegisterLiveRangesForBlock(getEmitter(), this);
-            varDsc->destructRegisterLiveRanges();
         }
         printf("\n\n\n////////////////////////////////////////\n");
         printf("////////////////////////////////////////\n\n\n");

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2302,24 +2302,25 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
 
     genSetScopeInfo();
 
-
+#if DEBUG
     if (compiler->verbose)
     {
         unsigned   varNum;
         LclVarDsc* varDsc;
         // Printing information of variable change lifetime
-        JITDUMP("\n\n\n////////////////////////////////////////\n");
-        JITDUMP("////////////////////////////////////////\n\n\n");
-        JITDUMP("PRINTING REGISTER LIVE RANGES:\n");
+        printf("\n\n\n////////////////////////////////////////\n");
+        printf("////////////////////////////////////////\n\n\n");
+        printf("PRINTING REGISTER LIVE RANGES:\n");
         for (varNum = 0, varDsc = compiler->lvaTable; varNum < compiler->lvaCount; varNum++, varDsc++)
         {
-            JITDUMP("IL Var Num %d:\n", compiler->compMap2ILvarNum(varNum));
+            printf("IL Var Num %d:\n", compiler->compMap2ILvarNum(varNum));
             varDsc->dumpAllRegisterLiveRangesForBlock(getEmitter(), this);
             varDsc->destructRegisterLiveRanges();
         }
-        JITDUMP("\n\n\n////////////////////////////////////////\n");
-        JITDUMP("////////////////////////////////////////\n\n\n");
+        printf("\n\n\n////////////////////////////////////////\n");
+        printf("////////////////////////////////////////\n\n\n");
     }
+#endif
     
 #ifdef LATE_DISASM
     unsigned finalHotCodeSize;

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -10642,8 +10642,8 @@ void CodeGen::genSetScopeInfoUsingVariableRanges()
             for (LiveRangeListIterator itLiveRanges = liveRanges->begin(); itLiveRanges != liveRanges->end();
                  itLiveRanges++, liveRangeIndex++)
             {
-                UNATIVE_OFFSET startOffs = itLiveRanges->startEmitLocation.CodeOffset(getEmitter());
-                UNATIVE_OFFSET endOffs   = itLiveRanges->endEmitLocation.CodeOffset(getEmitter());
+                UNATIVE_OFFSET startOffs = itLiveRanges->m_StartEmitLocation.CodeOffset(getEmitter());
+                UNATIVE_OFFSET endOffs   = itLiveRanges->m_EndEmitLocation.CodeOffset(getEmitter());
 
                 if (varDsc->lvIsParam && startOffs == endOffs)
                 {
@@ -10656,7 +10656,7 @@ void CodeGen::genSetScopeInfoUsingVariableRanges()
 
                 genSetScopeInfo(liveRangeIndex, startOffs, endOffs - startOffs, varNum,
                                 varNum /* I dont know what is the which in eeGetLvInfo */, true,
-                                &itLiveRanges->varLocation);
+                                &itLiveRanges->m_VarLocation);
             }
         }
     }

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -10518,7 +10518,7 @@ void CodeGen::genSetScopeInfo()
     lvCount = siScopeCnt + psiScopeCnt;
 #else
     const VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
-    lvCount = varLiveKeeper->getLiveRangesCount();
+    lvCount                                 = varLiveKeeper->getLiveRangesCount();
 #endif
 
 #ifdef USING_SCOPE_INFO
@@ -10678,13 +10678,13 @@ void CodeGen::genSetScopeInfoUsingVariableRanges()
 // Notes:
 //    Called for every scope info piece to record by the main genSetScopeInfo()
 
-void CodeGen::genSetScopeInfo(unsigned       which,
-                              UNATIVE_OFFSET startOffs,
-                              UNATIVE_OFFSET length,
-                              unsigned       varNum,
-                              unsigned       LVnum,
-                              bool           avail,
-                              const siVarLoc*      varLoc)
+void CodeGen::genSetScopeInfo(unsigned        which,
+                              UNATIVE_OFFSET  startOffs,
+                              UNATIVE_OFFSET  length,
+                              unsigned        varNum,
+                              unsigned        LVnum,
+                              bool            avail,
+                              const siVarLoc* varLoc)
 {
     // We need to do some mapping while reporting back these variables.
 
@@ -10731,7 +10731,7 @@ void CodeGen::genSetScopeInfo(unsigned       which,
 
         newVarLoc.vlType                   = VLT_FIXED_VA;
         newVarLoc.vlFixedVarArg.vlfvOffset = offset;
-        
+
         varLoc = &newVarLoc;
     }
 

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -619,14 +619,14 @@ regMaskTP Compiler::compHelperCallKillSet(CorInfoHelpFunc helper)
 }
 
 //------------------------------------------------------------------------
-// compChangeLife: Update the GC's masks, register's masks and reports change on variable's homes given a set of 
+// compChangeLife: Update the GC's masks, register's masks and reports change on variable's homes given a set of
 //    current live variables.
 //
 // Arguments:
 //    newLife - the set of variables that are alive.
 //
 // Assumptions:
-//    The set of live variables reflects the result of only emitted code, it should not be considering the becoming 
+//    The set of live variables reflects the result of only emitted code, it should not be considering the becoming
 //    live/dead of instructions that has not been emitted yet. This is used to ensure [) "VariableLiveRange"
 //    intervals when calling "startVariableLiveRange" and "endVariableLiveRange".
 //
@@ -700,7 +700,7 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
             {
                 codeGen->gcInfo.gcRegByrefSetCur &= ~regMask;
             }
-            
+
             codeGen->genUpdateRegLife(varDsc, false /*isBorn*/, true /*isDying*/ DEBUGARG(nullptr));
         }
         // This isn't in a register, so update the gcVarPtrSetCur.
@@ -748,7 +748,7 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
             VarSetOps::AddElemD(this, codeGen->gcInfo.gcVarPtrSetCur, bornVarIndex);
             JITDUMP("\t\t\t\t\t\t\tV%02u becoming live\n", varNum);
         }
-        
+
         startVariableLiveRange(varDsc);
     }
 
@@ -2320,7 +2320,7 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
         printf("////////////////////////////////////////\n\n\n");
     }
 #endif
-    
+
 #ifdef LATE_DISASM
     unsigned finalHotCodeSize;
     unsigned finalColdCodeSize;
@@ -10525,11 +10525,10 @@ void CodeGen::genSetScopeInfo()
         return;
     }
 
-    //noway_assert(compiler->opts.compScopeInfo && (compiler->info.compVarScopesCount > 0));
-    //noway_assert(psiOpenScopeList.scNext == nullptr);
+    // noway_assert(compiler->opts.compScopeInfo && (compiler->info.compVarScopesCount > 0));
+    // noway_assert(psiOpenScopeList.scNext == nullptr);
 
-
-    //unsigned scopeCnt = siScopeCnt + psiScopeCnt;
+    // unsigned scopeCnt = siScopeCnt + psiScopeCnt;
 
     compiler->eeSetLVcount(amountLiveRanges);
 
@@ -10606,16 +10605,17 @@ void CodeGen::genSetScopeInfo()
     */
 
     unsigned int varNum;
-    LclVarDsc *varDsc;
+    LclVarDsc*   varDsc;
     unsigned int liveRangeIndex = 0;
 
     for (varDsc = compiler->lvaTable, varNum = 0; varNum < compiler->lvaCount; varNum++, varDsc++)
     {
         LiveRangeList* liveRanges = varDsc->getLiveRanges();
-        
+
         if (compiler->compMap2ILvarNum(varNum) != (unsigned int)ICorDebugInfo::UNKNOWN_ILNUM)
         {
-            for (LiveRangeListIterator itLiveRanges = liveRanges->begin(); itLiveRanges != liveRanges->end(); itLiveRanges++, liveRangeIndex++)
+            for (LiveRangeListIterator itLiveRanges = liveRanges->begin(); itLiveRanges != liveRanges->end();
+                 itLiveRanges++, liveRangeIndex++)
             {
                 UNATIVE_OFFSET startOffs = itLiveRanges->startEmitLocation.CodeOffset(getEmitter());
                 UNATIVE_OFFSET endOffs   = itLiveRanges->endEmitLocation.CodeOffset(getEmitter());
@@ -10634,10 +10634,11 @@ void CodeGen::genSetScopeInfo()
                     endOffs++;
                 }
 
-                genSetScopeInfo(liveRangeIndex, startOffs, endOffs - startOffs, varNum, varNum /* I dont know what is the which in eeGetLvInfo */, true, &itLiveRanges->varLocation);
+                genSetScopeInfo(liveRangeIndex, startOffs, endOffs - startOffs, varNum,
+                                varNum /* I dont know what is the which in eeGetLvInfo */, true,
+                                &itLiveRanges->varLocation);
             }
         }
-
     }
 
     compiler->eeSetLVdone();

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -10630,7 +10630,10 @@ void CodeGen::genSetScopeInfo()
                 // at the argument on entry to the method.
                 if (varDsc->lvIsParam && startOffs == endOffs)
                 {
-                    noway_assert(startOffs == 0);
+                    // If the length is zero, it means that the prolog is empty. In that case,
+                    // CodeGen::genSetScopeInfo will report the liveness of all arguments
+                    // as spanning the first instruction in the method, so that they can
+                    // at least be inspected on entry to the method.
                     endOffs++;
                 }
 

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -10525,9 +10525,9 @@ void CodeGen::genSetScopeInfo()
         return;
     }
 
-    // noway_assert(compiler->opts.compScopeInfo && (compiler->info.compVarScopesCount > 0));
-    // noway_assert(psiOpenScopeList.scNext == nullptr);
-
+    // psiScopeInfo is not used anymore for variable tracking but I can leave its assertions
+    noway_assert(compiler->opts.compScopeInfo && (compiler->info.compVarScopesCount > 0));
+    noway_assert(psiOpenScopeList.scNext == nullptr);
     // unsigned scopeCnt = siScopeCnt + psiScopeCnt;
 
     compiler->eeSetLVcount(amountLiveRanges);

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -628,7 +628,7 @@ regMaskTP Compiler::compHelperCallKillSet(CorInfoHelpFunc helper)
 // Assumptions:
 //    The set of live variables reflects the result of only emitted code, it should not be considering the becoming 
 //    live/dead of instructions that has not been emitted yet. This is used to ensure [) "VariableLiveRange"
-//    intervals when calling "startLiveRangeFromEmitter" and "endLiveRangeAtEmitter".
+//    intervals when calling "startVariableLiveRange" and "endVariableLiveRange".
 //
 // Notes:
 //    If "ForCodeGen" is false, only "compCurLife" set (and no mask) will be setted.
@@ -710,7 +710,7 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
             JITDUMP("\t\t\t\t\t\t\tV%02u becoming dead\n", varNum);
         }
 
-        varDsc->endLiveRangeAtEmitter(getEmitter()); // Track for debugging that is dead
+        endVariableLiveRange(varDsc);
     }
 
     VarSetOps::Iter bornIter(this, bornSet);
@@ -748,12 +748,8 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
             VarSetOps::AddElemD(this, codeGen->gcInfo.gcVarPtrSetCur, bornVarIndex);
             JITDUMP("\t\t\t\t\t\t\tV%02u becoming live\n", varNum);
         }
-
-        // Build siVarLoc for this borning variable given the current stackLevel
-        CodeGenInterface::siVarLoc varLocation = codeGen->getSiVarLoc(varDsc, codeGen->getCurrentStackLevel());
-
-        // Track for debugging that is live
-        varDsc->startLiveRangeFromEmitter(varDsc->lvRegNum, varLocation, getEmitter());
+        
+        startVariableLiveRange(varDsc);
     }
 
     codeGen->siUpdate();

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -618,6 +618,20 @@ regMaskTP Compiler::compHelperCallKillSet(CorInfoHelpFunc helper)
     }
 }
 
+//------------------------------------------------------------------------
+// compChangeLife: Update the GC's masks, register's masks and reports change on variable's homes given a set of 
+//    current live variables.
+//
+// Arguments:
+//    newLife - the set of variables that are alive.
+//
+// Assumptions:
+//    The set of live variables reflects the result of only emitted code, it should not be considering the becoming 
+//    live/dead of instructions that has not been emitted yet. This is used to ensure [) "VariableLiveRange"
+//    intervals when calling "startLiveRangeFromEmitter" and "endLiveRangeAtEmitter".
+//
+// Notes:
+//    If "ForCodeGen" is false, only "compCurLife" set (and no mask) will be setted.
 template <bool ForCodeGen>
 void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
 {

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -10483,16 +10483,6 @@ void CodeGen::genPopRegs(regMaskTP regs, regMaskTP byrefRegs, regMaskTP noRefReg
 #endif // FEATURE_FIXED_OUT_ARGS
 }
 
-// Enable these macros to get psiScopes info or either VariableLiveRange info
-// reporting variables' home location on the prolog and epilog of the method.
-// Both can be used at the same time but only one will be sent to the debugger.
-#if 0
-#define USING_SCOPE_INFO
-#endif
-#if 1
-#define USING_VARIABLE_LIVE_RANGE
-#endif
-
 /*****************************************************************************
  *                          genSetScopeInfo
  *

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -10516,9 +10516,9 @@ void CodeGen::genSetScopeInfo()
     }
 #endif
 
-    unsigned int amountLiveRanges = compiler->getAmountLiveRangesReported();
+    unsigned int liveRangesCount = compiler->getLiveRangesCount();
 
-    if (amountLiveRanges == 0)
+    if (liveRangesCount == 0)
     {
         compiler->eeSetLVcount(0);
         compiler->eeSetLVdone();
@@ -10530,13 +10530,13 @@ void CodeGen::genSetScopeInfo()
     noway_assert(psiOpenScopeList.scNext == nullptr);
     // unsigned scopeCnt = siScopeCnt + psiScopeCnt;
 
-    compiler->eeSetLVcount(amountLiveRanges);
+    compiler->eeSetLVcount(liveRangesCount);
 
 #ifdef DEBUG
-    genTrnslLocalVarCount = amountLiveRanges;
-    if (amountLiveRanges)
+    genTrnslLocalVarCount = liveRangesCount;
+    if (liveRangesCount)
     {
-        genTrnslLocalVarInfo = new (compiler, CMK_DebugOnly) TrnslLocalVarInfo[amountLiveRanges];
+        genTrnslLocalVarInfo = new (compiler, CMK_DebugOnly) TrnslLocalVarInfo[liveRangesCount];
     }
 #endif
 

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -31,7 +31,7 @@
 #if 1
 #define USING_SCOPE_INFO
 #endif
-#if 1
+#if 0
 #define USING_VARIABLE_LIVE_RANGE
 #endif
 

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -28,10 +28,10 @@
 // Enable these macros to get psiScopes info or either VariableLiveRange info
 // reporting variables' home location on the prolog and epilog of the method.
 // Both can be used at the same time but only one will be sent to the debugger.
-#if 1
+#if 0
 #define USING_SCOPE_INFO
 #endif
-#if 0
+#if 1
 #define USING_VARIABLE_LIVE_RANGE
 #endif
 

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -536,7 +536,9 @@ public:
     };
 
 public:
+#if DEBUG
     void dumpSiVarLoc(const siVarLoc* varLoc) const;
+#endif
     siVarLoc getSiVarLoc(const LclVarDsc* varDsc, unsigned int stackLevel) const;
 
     unsigned getCurrentStackLevel() const;

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -25,6 +25,16 @@
 #include "jitgcinfo.h"
 #include "treelifeupdater.h"
 
+// Enable these macros to get psiScopes info or either VariableLiveRange info
+// reporting variables' home location on the prolog and epilog of the method.
+// Both can be used at the same time but only one will be sent to the debugger.
+#if 1
+#define USING_SCOPE_INFO
+#endif
+#if 1
+#define USING_VARIABLE_LIVE_RANGE
+#endif
+
 // Forward reference types
 
 class CodeGenInterface;

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -523,7 +523,7 @@ public:
         // Helper functions
 
         bool vlIsInReg(regNumber reg) const;
-        bool vlIsOnStk(regNumber reg, signed offset) const;
+        bool vlIsOnStack(regNumber reg, signed offset) const;
         bool vlIsOnStack() const;
 
         void storeVariableOnRegisters(regNumber reg, regNumber otherReg);

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -516,6 +516,9 @@ public:
         bool vlIsOnStk(regNumber reg, signed offset) const;
         bool vlIsOnStack() const;
 
+        void storeVariableOnRegisters(regNumber reg, regNumber otherReg);
+        void storeVariableOnStack(regNumber stackBaseReg, NATIVE_OFFSET variableStackOffset);
+
         siVarLoc(const LclVarDsc* varDsc, regNumber baseReg, int offset, bool isFramePointerUsed);
         siVarLoc(){};
 

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -538,7 +538,7 @@ public:
 public:
     void dumpSiVarLoc(const siVarLoc* varLoc) const;
     siVarLoc getSiVarLoc(const LclVarDsc* varDsc, unsigned int stackLevel) const;
-    
+
     unsigned getCurrentStackLevel() const;
 
 protected:

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -113,6 +113,9 @@ void CodeGen::genInitialize()
     // Make sure a set is allocated for compiler->compCurLife (in the long case), so we can set it to empty without
     // allocation at the start of each basic block.
     VarSetOps::AssignNoCopy(compiler, compiler->compCurLife, VarSetOps::MakeEmpty(compiler));
+
+    // we 0 initialize the stack level
+    SetStackLevel(0);
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -724,45 +724,10 @@ void CodeGen::genCodeForBBlist()
 
 
 #ifdef DEBUG
-        bool hasDumpedHistory = false;
-#endif
-        if (compiler->verbose)
-        {
-            JITDUMP("////////////////////////////////////////\n");
-            JITDUMP("////////////////////////////////////////\n");
-            JITDUMP("Var History Dump for Block %d \n", block->bbNum);
-        }
+        compiler->dumpBlockVariableLiveRanges(block);
 
-        unsigned   varNum;
-        LclVarDsc* varDsc;
-
-        for (varNum = 0, varDsc = compiler->lvaTable; varNum < compiler->lvaCount; varNum++, varDsc++)
-        {
-            if (varDsc->hasBeenAlive())
-            {
-#ifdef DEBUG
-                hasDumpedHistory = true;
-                JITDUMP("Var %d:\n", varNum);
-                varDsc->dumpRegisterLiveRangesForBlockBeforeCodeGenerated(this);
-#endif
-                varDsc->endBlockLiveRanges();
-            }
-        }
-
-#ifdef DEBUG
-        if (!hasDumpedHistory)
-        {
-            JITDUMP("..None..\n");
-        }
         compiler->compCurBB = nullptr;
 #endif
-        if (compiler->verbose)
-        {
-            JITDUMP("////////////////////////////////////////\n");
-            JITDUMP("////////////////////////////////////////\n");
-            JITDUMP("End Generating code for Block %d \n", block->bbNum);
-        }
-
     } //------------------ END-FOR each block of the method -------------------
 
     // Nothing is live at this point and all blocks instructions has been emited

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -721,7 +721,10 @@ void CodeGen::genCodeForBBlist()
         }
 
 #ifdef DEBUG
-        compiler->dumpBlockVariableLiveRanges(block);
+        if (compiler->verbose)
+        {
+            compiler->dumpBlockVariableLiveRanges(block);
+        }
 
         compiler->compCurBB = nullptr;
 #endif

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -40,8 +40,6 @@ void CodeGen::genInitializeRegisterState()
 
     for (varNum = 0, varDsc = compiler->lvaTable; varNum < compiler->lvaCount; varNum++, varDsc++)
     {
-        varDsc->initializeRegisterLiveRanges(compiler->getAllocator());
-
         // Is this variable a parameter assigned to a register?
         if (!varDsc->lvIsParam || !varDsc->lvRegister)
         {

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -94,7 +94,7 @@ void CodeGen::genInitialize()
 #ifdef USING_VARIABLE_LIVE_RANGE
     // Initialize Structures for VariableLiveRanges
     compiler->initializeVariableLiveKeeper();
-#endif
+#endif // USING_VARIABLE_LIVE_RANGE
 
     // The current implementation of switch tables requires the first block to have a label so it
     // can generate offsets to the switch label targets.
@@ -533,7 +533,7 @@ void CodeGen::genCodeForBBlist()
             VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
             varLvKeeper->siEndAllVariableLiveRange(&compiler->compCurLife);
         }
-#endif
+#endif // USING_VARIABLE_LIVE_RANGE
 
         if (compiler->opts.compScopeInfo && (compiler->info.compVarScopesCount > 0))
         {
@@ -742,11 +742,11 @@ void CodeGen::genCodeForBBlist()
             VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
             varLiveKeeper->dumpBlockVariableLiveRanges(block);
         }
-#endif
+#endif // USING_VARIABLE_LIVE_RANGE
 
         compiler->compCurBB = nullptr;
-#endif
-    } //------------------ END-FOR each block of the method -------------------
+#endif // DEBUG
+    }  //------------------ END-FOR each block of the method -------------------
 
     // There could be variables alive at this point. For example see lvaKeepAliveAndReportThis.
     // This method would clean the GC ref
@@ -768,7 +768,7 @@ void CodeGen::genCodeForBBlist()
                compiler->compSizeEstimate);
         printf("%s\n", compiler->info.compFullName);
     }
-#endif
+#endif // DEBUG
 }
 
 /*
@@ -852,7 +852,7 @@ void CodeGen::genSpillVar(GenTree* tree)
         VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
         varLvKeeper->siUpdateVariableLiveRange(varDsc);
     }
-#endif
+#endif // USING_VARIABLE_LIVE_RANGE
 }
 
 //------------------------------------------------------------------------
@@ -1017,7 +1017,7 @@ void CodeGen::genUnspillRegIfNeeded(GenTree* tree)
                 // Report the home change for this variable
                 VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
                 varLvKeeper->siUpdateVariableLiveRange(varDsc);
-#endif
+#endif // USING_VARIABLE_LIVE_RANGE
 
 #ifdef DEBUG
                 if (VarSetOps::IsMember(compiler, gcInfo.gcVarPtrSetCur, varDsc->lvVarIndex))

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -523,11 +523,12 @@ void CodeGen::genCodeForBBlist()
         {
             isLastBlockProcessed = (block->bbNext->bbNext == nullptr);
         }
-
+#ifdef USING_VARIABLE_LIVE_RANGE
         if (compiler->opts.compDbgInfo && isLastBlockProcessed)
         {
             compiler->siEndAllVariableLiveRange(&compiler->compCurLife);
         }
+#endif
 
         if (compiler->opts.compScopeInfo && (compiler->info.compVarScopesCount > 0))
         {
@@ -730,10 +731,12 @@ void CodeGen::genCodeForBBlist()
         }
 
 #ifdef DEBUG
+#ifdef USING_VARIABLE_LIVE_RANGE
         if (compiler->verbose)
         {
             compiler->dumpBlockVariableLiveRanges(block);
         }
+#endif
 
         compiler->compCurBB = nullptr;
 #endif
@@ -833,6 +836,7 @@ void CodeGen::genSpillVar(GenTree* tree)
         varDsc->lvOtherReg = REG_STK;
     }
 
+#ifdef USING_VARIABLE_LIVE_RANGE
     if (needsSpill)
     {
         // We need this after "lvRegNum" has change because now we are sure that varDsc->lvIsInReg() is false.
@@ -841,6 +845,7 @@ void CodeGen::genSpillVar(GenTree* tree)
         // Report the home change for this variable
         compiler->siUpdateVariableLiveRange(varDsc);
     }
+#endif
 }
 
 //------------------------------------------------------------------------
@@ -1001,8 +1006,10 @@ void CodeGen::genUnspillRegIfNeeded(GenTree* tree)
             {
                 genUpdateVarReg(varDsc, tree);
 
+#ifdef USING_VARIABLE_LIVE_RANGE
                 // Report the home change for this variable
                 compiler->siUpdateVariableLiveRange(varDsc);
+#endif
 
 #ifdef DEBUG
                 if (VarSetOps::IsMember(compiler, gcInfo.gcVarPtrSetCur, varDsc->lvVarIndex))

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -177,7 +177,7 @@ void CodeGen::genCodeForBBlist()
      */
 
     BasicBlock* block;
-    int blockNum;
+    int         blockNum;
     for (blockNum = 1, block = compiler->fgFirstBB; block != nullptr; block = block->bbNext, blockNum++)
     {
 
@@ -720,7 +720,6 @@ void CodeGen::genCodeForBBlist()
                 break;
         }
 
-
 #ifdef DEBUG
         compiler->dumpBlockVariableLiveRanges(block);
 
@@ -730,7 +729,6 @@ void CodeGen::genCodeForBBlist()
 
     // Nothing is live at this point and all blocks instructions has been emited
     genUpdateLife(VarSetOps::MakeEmpty(compiler));
-
 
     /* Finalize the spill  tracking logic */
 
@@ -822,10 +820,11 @@ void CodeGen::genSpillVar(GenTree* tree)
         varDsc->lvOtherReg = REG_STK;
     }
 
-    if (needsSpill) {
+    if (needsSpill)
+    {
         // We need this after "lvRegNum" has change because now we are sure that varDsc->lvIsInReg() is false.
         // "SiVarLoc" constructor uses the "LclVarDsc" of the variable.
-        
+
         // Report the home change for this variable
         compiler->updateVariableLiveRange(varDsc);
     }

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -530,7 +530,7 @@ void CodeGen::genCodeForBBlist()
 
             if (isLastBlockProcessed)
             {
-                compiler->siEndAllVariableLiveRange(compiler->compCurLife);
+                compiler->siEndAllVariableLiveRange(&compiler->compCurLife);
 
                 if (siOpenScopeList.scNext)
                 {

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -202,6 +202,8 @@ void CodeGen::genCodeForBBlist()
 
         compiler->m_pLinearScan->recordVarLocationsAtStartOfBB(block);
 
+        // Updating variable liveness after last instruction of previous block was emitted
+        // and before first of the current block is emitted
         genUpdateLife(block->bbLiveIn);
 
         // Even if liveness didn't change, we need to update the registers containing GC references.
@@ -763,7 +765,7 @@ void CodeGen::genCodeForBBlist()
 
     } //------------------ END-FOR each block of the method -------------------
 
-    /* Nothing is live at this point */
+    // Nothing is live at this point and all blocks instructions has been emited
     genUpdateLife(VarSetOps::MakeEmpty(compiler));
 
 
@@ -1747,7 +1749,7 @@ void CodeGen::genConsumeBlockOp(GenTreeBlk* blkNode, regNumber dstReg, regNumber
 
 //-------------------------------------------------------------------------
 // genProduceReg: do liveness update for register produced by the current
-// node in codegen.
+// node in codegen once it was emitted.
 //
 // Arguments:
 //     tree   -  Gentree node
@@ -1852,6 +1854,7 @@ void CodeGen::genProduceReg(GenTree* tree)
         }
     }
 
+    // Updating variable liveness after instruction was emitted
     genUpdateLife(tree);
 
     // If we've produced a register, mark it as a pointer, as needed.

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -829,7 +829,7 @@ void CodeGen::genSpillVar(GenTree* tree)
         // "SiVarLoc" constructor uses the "LclVarDsc" of the variable.
 
         // Report the home change for this variable
-        compiler->updateVariableLiveRange(varDsc);
+        compiler->siUpdateVariableLiveRange(varDsc);
     }
 }
 
@@ -992,7 +992,7 @@ void CodeGen::genUnspillRegIfNeeded(GenTree* tree)
                 genUpdateVarReg(varDsc, tree);
 
                 // Report the home change for this variable
-                compiler->updateVariableLiveRange(varDsc);
+                compiler->siUpdateVariableLiveRange(varDsc);
 
 #ifdef DEBUG
                 if (VarSetOps::IsMember(compiler, gcInfo.gcVarPtrSetCur, varDsc->lvVarIndex))

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -91,6 +91,11 @@ void CodeGen::genInitialize()
         siInit();
     }
 
+#ifdef USING_VARIABLE_LIVE_RANGE
+    // Initialize Structures for VariableLiveRanges
+    compiler->initializeVariableLiveKeeper();
+#endif
+
     // The current implementation of switch tables requires the first block to have a label so it
     // can generate offsets to the switch label targets.
     // TODO-CQ: remove this when switches have been re-implemented to not use this.
@@ -131,7 +136,6 @@ void CodeGen::genInitialize()
 //
 void CodeGen::genCodeForBBlist()
 {
-    compiler->lastBasicBlockHasBeenEmited = false;
     unsigned savedStkLvl;
 
 #ifdef DEBUG
@@ -526,7 +530,8 @@ void CodeGen::genCodeForBBlist()
 #ifdef USING_VARIABLE_LIVE_RANGE
         if (compiler->opts.compDbgInfo && isLastBlockProcessed)
         {
-            compiler->siEndAllVariableLiveRange(&compiler->compCurLife);
+            VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
+            varLvKeeper->siEndAllVariableLiveRange(&compiler->compCurLife);
         }
 #endif
 
@@ -734,7 +739,8 @@ void CodeGen::genCodeForBBlist()
 #ifdef USING_VARIABLE_LIVE_RANGE
         if (compiler->verbose)
         {
-            compiler->dumpBlockVariableLiveRanges(block);
+            VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
+            varLiveKeeper->dumpBlockVariableLiveRanges(block);
         }
 #endif
 
@@ -843,7 +849,8 @@ void CodeGen::genSpillVar(GenTree* tree)
         // "SiVarLoc" constructor uses the "LclVarDsc" of the variable.
 
         // Report the home change for this variable
-        compiler->siUpdateVariableLiveRange(varDsc);
+        VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
+        varLvKeeper->siUpdateVariableLiveRange(varDsc);
     }
 #endif
 }
@@ -1008,7 +1015,8 @@ void CodeGen::genUnspillRegIfNeeded(GenTree* tree)
 
 #ifdef USING_VARIABLE_LIVE_RANGE
                 // Report the home change for this variable
-                compiler->siUpdateVariableLiveRange(varDsc);
+                VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
+                varLvKeeper->siUpdateVariableLiveRange(varDsc);
 #endif
 
 #ifdef DEBUG

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -862,11 +862,9 @@ void CodeGen::genSpillVar(GenTree* tree)
     if (needsSpill) {
         // We need this after "lvRegNum" has change because now we are sure that varDsc->lvIsInReg() is false.
         // "SiVarLoc" constructor uses the "LclVarDsc" of the variable.
-
-        // Build the location of the variable
-        siVarLoc siVarLoc = CodeGenInterface::getSiVarLoc(varDsc, getCurrentStackLevel());
-
-        varDsc->UpdateRegisterHome(REG_STK, siVarLoc, getEmitter());
+        
+        // Report the home change for this variable
+        compiler->updateVariableLiveRange(varDsc);
     }
 }
 
@@ -1028,9 +1026,9 @@ void CodeGen::genUnspillRegIfNeeded(GenTree* tree)
             {
                 genUpdateVarReg(varDsc, tree);
 
-                // Build the location of the variable
-                siVarLoc siVarLoc = CodeGenInterface::getSiVarLoc(varDsc, getCurrentStackLevel());
-                varDsc->UpdateRegisterHome(varDsc->lvRegNum, siVarLoc, getEmitter());
+                // Report the home change for this variable
+                compiler->updateVariableLiveRange(varDsc);
+
 #ifdef DEBUG
                 if (VarSetOps::IsMember(compiler, gcInfo.gcVarPtrSetCur, varDsc->lvVarIndex))
                 {

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -4841,9 +4841,8 @@ void CodeGen::genRegCopy(GenTree* treeNode)
 
                     genUpdateVarReg(varDsc, treeNode);
 
-                    // Build siVarLoc for this variable
-                    CodeGenInterface::siVarLoc varLocation = CodeGenInterface::getSiVarLoc(varDsc, getCurrentStackLevel());
-                    varDsc->UpdateRegisterHome(varDsc->lvRegNum, varLocation, getEmitter());
+                    // Report the home change for this variable
+                    compiler->updateVariableLiveRange(varDsc);
 
                     // The new location is going live
                     genUpdateRegLife(varDsc, /*isBorn*/ true, /*isDying*/ false DEBUGARG(treeNode));

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -4490,6 +4490,7 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
     genConsumeRegs(op1);
     getEmitter()->emitInsBinary(ins_Store(targetType), emitTypeSize(tree), tree, op1);
 
+    // Updating variable liveness after instruction was emitted
     genUpdateLife(tree);
 }
 

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -4845,7 +4845,7 @@ void CodeGen::genRegCopy(GenTree* treeNode)
                     // Report the home change for this variable
                     VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
                     varLvKeeper->siUpdateVariableLiveRange(varDsc);
-#endif
+#endif // USING_VARIABLE_LIVE_RANGE
 
                     // The new location is going live
                     genUpdateRegLife(varDsc, /*isBorn*/ true, /*isDying*/ false DEBUGARG(treeNode));

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -4843,7 +4843,8 @@ void CodeGen::genRegCopy(GenTree* treeNode)
 
 #ifdef USING_VARIABLE_LIVE_RANGE
                     // Report the home change for this variable
-                    compiler->siUpdateVariableLiveRange(varDsc);
+                    VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
+                    varLvKeeper->siUpdateVariableLiveRange(varDsc);
 #endif
 
                     // The new location is going live

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -4841,8 +4841,10 @@ void CodeGen::genRegCopy(GenTree* treeNode)
 
                     genUpdateVarReg(varDsc, treeNode);
 
+#ifdef USING_VARIABLE_LIVE_RANGE
                     // Report the home change for this variable
                     compiler->siUpdateVariableLiveRange(varDsc);
+#endif
 
                     // The new location is going live
                     genUpdateRegLife(varDsc, /*isBorn*/ true, /*isDying*/ false DEBUGARG(treeNode));

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -4842,7 +4842,7 @@ void CodeGen::genRegCopy(GenTree* treeNode)
                     genUpdateVarReg(varDsc, treeNode);
 
                     // Report the home change for this variable
-                    compiler->updateVariableLiveRange(varDsc);
+                    compiler->siUpdateVariableLiveRange(varDsc);
 
                     // The new location is going live
                     genUpdateRegLife(varDsc, /*isBorn*/ true, /*isDying*/ false DEBUGARG(treeNode));

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11152,7 +11152,10 @@ void Compiler::siStartOrCloseVariableLiveRange(const LclVarDsc* varDsc, bool isB
     // "info.compLocalsCount".
     if (varDsc->lvSlotNum < info.compLocalsCount)
     {
-        if (isBorn && !isDying)
+        // If variable a variable is inside a try/catch block, we persist it on the stack during the 
+        // whole block and alive. It can be assigned/defined many times, but the "VariableLiveRange"
+        // has to still start on a "BasicBlock" boundary
+        if (isBorn && !isDying && !varDsc->lvLiveInOutOfHndlr)
         {
             // "varDsc" is valid from this point
             siStartVariableLiveRange(varDsc);

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11154,18 +11154,8 @@ void Compiler::siStartOrCloseVariableLiveRange(const LclVarDsc* varDsc, bool isB
     {
         if (isBorn && !isDying)
         {
-            // If variable a variable is inside a try/catch block, we persist it on the stack during the
-            // whole block and alive. It can be assigned/defined many times, but the "VariableLiveRange"
-            // has to still start on a "BasicBlock" boundary
-
-            // Update:: this is not entirely true, on same cases is not alive until first use. So we
-            // need to considerate both cases.
-
-            if (!varDsc->lvLiveInOutOfHndlr || !varDsc->hasVariableLiveRangeOpen())
-            {
-                // "varDsc" is valid from this point
-                siStartVariableLiveRange(varDsc);
-            }
+            // "varDsc" is valid from this point
+            siStartVariableLiveRange(varDsc);
         }
         if (isDying && !isBorn)
         {
@@ -11294,7 +11284,7 @@ void Compiler::siEndAllVariableLiveRange(VARSET_VALARG_TP varsToClose)
     {
         unsigned         lclNum = lvaTrackedToVarNum[varIndex];
         const LclVarDsc* lclVar = &lvaTable[lclNum];
-        
+
         siEndVariableLiveRange(lclVar);
     }
 

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11470,7 +11470,7 @@ VariableLiveDescriptor::VariableLiveDescriptor(CompAllocator allocator)
     memset(variableLifeBarrier, 0, variableLifeBarrierSize);
 
     new (variableLifeBarrier, jitstd::placement_t()) LiveRangeDumper(variableLiveRanges);
-#endif
+#endif // DEBUG
 }
 
 size_t VariableLiveDescriptor::getAmountLiveRanges() const
@@ -11501,7 +11501,7 @@ void VariableLiveDescriptor::endLiveRangeAtEmitter(emitter* _emitter) const
 #if DEBUG
     // There should be VariableLiveRanges reported during this basic block
     noway_assert(hasBeenAlive());
-#endif
+#endif // DEBUG
     noway_assert(hasVariableLiveRangeOpen());
 
     // Using [close, open) ranges so as to not compute the size of the last instruction
@@ -11531,7 +11531,7 @@ void VariableLiveDescriptor::startLiveRangeFromEmitter(CodeGenInterface::siVarLo
     noway_assert(variableLifeBarrier != nullptr);
     // Restart barrier so we can print from here
     variableLifeBarrier->setDumperStartAt(variableLiveRanges->backPosition());
-#endif
+#endif // DEBUG
 }
 
 void VariableLiveDescriptor::UpdateRegisterHome(CodeGenInterface::siVarLoc varLocation, emitter* _emitter) const
@@ -11539,7 +11539,7 @@ void VariableLiveDescriptor::UpdateRegisterHome(CodeGenInterface::siVarLoc varLo
 #if DEBUG
     // There should be VariableLiveRanges reported during this basic block
     noway_assert(hasBeenAlive());
-#endif
+#endif // DEBUG
     // This variable is changing home so it has been started before during this block
     noway_assert(variableLiveRanges != nullptr && !variableLiveRanges->empty());
 
@@ -11864,5 +11864,5 @@ void VariableLiveDescriptor::dumpAllRegisterLiveRangesForBlock(emitter* _emitter
         printf("]\n");
     }
 }
-#endif
-#endif
+#endif // DEBUG
+#endif // USING_VARIABLE_LIVE_RANGE

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11247,7 +11247,11 @@ void Compiler::siUpdateVariableLiveRange(const LclVarDsc* varDsc)
     // Only the variables that exists in the IL, "this", and special arguments
     // will be reported. This are locals and arguments, and are counted in
     // "info.compLocalsCount".
-    if (varDsc->lvSlotNum < info.compLocalsCount)
+
+    // When generating the prolog (after all code for "BasicBlock"s), "recordVarLocationsAtStartOfBB",
+    // which called this function to update variable's home at each BasicBlock beginnnings,
+    // is called to restore the positions of the variables at the beginning of the first block.
+    if (varDsc->lvSlotNum < info.compLocalsCount && !lastBasicBlockHasBeenEmited)
     {
         // Build the location of the variable
         CodeGenInterface::siVarLoc siVarLoc = codeGen->getSiVarLoc(varDsc, codeGen->getCurrentStackLevel());

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11169,7 +11169,7 @@ void Compiler::startVariableLiveRange(const LclVarDsc* varDsc)
     CodeGenInterface::siVarLoc varLocation = codeGen->getSiVarLoc(varDsc, codeGen->getCurrentStackLevel());
 
     // "varDsc" live range is valid from this point
-    varDsc->startLiveRangeFromEmitter(varDsc->lvRegNum, varLocation, getEmitter());
+    varDsc->startLiveRangeFromEmitter(varLocation, getEmitter());
 }
 
 //------------------------------------------------------------------------
@@ -11211,5 +11211,5 @@ void Compiler::updateVariableLiveRange(const LclVarDsc* varDsc)
     CodeGenInterface::siVarLoc siVarLoc = codeGen->getSiVarLoc(varDsc, codeGen->getCurrentStackLevel());
 
     // Report the home change for this variable
-    varDsc->UpdateRegisterHome(varDsc->lvRegNum, siVarLoc, getEmitter());
+    varDsc->UpdateRegisterHome(siVarLoc, getEmitter());
 }

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11489,7 +11489,7 @@ LiveRangeListIterator VariableLiveDescriptor::getLiveRangesIterator() const
     return variableLiveRanges->begin();
 }
 
-LiveRangeList* VariableLiveDescriptor::getLiveRanges() const
+const LiveRangeList* VariableLiveDescriptor::getLiveRanges() const
 {
     return variableLiveRanges;
 }
@@ -11573,6 +11573,29 @@ CodeGenInterface::siVarLoc VariableLiveDescriptor::getLastVarLocation() const
     noway_assert(variableLiveRanges != nullptr && !variableLiveRanges->empty());
 
     return variableLiveRanges->back().varLocation;
+}
+
+//------------------------------------------------------------------------
+// getLiveRangesForVar: Return the "VariableLiveRange" that correspond to
+//  the given "varNum".
+//
+// Arguments:
+//  varNum  - the index of the variable in lvaTable, which is the same as
+//      in lvaLiveDsc.
+//
+// Return Value:
+//  A const pointer to the "LiveRangeList" containing all the "VariableLiveRange"s
+//  of the variable with index "varNum".
+//
+// Notes:
+//  "varNum" should be always a valid inde ("varnum" < "lvLiveDscCount")
+const LiveRangeList* VariableLiveKeeper::getLiveRangesForVar(unsigned int varNum) const
+{
+    // There should be at least one variable for which its liveness is tracked
+    noway_assert(0 < lvLiveDscCount);
+    noway_assert(varNum < lvLiveDscCount);
+
+    return lvaLiveDsc[varNum].getLiveRanges();
 }
 
 #ifdef DEBUG

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11104,7 +11104,7 @@ unsigned int Compiler::getAmountLiveRangesReported()
     unsigned int varNum, amountOfLiveRanges = 0;
     LclVarDsc*   varDsc = lvaTable;
 
-    for (varNum = 0, varDsc = lvaTable; varNum < lvaCount; varNum++, varDsc++)
+    for (varNum = 0, varDsc = lvaTable; varNum < info.compLocalsCount; varNum++, varDsc++)
     {
         if (compMap2ILvarNum(varNum) != (unsigned int)ICorDebugInfo::UNKNOWN_ILNUM)
         {
@@ -11137,9 +11137,10 @@ unsigned int Compiler::getAmountLiveRangesReported()
 //    or both.
 void Compiler::startOrCloseVariableLiveRange(const LclVarDsc* varDsc, bool isBorning, bool isDying)
 {
-    // Only the variables that exists in the IL will be seen by the debugger.
-    // This are locals and arguments, and are counted in "lvaCount".
-    if (varDsc->lvSlotNum < lvaCount)
+    // Only the variables that exists in the IL, "this, and special arguments 
+    // will be reported. This are locals and arguments, and are counted in
+    // "info.compLocalsCount".
+    if (varDsc->lvSlotNum < info.compLocalsCount)
     {
         if (isBorning && !isDying)
         {
@@ -11170,9 +11171,10 @@ void Compiler::startOrCloseVariableLiveRange(const LclVarDsc* varDsc, bool isBor
 //    This method should be called on every place a Variable is becoming alive.
 void Compiler::startVariableLiveRange(const LclVarDsc* varDsc)
 {
-    // Only the variables that exists in the IL will be seen by the debugger.
-    // This are locals and arguments, and are counted in "lvaCount".
-    if (varDsc->lvSlotNum < lvaCount)
+    // Only the variables that exists in the IL, "this, and special arguments 
+    // will be reported. This are locals and arguments, and are counted in
+    // "info.compLocalsCount".
+    if (varDsc->lvSlotNum < info.compLocalsCount)
     {
         // Build siVarLoc for this borning "varDsc"
         CodeGenInterface::siVarLoc varLocation = codeGen->getSiVarLoc(varDsc, codeGen->getCurrentStackLevel());
@@ -11197,9 +11199,10 @@ void Compiler::startVariableLiveRange(const LclVarDsc* varDsc)
 //    This method should be called on every place a Variable is becoming dead.
 void Compiler::endVariableLiveRange(const LclVarDsc* varDsc)
 {
-    // Only the variables that exists in the IL will be seen by the debugger.
-    // This are locals and arguments, and are counted in "lvaCount".
-    if (varDsc->lvSlotNum < lvaCount)
+    // Only the variables that exists in the IL, "this, and special arguments 
+    // will be reported. This are locals and arguments, and are counted in
+    // "info.compLocalsCount".
+    if (varDsc->lvSlotNum < info.compLocalsCount)
     {
         // "varDsc" live range is no more valid from this point
         varDsc->endLiveRangeAtEmitter(getEmitter());
@@ -11222,9 +11225,10 @@ void Compiler::endVariableLiveRange(const LclVarDsc* varDsc)
 //    This method should be called on every place a Variable is changing its home.
 void Compiler::updateVariableLiveRange(const LclVarDsc* varDsc)
 {
-    // Only the variables that exists in the IL will be seen by the debugger.
-    // This are locals and arguments, and are counted in "lvaCount".
-    if (varDsc->lvSlotNum < lvaCount)
+    // Only the variables that exists in the IL, "this, and special arguments 
+    // will be reported. This are locals and arguments, and are counted in
+    // "info.compLocalsCount".
+    if (varDsc->lvSlotNum < info.compLocalsCount)
     {
         // Build the location of the variable
         CodeGenInterface::siVarLoc siVarLoc = codeGen->getSiVarLoc(varDsc, codeGen->getCurrentStackLevel());
@@ -11248,7 +11252,7 @@ void Compiler::dumpBlockVariableLiveRanges(const BasicBlock* block)
     unsigned   varNum;
     LclVarDsc* varDsc;
 
-    for (varNum = 0, varDsc = lvaTable; varNum < lvaCount; varNum++, varDsc++)
+    for (varNum = 0, varDsc = lvaTable; varNum < info.compLocalsCount; varNum++, varDsc++)
     {
         if (varDsc->hasBeenAlive())
         {

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11098,6 +11098,7 @@ bool Compiler::killGCRefs(GenTree* tree)
     return false;
 }
 
+#ifdef USING_VARIABLE_LIVE_RANGE
 //------------------------------------------------------------------------
 // getLiveRangesCount: Returns the count of VariableLiveRanges reported for arguments,
 //   special arguments, and local IL variables (not JIT temp variables).
@@ -11453,4 +11454,5 @@ void Compiler::dumpLvaVariableLiveRanges() const
         printf("////////////////////////////////////////\n");
     }
 }
+#endif
 #endif

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11137,19 +11137,22 @@ VariableLiveKeeper::VariableLiveKeeper(unsigned int totalLocalCount, unsigned in
     compiler = comp;
     lastBasicBlockHasBeenEmited = false;
 
-    // Get the allocator used for all the VariableLiveRange objects
-    CompAllocator allocator = compiler->getAllocator(CMK_VariableLiveRanges);
-    
-    // Allocate memory for "lvaLiveDsc" and initialize each "VariableLiveDescriptor"
-    lvaLiveDsc = allocator.allocate<VariableLiveDescriptor>(lvLiveDscCount);
-    size_t lvaLiveDscSize = sizeof(*lvaLiveDsc);
-    memset(lvaLiveDsc, 0, lvaLiveDscSize);
-
-    unsigned int varNum;
-    VariableLiveDescriptor* varLiveDsc;
-    for (varNum = 0, varLiveDsc = lvaLiveDsc; varNum < lvLiveDscCount; varNum++, varLiveDsc++)
+    if (0 < lvLiveDscCount)
     {
-        new (varLiveDsc, jitstd::placement_t()) VariableLiveDescriptor(allocator);
+        // Get the allocator used for all the VariableLiveRange objects
+        CompAllocator allocator = compiler->getAllocator(CMK_VariableLiveRanges);
+    
+        // Allocate memory for "lvaLiveDsc" and initialize each "VariableLiveDescriptor"
+        lvaLiveDsc = allocator.allocate<VariableLiveDescriptor>(lvLiveDscCount);
+        size_t lvaLiveDscSize = sizeof(*lvaLiveDsc);
+        memset(lvaLiveDsc, 0, lvaLiveDscSize);
+
+        unsigned int varNum;
+        VariableLiveDescriptor* varLiveDsc;
+        for (varNum = 0, varLiveDsc = lvaLiveDsc; varNum < lvLiveDscCount; varNum++, varLiveDsc++)
+        {
+            new (varLiveDsc, jitstd::placement_t()) VariableLiveDescriptor(allocator);
+        }
     }
 }
 

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11213,3 +11213,42 @@ void Compiler::updateVariableLiveRange(const LclVarDsc* varDsc)
     // Report the home change for this variable
     varDsc->UpdateRegisterHome(siVarLoc, getEmitter());
 }
+#ifdef DEBUG
+void Compiler::dumpBlockVariableLiveRanges(const BasicBlock* block)
+{
+    bool hasDumpedHistory = false;
+
+    if (verbose)
+    {
+        printf("////////////////////////////////////////\n");
+        printf("////////////////////////////////////////\n");
+        printf("Var History Dump for Block %d \n", block->bbNum);
+    }
+
+    unsigned   varNum;
+    LclVarDsc* varDsc;
+
+    for (varNum = 0, varDsc = lvaTable; varNum < lvaCount; varNum++, varDsc++)
+    {
+        if (varDsc->hasBeenAlive())
+        {
+            hasDumpedHistory = true;
+            printf("Var %d:\n", varNum);
+            varDsc->dumpRegisterLiveRangesForBlockBeforeCodeGenerated(codeGen);
+            varDsc->endBlockLiveRanges();
+        }
+    }
+
+    if (!hasDumpedHistory)
+    {
+        printf("..None..\n");
+    }
+
+    if (verbose)
+    {
+        printf("////////////////////////////////////////\n");
+        printf("////////////////////////////////////////\n");
+        printf("End Generating code for Block %d \n", block->bbNum);
+    }
+}
+#endif

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11126,7 +11126,7 @@ unsigned int Compiler::getLiveRangesCount()
 }
 
 //------------------------------------------------------------------------
-// startOrCloseVariableLiveRange: Starts or ends a "VariableLiveRange" for "varDsc" if it is
+// siStartOrCloseVariableLiveRange: Starts or ends a "VariableLiveRange" for "varDsc" if it is
 // borning or dying respectively. Ranges are close-open "[)" so nothing is done in case
 // of being borning and dying at the same line due to be an empty range.
 //
@@ -11145,7 +11145,7 @@ unsigned int Compiler::getLiveRangesCount()
 // Notes:
 //    This method is being called from treeLifeUpdater where the variable is becoming dead, live
 //    or both.
-void Compiler::startOrCloseVariableLiveRange(const LclVarDsc* varDsc, bool isBorning, bool isDying)
+void Compiler::siStartOrCloseVariableLiveRange(const LclVarDsc* varDsc, bool isBorning, bool isDying)
 {
     // Only the variables that exists in the IL, "this", and special arguments
     // will be reported. This are locals and arguments, and are counted in
@@ -11155,19 +11155,19 @@ void Compiler::startOrCloseVariableLiveRange(const LclVarDsc* varDsc, bool isBor
         if (isBorning && !isDying)
         {
             // "varDsc" is valid from this point
-            startVariableLiveRange(varDsc);
+            siStartVariableLiveRange(varDsc);
         }
 
         if (isDying && !isBorning)
         {
             // "varDsc" live range is no more valid from this point
-            endVariableLiveRange(varDsc);
+            siEndVariableLiveRange(varDsc);
         }
     }
 }
 
 //------------------------------------------------------------------------
-// startVariableLiveRange: Starts a "VariableLiveRange" for the given "varDsc".
+// siStartVariableLiveRange: Starts a "VariableLiveRange" for the given "varDsc".
 //
 // Arguments:
 //    varDsc    - the LclVarDsc of the variable for which a location changed will be reported.
@@ -11179,7 +11179,7 @@ void Compiler::startOrCloseVariableLiveRange(const LclVarDsc* varDsc, bool isBor
 //
 // Notes:
 //    This method should be called on every place a Variable is becoming alive.
-void Compiler::startVariableLiveRange(const LclVarDsc* varDsc)
+void Compiler::siStartVariableLiveRange(const LclVarDsc* varDsc)
 {
     // Only the variables that exists in the IL, "this", and special arguments
     // will be reported. This are locals and arguments, and are counted in
@@ -11195,7 +11195,7 @@ void Compiler::startVariableLiveRange(const LclVarDsc* varDsc)
 }
 
 //------------------------------------------------------------------------
-// endVariableLiveRange: Ends a "VariableLiveRange" for the given "varDsc".
+// siEndVariableLiveRange: Ends a "VariableLiveRange" for the given "varDsc".
 //
 // Arguments:
 //    varDsc    - the LclVarDsc of the variable for which a location changed will be reported.
@@ -11207,7 +11207,7 @@ void Compiler::startVariableLiveRange(const LclVarDsc* varDsc)
 //
 // Notes:
 //    This method should be called on every place a Variable is becoming dead.
-void Compiler::endVariableLiveRange(const LclVarDsc* varDsc)
+void Compiler::siEndVariableLiveRange(const LclVarDsc* varDsc)
 {
     // Only the variables that exists in the IL, "this", and special arguments
     // will be reported. This are locals and arguments, and are counted in
@@ -11220,7 +11220,7 @@ void Compiler::endVariableLiveRange(const LclVarDsc* varDsc)
 }
 
 //------------------------------------------------------------------------
-// updateVariableLiveRange: Calls updateRegisterHome on "varDsc" with the new variable location
+// siUpdateVariableLiveRange: Calls updateRegisterHome on "varDsc" with the new variable location
 // "siVarLoc"
 //
 // Arguments:
@@ -11233,7 +11233,7 @@ void Compiler::endVariableLiveRange(const LclVarDsc* varDsc)
 //
 // Notes:
 //    This method should be called on every place a Variable is changing its home.
-void Compiler::updateVariableLiveRange(const LclVarDsc* varDsc)
+void Compiler::siUpdateVariableLiveRange(const LclVarDsc* varDsc)
 {
     // Only the variables that exists in the IL, "this", and special arguments
     // will be reported. This are locals and arguments, and are counted in

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11102,7 +11102,7 @@ unsigned int Compiler::getAmountLiveRangesReported()
 {
 
     unsigned int varNum, amountOfLiveRanges = 0;
-    LclVarDsc* varDsc = lvaTable;
+    LclVarDsc*   varDsc = lvaTable;
 
     for (varNum = 0, varDsc = lvaTable; varNum < lvaCount; varNum++, varDsc++)
     {
@@ -11116,15 +11116,15 @@ unsigned int Compiler::getAmountLiveRangesReported()
 }
 
 //------------------------------------------------------------------------
-// startOrCloseVariableLiveRange: Starts or ends a "VariableLiveRange" for "varDsc" if it is 
-// borning or dying respectively. Ranges are close-open "[)" so nothing is done in case 
+// startOrCloseVariableLiveRange: Starts or ends a "VariableLiveRange" for "varDsc" if it is
+// borning or dying respectively. Ranges are close-open "[)" so nothing is done in case
 // of being borning and dying at the same line due to be an empty range.
 //
 // Arguments:
 //    varDsc    - the LclVarDsc of the variable for which a location changed will be reported
-//    isBorning - a boolean indicating if the VariableLiveRange is starting from the emitter 
-//                position. 
-//    isDying   - a boolean indicating if the VariableLiveRange is no more valid from the emitter 
+//    isBorning - a boolean indicating if the VariableLiveRange is starting from the emitter
+//                position.
+//    isDying   - a boolean indicating if the VariableLiveRange is no more valid from the emitter
 //                position
 //
 // Assumptions:
@@ -11133,7 +11133,7 @@ unsigned int Compiler::getAmountLiveRangesReported()
 //    The given "varDsc" should have its VariableRangeLists initialized.
 //
 // Notes:
-//    This method is being called from treeLifeUpdater where the variable is becoming dead, live 
+//    This method is being called from treeLifeUpdater where the variable is becoming dead, live
 //    or both.
 void Compiler::startOrCloseVariableLiveRange(const LclVarDsc* varDsc, bool isBorning, bool isDying)
 {

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11099,14 +11099,14 @@ bool Compiler::killGCRefs(GenTree* tree)
 }
 
 //------------------------------------------------------------------------
-// getLiveRangesCount: Returns the count of VariableLiveRanges reported for arguments, 
+// getLiveRangesCount: Returns the count of VariableLiveRanges reported for arguments,
 //   special arguments, and local IL variables (not JIT temp variables).
 //
 // Return Value:
 //    unsinged int - the count of VariableLiveRanges reported during genCodeForBBList
 //
 // Notes:
-//    This method is being called from genSetScopeInfo to know the count of "varResultInfo" 
+//    This method is being called from genSetScopeInfo to know the count of "varResultInfo"
 //    that should be created on eeSetLVcount.
 unsigned int Compiler::getLiveRangesCount()
 {
@@ -11127,38 +11127,38 @@ unsigned int Compiler::getLiveRangesCount()
 
 //------------------------------------------------------------------------
 // siStartOrCloseVariableLiveRange: Starts or ends a "VariableLiveRange" for "varDsc" if it is
-// borning or dying respectively. Ranges are close-open "[)" so nothing is done in case
-// of being borning and dying at the same line due to be an empty range.
+// being born or dying respectively. Ranges are close-open "[)" so nothing is done in case
+// of being born and dying at the same line due to be an empty range.
 //
 // Arguments:
 //    varDsc    - the LclVarDsc of the variable for which a location changed will be reported
-//    isBorning - a boolean indicating if the VariableLiveRange is starting from the emitter
+//    isBorn    - a boolean indicating if the VariableLiveRange is starting from the emitter
 //                position.
 //    isDying   - a boolean indicating if the VariableLiveRange is no more valid from the emitter
 //                position
 //
 // Assumptions:
 //    The emitter should be pointing to the first instruction from where the VariableLiveRange is
-//    becoming valid (when isBorning is true) or invalid (when isDying is true).
+//    becoming valid (when isBorn is true) or invalid (when isDying is true).
 //    The given "varDsc" should have its VariableRangeLists initialized.
 //
 // Notes:
 //    This method is being called from treeLifeUpdater where the variable is becoming dead, live
 //    or both.
-void Compiler::siStartOrCloseVariableLiveRange(const LclVarDsc* varDsc, bool isBorning, bool isDying)
+void Compiler::siStartOrCloseVariableLiveRange(const LclVarDsc* varDsc, bool isBorn, bool isDying)
 {
     // Only the variables that exists in the IL, "this", and special arguments
     // will be reported. This are locals and arguments, and are counted in
     // "info.compLocalsCount".
     if (varDsc->lvSlotNum < info.compLocalsCount)
     {
-        if (isBorning && !isDying)
+        if (isBorn && !isDying)
         {
             // "varDsc" is valid from this point
             siStartVariableLiveRange(varDsc);
         }
 
-        if (isDying && !isBorning)
+        if (isDying && !isBorn)
         {
             // "varDsc" live range is no more valid from this point
             siEndVariableLiveRange(varDsc);

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11137,7 +11137,7 @@ unsigned int Compiler::getAmountLiveRangesReported()
 //    or both.
 void Compiler::startOrCloseVariableLiveRange(const LclVarDsc* varDsc, bool isBorning, bool isDying)
 {
-    // Only the variables that exists in the IL, "this, and special arguments 
+    // Only the variables that exists in the IL, "this", and special arguments
     // will be reported. This are locals and arguments, and are counted in
     // "info.compLocalsCount".
     if (varDsc->lvSlotNum < info.compLocalsCount)
@@ -11171,7 +11171,7 @@ void Compiler::startOrCloseVariableLiveRange(const LclVarDsc* varDsc, bool isBor
 //    This method should be called on every place a Variable is becoming alive.
 void Compiler::startVariableLiveRange(const LclVarDsc* varDsc)
 {
-    // Only the variables that exists in the IL, "this, and special arguments 
+    // Only the variables that exists in the IL, "this", and special arguments
     // will be reported. This are locals and arguments, and are counted in
     // "info.compLocalsCount".
     if (varDsc->lvSlotNum < info.compLocalsCount)
@@ -11199,7 +11199,7 @@ void Compiler::startVariableLiveRange(const LclVarDsc* varDsc)
 //    This method should be called on every place a Variable is becoming dead.
 void Compiler::endVariableLiveRange(const LclVarDsc* varDsc)
 {
-    // Only the variables that exists in the IL, "this, and special arguments 
+    // Only the variables that exists in the IL, "this", and special arguments
     // will be reported. This are locals and arguments, and are counted in
     // "info.compLocalsCount".
     if (varDsc->lvSlotNum < info.compLocalsCount)
@@ -11225,7 +11225,7 @@ void Compiler::endVariableLiveRange(const LclVarDsc* varDsc)
 //    This method should be called on every place a Variable is changing its home.
 void Compiler::updateVariableLiveRange(const LclVarDsc* varDsc)
 {
-    // Only the variables that exists in the IL, "this, and special arguments 
+    // Only the variables that exists in the IL, "this", and special arguments
     // will be reported. This are locals and arguments, and are counted in
     // "info.compLocalsCount".
     if (varDsc->lvSlotNum < info.compLocalsCount)

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11129,12 +11129,12 @@ VariableLiveKeeper* Compiler::getVariableLiveKeeper() const
 // Notes:
 //    This method should be called after compiler has been initialized and before
 //    genCodeForBBList starts generating code.
-VariableLiveKeeper::VariableLiveKeeper(unsigned int totalLocalCount, unsigned int argsCount, Compiler* compiler)
+VariableLiveKeeper::VariableLiveKeeper(unsigned int totalLocalCount, unsigned int argsCount, Compiler* comp)
 {
     // Fill internal properties
     lvLiveDscCount = totalLocalCount;
     lvLiveArgsCount = argsCount;
-    compiler = compiler;
+    compiler = comp;
     lastBasicBlockHasBeenEmited = false;
 
     // Get the allocator used for all the VariableLiveRange objects

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11137,16 +11137,21 @@ unsigned int Compiler::getAmountLiveRangesReported()
 //    or both.
 void Compiler::startOrCloseVariableLiveRange(const LclVarDsc* varDsc, bool isBorning, bool isDying)
 {
-    if (isBorning && !isDying)
+    // Only the variables that exists in the IL will be seen by the debugger.
+    // This are locals and arguments, and are counted in "lvaCount".
+    if (varDsc->lvSlotNum < lvaCount)
     {
-        // "varDsc" is valid from this point
-        startVariableLiveRange(varDsc);
-    }
+        if (isBorning && !isDying)
+        {
+            // "varDsc" is valid from this point
+            startVariableLiveRange(varDsc);
+        }
 
-    if (isDying && !isBorning)
-    {
-        // "varDsc" live range is no more valid from this point
-        endVariableLiveRange(varDsc);
+        if (isDying && !isBorning)
+        {
+            // "varDsc" live range is no more valid from this point
+            endVariableLiveRange(varDsc);
+        }
     }
 }
 
@@ -11165,11 +11170,16 @@ void Compiler::startOrCloseVariableLiveRange(const LclVarDsc* varDsc, bool isBor
 //    This method should be called on every place a Variable is becoming alive.
 void Compiler::startVariableLiveRange(const LclVarDsc* varDsc)
 {
-    // Build siVarLoc for this borning "varDsc"
-    CodeGenInterface::siVarLoc varLocation = codeGen->getSiVarLoc(varDsc, codeGen->getCurrentStackLevel());
+    // Only the variables that exists in the IL will be seen by the debugger.
+    // This are locals and arguments, and are counted in "lvaCount".
+    if (varDsc->lvSlotNum < lvaCount)
+    {
+        // Build siVarLoc for this borning "varDsc"
+        CodeGenInterface::siVarLoc varLocation = codeGen->getSiVarLoc(varDsc, codeGen->getCurrentStackLevel());
 
-    // "varDsc" live range is valid from this point
-    varDsc->startLiveRangeFromEmitter(varLocation, getEmitter());
+        // "varDsc" live range is valid from this point
+        varDsc->startLiveRangeFromEmitter(varLocation, getEmitter());
+    }
 }
 
 //------------------------------------------------------------------------
@@ -11187,8 +11197,13 @@ void Compiler::startVariableLiveRange(const LclVarDsc* varDsc)
 //    This method should be called on every place a Variable is becoming dead.
 void Compiler::endVariableLiveRange(const LclVarDsc* varDsc)
 {
-    // "varDsc" live range is no more valid from this point
-    varDsc->endLiveRangeAtEmitter(getEmitter());
+    // Only the variables that exists in the IL will be seen by the debugger.
+    // This are locals and arguments, and are counted in "lvaCount".
+    if (varDsc->lvSlotNum < lvaCount)
+    {
+        // "varDsc" live range is no more valid from this point
+        varDsc->endLiveRangeAtEmitter(getEmitter());
+    }
 }
 
 //------------------------------------------------------------------------
@@ -11207,11 +11222,16 @@ void Compiler::endVariableLiveRange(const LclVarDsc* varDsc)
 //    This method should be called on every place a Variable is changing its home.
 void Compiler::updateVariableLiveRange(const LclVarDsc* varDsc)
 {
-    // Build the location of the variable
-    CodeGenInterface::siVarLoc siVarLoc = codeGen->getSiVarLoc(varDsc, codeGen->getCurrentStackLevel());
+    // Only the variables that exists in the IL will be seen by the debugger.
+    // This are locals and arguments, and are counted in "lvaCount".
+    if (varDsc->lvSlotNum < lvaCount)
+    {
+        // Build the location of the variable
+        CodeGenInterface::siVarLoc siVarLoc = codeGen->getSiVarLoc(varDsc, codeGen->getCurrentStackLevel());
 
-    // Report the home change for this variable
-    varDsc->UpdateRegisterHome(siVarLoc, getEmitter());
+        // Report the home change for this variable
+        varDsc->UpdateRegisterHome(siVarLoc, getEmitter());
+    }
 }
 #ifdef DEBUG
 void Compiler::dumpBlockVariableLiveRanges(const BasicBlock* block)

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11454,5 +11454,48 @@ void Compiler::dumpLvaVariableLiveRanges() const
         printf("////////////////////////////////////////\n");
     }
 }
+
+// Dump "VariableLiveRange" when code has not been generated and we don't have so the assembly native offset
+// but at least "emitLocation"s and "siVarLoc"
+void dumpVariableLiveRange(const VariableLiveRange* varLiveRange, const CodeGenInterface* codeGen)
+{
+    // Check pointers parameter are not nullptr
+    noway_assert(codeGen != nullptr);
+    noway_assert(varLiveRange != nullptr);
+
+    codeGen->dumpSiVarLoc(&varLiveRange->varLocation);
+    printf(" [ ");
+    varLiveRange->startEmitLocation.Print();
+    printf(", ");
+    if (varLiveRange->endEmitLocation.Valid())
+    {
+        varLiveRange->endEmitLocation.Print();
+    }
+    else
+    {
+        printf("NON_CLOSED_RANGE");
+    }
+    printf(" ]; ");
+}
+
+// Dump "VariableLiveRange" when code has been generated and we have the assembly native offset of each "emitLocation"
+void dumpVariableLiveRange(const VariableLiveRange* varLiveRange, emitter* _emitter, const CodeGenInterface* codeGen)
+{
+    // Check pointers parameter are not nullptr
+    noway_assert(varLiveRange != nullptr);
+    noway_assert(_emitter != nullptr);
+    noway_assert(codeGen != nullptr);
+
+    // "VariableLiveRanges" are created setting its location ("varLocation") and the initial assembly offset
+    // ("startEmitLocation")
+    codeGen->dumpSiVarLoc(&varLiveRange->varLocation);
+
+    // If this is an open "VariableLiveRange", "endEmitLocation" is non-valid and print -1
+    UNATIVE_OFFSET endAssemblyOffset =
+        varLiveRange->endEmitLocation.Valid() ? varLiveRange->endEmitLocation.CodeOffset(_emitter) : -1;
+
+    printf(" [%X , %X )", varLiveRange->startEmitLocation.CodeOffset(_emitter),
+           varLiveRange->endEmitLocation.CodeOffset(_emitter));
+}
 #endif
 #endif

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11308,9 +11308,9 @@ void Compiler::siUpdateVariableLiveRange(const LclVarDsc* varDsc)
 //    on the last block being generated and set a flag so no call to
 //    "siEndVariableLiveRange" from "genUpdateLife" get to close a "VariableLiveRange"
 //    outside the loop.
-void Compiler::siEndAllVariableLiveRange(VARSET_VALARG_TP varsToClose)
+void Compiler::siEndAllVariableLiveRange(const VARSET_TP* varsToClose)
 {
-    VarSetOps::Iter iter(this, varsToClose);
+    VarSetOps::Iter iter(this, *varsToClose);
     unsigned        varIndex = 0;
     while (iter.NextElem(&varIndex))
     {

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11098,7 +11098,17 @@ bool Compiler::killGCRefs(GenTree* tree)
     return false;
 }
 
-unsigned int Compiler::getAmountLiveRangesReported()
+//------------------------------------------------------------------------
+// getLiveRangesCount: Returns the count of VariableLiveRanges reported for arguments, 
+//   special arguments, and local IL variables (not JIT temp variables).
+//
+// Return Value:
+//    unsinged int - the count of VariableLiveRanges reported during genCodeForBBList
+//
+// Notes:
+//    This method is being called from genSetScopeInfo to know the count of "varResultInfo" 
+//    that should be created on eeSetLVcount.
+unsigned int Compiler::getLiveRangesCount()
 {
 
     unsigned int varNum, amountOfLiveRanges = 0;

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11335,7 +11335,7 @@ void Compiler::siEndAllVariableLiveRange(const VARSET_TP* varsToClose)
 }
 
 //------------------------------------------------------------------------
-// psiStartVariableLiveRange: Open a "VariableLiveRange" for the 
+// psiStartVariableLiveRange: Open a "VariableLiveRange" for the
 //  given parameter variable ("lclVarDsc") in the given location ("varLocation").
 //
 // Arguments:
@@ -11343,12 +11343,12 @@ void Compiler::siEndAllVariableLiveRange(const VARSET_TP* varsToClose)
 //  lclVarDsc   - the variable descriptor.
 //
 // Notes:
-//  This function is expected to be called from preffix "psi" functions that starts 
+//  This function is expected to be called from preffix "psi" functions that starts
 //  VariableLiveRanges for parameter of the method.
-void Compiler::psiStartVariableLiveRange(CodeGenInterface::siVarLoc varLocation, const LclVarDsc *lclVarDsc)
+void Compiler::psiStartVariableLiveRange(CodeGenInterface::siVarLoc varLocation, const LclVarDsc* lclVarDsc)
 {
     noway_assert(lclVarDsc != nullptr);
-    
+
     // This descriptor has to correspond to a parameter. The first slots in lvaTable
     // are arguments and special arguments.
     noway_assert(lclVarDsc->lvSlotNum < info.compArgsCount);
@@ -11366,7 +11366,7 @@ void Compiler::psiStartVariableLiveRange(CodeGenInterface::siVarLoc varLocation,
 void Compiler::psiClosePrologVariableRanges()
 {
     unsigned int varNum;
-    LclVarDsc* parameterDsc;
+    LclVarDsc*   parameterDsc;
     for (varNum = 0, parameterDsc = lvaTable; varNum < info.compArgsCount; varNum++, parameterDsc++)
     {
         if (parameterDsc->hasVariableLiveRangeOpen())

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11102,9 +11102,9 @@ bool Compiler::killGCRefs(GenTree* tree)
 void Compiler::initializeVariableLiveKeeper()
 {
     CompAllocator allocator = getAllocator(CMK_VariableLiveRanges);
-    
+
     int amountTrackedVariables = opts.compDbgInfo ? info.compLocalsCount : 0;
-    int amountTrackedArgs = opts.compDbgInfo ? info.compArgsCount : 0;
+    int amountTrackedArgs      = opts.compDbgInfo ? info.compArgsCount : 0;
 
     varLiveKeeper = allocator.allocate<VariableLiveKeeper>(1);
     memset(varLiveKeeper, 0, sizeof(*varLiveKeeper));
@@ -11121,7 +11121,7 @@ VariableLiveKeeper* Compiler::getVariableLiveKeeper() const
 //  VariableLiveRanges and intialize the array "lvaLiveDsc".
 //
 // Arguments:
-//    totalLocalCount   - the amount of args, special args and IL Local 
+//    totalLocalCount   - the amount of args, special args and IL Local
 //      variables in the method.
 //    argsCount         - the amount of args and special args in the method.
 //    compiler          - a compiler instance
@@ -11132,22 +11132,22 @@ VariableLiveKeeper* Compiler::getVariableLiveKeeper() const
 VariableLiveKeeper::VariableLiveKeeper(unsigned int totalLocalCount, unsigned int argsCount, Compiler* comp)
 {
     // Fill internal properties
-    lvLiveDscCount = totalLocalCount;
-    lvLiveArgsCount = argsCount;
-    compiler = comp;
+    lvLiveDscCount              = totalLocalCount;
+    lvLiveArgsCount             = argsCount;
+    compiler                    = comp;
     lastBasicBlockHasBeenEmited = false;
 
     if (0 < lvLiveDscCount)
     {
         // Get the allocator used for all the VariableLiveRange objects
         CompAllocator allocator = compiler->getAllocator(CMK_VariableLiveRanges);
-    
+
         // Allocate memory for "lvaLiveDsc" and initialize each "VariableLiveDescriptor"
-        lvaLiveDsc = allocator.allocate<VariableLiveDescriptor>(lvLiveDscCount);
+        lvaLiveDsc            = allocator.allocate<VariableLiveDescriptor>(lvLiveDscCount);
         size_t lvaLiveDscSize = sizeof(*lvaLiveDsc);
         memset(lvaLiveDsc, 0, lvaLiveDscSize);
 
-        unsigned int varNum;
+        unsigned int            varNum;
         VariableLiveDescriptor* varLiveDsc;
         for (varNum = 0, varLiveDsc = lvaLiveDsc; varNum < lvLiveDscCount; varNum++, varLiveDsc++)
         {
@@ -11169,17 +11169,17 @@ VariableLiveKeeper::VariableLiveKeeper(unsigned int totalLocalCount, unsigned in
 unsigned int VariableLiveKeeper::getLiveRangesCount() const
 {
     unsigned int liveRangesCount = 0;
-    
+
     if (compiler->opts.compDbgInfo)
     {
-        unsigned int varNum;
-        VariableLiveDescriptor*   varLiveDsc;
-        
+        unsigned int            varNum;
+        VariableLiveDescriptor* varLiveDsc;
+
         for (varNum = 0, varLiveDsc = lvaLiveDsc; varNum < lvLiveDscCount; varNum++, varLiveDsc++)
         {
             if (compiler->compMap2ILvarNum(varNum) != (unsigned int)ICorDebugInfo::UNKNOWN_ILNUM)
             {
-                liveRangesCount += (unsigned int) varLiveDsc->getAmountLiveRanges();
+                liveRangesCount += (unsigned int)varLiveDsc->getAmountLiveRanges();
             }
         }
     }
@@ -11258,7 +11258,7 @@ void VariableLiveKeeper::siStartOrCloseVariableLiveRanges(const VARSET_TP* varsI
         unsigned        varIndex = 0;
         while (iter.NextElem(&varIndex))
         {
-            unsigned int varNum = compiler->lvaTrackedToVarNum[varIndex];
+            unsigned int     varNum = compiler->lvaTrackedToVarNum[varIndex];
             const LclVarDsc* varDsc = compiler->lvaGetDesc(varNum);
             siStartOrCloseVariableLiveRange(varDsc, isBorn, isDying);
         }
@@ -11288,7 +11288,8 @@ void VariableLiveKeeper::siStartVariableLiveRange(const LclVarDsc* varDsc)
     if (compiler->opts.compDbgInfo && varDsc->lvSlotNum < lvLiveDscCount)
     {
         // Build siVarLoc for this borning "varDsc"
-        CodeGenInterface::siVarLoc varLocation = compiler->codeGen->getSiVarLoc(varDsc, compiler->codeGen->getCurrentStackLevel());
+        CodeGenInterface::siVarLoc varLocation =
+            compiler->codeGen->getSiVarLoc(varDsc, compiler->codeGen->getCurrentStackLevel());
 
         VariableLiveDescriptor* varLiveDsc = &lvaLiveDsc[varDsc->lvSlotNum];
         // "varDsc" live range is valid from this point
@@ -11355,11 +11356,12 @@ void VariableLiveKeeper::siUpdateVariableLiveRange(const LclVarDsc* varDsc)
     if (compiler->opts.compDbgInfo && varDsc->lvSlotNum < lvLiveDscCount && !lastBasicBlockHasBeenEmited)
     {
         // Build the location of the variable
-        CodeGenInterface::siVarLoc siVarLoc = compiler->codeGen->getSiVarLoc(varDsc, compiler->codeGen->getCurrentStackLevel());
-        
+        CodeGenInterface::siVarLoc siVarLoc =
+            compiler->codeGen->getSiVarLoc(varDsc, compiler->codeGen->getCurrentStackLevel());
+
         // Report the home change for this variable
         VariableLiveDescriptor* varLiveDsc = &lvaLiveDsc[varDsc->lvSlotNum];
-        
+
         varLiveDsc->UpdateRegisterHome(siVarLoc, compiler->getEmitter());
     }
 }
@@ -11431,10 +11433,10 @@ void VariableLiveKeeper::psiStartVariableLiveRange(CodeGenInterface::siVarLoc va
 void VariableLiveKeeper::psiClosePrologVariableRanges()
 {
     noway_assert(compiler->info.compArgsCount <= lvLiveDscCount);
-    
-    unsigned int varNum;
+
+    unsigned int            varNum;
     VariableLiveDescriptor* varLiveDsc;
-    
+
     for (varNum = 0, varLiveDsc = lvaLiveDsc; varNum < compiler->info.compArgsCount; varNum++, varLiveDsc++)
     {
         if (varLiveDsc->hasVariableLiveRangeOpen())
@@ -11614,7 +11616,7 @@ void VariableLiveKeeper::dumpBlockVariableLiveRanges(const BasicBlock* block)
 
         if (compiler->opts.compDbgInfo)
         {
-            unsigned   varNum;
+            unsigned                varNum;
             VariableLiveDescriptor* varLiveDsc;
 
             for (varNum = 0, varLiveDsc = lvaLiveDsc; varNum < lvLiveDscCount; varNum++, varLiveDsc++)
@@ -11652,7 +11654,7 @@ void VariableLiveKeeper::dumpLvaVariableLiveRanges() const
 
         if (compiler->opts.compDbgInfo)
         {
-            unsigned   varNum;
+            unsigned                varNum;
             VariableLiveDescriptor* varLiveDsc;
 
             for (varNum = 0, varLiveDsc = lvaLiveDsc; varNum < lvLiveDscCount; varNum++, varLiveDsc++)
@@ -11719,7 +11721,7 @@ void dumpVariableLiveRange(const VariableLiveRange* varLiveRange, emitter* _emit
            varLiveRange->endEmitLocation.CodeOffset(_emitter));
 }
 
-void LiveRangeBarrier::reset(const LiveRangeList *liveRanges)
+void LiveRangeBarrier::reset(const LiveRangeList* liveRanges)
 {
     // "list" should be a valid pointer
     noway_assert(liveRanges != nullptr);
@@ -11748,7 +11750,7 @@ void LiveRangeBarrier::setBarrierAtLastPositionInRegisterHistory(const LiveRange
     noway_assert(liveRanges != nullptr);
 
     haveReadAtLeastOneOfBlock = true;
-    beginLastBlock = liveRanges->backPosition();
+    beginLastBlock            = liveRanges->backPosition();
 }
 
 // Modified the barrier to print on next block only just that changes
@@ -11777,8 +11779,7 @@ void VariableLiveDescriptor::dumpRegisterLiveRangesForBlockBeforeCodeGenerated(c
     if (hasBeenAlive())
     {
         printf("[");
-        for (LiveRangeListIterator it = variableLifeBarrier->beginLastBlock; it != variableLiveRanges->end();
-            it++)
+        for (LiveRangeListIterator it = variableLifeBarrier->beginLastBlock; it != variableLiveRanges->end(); it++)
         {
             dumpVariableLiveRange(&it, codeGen);
         }

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11530,7 +11530,7 @@ void VariableLiveDescriptor::startLiveRangeFromEmitter(CodeGenInterface::siVarLo
 #if DEBUG
     noway_assert(variableLifeBarrier != nullptr);
     // Restart barrier so we can print from here
-    variableLifeBarrier->setBarrierAtLastPositionInRegisterHistory(variableLiveRanges->backPosition());
+    variableLifeBarrier->setDumperStartAt(variableLiveRanges->backPosition());
 #endif
 }
 
@@ -11782,6 +11782,32 @@ void LiveRangeDumper::setDumperStartAt(const LiveRangeListIterator liveRangeIt)
     m_StartingLiveRange   = liveRangeIt;
 }
 
+//------------------------------------------------------------------------
+// getStartForDump: Return an iterator to the first "VariableLiveRange" edited/added
+//  during the current "BasicBlock"
+//
+// Return Value:
+//  A LiveRangeListIterator to the first "VariableLiveRange" in "LiveRangeList" which
+//  was used during last "BasicBlock".
+//
+LiveRangeListIterator LiveRangeDumper::getStartForDump() const
+{
+    return m_StartingLiveRange;
+}
+
+//------------------------------------------------------------------------
+// hasLiveRangesToDump: Retutn wheter at least a "VariableLiveRange" was alive during
+//  the current "BasicBlock"'s code generation
+//
+// Return Value:
+//  A boolean indicating indicating if there is at least a "VariableLiveRange"
+//  that has been used for the variable during last "BasicBlock".
+//
+bool LiveRangeDumper::hasLiveRangesToDump() const
+{
+    return m_hasLiveRangestoDump;
+}
+
 // Modified the barrier to print on next block only just that changes
 void VariableLiveDescriptor::endBlockLiveRanges()
 {
@@ -11797,7 +11823,7 @@ bool VariableLiveDescriptor::hasBeenAlive() const
     // "variableLifeBarrier" should has been initialized
     noway_assert(variableLifeBarrier != nullptr);
 
-    return variableLifeBarrier->m_hasLiveRangestoDump;
+    return variableLifeBarrier->hasLiveRangesToDump();
 }
 
 void VariableLiveDescriptor::dumpRegisterLiveRangesForBlockBeforeCodeGenerated(const CodeGenInterface* codeGen) const
@@ -11808,7 +11834,7 @@ void VariableLiveDescriptor::dumpRegisterLiveRangesForBlockBeforeCodeGenerated(c
     if (hasBeenAlive())
     {
         printf("[");
-        for (LiveRangeListIterator it = variableLifeBarrier->m_StartingLiveRange; it != variableLiveRanges->end(); it++)
+        for (LiveRangeListIterator it = variableLifeBarrier->getStartForDump(); it != variableLiveRanges->end(); it++)
         {
             dumpVariableLiveRange(&it, codeGen);
         }

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11337,6 +11337,9 @@ void Compiler::siEndAllVariableLiveRange(const VARSET_TP* varsToClose)
 #ifdef DEBUG
 void Compiler::dumpBlockVariableLiveRanges(const BasicBlock* block)
 {
+    // "block" will be dereferenced
+    noway_assert(block != nullptr);
+
     bool hasDumpedHistory = false;
 
     if (verbose)
@@ -11344,35 +11347,68 @@ void Compiler::dumpBlockVariableLiveRanges(const BasicBlock* block)
         printf("////////////////////////////////////////\n");
         printf("////////////////////////////////////////\n");
         printf("Var History Dump for Block %d \n", block->bbNum);
-    }
 
-    if (opts.compDbgInfo)
-    {
-        unsigned   varNum;
-        LclVarDsc* varDsc;
-
-        for (varNum = 0, varDsc = lvaTable; varNum < info.compLocalsCount; varNum++, varDsc++)
+        if (opts.compDbgInfo)
         {
-            if (varDsc->hasBeenAlive())
+            unsigned   varNum;
+            LclVarDsc* varDsc;
+
+            for (varNum = 0, varDsc = lvaTable; varNum < info.compLocalsCount; varNum++, varDsc++)
             {
-                hasDumpedHistory = true;
-                printf("Var %d:\n", varNum);
-                varDsc->dumpRegisterLiveRangesForBlockBeforeCodeGenerated(codeGen);
-                varDsc->endBlockLiveRanges();
+                if (varDsc->hasBeenAlive())
+                {
+                    hasDumpedHistory = true;
+                    printf("Var %d:\n", varNum);
+                    varDsc->dumpRegisterLiveRangesForBlockBeforeCodeGenerated(codeGen);
+                    varDsc->endBlockLiveRanges();
+                }
             }
         }
-    }
 
-    if (!hasDumpedHistory)
-    {
-        printf("..None..\n");
+        if (!hasDumpedHistory)
+        {
+            printf("..None..\n");
+        }
+
+        printf("////////////////////////////////////////\n");
+        printf("////////////////////////////////////////\n");
+        printf("End Generating code for Block %d \n", block->bbNum);
     }
+}
+
+void Compiler::dumpLvaVariableLiveRanges() const
+{
+    bool hasDumpedHistory = false;
 
     if (verbose)
     {
         printf("////////////////////////////////////////\n");
         printf("////////////////////////////////////////\n");
-        printf("End Generating code for Block %d \n", block->bbNum);
+        printf("PRINTING REGISTER LIVE RANGES:\n");
+
+        if (opts.compDbgInfo)
+        {
+            unsigned   varNum;
+            LclVarDsc* varDsc;
+
+            for (varNum = 0, varDsc = lvaTable; varNum < info.compLocalsCount; varNum++, varDsc++)
+            {
+                if (varDsc->hasBeenAlive())
+                {
+                    hasDumpedHistory = true;
+                    printf("IL Var Num %d:\n", compMap2ILvarNum(varNum));
+                    varDsc->dumpAllRegisterLiveRangesForBlock(getEmitter(), codeGen);
+                }
+            }
+        }
+
+        if (!hasDumpedHistory)
+        {
+            printf("..None..\n");
+        }
+
+        printf("////////////////////////////////////////\n");
+        printf("////////////////////////////////////////\n");
     }
 }
 #endif

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11166,6 +11166,38 @@ void Compiler::siStartOrCloseVariableLiveRange(const LclVarDsc* varDsc, bool isB
 }
 
 //------------------------------------------------------------------------
+// siStartOrCloseVariableLiveRanges: Iterates the VARSET_TP* set calling "siStartOrCloseVariableLiveRange"
+//  for each of the LclVarDsc.
+//
+// Arguments:
+//    varsIndexSet    - the VARSET_TP with the variable to report start/end "VariableLiveRange"
+//    isBorn    - a boolean indicating if the VariableLiveRange is starting from the emitter
+//                position.
+//    isDying   - a boolean indicating if the VariableLiveRange is no more valid from the emitter
+//                position
+//
+// Assumptions:
+//    The emitter should be pointing to the first instruction from where the VariableLiveRanges are
+//    becoming valid (when isBorn is true) or invalid (when isDying is true).
+//    All the "LvlVarDsc" in the set "varsIndexSet" should have its "VariableRangeLists" initialized.
+//
+// Notes:
+//    This method is being called from treeLifeUpdater where the variable is becoming dead, live
+//    or both.
+void Compiler::siStartOrCloseVariableLiveRanges(const VARSET_TP* varsIndexSet, bool isBorn, bool isDying)
+{
+    VarSetOps::Iter iter(this, *varsIndexSet);
+    unsigned        varIndex = 0;
+    while (iter.NextElem(&varIndex))
+    {
+        unsigned         lclNum = lvaTrackedToVarNum[varIndex];
+        const LclVarDsc* lclVar = &lvaTable[lclNum];
+
+        siStartOrCloseVariableLiveRange(lclVar, isBorn, isDying);
+    }
+}
+
+//------------------------------------------------------------------------
 // siStartVariableLiveRange: Starts a "VariableLiveRange" for the given "varDsc".
 //
 // Arguments:

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11294,7 +11294,7 @@ void Compiler::siEndAllVariableLiveRange(VARSET_VALARG_TP varsToClose)
     {
         unsigned         lclNum = lvaTrackedToVarNum[varIndex];
         const LclVarDsc* lclVar = &lvaTable[lclNum];
-        assert(lclVar->hasBeenAlive());
+        
         siEndVariableLiveRange(lclVar);
     }
 

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11108,7 +11108,7 @@ unsigned int Compiler::getAmountLiveRangesReported()
     {
         if (compMap2ILvarNum(varNum) != (unsigned int)ICorDebugInfo::UNKNOWN_ILNUM)
         {
-            amountOfLiveRanges += varDsc->getAmountLiveRanges();
+            amountOfLiveRanges += (unsigned int)varDsc->getAmountLiveRanges();
         }
     }
 

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11497,5 +11497,37 @@ void dumpVariableLiveRange(const VariableLiveRange* varLiveRange, emitter* _emit
     printf(" [%X , %X )", varLiveRange->startEmitLocation.CodeOffset(_emitter),
            varLiveRange->endEmitLocation.CodeOffset(_emitter));
 }
+
+void LiveRangeBarrier::reset(const LiveRangeList *liveRanges)
+{
+    // "list" should be a valid pointer
+    noway_assert(liveRanges != nullptr);
+
+    // There must have reported something in order to reset
+    noway_assert(haveReadAtLeastOneOfBlock);
+
+    if (liveRanges->back().endEmitLocation.Valid())
+    {
+        haveReadAtLeastOneOfBlock = false;
+    }
+    else
+    {
+        // This live range will remain open until next block.
+        // If it is in "bbliveIn" in the next "BasicBlock", there is no problem.
+        // If it is not, then "compiler->compCurLife" will have a difference with "block->bbliveIn"
+        // and it will be indicated as dead.
+        beginLastBlock = liveRanges->backPosition();
+    }
+}
+
+// Move the barrier to the last position of variableLiveRanges
+// This is used to print only the changes in the last block
+void LiveRangeBarrier::setBarrierAtLastPositionInRegisterHistory(const LiveRangeList* liveRanges)
+{
+    noway_assert(liveRanges != nullptr);
+
+    haveReadAtLeastOneOfBlock = true;
+    beginLastBlock = liveRanges->backPosition();
+}
 #endif
 #endif

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -363,7 +363,7 @@ void dumpVariableLiveRange(const VariableLiveRange* varLiveRange, emitter* _emit
 //
 class LiveRangeDumper
 {
-public:
+private:
     LiveRangeListIterator m_StartingLiveRange; // Iterator to the first edited/added position
                                                // during actual block code generation. If last
                                                // block had a closed "VariableLiveRange" (with
@@ -373,13 +373,23 @@ public:
     bool m_hasLiveRangestoDump;                // True if a live range for this variable has been
                                                // reported from last call to EndBlock
 
+public:
     LiveRangeDumper(const LiveRangeList* liveRanges);
 
+    // Make the dumper point to the last "VariableLiveRange" opened or nullptr if all are closed
     void resetDumper(const LiveRangeList* list);
 
     //  Make "LiveRangeDumper" instance points the last "VariableLifeRange" added so we can
     // starts dumping from there after the actual "BasicBlock"s code is generated.
     void setDumperStartAt(const LiveRangeListIterator liveRangeIt);
+
+    // Return an iterator to the first "VariableLiveRange" edited/added during the current
+    // "BasicBlock"
+    LiveRangeListIterator getStartForDump() const;
+
+    // Retutn wheter at least a "VariableLiveRange" was alive during the current "BasicBlock"'s
+    // code generation
+    bool hasLiveRangesToDump() const;
 };
 #endif
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -432,7 +432,7 @@ public:
     void endBlockLiveRanges()
     {
         noway_assert(variableLifeBarrier != nullptr);
-        
+
         // make "variableLifeBarrier->beginLastBlock" now points to nullptr for printing purposes
         variableLifeBarrier->reset(variableLiveRanges);
     }
@@ -548,7 +548,7 @@ public:
 
         // Using [close, open) ranges so as to not compute the size of the last instruction
         variableLiveRanges->back().endEmitLocation.CaptureLocation(_emitter);
-        
+
         // No endEmitLocation has to be Valid
         noway_assert(variableLiveRanges->back().endEmitLocation.Valid());
     }
@@ -564,7 +564,7 @@ public:
         // Creates new live range with invalid end
         variableLiveRanges->emplace_back(varLocation, emitLocation(), emitLocation());
         variableLiveRanges->back().startEmitLocation.CaptureLocation(_emitter);
-        
+
         // startEmitLocationendEmitLocation has to be Valid and endEmitLocationendEmitLocation  not
         noway_assert(variableLiveRanges->back().startEmitLocation.Valid());
         noway_assert(!variableLiveRanges->back().endEmitLocation.Valid());
@@ -606,7 +606,7 @@ public:
     // getLastVarLocation: Return the last reported position of the variable.
     //
     // Return Value:
-    //  The last "siVarLoc" position where the variable was (or is if the last "VariableLiveRange" 
+    //  The last "siVarLoc" position where the variable was (or is if the last "VariableLiveRange"
     //  has not been closed).
     // Notes:
     //  There has to be at least one.
@@ -7416,9 +7416,9 @@ public:
 
     // Close all the "VariableLiveRanges" that are indicated in the given set
     void siEndAllVariableLiveRange(const VARSET_TP* varsToClose);
-    
+
     // Open a "VariableLiveRange" for the given parameter "lclVarDsc" in the given "varLocation"
-    void psiStartVariableLiveRange(CodeGenInterface::siVarLoc varLocation, const LclVarDsc *lclVarDsc);
+    void psiStartVariableLiveRange(CodeGenInterface::siVarLoc varLocation, const LclVarDsc* lclVarDsc);
 
     // Close all the open "VariableLiveRanges" after prolog has been generated
     void psiClosePrologVariableRanges();

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -519,11 +519,7 @@ public:
         // There should be VariableLiveRanges reported during this basic block
         noway_assert(hasBeenAlive());
 #endif
-        // We are closing a "VariableLiveRange" so it has been started before during this basic block
-        noway_assert(variableLiveRanges != nullptr && !variableLiveRanges->empty());
-
-        // And its last endEmitLocation has to be invalid (its the one we are reporting now)
-        noway_assert(!variableLiveRanges->back().endEmitLocation.Valid());
+        noway_assert(hasVariableLiveRangeOpen());
 
         // Using [close, open) ranges so as to not compute the size of the last instruction
         variableLiveRanges->back().endEmitLocation.CaptureLocation(_emitter);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7342,16 +7342,16 @@ public:
     // Starts or ends a "VariableLiveRange" for "varDsc" if it is borning or dying respectively.
     // Ranges are close-open [) so nothing is done in case of being borning and dying at the same line
     // due to be an empty range.
-    void startOrCloseVariableLiveRange(const LclVarDsc* varDsc, bool isBorning, bool isDying);
+    void siStartOrCloseVariableLiveRange(const LclVarDsc* varDsc, bool isBorning, bool isDying);
 
     // Starts a "VariableLiveRange" for "varDsc"
-    void startVariableLiveRange(const LclVarDsc* varDsc);
+    void siStartVariableLiveRange(const LclVarDsc* varDsc);
 
     // Close the last "VariableLiveRange" for "varDsc"
-    void endVariableLiveRange(const LclVarDsc* varDsc);
+    void siEndVariableLiveRange(const LclVarDsc* varDsc);
 
     // Calls updateRegisterHome on "varDsc" with the new variable location "siVarLoc"
-    void updateVariableLiveRange(const LclVarDsc* varDsc);
+    void siUpdateVariableLiveRange(const LclVarDsc* varDsc);
 
     bool isFramePointerUsed() const
     {

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -352,7 +352,7 @@ typedef LiveRangeList::iterator         LiveRangeListIterator;
 struct LiveRangeBarrier
 {
     LiveRangeListIterator beginLastBlock;
-    bool                  haveReadAtLeastOneOfBlock; // True if a live range for this variable has been 
+    bool                  haveReadAtLeastOneOfBlock; // True if a live range for this variable has been
                                                      // reported from last call to EndBlock
 
     LiveRangeBarrier(LiveRangeList* list)
@@ -401,7 +401,7 @@ public:
         lvPerSsaData()
     {
     }
-    
+
     LiveRangeList* variableLiveRanges;
 
 #if DEBUG
@@ -468,10 +468,10 @@ public:
     void initializeRegisterLiveRanges(CompAllocator allocator)
     {
         variableLiveRanges = allocator.allocate<LiveRangeList>(1);
-        
+
         size_t variableLiveRangesSize = sizeof(*variableLiveRanges);
         memset(variableLiveRanges, 0, variableLiveRangesSize);
-        
+
         new (variableLiveRanges, jitstd::placement_t()) LiveRangeList(allocator);
 
 #if DEBUG
@@ -493,8 +493,6 @@ public:
         }
         return result;
     }
-
-    
 
     LiveRangeListIterator getLiveRangesIterator() const
     {
@@ -548,8 +546,8 @@ public:
 #endif
         // This variable is changing home so it has been started before during this block
         noway_assert(variableLiveRanges != nullptr && !variableLiveRanges->empty());
-        
-        // And its last endEmitLocation has to be invalid 
+
+        // And its last endEmitLocation has to be invalid
         noway_assert(!variableLiveRanges->back().endEmitLocation.Valid());
 
         // If we are reporting again the same home, that means we are doing something twice?
@@ -3050,7 +3048,7 @@ public:
     }
 
     bool     lvaTrackedFixed; // true: We cannot add new 'tracked' variable
-    unsigned lvaCount;        // total number of locals, which includes function arguments, 
+    unsigned lvaCount;        // total number of locals, which includes function arguments,
                               // special arguments, IL local variables, and JIT temporary variables
 
     unsigned   lvaRefCount; // total number of references to locals

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -391,7 +391,7 @@ public:
     // code generation
     bool hasLiveRangesToDump() const;
 };
-#endif
+#endif // DEBUG
 
 class VariableLiveDescriptor
 {

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -602,6 +602,22 @@ public:
         noway_assert(!variableLiveRanges->back().endEmitLocation.Valid());
     }
 
+    //------------------------------------------------------------------------
+    // getLastVarLocation: Return the last reported position of the variable.
+    //
+    // Return Value:
+    //  The last "siVarLoc" position where the variable was (or is if the last "VariableLiveRange" 
+    //  has not been closed).
+    // Notes:
+    //  There has to be at least one.
+    CodeGenInterface::siVarLoc getLastVarLocation() const
+    {
+        // There should have at least one VariableLiveRange reported for this variable
+        noway_assert(variableLiveRanges != nullptr && !variableLiveRanges->empty());
+
+        return variableLiveRanges->back().varLocation;
+    }
+
     // note this only packs because var_types is a typedef of unsigned char
     var_types lvType : 5; // TYP_INT/LONG/FLOAT/DOUBLE/REF
 
@@ -7400,6 +7416,12 @@ public:
 
     // Close all the "VariableLiveRanges" that are indicated in the given set
     void siEndAllVariableLiveRange(const VARSET_TP* varsToClose);
+    
+    // Open a "VariableLiveRange" for the given parameter "lclVarDsc" in the given "varLocation"
+    void psiStartVariableLiveRange(CodeGenInterface::siVarLoc varLocation, const LclVarDsc *lclVarDsc);
+
+    // Close all the open "VariableLiveRanges" after prolog has been generated
+    void psiClosePrologVariableRanges();
 
     bool lastBasicBlockHasBeenEmited; // When true no more siEndVariableLiveRange is considered.
                                       // No update/start happens when code has been generated.

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -463,9 +463,9 @@ public:
 #endif
     }
 
-    unsigned int getAmountLiveRanges() const
+    size_t getAmountLiveRanges() const
     {
-        unsigned int result = 0;
+        size_t result = 0;
         if (variableLiveRanges != nullptr)
         {
             result = variableLiveRanges->size();

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -317,7 +317,7 @@ public:
 };
 
 typedef jitstd::list<VariableLiveRange> LiveRangeList;
-typedef LiveRangeList::const_iterator         LiveRangeListIterator;
+typedef LiveRangeList::const_iterator   LiveRangeListIterator;
 
 #if DEBUG
 // Dump "VariableLiveRange" when code has not been generated and we don't have so the assembly native offset
@@ -343,7 +343,7 @@ public:
     }
 
     void reset(const LiveRangeList* list);
-    
+
     // Move the barrier to the last position of variableLiveRanges
     // This is used to print only the changes in the last block
     void setBarrierAtLastPositionInRegisterHistory(const LiveRangeList* liveRanges);
@@ -370,9 +370,9 @@ public:
 #endif
 
     bool hasVariableLiveRangeOpen() const;
-    
+
     VariableLiveDescriptor(CompAllocator allocator);
-    
+
     size_t getAmountLiveRanges() const;
 
     LiveRangeListIterator getLiveRangesIterator() const;
@@ -395,16 +395,16 @@ public:
 class VariableLiveKeeper
 {
 private:
-    unsigned int lvLiveDscCount;        // count of args, special args, and IL local variables to report home
-    unsigned int lvLiveArgsCount;       // count of arguments to report home
-    
+    unsigned int lvLiveDscCount;  // count of args, special args, and IL local variables to report home
+    unsigned int lvLiveArgsCount; // count of arguments to report home
+
     Compiler* compiler;
 
     VariableLiveDescriptor* lvaLiveDsc; // Array of descriptors that manage VariableLiveRanges.
                                         // It's indexes correspond to lvaTable indexes (or lvSlotNum).
 
-    bool lastBasicBlockHasBeenEmited;   // When true no more siEndVariableLiveRange is considered.
-                                        // No update/start happens when code has been generated.
+    bool lastBasicBlockHasBeenEmited; // When true no more siEndVariableLiveRange is considered.
+                                      // No update/start happens when code has been generated.
 public:
     VariableLiveKeeper(unsigned int totalLocalCount, unsigned int argsCount, Compiler* compiler);
 
@@ -468,7 +468,7 @@ public:
         lvPerSsaData()
     {
     }
-    
+
     // note this only packs because var_types is a typedef of unsigned char
     var_types lvType : 5; // TYP_INT/LONG/FLOAT/DOUBLE/REF
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -400,7 +400,7 @@ private:
     
     Compiler* compiler;
 
-    VariableLiveDescriptor* lvaLiveDsc; // Array of descriptos that manage VariableLiveRanges.
+    VariableLiveDescriptor* lvaLiveDsc; // Array of descriptors that manage VariableLiveRanges.
                                         // It's indexes correspond to lvaTable indexes (or lvSlotNum).
 
     bool lastBasicBlockHasBeenEmited;   // When true no more siEndVariableLiveRange is considered.

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -314,7 +314,7 @@ public:
     }
 
 #if DEBUG
-    // Dump just the emitLocation as they are, we dont have generated the whole method yet
+    // Dump just the emitLocation as they are, we haven't generated the whole method yet
     void dump(const CodeGenInterface* codeGen) const
     {
         codeGen->dumpSiVarLoc(&varLocation);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -313,6 +313,7 @@ public:
         this->endEmitLocation   = endEmitLocation;
     }
 
+#if DEBUG
     // Dump just the emitLocation as they are, we dont have generated the whole method yet
     void dump(const CodeGenInterface* codeGen) const
     {
@@ -341,6 +342,7 @@ public:
 
         printf(" [%X , %X )", startEmitLocation.CodeOffset(_emitter), endEmitLocation.CodeOffset(_emitter));
     }
+#endif
 };
 
 typedef jitstd::list<VariableLiveRange> LiveRangeList;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2194,7 +2194,45 @@ class Compiler
     */
 
 public:
+#ifdef USING_VARIABLE_LIVE_RANGE
+
+    // Return the count of reported "VariableLiveRange"s for all the "LclVarDsc"
     unsigned int getLiveRangesCount();
+
+    // Starts or ends a "VariableLiveRange" for "varDsc" if it is borning or dying respectively.
+    // Ranges are close-open [) so nothing is done in case of being borning and dying at the same line
+    // due to be an empty range.
+    void siStartOrCloseVariableLiveRange(const LclVarDsc* varDsc, bool isBorning, bool isDying);
+
+    // Iterates the VARSET_TP* set calling "siStartOrCloseVariableLiveRange" for each of the LclVarDsc.
+    void siStartOrCloseVariableLiveRanges(const VARSET_TP* varsIndexSet, bool isBorn, bool isDying);
+
+    // Starts a "VariableLiveRange" for "varDsc"
+    void siStartVariableLiveRange(const LclVarDsc* varDsc);
+
+    // Close the last "VariableLiveRange" for "varDsc"
+    void siEndVariableLiveRange(const LclVarDsc* varDsc);
+
+    // Calls updateRegisterHome on "varDsc" with the new variable location "siVarLoc"
+    void siUpdateVariableLiveRange(const LclVarDsc* varDsc);
+
+    // Close all the "VariableLiveRanges" that are indicated in the given set
+    void siEndAllVariableLiveRange(const VARSET_TP* varsToClose);
+
+    // Open a "VariableLiveRange" for the given parameter "lclVarDsc" in the given "varLocation"
+    void psiStartVariableLiveRange(CodeGenInterface::siVarLoc varLocation, const LclVarDsc* lclVarDsc);
+
+    // Close all the open "VariableLiveRanges" after prolog has been generated
+    void psiClosePrologVariableRanges();
+
+    bool lastBasicBlockHasBeenEmited; // When true no more siEndVariableLiveRange is considered.
+                                      // No update/start happens when code has been generated.
+
+#ifdef DEBUG
+    void dumpBlockVariableLiveRanges(const BasicBlock* block);
+    void dumpLvaVariableLiveRanges() const;
+#endif
+#endif
 
     hashBvGlobalData hbvGlobalData; // Used by the hashBv bitvector package.
 
@@ -2235,8 +2273,6 @@ public:
     }
 
     DWORD expensiveDebugCheckLevel;
-    void dumpBlockVariableLiveRanges(const BasicBlock* block);
-    void dumpLvaVariableLiveRanges() const;
 #endif
 
 #if FEATURE_MULTIREG_RET
@@ -7396,35 +7432,6 @@ public:
     {
         return codeGen->getEmitter();
     }
-
-    // Starts or ends a "VariableLiveRange" for "varDsc" if it is borning or dying respectively.
-    // Ranges are close-open [) so nothing is done in case of being borning and dying at the same line
-    // due to be an empty range.
-    void siStartOrCloseVariableLiveRange(const LclVarDsc* varDsc, bool isBorning, bool isDying);
-
-    // Iterates the VARSET_TP* set calling "siStartOrCloseVariableLiveRange" for each of the LclVarDsc.
-    void siStartOrCloseVariableLiveRanges(const VARSET_TP* varsIndexSet, bool isBorn, bool isDying);
-
-    // Starts a "VariableLiveRange" for "varDsc"
-    void siStartVariableLiveRange(const LclVarDsc* varDsc);
-
-    // Close the last "VariableLiveRange" for "varDsc"
-    void siEndVariableLiveRange(const LclVarDsc* varDsc);
-
-    // Calls updateRegisterHome on "varDsc" with the new variable location "siVarLoc"
-    void siUpdateVariableLiveRange(const LclVarDsc* varDsc);
-
-    // Close all the "VariableLiveRanges" that are indicated in the given set
-    void siEndAllVariableLiveRange(const VARSET_TP* varsToClose);
-
-    // Open a "VariableLiveRange" for the given parameter "lclVarDsc" in the given "varLocation"
-    void psiStartVariableLiveRange(CodeGenInterface::siVarLoc varLocation, const LclVarDsc* lclVarDsc);
-
-    // Close all the open "VariableLiveRanges" after prolog has been generated
-    void psiClosePrologVariableRanges();
-
-    bool lastBasicBlockHasBeenEmited; // When true no more siEndVariableLiveRange is considered.
-                                      // No update/start happens when code has been generated.
 
     bool isFramePointerUsed() const
     {

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -410,7 +410,7 @@ public:
     void dumpRegisterLiveRangesForBlockBeforeCodeGenerated(const CodeGenInterface* codeGen) const;
 
     void dumpAllRegisterLiveRangesForBlock(emitter* _emitter, const CodeGenInterface* codeGen) const;
-#endif
+#endif // DEBUG
 
     bool hasVariableLiveRangeOpen() const;
 
@@ -486,9 +486,9 @@ public:
 #ifdef DEBUG
     void dumpBlockVariableLiveRanges(const BasicBlock* block);
     void dumpLvaVariableLiveRanges() const;
-#endif
+#endif // DEBUG
 };
-#endif
+#endif // USING_VARIABLE_LIVE_RANGE
 
 class LclVarDsc
 {
@@ -2095,7 +2095,7 @@ public:
     void initializeVariableLiveKeeper();
 
     VariableLiveKeeper* getVariableLiveKeeper() const;
-#endif
+#endif // USING_VARIABLE_LIVE_RANGE
 
     hashBvGlobalData hbvGlobalData; // Used by the hashBv bitvector package.
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2137,7 +2137,7 @@ class Compiler
     */
 
 public:
-    unsigned int getAmountLiveRangesReported();
+    unsigned int getLiveRangesCount();
 
     hashBvGlobalData hbvGlobalData; // Used by the hashBv bitvector package.
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -387,7 +387,7 @@ public:
     // "BasicBlock"
     LiveRangeListIterator getStartForDump() const;
 
-    // Retutn wheter at least a "VariableLiveRange" was alive during the current "BasicBlock"'s
+    // Return whether at least a "VariableLiveRange" was alive during the current "BasicBlock"'s
     // code generation
     bool hasLiveRangesToDump() const;
 };

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3036,7 +3036,8 @@ public:
     }
 
     bool     lvaTrackedFixed; // true: We cannot add new 'tracked' variable
-    unsigned lvaCount;        // total number of locals
+    unsigned lvaCount;        // total number of locals, which includes function arguments, 
+                              // special arguments, IL local variables, and JIT temporary variables
 
     unsigned   lvaRefCount; // total number of references to locals
     LclVarDsc* lvaTable;    // variable descriptor table

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7349,6 +7349,9 @@ public:
     // due to be an empty range.
     void siStartOrCloseVariableLiveRange(const LclVarDsc* varDsc, bool isBorning, bool isDying);
 
+    // Iterates the VARSET_TP* set calling "siStartOrCloseVariableLiveRange" for each of the LclVarDsc.
+    void siStartOrCloseVariableLiveRanges(const VARSET_TP* varsIndexSet, bool isBorn, bool isDying);
+
     // Starts a "VariableLiveRange" for "varDsc"
     void siStartVariableLiveRange(const LclVarDsc* varDsc);
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7330,6 +7330,20 @@ public:
         return codeGen->getEmitter();
     }
 
+    // Starts or ends a "VariableLiveRange" for "varDsc" if it is borning or dying respectively.
+    // Ranges are close-open [) so nothing is done in case of being borning and dying at the same line
+    // due to be an empty range.
+    void startOrCloseVariableLiveRange(const LclVarDsc* varDsc, bool isBorning, bool isDying);
+    
+    // Starts a "VariableLiveRange" for "varDsc"
+    void startVariableLiveRange(const LclVarDsc* varDsc);
+
+    // Close the last "VariableLiveRange" for "varDsc"
+    void endVariableLiveRange(const LclVarDsc* varDsc);
+
+    // Calls updateRegisterHome on "varDsc" with the new variable location "siVarLoc"
+    void updateVariableLiveRange(const LclVarDsc* varDsc);
+
     bool isFramePointerUsed() const
     {
         return codeGen->isFramePointerUsed();

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -521,12 +521,6 @@ public:
      */
     void startLiveRangeFromEmitter(regNumber registerNumber, CodeGenInterface::siVarLoc varLocation, emitter* _emitter) const
     {
-        // Note: This assert is been hitting because are variables that became dead and started in the same block.
-        // Is this a bug in the LSRA?
-
-        // Nothing should has been pushed before
-        // noway_assert(!hasBeenAlive());
-
         // Is the first "LiveRange" or the previous one has been closed
         noway_assert(variableLiveRanges->empty() || variableLiveRanges->back().endEmitLocation.Valid());
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -298,24 +298,40 @@ enum RefCountState
 };
 
 #ifdef USING_VARIABLE_LIVE_RANGE
-// A variable lives in a location (represented by a "siVarLoc") given two assembly offsets.
+//--------------------------------------------
+//
+// VariableLiveRange: Represent part of the life of a variable. A
+//      variable lives in a location (represented with struct "siVarLoc")
+//      between two assembly offsets.
+//
+// Notes:
+//    We use emitLocation and not NATTIVE_OFFSET because location
+//    is captured when code is being generated (genCodeForBBList
+//    and genGeneratePrologsAndEpilogs) but only once the whole
+//    methodit's code is done the NATTIVE_OFFSET won't change.
+//    It is also IL_OFFSET, but this is more accurate and the
+//    debugger is expeecting assembly offsets.
+//    This class doesn't have behaviour attached to itself, it is
+//    just putting a name to a representation. It is used to build
+//    typedefs LiveRangeList and LiveRangeListIterator, which are
+//    basically a list of this class and a const_iterator of that
+//    list.
 class VariableLiveRange
 {
 public:
-    emitLocation               startEmitLocation;
-    emitLocation               endEmitLocation;
-    CodeGenInterface::siVarLoc varLocation;
+    emitLocation               m_StartEmitLocation; // first position from where "m_VarLocation" becomes valid
+    emitLocation               m_EndEmitLocation;   // last position where "m_VarLocation" is valid
+    CodeGenInterface::siVarLoc m_VarLocation;       // variable home
 
     VariableLiveRange(CodeGenInterface::siVarLoc varLocation,
                       emitLocation               startEmitLocation,
                       emitLocation               endEmitLocation)
+        : m_VarLocation(varLocation), m_StartEmitLocation(startEmitLocation), m_EndEmitLocation(endEmitLocation)
     {
-        this->varLocation       = varLocation;
-        this->startEmitLocation = startEmitLocation;
-        this->endEmitLocation   = endEmitLocation;
     }
 };
 
+// Some typedefs to avoid rewriting
 typedef jitstd::list<VariableLiveRange> LiveRangeList;
 typedef LiveRangeList::const_iterator   LiveRangeListIterator;
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -300,19 +300,21 @@ enum RefCountState
 class VariableLiveRange
 {
 public:
-    emitLocation startEmitLocation;
-    emitLocation endEmitLocation;
+    emitLocation               startEmitLocation;
+    emitLocation               endEmitLocation;
     CodeGenInterface::siVarLoc varLocation;
 
-    VariableLiveRange(CodeGenInterface::siVarLoc varLocation, emitLocation startEmitLocation, emitLocation endEmitLocation)
+    VariableLiveRange(CodeGenInterface::siVarLoc varLocation,
+                      emitLocation               startEmitLocation,
+                      emitLocation               endEmitLocation)
     {
-        this->varLocation = varLocation;
+        this->varLocation       = varLocation;
         this->startEmitLocation = startEmitLocation;
-        this->endEmitLocation = endEmitLocation;
+        this->endEmitLocation   = endEmitLocation;
     }
 
     // Dump just the emitLocation as they are, we dont have generated the whole method yet
-    void dump(const CodeGenInterface *codeGen) const
+    void dump(const CodeGenInterface* codeGen) const
     {
         codeGen->dumpSiVarLoc(&varLocation);
         printf(" [ ");
@@ -329,37 +331,37 @@ public:
         printf(" ]; ");
     }
 
-    void dump(emitter *_emitter, const CodeGenInterface *codeGen) const
+    void dump(emitter* _emitter, const CodeGenInterface* codeGen) const
     {
         codeGen->dumpSiVarLoc(&varLocation);
-        
+
         // this could be a non closed range so endEmitLocation could be a non valid emit Location
         // live -1 in case of not being defined
         UNATIVE_OFFSET endAssemblyOffset = endEmitLocation.Valid() ? endEmitLocation.CodeOffset(_emitter) : -1;
-        
+
         printf(" [%X , %X )", startEmitLocation.CodeOffset(_emitter), endEmitLocation.CodeOffset(_emitter));
     }
 };
 
 typedef jitstd::list<VariableLiveRange> LiveRangeList;
-typedef LiveRangeList::iterator  LiveRangeListIterator;
+typedef LiveRangeList::iterator         LiveRangeListIterator;
 
 #if DEBUG
-struct LiveRangeBarrier 
+struct LiveRangeBarrier
 {
     LiveRangeListIterator beginLastBlock;
-    bool haveReadAtLeastOneOfBlock;
+    bool                  haveReadAtLeastOneOfBlock;
 
-    LiveRangeBarrier(LiveRangeList *list)
+    LiveRangeBarrier(LiveRangeList* list)
     {
         haveReadAtLeastOneOfBlock = false;
-        beginLastBlock = list->end();
-    }   
+        beginLastBlock            = list->end();
+    }
 
-    void reset(LiveRangeList *list)
+    void reset(LiveRangeList* list)
     {
         noway_assert(haveReadAtLeastOneOfBlock);
-        if (! list->back().endEmitLocation.Valid())
+        if (!list->back().endEmitLocation.Valid())
         {
             // This live range will remain open until next block.
             // If it is in "bbliveIn" in the next "BasicBlock", there is no problem.
@@ -393,8 +395,8 @@ public:
     {
     }
 
-    bool              hasReportVariableLiveRanges;
-    LiveRangeList*    variableLiveRanges;
+    bool           hasReportVariableLiveRanges;
+    LiveRangeList* variableLiveRanges;
 
 #if DEBUG
     LiveRangeBarrier* variableLifeBarrier;
@@ -404,16 +406,16 @@ public:
     void setBarrierAtLastPositionInRegisterHistory() const
     {
         variableLifeBarrier->haveReadAtLeastOneOfBlock = true;
-        variableLifeBarrier->beginLastBlock = variableLiveRanges->backPosition();
+        variableLifeBarrier->beginLastBlock            = variableLiveRanges->backPosition();
     }
 
-    void dumpRegisterLiveRangesForBlockBeforeCodeGenerated(const CodeGenInterface *codeGen) const
+    void dumpRegisterLiveRangesForBlockBeforeCodeGenerated(const CodeGenInterface* codeGen) const
     {
         if (hasBeenAlive())
         {
             printf("[");
             for (LiveRangeList::iterator it = variableLifeBarrier->beginLastBlock; it != variableLiveRanges->end();
-                it++)
+                 it++)
             {
                 it->dump(codeGen);
             }
@@ -535,7 +537,7 @@ public:
         noway_assert(hasBeenAlive());
 
         // If we are reporting again the same home, that means we are doing something twice?
-        //noway_assert(variableLiveRanges->back().varLocation != varLocation);
+        // noway_assert(variableLiveRanges->back().varLocation != varLocation);
 
         // Close previous live range
         endLiveRangeAtEmitter(_emitter);
@@ -7326,7 +7328,7 @@ public:
     // Ranges are close-open [) so nothing is done in case of being borning and dying at the same line
     // due to be an empty range.
     void startOrCloseVariableLiveRange(const LclVarDsc* varDsc, bool isBorning, bool isDying);
-    
+
     // Starts a "VariableLiveRange" for "varDsc"
     void startVariableLiveRange(const LclVarDsc* varDsc);
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -317,6 +317,9 @@ public:
     // Dump just the emitLocation as they are, we haven't generated the whole method yet
     void dump(const CodeGenInterface* codeGen) const
     {
+        // "codeGen" will be dereferenced
+        noway_assert(codeGen != nullptr);
+
         codeGen->dumpSiVarLoc(&varLocation);
         printf(" [ ");
         startEmitLocation.Print();
@@ -357,12 +360,18 @@ struct LiveRangeBarrier
 
     LiveRangeBarrier(LiveRangeList* list)
     {
+        // "list" should be a valid pointer
+        noway_assert(list != nullptr);
+
         haveReadAtLeastOneOfBlock = false;
         beginLastBlock            = list->end();
     }
 
     void reset(LiveRangeList* list)
     {
+        // "list" should be a valid pointer
+        noway_assert(list != nullptr);
+
         // There must have reported something in order to reset
         noway_assert(haveReadAtLeastOneOfBlock);
 
@@ -420,6 +429,7 @@ public:
     // Modified the barrier to print on next block only just that changes
     void endBlockLiveRanges()
     {
+        noway_assert(variableLifeBarrier != nullptr);
         // barrier now points to nullptr
         variableLifeBarrier->reset(variableLiveRanges);
     }
@@ -427,11 +437,17 @@ public:
     // Returns true if a live range for this variable has been recorded from last call to EndBlock
     bool hasBeenAlive() const
     {
+        // "variableLifeBarrier" should has been initialized
+        noway_assert(variableLifeBarrier != nullptr);
+
         return variableLifeBarrier->haveReadAtLeastOneOfBlock;
     }
 
     void dumpRegisterLiveRangesForBlockBeforeCodeGenerated(const CodeGenInterface* codeGen) const
     {
+        // "variableLifeBarrier" should has been initialized
+        noway_assert(variableLifeBarrier != nullptr);
+
         if (hasBeenAlive())
         {
             printf("[");
@@ -450,6 +466,9 @@ public:
 
     void dumpAllRegisterLiveRangesForBlock(emitter* _emitter, const CodeGenInterface* codeGen) const
     {
+        // "variableLiveRanges" should has been initialized
+        noway_assert(variableLiveRanges);
+
         if (variableLiveRanges->empty())
         {
             printf("None history\n");
@@ -505,6 +524,9 @@ public:
 
     LiveRangeListIterator getLiveRangesIterator() const
     {
+        // "variableLiveRanges" should has been initialized
+        noway_assert(variableLiveRanges != nullptr);
+
         return variableLiveRanges->begin();
     }
 
@@ -2184,6 +2206,7 @@ public:
 
     DWORD expensiveDebugCheckLevel;
     void dumpBlockVariableLiveRanges(const BasicBlock* block);
+    void dumpLvaVariableLiveRanges() const;
 #endif
 
 #if FEATURE_MULTIREG_RET

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -422,6 +422,8 @@ public:
     // This is used to print only the changes in the last block
     void setBarrierAtLastPositionInRegisterHistory() const
     {
+        noway_assert(variableLiveRanges != nullptr);
+
         variableLifeBarrier->haveReadAtLeastOneOfBlock = true;
         variableLifeBarrier->beginLastBlock            = variableLiveRanges->backPosition();
     }
@@ -430,7 +432,8 @@ public:
     void endBlockLiveRanges()
     {
         noway_assert(variableLifeBarrier != nullptr);
-        // barrier now points to nullptr
+        
+        // make "variableLifeBarrier->beginLastBlock" now points to nullptr for printing purposes
         variableLifeBarrier->reset(variableLiveRanges);
     }
 
@@ -467,7 +470,7 @@ public:
     void dumpAllRegisterLiveRangesForBlock(emitter* _emitter, const CodeGenInterface* codeGen) const
     {
         // "variableLiveRanges" should has been initialized
-        noway_assert(variableLiveRanges);
+        noway_assert(variableLiveRanges != nullptr);
 
         if (variableLiveRanges->empty())
         {
@@ -545,6 +548,9 @@ public:
 
         // Using [close, open) ranges so as to not compute the size of the last instruction
         variableLiveRanges->back().endEmitLocation.CaptureLocation(_emitter);
+        
+        // No endEmitLocation has to be Valid
+        noway_assert(variableLiveRanges->back().endEmitLocation.Valid());
     }
 
     /*
@@ -558,6 +564,10 @@ public:
         // Creates new live range with invalid end
         variableLiveRanges->emplace_back(varLocation, emitLocation(), emitLocation());
         variableLiveRanges->back().startEmitLocation.CaptureLocation(_emitter);
+        
+        // startEmitLocationendEmitLocation has to be Valid and endEmitLocationendEmitLocation  not
+        noway_assert(variableLiveRanges->back().startEmitLocation.Valid());
+        noway_assert(!variableLiveRanges->back().endEmitLocation.Valid());
 
 #if DEBUG
         // Restart barrier so we can print from here
@@ -586,6 +596,10 @@ public:
         // Open new live range with invalid end
         variableLiveRanges->emplace_back(varLocation, emitLocation(), emitLocation());
         variableLiveRanges->back().startEmitLocation.CaptureLocation(_emitter);
+
+        // startEmitLocationendEmitLocation has to be Valid and endEmitLocationendEmitLocation  not
+        noway_assert(variableLiveRanges->back().startEmitLocation.Valid());
+        noway_assert(!variableLiveRanges->back().endEmitLocation.Valid());
     }
 
     // note this only packs because var_types is a typedef of unsigned char

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7362,7 +7362,7 @@ public:
     void siUpdateVariableLiveRange(const LclVarDsc* varDsc);
 
     // Close all the "VariableLiveRanges" that are indicated in the given set
-    void siEndAllVariableLiveRange(VARSET_VALARG_TP varsToClose);
+    void siEndAllVariableLiveRange(const VARSET_TP* varsToClose);
 
     bool lastBasicBlockHasBeenEmited; // When true no more siEndVariableLiveRange is considered.
                                       // No update/start happens when code has been generated.

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -377,7 +377,7 @@ public:
 
     LiveRangeListIterator getLiveRangesIterator() const;
 
-    LiveRangeList* getLiveRanges() const;
+    const LiveRangeList* getLiveRanges() const;
 
     void endLiveRangeAtEmitter(emitter* _emitter) const;
 
@@ -436,6 +436,9 @@ public:
 
     // Close all the open "VariableLiveRanges" after prolog has been generated
     void psiClosePrologVariableRanges();
+
+    // Return the "VariableLiveRange" that correspond to the given "varNum".
+    const LiveRangeList* getLiveRangesForVar(unsigned int varNum) const;
 
 #ifdef DEBUG
     void dumpBlockVariableLiveRanges(const BasicBlock* block);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7353,6 +7353,12 @@ public:
     // Calls updateRegisterHome on "varDsc" with the new variable location "siVarLoc"
     void siUpdateVariableLiveRange(const LclVarDsc* varDsc);
 
+    // Close all the "VariableLiveRanges" that are indicated in the given set
+    void siEndAllVariableLiveRange(VARSET_VALARG_TP varsToClose);
+
+    bool lastBasicBlockHasBeenEmited;   // When true no more siEndVariableLiveRange is considered.
+                                        // No update/start happens when code has been generated.
+
     bool isFramePointerUsed() const
     {
         return codeGen->isFramePointerUsed();

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -448,21 +448,19 @@ public:
     {
         hasReportVariableLiveRanges = false;
 
-        variableLiveRanges = new LiveRangeList(allocator);
+        variableLiveRanges = allocator.allocate<LiveRangeList>(1);
+        new (variableLiveRanges, jitstd::placement_t()) LiveRangeList(allocator);
+
+        size_t variableLiveRangesSize = sizeof(*variableLiveRanges);
+        memset(variableLiveRanges, 0, variableLiveRangesSize);
 
 #if DEBUG
-        variableLifeBarrier = new LiveRangeBarrier(variableLiveRanges);
-#endif
-    }
+        variableLifeBarrier = allocator.allocate<LiveRangeBarrier>(1);
+        new (variableLifeBarrier, jitstd::placement_t()) LiveRangeBarrier(variableLiveRanges);
 
-    void destructRegisterLiveRanges()
-    {
-#if DEBUG
-        delete variableLifeBarrier;
-        variableLifeBarrier = nullptr;
+        size_t variableLifeBarrierSize = sizeof(*variableLifeBarrier);
+        memset(variableLifeBarrier, 0, variableLifeBarrierSize);
 #endif
-        delete variableLiveRanges;
-        variableLiveRanges = nullptr;
     }
 
     unsigned int getAmountLiveRanges() const

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -3128,14 +3128,14 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 */
 
 //------------------------------------------------------------------------
-// compUpdateLife: Update the GC's masks, register's masks and reports change on variable's homes given a set of 
+// compUpdateLife: Update the GC's masks, register's masks and reports change on variable's homes given a set of
 //    current live variables if changes have happened since "compCurLife".
 //
 // Arguments:
 //    newLife - the set of variables that are alive.
 //
 // Assumptions:
-//    The set of live variables reflects the result of only emitted code, it should not be considering the becoming 
+//    The set of live variables reflects the result of only emitted code, it should not be considering the becoming
 //    live/dead of instructions that has not been emitted yet. This is requires by "compChangeLife".
 template <bool ForCodeGen>
 inline void Compiler::compUpdateLife(VARSET_VALARG_TP newLife)

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -1581,6 +1581,7 @@ inline unsigned Compiler::lvaGrabTemp(bool shortLifetime DEBUGARG(const char* re
     lvaTable[tempNum].lvType    = TYP_UNDEF;
     lvaTable[tempNum].lvIsTemp  = shortLifetime;
     lvaTable[tempNum].lvOnFrame = true;
+    lvaTable[tempNum].lvSlotNum = tempNum;
 
     // If we've started normal ref counting, bump the ref count of this
     // local, as we no longer do any incremental counting, and we presume
@@ -1675,6 +1676,7 @@ inline unsigned Compiler::lvaGrabTemps(unsigned cnt DEBUGARG(const char* reason)
         lvaTable[lvaCount].lvType    = TYP_UNDEF; // Initialize lvType, lvIsTemp and lvOnFrame
         lvaTable[lvaCount].lvIsTemp  = false;
         lvaTable[lvaCount].lvOnFrame = true;
+        lvaTable[lvaCount].lvSlotNum = lvaCount;
         lvaCount++;
     }
 

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -3127,6 +3127,16 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 */
 
+//------------------------------------------------------------------------
+// compUpdateLife: Update the GC's masks, register's masks and reports change on variable's homes given a set of 
+//    current live variables if changes have happened since "compCurLife".
+//
+// Arguments:
+//    newLife - the set of variables that are alive.
+//
+// Assumptions:
+//    The set of live variables reflects the result of only emitted code, it should not be considering the becoming 
+//    live/dead of instructions that has not been emitted yet. This is requires by "compChangeLife".
 template <bool ForCodeGen>
 inline void Compiler::compUpdateLife(VARSET_VALARG_TP newLife)
 {

--- a/src/jit/compmemkind.h
+++ b/src/jit/compmemkind.h
@@ -54,6 +54,7 @@ CompMemKindMacro(RangeCheck)
 CompMemKindMacro(CopyProp)
 CompMemKindMacro(SideEffects)
 CompMemKindMacro(ObjectAllocator)
+CompMemKindMacro(VariableLiveRanges)
 //clang-format on
 
 #undef CompMemKindMacro

--- a/src/jit/copyprop.cpp
+++ b/src/jit/copyprop.cpp
@@ -310,6 +310,7 @@ void Compiler::optBlockCopyProp(BasicBlock* block, LclNumToGenTreePtrStack* curS
     }
 #endif
 
+    // We are not generating code so we don't need to deal with liveness change
     TreeLifeUpdater<false> treeLifeUpdater(this);
 
     // There are no definitions at the start of the block. So clear it.

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -2919,7 +2919,7 @@ void emitter::emitInsStoreInd(instruction ins, emitAttr attr, GenTreeStoreInd* m
 
         // Updating variable liveness after instruction was emitted
         codeGen->genUpdateLife(varNode);
-        
+
         return;
     }
 

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -2856,6 +2856,8 @@ void emitter::emitInsLoadInd(instruction ins, emitAttr attr, regNumber dstReg, G
     {
         GenTreeLclVarCommon* varNode = addr->AsLclVarCommon();
         emitIns_R_S(ins, attr, dstReg, varNode->GetLclNum(), 0);
+
+        // Updating variable liveness after instruction was emitted
         codeGen->genUpdateLife(varNode);
         return;
     }
@@ -2914,7 +2916,10 @@ void emitter::emitInsStoreInd(instruction ins, emitAttr attr, GenTreeStoreInd* m
             assert(!data->isContained());
             emitIns_S_R(ins, attr, data->gtRegNum, varNode->GetLclNum(), 0);
         }
+
+        // Updating variable liveness after instruction was emitted
         codeGen->genUpdateLife(varNode);
+        
         return;
     }
 
@@ -2972,6 +2977,7 @@ void emitter::emitInsStoreLcl(instruction ins, emitAttr attr, GenTreeLclVarCommo
         assert(!data->isContained());
         emitIns_S_R(ins, attr, data->gtRegNum, varNode->GetLclNum(), 0);
     }
+    // Updating variable liveness after instruction was emitted
     codeGen->genUpdateLife(varNode);
 }
 

--- a/src/jit/jitstd/list.h
+++ b/src/jit/jitstd/list.h
@@ -52,8 +52,8 @@ public:
     {
     private:
         const_iterator(Node* ptr);
-        const_iterator();
     public:
+        const_iterator();
         const_iterator(const const_iterator& it);
         const_iterator(const typename list<T, Allocator>::iterator& it);
 

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -389,7 +389,7 @@ void Compiler::lvaInitThisPtr(InitVarDscInfo* varDscInfo)
     {
         varDsc->lvIsParam = 1;
         varDsc->lvIsPtr   = 1;
-        
+
         // This will have the varNum 0 and will be show on debugger so
         // it's home history should be safe
         varDsc->initializeRegisterLiveRanges(getAllocator());
@@ -482,7 +482,7 @@ void Compiler::lvaInitRetBuffArg(InitVarDscInfo* varDscInfo)
         // This variables are shown by the debugger so
         // we need to initialize its structures
         varDsc->initializeRegisterLiveRanges(getAllocator());
-        
+
         // And store its index for tracking purpose
         varDsc->lvSlotNum = varDscInfo->varNum;
 

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -390,13 +390,6 @@ void Compiler::lvaInitThisPtr(InitVarDscInfo* varDscInfo)
         varDsc->lvIsParam = 1;
         varDsc->lvIsPtr   = 1;
 
-        if (opts.compDbgInfo)
-        {
-            // This will have the varNum 0 and will be show on debugger so
-            // it's home history should be safe
-            varDsc->initializeRegisterLiveRanges(getAllocator());
-        }
-
         // And store its index for tracking purpose
         varDsc->lvSlotNum = varDscInfo->varNum;
 
@@ -481,13 +474,6 @@ void Compiler::lvaInitRetBuffArg(InitVarDscInfo* varDscInfo)
         varDsc->lvType      = TYP_BYREF;
         varDsc->lvIsParam   = 1;
         varDsc->lvIsRegArg  = 1;
-
-        if (opts.compDbgInfo)
-        {
-            // This variables are shown by the debugger so
-            // we need to initialize its structures
-            varDsc->initializeRegisterLiveRanges(getAllocator());
-        }
 
         // And store its index for tracking purpose
         varDsc->lvSlotNum = varDscInfo->varNum;
@@ -1062,13 +1048,6 @@ void Compiler::lvaInitGenericsCtxt(InitVarDscInfo* varDscInfo)
         varDsc->lvIsParam = 1;
         varDsc->lvType    = TYP_I_IMPL;
 
-        if (opts.compDbgInfo)
-        {
-            // This will have the varNum 0 and will be show on debugger so
-            // it's home history should be safe
-            varDsc->initializeRegisterLiveRanges(getAllocator());
-        }
-
         // And store its index for tracking purpose
         varDsc->lvSlotNum = varDscInfo->varNum;
 
@@ -1124,13 +1103,6 @@ void Compiler::lvaInitVarArgsHandle(InitVarDscInfo* varDscInfo)
         LclVarDsc* varDsc = varDscInfo->varDsc;
         varDsc->lvType    = TYP_I_IMPL;
         varDsc->lvIsParam = 1;
-
-        if (opts.compDbgInfo)
-        {
-            // This variables are shown by the debugger so
-            // we need to initialize its structures
-            varDsc->initializeRegisterLiveRanges(getAllocator());
-        }
 
         // And store its index for tracking purpose
         varDsc->lvSlotNum = varDscInfo->varNum;
@@ -1231,13 +1203,6 @@ void Compiler::lvaInitVarDsc(LclVarDsc*              varDsc,
             break;
         default:
             break;
-    }
-
-    if (opts.compDbgInfo && varNum < info.compLocalsCount)
-    {
-        // If it is a variable that exists in the IL, then we want to register
-        // its home changes ("VariableLiveRanges") for debugging purpose
-        varDsc->initializeRegisterLiveRanges(getAllocator());
     }
 
     var_types type = JITtype2varType(corInfoType);

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1192,7 +1192,7 @@ void Compiler::lvaInitVarDsc(LclVarDsc*              varDsc,
             break;
     }
 
-    if (varNum < lvaCount)
+    if (varNum < info.compLocalsCount)
     {
         // If it is a variable that exists in the IL, then we want to register
         // its home changes ("VariableLiveRanges") for debugging purpose

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -390,9 +390,12 @@ void Compiler::lvaInitThisPtr(InitVarDscInfo* varDscInfo)
         varDsc->lvIsParam = 1;
         varDsc->lvIsPtr   = 1;
 
-        // This will have the varNum 0 and will be show on debugger so
-        // it's home history should be safe
-        varDsc->initializeRegisterLiveRanges(getAllocator());
+        if (opts.compDbgInfo)
+        {
+            // This will have the varNum 0 and will be show on debugger so
+            // it's home history should be safe
+            varDsc->initializeRegisterLiveRanges(getAllocator());
+        }
 
         // And store its index for tracking purpose
         varDsc->lvSlotNum = varDscInfo->varNum;
@@ -479,9 +482,12 @@ void Compiler::lvaInitRetBuffArg(InitVarDscInfo* varDscInfo)
         varDsc->lvIsParam   = 1;
         varDsc->lvIsRegArg  = 1;
 
-        // This variables are shown by the debugger so
-        // we need to initialize its structures
-        varDsc->initializeRegisterLiveRanges(getAllocator());
+        if (opts.compDbgInfo)
+        {
+            // This variables are shown by the debugger so
+            // we need to initialize its structures
+            varDsc->initializeRegisterLiveRanges(getAllocator());
+        }
 
         // And store its index for tracking purpose
         varDsc->lvSlotNum = varDscInfo->varNum;
@@ -1056,9 +1062,12 @@ void Compiler::lvaInitGenericsCtxt(InitVarDscInfo* varDscInfo)
         varDsc->lvIsParam = 1;
         varDsc->lvType    = TYP_I_IMPL;
 
-        // This will have the varNum 0 and will be show on debugger so
-        // it's home history should be safe
-        varDsc->initializeRegisterLiveRanges(getAllocator());
+        if (opts.compDbgInfo)
+        {
+            // This will have the varNum 0 and will be show on debugger so
+            // it's home history should be safe
+            varDsc->initializeRegisterLiveRanges(getAllocator());
+        }
 
         // And store its index for tracking purpose
         varDsc->lvSlotNum = varDscInfo->varNum;
@@ -1116,9 +1125,12 @@ void Compiler::lvaInitVarArgsHandle(InitVarDscInfo* varDscInfo)
         varDsc->lvType    = TYP_I_IMPL;
         varDsc->lvIsParam = 1;
 
-        // This variables are shown by the debugger so
-        // we need to initialize its structures
-        varDsc->initializeRegisterLiveRanges(getAllocator());
+        if (opts.compDbgInfo)
+        {
+            // This variables are shown by the debugger so
+            // we need to initialize its structures
+            varDsc->initializeRegisterLiveRanges(getAllocator());
+        }
 
         // And store its index for tracking purpose
         varDsc->lvSlotNum = varDscInfo->varNum;
@@ -1221,7 +1233,7 @@ void Compiler::lvaInitVarDsc(LclVarDsc*              varDsc,
             break;
     }
 
-    if (varNum < info.compLocalsCount)
+    if (opts.compDbgInfo && varNum < info.compLocalsCount)
     {
         // If it is a variable that exists in the IL, then we want to register
         // its home changes ("VariableLiveRanges") for debugging purpose

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1192,6 +1192,13 @@ void Compiler::lvaInitVarDsc(LclVarDsc*              varDsc,
             break;
     }
 
+    if (varNum < lvaCount)
+    {
+        // If it is a variable that exists in the IL, then we want to register
+        // its home changes ("VariableLiveRanges") for debugging purpose
+        varDsc->initializeRegisterLiveRanges(getAllocator());
+    }
+
     var_types type = JITtype2varType(corInfoType);
     if (varTypeIsFloating(type))
     {

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -389,6 +389,13 @@ void Compiler::lvaInitThisPtr(InitVarDscInfo* varDscInfo)
     {
         varDsc->lvIsParam = 1;
         varDsc->lvIsPtr   = 1;
+        
+        // This will have the varNum 0 and will be show on debugger so
+        // it's home history should be safe
+        varDsc->initializeRegisterLiveRanges(getAllocator());
+
+        // And store its index for tracking purpose
+        varDsc->lvSlotNum = varDscInfo->varNum;
 
         lvaArg0Var = info.compThisArg = varDscInfo->varNum;
         noway_assert(info.compThisArg == 0);
@@ -471,6 +478,13 @@ void Compiler::lvaInitRetBuffArg(InitVarDscInfo* varDscInfo)
         varDsc->lvType      = TYP_BYREF;
         varDsc->lvIsParam   = 1;
         varDsc->lvIsRegArg  = 1;
+
+        // This variables are shown by the debugger so
+        // we need to initialize its structures
+        varDsc->initializeRegisterLiveRanges(getAllocator());
+        
+        // And store its index for tracking purpose
+        varDsc->lvSlotNum = varDscInfo->varNum;
 
         if (hasFixedRetBuffReg())
         {
@@ -1042,6 +1056,13 @@ void Compiler::lvaInitGenericsCtxt(InitVarDscInfo* varDscInfo)
         varDsc->lvIsParam = 1;
         varDsc->lvType    = TYP_I_IMPL;
 
+        // This will have the varNum 0 and will be show on debugger so
+        // it's home history should be safe
+        varDsc->initializeRegisterLiveRanges(getAllocator());
+
+        // And store its index for tracking purpose
+        varDsc->lvSlotNum = varDscInfo->varNum;
+
         if (varDscInfo->canEnreg(TYP_I_IMPL))
         {
             /* Another register argument */
@@ -1094,6 +1115,14 @@ void Compiler::lvaInitVarArgsHandle(InitVarDscInfo* varDscInfo)
         LclVarDsc* varDsc = varDscInfo->varDsc;
         varDsc->lvType    = TYP_I_IMPL;
         varDsc->lvIsParam = 1;
+
+        // This variables are shown by the debugger so
+        // we need to initialize its structures
+        varDsc->initializeRegisterLiveRanges(getAllocator());
+
+        // And store its index for tracking purpose
+        varDsc->lvSlotNum = varDscInfo->varNum;
+
         // Make sure this lives in the stack -- address may be reported to the VM.
         // TODO-CQ: This should probably be:
         //   lvaSetVarDoNotEnregister(varDscInfo->varNum DEBUGARG(DNER_VMNeedsStackAddr));

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -1263,7 +1263,8 @@ void LinearScan::recordVarLocationsAtStartOfBB(BasicBlock* bb)
                 // varDsc was alive on previous block end ("bb->bbPrev->bbLiveOut"), so it has an open
                 // "VariableLiveRange"
                 // which should change to be according "getInVarToRegMap"
-                compiler->siUpdateVariableLiveRange(varDsc);
+                VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
+                varLvKeeper->siUpdateVariableLiveRange(varDsc);
             }
 #endif
         }

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -1257,6 +1257,7 @@ void LinearScan::recordVarLocationsAtStartOfBB(BasicBlock* bb)
             varDsc->lvRegNum = newRegNum;
             count++;
 
+#ifdef USING_VARIABLE_LIVE_RANGE
             if (bb->bbPrev != nullptr && VarSetOps::IsMember(compiler, bb->bbPrev->bbLiveOut, varIndex))
             {
                 // varDsc was alive on previous block end ("bb->bbPrev->bbLiveOut"), so it has an open
@@ -1264,6 +1265,7 @@ void LinearScan::recordVarLocationsAtStartOfBB(BasicBlock* bb)
                 // which should change to be according "getInVarToRegMap"
                 compiler->siUpdateVariableLiveRange(varDsc);
             }
+#endif
         }
         else if (newRegNum != REG_STK)
         {

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -1266,7 +1266,7 @@ void LinearScan::recordVarLocationsAtStartOfBB(BasicBlock* bb)
                 VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
                 varLvKeeper->siUpdateVariableLiveRange(varDsc);
             }
-#endif
+#endif // USING_VARIABLE_LIVE_RANGE
         }
         else if (newRegNum != REG_STK)
         {

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -1263,7 +1263,7 @@ void LinearScan::recordVarLocationsAtStartOfBB(BasicBlock* bb)
 
             // Variables in bblivein have been defined in the predecesor block, so they have an open "VariableLiveRange"
             // which should change the register number if this is for some reason changing
-            compiler->updateVariableLiveRange(varDsc);
+            compiler->siUpdateVariableLiveRange(varDsc);
         }
         else if (newRegNum != REG_STK)
         {

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -1262,7 +1262,7 @@ void LinearScan::recordVarLocationsAtStartOfBB(BasicBlock* bb)
             
             // Variables in bblivein have been defined in the predecesor block, so they have an open "VariableLiveRange"
             // which should change the register number if this is for some reason changing
-            varDsc->UpdateRegisterHome(varDsc->lvRegNum, siVarLoc, compiler->getEmitter());
+            compiler->updateVariableLiveRange(varDsc);
         }
         else if (newRegNum != REG_STK)
         {

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -1257,13 +1257,13 @@ void LinearScan::recordVarLocationsAtStartOfBB(BasicBlock* bb)
             varDsc->lvRegNum = newRegNum;
             count++;
 
-            // Build the location of the variable
-            CodeGenInterface::siVarLoc siVarLoc =
-                compiler->codeGen->getSiVarLoc(varDsc, compiler->codeGen->getCurrentStackLevel());
-
-            // Variables in bblivein have been defined in the predecesor block, so they have an open "VariableLiveRange"
-            // which should change the register number if this is for some reason changing
-            compiler->siUpdateVariableLiveRange(varDsc);
+            if (bb->bbPrev != nullptr && VarSetOps::IsMember(compiler, bb->bbPrev->bbLiveOut, varIndex))
+            {
+                // varDsc was alive on previous block end ("bb->bbPrev->bbLiveOut"), so it has an open
+                // "VariableLiveRange"
+                // which should change to be according "getInVarToRegMap"
+                compiler->siUpdateVariableLiveRange(varDsc);
+            }
         }
         else if (newRegNum != REG_STK)
         {

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -1260,8 +1260,8 @@ void LinearScan::recordVarLocationsAtStartOfBB(BasicBlock* bb)
             // Build the location of the variable
             CodeGenInterface::siVarLoc siVarLoc = compiler->codeGen->getSiVarLoc(varDsc, compiler->codeGen->getCurrentStackLevel());
             
-            // Variables in bblivein had been defined in a the predecesor block, so the have an open 
-            // LiveRange which should change the register number if this is for some reason changing
+            // Variables in bblivein have been defined in the predecesor block, so they have an open "VariableLiveRange"
+            // which should change the register number if this is for some reason changing
             varDsc->UpdateRegisterHome(varDsc->lvRegNum, siVarLoc, compiler->getEmitter());
         }
         else if (newRegNum != REG_STK)

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -1258,8 +1258,9 @@ void LinearScan::recordVarLocationsAtStartOfBB(BasicBlock* bb)
             count++;
 
             // Build the location of the variable
-            CodeGenInterface::siVarLoc siVarLoc = compiler->codeGen->getSiVarLoc(varDsc, compiler->codeGen->getCurrentStackLevel());
-            
+            CodeGenInterface::siVarLoc siVarLoc =
+                compiler->codeGen->getSiVarLoc(varDsc, compiler->codeGen->getCurrentStackLevel());
+
             // Variables in bblivein have been defined in the predecesor block, so they have an open "VariableLiveRange"
             // which should change the register number if this is for some reason changing
             compiler->updateVariableLiveRange(varDsc);

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -1487,7 +1487,7 @@ void CodeGen::psiBegProlog()
 #endif
 #ifdef USING_VARIABLE_LIVE_RANGE
         siVarLoc varLocation;
-#endif
+#endif // USING_VARIABLE_LIVE_RANGE
         if (lclVarDsc->lvIsRegArg)
         {
             bool isStructHandled = false;
@@ -1543,7 +1543,7 @@ void CodeGen::psiBegProlog()
 #endif
 #ifdef USING_VARIABLE_LIVE_RANGE
                     varLocation.storeVariableOnStack(REG_SPBASE, psiGetVarStackOffset(lclVarDsc));
-#endif
+#endif // USING_VARIABLE_LIVE_RANGE
                 }
 
                 isStructHandled = true;
@@ -1565,7 +1565,7 @@ void CodeGen::psiBegProlog()
 #endif
 #ifdef USING_VARIABLE_LIVE_RANGE
                 varLocation.storeVariableOnRegisters(lclVarDsc->lvArgReg, REG_NA);
-#endif
+#endif // USING_VARIABLE_LIVE_RANGE
             }
         }
         else
@@ -1575,14 +1575,14 @@ void CodeGen::psiBegProlog()
 #endif
 #ifdef USING_VARIABLE_LIVE_RANGE
             varLocation.storeVariableOnStack(REG_SPBASE, psiGetVarStackOffset(lclVarDsc));
-#endif
+#endif // USING_VARIABLE_LIVE_RANGE
         }
 
 #ifdef USING_VARIABLE_LIVE_RANGE
         // Start a VariableLiveRange for this LclVarDsc on the built location
         VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
         varLvKeeper->psiStartVariableLiveRange(varLocation, varScope->vsdVarNum);
-#endif
+#endif // USING_VARIABLE_LIVE_RANGE
     }
 }
 
@@ -1832,5 +1832,5 @@ void CodeGen::psiEndProlog()
 #ifdef USING_VARIABLE_LIVE_RANGE
     VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
     varLiveKeeper->psiClosePrologVariableRanges();
-#endif
+#endif // USING_VARIABLE_LIVE_RANGE
 }

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -66,7 +66,7 @@ bool CodeGenInterface::siVarLoc::vlIsOnStack() const
         case CodeGenInterface::VLT_STK2:
         case CodeGenInterface::VLT_FPSTK:
             return true;
-        
+
         default:
             return false;
     }
@@ -148,75 +148,75 @@ void CodeGenInterface::dumpSiVarLoc(const siVarLoc* varLoc) const
 {
     switch (varLoc->vlType)
     {
-    case VLT_REG:
-    case CodeGenInterface::VLT_REG_BYREF:
-    case CodeGenInterface::VLT_REG_FP:
-        printf("%s", getRegName(varLoc->vlReg.vlrReg));
-        if (varLoc->vlType == (ICorDebugInfo::VarLocType)CodeGenInterface::VLT_REG_BYREF)
-        {
-            printf(" byref");
-        }
-        break;
+        case VLT_REG:
+        case CodeGenInterface::VLT_REG_BYREF:
+        case CodeGenInterface::VLT_REG_FP:
+            printf("%s", getRegName(varLoc->vlReg.vlrReg));
+            if (varLoc->vlType == (ICorDebugInfo::VarLocType)CodeGenInterface::VLT_REG_BYREF)
+            {
+                printf(" byref");
+            }
+            break;
 
-    case CodeGenInterface::VLT_STK:
-    case CodeGenInterface::VLT_STK_BYREF:
-        if ((int)varLoc->vlStk.vlsBaseReg != (int)ICorDebugInfo::REGNUM_AMBIENT_SP)
-        {
-            printf("%s[%d] (1 slot)", getRegName(varLoc->vlStk.vlsBaseReg), varLoc->vlStk.vlsOffset);
-        }
-        else
-        {
-            printf(STR_SPBASE "'[%d] (1 slot)", varLoc->vlStk.vlsOffset);
-        }
-        if (varLoc->vlType == (ICorDebugInfo::VarLocType)CodeGenInterface::VLT_REG_BYREF)
-        {
-            printf(" byref");
-        }
-        break;
+        case CodeGenInterface::VLT_STK:
+        case CodeGenInterface::VLT_STK_BYREF:
+            if ((int)varLoc->vlStk.vlsBaseReg != (int)ICorDebugInfo::REGNUM_AMBIENT_SP)
+            {
+                printf("%s[%d] (1 slot)", getRegName(varLoc->vlStk.vlsBaseReg), varLoc->vlStk.vlsOffset);
+            }
+            else
+            {
+                printf(STR_SPBASE "'[%d] (1 slot)", varLoc->vlStk.vlsOffset);
+            }
+            if (varLoc->vlType == (ICorDebugInfo::VarLocType)CodeGenInterface::VLT_REG_BYREF)
+            {
+                printf(" byref");
+            }
+            break;
 
 #ifndef _TARGET_AMD64_
-    case CodeGenInterface::VLT_REG_REG:
-        printf("%s-%s", getRegName(varLoc->vlRegReg.vlrrReg1), getRegName(varLoc->vlRegReg.vlrrReg2));
-        break;
+        case CodeGenInterface::VLT_REG_REG:
+            printf("%s-%s", getRegName(varLoc->vlRegReg.vlrrReg1), getRegName(varLoc->vlRegReg.vlrrReg2));
+            break;
 
-    case CodeGenInterface::VLT_REG_STK:
-        if ((int)varLoc->vlRegStk.vlrsStk.vlrssBaseReg != (int)ICorDebugInfo::REGNUM_AMBIENT_SP)
-        {
-            printf("%s-%s[%d]", getRegName(varLoc->vlRegStk.vlrsReg),
-                getRegName(varLoc->vlRegStk.vlrsStk.vlrssBaseReg), varLoc->vlRegStk.vlrsStk.vlrssOffset);
-        }
-        else
-        {
-            printf("%s-" STR_SPBASE "'[%d]", getRegName(varLoc->vlRegStk.vlrsReg),
-                varLoc->vlRegStk.vlrsStk.vlrssOffset);
-        }
-        break;
+        case CodeGenInterface::VLT_REG_STK:
+            if ((int)varLoc->vlRegStk.vlrsStk.vlrssBaseReg != (int)ICorDebugInfo::REGNUM_AMBIENT_SP)
+            {
+                printf("%s-%s[%d]", getRegName(varLoc->vlRegStk.vlrsReg),
+                       getRegName(varLoc->vlRegStk.vlrsStk.vlrssBaseReg), varLoc->vlRegStk.vlrsStk.vlrssOffset);
+            }
+            else
+            {
+                printf("%s-" STR_SPBASE "'[%d]", getRegName(varLoc->vlRegStk.vlrsReg),
+                       varLoc->vlRegStk.vlrsStk.vlrssOffset);
+            }
+            break;
 
-    case CodeGenInterface::VLT_STK_REG:
-        unreached(); // unexpected
+        case CodeGenInterface::VLT_STK_REG:
+            unreached(); // unexpected
 
-    case CodeGenInterface::VLT_STK2:
-        if ((int)varLoc->vlStk2.vls2BaseReg != (int)ICorDebugInfo::REGNUM_AMBIENT_SP)
-        {
-            printf("%s[%d] (2 slots)", getRegName(varLoc->vlStk2.vls2BaseReg), varLoc->vlStk2.vls2Offset);
-        }
-        else
-        {
-            printf(STR_SPBASE "'[%d] (2 slots)", varLoc->vlStk2.vls2Offset);
-        }
-        break;
+        case CodeGenInterface::VLT_STK2:
+            if ((int)varLoc->vlStk2.vls2BaseReg != (int)ICorDebugInfo::REGNUM_AMBIENT_SP)
+            {
+                printf("%s[%d] (2 slots)", getRegName(varLoc->vlStk2.vls2BaseReg), varLoc->vlStk2.vls2Offset);
+            }
+            else
+            {
+                printf(STR_SPBASE "'[%d] (2 slots)", varLoc->vlStk2.vls2Offset);
+            }
+            break;
 
-    case CodeGenInterface::VLT_FPSTK:
-        printf("ST(L-%d)", varLoc->vlFPstk.vlfReg);
-        break;
+        case CodeGenInterface::VLT_FPSTK:
+            printf("ST(L-%d)", varLoc->vlFPstk.vlfReg);
+            break;
 
-    case CodeGenInterface::VLT_FIXED_VA:
-        printf("fxd_va[%d]", varLoc->vlFixedVarArg.vlfvOffset);
-        break;
+        case CodeGenInterface::VLT_FIXED_VA:
+            printf("fxd_va[%d]", varLoc->vlFixedVarArg.vlfvOffset);
+            break;
 #endif // !_TARGET_AMD64_
 
-    default:
-        unreached(); // unexpected
+        default:
+            unreached(); // unexpected
     }
 }
 

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -150,17 +150,17 @@ void CodeGenInterface::dumpSiVarLoc(const siVarLoc* varLoc) const
     switch (varLoc->vlType)
     {
         case VLT_REG:
-        case CodeGenInterface::VLT_REG_BYREF:
-        case CodeGenInterface::VLT_REG_FP:
+        case VLT_REG_BYREF:
+        case VLT_REG_FP:
             printf("%s", getRegName(varLoc->vlReg.vlrReg));
-            if (varLoc->vlType == (ICorDebugInfo::VarLocType)CodeGenInterface::VLT_REG_BYREF)
+            if (varLoc->vlType == VLT_REG_BYREF)
             {
                 printf(" byref");
             }
             break;
 
-        case CodeGenInterface::VLT_STK:
-        case CodeGenInterface::VLT_STK_BYREF:
+        case VLT_STK:
+        case VLT_STK_BYREF:
             if ((int)varLoc->vlStk.vlsBaseReg != (int)ICorDebugInfo::REGNUM_AMBIENT_SP)
             {
                 printf("%s[%d] (1 slot)", getRegName(varLoc->vlStk.vlsBaseReg), varLoc->vlStk.vlsOffset);
@@ -169,18 +169,18 @@ void CodeGenInterface::dumpSiVarLoc(const siVarLoc* varLoc) const
             {
                 printf(STR_SPBASE "'[%d] (1 slot)", varLoc->vlStk.vlsOffset);
             }
-            if (varLoc->vlType == (ICorDebugInfo::VarLocType)CodeGenInterface::VLT_REG_BYREF)
+            if (varLoc->vlType == VLT_REG_BYREF)
             {
                 printf(" byref");
             }
             break;
 
 #ifndef _TARGET_AMD64_
-        case CodeGenInterface::VLT_REG_REG:
+        case VLT_REG_REG:
             printf("%s-%s", getRegName(varLoc->vlRegReg.vlrrReg1), getRegName(varLoc->vlRegReg.vlrrReg2));
             break;
 
-        case CodeGenInterface::VLT_REG_STK:
+        case VLT_REG_STK:
             if ((int)varLoc->vlRegStk.vlrsStk.vlrssBaseReg != (int)ICorDebugInfo::REGNUM_AMBIENT_SP)
             {
                 printf("%s-%s[%d]", getRegName(varLoc->vlRegStk.vlrsReg),
@@ -193,10 +193,10 @@ void CodeGenInterface::dumpSiVarLoc(const siVarLoc* varLoc) const
             }
             break;
 
-        case CodeGenInterface::VLT_STK_REG:
+        case VLT_STK_REG:
             unreached(); // unexpected
 
-        case CodeGenInterface::VLT_STK2:
+        case VLT_STK2:
             if ((int)varLoc->vlStk2.vls2BaseReg != (int)ICorDebugInfo::REGNUM_AMBIENT_SP)
             {
                 printf("%s[%d] (2 slots)", getRegName(varLoc->vlStk2.vls2BaseReg), varLoc->vlStk2.vls2Offset);
@@ -207,11 +207,11 @@ void CodeGenInterface::dumpSiVarLoc(const siVarLoc* varLoc) const
             }
             break;
 
-        case CodeGenInterface::VLT_FPSTK:
+        case VLT_FPSTK:
             printf("ST(L-%d)", varLoc->vlFPstk.vlfReg);
             break;
 
-        case CodeGenInterface::VLT_FIXED_VA:
+        case VLT_FIXED_VA:
             printf("fxd_va[%d]", varLoc->vlFixedVarArg.vlfvOffset);
             break;
 #endif // !_TARGET_AMD64_

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -96,7 +96,7 @@ bool CodeGenInterface::siVarLoc::vlIsInReg(regNumber reg) const
     }
 }
 
-bool CodeGenInterface::siVarLoc::vlIsOnStk(regNumber reg, signed offset) const
+bool CodeGenInterface::siVarLoc::vlIsOnStack(regNumber reg, signed offset) const
 {
     regNumber actualReg;
 

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -1338,16 +1338,6 @@ void CodeGen::siDispOpenScopes()
  *============================================================================
  */
 
-// Enable these macros to get psiScopes info or either VariableLiveRange info
-// reporting variables' home location on the prolog and epilog of the method.
-// Both can be used at the same time but only one will be sent to the debugger.
-#if 1
-#define USING_SCOPE_INFO
-#endif
-#if 1
-#define USING_VARIABLE_LIVE_RANGE
-#endif
-
 /*****************************************************************************
  *                      psiNewPrologScope
  *

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -147,6 +147,9 @@ bool CodeGenInterface::siVarLoc::vlIsOnStk(regNumber reg, signed offset) const
 #if DEBUG
 void CodeGenInterface::dumpSiVarLoc(const siVarLoc* varLoc) const
 {
+    // "varLoc" cannot be null
+    noway_assert(varLoc != nullptr);
+
     switch (varLoc->vlType)
     {
         case VLT_REG:

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -1580,7 +1580,8 @@ void CodeGen::psiBegProlog()
 
 #ifdef USING_VARIABLE_LIVE_RANGE
         // Start a VariableLiveRange for this LclVarDsc on the built location
-        compiler->psiStartVariableLiveRange(varLocation, lclVarDsc);
+        VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
+        varLvKeeper->psiStartVariableLiveRange(varLocation, varScope->vsdVarNum);
 #endif
     }
 }
@@ -1829,6 +1830,7 @@ void CodeGen::psiEndProlog()
 #endif
 
 #ifdef USING_VARIABLE_LIVE_RANGE
-    compiler->psiClosePrologVariableRanges();
+    VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
+    varLiveKeeper->psiClosePrologVariableRanges();
 #endif
 }

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -144,6 +144,7 @@ bool CodeGenInterface::siVarLoc::vlIsOnStk(regNumber reg, signed offset) const
     }
 }
 
+#if DEBUG
 void CodeGenInterface::dumpSiVarLoc(const siVarLoc* varLoc) const
 {
     switch (varLoc->vlType)
@@ -219,6 +220,7 @@ void CodeGenInterface::dumpSiVarLoc(const siVarLoc* varLoc) const
             unreached(); // unexpected
     }
 }
+#endif
 
 //------------------------------------------------------------------------
 // siVarLoc: Non-empty constructor of siVarLoc struct

--- a/src/jit/treelifeupdater.cpp
+++ b/src/jit/treelifeupdater.cpp
@@ -259,9 +259,10 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
 #endif // DEBUG
             }
 
+#ifdef USING_VARIABLE_LIVE_RANGE
             // For each of the LclVarDsc that are reporting change, variable or fields
             compiler->siStartOrCloseVariableLiveRanges(&varDeltaSet, isBorn, isDying);
-
+#endif
             compiler->codeGen->siUpdate();
         }
     }

--- a/src/jit/treelifeupdater.cpp
+++ b/src/jit/treelifeupdater.cpp
@@ -31,7 +31,7 @@ TreeLifeUpdater<ForCodeGen>::TreeLifeUpdater(Compiler* compiler)
 //    intervals when calling "siStartOrCloseVariableLiveRange".
 //
 // Notes:
-//  If "ForCodeGen" is true, then the register mask use by CodeGen and the "LiveRangeList" of the "LclVadDsc"
+//  If "ForCodeGen" is true, then the register mask use by CodeGen and the "LiveRangeList" of the "LclVarDsc"
 //  are updated given the new updated value of the variable ("isBorn"/"isDead"/"spill")
 template <bool ForCodeGen>
 void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)

--- a/src/jit/treelifeupdater.cpp
+++ b/src/jit/treelifeupdater.cpp
@@ -28,7 +28,7 @@ TreeLifeUpdater<ForCodeGen>::TreeLifeUpdater(Compiler* compiler)
 // Assumptions:
 //    The code corresponding to the given tree has been emitted, which means that if a variable has become live/dead
 //    or been spilled then the emiter is positioned after that changed. This is used to ensure [) "VariableLiveRange"
-//    intervals when calling "startOrCloseVariableLiveRange".
+//    intervals when calling "siStartOrCloseVariableLiveRange".
 //
 // Notes:
 //  If "ForCodeGen" is true, then the register mask use by CodeGen and the "LiveRangeList" of the "LclVadDsc"
@@ -115,7 +115,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
                     VarSetOps::AddElemD(compiler, stackVarDeltaSet, varDsc->lvVarIndex);
                 }
 
-                compiler->startOrCloseVariableLiveRange(varDsc, isBorn, isDying);
+                compiler->siStartOrCloseVariableLiveRange(varDsc, isBorn, isDying);
             }
         }
         else if (varDsc->lvPromoted)
@@ -188,7 +188,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
                     {
                         // BRIAN:: see how scopes are reported for promoted structs. Are they considered in the
                         // amount of local variables to report?
-                        compiler->startOrCloseVariableLiveRange(fldVarDsc, isBorn, isDying);
+                        compiler->siStartOrCloseVariableLiveRange(fldVarDsc, isBorn, isDying);
                     }
                 }
             }

--- a/src/jit/treelifeupdater.cpp
+++ b/src/jit/treelifeupdater.cpp
@@ -114,8 +114,6 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
                     // Its putting in stackVarDeltaSet the variable no matter if its living or dying
                     VarSetOps::AddElemD(compiler, stackVarDeltaSet, varDsc->lvVarIndex);
                 }
-
-                compiler->siStartOrCloseVariableLiveRange(varDsc, isBorn, isDying);
             }
         }
         else if (varDsc->lvPromoted)
@@ -267,6 +265,8 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
                 }
 #endif // DEBUG
             }
+
+            compiler->siStartOrCloseVariableLiveRange(varDsc, isBorn, isDying);
 
             compiler->codeGen->siUpdate();
         }

--- a/src/jit/treelifeupdater.cpp
+++ b/src/jit/treelifeupdater.cpp
@@ -26,7 +26,7 @@ TreeLifeUpdater<ForCodeGen>::TreeLifeUpdater(Compiler* compiler)
 //    tree - the tree which affects liveness.
 //
 // Assumptions:
-//    The code corresponding to the given tree has been emitted, which means that if a variable has become live/dead 
+//    The code corresponding to the given tree has been emitted, which means that if a variable has become live/dead
 //    or been spilled then the emiter is positioned after that changed. This is used to ensure [) "VariableLiveRange"
 //    intervals when calling "startOrCloseVariableLiveRange".
 //
@@ -114,7 +114,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
                     // Its putting in stackVarDeltaSet the variable no matter if its living or dying
                     VarSetOps::AddElemD(compiler, stackVarDeltaSet, varDsc->lvVarIndex);
                 }
-                
+
                 compiler->startOrCloseVariableLiveRange(varDsc, isBorn, isDying);
             }
         }
@@ -122,7 +122,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
         {
             // If hasDeadTrackedFieldVars is true, then, for a LDOBJ(ADDR(<promoted struct local>)),
             // *deadTrackedFieldVars indicates which tracked field vars are dying.
-            // UPDATE: If hasDeadTrackedFieldVars is true, some fields are dying, 
+            // UPDATE: If hasDeadTrackedFieldVars is true, some fields are dying,
             // while other fields remain (or become) live.
             bool hasDeadTrackedFieldVars = false;
 
@@ -171,7 +171,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
                     {
                         if (compiler->lvaTable[i].lvIsInReg())
                         {
-                            if (isBorn) 
+                            if (isBorn)
                             {
                                 // should we include this var in newLife ?
                                 compiler->codeGen->genUpdateVarReg(fldVarDsc, tree);
@@ -186,7 +186,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
 
                     if (ForCodeGen)
                     {
-                        // BRIAN:: see how scopes are reported for promoted structs. Are they considered in the 
+                        // BRIAN:: see how scopes are reported for promoted structs. Are they considered in the
                         // amount of local variables to report?
                         compiler->startOrCloseVariableLiveRange(fldVarDsc, isBorn, isDying);
                     }
@@ -299,7 +299,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
 //    tree - the tree which effect on liveness is processed.
 //
 // Assumptions:
-//    The code corresponding to the given tree has been emitted, which means that if a variable has become live/dead 
+//    The code corresponding to the given tree has been emitted, which means that if a variable has become live/dead
 //    or been spilled then the emiter is positioned after that changed. This is required in UpdateLifeVar.
 template <bool ForCodeGen>
 void TreeLifeUpdater<ForCodeGen>::UpdateLife(GenTree* tree)

--- a/src/jit/treelifeupdater.cpp
+++ b/src/jit/treelifeupdater.cpp
@@ -25,6 +25,14 @@ TreeLifeUpdater<ForCodeGen>::TreeLifeUpdater(Compiler* compiler)
 // Arguments:
 //    tree - the tree which affects liveness.
 //
+// Assumptions:
+//    The code corresponding to the given tree has been emitted, which means that if a variable has become live/dead 
+//    or been spilled then the emiter is positioned after that changed. This is used to ensure [) "VariableLiveRange"
+//    intervals when calling "startLiveRangeFromEmitter" and "endLiveRangeAtEmitter".
+//
+// Notes:
+//  If "ForCodeGen" is true, then the register mask use by CodeGen and the "LiveRangeList" of the "LclVadDsc"
+//  are updated given the new updated value of the variable ("isBorn"/"isDead"/"spill")
 template <bool ForCodeGen>
 void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
 {
@@ -310,11 +318,14 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
 }
 
 //------------------------------------------------------------------------
-// UpdateLife: Determine whether the tree affects liveness, and update liveness sets accordingly.
+// UpdateLife: Determine whether the tree affects liveness, and update liveness sets and variables home accordingly.
 //
 // Arguments:
 //    tree - the tree which effect on liveness is processed.
 //
+// Assumptions:
+//    The code corresponding to the given tree has been emitted, which means that if a variable has become live/dead 
+//    or been spilled then the emiter is positioned after that changed. This is required in UpdateLifeVar.
 template <bool ForCodeGen>
 void TreeLifeUpdater<ForCodeGen>::UpdateLife(GenTree* tree)
 {

--- a/src/jit/treelifeupdater.cpp
+++ b/src/jit/treelifeupdater.cpp
@@ -181,13 +181,6 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
                             VarSetOps::AddElemD(compiler, stackVarDeltaSet, fldVarIndex);
                         }
                     }
-
-                    if (ForCodeGen)
-                    {
-                        // BRIAN:: see how scopes are reported for promoted structs. Are they considered in the
-                        // amount of local variables to report?
-                        compiler->siStartOrCloseVariableLiveRange(fldVarDsc, isBorn, isDying);
-                    }
                 }
             }
         }
@@ -266,7 +259,8 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
 #endif // DEBUG
             }
 
-            compiler->siStartOrCloseVariableLiveRange(varDsc, isBorn, isDying);
+            // For each of the LclVarDsc that are reporting change, variable or fields
+            compiler->siStartOrCloseVariableLiveRanges(&varDeltaSet, isBorn, isDying);
 
             compiler->codeGen->siUpdate();
         }

--- a/src/jit/treelifeupdater.cpp
+++ b/src/jit/treelifeupdater.cpp
@@ -261,7 +261,8 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
 
 #ifdef USING_VARIABLE_LIVE_RANGE
             // For each of the LclVarDsc that are reporting change, variable or fields
-            compiler->siStartOrCloseVariableLiveRanges(&varDeltaSet, isBorn, isDying);
+            VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
+            varLiveKeeper->siStartOrCloseVariableLiveRanges(&varDeltaSet, isBorn, isDying);
 #endif
             compiler->codeGen->siUpdate();
         }

--- a/src/jit/treelifeupdater.cpp
+++ b/src/jit/treelifeupdater.cpp
@@ -263,7 +263,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
             // For each of the LclVarDsc that are reporting change, variable or fields
             VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
             varLiveKeeper->siStartOrCloseVariableLiveRanges(&varDeltaSet, isBorn, isDying);
-#endif
+#endif // USING_VARIABLE_LIVE_RANGE
             compiler->codeGen->siUpdate();
         }
     }


### PR DESCRIPTION
I am reporting local variables now and the integration has been checked from VS IDE. I am opening this PR to start iterating the solution, but there are changes needed:

NO MORE DESIRED:
1. Move instantiation of VariableLiveRange to when LclVarDsc is been created. After moving this outside Compiler class, I don't see the point of not initializing the complete array on genInitialize before iterating blocks and generating code inside genCodeForBBList.

DONE:
1. Only store the home's history of the variables that are in the IL (now I am tracking all the variables used in the linear scan register allocation).
2. See what changes are done with the stack level when the stackframe is not using the ebp and if this is not affecting one of my offsets. **Response:** it seems I don't have to care about that, information si always true on LclVarDsc at the moment of beign born/dead.
3. Review the changes applied on "psiScopeList" after genCodeForBBList. I have read there are some changes on the prolog and I am not updating offset info of args nor variables. Most of the code is inside a flag which by default is disabled (harcoded) on code, so I will not add code there.
4. Move VariableLiveRanges structures/classes outside compiler/LclVarDsc classes

TODO:
1. Measure Time/Memory performance changes of the solution
2. Add documentation
4. Add at least a test to the project so the functionality is not affected with next changes.

OUT OF SCOPE:
1. See how scopes are reported for promoted structs. Are they considered in the amount of local variables to report? The struct's attributes would not have a IL matching, so, Do I need to care about?

The items are commutative and the list is not complete.
Please fill free to send reviews.