### PR TITLE
Disable IJW tests on Windows 7.

### DIFF
--- a/tests/src/Common/CoreCLRTestLibrary/Utilities.cs
+++ b/tests/src/Common/CoreCLRTestLibrary/Utilities.cs
@@ -66,6 +66,7 @@ namespace TestLibrary
         public static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         public static bool IsLinux => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
         public static bool IsMacOSX => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+        public static bool IsWindows7 => IsWindows && Environment.OSVersion.Version.Major == 6 && Environment.OSVersion.Version.Minor == 1;
         public static bool IsWindowsNanoServer => (!IsWindowsIoTCore && GetInstallationType().Equals("Nano Server", StringComparison.OrdinalIgnoreCase));
         public static bool IsWindowsIoTCore
         {

--- a/tests/src/Interop/IJW/ManagedCallingNative/ManagedCallingNative.cs
+++ b/tests/src/Interop/IJW/ManagedCallingNative/ManagedCallingNative.cs
@@ -14,7 +14,8 @@ namespace ManagedCallingNative
     {
         static int Main(string[] args)
         {
-            if(Environment.OSVersion.Platform != PlatformID.Win32NT)
+            // Disable running on Windows 7 until IJW activation work is complete. See dotnet/coreclr#21796
+            if(Environment.OSVersion.Platform != PlatformID.Win32NT || TestLibrary.Utilities.IsWindows7)
             {
                 return 100;
             }

--- a/tests/src/Interop/IJW/ManagedCallingNative/ManagedCallingNative.cs
+++ b/tests/src/Interop/IJW/ManagedCallingNative/ManagedCallingNative.cs
@@ -14,7 +14,7 @@ namespace ManagedCallingNative
     {
         static int Main(string[] args)
         {
-            // Disable running on Windows 7 until IJW activation work is complete. See dotnet/coreclr#21796
+            // Disable running on Windows 7 until IJW activation work is complete.
             if(Environment.OSVersion.Platform != PlatformID.Win32NT || TestLibrary.Utilities.IsWindows7)
             {
                 return 100;

--- a/tests/src/Interop/IJW/NativeCallingManaged/NativeCallingManaged.cs
+++ b/tests/src/Interop/IJW/NativeCallingManaged/NativeCallingManaged.cs
@@ -14,7 +14,7 @@ namespace NativeCallingManaged
     {
         static int Main(string[] args)
         {
-            // Disable running on Windows 7 until IJW activation work is complete. See dotnet/coreclr#21796
+            // Disable running on Windows 7 until IJW activation work is complete.
             if(Environment.OSVersion.Platform != PlatformID.Win32NT || TestLibrary.Utilities.IsWindows7)
             {
                 return 100;

--- a/tests/src/Interop/IJW/NativeCallingManaged/NativeCallingManaged.cs
+++ b/tests/src/Interop/IJW/NativeCallingManaged/NativeCallingManaged.cs
@@ -14,6 +14,12 @@ namespace NativeCallingManaged
     {
         static int Main(string[] args)
         {
+            // Disable running on Windows 7 until IJW activation work is complete. See dotnet/coreclr#21796
+            if(Environment.OSVersion.Platform != PlatformID.Win32NT || TestLibrary.Utilities.IsWindows7)
+            {
+                return 100;
+            }
+
             bool success = true;
             // Load a fake mscoree.dll to avoid starting desktop
             LoadLibraryEx(Path.Combine(Environment.CurrentDirectory, "mscoree.dll"), IntPtr.Zero, 0);


### PR DESCRIPTION
Windows 7 loads desktop mscoree.dll when loading System.Private.CoreLib, before we can load our fake mscoree. So, when IJW modules are loaded, they load the real mscoree.dll, which breaks coreclr's IJW loading. Once we have true .NET Core IJW support in the MSVC++ compiler and .NET Core, then we'll be able to reenable these tests on Win7.

Fixes #21796.

cc: @RussKeldorph @echesakovMSFT 
