### PR TITLE
Fix a rare JitStress assert.

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -2154,6 +2154,11 @@ unsigned char Compiler::compGetJitDefaultFill(Compiler* comp)
         {
             temp |= 0x80;
         }
+
+        // Make a misaligned pointer value to reduce probability of getting a valid value and firing
+        // assert(!IsUninitialized(pointer)).
+        temp |= 0x1;
+
         defaultFill = (unsigned char)temp;
     }
 

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -2135,14 +2135,15 @@ void Compiler::compDoComponentUnitTestsOnce()
 //    Note that we can't use small values like zero, because we have some
 //    asserts that can fire for such values.
 //
-unsigned char Compiler::compGetJitDefaultFill()
+// static
+unsigned char Compiler::compGetJitDefaultFill(Compiler* comp)
 {
     unsigned char defaultFill = (unsigned char)JitConfig.JitDefaultFill();
 
-    if ((this != nullptr) && (compStressCompile(STRESS_GENERIC_VARN, 50)))
+    if (comp != nullptr && comp->compStressCompile(STRESS_GENERIC_VARN, 50))
     {
         unsigned temp;
-        temp = info.compMethodHash();
+        temp = comp->info.compMethodHash();
         temp = (temp >> 16) ^ temp;
         temp = (temp >> 8) ^ temp;
         temp = temp & 0xff;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -8856,8 +8856,8 @@ public:
     bool compDonotInline();
 
 #ifdef DEBUG
-    unsigned char compGetJitDefaultFill(); // Get the default fill char value
-                                           // we randomize this value when JitStress is enabled
+    // Get the default fill char value we randomize this value when JitStress is enabled.
+    static unsigned char compGetJitDefaultFill(Compiler* comp);
 
     const char* compLocalVarName(unsigned varNum, unsigned offs);
     VarName compVarName(regNumber reg, bool isFloatReg = false);

--- a/src/jit/ee_il_dll.cpp
+++ b/src/jit/ee_il_dll.cpp
@@ -270,7 +270,7 @@ void JitTls::SetCompiler(Compiler* compiler)
     reinterpret_cast<JitTls*>(GetJitTls())->m_compiler = compiler;
 }
 
-#else // defined(DEBUG)
+#else // !defined(DEBUG)
 
 JitTls::JitTls(ICorJitInfo* jitInfo)
 {

--- a/src/jit/jit.h
+++ b/src/jit/jit.h
@@ -867,7 +867,7 @@ inline T UninitializedWord(Compiler* comp)
     {
         comp = JitTls::GetCompiler();
     }
-    defaultFill = comp->compGetJitDefaultFill();
+    defaultFill = Compiler::compGetJitDefaultFill(comp);
     assert(defaultFill <= 0xff);
     __int64 word = 0x0101010101010101LL * defaultFill;
     return (T)word;


### PR DESCRIPTION
flowgraph.cpp: assert(!IsUninitialized(tree)) can fail if `UninitializedWord` returns a valid pointer value.

Make pointers unaligned to avoid this situation.

Also fix undefined C++ behavior when we check `this == nullptr`.