### PR TITLE
Use join function in yaml

### DIFF
--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -137,7 +137,6 @@ jobs:
           - Ubuntu.1604.Amd64.Open
           - Ubuntu.1804.Amd64.Open
           - Centos.7.Amd64.Open
-          - Fedora.28.Amd64.Open
           - RedHat.7.Amd64.Open
         - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           - Debian.9.Amd64

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -95,8 +95,7 @@ jobs:
         osIdentifier: Linux_musl
         containerName: musl_arm64_build_image
         helixQueues:
-        - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          - (Alpine.38.Arm64.On.Docker.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-46e69dd-20190313223330
+        # TODO: enable (Alpine.38.Arm64.On.Docker.Open) once https://github.com/dotnet/coreclr/issues/23621 is resolved
         - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           - (Alpine.38.Arm64.On.Docker)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-46e69dd-20190313223330
         crossrootfsDir: '/crossrootfs/arm64'
@@ -113,8 +112,7 @@ jobs:
         osIdentifier: Linux_rhel6
         containerName: centos6_x64_build_image
         helixQueues:
-        - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          - RedHat.6.Amd64.Open
+        # TODO: enable RedHat.6.Amd64.Open once https://github.com/dotnet/coreclr/issues/23580 is resolved
         - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           - RedHat.6.Amd64
         ${{ insert }}: ${{ parameters.jobParameters }}

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -35,18 +35,18 @@ jobs:
         # The following is to balance the load on Linux/arm32 hardware between two different sets of machines (Ubuntu.1404.Arm32.Open and Ubuntu.1604.Arm32.Open).
         # This should make situations when a queue is overflowed with work items coming from different sources (PRs, CI and scheduled builds) less frequent.
         - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
-          - (Ubuntu.1804.Arm32.On.Docker.Open)Ubuntu.1604.Arm32.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-0a0ebdd-20190312215532
+          - (Ubuntu.1804.Arm32.Open)Ubuntu.1604.Arm32.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-0a0ebdd-20190312215532
         # Ubuntu.1404.Arm32.Open is used only by CI while Ubuntu.1604.Arm32.Open serves PRs and scheduled builds.
         - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
           - Ubuntu.1404.Arm32.Open
         - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-          - (Debian.9.Arm32.On.Docker.Open)Ubuntu.1604.Arm32.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm32v7-0a0ebdd-20190312215452
-          - (Ubuntu.1604.Arm32.On.Docker.Open)Ubuntu.1604.Arm32.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-helix-arm32v7-0a0ebdd-20190312215551
-          - (Ubuntu.1804.Arm32.On.Docker.Open)Ubuntu.1604.Arm32.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-0a0ebdd-20190312215532
+          - (Debian.9.Arm32.Open)Ubuntu.1604.Arm32.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm32v7-0a0ebdd-20190312215452
+          - (Ubuntu.1604.Arm32.Open)Ubuntu.1604.Arm32.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-helix-arm32v7-0a0ebdd-20190312215551
+          - (Ubuntu.1804.Arm32.Open)Ubuntu.1604.Arm32.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-0a0ebdd-20190312215532
         - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          - (Debian.9.Arm32.On.Docker)Ubuntu.1604.Arm32@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm32v7-0a0ebdd-20190312215452
-          - (Ubuntu.1604.Arm32.On.Docker)Ubuntu.1604.Arm32@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-helix-arm32v7-0a0ebdd-20190312215551
-          - (Ubuntu.1804.Arm32.On.Docker)Ubuntu.1604.Arm32@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-0a0ebdd-20190312215532
+          - (Debian.9.Arm32)Ubuntu.1604.Arm32@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm32v7-0a0ebdd-20190312215452
+          - (Ubuntu.1604.Arm32)Ubuntu.1604.Arm32@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-helix-arm32v7-0a0ebdd-20190312215551
+          - (Ubuntu.1804.Arm32)Ubuntu.1604.Arm32@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-0a0ebdd-20190312215532
         crossrootfsDir: '/crossrootfs/arm'
         ${{ insert }}: ${{ parameters.jobParameters }}
 
@@ -62,12 +62,12 @@ jobs:
         containerName: ubuntu_1604_arm64_cross_build_image
         helixQueues:
         - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          - (Ubuntu.1804.Arm64.On.Docker.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-0a0ebdd-20190312220351
+          - (Ubuntu.1804.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-0a0ebdd-20190312220351
         - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-          - (Debian.9.Arm64.On.Docker.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-0a0ebdd-20190312215438
+          - (Debian.9.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-0a0ebdd-20190312215438
         - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          - (Debian.9.Arm64.On.Docker)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-0a0ebdd-20190312215438
-          - (Ubuntu.1804.Arm64.On.Docker)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-0a0ebdd-20190312220351
+          - (Debian.9.Arm64)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-0a0ebdd-20190312215438
+          - (Ubuntu.1804.Arm64)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-0a0ebdd-20190312220351
         crossrootfsDir: '/crossrootfs/arm64'
         ${{ insert }}: ${{ parameters.jobParameters }}
 
@@ -83,7 +83,7 @@ jobs:
         containerName: musl_x64_build_image
         helixQueues:
         - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          - (Alpine.38.Amd64.On.Docker.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-45b1fa2-20190327215821
+          - (Alpine.38.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-45b1fa2-20190327215821
         - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           - Alpine.36.Amd64
           - Alpine.38.Amd64
@@ -100,9 +100,9 @@ jobs:
         osIdentifier: Linux_musl
         containerName: musl_arm64_build_image
         helixQueues:
-        # TODO: enable (Alpine.38.Arm64.On.Docker.Open) once https://github.com/dotnet/coreclr/issues/23621 is resolved
+        # TODO: enable (Alpine.38.Arm64.Open) once https://github.com/dotnet/coreclr/issues/23621 is resolved
         - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          - (Alpine.38.Arm64.On.Docker)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-46e69dd-20190313223330
+          - (Alpine.38.Arm64)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-46e69dd-20190313223330
         crossrootfsDir: '/crossrootfs/arm64'
         ${{ insert }}: ${{ parameters.jobParameters }}
 

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -96,9 +96,9 @@ jobs:
         containerName: musl_arm64_build_image
         helixQueues:
         - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          - Alpine.3.Arm64.Open
+          - (Alpine.38.Arm64.On.Docker.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-46e69dd-20190313223330
         - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          - Alpine.3.Arm64
+          - (Alpine.38.Arm64.On.Docker)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-46e69dd-20190313223330
         crossrootfsDir: '/crossrootfs/arm64'
         ${{ insert }}: ${{ parameters.jobParameters }}
 

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -32,8 +32,11 @@ jobs:
         osIdentifier: Linux
         containerName: ubuntu_1404_arm_cross_build_image
         helixQueues:
+        # The following is to balance the load on Linux/arm32 hardware between two different sets of machines (Ubuntu.1404.Arm32.Open and Ubuntu.1604.Arm32.Open).
+        # This should make situations when a queue is overflowed with work items coming from different sources (PRs, CI and scheduled builds) less frequent.
         - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
           - (Ubuntu.1804.Arm32.On.Docker.Open)Ubuntu.1604.Arm32.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-0a0ebdd-20190312215532
+        # Ubuntu.1404.Arm32.Open is used only by CI while Ubuntu.1604.Arm32.Open serves PRs and scheduled builds.
         - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
           - Ubuntu.1404.Arm32.Open
         - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -83,7 +83,7 @@ jobs:
         containerName: musl_x64_build_image
         helixQueues:
         - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          - (Alpine.38.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-45b1fa2-20190327215821
+          - (Alpine.38.Amd64.Open)Ubuntu.1604.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-45b1fa2-20190327215821
         - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           - Alpine.36.Amd64
           - Alpine.38.Amd64

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -80,7 +80,7 @@ jobs:
         containerName: musl_x64_build_image
         helixQueues:
         - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          - (Alpine.38.Amd64.On.Docker.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:2-alpine:3.8
+          - (Alpine.38.Amd64.On.Docker.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-45b1fa2-20190327215821
         - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           - Alpine.36.Amd64
           - Alpine.38.Amd64

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -79,6 +79,8 @@ jobs:
         osIdentifier: Linux_musl
         containerName: musl_x64_build_image
         helixQueues:
+        - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          - (Alpine.38.Amd64.On.Docker.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:2-alpine:3.8
         - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           - Alpine.36.Amd64
           - Alpine.38.Amd64

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -32,15 +32,9 @@ jobs:
         osIdentifier: Linux
         containerName: ubuntu_1404_arm_cross_build_image
         helixQueues:
-          # Ubuntu.1404.Arm32.Open hardware is not capable of dealing with all PRs
-          ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
-            asString: 'Ubuntu.1404.Arm32.Open'
-            asArray:
-            - Ubuntu.1404.Arm32.Open
-          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            # We don't have any Linux/arm32 internal Helix queues
-            asString: ''
-            asArray: []
+        # Ubuntu.1404.Arm32.Open hardware is not capable of dealing with all PRs
+        - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
+          - Ubuntu.1404.Arm32.Open
         crossrootfsDir: '/crossrootfs/arm'
         ${{ insert }}: ${{ parameters.jobParameters }}
 
@@ -55,22 +49,13 @@ jobs:
         osIdentifier: Linux
         containerName: ubuntu_1604_arm64_cross_build_image
         helixQueues:
-          ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-            asString: '(Ubuntu.1804.Arm64.On.Docker.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-0a0ebdd-20190312220351'
-            asArray:
-            - (Ubuntu.1804.Arm64.On.Docker.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-0a0ebdd-20190312220351
-          ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-            # TODO: add Ubuntu.1604.Arm64.Open once Jenkins has been shutdown
-            asString: '(Debian.9.Arm64.On.Docker.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-0a0ebdd-20190312215438,(Ubuntu.1804.Arm64.On.Docker.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-0a0ebdd-20190312220351'
-            asArray:
-            - (Debian.9.Arm64.On.Docker.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-0a0ebdd-20190312215438
-            - (Ubuntu.1804.Arm64.On.Docker.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-0a0ebdd-20190312220351
-          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            asString: '(Debian.9.Arm64.On.Docker)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-0a0ebdd-20190312215438,Ubuntu.1604.Arm64,(Ubuntu.1804.Arm64.On.Docker)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-0a0ebdd-20190312220351'
-            asArray:
-            - (Debian.9.Arm64.On.Docker)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-0a0ebdd-20190312215438
-            - Ubuntu.1604.Arm64
-            - (Ubuntu.1804.Arm64.On.Docker)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-0a0ebdd-20190312220351
+        - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          - (Ubuntu.1804.Arm64.On.Docker.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-0a0ebdd-20190312220351
+        - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+          - (Debian.9.Arm64.On.Docker.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-0a0ebdd-20190312215438
+        - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          - (Debian.9.Arm64.On.Docker)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-0a0ebdd-20190312215438
+          - (Ubuntu.1804.Arm64.On.Docker)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-0a0ebdd-20190312220351
         crossrootfsDir: '/crossrootfs/arm64'
         ${{ insert }}: ${{ parameters.jobParameters }}
 
@@ -85,15 +70,9 @@ jobs:
         osIdentifier: Linux_musl
         containerName: musl_x64_build_image
         helixQueues:
-          ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            # TODO: there are no open Alpine queues https://github.com/dotnet/core-eng/issues/4958
-            asString: ''
-            asArray: []
-          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            asString: 'Alpine.36.Amd64,Alpine.38.Amd64'
-            asArray:
-            - Alpine.36.Amd64
-            - Alpine.38.Amd64
+        - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          - Alpine.36.Amd64
+          - Alpine.38.Amd64
         ${{ insert }}: ${{ parameters.jobParameters }}
 
   # Linux musl arm64
@@ -107,14 +86,10 @@ jobs:
         osIdentifier: Linux_musl
         containerName: musl_arm64_build_image
         helixQueues:
-          ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            # TODO: there are no Alpine arm64 queues https://github.com/dotnet/core-eng/issues/5206
-            asString: ''
-            asArray: []
-          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            # TODO: there are no Alpine arm64 queues https://github.com/dotnet/core-eng/issues/5206
-            asString: ''
-            asArray: []
+        - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          - Alpine.3.Arm64.Open
+        - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          - Alpine.3.Arm64
         crossrootfsDir: '/crossrootfs/arm64'
         ${{ insert }}: ${{ parameters.jobParameters }}
 
@@ -129,15 +104,10 @@ jobs:
         osIdentifier: Linux_rhel6
         containerName: centos6_x64_build_image
         helixQueues:
-          ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            # TODO: enable RedHat.6.Amd64.Open
-            # when https://github.com/dotnet/core-eng/issues/4100 is resolved
-            asString: ''
-            asArray: []
-          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            asString: 'RedHat.6.Amd64'
-            asArray:
-            - RedHat.6.Amd64
+        - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          - RedHat.6.Amd64.Open
+        - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          - RedHat.6.Amd64
         ${{ insert }}: ${{ parameters.jobParameters }}
 
   # Linux x64
@@ -151,27 +121,22 @@ jobs:
         osIdentifier: Linux
         containerName: centos7_x64_build_image
         helixQueues:
-          ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-            asString: 'Ubuntu.1804.Amd64.Open'
-            asArray:
-            - Ubuntu.1804.Amd64.Open
-          ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-            asString: 'Debian.9.Amd64.Open,Ubuntu.1604.Amd64.Open,Ubuntu.1804.Amd64.Open,Centos.7.Amd64.Open,RedHat.7.Amd64.Open'
-            asArray:
-            - Debian.9.Amd64.Open
-            - Ubuntu.1604.Amd64.Open
-            - Ubuntu.1804.Amd64.Open
-            - Centos.7.Amd64.Open
-            - RedHat.7.Amd64.Open
-          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            asString: 'Debian.9.Amd64,Ubuntu.1604.Amd64,Ubuntu.1804.Amd64,Centos.7.Amd64,Fedora.28.Amd64,RedHat.7.Amd64'
-            asArray:
-            - Debian.9.Amd64
-            - Ubuntu.1604.Amd64
-            - Ubuntu.1804.Amd64
-            - Centos.7.Amd64
-            - Fedora.28.Amd64
-            - RedHat.7.Amd64
+        - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+          - Ubuntu.1804.Amd64.Open
+        - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+          - Debian.9.Amd64.Open
+          - Ubuntu.1604.Amd64.Open
+          - Ubuntu.1804.Amd64.Open
+          - Centos.7.Amd64.Open
+          - Fedora.28.Amd64.Open
+          - RedHat.7.Amd64.Open
+        - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          - Debian.9.Amd64
+          - Ubuntu.1604.Amd64
+          - Ubuntu.1804.Amd64
+          - Centos.7.Amd64
+          - Fedora.28.Amd64
+          - RedHat.7.Amd64
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # FreeBSD
@@ -201,22 +166,16 @@ jobs:
         osGroup: OSX
         osIdentifier: OSX
         helixQueues:
-          ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-            asString: 'OSX.1013.Amd64.Open'
-            asArray:
-            - OSX.1013.Amd64.Open
-          ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-            # TODO: add OSX.1012.Amd64.Open once Jenkins has been shutdown
-            asString: 'OSX.1013.Amd64.Open,OSX.1014.Amd64.Open'
-            asArray:
-            - OSX.1013.Amd64.Open
-            - OSX.1014.Amd64.Open
-          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            asString: 'OSX.1012.Amd64,OSX.1013.Amd64,OSX.1014.Amd64'
-            asArray:
-            - OSX.1012.Amd64
-            - OSX.1013.Amd64
-            - OSX.1014.Amd64
+        - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+          - OSX.1013.Amd64.Open
+        - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+          # TODO: add OSX.1012.Amd64.Open once Jenkins has been shutdown
+          - OSX.1013.Amd64.Open
+          - OSX.1014.Amd64.Open
+        - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          - OSX.1012.Amd64
+          - OSX.1013.Amd64
+          - OSX.1014.Amd64
         ${{ insert }}: ${{ parameters.jobParameters }}
 
   # Windows x64
@@ -229,25 +188,19 @@ jobs:
         osGroup: Windows_NT
         osIdentifier: Windows_NT
         helixQueues:
-          ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-            asString: 'Windows.10.Amd64.Open'
-            asArray:
-            - Windows.10.Amd64.Open
-          ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-            # TODO: add Windows.10.Nano.Amd64.Open once https://github.com/dotnet/coreclr/issues/21693 has been resolved
-            # TODO: add Windows.7.Amd64.Open once https://github.com/dotnet/coreclr/issues/21796 has been resolved
-            asString: 'Windows.10.Amd64.Open,Windows.81.Amd64.Open'
-            asArray:
-            - Windows.10.Amd64.Open
-            - Windows.81.Amd64.Open
-          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            asString: 'Windows.10.Amd64,Windows.10.Nano.Amd64,Windows.10.Amd64.Core,Windows.7.Amd64,Windows.81.Amd64'
-            asArray:
-            - Windows.10.Amd64
-            - Windows.10.Nano.Amd64
-            - Windows.10.Amd64.Core
-            - Windows.7.Amd64
-            - Windows.81.Amd64
+        - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+          - Windows.10.Amd64.Open
+        - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+          # TODO: add Windows.10.Nano.Amd64.Open once https://github.com/dotnet/coreclr/issues/21693 has been resolved
+          - Windows.7.Amd64.Open
+          - Windows.81.Amd64.Open
+          - Windows.10.Amd64.Open
+        - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          - Windows.7.Amd64
+          - Windows.81.Amd64
+          - Windows.10.Amd64
+          - Windows.10.Amd64.Core
+          - Windows.10.Nano.Amd64
         ${{ insert }}: ${{ parameters.jobParameters }}
 
   # Windows x86
@@ -260,23 +213,17 @@ jobs:
         osGroup: Windows_NT
         osIdentifier: Windows_NT
         helixQueues:
-          ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-            asString: 'Windows.10.Amd64.Open'
-            asArray:
-            - Windows.10.Amd64.Open
-          ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-            # TODO: add Windows.7.Amd64.Open once https://github.com/dotnet/coreclr/issues/21796 has been resolved
-            asString: 'Windows.10.Amd64.Open,Windows.81.Amd64.Open'
-            asArray:
-            - Windows.10.Amd64.Open
-            - Windows.81.Amd64.Open
-          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            asString: 'Windows.10.Amd64,Windows.10.Amd64.Core,Windows.7.Amd64,Windows.81.Amd64'
-            asArray:
-            - Windows.10.Amd64
-            - Windows.10.Amd64.Core
-            - Windows.7.Amd64
-            - Windows.81.Amd64
+        - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+          - Windows.10.Amd64.Open
+        - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+          - Windows.7.Amd64.Open
+          - Windows.81.Amd64.Open
+          - Windows.10.Amd64.Open
+        - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          - Windows.7.Amd64
+          - Windows.81.Amd64
+          - Windows.10.Amd64
+          - Windows.10.Amd64.Core
         ${{ insert }}: ${{ parameters.jobParameters }}
 
   # Windows arm
@@ -289,14 +236,9 @@ jobs:
         osGroup: Windows_NT
         osIdentifier: Windows_NT
         helixQueues:
-          ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            # TODO: add Windows.10.Arm64.Open once Jenkins has been shutdown
-            asString: ''
-            asArray: []
-          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            asString: 'Windows.10.Arm64'
-            asArray:
-            - Windows.10.Arm64
+        # TODO: add Windows.10.Arm64.Open once Jenkins has been shutdown
+        - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          - Windows.10.Arm64
         ${{ insert }}: ${{ parameters.jobParameters }}
 
   # Windows arm64
@@ -309,12 +251,7 @@ jobs:
         osGroup: Windows_NT
         osIdentifier: Windows_NT
         helixQueues:
-          ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            # TODO: add Windows.10.Arm64.Open once Jenkins has been shutdown
-            asString: ''
-            asArray: []
-          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            asString: 'Windows.10.Arm64'
-            asArray:
-            - Windows.10.Arm64
+        # TODO: add Windows.10.Arm64.Open once Jenkins has been shutdown
+        - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          - Windows.10.Arm64
         ${{ insert }}: ${{ parameters.jobParameters }}

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -32,9 +32,18 @@ jobs:
         osIdentifier: Linux
         containerName: ubuntu_1404_arm_cross_build_image
         helixQueues:
-        # Ubuntu.1404.Arm32.Open hardware is not capable of dealing with all PRs
+        - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+          - (Ubuntu.1804.Arm32.On.Docker.Open)Ubuntu.1604.Arm32.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-0a0ebdd-20190312215532
         - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
           - Ubuntu.1404.Arm32.Open
+        - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+          - (Debian.9.Arm32.On.Docker.Open)Ubuntu.1604.Arm32.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm32v7-0a0ebdd-20190312215452
+          - (Ubuntu.1604.Arm32.On.Docker.Open)Ubuntu.1604.Arm32.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-helix-arm32v7-0a0ebdd-20190312215551
+          - (Ubuntu.1804.Arm32.On.Docker.Open)Ubuntu.1604.Arm32.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-0a0ebdd-20190312215532
+        - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          - (Debian.9.Arm32.On.Docker)Ubuntu.1604.Arm32@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm32v7-0a0ebdd-20190312215452
+          - (Ubuntu.1604.Arm32.On.Docker)Ubuntu.1604.Arm32@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-helix-arm32v7-0a0ebdd-20190312215551
+          - (Ubuntu.1804.Arm32.On.Docker)Ubuntu.1604.Arm32@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-0a0ebdd-20190312215532
         crossrootfsDir: '/crossrootfs/arm'
         ${{ insert }}: ${{ parameters.jobParameters }}
 

--- a/eng/send-to-helix-step.yml
+++ b/eng/send-to-helix-step.yml
@@ -31,10 +31,10 @@ steps:
       _HelixAccessToken: ${{ parameters.helixAccessToken }}
       _HelixBuild: ${{ parameters.helixBuild }}
       _HelixSource: ${{ parameters.helixSource }}
-      _HelixTargetQueues: ${{ parameters.helixQueues }}
+      _HelixTargetQueues: ${{ join(',', parameters.helixQueues) }}
       _HelixType: ${{ parameters.helixType }}
       _RunCrossGen: ${{ parameters.runCrossGen }}
-      _Scenarios: ${{ parameters.scenarios.asString }}
+      _Scenarios: ${{ join(',', parameters.scenarios) }}
       _TimeoutPerTestCollectionInMinutes: ${{ parameters.timeoutPerTestCollectionInMinutes }}
       _TimeoutPerTestInMinutes: ${{ parameters.timeoutPerTestInMinutes }}
       ${{ if eq(parameters.publishTestResults, 'true') }}:
@@ -54,10 +54,10 @@ steps:
       _HelixAccessToken: ${{ parameters.helixAccessToken }}
       _HelixBuild: ${{ parameters.helixBuild }}
       _HelixSource: ${{ parameters.helixSource }}
-      _HelixTargetQueues: ${{ parameters.helixQueues }}
+      _HelixTargetQueues: ${{ join(',', parameters.helixQueues) }}
       _HelixType: ${{ parameters.helixType }}
       _RunCrossGen: ${{ parameters.runCrossGen }}
-      _Scenarios: ${{ parameters.scenarios.asString }}
+      _Scenarios: ${{ join(',', parameters.scenarios) }}
       _TimeoutPerTestCollectionInMinutes: ${{ parameters.timeoutPerTestCollectionInMinutes }}
       _TimeoutPerTestInMinutes: ${{ parameters.timeoutPerTestInMinutes }}
       ${{ if eq(parameters.publishTestResults, 'true') }}:

--- a/eng/send-to-helix-step.yml
+++ b/eng/send-to-helix-step.yml
@@ -31,7 +31,7 @@ steps:
       _HelixAccessToken: ${{ parameters.helixAccessToken }}
       _HelixBuild: ${{ parameters.helixBuild }}
       _HelixSource: ${{ parameters.helixSource }}
-      _HelixTargetQueues: ${{ parameters.helixQueues.asString }}
+      _HelixTargetQueues: ${{ parameters.helixQueues }}
       _HelixType: ${{ parameters.helixType }}
       _RunCrossGen: ${{ parameters.runCrossGen }}
       _Scenarios: ${{ parameters.scenarios.asString }}
@@ -54,7 +54,7 @@ steps:
       _HelixAccessToken: ${{ parameters.helixAccessToken }}
       _HelixBuild: ${{ parameters.helixBuild }}
       _HelixSource: ${{ parameters.helixSource }}
-      _HelixTargetQueues: ${{ parameters.helixQueues.asString }}
+      _HelixTargetQueues: ${{ parameters.helixQueues }}
       _HelixType: ${{ parameters.helixType }}
       _RunCrossGen: ${{ parameters.runCrossGen }}
       _Scenarios: ${{ parameters.scenarios.asString }}

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -185,49 +185,39 @@ jobs:
 
         ${{ if in(parameters.testGroup, 'innerloop', 'outerloop') }}:
           scenarios:
-            asString: 'normal,no_tiered_compilation'
-            asArray:
-            - normal
-            - no_tiered_compilation
+          - normal
+          - no_tiered_compilation
         ${{ if eq(parameters.testGroup, 'outerloop-jitminopts-jitstress1-jitstress2') }}:
           scenarios:
-            asString: 'jitminopts,jitstress1,jitstress1_tiered,jitstress2,jitstress2_tiered'
-            asArray:
-            - jitminopts
-            - jitstress1
-            - jitstress1_tiered
-            - jitstress2
-            - jitstress2_tiered
+          - jitminopts
+          - jitstress1
+          - jitstress1_tiered
+          - jitstress2
+          - jitstress2_tiered
         ${{ if eq(parameters.testGroup, 'outerloop-jitstressregs') }}:
           scenarios:
-            asString: 'jitstressregs1,jitstressregs2,jitstressregs3,jitstressregs4,jitstressregs8,jitstressregs0x10,jitstressregs0x80,jitstressregs0x1000'
-            asArray:
-            - jitstressregs1
-            - jitstressregs2
-            - jitstressregs3
-            - jitstressregs4
-            - jitstressregs8
-            - jitstressregs0x10
-            - jitstressregs0x80
-            - jitstressregs0x1000
+          - jitstressregs1
+          - jitstressregs2
+          - jitstressregs3
+          - jitstressregs4
+          - jitstressregs8
+          - jitstressregs0x10
+          - jitstressregs0x80
+          - jitstressregs0x1000
         ${{ if eq(parameters.testGroup, 'outerloop-jitstress2-jitstressregs') }}:
           scenarios:
-            asString: 'jitstress2_jitstressregs1,jitstress2_jitstressregs2,jitstress2_jitstressregs3,jitstress2_jitstressregs4,jitstress2_jitstressregs8,jitstress2_jitstressregs0x10,jitstress2_jitstressregs0x80,jitstress2_jitstressregs0x1000'
-            asArray:
-            - jitstress2_jitstressregs1
-            - jitstress2_jitstressregs2
-            - jitstress2_jitstressregs3
-            - jitstress2_jitstressregs4
-            - jitstress2_jitstressregs8
-            - jitstress2_jitstressregs0x10
-            - jitstress2_jitstressregs0x80
-            - jitstress2_jitstressregs0x1000
+          - jitstress2_jitstressregs1
+          - jitstress2_jitstressregs2
+          - jitstress2_jitstressregs3
+          - jitstress2_jitstressregs4
+          - jitstress2_jitstressregs8
+          - jitstress2_jitstressregs0x10
+          - jitstress2_jitstressregs0x80
+          - jitstress2_jitstressregs0x1000
         ${{ if eq(parameters.testGroup, 'outerloop-gcstress0x3-gcstress0xc') }}:
           scenarios:
-            asString: 'gcstress0x3,gcstress0xc'
-            asArray:
-            - gcstress0x3
-            - gcstress0xc
+          - gcstress0x3
+          - gcstress0xc
 
     # Publish Logs
     - task: PublishPipelineArtifact@0

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -155,7 +155,8 @@ jobs:
 
         helixQueues: ${{ parameters.helixQueues }}
 
-        ${{ if eq(join('-', parameters.helixQueues), '') }}:
+        # This tests whether an array is empty
+        ${{ if eq(join('', parameters.helixQueues), '') }}:
           condition: false
 
         publishTestResults: true

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -155,7 +155,7 @@ jobs:
 
         helixQueues: ${{ parameters.helixQueues }}
 
-        ${{ if eq(parameters.helixQueues.asString, '') }}:
+        ${{ if eq(join('-', parameters.helixQueues), '') }}:
           condition: false
 
         publishTestResults: true


### PR DESCRIPTION
Support for `join()` functions was added to Azure Pipelines (https://github.com/Microsoft/azure-pipelines-yaml/issues/90) - this will remove the workaround with `.asString/.asArray` (https://github.com/dotnet/coreclr/pull/22173)

Also this:
* Enables **Ubuntu.1804.Arm32.On.Docker.Open** (running on Ubuntu.1604.Arm32.Open) against PRs
* Restricts **Ubuntu.1404.Arm32.Open** running against CI (commit validation) only
* Enables **Debian.9.Arm32.On.Docker.Open**, **Ubuntu.1604.Arm32.On.Docker.Open** and **Ubuntu.1804.Arm32.On.Docker.Open** (running on Ubuntu.1604.Arm32.Open) against scheduled runs
* Enables **Debian.9.Arm32.On.Docker**, **Ubuntu.1604.Arm32.On.Docker** and **Ubuntu.1804.Arm32.On.Docker** (running on Ubuntu.1604.Arm32) in internal project (FYI, we haven't had any Linux arm32 testing in internal so far)
* Enables **Debian.9.Arm64.On.Docker.Open** (running on Ubuntu.1604.Arm64.Open) against scheduled runs
* Enables **Alpine.38.Arm64.On.Docker** (running on Ubuntu.1604.Arm64.Docker) in internal project