### PR TITLE
Do not treat warnings as errors during corefx build in docker.

### DIFF
--- a/tests/scripts/run-corefx-tests.py
+++ b/tests/scripts/run-corefx-tests.py
@@ -306,6 +306,9 @@ def main(args):
         # clang3.9, which is currently the default used by the native build.
         build_args += ' /p:BuildNativeClang=--clang5.0'
 
+    if not Is_windows and (arch == 'arm' or arch == 'arm64'):
+        build_args += ' --warnAsError false'
+
     command = ' '.join(('build.cmd' if Is_windows else './build.sh', build_args))
     log(command)
     returncode = 0 if testing else os.system(command)

--- a/tests/scripts/run-corefx-tests.py
+++ b/tests/scripts/run-corefx-tests.py
@@ -307,6 +307,7 @@ def main(args):
         build_args += ' /p:BuildNativeClang=--clang5.0'
 
     if not Is_windows and (arch == 'arm' or arch == 'arm64'):
+        # It is needed under docker where LC_ALL is not configured.
         build_args += ' --warnAsError false'
 
     command = ' '.join(('build.cmd' if Is_windows else './build.sh', build_args))


### PR DESCRIPTION
Use the same workaround that CoreFX uses (https://github.com/dotnet/corefx/blob/63175f02bc3cfba4a807d565f5c60832e7785aa2/eng/pipelines/linux.yml#L40)

Thanks @echesakovMSFT for finding this workaround.


Another approach could be to update all docker files to include SETLOCAL packages would take too long.
Also it is not clear if it is really necessary to have during build.

Closes #22823