### PR TITLE
Remove init_count zeroing from PAL cleanup at process exit

### DIFF
--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -1042,9 +1042,6 @@ PALCommonCleanup()
         PROCDumpThreadList();
 #endif
     }
-
-    // Mark that the PAL is uninitialized
-    init_count = 0;
 }
 
 BOOL PALIsShuttingDown()


### PR DESCRIPTION
Setting the init_count to 0 in the PALCommonCleanup was causing
intermittent crashes in the GC stress C tests on Linux with
SIGILL. The reason is that the signal handlers do nothing and call a
previous handler in case the PAL is not initialized, which is indicated
by the init_count being zero.

To fix that issue, I have removed the init_count zeroing at process
exit, since the PAL and runtime is still capable of handling the
signals.

Close #21582