### PR TITLE
Updated Exception Handling for Collection<T>

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
@@ -108,7 +108,7 @@ namespace System.Collections.ObjectModel
                 ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_ReadOnlyCollection);
             }
 
-            if (index < 0 || index > items.Count)
+            if ((uint)index > (uint)items.Count)
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_ListInsert);
             }
@@ -211,7 +211,7 @@ namespace System.Collections.ObjectModel
                 ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_ReadOnlyCollection);
             }
 
-            if (index < 0 || index >= items.Count)
+            if ((uint)index >= (uint)items.Count)
             {
                 ThrowHelper.ThrowArgumentOutOfRange_IndexException();
             }

--- a/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
@@ -110,7 +110,7 @@ namespace System.Collections.ObjectModel
 
             if ((uint)index > (uint)items.Count)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_ListInsert);
+                ThrowHelper.ThrowArgumentOutOfRange_IndexException();
             }
 
             InsertItem(index, item);
@@ -130,7 +130,7 @@ namespace System.Collections.ObjectModel
 
             if ((uint)index > (uint)items.Count)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_Index);
+                ThrowHelper.ThrowArgumentOutOfRange_IndexException();
             }
 
             InsertItemsRange(index, collection);

--- a/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
@@ -130,7 +130,7 @@ namespace System.Collections.ObjectModel
 
             if ((uint)index > (uint)items.Count)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_ListInsert);
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_Index);
             }
 
             InsertItemsRange(index, collection);

--- a/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
@@ -49,7 +49,7 @@ namespace System.Collections.ObjectModel
                     ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_ReadOnlyCollection);
                 }
 
-                if (index < 0 || index >= items.Count)
+                if ((uint)index >= (uint)items.Count)
                 {
                     ThrowHelper.ThrowArgumentOutOfRange_IndexException();
                 }

--- a/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ObjectModel/Collection.cs
@@ -125,7 +125,7 @@ namespace System.Collections.ObjectModel
 
             if (collection == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.list);
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.collection);
             }
 
             if ((uint)index > (uint)items.Count)
@@ -198,7 +198,7 @@ namespace System.Collections.ObjectModel
 
             if (collection == null)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.list);
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.collection);
             }
 
             ReplaceItemsRange(index, count, collection);


### PR DESCRIPTION
Part of #23166 

This change addresses follow-up concerns on how we are throwing different exceptions in the Collection<T> class for add range APIs which are used ObservableCollection<T> as well.

@stephentoub highlighted several follow up concerns which I believe I have covered in this PR and in the comment here.

https://github.com/dotnet/coreclr/pull/23166#discussion_r266012736
https://github.com/dotnet/coreclr/pull/23166#discussion_r266014304
>There's no list argument to this method, but the exception is going to be new ArgumentNullException("list"). The ExceptionArgument.list should be changed to ExceptionArgument.collection.

* Fixed

https://github.com/dotnet/coreclr/pull/23166#discussion_r266013413
>This exception message is "Index must be within the bounds of the List.". The code consuming this isn't using "List", though.

* Fixed

https://github.com/dotnet/coreclr/pull/23166#discussion_r266014089
https://github.com/dotnet/coreclr/pull/23166#discussion_r266014242
>The exception message here is "Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection"... but the arguments to this method are "index" and "count", not "offset" and "length"... are we ok with that mismatch?

* Not Fixed

I don't think is appropriate to adjust the parameters or code as recommended. As `List.cs` uses the exact same exception and we wrote our code to follow the same standard as `List.cs` which is what we have been doing while we work through this change. @stephentoub if this is not correct, please advise on direction.

https://github.com/dotnet/coreclr/blob/b93891a6e1705f7d8c671cd673abaaf03b0a09cb/src/System.Private.CoreLib/shared/System/Collections/Generic/List.cs#L927-L928

cc: @ahsonkhan, @safern, @justinvp 