### PR TITLE
Fix GetApartmentState value on Unix to be Unknown

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -397,7 +397,7 @@ namespace System.Threading
 #if FEATURE_COMINTEROP_APARTMENT_SUPPORT
             (ApartmentState)GetApartmentStateNative();
 #else // !FEATURE_COMINTEROP_APARTMENT_SUPPORT
-            ApartmentState.MTA;
+            ApartmentState.Unknown;
 #endif // FEATURE_COMINTEROP_APARTMENT_SUPPORT
 
         /// <summary>

--- a/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -404,7 +404,7 @@ namespace System.Threading
         /// An unstarted thread can be marked to indicate that it will host a
         /// single-threaded or multi-threaded apartment.
         /// </summary>
-        public bool TrySetApartmentStateUnchecked(ApartmentState state) =>
+        private bool TrySetApartmentStateUnchecked(ApartmentState state) =>
 #if FEATURE_COMINTEROP_APARTMENT_SUPPORT
             SetApartmentStateHelper(state, false);
 #else // !FEATURE_COMINTEROP_APARTMENT_SUPPORT


### PR DESCRIPTION
The code in corefx is returning ApartmentState.Unknown on Unix.  This new coreclr implementation should do the same.

cc: @jkotas, @filipnavara 