### PR TITLE
Improve resiliency of LoadIBCMethodHelper

### DIFF
--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -7442,6 +7442,11 @@ MethodDesc* Module::LoadIBCMethodHelper(DataImage *image, CORBBTPROF_BLOB_PARAM_
             DWORD slot;
             IfFailThrow(p.GetData(&slot));
 
+            if (slot >= pOwnerMT->GetNumVtableSlots())
+            {
+                COMPlusThrow(kTypeLoadException, IDS_IBC_MISSING_EXTERNAL_METHOD);
+            }
+
             pMethod = pOwnerMT->GetMethodDescForSlot(slot);
         }
         else  // otherwise we use the normal metadata MethodDef token encoding and we handle ibc tokens.


### PR DESCRIPTION
The encoded slot could be bogus and we would end up asserting for this.

Fixes #22855.