### PR TITLE
Fix Thread.ExecutionContext breaking change

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -254,10 +254,10 @@ namespace System.Threading
             }
         }
 
-        internal ExecutionContext ExecutionContext
+        public ExecutionContext ExecutionContext
         {
             get { return m_ExecutionContext; }
-            set { m_ExecutionContext = value; }
+            internal set { m_ExecutionContext = value; }
         }
 
         internal SynchronizationContext SynchronizationContext


### PR DESCRIPTION
Its getter is a public API and can't be made internal.

cc: @jkotas, @filipnavara 