### PR TITLE
Remove unneeded arm64 NYI

### DIFF
--- a/src/jit/register_arg_convention.cpp
+++ b/src/jit/register_arg_convention.cpp
@@ -72,10 +72,9 @@ bool InitVarDscInfo::enoughAvailRegs(var_types type, unsigned numRegs /* = 1 */)
     return regArgNum(type) + numRegs - backFillCount <= maxRegArgNum(type);
 }
 
+#ifdef _TARGET_ARM_
 unsigned InitVarDscInfo::alignReg(var_types type, unsigned requiredRegAlignment)
 {
-    NYI_ARM64("alignReg");
-
     assert(requiredRegAlignment > 0);
     if (requiredRegAlignment == 1)
     {
@@ -93,12 +92,10 @@ unsigned InitVarDscInfo::alignReg(var_types type, unsigned requiredRegAlignment)
     unsigned cAlignSkipped = requiredRegAlignment - alignMask;
     assert(cAlignSkipped == 1); // Alignment is currently only 1 or 2, so misalignment can only be 1.
 
-#ifdef _TARGET_ARM_
     if (varTypeIsFloating(type))
     {
         fltArgSkippedRegMask |= genMapFloatRegArgNumToRegMask(floatRegArgNum);
     }
-#endif // _TARGET_ARM_
 
     assert(regArgNum(type) + cAlignSkipped <= maxRegArgNum(type)); // if equal, then we aligned the last slot, and the
                                                                    // arg can't be enregistered
@@ -106,6 +103,7 @@ unsigned InitVarDscInfo::alignReg(var_types type, unsigned requiredRegAlignment)
 
     return cAlignSkipped;
 }
+#endif // _TARGET_ARM_
 
 bool InitVarDscInfo::canEnreg(var_types type, unsigned numRegs /* = 1 */)
 {

--- a/src/jit/register_arg_convention.h
+++ b/src/jit/register_arg_convention.h
@@ -71,12 +71,14 @@ public:
     // Returns the first argument register of the allocated set.
     unsigned allocRegArg(var_types type, unsigned numRegs = 1);
 
+#ifdef _TARGET_ARM_
     // We are aligning the register to an ABI-required boundary, such as putting
     // double-precision floats in even-numbered registers, by skipping one register.
     // "requiredRegAlignment" is the amount to align to: 1 for no alignment (everything
     // is 1-aligned), 2 for "double" alignment.
     // Returns the number of registers skipped.
     unsigned alignReg(var_types type, unsigned requiredRegAlignment);
+#endif // _TARGET_ARM_
 
     // Return true if it is an enregisterable type and there is room.
     // Note that for "type", we only care if it is float or not. In particular,


### PR DESCRIPTION
InitVarDscInfo::alignReg is only used by `_TARGET_ARM_`, so put
it under that ifdef.

Contributes to #18178