### PR TITLE
Replace #if BIGENDIAN with BitConverter.IsLittleEndian

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Decimal.DecCalc.cs
+++ b/src/System.Private.CoreLib/shared/System/Decimal.DecCalc.cs
@@ -21,7 +21,11 @@ namespace System
 
         internal int Scale => (byte)(flags >> ScaleShift);
 
-        private ulong Low64 => BitConverter.IsLittleEndian ? Unsafe.As<int, ulong>(ref Unsafe.AsRef(in lo)) : ((ulong)Mid << 32) | Low;
+        private ulong Low64
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get =>BitConverter.IsLittleEndian ? Unsafe.As<int, ulong>(ref Unsafe.AsRef(in lo)) : ((ulong)Mid << 32) | Low;
+        }
 
         private static ref DecCalc AsMutable(ref decimal d) => ref Unsafe.As<decimal, DecCalc>(ref d);
 
@@ -80,7 +84,9 @@ namespace System
 
             private ulong Low64
             {
-                get { return BitConverter.IsLittleEndian ? ulomidLE : (((ulong)umid << 32) | ulo); }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => BitConverter.IsLittleEndian ? ulomidLE : (((ulong)umid << 32) | ulo);
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 set
                 {
                     if (BitConverter.IsLittleEndian)
@@ -2562,7 +2568,9 @@ done:
 
                 public ulong Low64
                 {
+                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
                     get => BitConverter.IsLittleEndian ? ulo64LE : (((ulong)U1 << 32) | U0);
+                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
                     set
                     {
                         if (BitConverter.IsLittleEndian)
@@ -2582,7 +2590,9 @@ done:
                 /// </summary>
                 public ulong High64
                 {
+                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
                     get => BitConverter.IsLittleEndian ? uhigh64LE : (((ulong)U2 << 32) | U1);
+                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
                     set
                     {
                         if (BitConverter.IsLittleEndian)
@@ -2617,7 +2627,9 @@ done:
 
                 public ulong Low64
                 {
+                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
                     get => BitConverter.IsLittleEndian ? ulo64LE : (((ulong)U1 << 32) | U0);
+                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
                     set
                     {
                         if (BitConverter.IsLittleEndian)
@@ -2634,7 +2646,9 @@ done:
 
                 public ulong High64
                 {
+                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
                     get => BitConverter.IsLittleEndian ? uhigh64LE : (((ulong)U3 << 32) | U2);
+                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
                     set
                     {
                         if (BitConverter.IsLittleEndian)
@@ -2675,7 +2689,9 @@ done:
 
                 public ulong Low64
                 {
+                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
                     get => BitConverter.IsLittleEndian ? ulo64LE : (((ulong)U1 << 32) | U0);
+                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
                     set
                     {
                         if (BitConverter.IsLittleEndian)
@@ -2692,7 +2708,9 @@ done:
 
                 public ulong Mid64
                 {
+                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
                     get => BitConverter.IsLittleEndian ? umid64LE : (((ulong)U3 << 32) | U2);
+                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
                     set
                     {
                         if (BitConverter.IsLittleEndian)
@@ -2709,7 +2727,9 @@ done:
 
                 public ulong High64
                 {
+                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
                     get => BitConverter.IsLittleEndian ? uhigh64LE : (((ulong)U5 << 32) | U4);
+                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
                     set
                     {
                         if (BitConverter.IsLittleEndian)

--- a/src/System.Private.CoreLib/shared/System/Decimal.DecCalc.cs
+++ b/src/System.Private.CoreLib/shared/System/Decimal.DecCalc.cs
@@ -24,7 +24,7 @@ namespace System
         private ulong Low64
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get =>BitConverter.IsLittleEndian ? Unsafe.As<int, ulong>(ref Unsafe.AsRef(in lo)) : ((ulong)Mid << 32) | Low;
+            get => BitConverter.IsLittleEndian ? Unsafe.As<int, ulong>(ref Unsafe.AsRef(in lo)) : ((ulong)Mid << 32) | Low;
         }
 
         private static ref DecCalc AsMutable(ref decimal d) => ref Unsafe.As<decimal, DecCalc>(ref d);

--- a/src/System.Private.CoreLib/shared/System/Decimal.DecCalc.cs
+++ b/src/System.Private.CoreLib/shared/System/Decimal.DecCalc.cs
@@ -713,21 +713,36 @@ ThrowOverflow:
                     // 32-bit RyuJIT doesn't convert 64-bit division by constant into multiplication by reciprocal. Do half-width divisions instead.
                     Debug.Assert(power <= ushort.MaxValue);
 
-                    const int low16Le = 0;
-                    const int low16Be = 2;
-                    const int high16Le = 2;
-                    const int high16Be = 0;
 
                     // byte* is used here because Roslyn doesn't do constant propagation for pointer arithmetic
-                    uint num = *(ushort*)((byte*)result + i * 4 + (BitConverter.IsLittleEndian ? high16Le : high16Be)) + (remainder << 16);
-                    uint div = num / power;
-                    remainder = num - div * power;
-                    *(ushort*)((byte*)result + i * 4 + (BitConverter.IsLittleEndian ? high16Le : high16Be)) = (ushort)div;
+                    if (BitConverter.IsLittleEndian)
+                    {
+                        const int low16Le = 0;
+                        const int high16Le = 2;
+                        uint num = *(ushort*)((byte*)result + i * 4 + high16Le) + (remainder << 16);
+                        uint div = num / power;
+                        remainder = num - div * power;
+                        *(ushort*)((byte*)result + i * 4 + high16Le) = (ushort)div;
 
-                    num = *(ushort*)((byte*)result + i * 4 + (BitConverter.IsLittleEndian ? low16Le : low16Be)) + (remainder << 16);
-                    div = num / power;
-                    remainder = num - div * power;
-                    *(ushort*)((byte*)result + i * 4 + (BitConverter.IsLittleEndian ? low16Le : low16Be)) = (ushort)div;
+                        num = *(ushort*)((byte*)result + i * 4 + low16Le) + (remainder << 16);
+                        div = num / power;
+                        remainder = num - div * power;
+                        *(ushort*)((byte*)result + i * 4 + low16Le)) = (ushort)div;
+                    }
+                    else
+                    {
+                        const int low16Be = 2;
+                        const int high16Be = 0;
+                        uint num = *(ushort*)((byte*)result + i * 4 + high16Be) + (remainder << 16);
+                        uint div = num / power;
+                        remainder = num - div * power;
+                        *(ushort*)((byte*)result + i * 4 + high16Be) = (ushort)div;
+
+                        num = *(ushort*)((byte*)result + i * 4 + low16Be) + (remainder << 16);
+                        div = num / power;
+                        remainder = num - div * power;
+                        *(ushort*)((byte*)result + i * 4 + low16Be)) = (ushort)div;
+                    }
 #endif
                 }
                 return power;

--- a/src/System.Private.CoreLib/shared/System/Decimal.DecCalc.cs
+++ b/src/System.Private.CoreLib/shared/System/Decimal.DecCalc.cs
@@ -713,19 +713,21 @@ ThrowOverflow:
                     // 32-bit RyuJIT doesn't convert 64-bit division by constant into multiplication by reciprocal. Do half-width divisions instead.
                     Debug.Assert(power <= ushort.MaxValue);
 
-                    int low16 = BitConverter.IsLittleEndian ? 0 : 2;
-                    int high16 = BitConverter.IsLittleEndian ? 2 : 0;
+                    const int low16Le = 0;
+                    const int low16Be = 2;
+                    const int high16Le = 2;
+                    const int high16Be = 0;
 
                     // byte* is used here because Roslyn doesn't do constant propagation for pointer arithmetic
-                    uint num = *(ushort*)((byte*)result + i * 4 + high16) + (remainder << 16);
+                    uint num = *(ushort*)((byte*)result + i * 4 + (BitConverter.IsLittleEndian ? high16Le : high16Be)) + (remainder << 16);
                     uint div = num / power;
                     remainder = num - div * power;
-                    *(ushort*)((byte*)result + i * 4 + high16) = (ushort)div;
+                    *(ushort*)((byte*)result + i * 4 + (BitConverter.IsLittleEndian ? high16Le : high16Be)) = (ushort)div;
 
-                    num = *(ushort*)((byte*)result + i * 4 + low16) + (remainder << 16);
+                    num = *(ushort*)((byte*)result + i * 4 + (BitConverter.IsLittleEndian ? low16Le : low16Be)) + (remainder << 16);
                     div = num / power;
                     remainder = num - div * power;
-                    *(ushort*)((byte*)result + i * 4 + low16) = (ushort)div;
+                    *(ushort*)((byte*)result + i * 4 + (BitConverter.IsLittleEndian ? low16Le : low16Be)) = (ushort)div;
 #endif
                 }
                 return power;

--- a/src/System.Private.CoreLib/shared/System/Decimal.DecCalc.cs
+++ b/src/System.Private.CoreLib/shared/System/Decimal.DecCalc.cs
@@ -707,8 +707,8 @@ ThrowOverflow:
                     // 32-bit RyuJIT doesn't convert 64-bit division by constant into multiplication by reciprocal. Do half-width divisions instead.
                     Debug.Assert(power <= ushort.MaxValue);
 
-                    const int low16 = BitConverter.IsLittleEndian ? 0 : 2;
-                    const int high16 = BitConverter.IsLittleEndian ? 2 : 0;
+                    int low16 = BitConverter.IsLittleEndian ? 0 : 2;
+                    int high16 = BitConverter.IsLittleEndian ? 2 : 0;
 
                     // byte* is used here because Roslyn doesn't do constant propagation for pointer arithmetic
                     uint num = *(ushort*)((byte*)result + i * 4 + high16) + (remainder << 16);

--- a/src/System.Private.CoreLib/shared/System/Decimal.DecCalc.cs
+++ b/src/System.Private.CoreLib/shared/System/Decimal.DecCalc.cs
@@ -21,11 +21,7 @@ namespace System
 
         internal int Scale => (byte)(flags >> ScaleShift);
 
-#if BIGENDIAN
-        private ulong Low64 => ((ulong)Mid << 32) | Low;
-#else
-        private ulong Low64 => Unsafe.As<int, ulong>(ref Unsafe.AsRef(in lo));
-#endif
+        private ulong Low64 => BitConverter.IsLittleEndian ? Unsafe.As<int, ulong>(ref Unsafe.AsRef(in lo)) : ((ulong)Mid << 32) | Low;
 
         private static ref DecCalc AsMutable(ref decimal d) => ref Unsafe.As<decimal, DecCalc>(ref d);
 
@@ -84,13 +80,19 @@ namespace System
 
             private ulong Low64
             {
-#if BIGENDIAN
-                get { return ((ulong)umid << 32) | ulo; }
-                set { umid = (uint)(value >> 32); ulo = (uint)value; }
-#else
-                get => ulomidLE;
-                set => ulomidLE = value;
-#endif
+                get { return BitConverter.IsLittleEndian ? ulomidLE : (((ulong)umid << 32) | ulo); }
+                set
+                {
+                    if (BitConverter.IsLittleEndian)
+                    {
+                        ulomidLE = value;
+                    }
+                    else
+                    {
+                        umid = (uint)(value >> 32);
+                        ulo = (uint)value;
+                    }
+                }
             }
 
             private const uint SignMask = 0x80000000;
@@ -704,11 +706,10 @@ ThrowOverflow:
 #else
                     // 32-bit RyuJIT doesn't convert 64-bit division by constant into multiplication by reciprocal. Do half-width divisions instead.
                     Debug.Assert(power <= ushort.MaxValue);
-#if BIGENDIAN
-                    const int low16 = 2, high16 = 0;
-#else
-                    const int low16 = 0, high16 = 2;
-#endif
+
+                    const int low16 = BitConverter.IsLittleEndian ? 0 : 2;
+                    const int high16 = BitConverter.IsLittleEndian ? 2 : 0;
+
                     // byte* is used here because Roslyn doesn't do constant propagation for pointer arithmetic
                     uint num = *(ushort*)((byte*)result + i * 4 + high16) + (remainder << 16);
                     uint div = num / power;
@@ -2561,13 +2562,19 @@ done:
 
                 public ulong Low64
                 {
-#if BIGENDIAN
-                    get => ((ulong)U1 << 32) | U0;
-                    set { U1 = (uint)(value >> 32); U0 = (uint)value; }
-#else
-                    get => ulo64LE;
-                    set => ulo64LE = value;
-#endif
+                    get => BitConverter.IsLittleEndian ? ulo64LE : (((ulong)U1 << 32) | U0);
+                    set
+                    {
+                        if (BitConverter.IsLittleEndian)
+                        {
+                            ulo64LE = value;
+                        }
+                        else
+                        {
+                            U1 = (uint)(value >> 32);
+                            U0 = (uint)value;
+                        }
+                    }
                 }
 
                 /// <summary>
@@ -2575,13 +2582,19 @@ done:
                 /// </summary>
                 public ulong High64
                 {
-#if BIGENDIAN
-                    get => ((ulong)U2 << 32) | U1;
-                    set { U2 = (uint)(value >> 32); U1 = (uint)value; }
-#else
-                    get => uhigh64LE;
-                    set => uhigh64LE = value;
-#endif
+                    get => BitConverter.IsLittleEndian ? uhigh64LE : (((ulong)U2 << 32) | U1);
+                    set
+                    {
+                        if (BitConverter.IsLittleEndian)
+                        {
+                            uhigh64LE = value;
+                        }
+                        else
+                        {
+                            U2 = (uint)(value >> 32);
+                            U1 = (uint)value;
+                        }
+                    }
                 }
             }
 
@@ -2604,24 +2617,36 @@ done:
 
                 public ulong Low64
                 {
-#if BIGENDIAN
-                    get => ((ulong)U1 << 32) | U0;
-                    set { U1 = (uint)(value >> 32); U0 = (uint)value; }
-#else
-                    get => ulo64LE;
-                    set => ulo64LE = value;
-#endif
+                    get => BitConverter.IsLittleEndian ? ulo64LE : (((ulong)U1 << 32) | U0);
+                    set
+                    {
+                        if (BitConverter.IsLittleEndian)
+                        {
+                            ulo64LE = value;
+                        }
+                        else
+                        {
+                            U1 = (uint)(value >> 32);
+                            U0 = (uint)value;
+                        }
+                    }
                 }
 
                 public ulong High64
                 {
-#if BIGENDIAN
-                    get => ((ulong)U3 << 32) | U2;
-                    set { U3 = (uint)(value >> 32); U2 = (uint)value; }
-#else
-                    get => uhigh64LE;
-                    set => uhigh64LE = value;
-#endif
+                    get => BitConverter.IsLittleEndian ? uhigh64LE : (((ulong)U3 << 32) | U2);
+                    set
+                    {
+                        if (BitConverter.IsLittleEndian)
+                        {
+                            uhigh64LE = value;
+                        }
+                        else
+                        {
+                            U3 = (uint)(value >> 32);
+                            U2 = (uint)value;
+                        }
+                    }
                 }
             }
 
@@ -2650,35 +2675,53 @@ done:
 
                 public ulong Low64
                 {
-#if BIGENDIAN
-                    get => ((ulong)U1 << 32) | U0;
-                    set { U1 = (uint)(value >> 32); U0 = (uint)value; }
-#else
-                    get => ulo64LE;
-                    set => ulo64LE = value;
-#endif
+                    get => BitConverter.IsLittleEndian ? ulo64LE : (((ulong)U1 << 32) | U0);
+                    set
+                    {
+                        if (BitConverter.IsLittleEndian)
+                        {
+                            ulo64LE = value;
+                        }
+                        else
+                        {
+                            U1 = (uint)(value >> 32);
+                            U0 = (uint)value;
+                        }
+                    }
                 }
 
                 public ulong Mid64
                 {
-#if BIGENDIAN
-                    get => ((ulong)U3 << 32) | U2;
-                    set { U3 = (uint)(value >> 32); U2 = (uint)value; }
-#else
-                    get => umid64LE;
-                    set => umid64LE = value;
-#endif
+                    get => BitConverter.IsLittleEndian ? umid64LE : (((ulong)U3 << 32) | U2);
+                    set
+                    {
+                        if (BitConverter.IsLittleEndian)
+                        {
+                            umid64LE = value;
+                        }
+                        else
+                        {
+                            U3 = (uint)(value >> 32);
+                            U2 = (uint)value;
+                        }
+                    }
                 }
 
                 public ulong High64
                 {
-#if BIGENDIAN
-                    get => ((ulong)U5 << 32) | U4;
-                    set { U5 = (uint)(value >> 32); U4 = (uint)value; }
-#else
-                    get => uhigh64LE;
-                    set => uhigh64LE = value;
-#endif
+                    get => BitConverter.IsLittleEndian ? uhigh64LE : (((ulong)U5 << 32) | U4);
+                    set
+                    {
+                        if (BitConverter.IsLittleEndian)
+                        {
+                            uhigh64LE = value;
+                        }
+                        else
+                        {
+                            U5 = (uint)(value >> 32);
+                            U4 = (uint)value;
+                        }
+                    }
                 }
 
                 public int Length => 6;

--- a/src/System.Private.CoreLib/shared/System/Decimal.DecCalc.cs
+++ b/src/System.Private.CoreLib/shared/System/Decimal.DecCalc.cs
@@ -727,7 +727,7 @@ ThrowOverflow:
                         num = *(ushort*)((byte*)result + i * 4 + low16Le) + (remainder << 16);
                         div = num / power;
                         remainder = num - div * power;
-                        *(ushort*)((byte*)result + i * 4 + low16Le)) = (ushort)div;
+                        *(ushort*)((byte*)result + i * 4 + low16Le) = (ushort)div;
                     }
                     else
                     {
@@ -741,7 +741,7 @@ ThrowOverflow:
                         num = *(ushort*)((byte*)result + i * 4 + low16Be) + (remainder << 16);
                         div = num / power;
                         remainder = num - div * power;
-                        *(ushort*)((byte*)result + i * 4 + low16Be)) = (ushort)div;
+                        *(ushort*)((byte*)result + i * 4 + low16Be) = (ushort)div;
                     }
 #endif
                 }

--- a/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -1405,9 +1405,7 @@ namespace System.Reflection
                     {
                         // Metadata is always written in little-endian format. Must account for this on
                         // big-endian platforms.
-                        const int CustomAttributeVersion = BitConverter.IsLittleEndian ? 0x0001 : 0x0100;
-
-                        if (Marshal.ReadInt16(blobStart) != CustomAttributeVersion)
+                        if (Marshal.ReadInt16(blobStart) != (BitConverter.IsLittleEndian ? 0x0001 : 0x0100))
                         {
                             throw new CustomAttributeFormatException();
                         }

--- a/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -1405,11 +1405,8 @@ namespace System.Reflection
                     {
                         // Metadata is always written in little-endian format. Must account for this on
                         // big-endian platforms.
-#if BIGENDIAN
-                        const int CustomAttributeVersion = 0x0100;
-#else
-                        const int CustomAttributeVersion = 0x0001;
-#endif
+                        const int CustomAttributeVersion = BitConverter.IsLittleEndian ? 0x0001 : 0x0100;
+
                         if (Marshal.ReadInt16(blobStart) != CustomAttributeVersion)
                         {
                             throw new CustomAttributeFormatException();
@@ -1419,9 +1416,11 @@ namespace System.Reflection
 
                         cNamedArgs = Marshal.ReadInt16(blobStart);
                         blobStart = (IntPtr)((byte*)blobStart + 2); // skip namedArgs count
-#if BIGENDIAN
-                        cNamedArgs = ((cNamedArgs & 0xff00) >> 8) | ((cNamedArgs & 0x00ff) << 8);
-#endif
+
+                        if (!BitConverter.IsLittleEndian)
+                        {
+                            cNamedArgs = ((cNamedArgs & 0xff00) >> 8) | ((cNamedArgs & 0x00ff) << 8);
+                        }
                     }
                 }
 


### PR DESCRIPTION
JIT is able to eliminate one of the branches in `if (BitConverter.IsLittleEndian)` conditions. This PR is a copy of https://github.com/mono/mono/pull/13348.

So now on the managed side of CoreCLR only `BitConverter` has `#if BIGENDIAN` - is it needed there? In mono we have https://github.com/mono/mono/blob/master/mcs/class/corlib/System/BitConverter.cs