### PR TITLE
Fix GetFullAffinityMask for cpuCount==64

### DIFF
--- a/src/gc/unix/gcenv.unix.cpp
+++ b/src/gc/unix/gcenv.unix.cpp
@@ -449,7 +449,8 @@ the processors enabled.
 --*/
 static uintptr_t GetFullAffinityMask(int cpuCount)
 {
-    return ((uintptr_t)1 << (cpuCount)) - 1;
+    assert((cpuCount > 0) && (cpuCount <= sizeof(uintptr_t) * 8));
+    return (((uintptr_t)1 << (cpuCount - 1)) << 1) - 1;
 }
 
 // Get affinity mask of the current process

--- a/src/gc/unix/gcenv.unix.cpp
+++ b/src/gc/unix/gcenv.unix.cpp
@@ -449,8 +449,12 @@ the processors enabled.
 --*/
 static uintptr_t GetFullAffinityMask(int cpuCount)
 {
-    assert((cpuCount > 0) && (cpuCount <= sizeof(uintptr_t) * 8));
-    return (((uintptr_t)1 << (cpuCount - 1)) << 1) - 1;
+    if (cpuCount < sizeof(uintptr_t) * 8)
+    {
+        return ((uintptr_t)1 << cpuCount) - 1;
+    }
+
+    return ~(uintptr_t)0;
 }
 
 // Get affinity mask of the current process

--- a/src/pal/src/numa/numa.cpp
+++ b/src/pal/src/numa/numa.cpp
@@ -166,8 +166,12 @@ the processors enabled.
 --*/
 KAFFINITY GetFullAffinityMask(int cpuCount)
 {
-    _ASSERTE((cpuCount > 0) && (cpuCount <= sizeof(KAFFINITY) * 8));
-    return (((KAFFINITY)1 << (cpuCount - 1)) << 1) - 1;
+    if (cpuCount < sizeof(KAFFINITY) * 8)
+    {
+        return ((KAFFINITY)1 << (cpuCount)) - 1;
+    }
+
+    return ~(KAFFINITY)0;
 }
 
 /*++

--- a/src/pal/src/numa/numa.cpp
+++ b/src/pal/src/numa/numa.cpp
@@ -166,7 +166,8 @@ the processors enabled.
 --*/
 KAFFINITY GetFullAffinityMask(int cpuCount)
 {
-    return ((KAFFINITY)1 << (cpuCount)) - 1;
+    _ASSERTE((cpuCount > 0) && (cpuCount <= sizeof(KAFFINITY) * 8));
+    return (((KAFFINITY)1 << (cpuCount - 1)) << 1) - 1;
 }
 
 /*++


### PR DESCRIPTION
The function was incorrectly assuming that shifting 64 bit
constant 1 by 64 bits to the left gets result 0.