### PR TITLE
Fix keyword for PinPlugAtGCTime event

### DIFF
--- a/src/gc/gcevents.h
+++ b/src/gc/gcevents.h
@@ -45,7 +45,7 @@ KNOWN_EVENT(BGCAllocWaitEnd, GCEventProvider_Private, GCEventLevel_Information, 
 KNOWN_EVENT(GCFullNotify_V1, GCEventProvider_Private, GCEventLevel_Information, GCEventKeyword_GCPrivate)
 KNOWN_EVENT(PrvSetGCHandle, GCEventProvider_Private, GCEventLevel_Information, GCEventKeyword_GCHandlePrivate)
 KNOWN_EVENT(PrvDestroyGCHandle, GCEventProvider_Private, GCEventLevel_Information, GCEventKeyword_GCHandlePrivate)
-KNOWN_EVENT(PinPlugAtGCTime, GCEventProvider_Private, GCEventLevel_Verbose, GCEventKeyword_GC)
+KNOWN_EVENT(PinPlugAtGCTime, GCEventProvider_Private, GCEventLevel_Verbose, GCEventKeyword_GCPrivate)
 
 #undef KNOWN_EVENT
 #undef DYNAMIC_EVENT


### PR DESCRIPTION
Found this while working on #22306 - `PinPlugAtGCTime` should be checked against the private provider + GCprivate keyword, but that wasn't what it was checking for. 