### PR TITLE
Fixing a couple of issues in the Utf8Parsing/Formatting code

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Float.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Float.cs
@@ -100,18 +100,24 @@ namespace System.Buffers.Text
                 utf16Text = value.ToString(new string(formatText), CultureInfo.InvariantCulture);
             }
 
-            bytesWritten = 0;
+            // Copy the value to the destination, if it's large enough.
+
+            if (utf16Text.Length > destination.Length)
+            {
+                bytesWritten = 0;
+                return false;
+            }
 
             try
             {
                 bytesWritten = Encoding.UTF8.GetBytes(utf16Text, destination);
+                return true;
             }
             catch
             {
+                bytesWritten = 0;
                 return false;
             }
-
-            return true;
         }
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Float.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Float.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Globalization;
+using System.Text;
 
 namespace System.Buffers.Text
 {
@@ -99,21 +100,17 @@ namespace System.Buffers.Text
                 utf16Text = value.ToString(new string(formatText), CultureInfo.InvariantCulture);
             }
 
-            // Copy the value to the destination, if it's large enough.
+            bytesWritten = 0;
 
-            if (utf16Text.Length > destination.Length)
+            try
             {
-                bytesWritten = 0;
+                bytesWritten = Encoding.UTF8.GetBytes(utf16Text, destination);
+            }
+            catch
+            {
                 return false;
             }
 
-            for (int i = 0; i < utf16Text.Length; i++)
-            {
-                Debug.Assert(utf16Text[i] < 128, "A culture-invariant ToString() of a floating point expected to produce ASCII characters only.");
-                destination[i] = (byte)utf16Text[i];
-            }
-
-            bytesWritten = utf16Text.Length;
             return true;
         }
     }

--- a/src/System.Private.CoreLib/shared/System/Number.NumberToFloatingPointBits.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.NumberToFloatingPointBits.cs
@@ -336,6 +336,8 @@ namespace System
             Debug.Assert(number.Scale <= FloatingPointMaxExponent);
             Debug.Assert(number.Scale >= FloatingPointMinExponent);
 
+            Debug.Assert(number.DigitsCount != 0);
+
             // The input is of the form 0.Mantissa x 10^Exponent, where 'Mantissa' are
             // the decimal digits of the mantissa and 'Exponent' is the decimal exponent.
             // We decompose the mantissa into two parts: an integer part and a fractional
@@ -362,11 +364,6 @@ namespace System
             // we can rely on it to produce the correct result when both inputs are exact.
 
             byte* src = number.GetDigitsPointer();
-
-            if (totalDigits == 0)
-            {
-                return info.ZeroBits;
-            }
 
             if ((info.DenormalMantissaBits == 23) && (totalDigits <= 7) && (fastExponent <= 10))
             {

--- a/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
@@ -1975,13 +1975,13 @@ namespace System
             number.CheckConsistency();
             double result;
 
-            if (number.Scale > DoubleMaxExponent)
-            {
-                result = double.PositiveInfinity;
-            }
-            else if (number.Scale < DoubleMinExponent)
+            if ((number.DigitsCount == 0) || (number.Scale < DoubleMinExponent))
             {
                 result = 0;
+            }
+            else if (number.Scale > DoubleMaxExponent)
+            {
+                result = double.PositiveInfinity;
             }
             else
             {
@@ -1997,13 +1997,13 @@ namespace System
             number.CheckConsistency();
             float result;
 
-            if (number.Scale > SingleMaxExponent)
-            {
-                result = float.PositiveInfinity;
-            }
-            else if (number.Scale < SingleMinExponent)
+            if ((number.DigitsCount == 0) || (number.Scale < SingleMinExponent))
             {
                 result = 0;
+            }
+            else if (number.Scale > SingleMaxExponent)
+            {
+                result = float.PositiveInfinity;
             }
             else
             {


### PR DESCRIPTION
First commit fixes an issue where the Utf8Parser would create a number buffer with `DigitCount = 0` and `Scale != 0`. We now specially handle that in `NumberToDouble/Single` rather than in `NumberToFloatingPointBits`.

The second commit ensures that the floating-point Utf8Formatter will transcode any unicode text returned. For the common case, this will just hit the ASCII fast-path loop in `UTF8Encoder.GetBytes`. For the currency case, this will hit the slow path (since the invariant currency symbol is non-ASCII). This also better allows us to support other cultures in the future, if desired.