### PR TITLE
Disabling windows event log test till further investigation on failures

### DIFF
--- a/tests/src/baseservices/exceptions/WindowsEventLog/WindowsEventLog.csproj
+++ b/tests/src/baseservices/exceptions/WindowsEventLog/WindowsEventLog.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
   </PropertyGroup>
   <PropertyGroup>
-    <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>
+    <DisableProjectBuild>true</DisableProjectBuild>
   </PropertyGroup>
   <ItemGroup>
     <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">


### PR DESCRIPTION
This test has been failing intermittently - #20023. Disabling it for now till I have more time to look into the failure. 