### PR TITLE
Replace bbTreeList  with  GetBBTreeList()

### DIFF
--- a/src/jit/block.cpp
+++ b/src/jit/block.cpp
@@ -705,7 +705,7 @@ Statement* BasicBlock::lastStmt() const
 //
 GenTree* BasicBlock::firstNode()
 {
-    return IsLIR() ? bbTreeList : Compiler::fgGetFirstNode(firstStmt()->gtStmtExpr);
+    return IsLIR() ? GetBBTreeList() : Compiler::fgGetFirstNode(firstStmt()->gtStmtExpr);
 }
 
 //------------------------------------------------------------------------
@@ -819,7 +819,7 @@ bool BasicBlock::isValid()
     else
     {
         // Should not have tree list before LIR.
-        return (bbTreeList == nullptr);
+        return (GetBBTreeList() == nullptr);
     }
 }
 

--- a/src/jit/block.cpp
+++ b/src/jit/block.cpp
@@ -705,7 +705,7 @@ Statement* BasicBlock::lastStmt() const
 //
 GenTree* BasicBlock::firstNode()
 {
-    return IsLIR() ? GetBBTreeList() : Compiler::fgGetFirstNode(firstStmt()->gtStmtExpr);
+    return IsLIR() ? GetFirstLIRNode() : Compiler::fgGetFirstNode(firstStmt()->gtStmtExpr);
 }
 
 //------------------------------------------------------------------------
@@ -819,7 +819,7 @@ bool BasicBlock::isValid()
     else
     {
         // Should not have tree list before LIR.
-        return (GetBBTreeList() == nullptr);
+        return (GetFirstLIRNode() == nullptr);
     }
 }
 

--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -743,16 +743,14 @@ struct BasicBlock : private LIR::Range
         return bbRefs;
     }
 
-    __declspec(property(get = getBBTreeList, put = setBBTreeList)) GenTree* bbTreeList; // the body of the block.
-
     Statement* bbStmtList;
 
-    GenTree* getBBTreeList() const
+    GenTree* GetBBTreeList() const
     {
         return m_firstNode;
     }
 
-    void setBBTreeList(GenTree* tree)
+    void SetBBTreeList(GenTree* tree)
     {
         m_firstNode = tree;
     }

--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -750,7 +750,7 @@ struct BasicBlock : private LIR::Range
         return m_firstNode;
     }
 
-    void SetBBTreeList(GenTree* tree)
+    void SetFirstLIRNode(GenTree* tree)
     {
         m_firstNode = tree;
     }

--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -745,7 +745,7 @@ struct BasicBlock : private LIR::Range
 
     Statement* bbStmtList;
 
-    GenTree* GetBBTreeList() const
+    GenTree* GetFirstLIRNode() const
     {
         return m_firstNode;
     }

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -7968,7 +7968,7 @@ void CodeGen::genFnEpilog(BasicBlock* block)
         hasTailCalls = true;
 
         noway_assert(block->bbJumpKind == BBJ_RETURN);
-        noway_assert(block->bbTreeList != nullptr);
+        noway_assert(block->GetBBTreeList() != nullptr);
 
         /* figure out what jump we have */
         GenTree* jmpNode = lastNode;
@@ -8359,7 +8359,7 @@ void CodeGen::genFnEpilog(BasicBlock* block)
     if (jmpEpilog)
     {
         noway_assert(block->bbJumpKind == BBJ_RETURN);
-        noway_assert(block->bbTreeList);
+        noway_assert(block->GetBBTreeList());
 
         // figure out what jump we have
         GenTree* jmpNode = block->lastNode();

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -7968,7 +7968,7 @@ void CodeGen::genFnEpilog(BasicBlock* block)
         hasTailCalls = true;
 
         noway_assert(block->bbJumpKind == BBJ_RETURN);
-        noway_assert(block->GetBBTreeList() != nullptr);
+        noway_assert(block->GetFirstLIRNode() != nullptr);
 
         /* figure out what jump we have */
         GenTree* jmpNode = lastNode;
@@ -8359,7 +8359,7 @@ void CodeGen::genFnEpilog(BasicBlock* block)
     if (jmpEpilog)
     {
         noway_assert(block->bbJumpKind == BBJ_RETURN);
-        noway_assert(block->GetBBTreeList());
+        noway_assert(block->GetFirstLIRNode());
 
         // figure out what jump we have
         GenTree* jmpNode = block->lastNode();

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -8647,7 +8647,7 @@ void cBlockIR(Compiler* comp, BasicBlock* block)
     }
     else
     {
-        for (GenTree* node = block->bbTreeList; node != nullptr; node = node->gtNext)
+        for (GenTree* node = block->GetBBTreeList(); node != nullptr; node = node->gtNext)
         {
             cNodeIR(comp, node);
         }

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -8647,7 +8647,7 @@ void cBlockIR(Compiler* comp, BasicBlock* block)
     }
     else
     {
-        for (GenTree* node = block->GetBBTreeList(); node != nullptr; node = node->gtNext)
+        for (GenTree* node = block->GetFirstLIRNode(); node != nullptr; node = node->gtNext)
         {
             cNodeIR(comp, node);
         }

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -9540,7 +9540,7 @@ BasicBlock* Compiler::fgSplitBlockAtBeginning(BasicBlock* curr)
 
     if (curr->IsLIR())
     {
-        newBlock->SetBBTreeList(curr->GetBBTreeList());
+        newBlock->SetBBTreeList(curr->GetFirstLIRNode());
         curr->SetBBTreeList(nullptr);
     }
     else
@@ -21075,7 +21075,7 @@ void Compiler::fgDebugCheckBBlist(bool checkBBNum /* = false */, bool checkBBRef
     // Make sure the one return BB is not changed.
     if (genReturnBB != nullptr)
     {
-        assert(genReturnBB->GetBBTreeList() != nullptr || genReturnBB->bbStmtList != nullptr);
+        assert(genReturnBB->GetFirstLIRNode() != nullptr || genReturnBB->bbStmtList != nullptr);
     }
 
     // The general encoder/decoder (currently) only reports "this" as a generics context as a stack location,

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -9540,8 +9540,8 @@ BasicBlock* Compiler::fgSplitBlockAtBeginning(BasicBlock* curr)
 
     if (curr->IsLIR())
     {
-        newBlock->SetBBTreeList(curr->GetFirstLIRNode());
-        curr->SetBBTreeList(nullptr);
+        newBlock->SetFirstLIRNode(curr->GetFirstLIRNode());
+        curr->SetFirstLIRNode(nullptr);
     }
     else
     {

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -9540,8 +9540,8 @@ BasicBlock* Compiler::fgSplitBlockAtBeginning(BasicBlock* curr)
 
     if (curr->IsLIR())
     {
-        newBlock->bbTreeList = curr->bbTreeList;
-        curr->bbTreeList     = nullptr;
+        newBlock->SetBBTreeList(curr->GetBBTreeList());
+        curr->SetBBTreeList(nullptr);
     }
     else
     {
@@ -21075,7 +21075,7 @@ void Compiler::fgDebugCheckBBlist(bool checkBBNum /* = false */, bool checkBBRef
     // Make sure the one return BB is not changed.
     if (genReturnBB != nullptr)
     {
-        assert(genReturnBB->bbTreeList != nullptr || genReturnBB->bbStmtList != nullptr);
+        assert(genReturnBB->GetBBTreeList() != nullptr || genReturnBB->bbStmtList != nullptr);
     }
 
     // The general encoder/decoder (currently) only reports "this" as a generics context as a stack location,

--- a/src/jit/gtlist.h
+++ b/src/jit/gtlist.h
@@ -244,7 +244,7 @@ GTNODE(CALL             , GenTreeCall        ,0,(GTK_SPECIAL|GTK_NOCONTAIN))
 //-----------------------------------------------------------------------------
 //  Statement operator nodes:
 //-----------------------------------------------------------------------------
-GTNODE(STMT             , Statement        ,0,(GTK_SPECIAL|GTK_NOVALUE))// top-level list nodes in GetBBTreeList()
+GTNODE(STMT             , Statement        ,0,(GTK_SPECIAL|GTK_NOVALUE))// top-level list nodes in GetFirstLIRNode()
 
 GTNODE(RETURN           , GenTreeOp          ,0,(GTK_UNOP|GTK_NOVALUE))   // return from current function
 GTNODE(SWITCH           , GenTreeOp          ,0,(GTK_UNOP|GTK_NOVALUE))   // switch

--- a/src/jit/gtlist.h
+++ b/src/jit/gtlist.h
@@ -244,7 +244,7 @@ GTNODE(CALL             , GenTreeCall        ,0,(GTK_SPECIAL|GTK_NOCONTAIN))
 //-----------------------------------------------------------------------------
 //  Statement operator nodes:
 //-----------------------------------------------------------------------------
-GTNODE(STMT             , Statement        ,0,(GTK_SPECIAL|GTK_NOVALUE))// top-level list nodes in bbTreeList
+GTNODE(STMT             , Statement        ,0,(GTK_SPECIAL|GTK_NOVALUE))// top-level list nodes in GetBBTreeList()
 
 GTNODE(RETURN           , GenTreeOp          ,0,(GTK_UNOP|GTK_NOVALUE))   // return from current function
 GTNODE(SWITCH           , GenTreeOp          ,0,(GTK_UNOP|GTK_NOVALUE))   // switch

--- a/src/jit/lsrabuild.cpp
+++ b/src/jit/lsrabuild.cpp
@@ -1717,7 +1717,7 @@ void LinearScan::buildPhysRegRecords()
 //
 BasicBlock* getNonEmptyBlock(BasicBlock* block)
 {
-    while (block != nullptr && block->bbTreeList == nullptr)
+    while (block != nullptr && block->GetBBTreeList() == nullptr)
     {
         BasicBlock* nextBlock = block->bbNext;
         // Note that here we use the version of NumSucc that does not take a compiler.
@@ -1729,7 +1729,7 @@ BasicBlock* getNonEmptyBlock(BasicBlock* block)
         // assert( block->GetSucc(0) == nextBlock);
         block = nextBlock;
     }
-    assert(block != nullptr && block->bbTreeList != nullptr);
+    assert(block != nullptr && block->GetBBTreeList() != nullptr);
     return block;
 }
 

--- a/src/jit/lsrabuild.cpp
+++ b/src/jit/lsrabuild.cpp
@@ -1717,7 +1717,7 @@ void LinearScan::buildPhysRegRecords()
 //
 BasicBlock* getNonEmptyBlock(BasicBlock* block)
 {
-    while (block != nullptr && block->GetBBTreeList() == nullptr)
+    while (block != nullptr && block->GetFirstLIRNode() == nullptr)
     {
         BasicBlock* nextBlock = block->bbNext;
         // Note that here we use the version of NumSucc that does not take a compiler.
@@ -1729,7 +1729,7 @@ BasicBlock* getNonEmptyBlock(BasicBlock* block)
         // assert( block->GetSucc(0) == nextBlock);
         block = nextBlock;
     }
-    assert(block != nullptr && block->GetBBTreeList() != nullptr);
+    assert(block != nullptr && block->GetFirstLIRNode() != nullptr);
     return block;
 }
 


### PR DESCRIPTION
__declspec(property) is a MSVC construct and is not supported by GCC. Replace indirection to make the code portable.

@am11 @jkotas @janvorli 