### PR TITLE
Remove Timer _id from CoreCLR implementation

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/Timer.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Timer.CoreCLR.cs
@@ -59,14 +59,7 @@ namespace System.Threading
             }
         }
 
-        private readonly int _id; // TimerQueues[_id] == this
-
         private AppDomainTimerSafeHandle m_appDomainTimer;
-
-        private TimerQueue(int id)
-        {
-            _id = id;
-        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool SetTimer(uint actualDuration)


### PR DESCRIPTION
- Followup to https://github.com/dotnet/corert/pull/7071, would have to be merged into PR that ports https://github.com/dotnet/corert/pull/7071 to CoreCLR