### PR TITLE
Clean up some string.Format usage

### DIFF
--- a/src/System.Private.CoreLib/Common/System/SR.cs
+++ b/src/System.Private.CoreLib/Common/System/SR.cs
@@ -149,13 +149,28 @@ namespace System
             }
         }
 
+        internal static string Format(IFormatProvider provider, string resourceFormat, params object[] args)
+        {
+            if (args != null)
+            {
+                if (UsingResourceKeys())
+                {
+                    return resourceFormat + ", " + string.Join(", ", args);
+                }
+
+                return string.Format(provider, resourceFormat, args);
+            }
+
+            return resourceFormat;
+        }
+
         internal static string Format(string resourceFormat, params object[] args)
         {
             if (args != null)
             {
                 if (UsingResourceKeys())
                 {
-                    return resourceFormat + string.Join(", ", args);
+                    return resourceFormat + ", " + string.Join(", ", args);
                 }
 
                 return string.Format(resourceFormat, args);

--- a/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -25,7 +25,7 @@
     <CLSCompliant>true</CLSCompliant>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>649,1573,1591,0419</NoWarn>
+    <NoWarn>649,1573,1591,0419,BCL0020</NoWarn> <!-- Remove BCL0020 once https://github.com/dotnet/arcade/pull/2158 is available -->
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <SignAssembly>true</SignAssembly>
     <DelaySign>true</DelaySign>

--- a/src/System.Private.CoreLib/shared/Interop/Unix/Interop.Errors.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Unix/Interop.Errors.cs
@@ -147,9 +147,7 @@ internal static partial class Interop
 
         public override string ToString()
         {
-            return string.Format(
-                "RawErrno: {0} Error: {1} GetErrorMessage: {2}", // No localization required; text is member names used for debugging purposes
-                RawErrno, Error, GetErrorMessage());
+            return $"RawErrno: {RawErrno} Error: {Error} GetErrorMessage: {GetErrorMessage()}"; // No localization required; text is member names used for debugging purposes
         }
     }
 

--- a/src/System.Private.CoreLib/shared/Interop/Unix/System.Native/Interop.GetHostName.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Unix/System.Native/Interop.GetHostName.cs
@@ -27,8 +27,8 @@ internal static partial class Interop
                 // which should only happen if the buffer we supply isn't big
                 // enough, and we're using a buffer size that the man page
                 // says is the max for POSIX (and larger than the max for Linux).
-                Debug.Fail("gethostname failed");
-                throw new InvalidOperationException(string.Format("gethostname returned {0}", err));
+                Debug.Fail($"GetHostName failed with error {err}");
+                throw new InvalidOperationException($"{nameof(GetHostName)}: {err}");
             }
 
             // If the hostname is truncated, it is unspecified whether the returned buffer includes a terminating null byte.

--- a/src/System.Private.CoreLib/shared/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/System.Private.CoreLib/shared/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -122,14 +122,7 @@ namespace Microsoft.Win32.SafeHandles
             // to retry, as the descriptor could actually have been closed, been subsequently reassigned, and
             // be in use elsewhere in the process.  Instead, we simply check whether the call was successful.
             int result = Interop.Sys.Close(handle);
-#if DEBUG
-            if (result != 0)
-            {
-                Debug.Fail(string.Format(
-                    "Close failed with result {0} and error {1}", 
-                    result, Interop.Sys.GetLastErrorInfo()));
-            }
-#endif
+            Debug.Assert(result == 0, $"Close failed with result {result} and error {Interop.Sys.GetLastErrorInfo()}");
             return result == 0;
         }
 

--- a/src/System.Private.CoreLib/shared/System/ArgumentOutOfRangeException.cs
+++ b/src/System.Private.CoreLib/shared/System/ArgumentOutOfRangeException.cs
@@ -79,7 +79,7 @@ namespace System
                 string s = base.Message;
                 if (_actualValue != null)
                 {
-                    string valueMessage = SR.Format(SR.ArgumentOutOfRange_ActualValue, _actualValue.ToString());
+                    string valueMessage = SR.Format(SR.ArgumentOutOfRange_ActualValue, _actualValue);
                     if (s == null)
                         return valueMessage;
                     return s + Environment.NewLine + valueMessage;

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/TraceLogging/EventPayload.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/TraceLogging/EventPayload.cs
@@ -54,7 +54,7 @@ namespace System.Diagnostics.Tracing
                     position++;
                 }
 
-                throw new System.Collections.Generic.KeyNotFoundException(SR.Format(SR.Arg_KeyNotFoundWithKey, key.ToString()));
+                throw new System.Collections.Generic.KeyNotFoundException(SR.Format(SR.Arg_KeyNotFoundWithKey, key));
             }
             set
             {

--- a/src/System.Private.CoreLib/shared/System/Environment.Variables.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Environment.Variables.Windows.cs
@@ -61,7 +61,7 @@ namespace System
                     case Interop.Errors.ERROR_FILENAME_EXCED_RANGE:
                         // The error message from Win32 is "The filename or extension is too long",
                         // which is not accurate.
-                        throw new ArgumentException(SR.Format(SR.Argument_LongEnvVarValue));
+                        throw new ArgumentException(SR.Argument_LongEnvVarValue);
 
                     case Interop.Errors.ERROR_NOT_ENOUGH_MEMORY:
                     case Interop.Errors.ERROR_NO_SYSTEM_RESOURCES:

--- a/src/System.Private.CoreLib/shared/System/Globalization/CalendarData.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CalendarData.Unix.cs
@@ -312,9 +312,7 @@ namespace System.Globalization
                     default:
                         const string unsupportedDateFieldSymbols = "YuUrQqwWDFg";
                         Debug.Assert(!unsupportedDateFieldSymbols.Contains(input[index]),
-                            string.Format(CultureInfo.InvariantCulture,
-                                "Encountered an unexpected date field symbol '{0}' from ICU which has no known corresponding .NET equivalent.", 
-                                input[index]));
+                            $"Encountered an unexpected date field symbol '{input[index]}' from ICU which has no known corresponding .NET equivalent.");
 
                         destination.Append(input[index++]);
                         break;

--- a/src/System.Private.CoreLib/shared/System/Globalization/DateTimeFormat.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/DateTimeFormat.cs
@@ -347,7 +347,7 @@ namespace System
             {
                 // Here we can't find the matching quote.
                 throw new FormatException(
-                        string.Format(
+                        SR.Format(
                             CultureInfo.CurrentCulture,
                             SR.Format_BadQuote, quoteChar));
             }

--- a/src/System.Private.CoreLib/shared/System/Globalization/DateTimeFormat.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/DateTimeFormat.cs
@@ -346,10 +346,7 @@ namespace System
             if (!foundQuote)
             {
                 // Here we can't find the matching quote.
-                throw new FormatException(
-                        SR.Format(
-                            CultureInfo.CurrentCulture,
-                            SR.Format_BadQuote, quoteChar));
+                throw new FormatException(SR.Format(SR.Format_BadQuote, quoteChar));
             }
 
             //

--- a/src/System.Private.CoreLib/shared/System/Globalization/EastAsianLunisolarCalendar.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/EastAsianLunisolarCalendar.cs
@@ -147,7 +147,7 @@ namespace System.Globalization
                 throw new ArgumentOutOfRangeException(
                                 "time",
                                 ticks,
-                                string.Format(CultureInfo.InvariantCulture, SR.ArgumentOutOfRange_CalendarRange,
+                                SR.Format(CultureInfo.InvariantCulture, SR.ArgumentOutOfRange_CalendarRange,
                                 MinSupportedDateTime, MaxSupportedDateTime));
             }
         }

--- a/src/System.Private.CoreLib/shared/System/Globalization/GregorianCalendarHelper.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/GregorianCalendarHelper.cs
@@ -183,7 +183,6 @@ namespace System.Globalization
                         throw new ArgumentOutOfRangeException(
                                     nameof(year),
                                     SR.Format(
-                                        CultureInfo.CurrentCulture,
                                         SR.ArgumentOutOfRange_Range,
                                         m_EraInfo[i].minEraYear,
                                         m_EraInfo[i].maxEraYear));
@@ -325,7 +324,6 @@ namespace System.Globalization
                     throw new ArgumentOutOfRangeException(
                                 nameof(millisecond),
                                 SR.Format(
-                                    CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
                                     0,
                                     MillisPerSecond - 1));
@@ -374,7 +372,6 @@ namespace System.Globalization
                 throw new ArgumentOutOfRangeException(
                             nameof(months),
                             SR.Format(
-                                CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,
                                 -120000,
                                 120000));
@@ -572,7 +569,6 @@ namespace System.Globalization
                 throw new ArgumentOutOfRangeException(
                             nameof(day),
                             SR.Format(
-                                CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,
                                 1,
                                 GetDaysInMonth(year, month, era)));
@@ -611,7 +607,6 @@ namespace System.Globalization
                 throw new ArgumentOutOfRangeException(
                             nameof(month),
                             SR.Format(
-                                CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,
                                 1,
                                 12));
@@ -665,9 +660,7 @@ namespace System.Globalization
             {
                 throw new ArgumentOutOfRangeException(
                             nameof(year),
-                            SR.Format(
-                                CultureInfo.CurrentCulture,
-                                SR.ArgumentOutOfRange_Range, m_minYear, m_maxYear));
+                            SR.Format(SR.ArgumentOutOfRange_Range, m_minYear, m_maxYear));
             }
             // If the year value is above 100, just return the year value.  Don't have to do
             // the TwoDigitYearMax comparison.

--- a/src/System.Private.CoreLib/shared/System/Globalization/GregorianCalendarHelper.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/GregorianCalendarHelper.cs
@@ -182,7 +182,7 @@ namespace System.Globalization
                     {
                         throw new ArgumentOutOfRangeException(
                                     nameof(year),
-                                    string.Format(
+                                    SR.Format(
                                         CultureInfo.CurrentCulture,
                                         SR.ArgumentOutOfRange_Range,
                                         m_EraInfo[i].minEraYear,
@@ -324,7 +324,7 @@ namespace System.Globalization
                 {
                     throw new ArgumentOutOfRangeException(
                                 nameof(millisecond),
-                                string.Format(
+                                SR.Format(
                                     CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
                                     0,
@@ -342,7 +342,7 @@ namespace System.Globalization
             {
                 throw new ArgumentOutOfRangeException(
                             "time",
-                            string.Format(
+                            SR.Format(
                                 CultureInfo.InvariantCulture,
                                 SR.ArgumentOutOfRange_CalendarRange,
                                 m_Cal.MinSupportedDateTime,
@@ -373,7 +373,7 @@ namespace System.Globalization
             {
                 throw new ArgumentOutOfRangeException(
                             nameof(months),
-                            string.Format(
+                            SR.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,
                                 -120000,
@@ -571,7 +571,7 @@ namespace System.Globalization
             {
                 throw new ArgumentOutOfRangeException(
                             nameof(day),
-                            string.Format(
+                            SR.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,
                                 1,
@@ -610,7 +610,7 @@ namespace System.Globalization
             {
                 throw new ArgumentOutOfRangeException(
                             nameof(month),
-                            string.Format(
+                            SR.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range,
                                 1,
@@ -665,7 +665,7 @@ namespace System.Globalization
             {
                 throw new ArgumentOutOfRangeException(
                             nameof(year),
-                            string.Format(
+                            SR.Format(
                                 CultureInfo.CurrentCulture,
                                 SR.ArgumentOutOfRange_Range, m_minYear, m_maxYear));
             }

--- a/src/System.Private.CoreLib/shared/System/Globalization/HebrewCalendar.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/HebrewCalendar.cs
@@ -353,7 +353,7 @@ namespace System.Globalization
                     "time",
                     ticks,
                     // Print out the date in Gregorian using InvariantCulture since the DateTime is based on GreograinCalendar.
-                    string.Format(
+                    SR.Format(
                         CultureInfo.InvariantCulture,
                         SR.ArgumentOutOfRange_CalendarRange,
                         s_calendarMinValue,

--- a/src/System.Private.CoreLib/shared/System/Globalization/HijriCalendar.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/HijriCalendar.cs
@@ -145,7 +145,7 @@ namespace System.Globalization
                 throw new ArgumentOutOfRangeException(
                     "time",
                     ticks,
-                    string.Format(
+                    SR.Format(
                         CultureInfo.InvariantCulture,
                         SR.ArgumentOutOfRange_CalendarRange,
                         s_calendarMinValue,

--- a/src/System.Private.CoreLib/shared/System/Globalization/NumberFormatInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/NumberFormatInfo.cs
@@ -250,7 +250,7 @@ namespace System.Globalization
                 {
                     throw new ArgumentOutOfRangeException(
                                 nameof(CurrencyDecimalDigits),
-                                string.Format(
+                                SR.Format(
                                     CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
                                     0,
@@ -446,7 +446,7 @@ namespace System.Globalization
                 {
                     throw new ArgumentOutOfRangeException(
                                 nameof(CurrencyNegativePattern),
-                                string.Format(
+                                SR.Format(
                                     CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
                                     0,
@@ -470,7 +470,7 @@ namespace System.Globalization
                 {
                     throw new ArgumentOutOfRangeException(
                                 nameof(NumberNegativePattern),
-                                string.Format(
+                                SR.Format(
                                     CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
                                     0,
@@ -494,7 +494,7 @@ namespace System.Globalization
                 {
                     throw new ArgumentOutOfRangeException(
                                 nameof(PercentPositivePattern),
-                                string.Format(
+                                SR.Format(
                                     CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
                                     0,
@@ -518,7 +518,7 @@ namespace System.Globalization
                 {
                     throw new ArgumentOutOfRangeException(
                                 nameof(PercentNegativePattern),
-                                string.Format(
+                                SR.Format(
                                     CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
                                     0,
@@ -575,7 +575,7 @@ namespace System.Globalization
                 {
                     throw new ArgumentOutOfRangeException(
                                 nameof(NumberDecimalDigits),
-                                string.Format(
+                                SR.Format(
                                     CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
                                     0,
@@ -620,7 +620,7 @@ namespace System.Globalization
                 {
                     throw new ArgumentOutOfRangeException(
                                 nameof(CurrencyPositivePattern),
-                                string.Format(
+                                SR.Format(
                                     CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
                                     0,
@@ -677,7 +677,7 @@ namespace System.Globalization
                 {
                     throw new ArgumentOutOfRangeException(
                                 nameof(PercentDecimalDigits),
-                                string.Format(
+                                SR.Format(
                                     CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
                                     0,

--- a/src/System.Private.CoreLib/shared/System/Globalization/NumberFormatInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/NumberFormatInfo.cs
@@ -251,7 +251,6 @@ namespace System.Globalization
                     throw new ArgumentOutOfRangeException(
                                 nameof(CurrencyDecimalDigits),
                                 SR.Format(
-                                    CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
                                     0,
                                     99));
@@ -447,7 +446,6 @@ namespace System.Globalization
                     throw new ArgumentOutOfRangeException(
                                 nameof(CurrencyNegativePattern),
                                 SR.Format(
-                                    CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
                                     0,
                                     15));
@@ -471,7 +469,6 @@ namespace System.Globalization
                     throw new ArgumentOutOfRangeException(
                                 nameof(NumberNegativePattern),
                                 SR.Format(
-                                    CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
                                     0,
                                     4));
@@ -495,7 +492,6 @@ namespace System.Globalization
                     throw new ArgumentOutOfRangeException(
                                 nameof(PercentPositivePattern),
                                 SR.Format(
-                                    CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
                                     0,
                                     3));
@@ -519,7 +515,6 @@ namespace System.Globalization
                     throw new ArgumentOutOfRangeException(
                                 nameof(PercentNegativePattern),
                                 SR.Format(
-                                    CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
                                     0,
                                     11));
@@ -576,7 +571,6 @@ namespace System.Globalization
                     throw new ArgumentOutOfRangeException(
                                 nameof(NumberDecimalDigits),
                                 SR.Format(
-                                    CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
                                     0,
                                     99));
@@ -621,7 +615,6 @@ namespace System.Globalization
                     throw new ArgumentOutOfRangeException(
                                 nameof(CurrencyPositivePattern),
                                 SR.Format(
-                                    CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
                                     0,
                                     3));
@@ -678,7 +671,6 @@ namespace System.Globalization
                     throw new ArgumentOutOfRangeException(
                                 nameof(PercentDecimalDigits),
                                 SR.Format(
-                                    CultureInfo.CurrentCulture,
                                     SR.ArgumentOutOfRange_Range,
                                     0,
                                     99));

--- a/src/System.Private.CoreLib/shared/System/Globalization/RegionInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/RegionInfo.cs
@@ -71,7 +71,7 @@ namespace System.Globalization
             _cultureData = CultureData.GetCultureDataForRegion(name, true);
             if (_cultureData == null)
                 throw new ArgumentException(
-                    string.Format(
+                    SR.Format(
                         CultureInfo.CurrentCulture,
                         SR.Argument_InvalidCultureName, name), nameof(name));
 

--- a/src/System.Private.CoreLib/shared/System/Globalization/RegionInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/RegionInfo.cs
@@ -71,9 +71,7 @@ namespace System.Globalization
             _cultureData = CultureData.GetCultureDataForRegion(name, true);
             if (_cultureData == null)
                 throw new ArgumentException(
-                    SR.Format(
-                        CultureInfo.CurrentCulture,
-                        SR.Argument_InvalidCultureName, name), nameof(name));
+                    SR.Format(SR.Argument_InvalidCultureName, name), nameof(name));
 
 
             // Not supposed to be neutral

--- a/src/System.Private.CoreLib/shared/System/Globalization/UmAlQuraCalendar.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/UmAlQuraCalendar.cs
@@ -303,7 +303,7 @@ namespace System.Globalization
                 throw new ArgumentOutOfRangeException(
                     "time",
                     ticks,
-                    string.Format(
+                    SR.Format(
                         CultureInfo.InvariantCulture,
                         SR.ArgumentOutOfRange_CalendarRange,
                         s_minDate,

--- a/src/System.Private.CoreLib/shared/System/Resources/ManifestBasedResourceGroveler.cs
+++ b/src/System.Private.CoreLib/shared/System/Resources/ManifestBasedResourceGroveler.cs
@@ -172,7 +172,7 @@ namespace System.Resources
                     return CultureInfo.InvariantCulture;
                 }
 
-                throw new ArgumentException(SR.Format(SR.Arg_InvalidNeutralResourcesLanguage_Asm_Culture, a.ToString(), attr.CultureName), e);
+                throw new ArgumentException(SR.Format(SR.Arg_InvalidNeutralResourcesLanguage_Asm_Culture, a, attr.CultureName), e);
             }
         }
 

--- a/src/System.Private.CoreLib/shared/System/Resources/ResourceManager.cs
+++ b/src/System.Private.CoreLib/shared/System/Resources/ResourceManager.cs
@@ -544,7 +544,7 @@ namespace System.Resources
 
             if (!Version.TryParse(v, out Version version))
             {
-                throw new ArgumentException(SR.Format(SR.Arg_InvalidSatelliteContract_Asm_Ver, a.ToString(), v));
+                throw new ArgumentException(SR.Format(SR.Arg_InvalidSatelliteContract_Asm_Ver, a, v));
             }
 
             return version;

--- a/src/System.Private.CoreLib/shared/System/Security/CryptographicException.cs
+++ b/src/System.Private.CoreLib/shared/System/Security/CryptographicException.cs
@@ -33,7 +33,7 @@ namespace System.Security.Cryptography
         }
 
         public CryptographicException(string format, string insert)
-            : base(string.Format(CultureInfo.CurrentCulture, format, insert))
+            : base(string.Format(format, insert))
         {
         }
 

--- a/src/System.Private.CoreLib/shared/System/Security/SecurityElement.cs
+++ b/src/System.Private.CoreLib/shared/System/Security/SecurityElement.cs
@@ -64,7 +64,7 @@ namespace System.Security
                 throw new ArgumentNullException(nameof(tag));
 
             if (!IsValidTag(tag))
-                throw new ArgumentException(SR.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementTag, tag));
+                throw new ArgumentException(SR.Format(SR.Argument_InvalidElementTag, tag));
 
             _tag = tag;
             _text = null;
@@ -76,10 +76,10 @@ namespace System.Security
                 throw new ArgumentNullException(nameof(tag));
 
             if (!IsValidTag(tag))
-                throw new ArgumentException(SR.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementTag, tag));
+                throw new ArgumentException(SR.Format(SR.Argument_InvalidElementTag, tag));
 
             if (text != null && !IsValidText(text))
-                throw new ArgumentException(SR.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementText, text));
+                throw new ArgumentException(SR.Format(SR.Argument_InvalidElementText, text));
 
             _tag = tag;
             _text = text;
@@ -100,7 +100,7 @@ namespace System.Security
                     throw new ArgumentNullException(nameof(Tag));
 
                 if (!IsValidTag(value))
-                    throw new ArgumentException(SR.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementTag, value));
+                    throw new ArgumentException(SR.Format(SR.Argument_InvalidElementTag, value));
 
                 _tag = value;
             }
@@ -147,10 +147,10 @@ namespace System.Security
                         string attrValue = (string)enumerator.Value;
 
                         if (!IsValidAttributeName(attrName))
-                            throw new ArgumentException(SR.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementName, attrName));
+                            throw new ArgumentException(SR.Format(SR.Argument_InvalidElementName, attrName));
 
                         if (!IsValidAttributeValue(attrValue))
-                            throw new ArgumentException(SR.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementValue, attrValue));
+                            throw new ArgumentException(SR.Format(SR.Argument_InvalidElementValue, attrValue));
 
                         list.Add(attrName);
                         list.Add(attrValue);
@@ -177,7 +177,7 @@ namespace System.Security
                 else
                 {
                     if (!IsValidText(value))
-                        throw new ArgumentException(SR.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementTag, value));
+                        throw new ArgumentException(SR.Format(SR.Argument_InvalidElementTag, value));
 
                     _text = value;
                 }
@@ -250,10 +250,10 @@ namespace System.Security
                 throw new ArgumentNullException(nameof(value));
 
             if (!IsValidAttributeName(name))
-                throw new ArgumentException(SR.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementName, name));
+                throw new ArgumentException(SR.Format(SR.Argument_InvalidElementName, name));
 
             if (!IsValidAttributeValue(value))
-                throw new ArgumentException(SR.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementValue, value));
+                throw new ArgumentException(SR.Format(SR.Argument_InvalidElementValue, value));
 
             AddAttributeSafe(name, value);
         }

--- a/src/System.Private.CoreLib/shared/System/Security/SecurityElement.cs
+++ b/src/System.Private.CoreLib/shared/System/Security/SecurityElement.cs
@@ -64,7 +64,7 @@ namespace System.Security
                 throw new ArgumentNullException(nameof(tag));
 
             if (!IsValidTag(tag))
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementTag, tag));
+                throw new ArgumentException(SR.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementTag, tag));
 
             _tag = tag;
             _text = null;
@@ -76,10 +76,10 @@ namespace System.Security
                 throw new ArgumentNullException(nameof(tag));
 
             if (!IsValidTag(tag))
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementTag, tag));
+                throw new ArgumentException(SR.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementTag, tag));
 
             if (text != null && !IsValidText(text))
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementText, text));
+                throw new ArgumentException(SR.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementText, text));
 
             _tag = tag;
             _text = text;
@@ -100,7 +100,7 @@ namespace System.Security
                     throw new ArgumentNullException(nameof(Tag));
 
                 if (!IsValidTag(value))
-                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementTag, value));
+                    throw new ArgumentException(SR.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementTag, value));
 
                 _tag = value;
             }
@@ -147,10 +147,10 @@ namespace System.Security
                         string attrValue = (string)enumerator.Value;
 
                         if (!IsValidAttributeName(attrName))
-                            throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementName, attrName));
+                            throw new ArgumentException(SR.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementName, attrName));
 
                         if (!IsValidAttributeValue(attrValue))
-                            throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementValue, attrValue));
+                            throw new ArgumentException(SR.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementValue, attrValue));
 
                         list.Add(attrName);
                         list.Add(attrValue);
@@ -177,7 +177,7 @@ namespace System.Security
                 else
                 {
                     if (!IsValidText(value))
-                        throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementTag, value));
+                        throw new ArgumentException(SR.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementTag, value));
 
                     _text = value;
                 }
@@ -250,10 +250,10 @@ namespace System.Security
                 throw new ArgumentNullException(nameof(value));
 
             if (!IsValidAttributeName(name))
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementName, name));
+                throw new ArgumentException(SR.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementName, name));
 
             if (!IsValidAttributeValue(value))
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementValue, value));
+                throw new ArgumentException(SR.Format(CultureInfo.CurrentCulture, SR.Argument_InvalidElementValue, value));
 
             AddAttributeSafe(name, value);
         }

--- a/src/System.Private.CoreLib/shared/System/ThrowHelper.cs
+++ b/src/System.Private.CoreLib/shared/System/ThrowHelper.cs
@@ -366,7 +366,7 @@ namespace System
 
         private static KeyNotFoundException GetKeyNotFoundException(object key)
         {
-            return new KeyNotFoundException(SR.Format(SR.Arg_KeyNotFoundWithKey, key.ToString()));
+            return new KeyNotFoundException(SR.Format(SR.Arg_KeyNotFoundWithKey, key));
         }
 
         private static ArgumentOutOfRangeException GetArgumentOutOfRangeException(ExceptionArgument argument, ExceptionResource resource)

--- a/src/System.Private.CoreLib/shared/System/ThrowHelper.cs
+++ b/src/System.Private.CoreLib/shared/System/ThrowHelper.cs
@@ -731,8 +731,7 @@ namespace System
                 case ExceptionResource.Arg_TypeNotSupported:
                     return SR.Arg_TypeNotSupported;
                 default:
-                    Debug.Assert(false,
-                        "The enum value is not defined, please check the ExceptionResource Enum.");
+                    Debug.Fail("The enum value is not defined, please check the ExceptionResource Enum.");
                     return "";
             }
         }

--- a/src/System.Private.CoreLib/shared/System/Tuple.cs
+++ b/src/System.Private.CoreLib/shared/System/Tuple.cs
@@ -143,7 +143,7 @@ namespace System
 
             if (!(other is Tuple<T1> objTuple))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_TupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_TupleIncorrectType, GetType()), nameof(other));
             }
 
             return comparer.Compare(m_Item1, objTuple.m_Item1);
@@ -242,7 +242,7 @@ namespace System
 
             if (!(other is Tuple<T1, T2> objTuple))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_TupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_TupleIncorrectType, GetType()), nameof(other));
             }
 
             int c = 0;
@@ -356,7 +356,7 @@ namespace System
 
             if (!(other is Tuple<T1, T2, T3> objTuple))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_TupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_TupleIncorrectType, GetType()), nameof(other));
             }
 
             int c = 0;
@@ -481,7 +481,7 @@ namespace System
 
             if (!(other is Tuple<T1, T2, T3, T4> objTuple))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_TupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_TupleIncorrectType, GetType()), nameof(other));
             }
 
             int c = 0;
@@ -617,7 +617,7 @@ namespace System
 
             if (!(other is Tuple<T1, T2, T3, T4, T5> objTuple))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_TupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_TupleIncorrectType, GetType()), nameof(other));
             }
 
             int c = 0;
@@ -764,7 +764,7 @@ namespace System
 
             if (!(other is Tuple<T1, T2, T3, T4, T5, T6> objTuple))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_TupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_TupleIncorrectType, GetType()), nameof(other));
             }
 
             int c = 0;
@@ -922,7 +922,7 @@ namespace System
 
             if (!(other is Tuple<T1, T2, T3, T4, T5, T6, T7> objTuple))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_TupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_TupleIncorrectType, GetType()), nameof(other));
             }
 
             int c = 0;
@@ -1096,7 +1096,7 @@ namespace System
 
             if (!(other is Tuple<T1, T2, T3, T4, T5, T6, T7, TRest> objTuple))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_TupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_TupleIncorrectType, GetType()), nameof(other));
             }
 
             int c = 0;

--- a/src/System.Private.CoreLib/shared/System/Type.Enum.cs
+++ b/src/System.Private.CoreLib/shared/System/Type.Enum.cs
@@ -32,7 +32,7 @@ namespace System
             if (valueType.IsEnum)
             {
                 if (!valueType.IsEquivalentTo(this))
-                    throw new ArgumentException(SR.Format(SR.Arg_EnumAndObjectMustBeSameType, valueType, ToString()));
+                    throw new ArgumentException(SR.Format(SR.Arg_EnumAndObjectMustBeSameType, valueType, this));
 
                 valueType = valueType.GetEnumUnderlyingType();
             }

--- a/src/System.Private.CoreLib/shared/System/Type.Enum.cs
+++ b/src/System.Private.CoreLib/shared/System/Type.Enum.cs
@@ -32,7 +32,7 @@ namespace System
             if (valueType.IsEnum)
             {
                 if (!valueType.IsEquivalentTo(this))
-                    throw new ArgumentException(SR.Format(SR.Arg_EnumAndObjectMustBeSameType, valueType.ToString(), this.ToString()));
+                    throw new ArgumentException(SR.Format(SR.Arg_EnumAndObjectMustBeSameType, valueType, ToString()));
 
                 valueType = valueType.GetEnumUnderlyingType();
             }
@@ -53,7 +53,7 @@ namespace System
                 Type underlyingType = GetEnumUnderlyingType();
                 // We cannot compare the types directly because valueType is always a runtime type but underlyingType might not be.
                 if (underlyingType.GetTypeCodeImpl() != valueType.GetTypeCodeImpl())
-                    throw new ArgumentException(SR.Format(SR.Arg_EnumUnderlyingTypeAndObjectMustBeSameType, valueType.ToString(), underlyingType.ToString()));
+                    throw new ArgumentException(SR.Format(SR.Arg_EnumUnderlyingTypeAndObjectMustBeSameType, valueType, underlyingType));
 
                 Array values = GetEnumRawConstantValues();
                 return (BinarySearch(values, value) >= 0);

--- a/src/System.Private.CoreLib/shared/System/ValueTuple.cs
+++ b/src/System.Private.CoreLib/shared/System/ValueTuple.cs
@@ -62,7 +62,7 @@ namespace System
 
             if (!(other is ValueTuple))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, GetType()), nameof(other));
             }
 
             return 0;
@@ -87,7 +87,7 @@ namespace System
 
             if (!(other is ValueTuple))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, GetType()), nameof(other));
             }
 
             return 0;
@@ -365,7 +365,7 @@ namespace System
 
             if (!(other is ValueTuple<T1>))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, GetType()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1>)other;
@@ -392,7 +392,7 @@ namespace System
 
             if (!(other is ValueTuple<T1>))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, GetType()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1>)other;
@@ -559,7 +559,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2>))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, GetType()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2>)other);
@@ -587,7 +587,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2>))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, GetType()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2>)other;
@@ -759,7 +759,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3>))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, GetType()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3>)other);
@@ -790,7 +790,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3>))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, GetType()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3>)other;
@@ -976,7 +976,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4>))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, GetType()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4>)other);
@@ -1010,7 +1010,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4>))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, GetType()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4>)other;
@@ -1212,7 +1212,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5>))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, GetType()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4, T5>)other);
@@ -1249,7 +1249,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5>))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, GetType()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4, T5>)other;
@@ -1467,7 +1467,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6>))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, GetType()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6>)other);
@@ -1507,7 +1507,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6>))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, GetType()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6>)other;
@@ -1741,7 +1741,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7>))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, GetType()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6, T7>)other);
@@ -1784,7 +1784,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7>))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, GetType()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6, T7>)other;
@@ -2040,7 +2040,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, GetType()), nameof(other));
             }
 
             return CompareTo((ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)other);
@@ -2086,7 +2086,7 @@ namespace System
 
             if (!(other is ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>))
             {
-                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, this.GetType().ToString()), nameof(other));
+                throw new ArgumentException(SR.Format(SR.ArgumentException_ValueTupleIncorrectType, GetType()), nameof(other));
             }
 
             var objTuple = (ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>)other;

--- a/src/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/System.Private.CoreLib/src/System/Enum.cs
@@ -924,7 +924,7 @@ namespace System
             if (valueType.IsEnum)
             {
                 if (!valueType.IsEquivalentTo(enumType))
-                    throw new ArgumentException(SR.Format(SR.Arg_EnumAndObjectMustBeSameType, valueType.ToString(), enumType.ToString()));
+                    throw new ArgumentException(SR.Format(SR.Arg_EnumAndObjectMustBeSameType, valueType, enumType));
 
                 if (format.Length != 1)
                 {
@@ -938,7 +938,7 @@ namespace System
             Type underlyingType = GetUnderlyingType(enumType);
             if (valueType != underlyingType)
             {
-                throw new ArgumentException(SR.Format(SR.Arg_EnumFormatUnderlyingTypeAndObjectMustBeSameType, valueType.ToString(), underlyingType.ToString()));
+                throw new ArgumentException(SR.Format(SR.Arg_EnumFormatUnderlyingTypeAndObjectMustBeSameType, valueType, underlyingType));
             }
 
             if (format.Length == 1)
@@ -1156,7 +1156,7 @@ namespace System
                 Type thisType = this.GetType();
                 Type targetType = target.GetType();
 
-                throw new ArgumentException(SR.Format(SR.Arg_EnumAndObjectMustBeSameType, targetType.ToString(), thisType.ToString()));
+                throw new ArgumentException(SR.Format(SR.Arg_EnumAndObjectMustBeSameType, targetType, thisType));
             }
             else
             {

--- a/src/System.Private.CoreLib/src/System/GC.cs
+++ b/src/System.Private.CoreLib/src/System/GC.cs
@@ -350,8 +350,7 @@ namespace System
             if ((maxGenerationThreshold <= 0) || (maxGenerationThreshold >= 100))
             {
                 throw new ArgumentOutOfRangeException(nameof(maxGenerationThreshold),
-                                                      string.Format(
-                                                          CultureInfo.CurrentCulture,
+                                                      SR.Format(
                                                           SR.ArgumentOutOfRange_Bounds_Lower_Upper,
                                                           1,
                                                           99));
@@ -360,8 +359,7 @@ namespace System
             if ((largeObjectHeapThreshold <= 0) || (largeObjectHeapThreshold >= 100))
             {
                 throw new ArgumentOutOfRangeException(nameof(largeObjectHeapThreshold),
-                                                      string.Format(
-                                                          CultureInfo.CurrentCulture,
+                                                      SR.Format(
                                                           SR.ArgumentOutOfRange_Bounds_Lower_Upper,
                                                           1,
                                                           99));

--- a/src/System.Private.CoreLib/src/System/IO/FileLoadException.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/IO/FileLoadException.CoreCLR.cs
@@ -32,7 +32,7 @@ namespace System.IO
             else 
                 GetMessageForHR(hResult, JitHelpers.GetStringHandleOnStack(ref message));
 
-            return string.Format(CultureInfo.CurrentCulture, format, fileName, message);
+            return string.Format(format, fileName, message);
         }
 
         [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]

--- a/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -427,13 +427,13 @@ namespace System.Reflection
         {
             string ctorArgs = "";
             for (int i = 0; i < ConstructorArguments.Count; i++)
-                ctorArgs += string.Format(CultureInfo.CurrentCulture, i == 0 ? "{0}" : ", {0}", ConstructorArguments[i]);
+                ctorArgs += string.Format(i == 0 ? "{0}" : ", {0}", ConstructorArguments[i]);
 
             string namedArgs = "";
             for (int i = 0; i < NamedArguments.Count; i++)
-                namedArgs += string.Format(CultureInfo.CurrentCulture, i == 0 && ctorArgs.Length == 0 ? "{0}" : ", {0}", NamedArguments[i]);
+                namedArgs += string.Format(i == 0 && ctorArgs.Length == 0 ? "{0}" : ", {0}", NamedArguments[i]);
 
-            return string.Format(CultureInfo.CurrentCulture, "[{0}({1}{2})]", Constructor.DeclaringType.FullName, ctorArgs, namedArgs);
+            return string.Format("[{0}({1}{2})]", Constructor.DeclaringType.FullName, ctorArgs, namedArgs);
         }
         public override int GetHashCode() => base.GetHashCode();
         public override bool Equals(object obj) => obj == (object)this;
@@ -548,7 +548,7 @@ namespace System.Reflection
             if (m_memberInfo == null)
                 return base.ToString();
 
-            return string.Format(CultureInfo.CurrentCulture, "{0} = {1}", MemberInfo.Name, TypedValue.ToString(ArgumentType != typeof(object)));
+            return string.Format("{0} = {1}", MemberInfo.Name, TypedValue.ToString(ArgumentType != typeof(object)));
         }
         public override int GetHashCode()
         {
@@ -694,7 +694,7 @@ namespace System.Reflection
 
             if (type == null)
                 throw new InvalidOperationException(
-                    string.Format(CultureInfo.CurrentUICulture, SR.Arg_CATypeResolutionFailed, typeName));
+                    SR.Format(CultureInfo.CurrentUICulture, SR.Arg_CATypeResolutionFailed, typeName));
 
             return type;
         }
@@ -806,30 +806,30 @@ namespace System.Reflection
                 return base.ToString();
 
             if (ArgumentType.IsEnum)
-                return string.Format(CultureInfo.CurrentCulture, typed ? "{0}" : "({1}){0}", Value, ArgumentType.FullName);
+                return string.Format(typed ? "{0}" : "({1}){0}", Value, ArgumentType.FullName);
 
             else if (Value == null)
-                return string.Format(CultureInfo.CurrentCulture, typed ? "null" : "({0})null", ArgumentType.Name);
+                return string.Format(typed ? "null" : "({0})null", ArgumentType.Name);
 
             else if (ArgumentType == typeof(string))
-                return string.Format(CultureInfo.CurrentCulture, "\"{0}\"", Value);
+                return string.Format("\"{0}\"", Value);
 
             else if (ArgumentType == typeof(char))
-                return string.Format(CultureInfo.CurrentCulture, "'{0}'", Value);
+                return string.Format("'{0}'", Value);
 
             else if (ArgumentType == typeof(Type))
-                return string.Format(CultureInfo.CurrentCulture, "typeof({0})", ((Type)Value).FullName);
+                return string.Format("typeof({0})", ((Type)Value).FullName);
 
             else if (ArgumentType.IsArray)
             {
                 IList<CustomAttributeTypedArgument> array = (IList<CustomAttributeTypedArgument>)Value;
 
                 Type elementType = ArgumentType.GetElementType();
-                string result = string.Format(CultureInfo.CurrentCulture, @"new {0}[{1}] {{ ", elementType.IsEnum ? elementType.FullName : elementType.Name, array.Count);
+                string result = string.Format(@"new {0}[{1}] {{ ", elementType.IsEnum ? elementType.FullName : elementType.Name, array.Count);
 
                 for (int i = 0; i < array.Count; i++)
                 {
-                    result += string.Format(CultureInfo.CurrentCulture, i == 0 ? "{0}" : ", {0}", array[i].ToString(elementType != typeof(object)));
+                    result += string.Format(i == 0 ? "{0}" : ", {0}", array[i].ToString(elementType != typeof(object)));
                 }
 
                 result += " }";
@@ -837,7 +837,7 @@ namespace System.Reflection
                 return result;
             }
 
-            return string.Format(CultureInfo.CurrentCulture, typed ? "{0}" : "({1}){0}", Value, ArgumentType.Name);
+            return string.Format(typed ? "{0}" : "({1}){0}", Value, ArgumentType.Name);
         }
 
         public override int GetHashCode() => base.GetHashCode();
@@ -1450,7 +1450,7 @@ namespace System.Reflection
                             if (property == null)
                             {
                                 throw new CustomAttributeFormatException(
-                                    string.Format(CultureInfo.CurrentUICulture, 
+                                    SR.Format(CultureInfo.CurrentUICulture, 
                                         SR.RFLCT_InvalidPropFail, name));
                             }
 
@@ -1473,7 +1473,7 @@ namespace System.Reflection
                     catch (Exception e)
                     {
                         throw new CustomAttributeFormatException(
-                            string.Format(CultureInfo.CurrentUICulture,
+                            SR.Format(CultureInfo.CurrentUICulture,
                                 isProperty ? SR.RFLCT_InvalidPropFail : SR.RFLCT_InvalidFieldFail, name), e);
                     }
                 }
@@ -1640,7 +1640,7 @@ namespace System.Reflection
                     continue;
 
                 if (attributeUsageAttribute != null)
-                    throw new FormatException(string.Format(
+                    throw new FormatException(SR.Format(
                         CultureInfo.CurrentUICulture, SR.Format_AttributeUsage, attributeType));
 
                 ParseAttributeUsageAttribute(caRecord.blob, out AttributeTargets targets, out bool inherited, out bool allowMultiple);

--- a/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -694,7 +694,7 @@ namespace System.Reflection
 
             if (type == null)
                 throw new InvalidOperationException(
-                    SR.Format(CultureInfo.CurrentUICulture, SR.Arg_CATypeResolutionFailed, typeName));
+                    SR.Format(SR.Arg_CATypeResolutionFailed, typeName));
 
             return type;
         }
@@ -1450,8 +1450,7 @@ namespace System.Reflection
                             if (property == null)
                             {
                                 throw new CustomAttributeFormatException(
-                                    SR.Format(CultureInfo.CurrentUICulture, 
-                                        SR.RFLCT_InvalidPropFail, name));
+                                    SR.Format(SR.RFLCT_InvalidPropFail, name));
                             }
 
                             MethodInfo setMethod = property.GetSetMethod(true);
@@ -1473,8 +1472,7 @@ namespace System.Reflection
                     catch (Exception e)
                     {
                         throw new CustomAttributeFormatException(
-                            SR.Format(CultureInfo.CurrentUICulture,
-                                isProperty ? SR.RFLCT_InvalidPropFail : SR.RFLCT_InvalidFieldFail, name), e);
+                            SR.Format(isProperty ? SR.RFLCT_InvalidPropFail : SR.RFLCT_InvalidFieldFail, name), e);
                     }
                 }
 
@@ -1640,8 +1638,7 @@ namespace System.Reflection
                     continue;
 
                 if (attributeUsageAttribute != null)
-                    throw new FormatException(SR.Format(
-                        CultureInfo.CurrentUICulture, SR.Format_AttributeUsage, attributeType));
+                    throw new FormatException(SR.Format(SR.Format_AttributeUsage, attributeType));
 
                 ParseAttributeUsageAttribute(caRecord.blob, out AttributeTargets targets, out bool inherited, out bool allowMultiple);
                 attributeUsageAttribute = new AttributeUsageAttribute(targets, allowMultiple, inherited);

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/CustomAttributeBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/CustomAttributeBuilder.cs
@@ -301,7 +301,7 @@ namespace System.Reflection.Emit
             }
             if (passedType == typeof(IntPtr) || passedType == typeof(UIntPtr))
             {
-                throw new ArgumentException(SR.Format(SR.Argument_BadParameterTypeForCAB, passedType.ToString()), paramName);
+                throw new ArgumentException(SR.Format(SR.Argument_BadParameterTypeForCAB, passedType), paramName);
             }
         }
 
@@ -524,7 +524,7 @@ namespace System.Reflection.Emit
                 // value cannot be a "System.Object" object.
                 // If we allow this we will get into an infinite recursion
                 if (ot == typeof(object))
-                    throw new ArgumentException(SR.Format(SR.Argument_BadParameterTypeForCAB, ot.ToString()));
+                    throw new ArgumentException(SR.Format(SR.Argument_BadParameterTypeForCAB, ot));
 
                 EmitType(writer, ot);
                 EmitValue(writer, ot, value);

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
@@ -1064,8 +1064,7 @@ namespace System.Reflection.Emit
                     MethodBase m = RuntimeType.GetMethodBase(methodReal);
                     Type t = m.DeclaringType.GetGenericTypeDefinition();
 
-                    throw new ArgumentException(string.Format(
-                        CultureInfo.CurrentCulture, SR.Argument_MethodDeclaringTypeGenericLcg, m, t));
+                    throw new ArgumentException(SR.Format(SR.Argument_MethodDeclaringTypeGenericLcg, m, t));
                 }
             }
 

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
@@ -384,7 +384,7 @@ namespace System.Reflection.Emit
                         }
                         else
                         {
-                            throw new ArgumentException(SR.Format(SR.Argument_ConstantNotSupported, type.ToString()));
+                            throw new ArgumentException(SR.Format(SR.Argument_ConstantNotSupported, type));
                         }
                         break;
                 }

--- a/src/System.Private.CoreLib/src/System/Reflection/FieldInfo.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/FieldInfo.CoreCLR.cs
@@ -17,8 +17,8 @@ namespace System.Reflection
 
             Type declaringType = f.DeclaringType;
             if (declaringType != null && declaringType.IsGenericType)
-                throw new ArgumentException(string.Format(
-                    CultureInfo.CurrentCulture, SR.Argument_FieldDeclaringTypeGeneric,
+                throw new ArgumentException(SR.Format(
+                    SR.Argument_FieldDeclaringTypeGeneric,
                     f.Name, declaringType.GetGenericTypeDefinition()));
 
             return f;

--- a/src/System.Private.CoreLib/src/System/Reflection/MdImport.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/MdImport.cs
@@ -629,7 +629,7 @@ namespace System.Reflection
 
         public override string ToString()
         {
-            return string.Format(CultureInfo.CurrentCulture, "MetadataException HResult = {0:x}.", m_hr);
+            return string.Format("MetadataException HResult = {0:x}.", m_hr);
         }
     }
 }

--- a/src/System.Private.CoreLib/src/System/Reflection/MethodBase.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/MethodBase.CoreCLR.cs
@@ -20,8 +20,8 @@ namespace System.Reflection
 
             Type declaringType = m.DeclaringType;
             if (declaringType != null && declaringType.IsGenericType)
-                throw new ArgumentException(string.Format(
-                    CultureInfo.CurrentCulture, SR.Argument_MethodDeclaringTypeGeneric,
+                throw new ArgumentException(SR.Format(
+                    SR.Argument_MethodDeclaringTypeGeneric,
                     m, declaringType.GetGenericTypeDefinition()));
 
             return m;

--- a/src/System.Private.CoreLib/src/System/Reflection/RtFieldInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RtFieldInfo.cs
@@ -102,7 +102,7 @@ namespace System.Reflection
                     else
                     {
                         throw new ArgumentException(
-                            string.Format(CultureInfo.CurrentUICulture, SR.Arg_FieldDeclTarget,
+                            SR.Format(CultureInfo.CurrentUICulture, SR.Arg_FieldDeclTarget,
                                 Name, m_declaringType, target.GetType()));
                     }
                 }
@@ -137,7 +137,7 @@ namespace System.Reflection
         {
             get
             {
-                return string.Format("{0}.{1}", DeclaringType.FullName, Name);
+                return DeclaringType.FullName + "." + Name;
             }
         }
 

--- a/src/System.Private.CoreLib/src/System/Reflection/RtFieldInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RtFieldInfo.cs
@@ -102,7 +102,7 @@ namespace System.Reflection
                     else
                     {
                         throw new ArgumentException(
-                            SR.Format(CultureInfo.CurrentUICulture, SR.Arg_FieldDeclTarget,
+                            SR.Format(SR.Arg_FieldDeclTarget,
                                 Name, m_declaringType, target.GetType()));
                     }
                 }

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -658,7 +658,7 @@ namespace System.Reflection
 
             if (retAssembly == null && throwOnFileNotFound)
             {
-                throw new FileNotFoundException(string.Format(culture, SR.IO_FileNotFound_FileName, an.Name));
+                throw new FileNotFoundException(SR.Format(culture, SR.IO_FileNotFound_FileName, an.Name));
             }
 
             return retAssembly;

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
@@ -301,12 +301,12 @@ namespace System.Reflection
             // ctor is declared on interface class
             if (declaringType.IsInterface)
                 throw new MemberAccessException(
-                    SR.Format(CultureInfo.CurrentUICulture, SR.Acc_CreateInterfaceEx, declaringType));
+                    SR.Format(SR.Acc_CreateInterfaceEx, declaringType));
 
             // ctor is on an abstract class
             else if (declaringType.IsAbstract)
                 throw new MemberAccessException(
-                    SR.Format(CultureInfo.CurrentUICulture, SR.Acc_CreateAbstEx, declaringType));
+                    SR.Format(SR.Acc_CreateAbstEx, declaringType));
 
             // ctor is on a class that contains stack pointers
             else if (declaringType.GetRootElementType() == typeof(ArgIterator))
@@ -320,7 +320,7 @@ namespace System.Reflection
             else if (declaringType.ContainsGenericParameters)
             {
                 throw new MemberAccessException(
-                    SR.Format(CultureInfo.CurrentUICulture, SR.Acc_CreateGenericEx, declaringType));
+                    SR.Format(SR.Acc_CreateGenericEx, declaringType));
             }
 
             // ctor is declared on System.Void

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
@@ -301,12 +301,12 @@ namespace System.Reflection
             // ctor is declared on interface class
             if (declaringType.IsInterface)
                 throw new MemberAccessException(
-                    string.Format(CultureInfo.CurrentUICulture, SR.Acc_CreateInterfaceEx, declaringType));
+                    SR.Format(CultureInfo.CurrentUICulture, SR.Acc_CreateInterfaceEx, declaringType));
 
             // ctor is on an abstract class
             else if (declaringType.IsAbstract)
                 throw new MemberAccessException(
-                    string.Format(CultureInfo.CurrentUICulture, SR.Acc_CreateAbstEx, declaringType));
+                    SR.Format(CultureInfo.CurrentUICulture, SR.Acc_CreateAbstEx, declaringType));
 
             // ctor is on a class that contains stack pointers
             else if (declaringType.GetRootElementType() == typeof(ArgIterator))
@@ -320,7 +320,7 @@ namespace System.Reflection
             else if (declaringType.ContainsGenericParameters)
             {
                 throw new MemberAccessException(
-                    string.Format(CultureInfo.CurrentUICulture, SR.Acc_CreateGenericEx, declaringType));
+                    SR.Format(CultureInfo.CurrentUICulture, SR.Acc_CreateGenericEx, declaringType));
             }
 
             // ctor is declared on System.Void

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
@@ -145,7 +145,7 @@ namespace System.Reflection
 
             if (!MetadataImport.IsValidToken(tk) || !tk.IsFieldDef)
                 throw new ArgumentOutOfRangeException(nameof(metadataToken),
-                    SR.Format(CultureInfo.CurrentUICulture, SR.Argument_InvalidToken, tk, this));
+                    SR.Format(SR.Argument_InvalidToken, tk, this));
 
             int tkDeclaringType;
             string fieldName;
@@ -305,17 +305,17 @@ namespace System.Reflection
             MetadataToken tk = new MetadataToken(metadataToken);
             if (!tk.IsString)
                 throw new ArgumentException(
-                    SR.Format(CultureInfo.CurrentUICulture, SR.Argument_ResolveString, metadataToken, ToString()));
+                    SR.Format(SR.Argument_ResolveString, metadataToken, this));
 
             if (!MetadataImport.IsValidToken(tk))
                 throw new ArgumentOutOfRangeException(nameof(metadataToken),
-                    SR.Format(CultureInfo.CurrentUICulture, SR.Argument_InvalidToken, tk, this));
+                    SR.Format(SR.Argument_InvalidToken, tk, this));
 
             string str = MetadataImport.GetUserString(metadataToken);
 
             if (str == null)
                 throw new ArgumentException(
-                    SR.Format(CultureInfo.CurrentUICulture, SR.Argument_ResolveString, metadataToken, ToString()));
+                    SR.Format(SR.Argument_ResolveString, metadataToken, this));
 
             return str;
         }

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
@@ -145,7 +145,7 @@ namespace System.Reflection
 
             if (!MetadataImport.IsValidToken(tk) || !tk.IsFieldDef)
                 throw new ArgumentOutOfRangeException(nameof(metadataToken),
-                    string.Format(CultureInfo.CurrentUICulture, SR.Format(SR.Argument_InvalidToken, tk, this)));
+                    SR.Format(CultureInfo.CurrentUICulture, SR.Argument_InvalidToken, tk, this));
 
             int tkDeclaringType;
             string fieldName;
@@ -305,17 +305,17 @@ namespace System.Reflection
             MetadataToken tk = new MetadataToken(metadataToken);
             if (!tk.IsString)
                 throw new ArgumentException(
-                    string.Format(CultureInfo.CurrentUICulture, SR.Argument_ResolveString, metadataToken, ToString()));
+                    SR.Format(CultureInfo.CurrentUICulture, SR.Argument_ResolveString, metadataToken, ToString()));
 
             if (!MetadataImport.IsValidToken(tk))
                 throw new ArgumentOutOfRangeException(nameof(metadataToken),
-                    string.Format(CultureInfo.CurrentUICulture, SR.Format(SR.Argument_InvalidToken, tk, this)));
+                    SR.Format(CultureInfo.CurrentUICulture, SR.Argument_InvalidToken, tk, this));
 
             string str = MetadataImport.GetUserString(metadataToken);
 
             if (str == null)
                 throw new ArgumentException(
-                    string.Format(CultureInfo.CurrentUICulture, SR.Argument_ResolveString, metadataToken, ToString()));
+                    SR.Format(CultureInfo.CurrentUICulture, SR.Argument_ResolveString, metadataToken, ToString()));
 
             return str;
         }

--- a/src/System.Private.CoreLib/src/System/RtType.cs
+++ b/src/System.Private.CoreLib/src/System/RtType.cs
@@ -1778,7 +1778,7 @@ namespace System
                     if (!loaderAssuredCompatible)
                         throw new ArgumentException(SR.Format(
                             SR.Argument_ResolveMethodHandle,
-                            reflectedType.ToString(), declaredType.ToString()));
+                            reflectedType, declaredType));
                 }
                 // Action<in string> is assignable from, but not a subclass of Action<in object>.
                 else if (declaredType.IsGenericType)
@@ -1806,7 +1806,7 @@ namespace System
                         // ignoring instantiation is the ReflectedType is not a subtype of the DeclaringType
                         throw new ArgumentException(SR.Format(
                             SR.Argument_ResolveMethodHandle,
-                            reflectedType.ToString(), declaredType.ToString()));
+                            reflectedType, declaredType));
                     }
 
                     // remap the method to same method on the subclass ReflectedType
@@ -1896,8 +1896,8 @@ namespace System
                     {
                         throw new ArgumentException(SR.Format(
                             SR.Argument_ResolveFieldHandle,
-                            reflectedType.ToString(),
-                            declaredType.ToString()));
+                            reflectedType,
+                            declaredType));
                     }
                 }
             }
@@ -1929,7 +1929,7 @@ namespace System
         {
             if (type.IsPointer || type.IsByRef || type == typeof(void))
                 throw new ArgumentException(
-                    SR.Format(SR.Argument_NeverValidGenericArgument, type.ToString()));
+                    SR.Format(SR.Argument_NeverValidGenericArgument, type));
         }
 
 
@@ -1985,7 +1985,7 @@ namespace System
                     typeContext, methodContext, genericArgument.GetTypeHandleInternal().GetTypeChecked()))
                 {
                     throw new ArgumentException(
-                        SR.Format(SR.Argument_GenConstraintViolation, i.ToString(CultureInfo.CurrentCulture), genericArgument.ToString(), definition.ToString(), genericParameter.ToString()), e);
+                        SR.Format(SR.Argument_GenConstraintViolation, i.ToString(), genericArgument, definition, genericParameter), e);
                 }
             }
         }
@@ -3466,7 +3466,7 @@ namespace System
             if (valueType.IsEnum)
             {
                 if (!valueType.IsEquivalentTo(this))
-                    throw new ArgumentException(SR.Format(SR.Arg_EnumAndObjectMustBeSameType, valueType.ToString(), ToString()));
+                    throw new ArgumentException(SR.Format(SR.Arg_EnumAndObjectMustBeSameType, valueType, this));
 
                 valueType = (RuntimeType)valueType.GetEnumUnderlyingType();
             }
@@ -3487,7 +3487,7 @@ namespace System
             {
                 RuntimeType underlyingType = Enum.InternalGetUnderlyingType(this);
                 if (underlyingType != valueType)
-                    throw new ArgumentException(SR.Format(SR.Arg_EnumUnderlyingTypeAndObjectMustBeSameType, valueType.ToString(), underlyingType.ToString()));
+                    throw new ArgumentException(SR.Format(SR.Arg_EnumUnderlyingTypeAndObjectMustBeSameType, valueType, underlyingType));
 
                 ulong[] ulValues = Enum.InternalGetValues(this);
                 ulong ulValue = Enum.ToUInt64(value);
@@ -3750,7 +3750,7 @@ namespace System
             }
 
             if ((invokeAttr & BindingFlags.ExactBinding) == BindingFlags.ExactBinding)
-                throw new ArgumentException(SR.Format(CultureInfo.CurrentUICulture, SR.Arg_ObjObjEx, value.GetType(), this));
+                throw new ArgumentException(SR.Format(SR.Arg_ObjObjEx, value.GetType(), this));
 
             return TryChangeType(value, binder, culture, needsSpecialCast);
         }
@@ -3791,7 +3791,7 @@ namespace System
                 }
             }
 
-            throw new ArgumentException(SR.Format(CultureInfo.CurrentUICulture, SR.Arg_ObjObjEx, value.GetType(), this));
+            throw new ArgumentException(SR.Format(SR.Arg_ObjObjEx, value.GetType(), this));
         }
 
         // GetDefaultMembers

--- a/src/System.Private.CoreLib/src/System/RtType.cs
+++ b/src/System.Private.CoreLib/src/System/RtType.cs
@@ -1776,8 +1776,8 @@ namespace System
                     }
 
                     if (!loaderAssuredCompatible)
-                        throw new ArgumentException(string.Format(
-                            CultureInfo.CurrentCulture, SR.Argument_ResolveMethodHandle,
+                        throw new ArgumentException(SR.Format(
+                            SR.Argument_ResolveMethodHandle,
                             reflectedType.ToString(), declaredType.ToString()));
                 }
                 // Action<in string> is assignable from, but not a subclass of Action<in object>.
@@ -1804,8 +1804,8 @@ namespace System
                     if (baseType == null)
                     {
                         // ignoring instantiation is the ReflectedType is not a subtype of the DeclaringType
-                        throw new ArgumentException(string.Format(
-                            CultureInfo.CurrentCulture, SR.Argument_ResolveMethodHandle,
+                        throw new ArgumentException(SR.Format(
+                            SR.Argument_ResolveMethodHandle,
                             reflectedType.ToString(), declaredType.ToString()));
                     }
 
@@ -1894,8 +1894,8 @@ namespace System
                     if (!RuntimeFieldHandle.AcquiresContextFromThis(fieldHandle) ||
                         !RuntimeTypeHandle.CompareCanonicalHandles(declaredType, reflectedType))
                     {
-                        throw new ArgumentException(string.Format(
-                            CultureInfo.CurrentCulture, SR.Argument_ResolveFieldHandle,
+                        throw new ArgumentException(SR.Format(
+                            SR.Argument_ResolveFieldHandle,
                             reflectedType.ToString(),
                             declaredType.ToString()));
                     }
@@ -3750,7 +3750,7 @@ namespace System
             }
 
             if ((invokeAttr & BindingFlags.ExactBinding) == BindingFlags.ExactBinding)
-                throw new ArgumentException(string.Format(CultureInfo.CurrentUICulture, SR.Arg_ObjObjEx, value.GetType(), this));
+                throw new ArgumentException(SR.Format(CultureInfo.CurrentUICulture, SR.Arg_ObjObjEx, value.GetType(), this));
 
             return TryChangeType(value, binder, culture, needsSpecialCast);
         }
@@ -3791,7 +3791,7 @@ namespace System
                 }
             }
 
-            throw new ArgumentException(string.Format(CultureInfo.CurrentUICulture, SR.Arg_ObjObjEx, value.GetType(), this));
+            throw new ArgumentException(SR.Format(CultureInfo.CurrentUICulture, SR.Arg_ObjObjEx, value.GetType(), this));
         }
 
         // GetDefaultMembers
@@ -4398,8 +4398,7 @@ namespace System
                     {
                         Debug.Assert((invokeMethod.CallingConvention & CallingConventions.VarArgs) ==
                                             CallingConventions.VarArgs);
-                        throw new NotSupportedException(string.Format(CultureInfo.CurrentCulture,
-                            SR.NotSupported_CallToVarArg));
+                        throw new NotSupportedException(SR.NotSupported_CallToVarArg);
                     }
 
                     // fast path??

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/CustomPropertyImpl.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/CustomPropertyImpl.cs
@@ -109,8 +109,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
             if (!accessor.IsPublic)
                 throw new MethodAccessException(
-                    string.Format(
-                        CultureInfo.CurrentCulture,
+                    SR.Format(
                         SR.Arg_MethodAccessException_WithMethodName,
                         accessor.ToString(),
                         accessor.DeclaringType.FullName));

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/CustomPropertyImpl.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/CustomPropertyImpl.cs
@@ -111,7 +111,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
                 throw new MethodAccessException(
                     SR.Format(
                         SR.Arg_MethodAccessException_WithMethodName,
-                        accessor.ToString(),
+                        accessor,
                         accessor.DeclaringType.FullName));
 
             RuntimeMethodInfo rtMethod = accessor as RuntimeMethodInfo;

--- a/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyDependencyResolver.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyDependencyResolver.cs
@@ -83,7 +83,7 @@ namespace System.Runtime.Loader
                     SR.AssemblyDependencyResolver_FailedToResolveDependencies,
                     componentAssemblyPath,
                     returnCode,
-                    errorMessage.ToString()));
+                    errorMessage));
             }
 
             string[] assemblyPaths = SplitPathsList(assemblyPathsList);

--- a/src/System.Private.CoreLib/src/System/Runtime/Serialization/FormatterServices.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Serialization/FormatterServices.cs
@@ -47,7 +47,7 @@ namespace System.Runtime.Serialization
 
             if (!(type is RuntimeType))
             {
-                throw new SerializationException(SR.Format(SR.Serialization_InvalidType, type.ToString()));
+                throw new SerializationException(SR.Format(SR.Serialization_InvalidType, type));
             }
 
             return nativeGetUninitializedObject((RuntimeType)type);

--- a/src/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -1302,7 +1302,7 @@ namespace System.StubHelpers
             {
                 if (managedType.GetType() != typeof(System.RuntimeType))
                 {   // The type should be exactly System.RuntimeType (and not its child System.ReflectionOnlyType, or other System.Type children)
-                    throw new ArgumentException(SR.Format(SR.Argument_WinRTSystemRuntimeType, managedType.GetType().ToString()));
+                    throw new ArgumentException(SR.Format(SR.Argument_WinRTSystemRuntimeType, managedType.GetType()));
                 }
 
                 bool isPrimitive;

--- a/src/System.Private.CoreLib/src/System/TypeLoadException.cs
+++ b/src/System.Private.CoreLib/src/System/TypeLoadException.cs
@@ -70,7 +70,7 @@ namespace System
 
                     string format = null;
                     GetTypeLoadExceptionMessage(ResourceId, JitHelpers.GetStringHandleOnStack(ref format));
-                    _message = string.Format(CultureInfo.CurrentCulture, format, ClassName, AssemblyName, MessageArg);
+                    _message = string.Format(format, ClassName, AssemblyName, MessageArg);
                 }
             }
         }


### PR DESCRIPTION
Mainly changes some string.Format usage to be SR.Format when working with resource strings.  Also cleans up a few asserts that were using string.Format.

Contributes to https://github.com/dotnet/corefx/issues/35001
Related to https://github.com/dotnet/arcade/pull/2158
Related to https://github.com/dotnet/corefx/pull/35777