### PR TITLE
Improve LclVar sorting throughput

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -621,8 +621,6 @@ regMaskTP Compiler::compHelperCallKillSet(CorInfoHelpFunc helper)
 template <bool ForCodeGen>
 void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
 {
-    LclVarDsc* varDsc;
-
 #ifdef DEBUG
     if (verbose)
     {
@@ -668,10 +666,10 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
     unsigned        deadVarIndex = 0;
     while (deadIter.NextElem(&deadVarIndex))
     {
-        unsigned varNum = lvaTrackedToVarNum[deadVarIndex];
-        varDsc          = lvaTable + varNum;
-        bool isGCRef    = (varDsc->TypeGet() == TYP_REF);
-        bool isByRef    = (varDsc->TypeGet() == TYP_BYREF);
+        unsigned   varNum  = lvaTrackedIndexToLclNum(deadVarIndex);
+        LclVarDsc* varDsc  = lvaGetDesc(varNum);
+        bool       isGCRef = (varDsc->TypeGet() == TYP_REF);
+        bool       isByRef = (varDsc->TypeGet() == TYP_BYREF);
 
         if (varDsc->lvIsInReg())
         {
@@ -704,10 +702,10 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
     unsigned        bornVarIndex = 0;
     while (bornIter.NextElem(&bornVarIndex))
     {
-        unsigned varNum = lvaTrackedToVarNum[bornVarIndex];
-        varDsc          = lvaTable + varNum;
-        bool isGCRef    = (varDsc->TypeGet() == TYP_REF);
-        bool isByRef    = (varDsc->TypeGet() == TYP_BYREF);
+        unsigned   varNum  = lvaTrackedIndexToLclNum(bornVarIndex);
+        LclVarDsc* varDsc  = lvaGetDesc(varNum);
+        bool       isGCRef = (varDsc->TypeGet() == TYP_REF);
+        bool       isByRef = (varDsc->TypeGet() == TYP_BYREF);
 
         if (varDsc->lvIsInReg())
         {
@@ -12183,7 +12181,7 @@ void CodeGenInterface::VariableLiveKeeper::siStartOrCloseVariableLiveRanges(VARS
         unsigned        varIndex = 0;
         while (iter.NextElem(&varIndex))
         {
-            unsigned int     varNum = m_Compiler->lvaTrackedToVarNum[varIndex];
+            unsigned int     varNum = m_Compiler->lvaTrackedIndexToLclNum(varIndex);
             const LclVarDsc* varDsc = m_Compiler->lvaGetDesc(varNum);
             siStartOrCloseVariableLiveRange(varDsc, varNum, isBorn, isDying);
         }
@@ -12312,7 +12310,7 @@ void CodeGenInterface::VariableLiveKeeper::siEndAllVariableLiveRange(VARSET_VALA
             unsigned        varIndex = 0;
             while (iter.NextElem(&varIndex))
             {
-                unsigned int varNum = m_Compiler->lvaTrackedToVarNum[varIndex];
+                unsigned int varNum = m_Compiler->lvaTrackedIndexToLclNum(varIndex);
                 siEndVariableLiveRange(varNum);
             }
         }

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -224,8 +224,7 @@ void CodeGen::genCodeForBBlist()
         unsigned        varIndex = 0;
         while (iter.NextElem(&varIndex))
         {
-            unsigned   varNum = compiler->lvaTrackedToVarNum[varIndex];
-            LclVarDsc* varDsc = &(compiler->lvaTable[varNum]);
+            LclVarDsc* varDsc = compiler->lvaGetDescByTrackedIndex(varIndex);
 
             if (varDsc->lvIsInReg())
             {
@@ -563,8 +562,7 @@ void CodeGen::genCodeForBBlist()
         bool            foundMismatchedRegVar = false;
         while (mismatchLiveVarIter.NextElem(&mismatchLiveVarIndex))
         {
-            unsigned   varNum = compiler->lvaTrackedToVarNum[mismatchLiveVarIndex];
-            LclVarDsc* varDsc = compiler->lvaTable + varNum;
+            LclVarDsc* varDsc = compiler->lvaGetDescByTrackedIndex(mismatchLiveVarIndex);
             if (varDsc->lvIsRegCandidate())
             {
                 if (!foundMismatchedRegVar)
@@ -572,7 +570,7 @@ void CodeGen::genCodeForBBlist()
                     JITDUMP("Mismatched live reg vars after BB%02u:", block->bbNum);
                     foundMismatchedRegVar = true;
                 }
-                JITDUMP(" V%02u", varNum);
+                JITDUMP(" V%02u", compiler->lvaTrackedIndexToLclNum(mismatchLiveVarIndex));
             }
         }
         if (foundMismatchedRegVar)

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -8086,8 +8086,7 @@ void dumpConvertedVarSet(Compiler* comp, VARSET_VALARG_TP vars)
     unsigned        varIndex = 0;
     while (iter.NextElem(&varIndex))
     {
-        unsigned varNum = comp->lvaTrackedToVarNum[varIndex];
-        assert(varNum < comp->lvaCount);
+        unsigned varNum    = comp->lvaTrackedIndexToLclNum(varIndex);
         pVarNumSet[varNum] = 1; // This varNum is in the set
     }
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -6866,7 +6866,7 @@ private:
     LinearScanInterface* m_pLinearScan; // Linear Scan allocator
 
     /* raIsVarargsStackArg is called by raMaskStkVars and by
-       lvaSortByRefCount.  It identifies the special case
+       lvaComputeRefCounts.  It identifies the special case
        where a varargs function has a parameter passed on the
        stack, other than the special varargs handle.  Such parameters
        require special treatment, because they cannot be tracked

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2942,7 +2942,7 @@ public:
 
     LclVarDsc** lvaRefSorted; // table sorted by refcount
 
-    unsigned short lvaTrackedCount;       // actual # of locals being tracked
+    unsigned lvaTrackedCount;             // actual # of locals being tracked
     unsigned lvaTrackedCountInSizeTUnits; // min # of size_t's sufficient to hold a bit for all the locals being tracked
 
 #ifdef DEBUG
@@ -3173,6 +3173,19 @@ public:
     {
         assert(lclVar->GetLclNum() < lvaCount);
         return &lvaTable[lclVar->GetLclNum()];
+    }
+
+    unsigned lvaTrackedIndexToLclNum(unsigned trackedIndex)
+    {
+        assert(trackedIndex < lvaTrackedCount);
+        unsigned lclNum = lvaTrackedToVarNum[trackedIndex];
+        assert(lclNum < lvaCount);
+        return lclNum;
+    }
+
+    LclVarDsc* lvaGetDescByTrackedIndex(unsigned trackedIndex)
+    {
+        return lvaGetDesc(lvaTrackedIndexToLclNum(trackedIndex));
     }
 
     unsigned lvaLclSize(unsigned varNum);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2937,8 +2937,6 @@ public:
     LclVarDsc* lvaTable;    // variable descriptor table
     unsigned   lvaTableCnt; // lvaTable size (>= lvaCount)
 
-    LclVarDsc** lvaRefSorted; // table sorted by refcount
-
     unsigned lvaTrackedCount;             // actual # of locals being tracked
     unsigned lvaTrackedCountInSizeTUnits; // min # of size_t's sufficient to hold a bit for all the locals being tracked
 
@@ -2960,6 +2958,7 @@ public:
     }
 
     // reverse map of tracked number to var number
+    unsigned  lvaTrackedToVarNumSize;
     unsigned* lvaTrackedToVarNum;
 
 #if DOUBLE_ALIGN
@@ -3194,9 +3193,7 @@ public:
     unsigned lvaGrabTemps(unsigned cnt DEBUGARG(const char* reason));
     unsigned lvaGrabTempWithImplicitUse(bool shortLifetime DEBUGARG(const char* reason));
 
-    void lvaSortOnly();
     void lvaSortByRefCount();
-    void lvaDumpRefCounts();
 
     void lvaMarkLocalVars(); // Local variable ref-counting
     void lvaComputeRefCounts(bool isRecompute, bool setSlotNumbers);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2910,9 +2910,6 @@ public:
                                     //   but its field locals depend on its parent struct local.
     };
 
-    static int __cdecl RefCntCmp(const void* op1, const void* op2);
-    static int __cdecl WtdRefCntCmp(const void* op1, const void* op2);
-
     /*****************************************************************************/
 
     enum FrameLayoutState

--- a/src/jit/jitstd/algorithm.h
+++ b/src/jit/jitstd/algorithm.h
@@ -46,4 +46,191 @@ Function for_each(InputIterator first, InputIterator last, Function func)
     return func;
 }
 
+namespace
+{
+template <typename RandomAccessIterator, typename Less>
+void insertion_sort(RandomAccessIterator first, RandomAccessIterator last, Less less)
+{
+    for (; first < last; first++)
+    {
+        RandomAccessIterator min = first;
+
+        for (RandomAccessIterator i = min + 1; i <= last; i++)
+        {
+            if (less(*i, *min))
+            {
+                min = i;
+            }
+        }
+
+        if (min != first)
+        {
+            swap(*min, *first);
+        }
+    }
+}
+
+template <typename RandomAccessIterator, typename Less>
+void quick_sort(RandomAccessIterator first, RandomAccessIterator last, Less less)
+{
+    // Avoid real recursion as it can be slower, at least due to the extra "less"
+    // parameter that needs to be passed around. It's also likely to need more
+    // stack space. Use manual tail recursion for one partition and push the other
+    // partition on a stack. Assuming a proper implementation (sorting the smaller
+    // partition using tail recursion and push the larger partition) then the
+    // maximum stack depth should not exceed log2(n). So a depth of 32 should be
+    // more than enough to sort INT32_MAX elements which is then far more than the
+    // JIT should ever need.
+    RandomAccessIterator firstStack[32];
+    RandomAccessIterator lastStack[32];
+    size_t depth = 0;
+
+    for (;;)
+    {
+        size_t count = (last - first) + 1;
+
+        // Switch to insertion sort if we have only a few elements to sort.
+        if (count <= 8)
+        {
+            insertion_sort(first, last, less);
+
+            if (depth == 0)
+            {
+                // If there's nothing left on the stack then we're done.
+                break;
+            }
+
+            depth--;
+            first = firstStack[depth];
+            last = lastStack[depth];
+            continue;
+        }
+
+        RandomAccessIterator pivot = first + count / 2;
+
+        // The usual median of 3 pivot, we'll have *first <= *pivot <= *last.
+        if (less(*pivot, *first))
+        {
+            swap(*pivot, *first);
+        }
+
+        if (less(*last, *pivot))
+        {
+            swap(*pivot, *last);
+
+            if (less(*pivot, *first))
+            {
+                swap(*pivot, *first);
+            }
+        }
+
+        // Partition the [first, last] range into [first, newLast) and [newLast, last].
+        // Note that first and last have alreay been partitioned so the loops below
+        // start by moving the iterator to the next position of interest.
+        RandomAccessIterator newFirst = first;
+        RandomAccessIterator newLast = last;
+
+        for (;;)
+        {
+            // Find newFirst such that *newFirst >= *pivot.
+            //
+            // less(*pivot, *pivot) is expected to return false so we should stop
+            // if we reach the pivot. However, the current JIT uses of std::sort
+            // have relatively expensive "less" predicates while the iterators are
+            // just pointers so they are cheap to compare. Thus it's best to check
+            // for the newFirst == pivot case and skip a "less" call.
+            //
+            // It's not possible for newFirst to go past the end of the sort range:
+            //   - If newFirst reaches the pivot before newLast then the pivot is
+            //	   swapped to the right and we'll stop again when we reach it.
+            //   - If newLast reaches the pivot before newFirst then the pivot is
+            //	   swapped to the left and the value at newFirst will take its place
+            //     to the right so less(newFirst, pivot) will again be false when the
+            //     old pivot's position is reached.
+            do
+            {
+                ++newFirst;
+            } while ((newFirst != pivot) && less(*newFirst, *pivot));
+
+            // Find newLast such that *newLast <= *pivot.
+            //
+            // Like above, this stops when the pivot is reached and also does not
+            // go before the start of the sort range.
+            do
+            {
+                --newLast;
+            } while ((newLast != pivot) && less(*pivot, *newLast));
+
+            // If newFirst reaches newLast then we're done.
+            if (newFirst >= newLast)
+            {
+                break;
+            }
+
+            // We now have *newLast <= *pivot <= *newFirst so we need to swap
+            // *newFirst and *newLast.
+            swap(*newFirst, *newLast);
+
+            // pivot is an iterator and not the actual value, if the value gets
+            // swapped we need to update the iterator to point to the new place.
+            if (pivot == newFirst)
+            {
+                pivot = newLast;
+            }
+            else if (pivot == newLast)
+            {
+                pivot = newFirst;
+            }
+        }
+
+        RandomAccessIterator leftFirst = first;
+        RandomAccessIterator leftLast = newLast;
+        RandomAccessIterator rightFirst = newLast + 1;
+        RandomAccessIterator rightLast = last;
+
+        assert(depth < _countof(firstStack));
+
+        // Ideally, the 2 partitions should have the same size, that would guarantee
+        // log2(n) stack space. If that's not the case then push the larger partition
+        // onto the stack and sort the smaller one using tail recursion.
+        if ((leftLast - leftFirst) < (rightLast - rightFirst))
+        {
+            firstStack[depth] = rightFirst;
+            lastStack[depth] = rightLast;
+
+            first = leftFirst;
+            last = leftLast;
+        }
+        else
+        {
+            firstStack[depth] = leftFirst;
+            lastStack[depth] = leftLast;
+
+            first = rightFirst;
+            last = rightLast;
+        }
+
+        depth++;
+    }
+}
+}
+
+template<typename RandomAccessIterator, typename Less>
+void sort(RandomAccessIterator first, RandomAccessIterator last, Less less)
+{
+    assert(first <= last);
+    assert((last - first) < INT32_MAX);
+
+    if (first != last)
+    {
+        quick_sort(first, last - 1, less);
+
+#ifdef DEBUG
+        for (RandomAccessIterator i = first; i != last - 1; ++i)
+        {
+            assert(!less(*(first + 1), *first));
+        }
+#endif // DEBUG
+    }
+}
 }

--- a/src/jit/jitstd/algorithm.h
+++ b/src/jit/jitstd/algorithm.h
@@ -48,7 +48,7 @@ Function for_each(InputIterator first, InputIterator last, Function func)
 
 namespace
 {
-// Sort the elements in range [first, last) using insertion sort, an efficient alternative
+// Sort the elements in range [first, last] using insertion sort, an efficient alternative
 // to quick sort when the range to be sorted is small enough.
 template <typename RandomAccessIterator, typename Less>
 void insertion_sort(RandomAccessIterator first, RandomAccessIterator last, Less less)
@@ -72,7 +72,7 @@ void insertion_sort(RandomAccessIterator first, RandomAccessIterator last, Less 
     }
 }
 
-// Sort the elements in range [first, last) using quick sort.
+// Sort the elements in range [first, last] using quick sort.
 template <typename RandomAccessIterator, typename Less>
 void quick_sort(RandomAccessIterator first, RandomAccessIterator last, Less less)
 {

--- a/src/jit/jitstd/algorithm.h
+++ b/src/jit/jitstd/algorithm.h
@@ -53,22 +53,17 @@ namespace
 template <typename RandomAccessIterator, typename Less>
 void insertion_sort(RandomAccessIterator first, RandomAccessIterator last, Less less)
 {
-    for (; first < last; first++)
+    for (RandomAccessIterator i = first; i < last; ++i)
     {
-        RandomAccessIterator min = first;
+        RandomAccessIterator j = i;
+        auto temp = *(j + 1);
 
-        for (RandomAccessIterator i = min + 1; i <= last; i++)
+        for (; (j >= first) && less(temp, *j); --j)
         {
-            if (less(*i, *min))
-            {
-                min = i;
-            }
+            *(j + 1) = *j;
         }
 
-        if (min != first)
-        {
-            swap(*min, *first);
-        }
+        *(j + 1) = temp;
     }
 }
 

--- a/src/jit/jitstd/algorithm.h
+++ b/src/jit/jitstd/algorithm.h
@@ -48,6 +48,8 @@ Function for_each(InputIterator first, InputIterator last, Function func)
 
 namespace
 {
+// Sort the elements in range [first, last) using insertion sort, an efficient alternative
+// to quick sort when the range to be sorted is small enough.
 template <typename RandomAccessIterator, typename Less>
 void insertion_sort(RandomAccessIterator first, RandomAccessIterator last, Less less)
 {
@@ -70,12 +72,13 @@ void insertion_sort(RandomAccessIterator first, RandomAccessIterator last, Less 
     }
 }
 
+// Sort the elements in range [first, last) using quick sort.
 template <typename RandomAccessIterator, typename Less>
 void quick_sort(RandomAccessIterator first, RandomAccessIterator last, Less less)
 {
     // Avoid real recursion as it can be slower, at least due to the extra "less"
     // parameter that needs to be passed around. It's also likely to need more
-    // stack space. Use manual tail recursion for one partition and push the other
+    // stack space. Use "manual" tail recursion for one partition and push the other
     // partition on a stack. Assuming a proper implementation (sorting the smaller
     // partition using tail recursion and push the larger partition) then the
     // maximum stack depth should not exceed log2(n). So a depth of 32 should be
@@ -192,7 +195,7 @@ void quick_sort(RandomAccessIterator first, RandomAccessIterator last, Less less
 
         // Ideally, the 2 partitions should have the same size, that would guarantee
         // log2(n) stack space. If that's not the case then push the larger partition
-        // onto the stack and sort the smaller one using tail recursion.
+        // onto the stack and sort the smaller one using "manual" tail recursion.
         if ((leftLast - leftFirst) < (rightLast - rightFirst))
         {
             firstStack[depth] = rightFirst;
@@ -215,6 +218,9 @@ void quick_sort(RandomAccessIterator first, RandomAccessIterator last, Less less
 }
 }
 
+// Sort the elements in range [first, last) in ascending order, where the order
+// is defined by the specified "less" predicate. This implementation does not
+// use a stable sort algorithm.
 template<typename RandomAccessIterator, typename Less>
 void sort(RandomAccessIterator first, RandomAccessIterator last, Less less)
 {
@@ -223,6 +229,8 @@ void sort(RandomAccessIterator first, RandomAccessIterator last, Less less)
 
     if (first != last)
     {
+        // For convenience, quick_sort sorts the [first, last] range
+        // so "last" needs to be adjusted accordingly.
         quick_sort(first, last - 1, less);
 
 #ifdef DEBUG

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -4096,8 +4096,6 @@ void Compiler::lvaMarkLocalVars()
     {
         lvaTable[info.compTypeCtxtArg].lvImplicitlyReferenced = 1;
     }
-
-    lvaSortByRefCount();
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -3029,7 +3029,7 @@ BasicBlock::weight_t BasicBlock::getBBWeight(Compiler* comp)
     }
 }
 
-// LclVarDsc "less" comparer for small code.
+// LclVarDsc "less" comparer used to compare the weight of two locals, when optimizing for small code.
 class LclVarDsc_SmallCode_Less
 {
     const LclVarDsc* m_lvaTable;
@@ -3099,7 +3099,6 @@ public:
         // Break the tie by:
         //   - Increasing the weight by 2   if we are a register arg.
         //   - Increasing the weight by 0.5 if we are a GC type.
-        //   - Increasing the weight by 0.5 if we were enregistered in the previous pass.
 
         if (weight1 != 0)
         {
@@ -3137,7 +3136,7 @@ public:
     }
 };
 
-// LclVarDsc "less" comparer for blended code.
+// LclVarDsc "less" comparer used to compare the weight of two locals, when optimizing for blended code.
 class LclVarDsc_BlendedCode_Less
 {
     const LclVarDsc* m_lvaTable;
@@ -3207,7 +3206,7 @@ public:
             return weight1 > weight2;
         }
 
-        // If the unweighted ref counts are different then try the unweighted ref counts.
+        // If the weighted ref counts are different then try the unweighted ref counts.
         if (dsc1->lvRefCnt() != dsc2->lvRefCnt())
         {
             return dsc1->lvRefCnt() > dsc2->lvRefCnt();
@@ -3404,13 +3403,13 @@ void Compiler::lvaSortByRefCount()
     JITDUMP("Tracked variable (%u out of %u) table:\n", lvaTrackedCount, lvaCount);
 
     // Assign indices to all the variables we've decided to track
-    for (unsigned i = 0; i < lvaTrackedCount; i++)
+    for (unsigned varIndex = 0; varIndex < lvaTrackedCount; varIndex++)
     {
-        LclVarDsc* varDsc = lvaGetDesc(tracked[i]);
+        LclVarDsc* varDsc = lvaGetDesc(tracked[varIndex]);
         assert(varDsc->lvTracked);
-        varDsc->lvVarIndex = static_cast<unsigned short>(i);
+        varDsc->lvVarIndex = static_cast<unsigned short>(varIndex);
 
-        INDEBUG(if (verbose) { gtDispLclVar(tracked[i]); })
+        INDEBUG(if (verbose) { gtDispLclVar(tracked[varIndex]); })
         JITDUMP(" [%6s]: refCnt = %4u, refCntWtd = %6s\n", varTypeName(varDsc->TypeGet()), varDsc->lvRefCnt(),
                 refCntWtd2str(varDsc->lvRefCntWtd()));
     }
@@ -3418,9 +3417,9 @@ void Compiler::lvaSortByRefCount()
     JITDUMP("\n");
 
     // Mark all variables past the first 'lclMAX_TRACKED' as untracked
-    for (unsigned i = lvaTrackedCount; i < trackedCount; i++)
+    for (unsigned varIndex = lvaTrackedCount; varIndex < trackedCount; varIndex++)
     {
-        LclVarDsc* varDsc = lvaGetDesc(tracked[i]);
+        LclVarDsc* varDsc = lvaGetDesc(tracked[varIndex]);
         assert(varDsc->lvTracked);
         varDsc->lvTracked = 0;
     }

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -3043,6 +3043,9 @@ int RefCntCmp(const LclVarDsc* dsc1, const LclVarDsc* dsc2)
     // We should not be sorting untracked variables
     assert(dsc1->lvTracked);
     assert(dsc2->lvTracked);
+    // We should not be sorting after registers have been allocated
+    assert(!dsc1->lvRegister);
+    assert(!dsc2->lvRegister);
 
     unsigned weight1 = dsc1->lvRefCnt();
     unsigned weight2 = dsc2->lvRefCnt();
@@ -3103,11 +3106,6 @@ int RefCntCmp(const LclVarDsc* dsc1, const LclVarDsc* dsc2)
         {
             weight1 += BB_UNITY_WEIGHT / 2;
         }
-
-        if (dsc1->lvRegister)
-        {
-            weight1 += BB_UNITY_WEIGHT / 2;
-        }
     }
 
     if (weight2)
@@ -3118,11 +3116,6 @@ int RefCntCmp(const LclVarDsc* dsc1, const LclVarDsc* dsc2)
         }
 
         if (varTypeIsGC(dsc2->TypeGet()))
-        {
-            weight2 += BB_UNITY_WEIGHT / 2;
-        }
-
-        if (dsc2->lvRegister)
         {
             weight2 += BB_UNITY_WEIGHT / 2;
         }
@@ -3163,6 +3156,9 @@ int WtdRefCntCmp(const LclVarDsc* dsc1, const LclVarDsc* dsc2)
     // We should not be sorting untracked variables
     assert(dsc1->lvTracked);
     assert(dsc2->lvTracked);
+    // We should not be sorting after registers have been allocated
+    assert(!dsc1->lvRegister);
+    assert(!dsc2->lvRegister);
 
     unsigned weight1 = dsc1->lvRefCntWtd();
     unsigned weight2 = dsc2->lvRefCntWtd();
@@ -3222,21 +3218,6 @@ int WtdRefCntCmp(const LclVarDsc* dsc1, const LclVarDsc* dsc2)
     if (varTypeIsGC(dsc1->TypeGet()) != varTypeIsGC(dsc2->TypeGet()))
     {
         if (varTypeIsGC(dsc1->TypeGet()))
-        {
-            diff = -1;
-        }
-        else
-        {
-            diff = +1;
-        }
-
-        return diff;
-    }
-
-    /* If one was enregistered in the previous pass then it wins */
-    if (dsc1->lvRegister != dsc2->lvRegister)
-    {
-        if (dsc1->lvRegister)
         {
             diff = -1;
         }

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -969,8 +969,8 @@ void Compiler::fgExtendDbgLifetimes()
         {
             /* Create initialization tree */
 
-            unsigned   varNum = lvaTrackedToVarNum[varIndex];
-            LclVarDsc* varDsc = &lvaTable[varNum];
+            unsigned   varNum = lvaTrackedIndexToLclNum(varIndex);
+            LclVarDsc* varDsc = lvaGetDesc(varNum);
             var_types  type   = varDsc->TypeGet();
 
             // Don't extend struct lifetimes -- they aren't enregistered, anyway.

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -1392,10 +1392,9 @@ public:
 #endif
         }
 
-        unsigned sortNum = 0;
-        while (sortNum < m_pCompiler->lvaTrackedCount)
+        for (unsigned trackedIndex = 0; trackedIndex < m_pCompiler->lvaTrackedCount; trackedIndex++)
         {
-            LclVarDsc* varDsc = m_pCompiler->lvaRefSorted[sortNum++];
+            LclVarDsc* varDsc = m_pCompiler->lvaGetDescByTrackedIndex(trackedIndex);
             var_types  varTyp = varDsc->TypeGet();
 
             if (varDsc->lvDoNotEnregister)

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -1001,12 +1001,13 @@ void CodeGen::siBeginBlock(BasicBlock* block)
         unsigned        varIndex = 0;
         while (iter.NextElem(&varIndex))
         {
-            unsigned varNum = compiler->lvaTrackedToVarNum[varIndex];
+            unsigned   varNum = compiler->lvaTrackedIndexToLclNum(varIndex);
+            LclVarDsc* varDsc = compiler->lvaGetDesc(varNum);
             // lvRefCnt may go down to 0 after liveness-analysis.
             // So we need to check if this tracked variable is actually used.
-            if (!compiler->lvaTable[varNum].lvIsInReg() && !compiler->lvaTable[varNum].lvOnFrame)
+            if (!varDsc->lvIsInReg() && !varDsc->lvOnFrame)
             {
-                assert(compiler->lvaTable[varNum].lvRefCnt() == 0);
+                assert(varDsc->lvRefCnt() == 0);
                 continue;
             }
 
@@ -1251,11 +1252,7 @@ void CodeGen::siUpdate()
     unsigned        varIndex = 0;
     while (iter.NextElem(&varIndex))
     {
-#ifdef DEBUG
-        unsigned   lclNum = compiler->lvaTrackedToVarNum[varIndex];
-        LclVarDsc* lclVar = &compiler->lvaTable[lclNum];
-        assert(lclVar->lvTracked);
-#endif
+        assert(compiler->lvaGetDescByTrackedIndex(varIndex)->lvTracked);
         siEndTrackedScope(varIndex);
     }
 

--- a/src/jit/ssabuilder.cpp
+++ b/src/jit/ssabuilder.cpp
@@ -715,7 +715,7 @@ void SsaBuilder::InsertPhiFunctions(BasicBlock** postOrder, int count)
         unsigned        varIndex = 0;
         while (defVars.NextElem(&varIndex))
         {
-            unsigned lclNum = m_pCompiler->lvaTrackedToVarNum[varIndex];
+            unsigned lclNum = m_pCompiler->lvaTrackedIndexToLclNum(varIndex);
             DBG_SSA_JITDUMP("  Considering local var V%02u:\n", lclNum);
 
             if (!m_pCompiler->lvaInSsa(lclNum))


### PR DESCRIPTION
Fixes #18869

PIN data - 1.34% instruction decrease - https://1drv.ms/x/s!Av4baJYSo5pjgsVn0CgTZP9OSY0gQw

This also reduces memory usage by 2.7% - https://gist.github.com/mikedn/a03b5e9218c435858f31390bbd31ee2d

No diffs.

Additional details available in commit comments.