### PR TITLE
Add Rune.TryEncodeToUtf8 and related APIs

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Text/DecoderFallback.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/DecoderFallback.cs
@@ -278,7 +278,7 @@ namespace System.Text
             Rune thisRune;
             while ((thisRune = GetNextRune()).Value != 0)
             {
-                if (thisRune.TryEncode(chars, out int charsWrittenJustNow))
+                if (thisRune.TryEncodeToUtf16(chars, out int charsWrittenJustNow))
                 {
                     chars = chars.Slice(charsWrittenJustNow);
                     continue;

--- a/src/System.Private.CoreLib/shared/System/Text/DecoderNLS.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/DecoderNLS.cs
@@ -332,7 +332,7 @@ namespace System.Text
             switch (_encoding.DecodeFirstRune(combinedBuffer, out Rune value, out int combinedBufferBytesConsumed))
             {
                 case OperationStatus.Done:
-                    if (value.TryEncode(chars, out charsWritten))
+                    if (value.TryEncodeToUtf16(chars, out charsWritten))
                     {
                         goto Finish; // successfully transcoded bytes -> chars
                     }

--- a/src/System.Private.CoreLib/shared/System/Text/Encoding.Internal.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/Encoding.Internal.cs
@@ -327,7 +327,7 @@ namespace System.Text
                     // There are two scenarios: (a) the source buffer contained invalid / incomplete UTF-16 data;
                     // or (b) the encoding can't translate this scalar value.
 
-                    if (Rune.DecodeUtf16(chars, out Rune firstScalarValue, out int charsConsumedThisIteration) == OperationStatus.NeedMoreData
+                    if (Rune.DecodeFromUtf16(chars, out Rune firstScalarValue, out int charsConsumedThisIteration) == OperationStatus.NeedMoreData
                            && encoder != null
                            && !encoder.MustFlush)
                     {
@@ -603,7 +603,7 @@ namespace System.Text
                     // There are two scenarios: (a) the source buffer contained invalid / incomplete UTF-16 data;
                     // or (b) the encoding can't translate this scalar value.
 
-                    switch (Rune.DecodeUtf16(chars, out Rune firstScalarValue, out int charsConsumedThisIteration))
+                    switch (Rune.DecodeFromUtf16(chars, out Rune firstScalarValue, out int charsConsumedThisIteration))
                     {
                         case OperationStatus.NeedMoreData:
                             Debug.Assert(charsConsumedThisIteration == chars.Length, "If returning NeedMoreData, should out the entire buffer length as chars consumed.");

--- a/src/System.Private.CoreLib/shared/System/Text/Rune.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/Rune.cs
@@ -182,7 +182,7 @@ namespace System.Text
             Span<char> original = stackalloc char[2]; // worst case scenario = 2 code units (for a surrogate pair)
             Span<char> modified = stackalloc char[2]; // case change should preserve UTF-16 code unit count
 
-            int charCount = rune.Encode(original);
+            int charCount = rune.EncodeToUtf16(original);
             original = original.Slice(0, charCount);
             modified = modified.Slice(0, charCount);
 
@@ -670,9 +670,9 @@ namespace System.Text
         /// <exception cref="ArgumentException">
         /// If <paramref name="destination"/> is not large enough to hold the output.
         /// </exception>
-        public int Encode(Span<char> destination)
+        public int EncodeToUtf16(Span<char> destination)
         {
-            if (!TryEncode(destination, out int charsWritten))
+            if (!TryEncodeToUtf16(destination, out int charsWritten))
             {
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
@@ -688,9 +688,9 @@ namespace System.Text
         /// <exception cref="ArgumentException">
         /// If <paramref name="destination"/> is not large enough to hold the output.
         /// </exception>
-        public int EncodeAsUtf8(Span<byte> destination)
+        public int EncodeToUtf8(Span<byte> destination)
         {
-            if (!TryEncodeAsUtf8(destination, out int bytesWritten))
+            if (!TryEncodeToUtf8(destination, out int bytesWritten))
             {
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
@@ -920,7 +920,7 @@ namespace System.Text
         /// The <see cref="Utf16SequenceLength"/> property can be queried ahead of time to determine
         /// the required size of the <paramref name="destination"/> buffer.
         /// </remarks>
-        public bool TryEncode(Span<char> destination, out int charsWritten)
+        public bool TryEncodeToUtf16(Span<char> destination, out int charsWritten)
         {
             if (destination.Length >= 1)
             {
@@ -944,6 +944,16 @@ namespace System.Text
             return false;
         }
 
+        public bool TryEncode(Span<char> destination, out int charsWritten)
+        {
+            // This method was renamed to TryEncodeToUtf16. We'll leave this copy of
+            // the method here temporarily so that we don't break corefx consumers
+            // while the rename takes place.
+            // Tracking issue: https://github.com/dotnet/coreclr/issues/23319
+
+            return TryEncodeToUtf16(destination, out charsWritten);
+        }
+
         /// <summary>
         /// Encodes this <see cref="Rune"/> to a destination buffer as UTF-8 bytes.
         /// </summary>
@@ -956,7 +966,7 @@ namespace System.Text
         /// The <see cref="Utf8SequenceLength"/> property can be queried ahead of time to determine
         /// the required size of the <paramref name="destination"/> buffer.
         /// </remarks>
-        public bool TryEncodeAsUtf8(Span<byte> destination, out int bytesWritten)
+        public bool TryEncodeToUtf8(Span<byte> destination, out int bytesWritten)
         {
             // The bit patterns below come from the Unicode Standard, Table 3-6.
 
@@ -1014,11 +1024,12 @@ namespace System.Text
 
         public bool TryEncodeToUtf8Bytes(Span<byte> destination, out int bytesWritten)
         {
-            // This method was renamed to TryEncodeAsUtf8. We'll leave this copy of
+            // This method was renamed to TryEncodeToUtf8. We'll leave this copy of
             // the method here temporarily so that we don't break corefx consumers
             // while the rename takes place.
+            // Tracking issue: https://github.com/dotnet/coreclr/issues/23319
 
-            return TryEncodeAsUtf8(destination, out bytesWritten);
+            return TryEncodeToUtf8(destination, out bytesWritten);
         }
 
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Text/Rune.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/Rune.cs
@@ -231,20 +231,20 @@ namespace System.Text
         /// </para>
         /// </returns>
         /// <remarks>
-        /// The general calling convention is to call this method in a loop, slicing the <paramref name="utf16Source"/> buffer by
+        /// The general calling convention is to call this method in a loop, slicing the <paramref name="source"/> buffer by
         /// <paramref name="charsConsumed"/> elements on each iteration of the loop. On each iteration of the loop <paramref name="result"/>
         /// will contain the real scalar value if successfully decoded, or it will contain <see cref="ReplacementChar"/> if
         /// the data could not be successfully decoded. This pattern provides convenient automatic U+FFFD substitution of
         /// invalid sequences while iterating through the loop.
         /// </remarks>
-        public static OperationStatus DecodeUtf16(ReadOnlySpan<char> utf16Source, out Rune result, out int charsConsumed)
+        public static OperationStatus DecodeFromUtf16(ReadOnlySpan<char> source, out Rune result, out int charsConsumed)
         {
-            if (!utf16Source.IsEmpty)
+            if (!source.IsEmpty)
             {
                 // First, check for the common case of a BMP scalar value.
                 // If this is correct, return immediately.
 
-                char firstChar = utf16Source[0];
+                char firstChar = source[0];
                 if (TryCreate(firstChar, out result))
                 {
                     charsConsumed = 1;
@@ -255,9 +255,9 @@ namespace System.Text
                 // Let's optimistically assume for now it's a high surrogate and hope
                 // that combining it with the next char yields useful results.
 
-                if (1 < (uint)utf16Source.Length)
+                if (1 < (uint)source.Length)
                 {
-                    char secondChar = utf16Source[1];
+                    char secondChar = source[1];
                     if (TryCreate(firstChar, secondChar, out result))
                     {
                         // Success! Formed a supplementary scalar value.
@@ -284,7 +284,7 @@ namespace System.Text
             // If we got to this point, the input buffer was empty, or the buffer
             // was a single element in length and that element was a high surrogate char.
 
-            charsConsumed = utf16Source.Length;
+            charsConsumed = source.Length;
             result = ReplacementChar;
             return OperationStatus.NeedMoreData;
 
@@ -293,66 +293,6 @@ namespace System.Text
             charsConsumed = 1; // maximal invalid subsequence for UTF-16 is always a single code unit in length
             result = ReplacementChar;
             return OperationStatus.InvalidData;
-        }
-
-        /// <summary>
-        /// Decodes the <see cref="Rune"/> at the end of the provided UTF-16 source buffer.
-        /// </summary>
-        /// <remarks>
-        /// This method is very similar to <see cref="DecodeUtf16(ReadOnlySpan{char}, out Rune, out int)"/>, but it allows
-        /// the caller to loop backward instead of forward. The typical calling convention is that on each iteration
-        /// of the loop, the caller should slice off the final <paramref name="charsConsumed"/> elements of
-        /// the <paramref name="utf16Source"/> buffer.
-        /// </remarks>
-        public static OperationStatus DecodeUtf16FromEnd(ReadOnlySpan<char> utf16Source, out Rune result, out int charsConsumed)
-        {
-            int index = utf16Source.Length - 1;
-            if ((uint)index < (uint)utf16Source.Length)
-            {
-                // First, check for the common case of a BMP scalar value.
-                // If this is correct, return immediately.
-
-                char finalChar = utf16Source[index];
-                if (TryCreate(finalChar, out result))
-                {
-                    charsConsumed = 1;
-                    return OperationStatus.Done;
-                }
-
-                if (char.IsLowSurrogate(finalChar))
-                {
-                    // The final character was a UTF-16 low surrogate code point.
-                    // This must be preceded by a UTF-16 high surrogate code point, otherwise
-                    // we have a standalone low surrogate, which is always invalid.
-
-                    index--;
-                    if ((uint)index < (uint)utf16Source.Length)
-                    {
-                        char penultimateChar = utf16Source[index];
-                        if (TryCreate(penultimateChar, finalChar, out result))
-                        {
-                            // Success! Formed a supplementary scalar value.
-                            charsConsumed = 2;
-                            return OperationStatus.Done;
-                        }
-                    }
-
-                    // If we got to this point, we saw a standalone low surrogate
-                    // and must report an error.
-
-                    charsConsumed = 1; // standalone surrogate
-                    result = ReplacementChar;
-                    return OperationStatus.InvalidData;
-                }
-            }
-
-            // If we got this far, the source buffer was empty, or the source buffer ended
-            // with a UTF-16 high surrogate code point. These aren't errors since they could
-            // be valid given more input data.
-
-            charsConsumed = (int)((uint)(-utf16Source.Length) >> 31); // 0 -> 0, all other lengths -> 1
-            result = ReplacementChar;
-            return OperationStatus.NeedMoreData;
         }
 
         /// <summary>
@@ -375,13 +315,13 @@ namespace System.Text
         /// </para>
         /// </returns>
         /// <remarks>
-        /// The general calling convention is to call this method in a loop, slicing the <paramref name="utf8Source"/> buffer by
+        /// The general calling convention is to call this method in a loop, slicing the <paramref name="source"/> buffer by
         /// <paramref name="bytesConsumed"/> elements on each iteration of the loop. On each iteration of the loop <paramref name="result"/>
         /// will contain the real scalar value if successfully decoded, or it will contain <see cref="ReplacementChar"/> if
         /// the data could not be successfully decoded. This pattern provides convenient automatic U+FFFD substitution of
         /// invalid sequences while iterating through the loop.
         /// </remarks>
-        public static OperationStatus DecodeUtf8(ReadOnlySpan<byte> utf8Source, out Rune result, out int bytesConsumed)
+        public static OperationStatus DecodeFromUtf8(ReadOnlySpan<byte> source, out Rune result, out int bytesConsumed)
         {
             // This method follows the Unicode Standard's recommendation for detecting
             // the maximal subpart of an ill-formed subsequence. See The Unicode Standard,
@@ -393,12 +333,12 @@ namespace System.Text
 
             // Try reading input[0].
 
-            if ((uint)index >= (uint)utf8Source.Length)
+            if ((uint)index >= (uint)source.Length)
             {
                 goto NeedsMoreData;
             }
 
-            uint tempValue = utf8Source[index];
+            uint tempValue = source[index];
             if (!UnicodeUtility.IsAsciiCodePoint(tempValue))
             {
                 goto NotAscii;
@@ -428,7 +368,7 @@ namespace System.Text
             // Try reading input[1].
 
             index++;
-            if ((uint)index >= (uint)utf8Source.Length)
+            if ((uint)index >= (uint)source.Length)
             {
                 goto NeedsMoreData;
             }
@@ -437,7 +377,7 @@ namespace System.Text
             // complement representation is in the range [-65..-128]. This allows us to
             // perform a single comparison to see if a byte is a continuation byte.
 
-            int thisByteSignExtended = (sbyte)utf8Source[index];
+            int thisByteSignExtended = (sbyte)source[index];
             if (thisByteSignExtended >= -64)
             {
                 goto Invalid;
@@ -482,12 +422,12 @@ namespace System.Text
             // Try reading input[2].
 
             index++;
-            if ((uint)index >= (uint)utf8Source.Length)
+            if ((uint)index >= (uint)source.Length)
             {
                 goto NeedsMoreData;
             }
 
-            thisByteSignExtended = (sbyte)utf8Source[index];
+            thisByteSignExtended = (sbyte)source[index];
             if (thisByteSignExtended >= -64)
             {
                 goto Invalid; // this byte is not a UTF-8 continuation byte
@@ -507,12 +447,12 @@ namespace System.Text
             // Try reading input[3].
 
             index++;
-            if ((uint)index >= (uint)utf8Source.Length)
+            if ((uint)index >= (uint)source.Length)
             {
                 goto NeedsMoreData;
             }
 
-            thisByteSignExtended = (sbyte)utf8Source[index];
+            thisByteSignExtended = (sbyte)source[index];
             if (thisByteSignExtended >= -64)
             {
                 goto Invalid; // this byte is not a UTF-8 continuation byte
@@ -546,23 +486,83 @@ namespace System.Text
         }
 
         /// <summary>
+        /// Decodes the <see cref="Rune"/> at the end of the provided UTF-16 source buffer.
+        /// </summary>
+        /// <remarks>
+        /// This method is very similar to <see cref="DecodeFromUtf16(ReadOnlySpan{char}, out Rune, out int)"/>, but it allows
+        /// the caller to loop backward instead of forward. The typical calling convention is that on each iteration
+        /// of the loop, the caller should slice off the final <paramref name="charsConsumed"/> elements of
+        /// the <paramref name="source"/> buffer.
+        /// </remarks>
+        public static OperationStatus DecodeLastFromUtf16(ReadOnlySpan<char> source, out Rune result, out int charsConsumed)
+        {
+            int index = source.Length - 1;
+            if ((uint)index < (uint)source.Length)
+            {
+                // First, check for the common case of a BMP scalar value.
+                // If this is correct, return immediately.
+
+                char finalChar = source[index];
+                if (TryCreate(finalChar, out result))
+                {
+                    charsConsumed = 1;
+                    return OperationStatus.Done;
+                }
+
+                if (char.IsLowSurrogate(finalChar))
+                {
+                    // The final character was a UTF-16 low surrogate code point.
+                    // This must be preceded by a UTF-16 high surrogate code point, otherwise
+                    // we have a standalone low surrogate, which is always invalid.
+
+                    index--;
+                    if ((uint)index < (uint)source.Length)
+                    {
+                        char penultimateChar = source[index];
+                        if (TryCreate(penultimateChar, finalChar, out result))
+                        {
+                            // Success! Formed a supplementary scalar value.
+                            charsConsumed = 2;
+                            return OperationStatus.Done;
+                        }
+                    }
+
+                    // If we got to this point, we saw a standalone low surrogate
+                    // and must report an error.
+
+                    charsConsumed = 1; // standalone surrogate
+                    result = ReplacementChar;
+                    return OperationStatus.InvalidData;
+                }
+            }
+
+            // If we got this far, the source buffer was empty, or the source buffer ended
+            // with a UTF-16 high surrogate code point. These aren't errors since they could
+            // be valid given more input data.
+
+            charsConsumed = (int)((uint)(-source.Length) >> 31); // 0 -> 0, all other lengths -> 1
+            result = ReplacementChar;
+            return OperationStatus.NeedMoreData;
+        }
+
+        /// <summary>
         /// Decodes the <see cref="Rune"/> at the end of the provided UTF-8 source buffer.
         /// </summary>
         /// <remarks>
-        /// This method is very similar to <see cref="DecodeUtf8(ReadOnlySpan{byte}, out Rune, out int)"/>, but it allows
+        /// This method is very similar to <see cref="DecodeFromUtf8(ReadOnlySpan{byte}, out Rune, out int)"/>, but it allows
         /// the caller to loop backward instead of forward. The typical calling convention is that on each iteration
         /// of the loop, the caller should slice off the final <paramref name="bytesConsumed"/> elements of
-        /// the <paramref name="utf8Source"/> buffer.
+        /// the <paramref name="source"/> buffer.
         /// </remarks>
-        public static OperationStatus DecodeUtf8FromEnd(ReadOnlySpan<byte> utf8Source, out Rune value, out int bytesConsumed)
+        public static OperationStatus DecodeLastFromUtf8(ReadOnlySpan<byte> source, out Rune value, out int bytesConsumed)
         {
-            int index = utf8Source.Length - 1;
-            if ((uint)index < (uint)utf8Source.Length)
+            int index = source.Length - 1;
+            if ((uint)index < (uint)source.Length)
             {
                 // The buffer contains at least one byte. Let's check the fast case where the
                 // buffer ends with an ASCII byte.
 
-                uint tempValue = utf8Source[index];
+                uint tempValue = source[index];
                 if (UnicodeUtility.IsAsciiCodePoint(tempValue))
                 {
                     bytesConsumed = 1;
@@ -582,7 +582,7 @@ namespace System.Text
                     // This is a UTF-8 leading byte. We'll do a forward read from here.
                     // It'll return invalid (if given C0, F5, etc.) or incomplete. Both are fine.
 
-                    return DecodeUtf8(utf8Source.Slice(index), out value, out bytesConsumed);
+                    return DecodeFromUtf8(source.Slice(index), out value, out bytesConsumed);
                 }
 
                 // If we got to this point, the final byte was a UTF-8 continuation byte.
@@ -591,7 +591,7 @@ namespace System.Text
                 for (int i = 3; i > 0; i--)
                 {
                     index--;
-                    if ((uint)index >= (uint)utf8Source.Length)
+                    if ((uint)index >= (uint)source.Length)
                     {
                         goto Invalid; // out of data
                     }
@@ -600,7 +600,7 @@ namespace System.Text
                     // (bits 0xC0 set, values C0..FF). In two's complement this is the range [-64..127].
                     // It's just a fast way for us to terminate the search.
 
-                    if ((sbyte)utf8Source[index] >= -64)
+                    if ((sbyte)source[index] >= -64)
                     {
                         goto ForwardDecode;
                     }
@@ -628,11 +628,11 @@ namespace System.Text
                 // fine since it'll be handled by the forward read. From this position, we'll perform a forward read
                 // and see if we consumed the entirety of the buffer.
 
-                utf8Source = utf8Source.Slice(index);
-                Debug.Assert(!utf8Source.IsEmpty, "Shouldn't reach this for empty inputs.");
+                source = source.Slice(index);
+                Debug.Assert(!source.IsEmpty, "Shouldn't reach this for empty inputs.");
 
-                OperationStatus operationStatus = DecodeUtf8(utf8Source, out Rune tempRune, out int tempBytesConsumed);
-                if (tempBytesConsumed == utf8Source.Length)
+                OperationStatus operationStatus = DecodeFromUtf8(source, out Rune tempRune, out int tempBytesConsumed);
+                if (tempBytesConsumed == source.Length)
                 {
                     // If this forward read consumed the entirety of the end of the input buffer, we can return it
                     // as the result of this function. It could be well-formed, incomplete, or invalid. If it's
@@ -660,6 +660,46 @@ namespace System.Text
                 bytesConsumed = 0;
                 return OperationStatus.NeedMoreData;
             }
+        }
+
+        public static OperationStatus DecodeUtf16(ReadOnlySpan<char> utf16Source, out Rune result, out int charsConsumed)
+        {
+            // [TODO] This method was renamed to DecodeFromUtf16. We'll leave this copy of
+            // the method here temporarily so that we don't break corefx consumers
+            // while the rename takes place.
+            // Tracking issue: https://github.com/dotnet/coreclr/issues/23319
+
+            return DecodeFromUtf16(utf16Source, out result, out charsConsumed);
+        }
+
+        public static OperationStatus DecodeUtf16FromEnd(ReadOnlySpan<char> utf16Source, out Rune result, out int charsConsumed)
+        {
+            // [TODO] This method was renamed to DecodeLastFromUtf16. We'll leave this copy of
+            // the method here temporarily so that we don't break corefx consumers
+            // while the rename takes place.
+            // Tracking issue: https://github.com/dotnet/coreclr/issues/23319
+
+            return DecodeLastFromUtf16(utf16Source, out result, out charsConsumed);
+        }
+
+        public static OperationStatus DecodeUtf8(ReadOnlySpan<byte> utf8Source, out Rune result, out int bytesConsumed)
+        {
+            // [TODO] This method was renamed to DecodeFromUtf8. We'll leave this copy of
+            // the method here temporarily so that we don't break corefx consumers
+            // while the rename takes place.
+            // Tracking issue: https://github.com/dotnet/coreclr/issues/23319
+
+            return DecodeFromUtf8(utf8Source, out result, out bytesConsumed);
+        }
+
+        public static OperationStatus DecodeUtf8FromEnd(ReadOnlySpan<byte> utf8Source, out Rune result, out int bytesConsumed)
+        {
+            // [TODO] This method was renamed to DecodeLastFromUtf8. We'll leave this copy of
+            // the method here temporarily so that we don't break corefx consumers
+            // while the rename takes place.
+            // Tracking issue: https://github.com/dotnet/coreclr/issues/23319
+
+            return DecodeLastFromUtf8(utf8Source, out result, out bytesConsumed);
         }
 
         /// <summary>
@@ -946,7 +986,7 @@ namespace System.Text
 
         public bool TryEncode(Span<char> destination, out int charsWritten)
         {
-            // This method was renamed to TryEncodeToUtf16. We'll leave this copy of
+            // [TODO] This method was renamed to TryEncodeToUtf16. We'll leave this copy of
             // the method here temporarily so that we don't break corefx consumers
             // while the rename takes place.
             // Tracking issue: https://github.com/dotnet/coreclr/issues/23319
@@ -1024,7 +1064,7 @@ namespace System.Text
 
         public bool TryEncodeToUtf8Bytes(Span<byte> destination, out int bytesWritten)
         {
-            // This method was renamed to TryEncodeToUtf8. We'll leave this copy of
+            // [TODO] This method was renamed to TryEncodeToUtf8. We'll leave this copy of
             // the method here temporarily so that we don't break corefx consumers
             // while the rename takes place.
             // Tracking issue: https://github.com/dotnet/coreclr/issues/23319

--- a/src/System.Private.CoreLib/shared/System/Text/Unicode/Utf8.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/Unicode/Utf8.cs
@@ -48,7 +48,7 @@ namespace System.Text.Unicode
 
             while (!source.IsEmpty)
             {
-                status = Rune.DecodeUtf16(source, out Rune firstScalarValue, out int charsConsumed);
+                status = Rune.DecodeFromUtf16(source, out Rune firstScalarValue, out int charsConsumed);
 
                 switch (status)
                 {
@@ -131,7 +131,7 @@ namespace System.Text.Unicode
 
             while (!source.IsEmpty)
             {
-                status = Rune.DecodeUtf8(source, out Rune firstScalarValue, out int bytesConsumed);
+                status = Rune.DecodeFromUtf8(source, out Rune firstScalarValue, out int bytesConsumed);
 
                 switch (status)
                 {

--- a/src/System.Private.CoreLib/shared/System/Text/Unicode/Utf8.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/Unicode/Utf8.cs
@@ -86,7 +86,7 @@ namespace System.Text.Unicode
                         // Do so now, and only terminate the loop if we ran out of space
                         // in the destination buffer.
 
-                        if (firstScalarValue.TryEncodeToUtf8Bytes(destination, out int bytesWritten))
+                        if (firstScalarValue.TryEncodeToUtf8(destination, out int bytesWritten))
                         {
                             source = source.Slice(charsConsumed); // don't use Rune.Utf8SequenceLength; we may have performed substitution
                             destination = destination.Slice(bytesWritten);
@@ -169,7 +169,7 @@ namespace System.Text.Unicode
                         // Do so now, and only terminate the loop if we ran out of space
                         // in the destination buffer.
 
-                        if (firstScalarValue.TryEncode(destination, out int charsWritten))
+                        if (firstScalarValue.TryEncodeToUtf16(destination, out int charsWritten))
                         {
                             source = source.Slice(bytesConsumed); // don't use Rune.Utf16SequenceLength; we may have performed substitution
                             destination = destination.Slice(charsWritten);

--- a/src/System.Private.CoreLib/shared/System/ThrowHelper.cs
+++ b/src/System.Private.CoreLib/shared/System/ThrowHelper.cs
@@ -68,7 +68,7 @@ namespace System
 
         internal static void ThrowArgumentException_DestinationTooShort()
         {
-            throw new ArgumentException(SR.Argument_DestinationTooShort);
+            throw new ArgumentException(SR.Argument_DestinationTooShort, "destination");
         }
 
         internal static void ThrowArgumentException_OverlapAlignmentMismatch()

--- a/tests/CoreFX/CoreFX.issues.json
+++ b/tests/CoreFX/CoreFX.issues.json
@@ -1254,6 +1254,10 @@
                     "reason": "Needs updates for XUnit 2.4"
                 },
                 {
+                    "name": "System.Tests.ArraySegment_Tests.CopyTo_Invalid",
+                    "reason": "Needs parameter name updated to 'destination'."
+                },
+                {
                     "name": "System.Tests.TimeSpanTests.Parse_Invalid",
                     "reason": "Temporary disabling till merging the PR https://github.com/dotnet/corefx/pull/34561"
                 },


### PR DESCRIPTION
Implementation of API review at https://github.com/dotnet/corefx/issues/35530.

Approved APIs:

`Rune.TryEncode` (already exists)
`Rune.TryEncodeAsUtf8` (already exists, but under a different name)

Suggested during review that we also add these (/cc @bartonjs):

`Rune.Encode` (new API, throws if destination too small)
`Rune.EncodeAsUtf8` (new API, throws if destination too small)

Since corefx currently exposes the old name of `TryEncodeAsUtf8`, I'm leaving both names temporarily until this syncs over to corefx, after which point we can clean it up.