### PR TITLE
Disable Jenkins Innerloop Jobs

### DIFF
--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -33,7 +33,7 @@ jobs:
         containerName: ubuntu_1404_arm_cross_build_image
         helixQueues:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            asString: 'Ubuntu.1404.Arm32'
+            asString: 'Ubuntu.1404.Arm32.Open'
             asArray: []
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             # We don't have any Linux/arm32 internal Helix queues

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -33,8 +33,7 @@ jobs:
         containerName: ubuntu_1404_arm_cross_build_image
         helixQueues:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            # TODO: add Ubuntu.1404.Arm32.Open once Jenkins has been shutdown
-            asString: ''
+            asString: 'Ubuntu.1404.Arm32'
             asArray: []
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             # We don't have any Linux/arm32 internal Helix queues

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -34,7 +34,8 @@ jobs:
         helixQueues:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             asString: 'Ubuntu.1404.Arm32.Open'
-            asArray: []
+            asArray:
+            - Ubuntu.1404.Arm32.Open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             # We don't have any Linux/arm32 internal Helix queues
             asString: ''

--- a/netci.groovy
+++ b/netci.groovy
@@ -169,13 +169,6 @@ class Constants {
     // Valid PR trigger combinations.
     def static prTriggeredValidInnerLoopCombos = [
         'Windows_NT': [
-            'x64': [
-                'Checked'
-            ], 
-            'x86': [
-                'Checked',
-                'Release'
-            ], 
             'arm': [
                 'Debug',
                 'Checked'
@@ -186,41 +179,9 @@ class Constants {
             ]
         ],
         'Windows_NT_BuildOnly': [
-            'x64': [
-                'Checked',
-                'Release'
-            ],
-            'x86': [
-                'Checked',
-                'Release'
-            ], 
             'arm': [
                 'Checked'
             ], 
-        ],
-        'Ubuntu': [
-            'x64': [
-                'Checked'
-            ],
-            'arm': [
-                'Checked'
-            ]
-        ],
-        'Ubuntu16.04': [
-            'arm64': [
-                'Checked'
-            ]
-        ],
-        'CentOS7.1': [
-            'x64': [
-                'Debug',
-                'Checked'
-            ]
-        ],
-        'OSX10.12': [
-            'x64': [
-                'Checked'
-            ]
         ]
     ]
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -638,8 +638,9 @@ def static addPeriodicTriggerHelper(def job, String cronString, boolean alwaysRu
 }
 
 def static addGithubPushTriggerHelper(def job) {
-    addToMergeView(job)
-    Utilities.addGithubPushTrigger(job)
+    // Disable all Push trigger jobs. All jobs will need to be requested.
+    // addToMergeView(job)
+    // Utilities.addGithubPushTrigger(job)
 }
 
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -170,11 +170,9 @@ class Constants {
     def static prTriggeredValidInnerLoopCombos = [
         'Windows_NT': [
             'arm': [
-                'Debug',
                 'Checked'
             ],
             'arm64': [
-                'Debug',
                 'Checked'
             ]
         ],


### PR DESCRIPTION
This change will:

1) Remove default PR trigger jobs from being run in jenkins
2) Start submitting tests for linux arm32 in coreclr-ci

It is worth noting that this change will not remove jobs from netci.groovy.
This is to say that it is still possible to trigger innerloop and outerloop
jobs in jenkins, they will just not be run automatically on each new PR.

Past this point the following jobs will be created:

1) Coreclr-ci
2) Windows_NT x64 Formatting
3) Windows_NT x64 Checked CoreFX Tests 
4) Windows_NT x64 Release CoreFX Tests 
5) Ubuntu arm Cross Checked crossgen_comparison Build and Test
6) Windows_NT x86 full_opt ryujit CoreCLR Perf Tests Correctness
7) Windows_NT x86 min_opt ryujit CoreCLR Perf Tests Correctness
8) Windows_NT x64 full_opt ryujit CoreCLR Perf Tests Correctness
9) Windows_NT x64 min_opt ryujit CoreCLR Perf Tests Correctness

Removed jobs (but still explicitly request-able):

1) CentOS7.1 x64 Debug Innerloop Build
2) OSX10.12 x64 Checked Innerloop Build and Test
3) Windows_NT x64 Checked Innerloop Build and Test
4) Windows_NT x64 Checked Innerloop Build and Test (Jit - TieredCompilation=0)
5) Windows_NT x86 Checked Innerloop Build and Test 
6) Windows_NT x86 Checked Innerloop Build and Test (Jit - TieredCompilation=0)
7) Windows_NT arm Debug Innerloop Build
8) Windows_NT arm64 Debug Innerloop Build

To see test results, navigate to the coreclr-ci Azure Dev Ops page at:
https://dev.azure.com/dnceng/public/_build?definitionId=228 and view the build related to your PR.
There is a test tab which will report all test results.