### PR TITLE
Added Range Manipulation APIs to Collection<T> and ObservableCollection<T>

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
@@ -215,7 +215,7 @@ namespace System.Collections.ObjectModel
 
             for (int i = index; i < length; i++)
             {
-                RemoveAt(index);
+                RemoveAt(i);
             }
         }
 

--- a/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
@@ -220,7 +220,7 @@ namespace System.Collections.ObjectModel
 
             for (int i = index; i < length; i++)
             {
-                RemoveAt(i);
+                RemoveAt(index);
             }
         }
 

--- a/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
@@ -192,7 +192,7 @@ namespace System.Collections.ObjectModel
             }
 
             int i = 0;
-            foreach (var item in collection)
+            foreach (T item in collection)
             {
                 Insert(index + i, item);
                 i++;

--- a/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
@@ -69,7 +69,7 @@ namespace System.Collections.ObjectModel
             InsertItem(index, item);
         }
 
-        public void AddRange(IEnumerable<T> collection) => InsertItemsRange(items.Count > 0 ? items.Count : 0, collection);
+        public void AddRange(IEnumerable<T> collection) => InsertItemsRange(items.Count, collection);
 
         public void Clear()
         {

--- a/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
@@ -207,6 +207,11 @@ namespace System.Collections.ObjectModel
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_ListInsert);
             }
 
+            if (count < 0)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_ListInsert);
+            }
+
             int length = items.Count;
             if (index < items.Count - count)
             {

--- a/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
@@ -69,6 +69,8 @@ namespace System.Collections.ObjectModel
             InsertItem(index, item);
         }
 
+        public void AddRange(IEnumerable<T> collection) => InsertItemsRange(items.Count > 0 ? items.Count : 0, collection);
+
         public void Clear()
         {
             if (items.IsReadOnly)
@@ -114,6 +116,8 @@ namespace System.Collections.ObjectModel
             InsertItem(index, item);
         }
 
+        public void InsertRange(int index, IEnumerable<T> collection) => InsertItemsRange(index, collection);
+
         public bool Remove(T item)
         {
             if (items.IsReadOnly)
@@ -125,6 +129,14 @@ namespace System.Collections.ObjectModel
             if (index < 0) return false;
             RemoveItem(index);
             return true;
+        }
+
+        public void RemoveRange(int index, int count) => RemoveItemsRange(index, count);
+
+        public void ReplaceRange(int index, int count, IEnumerable<T> collection)
+        {
+            RemoveItemsRange(index, count);
+            InsertItemsRange(index, collection);
         }
 
         public void RemoveAt(int index)
@@ -160,6 +172,47 @@ namespace System.Collections.ObjectModel
         protected virtual void SetItem(int index, T item)
         {
             items[index] = item;
+        }
+
+        protected virtual void InsertItemsRange(int index, IEnumerable<T> collection)
+        {
+            if (collection == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.list);
+            }
+
+            if (items.IsReadOnly)
+            {
+                ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_ReadOnlyCollection);
+            }
+
+            if (index < 0 || index > items.Count)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_ListInsert);
+            }
+
+            int i = 0;
+            foreach (var item in collection)
+            {
+                Insert(index + i, item);
+                i++;
+            }
+        }
+
+        protected virtual void RemoveItemsRange(int index, int count)
+        {
+            if (items.IsReadOnly)
+            {
+                ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_ReadOnlyCollection);
+            }
+
+            if (index < 0 || index > items.Count)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_ListInsert);
+            }
+
+            for (int i = index; i < (index + count); i++)
+                RemoveAt(index);
         }
 
         bool ICollection<T>.IsReadOnly

--- a/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
@@ -212,7 +212,9 @@ namespace System.Collections.ObjectModel
             }
 
             for (int i = index; i < (index + count); i++)
+            {
                 RemoveAt(index);
+            }
         }
 
         bool ICollection<T>.IsReadOnly

--- a/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
@@ -220,11 +220,18 @@ namespace System.Collections.ObjectModel
             if (index > items.Count - count)
             {
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
-            }            
+            }
 
-            for (int i = 0; i < count; i++)
+            if (GetType() == typeof(Collection<T>) && items is List<T> list)
             {
-                RemoveItem(index);
+                list.RemoveRange(index, count);
+            }
+            else
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    RemoveItem(index);
+                }
             }
         }
 

--- a/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
@@ -220,7 +220,7 @@ namespace System.Collections.ObjectModel
 
             for (int i = index; i < length; i++)
             {
-                RemoveAt(index);
+                RemoveItem(index);
             }
         }
 

--- a/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
@@ -187,11 +187,16 @@ namespace System.Collections.ObjectModel
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_ListInsert);
             }
 
-            int i = 0;
-            foreach (T item in collection)
+            if (GetType() == typeof(Collection<T>) && items is List<T> list)
             {
-                Insert(index + i, item);
-                i++;
+                list.InsertRange(index, collection);
+            }
+            else
+            {
+                foreach (T item in collection)
+                {
+                    InsertItem(index++, item);
+                }
             }
         }
 

--- a/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
@@ -133,11 +133,7 @@ namespace System.Collections.ObjectModel
 
         public void RemoveRange(int index, int count) => RemoveItemsRange(index, count);
 
-        public void ReplaceRange(int index, int count, IEnumerable<T> collection)
-        {
-            RemoveItemsRange(index, count);
-            InsertItemsRange(index, collection);
-        }
+        public void ReplaceRange(int index, int count, IEnumerable<T> collection) => ReplaceItemsRange(index, count, collection);
 
         public void RemoveAt(int index)
         {
@@ -211,10 +207,18 @@ namespace System.Collections.ObjectModel
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_ListInsert);
             }
 
-            for (int i = index; i < (index + count); i++)
+            int indexCount = index + count;
+            int length = indexCount > items.Count ? items.Count : indexCount;
+            for (int i = index; i < length; i++)
             {
                 RemoveAt(index);
             }
+        }
+
+        protected virtual void ReplaceItemsRange(int index, int count, IEnumerable<T> collection)
+        {
+            RemoveItemsRange(index, count);
+            InsertItemsRange(index, collection);
         }
 
         bool ICollection<T>.IsReadOnly

--- a/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
@@ -209,12 +209,17 @@ namespace System.Collections.ObjectModel
 
             if ((uint)index > (uint)items.Count)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_ListInsert);
+                ThrowHelper.ThrowArgumentOutOfRange_IndexException();
             }
 
             if (count < 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_ListInsert);
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            if ((Int64)index + (Int64)count > items.Count)
+            {
+                ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
             }
 
             int length = items.Count;

--- a/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
@@ -220,15 +220,9 @@ namespace System.Collections.ObjectModel
             if (index > items.Count - count)
             {
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
-            }
+            }            
 
-            int length = items.Count;
-            if (index < items.Count - count)
-            {
-                length = index + count;
-            }
-
-            for (int i = index; i < length; i++)
+            for (int i = 0; i < count; i++)
             {
                 RemoveItem(index);
             }

--- a/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
@@ -207,8 +207,12 @@ namespace System.Collections.ObjectModel
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_ListInsert);
             }
 
-            int indexCount = index + count;
-            int length = indexCount > items.Count ? items.Count : indexCount;
+            int length = items.Count;
+            if (index < items.Count - count)
+            {
+                length = index + count;
+            }
+
             for (int i = index; i < length; i++)
             {
                 RemoveAt(index);

--- a/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
@@ -186,7 +186,7 @@ namespace System.Collections.ObjectModel
                 ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_ReadOnlyCollection);
             }
 
-            if (index < 0 || index > items.Count)
+            if ((uint)index > (uint)items.Count)
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_ListInsert);
             }
@@ -206,7 +206,7 @@ namespace System.Collections.ObjectModel
                 ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_ReadOnlyCollection);
             }
 
-            if (index < 0 || index > items.Count)
+            if ((uint)index > (uint)items.Count)
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_ListInsert);
             }

--- a/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
@@ -217,7 +217,7 @@ namespace System.Collections.ObjectModel
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
             }
 
-            if ((Int64)index + (Int64)count > items.Count)
+            if (index > items.Count - count)
             {
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
             }

--- a/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
@@ -172,14 +172,14 @@ namespace System.Collections.ObjectModel
 
         protected virtual void InsertItemsRange(int index, IEnumerable<T> collection)
         {
-            if (collection == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.list);
-            }
-
             if (items.IsReadOnly)
             {
                 ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_ReadOnlyCollection);
+            }
+
+            if (collection == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.list);
             }
 
             if ((uint)index > (uint)items.Count)


### PR DESCRIPTION
Added Range Manipulation APIs to Collection<T> and ObservableCollection<T>.

Part of : [dotnet/corefx#10752](https://github.com/dotnet/corefx/issues/10752) - migrated to: https://github.com/dotnet/runtime/issues/18087
Part of: dotnet/corefx#35772

Added the following new API that was approved:

```c#
    // Adds a range to the end of the collection.
    // Raises CollectionChanged (NotifyCollectionChangedAction.Add)
    public void AddRange(IEnumerable<T> collection) => InsertItemsRange(0, collection);

    // Inserts a range
    // Raises CollectionChanged (NotifyCollectionChangedAction.Add)
    public void InsertRange(int index, IEnumerable<T> collection) => InsertItemsRange(index, collection);

    // Removes a range.
    // Raises CollectionChanged (NotifyCollectionChangedAction.Remove)
    public void RemoveRange(int index, int count) => RemoveItemsRange(index, count);

    // Will allow to replace a range with fewer, equal, or more items.
    // Raises CollectionChanged (NotifyCollectionChangedAction.Replace)
    public void ReplaceRange(int index, int count, IEnumerable<T> collection)
    {
         RemoveItemsRange(index, count);
         InsertItemsRange(index, collection);
    }

    #region virtual methods
    protected virtual void InsertItemsRange(int index, IEnumerable<T> collection);
    protected virtual void RemoveItemsRange(int index, int count);
    #endregion
```

Looking forward to everyone's feedback on this

