### PR TITLE
Move Buffer to shared

### DIFF
--- a/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -122,7 +122,7 @@
     <Compile Include="$(BclSourcesRoot)\System\Array.CoreCLR.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Attribute.CoreCLR.cs" />
     <Compile Include="$(BclSourcesRoot)\System\BadImageFormatException.CoreCLR.cs" />
-    <Compile Include="$(BclSourcesRoot)\System\Buffer.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Buffer.CoreCLR.cs" />
     <Compile Include="$(BclSourcesRoot)\System\CLRConfig.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Collections\EmptyReadOnlyDictionaryInternal.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Collections\Generic\ArraySortHelper.CoreCLR.cs" />

--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -54,6 +54,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\BadImageFormatException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\BitConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Boolean.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Buffer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\ArrayPool.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\ArrayPoolEventSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\ConfigurableArrayPool.cs" />

--- a/src/System.Private.CoreLib/shared/System/Buffer.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffer.cs
@@ -23,30 +23,8 @@ using nuint = System.UInt32;
 
 namespace System
 {
-    public static class Buffer
+    public static partial class Buffer
     {
-        // Copies from one primitive array to another primitive array without
-        // respecting types.  This calls memmove internally.  The count and 
-        // offset parameters here are in bytes.  If you want to use traditional
-        // array element indices and counts, use Array.Copy.
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        public static extern void BlockCopy(Array src, int srcOffset,
-            Array dst, int dstOffset, int count);
-
-        // Returns a bool to indicate if the array is of primitive data types
-        // or not.
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern bool IsPrimitiveTypeArray(Array array);
-
-        // Gets the length of the array in bytes.  The array must be an
-        // array of primitives.
-        //
-        // This essentially does the following:
-        // return array.length * sizeof(array.UnderlyingElementType).
-        //
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern int _ByteLength(Array array);
-
         public static int ByteLength(Array array)
         {
             // Is the array present?
@@ -160,24 +138,6 @@ namespace System
                 Memcpy(pDest + destIndex, pSrc + srcIndex, len);
             }
         }
-
-        // This method has a slightly different behavior on arm and other platforms.
-        // On arm this method behaves like memcpy and does not handle overlapping buffers.
-        // While on other platforms it behaves like memmove and handles overlapping buffers.
-        // This behavioral difference is unfortunate but intentional because
-        // 1. This method is given access to other internal dlls and this close to release we do not want to change it.
-        // 2. It is difficult to get this right for arm and again due to release dates we would like to visit it later.
-#if ARM
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern unsafe void Memcpy(byte* dest, byte* src, int len);
-#else // ARM
-        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
-        internal static unsafe void Memcpy(byte* dest, byte* src, int len)
-        {
-            Debug.Assert(len >= 0, "Negative length in memcpy!");
-            Memmove(dest, src, (nuint)len);
-        }
-#endif // ARM
 
         // This method has different signature for x64 and other platforms and is done for performance reasons.
         internal static unsafe void Memmove(byte* dest, byte* src, nuint len)
@@ -614,9 +574,6 @@ namespace System
             fixed (byte* pSrc = &src)
                 __Memmove(pDest, pSrc, len);
         }
-
-        [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
-        private static extern unsafe void __Memmove(byte* dest, byte* src, nuint len);
 
 #if HAS_CUSTOM_BLOCKS
         [StructLayout(LayoutKind.Sequential, Size = 16)]

--- a/src/System.Private.CoreLib/src/System/Buffer.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Buffer.CoreCLR.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#if BIT64
+using nuint = System.UInt64;
+#else
+using nuint = System.UInt32;
+#endif
+
+namespace System
+{
+    partial class Buffer
+    {
+        // Copies from one primitive array to another primitive array without
+        // respecting types.  This calls memmove internally.  The count and 
+        // offset parameters here are in bytes.  If you want to use traditional
+        // array element indices and counts, use Array.Copy.
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        public static extern void BlockCopy(Array src, int srcOffset,
+            Array dst, int dstOffset, int count);
+
+        // Returns a bool to indicate if the array is of primitive data types
+        // or not.
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        private static extern bool IsPrimitiveTypeArray(Array array);
+
+        // Gets the length of the array in bytes.  The array must be an
+        // array of primitives.
+        //
+        // This essentially does the following:
+        // return array.length * sizeof(array.UnderlyingElementType).
+        //
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        private static extern int _ByteLength(Array array);
+
+        // This method has a slightly different behavior on arm and other platforms.
+        // On arm this method behaves like memcpy and does not handle overlapping buffers.
+        // While on other platforms it behaves like memmove and handles overlapping buffers.
+        // This behavioral difference is unfortunate but intentional because
+        // 1. This method is given access to other internal dlls and this close to release we do not want to change it.
+        // 2. It is difficult to get this right for arm and again due to release dates we would like to visit it later.
+#if ARM
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        internal static extern unsafe void Memcpy(byte* dest, byte* src, int len);
+#else // ARM
+        [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
+        internal static unsafe void Memcpy(byte* dest, byte* src, int len)
+        {
+            Debug.Assert(len >= 0, "Negative length in memcpy!");
+            Memmove(dest, src, (nuint)len);
+        }
+#endif // ARM
+
+        [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
+        private static extern unsafe void __Memmove(byte* dest, byte* src, nuint len);
+    }
+}


### PR DESCRIPTION
Tested on CoreRT with [Buffer.CoreRT.cs](https://gist.github.com/EgorBo/ec9b68373f02f636c6c1212fba72bbbe) locally:
1) `IsPrimitiveTypeArray` is implemented as `return array.ElementEEType.IsPrimitive`
2) `_ByteLength`, `BlockCopy` and `Memcpy` are not modified 
3) `__Memmove` is implemented as `RuntimeImports.memmove(dest, src, len);`

PS: also, tested on mono
cc @marek-safar 