### PR TITLE
JIT: rework codegen for Arm64 SIMD Extract/Insert intrinsics

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -5236,66 +5236,21 @@ void CodeGen::genHWIntrinsicSimdBinaryOp(GenTreeHWIntrinsic* node)
 }
 
 //------------------------------------------------------------------------
-// genHWIntrinsicSwitchTable:
-//
-// Generate code for an immediate switch table
-//
-// In cases where an instruction only supports const immediate operands, we
-// need to generate functionally correct code when the operand is not constant
-//
-// This is required by the HW Intrinsic design to handle indirect calls, such as:
-//   debugger calls
-//   reflection
-//   call backs
-//
-// Generated code implements a switch of this form
-//
-// switch (swReg)
-// {
-// case 0:
-//    ins0; // emitSwCase(0)
-//    break;
-// case 1:
-//    ins1; // emitSwCase(1)
-//    break;
-// ...
-// ...
-// ...
-// case swMax - 1:
-//    insLast; // emitSwCase(swMax - 1)
-//    break;
-// default:
-//    throw ArgumentOutOfRangeException
-// }
-//
-// Generated code looks like:
-//
-//     cmp swReg, #swMax
-//     b.hs ThrowArgumentOutOfRangeExceptionHelper
-//     adr tmpReg, labelFirst
-//     add tmpReg, tmpReg, swReg, LSL #3
-//     b   [tmpReg]
-// labelFirst:
-//     ins0
-//     b labelBreakTarget
-//     ins1
-//     b labelBreakTarget
-//     ...
-//     ...
-//     ...
-//     insLast
-//     b labelBreakTarget
-// labelBreakTarget:
-//
+// genHWIntrinsicSwitchTable: generate the jump-table for imm-intrinsics
+//    with non-constant argument
 //
 // Arguments:
 //    swReg      - register containing the switch case to execute
 //    tmpReg     - temporary integer register for calculating the switch indirect branch target
-//    swMax      - the number of switch cases.  If swReg >= swMax throw SCK_ARG_RNG_EXCPN
-//    emitSwCase - function like argument taking an immediate value and emitting one instruction
+//    swMax      - the number of switch cases.
+//    emitSwCase - lambda to generate an individual switch case
 //
-// Return Value:
-//    None.
+// Notes:
+//    Used for cases where an instruction only supports immediate operands,
+//    but at jit time the operand is not a constant.
+//
+//    The importer is responsible for inserting an upstream range check
+//    (GT_HW_INTRINSIC_CHK) for swReg, so no range check is needed here.
 //
 template <typename HWIntrinsicSwitchCaseBody>
 void CodeGen::genHWIntrinsicSwitchTable(regNumber                 swReg,
@@ -5309,27 +5264,24 @@ void CodeGen::genHWIntrinsicSwitchTable(regNumber                 swReg,
     assert(genIsValidIntReg(tmpReg));
     assert(genIsValidIntReg(swReg));
 
-    BasicBlock* labelFirst       = genCreateTempLabel();
-    BasicBlock* labelBreakTarget = genCreateTempLabel();
-
-    // Detect and throw out of range exception
-    getEmitter()->emitIns_R_I(INS_cmp, EA_4BYTE, swReg, swMax);
-
-    genJumpToThrowHlpBlk(EJ_hs, SCK_ARG_RNG_EXCPN);
+    BasicBlock* switchTableBeg = genCreateTempLabel();
+    BasicBlock* switchTableEnd = genCreateTempLabel();
 
     // Calculate switch target
-    labelFirst->bbFlags |= BBF_JMP_TARGET;
+    //
+    // Each switch table case needs exactly 8 bytes of code.
+    switchTableBeg->bbFlags |= BBF_JMP_TARGET;
 
-    // tmpReg = labelFirst
-    getEmitter()->emitIns_R_L(INS_adr, EA_PTRSIZE, labelFirst, tmpReg);
+    // tmpReg = switchTableBeg
+    getEmitter()->emitIns_R_L(INS_adr, EA_PTRSIZE, switchTableBeg, tmpReg);
 
-    // tmpReg = labelFirst + swReg * 8
+    // tmpReg = switchTableBeg + swReg * 8
     getEmitter()->emitIns_R_R_R_I(INS_add, EA_PTRSIZE, tmpReg, tmpReg, swReg, 3, INS_OPTS_LSL);
 
     // br tmpReg
     getEmitter()->emitIns_R(INS_br, EA_PTRSIZE, tmpReg);
 
-    genDefineTempLabel(labelFirst);
+    genDefineTempLabel(switchTableBeg);
     for (int i = 0; i < swMax; ++i)
     {
         unsigned prevInsCount = getEmitter()->emitInsCount;
@@ -5338,11 +5290,11 @@ void CodeGen::genHWIntrinsicSwitchTable(regNumber                 swReg,
 
         assert(getEmitter()->emitInsCount == prevInsCount + 1);
 
-        inst_JMP(EJ_jmp, labelBreakTarget);
+        inst_JMP(EJ_jmp, switchTableEnd);
 
         assert(getEmitter()->emitInsCount == prevInsCount + 2);
     }
-    genDefineTempLabel(labelBreakTarget);
+    genDefineTempLabel(switchTableEnd);
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -374,6 +374,9 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
 #ifdef FEATURE_SIMD
         case GT_SIMD_CHK:
 #endif // FEATURE_SIMD
+#ifdef FEATURE_HW_INTRINSICS
+        case GT_HW_INTRINSIC_CHK:
+#endif // FEATURE_HW_INTRINSICS
             genRangeCheck(treeNode);
             break;
 
@@ -1312,12 +1315,7 @@ void CodeGen::genMultiRegCallStoreToLocal(GenTree* treeNode)
 //
 void CodeGen::genRangeCheck(GenTree* oper)
 {
-#ifdef FEATURE_SIMD
-    noway_assert(oper->OperGet() == GT_ARR_BOUNDS_CHECK || oper->OperGet() == GT_SIMD_CHK);
-#else  // !FEATURE_SIMD
-    noway_assert(oper->OperGet() == GT_ARR_BOUNDS_CHECK);
-#endif // !FEATURE_SIMD
-
+    noway_assert(oper->OperIsBoundsCheck());
     GenTreeBoundsChk* bndsChk = oper->AsBoundsChk();
 
     GenTree* arrLen    = bndsChk->gtArrLen;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3510,7 +3510,7 @@ protected:
 #ifdef _TARGET_ARM64_
     InstructionSet lookupHWIntrinsicISA(const char* className);
     NamedIntrinsic lookupHWIntrinsic(const char* className, const char* methodName);
-    bool impCheckImmediate(GenTree* immediateOp, unsigned int max);
+    GenTree* addRangeCheckIfNeeded(GenTree* lastOp, unsigned int max, bool mustExpand);
 #endif // _TARGET_ARM64_
 #endif // FEATURE_HW_INTRINSICS
     GenTree* impArrayAccessIntrinsic(CORINFO_CLASS_HANDLE clsHnd,

--- a/src/jit/hwintrinsicArm64.cpp
+++ b/src/jit/hwintrinsicArm64.cpp
@@ -129,14 +129,6 @@ NamedIntrinsic Compiler::lookupHWIntrinsic(const char* className, const char* me
 }
 
 //------------------------------------------------------------------------
-// impCheckImmediate: check if immediate is const and in range for inlining
-//
-bool Compiler::impCheckImmediate(GenTree* immediateOp, unsigned int max)
-{
-    return immediateOp->IsCnsIntOrI() && (immediateOp->AsIntConCommon()->IconValue() < max);
-}
-
-//------------------------------------------------------------------------
 // isFullyImplementedIsa: Gets a value that indicates whether the InstructionSet is fully implemented
 //
 // Arguments:
@@ -192,6 +184,46 @@ bool HWIntrinsicInfo::isScalarIsa(InstructionSet isa)
         default:
             assert(!"Unexpected Arm64 HW intrinsics ISA");
             return true;
+    }
+}
+
+//------------------------------------------------------------------------
+// addRangeCheckIfNeeded: add a GT_HW_INTRINSIC_CHK node for non-full-range imm-intrinsic
+//
+// Arguments:
+//    immOp      -- the operand of the intrinsic that points to the imm-arg
+//    max        -- maximum allowable value for the immOp
+//    mustExpand -- true if the compiler is compiling the fallback(GT_CALL) of this intrinsics
+//
+// Return Value:
+//     if necessary, add a GT_HW_INTRINSIC_CHK node which throws an ArgumentOutOfRangeException
+//     when the immOp is not in the valid range
+//
+GenTree* Compiler::addRangeCheckIfNeeded(GenTree* immOp, unsigned int max, bool mustExpand)
+{
+    assert(immOp != nullptr);
+
+    // Need to range check only if we're must expand and don't have an appropriate constant
+    if (mustExpand && (!immOp->IsCnsIntOrI() || (immOp->AsIntConCommon()->IconValue() < max)))
+    {
+        GenTree* upperBoundNode = new (this, GT_CNS_INT) GenTreeIntCon(TYP_INT, max);
+        GenTree* index          = nullptr;
+        if ((immOp->gtFlags & GTF_SIDE_EFFECT) != 0)
+        {
+            index = fgInsertCommaFormTemp(&immOp);
+        }
+        else
+        {
+            index = gtCloneExpr(immOp);
+        }
+        GenTreeBoundsChk* hwIntrinsicChk = new (this, GT_HW_INTRINSIC_CHK)
+            GenTreeBoundsChk(GT_HW_INTRINSIC_CHK, TYP_VOID, index, upperBoundNode, SCK_RNGCHK_FAIL);
+        hwIntrinsicChk->gtThrowKind = SCK_ARG_RNG_EXCPN;
+        return gtNewOperNode(GT_COMMA, immOp->TypeGet(), hwIntrinsicChk, immOp);
+    }
+    else
+    {
+        return immOp;
     }
 }
 
@@ -426,24 +458,16 @@ GenTree* Compiler::impHWIntrinsic(NamedIntrinsic        intrinsic,
             return gtNewSimdHWIntrinsicNode(simdType, op1, intrinsic, simdBaseType, simdSizeBytes);
 
         case HWIntrinsicInfo::SimdExtractOp:
-            if (!mustExpand && !impCheckImmediate(impStackTop(0).val, getSIMDVectorLength(simdSizeBytes, simdBaseType)))
-            {
-                // Immediate lane not constant or out of range
-                return nullptr;
-            }
-            op2 = impPopStack().val;
+            op2 =
+                addRangeCheckIfNeeded(impPopStack().val, getSIMDVectorLength(simdSizeBytes, simdBaseType), mustExpand);
             op1 = impSIMDPopStack(simdType);
 
             return gtNewScalarHWIntrinsicNode(JITtype2varType(sig->retType), op1, op2, intrinsic);
 
         case HWIntrinsicInfo::SimdInsertOp:
-            if (!mustExpand && !impCheckImmediate(impStackTop(1).val, getSIMDVectorLength(simdSizeBytes, simdBaseType)))
-            {
-                // Immediate lane not constant or out of range
-                return nullptr;
-            }
             op3 = impPopStack().val;
-            op2 = impPopStack().val;
+            op2 =
+                addRangeCheckIfNeeded(impPopStack().val, getSIMDVectorLength(simdSizeBytes, simdBaseType), mustExpand);
             op1 = impSIMDPopStack(simdType);
 
             return gtNewSimdHWIntrinsicNode(simdType, op1, op2, op3, intrinsic, simdBaseType, simdSizeBytes);

--- a/src/jit/hwintrinsicArm64.cpp
+++ b/src/jit/hwintrinsicArm64.cpp
@@ -197,7 +197,7 @@ bool HWIntrinsicInfo::isScalarIsa(InstructionSet isa)
 //
 // Return Value:
 //     if necessary, add a GT_HW_INTRINSIC_CHK node which throws an ArgumentOutOfRangeException
-//     when the immOp is not in the valid range
+//     when the immOp is not in the valid range; otherwise, just return the provided immOp.
 //
 GenTree* Compiler::addRangeCheckIfNeeded(GenTree* immOp, unsigned int max, bool mustExpand)
 {

--- a/src/jit/hwintrinsiccodegenxarch.cpp
+++ b/src/jit/hwintrinsiccodegenxarch.cpp
@@ -1197,7 +1197,7 @@ void CodeGen::genHWIntrinsic_R_R_R_RM(
 //    nonConstImmReg - the register contains non-constant imm8 argument
 //    baseReg        - a register for the start of the switch table
 //    offsReg        - a register for the offset into the switch table
-//    emitSwCase     - the lambda to generate siwtch-case
+//    emitSwCase     - the lambda to generate a switch case
 //
 // Return Value:
 //    generate the jump-table fallback for imm-intrinsics with non-constant argument.

--- a/src/jit/lsraarm64.cpp
+++ b/src/jit/lsraarm64.cpp
@@ -596,6 +596,9 @@ int LinearScan::BuildNode(GenTree* tree)
 #ifdef FEATURE_SIMD
         case GT_SIMD_CHK:
 #endif // FEATURE_SIMD
+#ifdef FEATURE_HW_INTRINSICS
+        case GT_HW_INTRINSIC_CHK:
+#endif // FEATURE_HW_INTRINSICS
         {
             GenTreeBoundsChk* node = tree->AsBoundsChk();
             // Consumes arrLen & index - has no result


### PR DESCRIPTION
Add an up-front bounds check during importation instead of waiting
until codegen. Mirrors what we do for similar cases on xarch.

Closes #20260.