### PR TITLE
JIT: remove unneeded ref count updating traversal from optimizer

### DIFF
--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -4651,8 +4651,8 @@ struct VNAssertionPropVisitorInfo
 
 //------------------------------------------------------------------------------
 // optPrepareTreeForReplacement
-//    Updates ref counts and extracts side effects from a tree so it can be
-//    replaced with a comma separated list of side effects + a new tree.
+//    Extracts side effects from a tree so it can be replaced with a comma
+//    separated list of side effects + a new tree.
 //
 // Note:
 //    The old and new trees may be the same. In this case, the tree will be
@@ -4674,10 +4674,6 @@ struct VNAssertionPropVisitorInfo
 //      2. When no side-effects are present, returns null.
 //
 // Description:
-//    Decrements ref counts for the "oldTree" that is going to be replaced. If there
-//    are side effects in the tree, then ref counts for variables in the side effects
-//    are incremented because they need to be kept in the stmt expr.
-//
 //    Either the "newTree" is returned when no side effects are present or a comma
 //    separated side effect list with "newTree" is returned.
 //

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5468,10 +5468,6 @@ public:
 
 protected:
     static fgWalkPreFn optValidRangeCheckIndex;
-    static fgWalkPreFn optRemoveTreeVisitor; // Helper passed to Compiler::fgWalkAllTreesPre() to decrement the LclVar
-                                             // usage counts
-
-    void optRemoveTree(GenTree* deadTree, GenTree* keepList);
 
     /**************************************************************************
      *

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2503,8 +2503,7 @@ int Compiler::fgEstimateCallStackSize(GenTreeCall* call)
 }
 
 //------------------------------------------------------------------------------
-// fgMakeMultiUse : If the node is a local, clone it and increase the ref count
-//                  otherwise insert a comma form temp
+// fgMakeMultiUse : If the node is a local, clone it, otherwise insert a comma form temp
 //
 // Arguments:
 //    ppTree  - a pointer to the child node we will be replacing with the comma expression that
@@ -2512,10 +2511,6 @@ int Compiler::fgEstimateCallStackSize(GenTreeCall* call)
 //
 // Return Value:
 //    A fresh GT_LCL_VAR node referencing the temp which has not been used
-//
-// Assumption:
-//    The result tree MUST be added to the tree structure since the ref counts are
-//    already incremented.
 
 GenTree* Compiler::fgMakeMultiUse(GenTree** pOp)
 {

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -2225,7 +2225,7 @@ public:
                 // these are appended to the sideEffList
 
                 // Afterwards the set of nodes in the 'sideEffectList' are preserved and
-                // all other nodes are removed and have their ref counts decremented
+                // all other nodes are removed.
                 //
                 exp->gtCSEnum = NO_CSE; // clear the gtCSEnum field
 


### PR DESCRIPTION
The ref count update traversal in the optimizer is not doing anything,
so remove it. This was overlooked when we changed away from incremental
updates in #19345.

Also: fix up comments and documentation to reflect the current approach
to local var ref counts.