### PR TITLE
Port Japanese era fix from master

### DIFF
--- a/src/corefx/System.Globalization.Native/calendarData.cpp
+++ b/src/corefx/System.Globalization.Native/calendarData.cpp
@@ -509,7 +509,7 @@ the callback for each value in the collection.
 The context parameter is passed through to the callback along with each string.
 */
 extern "C" int32_t GlobalizationNative_EnumCalendarInfo(
-                        EnumCalendarInfoCallback callback, 
+                        EnumCalendarInfoCallback callback,
                         const UChar* localeName,
                         CalendarId calendarId,
                         CalendarDataType dataType,
@@ -581,7 +581,8 @@ extern "C" int32_t GlobalizationNative_GetLatestJapaneseEra()
     if (U_FAILURE(err))
         return 0;
 
-    int32_t ret = ucal_getLimit(pCal, UCAL_ERA, UCAL_MAXIMUM, &err);
+    ucal_set(pCal, UCAL_EXTENDED_YEAR, 9999);
+    int32_t ret = ucal_get(pCal, UCAL_ERA, &err);
 
     return U_SUCCESS(err) ? ret : 0;
 }


### PR DESCRIPTION
This is straight port of the fix https://github.com/dotnet/coreclr/pull/21087

edit:

Description
We have fixed an issue with Japanese era in 3.0 through the PR https://github.com/dotnet/coreclr/pull/21087 and we got the request https://github.com/dotnet/coreclr/pull/21087 to port that to 2.1 and 2.2. I think it make sense to port the fix to the servicing branches to avoid any problem can happen when starting the new Japanese era in May 1st. 
The issue we fixed is, on Linux we depend on ICU library for getting the list of the supported Japanese eras. We use ICU API ucal_getLimit to do that. Unfortunately, this API return the list of the eras up to the system clock time and not reporting any future eras even if the system support that. This means, if the system updated with the new era before May 1st we’ll not be able to handle this new era. We have raised the issue to ICU and this maybe end as by design for them or they may decide to change it but so far is not clear what they will do. Our fix is we get the era list more reliably by would be better just to get the era of Gregorian year 9999 which always should return the max era anyway.

Here is the opened PR’s for porting the fix

https://github.com/dotnet/coreclr/pull/20727
https://github.com/dotnet/coreclr/pull/20729

These fixes originally code reviewed by Eric Erhardt.

Customer Impact 
This is important fix specific because we learned Japan is going to announce the era name by April which means the software companies will try to update their software before May 1st with the new era information. That create a risk if anyone using 2.1 or 2.2 can run into problems at that time.

Regression? 
No. 
 
Risk
The risk is really very low as the change is very scoped to Japanese calendar with the era scenario and the fix has been in 3.0 master branch for awhile too. So, the fix is exercised for a while now.
