### PR TITLE
Turn on IBC and enforce PGO in official and release builds.

### DIFF
--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -77,11 +77,13 @@ jobs:
     - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
       - name: officialBuildIdArg
         value: '-officialbuildid=$(Build.BuildNumber)'
-      - name: ibcOptimizeArg
-        value: '-ibcoptimize'
+      # IBCMerge is currently Windows-only and x86/x64-only
+      - ${{ if and(eq(parameters.osGroup, 'Windows_NT'), or(eq(parameters.archType, 'x64'), eq(parameters.archType, 'x86'))) }}:
+        - name: ibcOptimizeArg
+          value: '-ibcoptimize'
     - name: enforcePgoArg
       value: ''
-    # the EnforcePGO script is only supported on Windows and is not supported on arm or arm64.
+    # The EnforcePGO script is only supported on Windows and is not supported on arm or arm64.
     - ${{ if and(eq(parameters.buildConfig, 'Release'), and(eq(parameters.osGroup, 'Windows_NT'), not(or(eq(parameters.archType, 'arm64'), eq(parameters.archType, 'arm'))))) }}:
       - name: enforcePgoArg
         value: '-enforcepgo'

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -72,9 +72,19 @@ jobs:
         value: $(buildConfigUpper)
     - name: officialBuildIdArg
       value: ''
+    - name: ibcOptimizeArg
+      value: ''
     - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
       - name: officialBuildIdArg
         value: '-officialbuildid=$(Build.BuildNumber)'
+      - name: ibcOptimizeArg
+        value: '-ibcoptimize'
+    - name: enforcePgoArg
+      value: ''
+    # the EnforcePGO script is only supported on Windows and is not supported on arm or arm64.
+    - ${{ if and(eq(parameters.buildConfig, 'Release'), and(eq(parameters.osGroup, 'Windows_NT'), not(or(eq(parameters.archType, 'arm64'), eq(parameters.archType, 'arm'))))) }}:
+      - name: enforcePgoArg
+        value: '-enforcepgo'
 
     steps:
 
@@ -100,8 +110,7 @@ jobs:
             # Once we are using Arcade, use DotNetCoreSdkDir instead, as we do below.
             DotNetBootstrapCliTarPath: /dotnet-sdk-freebsd-x64.tar
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-      # TODO: IBCOptimize? EnforcePGO? file logging parameters?
-      - script: set __TestIntermediateDir=int&&build.cmd $(buildConfig) $(archType) -skiptests -skipbuildpackages $(officialBuildIdArg)
+      - script: set __TestIntermediateDir=int&&build.cmd $(buildConfig) $(archType) -skiptests -skipbuildpackages $(officialBuildIdArg) $(ibcOptimizeArg) $(enforcePgoArg)
         displayName: Build product
 
     # Sign on Windows

--- a/src/scripts/pgocheck.py
+++ b/src/scripts/pgocheck.py
@@ -26,7 +26,9 @@ pgo_pattern_str = r'coffgrp(?:\s+[0-9A-F]+){4}\s+\((\S*)\)'
 pgo_pattern = re.compile(pgo_pattern_str)
 
 def was_compiled_with_pgo(filename):
-    headers = subprocess.check_output(["link", "/dump", "/headers", filename])
+    # When running on Python 3, check_output returns a bytes object, which we need to
+    # decode to a string object.
+    headers = subprocess.check_output(["link", "/dump", "/headers", filename]).decode('utf-8')
     
     match = pgo_pattern.search(headers)
 


### PR DESCRIPTION
- Turn on the `-ibcoptimize` flag on official builds.
- Add the `-enforcepgo` flag to Windows non-arm release builds (same as Jenkins implementation).

Additionally, fix the pgocheck script to work on both python2 and python3 for local builds with `-enforcepgo` turned on and python3 installed.

Fixes #22467 
