### PR TITLE
JIT: clear stub register assignment for tail calls via helper

### DIFF
--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -606,6 +606,12 @@ public:
         assert(_gtRegNum == reg);
     }
 
+    void ClearRegNum()
+    {
+        _gtRegNum = REG_NA;
+        INDEBUG(gtRegTag = GT_REGTAG_NONE;)
+    }
+
     // Copy the _gtRegNum/gtRegTag fields
     void CopyReg(GenTree* from);
     bool gtHasReg() const;

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -606,12 +606,6 @@ public:
         assert(_gtRegNum == reg);
     }
 
-    void ClearRegNum()
-    {
-        _gtRegNum = REG_NA;
-        INDEBUG(gtRegTag = GT_REGTAG_NONE;)
-    }
-
     // Copy the _gtRegNum/gtRegTag fields
     void CopyReg(GenTree* from);
     bool gtHasReg() const;

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7372,6 +7372,12 @@ void Compiler::fgMorphTailCall(GenTreeCall* call, void* pfnCopyArgs)
     if (call->IsVirtualStub())
     {
         GenTree* stubAddrArg = fgGetStubAddrArg(call);
+
+        // We don't need this arg to be in the normal stub register, so
+        // clear out the register assignment.
+        assert(stubAddrArg->gtRegNum == virtualStubParamInfo->GetReg());
+        stubAddrArg->ClearRegNum();
+
         // And push the stub address onto the list of arguments
         call->gtCallArgs = gtNewListNode(stubAddrArg, call->gtCallArgs);
     }
@@ -7606,6 +7612,12 @@ void Compiler::fgMorphTailCall(GenTreeCall* call, void* pfnCopyArgs)
     if (call->IsVirtualStub())
     {
         GenTree* stubAddrArg = fgGetStubAddrArg(call);
+
+        // We don't need this arg to be in the normal stub register, so
+        // clear out the register assignment.
+        assert(stubAddrArg->gtRegNum == virtualStubParamInfo->GetReg());
+        stubAddrArg->ClearRegNum();
+
         // And push the stub address onto the list of arguments
         call->gtCallArgs = gtNewListNode(stubAddrArg, call->gtCallArgs);
     }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7376,7 +7376,7 @@ void Compiler::fgMorphTailCall(GenTreeCall* call, void* pfnCopyArgs)
         // We don't need this arg to be in the normal stub register, so
         // clear out the register assignment.
         assert(stubAddrArg->gtRegNum == virtualStubParamInfo->GetReg());
-        stubAddrArg->ClearRegNum();
+        stubAddrArg->gtRegNum = REG_NA;
 
         // And push the stub address onto the list of arguments
         call->gtCallArgs = gtNewListNode(stubAddrArg, call->gtCallArgs);
@@ -7616,7 +7616,7 @@ void Compiler::fgMorphTailCall(GenTreeCall* call, void* pfnCopyArgs)
         // We don't need this arg to be in the normal stub register, so
         // clear out the register assignment.
         assert(stubAddrArg->gtRegNum == virtualStubParamInfo->GetReg());
-        stubAddrArg->ClearRegNum();
+        stubAddrArg->gtRegNum = REG_NA;
 
         // And push the stub address onto the list of arguments
         call->gtCallArgs = gtNewListNode(stubAddrArg, call->gtCallArgs);


### PR DESCRIPTION
When we have a VSD tail call via a helper, the stub arg is passed as a normal
arg to the helper and moved to the right special register by the copy routine
that the helper invokes. So the jit does not need to pass the stub value in the
special register when calling the helper.

The stub arg gets set to that register by default, so we now unset it for the
tail call via helper case.

Closes #18943.