### PR TITLE
Pass -priority=1 argument directly to build-test.cmd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -240,7 +240,6 @@ if defined __Priority (
     ) else (
         set __PassThroughArgs=-priority=%__Priority%
     )
-    set __UnprocessedBuildArgs=!__UnprocessedBuildArgs! /p:CLRTestPriorityToBuild=%__Priority%
 )
 
 if defined __BuildAll goto BuildAll
@@ -877,7 +876,11 @@ REM ============================================================================
 if %__BuildTests% EQU 1 (
     echo %__MsgPrefix%Commencing build of tests for %__BuildOS%.%__BuildArch%.%__BuildType%
 
-    set NEXTCMD=call %__ProjectDir%\build-test.cmd %__BuildArch% %__BuildType% %__UnprocessedBuildArgs%
+    set  __PriorityArg=
+    if defined __Priority (
+        set __PriorityArg=-priority=%__Priority%
+    )
+    set NEXTCMD=call %__ProjectDir%\build-test.cmd %__BuildArch% %__BuildType% !__PriorityArg! %__UnprocessedBuildArgs%
     echo %__MsgPrefix%!NEXTCMD!
     !NEXTCMD!
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/22995

Before #21608 build.cmd was calling build-test.cmd with -priority=n argument. After that change this call has been transformed to build-test.cmd arm64 Checked  /p:CLRTestPriorityToBuild=1.

Also see https://github.com/dotnet/coreclr/issues/22995#issuecomment-469366377