### PR TITLE
Cleanup more GCC warnings

### DIFF
--- a/src/ToolBox/SOS/Strike/sildasm.cpp
+++ b/src/ToolBox/SOS/Strike/sildasm.cpp
@@ -65,6 +65,7 @@ static OpCode opcodes[] =
 
 static ULONG position = 0;
 static BYTE *pBuffer = NULL;
+static char* asString(CQuickBytes *out);
 
 // The UNALIGNED is because on IA64 alignment rules would prevent
 // us from reading a pointer from an unaligned source.

--- a/src/ToolBox/SOS/Strike/sos_md.h
+++ b/src/ToolBox/SOS/Strike/sos_md.h
@@ -872,8 +872,6 @@ typedef enum
 }
 PPFormatFlags;
 
-char* asString(CQuickBytes *out);
-
 PCCOR_SIGNATURE PrettyPrintType(
     PCCOR_SIGNATURE typePtr,            // type to convert,     
     CQuickBytes *out,                   // where to put the pretty printed string   

--- a/src/classlibnative/bcltype/varargsnative.cpp
+++ b/src/classlibnative/bcltype/varargsnative.cpp
@@ -87,8 +87,8 @@ static void InitCommon(VARARGS *data, VASigCookie** cookie)
     //  STACK_GROWS_DOWN_ON_ARGS_WALK
 
     //   <return address>  ;; lower memory                  
-    //   <varargs_cookie>         \
-    //   <argN>                    \
+    //   <varargs_cookie>         '\'
+    //   <argN>                    '\'
     //                              += sizeOfArgs     
     //                             /
     //   <arg1>                   /

--- a/src/debug/di/module.cpp
+++ b/src/debug/di/module.cpp
@@ -4988,7 +4988,7 @@ HRESULT CordbNativeCode::EnsureReturnValueAllowedWorker(Instantiation *currentIn
         IfFailRet(CordbType::SigToType(GetModule(), &original, &inst, &pType));
 
         
-        IfFailRet(hr = pType->ReturnedByValue());
+        IfFailRet(pType->ReturnedByValue());
         if (hr == S_OK) // not S_FALSE
             return S_OK;
 
@@ -5001,7 +5001,7 @@ HRESULT CordbNativeCode::EnsureReturnValueAllowedWorker(Instantiation *currentIn
         CordbType *pType = 0;
         IfFailRet(CordbType::SigToType(GetModule(), &original, &inst, &pType));
 
-        IfFailRet(hr = pType->ReturnedByValue());
+        IfFailRet(pType->ReturnedByValue());
         if (hr == S_OK) // not S_FALSE
             return S_OK;
 

--- a/src/inc/ex.h
+++ b/src/inc/ex.h
@@ -1084,10 +1084,7 @@ Exception *ExThrowWithInnerHelper(Exception *inner);
 #define EX_CATCH_THROWABLE(ppThrowable)                                         \
     EX_CATCH                                                                    \
     {                                                                           \
-        if (NULL != ppThrowable)                                                \
-        {                                                                       \
-            *ppThrowable = GET_THROWABLE();                                     \
-        }                                                                       \
+        *ppThrowable = GET_THROWABLE();                                         \
     }                                                                           \
     EX_END_CATCH(SwallowAllExceptions)
 

--- a/src/vm/sha1.cpp
+++ b/src/vm/sha1.cpp
@@ -90,7 +90,7 @@ static void SHA1_block(SHA1_CTX *ctx)
                         //  (check cases B = 0 and B = 1)
 #define ROUND2(B, C, D) ((B ^ C ^ D) + sha1_round2)
 
-#define ROUND3(B, C, D) ((C & (B | D) | (B & D)) + sha1_round3)
+#define ROUND3(B, C, D) (((C & (B | D)) | (B & D)) + sha1_round3)
 
 #define ROUND4(B, C, D) ((B ^ C ^ D) + sha1_round4)
 

--- a/src/zap/zapimage.cpp
+++ b/src/zap/zapimage.cpp
@@ -1025,8 +1025,8 @@ HANDLE ZapImage::GenerateFile(LPCWSTR wszOutputFileName, CORCOMPILE_NGEN_SIGNATU
     {    
         // Write the debug directory entry for the NGEN PDB
         RSDS rsds = {0};
-        
-        rsds.magic = 'SDSR';
+
+        rsds.magic = VAL32(0x53445352); // "SDSR";
         rsds.age = 1;
         // our PDB signature will be the same as our NGEN signature.  
         // However we want the printed version of the GUID to be be the same as the


### PR DESCRIPTION
Suppress will never be NULL warnings
Convert multi-character literal
Fix mutli-line comment warning
Remove hr=hr undefined assignment
Move declaration into same file as one was defined Extern the other one was static
Add parenthesis
