### PR TITLE
Enable function unwind data splitting stress

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -8446,6 +8446,7 @@ public:
         STRESS_MODE(PINVOKE_RESTORE_ESP)                                                        \
         STRESS_MODE(RANDOM_INLINE)                                                              \
         STRESS_MODE(SWITCH_CMP_BR_EXPANSION)                                                    \
+        STRESS_MODE(UNWIND)                                                                     \
         STRESS_MODE(GENERIC_VARN)                                                               \
                                                                                                 \
         /* After COUNT_VARN, stress level 2 does all of these all the time */                   \

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -2475,6 +2475,15 @@ void emitter::emitSplit(emitLocation*         startLoc,
         {
             // We can't update the candidate
         }
+        else if (ig->igFlags & IGF_EMIT_ADD)
+        {
+            // We can't split on emit add (overflow) groups: IGs are allocated using a fixed allocation size on the
+            // host, and filled with as many instrDescs as will fit. However, these instrDescs contain host
+            // architecture pointers, so in a cross-bitness scenario, the number of instrDescs in an IG will
+            // differ between the cross and native crossgen generation. This breaks our testing that checks
+            // for bit equality between the cross-bitness and native generated code. So, only split on
+            // non-emitAdd labels, those which have program semantic meaning, like jump labels.
+        }
         else
         {
             igLastCandidate = ig;

--- a/src/jit/emitpub.h
+++ b/src/jit/emitpub.h
@@ -143,6 +143,7 @@ bool emitIsFuncEnd(emitLocation* emitLoc, emitLocation* emitLocNextFragment = NU
 
 void emitSplit(emitLocation*         startLoc,
                emitLocation*         endLoc,
+               UNATIVE_OFFSET        requestedSplitSize,
                UNATIVE_OFFSET        maxSplitSize,
                void*                 context,
                emitSplitCallbackType callbackFunc);

--- a/src/jit/unwindarm.cpp
+++ b/src/jit/unwindarm.cpp
@@ -1829,7 +1829,7 @@ void UnwindInfo::HotColdSplitCodes(UnwindInfo* puwi)
 // expand!) during issuing (although this is extremely rare in any case, and may not
 // actually occur on ARM), so we don't finalize actual sizes or offsets.
 //
-// ARM64 has very similar limitations, except functions can be up to 1MB. TODO-ARM64-Bug?: make sure this works!
+// ARM64 has very similar limitations, except functions can be up to 1MB.
 //
 // We don't split any prolog or epilog. Ideally, we might not split an instruction,
 // although that doesn't matter because the unwind at any point would still be
@@ -1844,6 +1844,15 @@ void UnwindInfo::Split()
 #ifdef DEBUG
     // Consider COMPlus_JitSplitFunctionSize
     unsigned splitFunctionSize = (unsigned)JitConfig.JitSplitFunctionSize();
+    if (uwiComp->compStressCompile(Compiler::STRESS_UNWIND, 10))
+    {
+        // Stress splitting functions. The size to split here is arbitrarily chosen to
+        // kick in frequently, but not maximally.
+        splitFunctionSize = 75;
+    }
+
+    // TESTING ONLY: force splitting all the time
+    splitFunctionSize = 75;
 
     if (splitFunctionSize != 0)
         if (splitFunctionSize < maxFragmentSize)

--- a/src/jit/unwindarm.cpp
+++ b/src/jit/unwindarm.cpp
@@ -1852,7 +1852,7 @@ void UnwindInfo::Split()
     }
 
     // TESTING ONLY: force splitting all the time
-    splitFunctionSize = 75;
+    splitFunctionSize = 10;
 
     if (splitFunctionSize != 0)
         if (splitFunctionSize < maxFragmentSize)
@@ -1930,8 +1930,8 @@ void UnwindInfo::Split()
 #endif // DEBUG
 
     // Call the emitter to do the split, and call us back for every split point it chooses.
-    uwiComp->genEmitter->emitSplit(uwiFragmentLast->ufiEmitLoc, uwiEndLoc, maxFragmentSize, (void*)this,
-                                   EmitSplitCallback);
+    uwiComp->genEmitter->emitSplit(uwiFragmentLast->ufiEmitLoc, uwiEndLoc, maxFragmentSize, UW_MAX_FRAGMENT_SIZE_BYTES,
+                                   (void*)this, EmitSplitCallback);
 
 #ifdef DEBUG
     // Did the emitter split the function/funclet into as many fragments as we asked for?


### PR DESCRIPTION
This applies to arm32 and arm64.

Add new stress mode STRESS_UNWIND. Under this switch, force creating
multiple unwind fragments. This is most interesting in conjunction
with GCStress, which does more stack walks.

Fixes #22169 