### PR TITLE
Fix Ubuntu arm build break.

### DIFF
--- a/tests/src/Common/hostpolicymock/CMakeLists.txt
+++ b/tests/src/Common/hostpolicymock/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.6)
 project (hostpolicy)
 
+include_directories(${INC_PLATFORM_DIR})
+
 set(SOURCES HostpolicyMock.cpp )
 add_library(hostpolicy SHARED ${SOURCES})
 

--- a/tests/src/Common/hostpolicymock/HostpolicyMock.cpp
+++ b/tests/src/Common/hostpolicymock/HostpolicyMock.cpp
@@ -6,7 +6,7 @@
 // Used for testing CoreCLR/Corlib functionality which calls into hostpolicy.
 
 #include <string>
-#include "platformdefines.h"
+#include <platformdefines.h>
 
 // dllexport
 #if defined _WIN32

--- a/tests/src/Common/hostpolicymock/HostpolicyMock.cpp
+++ b/tests/src/Common/hostpolicymock/HostpolicyMock.cpp
@@ -6,6 +6,7 @@
 // Used for testing CoreCLR/Corlib functionality which calls into hostpolicy.
 
 #include <string>
+#include "platformdefines.h"
 
 // dllexport
 #if defined _WIN32


### PR DESCRIPTION
Add platformdefines.h include to fix build break.

Fixes #23268 
