### PR TITLE
DictionarySlim backport improvements, retaining more entropy

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
@@ -55,6 +55,7 @@ namespace System.Collections.Generic
         private IEqualityComparer<TKey> _comparer;
         private KeyCollection _keys;
         private ValueCollection _values;
+        private const int StartOfFreeList = -3;
 
         // constants for serialization
         private const string VersionName = "Version"; // Do not rename (binary serialization)
@@ -640,7 +641,7 @@ namespace System.Collections.Generic
 
             if (updateFreeList)
             {
-                _freeList = -3 - entries[_freeList].next;
+                _freeList = StartOfFreeList - entries[_freeList].next;
             }
             entry.hashCode = hashCode;
             // Value in _buckets is 1-based
@@ -787,7 +788,7 @@ namespace System.Collections.Generic
                             entries[last].next = entry.next;
                         }
 
-                        entry.next = -3 - _freeList;
+                        entry.next = StartOfFreeList - _freeList;
 
                         if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
                         {
@@ -854,7 +855,7 @@ namespace System.Collections.Generic
 
                         value = entry.value;
 
-                        entry.next = -3 - _freeList;
+                        entry.next = StartOfFreeList - _freeList;
 
                         if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
                         {

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
@@ -641,6 +641,8 @@ namespace System.Collections.Generic
 
             if (updateFreeList)
             {
+                Debug.Assert((StartOfFreeList - entries[_freeList].next) >= -2, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD");
+
                 _freeList = StartOfFreeList - entries[_freeList].next;
             }
             entry.hashCode = hashCode;
@@ -740,7 +742,7 @@ namespace System.Collections.Generic
             {
                 if (entries[i].next >= -1)
                 {
-                    int bucket = (int)(entries[i].hashCode % (uint)newSize);
+                    uint bucket = entries[i].hashCode % (uint)newSize;
                     // Value in _buckets is 1-based
                     entries[i].next = buckets[bucket] - 1;
                     // Value in _buckets is 1-based
@@ -768,7 +770,7 @@ namespace System.Collections.Generic
             if (buckets != null)
             {
                 uint hashCode = (uint)(_comparer?.GetHashCode(key) ?? key.GetHashCode());
-                int bucket = (int)(hashCode % (uint)buckets.Length);
+                uint bucket = hashCode % (uint)buckets.Length;
                 int last = -1;
                 // Value in buckets is 1-based
                 int i = buckets[bucket] - 1;
@@ -787,6 +789,8 @@ namespace System.Collections.Generic
                         {
                             entries[last].next = entry.next;
                         }
+
+                        Debug.Assert((StartOfFreeList - _freeList) >= -2, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD");
 
                         entry.next = StartOfFreeList - _freeList;
 
@@ -833,7 +837,7 @@ namespace System.Collections.Generic
             if (buckets != null)
             {
                 uint hashCode = (uint)(_comparer?.GetHashCode(key) ?? key.GetHashCode());
-                int bucket = (int)(hashCode % (uint)buckets.Length);
+                uint bucket = hashCode % (uint)buckets.Length;
                 int last = -1;
                 // Value in buckets is 1-based
                 int i = buckets[bucket] - 1;
@@ -854,6 +858,8 @@ namespace System.Collections.Generic
                         }
 
                         value = entry.value;
+
+                        Debug.Assert((StartOfFreeList - _freeList) >= -2, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD");
 
                         entry.next = StartOfFreeList - _freeList;
 
@@ -1025,7 +1031,7 @@ namespace System.Collections.Generic
                 {
                     ref Entry entry = ref entries[count];
                     entry = oldEntries[i];
-                    int bucket = (int)(hashCode % (uint)newSize);
+                    uint bucket = hashCode % (uint)newSize;
                     // Value in _buckets is 1-based
                     entry.next = buckets[bucket] - 1;
                     // Value in _buckets is 1-based

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
@@ -5,7 +5,6 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
-using System.Threading;
 
 namespace System.Collections.Generic
 {
@@ -38,8 +37,11 @@ namespace System.Collections.Generic
     {
         private struct Entry
         {
-            public int hashCode;    // Lower 31 bits of hash code, -1 if unused
-            public int next;        // Index of next entry, -1 if last
+            public uint hashCode;
+            // 0-based index of next entry in chain: -1 means end of chain
+            // also encodes whether this entry _itself_ is part of the free list by changing sign and subtracting 3,
+            // so -2 means end of free list, -3 means index 0 but on free list, -4 means index 1 but on free list, etc.
+            public int next;
             public TKey key;           // Key of entry
             public TValue value;         // Value of entry
         }
@@ -103,7 +105,7 @@ namespace System.Collections.Generic
                 Entry[] entries = d._entries;
                 for (int i = 0; i < count; i++)
                 {
-                    if (entries[i].hashCode >= 0)
+                    if (entries[i].next >= -1)
                     {
                         Add(entries[i].key, entries[i].value);
                     }
@@ -278,7 +280,7 @@ namespace System.Collections.Generic
             {
                 for (int i = 0; i < _count; i++)
                 {
-                    if (entries[i].hashCode >= 0 && entries[i].value == null) return true;
+                    if (entries[i].next >= -1 && entries[i].value == null) return true;
                 }
             }
             else
@@ -288,7 +290,7 @@ namespace System.Collections.Generic
                     // ValueType: Devirtualize with EqualityComparer<TValue>.Default intrinsic
                     for (int i = 0; i < _count; i++)
                     {
-                        if (entries[i].hashCode >= 0 && EqualityComparer<TValue>.Default.Equals(entries[i].value, value)) return true;
+                        if (entries[i].next >= -1 && EqualityComparer<TValue>.Default.Equals(entries[i].value, value)) return true;
                     }
                 }
                 else
@@ -299,7 +301,7 @@ namespace System.Collections.Generic
                     EqualityComparer<TValue> defaultComparer = EqualityComparer<TValue>.Default;
                     for (int i = 0; i < _count; i++)
                     {
-                        if (entries[i].hashCode >= 0 && defaultComparer.Equals(entries[i].value, value)) return true;
+                        if (entries[i].next >= -1 && defaultComparer.Equals(entries[i].value, value)) return true;
                     }
                 }
             }
@@ -327,7 +329,7 @@ namespace System.Collections.Generic
             Entry[] entries = _entries;
             for (int i = 0; i < count; i++)
             {
-                if (entries[i].hashCode >= 0)
+                if (entries[i].next >= -1)
                 {
                     array[index++] = new KeyValuePair<TKey, TValue>(entries[i].key, entries[i].value);
                 }
@@ -375,9 +377,9 @@ namespace System.Collections.Generic
                 IEqualityComparer<TKey> comparer = _comparer;
                 if (comparer == null)
                 {
-                    int hashCode = key.GetHashCode() & 0x7FFFFFFF;
+                    uint hashCode = (uint)key.GetHashCode();
                     // Value in _buckets is 1-based
-                    i = buckets[hashCode % buckets.Length] - 1;
+                    i = buckets[hashCode % (uint)buckets.Length] - 1;
                     if (default(TKey) != null)
                     {
                         // ValueType: Devirtualize with EqualityComparer<TValue>.Default intrinsic
@@ -428,9 +430,9 @@ namespace System.Collections.Generic
                 }
                 else
                 {
-                    int hashCode = comparer.GetHashCode(key) & 0x7FFFFFFF;
+                    uint hashCode = (uint)comparer.GetHashCode(key);
                     // Value in _buckets is 1-based
-                    i = buckets[hashCode % buckets.Length] - 1;
+                    i = buckets[hashCode % (uint)buckets.Length] - 1;
                     do
                     {
                         // Should be a while loop https://github.com/dotnet/coreclr/issues/15476
@@ -482,10 +484,10 @@ namespace System.Collections.Generic
             Entry[] entries = _entries;
             IEqualityComparer<TKey> comparer = _comparer;
 
-            int hashCode = ((comparer == null) ? key.GetHashCode() : comparer.GetHashCode(key)) & 0x7FFFFFFF;
+            uint hashCode = (uint)((comparer == null) ? key.GetHashCode() : comparer.GetHashCode(key));
 
             int collisionCount = 0;
-            ref int bucket = ref _buckets[hashCode % _buckets.Length];
+            ref int bucket = ref _buckets[hashCode % (uint)_buckets.Length];
             // Value in _buckets is 1-based
             int i = bucket - 1;
 
@@ -627,7 +629,7 @@ namespace System.Collections.Generic
                 if (count == entries.Length)
                 {
                     Resize();
-                    bucket = ref _buckets[hashCode % _buckets.Length];
+                    bucket = ref _buckets[hashCode % (uint)_buckets.Length];
                 }
                 index = count;
                 _count = count + 1;
@@ -638,7 +640,7 @@ namespace System.Collections.Generic
 
             if (updateFreeList)
             {
-                _freeList = entry.next;
+                _freeList = -3 - entries[_freeList].next;
             }
             entry.hashCode = hashCode;
             // Value in _buckets is 1-based
@@ -725,19 +727,19 @@ namespace System.Collections.Generic
             {
                 for (int i = 0; i < count; i++)
                 {
-                    if (entries[i].hashCode >= 0)
+                    if (entries[i].next >= -1)
                     {
                         Debug.Assert(_comparer == null);
-                        entries[i].hashCode = (entries[i].key.GetHashCode() & 0x7FFFFFFF);
+                        entries[i].hashCode = (uint)entries[i].key.GetHashCode();
                     }
                 }
             }
 
             for (int i = 0; i < count; i++)
             {
-                if (entries[i].hashCode >= 0)
+                if (entries[i].next >= -1)
                 {
-                    int bucket = entries[i].hashCode % newSize;
+                    int bucket = (int)(entries[i].hashCode % (uint)newSize);
                     // Value in _buckets is 1-based
                     entries[i].next = buckets[bucket] - 1;
                     // Value in _buckets is 1-based
@@ -764,8 +766,8 @@ namespace System.Collections.Generic
             int collisionCount = 0;
             if (buckets != null)
             {
-                int hashCode = (_comparer?.GetHashCode(key) ?? key.GetHashCode()) & 0x7FFFFFFF;
-                int bucket = hashCode % buckets.Length;
+                uint hashCode = (uint)(_comparer?.GetHashCode(key) ?? key.GetHashCode());
+                int bucket = (int)(hashCode % (uint)buckets.Length);
                 int last = -1;
                 // Value in buckets is 1-based
                 int i = buckets[bucket] - 1;
@@ -784,8 +786,8 @@ namespace System.Collections.Generic
                         {
                             entries[last].next = entry.next;
                         }
-                        entry.hashCode = -1;
-                        entry.next = _freeList;
+
+                        entry.next = -3 - _freeList;
 
                         if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
                         {
@@ -829,8 +831,8 @@ namespace System.Collections.Generic
             int collisionCount = 0;
             if (buckets != null)
             {
-                int hashCode = (_comparer?.GetHashCode(key) ?? key.GetHashCode()) & 0x7FFFFFFF;
-                int bucket = hashCode % buckets.Length;
+                uint hashCode = (uint)(_comparer?.GetHashCode(key) ?? key.GetHashCode());
+                int bucket = (int)(hashCode % (uint)buckets.Length);
                 int last = -1;
                 // Value in buckets is 1-based
                 int i = buckets[bucket] - 1;
@@ -852,8 +854,7 @@ namespace System.Collections.Generic
 
                         value = entry.value;
 
-                        entry.hashCode = -1;
-                        entry.next = _freeList;
+                        entry.next = -3 - _freeList;
 
                         if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
                         {
@@ -925,7 +926,7 @@ namespace System.Collections.Generic
                 Entry[] entries = _entries;
                 for (int i = 0; i < _count; i++)
                 {
-                    if (entries[i].hashCode >= 0)
+                    if (entries[i].next >= -1)
                     {
                         dictEntryArray[index++] = new DictionaryEntry(entries[i].key, entries[i].value);
                     }
@@ -945,7 +946,7 @@ namespace System.Collections.Generic
                     Entry[] entries = _entries;
                     for (int i = 0; i < count; i++)
                     {
-                        if (entries[i].hashCode >= 0)
+                        if (entries[i].next >= -1)
                         {
                             objects[index++] = new KeyValuePair<TKey, TValue>(entries[i].key, entries[i].value);
                         }
@@ -1018,12 +1019,12 @@ namespace System.Collections.Generic
             int count = 0;
             for (int i = 0; i < oldCount; i++)
             {
-                int hashCode = oldEntries[i].hashCode;
-                if (hashCode >= 0)
+                uint hashCode = oldEntries[i].hashCode;
+                if (oldEntries[i].next >= -1)
                 {
                     ref Entry entry = ref entries[count];
                     entry = oldEntries[i];
-                    int bucket = hashCode % newSize;
+                    int bucket = (int)(hashCode % (uint)newSize);
                     // Value in _buckets is 1-based
                     entry.next = buckets[bucket] - 1;
                     // Value in _buckets is 1-based
@@ -1179,7 +1180,7 @@ namespace System.Collections.Generic
                 {
                     ref Entry entry = ref _dictionary._entries[_index++];
 
-                    if (entry.hashCode >= 0)
+                    if (entry.next >= -1)
                     {
                         _current = new KeyValuePair<TKey, TValue>(entry.key, entry.value);
                         return true;
@@ -1307,7 +1308,7 @@ namespace System.Collections.Generic
                 Entry[] entries = _dictionary._entries;
                 for (int i = 0; i < count; i++)
                 {
-                    if (entries[i].hashCode >= 0) array[index++] = entries[i].key;
+                    if (entries[i].next >= -1) array[index++] = entries[i].key;
                 }
             }
 
@@ -1367,7 +1368,7 @@ namespace System.Collections.Generic
                     {
                         for (int i = 0; i < count; i++)
                         {
-                            if (entries[i].hashCode >= 0) objects[index++] = entries[i].key;
+                            if (entries[i].next >= -1) objects[index++] = entries[i].key;
                         }
                     }
                     catch (ArrayTypeMismatchException)
@@ -1411,7 +1412,7 @@ namespace System.Collections.Generic
                     {
                         ref Entry entry = ref _dictionary._entries[_index++];
 
-                        if (entry.hashCode >= 0)
+                        if (entry.next >= -1)
                         {
                             _currentKey = entry.key;
                             return true;
@@ -1490,7 +1491,7 @@ namespace System.Collections.Generic
                 Entry[] entries = _dictionary._entries;
                 for (int i = 0; i < count; i++)
                 {
-                    if (entries[i].hashCode >= 0) array[index++] = entries[i].value;
+                    if (entries[i].next >= -1) array[index++] = entries[i].value;
                 }
             }
 
@@ -1550,7 +1551,7 @@ namespace System.Collections.Generic
                     {
                         for (int i = 0; i < count; i++)
                         {
-                            if (entries[i].hashCode >= 0) objects[index++] = entries[i].value;
+                            if (entries[i].next >= -1) objects[index++] = entries[i].value;
                         }
                     }
                     catch (ArrayTypeMismatchException)
@@ -1594,7 +1595,7 @@ namespace System.Collections.Generic
                     {
                         ref Entry entry = ref _dictionary._entries[_index++];
 
-                        if (entry.hashCode >= 0)
+                        if (entry.next >= -1)
                         {
                             _currentValue = entry.value;
                             return true;

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
@@ -641,7 +641,7 @@ namespace System.Collections.Generic
 
             if (updateFreeList)
             {
-                Debug.Assert((StartOfFreeList - entries[_freeList].next) >= -2, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD");
+                Debug.Assert((StartOfFreeList - entries[_freeList].next) >= -1, "shouldn't overflow because `next` cannot underflow");
 
                 _freeList = StartOfFreeList - entries[_freeList].next;
             }
@@ -790,7 +790,7 @@ namespace System.Collections.Generic
                             entries[last].next = entry.next;
                         }
 
-                        Debug.Assert((StartOfFreeList - _freeList) >= -2, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD");
+                        Debug.Assert((StartOfFreeList - _freeList) < 0, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD(2146435069) _freelist underflow threshold 2147483646");
 
                         entry.next = StartOfFreeList - _freeList;
 
@@ -859,7 +859,7 @@ namespace System.Collections.Generic
 
                         value = entry.value;
 
-                        Debug.Assert((StartOfFreeList - _freeList) >= -2, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD");
+                        Debug.Assert((StartOfFreeList - _freeList) < 0, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD(2146435069) _freelist underflow threshold 2147483646");
 
                         entry.next = StartOfFreeList - _freeList;
 

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
@@ -37,11 +37,11 @@ namespace System.Collections.Generic
     {
         private struct Entry
         {
-            public uint hashCode;
             // 0-based index of next entry in chain: -1 means end of chain
             // also encodes whether this entry _itself_ is part of the free list by changing sign and subtracting 3,
             // so -2 means end of free list, -3 means index 0 but on free list, -4 means index 1 but on free list, etc.
             public int next;
+            public uint hashCode;
             public TKey key;           // Key of entry
             public TValue value;         // Value of entry
         }


### PR DESCRIPTION
contributes to https://github.com/dotnet/corefx/issues/33392

Use uint hashcode to retain more entropy

before 

``` ini

BenchmarkDotNet=v0.11.3.1003-nightly, OS=Windows 10.0.17134.590 (1803/April2018Update/Redstone4)
Intel Core i7 CPU 860 2.80GHz (Nehalem), 1 CPU, 8 logical and 4 physical cores
Frequency=2727535 Hz, Resolution=366.6314 ns, Timer=TSC
.NET Core SDK=3.0.100-preview-010184
  [Host]     : .NET Core 3.0.0-preview-27324-5 (CoreCLR 4.6.27322.0, CoreFX 4.7.19.7311), 64bit RyuJIT
  Job-SOCKON : .NET Core f01bf9f8-609f-443f-b1f9-73654bd6fdd8 (CoreCLR 4.6.27523.0, CoreFX 4.7.19.12501), 64bit RyuJIT
  Job-LPCBGO : .NET Core f01bf9f8-609f-443f-b1f9-73654bd6fdd8 (CoreCLR 4.6.27523.0, CoreFX 4.7.19.12501), 64bit RyuJIT

Runtime=Core  Toolchain=CoreRun  IterationTime=250.0000 ms  
MaxIterationCount=20  MinIterationCount=15  WarmupCount=1  

```
|                     Namespace |                             Type |        Method | InvocationCount | UnrollFactor | Size |   Items | Count |                 Mean |             Error |            StdDev |               Median |                  Min |                  Max | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------------------------------ |--------------------------------- |-------------- |---------------- |------------- |----- |-------- |------ |---------------------:|------------------:|------------------:|---------------------:|---------------------:|---------------------:|------------:|------------:|------------:|--------------------:|
|            **System.Collections** |           **CtorDefaultSize&lt;Int32&gt;** |    **Dictionary** |               **1** |           **16** |    **?** |       **?** |     **?** |            **21.138 ns** |         **0.5386 ns** |         **0.4498 ns** |            **21.034 ns** |            **20.602 ns** |            **22.054 ns** |      **0.0171** |           **-** |           **-** |                **72 B** |
|            System.Collections |          CtorDefaultSize&lt;String&gt; |    Dictionary |               1 |           16 |    ? |       ? |     ? |           115.775 ns |         2.1777 ns |         2.0370 ns |           115.759 ns |           112.713 ns |           119.546 ns |      0.0169 |           - |           - |                72 B |
| **System.Collections.Concurrent** |                   **IsEmpty&lt;Int32&gt;** |    **Dictionary** |               **1** |           **16** |    **0** |       **?** |     **?** |           **167.668 ns** |         **1.7925 ns** |         **1.6767 ns** |           **167.952 ns** |           **164.903 ns** |           **171.290 ns** |           **-** |           **-** |           **-** |                   **-** |
| System.Collections.Concurrent |                  IsEmpty&lt;String&gt; |    Dictionary |               1 |           16 |    0 |       ? |     ? |           175.245 ns |         3.1680 ns |         2.9634 ns |           175.101 ns |           170.252 ns |           181.164 ns |           - |           - |           - |                   - |
|            **System.Collections** |        **DictionaryMappingFunction** |       **Entropy** |               **1** |           **16** |    **?** |     **500** |     **?** |        **85,153.309 ns** |       **967.4673 ns** |       **904.9695 ns** |        **85,026.696 ns** |        **84,090.283 ns** |        **87,115.608 ns** |     **17.1371** |      **0.3360** |           **-** |             **73160 B** |
|            **System.Collections** |         **TryAddDefaultSize&lt;Int32&gt;** |    **Dictionary** |               **1** |           **16** |    **?** |       **?** |  **2048** |       **151,853.548 ns** |     **1,614.4616 ns** |     **1,510.1684 ns** |       **152,020.658 ns** |       **149,280.358 ns** |       **154,742.987 ns** |     **24.5098** |     **12.2549** |           **-** |            **154192 B** |
|            System.Collections |        TryAddDefaultSize&lt;String&gt; |    Dictionary |               1 |           16 |    ? |       ? |  2048 |       260,378.396 ns |     3,333.4320 ns |     3,118.0943 ns |       260,265.627 ns |       254,684.640 ns |       266,279.359 ns |     46.1066 |     40.9836 |     26.6393 |            215717 B |
|            System.Collections |          TryAddGiventSize&lt;Int32&gt; |    Dictionary |               1 |           16 |    ? |       ? |  2048 |        62,035.232 ns |       625.4011 ns |       554.4018 ns |        61,999.683 ns |        61,072.372 ns |        63,033.053 ns |      7.4111 |      3.7055 |           - |             46784 B |
|            System.Collections |         TryAddGiventSize&lt;String&gt; |    Dictionary |               1 |           16 |    ? |       ? |  2048 |       147,364.413 ns |     2,351.7824 ns |     2,084.7938 ns |       146,609.444 ns |       145,433.525 ns |       152,536.152 ns |     10.5140 |      5.2570 |           - |             65448 B |
|            System.Collections |            AddDefaultSize&lt;Int32&gt; |    Dictionary |               1 |           16 |    ? |       ? |  2048 |       151,457.558 ns |     2,898.9032 ns |     2,711.6358 ns |       150,197.879 ns |       148,626.916 ns |       156,803.193 ns |     24.0385 |     12.0192 |           - |            154192 B |
|            System.Collections |           AddDefaultSize&lt;String&gt; |    Dictionary |               1 |           16 |    ? |       ? |  2048 |       258,826.523 ns |     1,935.8032 ns |     1,810.7515 ns |       258,518.343 ns |       255,039.852 ns |       261,568.971 ns |     46.1066 |     44.0574 |     26.6393 |            215722 B |
|            **System.Collections** |                    **Remove&lt;Int32&gt;** |    **Dictionary** |            **1000** |            **1** | **2048** |       **?** |     **?** |        **62,786.129 ns** |       **834.9818 ns** |       **740.1896 ns** |        **62,748.654 ns** |        **61,766.815 ns** |        **64,588.044 ns** |           **-** |           **-** |           **-** |                   **-** |
|            System.Collections |                   Remove&lt;String&gt; |    Dictionary |            1000 |            1 | 2048 |       ? |     ? |       133,691.245 ns |     2,540.5734 ns |     2,376.4540 ns |       132,631.167 ns |       130,215.066 ns |       137,910.659 ns |           - |           - |           - |                   - |
|            System.Collections |                     Clear&lt;Int32&gt; |    Dictionary |            1000 |            1 | 2048 |       ? |     ? |         8,307.190 ns |       192.6903 ns |       214.1748 ns |         8,305.994 ns |         7,901.233 ns |         8,650.261 ns |           - |           - |           - |                   - |
|            System.Collections |                    Clear&lt;String&gt; |    Dictionary |            1000 |            1 | 2048 |       ? |     ? |        10,672.075 ns |       140.5965 ns |       117.4045 ns |        10,662.063 ns |        10,496.712 ns |        10,923.105 ns |           - |           - |           - |                   - |
|            System.Collections |   ContainsKeyFalse&lt;Int32, Int32&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |        46,885.587 ns |       552.1149 ns |       516.4486 ns |        46,941.644 ns |        45,685.077 ns |        47,682.228 ns |           - |           - |           - |                   - |
|            System.Collections | ContainsKeyFalse&lt;String, String&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |       109,510.313 ns |       851.8671 ns |       796.8370 ns |       109,437.392 ns |       108,226.451 ns |       110,776.526 ns |           - |           - |           - |                   - |
|            System.Collections |    ContainsKeyTrue&lt;Int32, Int32&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |        42,012.134 ns |       350.9807 ns |       328.3075 ns |        42,010.042 ns |        41,423.956 ns |        42,699.365 ns |           - |           - |           - |                   - |
|            System.Collections |  ContainsKeyTrue&lt;String, String&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |       109,269.743 ns |     1,116.3895 ns |     1,044.2715 ns |       109,322.904 ns |       108,074.619 ns |       111,986.671 ns |           - |           - |           - |                   - |
| System.Collections.Concurrent |                     Count&lt;Int32&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |        21,219.886 ns |       640.3695 ns |       737.4505 ns |        21,284.655 ns |        19,958.709 ns |        22,553.940 ns |           - |           - |           - |                   - |
| System.Collections.Concurrent |                    Count&lt;String&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |        20,212.199 ns |       175.6823 ns |       164.3333 ns |        20,235.303 ns |        19,916.917 ns |        20,478.918 ns |           - |           - |           - |                   - |
| System.Collections.Concurrent |                   IsEmpty&lt;Int32&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |             2.983 ns |         0.1841 ns |         0.1722 ns |             2.970 ns |             2.709 ns |             3.323 ns |           - |           - |           - |                   - |
| System.Collections.Concurrent |                  IsEmpty&lt;String&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |             3.017 ns |         0.1457 ns |         0.1291 ns |             2.981 ns |             2.854 ns |             3.276 ns |           - |           - |           - |                   - |
|            System.Collections |              AddGivenSize&lt;Int32&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |        63,489.339 ns |     1,488.1789 ns |     1,713.7890 ns |        63,791.385 ns |        60,512.448 ns |        66,618.257 ns |      7.4588 |      3.6008 |           - |             46784 B |
|            System.Collections |             AddGivenSize&lt;String&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |       145,403.806 ns |     1,692.4725 ns |     1,583.1399 ns |       145,222.810 ns |       143,469.853 ns |       149,133.757 ns |     10.4167 |      5.2083 |           - |             65448 B |
|            System.Collections |        CtorFromCollection&lt;Int32&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |        64,083.569 ns |       707.7096 ns |       661.9920 ns |        64,151.889 ns |        63,065.820 ns |        65,028.320 ns |      7.4897 |      3.6157 |           - |             46784 B |
|            System.Collections |       CtorFromCollection&lt;String&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |       150,999.660 ns |     2,020.8942 ns |     1,890.3456 ns |       150,848.377 ns |       147,695.729 ns |       155,176.823 ns |     10.4167 |      5.2083 |           - |             65448 B |
|            System.Collections |             CtorGivenSize&lt;Int32&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |        12,027.516 ns |       209.0856 ns |       195.5788 ns |        12,082.695 ns |        11,642.689 ns |        12,331.592 ns |      7.4472 |      3.7236 |           - |             46784 B |
|            System.Collections |            CtorGivenSize&lt;String&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |        23,727.781 ns |       369.4205 ns |       345.5561 ns |        23,688.431 ns |        23,077.184 ns |        24,386.122 ns |     10.3855 |      5.1460 |           - |             65448 B |
|            System.Collections |                IndexerSet&lt;Int32&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |        50,974.114 ns |       941.5698 ns |       880.7450 ns |        50,592.549 ns |        49,743.466 ns |        52,757.452 ns |           - |           - |           - |                   - |
|            System.Collections |               IndexerSet&lt;String&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |       124,769.958 ns |     1,494.9546 ns |     1,398.3814 ns |       124,507.891 ns |       122,417.082 ns |       127,556.236 ns |           - |           - |           - |                   - |
|            System.Collections |            IterateForEach&lt;Int32&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |        18,215.827 ns |       203.7896 ns |       190.6249 ns |        18,195.956 ns |        17,896.050 ns |        18,554.976 ns |           - |           - |           - |                   - |
|            System.Collections |           IterateForEach&lt;String&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |        18,497.016 ns |       190.6483 ns |       178.3325 ns |        18,461.196 ns |        18,305.749 ns |        18,943.396 ns |           - |           - |           - |                   - |
|      **System.Collections.Tests** |                  **Perf_Dictionary** | **ContainsValue** |               **1** |           **16** |    **?** |    **3000** |     **?** |     **7,479,647.883 ns** |    **84,846.0839 ns** |    **79,365.0796 ns** |     **7,503,163.724 ns** |     **7,335,345.834 ns** |     **7,575,527.598 ns** |           **-** |           **-** |           **-** |                   **-** |
|            **System.Collections** |        **DictionaryMappingFunction** |       **Entropy** |               **1** |           **16** |    **?** |    **5000** |     **?** |     **1,047,806.953 ns** |    **12,991.8550 ns** |    **12,152.5892 ns** |     **1,049,529.001 ns** |     **1,028,935.009 ns** |     **1,069,438.614 ns** |    **120.8333** |    **120.8333** |    **120.8333** |            **673056 B** |
|            **System.Collections** |        **DictionaryMappingFunction** |       **Entropy** |               **1** |           **16** |    **?** |   **50000** |     **?** |     **8,611,516.872 ns** |   **160,790.0849 ns** |   **157,917.3629 ns** |     **8,648,810.877 ns** |     **8,290,096.415 ns** |     **8,892,345.790 ns** |   **1062.5000** |   **1031.2500** |   **1031.2500** |           **6037793 B** |
|            **System.Collections** |        **DictionaryMappingFunction** |       **Entropy** |               **1** |           **16** |    **?** |  **500000** |     **?** |   **115,474,366.049 ns** | **2,256,936.6814 ns** | **2,216,613.6005 ns** |   **115,663,043.738 ns** |   **111,832,845.410 ns** |   **118,933,395.905 ns** |   **2500.0000** |   **2500.0000** |   **2500.0000** |          **53888568 B** |
|            **System.Collections** |        **DictionaryMappingFunction** |       **Entropy** |               **1** |           **16** |    **?** | **5000000** |     **?** | **1,060,218,842.288 ns** | **6,433,913.8710 ns** | **6,018,287.0268 ns** | **1,058,696,955.310 ns** | **1,048,741,079.400 ns** | **1,071,752,699.780 ns** |   **4000.0000** |   **4000.0000** |   **4000.0000** |         **471722104 B** |

After 

``` ini

BenchmarkDotNet=v0.11.3.1003-nightly, OS=Windows 10.0.17134.590 (1803/April2018Update/Redstone4)
Intel Core i7 CPU 860 2.80GHz (Nehalem), 1 CPU, 8 logical and 4 physical cores
Frequency=2727535 Hz, Resolution=366.6314 ns, Timer=TSC
.NET Core SDK=3.0.100-preview-010184
  [Host]     : .NET Core 3.0.0-preview-27324-5 (CoreCLR 4.6.27322.0, CoreFX 4.7.19.7311), 64bit RyuJIT
  Job-BXGUAA : .NET Core 87f9cb2e-5075-4cbd-ab6c-b5da46079c94 (CoreCLR 4.6.27523.0, CoreFX 4.7.19.12501), 64bit RyuJIT
  Job-KJQYMZ : .NET Core 87f9cb2e-5075-4cbd-ab6c-b5da46079c94 (CoreCLR 4.6.27523.0, CoreFX 4.7.19.12501), 64bit RyuJIT

Runtime=Core  Toolchain=CoreRun  IterationTime=250.0000 ms  
MaxIterationCount=20  MinIterationCount=15  WarmupCount=1  

```
|                     Namespace |                             Type |        Method | InvocationCount | UnrollFactor | Size |   Items | Count |                 Mean |             Error |            StdDev |               Median |                  Min |                  Max | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------------------------------ |--------------------------------- |-------------- |---------------- |------------- |----- |-------- |------ |---------------------:|------------------:|------------------:|---------------------:|---------------------:|---------------------:|------------:|------------:|------------:|--------------------:|
|            **System.Collections** |           **CtorDefaultSize&lt;Int32&gt;** |    **Dictionary** |               **1** |           **16** |    **?** |       **?** |     **?** |            **23.805 ns** |         **0.2385 ns** |         **0.2231 ns** |            **23.704 ns** |            **23.541 ns** |            **24.239 ns** |      **0.0171** |           **-** |           **-** |                **72 B** |
|            System.Collections |          CtorDefaultSize&lt;String&gt; |    Dictionary |               1 |           16 |    ? |       ? |     ? |           113.941 ns |         0.9883 ns |         0.9245 ns |           113.855 ns |           112.458 ns |           115.495 ns |      0.0170 |           - |           - |                72 B |
| **System.Collections.Concurrent** |                   **IsEmpty&lt;Int32&gt;** |    **Dictionary** |               **1** |           **16** |    **0** |       **?** |     **?** |           **170.869 ns** |         **1.9216 ns** |         **1.7975 ns** |           **170.418 ns** |           **166.628 ns** |           **173.358 ns** |           **-** |           **-** |           **-** |                   **-** |
| System.Collections.Concurrent |                  IsEmpty&lt;String&gt; |    Dictionary |               1 |           16 |    0 |       ? |     ? |           179.837 ns |         1.7561 ns |         1.6427 ns |           180.384 ns |           176.214 ns |           181.830 ns |           - |           - |           - |                   - |
|            **System.Collections** |        **DictionaryMappingFunction** |       **Entropy** |               **1** |           **16** |    **?** |     **500** |     **?** |        **82,340.128 ns** |       **978.2604 ns** |       **915.0654 ns** |        **82,026.180 ns** |        **81,309.353 ns** |        **83,891.009 ns** |     **17.3429** |      **0.3272** |           **-** |             **73160 B** |
|            **System.Collections** |         **TryAddDefaultSize&lt;Int32&gt;** |    **Dictionary** |               **1** |           **16** |    **?** |       **?** |  **2048** |       **150,153.371 ns** |     **1,618.9973 ns** |     **1,514.4110 ns** |       **150,124.634 ns** |       **147,893.717 ns** |       **152,240.763 ns** |     **24.1745** |     **11.7925** |           **-** |            **154192 B** |
|            System.Collections |        TryAddDefaultSize&lt;String&gt; |    Dictionary |               1 |           16 |    ? |       ? |  2048 |       261,100.120 ns |     1,934.8411 ns |     1,809.8516 ns |       261,193.832 ns |       257,340.070 ns |       264,332.737 ns |     46.1066 |     39.9590 |     26.6393 |            215717 B |
|            System.Collections |          TryAddGiventSize&lt;Int32&gt; |    Dictionary |               1 |           16 |    ? |       ? |  2048 |        63,706.533 ns |     2,213.4287 ns |     2,548.9878 ns |        63,218.560 ns |        60,307.853 ns |        67,743.168 ns |      7.2614 |      3.6307 |           - |             46784 B |
|            System.Collections |         TryAddGiventSize&lt;String&gt; |    Dictionary |               1 |           16 |    ? |       ? |  2048 |       142,825.956 ns |       868.1599 ns |       724.9528 ns |       142,806.871 ns |       141,892.376 ns |       144,623.363 ns |     10.2273 |      5.1136 |           - |             65448 B |
|            System.Collections |            AddDefaultSize&lt;Int32&gt; |    Dictionary |               1 |           16 |    ? |       ? |  2048 |       151,037.858 ns |     2,873.2948 ns |     3,074.3933 ns |       150,303.520 ns |       146,159.005 ns |       155,900.099 ns |     24.2718 |     12.1359 |           - |            154192 B |
|            System.Collections |           AddDefaultSize&lt;String&gt; |    Dictionary |               1 |           16 |    ? |       ? |  2048 |       267,313.615 ns |     4,137.9096 ns |     3,668.1491 ns |       268,283.291 ns |       259,293.248 ns |       271,946.692 ns |     45.5508 |     40.2542 |     26.4831 |            215720 B |
|            **System.Collections** |                    **Remove&lt;Int32&gt;** |    **Dictionary** |            **1000** |            **1** | **2048** |       **?** |     **?** |        **62,601.610 ns** |     **1,216.2933 ns** |     **1,137.7215 ns** |        **62,405.854 ns** |        **60,909.264 ns** |        **65,463.193 ns** |           **-** |           **-** |           **-** |                   **-** |
|            System.Collections |                   Remove&lt;String&gt; |    Dictionary |            1000 |            1 | 2048 |       ? |     ? |       128,512.905 ns |     1,917.1579 ns |     1,600.9137 ns |       128,483.997 ns |       126,116.292 ns |       132,111.082 ns |           - |           - |           - |                   - |
|            System.Collections |                     Clear&lt;Int32&gt; |    Dictionary |            1000 |            1 | 2048 |       ? |     ? |         8,145.743 ns |       170.3186 ns |       182.2390 ns |         8,082.011 ns |         7,897.778 ns |         8,482.189 ns |           - |           - |           - |                   - |
|            System.Collections |                    Clear&lt;String&gt; |    Dictionary |            1000 |            1 | 2048 |       ? |     ? |        10,767.409 ns |       131.9702 ns |       110.2011 ns |        10,776.067 ns |        10,551.322 ns |        10,956.083 ns |           - |           - |           - |                   - |
|            System.Collections |   ContainsKeyFalse&lt;Int32, Int32&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |        44,879.415 ns |       333.7097 ns |       278.6627 ns |        44,902.335 ns |        44,395.467 ns |        45,463.019 ns |           - |           - |           - |                   - |
|            System.Collections | ContainsKeyFalse&lt;String, String&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |       110,064.587 ns |     1,119.4218 ns |     1,047.1078 ns |       110,064.819 ns |       107,313.029 ns |       111,583.653 ns |           - |           - |           - |                   - |
|            System.Collections |    ContainsKeyTrue&lt;Int32, Int32&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |        41,055.418 ns |       778.8534 ns |       728.5399 ns |        40,913.175 ns |        40,131.967 ns |        42,263.798 ns |           - |           - |           - |                   - |
|            System.Collections |  ContainsKeyTrue&lt;String, String&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |       109,705.450 ns |       997.1031 ns |       932.6908 ns |       109,501.575 ns |       108,489.520 ns |       111,074.399 ns |           - |           - |           - |                   - |
| System.Collections.Concurrent |                     Count&lt;Int32&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |        20,438.584 ns |       196.3024 ns |       183.6214 ns |        20,467.289 ns |        20,101.198 ns |        20,709.797 ns |           - |           - |           - |                   - |
| System.Collections.Concurrent |                    Count&lt;String&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |        20,203.623 ns |       205.4737 ns |       192.2002 ns |        20,219.996 ns |        19,945.734 ns |        20,448.163 ns |           - |           - |           - |                   - |
| System.Collections.Concurrent |                   IsEmpty&lt;Int32&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |             2.866 ns |         0.1173 ns |         0.1097 ns |             2.858 ns |             2.676 ns |             3.075 ns |           - |           - |           - |                   - |
| System.Collections.Concurrent |                  IsEmpty&lt;String&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |             3.092 ns |         0.1544 ns |         0.1445 ns |             3.113 ns |             2.887 ns |             3.399 ns |           - |           - |           - |                   - |
|            System.Collections |              AddGivenSize&lt;Int32&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |        60,760.020 ns |       894.4473 ns |       836.6666 ns |        60,721.554 ns |        59,326.054 ns |        62,369.815 ns |      7.4234 |      3.5920 |           - |             46784 B |
|            System.Collections |             AddGivenSize&lt;String&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |       143,719.715 ns |     1,504.3490 ns |     1,407.1690 ns |       143,787.977 ns |       141,109.049 ns |       146,574.665 ns |     10.1351 |      5.0676 |           - |             65448 B |
|            System.Collections |        CtorFromCollection&lt;Int32&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |        62,795.952 ns |       444.3428 ns |       415.6385 ns |        62,860.373 ns |        61,932.473 ns |        63,377.986 ns |      7.4111 |      3.7055 |           - |             46784 B |
|            System.Collections |       CtorFromCollection&lt;String&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |       152,208.271 ns |     1,459.9787 ns |     1,365.6649 ns |       152,484.915 ns |       149,151.577 ns |       154,605.696 ns |     10.4167 |      5.2083 |           - |             65448 B |
|            System.Collections |             CtorGivenSize&lt;Int32&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |        11,921.263 ns |       178.5901 ns |       167.0533 ns |        11,967.958 ns |        11,558.556 ns |        12,132.757 ns |      7.4494 |      3.7013 |           - |             46784 B |
|            System.Collections |            CtorGivenSize&lt;String&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |        23,713.601 ns |       199.5404 ns |       186.6502 ns |        23,718.992 ns |        23,359.783 ns |        24,099.413 ns |     10.3083 |      5.1077 |           - |             65448 B |
|            System.Collections |                IndexerSet&lt;Int32&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |        51,615.680 ns |       457.0949 ns |       427.5669 ns |        51,389.743 ns |        51,137.684 ns |        52,246.152 ns |           - |           - |           - |                   - |
|            System.Collections |               IndexerSet&lt;String&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |       121,926.922 ns |     1,032.9373 ns |       862.5494 ns |       121,878.959 ns |       120,175.949 ns |       123,460.236 ns |           - |           - |           - |                   - |
|            System.Collections |            IterateForEach&lt;Int32&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |        18,384.410 ns |       128.4349 ns |       120.1381 ns |        18,416.393 ns |        18,183.731 ns |        18,545.727 ns |           - |           - |           - |                   - |
|            System.Collections |           IterateForEach&lt;String&gt; |    Dictionary |               1 |           16 | 2048 |       ? |     ? |        18,341.761 ns |       195.1433 ns |       172.9895 ns |        18,307.120 ns |        18,026.805 ns |        18,753.731 ns |           - |           - |           - |                   - |
|      **System.Collections.Tests** |                  **Perf_Dictionary** | **ContainsValue** |               **1** |           **16** |    **?** |    **3000** |     **?** |     **7,975,044.826 ns** |   **105,824.8983 ns** |    **98,988.6755 ns** |     **7,981,264.829 ns** |     **7,840,340.882 ns** |     **8,226,755.110 ns** |           **-** |           **-** |           **-** |                   **-** |
|            **System.Collections** |        **DictionaryMappingFunction** |       **Entropy** |               **1** |           **16** |    **?** |    **5000** |     **?** |     **1,031,586.157 ns** |    **20,160.3601 ns** |    **21,571.3594 ns** |     **1,033,572.395 ns** |       **989,414.793 ns** |     **1,075,720.686 ns** |    **121.0938** |    **121.0938** |    **121.0938** |            **673056 B** |
|            **System.Collections** |        **DictionaryMappingFunction** |       **Entropy** |               **1** |           **16** |    **?** |   **50000** |     **?** |     **8,016,221.116 ns** |   **105,045.7129 ns** |    **93,120.2884 ns** |     **8,006,054.459 ns** |     **7,824,377.139 ns** |     **8,183,526.976 ns** |   **1062.5000** |   **1031.2500** |   **1031.2500** |           **6037793 B** |
|            **System.Collections** |        **DictionaryMappingFunction** |       **Entropy** |               **1** |           **16** |    **?** |  **500000** |     **?** |   **112,127,287.093 ns** | **1,208,900.5710 ns** | **1,130,806.3442 ns** |   **111,575,103.530 ns** |   **110,162,839.340 ns** |   **114,698,069.870 ns** |   **2500.0000** |   **2500.0000** |   **2500.0000** |          **53888568 B** |
|            **System.Collections** |        **DictionaryMappingFunction** |       **Entropy** |               **1** |           **16** |    **?** | **5000000** |     **?** | **1,030,821,064.930 ns** | **8,349,924.7036 ns** | **7,810,524.7484 ns** | **1,028,937,483.850 ns** | **1,020,771,502.470 ns** | **1,045,766,965.410 ns** |   **4000.0000** |   **4000.0000** |   **4000.0000** |         **471722104 B** |

Comparer

| Slower                                                              | diff/base | Base Median (ns) | Diff Median (ns) | Modality|
| ------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Collections.CtorDefaultSize<Int32>.Dictionary                |      1.13 |            21.03 |            23.70 |         |
| System.Collections.Tests.Perf_Dictionary.ContainsValue(Items: 3000) |      1.06 |       7503163.72 |       7981264.83 |         |
| System.Collections.AddDefaultSize<String>.Dictionary(Count: 2048)   |      1.04 |        258518.34 |        268283.29 |         |

| Faster                                                                   | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| ------------------------------------------------------------------------ | ---------:| ----------------:| ----------------:| --------:|
| System.Collections.DictionaryMappingFunction.Entropy(Items: 50000)       |      1.08 |       8648810.88 |       8006054.46 |         |
| System.Collections.AddGivenSize<Int32>.Dictionary(Size: 2048)            |      1.05 |         63791.39 |         60721.55 |         |
| System.Collections.ContainsKeyFalse<Int32, Int32>.Dictionary(Size: 2048) |      1.05 |         46941.64 |         44902.33 |         |
| System.Collections.Concurrent.Count<Int32>.Dictionary(Size: 2048)        |      1.04 |         21284.66 |         20467.29 |         |
| System.Collections.DictionaryMappingFunction.Entropy(Items: 500)         |      1.04 |         85026.70 |         82026.18 |         |
| System.Collections.Remove<String>.Dictionary(Size: 2048)                 |      1.03 |        132631.17 |        128484.00 |         |
| System.Collections.DictionaryMappingFunction.Entropy(Items: 5000000)     |      1.03 |    1058696955.31 |    1028937483.85 |         |
| System.Collections.TryAddGiventSize<String>.Dictionary(Count: 2048)      |      1.03 |        146609.44 |        142806.87 |         |

More interesting tests is custom test for entropy https://github.com/dotnet/performance/compare/master...MarcoRossignoli:newbenchdic , ctor diff seems an outlier no code changed there.
My thoughts, better entropy on mapping function, code is not so different, the difference is not so great also in case of frequent buckets collision(my test is not "perfect" I tested only chain with max 2 item for every inserted item)

I did also some tests with different mapping functions and "and" perform better than "div" as expected(I don't know if this test have been already done in past), maybe on other PR we could try to measure better inside actual dic if it makes sense.
```cs
   public class Bench
    {
        int[] _buckets;

        [Params(10, 100, 1_000, 10_000, 50_000, 100_000, 1_000_000)]
        public int Size;

        [GlobalSetup]
        public void Setup()
        {
            _buckets = new int[Size];
        }


        [Benchmark(Baseline = true)]
        public ref int RemainderOp()
        {
            uint hashCode = (uint)Guid.NewGuid().GetHashCode();
            return ref _buckets[hashCode % _buckets.Length];
        }

        [Benchmark]
        public ref int AndOp()
        {
            uint hashCode = (uint)Guid.NewGuid().GetHashCode();
            return ref _buckets[hashCode & (uint)(_buckets.Length - 1)];
        }
    }
```
``` ini

BenchmarkDotNet=v0.11.4, OS=Windows 10.0.17134.590 (1803/April2018Update/Redstone4)
Intel Core i7-3740QM CPU 2.70GHz (Ivy Bridge), 1 CPU, 8 logical and 4 physical cores
Frequency=2628192 Hz, Resolution=380.4897 ns, Timer=TSC
.NET Core SDK=3.0.100-preview-010184
  [Host]     : .NET Core 3.0.0-preview-27324-5 (CoreCLR 4.6.27322.0, CoreFX 4.7.19.7311), 64bit RyuJIT
  DefaultJob : .NET Core 3.0.0-preview-27324-5 (CoreCLR 4.6.27322.0, CoreFX 4.7.19.7311), 64bit RyuJIT


```
|      Method |    Size |      Mean |     Error |    StdDev | Ratio | RatioSD |
|------------ |-------- |----------:|----------:|----------:|------:|--------:|
| **RemainderOp** |      **10** | **108.73 ns** | **0.2949 ns** | **0.2759 ns** |  **1.00** |    **0.00** |
|       AndOp |      10 |  96.15 ns | 0.2909 ns | 0.2721 ns |  0.88 |    0.00 |
|             |         |           |           |           |       |         |
| **RemainderOp** |     **100** | **108.29 ns** | **0.1940 ns** | **0.1720 ns** |  **1.00** |    **0.00** |
|       AndOp |     100 |  95.78 ns | 0.3034 ns | 0.2689 ns |  0.88 |    0.00 |
|             |         |           |           |           |       |         |
| **RemainderOp** |    **1000** | **108.89 ns** | **1.0818 ns** | **1.0120 ns** |  **1.00** |    **0.00** |
|       AndOp |    1000 |  96.96 ns | 1.4925 ns | 1.3231 ns |  0.89 |    0.02 |
|             |         |           |           |           |       |         |
| **RemainderOp** |   **10000** | **109.44 ns** | **0.2673 ns** | **0.2369 ns** |  **1.00** |    **0.00** |
|       AndOp |   10000 |  97.62 ns | 1.9298 ns | 1.8051 ns |  0.89 |    0.02 |
|             |         |           |           |           |       |         |
| **RemainderOp** |   **50000** | **110.83 ns** | **0.2706 ns** | **0.2532 ns** |  **1.00** |    **0.00** |
|       AndOp |   50000 |  97.67 ns | 1.9822 ns | 1.8542 ns |  0.88 |    0.02 |
|             |         |           |           |           |       |         |
| **RemainderOp** |  **100000** | **113.69 ns** | **0.7799 ns** | **0.6914 ns** |  **1.00** |    **0.00** |
|       AndOp |  100000 |  96.78 ns | 0.3589 ns | 0.3357 ns |  0.85 |    0.01 |
|             |         |           |           |           |       |         |
| **RemainderOp** | **1000000** | **158.42 ns** | **3.1855 ns** | **6.2879 ns** |  **1.00** |    **0.00** |
|       AndOp | 1000000 | 100.77 ns | 0.5143 ns | 0.4295 ns |  0.66 |    0.02 |


I did also work on last point of list 
* Eliminate the `_freeCount` field and use `_freeList == -1` as a sentinel instead`

and the result are not so great, we remove the local var freeCount but after that we use count as a "real item count" and it's no more aligned with entries count. This lead to change every piece of code that iterate throught entries using a local `count = _count` (to decrement after every "valid item" found, next > -1) . Another issue is that DictionarySlim doesn't support "versioning" so I had to change also every enumerator to support current dictionary behaviour(support remove during enumeration). We need also to change code for features like Trim(), EnsureCapacity() that slim one doesn't have.
I'll show result if you want, but the complexity of change it's not worth to me.
Some preview code(not optimized but to understand the complexity) https://github.com/MarcoRossignoli/marcorossignoli.github.io/blob/dicbackporting/src/DicBackportingBenchmark/Dic/Dic/Dictionary.cs#L107 https://github.com/MarcoRossignoli/marcorossignoli.github.io/blob/dicbackporting/src/DicBackportingBenchmark/Dic/Dic/Dictionary.cs#L1610

Thank's for chance to explore dictionary so deeply, very interesting and funny!
I hope I was helpful.

/cc @danmosemsft 