### PR TITLE
Initialize LclVarDsc::lvSlotNum when creating LclVarDsc

### DIFF
--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -1581,6 +1581,7 @@ inline unsigned Compiler::lvaGrabTemp(bool shortLifetime DEBUGARG(const char* re
     lvaTable[tempNum].lvType    = TYP_UNDEF;
     lvaTable[tempNum].lvIsTemp  = shortLifetime;
     lvaTable[tempNum].lvOnFrame = true;
+    lvaTable[tempNum].lvSlotNum = tempNum;
 
     // If we've started normal ref counting, bump the ref count of this
     // local, as we no longer do any incremental counting, and we presume
@@ -1675,6 +1676,7 @@ inline unsigned Compiler::lvaGrabTemps(unsigned cnt DEBUGARG(const char* reason)
         lvaTable[lvaCount].lvType    = TYP_UNDEF; // Initialize lvType, lvIsTemp and lvOnFrame
         lvaTable[lvaCount].lvIsTemp  = false;
         lvaTable[lvaCount].lvOnFrame = true;
+        lvaTable[lvaCount].lvSlotNum = lvaCount;
         lvaCount++;
     }
 

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -389,6 +389,7 @@ void Compiler::lvaInitThisPtr(InitVarDscInfo* varDscInfo)
     {
         varDsc->lvIsParam = 1;
         varDsc->lvIsPtr   = 1;
+        varDsc->lvSlotNum = varDscInfo->varNum;
 
         lvaArg0Var = info.compThisArg = varDscInfo->varNum;
         noway_assert(info.compThisArg == 0);
@@ -471,6 +472,7 @@ void Compiler::lvaInitRetBuffArg(InitVarDscInfo* varDscInfo)
         varDsc->lvType      = TYP_BYREF;
         varDsc->lvIsParam   = 1;
         varDsc->lvIsRegArg  = 1;
+        varDsc->lvSlotNum   = varDscInfo->varNum;
 
         if (hasFixedRetBuffReg())
         {
@@ -1041,6 +1043,7 @@ void Compiler::lvaInitGenericsCtxt(InitVarDscInfo* varDscInfo)
         LclVarDsc* varDsc = varDscInfo->varDsc;
         varDsc->lvIsParam = 1;
         varDsc->lvType    = TYP_I_IMPL;
+        varDsc->lvSlotNum = varDscInfo->varNum;
 
         if (varDscInfo->canEnreg(TYP_I_IMPL))
         {
@@ -1094,6 +1097,8 @@ void Compiler::lvaInitVarArgsHandle(InitVarDscInfo* varDscInfo)
         LclVarDsc* varDsc = varDscInfo->varDsc;
         varDsc->lvType    = TYP_I_IMPL;
         varDsc->lvIsParam = 1;
+        varDsc->lvSlotNum = varDscInfo->varNum;
+
         // Make sure this lives in the stack -- address may be reported to the VM.
         // TODO-CQ: This should probably be:
         //   lvaSetVarDoNotEnregister(varDscInfo->varNum DEBUGARG(DNER_VMNeedsStackAddr));


### PR DESCRIPTION
I am using the same index that is used for a variable in Compiler::lvaTable on my array of VariableLiveDescriptor. There are some cases where I have a LclVarDsc* and not the varNum. This property is already on LclVarDsc but is not set for all the variables. I am intializing it when initializing the lvaTable.