### PR TITLE
Moving gen stack level to code gen interface

### DIFF
--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -126,10 +126,6 @@ private:
     bool     genUseBlockInit;  // true if we plan to block-initialize the local stack frame
     unsigned genInitStkLclCnt; // The count of local variables that we need to zero init
 
-    //  Keeps track of how many bytes we've pushed on the processor's stack.
-    //
-    unsigned genStackLevel;
-
     void SubtractStackLevel(unsigned adjustment)
     {
         assert(genStackLevel >= adjustment);

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -11557,3 +11557,8 @@ void CodeGen::genStackPointerCheck(bool doStackPointerCheck, unsigned lvaStackPo
 }
 
 #endif // defined(DEBUG) && defined(_TARGET_XARCH_)
+
+unsigned CodeGenInterface::getCurrentStackLevel() const
+{
+    return genStackLevel;
+}

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -539,7 +539,6 @@ public:
 
 protected:
     //  Keeps track of how many bytes we've pushed on the processor's stack.
-    //
     unsigned genStackLevel;
 
 #ifdef LATE_DISASM

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -534,6 +534,14 @@ public:
             const LclVarDsc* varDsc, var_types type, regNumber baseReg, int offset, bool isFramePointerUsed);
     };
 
+public:
+    unsigned getCurrentStackLevel() const;
+
+protected:
+    //  Keeps track of how many bytes we've pushed on the processor's stack.
+    //
+    unsigned genStackLevel;
+
 #ifdef LATE_DISASM
 public:
     virtual const char* siRegVarName(size_t offs, size_t size, unsigned reg) = 0;

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -113,6 +113,10 @@ void CodeGen::genInitialize()
     // Make sure a set is allocated for compiler->compCurLife (in the long case), so we can set it to empty without
     // allocation at the start of each basic block.
     VarSetOps::AssignNoCopy(compiler, compiler->compCurLife, VarSetOps::MakeEmpty(compiler));
+
+    // We initialize the stack level before fist "BasicBlock" code is generated in case we need to report stack
+    // variable needs home and so its stack offset.
+    SetStackLevel(0);
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -114,7 +114,7 @@ void CodeGen::genInitialize()
     // allocation at the start of each basic block.
     VarSetOps::AssignNoCopy(compiler, compiler->compCurLife, VarSetOps::MakeEmpty(compiler));
 
-    // We initialize the stack level before fist "BasicBlock" code is generated in case we need to report stack
+    // We initialize the stack level before first "BasicBlock" code is generated in case we need to report stack
     // variable needs home and so its stack offset.
     SetStackLevel(0);
 }


### PR DESCRIPTION
1) Making genStackLevel accessible from CodeGenInterface so we can access compute stack offset from compiler.cpp when creating CodeGenInterface::siVarLoc for variable's home. It can only be access and not modified from compiler.cpp.

2) Initializing stack level to 0 before generating the first block so the offset we get for the stack variable that become alive at the beginning can used it.

Those are changes I am moving out of other [PR](https://github.com/dotnet/coreclr/pull/22770)