### PR TITLE
Special-case 1 module per assembly in Assembly.GetTypes/DefinedTypes

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Reflection/Assembly.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Assembly.cs
@@ -37,6 +37,10 @@ namespace System.Reflection
         public virtual Type[] GetTypes()
         {
             Module[] m = GetModules(false);
+            if (m.Length == 1)
+            {
+                return m[0].GetTypes();
+            }
 
             int finalLength = 0;
             Type[][] moduleTypes = new Type[m.Length][];

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -175,9 +175,13 @@ namespace System.Reflection
         {
             get
             {
-                List<RuntimeType> rtTypes = new List<RuntimeType>();
-
                 RuntimeModule[] modules = GetModulesInternal(true, false);
+                if (modules.Length == 1)
+                {
+                    return modules[0].GetDefinedTypes();
+                }
+
+                List<RuntimeType> rtTypes = new List<RuntimeType>();
 
                 for (int i = 0; i < modules.Length; i++)
                 {


### PR DESCRIPTION
It's very common for an assembly to have only one module, in which case we can avoid unnecessary allocations and copies in Assembly.GetTypes() and Assembly.DefinedTypes.

Before
```
       Method |      Mean |     Error |    StdDev | Gen 0/1k Op | Allocated Memory/Op |
------------- |----------:|----------:|----------:|------------:|--------------------:|
     GetTypes |  93.62 us | 0.6061 us | 0.5373 us |     14.4043 |            59.03 KB |
 DefinedTypes | 114.03 us | 1.1998 us | 1.0019 us |     21.6064 |            88.55 KB |
```

After
```
       Method |      Mean |     Error |    StdDev | Gen 0/1k Op | Allocated Memory/Op |
------------- |----------:|----------:|----------:|------------:|--------------------:|
     GetTypes |  90.07 us | 1.7718 us | 1.8958 us |      7.2021 |            29.55 KB |
 DefinedTypes | 106.83 us | 0.8118 us | 0.6779 us |      7.2021 |            29.73 KB |
```

Benchmark:
```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System;
using System.Collections;
using System.IO;
using System.Net;
using System.Net.Http;
using System.Net.Sockets;
using System.Reflection;

[InProcess]
[MemoryDiagnoser]
public class Test
{
    public static void Main() => BenchmarkRunner.Run<Test>();

    private static readonly Assembly[] s_assemblies = new[]
    {
        typeof(object).Assembly,
        typeof(HttpClient).Assembly,
        typeof(Socket).Assembly,
        typeof(BitArray).Assembly,
        typeof(File).Assembly,
        typeof(InProcessAttribute).Assembly
    };

    [Benchmark]
    public int GetTypes()
    {
        int count = 0;
        foreach (Assembly asm in s_assemblies) count += asm.GetTypes().Length;
        return count;
    }

    [Benchmark]
    public int DefinedTypes()
    {
        int count = 0;
        foreach (Assembly asm in s_assemblies)
            foreach (TypeInfo ti in asm.DefinedTypes)
                count++;
        return count;
    }
}
```