### PR TITLE
Reduce running time of GitHub_19361 test case

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -513,9 +513,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/eh/FinallyExec/nonlocalexitinroot/*">
             <Issue>Test times out</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/GitHub_19361/GitHub_19361/*">
-            <Issue>20232</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/GC/Scenarios/DoublinkList/dlstack/*">
             <Issue>Release only crash</Issue>
         </ExcludeList>
@@ -546,9 +543,6 @@
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(BuildArch)' == 'arm' or '$(AltJitArch)' == 'arm') and '$(TargetsWindows)' != 'true'">
         <ExcludeList Include="$(XunitTestBinBase)/tracing/runtimeeventsource/runtimeeventsource/*">
             <Issue>19340</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/GitHub_19361/GitHub_19361/*">
-            <Issue>20232</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/GC/Scenarios/Dynamo/dynamo/*">
             <Issue>17129</Issue>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_19361/GitHub_19361.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_19361/GitHub_19361.cs
@@ -46,7 +46,7 @@ namespace Repro
         {
             var items = new List<(DateTime Date, CompositeSource Key, decimal Attribution)>();
 
-            foreach (var _ in Enumerable.Range(0, rng.Next(1000, 10000)))
+            foreach (var _ in Enumerable.Range(0, rng.Next(50, 100)))
             {
                 items.Add((
                     BaseDate.AddDays(rng.Next(1, 100)),
@@ -66,7 +66,7 @@ namespace Repro
         {
 
             var list = new List<CompositeSource>();
-            foreach (var _ in Enumerable.Range(0, 100))
+            foreach (var _ in Enumerable.Range(0, 50))
             {
                 lock (Rng)
                 {
@@ -89,7 +89,7 @@ namespace Repro
         {
             Console.WriteLine("Starting stress loop");
             var compositeSources = GetCompositeSources();
-            var res = Parallel.For(0, 10, i =>
+            var res = Parallel.For(0, 5, i =>
             {
                 int seed;
                 lock (Rng)


### PR DESCRIPTION
This is a regression test and the original issue indicated that the test
would fail reliably under GC stress. So cut down the size of the lists
being processed and remove the various exclusions.

This reduces execution time on arm64 debug from ~30 mins to 2 seconds.

Closes #20232.