### PR TITLE
Simplify callers of JitHelpers.GetRawSzArrayData

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Array.cs
+++ b/src/System.Private.CoreLib/shared/System/Array.cs
@@ -1027,7 +1027,7 @@ namespace System
             if (typeof(T) == typeof(byte))
             {
                 int result = SpanHelpers.IndexOf(
-                    ref Unsafe.Add(ref array.GetRawSzArrayData(), startIndex),
+                    ref Unsafe.As<byte[]>(array).GetRawSzArrayData(startIndex),
                     Unsafe.As<T, byte>(ref value),
                     count);
 
@@ -1037,7 +1037,7 @@ namespace System
             if (typeof(T) == typeof(char))
             {
                 int result = SpanHelpers.IndexOf(
-                    ref Unsafe.Add(ref Unsafe.As<byte, char>(ref array.GetRawSzArrayData()), startIndex),
+                    ref Unsafe.As<char[]>(array).GetRawSzArrayData(startIndex),
                     Unsafe.As<T, char>(ref value),
                     count);
 
@@ -1216,7 +1216,7 @@ namespace System
             {
                 int endIndex = startIndex - count + 1;
                 int result = SpanHelpers.LastIndexOf(
-                    ref Unsafe.Add(ref array.GetRawSzArrayData(), endIndex),
+                    ref Unsafe.As<byte[]>(array).GetRawSzArrayData(endIndex),
                     Unsafe.As<T, byte>(ref value),
                     count);
 
@@ -1227,7 +1227,7 @@ namespace System
             {
                 int endIndex = startIndex - count + 1;
                 int result = SpanHelpers.LastIndexOf(
-                    ref Unsafe.Add(ref Unsafe.As<byte, char>(ref array.GetRawSzArrayData()), endIndex),
+                    ref Unsafe.As<char[]>(array).GetRawSzArrayData(endIndex),
                     Unsafe.As<T, char>(ref value),
                     count);
 
@@ -1324,7 +1324,7 @@ namespace System
             if (length <= 1)
                 return;
 
-            ref T first = ref Unsafe.Add(ref Unsafe.As<byte, T>(ref array.GetRawSzArrayData()), index);
+            ref T first = ref array.GetRawSzArrayData(index);
             ref T last = ref Unsafe.Add(ref Unsafe.Add(ref first, length), -1);
             do
             {

--- a/src/System.Private.CoreLib/shared/System/Memory.cs
+++ b/src/System.Private.CoreLib/shared/System/Memory.cs
@@ -327,7 +327,7 @@ namespace System
                         // 'tmpObject is T[]' below also handles things like int[] <-> uint[] being convertible
                         Debug.Assert(tmpObject is T[]);
 
-                        refToReturn = ref Unsafe.As<byte, T>(ref Unsafe.As<T[]>(tmpObject).GetRawSzArrayData());
+                        refToReturn = ref Unsafe.As<T[]>(tmpObject).GetRawSzArrayData();
                         lengthOfUnderlyingSpan = Unsafe.As<T[]>(tmpObject).Length;
                     }
                     else
@@ -435,13 +435,13 @@ namespace System
                     // Array is already pre-pinned
                     if (_index < 0)
                     {
-                        void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref Unsafe.As<T[]>(tmpObject).GetRawSzArrayData()), _index & ReadOnlyMemory<T>.RemoveFlagsBitMask);
+                        void* pointer = Unsafe.AsPointer(ref Unsafe.As<T[]>(tmpObject).GetRawSzArrayData(_index & ReadOnlyMemory<T>.RemoveFlagsBitMask));
                         return new MemoryHandle(pointer);
                     }
                     else
                     {
                         GCHandle handle = GCHandle.Alloc(tmpObject, GCHandleType.Pinned);
-                        void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref Unsafe.As<T[]>(tmpObject).GetRawSzArrayData()), _index);
+                        void* pointer = Unsafe.AsPointer(ref Unsafe.As<T[]>(tmpObject).GetRawSzArrayData(_index));
                         return new MemoryHandle(pointer, handle);
                     }
                 }

--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
@@ -397,7 +397,7 @@ namespace System
             if ((uint)start > (uint)array.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 
-            return new Span<T>(ref Unsafe.Add(ref Unsafe.As<byte, T>(ref array.GetRawSzArrayData()), start), array.Length - start);
+            return new Span<T>(ref array.GetRawSzArrayData(start), array.Length - start);
         }
 
         /// <summary>
@@ -421,7 +421,7 @@ namespace System
             if ((uint)actualIndex > (uint)array.Length)
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 
-            return new Span<T>(ref Unsafe.Add(ref Unsafe.As<byte, T>(ref array.GetRawSzArrayData()), actualIndex), array.Length - actualIndex);
+            return new Span<T>(ref array.GetRawSzArrayData(actualIndex), array.Length - actualIndex);
         }
 
         /// <summary>
@@ -445,7 +445,7 @@ namespace System
                 ThrowHelper.ThrowArrayTypeMismatchException();
 
             (int start, int length) = range.GetOffsetAndLength(array.Length);
-            return new Span<T>(ref Unsafe.Add(ref Unsafe.As<byte, T>(ref array.GetRawSzArrayData()), start), length);
+            return new Span<T>(ref array.GetRawSzArrayData(start), length);
         }
 
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/ReadOnlyMemory.cs
+++ b/src/System.Private.CoreLib/shared/System/ReadOnlyMemory.cs
@@ -249,7 +249,7 @@ namespace System
                         // 'tmpObject is T[]' below also handles things like int[] <-> uint[] being convertible
                         Debug.Assert(tmpObject is T[]);
 
-                        refToReturn = ref Unsafe.As<byte, T>(ref Unsafe.As<T[]>(tmpObject).GetRawSzArrayData());
+                        refToReturn = ref Unsafe.As<T[]>(tmpObject).GetRawSzArrayData();
                         lengthOfUnderlyingSpan = Unsafe.As<T[]>(tmpObject).Length;
                     }
                     else
@@ -350,13 +350,13 @@ namespace System
                     // Array is already pre-pinned
                     if (_index < 0)
                     {
-                        void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref Unsafe.As<T[]>(tmpObject).GetRawSzArrayData()), _index & RemoveFlagsBitMask);
+                        void* pointer = Unsafe.AsPointer(ref Unsafe.As<T[]>(tmpObject).GetRawSzArrayData(_index & ReadOnlyMemory<T>.RemoveFlagsBitMask));
                         return new MemoryHandle(pointer);
                     }
                     else
                     {
                         GCHandle handle = GCHandle.Alloc(tmpObject, GCHandleType.Pinned);
-                        void* pointer = Unsafe.Add<T>(Unsafe.AsPointer(ref Unsafe.As<T[]>(tmpObject).GetRawSzArrayData()), _index);
+                        void* pointer = Unsafe.AsPointer(ref Unsafe.As<T[]>(tmpObject).GetRawSzArrayData(_index));
                         return new MemoryHandle(pointer, handle);
                     }
                 }

--- a/src/System.Private.CoreLib/shared/System/ReadOnlySpan.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/ReadOnlySpan.Fast.cs
@@ -48,7 +48,7 @@ namespace System
                 return; // returns default
             }
 
-            _pointer = new ByReference<T>(ref Unsafe.As<byte, T>(ref array.GetRawSzArrayData()));
+            _pointer = new ByReference<T>(ref array.GetRawSzArrayData());
             _length = array.Length;
         }
 
@@ -82,7 +82,7 @@ namespace System
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 #endif
 
-            _pointer = new ByReference<T>(ref Unsafe.Add(ref Unsafe.As<byte, T>(ref array.GetRawSzArrayData()), start));
+            _pointer = new ByReference<T>(ref array.GetRawSzArrayData(start));
             _length = length;
         }
 
@@ -326,7 +326,7 @@ namespace System
                 return Array.Empty<T>();
 
             var destination = new T[_length];
-            Buffer.Memmove(ref Unsafe.As<byte, T>(ref destination.GetRawSzArrayData()), ref _pointer.Value, (nuint)_length);
+            Buffer.Memmove(ref destination.GetRawSzArrayData(), ref _pointer.Value, (nuint)_length);
             return destination;
         }
     }

--- a/src/System.Private.CoreLib/shared/System/Span.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/Span.Fast.cs
@@ -51,7 +51,7 @@ namespace System
             if (default(T) == null && array.GetType() != typeof(T[]))
                 ThrowHelper.ThrowArrayTypeMismatchException();
 
-            _pointer = new ByReference<T>(ref Unsafe.As<byte, T>(ref array.GetRawSzArrayData()));
+            _pointer = new ByReference<T>(ref array.GetRawSzArrayData());
             _length = array.Length;
         }
 
@@ -88,7 +88,7 @@ namespace System
                 ThrowHelper.ThrowArgumentOutOfRangeException();
 #endif
 
-            _pointer = new ByReference<T>(ref Unsafe.Add(ref Unsafe.As<byte, T>(ref array.GetRawSzArrayData()), start));
+            _pointer = new ByReference<T>(ref array.GetRawSzArrayData(start));
             _length = length;
         }
 
@@ -406,7 +406,7 @@ namespace System
                 return Array.Empty<T>();
 
             var destination = new T[_length];
-            Buffer.Memmove(ref Unsafe.As<byte, T>(ref destination.GetRawSzArrayData()), ref _pointer.Value, (nuint)_length);
+            Buffer.Memmove(ref destination.GetRawSzArrayData(), ref _pointer.Value, (nuint)_length);
             return destination;
         }
     }

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/jithelpers.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/jithelpers.cs
@@ -102,7 +102,17 @@ namespace System.Runtime.CompilerServices
         internal static ref byte GetRawData(this object obj) =>
             ref Unsafe.As<RawData>(obj).Data;
 
-        internal static ref byte GetRawSzArrayData(this Array array) =>
-            ref Unsafe.As<RawSzArrayData>(array).Data;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static ref T GetRawSzArrayData<T>(this T[] array) =>
+            ref Unsafe.As<byte, T>(ref Unsafe.As<RawSzArrayData>(array).Data);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static ref T GetRawSzArrayData<T>(this T[] array, int index)
+        {
+            // It's valid for a ref to point _just past_ the end of an array, and it'll
+            // be properly GC-tracked. (Though dereferencing it may result in undefined behavior.)
+            Debug.Assert((uint)index <= (uint)array.Length, "Returned reference is no longer GC-trackable.");
+            return ref Unsafe.Add(ref GetRawSzArrayData(array), index);
+        }
     }
 }


### PR DESCRIPTION
No behavioral changes. The goal of this is to simplify the callers of the `JitHelpers.GetRawSzArrayData` method.

In particular, the call sites often use the pattern `Unsafe.As<byte, T>(...)` or `Unsafe.Add(ref Unsafe.As<byte, T>(...), ...)`, which is error-prone (were the methods called in the correct order?) and somewhat unreadable. The reworking of the `GetRawSzArrayData` method allows specifying the index as a parameter to the method directly, making the call sites look cleaner and more readable.