### PR TITLE
exclude tracing/keyword/TwoKeywords/TwoKeywords on WIndows x86.

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -314,6 +314,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/varargs/varargsupport_r/*">
             <Issue>Varargs supported on this platform</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/keyword/TwoKeywords/TwoKeywords/*">
+            <Issue>23235, often fails with timeout in release</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- Windows arm32 specific excludes -->


### PR DESCRIPTION
Revert when #23235 get fixed.