### PR TITLE
JIT: fix issue with assertion prop on isinst helpers

### DIFF
--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -1989,11 +1989,23 @@ AssertionInfo Compiler::optAssertionGenJtrue(GenTree* tree)
     op2 = op1->gtCall.gtCallLateArgs->gtOp.gtOp2;
     op1 = op1->gtCall.gtCallLateArgs;
 
+    // For the assertion, ensure op1 is the object being tested.
+    // Morph may have swizzled the operand order.
+    GenTree* op1op = op1->gtOp.gtOp1;
+
+    if (op1op->TypeGet() == TYP_I_IMPL)
+    {
+        jitstd::swap(op1, op2);
+        op1op = op1->gtOp.gtOp1;
+    }
+
+    assert(op1op->TypeGet() == TYP_REF);
+
     // Reverse the assertion
     assert(assertionKind == OAK_EQUAL || assertionKind == OAK_NOT_EQUAL);
     assertionKind = (assertionKind == OAK_EQUAL) ? OAK_NOT_EQUAL : OAK_EQUAL;
 
-    if (op1->gtOp.gtOp1->gtOper == GT_LCL_VAR)
+    if (op1op->OperIs(GT_LCL_VAR))
     {
         return optCreateJtrueAssertions(op1, op2, assertionKind);
     }

--- a/tests/src/JIT/Regression/JitBlue/GitHub_23039/GitHub_23039.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_23039/GitHub_23039.il
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib
+{
+}
+
+.assembly GitHub_23039
+{
+}
+
+// Bug where assertion prop was tripped up because morph swapped arg
+// order on an isinst helper call that fed into a conditional jump,
+// and the object being queried was null.
+
+.class public auto ansi beforefieldinit X`1<T> extends [mscorlib]System.Object
+{
+   .method public static hidebysig int32 F() cil managed noinlining
+   {
+       .locals init ([0] object)
+       ldloc.0
+       isinst class X`1<!T>
+       brtrue IS
+       ldc.i4 100
+       ret
+IS:    ldc.i4 -1
+       ret
+   }
+}
+
+.class public auto ansi beforefieldinit Y extends [mscorlib]System.Object
+{
+   .method public static hidebysig int32 Main() cil managed 
+   {
+      .entrypoint
+      call int32 class X`1<object>::F()
+      ret      
+   }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_23039/GitHub_23039.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_23039/GitHub_23039.ilproj
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_23039.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
For calls to isinst helpers, morph may rearrange the order of args on the late
arg list, so examine the operands to ensure the right ones are passed into the
assertion creation code.

Added simplified test case.

Closes #23039.