### PR TITLE
Use 4 core external build queues

### DIFF
--- a/eng/xplat-job.yml
+++ b/eng/xplat-job.yml
@@ -35,21 +35,36 @@ jobs:
     enableMicrobuild: ${{ parameters.enableMicrobuild }}
 
     pool:
+
+      # Public Linux Build Pool
       ${{ if and(eq(parameters.osGroup, 'Linux'), eq(variables['System.TeamProject'], 'public')) }}:
-        name: dnceng-linux-external-temp
+        name:  NetCorePublic-Int-Pool
+        queue: BuildPool.Ubuntu.1604.Amd64.Open
+
+      # Official Build Linux Pool
       ${{ if and(eq(parameters.osGroup, 'Linux'), ne(variables['System.TeamProject'], 'public')) }}:
         name: dnceng-linux-internal-temp
+
       # FreeBSD builds only in the internal project
       ${{ if and(eq(parameters.osGroup, 'FreeBSD'), ne(variables['System.TeamProject'], 'public')) }}:
         name: dnceng-freebsd-internal
+
+      # Public OSX Build Pool
       ${{ if and(eq(parameters.osGroup, 'OSX'), ne(variables['System.TeamProject'], 'public')) }}:
         name: Hosted Mac Internal
+
+      # Official Build OSX Pool
       ${{ if and(eq(parameters.osGroup, 'OSX'), eq(variables['System.TeamProject'], 'public')) }}:
         name: Hosted MacOS
+
+      # Public Windows Build Pool
       ${{ if and(eq(parameters.osGroup, 'Windows_NT'), ne(variables['System.TeamProject'], 'public')) }}:
         name: dotnet-internal-temp
+
+      # Official Build Windows Pool
       ${{ if and(eq(parameters.osGroup, 'Windows_NT'), eq(variables['System.TeamProject'], 'public')) }}:
-        name: dotnet-external-temp
+        name: NetCorePublic-Int-Pool
+        queue: BuildPool.Windows.10.Amd64.VS2017.Open
 
     workspace:
       clean: all


### PR DESCRIPTION
This uses the bring your own cloud machine pools for windows and linux external builds.