### PR TITLE
[WIP] Convert uses of go_through_object macros to use templates and lambdas

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -19100,7 +19100,7 @@ void gc_heap::background_mark_simple1 (uint8_t* oo THREAD_NUMBER_DCL)
                     int i = num_partial_refs; 
 
                     if (!go_through_object_lambda (method_table(oo), oo, s,
-                                       start, (oo + s),[CAPTURE_HEAP_AND(thread, place, &i)](uint8_t ** ppslot)
+                                       start, (oo + s),[CAPTURE_HEAP_AND_THREAD(place, &i)](uint8_t ** ppslot)
                     {
                         uint8_t* o = *ppslot;
                         Prefetch(o);

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -19100,7 +19100,7 @@ void gc_heap::background_mark_simple1 (uint8_t* oo THREAD_NUMBER_DCL)
                     int i = num_partial_refs; 
 
                     if (!go_through_object_lambda (method_table(oo), oo, s,
-                                       start, (oo + s),[CAPTURE_HEAP_AND_THREAD(place, &i)](uint8_t ** ppslot)
+                                       start, (oo + s),[CAPTURE_HEAP_AND_THREAD_AND(place, &i)](uint8_t ** ppslot)
                     {
                         uint8_t* o = *ppslot;
                         Prefetch(o);

--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -229,12 +229,16 @@ void GCLogConfig (const char *fmt, ... );
 #ifdef MULTIPLE_HEAPS
 #define THREAD_NUMBER_DCL ,int thread
 #define THREAD_NUMBER_ARG ,thread
+#define ONLY_THREAD_NUMBER_DCL int thread
+#define ONLY_THREAD_NUMBER_ARG thread
 #define THREAD_NUMBER_FROM_CONTEXT int thread = sc->thread_number;
 #define THREAD_FROM_HEAP  int thread = heap_number;
 #define HEAP_FROM_THREAD  gc_heap* hpt = gc_heap::g_heaps[thread];
 #else
 #define THREAD_NUMBER_DCL
 #define THREAD_NUMBER_ARG
+#define ONLY_THREAD_NUMBER_DCL
+#define ONLY_THREAD_NUMBER_ARG
 #define THREAD_NUMBER_FROM_CONTEXT
 #define THREAD_FROM_HEAP
 #define HEAP_FROM_THREAD  gc_heap* hpt = 0;
@@ -1907,7 +1911,7 @@ protected:
     gc_heap* heap_of_gc (uint8_t* object);
 
     PER_HEAP_ISOLATED
-    size_t&  promoted_bytes (int);
+    size_t&  promoted_bytes (ONLY_THREAD_NUMBER_DCL);
 
     PER_HEAP
     uint8_t* find_object (uint8_t* o, uint8_t* low);
@@ -1973,7 +1977,7 @@ protected:
 #endif
 #ifdef BACKGROUND_GC
     PER_HEAP_ISOLATED
-    size_t&  bpromoted_bytes (int);
+    size_t&  bpromoted_bytes (ONLY_THREAD_NUMBER_DCL);
     PER_HEAP
     void make_background_mark_stack (uint8_t** arr);
     PER_HEAP


### PR DESCRIPTION
This is done naively, without any special concern for performance. As we determine if this is a feasible approach, there will likely need to be performance tweaks such as force-inline/regeneration of pgo data, etc. to allow macro replacement to work well.