### PR TITLE
Exclude GC/Collect from GCStress testing.

### DIFF
--- a/tests/src/GC/API/GC/Collect.csproj
+++ b/tests/src/GC/API/GC/Collect.csproj
@@ -11,6 +11,7 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <CLRTestPriority>1</CLRTestPriority>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>


### PR DESCRIPTION
This test fails in ADO testing, [example](https://mc.dot.net/#/user/coreclr-outerloop-gcstress0x3-gcstress0xc/ci~2Fdotnet~2Fcoreclr~2Frefs~2Fheads~2Fmaster/test~2Ffunctional~2Fcli~2F/20190317.71/workItem/GC.API/analysis/xunit/GC_API._GC_Collect_Collect_~2F_GC_Collect_Collect_cmd).

Output is:
```
Array is in generation: 0
Array is in generation: 0
Test for GC.Collect() failed!
Expected: 100
Actual: 1
```

https://github.com/dotnet/coreclr/blob/21075b3f0150084e341a7d37374de67c616b9870/tests/src/GC/API/GC/Collect.cs#L14-L30

In the failed case `Array` was not promoted from 0 gen to 1 or 2, as I understand it is legal for GC to decide not to promote live objects, @Maoni0 am I right?
But in this case how do we guarantee that this promotion happens without GCStress in normal runs?