### PR TITLE
Add UTF8 DateTime(Offset) parser for new date and time format "I"

### DIFF
--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -99,6 +99,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Utf8Parser\Utf8Parser.Date.Default.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Utf8Parser\Utf8Parser.Date.G.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Utf8Parser\Utf8Parser.Date.Helpers.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Utf8Parser\Utf8Parser.Date.J.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Utf8Parser\Utf8Parser.Date.O.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Utf8Parser\Utf8Parser.Date.R.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Utf8Parser\Utf8Parser.Decimal.cs" />

--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -99,7 +99,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Utf8Parser\Utf8Parser.Date.Default.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Utf8Parser\Utf8Parser.Date.G.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Utf8Parser\Utf8Parser.Date.Helpers.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Utf8Parser\Utf8Parser.Date.J.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Utf8Parser\Utf8Parser.Date.I.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Utf8Parser\Utf8Parser.Date.O.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Utf8Parser\Utf8Parser.Date.R.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Utf8Parser\Utf8Parser.Decimal.cs" />

--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Constants.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Constants.cs
@@ -14,21 +14,22 @@ namespace System.Buffers.Text
         public const byte Slash = (byte)'/';
         public const byte Space = (byte)' ';
         public const byte Hyphen = (byte)'-';
-		public const byte UtcOffsetToken = (byte)'Z';
-		public const byte TimePrefix = (byte)'T';
+        public const byte UtcOffsetToken = (byte)'Z';
+        public const byte TimePrefix = (byte)'T';
 
-		public const byte Separator = (byte)',';
+        public const byte Separator = (byte)',';
 
-		// Invariant formatting uses groups of 3 for each number group separated by commas.
-		//   ex. 1,234,567,890
-		public const int GroupSize = 3;
+        // Invariant formatting uses groups of 3 for each number group separated by commas.
+        //   ex. 1,234,567,890
+        public const int GroupSize = 3;
 
         public static readonly TimeSpan NullUtcOffset = TimeSpan.MinValue;  // Utc offsets must range from -14:00 to 14:00 so this is never a valid offset.
 
         public const int DateTimeMaxUtcOffsetHours = 14; // The UTC offset portion of a TimeSpan or DateTime can be no more than 14 hours and no less than -14 hours.
 
         public const int DateTimeNumFractionDigits = 7;  // TimeSpan and DateTime formats allow exactly up to many digits for specifying the fraction after the seconds.
-        public const int MaxDateTimeFraction = 9999999;  // ... and hence, the largest fraction expressible is this.
+        public const int MaxDateTimeFraction = 9_999_999;  // ... and hence, the largest fraction expressible is this.
+        public const int MaxDateTimeFractionDiv10 = 999_999;
 
         public const ulong BillionMaxUIntValue = (ulong)uint.MaxValue * Billion; // maximum value that can be split into two uint32 {1-10 digits}{9 digits}
         public const uint Billion = 1000000000; // 10^9, used to split int64/uint64 into three uint32 {1-2 digits}{9 digits}{9 digits}

--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Constants.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Constants.cs
@@ -14,7 +14,7 @@ namespace System.Buffers.Text
         public const byte Slash = (byte)'/';
         public const byte Space = (byte)' ';
         public const byte Hyphen = (byte)'-';
-		public const byte UtcOffsetChar = (byte)'Z';
+		public const byte UtcOffsetToken = (byte)'Z';
 		public const byte TimePrefix = (byte)'T';
 
 		public const byte Separator = (byte)',';
@@ -32,19 +32,5 @@ namespace System.Buffers.Text
 
         public const ulong BillionMaxUIntValue = (ulong)uint.MaxValue * Billion; // maximum value that can be split into two uint32 {1-10 digits}{9 digits}
         public const uint Billion = 1000000000; // 10^9, used to split int64/uint64 into three uint32 {1-2 digits}{9 digits}{9 digits}
-
-        public enum DateJParserState
-		{
-			Year = 0,
-			Month = 1,
-			Day = 2,
-			Hour = 3,
-			Minute = 4,
-			Second = 5,
-			Fraction = 6,
-			OffsetHours = 7,
-			OffsetMinutes = 8,
-			Invalid = 9,
-		}
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Constants.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Constants.cs
@@ -14,12 +14,14 @@ namespace System.Buffers.Text
         public const byte Slash = (byte)'/';
         public const byte Space = (byte)' ';
         public const byte Hyphen = (byte)'-';
+		public const byte UtcOffsetChar = (byte)'Z';
+		public const byte TimePrefix = (byte)'T';
 
-        public const byte Separator = (byte)',';
+		public const byte Separator = (byte)',';
 
-        // Invariant formatting uses groups of 3 for each number group separated by commas.
-        //   ex. 1,234,567,890
-        public const int GroupSize = 3;
+		// Invariant formatting uses groups of 3 for each number group separated by commas.
+		//   ex. 1,234,567,890
+		public const int GroupSize = 3;
 
         public static readonly TimeSpan NullUtcOffset = TimeSpan.MinValue;  // Utc offsets must range from -14:00 to 14:00 so this is never a valid offset.
 
@@ -30,5 +32,19 @@ namespace System.Buffers.Text
 
         public const ulong BillionMaxUIntValue = (ulong)uint.MaxValue * Billion; // maximum value that can be split into two uint32 {1-10 digits}{9 digits}
         public const uint Billion = 1000000000; // 10^9, used to split int64/uint64 into three uint32 {1-2 digits}{9 digits}{9 digits}
+
+        public enum DateJParserState
+		{
+			Year = 0,
+			Month = 1,
+			Day = 2,
+			Hour = 3,
+			Minute = 4,
+			Second = 5,
+			Fraction = 6,
+			OffsetHours = 7,
+			OffsetMinutes = 8,
+			Invalid = 9,
+		}
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/ParserHelpers.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/ParserHelpers.cs
@@ -70,5 +70,29 @@ namespace System.Buffers.Text
             value = default;
             return TryParseThrowFormatException(out bytesConsumed);
         }
+
+        public static bool TryGetNextTwoDigits(ReadOnlySpan<byte> source, int prevSourceIndex, out int sourceIndex, out int value)
+        {
+            if (source.Length - prevSourceIndex < 2)
+            {
+                sourceIndex = prevSourceIndex;
+                value = default;
+                return false;
+            }
+
+            uint digit1 = source[prevSourceIndex++] - 48u;
+            uint digit2 = source[prevSourceIndex++] - 48u;
+
+            sourceIndex = prevSourceIndex;
+
+            if (digit1 > 9 || digit2 > 9)
+            {
+                value = default;
+                return false;
+            }
+
+            value = (int)(digit1 * 10 + digit2);
+            return true;
+        }
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/ParserHelpers.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/ParserHelpers.cs
@@ -72,22 +72,22 @@ namespace System.Buffers.Text
             return TryParseThrowFormatException(out bytesConsumed);
         }
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static bool TryGetNextTwoDigits(ReadOnlySpan<byte> source, out int value)
-		{
-			Debug.Assert(source.Length == 2);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryGetNextTwoDigits(ReadOnlySpan<byte> source, out int value)
+        {
+            Debug.Assert(source.Length == 2);
 
-			uint digit1 = source[0] - (uint)'0';
-			uint digit2 = source[1] - (uint)'0';
+            uint digit1 = source[0] - (uint)'0';
+            uint digit2 = source[1] - (uint)'0';
 
-			if (digit1 > 9 || digit2 > 9)
-			{
-				value = default;
-				return false;
-			}
+            if (digit1 > 9 || digit2 > 9)
+            {
+                value = default;
+                return false;
+            }
 
-			value = (int)(digit1 * 10 + digit2);
-			return true;
-		}
-	}
+            value = (int)(digit1 * 10 + digit2);
+            return true;
+        }
+    }
 }

--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/ParserHelpers.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/ParserHelpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace System.Buffers.Text
@@ -71,28 +72,22 @@ namespace System.Buffers.Text
             return TryParseThrowFormatException(out bytesConsumed);
         }
 
-        public static bool TryGetNextTwoDigits(ReadOnlySpan<byte> source, int prevSourceIndex, out int sourceIndex, out int value)
-        {
-            if (source.Length - prevSourceIndex < 2)
-            {
-                sourceIndex = prevSourceIndex;
-                value = default;
-                return false;
-            }
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool TryGetNextTwoDigits(ReadOnlySpan<byte> source, out int value)
+		{
+			Debug.Assert(source.Length == 2);
 
-            uint digit1 = source[prevSourceIndex++] - 48u;
-            uint digit2 = source[prevSourceIndex++] - 48u;
+			uint digit1 = source[0] - 48u;
+			uint digit2 = source[1] - 48u;
 
-            sourceIndex = prevSourceIndex;
+			if (digit1 > 9 || digit2 > 9)
+			{
+				value = default;
+				return false;
+			}
 
-            if (digit1 > 9 || digit2 > 9)
-            {
-                value = default;
-                return false;
-            }
-
-            value = (int)(digit1 * 10 + digit2);
-            return true;
-        }
-    }
+			value = (int)(digit1 * 10 + digit2);
+			return true;
+		}
+	}
 }

--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/ParserHelpers.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/ParserHelpers.cs
@@ -77,8 +77,8 @@ namespace System.Buffers.Text
 		{
 			Debug.Assert(source.Length == 2);
 
-			uint digit1 = source[0] - 48u;
-			uint digit2 = source[1] - 48u;
+			uint digit1 = source[0] - (uint)'0';
+			uint digit2 = source[1] - (uint)'0';
 
 			if (digit1 > 9 || digit2 > 9)
 			{

--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/Utf8Parser.Date.I.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/Utf8Parser.Date.I.cs
@@ -21,7 +21,7 @@ namespace System.Buffers.Text
 		// YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45Z)
 		// YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45+01:00)
 		// YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45-01:00)
-		private static bool TryParseDateTimeOffsetJ(ReadOnlySpan<byte> source, out DateTimeOffset value, out int bytesConsumed, out DateTimeKind kind)
+		private static bool TryParseDateTimeOffsetI(ReadOnlySpan<byte> source, out DateTimeOffset value, out int bytesConsumed, out DateTimeKind kind)
 		{
 			// Source does not have enough characters for YYYY-MM-DD
 			if (source.Length < 10)

--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/Utf8Parser.Date.I.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/Utf8Parser.Date.I.cs
@@ -6,300 +6,300 @@ using System.Diagnostics;
 
 namespace System.Buffers.Text
 {
-	public static partial class Utf8Parser
-	{
-		//
-		// Flexible ISO 8601 format. One of
-		//
-		// ---------------------------------
-		// YYYY-MM-DD (eg 1997-07-16)
-		// YYYY-MM-DDThh:mm (eg 1997-07-16T19:20)
-		// YYYY-MM-DDThh:mm:ss (eg 1997-07-16T19:20:30)
-		// YYYY-MM-DDThh:mm:ss.s (eg 1997-07-16T19:20:30.45)
-		// YYYY-MM-DDThh:mmTZD (eg 1997-07-16T19:20+01:00)
-		// YYYY-MM-DDThh:mm:ssTZD (eg 1997-07-16T19:20:30+01:00)
-		// YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45Z)
-		// YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45+01:00)
-		// YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45-01:00)
-		private static bool TryParseDateTimeOffsetI(ReadOnlySpan<byte> source, out DateTimeOffset value, out int bytesConsumed, out DateTimeKind kind)
-		{
-			// Source does not have enough characters for YYYY-MM-DD
-			if (source.Length < 10)
-			{
-				goto ReturnFalse;
-			}
+    public static partial class Utf8Parser
+    {
+        //
+        // Flexible ISO 8601 format. One of
+        //
+        // ---------------------------------
+        // YYYY-MM-DD (eg 1997-07-16)
+        // YYYY-MM-DDThh:mm (eg 1997-07-16T19:20)
+        // YYYY-MM-DDThh:mm:ss (eg 1997-07-16T19:20:30)
+        // YYYY-MM-DDThh:mm:ss.s (eg 1997-07-16T19:20:30.45)
+        // YYYY-MM-DDThh:mmTZD (eg 1997-07-16T19:20+01:00)
+        // YYYY-MM-DDThh:mm:ssTZD (eg 1997-07-16T19:20:30+01:00)
+        // YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45Z)
+        // YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45+01:00)
+        // YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45-01:00)
+        private static bool TryParseDateTimeOffsetI(ReadOnlySpan<byte> source, out DateTimeOffset value, out int bytesConsumed, out DateTimeKind kind)
+        {
+            // Source does not have enough characters for YYYY-MM-DD
+            if (source.Length < 10)
+            {
+                goto ReturnFalse;
+            }
 
-			int year;
-			{
-				uint digit1 = source[0] - (uint)'0';
-				uint digit2 = source[1] - (uint)'0';
-				uint digit3 = source[2] - (uint)'0';
-				uint digit4 = source[3] - (uint)'0';
+            int year;
+            {
+                uint digit1 = source[0] - (uint)'0';
+                uint digit2 = source[1] - (uint)'0';
+                uint digit3 = source[2] - (uint)'0';
+                uint digit4 = source[3] - (uint)'0';
 
-				if (digit1 > 9 || digit2 > 9 || digit3 > 9 || digit4 > 9)
-				{
-					goto ReturnFalse;
-				}
+                if (digit1 > 9 || digit2 > 9 || digit3 > 9 || digit4 > 9)
+                {
+                    goto ReturnFalse;
+                }
 
-				year = (int)(digit1 * 1000 + digit2 * 100 + digit3 * 10 + digit4);
-			}
+                year = (int)(digit1 * 1000 + digit2 * 100 + digit3 * 10 + digit4);
+            }
 
-			if (source[4] != Utf8Constants.Hyphen)
-			{
-				goto ReturnFalse;
-			}
+            if (source[4] != Utf8Constants.Hyphen)
+            {
+                goto ReturnFalse;
+            }
 
-			int month;
-			if (!ParserHelpers.TryGetNextTwoDigits(source.Slice(start: 5, length: 2), out month))
-			{
-				goto ReturnFalse;
-			}
+            int month;
+            if (!ParserHelpers.TryGetNextTwoDigits(source.Slice(start: 5, length: 2), out month))
+            {
+                goto ReturnFalse;
+            }
 
-			if (source[7] != Utf8Constants.Hyphen)
-			{
-				goto ReturnFalse;
-			}
+            if (source[7] != Utf8Constants.Hyphen)
+            {
+                goto ReturnFalse;
+            }
 
-			int day;
-			if (!ParserHelpers.TryGetNextTwoDigits(source.Slice(start: 8, length: 2), out day))
-			{
-				goto ReturnFalse;
-			}
+            int day;
+            if (!ParserHelpers.TryGetNextTwoDigits(source.Slice(start: 8, length: 2), out day))
+            {
+                goto ReturnFalse;
+            }
 
-			// We now have YYYY-MM-DD
-			bytesConsumed = 10;
+            // We now have YYYY-MM-DD
+            bytesConsumed = 10;
 
-			int hour = 0;
-			int minute = 0;
-			int second = 0;
-			int fraction = 0;
-			int offsetHours = 0;
-			int offsetMinutes = 0;
-			byte offsetToken = default;
+            int hour = 0;
+            int minute = 0;
+            int second = 0;
+            int fraction = 0;
+            int offsetHours = 0;
+            int offsetMinutes = 0;
+            byte offsetToken = default;
 
-			if (source.Length < 11)
-			{
-				goto FinishedParsing;
-			}
+            if (source.Length < 11)
+            {
+                goto FinishedParsing;
+            }
 
-			byte curByte = source[10];
+            byte curByte = source[10];
 
-			if (curByte == Utf8Constants.UtcOffsetToken || curByte == Utf8Constants.Plus || curByte == Utf8Constants.Minus)
-			{
-				goto ReturnFalse;
-			}
-			else if (curByte != Utf8Constants.TimePrefix)
-			{
-				goto FinishedParsing;
-			}
+            if (curByte == Utf8Constants.UtcOffsetToken || curByte == Utf8Constants.Plus || curByte == Utf8Constants.Minus)
+            {
+                goto ReturnFalse;
+            }
+            else if (curByte != Utf8Constants.TimePrefix)
+            {
+                goto FinishedParsing;
+            }
 
-			// Source does not have enough characters for YYYY-MM-DDThh:mm
-			if (source.Length < 16)
-			{
-				goto ReturnFalse;
-			}
+            // Source does not have enough characters for YYYY-MM-DDThh:mm
+            if (source.Length < 16)
+            {
+                goto ReturnFalse;
+            }
 
-			if (!ParserHelpers.TryGetNextTwoDigits(source.Slice(start: 11, length: 2), out hour))
-			{
-				goto ReturnFalse;
-			}
+            if (!ParserHelpers.TryGetNextTwoDigits(source.Slice(start: 11, length: 2), out hour))
+            {
+                goto ReturnFalse;
+            }
 
-			if (source[13] != Utf8Constants.Colon)
-			{
-				goto ReturnFalse;
-			}
+            if (source[13] != Utf8Constants.Colon)
+            {
+                goto ReturnFalse;
+            }
 
-			if (!ParserHelpers.TryGetNextTwoDigits(source.Slice(start: 14, length: 2), out minute))
-			{
-				goto ReturnFalse;
-			}
+            if (!ParserHelpers.TryGetNextTwoDigits(source.Slice(start: 14, length: 2), out minute))
+            {
+                goto ReturnFalse;
+            }
 
-			// We now have YYYY-MM-DDThh:mm
-			bytesConsumed = 16;
+            // We now have YYYY-MM-DDThh:mm
+            bytesConsumed = 16;
 
-			if (source.Length < 17)
-			{
-				goto FinishedParsing;
-			}
+            if (source.Length < 17)
+            {
+                goto FinishedParsing;
+            }
 
-			curByte = source[16];
+            curByte = source[16];
 
-			int sourceIndex = 16;
+            int sourceIndex = 16;
 
-			if (curByte == Utf8Constants.UtcOffsetToken)
-			{
-				bytesConsumed++;
-				offsetToken = Utf8Constants.UtcOffsetToken;
-				goto FinishedParsing;
-			}
-			else if (curByte == Utf8Constants.Plus || curByte == Utf8Constants.Minus)
-			{
-				offsetToken = curByte;
-				sourceIndex++;
-				goto ParseOffset;
-			}
-			else if (curByte != Utf8Constants.Colon)
-			{
-				goto FinishedParsing;
-			}
+            if (curByte == Utf8Constants.UtcOffsetToken)
+            {
+                bytesConsumed++;
+                offsetToken = Utf8Constants.UtcOffsetToken;
+                goto FinishedParsing;
+            }
+            else if (curByte == Utf8Constants.Plus || curByte == Utf8Constants.Minus)
+            {
+                offsetToken = curByte;
+                sourceIndex++;
+                goto ParseOffset;
+            }
+            else if (curByte != Utf8Constants.Colon)
+            {
+                goto FinishedParsing;
+            }
 
-			if (!ParserHelpers.TryGetNextTwoDigits(source.Slice(start: 17, length: 2), out second))
-			{
-				goto ReturnFalse;
-			}
+            if (!ParserHelpers.TryGetNextTwoDigits(source.Slice(start: 17, length: 2), out second))
+            {
+                goto ReturnFalse;
+            }
 
-			// We now have YYYY-MM-DDThh:mm:ss
-			bytesConsumed = 19;
+            // We now have YYYY-MM-DDThh:mm:ss
+            bytesConsumed = 19;
 
-			if (source.Length < 20)
-			{
-				goto FinishedParsing;
-			}
+            if (source.Length < 20)
+            {
+                goto FinishedParsing;
+            }
 
-			curByte = source[19];
-			sourceIndex = 19;
+            curByte = source[19];
+            sourceIndex = 19;
 
-			if (curByte == Utf8Constants.UtcOffsetToken)
-			{
-				bytesConsumed++;
-				offsetToken = Utf8Constants.UtcOffsetToken;
-				goto FinishedParsing;
-			}
-			else if (curByte == Utf8Constants.Plus || curByte == Utf8Constants.Minus)
-			{
-				offsetToken = curByte;
-				sourceIndex += 1;
-				goto ParseOffset;
-			}
-			else if (curByte != Utf8Constants.Period)
-			{
-				goto FinishedParsing;
-			}
+            if (curByte == Utf8Constants.UtcOffsetToken)
+            {
+                bytesConsumed++;
+                offsetToken = Utf8Constants.UtcOffsetToken;
+                goto FinishedParsing;
+            }
+            else if (curByte == Utf8Constants.Plus || curByte == Utf8Constants.Minus)
+            {
+                offsetToken = curByte;
+                sourceIndex++;
+                goto ParseOffset;
+            }
+            else if (curByte != Utf8Constants.Period)
+            {
+                goto FinishedParsing;
+            }
 
-			// Source does not have enough characters for YYYY-MM-DDThh:mm:ss.s
-			if (source.Length < 21)
-			{
-				value = default;
-				bytesConsumed = 0;
-				kind = default;
-				return false;
-			}
+            // Source does not have enough characters for YYYY-MM-DDThh:mm:ss.s
+            if (source.Length < 21)
+            {
+                value = default;
+                bytesConsumed = 0;
+                kind = default;
+                return false;
+            }
 
-			sourceIndex = 20;
+            sourceIndex = 20;
 
-			{
-				while (sourceIndex < source.Length && ParserHelpers.IsDigit(curByte = source[sourceIndex]))
-				{
-					int prevFractionTimesTen = fraction * 10;
+            {
+                while (sourceIndex < source.Length && ParserHelpers.IsDigit(curByte = source[sourceIndex]))
+                {
+                    int prevFractionTimesTen = fraction * 10;
 
-					if (!(prevFractionTimesTen + (int)(curByte - (uint)'0') <= Utf8Constants.MaxDateTimeFraction))
-					{
-						sourceIndex++;
-						break;
-					}
+                    if (!(prevFractionTimesTen + (int)(curByte - (uint)'0') <= Utf8Constants.MaxDateTimeFraction))
+                    {
+                        sourceIndex++;
+                        break;
+                    }
 
-					fraction = prevFractionTimesTen + (int)(curByte - (uint)'0');
-					sourceIndex++;
-				}
-			}
+                    fraction = prevFractionTimesTen + (int)(curByte - (uint)'0');
+                    sourceIndex++;
+                }
+            }
 
-			if (fraction != 0)
-			{
-				// Note this is 1 order of magnitude less than Utf8Constants.MaxDateTimeFraction
-				while (fraction <= 999_999)
-				{
-					fraction *= 10;
-				}
-			}
+            if (fraction != 0)
+            {
+                // Note this is 1 order of magnitude less than Utf8Constants.MaxDateTimeFraction
+                while (fraction <= Utf8Constants.MaxDateTimeFractionDiv10)
+                {
+                    fraction *= 10;
+                }
+            }
 
-			// We now have YYYY-MM-DDThh:mm:ss.s
-			bytesConsumed = sourceIndex;
+            // We now have YYYY-MM-DDThh:mm:ss.s
+            bytesConsumed = sourceIndex;
 
-			if (sourceIndex == source.Length)
-			{
-				goto FinishedParsing;
-			}
+            if (sourceIndex == source.Length)
+            {
+                goto FinishedParsing;
+            }
 
-			if (curByte == Utf8Constants.UtcOffsetToken)
-			{
-				bytesConsumed++;
-				offsetToken = Utf8Constants.UtcOffsetToken;
-				goto FinishedParsing;
-			}
-			else if (curByte == Utf8Constants.Plus || curByte == Utf8Constants.Minus)
-			{
-				offsetToken = source[sourceIndex++];
-				goto ParseOffset;
-			}
+            if (curByte == Utf8Constants.UtcOffsetToken)
+            {
+                bytesConsumed++;
+                offsetToken = Utf8Constants.UtcOffsetToken;
+                goto FinishedParsing;
+            }
+            else if (curByte == Utf8Constants.Plus || curByte == Utf8Constants.Minus)
+            {
+                offsetToken = source[sourceIndex++];
+                goto ParseOffset;
+            }
 
-			goto FinishedParsing;
+            goto FinishedParsing;
 
-		ParseOffset:
-			// Source does not have enough characters for YYYY-MM-DDThh:mm:ss.s+|-hh:mm
-			if (source.Length - sourceIndex < 5)
-			{
-				goto ReturnFalse;
-			}
+        ParseOffset:
+            // Source does not have enough characters for YYYY-MM-DDThh:mm:ss.s+|-hh:mm
+            if (source.Length - sourceIndex < 5)
+            {
+                goto ReturnFalse;
+            }
 
-			if (!ParserHelpers.TryGetNextTwoDigits(source.Slice(start: sourceIndex, length: 2), out offsetHours))
-			{
-				goto ReturnFalse;
-			}
-			sourceIndex += 2;
+            if (!ParserHelpers.TryGetNextTwoDigits(source.Slice(start: sourceIndex, length: 2), out offsetHours))
+            {
+                goto ReturnFalse;
+            }
+            sourceIndex += 2;
 
-			if (source[sourceIndex++] != Utf8Constants.Colon)
-			{
-				goto ReturnFalse;
-			}
+            if (source[sourceIndex++] != Utf8Constants.Colon)
+            {
+                goto ReturnFalse;
+            }
 
-			if (!ParserHelpers.TryGetNextTwoDigits(source.Slice(start: sourceIndex, length: 2), out offsetMinutes))
-			{
-				goto ReturnFalse;
-			}
-			sourceIndex += 2;
+            if (!ParserHelpers.TryGetNextTwoDigits(source.Slice(start: sourceIndex, length: 2), out offsetMinutes))
+            {
+                goto ReturnFalse;
+            }
+            sourceIndex += 2;
 
-			// We now have YYYY-MM-DDThh:mm:ss.s+|-hh:mm
-			bytesConsumed = sourceIndex;
+            // We now have YYYY-MM-DDThh:mm:ss.s+|-hh:mm
+            bytesConsumed = sourceIndex;
 
-		FinishedParsing:
-			if ((offsetToken != Utf8Constants.UtcOffsetToken) && (offsetToken != Utf8Constants.Plus) && (offsetToken != Utf8Constants.Minus))
-			{
-				if (!TryCreateDateTimeOffsetInterpretingDataAsLocalTime(year: year, month: month, day: day, hour: hour, minute: minute, second: second, fraction: fraction, out value))
-				{
-					goto ReturnFalse;
-				}
+        FinishedParsing:
+            if ((offsetToken != Utf8Constants.UtcOffsetToken) && (offsetToken != Utf8Constants.Plus) && (offsetToken != Utf8Constants.Minus))
+            {
+                if (!TryCreateDateTimeOffsetInterpretingDataAsLocalTime(year: year, month: month, day: day, hour: hour, minute: minute, second: second, fraction: fraction, out value))
+                {
+                    goto ReturnFalse;
+                }
 
-				kind = DateTimeKind.Unspecified;
-				return true;
-			}
+                kind = DateTimeKind.Unspecified;
+                return true;
+            }
 
-			if (offsetToken == Utf8Constants.UtcOffsetToken)
-			{
-				// Same as specifying an offset of "+00:00", except that DateTime's Kind gets set to UTC rather than Local
-				if (!TryCreateDateTimeOffset(year: year, month: month, day: day, hour: hour, minute: minute, second: second, fraction: fraction, offsetNegative: false, offsetHours: 0, offsetMinutes: 0, out value))
-				{
-					goto ReturnFalse;
-				}
+            if (offsetToken == Utf8Constants.UtcOffsetToken)
+            {
+                // Same as specifying an offset of "+00:00", except that DateTime's Kind gets set to UTC rather than Local
+                if (!TryCreateDateTimeOffset(year: year, month: month, day: day, hour: hour, minute: minute, second: second, fraction: fraction, offsetNegative: false, offsetHours: 0, offsetMinutes: 0, out value))
+                {
+                    goto ReturnFalse;
+                }
 
-				kind = DateTimeKind.Utc;
-				return true;
-			}
+                kind = DateTimeKind.Utc;
+                return true;
+            }
 
-			Debug.Assert(offsetToken == Utf8Constants.Plus || offsetToken == Utf8Constants.Minus);
+            Debug.Assert(offsetToken == Utf8Constants.Plus || offsetToken == Utf8Constants.Minus);
 
-			if (!TryCreateDateTimeOffset(year: year, month: month, day: day, hour: hour, minute: minute, second: second, fraction: fraction, offsetNegative: offsetToken == Utf8Constants.Minus, offsetHours: offsetHours, offsetMinutes: offsetMinutes, out value))
-			{
-				goto ReturnFalse;
-			}
+            if (!TryCreateDateTimeOffset(year: year, month: month, day: day, hour: hour, minute: minute, second: second, fraction: fraction, offsetNegative: offsetToken == Utf8Constants.Minus, offsetHours: offsetHours, offsetMinutes: offsetMinutes, out value))
+            {
+                goto ReturnFalse;
+            }
 
-			kind = DateTimeKind.Local;
-			return true;
+            kind = DateTimeKind.Local;
+            return true;
 
-		ReturnFalse:
-			value = default;
-			bytesConsumed = 0;
-			kind = default;
-			return false;
-		}
-	}
+        ReturnFalse:
+            value = default;
+            bytesConsumed = 0;
+            kind = default;
+            return false;
+        }
+    }
 }

--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/Utf8Parser.Date.J.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/Utf8Parser.Date.J.cs
@@ -1,0 +1,298 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace System.Buffers.Text
+{
+	public static partial class Utf8Parser
+	{
+		//
+		// Flexible ISO 8601 format. One of
+		//
+		// ---------------------------------
+		// YYYY-MM-DD (eg 1997-07-16)
+		// YYYY-MM-DDThh:mm (eg 1997-07-16T19:20)
+		// YYYY-MM-DDThh:mm:ss (eg 1997-07-16T19:20:30)
+		// YYYY-MM-DDThh:mm:ss.s (eg 1997-07-16T19:20:30.45)
+		// YYYY-MM-DDThh:mmTZD (eg 1997-07-16T19:20+01:00)
+		// YYYY-MM-DDThh:mm:ssTZD (eg 1997-07-16T19:20:30+01:00)
+		// YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45+01:00)
+		private static bool TryParseDateTimeOffsetJ(ReadOnlySpan<byte> source, out DateTimeOffset value, out int bytesConsumed, out DateTimeKind kind)
+		{
+			int year = 0;
+			int month = 0;
+			int day = 0;
+			int hour = 0;
+			int minute = 0;
+			int second = 0;
+			int fraction = 0;
+
+			byte offsetChar = default;
+			int offsetHours = 0;
+			int offsetMinutes = 0;
+
+			Utf8Constants.DateJParserState state = Utf8Constants.DateJParserState.Year;
+            bool continueParsing = true;
+			int sourceLength = source.Length;
+            int sourceIndex = 0;
+
+			while (continueParsing && (sourceIndex < sourceLength))
+			{
+				switch (state)
+				{
+					case Utf8Constants.DateJParserState.Year:
+    					if (source.Length - sourceIndex < 4)
+                        {
+                            state = Utf8Constants.DateJParserState.Invalid;
+                            break;
+                        }
+                        
+                        uint digit1 = source[sourceIndex++] - 48u;
+                        uint digit2 = source[sourceIndex++] - 48u;
+                        uint digit3 = source[sourceIndex++] - 48u;
+                        uint digit4 = source[sourceIndex++] - 48u;
+
+                        if (digit1 > 9 || digit2 > 9 || digit3 > 9 || digit4 > 9)
+                        {
+                            state = Utf8Constants.DateJParserState.Invalid;
+                            break;
+                        }
+
+                        year = (int)(digit1 * 1000 + digit2 * 100 + digit3 * 10 + digit4);
+
+                        state = (sourceLength - sourceIndex > 1) && (source[sourceIndex++] == Utf8Constants.Hyphen) ? Utf8Constants.DateJParserState.Month : Utf8Constants.DateJParserState.Invalid;
+						break;
+					case Utf8Constants.DateJParserState.Month:
+                        state = ParserHelpers.TryGetNextTwoDigits(source, sourceIndex, out sourceIndex, out month) && (sourceLength - sourceIndex > 1) && (source[sourceIndex++] == Utf8Constants.Hyphen) ?
+                            Utf8Constants.DateJParserState.Day:
+                            Utf8Constants.DateJParserState.Invalid;
+						break;
+					case Utf8Constants.DateJParserState.Day:
+						if (!ParserHelpers.TryGetNextTwoDigits(source, sourceIndex, out sourceIndex, out day))
+                        {
+                            state = Utf8Constants.DateJParserState.Invalid;
+                            break;
+                        }
+
+                        if (sourceLength - sourceIndex > 1)
+                        {
+                            switch (source[sourceIndex])
+                            {
+								case Utf8Constants.TimePrefix:
+									state = Utf8Constants.DateJParserState.Hour;
+									sourceIndex++;
+									break;
+								case Utf8Constants.UtcOffsetChar:
+								case Utf8Constants.Plus:
+								case Utf8Constants.Minus:
+                                    state = Utf8Constants.DateJParserState.Invalid;
+									break;
+								default:
+									continueParsing = false;
+									break;
+							}
+                        }
+						break;
+					case Utf8Constants.DateJParserState.Hour:
+						state = ParserHelpers.TryGetNextTwoDigits(source, sourceIndex, out sourceIndex, out hour) && (sourceLength - sourceIndex > 1) && (source[sourceIndex++] == Utf8Constants.Colon) ?
+                            Utf8Constants.DateJParserState.Minute:
+                            Utf8Constants.DateJParserState.Invalid;
+						break;
+					case Utf8Constants.DateJParserState.Minute:
+						if (!ParserHelpers.TryGetNextTwoDigits(source, sourceIndex, out sourceIndex, out minute))
+                        {
+                            state = Utf8Constants.DateJParserState.Invalid;
+                            break;
+                        }
+
+                        if (sourceLength - sourceIndex > 1)
+                        {
+                            if (source[sourceIndex] == Utf8Constants.Colon)
+                                state = Utf8Constants.DateJParserState.Second;
+                            else if (source[sourceIndex] == Utf8Constants.UtcOffsetChar)
+				            {
+					            offsetChar = Utf8Constants.UtcOffsetChar;
+					            continueParsing = false;
+				            }
+                            else if (source[sourceIndex] == Utf8Constants.Plus)
+                            {
+                                offsetChar = Utf8Constants.Plus;
+                                state = Utf8Constants.DateJParserState.OffsetHours;
+                            }
+                            else if (source[sourceIndex] == Utf8Constants.Minus)
+                            {
+                                offsetChar = Utf8Constants.Minus;
+                                state = Utf8Constants.DateJParserState.OffsetHours;
+                            }
+                            else
+							{
+								continueParsing = false;
+								break;
+							}
+
+                            sourceIndex++;
+                        }
+						break;
+					case Utf8Constants.DateJParserState.Second:
+						if (!ParserHelpers.TryGetNextTwoDigits(source, sourceIndex, out sourceIndex, out second))
+                        {
+                            state = Utf8Constants.DateJParserState.Invalid;
+                            break;
+                        }
+
+						if (sourceLength - sourceIndex > 1)
+                        {
+                            if (source[sourceIndex] == Utf8Constants.Period)
+                                state = Utf8Constants.DateJParserState.Fraction;
+                            else if (source[sourceIndex] == Utf8Constants.UtcOffsetChar)
+				            {
+					            offsetChar = Utf8Constants.UtcOffsetChar;
+					            continueParsing = false;
+				            }
+                            else if (source[sourceIndex] == Utf8Constants.Plus)
+                            {
+                                offsetChar = Utf8Constants.Plus;
+                                state = Utf8Constants.DateJParserState.OffsetHours;
+                            }
+                            else if (source[sourceIndex] == Utf8Constants.Minus)
+                            {
+                                offsetChar = Utf8Constants.Minus;
+                                state = Utf8Constants.DateJParserState.OffsetHours;
+                            }
+                            else
+							{
+								continueParsing = false;
+								break;
+							}
+
+                            sourceIndex++;
+                        }
+						break;
+					case Utf8Constants.DateJParserState.Fraction:
+						while (sourceIndex < sourceLength && ParserHelpers.IsDigit(source[sourceIndex]))
+						{
+                            if (!((fraction * 10) + (int)(source[sourceIndex] - 48u) <= Utf8Constants.MaxDateTimeFraction))
+                            {
+                                sourceIndex++;
+                                break;
+                            }
+
+                            fraction = (fraction * 10) + (int)(source[sourceIndex++] - 48u);
+						}
+
+						if (fraction != 0)
+						{
+							while (fraction * 10 <= Utf8Constants.MaxDateTimeFraction)
+								fraction *= 10;
+			            }
+
+						if (sourceIndex == sourceLength)
+							break;
+						
+						if (source[sourceIndex] == Utf8Constants.UtcOffsetChar)
+						{
+							offsetChar = Utf8Constants.UtcOffsetChar;
+							continueParsing = false;
+							sourceIndex++;
+						}
+						else if (source[sourceIndex] == Utf8Constants.Plus)
+                        {
+                            offsetChar = Utf8Constants.Plus;
+                            state = Utf8Constants.DateJParserState.OffsetHours;
+							sourceIndex++;
+                        }
+                        else if (source[sourceIndex] == Utf8Constants.Minus)
+                        {
+                            offsetChar = Utf8Constants.Minus;
+                            state = Utf8Constants.DateJParserState.OffsetHours;
+							sourceIndex++;
+						}
+                        else
+                            continueParsing = false;
+                        break;
+					case Utf8Constants.DateJParserState.OffsetHours:
+						state = ParserHelpers.TryGetNextTwoDigits(source, sourceIndex, out sourceIndex, out offsetHours) && (sourceLength - sourceIndex > 1) && (source[sourceIndex++] == Utf8Constants.Colon) ?
+                            Utf8Constants.DateJParserState.OffsetMinutes:
+                            Utf8Constants.DateJParserState.Invalid;
+						break;
+					case Utf8Constants.DateJParserState.OffsetMinutes:
+						if (!ParserHelpers.TryGetNextTwoDigits(source, sourceIndex, out sourceIndex, out offsetMinutes))
+                        {
+                            state = Utf8Constants.DateJParserState.Invalid;
+                            break;
+                        }
+
+                        continueParsing = false;
+						break;
+					case Utf8Constants.DateJParserState.Invalid:
+					default:
+						value = default;
+						bytesConsumed = 0;
+						kind = default;
+						return false;
+				}
+			}
+
+			switch(state)
+			{
+				case Utf8Constants.DateJParserState.Day:
+				case Utf8Constants.DateJParserState.Minute:
+				case Utf8Constants.DateJParserState.Second:
+				case Utf8Constants.DateJParserState.Fraction:
+				case Utf8Constants.DateJParserState.OffsetMinutes:
+					break;
+				default:
+					value = default;
+					bytesConsumed = 0;
+					kind = default;
+					return false;
+			}
+
+			bytesConsumed = sourceIndex;
+
+			if ((offsetChar != Utf8Constants.UtcOffsetChar) && (offsetChar != Utf8Constants.Plus) && (offsetChar != Utf8Constants.Minus))
+			{
+				if (!TryCreateDateTimeOffsetInterpretingDataAsLocalTime(year: year, month: month, day: day, hour: hour, minute: minute, second: second, fraction: fraction, out value))
+				{
+					value = default;
+					bytesConsumed = 0;
+					kind = default;
+					return false;
+				}
+
+				kind = DateTimeKind.Unspecified;
+				return true;
+			}
+
+			if (offsetChar == 'Z')
+			{
+				// Same as specifying an offset of "+00:00", except that DateTime's Kind gets set to UTC rather than Local
+				if (!TryCreateDateTimeOffset(year: year, month: month, day: day, hour: hour, minute: minute, second: second, fraction: fraction, offsetNegative: false, offsetHours: 0, offsetMinutes: 0, out value))
+				{
+					value = default;
+					bytesConsumed = 0;
+					kind = default;
+					return false;
+				}
+
+				kind = DateTimeKind.Utc;
+				return true;
+			}
+
+			Debug.Assert(offsetChar == Utf8Constants.Plus || offsetChar == Utf8Constants.Minus);
+
+			if (!TryCreateDateTimeOffset(year: year, month: month, day: day, hour: hour, minute: minute, second: second, fraction: fraction, offsetNegative: offsetChar == Utf8Constants.Minus, offsetHours: offsetHours, offsetMinutes: offsetMinutes, out value))
+			{
+				value = default;
+                bytesConsumed = 0;
+				kind = default;
+				return false;
+			}
+
+			kind = DateTimeKind.Local;
+			return true;
+		}
+	}
+}

--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/Utf8Parser.Date.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/Utf8Parser.Date.cs
@@ -26,7 +26,7 @@ namespace System.Buffers.Text
         ///     R             Tue, 03 Jan 2017 08:08:05 GMT            (RFC 1123)
         ///     l             tue, 03 jan 2017 08:08:05 gmt            (Lowercase RFC 1123)
         ///     O             2017-06-12T05:30:45.7680000-07:00        (Round-trippable)
-        ///     J             2017-06-12[T05:30[:45[.7680000]][-07:00] (ISO 8601)
+        ///     I             2017-06-12[T05:30[:45[.7680000]][-07:00] (ISO 8601)
         /// </remarks>
         /// <exceptions>
         /// <cref>System.FormatException</cref> if the format is not valid for this data type.
@@ -90,9 +90,9 @@ namespace System.Buffers.Text
                         return true;
 					}
 
-                    case 'J':
+                    case 'I':
                     {
-                        if (!TryParseDateTimeOffsetJ(source, out DateTimeOffset dateTimeOffset, out bytesConsumed, out DateTimeKind kind))
+                        if (!TryParseDateTimeOffsetI(source, out DateTimeOffset dateTimeOffset, out bytesConsumed, out DateTimeKind kind))
                         {
                             value = default;
                             bytesConsumed = 0;
@@ -142,7 +142,7 @@ namespace System.Buffers.Text
         ///     R             Tue, 03 Jan 2017 08:08:05 GMT            (RFC 1123)
         ///     l             tue, 03 jan 2017 08:08:05 gmt            (Lowercase RFC 1123)
         ///     O             2017-06-12T05:30:45.7680000-07:00        (Round-trippable)
-        ///     J             2017-06-12[T05:30[:45[.7680000]][-07:00] (ISO 8601)
+        ///     I             2017-06-12[T05:30[:45[.7680000]][-07:00] (ISO 8601)
         /// </remarks>
         /// <exceptions>
         /// <cref>System.FormatException</cref> if the format is not valid for this data type.
@@ -160,8 +160,8 @@ namespace System.Buffers.Text
                 case 'O':
                     return TryParseDateTimeOffsetO(source, out value, out bytesConsumed, out _);
 
-                case 'J':
-                    return TryParseDateTimeOffsetJ(source, out value, out bytesConsumed, out _);
+                case 'I':
+                    return TryParseDateTimeOffsetI(source, out value, out bytesConsumed, out _);
 
                 case default(char):
                     return TryParseDateTimeOffsetDefault(source, out value, out bytesConsumed);

--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/Utf8Parser.Date.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/Utf8Parser.Date.cs
@@ -89,6 +89,32 @@ namespace System.Buffers.Text
                         return true;
                     }
 
+                case 'J':
+                    {
+                        if (!TryParseDateTimeOffsetJ(source, out DateTimeOffset dateTimeOffset, out bytesConsumed, out DateTimeKind kind))
+                        {
+                            value = default;
+                            bytesConsumed = 0;
+                            return false;
+                        }
+
+                        switch (kind)
+                        {
+                            case DateTimeKind.Local:
+                                value = dateTimeOffset.LocalDateTime;
+                                break;
+                            case DateTimeKind.Utc:
+                                value = dateTimeOffset.UtcDateTime;
+                                break;
+                            default:
+                                Debug.Assert(kind == DateTimeKind.Unspecified);
+                                value = dateTimeOffset.DateTime;
+                                break;
+                        }
+
+                        return true;
+                    }
+
                 case default(char):
                 case 'G':
                     return TryParseDateTimeG(source, out value, out _, out bytesConsumed);
@@ -131,6 +157,9 @@ namespace System.Buffers.Text
 
                 case 'O':
                     return TryParseDateTimeOffsetO(source, out value, out bytesConsumed, out _);
+
+                case 'J':
+                    return TryParseDateTimeOffsetJ(source, out value, out bytesConsumed, out _);
 
                 case default(char):
                     return TryParseDateTimeOffsetDefault(source, out value, out bytesConsumed);

--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/Utf8Parser.Date.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/Utf8Parser.Date.cs
@@ -88,9 +88,9 @@ namespace System.Buffers.Text
                         }
 
                         return true;
-					}
+                    }
 
-                    case 'I':
+                case 'I':
                     {
                         if (!TryParseDateTimeOffsetI(source, out DateTimeOffset dateTimeOffset, out bytesConsumed, out DateTimeKind kind))
                         {

--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/Utf8Parser.Date.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/Utf8Parser.Date.cs
@@ -23,9 +23,10 @@ namespace System.Buffers.Text
         /// Formats supported:
         ///     default       05/25/2017 10:30:15 -08:00
         ///     G             05/25/2017 10:30:15
-        ///     R             Tue, 03 Jan 2017 08:08:05 GMT       (RFC 1123)
-        ///     l             tue, 03 jan 2017 08:08:05 gmt       (Lowercase RFC 1123)
-        ///     O             2017-06-12T05:30:45.7680000-07:00   (Round-trippable)
+        ///     R             Tue, 03 Jan 2017 08:08:05 GMT            (RFC 1123)
+        ///     l             tue, 03 jan 2017 08:08:05 gmt            (Lowercase RFC 1123)
+        ///     O             2017-06-12T05:30:45.7680000-07:00        (Round-trippable)
+        ///     J             2017-06-12[T05:30[:45[.7680000]][-07:00] (ISO 8601)
         /// </remarks>
         /// <exceptions>
         /// <cref>System.FormatException</cref> if the format is not valid for this data type.
@@ -87,9 +88,9 @@ namespace System.Buffers.Text
                         }
 
                         return true;
-                    }
+					}
 
-                case 'J':
+                    case 'J':
                     {
                         if (!TryParseDateTimeOffsetJ(source, out DateTimeOffset dateTimeOffset, out bytesConsumed, out DateTimeKind kind))
                         {
@@ -138,9 +139,10 @@ namespace System.Buffers.Text
         /// <remarks>
         /// Formats supported:
         ///     G  (default)  05/25/2017 10:30:15
-        ///     R             Tue, 03 Jan 2017 08:08:05 GMT       (RFC 1123)
-        ///     l             tue, 03 jan 2017 08:08:05 gmt       (Lowercase RFC 1123)
-        ///     O             2017-06-12T05:30:45.7680000-07:00   (Round-trippable)
+        ///     R             Tue, 03 Jan 2017 08:08:05 GMT            (RFC 1123)
+        ///     l             tue, 03 jan 2017 08:08:05 gmt            (Lowercase RFC 1123)
+        ///     O             2017-06-12T05:30:45.7680000-07:00        (Round-trippable)
+        ///     J             2017-06-12[T05:30[:45[.7680000]][-07:00] (ISO 8601)
         /// </remarks>
         /// <exceptions>
         /// <cref>System.FormatException</cref> if the format is not valid for this data type.


### PR DESCRIPTION
This addresses parts of #34690. The  parser will be utilized by `Utf8JsonReader` to parse strings as `DateTime`.

The standard date and time format strings do not include a token "I". This token is now reserved to represent date and time strings that follow one of these variants of the ISO 8601 standard:

YYYY-MM-DD (eg 1997-07-16)
YYYY-MM-DDThh:mm (eg 1997-07-16T19:20)
YYYY-MM-DDThh:mm:ss (eg 1997-07-16T19:20:30)
YYYY-MM-DDThh:mm:ss.s (eg 1997-07-16T19:20:30.45)
YYYY-MM-DDThh:mmTZD (eg 1997-07-16T19:20+01:00)
YYYY-MM-DDThh:mm:ssTZD (eg 1997-07-16T19:20:30+01:00)
YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45+01:00)

where:
    YYYY = four-digit year
     MM   = two-digit month (01=January, etc.)
     DD   = two-digit day of month (01 through 31)
     hh   = two digits of hour (00 through 23) (am/pm NOT allowed)
     mm   = two digits of minute (00 through 59)
     ss   = two digits of second (00 through 59)
     s    = one or more digits representing a decimal fraction of a second
     TZD  = time zone designator (Z or +hh:mm or -hh:mm)

If specified, the decimal fraction of a second must contain >= 1 digit, but the parser will truncate digits after the 7th decimal place.

The parser validates input strings according to these formats and returns the corresponding `DateTime` values.