### PR TITLE
Extend WindowsEventLog test for EntryPointFilter

### DIFF
--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -269,6 +269,8 @@ CONFIG_DWORD_INFO_DIRECT_ACCESS(INTERNAL_AssertOnFailFast, W("AssertOnFailFast")
 RETAIL_CONFIG_DWORD_INFO_EX(UNSUPPORTED_legacyCorruptedStateExceptionsPolicy, W("legacyCorruptedStateExceptionsPolicy"), 0, "Enabled Pre-V4 CSE behavior", CLRConfig::FavorConfigFile)
 CONFIG_DWORD_INFO_EX(INTERNAL_SuppressLostExceptionTypeAssert, W("SuppressLostExceptionTypeAssert"), 0, "", CLRConfig::REGUTIL_default)
 RETAIL_CONFIG_DWORD_INFO_EX(UNSUPPORTED_FailFastOnCorruptedStateException, W("FailFastOnCorruptedStateException"), 0, "Failfast if a CSE is encountered", CLRConfig::FavorConfigFile)
+RETAIL_CONFIG_DWORD_INFO_EX(INTERNAL_UseEntryPointFilter, W("UseEntryPointFilter"), 0, "", CLRConfig::REGUTIL_default)
+RETAIL_CONFIG_DWORD_INFO_EX(INTERNAL_Corhost_Swallow_Uncaught_Exceptions, W("Corhost_Swallow_Uncaught_Exceptions"), 0, "", CLRConfig::REGUTIL_default)
 
 ///
 /// Garbage collector

--- a/src/vm/corhost.cpp
+++ b/src/vm/corhost.cpp
@@ -460,10 +460,23 @@ HRESULT CorHost2::ExecuteAssembly(DWORD dwAppDomainId,
             arguments->SetAt(i, argument);
         }
 
-        DWORD retval = pAssembly->ExecuteMainMethod(&arguments, TRUE /* waitForOtherThreads */);
-        if (pReturnValue)
+        if(CLRConfig::GetConfigValue(CLRConfig::INTERNAL_Corhost_Swallow_Uncaught_Exceptions))
         {
-            *pReturnValue = retval;
+            EX_TRY
+                DWORD retval = pAssembly->ExecuteMainMethod(&arguments, TRUE /* waitForOtherThreads */);
+                if (pReturnValue)
+                {
+                    *pReturnValue = retval;
+                }
+            EX_CATCH_HRESULT (hr)
+        }
+        else
+        {
+            DWORD retval = pAssembly->ExecuteMainMethod(&arguments, TRUE /* waitForOtherThreads */);
+            if (pReturnValue)
+            {
+                *pReturnValue = retval;
+            }
         }
 
         GCPROTECT_END();

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -5140,21 +5140,28 @@ LONG InternalUnhandledExceptionFilter(
 } // LONG InternalUnhandledExceptionFilter()
 
 
-#ifdef PLATFORM_WINDOWS
-static bool s_useEntryPointFilter = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_UseEntryPointFilter) != 0;
-#else
-static bool s_useEntryPointFilter = false;
-#endif
+// Represent the value of USE_ENTRYPOINT_FILTER as passed in the property bag to the host during construction
+static bool s_useEntryPointFilterCorhostProperty = false;
 
 void ParseUseEntryPointFilter(LPCWSTR value)
 {
-#ifdef PLATFORM_WINDOWS // This feature has only been tested on Windows, keep it disabled on other platforms
     // set s_useEntryPointFilter true if value != "0"
     if (value && (_wcsicmp(value, W("0")) != 0))
     {
-        s_useEntryPointFilter = true;
+        s_useEntryPointFilterCorhostProperty = true;
     }
+}
+
+bool GetUseEntryPointFilter()
+{
+#ifdef PLATFORM_WINDOWS // This feature has only been tested on Windows, keep it disabled on other platforms
+    static bool s_useEntryPointFilterEnv = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_UseEntryPointFilter) != 0;
+
+    return s_useEntryPointFilterCorhostProperty || s_useEntryPointFilterEnv;
+#else
+    return false;
 #endif
+
 }
 
 // This filter is used to trigger unhandled exception processing for the entrypoint thread
@@ -5177,7 +5184,7 @@ LONG EntryPointFilter(PEXCEPTION_POINTERS pExceptionInfo, PVOID _pData)
         return ret;
     }
 
-    if (!s_useEntryPointFilter)
+    if (!GetUseEntryPointFilter())
     {
         return EXCEPTION_CONTINUE_SEARCH;
     }

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -5139,7 +5139,12 @@ LONG InternalUnhandledExceptionFilter(
 
 } // LONG InternalUnhandledExceptionFilter()
 
+
+#ifdef PLATFORM_WINDOWS
+static bool s_useEntryPointFilter = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_UseEntryPointFilter) != 0;
+#else
 static bool s_useEntryPointFilter = false;
+#endif
 
 void ParseUseEntryPointFilter(LPCWSTR value)
 {


### PR DESCRIPTION
Verify EntryPointFilter solves logging problem with native host swallowing exceptions

WindowsEventLog only look at new entries
WindowsEventLog remove time check

Add mechanism to corhost to emulate host swallowing all exceptions