### PR TITLE
Fixing some payload serialization issue on new EventCounters

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterPayload.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterPayload.cs
@@ -150,7 +150,7 @@ namespace System.Diagnostics.Tracing
             {
                 yield return new KeyValuePair<string, object>("Name", Name);
                 yield return new KeyValuePair<string, object>("DisplayName", DisplayName);
-                yield return new KeyValuePair<string, object>("DisplayRateTimeScale");
+                yield return new KeyValuePair<string, object>("DisplayRateTimeScale", DisplayRateTimeScale);
                 yield return new KeyValuePair<string, object>("Increment", Increment);
                 yield return new KeyValuePair<string, object>("IntervalSec", IntervalSec);
                 yield return new KeyValuePair<string, object>("Series", $"Interval={IntervalSec}");

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterPayload.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterPayload.cs
@@ -124,7 +124,7 @@ namespace System.Diagnostics.Tracing
 
         public string DisplayName { get; set; }
 
-        public TimeSpan DisplayRateTimeScale { get; set; }
+        public string DisplayRateTimeScale { get; set; }
 
         public float Increment { get; set; }
 
@@ -150,7 +150,7 @@ namespace System.Diagnostics.Tracing
             {
                 yield return new KeyValuePair<string, object>("Name", Name);
                 yield return new KeyValuePair<string, object>("DisplayName", DisplayName);
-                yield return new KeyValuePair<string, object>("DisplayRateTimeScale", DisplayRateTimeScale.ToString("c"));
+                yield return new KeyValuePair<string, object>("DisplayRateTimeScale");
                 yield return new KeyValuePair<string, object>("Increment", Increment);
                 yield return new KeyValuePair<string, object>("IntervalSec", IntervalSec);
                 yield return new KeyValuePair<string, object>("Series", $"Interval={IntervalSec}");

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/IncrementingEventCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/IncrementingEventCounter.cs
@@ -62,8 +62,8 @@ namespace System.Diagnostics.Tracing
                 IncrementingCounterPayload payload = new IncrementingCounterPayload();
                 payload.Name = _name;
                 payload.IntervalSec = intervalSec;
-                payload.DisplayName = DisplayName;
-                payload.DisplayRateTimeScale = DisplayRateTimeScale;
+                payload.DisplayName = (DisplayName == null) ? "" : DisplayName;
+                payload.DisplayRateTimeScale = (DisplayRateTimeScale == TimeSpan.Zero) ? "" : DisplayRateTimeScale.ToString("c");
                 payload.MetaData = GetMetaDataString();
                 payload.Increment = _increment - _prevIncrement;
                 _prevIncrement = _increment;

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/IncrementingPollingCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/IncrementingPollingCounter.cs
@@ -71,8 +71,8 @@ namespace System.Diagnostics.Tracing
             {
                 IncrementingCounterPayload payload = new IncrementingCounterPayload();
                 payload.Name = _name;
-                payload.DisplayName = DisplayName;
-                payload.DisplayRateTimeScale = DisplayRateTimeScale;
+                payload.DisplayName = (DisplayName == null) ? "" : DisplayName;
+                payload.DisplayRateTimeScale = (DisplayRateTimeScale == TimeSpan.Zero) ? "" : DisplayRateTimeScale.ToString("c");
                 payload.IntervalSec = intervalSec;
                 payload.MetaData = GetMetaDataString();
                 payload.Increment = _increment - _prevIncrement;

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/PollingCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/PollingCounter.cs
@@ -58,6 +58,7 @@ namespace System.Diagnostics.Tracing
 
                 CounterPayload payload = new CounterPayload();
                 payload.Name = _name;
+                payload.DisplayName = (DisplayName == null) ? "" : DisplayName;
                 payload.Count = 1; // NOTE: These dumb-looking statistics is intentional
                 payload.IntervalSec = intervalSec;
                 payload.Mean = value;


### PR DESCRIPTION
Found this while working on some tests for the new EventCounter APIs. If DisplayRateTimeScale and DisplayName properties are not set, we may incorrectly serialize the payload and TraceEvent hiccups when it sees payloads like this. 