### PR TITLE
For linux-musl-arm64 use OutputRid

### DIFF
--- a/build-packages.sh
+++ b/build-packages.sh
@@ -118,6 +118,11 @@ if [ "${__DistroRid}" = "linux-musl-arm64" ]; then
     # will break this logic. To work around this, pass ArchGroup explicitely.
 
     export ArchGroup=arm64
+
+    # Currently the decision tree in src/.nuget/dirs.props will incorrectly
+    # reparse the already calculated __DistroRid. For linux-musl-arm64 use
+    # the hack/hook to specifically bypass this logic.
+    export OutputRID=${__DistroRid}
 fi
 
 $__ProjectRoot/dotnet.sh msbuild /nologo /verbosity:minimal /clp:Summary \


### PR DESCRIPTION
This variable was added for linux-musl-x64 in our old official builds,
because our current logic in src/.nuget/dirs.props incorrectly parses
the __DistroRid passed.

Fixes https://github.com/dotnet/coreclr/issues/22833. We need a todo issue as well to either remove or standardize all our distrorid logic. The tendrils are apparently larger than build.sh/build-test.sh/runtest.sh/build-packages.sh