### PR TITLE
Fixing hwintrinsicArm64 to return nullptr for the Base_As intrinsics if featureSimd is false

### DIFF
--- a/src/jit/hwintrinsicArm64.cpp
+++ b/src/jit/hwintrinsicArm64.cpp
@@ -312,6 +312,11 @@ GenTree* Compiler::impHWIntrinsic(NamedIntrinsic        intrinsic,
         case NI_Base_Vector128_AsUInt32:
         case NI_Base_Vector128_AsUInt64:
         {
+            if (!featureSIMD)
+            {
+                return nullptr;
+            }
+
             // We fold away the cast here, as it only exists to satisfy
             // the type system. It is safe to do this here since the retNode type
             // and the signature return type are both the same TYP_SIMD.


### PR DESCRIPTION
This resolves https://github.com/dotnet/coreclr/issues/22824

It was introduced in https://github.com/dotnet/coreclr/pull/22705 when the base intrinsic support was split into the ARM64/X86 specific files.

CC. @CarolEidt