### PR TITLE
Eliminate SampleProfilerEventInstance

### DIFF
--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -20,7 +20,6 @@ class EventPipeBufferManager;
 class EventPipeEventSource;
 class EventPipeProvider;
 class MethodDesc;
-class SampleProfilerEventInstance;
 struct EventPipeProviderConfiguration;
 class EventPipeSession;
 

--- a/src/vm/eventpipeeventinstance.cpp
+++ b/src/vm/eventpipeeventinstance.cpp
@@ -155,10 +155,4 @@ bool EventPipeEventInstance::EnsureConsistency()
 }
 #endif // _DEBUG
 
-SampleProfilerEventInstance::SampleProfilerEventInstance(EventPipeSession &session, EventPipeEvent &event, Thread *pThread, BYTE *pData, unsigned int length)
-    :EventPipeEventInstance(session, event, pThread->GetOSThreadId(), pData, length, NULL /* pActivityId */, NULL /* pRelatedActivityId */)
-{
-    LIMITED_METHOD_CONTRACT;
-}
-
 #endif // FEATURE_PERFTRACING

--- a/src/vm/eventpipeeventinstance.h
+++ b/src/vm/eventpipeeventinstance.h
@@ -138,17 +138,6 @@ private:
     void SetTimeStamp(LARGE_INTEGER timeStamp);
 };
 
-// A specific type of event instance for use by the SampleProfiler.
-// This is needed because the SampleProfiler knows how to walk stacks belonging
-// to threads other than the current thread.
-class SampleProfilerEventInstance : public EventPipeEventInstance
-{
-
-public:
-
-    SampleProfilerEventInstance(EventPipeSession &session, EventPipeEvent &event, Thread *pThread, BYTE *pData, unsigned int length);
-};
-
 #endif // FEATURE_PERFTRACING
 
 #endif // __EVENTPIPE_EVENTINSTANCE_H__

--- a/src/vm/sampleprofiler.h
+++ b/src/vm/sampleprofiler.h
@@ -22,7 +22,6 @@ class SampleProfiler
 
     // Declare friends.
     friend class EventPipe;
-    friend class SampleProfilerEventInstance;
 
     public:
 


### PR DESCRIPTION
Feel like obsolete code to me - the constructor is never used anywhere.