### PR TITLE
Adding *.nuget.dgspec.json to the gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,7 @@ publish/
 *.nuget.g.targets
 *.nuget.cache
 **/packages/*
+*.nuget.dgspec.json
 project.lock.json
 project.assets.json
 


### PR DESCRIPTION
This file was recently added by NuGet and impacts users building locally with VS2019.

You can see more details about this file here: https://github.com/NuGet/Home/wiki/Allow-restore-to-succeed-for-unloaded-projects-in-Visual-Studio#solution