### PR TITLE
Fix `optVNConstantPropOnJTrue`.

### DIFF
--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -4777,8 +4777,9 @@ GenTree* Compiler::optVNConstantPropOnJTrue(BasicBlock* block, GenTree* stmt, Ge
     //
     assert((relop->gtFlags & GTF_RELOP_JMP_USED) != 0);
 
-    ValueNum vnCns = relop->gtVNPair.GetConservative();
-    ValueNum vnLib = relop->gtVNPair.GetLiberal();
+    // We want to use the Normal ValueNumber when checking for constants.
+    ValueNum vnCns = vnStore->VNConservativeNormalValue(relop->gtVNPair);
+    ValueNum vnLib = vnStore->VNLiberalNormalValue(relop->gtVNPair);
     if (!vnStore->IsVNConstant(vnCns))
     {
         return nullptr;


### PR DESCRIPTION
It should use the same VN that `optVNConstantPropOnTree` uses. That was changed in #20033 but this method slipped through.

`optVNConstantPropOnJTrue` stopped working properly after #21386.

Found it when worked at #18291.

Windows x64 Checked fx pmi diffs:
```
Total bytes of diff: -70 (0.00% of base)
    diff is an improvement.
Top file improvements by size (bytes):
         -49 : Microsoft.CodeAnalysis.dasm (0.00% of base)
         -12 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (0.00% of base)
          -9 : Microsoft.DotNet.Cli.Utils.dasm (-0.01% of base)
3 total files with size differences (3 improved, 0 regressed), 126 unchanged.
Top method improvements by size (bytes):
         -49 (-24.75% of base) : Microsoft.CodeAnalysis.dasm - Roslyn.Utilities.ArrayExtensions:Append(ref,struct):ref
         -12 (-14.29% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Symbols.SourceFile:ArrayEquals(ref,ref):bool
          -9 (-2.46% of base) : Microsoft.DotNet.Cli.Utils.dasm - Microsoft.DotNet.Cli.Utils.BlockingMemoryStream:Read(ref,int,int):int:this
Top method improvements by size (percentage):
         -49 (-24.75% of base) : Microsoft.CodeAnalysis.dasm - Roslyn.Utilities.ArrayExtensions:Append(ref,struct):ref
         -12 (-14.29% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Symbols.SourceFile:ArrayEquals(ref,ref):bool
          -9 (-2.46% of base) : Microsoft.DotNet.Cli.Utils.dasm - Microsoft.DotNet.Cli.Utils.BlockingMemoryStream:Read(ref,int,int):int:this
3 total methods with size differences (3 improved, 0 regressed), 225349 unchanged.
1 files had text diffs but not size diffs.
System.Private.CoreLib.dasm had 1140 diffs
```

cc @dotnet/jit-contrib 