### PR TITLE
Add platforms parameter to platform-matrix.yml

### DIFF
--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -43,34 +43,35 @@ jobs:
         crossrootfsDir: '/crossrootfs/arm'
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux arm64
+  # Linux arm64
 
-- template: ${{ parameters.jobTemplate }}
-  parameters:
-    buildConfig: ${{ parameters.buildConfig }}
-    archType: arm64
-    osGroup: Linux
-    osIdentifier: Linux
-    containerName: ubuntu_1604_arm64_cross_build_image
-    helixQueues:
-      ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-        asString: 'Ubuntu.1804.Arm64.Open'
-        asArray:
-        - Ubuntu.1804.Arm64.Open
-      ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-        # TODO: add Ubuntu.1604.Arm64.Open once Jenkins has been shutdown
-        asString: 'Debian.9.Arm64.Open,Ubuntu.1804.Arm64.Open'
-        asArray:
-        - Debian.9.Arm64.Open
-        - Ubuntu.1804.Arm64.Open
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        asString: 'Debian.9.Arm64,Ubuntu.1604.Arm64,Ubuntu.1804.Arm64'
-        asArray:
-        - Debian.9.Arm64
-        - Ubuntu.1604.Arm64
-        - Ubuntu.1804.Arm64
-    crossrootfsDir: '/crossrootfs/arm64'
-    ${{ insert }}: ${{ parameters.jobParameters }}
+  - ${{ if eq(platform, 'Linux_arm64') }}:
+    - template: ${{ parameters.jobTemplate }}
+      parameters:
+        buildConfig: ${{ parameters.buildConfig }}
+        archType: arm64
+        osGroup: Linux
+        osIdentifier: Linux
+        containerName: ubuntu_1604_arm64_cross_build_image
+        helixQueues:
+          ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+            asString: 'Ubuntu.1804.Arm64.Open'
+            asArray:
+            - Ubuntu.1804.Arm64.Open
+          ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+            # TODO: add Ubuntu.1604.Arm64.Open once Jenkins has been shutdown
+            asString: 'Debian.9.Arm64.Open,Ubuntu.1804.Arm64.Open'
+            asArray:
+            - Debian.9.Arm64.Open
+            - Ubuntu.1804.Arm64.Open
+          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+            asString: 'Debian.9.Arm64,Ubuntu.1604.Arm64,Ubuntu.1804.Arm64'
+            asArray:
+            - Debian.9.Arm64
+            - Ubuntu.1604.Arm64
+            - Ubuntu.1804.Arm64
+        crossrootfsDir: '/crossrootfs/arm64'
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux musl
 

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -95,26 +95,27 @@ jobs:
             - Alpine.38.Amd64
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux musl arm64
+  # Linux musl arm64
 
-- template: ${{ parameters.jobTemplate }}
-  parameters:
-    buildConfig: ${{ parameters.buildConfig }}
-    archType: arm64
-    osGroup: Linux
-    osIdentifier: Linux_musl
-    containerName: musl_arm64_build_image
-    helixQueues:
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        # TODO: there are no Alpine arm64 queues https://github.com/dotnet/core-eng/issues/5206
-        asString: ''
-        asArray: []
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        # TODO: there are no Alpine arm64 queues https://github.com/dotnet/core-eng/issues/5206
-        asString: ''
-        asArray: []
-    crossrootfsDir: '/crossrootfs/arm64'
-    ${{ insert }}: ${{ parameters.jobParameters }}
+  - ${{ if eq(platform, 'Linux_musl_arm64') }}:
+    - template: ${{ parameters.jobTemplate }}
+      parameters:
+        buildConfig: ${{ parameters.buildConfig }}
+        archType: arm64
+        osGroup: Linux
+        osIdentifier: Linux_musl
+        containerName: musl_arm64_build_image
+        helixQueues:
+          ${{ if eq(variables['System.TeamProject'], 'public') }}:
+            # TODO: there are no Alpine arm64 queues https://github.com/dotnet/core-eng/issues/5206
+            asString: ''
+            asArray: []
+          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+            # TODO: there are no Alpine arm64 queues https://github.com/dotnet/core-eng/issues/5206
+            asString: ''
+            asArray: []
+        crossrootfsDir: '/crossrootfs/arm64'
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
 # RHEL 6
 

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -299,19 +299,22 @@ jobs:
             - Windows.10.Arm64
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-- template: ${{ parameters.jobTemplate }}
-  parameters:
-    buildConfig: ${{ parameters.buildConfig }}
-    archType: arm64
-    osGroup: Windows_NT
-    osIdentifier: Windows_NT
-    helixQueues:
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        # TODO: add Windows.10.Arm64.Open once Jenkins has been shutdown
-        asString: ''
-        asArray: []
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        asString: 'Windows.10.Arm64'
-        asArray:
-        - Windows.10.Arm64
-    ${{ insert }}: ${{ parameters.jobParameters }}
+  # Windows arm64
+
+  - ${{ if eq(platform, 'Windows_NT_arm64') }}:
+    - template: ${{ parameters.jobTemplate }}
+      parameters:
+        buildConfig: ${{ parameters.buildConfig }}
+        archType: arm64
+        osGroup: Windows_NT
+        osIdentifier: Windows_NT
+        helixQueues:
+          ${{ if eq(variables['System.TeamProject'], 'public') }}:
+            # TODO: add Windows.10.Arm64.Open once Jenkins has been shutdown
+            asString: ''
+            asArray: []
+          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+            asString: 'Windows.10.Arm64'
+            asArray:
+            - Windows.10.Arm64
+        ${{ insert }}: ${{ parameters.jobParameters }}

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -279,24 +279,25 @@ jobs:
             - Windows.81.Amd64
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Windows arm/arm64
+  # Windows arm
 
-- template: ${{ parameters.jobTemplate }}
-  parameters:
-    buildConfig: ${{ parameters.buildConfig }}
-    archType: arm
-    osGroup: Windows_NT
-    osIdentifier: Windows_NT
-    helixQueues:
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        # TODO: add Windows.10.Arm64.Open once Jenkins has been shutdown
-        asString: ''
-        asArray: []
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        asString: 'Windows.10.Arm64'
-        asArray:
-        - Windows.10.Arm64
-    ${{ insert }}: ${{ parameters.jobParameters }}
+  - ${{ if eq(platform, 'Windows_NT_arm') }}:
+    - template: ${{ parameters.jobTemplate }}
+      parameters:
+        buildConfig: ${{ parameters.buildConfig }}
+        archType: arm
+        osGroup: Windows_NT
+        osIdentifier: Windows_NT
+        helixQueues:
+          ${{ if eq(variables['System.TeamProject'], 'public') }}:
+            # TODO: add Windows.10.Arm64.Open once Jenkins has been shutdown
+            asString: ''
+            asArray: []
+          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+            asString: 'Windows.10.Arm64'
+            asArray:
+            - Windows.10.Arm64
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
 - template: ${{ parameters.jobTemplate }}
   parameters:

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -139,39 +139,40 @@ jobs:
             - RedHat.6.Amd64
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux x64
+  # Linux x64
 
-- template: ${{ parameters.jobTemplate }}
-  parameters:
-    buildConfig: ${{ parameters.buildConfig }}
-    archType: x64
-    osGroup: Linux
-    osIdentifier: Linux
-    containerName: centos7_x64_build_image
-    helixQueues:
-      ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-        asString: 'Ubuntu.1804.Amd64.Open'
-        asArray:
-        - Ubuntu.1804.Amd64.Open
-      ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-        asString: 'Debian.9.Amd64.Open,Ubuntu.1604.Amd64.Open,Ubuntu.1804.Amd64.Open,Centos.7.Amd64.Open,Fedora.28.Amd64.Open,RedHat.7.Amd64.Open'
-        asArray:
-        - Debian.9.Amd64.Open
-        - Ubuntu.1604.Amd64.Open
-        - Ubuntu.1804.Amd64.Open
-        - Centos.7.Amd64.Open
-        - Fedora.28.Amd64.Open
-        - RedHat.7.Amd64.Open
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        asString: 'Debian.9.Amd64,Ubuntu.1604.Amd64,Ubuntu.1804.Amd64,Centos.7.Amd64,Fedora.28.Amd64,RedHat.7.Amd64'
-        asArray:
-        - Debian.9.Amd64
-        - Ubuntu.1604.Amd64
-        - Ubuntu.1804.Amd64
-        - Centos.7.Amd64
-        - Fedora.28.Amd64
-        - RedHat.7.Amd64
-    ${{ insert }}: ${{ parameters.jobParameters }}
+  - ${{ if eq(platform, 'Linux_x64') }}:
+    - template: ${{ parameters.jobTemplate }}
+      parameters:
+        buildConfig: ${{ parameters.buildConfig }}
+        archType: x64
+        osGroup: Linux
+        osIdentifier: Linux
+        containerName: centos7_x64_build_image
+        helixQueues:
+          ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+            asString: 'Ubuntu.1804.Amd64.Open'
+            asArray:
+            - Ubuntu.1804.Amd64.Open
+          ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+            asString: 'Debian.9.Amd64.Open,Ubuntu.1604.Amd64.Open,Ubuntu.1804.Amd64.Open,Centos.7.Amd64.Open,Fedora.28.Amd64.Open,RedHat.7.Amd64.Open'
+            asArray:
+            - Debian.9.Amd64.Open
+            - Ubuntu.1604.Amd64.Open
+            - Ubuntu.1804.Amd64.Open
+            - Centos.7.Amd64.Open
+            - Fedora.28.Amd64.Open
+            - RedHat.7.Amd64.Open
+          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+            asString: 'Debian.9.Amd64,Ubuntu.1604.Amd64,Ubuntu.1804.Amd64,Centos.7.Amd64,Fedora.28.Amd64,RedHat.7.Amd64'
+            asArray:
+            - Debian.9.Amd64
+            - Ubuntu.1604.Amd64
+            - Ubuntu.1804.Amd64
+            - Centos.7.Amd64
+            - Fedora.28.Amd64
+            - RedHat.7.Amd64
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
 # FreeBSD
 

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -250,31 +250,34 @@ jobs:
             - Windows.81.Amd64
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-- template: ${{ parameters.jobTemplate }}
-  parameters:
-    buildConfig: ${{ parameters.buildConfig }}
-    archType: x86
-    osGroup: Windows_NT
-    osIdentifier: Windows_NT
-    helixQueues:
-      ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-        asString: 'Windows.10.Amd64.Open'
-        asArray:
-        - Windows.10.Amd64.Open
-      ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-        # TODO: add Windows.7.Amd64.Open once https://github.com/dotnet/coreclr/issues/21796 has been resolved
-        asString: 'Windows.10.Amd64.Open,Windows.81.Amd64.Open'
-        asArray:
-        - Windows.10.Amd64.Open
-        - Windows.81.Amd64.Open
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        asString: 'Windows.10.Amd64,Windows.10.Amd64.Core,Windows.7.Amd64,Windows.81.Amd64'
-        asArray:
-        - Windows.10.Amd64
-        - Windows.10.Amd64.Core
-        - Windows.7.Amd64
-        - Windows.81.Amd64
-    ${{ insert }}: ${{ parameters.jobParameters }}
+  # Windows x86
+
+  - ${{ if eq(platform, 'Windows_NT_x86') }}:
+    - template: ${{ parameters.jobTemplate }}
+      parameters:
+        buildConfig: ${{ parameters.buildConfig }}
+        archType: x86
+        osGroup: Windows_NT
+        osIdentifier: Windows_NT
+        helixQueues:
+          ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+            asString: 'Windows.10.Amd64.Open'
+            asArray:
+            - Windows.10.Amd64.Open
+          ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+            # TODO: add Windows.7.Amd64.Open once https://github.com/dotnet/coreclr/issues/21796 has been resolved
+            asString: 'Windows.10.Amd64.Open,Windows.81.Amd64.Open'
+            asArray:
+            - Windows.10.Amd64.Open
+            - Windows.81.Amd64.Open
+          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+            asString: 'Windows.10.Amd64,Windows.10.Amd64.Core,Windows.7.Amd64,Windows.81.Amd64'
+            asArray:
+            - Windows.10.Amd64
+            - Windows.10.Amd64.Core
+            - Windows.7.Amd64
+            - Windows.81.Amd64
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Windows arm/arm64
 

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -191,32 +191,33 @@ jobs:
 #       asArray: []
 #     ${{ insert }}: ${{ parameters.jobParameters }}
 
-# macOS x64
+  # macOS x64
 
-- template: ${{ parameters.jobTemplate }}
-  parameters:
-    buildConfig: ${{ parameters.buildConfig }}
-    archType: x64
-    osGroup: OSX
-    osIdentifier: OSX
-    helixQueues:
-      ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-        asString: 'OSX.1013.Amd64.Open'
-        asArray:
-        - OSX.1013.Amd64.Open
-      ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-        # TODO: add OSX.1012.Amd64.Open once Jenkins has been shutdown
-        asString: 'OSX.1013.Amd64.Open,OSX.1014.Amd64.Open'
-        asArray:
-        - OSX.1013.Amd64.Open
-        - OSX.1014.Amd64.Open
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        asString: 'OSX.1012.Amd64,OSX.1013.Amd64,OSX.1014.Amd64'
-        asArray:
-        - OSX.1012.Amd64
-        - OSX.1013.Amd64
-        - OSX.1014.Amd64
-    ${{ insert }}: ${{ parameters.jobParameters }}
+  - ${{ if eq(platform, 'OSX_x64') }}:
+    - template: ${{ parameters.jobTemplate }}
+      parameters:
+        buildConfig: ${{ parameters.buildConfig }}
+        archType: x64
+        osGroup: OSX
+        osIdentifier: OSX
+        helixQueues:
+          ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+            asString: 'OSX.1013.Amd64.Open'
+            asArray:
+            - OSX.1013.Amd64.Open
+          ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+            # TODO: add OSX.1012.Amd64.Open once Jenkins has been shutdown
+            asString: 'OSX.1013.Amd64.Open,OSX.1014.Amd64.Open'
+            asArray:
+            - OSX.1013.Amd64.Open
+            - OSX.1014.Amd64.Open
+          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+            asString: 'OSX.1012.Amd64,OSX.1013.Amd64,OSX.1014.Amd64'
+            asArray:
+            - OSX.1012.Amd64
+            - OSX.1013.Amd64
+            - OSX.1014.Amd64
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Windows x64/x86
 

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -219,35 +219,36 @@ jobs:
             - OSX.1014.Amd64
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Windows x64/x86
+  # Windows x64
 
-- template: ${{ parameters.jobTemplate }}
-  parameters:
-    buildConfig: ${{ parameters.buildConfig }}
-    archType: x64
-    osGroup: Windows_NT
-    osIdentifier: Windows_NT
-    helixQueues:
-      ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-        asString: 'Windows.10.Amd64.Open'
-        asArray:
-        - Windows.10.Amd64.Open
-      ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-        # TODO: add Windows.10.Nano.Amd64.Open once https://github.com/dotnet/coreclr/issues/21693 has been resolved
-        # TODO: add Windows.7.Amd64.Open once https://github.com/dotnet/coreclr/issues/21796 has been resolved
-        asString: 'Windows.10.Amd64.Open,Windows.81.Amd64.Open'
-        asArray:
-        - Windows.10.Amd64.Open
-        - Windows.81.Amd64.Open
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        asString: 'Windows.10.Amd64,Windows.10.Nano.Amd64,Windows.10.Amd64.Core,Windows.7.Amd64,Windows.81.Amd64'
-        asArray:
-        - Windows.10.Amd64
-        - Windows.10.Nano.Amd64
-        - Windows.10.Amd64.Core
-        - Windows.7.Amd64
-        - Windows.81.Amd64
-    ${{ insert }}: ${{ parameters.jobParameters }}
+  - ${{ if eq(platform, 'Windows_NT_x64') }}:
+    - template: ${{ parameters.jobTemplate }}
+      parameters:
+        buildConfig: ${{ parameters.buildConfig }}
+        archType: x64
+        osGroup: Windows_NT
+        osIdentifier: Windows_NT
+        helixQueues:
+          ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+            asString: 'Windows.10.Amd64.Open'
+            asArray:
+            - Windows.10.Amd64.Open
+          ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+            # TODO: add Windows.10.Nano.Amd64.Open once https://github.com/dotnet/coreclr/issues/21693 has been resolved
+            # TODO: add Windows.7.Amd64.Open once https://github.com/dotnet/coreclr/issues/21796 has been resolved
+            asString: 'Windows.10.Amd64.Open,Windows.81.Amd64.Open'
+            asArray:
+            - Windows.10.Amd64.Open
+            - Windows.81.Amd64.Open
+          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+            asString: 'Windows.10.Amd64,Windows.10.Nano.Amd64,Windows.10.Amd64.Core,Windows.7.Amd64,Windows.81.Amd64'
+            asArray:
+            - Windows.10.Amd64
+            - Windows.10.Nano.Amd64
+            - Windows.10.Amd64.Core
+            - Windows.7.Amd64
+            - Windows.81.Amd64
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
 - template: ${{ parameters.jobTemplate }}
   parameters:

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -73,26 +73,27 @@ jobs:
         crossrootfsDir: '/crossrootfs/arm64'
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux musl
+  # Linux musl x64
 
-- template: ${{ parameters.jobTemplate }}
-  parameters:
-    buildConfig: ${{ parameters.buildConfig }}
-    archType: x64
-    osGroup: Linux
-    osIdentifier: Linux_musl
-    containerName: musl_x64_build_image
-    helixQueues:
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        # TODO: there are no open Alpine queues https://github.com/dotnet/core-eng/issues/4958
-        asString: ''
-        asArray: []
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        asString: 'Alpine.36.Amd64,Alpine.38.Amd64'
-        asArray:
-        - Alpine.36.Amd64
-        - Alpine.38.Amd64
-    ${{ insert }}: ${{ parameters.jobParameters }}
+  - ${{ if eq(platform, 'Linux_musl_x64') }}:
+    - template: ${{ parameters.jobTemplate }}
+      parameters:
+        buildConfig: ${{ parameters.buildConfig }}
+        archType: x64
+        osGroup: Linux
+        osIdentifier: Linux_musl
+        containerName: musl_x64_build_image
+        helixQueues:
+          ${{ if eq(variables['System.TeamProject'], 'public') }}:
+            # TODO: there are no open Alpine queues https://github.com/dotnet/core-eng/issues/4958
+            asString: ''
+            asArray: []
+          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+            asString: 'Alpine.36.Amd64,Alpine.38.Amd64'
+            asArray:
+            - Alpine.36.Amd64
+            - Alpine.38.Amd64
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux musl arm64
 

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -117,26 +117,27 @@ jobs:
         crossrootfsDir: '/crossrootfs/arm64'
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# RHEL 6
+  # Linux rhel6 x64
 
-- template: ${{ parameters.jobTemplate }}
-  parameters:
-    buildConfig: ${{ parameters.buildConfig }}
-    archType: x64
-    osGroup: Linux
-    osIdentifier: Linux_rhel6
-    containerName: centos6_x64_build_image
-    helixQueues:
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        # TODO: enable RedHat.6.Amd64.Open
-        # when https://github.com/dotnet/core-eng/issues/4100 is resolved
-        asString: ''
-        asArray: []
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        asString: 'RedHat.6.Amd64'
-        asArray:
-        - RedHat.6.Amd64
-    ${{ insert }}: ${{ parameters.jobParameters }}
+  - ${{ if eq(platform, 'Linux_rhel6_x64') }}:
+    - template: ${{ parameters.jobTemplate }}
+      parameters:
+        buildConfig: ${{ parameters.buildConfig }}
+        archType: x64
+        osGroup: Linux
+        osIdentifier: Linux_rhel6
+        containerName: centos6_x64_build_image
+        helixQueues:
+          ${{ if eq(variables['System.TeamProject'], 'public') }}:
+            # TODO: enable RedHat.6.Amd64.Open
+            # when https://github.com/dotnet/core-eng/issues/4100 is resolved
+            asString: ''
+            asArray: []
+          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+            asString: 'RedHat.6.Amd64'
+            asArray:
+            - RedHat.6.Amd64
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux x64
 

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -20,26 +20,28 @@ jobs:
 # TODO: simplify osIdentifier by adding osGroup and osSubGroup. See
 # https://github.com/Microsoft/azure-pipelines-yaml/pull/46 for more information
 
-# Linux arm
+- ${{ each platform in parameters.platforms }}:
+  # Linux arm
 
-- template: ${{ parameters.jobTemplate }}
-  parameters:
-    buildConfig: ${{ parameters.buildConfig }}
-    archType: arm
-    osGroup: Linux
-    osIdentifier: Linux
-    containerName: ubuntu_1404_arm_cross_build_image
-    helixQueues:
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        # TODO: add Ubuntu.1404.Arm32.Open once Jenkins has been shutdown
-        asString: ''
-        asArray: []
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        # We don't have any Linux/arm32 internal Helix queues
-        asString: ''
-        asArray: []
-    crossrootfsDir: '/crossrootfs/arm'
-    ${{ insert }}: ${{ parameters.jobParameters }}
+  - ${{ if eq(platform, 'Linux_arm') }}:
+    - template: ${{ parameters.jobTemplate }}
+      parameters:
+        buildConfig: ${{ parameters.buildConfig }}
+        archType: arm
+        osGroup: Linux
+        osIdentifier: Linux
+        containerName: ubuntu_1404_arm_cross_build_image
+        helixQueues:
+          ${{ if eq(variables['System.TeamProject'], 'public') }}:
+            # TODO: add Ubuntu.1404.Arm32.Open once Jenkins has been shutdown
+            asString: ''
+            asArray: []
+          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+            # We don't have any Linux/arm32 internal Helix queues
+            asString: ''
+            asArray: []
+        crossrootfsDir: '/crossrootfs/arm'
+        ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux arm64
 

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -1,6 +1,18 @@
 parameters:
   jobTemplate: ''
   buildConfig: ''
+  platforms:
+  - Linux_arm
+  - Linux_arm64
+  - Linux_musl_x64
+  - Linux_musl_arm64
+  - Linux_rhel6_x64
+  - Linux_x64
+  - OSX_x64
+  - Windows_NT_x64
+  - Windows_NT_x86
+  - Windows_NT_arm
+  - Windows_NT_arm64
   jobParameters: {}
 
 jobs:


### PR DESCRIPTION
This adds a way to specify target platforms for a job generated by platform-matrix.yml template.

For example, if want to limit our CI test jobs to Windows_NT/x86 and Windows_NT/x64 we can do this in azure-pipelines.yml
```yaml
- ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
  - template: eng/platform-matrix.yml
    parameters:
      jobTemplate: test-job.yml
      buildConfig: checked
      platforms:
      - Windows_NT_x64
      - Windows_NT_x86
      jobParameters:
        testGroup: outerloop
```

These changes is better viewed with [hidden whitespace changes](https://github.com/dotnet/coreclr/pull/22800/files?utf8=%E2%9C%93&diff=split&w=1)