### PR TITLE
Change IBC data path to match Arcade standard

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -674,7 +674,7 @@ if %__BuildCoreLib% EQU 1 (
         set IbcMergePath=%__PackagesDir%\microsoft.dotnet.ibcmerge\!__IbcMergeVersion!\lib\net45\ibcmerge.exe
         if exist !IbcMergePath! (
             echo %__MsgPrefix%Optimizing using IBC training data
-            set OptimizationDataDir=%__PackagesDir%\optimization.%__BuildOS%-%__BuildArch%.IBC.CoreCLR\!__IbcOptDataVersion!\data\System.Private.CoreLib\
+            set OptimizationDataDir=%__PackagesDir%\optimization.%__BuildOS%-%__BuildArch%.IBC.CoreCLR\!__IbcOptDataVersion!\data\System.Private.CoreLib.dll\
             set InputAssemblyFile=!OptimizationDataDir!System.Private.CoreLib.dll
             set TargetOptimizationDataFile=!OptimizationDataDir!System.Private.CoreLib.pgo
 


### PR DESCRIPTION
[This change](https://dev.azure.com/dnceng/internal/_git/dotnet-optimization/pullrequest/588?_a=overview) modifies the path for IBC data for coreclr and corefx to match what arcade expects. This change updates the coreclr code to match the package.