### PR TITLE
Fix Linux FP exception when NUMA nodes greater than 1

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -34202,7 +34202,10 @@ HRESULT GCHeap::Initialize()
 #ifdef MULTIPLE_HEAPS
     nhp_from_config = static_cast<uint32_t>(GCConfig::GetHeapCount());
     
-    uint32_t nhp_from_process = GCToOSInterface::GetCurrentProcessCpuCount();
+    // GetCurrentProcessCpuCount only returns up to 64 procs.
+    uint32_t nhp_from_process = GCToOSInterface::CanEnableGCCPUGroups() ?
+                                GCToOSInterface::GetTotalProcessorCount():
+                                GCToOSInterface::GetCurrentProcessCpuCount();
 
     if (nhp_from_config)
     {
@@ -34233,6 +34236,20 @@ HRESULT GCHeap::Initialize()
             {
                 pmask &= smask;
 
+#ifdef FEATURE_PAL
+                // GetCurrentProcessAffinityMask can return pmask=0 and smask=0 on
+                // systems with more than 1 NUMA node. The pmask decides the
+                // number of GC heaps to be used and the processors they are
+                // affinitized with. So pmask is now set to reflect that 64
+                // processors are available to begin with. The actual processors in
+                // the system may be lower and are taken into account before
+                // finalizing the number of heaps.
+                if (!pmask)
+                {
+                    pmask = SIZE_T_MAX;
+                }
+#endif // FEATURE_PAL
+
                 if (gc_thread_affinity_mask)
                 {
                     pmask &= gc_thread_affinity_mask;
@@ -34249,6 +34266,11 @@ HRESULT GCHeap::Initialize()
                 }
 
                 nhp = min (nhp, set_bits_in_pmask);
+
+#ifdef FEATURE_PAL
+                // Limit the GC heaps to the number of processors available in the system.
+                nhp = min (nhp, GCToOSInterface::GetTotalProcessorCount());
+#endif // FEATURE_PAL
             }
             else
             {

--- a/src/inc/utilcode.h
+++ b/src/inc/utilcode.h
@@ -1355,31 +1355,10 @@ public:
     static void InitNumaNodeInfo();
 
 #if !defined(FEATURE_REDHAWK)
-private:	// apis types
-
-    //GetNumaHighestNodeNumber()
-    typedef BOOL
-    (WINAPI *PGNHNN)(PULONG);
-    //VirtualAllocExNuma()
-    typedef LPVOID
-    (WINAPI *PVAExN)(HANDLE,LPVOID,SIZE_T,DWORD,DWORD,DWORD);
-
-    // api pfns and members
-    static PGNHNN   m_pGetNumaHighestNodeNumber;
-    static PVAExN   m_pVirtualAllocExNuma;
-
 public: 	// functions
 
     static LPVOID VirtualAllocExNuma(HANDLE hProc, LPVOID lpAddr, SIZE_T size,
                                      DWORD allocType, DWORD prot, DWORD node);
-
-private:
-    //GetNumaProcessorNodeEx()
-    typedef BOOL
-    (WINAPI *PGNPNEx)(PPROCESSOR_NUMBER, PUSHORT);
-    static PGNPNEx  m_pGetNumaProcessorNodeEx;
-
-public:
     static BOOL GetNumaProcessorNodeEx(PPROCESSOR_NUMBER proc_no, PUSHORT node_no);
 #endif
 };
@@ -1407,7 +1386,6 @@ private:
     static CPU_Group_Info *m_CPUGroupInfoArray;
     static bool s_hadSingleProcessorAtStartup;
 
-    static BOOL InitCPUGroupInfoAPI();
     static BOOL InitCPUGroupInfoArray();
     static BOOL InitCPUGroupInfoRange();
     static void InitCPUGroupInfo();
@@ -1424,34 +1402,8 @@ public:
     //static void PopulateCPUUsageArray(void * infoBuffer, ULONG infoSize);
 
 #if !defined(FEATURE_REDHAWK)
-private:
-    //GetLogicalProcessorInforomationEx()
-    typedef BOOL
-    (WINAPI *PGLPIEx)(DWORD, SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *, PDWORD);
-    //SetThreadGroupAffinity()
-    typedef BOOL
-    (WINAPI *PSTGA)(HANDLE, GROUP_AFFINITY *, GROUP_AFFINITY *);
-    //GetThreadGroupAffinity()
-    typedef BOOL
-    (WINAPI *PGTGA)(HANDLE, GROUP_AFFINITY *);
-    //GetCurrentProcessorNumberEx()
-    typedef void
-    (WINAPI *PGCPNEx)(PROCESSOR_NUMBER *);
-    //GetSystemTimes()
-    typedef BOOL
-    (WINAPI *PGST)(FILETIME *, FILETIME *, FILETIME *);
-    //NtQuerySystemInformationEx()
-    //typedef int
-    //(WINAPI *PNTQSIEx)(SYSTEM_INFORMATION_CLASS, PULONG, ULONG, PVOID, ULONG, PULONG);
-    static PGLPIEx m_pGetLogicalProcessorInformationEx;
-    static PSTGA   m_pSetThreadGroupAffinity;
-    static PGTGA   m_pGetThreadGroupAffinity;
-    static PGCPNEx m_pGetCurrentProcessorNumberEx;
-    static PGST    m_pGetSystemTimes;
-    //static PNTQSIEx m_pNtQuerySystemInformationEx;
-
 public:
-    static BOOL GetLogicalProcessorInformationEx(DWORD relationship,
+    static BOOL GetLogicalProcessorInformationEx(LOGICAL_PROCESSOR_RELATIONSHIP relationship,
 		   SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *slpiex, PDWORD count); 
     static BOOL SetThreadGroupAffinity(HANDLE h,
 		    GROUP_AFFINITY *groupAffinity, GROUP_AFFINITY *previousGroupAffinity);

--- a/src/utilcode/staticnohost/CMakeLists.txt
+++ b/src/utilcode/staticnohost/CMakeLists.txt
@@ -9,4 +9,7 @@ add_library_clr(utilcodestaticnohost STATIC ${UTILCODE_STATICNOHOST_SOURCES})
 
 if(CLR_CMAKE_PLATFORM_UNIX)
   target_link_libraries(utilcodestaticnohost  nativeresourcestring)
+  if(CLR_CMAKE_PLATFORM_DARWIN)
+    target_link_libraries(utilcodestaticnohost  coreclrpal)
+  endif(CLR_CMAKE_PLATFORM_DARWIN)
 endif(CLR_CMAKE_PLATFORM_UNIX)


### PR DESCRIPTION
The GC heap count is currently being set to zero when the available NUMA nodes are greater than 1 on Linux, leading to a Divide by Zero error. Reverting the GC heap count calculation logic to the version before PR #[22180](https://github.com/dotnet/coreclr/pull/22180).

Fixed the process mask on Linux for GC threads to get affinitized to the right core & for GCHeapAffinitizeMask to control the number of heaps and processor affinities when GCCpuGroup is not set.

Also, [GCToOSInterface::CanEnableGCCPUGroups](https://github.com/dotnet/coreclr/blob/master/src/vm/gcenv.os.cpp#L757) always returned FALSE on Linux when NUMA nodes > 1. Some GetProcAddress calls in util.cpp were failing, which made [CPUGroupInfo::InitCPUGroupInfoAPI](https://github.com/dotnet/coreclr/blob/master/src/utilcode/util.cpp#L861) & [NumaNodeInfo::InitNumaNodeInfoAPI](https://github.com/dotnet/coreclr/blob/master/src/utilcode/util.cpp#L763) to return FALSE. Fixed these by changing the GetProcAddress calls to direct API calls instead as all of them are present at least from Windows 7 on.

PTAL @Maoni0 @janvorli 