### PR TITLE
Restrict gc stress platforms for ADO runs.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,6 +108,13 @@ jobs:
     parameters:
       jobTemplate: build-job.yml
       buildConfig: checked
+      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress0x3-gcstress0xc') }}:
+        platforms:
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - Windows_NT_x64
+        - Windows_NT_x86
 
 #
 # Release build (Pull request)
@@ -142,6 +149,13 @@ jobs:
     parameters:
       jobTemplate: test-job.yml
       buildConfig: checked
+      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress0x3-gcstress0xc') }}:
+        platforms:
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - Windows_NT_x64
+        - Windows_NT_x86
       jobParameters:
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-ci') }}:
           testGroup: innerloop


### PR DESCRIPTION
Run GCStress testing only on supported platforms. Exclude OSX (does not have CoreDisTools) and arm platforms where we do not run tests.