### PR TITLE
Adding a flag to able/disable scope info

### DIFF
--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -757,6 +757,8 @@ protected:
      * This struct holds the LocalVarInfo in terms of the generated native code
      * after a call to genSetScopeInfo()
      */
+
+protected:
 #ifdef DEBUG
 
     struct TrnslLocalVarInfo

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -565,6 +565,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     void genSetScopeInfoUsingsiScope();
 #endif
 
+#ifdef USING_SCOPE_INFO
 protected:
     /*
     XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -752,7 +753,7 @@ protected:
     void psiEndPrologScope(psiScope* scope);
 
     void psSetScopeOffset(psiScope* newScope, LclVarDsc* lclVarDsc1);
-
+#endif
 /*****************************************************************************
  *                        TrnslLocalVarInfo
  *

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -563,7 +563,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     void genSetScopeInfo();
 #ifdef USING_SCOPE_INFO
     void genSetScopeInfoUsingsiScope();
-#endif
+#endif // USING_SCOPE_INFO
 
 #ifdef USING_SCOPE_INFO
 protected:
@@ -753,13 +753,13 @@ protected:
     void psiEndPrologScope(psiScope* scope);
 
     void psSetScopeOffset(psiScope* newScope, LclVarDsc* lclVarDsc1);
-#endif
-/*****************************************************************************
- *                        TrnslLocalVarInfo
- *
- * This struct holds the LocalVarInfo in terms of the generated native code
- * after a call to genSetScopeInfo()
- */
+#endif // USING_SCOPE_INFO
+       /*****************************************************************************
+        *                        TrnslLocalVarInfo
+        *
+        * This struct holds the LocalVarInfo in terms of the generated native code
+        * after a call to genSetScopeInfo()
+        */
 
 #ifdef DEBUG
 

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -563,10 +563,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     void genSetScopeInfo();
 #ifdef USING_SCOPE_INFO
     void genSetScopeInfoUsingsiScope();
-#endif // USING_SCOPE_INFO
 
-#ifdef USING_SCOPE_INFO
-protected:
     /*
     XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -672,7 +669,6 @@ public:
     const char* siStackVarName(size_t offs, size_t size, unsigned reg, unsigned stkOffs);
 #endif // LATE_DISASM
 
-public:
     /*
     XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -754,13 +750,13 @@ protected:
 
     void psSetScopeOffset(psiScope* newScope, LclVarDsc* lclVarDsc1);
 #endif // USING_SCOPE_INFO
-       /*****************************************************************************
-        *                        TrnslLocalVarInfo
-        *
-        * This struct holds the LocalVarInfo in terms of the generated native code
-        * after a call to genSetScopeInfo()
-        */
 
+    /*****************************************************************************
+     *                        TrnslLocalVarInfo
+     *
+     * This struct holds the LocalVarInfo in terms of the generated native code
+     * after a call to genSetScopeInfo()
+     */
 #ifdef DEBUG
 
     struct TrnslLocalVarInfo

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -561,6 +561,9 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
                          siVarLoc*      varLoc);
 
     void genSetScopeInfo();
+#ifdef USING_SCOPE_INFO
+    void genSetScopeInfoUsingsiScope();
+#endif
 
 protected:
     /*

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -3860,11 +3860,12 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
 
 #ifdef _TARGET_ARM_
     compiler->unwindAllocStack(frameSize);
-
+#ifdef USING_SCOPE_INFO
     if (!doubleAlignOrFramePointerUsed())
     {
         psiAdjustStackLevel(frameSize);
     }
+#endif
 #endif // _TARGET_ARM_
 }
 

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -3865,7 +3865,7 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
     {
         psiAdjustStackLevel(frameSize);
     }
-#endif
+#endif // USING_SCOPE_INFO
 #endif // _TARGET_ARM_
 }
 

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -734,7 +734,7 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
     }
 #ifdef USING_SCOPE_INFO
     codeGen->siUpdate();
-#endif
+#endif // USING_SCOPE_INFO
 }
 
 // Need an explicit instantiation.
@@ -3810,7 +3810,7 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
             {
                 psiMoveToStack(varNum);
             }
-#endif
+#endif // USING_SCOPE_INFO
         }
 
         /* mark the argument as processed */
@@ -3957,7 +3957,7 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
 #ifdef USING_SCOPE_INFO
                 psiMoveToReg(varNumSrc);
                 psiMoveToReg(varNumDest);
-#endif
+#endif // USING_SCOPE_INFO
             }
             else
 #endif // _TARGET_XARCH_
@@ -4021,7 +4021,7 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
                 *pXtraRegClobbered = true;
 #ifdef USING_SCOPE_INFO
                 psiMoveToReg(varNumDest, xtraReg);
-#endif
+#endif // USING_SCOPE_INFO
                 /* start moving everything to its right place */
 
                 while (srcReg != begReg)
@@ -4088,7 +4088,7 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
                 regSet.verifyRegUsed(destRegNum);
 #ifdef USING_SCOPE_INFO
                 psiMoveToReg(varNumSrc);
-#endif
+#endif // USING_SCOPE_INFO
                 /* mark the beginning register as processed */
 
                 regArgTab[srcReg].processed = true;
@@ -4274,7 +4274,7 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
                 getEmitter()->emitIns_R_R(ins_Copy(destMemType), size, destRegNum, regNum);
 #ifdef USING_SCOPE_INFO
                 psiMoveToReg(varNum);
-#endif
+#endif // USING_SCOPE_INFO
             }
 
             /* mark the argument as processed */
@@ -4410,7 +4410,7 @@ void CodeGen::genEnregisterIncomingStackArgs()
         regSet.verifyRegUsed(regNum);
 #ifdef USING_SCOPE_INFO
         psiMoveToReg(varNum);
-#endif
+#endif // USING_SCOPE_INFO
     }
 }
 
@@ -5257,7 +5257,7 @@ void          CodeGen::genPushCalleeSavedRegisters()
             {
                 psiAdjustStackLevel(REGSIZE_BYTES);
             }
-#endif
+#endif // USING_SCOPE_INFO
             rsPushRegs &= ~regBit;
         }
     }
@@ -7538,7 +7538,7 @@ void CodeGen::genEstablishFramePointer(int delta, bool reportUnwindData)
         getEmitter()->emitIns_R_R(INS_mov, EA_PTRSIZE, REG_FPBASE, REG_SPBASE);
 #ifdef USING_SCOPE_INFO
         psiMoveESPtoEBP();
-#endif
+#endif // USING_SCOPE_INFO
     }
     else
     {
@@ -7646,7 +7646,7 @@ void CodeGen::genFnProlog()
         // Create new scopes for the method-parameters for the prolog-block.
         psiBegProlog();
     }
-#endif
+#endif // USING_SCOPE_INFO
 
 #ifdef DEBUG
 
@@ -7973,7 +7973,7 @@ void CodeGen::genFnProlog()
         compiler->unwindPush(REG_FPBASE);
 #ifdef USING_SCOPE_INFO
         psiAdjustStackLevel(REGSIZE_BYTES);
-#endif
+#endif                 // USING_SCOPE_INFO
 #ifndef _TARGET_AMD64_ // On AMD64, establish the frame pointer after the "sub rsp"
         genEstablishFramePointer(0, /*reportUnwindData*/ true);
 #endif // !_TARGET_AMD64_
@@ -8298,7 +8298,7 @@ void CodeGen::genFnProlog()
     {
         psiEndProlog();
     }
-#endif
+#endif // USING_SCOPE_INFO
     if (hasGCRef)
     {
         getEmitter()->emitSetFrameRangeGCRs(GCrefLo, GCrefHi);
@@ -10499,7 +10499,7 @@ void CodeGen::genSetScopeInfo()
     unsigned varsHomeCount = 0;
 #ifdef USING_SCOPE_INFO
     varsHomeCount = siScopeCnt + psiScopeCnt;
-#endif
+#endif // USING_SCOPE_INFO
     compiler->eeSetLVcount(varsHomeCount);
 
 #ifdef DEBUG
@@ -10512,7 +10512,7 @@ void CodeGen::genSetScopeInfo()
 
 #ifdef USING_SCOPE_INFO
     genSetScopeInfoUsingsiScope();
-#endif
+#endif // USING_SCOPE_INFO
 
     compiler->eeSetLVdone();
 }
@@ -10586,7 +10586,7 @@ void CodeGen::genSetScopeInfoUsingsiScope()
                         scopeL->scAvailable, &varLoc);
     }
 }
-#endif
+#endif // USING_SCOPE_INFO
 
 //------------------------------------------------------------------------
 // genSetScopeInfo: Record scope information for debug info

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -732,8 +732,9 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
             JITDUMP("\t\t\t\t\t\t\tV%02u becoming live\n", varNum);
         }
     }
-
+#ifdef USING_SCOPE_INFO
     codeGen->siUpdate();
+#endif
 }
 
 // Need an explicit instantiation.
@@ -3804,11 +3805,12 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
                 assert(varDsc->lvSize() >= baseOffset + (unsigned)size);
             }
 #endif // !UNIX_AMD64_ABI
-
+#ifdef USING_SCOPE_INFO
             if (regArgTab[argNum].slot == 1)
             {
                 psiMoveToStack(varNum);
             }
+#endif
         }
 
         /* mark the argument as processed */
@@ -3952,9 +3954,10 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
 
                 regArgMaskLive &= ~genRegMask(varDscSrc->lvArgReg);
                 regArgMaskLive &= ~genRegMask(varDscDest->lvArgReg);
-
+#ifdef USING_SCOPE_INFO
                 psiMoveToReg(varNumSrc);
                 psiMoveToReg(varNumDest);
+#endif
             }
             else
 #endif // _TARGET_XARCH_
@@ -4016,9 +4019,9 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
                 regSet.verifyRegUsed(xtraReg);
 
                 *pXtraRegClobbered = true;
-
+#ifdef USING_SCOPE_INFO
                 psiMoveToReg(varNumDest, xtraReg);
-
+#endif
                 /* start moving everything to its right place */
 
                 while (srcReg != begReg)
@@ -4083,9 +4086,9 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
                 getEmitter()->emitIns_R_R(insCopy, size, destRegNum, xtraReg);
 
                 regSet.verifyRegUsed(destRegNum);
-
+#ifdef USING_SCOPE_INFO
                 psiMoveToReg(varNumSrc);
-
+#endif
                 /* mark the beginning register as processed */
 
                 regArgTab[srcReg].processed = true;
@@ -4269,8 +4272,9 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
 #endif
 
                 getEmitter()->emitIns_R_R(ins_Copy(destMemType), size, destRegNum, regNum);
-
+#ifdef USING_SCOPE_INFO
                 psiMoveToReg(varNum);
+#endif
             }
 
             /* mark the argument as processed */
@@ -4404,8 +4408,9 @@ void CodeGen::genEnregisterIncomingStackArgs()
 
         getEmitter()->emitIns_R_S(ins_Load(type), emitTypeSize(type), regNum, varNum, 0);
         regSet.verifyRegUsed(regNum);
-
+#ifdef USING_SCOPE_INFO
         psiMoveToReg(varNum);
+#endif
     }
 }
 
@@ -5247,12 +5252,12 @@ void          CodeGen::genPushCalleeSavedRegisters()
         {
             inst_RV(INS_push, reg, TYP_REF);
             compiler->unwindPush(reg);
-
+#ifdef USING_SCOPE_INFO
             if (!doubleAlignOrFramePointerUsed())
             {
                 psiAdjustStackLevel(REGSIZE_BYTES);
             }
-
+#endif
             rsPushRegs &= ~regBit;
         }
     }
@@ -7531,7 +7536,9 @@ void CodeGen::genEstablishFramePointer(int delta, bool reportUnwindData)
     if (delta == 0)
     {
         getEmitter()->emitIns_R_R(INS_mov, EA_PTRSIZE, REG_FPBASE, REG_SPBASE);
+#ifdef USING_SCOPE_INFO
         psiMoveESPtoEBP();
+#endif
     }
     else
     {
@@ -7633,12 +7640,13 @@ void CodeGen::genFnProlog()
         printf("\n__prolog:\n");
     }
 #endif
-
+#ifdef USING_SCOPE_INFO
     if (compiler->opts.compScopeInfo && (compiler->info.compVarScopesCount > 0))
     {
         // Create new scopes for the method-parameters for the prolog-block.
         psiBegProlog();
     }
+#endif
 
 #ifdef DEBUG
 
@@ -7963,8 +7971,9 @@ void CodeGen::genFnProlog()
     {
         inst_RV(INS_push, REG_FPBASE, TYP_REF);
         compiler->unwindPush(REG_FPBASE);
+#ifdef USING_SCOPE_INFO
         psiAdjustStackLevel(REGSIZE_BYTES);
-
+#endif
 #ifndef _TARGET_AMD64_ // On AMD64, establish the frame pointer after the "sub rsp"
         genEstablishFramePointer(0, /*reportUnwindData*/ true);
 #endif // !_TARGET_AMD64_
@@ -8284,12 +8293,12 @@ void CodeGen::genFnProlog()
         genPrologPadForReJit();
         getEmitter()->emitMarkPrologEnd();
     }
-
+#ifdef USING_SCOPE_INFO
     if (compiler->opts.compScopeInfo && (compiler->info.compVarScopesCount > 0))
     {
         psiEndProlog();
     }
-
+#endif
     if (hasGCRef)
     {
         getEmitter()->emitSetFrameRangeGCRs(GCrefLo, GCrefHi);

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -25,6 +25,12 @@
 #include "jitgcinfo.h"
 #include "treelifeupdater.h"
 
+// Disable this flag to avoid using psiScope/siScope info to report reporting 
+// variables' home location during the method/prolog code.
+#if 1
+#define USING_SCOPE_INFO
+#endif
+
 // Forward reference types
 
 class CodeGenInterface;

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -391,7 +391,9 @@ private:
     bool m_cgFullPtrRegMap;
 
 public:
+#ifdef USING_SCOPE_INFO
     virtual void siUpdate() = 0;
+#endif
 
     /* These are the different addressing modes used to access a local var.
      * The JIT has to report the location of the locals back to the EE

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -29,7 +29,7 @@
 // variables' home location during the method/prolog code.
 #if 0
 #define USING_SCOPE_INFO
-#endif
+#endif // USING_SCOPE_INFO
 
 // Forward reference types
 
@@ -393,7 +393,7 @@ private:
 public:
 #ifdef USING_SCOPE_INFO
     virtual void siUpdate() = 0;
-#endif
+#endif // USING_SCOPE_INFO
 
     /* These are the different addressing modes used to access a local var.
      * The JIT has to report the location of the locals back to the EE

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -25,9 +25,9 @@
 #include "jitgcinfo.h"
 #include "treelifeupdater.h"
 
-// Disable this flag to avoid using psiScope/siScope info to report reporting 
+// Disable this flag to avoid using psiScope/siScope info to report reporting
 // variables' home location during the method/prolog code.
-#if 1
+#if 0
 #define USING_SCOPE_INFO
 #endif
 

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -27,7 +27,7 @@
 
 // Disable this flag to avoid using psiScope/siScope info to report reporting
 // variables' home location during the method/prolog code.
-#if 0
+#if 1
 #define USING_SCOPE_INFO
 #endif // USING_SCOPE_INFO
 

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -84,8 +84,8 @@ void CodeGen::genInitializeRegisterState()
 //    iterated.
 void CodeGen::genInitialize()
 {
-    // Initialize the line# tracking logic
 #ifdef USING_SCOPE_INFO
+    // Initialize the line# tracking logic
     if (compiler->opts.compScopeInfo)
     {
         siInit();

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -351,7 +351,7 @@ void CodeGen::genCodeForBBlist()
         /* Tell everyone which basic block we're working on */
 
         compiler->compCurBB = block;
-#ifdef USUSING_SCOPE_INFOING_
+#ifdef USING_SCOPE_INFO
         siBeginBlock(block);
 #endif
         // BBF_INTERNAL blocks don't correspond to any single IL instruction.

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -85,11 +85,12 @@ void CodeGen::genInitializeRegisterState()
 void CodeGen::genInitialize()
 {
     // Initialize the line# tracking logic
-
+#ifdef USING_SCOPE_INFO
     if (compiler->opts.compScopeInfo)
     {
         siInit();
     }
+#endif
 
     // The current implementation of switch tables requires the first block to have a label so it
     // can generate offsets to the switch label targets.
@@ -350,9 +351,9 @@ void CodeGen::genCodeForBBlist()
         /* Tell everyone which basic block we're working on */
 
         compiler->compCurBB = block;
-
+#ifdef USUSING_SCOPE_INFOING_
         siBeginBlock(block);
-
+#endif
         // BBF_INTERNAL blocks don't correspond to any single IL instruction.
         if (compiler->opts.compDbgInfo && (block->bbFlags & BBF_INTERNAL) &&
             !compiler->fgBBisScratch(block)) // If the block is the distinguished first scratch block, then no need to
@@ -508,7 +509,7 @@ void CodeGen::genCodeForBBlist()
         // This can lead to problems when debugging the generated code. To prevent these issues, make sure
         // we've generated code for the last IL offset we saw in the block.
         genEnsureCodeEmitted(currentILOffset);
-
+#ifdef USING_SCOPE_INFO
         if (compiler->opts.compScopeInfo && (compiler->info.compVarScopesCount > 0))
         {
             siEndBlock(block);
@@ -533,6 +534,7 @@ void CodeGen::genCodeForBBlist()
                 siCloseAllOpenScopes();
             }
         }
+#endif
 
         SubtractStackLevel(savedStkLvl);
 

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -90,7 +90,7 @@ void CodeGen::genInitialize()
     {
         siInit();
     }
-#endif
+#endif // USING_SCOPE_INFO
 
     // The current implementation of switch tables requires the first block to have a label so it
     // can generate offsets to the switch label targets.
@@ -353,7 +353,7 @@ void CodeGen::genCodeForBBlist()
         compiler->compCurBB = block;
 #ifdef USING_SCOPE_INFO
         siBeginBlock(block);
-#endif
+#endif // USING_SCOPE_INFO
         // BBF_INTERNAL blocks don't correspond to any single IL instruction.
         if (compiler->opts.compDbgInfo && (block->bbFlags & BBF_INTERNAL) &&
             !compiler->fgBBisScratch(block)) // If the block is the distinguished first scratch block, then no need to
@@ -534,7 +534,7 @@ void CodeGen::genCodeForBBlist()
                 siCloseAllOpenScopes();
             }
         }
-#endif
+#endif // USING_SCOPE_INFO
 
         SubtractStackLevel(savedStkLvl);
 

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -2338,7 +2338,7 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
     {
         psiAdjustStackLevel(frameSize);
     }
-#endif
+#endif // USING_SCOPE_INFO
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -2333,11 +2333,12 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
     }
 
     compiler->unwindAllocStack(frameSize);
-
+#ifdef USING_SCOPE_INFO
     if (!doubleAlignOrFramePointerUsed())
     {
         psiAdjustStackLevel(frameSize);
     }
+#endif
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -1614,4 +1614,4 @@ void CodeGen::psiEndProlog()
         psiEndPrologScope(scope);
     }
 }
-#endif
+#endif // USING_SCOPE_INFO

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -131,30 +131,6 @@ bool CodeGenInterface::siVarLoc::vlIsOnStk(regNumber reg, signed offset)
 }
 
 //------------------------------------------------------------------------
-// siVarLoc: Non-empty constructor of siVarLoc struct
-// Arguments:
-//    varDsc    - a "LclVarDsc *" to the variable it is desired to build the "siVarLoc".
-//    baseReg   - a "regNumber" use as a base for the offset.
-//    offset    - a signed amount of bytes distance from "baseReg" for the position of the variable.
-//    isFramePointerUsed - a boolean variable
-//
-// Notes:
-//    Called for every psiScope in "psiScopeList" codegen.h
-CodeGenInterface::siVarLoc::siVarLoc(const LclVarDsc* varDsc, regNumber baseReg, int offset, bool isFramePointerUsed)
-{
-    var_types type = genActualType(varDsc->TypeGet());
-
-    if (varDsc->lvIsInReg())
-    {
-        siFillRegisterVarLoc(varDsc, type, baseReg, offset, isFramePointerUsed);
-    }
-    else
-    {
-        siFillStackVarLoc(varDsc, type, baseReg, offset, isFramePointerUsed);
-    }
-}
-
-//------------------------------------------------------------------------
 // Equals: Compares first reference and then values of the structures.
 //
 // Arguments:
@@ -225,65 +201,6 @@ bool CodeGenInterface::siVarLoc::Equals(const siVarLoc* lhs, const siVarLoc* rhs
         default:
             unreached();
     }
-}
-
-//------------------------------------------------------------------------
-// getSiVarLoc: Creates a "CodegenInterface::siVarLoc" instance from using the properties
-// of the "psiScope" instance.
-//
-// Notes:
-//    Called for every psiScope in "psiScopeList" codegen.h
-CodeGenInterface::siVarLoc CodeGen::psiScope::getSiVarLoc() const
-{
-    CodeGenInterface::siVarLoc varLoc;
-
-    if (scRegister)
-    {
-        varLoc.vlType       = VLT_REG;
-        varLoc.vlReg.vlrReg = (regNumber)u1.scRegNum;
-    }
-    else
-    {
-        varLoc.vlType           = VLT_STK;
-        varLoc.vlStk.vlsBaseReg = (regNumber)u2.scBaseReg;
-        varLoc.vlStk.vlsOffset  = u2.scOffset;
-    }
-
-    return varLoc;
-}
-
-//------------------------------------------------------------------------
-// getSiVarLoc: Returns a "siVarLoc" instance representing the place where the variable
-// is given its description, "baseReg", and "offset" (if needed).
-//
-// Arguments:
-//    varDsc    - a "LclVarDsc *" to the variable it is desired to build the "siVarLoc".
-//    scope   - a "siScope" Scope info of the variable.
-//
-// Return Value:
-//    A "siVarLoc" filled with the correct case struct fields for the variable, which could live
-//    in a register, an stack position, or a combination of both.
-//
-// Notes:
-//    Called for each siScope in siScopeList when "genSetScopeInfo".
-CodeGenInterface::siVarLoc CodeGen::getSiVarLoc(const LclVarDsc* varDsc, const siScope* scope) const
-{
-    // For stack vars, find the base register, and offset
-
-    regNumber baseReg;
-    signed    offset = varDsc->lvStkOffs;
-
-    if (!varDsc->lvFramePointerBased)
-    {
-        baseReg = REG_SPBASE;
-        offset += scope->scStackLevel;
-    }
-    else
-    {
-        baseReg = REG_FPBASE;
-    }
-
-    return CodeGenInterface::siVarLoc(varDsc, baseReg, offset, isFramePointerUsed());
 }
 
 //------------------------------------------------------------------------
@@ -469,6 +386,90 @@ void CodeGenInterface::siVarLoc::siFillRegisterVarLoc(
         default:
             noway_assert(!"Invalid type");
     }
+}
+
+//------------------------------------------------------------------------
+// siVarLoc: Non-empty constructor of siVarLoc struct
+// Arguments:
+//    varDsc    - a "LclVarDsc *" to the variable it is desired to build the "siVarLoc".
+//    baseReg   - a "regNumber" use as a base for the offset.
+//    offset    - a signed amount of bytes distance from "baseReg" for the position of the variable.
+//    isFramePointerUsed - a boolean variable
+//
+// Notes:
+//    Called for every psiScope in "psiScopeList" codegen.h
+CodeGenInterface::siVarLoc::siVarLoc(const LclVarDsc* varDsc, regNumber baseReg, int offset, bool isFramePointerUsed)
+{
+    var_types type = genActualType(varDsc->TypeGet());
+
+    if (varDsc->lvIsInReg())
+    {
+        siFillRegisterVarLoc(varDsc, type, baseReg, offset, isFramePointerUsed);
+    }
+    else
+    {
+        siFillStackVarLoc(varDsc, type, baseReg, offset, isFramePointerUsed);
+    }
+}
+
+#ifdef USING_SCOPE_INFO
+//------------------------------------------------------------------------
+// getSiVarLoc: Returns a "siVarLoc" instance representing the place where the variable
+// is given its description, "baseReg", and "offset" (if needed).
+//
+// Arguments:
+//    varDsc    - a "LclVarDsc *" to the variable it is desired to build the "siVarLoc".
+//    scope   - a "siScope" Scope info of the variable.
+//
+// Return Value:
+//    A "siVarLoc" filled with the correct case struct fields for the variable, which could live
+//    in a register, an stack position, or a combination of both.
+//
+// Notes:
+//    Called for each siScope in siScopeList when "genSetScopeInfo".
+CodeGenInterface::siVarLoc CodeGen::getSiVarLoc(const LclVarDsc* varDsc, const siScope* scope) const
+{
+    // For stack vars, find the base register, and offset
+
+    regNumber baseReg;
+    signed    offset = varDsc->lvStkOffs;
+
+    if (!varDsc->lvFramePointerBased)
+    {
+        baseReg = REG_SPBASE;
+        offset += scope->scStackLevel;
+    }
+    else
+    {
+        baseReg = REG_FPBASE;
+    }
+
+    return CodeGenInterface::siVarLoc(varDsc, baseReg, offset, isFramePointerUsed());
+}
+
+//------------------------------------------------------------------------
+// getSiVarLoc: Creates a "CodegenInterface::siVarLoc" instance from using the properties
+// of the "psiScope" instance.
+//
+// Notes:
+//    Called for every psiScope in "psiScopeList" codegen.h
+CodeGenInterface::siVarLoc CodeGen::psiScope::getSiVarLoc() const
+{
+    CodeGenInterface::siVarLoc varLoc;
+
+    if (scRegister)
+    {
+        varLoc.vlType       = VLT_REG;
+        varLoc.vlReg.vlrReg = (regNumber)u1.scRegNum;
+    }
+    else
+    {
+        varLoc.vlType           = VLT_STK;
+        varLoc.vlStk.vlsBaseReg = (regNumber)u2.scBaseReg;
+        varLoc.vlStk.vlsOffset  = u2.scOffset;
+    }
+
+    return varLoc;
 }
 
 /*============================================================================
@@ -1613,3 +1614,4 @@ void CodeGen::psiEndProlog()
         psiEndPrologScope(scope);
     }
 }
+#endif

--- a/src/jit/treelifeupdater.cpp
+++ b/src/jit/treelifeupdater.cpp
@@ -245,8 +245,9 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
                 }
 #endif // DEBUG
             }
-
+#ifdef USING_SCOPE_INFO
             compiler->codeGen->siUpdate();
+#endif
         }
     }
 

--- a/src/jit/treelifeupdater.cpp
+++ b/src/jit/treelifeupdater.cpp
@@ -247,7 +247,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
             }
 #ifdef USING_SCOPE_INFO
             compiler->codeGen->siUpdate();
-#endif
+#endif // USING_SCOPE_INFO
         }
     }
 


### PR DESCRIPTION
We are adding a [new way of tracking variables' home](https://github.com/dotnet/coreclr/pull/22770). It is useless to have both activated at the same time, so this PR is for able/disable siScope and psiScope info.