### PR TITLE
[WIP] Remove extra bound checks for explicit range checks

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -6633,6 +6633,9 @@ public:
         }
     };
 
+    bool optExtractUniqueBBFromCondScope(BasicBlock*                  bbCond,
+                                         jitstd::vector<BasicBlock*>* extracted,
+                                         bool                         isReversedCond = false);
     bool optIsStackLocalInvariant(unsigned loopNum, unsigned lclNum);
     bool optExtractArrIndex(GenTree* tree, ArrIndex* result, unsigned lhsNum);
     bool optReconstructArrIndex(GenTree* tree, ArrIndex* result, unsigned lhsNum);

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -8353,6 +8353,7 @@ bool Compiler::optExtractUniqueBBFromCondScope(BasicBlock*                  bbCo
                     return false;
             }
         }
+        recNext.clear();
 
         for (BasicBlock* bbToAnalysis : recTemp)
         {

--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -293,19 +293,17 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, GenTree* stmt, GenTree* t
         m_pCompiler->optRemoveRangeCheck(treeParent, stmt);
     }
 
-        /* TODO : When only enabled explicitly, also extend extra slots for handling explicit range checks.
-     * Check for previuos stmts has explicit range check. for example.
-     * if (array.Length > 0 && array[0]) { ~ } 
-     * 
-     * To make sure, this block is ONLY executed after 'array.Length > 0' check
-     */
-    
+    /* TODO : When only enabled explicitly, also extend extra slots for handling explicit range checks.
+    * Check for previuos stmts has explicit range check. for example.
+    * if (array.Length > 0 && array[0]) { ~ }
+    *
+    * To make sure, this block is ONLY executed after 'array.Length > 0' check
+    */
+
     BasicBlock* bbJmpFrom = block->bbPrev;
-    if (bbJmpFrom != nullptr              && 
-        bbJmpFrom->bbJumpKind == BBJ_COND &&
-        bbJmpFrom->firstStmt()->gtNextStmt == nullptr)
+    if (bbJmpFrom != nullptr && bbJmpFrom->bbJumpKind == BBJ_COND && bbJmpFrom->firstStmt()->gtNextStmt == nullptr)
     {
-        GenTree* gtCond  = bbJmpFrom->firstStmt()->gtStmtExpr->gtGetOp1();
+        GenTree* gtCond = bbJmpFrom->firstStmt()->gtStmtExpr->gtGetOp1();
 
         GenTree* gtCondV = gtCond->gtGetOp1();
         GenTree* gtCondC = gtCond->gtGetOp2();
@@ -318,28 +316,28 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, GenTree* stmt, GenTree* t
 
             switch (gtCond->OperGet())
             {
-            case GT_LE:
-                condVal += 1;
-            case GT_LT:
-                if (condVal > rngcVal)
-                {
-                    m_pCompiler->optRemoveRangeCheck(treeParent, stmt);
-                }
-                break;
+                case GT_LE:
+                    condVal += 1;
+                case GT_LT:
+                    if (condVal > rngcVal)
+                    {
+                        m_pCompiler->optRemoveRangeCheck(treeParent, stmt);
+                    }
+                    break;
 
-            case GT_GT:
-                condVal += 1;
-            case GT_GE:
-            case GT_EQ:
-                if (condVal < rngcVal)
-                {
-                    m_pCompiler->optRemoveRangeCheck(treeParent, stmt);
-                }
-                break;
-            
-            default:
-                // this is not condtional operator. such as GT_LE, GT_EQ, etc.
-                break;
+                case GT_GT:
+                    condVal += 1;
+                case GT_GE:
+                case GT_EQ:
+                    if (condVal < rngcVal)
+                    {
+                        m_pCompiler->optRemoveRangeCheck(treeParent, stmt);
+                    }
+                    break;
+
+                default:
+                    // this is not condtional operator. such as GT_LE, GT_EQ, etc.
+                    break;
             }
         }
     }

--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -292,6 +292,58 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, GenTree* stmt, GenTree* t
         JITDUMP("[RangeCheck::OptimizeRangeCheck] Between bounds\n");
         m_pCompiler->optRemoveRangeCheck(treeParent, stmt);
     }
+
+        /* TODO : When only enabled explicitly, also extend extra slots for handling explicit range checks.
+     * Check for previuos stmts has explicit range check. for example.
+     * if (array.Length > 0 && array[0]) { ~ } 
+     * 
+     * To make sure, this block is ONLY executed after 'array.Length > 0' check
+     */
+    
+    BasicBlock* bbJmpFrom = block->bbPrev;
+    if (bbJmpFrom != nullptr              && 
+        bbJmpFrom->bbJumpKind == BBJ_COND &&
+        bbJmpFrom->firstStmt()->gtNextStmt == nullptr)
+    {
+        GenTree* gtCond  = bbJmpFrom->firstStmt()->gtStmtExpr->gtGetOp1();
+
+        GenTree* gtCondV = gtCond->gtGetOp1();
+        GenTree* gtCondC = gtCond->gtGetOp2();
+
+        if (gtCondC->IsCnsIntOrI() && m_pCompiler->vnStore->VNConservativeNormalValue(gtCondV->gtVNPair) == arrLenVn)
+        {
+            genTreeOps condTyp = gtCond->OperGet();
+            ssize_t    condVal = gtCondC->gtIntCon.IconValue();
+            ssize_t    rngcVal = treeIndex->gtIntCon.IconValue();
+
+            switch (gtCond->OperGet())
+            {
+            case GT_LE:
+                condVal += 1;
+            case GT_LT:
+                if (condVal > rngcVal)
+                {
+                    m_pCompiler->optRemoveRangeCheck(treeParent, stmt);
+                }
+                break;
+
+            case GT_GT:
+                condVal += 1;
+            case GT_GE:
+            case GT_EQ:
+                if (condVal < rngcVal)
+                {
+                    m_pCompiler->optRemoveRangeCheck(treeParent, stmt);
+                }
+                break;
+            
+            default:
+                // this is not condtional operator. such as GT_LE, GT_EQ, etc.
+                break;
+            }
+        }
+    }
+
     return;
 }
 

--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -291,6 +291,8 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, GenTree* stmt, GenTree* t
     {
         JITDUMP("[RangeCheck::OptimizeRangeCheck] Between bounds\n");
         m_pCompiler->optRemoveRangeCheck(treeParent, stmt);
+
+        return;
     }
 
     /* TODO : When only enabled explicitly, also extend extra slots for handling explicit range checks.

--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -209,7 +209,7 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, GenTree* stmt, GenTree* t
             GenTree*   gtCmpCns = gtCmp->gtGetOp2IfPresent();
 
             // The compare expression can be comma because of CSE expansion. extract effeictive value before checking it
-            if (gtCmpLen->OperIs(GT_COMMA) && gtCmpLen->gtFlags & GTF_STMT_HAS_CSE)
+            if (gtCmpLen->OperIs(GT_COMMA))
             {
                 GenTree* cmmOp1 = gtCmpLen->gtGetOp1();
                 GenTree* cmmOp2 = gtCmpLen->gtGetOp2();
@@ -391,14 +391,13 @@ void RangeCheck::OptimizeRangeCheckWithExplicitCheck(BasicBlock*  block,
     {
         for (GenTreeStmt* gtStmtIter = bbIter->bbTreeList->AsStmt(); gtStmtIter; gtStmtIter = gtStmtIter->gtNextStmt)
         {
-            for (GenTree* gtTreeIter = gtStmtIter->gtStmtExpr; gtTreeIter; gtTreeIter = gtTreeIter->gtNext)
+            for (GenTree* gtTreeIter = gtStmtIter->gtStmtList; gtTreeIter; gtTreeIter = gtTreeIter->gtNext)
             {
-                if (gtTreeIter->OperIs(GT_ARR_BOUNDS_CHECK))
+                if (gtTreeIter->OperIs(GT_COMMA) && gtTreeIter->gtGetOp1()->OperIs(GT_ARR_BOUNDS_CHECK))
                 {
-                    GenTreeBoundsChk* gtBndChk = gtTreeIter->AsBoundsChk();
+                    GenTreeBoundsChk* gtBndChk = gtTreeIter->gtGetOp1()->AsBoundsChk();
 
-                    if (ValueNum arrLenVN =
-                            m_pCompiler->vnStore->VNConservativeNormalValue(gtBndChk->gtArrLen->gtVNPair) != arrVn)
+                    if (m_pCompiler->vnStore->VNConservativeNormalValue(gtBndChk->gtArrLen->gtVNPair) != arrVn)
                     {
                         continue;
                     }

--- a/src/jit/rangecheck.h
+++ b/src/jit/rangecheck.h
@@ -465,6 +465,9 @@ public:
     // contain the tree.
     void OptimizeRangeCheck(BasicBlock* block, GenTree* stmt, GenTree* tree);
 
+    void OptimizeRangeCheckWithAssertion(BasicBlock* block, GenTree* stmt, GenTree* treeParent);
+    void OptimizeRangeCheckWithExplicitCheck(BasicBlock* block, GenTree* stmt, GenTree* treeParent, unsigned int arrVn);
+
     // Given the index expression try to find its range.
     // The range of a variable depends on its rhs which in turn depends on its constituent variables.
     // The "path" is the path taken in the search for the rhs' range and its constituents' range.


### PR DESCRIPTION
Currently, removing bound checks for explicit array range check on some major patterns.
such as
```
if (array.Length > 0)
{
    // Some (array) use expressions.
}
```

The explicit range check removal will be triggered if only the code scope of `if` expression is only can reach with `if` expressions, which means there is no Side-Effect on that code scope.


Related to https://github.com/dotnet/coreclr/issues/19620