### PR TITLE
Adding function Compiler::lvaGetVarNum(const LclVarDsc*) 

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -487,7 +487,7 @@ void CodeGenInterface::genUpdateRegLife(const LclVarDsc* varDsc, bool isBorn, bo
 #ifdef DEBUG
     if (compiler->verbose)
     {
-        printf("\t\t\t\t\t\t\tV%02u in reg ", (varDsc - compiler->lvaTable));
+        printf("\t\t\t\t\t\t\tV%02u in reg ", compiler->lvaGetVarNum(varDsc));
         varDsc->PrintVarReg();
         printf(" is becoming %s  ", (isDying) ? "dead" : "live");
         Compiler::printTreeID(tree);

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -8471,7 +8471,7 @@ void cVarDsc(Compiler* comp, LclVarDsc* varDsc)
 {
     static unsigned sequenceNumber = 0; // separate calls with a number to indicate this function has been called
     printf("===================================================================== *VarDsc %u\n", sequenceNumber++);
-    unsigned lclNum = (unsigned)(varDsc - comp->lvaTable);
+    unsigned lclNum = comp->lvaGetVarNum(varDsc);
     comp->lvaDumpEntry(lclNum, Compiler::FINAL_FRAME_LAYOUT);
 }
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3047,7 +3047,7 @@ public:
     unsigned int lvaGetVarNum(const LclVarDsc* varDsc)
     {
         assert(varDsc != nullptr);
-        return varDsc - lvaTable;
+        return (unsigned int)(varDsc - lvaTable);
     }
 
     unsigned lvaLclSize(unsigned varNum);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3044,6 +3044,12 @@ public:
         return &lvaTable[lclVar->GetLclNum()];
     }
 
+    unsigned int lvaGetVarNum(const LclVarDsc* varDsc)
+    {
+        assert(varDsc != nullptr);
+        return varDsc - lvaTable;
+    }
+
     unsigned lvaLclSize(unsigned varNum);
     unsigned lvaLclExactSize(unsigned varNum);
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3044,11 +3044,15 @@ public:
         return &lvaTable[lclVar->GetLclNum()];
     }
 
+#ifdef DEBUG
+    // This method should only be used on debug code. The substraction needs a division,
+    // which is more expensive than forwarding the varNum and indexing.
     unsigned int lvaGetVarNum(const LclVarDsc* varDsc)
     {
         assert(varDsc != nullptr);
         return (unsigned int)(varDsc - lvaTable);
     }
+#endif // DEBUG
 
     unsigned lvaLclSize(unsigned varNum);
     unsigned lvaLclExactSize(unsigned varNum);

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -1803,7 +1803,7 @@ inline void LclVarDsc::incRefCnts(BasicBlock::weight_t weight, Compiler* comp, R
 #ifdef DEBUG
     if (comp->verbose)
     {
-        unsigned varNum = (unsigned)(this - comp->lvaTable);
+        unsigned varNum = comp->lvaGetVarNum(this);
         assert(&comp->lvaTable[varNum] == this);
         printf("New refCnts for V%02u: refCnt = %2u, refCntWtd = %s\n", varNum, lvRefCnt(state),
                refCntWtd2str(lvRefCntWtd(state)));

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -2286,7 +2286,7 @@ unsigned Compiler::lvaGetFieldLocal(const LclVarDsc* varDsc, unsigned int fldOff
     for (unsigned i = varDsc->lvFieldLclStart; i < varDsc->lvFieldLclStart + varDsc->lvFieldCnt; ++i)
     {
         noway_assert(lvaTable[i].lvIsStructField);
-        noway_assert(lvaTable[i].lvParentLcl == (unsigned)(varDsc - lvaTable));
+        noway_assert(lvaTable[i].lvParentLcl == lvaGetVarNum(varDsc));
         if (lvaTable[i].lvFldOffset == fldOffset)
         {
             return i;
@@ -3245,7 +3245,7 @@ void Compiler::lvaDumpRefCounts()
             unsigned refCntWtd = lvaRefSorted[lclNum]->lvRefCntWtd();
 
             printf("   ");
-            gtDispLclVar((unsigned)(lvaRefSorted[lclNum] - lvaTable));
+            gtDispLclVar(lvaGetVarNum(lvaRefSorted[lclNum]));
             printf(" [%6s]: refCnt = %4u, refCntWtd = %6s", varTypeName(lvaRefSorted[lclNum]->TypeGet()), refCnt,
                    refCntWtd2str(refCntWtd));
             printf("\n");
@@ -3455,7 +3455,7 @@ void Compiler::lvaSortByRefCount()
 
             /* This variable will be tracked - assign it an index */
 
-            lvaTrackedToVarNum[lvaTrackedCount] = (unsigned)(varDsc - lvaTable); // The type of varDsc and lvaTable
+            lvaTrackedToVarNum[lvaTrackedCount] = lvaGetVarNum(varDsc); // The type of varDsc and lvaTable
             // is LclVarDsc. Subtraction will give us
             // the index.
             varDsc->lvVarIndex = lvaTrackedCount++;

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -3455,7 +3455,7 @@ void Compiler::lvaSortByRefCount()
 
             /* This variable will be tracked - assign it an index */
 
-            lvaTrackedToVarNum[lvaTrackedCount] = lvaGetVarNum(varDsc); // The type of varDsc and lvaTable
+            lvaTrackedToVarNum[lvaTrackedCount] = (unsigned int)(varDsc - lvaTable); // The type of varDsc and lvaTable
             // is LclVarDsc. Subtraction will give us
             // the index.
             varDsc->lvVarIndex = lvaTrackedCount++;

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -1403,7 +1403,7 @@ bool LinearScan::isRegCandidate(LclVarDsc* varDsc)
     // Pinned variables may not be tracked (a condition of the GCInfo representation)
     // or enregistered, on x86 -- it is believed that we can enregister pinned (more properly, "pinning")
     // references when using the general GC encoding.
-    unsigned lclNum = (unsigned)(varDsc - compiler->lvaTable);
+    unsigned lclNum = compiler->lvaGetVarNum(varDsc);
     if (varDsc->lvAddrExposed || !varTypeIsEnregisterableStruct(varDsc))
     {
 #ifdef DEBUG

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -1403,7 +1403,7 @@ bool LinearScan::isRegCandidate(LclVarDsc* varDsc)
     // Pinned variables may not be tracked (a condition of the GCInfo representation)
     // or enregistered, on x86 -- it is believed that we can enregister pinned (more properly, "pinning")
     // references when using the general GC encoding.
-    unsigned lclNum = compiler->lvaGetVarNum(varDsc);
+    unsigned lclNum = (unsigned)(varDsc - compiler->lvaTable);
     if (varDsc->lvAddrExposed || !varTypeIsEnregisterableStruct(varDsc))
     {
 #ifdef DEBUG

--- a/src/jit/lsrabuild.cpp
+++ b/src/jit/lsrabuild.cpp
@@ -1859,12 +1859,12 @@ void LinearScan::updateRegStateForArg(LclVarDsc* argDsc)
 
         if (isFloat)
         {
-            JITDUMP("Float arg V%02u in reg %s\n", compiler->lvaGetVarNum(varDsc), getRegName(argDsc->lvArgReg));
+            JITDUMP("Float arg V%02u in reg %s\n", compiler->lvaGetVarNum(argDsc), getRegName(argDsc->lvArgReg));
             compiler->raUpdateRegStateForArg(floatRegState, argDsc);
         }
         else
         {
-            JITDUMP("Int arg V%02u in reg %s\n", compiler->lvaGetVarNum(varDsc), getRegName(argDsc->lvArgReg));
+            JITDUMP("Int arg V%02u in reg %s\n", compiler->lvaGetVarNum(argDsc), getRegName(argDsc->lvArgReg));
 #if FEATURE_MULTIREG_ARGS
             if (argDsc->lvOtherArgReg != REG_NA)
             {

--- a/src/jit/lsrabuild.cpp
+++ b/src/jit/lsrabuild.cpp
@@ -1859,12 +1859,12 @@ void LinearScan::updateRegStateForArg(LclVarDsc* argDsc)
 
         if (isFloat)
         {
-            JITDUMP("Float arg V%02u in reg %s\n", (argDsc - compiler->lvaTable), getRegName(argDsc->lvArgReg));
+            JITDUMP("Float arg V%02u in reg %s\n", compiler->lvaGetVarNum(varDsc), getRegName(argDsc->lvArgReg));
             compiler->raUpdateRegStateForArg(floatRegState, argDsc);
         }
         else
         {
-            JITDUMP("Int arg V%02u in reg %s\n", (argDsc - compiler->lvaTable), getRegName(argDsc->lvArgReg));
+            JITDUMP("Int arg V%02u in reg %s\n", compiler->lvaGetVarNum(varDsc), getRegName(argDsc->lvArgReg));
 #if FEATURE_MULTIREG_ARGS
             if (argDsc->lvOtherArgReg != REG_NA)
             {

--- a/src/jit/treelifeupdater.cpp
+++ b/src/jit/treelifeupdater.cpp
@@ -262,7 +262,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
 #ifdef DEBUG
                 if (compiler->verbose)
                 {
-                    printf("\t\t\t\t\t\t\tVar V%02u becoming live\n", varDsc - compiler->lvaTable);
+                    printf("\t\t\t\t\t\t\tVar V%02u becoming live\n", compiler->lvaGetVarNum(varDsc));
                 }
 #endif // DEBUG
             }


### PR DESCRIPTION
As a way of getting the index of a variable in compiler::lvaTable. There is a property of LclVarDsc for this purpose called lvSlotNum, which is not set for every variable.