### PR TITLE
Intrinsicify SpanHelpers.IndexOfAny(char,char)

### DIFF
--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
@@ -462,101 +462,240 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public static unsafe int IndexOfAny(ref char searchSpace, char value0, char value1, int length)
+        public static int IndexOfAny(ref char searchStart, char value0, char value1, int length)
         {
             Debug.Assert(length >= 0);
+            // If vectors are supported, we first align to Vector.
+            // If the searchSpan has not been fixed or pinned the GC can relocate it during the
+            // execution of this method, so the alignment only acts as best endeavour.
+            // The GC cost is likely to dominate over the misalignment that may occur after;
+            // so we give the GC a free hand to relocate and it is up to the caller
+            // whether they are operating over fixed data.
 
-            fixed (char* pChars = &searchSpace)
+            nint offset = 0;
+            nint lengthToExamine = length;
+            if (Sse2.IsSupported)
             {
-                char* pCh = pChars;
-                char* pEndCh = pCh + length;
-
-                if (Vector.IsHardwareAccelerated && length >= Vector<ushort>.Count * 2)
+                // Avx2 branch also operates on Sse2 sizes, so check is combined.
+                // Needs to be double length to allow us to align the data first.
+                if (length >= Vector128<byte>.Count * 2)
                 {
-                    // Figure out how many characters to read sequentially until we are vector aligned
-                    // This is equivalent to:
-                    //         unaligned = ((int)pCh % Unsafe.SizeOf<Vector<ushort>>()) / elementsPerByte
-                    //         length = (Vector<ushort>.Count - unaligned) % Vector<ushort>.Count
-                    const int elementsPerByte = sizeof(ushort) / sizeof(byte);
-                    int unaligned = ((int)pCh & (Unsafe.SizeOf<Vector<ushort>>() - 1)) / elementsPerByte;
-                    length = (Vector<ushort>.Count - unaligned) & (Vector<ushort>.Count - 1);
+                    lengthToExamine = UnalignedCountVector128(ref searchStart);
                 }
-
-            SequentialScan:
-                while (length >= 4)
+            }
+            else if (Vector.IsHardwareAccelerated)
+            {
+                // Needs to be double length to allow us to align the data first.
+                if (length >= Vector<ushort>.Count * 2)
                 {
-                    length -= 4;
-
-                    if (pCh[0] == value0 || pCh[0] == value1)
-                        goto Found;
-                    if (pCh[1] == value0 || pCh[1] == value1)
-                        goto Found1;
-                    if (pCh[2] == value0 || pCh[2] == value1)
-                        goto Found2;
-                    if (pCh[3] == value0 || pCh[3] == value1)
-                        goto Found3;
-
-                    pCh += 4;
+                    lengthToExamine = UnalignedCountVector(ref searchStart);
                 }
+            }
 
-                while (length > 0)
+        SequentialScan:
+            // In the non-vector case lengthToExamine is the total length.
+            // In the vector case lengthToExamine first aligns to Vector,
+            // then in a second pass after the Vector lengths is the
+            // remaining data that is shorter than a Vector length.
+            int lookUp;
+            while (lengthToExamine >= 4)
+            {
+                ref char current = ref Add(ref searchStart, offset);
+
+                lookUp = current;
+                if (value0 == lookUp || value1 == lookUp)
+                    goto Found;
+                lookUp = Add(ref current, 1);
+                if (value0 == lookUp || value1 == lookUp)
+                    goto Found1;
+                lookUp = Add(ref current, 2);
+                if (value0 == lookUp || value1 == lookUp)
+                    goto Found2;
+                lookUp = Add(ref current, 3);
+                if (value0 == lookUp || value1 == lookUp)
+                    goto Found3;
+
+                offset += 4;
+                lengthToExamine -= 4;
+            }
+
+            while (lengthToExamine > 0)
+            {
+                lookUp = Add(ref searchStart, offset);
+                if (value0 == lookUp || value1 == lookUp)
+                    goto Found;
+
+                offset += 1;
+                lengthToExamine -= 1;
+            }
+
+            if (offset < length)
+            {
+                if (Sse2.IsSupported || Vector.IsHardwareAccelerated)
                 {
-                    length--;
-
-                    if (pCh[0] == value0 || pCh[0] == value1)
-                        goto Found;
-
-                    pCh++;
+                    goto VectorizedScan;
                 }
-
-                // We get past SequentialScan only if IsHardwareAccelerated is true. However, we still have the redundant check to allow
-                // the JIT to see that the code is unreachable and eliminate it when the platform does not have hardware accelerated.
-                if (Vector.IsHardwareAccelerated && pCh < pEndCh)
+                else
                 {
-                    // Get the highest multiple of Vector<ushort>.Count that is within the search space.
-                    // That will be how many times we iterate in the loop below.
-                    // This is equivalent to: length = Vector<ushort>.Count * ((int)(pEndCh - pCh) / Vector<ushort>.Count)
-                    length = (int)((pEndCh - pCh) & ~(Vector<ushort>.Count - 1));
+                    Debug.Fail("Moving to Vectorized scan when not supported");
+                }
+            }
 
-                    // Get comparison Vector
-                    Vector<ushort> values0 = new Vector<ushort>(value0);
-                    Vector<ushort> values1 = new Vector<ushort>(value1);
+        NotFound:
+            return -1;
+        Found3:
+            return (int)(offset + 3);
+        Found2:
+            return (int)(offset + 2);
+        Found1:
+            return (int)(offset + 1);
+        Found:
+            return (int)offset;
 
-                    while (length > 0)
+        VectorizedScan:
+            // We get past SequentialScan only if IsHardwareAccelerated or intrinsic .IsSupported is true. However, we still have the redundant check to allow
+            // the JIT to see that the code is unreachable and eliminate it when the platform does not have hardware accelerated.
+            if (Avx2.IsSupported)
+            {
+                lengthToExamine = GetCharVector256SpanLength(offset, length);
+                if (lengthToExamine > 0)
+                {
+                    Vector256<ushort> values0 = Vector256.Create(value0);
+                    Vector256<ushort> values1 = Vector256.Create(value1);
+                    do
                     {
-                        // Using Unsafe.Read instead of ReadUnaligned since the search space is pinned and pCh is always vector aligned
-                        Debug.Assert(((int)pCh & (Unsafe.SizeOf<Vector<ushort>>() - 1)) == 0);
-                        Vector<ushort> vData = Unsafe.Read<Vector<ushort>>(pCh);
-                        var vMatches = Vector.BitwiseOr(
-                                        Vector.Equals(vData, values0),
-                                        Vector.Equals(vData, values1));
-                        if (Vector<ushort>.Zero.Equals(vMatches))
+                        Debug.Assert(length - offset >= Vector256<ushort>.Count);
+
+                        Vector256<ushort> search = LoadVector256(ref searchStart, offset);
+                        // Bitwise Or to combine the flagged matches for the second value to our match flags
+                        int matches = Avx2.MoveMask(
+                                        Avx2.Or(
+                                            Avx2.CompareEqual(values0, search),
+                                            Avx2.CompareEqual(values1, search))
+                                        .AsByte());
+                        // Note that MoveMask has converted the equal vector elements into a set of bit flags,
+                        // So the bit position in 'matches' corresponds to the element offset.
+                        if (matches == 0)
                         {
-                            pCh += Vector<ushort>.Count;
-                            length -= Vector<ushort>.Count;
+                            // Zero flags set so no matches
+                            offset += Vector256<ushort>.Count;
+                            lengthToExamine -= Vector256<ushort>.Count;
                             continue;
                         }
-                        // Find offset of first match
-                        return (int)(pCh - pChars) + LocateFirstFoundChar(vMatches);
-                    }
 
-                    if (pCh < pEndCh)
+                        // Find bitflag offset of first match and add to current offset,
+                        // flags are in bytes so divide for chars
+                        return (int)(offset + (BitOperations.TrailingZeroCount(matches) / sizeof(char)));
+                    } while (lengthToExamine > 0);
+                }
+
+                lengthToExamine = GetCharVector128SpanLength(offset, length);
+                if (lengthToExamine > 0)
+                {
+                    Debug.Assert(length - offset >= Vector128<ushort>.Count);
+
+                    Vector128<ushort> values0 = Vector128.Create(value0);
+                    Vector128<ushort> values1 = Vector128.Create(value1);
+                    Vector128<ushort> search = LoadVector128(ref searchStart, offset);
+
+                    // Same method as above
+                    int matches = Sse2.MoveMask(
+                                    Sse2.Or(
+                                        Sse2.CompareEqual(values0, search),
+                                        Sse2.CompareEqual(values1, search))
+                                    .AsByte());
+                    if (matches == 0)
                     {
-                        length = (int)(pEndCh - pCh);
-                        goto SequentialScan;
+                        // Zero flags set so no matches
+                        offset += Vector128<ushort>.Count;
+                        // Don't need to change lengthToExamine here as we don't use its current value again.
+                    }
+                    else
+                    {
+                        // Find bitflag offset of first match and add to current offset,
+                        // flags are in bytes so divide for chars
+                        return (int)(offset + (BitOperations.TrailingZeroCount(matches) / sizeof(char)));
                     }
                 }
 
-                return -1;
-            Found3:
-                pCh++;
-            Found2:
-                pCh++;
-            Found1:
-                pCh++;
-            Found:
-                return (int)(pCh - pChars);
+                lengthToExamine = length - offset;
+                if (lengthToExamine > 0)
+                {
+                    goto SequentialScan;
+                }
             }
+            else if (Sse2.IsSupported)
+            {
+                lengthToExamine = GetCharVector128SpanLength(offset, length);
+                Debug.Assert(lengthToExamine > 0);
+
+                Vector128<ushort> values0 = Vector128.Create(value0);
+                Vector128<ushort> values1 = Vector128.Create(value1);
+                do
+                {
+                    Debug.Assert(length - offset >= Vector128<ushort>.Count);
+
+                    Vector128<ushort> search = LoadVector128(ref searchStart, offset);
+
+                    // Same method as above
+                    int matches = Sse2.MoveMask(
+                                    Sse2.Or(
+                                        Sse2.CompareEqual(values0, search),
+                                        Sse2.CompareEqual(values1, search))
+                                    .AsByte());
+                    if (matches == 0)
+                    {
+                        // Zero flags set so no matches
+                        offset += Vector128<ushort>.Count;
+                        lengthToExamine -= Vector128<ushort>.Count;
+                        continue;
+                    }
+
+                    // Find bitflag offset of first match and add to current offset,
+                    // flags are in bytes so divide for chars
+                    return (int)(offset + (BitOperations.TrailingZeroCount(matches) / sizeof(char)));
+                } while (lengthToExamine > 0);
+
+                lengthToExamine = length - offset;
+                if (lengthToExamine > 0)
+                {
+                    goto SequentialScan;
+                }
+            }
+            else if (Vector.IsHardwareAccelerated)
+            {
+                lengthToExamine = GetCharVectorSpanLength(offset, length);
+                Debug.Assert(lengthToExamine > 0);
+
+                Vector<ushort> values0 = new Vector<ushort>(value0);
+                Vector<ushort> values1 = new Vector<ushort>(value1);
+                do
+                {
+                    Debug.Assert(length - offset >= Vector<ushort>.Count);
+
+                    Vector<ushort> search = LoadVector(ref searchStart, offset);
+                    var matches = Vector.BitwiseOr(
+                                    Vector.Equals(search, values0),
+                                    Vector.Equals(search, values1));
+                    if (Vector<ushort>.Zero.Equals(matches))
+                    {
+                        offset += Vector<ushort>.Count;
+                        lengthToExamine -= Vector<ushort>.Count;
+                        continue;
+                    }
+
+                    // Find offset of first match
+                    return (int)(offset + LocateFirstFoundChar(matches));
+                } while (lengthToExamine > 0);
+
+                lengthToExamine = length - offset;
+                if (lengthToExamine > 0)
+                {
+                    goto SequentialScan;
+                }
+            }
+
+            goto NotFound;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]


### PR DESCRIPTION
From #22187

Based on #22875 which is first commit

```diff
               Method | Position |       Mean |
 -------------------- |--------- |-----------:|
- String_IndexOfAny_2 |        7 |   9.353 ns |
+ String_IndexOfAny_2 |        7 |   9.097 ns |
- String_IndexOfAny_2 |        8 |   9.716 ns |
+ String_IndexOfAny_2 |        8 |   9.133 ns |
- String_IndexOfAny_2 |       15 |  11.978 ns |
+ String_IndexOfAny_2 |       15 |   8.620 ns |
- String_IndexOfAny_2 |       16 |  11.919 ns |
+ String_IndexOfAny_2 |       16 |   8.616 ns |
- String_IndexOfAny_2 |       31 |  12.521 ns |
+ String_IndexOfAny_2 |       31 |   9.206 ns |
- String_IndexOfAny_2 |       32 |  12.519 ns |
+ String_IndexOfAny_2 |       32 |   9.208 ns |
- String_IndexOfAny_2 |       63 |  14.935 ns |
+ String_IndexOfAny_2 |       63 |  10.207 ns |
- String_IndexOfAny_2 |       64 |  14.828 ns |
+ String_IndexOfAny_2 |       64 |  10.332 ns |
- String_IndexOfAny_2 |      127 |  21.806 ns |
+ String_IndexOfAny_2 |      127 |  12.716 ns |
- String_IndexOfAny_2 |      128 |  21.848 ns |
+ String_IndexOfAny_2 |      128 |  12.544 ns |
- String_IndexOfAny_2 |      255 |  30.815 ns |
+ String_IndexOfAny_2 |      255 |  17.898 ns |
- String_IndexOfAny_2 |      256 |  30.896 ns |
+ String_IndexOfAny_2 |      256 |  17.715 ns |
- String_IndexOfAny_2 |     1023 |  88.839 ns |
+ String_IndexOfAny_2 |     1023 |  68.134 ns |
- String_IndexOfAny_2 |     1024 |  89.023 ns |
+ String_IndexOfAny_2 |     1024 |  68.261 ns |
```

Resolves https://github.com/dotnet/coreclr/issues/22764

/cc @tannergooding @GrabYourPitchforks