### PR TITLE
Disable test correctly. Missed casing

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -75,7 +75,7 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/ExecInDefAppDom/ExecInDefAppDom/*">
             <Issue>Issue building native components for the test.</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/1514/interlockexchange/*">
+        <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/1514/InterlockExchange/*">
             <Issue>22975</Issue>
         </ExcludeList>
     </ItemGroup>


### PR DESCRIPTION
This has been reviewed by #22976. Merging to avoid using ci resources.