### PR TITLE
Miscellaneous R2RDump improvements

### DIFF
--- a/src/tools/r2rdump/DisassemblingTypeProvider.cs
+++ b/src/tools/r2rdump/DisassemblingTypeProvider.cs
@@ -34,51 +34,17 @@ namespace R2RDump
 
         public virtual string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind = 0)
         {
-            TypeDefinition definition = reader.GetTypeDefinition(handle);
-
-            string name = definition.Namespace.IsNil
-                ? reader.GetString(definition.Name)
-                : reader.GetString(definition.Namespace) + "." + reader.GetString(definition.Name);
-
-            if ((definition.Attributes & TypeAttributes.NestedPublic) != 0 || (definition.Attributes & TypeAttributes.NestedFamily) != 0)
-            {
-                TypeDefinitionHandle declaringTypeHandle = definition.GetDeclaringType();
-                return GetTypeFromDefinition(reader, declaringTypeHandle, 0) + "." + name;
-            }
-
-            return name;
+            return MetadataNameFormatter.FormatHandle(reader, handle);
         }
 
         public virtual string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind = 0)
         {
-            TypeReference reference = reader.GetTypeReference(handle);
-            Handle scope = reference.ResolutionScope;
-
-            string name = reference.Namespace.IsNil
-                ? reader.GetString(reference.Name)
-                : reader.GetString(reference.Namespace) + "." + reader.GetString(reference.Name);
-
-            switch (scope.Kind)
-            {
-                case HandleKind.ModuleReference:
-                    return "[.module  " + reader.GetString(reader.GetModuleReference((ModuleReferenceHandle)scope).Name) + "]" + name;
-
-                case HandleKind.AssemblyReference:
-                    var assemblyReferenceHandle = (AssemblyReferenceHandle)scope;
-                    var assemblyReference = reader.GetAssemblyReference(assemblyReferenceHandle);
-                    return "[" + reader.GetString(assemblyReference.Name) + "]" + name;
-
-                case HandleKind.TypeReference:
-                    return GetTypeFromReference(reader, (TypeReferenceHandle)scope) + "+" + name;
-
-                default:
-                    return name;
-            }
+            return MetadataNameFormatter.FormatHandle(reader, handle);
         }
 
         public virtual string GetTypeFromSpecification(MetadataReader reader, DisassemblingGenericContext genericContext, TypeSpecificationHandle handle, byte rawTypeKind = 0)
         {
-            return reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+            return MetadataNameFormatter.FormatHandle(reader, handle);
         }
 
         public virtual string GetSZArrayType(string elementType)
@@ -161,20 +127,7 @@ namespace R2RDump
 
         public virtual string GetTypeFromHandle(MetadataReader reader, DisassemblingGenericContext genericContext, EntityHandle handle)
         {
-            switch (handle.Kind)
-            {
-                case HandleKind.TypeDefinition:
-                    return GetTypeFromDefinition(reader, (TypeDefinitionHandle)handle);
-
-                case HandleKind.TypeReference:
-                    return GetTypeFromReference(reader, (TypeReferenceHandle)handle);
-
-                case HandleKind.TypeSpecification:
-                    return GetTypeFromSpecification(reader, genericContext, (TypeSpecificationHandle)handle);
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(handle));
-            }
+            return MetadataNameFormatter.FormatHandle(reader, handle);
         }
 
         public virtual string GetModifiedType(string modifierType, string unmodifiedType, bool isRequired)

--- a/src/tools/r2rdump/R2RDump.cs
+++ b/src/tools/r2rdump/R2RDump.cs
@@ -449,7 +449,7 @@ namespace R2RDump
                 foreach (string filename in _inputFilenames)
                 {
                     // parse the ReadyToRun image
-                    R2RReader r2r = new R2RReader(filename);
+                    R2RReader r2r = new R2RReader(_options, filename);
 
                     if (_options.Disasm)
                     {

--- a/src/tools/r2rdump/R2RReader.cs
+++ b/src/tools/r2rdump/R2RReader.cs
@@ -78,6 +78,11 @@ namespace R2RDump
     public class R2RReader
     {
         /// <summary>
+        /// Option are used to specify details of signature formatting.
+        /// </summary>
+        public readonly DumpOptions Options;
+
+        /// <summary>
         /// Underlying PE image reader is used to access raw PE structures like header
         /// or section list.
         /// </summary>
@@ -178,8 +183,9 @@ namespace R2RDump
         /// </summary>
         /// <param name="filename">PE image</param>
         /// <exception cref="BadImageFormatException">The Cor header flag must be ILLibrary</exception>
-        public unsafe R2RReader(string filename)
+        public unsafe R2RReader(DumpOptions options, string filename)
         {
+            Options = options;
             Filename = filename;
             Image = File.ReadAllBytes(filename);
 
@@ -370,7 +376,7 @@ namespace R2RDump
             NativeParser curParser = allEntriesEnum.GetNext();
             while (!curParser.IsNull())
             {
-                SignatureDecoder decoder = new SignatureDecoder(this, (int)curParser.Offset);
+                SignatureDecoder decoder = new SignatureDecoder(Options, this, (int)curParser.Offset);
 
                 string owningType = null;
 
@@ -634,7 +640,7 @@ namespace R2RDump
                     long section = NativeReader.ReadInt64(Image, ref sectionOffset);
                     uint sigRva = NativeReader.ReadUInt32(Image, ref signatureOffset);
                     int sigOffset = GetOffset((int)sigRva);
-                    string cellName = MetadataNameFormatter.FormatSignature(this, sigOffset);
+                    string cellName = MetadataNameFormatter.FormatSignature(Options, this, sigOffset);
                     entries.Add(new R2RImportSection.ImportSectionEntry(entries.Count, entryOffset, entryOffset + rva, section, sigRva, cellName));
                     ImportCellNames.Add(rva + entrySize * i, cellName);
                 }


### PR DESCRIPTION
1) In Naked mode, hide the distinction amongst METHOD_ENTRY vs.
METHOD_ENTRY_REF_TOKEN vs. METHOD_ENTRY_DEF_TOKEN as it's not
important for correctness and causes undesirable churn in diffs.
This required propagating the DumpOptions around in a couple
of places.

2) For historical reasons, the DisassemblingTypeProvider had
its own implementations of metadata formatting that is now provided
by MetadataNameFormatter. I have removed at least a part of this
duplication in this change. [It was causing undesirable diffs as
one version used to output type owner assemblies whereas the other
did not.]

Thanks

Tomas