### PR TITLE
Label implements IEquatable<Label>

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Reflection/Emit/Label.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Emit/Label.cs
@@ -26,7 +26,7 @@ namespace System.Reflection.Emit
     // is passed to the MethodWriter.
     // Labels are created by using ILGenerator.CreateLabel and their position is set
     // by using ILGenerator.MarkLabel.
-    public struct Label
+    public struct Label : IEquatable<Label>
     {
         internal int m_label;
 


### PR DESCRIPTION
Adds an implementation of `IEquatable<Label>` to `System.Reflection.Emit.Label`.

Fixes dotnet/corefx#32959
Exposed in [dotnet/corefx/pull/35673](https://github.com/dotnet/corefx/pull/35673)