### PR TITLE
Fix for Issue 21231

### DIFF
--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -3291,7 +3291,7 @@ inline void Compiler::LoopDsc::AddModifiedField(Compiler* comp, CORINFO_FIELD_HA
         lpFieldsModified =
             new (comp->getAllocatorLoopHoist()) Compiler::LoopDsc::FieldHandleSet(comp->getAllocatorLoopHoist());
     }
-    lpFieldsModified->Set(fldHnd, true);
+    lpFieldsModified->Set(fldHnd, true, FieldHandleSet::Overwrite);
 }
 
 inline void Compiler::LoopDsc::AddModifiedElemType(Compiler* comp, CORINFO_CLASS_HANDLE structHnd)
@@ -3301,7 +3301,7 @@ inline void Compiler::LoopDsc::AddModifiedElemType(Compiler* comp, CORINFO_CLASS
         lpArrayElemTypesModified =
             new (comp->getAllocatorLoopHoist()) Compiler::LoopDsc::ClassHandleSet(comp->getAllocatorLoopHoist());
     }
-    lpArrayElemTypesModified->Set(structHnd, true);
+    lpArrayElemTypesModified->Set(structHnd, true, ClassHandleSet::Overwrite);
 }
 
 inline void Compiler::LoopDsc::VERIFY_lpIterTree()

--- a/src/jit/copyprop.cpp
+++ b/src/jit/copyprop.cpp
@@ -365,7 +365,7 @@ void Compiler::optBlockCopyProp(BasicBlock* block, LclNumToGenTreePtrStack* curS
                     stack = new (curSsaName->GetAllocator()) GenTreePtrStack(curSsaName->GetAllocator());
                 }
                 stack->Push(tree);
-                curSsaName->Set(lclNum, stack);
+                curSsaName->Set(lclNum, stack, LclNumToGenTreePtrStack::Overwrite);
             }
             // If we encounter first use of a param or this pointer add it as a live definition.
             // Since they are always live, do it only once.

--- a/src/jit/jithashtable.h
+++ b/src/jit/jithashtable.h
@@ -234,15 +234,25 @@ public:
     // Arguments:
     //    k - the key
     //    v - the value
+    //    kind - Normal, we are not allowed to overwrite
+    //           Overwrite, we are allowed to overwrite
+    //           currently only used by CHK/DBG builds in an assert.
     //
     // Return Value:
-    //    `true` if the key already exists, `false` otherwise.
+    //    `true` if the key exists and was overwritten,
+    //    `false` otherwise.
     //
     // Notes:
-    //    If the key already exists then its associated value is updated to
-    //    the new value.
+    //    If the key already exists and kind is Normal
+    //    this method will assert
     //
-    bool Set(Key k, Value v)
+    enum SetKind
+    {
+        None,
+        Overwrite
+    };
+
+    bool Set(Key k, Value v, SetKind kind = None)
     {
         CheckGrowth();
 
@@ -257,6 +267,7 @@ public:
         }
         if (pN != nullptr)
         {
+            assert(kind == Overwrite);
             pN->m_val = v;
             return true;
         }

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1949,7 +1949,7 @@ Compiler::lvaStructFieldInfo Compiler::StructPromotionHelper::GetFieldInfo(CORIN
             fieldInfo.fldType = compiler->getSIMDTypeForSize(simdSize);
             fieldInfo.fldSize = simdSize;
 #ifdef DEBUG
-            retypedFieldsMap.Set(fieldInfo.fldHnd, fieldInfo.fldType);
+            retypedFieldsMap.Set(fieldInfo.fldHnd, fieldInfo.fldType, RetypedAsScalarFieldsMap::Overwrite);
 #endif // DEBUG
         }
     }
@@ -2053,7 +2053,7 @@ bool Compiler::StructPromotionHelper::TryPromoteStructField(lvaStructFieldInfo& 
     fieldInfo.fldType = fieldVarType;
     fieldInfo.fldSize = fieldSize;
 #ifdef DEBUG
-    retypedFieldsMap.Set(fieldInfo.fldHnd, fieldInfo.fldType);
+    retypedFieldsMap.Set(fieldInfo.fldHnd, fieldInfo.fldType, RetypedAsScalarFieldsMap::Overwrite);
 #endif // DEBUG
     return true;
 }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -13640,8 +13640,15 @@ DONE_MORPHING_CHILDREN:
 
                 if (isZeroOffset)
                 {
+                    // The "op1" node might already be annotated with a zero-offset field sequence.
+                    FieldSeqNode* existingZeroOffsetFldSeq = nullptr;
+                    if (GetZeroOffsetFieldMap()->Lookup(op1, &existingZeroOffsetFldSeq))
+                    {
+                        // Append the zero field sequences
+                        zeroFieldSeq = GetFieldSeqStore()->Append(existingZeroOffsetFldSeq, zeroFieldSeq);
+                    }
                     // Transfer the annotation to the new GT_ADDR node.
-                    GetZeroOffsetFieldMap()->Set(op1, zeroFieldSeq);
+                    GetZeroOffsetFieldMap()->Set(op1, zeroFieldSeq, NodeToFieldSeqMap::Overwrite);
                 }
                 commaNode->gtOp.gtOp2 = op1;
                 // Originally, I gave all the comma nodes type "byref".  But the ADDR(IND(x)) == x transform
@@ -18743,7 +18750,16 @@ void Compiler::fgAddFieldSeqForZeroOffset(GenTree* op1, FieldSeqNode* fieldSeq)
 
         default:
             // Record in the general zero-offset map.
-            GetZeroOffsetFieldMap()->Set(op1, fieldSeq);
+
+            // The "op1" node might already be annotated with a zero-offset field sequence.
+            FieldSeqNode* existingZeroOffsetFldSeq = nullptr;
+            if (GetZeroOffsetFieldMap()->Lookup(op1, &existingZeroOffsetFldSeq))
+            {
+                // Append the zero field sequences
+                fieldSeq = GetFieldSeqStore()->Append(existingZeroOffsetFldSeq, fieldSeq);
+            }
+            // Set the new field sequence annotation for op1
+            GetZeroOffsetFieldMap()->Set(op1, fieldSeq, NodeToFieldSeqMap::Overwrite);
             break;
     }
 }

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -3775,7 +3775,7 @@ void Compiler::optUnrollLoops()
                 {
                     BasicBlock* newBlock = insertAfter =
                         fgNewBBafter(block->bbJumpKind, insertAfter, /*extendRegion*/ true);
-                    blockMap.Set(block, newBlock);
+                    blockMap.Set(block, newBlock, BlockToBlockMap::Overwrite);
 
                     if (!BasicBlock::CloneBlockState(this, newBlock, block, lvar, lval))
                     {

--- a/tests/src/JIT/Regression/JitBlue/GitHub_21231/GitHub_21231a.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_21231/GitHub_21231a.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+// Test case for issue 21231
+//
+// 
+// Debug: Outputs 2
+// Release: Outputs 1
+struct S0
+{
+    public sbyte F0;
+    public S0(sbyte p0): this()
+    {
+        F0 = p0;
+    }
+}
+
+struct S1
+{
+    public S0 F2;
+    public ushort F1;
+    public S1(S0 p2): this()
+    {
+        F2 = p2;
+    }
+}
+
+public class Program
+{
+    public static int Main()
+    {
+        var vr22 = new S1[]{new S1(new S0(1))};
+        S1 vr26;
+        vr26.F2 = vr22[0].F2;
+        vr22[0].F2.F0 += vr22[0].F2.F0;
+        vr26.F2 = vr22[0].F2;
+
+        if (vr26.F2.F0 != 2)
+        {
+            System.Console.WriteLine("Failed");
+	    return -1;
+        }
+        else
+        {
+            System.Console.WriteLine("Passed");
+	    return 100;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_21231/GitHub_21231a.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_21231/GitHub_21231a.csproj
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_21231/GitHub_21231b.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_21231/GitHub_21231b.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+// Test case for issue 21231
+//
+// 
+// Debug: Outputs 2
+// Release: Outputs 1
+struct S0
+{
+    public sbyte F0;
+    public S0(sbyte p0): this()
+    {
+        F0 = p0;
+    }
+}
+
+struct S1
+{
+    public S0 F1;
+    public ushort F2;
+    public S1(S0 p2): this()
+    {
+        F1 = p2;
+    }
+}
+
+struct S2
+{
+    public S1 F3;
+    public S2(S0 p3): this()
+    {
+        F3 = new S1(p3);
+    }
+}
+
+public class Program
+{
+    public static int Main()
+    {
+        var vr22 = new S2[]{new S2(new S0(1))};
+        S2 vr26;
+        vr26.F3.F1 = vr22[0].F3.F1;
+        vr22[0].F3.F1.F0 += vr22[0].F3.F1.F0;
+        vr26.F3.F1 = vr22[0].F3.F1;
+
+        if (vr26.F3.F1.F0 != 2)
+        {
+            System.Console.WriteLine("Failed");
+	    return -1;
+        }
+        else
+        {
+            System.Console.WriteLine("Passed");
+	    return 100;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_21231/GitHub_21231b.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_21231/GitHub_21231b.csproj
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Fix for Issue #21231

When transferring a Zero offset from one GenTree node to another, we need to check if there already is a FieldSeq and append to it.
    Added third parameter 'kind' to JitHashTable::Set, and Added enum SetKind
    Only allow Set to overwrite an existing entry when kind is set to Overwrite.
    Added validation for all calls to JitHashTable::Set
    asserting that we don't expect the key to already exist or that we passed Overwrite indicating that we expect to handle it properly.
Added two test cases for Issue 21231