### PR TITLE
Fix and re-enable some finalizer tests

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -115,12 +115,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/GC/Features/HeapExpansion/pluggaps/*">
             <Issue>needs triage</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/GC/Features/Finalizer/finalizeother/finalizearray/*">
-            <Issue>19218</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/GC/Features/Finalizer/finalizeother/finalizearraysleep/*">
-            <Issue>19218</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/GC/Regressions/v2.0-beta2/460373/460373/*">
             <Issue>needs triage</Issue>
         </ExcludeList>

--- a/tests/src/GC/Features/Finalizer/finalizeother/finalizearray.cs
+++ b/tests/src/GC/Features/Finalizer/finalizeother/finalizearray.cs
@@ -22,6 +22,8 @@ public class Test
     {
         public Dummy[] obj;
 
+        // No inline to ensure no stray refs to the new array
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public CreateObj() {
             obj = new Dummy[10000];
             for(int i=0;i<10000;i++) {

--- a/tests/src/GC/Features/Finalizer/finalizeother/finalizearraysleep.cs
+++ b/tests/src/GC/Features/Finalizer/finalizeother/finalizearraysleep.cs
@@ -22,6 +22,8 @@ public class Test {
         public Dummy[] obj;
         public int ExitCode = 0;		
 
+        // No inline to ensure no stray refs to the new array
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public CreateObj() {
             obj = new Dummy[10];
 

--- a/tests/src/GC/Features/Finalizer/finalizeother/finalizedest.cs
+++ b/tests/src/GC/Features/Finalizer/finalizeother/finalizedest.cs
@@ -29,6 +29,8 @@ public class Test
         Dummy obj;
 #pragma warning restore 0414
 
+        // No inline to ensure no stray refs to the Dummy object
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public CreateObj()
         {
             obj = new Dummy();

--- a/tests/src/GC/Features/Finalizer/finalizeother/finalizeexcep.cs
+++ b/tests/src/GC/Features/Finalizer/finalizeother/finalizeexcep.cs
@@ -32,6 +32,8 @@ public class Test {
     public class CreateObj {
         public Dummy obj;
 
+        // No inline to ensure no stray refs to the Dummy object
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public CreateObj() {
             obj = new Dummy();
         }

--- a/tests/src/GC/Features/Finalizer/finalizeother/finalizeinherit.cs
+++ b/tests/src/GC/Features/Finalizer/finalizeother/finalizeinherit.cs
@@ -55,6 +55,8 @@ namespace Three {
 #pragma warning restore 0414
         C c;
 
+        // No inline to ensure no stray refs to the B, C, D objects.
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public CreateObj()
         {
             b = new B();


### PR DESCRIPTION
Mark key allocating methods noinline, otherwise they may get inlined
under jit stress and leave jit temps referring to allocations that the test
expects should be collectible.

Resolves #19218.