### PR TITLE
Fix WaitTimeout breaking change

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/WaitHandle.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/WaitHandle.cs
@@ -42,7 +42,7 @@ namespace System.Threading
         // waitIndex).
         internal const int WaitAbandoned = 0x80;
 
-        internal const int WaitTimeout = 0x102;
+        public const int WaitTimeout = 0x102;
 
         protected WaitHandle()
         {


### PR DESCRIPTION
WaitHandle.WaitTimeout is a public API.  It can't be made internal.

cc: @jkotas, @filipnavara 