### PR TITLE
Remove fixed sign tool version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -22,9 +22,4 @@
     <optimizationIBCCoreCLRPackage>optimization.IBC.CoreCLR</optimizationIBCCoreCLRPackage>
     <optimizationPGOCoreCLRPackage>optimization.PGO.CoreCLR</optimizationPGOCoreCLRPackage>
   </PropertyGroup>
-  <PropertyGroup>
-    <!-- Override signing package version. Current version breaks signing SPC, remove
-         this property group once SignTool supports the scenario. -->
-    <MicrosoftDotNetSignToolVersion>1.0.0-beta.19067.6</MicrosoftDotNetSignToolVersion>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes #23081 

Tested with SignTool version `1.0.0-beta.19159.2` as test signed in https://dev.azure.com/dnceng/internal/_build/results?buildId=120800 and signing step succeeded. Manually downloaded the ARM binaries to verify that SPC is crossgened and signed with a proper Microsoft issued SHA256 cert.

cc: @RussKeldorph @jashook 

