### PR TITLE
Allow containing ExtractVector128 into Store

### DIFF
--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -5339,26 +5339,20 @@ void emitter::emitIns_S_R_I(instruction ins, emitAttr attr, int varNum, int offs
     emitCurIGsize += sz;
 }
 
-void emitter::emitIns_AR_R_I(instruction ins, emitAttr attr, regNumber base, int disp, regNumber ireg, int ival)
+void emitter::emitIns_A_R_I(instruction ins, emitAttr attr, GenTreeIndir* indir, regNumber reg, int imm)
 {
-    assert(ins == INS_vextracti128 || ins == INS_vextractf128);
-    assert(base != REG_NA);
-    assert(ireg != REG_NA);
-    instrDesc* id = emitNewInstrAmdCns(attr, disp, ival);
+    assert((ins == INS_vextracti128) || (ins == INS_vextractf128));
+    assert(attr == EA_32BYTE);
+    assert(reg != REG_NA);
 
+    instrDesc* id = emitNewInstrAmdCns(attr, indir->Offset(), imm);
     id->idIns(ins);
-    id->idInsFmt(IF_AWR_RRD_CNS);
-    id->idAddr()->iiaAddrMode.amBaseReg = base;
-    id->idAddr()->iiaAddrMode.amIndxReg = REG_NA;
-    id->idReg1(ireg);
-
-    assert(emitGetInsAmdAny(id) == disp); // make sure "disp" is stored properly
-
-    UNATIVE_OFFSET sz = emitInsSizeAM(id, insCodeMR(ins), ival);
-    id->idCodeSize(sz);
-
+    id->idReg1(reg);
+    emitHandleMemOp(indir, id, IF_AWR_RRD_CNS, ins);
+    UNATIVE_OFFSET size = emitInsSizeAM(id, insCodeMR(ins), imm);
+    id->idCodeSize(size);
     dispIns(id);
-    emitCurIGsize += sz;
+    emitCurIGsize += size;
 }
 
 void emitter::emitIns_AI_R(instruction ins, emitAttr attr, regNumber ireg, ssize_t disp)

--- a/src/jit/emitxarch.h
+++ b/src/jit/emitxarch.h
@@ -350,7 +350,7 @@ void emitIns_R_R_AR_I(
     instruction ins, emitAttr attr, regNumber reg1, regNumber reg2, regNumber base, int offs, int ival);
 void emitIns_S_R_I(instruction ins, emitAttr attr, int varNum, int offs, regNumber reg, int ival);
 
-void emitIns_AR_R_I(instruction ins, emitAttr attr, regNumber base, int disp, regNumber ireg, int ival);
+void emitIns_A_R_I(instruction ins, emitAttr attr, GenTreeIndir* indir, regNumber reg, int imm);
 
 void emitIns_R_R_C_I(
     instruction ins, emitAttr attr, regNumber reg1, regNumber reg2, CORINFO_FIELD_HANDLE fldHnd, int offs, int ival);

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -17762,6 +17762,8 @@ bool GenTree::isContainableHWIntrinsic() const
         case NI_SSE2_LoadVector128:
         case NI_AVX_LoadAlignedVector256:
         case NI_AVX_LoadVector256:
+        case NI_AVX_ExtractVector128:
+        case NI_AVX2_ExtractVector128:
         {
             return true;
         }

--- a/src/jit/hwintrinsiccodegenxarch.cpp
+++ b/src/jit/hwintrinsiccodegenxarch.cpp
@@ -152,13 +152,13 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
                         assert((extract->gtHWIntrinsicId == NI_AVX_ExtractVector128) ||
                                (extract->gtHWIntrinsicId == NI_AVX2_ExtractVector128));
 
-                        regNumber regAddr = op1->GetRegNum();
                         regNumber regData = genConsumeReg(extract->gtGetOp1());
 
                         ins  = HWIntrinsicInfo::lookupIns(extract->gtHWIntrinsicId, extract->gtSIMDBaseType);
                         ival = static_cast<int>(extract->gtGetOp2()->AsIntCon()->IconValue());
 
-                        emit->emitIns_AR_R_I(ins, EA_32BYTE, regAddr, 0, regData, ival);
+                        GenTreeIndir indir = indirForm(TYP_SIMD16, op1);
+                        emit->emitIns_A_R_I(ins, EA_32BYTE, &indir, regData, ival);
                     }
                     else
                     {

--- a/src/jit/hwintrinsiccodegenxarch.cpp
+++ b/src/jit/hwintrinsiccodegenxarch.cpp
@@ -144,11 +144,30 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
                 if (category == HW_Category_MemoryStore)
                 {
                     genConsumeAddress(op1);
-                    genConsumeReg(op2);
-                    // Until we improve the handling of addressing modes in the emitter, we'll create a
-                    // temporary GT_STORE_IND to generate code with.
-                    GenTreeStoreInd store = storeIndirForm(node->TypeGet(), op1, op2);
-                    emit->emitInsStoreInd(ins, simdSize, &store);
+
+                    if (((intrinsicId == NI_SSE_Store) || (intrinsicId == NI_SSE2_Store)) && op2->isContained())
+                    {
+                        GenTreeHWIntrinsic* extract = op2->AsHWIntrinsic();
+
+                        assert((extract->gtHWIntrinsicId == NI_AVX_ExtractVector128) ||
+                               (extract->gtHWIntrinsicId == NI_AVX2_ExtractVector128));
+
+                        regNumber regAddr = op1->GetRegNum();
+                        regNumber regData = genConsumeReg(extract->gtGetOp1());
+
+                        ins  = HWIntrinsicInfo::lookupIns(extract->gtHWIntrinsicId, extract->gtSIMDBaseType);
+                        ival = static_cast<int>(extract->gtGetOp2()->AsIntCon()->IconValue());
+
+                        emit->emitIns_AR_R_I(ins, EA_32BYTE, regAddr, 0, regData, ival);
+                    }
+                    else
+                    {
+                        genConsumeReg(op2);
+                        // Until we improve the handling of addressing modes in the emitter, we'll create a
+                        // temporary GT_STORE_IND to generate code with.
+                        GenTreeStoreInd store = storeIndirForm(node->TypeGet(), op1, op2);
+                        emit->emitInsStoreInd(ins, simdSize, &store);
+                    }
                     break;
                 }
                 genConsumeRegs(op1);

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -2996,8 +2996,7 @@ void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
                     GenTree** pAddr = &node->gtOp1;
                     ContainCheckHWIntrinsicAddr(node, pAddr);
 
-                    if (!node->gtGetOp1()->isContained() &&
-                        ((intrinsicId == NI_SSE_Store) || (intrinsicId == NI_SSE2_Store)) && op2->OperIsHWIntrinsic() &&
+                    if (((intrinsicId == NI_SSE_Store) || (intrinsicId == NI_SSE2_Store)) && op2->OperIsHWIntrinsic() &&
                         ((op2->AsHWIntrinsic()->gtHWIntrinsicId == NI_AVX_ExtractVector128) ||
                          (op2->AsHWIntrinsic()->gtHWIntrinsicId == NI_AVX2_ExtractVector128)) &&
                         op2->gtGetOp2()->IsIntegralConst())

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -2995,6 +2995,15 @@ void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
                 {
                     GenTree** pAddr = &node->gtOp1;
                     ContainCheckHWIntrinsicAddr(node, pAddr);
+
+                    if (!node->gtGetOp1()->isContained() &&
+                        ((intrinsicId == NI_SSE_Store) || (intrinsicId == NI_SSE2_Store)) && op2->OperIsHWIntrinsic() &&
+                        ((op2->AsHWIntrinsic()->gtHWIntrinsicId == NI_AVX_ExtractVector128) ||
+                         (op2->AsHWIntrinsic()->gtHWIntrinsicId == NI_AVX2_ExtractVector128)) &&
+                        op2->gtGetOp2()->IsIntegralConst())
+                    {
+                        MakeSrcContained(node, op2);
+                    }
                     break;
                 }
                 case HW_Category_SimpleSIMD:


### PR DESCRIPTION
This enables generation of the `vextract128 mem128, ymm2, imm8` form by containing the extract into a store:
```C#
Avx2.Store(p + i + 4, Avx2.ExtractVector128(Avx2.Add(x, y), 0));
```
generates
```asm
C4E37D3944811000     vextracti128 xmmword ptr [rcx+4*rax+16], ymm0, 0
```
I went back and forth regarding the placement of the special codegen code. I'd make `NI_SSE_Store` have special codegen but then this also applies to `NI_SSE2_Store` and that's handled by a different function. Not sure why we need different functions for different ISAs, maybe `genSSEIntrinsic` and `genSSE2Intrinsic` should be merged, especially after #22043 which removes a lot of code.

But then we still need the normal codegen for stores so perhaps it's not worth duplicating that in the special codegen functions. So `genHWIntrinsic` it is, it's as good as any other place for such a singular special case.