### PR TITLE
Make StackTrace Aware of Collectible Types (Phase 2) 

### DIFF
--- a/src/System.Private.CoreLib/src/System/Diagnostics/StackFrameHelper.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/StackFrameHelper.cs
@@ -29,7 +29,7 @@ namespace System.Diagnostics
 
 #pragma warning disable 414
         // dynamicMethods is an array of System.Resolver objects, used to keep
-        // DynamicMethodDescs alive for the lifetime of StackFrameHelper.
+        // DynamicMethodDescs AND collectible LoaderAllocators alive for the lifetime of StackFrameHelper.
         private object dynamicMethods; // Field is not used from managed.        
 
         private IntPtr[] rgMethodHandle;
@@ -48,7 +48,7 @@ namespace System.Diagnostics
         private int iFrameCount;
 #pragma warning restore 414
 
-        private delegate void GetSourceLineInfoDelegate(string assemblyPath, IntPtr loadedPeAddress,
+        private delegate void GetSourceLineInfoDelegate(Assembly assembly, string assemblyPath, IntPtr loadedPeAddress,
             int loadedPeSize, IntPtr inMemoryPdbAddress, int inMemoryPdbSize, int methodToken, int ilOffset,
             out string sourceFile, out int sourceLine, out int sourceColumn);
 
@@ -119,7 +119,7 @@ namespace System.Diagnostics
 
                     Type[] parameterTypes = new Type[] 
                     {
-                        typeof(string), typeof(IntPtr), typeof(int), typeof(IntPtr), 
+                        typeof(Assembly), typeof(string), typeof(IntPtr), typeof(int), typeof(IntPtr), 
                         typeof(int), typeof(int), typeof(int), 
                         typeof(string).MakeByRefType(), typeof(int).MakeByRefType(), typeof(int).MakeByRefType() 
                     };
@@ -146,7 +146,7 @@ namespace System.Diagnostics
                     // ENC or the source/line info was already retrieved, the method token is 0.
                     if (rgiMethodToken[index] != 0)
                     {
-                        s_getSourceLineInfo(rgAssemblyPath[index], rgLoadedPeAddress[index], rgiLoadedPeSize[index],
+                        s_getSourceLineInfo(rgAssembly[index], rgAssemblyPath[index], rgLoadedPeAddress[index], rgiLoadedPeSize[index],
                             rgInMemoryPdbAddress[index], rgiInMemoryPdbSize[index], rgiMethodToken[index],
                             rgiILOffset[index], out rgFilename[index], out rgiLineNumber[index], out rgiColumnNumber[index]);
                     }


### PR DESCRIPTION
Updates the delegate signature of `GetSourceLineInfo` to use the new overload that consumes an `Assembly` (see: dotnet/corefx#35541).

#20179 

CC - @janvorli @sergiy-k 