### PR TITLE
Fix DisableTier0Jit when multi-core JIT is enabled

### DIFF
--- a/src/vm/callcounter.h
+++ b/src/vm/callcounter.h
@@ -24,6 +24,8 @@ struct CallCounterEntry
     int tier0CallCountLimit;
 
 #if !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
+    static CallCounterEntry CreateWithTier0CallCountingDisabled(const MethodDesc *m);
+
     bool IsTier0CallCountingEnabled() const
     {
         LIMITED_METHOD_CONTRACT;


### PR DESCRIPTION
- With multi-core JIT, a method may be jitted before it is called, in which case the call counting entry would not already exist