### PR TITLE
Temporarily disable some WaitAny tests that have been failing periodically in the CI

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -53,6 +53,15 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/StackTracePreserve/StackTracePreserveTests/*">
             <Issue>20322</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/waithandle/waitany/waitanyex2/*">
+            <Issue>19515</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/waithandle/waitany/waitanyex2a/*">
+            <Issue>19406</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/waithandle/waitany/waitanyex4/*">
+            <Issue>14249</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/mutex/misc/waitone2/*">
             <Issue>6397</Issue>
         </ExcludeList>


### PR DESCRIPTION
There have been failures on various archs and platforms. Issues:
- https://github.com/dotnet/coreclr/issues/19515
- https://github.com/dotnet/coreclr/issues/19406
- https://github.com/dotnet/coreclr/issues/14249