### PR TITLE
Don't retain modifiers for instantation stub signatures

### DIFF
--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -1234,7 +1234,7 @@ void CreateInstantiatingILStubTargetSig(MethodDesc *pBaseMD,
 
     // Return type
     SigPointer pReturn = msig.GetReturnProps();
-    pReturn.ConvertToInternalExactlyOne(msig.GetModule(), &typeContext, stubSigBuilder, FALSE);
+    pReturn.ConvertToInternalExactlyOne(msig.GetModule(), &typeContext, stubSigBuilder);
 
 #ifndef _TARGET_X86_
     // The hidden context parameter

--- a/src/vm/siginfo.cpp
+++ b/src/vm/siginfo.cpp
@@ -321,6 +321,7 @@ void SigPointer::ConvertToInternalExactlyOne(Module* pSigModule, SigTypeContext 
                     mdToken tk;
                     IfFailThrowBF(GetToken(&tk), BFA_BAD_COMPLUS_SIG, pSigModule);
                     TypeHandle th = ClassLoader::LoadTypeDefOrRefThrowing(pSigModule, tk);                    
+                    pSigBuilder->AppendElementType(ELEMENT_TYPE_INTERNAL);
                     pSigBuilder->AppendPointer(th.AsPtr());
                     
                     ConvertToInternalExactlyOne(pSigModule, pTypeContext, pSigBuilder, bSkipCustomModifier);


### PR DESCRIPTION
`ConvToJitSig` is not expecting to see modifiers for return types in sigs,
so don't bother preserving them when creating instantiation stubs.

This comes up for instantiation stubs for methods of `ReadOnlySpan<T>`.

Also, if we are preserving modifiers in a sig, make sure to prefix their type
handles with `ELEM_TYPE_INTERNAL`.

Fixes #23136.