### PR TITLE
Remove 'from HRESULT' string

### DIFF
--- a/src/dlls/mscorrc/mscorrc.rc
+++ b/src/dlls/mscorrc/mscorrc.rc
@@ -496,7 +496,6 @@ BEGIN
 STRINGTABLE DISCARDABLE 
 BEGIN
     CEE_E_CVTRES_NOT_FOUND                  "Could not execute CVTRES.EXE."
-    IDS_EE_EXCEPTION_FROM_HRESULT           "Exception from HRESULT: "
     IDS_EE_NDIRECT_UNSUPPORTED_SIG          "Method's type signature is not PInvoke compatible."
     IDS_EE_COM_UNSUPPORTED_SIG              "Method's type signature is not Interop compatible."
     IDS_EE_COM_UNSUPPORTED_TYPE             "The method returned a COM Variant type that is not Interop compatible."

--- a/src/dlls/mscorrc/resource.h
+++ b/src/dlls/mscorrc/resource.h
@@ -88,7 +88,6 @@
 #define IDS_DS_DSOTHREADMODEL                   0x1707
 
 #define IDS_EE_NDIRECT_UNSUPPORTED_SIG          0x1708
-#define IDS_EE_EXCEPTION_FROM_HRESULT           0x1709
 #define IDS_EE_NDIRECT_BADNATL                  0x170a
 #define IDS_EE_NDIRECT_LOADLIB_WIN              0x170b
 #define IDS_EE_NDIRECT_GETPROCADDRESS_WIN       0x170c

--- a/src/utilcode/ex.cpp
+++ b/src/utilcode/ex.cpp
@@ -1200,7 +1200,6 @@ void GetHRMsg(HRESULT hr, SString &result, BOOL bNoGeekStuff/* = FALSE*/)
         result.Append(strDescr);
     }
 
-    
     if (!bNoGeekStuff)
     {
         if (fHaveDescr)
@@ -1208,21 +1207,16 @@ void GetHRMsg(HRESULT hr, SString &result, BOOL bNoGeekStuff/* = FALSE*/)
             result.Append(W(" ("));
         }
 
-        SString strExcepFromHR;
-        strExcepFromHR.LoadResource(CCompRC::Error, IDS_EE_EXCEPTION_FROM_HRESULT);
-        result.Append(strExcepFromHR);
         result.AppendPrintf(W("0x%.8X"), hr);
         if (name != NULL)
         {
             result.AppendPrintf(W(" (%S)"), name);
         }
 
-
         if (fHaveDescr)
         {
             result.Append(W(")"));
         }
-        
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/35456

HRESULT is a Windows specific concept, and as the issue shows, the value marked as HRESULT is sometimes not even in HRESULT form.

Change eg 
`Could not load file or assembly 'System.Runtime.Loader.Test.Assembly, Culture=neutral, PublicKeyToken=null'. Error 28 (Exception from HRESULT: 0x0000001C)`
to 
`Could not load file or assembly 'System.Runtime.Loader.Test.Assembly, Culture=neutral, PublicKeyToken=null'. Error 28 (0x0000001C)`

Some future change could possibly reduce the redundancy in cases like the specific example.