### PR TITLE
Set the MarshalByRefObject to be ComVisible

### DIFF
--- a/src/System.Private.CoreLib/shared/System/MarshalByRefObject.cs
+++ b/src/System.Private.CoreLib/shared/System/MarshalByRefObject.cs
@@ -2,8 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+
 namespace System
 {
+    [ClassInterface(ClassInterfaceType.AutoDispatch)]
+    [ComVisible(true)]
     public abstract class MarshalByRefObject
     {
         protected MarshalByRefObject()


### PR DESCRIPTION
Also set the class interface as IDispatch. This is being done to ensure WinForms consumers can interact with COM based controls.

See #22916 