### PR TITLE
Fix bad test

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -71,9 +71,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/threading/waithandle/waitany/waitanyex2a/*">
             <Issue>19406</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/regressions/429802/CMain/*">
-            <Issue>23096</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- All Unix targets -->

--- a/tests/src/Loader/classloader/regressions/429802/CMain.il
+++ b/tests/src/Loader/classloader/regressions/429802/CMain.il
@@ -82,16 +82,16 @@
     IL_002d:  call       void [mscorlib_1]System.Console::WriteLine(string)
     IL_0032:  ldc.i4.0
     IL_0033:  stloc.0
-    IL_0034:  ldc.i4.1
-    IL_0035:  ldloc.2
-    IL_0036:  call       instance int32 [MyBar]MyBar::DoBar()
-    IL_003b:  beq.s      IL_0049
+    IL_0034:
 
-    IL_003d:  ldstr      "FAIL: expected MyBar.DoSelfBar to execute, but ano"
-    + "ther method was executed instead."
-    IL_0042:  call       void [mscorlib_1]System.Console::WriteLine(string)
-    IL_0047:  ldc.i4.0
-    IL_0048:  stloc.0
+
+
+
+
+
+
+
+
     IL_0049:  ldloc.0
     IL_004a:  brtrue.s   IL_005b
 


### PR DESCRIPTION
The test was testing that a non-virtual call to an abstract method that is methodimpl on the same type will land in the methodimpl. This behavior is not specced and cannot be hit with any mainstream .NET languages. We are making non-virtual calls to abstract methods throw a BadImageFormatException instead.

Fixes #23096.