### PR TITLE
A new way of tracking variables

### DIFF
--- a/Documentation/design-docs/variabletracking.md
+++ b/Documentation/design-docs/variabletracking.md
@@ -308,7 +308,7 @@ There are many things we can do to improve optimized debugging:
     Currently we don't have the IL offset of them.
     And this is broadly used to improve code performance.
 
--   Promoted structs: There is no debug support for fields of promoted structs, we just report the struct itself.
+-   [Promoted structs](https://github.com/dotnet/coreclr/issues/23542): There is no debug support for fields of promoted structs, we just report the struct itself.
 
--   Reduce space used for VariableLiveDescriptor: we are currently using a `jitstd::list`, which is a double linked list. 
+-   [Reduce space used for VariableLiveDescriptor](https://github.com/dotnet/coreclr/issues/23544): we are currently using a `jitstd::list`, which is a double linked list. 
     We could use a simple single linked list with push_back(), head(), tail(), size() operations and an iterator and we would be saving memory.

--- a/Documentation/design-docs/variabletracking.md
+++ b/Documentation/design-docs/variabletracking.md
@@ -1,0 +1,314 @@
+Reporting Variable Location
+===================
+Table of Contents
+-----------------
+
+[Debug Info](#debug-info)
+
+[Context](#context)
+
+[Debug Code vs Optimized Code](#debug-code-vs-optimized-code)
+
+[siScope / psiScope Structures](#siscope-psiscope-structure)
+
+[Generating siScope / psiScope info](#siscope-psiscope)
+
+[Variable Live Range Structure](#variable-live-range-structure)
+
+[Generating Variable Live Range](#variable-live-range)
+
+[Turning On Debug Info](#debug-indo-flags)
+
+[Dumps and Debugging Support](#dumps-and-debugging-support)
+
+[Future Extensions and Enhancements](#future-extensions-and-enhancements)
+
+Debug Info
+--------
+
+The debugger expects to receive an array of `VarResultInfo` which indicates:
+
+-   IL variable number
+
+-   Location
+
+-   First native offset this location is valid
+
+-   First native offset this location is no longer valid
+
+There could be more than one per variable.
+There should be no overlap in terms of starting/ending native offsets for the same variable.
+Given a native offset, no two variables should share the same location.
+
+Context  
+--------
+
+We generate variables debug info while we generate the assembly intructions of the code. This is happening in `genCodeForBBList()` and `genFnProlog()`.
+
+If we are jitting release code, information about variable liveness will be included in `GenTree`s and `BasicBlock` when `genCodeForBBList` is reached.
+For each When `BasicBlock`:
+
+-   `bbLiveIn`: alive at the beginning
+
+-   `bbLiveOut`: alive at the end
+
+Also each `GenTree` has a mask `gtFlags` indicating will include if a variable:
+
+-   is being born
+
+-   is becoming death
+
+-   is being spilled
+
+-   has been spilled
+
+When generating each instruction, this flags are used to know if we need to start/end tracking a variable or update its location (which means in practice "end and start").
+The blocks set of live variables are also used to start/end variables tracking information. 
+
+Once the code is done we know the native offset of every assembly instruction, which is required for the debug info.
+While we are generating code we don't work with native offsets but `emitLocation`s that the `emitter` can generate, and once the code is done we can get the native offset corresponding to each of them.
+
+Debug Code vs Optimized Code
+--------
+
+Variables on debug code:
+-   are alive during the whole method
+
+-   live in a fixed location on the stack the whole method
+
+-   `bbLiveIn` and `bbLiveOut` sets are empty
+
+-   there is no flag for spill/unspill variables
+
+Variables on optimized code:
+
+-   could change their location during code execution
+
+-   could change their liveness during code execution
+
+siScope / psiScope Structures
+--------
+
+#### siScope
+
+This struct is used to represent the ranges where a variable is alive during code generation.
+
+It has two field to denote the native offset where it is valid:
+
+-   `scStartLoc`: an emitLocation indicating from which instruction
+
+-   `scStartLoc`: an emitLocation indication to which instruction
+
+and more fields to indicate from which variable is this scope.
+
+It doesn't have information about the location of the variable, only the stack level of the variable in the case it was on the stack.
+
+#### psiScope
+
+This struct is used to represente the ranges where a variable is alive during the prolog.
+It holds the same information than siScope with the addition of a way of describing the location.
+It describes the variable location with two registers or a base register and the offset.
+
+Generating siScope / psiScope info
+--------
+
+In order to use Scope Info for tracking variables location, the Flag `USING_SCOPE_INFO` in codegeninterface.h should be defined.
+
+#### For Prolog
+
+We open a `psiScope` for every paramater indicating its location at the beginning of the prolog. We then close them all at the end of the prolog.
+
+#### For Method Code
+
+We start generating code for every `BasicBlock`:
+
+-   checking at the beginning of each one if there is a variable which hasn't an open siScope and has a `varScope` with an starting IL offset lower or equal to the beginning of the block.
+
+-   closing a siScope if a variable is last used.
+
+and we close all the open `siScope`s when the last block is reached.
+
+##### Reporting Information
+
+Once the code for the block and each of the `BasicBlock` is done, `genSetScopeInfo()` is called.
+In the case of having the flag `USING_SCOPE_INFO`, 
+
+All the `psiScope` list is iterated filling the debug info structure.
+Then the list of `siScope` created is iterated, using the `LclVarDsc` class to get the location of the variable, which would hold the description of the last position it has.
+This is not a problem for debug code because variables live in a fixed location the whole method. 
+
+This is done in `CodeGen::genSetScopeInfoUsingsiScope()`
+
+Variable Live Range Structure
+--------
+
+### VariableLiveRange
+
+This class is used to represent an uninterruptible portion of variable live in one location.
+Owns two emitLocations indicating the first instructions that make it valid and invalid respectively.
+It also has the location of the variable in this range, which is stored at the moment of being created.
+
+To save space, we save the ending emitLocation only when the variable is being moved or its liveness change, which could happen many blocks after it was being born.
+This means a `VariableLiveRange` native offsets range could be longer than a `BasicBlock`.
+
+### VariableLiveDescriptor
+
+This class is used to represent the liveness of a variable.
+It has a list of `VariableLiveRange`s and common operations to update the variable liveness.
+
+### VariableLiveKeeper
+
+It holds an array of `VariableLiveDescriptor`s, one per variable that is being tracked.
+The index of each variable inside this array is the same as in `Compiler::lvaTable`.
+
+We could have `VariableLiveDescriptor` inside each LclVarDsc or an array of `VariableLiveDescriptor` inside `Compiler`, but the intention is to move code out of `Compiler` and not increse it.
+
+Generating Variable Live Range
+--------
+
+In order to use Variable Live Range for tracking variables location, the Flag `USING_VARIABLE_LIVE_RANGE` in codegeninterface.h should be defined.
+
+### For optimized code
+
+In `genCodeForBBList()`, we start generating code for each block dealing with some cases.
+
+On `BasicBlock` boundaries:
+
+-   `BasicBlock`s beginning:
+
+    -   If a variable has an open `VariableLiveRange` but the location is different than what is expected to be in this block we update it (close the existing one and create another).
+        This could happen because a variable could be in the `bbLiveOut` of a block and in the `BasicBlock`s `bbLiveOut` of the next one, but that doesn't mean that the execution thread would go from one inmeadiatly to the next one.
+        For this kind of cases another block that moves the variable from its original to the expected position is created.
+        This is handled in `LinearScan::recordVarLocationsAtStartOfBB(BasicBlock* bb)`.
+
+    -   If a variable has not an open `VariableLiveRange` and is in `bbLiveIn`, we open one.
+        This is done in `genUpdateLife` inmeadiatly after the the previous method is called.
+
+    -   If a variable has an open `VariableLiveRange` and is not in `bbLiveIn`, we close it.
+        This is handled considered in `genUpdateLife` too.
+
+-   last `BasicBlock`s ending:
+
+    -   We close every open `VariableLiveRange`.
+        This is handled in `genCodeForBBList` when iterating the blocks, after the code for each block is done.
+
+For each instruction in `BasicBlock`:
+-   a `VariableLiveRange` is opened for each variable that is being born and not is becoming dead at the same instruction
+    Handled in `TreeLifeUpdater::UpdateLifeVar(GenTree* tree)`
+
+-   a `VariableLiveRange` is closed and another one opened for each variable that is being spill, unspill or copy and is not becoming death at the same instruction.
+    Spills and copies are handled in `TreeLifeUpdater::UpdateLifeVar(GenTree* tree)`, unspills in `CodeGen::genUnspillRegIfNeeded(GenTree* tree)`.
+
+-   a `VariableLiveRange` is closed for each variable that is becoming death.
+    Handled in `TreeLifeUpdater::UpdateLifeVar(GenTree* tree)`
+
+We are not reporing the cases where a variable liveness is being modify and also becoming dead to save memory.
+
+### For debug code
+
+As no flag is being added `GenTree` that we can consume and no variable is included in `bbLiveIn` or `bbLiveOut`, we are currently reporting a variable as being born the same way is done for siScope info in `siBeginBlock` each time before `BasicBlock`s code is generated.
+The death of a variable is handled at the end of the last `BasicBlock` as variable live during the whole method.
+
+### Reporting Information
+
+We just iterate throught all the `VariableLiveRange`s of all the variables that are tracked in `CodeGen::genSetScopeInfoUsingVariableRanges()`.
+
+Turning On Debug Info
+--------
+
+There is a flag to turn on each of this ways of tracking variable debug info:
+-   : for `siScope` and `psiScope`
+
+-   : for `VariableLiveRange`
+
+In case only one of them is defined, that one will be sent to the debugger.
+If both are defined, Scope info is sent to the debugger.
+If none is defined, no info is sent to the debugger.
+
+Both flags can be found at the beginnig of `codegeninterace.h`
+
+Dumps and Debugging Support
+--------
+
+#### Variable Live Ranges activity during a BasicBlock
+
+If we have the flag for `VariableLiveRange`s we would get on the jitdump a verbose message after each BasicBlock is donde indicating the changes for each variable.
+For example: 
+
+```
+////////////////////////////////////////
+////////////////////////////////////////
+Var History Dump for Block 44 
+Var 1:
+[esi [ (G_M8533_IG29,ins#2,ofs#3), NON_CLOSED_RANGE ]; ]
+Var 12:
+[ebp[-44] (1 slot) [ (G_M8533_IG29,ins#2,ofs#3), NON_CLOSED_RANGE ]; ]
+Var 17:
+[ebp[-56] (1 slot) [ (G_M8533_IG32,ins#2,ofs#7), (G_M8533_IG33,ins#10,ofs#32) ]; edx [ (G_M8533_IG33,ins#10,ofs#32), (G_M8533_IG33,ins#10,ofs#32) ]; ]
+////////////////////////////////////////
+////////////////////////////////////////
+```
+
+indicating that:
+
+-   Variable with index number 1 is living in register esi since instruction group 29 and it is still living there at the end of the block.
+
+-   Variable with index number 12 in a similar situation as 1 but living on the stack.
+
+-   Variable with index number 17 was living on the stack since instruction group 32 and it was unspill on ig 33, which is the instruction group of this BasicBlock, and it isn't alive at the end of the block.
+
+-   Those are the only variables that are being tracked in this method and were alive during part or the whole method. 
+
+Each `VariableLiveRange` is dumped as:
+```
+Location [ starting_emit_location, ending_emit_location )
+```
+and a list of them for a variable.
+
+Something to consider is that as we don't have the final native offsets while we are generating code, we are just dumping `emitLocation`s.
+
+#### All the Variable Live Ranges
+
+We also get all the `VariableLiveRange`s dumped for all the variables once the code for the whole method is done with the native offsets in place of `emitLocation`s.
+
+The information follows the same pattern as before.
+
+```
+////////////////////////////////////////
+////////////////////////////////////////
+PRINTING REGISTER LIVE RANGES:
+[esi [3C , 270 )esi [275 , 2BE )esi [2DA , 390 )]
+IL Var Num 12:
+[ebp[-44] (1 slot) [200 , 270 )ebp[-44] (1 slot) [275 , 28A )ebp[-44] (1 slot) [292 , 2BE )ebp[-44] (1 slot) [2DA , 401 )ebp[-44] (1 slot) [406 , 449 )ebp[-44] (1 slot) [465 , 468 )edi [468 , 468 )]
+IL Var Num 17:
+[ebp[-56] (1 slot) [331 , 373 )edx [373 , 373 )]
+////////////////////////////////////////
+////////////////////////////////////////
+```
+
+#### Debug Info sent to the debugger
+
+The information sent to the debugger is dumped to as:
+```
+*************** In genSetScopeInfo()
+VarLocInfo count is 95
+*************** Variable debug info
+3 live ranges
+  0(   UNKNOWN) : From 00000000h to 0000001Ah, in ecx
+  1(   UNKNOWN) : From 0000003Ch to 00000270h, in esi
+  1(   UNKNOWN) : From 00000275h to 000002BEh, in esi
+```
+
+Future Extensions and Enhancements
+--------
+
+There are many things we can do to improve optimized debugging:
+
+-   Inline functions: If you crash inside one, you get no info of your variables.
+    Currently we don't have the IL offset of them.
+    And this is broadly used to improve code performance.
+
+-   Promoted structs: There is no debug support for fields of promoted structs, we just report the struct itself.
+
+-   Reduce space used for VariableLiveDescriptor: we are currently using a `jitstd::list`, which is a double linked list. 
+    We could use a simple single linked list with push_back(), head(), tail(), size() operations and an iterator and we would be saving memory.

--- a/Documentation/design-docs/variabletracking.md
+++ b/Documentation/design-docs/variabletracking.md
@@ -7,6 +7,8 @@ Table of Contents
 
 [Context](#context)
 
+[Variable Number](#variable-number)
+
 [Debug Code vs Optimized Code](#debug-code-vs-optimized-code)
 
 [siScope / psiScope Structures](#siscope-psiscope-structure)
@@ -32,7 +34,7 @@ The debugger expects to receive an array of `VarResultInfo` which indicates:
 
 -   Location
 
--   First native offset this location is valid
+-   First native offset this location is valid.
 
 -   First native offset this location is no longer valid
 
@@ -46,7 +48,7 @@ Context
 We generate variables debug info while we generate the assembly intructions of the code. This is happening in `genCodeForBBList()` and `genFnProlog()`.
 
 If we are jitting release code, information about variable liveness will be included in `GenTree`s and `BasicBlock` when `genCodeForBBList` is reached.
-For each When `BasicBlock`:
+For each `BasicBlock`:
 
 -   `bbLiveIn`: alive at the beginning
 
@@ -56,17 +58,31 @@ Also each `GenTree` has a mask `gtFlags` indicating will include if a variable:
 
 -   is being born
 
--   is becoming death
+-   is becoming dead
 
 -   is being spilled
 
 -   has been spilled
 
-When generating each instruction, this flags are used to know if we need to start/end tracking a variable or update its location (which means in practice "end and start").
+When generating each instruction, these flags are used to know if we need to start/end tracking a variable or update its location (which means in practice "end and start").
 The blocks set of live variables are also used to start/end variables tracking information. 
 
 Once the code is done we know the native offset of every assembly instruction, which is required for the debug info.
 While we are generating code we don't work with native offsets but `emitLocation`s that the `emitter` can generate, and once the code is done we can get the native offset corresponding to each of them.
+
+Variable Number 
+--------
+
+If we compile a method and inspect the generated IL we can see there is a "locals" section which holds the local variables of you C# code named with a Vxx pattern.
+When we report debug info to the debugger, we also have to report arguments and special arguments.
+Those are included at the beginning, so if we have three locals named as V00, V01 and V02, two arguments named as arg00, arg01 and one special argument named as sarg00, we would end with these variable numbers.
+
+Variable Name:      arg00   arg01   sarg00  V00  V01  V02
+Variable Number:      0       1       2      3    4    5
+
+This correspond to the index in `Compiler::lvaTable` and `VariableLiveKeeeper::m_vlrLiveDsc`.
+
+If any change is applied to this, probably changes on `CordbJITILFrame::ILVariableToNative` are needed.
 
 Debug Code vs Optimized Code
 --------
@@ -93,11 +109,11 @@ siScope / psiScope Structures
 
 This struct is used to represent the ranges where a variable is alive during code generation.
 
-It has two field to denote the native offset where it is valid:
+The struct has two fields to denote the native offset where a variable is valid:
 
 -   `scStartLoc`: an emitLocation indicating from which instruction
 
--   `scStartLoc`: an emitLocation indication to which instruction
+-   `scEndLoc`: an emitLocation indicating to which instruction
 
 and more fields to indicate from which variable is this scope.
 
@@ -105,7 +121,7 @@ It doesn't have information about the location of the variable, only the stack l
 
 #### psiScope
 
-This struct is used to represente the ranges where a variable is alive during the prolog.
+This struct is used to represent the ranges where a variable is alive during the prolog.
 It holds the same information than siScope with the addition of a way of describing the location.
 It describes the variable location with two registers or a base register and the offset.
 
@@ -116,13 +132,13 @@ In order to use Scope Info for tracking variables location, the Flag `USING_SCOP
 
 #### For Prolog
 
-We open a `psiScope` for every paramater indicating its location at the beginning of the prolog. We then close them all at the end of the prolog.
+We open a `psiScope` for every parameter indicating its location at the beginning of the prolog. We then close them all at the end of the prolog.
 
 #### For Method Code
 
 We start generating code for every `BasicBlock`:
 
--   checking at the beginning of each one if there is a variable which hasn't an open siScope and has a `varScope` with an starting IL offset lower or equal to the beginning of the block.
+-   checking at the beginning of each one if there is a variable which does not have an open siScope and has a `varScope` with an starting IL offset lower or equal to the beginning of the block.
 
 -   closing a siScope if a variable is last used.
 
@@ -161,7 +177,7 @@ It has a list of `VariableLiveRange`s and common operations to update the variab
 It holds an array of `VariableLiveDescriptor`s, one per variable that is being tracked.
 The index of each variable inside this array is the same as in `Compiler::lvaTable`.
 
-We could have `VariableLiveDescriptor` inside each LclVarDsc or an array of `VariableLiveDescriptor` inside `Compiler`, but the intention is to move code out of `Compiler` and not increse it.
+We could have `VariableLiveDescriptor` inside each LclVarDsc or an array of `VariableLiveDescriptor` inside `Compiler`, but the intention is to move code out of `Compiler` and not increase it.
 
 Generating Variable Live Range
 --------
@@ -177,15 +193,15 @@ On `BasicBlock` boundaries:
 -   `BasicBlock`s beginning:
 
     -   If a variable has an open `VariableLiveRange` but the location is different than what is expected to be in this block we update it (close the existing one and create another).
-        This could happen because a variable could be in the `bbLiveOut` of a block and in the `BasicBlock`s `bbLiveOut` of the next one, but that doesn't mean that the execution thread would go from one inmeadiatly to the next one.
+        This could happen because a variable could be in the `bbLiveOut` of a block and in the `BasicBlock`s `bbLiveOut` of the next one, but that doesn't mean that the execution thread would go from one immediately to the next one.
         For this kind of cases another block that moves the variable from its original to the expected position is created.
         This is handled in `LinearScan::recordVarLocationsAtStartOfBB(BasicBlock* bb)`.
 
-    -   If a variable has not an open `VariableLiveRange` and is in `bbLiveIn`, we open one.
-        This is done in `genUpdateLife` inmeadiatly after the the previous method is called.
+    -   If a variable doesn't have an open `VariableLiveRange` and is in `bbLiveIn`, we open one.
+        This is done in `genUpdateLife` immediately after the the previous method is called.
 
     -   If a variable has an open `VariableLiveRange` and is not in `bbLiveIn`, we close it.
-        This is handled considered in `genUpdateLife` too.
+        This is handled in `genUpdateLife` too.
 
 -   last `BasicBlock`s ending:
 
@@ -193,16 +209,30 @@ On `BasicBlock` boundaries:
         This is handled in `genCodeForBBList` when iterating the blocks, after the code for each block is done.
 
 For each instruction in `BasicBlock`:
--   a `VariableLiveRange` is opened for each variable that is being born and not is becoming dead at the same instruction
-    Handled in `TreeLifeUpdater::UpdateLifeVar(GenTree* tree)`
+-   a `VariableLiveRange` is opened for each variable that is being born and is not becoming dead at the same instruction
+    Handled in `TreeLifeUpdater::UpdateLifeVar(GenTree* tree)`.
 
--   a `VariableLiveRange` is closed and another one opened for each variable that is being spill, unspill or copy and is not becoming death at the same instruction.
+-   a `VariableLiveRange` is closed and another one opened for each variable that is being spilled, unspilled or copied and is not dying at the same instruction.
     Spills and copies are handled in `TreeLifeUpdater::UpdateLifeVar(GenTree* tree)`, unspills in `CodeGen::genUnspillRegIfNeeded(GenTree* tree)`.
 
--   a `VariableLiveRange` is closed for each variable that is becoming death.
+-   a `VariableLiveRange` is closed for each variable that is dying.
     Handled in `TreeLifeUpdater::UpdateLifeVar(GenTree* tree)`
 
-We are not reporing the cases where a variable liveness is being modify and also becoming dead to save memory.
+We are not reporting the cases where a variable liveness is being modified and also becoming dead for some reasons:
+-   We are using inclusive native offset for the beginning and exclusive native offset for the ending of a VariableLiveRange.
+    This property is used when the debugger is looking the location of a variable in `FindNativeInfoInILVariableArray`.
+    So a `VariableLiveRange` with exactly the same native offset for both would represent an empty live range and will not been found by the debugger.
+
+-   Each C# line commonly end being more than one assembly instruction, if it exist on the assembly code.
+    When you put a breakpoint in one C# line, you are stoping at the first of this group of instruction.
+    A `VariableLiveRange` of just on assembly instruction seems unlikely to affect user debugging experience.
+
+-   Less memory used to save VariabeLiveRanges
+
+-   We are just changing the variable location.
+    We are not changing the variable value and the "old" variable location is not being modified.
+    So during that only assembly instruction, both `VariableLiveRange`s are valid, and we can increase the previous `VariableLiveRange` ending native offset a few bytes (we are not doing that now) and avoid creating a new `VariableLiveRange`. 
+     
 
 ### For debug code
 
@@ -225,14 +255,14 @@ In case only one of them is defined, that one will be sent to the debugger.
 If both are defined, Scope info is sent to the debugger.
 If none is defined, no info is sent to the debugger.
 
-Both flags can be found at the beginnig of `codegeninterace.h`
+Both flags can be found at the beginnig of `codegeninterface.h`
 
 Dumps and Debugging Support
 --------
 
 #### Variable Live Ranges activity during a BasicBlock
 
-If we have the flag for `VariableLiveRange`s we would get on the jitdump a verbose message after each BasicBlock is donde indicating the changes for each variable.
+If we have the flag for `VariableLiveRange`s we would get on the jitdump a verbose message after each `BasicBlock` is done indicating the changes for each variable.
 For example: 
 
 ```

--- a/src/jit/block.cpp
+++ b/src/jit/block.cpp
@@ -215,7 +215,7 @@ flowList* Compiler::BlockPredsWithEH(BasicBlock* blk)
 //------------------------------------------------------------------------
 // dspBlockILRange(): Display the block's IL range as [XXX...YYY), where XXX and YYY might be "???" for BAD_IL_OFFSET.
 //
-void BasicBlock::dspBlockILRange()
+void BasicBlock::dspBlockILRange() const
 {
     if (bbCodeOffs != BAD_IL_OFFSET)
     {

--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -897,9 +897,9 @@ struct BasicBlock : private LIR::Range
                              // is bbCodeOffsEnd - bbCodeOffs, assuming neither are BAD_IL_OFFSET.
 
 #ifdef DEBUG
-    void dspBlockILRange(); // Display the block's IL range as [XXX...YYY), where XXX and YYY might be "???" for
-                            // BAD_IL_OFFSET.
-#endif                      // DEBUG
+    void dspBlockILRange() const; // Display the block's IL range as [XXX...YYY), where XXX and YYY might be "???" for
+                                  // BAD_IL_OFFSET.
+#endif                            // DEBUG
 
     VARSET_TP bbVarUse; // variables used     by block (before an assignment)
     VARSET_TP bbVarDef; // variables assigned by block (before a use)

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -555,7 +555,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
                          unsigned       varNum,
                          unsigned       LVnum,
                          bool           avail,
-                         siVarLoc&      varLoc);
+                         siVarLoc*      varLoc);
 
     void genSetScopeInfo();
 #ifdef USING_VARIABLE_LIVE_RANGE

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -670,23 +670,26 @@ public:
     const char* siStackVarName(size_t offs, size_t size, unsigned reg, unsigned stkOffs);
 #endif // LATE_DISASM
 
-    /*
-    XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-    XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-    XX                                                                           XX
-    XX                          PrologScopeInfo                                  XX
-    XX                                                                           XX
-    XX We need special handling in the prolog block, as the parameter variables  XX
-    XX may not be in the same position described by genLclVarTable - they all    XX
-    XX start out on the stack                                                    XX
-    XX                                                                           XX
-    XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-    XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-    */
-
+/*
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XX                                                                           XX
+XX                          PrologScopeInfo                                  XX
+XX                                                                           XX
+XX We need special handling in the prolog block, as the parameter variables  XX
+XX may not be in the same position described by genLclVarTable - they all    XX
+XX start out on the stack                                                    XX
+XX                                                                           XX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+*/
+#endif // USING_SCOPE_INFO
 public:
     void psiBegProlog();
 
+    void psiEndProlog();
+
+#ifdef USING_SCOPE_INFO
     void psiAdjustStackLevel(unsigned size);
 
     void psiMoveESPtoEBP();
@@ -694,8 +697,6 @@ public:
     void psiMoveToReg(unsigned varNum, regNumber reg = REG_NA, regNumber otherReg = REG_NA);
 
     void psiMoveToStack(unsigned varNum);
-
-    void psiEndProlog();
 
     /**************************************************************************
      *                          PROTECTED
@@ -749,8 +750,10 @@ protected:
 
     void psiEndPrologScope(psiScope* scope);
 
-    void psSetScopeOffset(psiScope* newScope, LclVarDsc* lclVarDsc1);
+    void psiSetScopeOffset(psiScope* newScope, const LclVarDsc* lclVarDsc) const;
 #endif // USING_SCOPE_INFO
+
+    NATIVE_OFFSET psiGetVarStackOffset(const LclVarDsc* lclVarDsc) const;
 
     /*****************************************************************************
      *                        TrnslLocalVarInfo

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -592,8 +592,23 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 public:
     void siInit();
 
+#endif // USING_VARIABLE_LIVE_RANGE
+
+    void checkICodeDebugInfo();
+
     void siBeginBlock(BasicBlock* block);
 
+    // VariableLiveRange and siScope needs this method to report variables on debug code
+    void siOpenScopesForNonTrackedVars(const BasicBlock* block, unsigned int lastBlockILEndOffset);
+
+protected:
+#if FEATURE_EH_FUNCLETS
+    bool siInFuncletRegion; // Have we seen the start of the funclet region?
+#endif                      // FEATURE_EH_FUNCLETS
+
+#ifdef USING_SCOPE_INFO
+
+public:
     void siEndBlock(BasicBlock* block);
     // Closes the "ScopeInfo" of the tracked variables that has become dead.
     virtual void siUpdate();
@@ -641,10 +656,6 @@ protected:
     siScope** siLatestTrackedScopes;
 
     IL_OFFSET siLastEndOffs; // IL offset of the (exclusive) end of the last block processed
-
-#if FEATURE_EH_FUNCLETS
-    bool siInFuncletRegion; // Have we seen the start of the funclet region?
-#endif                      // FEATURE_EH_FUNCLETS
 
     // Functions
 

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -549,13 +549,13 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     //-------------------------------------------------------------------------
     // scope info for the variables
 
-    void genSetScopeInfo(unsigned        which,
-                         UNATIVE_OFFSET  startOffs,
-                         UNATIVE_OFFSET  length,
-                         unsigned        varNum,
-                         unsigned        LVnum,
-                         bool            avail,
-                         const siVarLoc* varLoc);
+    void genSetScopeInfo(unsigned       which,
+                         UNATIVE_OFFSET startOffs,
+                         UNATIVE_OFFSET length,
+                         unsigned       varNum,
+                         unsigned       LVnum,
+                         bool           avail,
+                         siVarLoc&      varLoc);
 
     void genSetScopeInfo();
 #ifdef USING_VARIABLE_LIVE_RANGE

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -549,15 +549,19 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     //-------------------------------------------------------------------------
     // scope info for the variables
 
-    void genSetScopeInfo(unsigned       which,
-                         UNATIVE_OFFSET startOffs,
-                         UNATIVE_OFFSET length,
-                         unsigned       varNum,
-                         unsigned       LVnum,
-                         bool           avail,
-                         siVarLoc*      varLoc);
+    void genSetScopeInfo(unsigned        which,
+                         UNATIVE_OFFSET  startOffs,
+                         UNATIVE_OFFSET  length,
+                         unsigned        varNum,
+                         unsigned        LVnum,
+                         bool            avail,
+                         const siVarLoc* varLoc);
 
     void genSetScopeInfo();
+#ifdef USING_VARIABLE_LIVE_RANGE
+    void genSetScopeInfoUsingVariableRanges();
+#endif // USING_VARIABLE_LIVE_RANGE
+
 #ifdef USING_SCOPE_INFO
     void genSetScopeInfoUsingsiScope();
 

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -559,6 +559,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
     void genSetScopeInfo();
 #ifdef USING_VARIABLE_LIVE_RANGE
+    // Send VariableLiveRanges as debug info to the debugger
     void genSetScopeInfoUsingVariableRanges();
 #endif // USING_VARIABLE_LIVE_RANGE
 

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -566,37 +566,38 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #ifdef USING_SCOPE_INFO
     void genSetScopeInfoUsingsiScope();
 
-    /*
-    XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-    XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-    XX                                                                           XX
-    XX                           ScopeInfo                                       XX
-    XX                                                                           XX
-    XX  Keeps track of the scopes during code-generation.                        XX
-    XX  This is used to translate the local-variable debugging information       XX
-    XX  from IL offsets to native code offsets.                                  XX
-    XX                                                                           XX
-    XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-    XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-    */
+/*
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XX                                                                           XX
+XX                           ScopeInfo                                       XX
+XX                                                                           XX
+XX  Keeps track of the scopes during code-generation.                        XX
+XX  This is used to translate the local-variable debugging information       XX
+XX  from IL offsets to native code offsets.                                  XX
+XX                                                                           XX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+*/
 
-    /*****************************************************************************/
-    /*****************************************************************************
-     *                              ScopeInfo
-     *
-     * This class is called during code gen at block-boundaries, and when the
-     * set of live variables changes. It keeps track of the scope of the variables
-     * in terms of the native code PC.
-     */
-
-public:
-    void siInit();
+/*****************************************************************************/
+/*****************************************************************************
+ *                              ScopeInfo
+ *
+ * This class is called during code gen at block-boundaries, and when the
+ * set of live variables changes. It keeps track of the scope of the variables
+ * in terms of the native code PC.
+ */
 
 #endif // USING_VARIABLE_LIVE_RANGE
-
+public:
+    void siInit();
     void checkICodeDebugInfo();
 
+    // The logic used to report debug info on debug code is the same for ScopeInfo and
+    // VariableLiveRange
     void siBeginBlock(BasicBlock* block);
+    void siEndBlock(BasicBlock* block);
 
     // VariableLiveRange and siScope needs this method to report variables on debug code
     void siOpenScopesForNonTrackedVars(const BasicBlock* block, unsigned int lastBlockILEndOffset);
@@ -606,10 +607,11 @@ protected:
     bool siInFuncletRegion; // Have we seen the start of the funclet region?
 #endif                      // FEATURE_EH_FUNCLETS
 
+    IL_OFFSET siLastEndOffs; // IL offset of the (exclusive) end of the last block processed
+
 #ifdef USING_SCOPE_INFO
 
 public:
-    void siEndBlock(BasicBlock* block);
     // Closes the "ScopeInfo" of the tracked variables that has become dead.
     virtual void siUpdate();
 
@@ -654,8 +656,6 @@ protected:
     // Tracks the last entry for each tracked register variable
 
     siScope** siLatestTrackedScopes;
-
-    IL_OFFSET siLastEndOffs; // IL offset of the (exclusive) end of the last block processed
 
     // Functions
 

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -2176,9 +2176,11 @@ void CodeGen::genRegCopy(GenTree* treeNode)
 
                 genUpdateVarReg(varDsc, treeNode);
 
+#ifdef USING_VARIABLE_LIVE_RANGE
                 // Report the home change for this variable
                 VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
                 varLvKeeper->siUpdateVariableLiveRange(varDsc, lcl->gtLclNum);
+#endif // USING_VARIABLE_LIVE_RANGE
 
                 // The new location is going live
                 genUpdateRegLife(varDsc, /*isBorn*/ true, /*isDying*/ false DEBUGARG(treeNode));

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -2176,6 +2176,10 @@ void CodeGen::genRegCopy(GenTree* treeNode)
 
                 genUpdateVarReg(varDsc, treeNode);
 
+                // Report the home change for this variable
+                VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
+                varLvKeeper->siUpdateVariableLiveRange(varDsc, lcl->gtLclNum);
+
                 // The new location is going live
                 genUpdateRegLife(varDsc, /*isBorn*/ true, /*isDying*/ false DEBUGARG(treeNode));
             }

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -2178,8 +2178,7 @@ void CodeGen::genRegCopy(GenTree* treeNode)
 
 #ifdef USING_VARIABLE_LIVE_RANGE
                 // Report the home change for this variable
-                VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
-                varLvKeeper->siUpdateVariableLiveRange(varDsc, lcl->gtLclNum);
+                compiler->getVariableLiveKeeper()->siUpdateVariableLiveRange(varDsc, lcl->gtLclNum);
 #endif // USING_VARIABLE_LIVE_RANGE
 
                 // The new location is going live

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -686,7 +686,7 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
             {
                 codeGen->gcInfo.gcRegByrefSetCur &= ~regMask;
             }
-            codeGen->genUpdateRegLife(varDsc, false /*isBorn*/, true /*isDying*/ DEBUGARG(nullptr));
+            codeGen->genUpdateRegLife(varDsc, varNum, false /*isBorn*/, true /*isDying*/ DEBUGARG(nullptr));
         }
         // This isn't in a register, so update the gcVarPtrSetCur.
         else if (isGCRef || isByRef)
@@ -694,6 +694,9 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
             VarSetOps::RemoveElemD(this, codeGen->gcInfo.gcVarPtrSetCur, deadVarIndex);
             JITDUMP("\t\t\t\t\t\t\tV%02u becoming dead\n", varNum);
         }
+
+        VariableLiveKeeper* varLiveKeeper = getVariableLiveKeeper();
+        varLiveKeeper->siEndVariableLiveRange(varNum);
     }
 
     VarSetOps::Iter bornIter(this, bornSet);
@@ -731,6 +734,9 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
             VarSetOps::AddElemD(this, codeGen->gcInfo.gcVarPtrSetCur, bornVarIndex);
             JITDUMP("\t\t\t\t\t\t\tV%02u becoming live\n", varNum);
         }
+
+        VariableLiveKeeper* varLiveKeeper = getVariableLiveKeeper();
+        varLiveKeeper->siStartVariableLiveRange(varDsc, varNum);
     }
 #ifdef USING_SCOPE_INFO
     codeGen->siUpdate();

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -686,7 +686,7 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
             {
                 codeGen->gcInfo.gcRegByrefSetCur &= ~regMask;
             }
-            codeGen->genUpdateRegLife(varDsc, varNum, false /*isBorn*/, true /*isDying*/ DEBUGARG(nullptr));
+            codeGen->genUpdateRegLife(varDsc, false /*isBorn*/, true /*isDying*/ DEBUGARG(nullptr));
         }
         // This isn't in a register, so update the gcVarPtrSetCur.
         else if (isGCRef || isByRef)

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -695,8 +695,10 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
             JITDUMP("\t\t\t\t\t\t\tV%02u becoming dead\n", varNum);
         }
 
+#ifdef USING_VARIABLE_LIVE_RANGE
         VariableLiveKeeper* varLiveKeeper = getVariableLiveKeeper();
         varLiveKeeper->siEndVariableLiveRange(varNum);
+#endif // USING_VARIABLE_LIVE_RANGE
     }
 
     VarSetOps::Iter bornIter(this, bornSet);
@@ -735,9 +737,12 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
             JITDUMP("\t\t\t\t\t\t\tV%02u becoming live\n", varNum);
         }
 
+#ifdef USING_VARIABLE_LIVE_RANGE
         VariableLiveKeeper* varLiveKeeper = getVariableLiveKeeper();
         varLiveKeeper->siStartVariableLiveRange(varDsc, varNum);
+#endif // USING_VARIABLE_LIVE_RANGE
     }
+
 #ifdef USING_SCOPE_INFO
     codeGen->siUpdate();
 #endif // USING_SCOPE_INFO

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -10662,7 +10662,7 @@ void CodeGen::genSetScopeInfoUsingVariableRanges()
 
                 genSetScopeInfo(liveRangeIndex, startOffs, endOffs - startOffs, varNum,
                                 varNum /* I dont know what is the which in eeGetLvInfo */, true,
-                                liveRange.m_VarLocation);
+                                &liveRange.m_VarLocation);
                 liveRangeIndex++;
             }
         }
@@ -10691,7 +10691,7 @@ void CodeGen::genSetScopeInfo(unsigned       which,
                               unsigned       varNum,
                               unsigned       LVnum,
                               bool           avail,
-                              siVarLoc&      varLoc)
+                              siVarLoc*      varLoc)
 {
     // We need to do some mapping while reporting back these variables.
 
@@ -10706,7 +10706,7 @@ void CodeGen::genSetScopeInfo(unsigned       which,
     if (compiler->info.compIsVarArgs && varNum != compiler->lvaVarargsHandleArg &&
         varNum < compiler->info.compArgsCount && !compiler->lvaTable[varNum].lvIsRegArg)
     {
-        noway_assert(varLoc.vlType == VLT_STK || varLoc.vlType == VLT_STK2);
+        noway_assert(varLoc->vlType == VLT_STK || varLoc->vlType == VLT_STK2);
 
         // All stack arguments (except the varargs handle) have to be
         // accessed via the varargs cookie. Discard generated info,
@@ -10731,8 +10731,8 @@ void CodeGen::genSetScopeInfo(unsigned       which,
         noway_assert(offset < stkArgSize);
         offset = stkArgSize - offset;
 
-        varLoc.vlType                   = VLT_FIXED_VA;
-        varLoc.vlFixedVarArg.vlfvOffset = offset;
+        varLoc->vlType                   = VLT_FIXED_VA;
+        varLoc->vlFixedVarArg.vlfvOffset = offset;
     }
 
 #endif // _TARGET_X86_
@@ -10759,11 +10759,11 @@ void CodeGen::genSetScopeInfo(unsigned       which,
     tlvi.tlviStartPC   = startOffs;
     tlvi.tlviLength    = length;
     tlvi.tlviAvailable = avail;
-    tlvi.tlviVarLoc    = varLoc;
+    tlvi.tlviVarLoc    = *varLoc;
 
 #endif // DEBUG
 
-    compiler->eeSetLVinfo(which, startOffs, length, ilVarNum, varLoc);
+    compiler->eeSetLVinfo(which, startOffs, length, ilVarNum, *varLoc);
 }
 
 /*****************************************************************************/

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -10667,6 +10667,7 @@ void CodeGen::genSetScopeInfoUsingVariableRanges()
                 genSetScopeInfo(liveRangeIndex, startOffs, endOffs - startOffs, varNum,
                                 varNum /* I dont know what is the which in eeGetLvInfo */, true,
                                 &liveRange.m_VarLocation);
+                liveRangeIndex++;
             }
         }
     }

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2295,15 +2295,13 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
 
     genSetScopeInfo();
 
-#ifdef USING_VARIABLE_LIVE_RANGE
-#ifdef DEBUG
+#if defined(USING_VARIABLE_LIVE_RANGE) && defined(DEBUG)
     if (compiler->verbose)
     {
         VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
         varLiveKeeper->dumpLvaVariableLiveRanges();
     }
-#endif // DEBUG
-#endif // USING_VARIABLE_LIVE_RANGE
+#endif // defined(USING_VARIABLE_LIVE_RANGE) && defined(DEBUG)
 
 #ifdef LATE_DISASM
     unsigned finalHotCodeSize;

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -10546,7 +10546,7 @@ void CodeGen::genSetScopeInfo()
 #ifdef USING_VARIABLE_LIVE_RANGE
     // We can have one of both flags defined, both, or none. Specially if we need to compare both
     // both results. But we cannot report both to the debugger, since there would be overlapping
-    // intervals, and may not indicate the same variable home.
+    // intervals, and may not indicate the same variable location.
 
     genSetScopeInfoUsingVariableRanges();
 
@@ -10665,7 +10665,8 @@ void CodeGen::genSetScopeInfoUsingVariableRanges()
                 }
 
                 genSetScopeInfo(liveRangeIndex, startOffs, endOffs - startOffs, varNum,
-                                varNum /* I dont know what is the which in eeGetLvInfo */, true, &liveRange.m_VarHome);
+                                varNum /* I dont know what is the which in eeGetLvInfo */, true,
+                                &liveRange.m_VarLocation);
             }
         }
     }

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -7650,13 +7650,12 @@ void CodeGen::genFnProlog()
         printf("\n__prolog:\n");
     }
 #endif
-#ifdef USING_SCOPE_INFO
+
     if (compiler->opts.compScopeInfo && (compiler->info.compVarScopesCount > 0))
     {
         // Create new scopes for the method-parameters for the prolog-block.
         psiBegProlog();
     }
-#endif // USING_SCOPE_INFO
 
 #ifdef DEBUG
 
@@ -8303,12 +8302,11 @@ void CodeGen::genFnProlog()
         genPrologPadForReJit();
         getEmitter()->emitMarkPrologEnd();
     }
-#ifdef USING_SCOPE_INFO
     if (compiler->opts.compScopeInfo && (compiler->info.compVarScopesCount > 0))
     {
         psiEndProlog();
     }
-#endif // USING_SCOPE_INFO
+
     if (hasGCRef)
     {
         getEmitter()->emitSetFrameRangeGCRs(GCrefLo, GCrefHi);

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -10516,7 +10516,7 @@ void CodeGen::genSetScopeInfo()
 
 #ifdef USING_VARIABLE_LIVE_RANGE
     const VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
-    varsLocationsCount                      = varLiveKeeper->getLiveRangesCount();
+    varsLocationsCount                      = (unsigned int)varLiveKeeper->getLiveRangesCount();
 #endif // USING_VARIABLE_LIVE_RANGE
 
 #endif // USING_SCOPE_INFO

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -10505,23 +10505,23 @@ void CodeGen::genSetScopeInfo()
     }
 #endif
 
-    unsigned varsHomeCount = 0;
+    unsigned varsLocationsCount = 0;
 
 #ifdef USING_SCOPE_INFO
     if (compiler->info.compVarScopesCount > 0)
     {
-        varsHomeCount = siScopeCnt + psiScopeCnt;
+        varsLocationsCount = siScopeCnt + psiScopeCnt;
     }
 #else // USING_SCOPE_INFO
 
 #ifdef USING_VARIABLE_LIVE_RANGE
     const VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
-    varsHomeCount                           = varLiveKeeper->getLiveRangesCount();
+    varsLocationsCount                      = varLiveKeeper->getLiveRangesCount();
 #endif // USING_VARIABLE_LIVE_RANGE
 
 #endif // USING_SCOPE_INFO
 
-    if (varsHomeCount == 0)
+    if (varsLocationsCount == 0)
     {
         compiler->eeSetLVcount(0);
         compiler->eeSetLVdone();
@@ -10530,13 +10530,13 @@ void CodeGen::genSetScopeInfo()
 
     noway_assert(compiler->opts.compScopeInfo && (compiler->info.compVarScopesCount > 0));
 
-    compiler->eeSetLVcount(varsHomeCount);
+    compiler->eeSetLVcount(varsLocationsCount);
 
 #ifdef DEBUG
-    genTrnslLocalVarCount = varsHomeCount;
-    if (varsHomeCount)
+    genTrnslLocalVarCount = varsLocationsCount;
+    if (varsLocationsCount)
     {
-        genTrnslLocalVarInfo = new (compiler, CMK_DebugOnly) TrnslLocalVarInfo[varsHomeCount];
+        genTrnslLocalVarInfo = new (compiler, CMK_DebugOnly) TrnslLocalVarInfo[varsLocationsCount];
     }
 #endif
 

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -10515,8 +10515,8 @@ void CodeGen::genSetScopeInfo()
 #else // USING_SCOPE_INFO
 
 #ifdef USING_VARIABLE_LIVE_RANGE
-    const VariableLiveKeeper varLiveKeeper = compiler->getVariableLiveKeeper();
-    varsHomeCount                          = varLiveKeeper->getLiveRangesCount();
+    const VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
+    varsHomeCount                           = varLiveKeeper->getLiveRangesCount();
 #endif // USING_VARIABLE_LIVE_RANGE
 
 #endif // USING_SCOPE_INFO

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -10644,9 +10644,9 @@ void CodeGen::genSetScopeInfoUsingVariableRanges()
 
         if (compiler->compMap2ILvarNum(varNum) != (unsigned int)ICorDebugInfo::UNKNOWN_ILNUM)
         {
-            LiveRangeList* liveRanges = varLiveKeeper->getLiveRangesForVar(varNum);
+            VariableLiveKeeper::LiveRangeList* liveRanges = varLiveKeeper->getLiveRangesForVar(varNum);
 
-            for (VariableLiveRange& liveRange : *liveRanges)
+            for (VariableLiveKeeper::VariableLiveRange& liveRange : *liveRanges)
             {
                 UNATIVE_OFFSET startOffs = liveRange.m_StartEmitLocation.CodeOffset(getEmitter());
                 UNATIVE_OFFSET endOffs   = liveRange.m_EndEmitLocation.CodeOffset(getEmitter());

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -10763,7 +10763,7 @@ void CodeGen::genSetScopeInfo(unsigned       which,
 
 #endif // DEBUG
 
-    compiler->eeSetLVinfo(which, startOffs, length, ilVarNum, LVnum, name, avail, varLoc);
+    compiler->eeSetLVinfo(which, startOffs, length, ilVarNum, varLoc);
 }
 
 /*****************************************************************************/

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2298,8 +2298,7 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
 #if defined(USING_VARIABLE_LIVE_RANGE) && defined(DEBUG)
     if (compiler->verbose)
     {
-        VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
-        varLiveKeeper->dumpLvaVariableLiveRanges();
+        compiler->getVariableLiveKeeper()->dumpLvaVariableLiveRanges();
     }
 #endif // defined(USING_VARIABLE_LIVE_RANGE) && defined(DEBUG)
 
@@ -10513,8 +10512,7 @@ void CodeGen::genSetScopeInfo()
 #else // USING_SCOPE_INFO
 
 #ifdef USING_VARIABLE_LIVE_RANGE
-    const VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
-    varsLocationsCount                      = (unsigned int)varLiveKeeper->getLiveRangesCount();
+    varsLocationsCount = (unsigned int)compiler->getVariableLiveKeeper()->getLiveRangesCount();
 #endif // USING_VARIABLE_LIVE_RANGE
 
 #endif // USING_SCOPE_INFO

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -524,7 +524,11 @@ public:
         // Helper functions
 
         bool vlIsInReg(regNumber reg) const;
-        bool vlIsOnStk(regNumber reg, signed offset) const;
+        bool vlIsOnStack(regNumber reg, signed offset) const;
+        bool vlIsOnStack() const;
+
+        void storeVariableOnRegisters(regNumber reg, regNumber otherReg);
+        void storeVariableOnStack(regNumber stackBaseReg, NATIVE_OFFSET variableStackOffset);
 
         siVarLoc(const LclVarDsc* varDsc, regNumber baseReg, int offset, bool isFramePointerUsed);
         siVarLoc(){};

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -25,11 +25,14 @@
 #include "jitgcinfo.h"
 #include "treelifeupdater.h"
 
-// Disable this flag to avoid using psiScope/siScope info to report reporting
-// variables' home location during the method/prolog code.
+// Disable this flag to avoid using psiScope/siScope or VariableLiveRange
+// info to report reporting variables' home location during the method/prolog code.
 #if 1
 #define USING_SCOPE_INFO
 #endif // USING_SCOPE_INFO
+#if 1
+#define USING_VARIABLE_LIVE_RANGE
+#endif
 
 // Forward reference types
 

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -543,6 +543,8 @@ public:
     };
 
 public:
+    siVarLoc getSiVarLoc(const LclVarDsc* varDsc, unsigned int stackLevel) const;
+
     unsigned getCurrentStackLevel() const;
 
 protected:

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -552,6 +552,10 @@ public:
 public:
     siVarLoc getSiVarLoc(const LclVarDsc* varDsc, unsigned int stackLevel) const;
 
+#if DEBUG
+    void dumpSiVarLoc(const siVarLoc* varLoc) const;
+#endif
+
     unsigned getCurrentStackLevel() const;
 
 protected:

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -29,7 +29,7 @@
 // Enable USING_SCOPE_INFO flag to use psiScope/siScope info to report variables' locations.
 #define USING_SCOPE_INFO
 #endif
-#if 1
+#if 0
 // Enable USING_VARIABLE_LIVE_RANGE flag to use VariableLiveRange info to report variables' locations.
 // Note: if both USING_SCOPE_INFO and USING_VARIABLE_LIVE_RANGE are defined, then USING_SCOPE_INFO
 // information is reported to the debugger.

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -25,12 +25,12 @@
 #include "jitgcinfo.h"
 #include "treelifeupdater.h"
 
-// Disable this flag to avoid using psiScope/siScope or VariableLiveRange
-// info to report reporting variables' home location during the method/prolog code.
 #if 1
+// Disable this flag to prevent using psiScope/siScope info to report variables' locations.
 #define USING_SCOPE_INFO
-#endif // USING_SCOPE_INFO
+#endif
 #if 1
+// Disable this flag to prevent using VariableLiveRange info to report variables' locations.
 #define USING_VARIABLE_LIVE_RANGE
 #endif
 
@@ -527,7 +527,7 @@ public:
         bool vlIsOnStack(regNumber reg, signed offset) const;
         bool vlIsOnStack() const;
 
-        void storeVariableOnRegisters(regNumber reg, regNumber otherReg);
+        void storeVariableInRegisters(regNumber reg, regNumber otherReg);
         void storeVariableOnStack(regNumber stackBaseReg, NATIVE_OFFSET variableStackOffset);
 
         siVarLoc(const LclVarDsc* varDsc, regNumber baseReg, int offset, bool isFramePointerUsed);

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -26,11 +26,13 @@
 #include "treelifeupdater.h"
 
 #if 1
-// Disable this flag to prevent using psiScope/siScope info to report variables' locations.
+// Enable USING_SCOPE_INFO flag to use psiScope/siScope info to report variables' locations.
 #define USING_SCOPE_INFO
 #endif
 #if 1
-// Disable this flag to prevent using VariableLiveRange info to report variables' locations.
+// Enable USING_VARIABLE_LIVE_RANGE flag to use VariableLiveRange info to report variables' locations.
+// Note: if both USING_SCOPE_INFO and USING_VARIABLE_LIVE_RANGE are defined, then USING_SCOPE_INFO
+// information is reported to the debugger.
 #define USING_VARIABLE_LIVE_RANGE
 #endif
 

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -552,7 +552,7 @@ public:
 public:
     siVarLoc getSiVarLoc(const LclVarDsc* varDsc, unsigned int stackLevel) const;
 
-#if DEBUG
+#ifdef DEBUG
     void dumpSiVarLoc(const siVarLoc* varLoc) const;
 #endif
 

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -727,8 +727,16 @@ void CodeGen::genCodeForBBlist()
         }
 
 #ifdef DEBUG
+#ifdef USING_VARIABLE_LIVE_RANGE
+        if (compiler->verbose)
+        {
+            VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
+            varLiveKeeper->dumpBlockVariableLiveRanges(block);
+        }
+#endif // USING_VARIABLE_LIVE_RANGE
+
         compiler->compCurBB = nullptr;
-#endif
+#endif // DEBUG
 
     } //------------------ END-FOR each block of the method -------------------
 

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -92,6 +92,9 @@ void CodeGen::genInitialize()
     }
 #endif // USING_SCOPE_INFO
 
+    // Initialize Structures for VariableLiveRanges
+    compiler->initializeVariableLiveKeeper();
+
     // The current implementation of switch tables requires the first block to have a label so it
     // can generate offsets to the switch label targets.
     // TODO-CQ: remove this when switches have been re-implemented to not use this.

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -823,6 +823,15 @@ void CodeGen::genSpillVar(GenTree* tree)
     {
         varDsc->lvOtherReg = REG_STK;
     }
+
+    if (needsSpill)
+    {
+        // We need this after "lvRegNum" has change because now we are sure that varDsc->lvIsInReg() is false.
+        // "SiVarLoc" constructor uses the "LclVarDsc" of the variable.
+
+        VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
+        varLvKeeper->siUpdateVariableLiveRange(varDsc, varNum);
+    }
 }
 
 //------------------------------------------------------------------------
@@ -982,6 +991,11 @@ void CodeGen::genUnspillRegIfNeeded(GenTree* tree)
             if ((unspillTree->gtFlags & GTF_SPILL) == 0)
             {
                 genUpdateVarReg(varDsc, tree);
+
+                // Report the home change for this variable
+                VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
+                varLvKeeper->siUpdateVariableLiveRange(varDsc, lcl->gtLclNum);
+
 #ifdef DEBUG
                 if (VarSetOps::IsMember(compiler, gcInfo.gcVarPtrSetCur, varDsc->lvVarIndex))
                 {

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -824,6 +824,7 @@ void CodeGen::genSpillVar(GenTree* tree)
         varDsc->lvOtherReg = REG_STK;
     }
 
+#ifdef USING_VARIABLE_LIVE_RANGE
     if (needsSpill)
     {
         // We need this after "lvRegNum" has change because now we are sure that varDsc->lvIsInReg() is false.
@@ -832,6 +833,7 @@ void CodeGen::genSpillVar(GenTree* tree)
         VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
         varLvKeeper->siUpdateVariableLiveRange(varDsc, varNum);
     }
+#endif // USING_VARIABLE_LIVE_RANGE
 }
 
 //------------------------------------------------------------------------
@@ -992,9 +994,11 @@ void CodeGen::genUnspillRegIfNeeded(GenTree* tree)
             {
                 genUpdateVarReg(varDsc, tree);
 
+#ifdef USING_VARIABLE_LIVE_RANGE
                 // Report the home change for this variable
                 VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
                 varLvKeeper->siUpdateVariableLiveRange(varDsc, lcl->gtLclNum);
+#endif // USING_VARIABLE_LIVE_RANGE
 
 #ifdef DEBUG
                 if (VarSetOps::IsMember(compiler, gcInfo.gcVarPtrSetCur, varDsc->lvVarIndex))

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -90,8 +90,9 @@ void CodeGen::genInitialize()
         siInit();
     }
 
-    // Initialize structures for VariableLiveRanges
+#ifdef USING_VARIABLE_LIVE_RANGE
     compiler->initializeVariableLiveKeeper();
+#endif //  USING_VARIABLE_LIVE_RANGE
 
     // The current implementation of switch tables requires the first block to have a label so it
     // can generate offsets to the switch label targets.

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -527,8 +527,7 @@ void CodeGen::genCodeForBBlist()
 #ifdef USING_VARIABLE_LIVE_RANGE
         if (compiler->opts.compDbgInfo && isLastBlockProcessed)
         {
-            VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
-            varLvKeeper->siEndAllVariableLiveRange(compiler->compCurLife);
+            compiler->getVariableLiveKeeper()->siEndAllVariableLiveRange(compiler->compCurLife);
         }
 #endif // USING_VARIABLE_LIVE_RANGE
 
@@ -737,8 +736,7 @@ void CodeGen::genCodeForBBlist()
 #if defined(DEBUG) && defined(USING_VARIABLE_LIVE_RANGE)
         if (compiler->verbose)
         {
-            VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
-            varLiveKeeper->dumpBlockVariableLiveRanges(block);
+            compiler->getVariableLiveKeeper()->dumpBlockVariableLiveRanges(block);
         }
 #endif // defined(DEBUG) && defined(USING_VARIABLE_LIVE_RANGE)
 
@@ -843,9 +841,7 @@ void CodeGen::genSpillVar(GenTree* tree)
     {
         // We need this after "lvRegNum" has change because now we are sure that varDsc->lvIsInReg() is false.
         // "SiVarLoc" constructor uses the "LclVarDsc" of the variable.
-
-        VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
-        varLvKeeper->siUpdateVariableLiveRange(varDsc, varNum);
+        compiler->getVariableLiveKeeper()->siUpdateVariableLiveRange(varDsc, varNum);
     }
 #endif // USING_VARIABLE_LIVE_RANGE
 }
@@ -1015,8 +1011,7 @@ void CodeGen::genUnspillRegIfNeeded(GenTree* tree)
                 if ((unspillTree->gtFlags & GTF_VAR_DEATH) == 0)
                 {
                     // Report the home change for this variable
-                    VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
-                    varLvKeeper->siUpdateVariableLiveRange(varDsc, lcl->gtLclNum);
+                    compiler->getVariableLiveKeeper()->siUpdateVariableLiveRange(varDsc, lcl->gtLclNum);
                 }
 #endif // USING_VARIABLE_LIVE_RANGE
 

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -1007,7 +1007,7 @@ void CodeGen::genUnspillRegIfNeeded(GenTree* tree)
 #ifdef USING_VARIABLE_LIVE_RANGE
                 // We want "VariableLiveRange" inclusive on the beginbing and exclusive on the ending.
                 // For that we shouldn't report an update of the variable location if is becoming dead
-                // on the same assembly offset.
+                // on the same native offset.
                 if ((unspillTree->gtFlags & GTF_VAR_DEATH) == 0)
                 {
                     // Report the home change for this variable

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -529,7 +529,7 @@ void CodeGen::genCodeForBBlist()
         if (compiler->opts.compDbgInfo && isLastBlockProcessed)
         {
             VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
-            varLvKeeper->siEndAllVariableLiveRange(&compiler->compCurLife);
+            varLvKeeper->siEndAllVariableLiveRange(compiler->compCurLife);
         }
 #endif // USING_VARIABLE_LIVE_RANGE
 

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -92,7 +92,7 @@ void CodeGen::genInitialize()
     }
 #endif // USING_SCOPE_INFO
 
-    // Initialize Structures for VariableLiveRanges
+    // Initialize structures for VariableLiveRanges
     compiler->initializeVariableLiveKeeper();
 
     // The current implementation of switch tables requires the first block to have a label so it

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -734,17 +734,15 @@ void CodeGen::genCodeForBBlist()
                 break;
         }
 
-#ifdef DEBUG
-#ifdef USING_VARIABLE_LIVE_RANGE
+#if defined(DEBUG) && defined(USING_VARIABLE_LIVE_RANGE)
         if (compiler->verbose)
         {
             VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
             varLiveKeeper->dumpBlockVariableLiveRanges(block);
         }
-#endif // USING_VARIABLE_LIVE_RANGE
+#endif // defined(DEBUG) && defined(USING_VARIABLE_LIVE_RANGE)
 
-        compiler->compCurBB = nullptr;
-#endif // DEBUG
+        INDEBUG(compiler->compCurBB = nullptr);
 
     } //------------------ END-FOR each block of the method -------------------
 

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -532,11 +532,11 @@ void CodeGen::genCodeForBBlist()
         }
 #endif // USING_VARIABLE_LIVE_RANGE
 
-#ifdef USING_SCOPE_INFO
         if (compiler->opts.compScopeInfo && (compiler->info.compVarScopesCount > 0))
         {
             siEndBlock(block);
 
+#ifdef USING_SCOPE_INFO
             if (isLastBlockProcessed && siOpenScopeList.scNext)
             {
                 /* This assert no longer holds, because we may insert a throw
@@ -548,8 +548,8 @@ void CodeGen::genCodeForBBlist()
 
                 siCloseAllOpenScopes();
             }
-        }
 #endif // USING_SCOPE_INFO
+        }
 
         SubtractStackLevel(savedStkLvl);
 

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -1011,9 +1011,15 @@ void CodeGen::genUnspillRegIfNeeded(GenTree* tree)
                 genUpdateVarReg(varDsc, tree);
 
 #ifdef USING_VARIABLE_LIVE_RANGE
-                // Report the home change for this variable
-                VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
-                varLvKeeper->siUpdateVariableLiveRange(varDsc, lcl->gtLclNum);
+                // We want "VariableLiveRange" inclusive on the beginbing and exclusive on the ending.
+                // For that we shouldn't report an update of the variable location if is becoming dead
+                // on the same assembly offset.
+                if ((unspillTree->gtFlags & GTF_VAR_DEATH) == 0)
+                {
+                    // Report the home change for this variable
+                    VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
+                    varLvKeeper->siUpdateVariableLiveRange(varDsc, lcl->gtLclNum);
+                }
 #endif // USING_VARIABLE_LIVE_RANGE
 
 #ifdef DEBUG

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -84,13 +84,11 @@ void CodeGen::genInitializeRegisterState()
 //    iterated.
 void CodeGen::genInitialize()
 {
-#ifdef USING_SCOPE_INFO
     // Initialize the line# tracking logic
     if (compiler->opts.compScopeInfo)
     {
         siInit();
     }
-#endif // USING_SCOPE_INFO
 
     // Initialize structures for VariableLiveRanges
     compiler->initializeVariableLiveKeeper();
@@ -358,9 +356,10 @@ void CodeGen::genCodeForBBlist()
         /* Tell everyone which basic block we're working on */
 
         compiler->compCurBB = block;
-#ifdef USING_SCOPE_INFO
+
+        // Needed when jitting debug code
         siBeginBlock(block);
-#endif // USING_SCOPE_INFO
+
         // BBF_INTERNAL blocks don't correspond to any single IL instruction.
         if (compiler->opts.compDbgInfo && (block->bbFlags & BBF_INTERNAL) &&
             !compiler->fgBBisScratch(block)) // If the block is the distinguished first scratch block, then no need to

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -4841,6 +4841,10 @@ void CodeGen::genRegCopy(GenTree* treeNode)
 
                     genUpdateVarReg(varDsc, treeNode);
 
+                    // Report the home change for this variable
+                    VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
+                    varLvKeeper->siUpdateVariableLiveRange(varDsc, lcl->gtLclNum);
+
                     // The new location is going live
                     genUpdateRegLife(varDsc, /*isBorn*/ true, /*isDying*/ false DEBUGARG(treeNode));
                 }

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -4841,9 +4841,11 @@ void CodeGen::genRegCopy(GenTree* treeNode)
 
                     genUpdateVarReg(varDsc, treeNode);
 
+#ifdef USING_VARIABLE_LIVE_RANGE
                     // Report the home change for this variable
                     VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
                     varLvKeeper->siUpdateVariableLiveRange(varDsc, lcl->gtLclNum);
+#endif // USING_VARIABLE_LIVE_RANGE
 
                     // The new location is going live
                     genUpdateRegLife(varDsc, /*isBorn*/ true, /*isDying*/ false DEBUGARG(treeNode));

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -4843,8 +4843,7 @@ void CodeGen::genRegCopy(GenTree* treeNode)
 
 #ifdef USING_VARIABLE_LIVE_RANGE
                     // Report the home change for this variable
-                    VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
-                    varLvKeeper->siUpdateVariableLiveRange(varDsc, lcl->gtLclNum);
+                    compiler->getVariableLiveKeeper()->siUpdateVariableLiveRange(varDsc, lcl->gtLclNum);
 #endif // USING_VARIABLE_LIVE_RANGE
 
                     // The new location is going live

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11171,6 +11171,13 @@ void VariableLiveDescriptor::startLiveRangeFromEmitter(CodeGenInterface::siVarLo
     m_VariableLiveRanges->emplace_back(varLocation, emitLocation(), emitLocation());
     m_VariableLiveRanges->back().m_StartEmitLocation.CaptureLocation(emit);
 
+#ifdef DEBUG
+    if (!m_VariableLifeBarrier->hasLiveRangesToDump())
+    {
+        m_VariableLifeBarrier->setDumperStartAt(m_VariableLiveRanges->backPosition());
+    }
+#endif // DEBUG
+
     // startEmitLocationendEmitLocation has to be Valid and endEmitLocationendEmitLocation  not
     noway_assert(m_VariableLiveRanges->back().m_StartEmitLocation.Valid());
     noway_assert(!m_VariableLiveRanges->back().m_EndEmitLocation.Valid());

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11312,7 +11312,7 @@ void Compiler::initializeVariableLiveKeeper()
     int amountTrackedVariables = opts.compDbgInfo ? info.compLocalsCount : 0;
     int amountTrackedArgs      = opts.compDbgInfo ? info.compArgsCount : 0;
 
-    varLiveKeeper = new (allocator) VariableLiveKeeper(amountTrackedArgs, amountTrackedArgs, this, allocator);
+    varLiveKeeper = new (allocator) VariableLiveKeeper(amountTrackedVariables, amountTrackedArgs, this, allocator);
 }
 
 VariableLiveKeeper* Compiler::getVariableLiveKeeper() const

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11005,7 +11005,7 @@ void VariableLiveRange::dumpVariableLiveRange(emitter* emit, const CodeGenInterf
     // Check pointers parameter are not nullptr
     assert(emit != nullptr);
 
-    // "VariableLiveRanges" are created setting its location ("m_VarLocation") and the initial assembly offset
+    // "VariableLiveRanges" are created setting its location ("m_VarLocation") and the initial native offset
     // ("m_StartEmitLocation")
     codeGen->dumpSiVarLoc(&m_VarLocation);
 

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11002,7 +11002,6 @@ void VariableLiveRange::dumpVariableLiveRange(const CodeGenInterface* codeGen) c
 // Dump "VariableLiveRange" when code has been generated and we have the assembly native offset of each "emitLocation"
 void VariableLiveRange::dumpVariableLiveRange(emitter* emit, const CodeGenInterface* codeGen) const
 {
-    // Check pointers parameter are not nullptr
     assert(emit != nullptr);
 
     // "VariableLiveRanges" are created setting its location ("m_VarLocation") and the initial native offset
@@ -11115,8 +11114,6 @@ VariableLiveDescriptor::VariableLiveDescriptor(CompAllocator allocator)
 //
 bool VariableLiveDescriptor::hasVariableLiveRangeOpen() const
 {
-    noway_assert(m_VariableLiveRanges != nullptr);
-
     return !m_VariableLiveRanges->empty() && !m_VariableLiveRanges->back().m_EndEmitLocation.Valid();
 }
 
@@ -11234,9 +11231,6 @@ void VariableLiveDescriptor::updateLiveRangeAtEmitter(CodeGenInterface::siVarLoc
 #ifdef DEBUG
 void VariableLiveDescriptor::dumpAllRegisterLiveRangesForBlock(emitter* emit, const CodeGenInterface* codeGen) const
 {
-    // "m_VariableLiveRanges" should has been initialized
-    noway_assert(m_VariableLiveRanges != nullptr);
-
     if (m_VariableLiveRanges->empty())
     {
         printf("None history\n");
@@ -11254,8 +11248,6 @@ void VariableLiveDescriptor::dumpAllRegisterLiveRangesForBlock(emitter* emit, co
 
 void VariableLiveDescriptor::dumpRegisterLiveRangesForBlockBeforeCodeGenerated(const CodeGenInterface* codeGen) const
 {
-    // "m_VariableLifeBarrier" should has been initialized
-    noway_assert(m_VariableLifeBarrier != nullptr);
     noway_assert(codeGen != nullptr);
 
     if (hasVarLiveRangesToDump())
@@ -11277,25 +11269,18 @@ void VariableLiveDescriptor::dumpRegisterLiveRangesForBlockBeforeCodeGenerated(c
 // Returns true if a live range for this variable has been recorded
 bool VariableLiveDescriptor::hasVarLiveRangesToDump() const
 {
-    // "m_VariableLifeBarrier" should has been initialized
-    noway_assert(m_VariableLiveRanges != nullptr);
-
     return !m_VariableLiveRanges->empty();
 }
 
 // Returns true if a live range for this variable has been recorded from last call to EndBlock
 bool VariableLiveDescriptor::hasVarLiverRangesFromLastBlockToDump() const
 {
-    // "m_VariableLifeBarrier" should has been initialized
-    noway_assert(m_VariableLifeBarrier != nullptr);
-
     return m_VariableLifeBarrier->hasLiveRangesToDump();
 }
+
 // Reset the barrier so as to dump only next block changes on next block
 void VariableLiveDescriptor::endBlockLiveRanges()
 {
-    noway_assert(m_VariableLifeBarrier != nullptr);
-
     // make "m_VariableLifeBarrier->m_StartingLiveRange" now points to nullptr for printing purposes
     m_VariableLifeBarrier->resetDumper(m_VariableLiveRanges);
 }

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -10974,6 +10974,7 @@ bool Compiler::killGCRefs(GenTree* tree)
     return false;
 }
 
+#ifdef USING_VARIABLE_LIVE_RANGE
 #ifdef DEBUG
 //------------------------------------------------------------------------
 //                      VariableLiveRanges dumpers
@@ -11811,3 +11812,4 @@ void VariableLiveKeeper::dumpLvaVariableLiveRanges() const
     }
 }
 #endif // DEBUG
+#endif // USING_VARIABLE_LIVE_RANGE

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -10982,7 +10982,7 @@ bool Compiler::killGCRefs(GenTree* tree)
 
 // Dump "VariableLiveRange" when code has not been generated and we don't have so the assembly native offset
 // but at least "emitLocation"s and "siVarLoc"
-void VariableLiveRange::dumpVariableLiveRange(const CodeGenInterface* codeGen) const
+void VariableLiveKeeper::VariableLiveRange::dumpVariableLiveRange(const CodeGenInterface* codeGen) const
 {
     codeGen->dumpSiVarLoc(&m_VarLocation);
     printf(" [ ");
@@ -11000,7 +11000,7 @@ void VariableLiveRange::dumpVariableLiveRange(const CodeGenInterface* codeGen) c
 }
 
 // Dump "VariableLiveRange" when code has been generated and we have the assembly native offset of each "emitLocation"
-void VariableLiveRange::dumpVariableLiveRange(emitter* emit, const CodeGenInterface* codeGen) const
+void VariableLiveKeeper::VariableLiveRange::dumpVariableLiveRange(emitter* emit, const CodeGenInterface* codeGen) const
 {
     assert(emit != nullptr);
 
@@ -11031,7 +11031,7 @@ void VariableLiveRange::dumpVariableLiveRange(emitter* emit, const CodeGenInterf
 //  This method is expected to be called once a the code for a BasicBlock has been
 //  generated and all the new "VariableLiveRange"s of the variable during this block
 //  has been dumped.
-void LiveRangeDumper::resetDumper(const LiveRangeList* liveRanges)
+void VariableLiveKeeper::LiveRangeDumper::resetDumper(const LiveRangeList* liveRanges)
 {
     // There must have reported something in order to reset
     assert(m_hasLiveRangestoDump);
@@ -11063,7 +11063,7 @@ void LiveRangeDumper::resetDumper(const LiveRangeList* liveRanges)
 //
 // Notes:
 //  "varNum" should be always a valid inde ("varnum" < "m_LiveDscCount")
-void LiveRangeDumper::setDumperStartAt(const LiveRangeListIterator liveRangeIt)
+void VariableLiveKeeper::LiveRangeDumper::setDumperStartAt(const LiveRangeListIterator liveRangeIt)
 {
     m_hasLiveRangestoDump = true;
     m_StartingLiveRange   = liveRangeIt;
@@ -11077,7 +11077,7 @@ void LiveRangeDumper::setDumperStartAt(const LiveRangeListIterator liveRangeIt)
 //  A LiveRangeListIterator to the first "VariableLiveRange" in "LiveRangeList" which
 //  was used during last "BasicBlock".
 //
-LiveRangeListIterator LiveRangeDumper::getStartForDump() const
+VariableLiveKeeper::LiveRangeListIterator VariableLiveKeeper::LiveRangeDumper::getStartForDump() const
 {
     return m_StartingLiveRange;
 }
@@ -11090,7 +11090,7 @@ LiveRangeListIterator LiveRangeDumper::getStartForDump() const
 //  A boolean indicating indicating if there is at least a "VariableLiveRange"
 //  that has been used for the variable during last "BasicBlock".
 //
-bool LiveRangeDumper::hasLiveRangesToDump() const
+bool VariableLiveKeeper::LiveRangeDumper::hasLiveRangesToDump() const
 {
     return m_hasLiveRangestoDump;
 }
@@ -11100,7 +11100,7 @@ bool LiveRangeDumper::hasLiveRangesToDump() const
 //                      VariableLiveDescriptor
 //------------------------------------------------------------------------
 
-VariableLiveDescriptor::VariableLiveDescriptor(CompAllocator allocator)
+VariableLiveKeeper::VariableLiveDescriptor::VariableLiveDescriptor(CompAllocator allocator)
 {
     // Initialize an empty list
     m_VariableLiveRanges = new (allocator) LiveRangeList(allocator);
@@ -11112,7 +11112,7 @@ VariableLiveDescriptor::VariableLiveDescriptor(CompAllocator allocator)
 // hasVariableLiveRangeOpen: Return true if the variable is still alive,
 //  false in other case.
 //
-bool VariableLiveDescriptor::hasVariableLiveRangeOpen() const
+bool VariableLiveKeeper::VariableLiveDescriptor::hasVariableLiveRangeOpen() const
 {
     return !m_VariableLiveRanges->empty() && !m_VariableLiveRanges->back().m_EndEmitLocation.Valid();
 }
@@ -11124,7 +11124,7 @@ bool VariableLiveDescriptor::hasVariableLiveRangeOpen() const
 //  A const LiveRangeList* pointing to the first variable location if it has
 //  any or the end of the list in other case.
 //
-LiveRangeList* VariableLiveDescriptor::getLiveRanges() const
+VariableLiveKeeper::LiveRangeList* VariableLiveKeeper::VariableLiveDescriptor::getLiveRanges() const
 {
     return m_VariableLiveRanges;
 }
@@ -11145,7 +11145,8 @@ LiveRangeList* VariableLiveDescriptor::getLiveRanges() const
 //  The position of "emit" matters to ensure intervals inclusive of the
 //  beginning and exclusive of the end.
 //
-void VariableLiveDescriptor::startLiveRangeFromEmitter(CodeGenInterface::siVarLoc varLocation, emitter* emit) const
+void VariableLiveKeeper::VariableLiveDescriptor::startLiveRangeFromEmitter(CodeGenInterface::siVarLoc varLocation,
+                                                                           emitter*                   emit) const
 {
     noway_assert(emit != nullptr);
 
@@ -11183,7 +11184,7 @@ void VariableLiveDescriptor::startLiveRangeFromEmitter(CodeGenInterface::siVarLo
 //  The position of "emit" matters to ensure intervals inclusive of the
 //  beginning and exclusive of the end.
 //
-void VariableLiveDescriptor::endLiveRangeAtEmitter(emitter* emit) const
+void VariableLiveKeeper::VariableLiveDescriptor::endLiveRangeAtEmitter(emitter* emit) const
 {
     noway_assert(emit != nullptr);
     noway_assert(hasVariableLiveRangeOpen());
@@ -11211,7 +11212,8 @@ void VariableLiveDescriptor::endLiveRangeAtEmitter(emitter* emit) const
 //  The position of "emit" matters to ensure intervals inclusive of the
 //  beginning and exclusive of the end.
 //
-void VariableLiveDescriptor::updateLiveRangeAtEmitter(CodeGenInterface::siVarLoc varLocation, emitter* emit) const
+void VariableLiveKeeper::VariableLiveDescriptor::updateLiveRangeAtEmitter(CodeGenInterface::siVarLoc varLocation,
+                                                                          emitter*                   emit) const
 {
     // This variable is changing home so it has been started before during this block
     noway_assert(m_VariableLiveRanges != nullptr && !m_VariableLiveRanges->empty());
@@ -11229,7 +11231,8 @@ void VariableLiveDescriptor::updateLiveRangeAtEmitter(CodeGenInterface::siVarLoc
 }
 
 #ifdef DEBUG
-void VariableLiveDescriptor::dumpAllRegisterLiveRangesForBlock(emitter* emit, const CodeGenInterface* codeGen) const
+void VariableLiveKeeper::VariableLiveDescriptor::dumpAllRegisterLiveRangesForBlock(
+    emitter* emit, const CodeGenInterface* codeGen) const
 {
     printf("[");
     for (LiveRangeListIterator it = m_VariableLiveRanges->begin(); it != m_VariableLiveRanges->end(); it++)
@@ -11239,7 +11242,8 @@ void VariableLiveDescriptor::dumpAllRegisterLiveRangesForBlock(emitter* emit, co
     printf("]\n");
 }
 
-void VariableLiveDescriptor::dumpRegisterLiveRangesForBlockBeforeCodeGenerated(const CodeGenInterface* codeGen) const
+void VariableLiveKeeper::VariableLiveDescriptor::dumpRegisterLiveRangesForBlockBeforeCodeGenerated(
+    const CodeGenInterface* codeGen) const
 {
     noway_assert(codeGen != nullptr);
 
@@ -11252,19 +11256,19 @@ void VariableLiveDescriptor::dumpRegisterLiveRangesForBlockBeforeCodeGenerated(c
 }
 
 // Returns true if a live range for this variable has been recorded
-bool VariableLiveDescriptor::hasVarLiveRangesToDump() const
+bool VariableLiveKeeper::VariableLiveDescriptor::hasVarLiveRangesToDump() const
 {
     return !m_VariableLiveRanges->empty();
 }
 
 // Returns true if a live range for this variable has been recorded from last call to EndBlock
-bool VariableLiveDescriptor::hasVarLiverRangesFromLastBlockToDump() const
+bool VariableLiveKeeper::VariableLiveDescriptor::hasVarLiverRangesFromLastBlockToDump() const
 {
     return m_VariableLifeBarrier->hasLiveRangesToDump();
 }
 
 // Reset the barrier so as to dump only next block changes on next block
-void VariableLiveDescriptor::endBlockLiveRanges()
+void VariableLiveKeeper::VariableLiveDescriptor::endBlockLiveRanges()
 {
     // make "m_VariableLifeBarrier->m_StartingLiveRange" now points to nullptr for printing purposes
     m_VariableLifeBarrier->resetDumper(m_VariableLiveRanges);
@@ -11274,7 +11278,7 @@ void VariableLiveDescriptor::endBlockLiveRanges()
 //------------------------------------------------------------------------
 //                      VariableLiveKeeper
 //------------------------------------------------------------------------
-
+// Initialize structures for VariableLiveRanges
 void Compiler::initializeVariableLiveKeeper()
 {
     CompAllocator allocator = getAllocator(CMK_VariableLiveRanges);
@@ -11570,7 +11574,7 @@ void VariableLiveKeeper::siEndAllVariableLiveRange()
 // Assumtions:
 //  This variable should be an argument, a special argument or an IL local
 //  variable.
-LiveRangeList* VariableLiveKeeper::getLiveRangesForVar(unsigned int varNum) const
+VariableLiveKeeper::LiveRangeList* VariableLiveKeeper::getLiveRangesForVar(unsigned int varNum) const
 {
     // There should be at least one variable for which its liveness is tracked
     noway_assert(varNum < m_LiveDscCount);

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11360,37 +11360,6 @@ VariableLiveKeeper::VariableLiveKeeper(unsigned int totalLocalCount, unsigned in
 }
 
 //------------------------------------------------------------------------
-// getLiveRangesCount: Returns the count of variable locations reported for the tracked
-//  variables, which are arguments, special arguments, and local IL variables.
-//
-// Return Value:
-//    size_t - the count of variable locations
-//
-// Notes:
-//    This method is being called from "genSetScopeInfo" to know the count of
-//    "varResultInfo" that should be created on eeSetLVcount.
-//
-size_t VariableLiveKeeper::getLiveRangesCount() const
-{
-    size_t liveRangesCount = 0;
-
-    if (m_Compiler->opts.compDbgInfo)
-    {
-        for (unsigned int varNum = 0; varNum < m_LiveDscCount; varNum++)
-        {
-            VariableLiveDescriptor* varLiveDsc = lvaLiveDsc + varNum;
-
-            if (m_Compiler->compMap2ILvarNum(varNum) != (unsigned int)ICorDebugInfo::UNKNOWN_ILNUM)
-            {
-                liveRangesCount += varLiveDsc->getLiveRanges()->size();
-            }
-        }
-    }
-
-    return liveRangesCount;
-}
-
-//------------------------------------------------------------------------
 // siStartOrCloseVariableLiveRange: Reports the given variable as beign born
 //  or becoming dead.
 //
@@ -11645,6 +11614,36 @@ const LiveRangeList* VariableLiveKeeper::getLiveRangesForVar(unsigned int varNum
     noway_assert(varNum < m_LiveDscCount);
 
     return lvaLiveDsc[varNum].getLiveRanges();
+}
+
+//------------------------------------------------------------------------
+// getLiveRangesCount: Returns the count of variable locations reported for the tracked
+//  variables, which are arguments, special arguments, and local IL variables.
+//
+// Return Value:
+//    size_t - the count of variable locations
+//
+// Notes:
+//    This method is being called from "genSetScopeInfo" to know the count of
+//    "varResultInfo" that should be created on eeSetLVcount.
+//
+size_t VariableLiveKeeper::getLiveRangesCount() const
+{
+    size_t liveRangesCount = 0;
+
+    if (m_Compiler->opts.compDbgInfo)
+    {
+        for (unsigned int varNum = 0; varNum < m_LiveDscCount; varNum++)
+        {
+            VariableLiveDescriptor* varLiveDsc = lvaLiveDsc + varNum;
+
+            if (m_Compiler->compMap2ILvarNum(varNum) != (unsigned int)ICorDebugInfo::UNKNOWN_ILNUM)
+            {
+                liveRangesCount += varLiveDsc->getLiveRanges()->size();
+            }
+        }
+    }
+    return liveRangesCount;
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11139,7 +11139,7 @@ bool VariableLiveDescriptor::hasVariableLiveRangeOpen() const
 //  A const LiveRangeList* pointing to the first variable location if it has
 //  any or the end of the list in other case.
 //
-const LiveRangeList* VariableLiveDescriptor::getLiveRanges() const
+LiveRangeList* VariableLiveDescriptor::getLiveRanges() const
 {
     return m_VariableLiveRanges;
 }
@@ -11614,7 +11614,7 @@ void VariableLiveKeeper::siEndAllVariableLiveRange()
 // Assumtions:
 //  This variable should be an argument, a special argument or an IL local
 //  variable.
-const LiveRangeList* VariableLiveKeeper::getLiveRangesForVar(unsigned int varNum) const
+LiveRangeList* VariableLiveKeeper::getLiveRangesForVar(unsigned int varNum) const
 {
     // There should be at least one variable for which its liveness is tracked
     noway_assert(varNum < m_LiveDscCount);

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11111,7 +11111,7 @@ VariableLiveDescriptor::VariableLiveDescriptor(CompAllocator allocator)
 
     new (m_VariableLiveRanges, jitstd::placement_t()) LiveRangeList(allocator);
 
-#if DEBUG
+#ifdef DEBUG
     m_VariableLifeBarrier = allocator.allocate<LiveRangeDumper>(1);
 
     size_t m_VariableLifeBarrierSize = sizeof(*m_VariableLifeBarrier);
@@ -11311,7 +11311,6 @@ void VariableLiveDescriptor::endBlockLiveRanges()
     // make "m_VariableLifeBarrier->m_StartingLiveRange" now points to nullptr for printing purposes
     m_VariableLifeBarrier->resetDumper(m_VariableLiveRanges);
 }
-
 #endif // DEBUG
 
 //------------------------------------------------------------------------

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -10983,7 +10983,7 @@ bool Compiler::killGCRefs(GenTree* tree)
 // but at least "emitLocation"s and "siVarLoc"
 void VariableLiveRange::dumpVariableLiveRange(const CodeGenInterface* codeGen) const
 {
-    codeGen->dumpSiVarLoc(&m_VarHome);
+    codeGen->dumpSiVarLoc(&m_VarLocation);
     printf(" [ ");
     m_StartEmitLocation.Print();
     printf(", ");
@@ -11006,7 +11006,7 @@ void VariableLiveRange::dumpVariableLiveRange(emitter* emit, const CodeGenInterf
 
     // "VariableLiveRanges" are created setting its location ("m_VarLocation") and the initial assembly offset
     // ("m_StartEmitLocation")
-    codeGen->dumpSiVarLoc(&m_VarHome);
+    codeGen->dumpSiVarLoc(&m_VarLocation);
 
     // If this is an open "VariableLiveRange", "m_EndEmitLocation" is non-valid and print -1
     UNATIVE_OFFSET endAssemblyOffset = m_EndEmitLocation.Valid() ? m_EndEmitLocation.CodeOffset(emit) : -1;
@@ -11148,7 +11148,7 @@ bool VariableLiveDescriptor::hasVariableLiveRangeOpen() const
 }
 
 //------------------------------------------------------------------------
-// getLiveRangesCount: Return amount of variable homes reported for this
+// getLiveRangesCount: Return amount of variable locations reported for this
 //  variable.
 //
 // Return Value:
@@ -11165,10 +11165,10 @@ size_t VariableLiveDescriptor::getLiveRangesCount() const
 }
 
 //------------------------------------------------------------------------
-// getLiveRanges: Return the list of variable homes for this variable.
+// getLiveRanges: Return the list of variable locations for this variable.
 //
 // Return Value:
-//  A const LiveRangeList* pointing to the first variable home if it has
+//  A const LiveRangeList* pointing to the first variable location if it has
 //  any or the end of the list in other case.
 //
 const LiveRangeList* VariableLiveDescriptor::getLiveRanges() const
@@ -11240,7 +11240,7 @@ void VariableLiveDescriptor::endLiveRangeAtEmitter(emitter* emit) const
 //  home to "varHome" since the instruction where "emit" is located.
 //
 // Arguments:
-//  varHome  - the new variable home.
+//  varHome  - the new variable location.
 //  emit - an emitter* instance located at the first instruction from
 //   where "varHome" becomes valid.
 //
@@ -11260,7 +11260,7 @@ void VariableLiveDescriptor::updateLiveRangeAtEmitter(CodeGenInterface::siVarLoc
     noway_assert(!m_VariableLiveRanges->back().m_EndEmitLocation.Valid());
 
     // If we are reporting again the same home, that means we are doing something twice?
-    // noway_assert(! CodeGenInterface::siVarLoc::Equals(&m_VariableLiveRanges->back().m_VarHome, varLocation));
+    // noway_assert(! CodeGenInterface::siVarLoc::Equals(&m_VariableLiveRanges->back().m_VarLocation, varLocation));
 
     // Close previous live range
     endLiveRangeAtEmitter(emit);
@@ -11392,11 +11392,11 @@ VariableLiveKeeper::~VariableLiveKeeper()
 }
 
 //------------------------------------------------------------------------
-// getLiveRangesCount: Returns the count of variable homes reported for the tracked
+// getLiveRangesCount: Returns the count of variable locations reported for the tracked
 //  variables, which are arguments, special arguments, and local IL variables.
 //
 // Return Value:
-//    unsinged int - the count of variable homes
+//    unsinged int - the count of variable locations
 //
 // Notes:
 //    This method is being called from "genSetScopeInfo" to know the count of
@@ -11560,7 +11560,7 @@ void VariableLiveKeeper::siEndVariableLiveRange(unsigned int varNum)
 }
 
 //------------------------------------------------------------------------
-// siUpdateVariableLiveRange: Reports the change of variable home for the
+// siUpdateVariableLiveRange: Reports the change of variable location for the
 //  given variable.
 //
 // Arguments:
@@ -11570,7 +11570,7 @@ void VariableLiveKeeper::siEndVariableLiveRange(unsigned int varNum)
 // Assumptions:
 //    The given variable should be alive.
 //    The emitter should be pointing to the first instruction from where
-//    the new variable home is becoming valid.
+//    the new variable location is becoming valid.
 //
 void VariableLiveKeeper::siUpdateVariableLiveRange(const LclVarDsc* varDsc, unsigned int varNum)
 {
@@ -11606,7 +11606,7 @@ void VariableLiveKeeper::siUpdateVariableLiveRange(const LclVarDsc* varDsc, unsi
 //
 // Notes:
 //    This method is called when the last block being generated to killed all
-//    the live variables and set a flag to avoid reporting variable homes for
+//    the live variables and set a flag to avoid reporting variable locations for
 //    on next calls to method that update variable liveness.
 void VariableLiveKeeper::siEndAllVariableLiveRange(VARSET_VALARG_TP varsToClose)
 {
@@ -11633,7 +11633,7 @@ void VariableLiveKeeper::siEndAllVariableLiveRange(VARSET_VALARG_TP varsToClose)
 //      in lvaTable.
 //
 // Return Value:
-//  A const pointer to the list of variable homes reported for the variable.
+//  A const pointer to the list of variable locations reported for the variable.
 //
 // Assumtions:
 //  This variable should be an argument, a special argument or an IL local
@@ -11651,7 +11651,7 @@ const LiveRangeList* VariableLiveKeeper::getLiveRangesForVar(unsigned int varNum
 // psiStartVariableLiveRange: Reports the given variable as being born.
 //
 // Arguments:
-//  varLcation  - the variable home
+//  varLcation  - the variable location
 //  varNum      - the index of the variable in "compiler->lvaTable" or
 //      "VariableLivekeeper->lvaLiveDsc"
 //

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11231,39 +11231,24 @@ void VariableLiveDescriptor::updateLiveRangeAtEmitter(CodeGenInterface::siVarLoc
 #ifdef DEBUG
 void VariableLiveDescriptor::dumpAllRegisterLiveRangesForBlock(emitter* emit, const CodeGenInterface* codeGen) const
 {
-    if (m_VariableLiveRanges->empty())
+    printf("[");
+    for (LiveRangeListIterator it = m_VariableLiveRanges->begin(); it != m_VariableLiveRanges->end(); it++)
     {
-        printf("None history\n");
+        it->dumpVariableLiveRange(emit, codeGen);
     }
-    else
-    {
-        printf("[");
-        for (LiveRangeListIterator it = m_VariableLiveRanges->begin(); it != m_VariableLiveRanges->end(); it++)
-        {
-            it->dumpVariableLiveRange(emit, codeGen);
-        }
-        printf("]\n");
-    }
+    printf("]\n");
 }
 
 void VariableLiveDescriptor::dumpRegisterLiveRangesForBlockBeforeCodeGenerated(const CodeGenInterface* codeGen) const
 {
     noway_assert(codeGen != nullptr);
 
-    if (hasVarLiveRangesToDump())
+    printf("[");
+    for (LiveRangeListIterator it = m_VariableLifeBarrier->getStartForDump(); it != m_VariableLiveRanges->end(); it++)
     {
-        printf("[");
-        for (LiveRangeListIterator it = m_VariableLifeBarrier->getStartForDump(); it != m_VariableLiveRanges->end();
-             it++)
-        {
-            it->dumpVariableLiveRange(codeGen);
-        }
-        printf("]\n");
+        it->dumpVariableLiveRange(codeGen);
     }
-    else
-    {
-        printf("None history\n");
-    }
+    printf("]\n");
 }
 
 // Returns true if a live range for this variable has been recorded
@@ -11679,7 +11664,7 @@ void VariableLiveKeeper::dumpBlockVariableLiveRanges(const BasicBlock* block)
     {
         printf("////////////////////////////////////////\n");
         printf("////////////////////////////////////////\n");
-        printf("Var History Dump for Block %d \n", block->bbNum);
+        printf("Variable Live Range History Dump for Block %d \n", block->bbNum);
 
         if (m_Compiler->opts.compDbgInfo)
         {
@@ -11690,7 +11675,7 @@ void VariableLiveKeeper::dumpBlockVariableLiveRanges(const BasicBlock* block)
                 if (varLiveDsc->hasVarLiverRangesFromLastBlockToDump())
                 {
                     hasDumpedHistory = true;
-                    printf("Var %d:\n", varNum);
+                    printf("IL Var Num %d:\n", m_Compiler->compMap2ILvarNum(varNum));
                     varLiveDsc->dumpRegisterLiveRangesForBlockBeforeCodeGenerated(m_Compiler->codeGen);
                     varLiveDsc->endBlockLiveRanges();
                 }
@@ -11716,7 +11701,7 @@ void VariableLiveKeeper::dumpLvaVariableLiveRanges() const
     {
         printf("////////////////////////////////////////\n");
         printf("////////////////////////////////////////\n");
-        printf("PRINTING REGISTER LIVE RANGES:\n");
+        printf("PRINTING VARIABLE LIVE RANGES:\n");
 
         if (m_Compiler->opts.compDbgInfo)
         {

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11018,10 +11018,6 @@ void VariableLiveRange::dumpVariableLiveRange(emitter* emit, const CodeGenInterf
 //------------------------------------------------------------------------
 //                      LiveRangeDumper
 //------------------------------------------------------------------------
-
-LiveRangeDumper::LiveRangeDumper(const LiveRangeList* liveRanges)
-    : m_StartingLiveRange(liveRanges->end()), m_hasLiveRangestoDump(false){};
-
 //------------------------------------------------------------------------
 // resetDumper: If the the "liveRange" has its last "VariableLiveRange" closed, it makes
 //  the "LiveRangeDumper" points to end of "liveRange" (nullptr). In other case,

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11488,12 +11488,12 @@ void VariableLiveKeeper::siStartOrCloseVariableLiveRanges(VARSET_VALARG_TP varsI
 {
     if (m_Compiler->opts.compDbgInfo)
     {
-        VarSetOps::Iter iter(compiler, varsIndexSet);
+        VarSetOps::Iter iter(m_Compiler, varsIndexSet);
         unsigned        varIndex = 0;
         while (iter.NextElem(&varIndex))
         {
-            unsigned int     varNum = compiler->lvaTrackedToVarNum[varIndex];
-            const LclVarDsc* varDsc = compiler->lvaGetDesc(varNum);
+            unsigned int     varNum = m_Compiler->lvaTrackedToVarNum[varIndex];
+            const LclVarDsc* varDsc = m_Compiler->lvaGetDesc(varNum);
             siStartOrCloseVariableLiveRange(varDsc, varNum, isBorn, isDying);
         }
     }
@@ -11523,11 +11523,11 @@ void VariableLiveKeeper::siStartVariableLiveRange(const LclVarDsc* varDsc, unsig
     {
         // Build siVarLoc for this borning "varDsc"
         CodeGenInterface::siVarLoc varLocation =
-            compiler->codeGen->getSiVarLoc(varDsc, compiler->codeGen->getCurrentStackLevel());
+            m_Compiler->codeGen->getSiVarLoc(varDsc, m_Compiler->codeGen->getCurrentStackLevel());
 
         VariableLiveDescriptor* varLiveDsc = &lvaLiveDsc[varNum];
         // this variable live range is valid from this point
-        varLiveDsc->startLiveRangeFromEmitter(varLocation, compiler->getEmitter());
+        varLiveDsc->startLiveRangeFromEmitter(varLocation, m_Compiler->getEmitter());
     }
 }
 
@@ -11755,7 +11755,7 @@ void VariableLiveKeeper::dumpLvaVariableLiveRanges() const
                 {
                     hasDumpedHistory = true;
                     printf("IL Var Num %d:\n", m_Compiler->compMap2ILvarNum(varNum));
-                    varLiveDsc->dumpAllRegisterLiveRangesForBlock(compiler->getEmitter(), compiler->codeGen);
+                    varLiveDsc->dumpAllRegisterLiveRangesForBlock(m_Compiler->getEmitter(), m_Compiler->codeGen);
                 }
             }
         }

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11104,21 +11104,9 @@ bool LiveRangeDumper::hasLiveRangesToDump() const
 VariableLiveDescriptor::VariableLiveDescriptor(CompAllocator allocator)
 {
     // Initialize an empty list
-    m_VariableLiveRanges = allocator.allocate<LiveRangeList>(1);
+    m_VariableLiveRanges = new (allocator) LiveRangeList(allocator);
 
-    size_t m_VariableLiveRangesSize = sizeof(*m_VariableLiveRanges);
-    memset(m_VariableLiveRanges, 0, m_VariableLiveRangesSize);
-
-    new (m_VariableLiveRanges, jitstd::placement_t()) LiveRangeList(allocator);
-
-#ifdef DEBUG
-    m_VariableLifeBarrier = allocator.allocate<LiveRangeDumper>(1);
-
-    size_t m_VariableLifeBarrierSize = sizeof(*m_VariableLifeBarrier);
-    memset(m_VariableLifeBarrier, 0, m_VariableLifeBarrierSize);
-
-    new (m_VariableLifeBarrier, jitstd::placement_t()) LiveRangeDumper(m_VariableLiveRanges);
-#endif // DEBUG
+    INDEBUG(m_VariableLifeBarrier = new (allocator) LiveRangeDumper(m_VariableLiveRanges));
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11121,15 +11121,6 @@ VariableLiveDescriptor::VariableLiveDescriptor(CompAllocator allocator)
 #endif // DEBUG
 }
 
-VariableLiveDescriptor::~VariableLiveDescriptor()
-{
-    noway_assert(m_VariableLiveRanges != nullptr);
-
-    m_VariableLiveRanges->~list();
-
-    INDEBUG(m_VariableLifeBarrier->~LiveRangeDumper());
-}
-
 //------------------------------------------------------------------------
 // hasVariableLiveRangeOpen: Return true if the variable is still alive,
 //  false in other case.
@@ -11366,11 +11357,6 @@ VariableLiveKeeper::VariableLiveKeeper(unsigned int totalLocalCount, unsigned in
             new (lvaLiveDsc + varNum, jitstd::placement_t()) VariableLiveDescriptor(allocator);
         }
     }
-}
-
-VariableLiveKeeper::~VariableLiveKeeper()
-{
-    delete[] lvaLiveDsc;
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11137,6 +11137,23 @@ void VariableLiveDescriptor::updateLiveRangeAtEmitter(CodeGenInterface::siVarLoc
 //                      VariableLiveKeeper
 //------------------------------------------------------------------------
 
+void Compiler::initializeVariableLiveKeeper()
+{
+    CompAllocator allocator = getAllocator(CMK_VariableLiveRanges);
+
+    int amountTrackedVariables = opts.compDbgInfo ? info.compLocalsCount : 0;
+    int amountTrackedArgs      = opts.compDbgInfo ? info.compArgsCount : 0;
+
+    varLiveKeeper = allocator.allocate<VariableLiveKeeper>(1);
+    memset(varLiveKeeper, 0, sizeof(*varLiveKeeper));
+    new (varLiveKeeper, jitstd::placement_t()) VariableLiveKeeper(amountTrackedVariables, amountTrackedArgs, this);
+}
+
+VariableLiveKeeper* Compiler::getVariableLiveKeeper() const
+{
+    return varLiveKeeper;
+};
+
 //------------------------------------------------------------------------
 // VariableLiveKeeper: Create an instance of the object in charge of managing
 //  VariableLiveRanges and intialize the array "lvaLiveDsc".

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11324,9 +11324,7 @@ void Compiler::initializeVariableLiveKeeper()
     int amountTrackedVariables = opts.compDbgInfo ? info.compLocalsCount : 0;
     int amountTrackedArgs      = opts.compDbgInfo ? info.compArgsCount : 0;
 
-    varLiveKeeper = allocator.allocate<VariableLiveKeeper>(1);
-    memset(varLiveKeeper, 0, sizeof(*varLiveKeeper));
-    new (varLiveKeeper, jitstd::placement_t()) VariableLiveKeeper(amountTrackedVariables, amountTrackedArgs, this);
+    varLiveKeeper = new (allocator) VariableLiveKeeper(amountTrackedArgs, amountTrackedArgs, this, allocator);
 }
 
 VariableLiveKeeper* Compiler::getVariableLiveKeeper() const
@@ -11344,7 +11342,10 @@ VariableLiveKeeper* Compiler::getVariableLiveKeeper() const
 //    argsCount         - the count of args and special args in the method.
 //    compiler          - a compiler instance
 //
-VariableLiveKeeper::VariableLiveKeeper(unsigned int totalLocalCount, unsigned int argsCount, Compiler* comp)
+VariableLiveKeeper::VariableLiveKeeper(unsigned int  totalLocalCount,
+                                       unsigned int  argsCount,
+                                       Compiler*     comp,
+                                       CompAllocator allocator)
     : m_LiveDscCount(totalLocalCount)
     , m_LiveArgsCount(argsCount)
     , m_Compiler(comp)
@@ -11352,9 +11353,6 @@ VariableLiveKeeper::VariableLiveKeeper(unsigned int totalLocalCount, unsigned in
 {
     if (m_LiveDscCount > 0)
     {
-        // Get the allocator used for all the VariableLiveRange objects
-        CompAllocator allocator = m_Compiler->getAllocator(CMK_VariableLiveRanges);
-
         // Allocate memory for "lvaLiveDsc" and initialize each "VariableLiveDescriptor"
         lvaLiveDsc = allocator.allocate<VariableLiveDescriptor>(m_LiveDscCount);
 

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -11481,13 +11481,11 @@ void VariableLiveKeeper::siStartOrCloseVariableLiveRange(const LclVarDsc* varDsc
 //    This method is being called from treeLifeUpdater when a set of variables
 //    is being born, becoming dead, or both.
 //
-void VariableLiveKeeper::siStartOrCloseVariableLiveRanges(const VARSET_TP* varsIndexSet, bool isBorn, bool isDying)
+void VariableLiveKeeper::siStartOrCloseVariableLiveRanges(VARSET_VALARG_TP varsIndexSet, bool isBorn, bool isDying)
 {
-    noway_assert(varsIndexSet != nullptr);
-
     if (compiler->opts.compDbgInfo)
     {
-        VarSetOps::Iter iter(compiler, *varsIndexSet);
+        VarSetOps::Iter iter(compiler, varsIndexSet);
         unsigned        varIndex = 0;
         while (iter.NextElem(&varIndex))
         {
@@ -11610,12 +11608,11 @@ void VariableLiveKeeper::siUpdateVariableLiveRange(const LclVarDsc* varDsc, unsi
 //    This method is called when the last block being generated to killed all
 //    the live variables and set a flag to avoid reporting variable homes for
 //    on next calls to method that update variable liveness.
-void VariableLiveKeeper::siEndAllVariableLiveRange(const VARSET_TP* varsToClose)
+void VariableLiveKeeper::siEndAllVariableLiveRange(VARSET_VALARG_TP varsToClose)
 {
-    noway_assert(varsToClose != nullptr);
     if (compiler->opts.compDbgInfo)
     {
-        VarSetOps::Iter iter(compiler, *varsToClose);
+        VarSetOps::Iter iter(compiler, varsToClose);
         unsigned        varIndex = 0;
         while (iter.NextElem(&varIndex))
         {

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -331,6 +331,9 @@ public:
     }
 };
 
+typedef jitstd::list<VariableLiveRange> LiveRangeList;
+typedef LiveRangeList::const_iterator   LiveRangeListIterator;
+
 class LclVarDsc
 {
 public:

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -412,6 +412,12 @@ public:
     void siEndAllVariableLiveRange(const VARSET_TP* varsToClose);
 
     const LiveRangeList* getLiveRangesForVar(unsigned int varNum) const;
+
+    // For parameters variable homes on prolog
+
+    void psiStartVariableLiveRange(CodeGenInterface::siVarLoc varLocation, unsigned int varNum);
+
+    void psiClosePrologVariableRanges();
 };
 
 class LclVarDsc

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -321,18 +321,49 @@ class VariableLiveRange
 public:
     emitLocation               m_StartEmitLocation; // first position from where "m_VarLocation" becomes valid
     emitLocation               m_EndEmitLocation;   // last position where "m_VarLocation" is valid
-    CodeGenInterface::siVarLoc m_VarLocation;       // variable home
+    CodeGenInterface::siVarLoc m_VarHome;           // variable home
 
-    VariableLiveRange(CodeGenInterface::siVarLoc varLocation,
-                      emitLocation               startEmitLocation,
-                      emitLocation               endEmitLocation)
-        : m_VarLocation(varLocation), m_StartEmitLocation(startEmitLocation), m_EndEmitLocation(endEmitLocation)
+    VariableLiveRange(CodeGenInterface::siVarLoc varHome, emitLocation startEmitLocation, emitLocation endEmitLocation)
+        : m_VarHome(varHome), m_StartEmitLocation(startEmitLocation), m_EndEmitLocation(endEmitLocation)
     {
     }
 };
 
 typedef jitstd::list<VariableLiveRange> LiveRangeList;
 typedef LiveRangeList::const_iterator   LiveRangeListIterator;
+
+//--------------------------------------------
+//
+// VariableLiveDescriptor: This class persist and update all the changes
+//  on the variable home of a variable. It has an instance of "LiveRangeList"
+//  and methods to report the start/end of a VariableLiveRange.
+//
+// Notes:
+//  It has an instance of "LiveRangeList"
+//  and methods to report the start/end of a VariableLiveRange.
+//
+class VariableLiveDescriptor
+{
+private:
+    LiveRangeList* variableLiveRanges; // the variable homes of this variable
+
+public:
+    VariableLiveDescriptor(CompAllocator allocator);
+
+    ~VariableLiveDescriptor();
+
+    bool hasVariableLiveRangeOpen() const;
+
+    size_t getAmountLiveRanges() const;
+
+    const LiveRangeList* getLiveRanges() const;
+
+    void startLiveRangeFromEmitter(CodeGenInterface::siVarLoc varHome, emitter* _emitter) const;
+
+    void endLiveRangeAtEmitter(emitter* _emitter) const;
+
+    void UpdateLiveRangeAtEmitter(CodeGenInterface::siVarLoc varHome, emitter* _emitter) const;
+};
 
 class LclVarDsc
 {

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2012,6 +2012,12 @@ class Compiler
     */
 
 public:
+    VariableLiveKeeper* varLiveKeeper; // Used to manage VariableLiveRanges of variables
+
+    void initializeVariableLiveKeeper();
+
+    VariableLiveKeeper* getVariableLiveKeeper() const;
+
     hashBvGlobalData hbvGlobalData; // Used by the hashBv bitvector package.
 
 #ifdef DEBUG

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -297,6 +297,40 @@ enum RefCountState
     RCS_NORMAL,  // normal ref counts (from lvaMarkRefs onward)
 };
 
+//--------------------------------------------
+//
+// VariableLiveRange: Represent part of the life of a variable. A
+//      variable lives in a location (represented with struct "siVarLoc")
+//      between two assembly offsets.
+//
+// Notes:
+//    We use emitLocation and not NATTIVE_OFFSET because location
+//    is captured when code is being generated (genCodeForBBList
+//    and genGeneratePrologsAndEpilogs) but only once the whole
+//    methodit's code is done the NATTIVE_OFFSET won't change.
+//    It is also IL_OFFSET, but this is more accurate and the
+//    debugger is expeecting assembly offsets.
+//    This class doesn't have behaviour attached to itself, it is
+//    just putting a name to a representation. It is used to build
+//    typedefs LiveRangeList and LiveRangeListIterator, which are
+//    basically a list of this class and a const_iterator of that
+//    list.
+//
+class VariableLiveRange
+{
+public:
+    emitLocation               m_StartEmitLocation; // first position from where "m_VarLocation" becomes valid
+    emitLocation               m_EndEmitLocation;   // last position where "m_VarLocation" is valid
+    CodeGenInterface::siVarLoc m_VarLocation;       // variable home
+
+    VariableLiveRange(CodeGenInterface::siVarLoc varLocation,
+                      emitLocation               startEmitLocation,
+                      emitLocation               endEmitLocation)
+        : m_VarLocation(varLocation), m_StartEmitLocation(startEmitLocation), m_EndEmitLocation(endEmitLocation)
+    {
+    }
+};
+
 class LclVarDsc
 {
 public:

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -407,8 +407,8 @@ class VariableLiveDescriptor
 public:
     VariableLiveDescriptor(CompAllocator allocator);
 
-    bool                 hasVariableLiveRangeOpen() const;
-    const LiveRangeList* getLiveRanges() const;
+    bool           hasVariableLiveRangeOpen() const;
+    LiveRangeList* getLiveRanges() const;
 
     void startLiveRangeFromEmitter(CodeGenInterface::siVarLoc varLocation, emitter* emit) const;
     void endLiveRangeAtEmitter(emitter* emit) const;
@@ -462,7 +462,7 @@ public:
     void siEndAllVariableLiveRange(VARSET_VALARG_TP varsToClose);
     void siEndAllVariableLiveRange();
 
-    const LiveRangeList* getLiveRangesForVar(unsigned int varNum) const;
+    LiveRangeList* getLiveRangesForVar(unsigned int varNum) const;
     size_t getLiveRangesCount() const;
 
     // For parameters locations on prolog
@@ -7148,7 +7148,7 @@ public:
                      unsigned                          LVnum,
                      VarName                           namex,
                      bool                              avail,
-                     const CodeGenInterface::siVarLoc* loc);
+                     const CodeGenInterface::siVarLoc& loc);
     void eeSetLVdone();
 
 #ifdef DEBUG

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7145,9 +7145,6 @@ public:
                      UNATIVE_OFFSET                    startOffs,
                      UNATIVE_OFFSET                    length,
                      unsigned                          varNum,
-                     unsigned                          LVnum,
-                     VarName                           namex,
-                     bool                              avail,
                      const CodeGenInterface::siVarLoc& loc);
     void eeSetLVdone();
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -321,12 +321,12 @@ enum RefCountState
 class VariableLiveRange
 {
 public:
-    emitLocation               m_StartEmitLocation; // first position from where "m_VarHome" becomes valid
-    emitLocation               m_EndEmitLocation;   // last position where "m_VarHome" is valid
-    CodeGenInterface::siVarLoc m_VarHome;           // variable home
+    emitLocation               m_StartEmitLocation; // first position from where "m_VarLocation" becomes valid
+    emitLocation               m_EndEmitLocation;   // last position where "m_VarLocation" is valid
+    CodeGenInterface::siVarLoc m_VarLocation;       // variable location
 
     VariableLiveRange(CodeGenInterface::siVarLoc varHome, emitLocation startEmitLocation, emitLocation endEmitLocation)
-        : m_StartEmitLocation(startEmitLocation), m_EndEmitLocation(endEmitLocation), m_VarHome(varHome)
+        : m_StartEmitLocation(startEmitLocation), m_EndEmitLocation(endEmitLocation), m_VarLocation(varHome)
     {
     }
 
@@ -398,7 +398,7 @@ public:
 //
 class VariableLiveDescriptor
 {
-    LiveRangeList* m_VariableLiveRanges; // the variable homes of this variable
+    LiveRangeList* m_VariableLiveRanges; // the variable locations of this variable
 
     INDEBUG(LiveRangeDumper* m_VariableLifeBarrier);
 
@@ -442,7 +442,7 @@ public:
 //  out of that class, which is huge. With this solution the only code needed in Compiler is
 //  a getter and an initializer of this class.
 //  The index of each variable in this array corresponds to the one in "compiler->lvaTable".
-//  We care about tracking the variable homes of arguments, special arguments, and local IL
+//  We care about tracking the variable locations of arguments, special arguments, and local IL
 //  variables, and we ignore any other variable (like JIT temporary variables).
 //
 class VariableLiveKeeper
@@ -478,7 +478,7 @@ public:
 
     const LiveRangeList* getLiveRangesForVar(unsigned int varNum) const;
 
-    // For parameters variable homes on prolog
+    // For parameters variable locations on prolog
 
     void psiStartVariableLiveRange(CodeGenInterface::siVarLoc varLocation, unsigned int varNum);
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -408,8 +408,6 @@ class VariableLiveDescriptor
 public:
     VariableLiveDescriptor(CompAllocator allocator);
 
-    ~VariableLiveDescriptor();
-
     bool hasVariableLiveRangeOpen() const;
 
     const LiveRangeList* getLiveRanges() const;
@@ -462,8 +460,6 @@ class VariableLiveKeeper
                                         // No update/start happens when code has been generated.
 public:
     VariableLiveKeeper(unsigned int totalLocalCount, unsigned int argsCount, Compiler* compiler);
-
-    ~VariableLiveKeeper();
 
     size_t getLiveRangesCount() const;
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -466,7 +466,7 @@ public:
 
     void siStartOrCloseVariableLiveRange(const LclVarDsc* varDsc, unsigned int varNum, bool isBorn, bool isDying);
 
-    void siStartOrCloseVariableLiveRanges(const VARSET_TP* varsIndexSet, bool isBorn, bool isDying);
+    void siStartOrCloseVariableLiveRanges(VARSET_VALARG_TP varsIndexSet, bool isBorn, bool isDying);
 
     void siStartVariableLiveRange(const LclVarDsc* varDsc, unsigned int varNum);
 
@@ -474,7 +474,7 @@ public:
 
     void siUpdateVariableLiveRange(const LclVarDsc* varDsc, unsigned int varNum);
 
-    void siEndAllVariableLiveRange(const VARSET_TP* varsToClose);
+    void siEndAllVariableLiveRange(VARSET_VALARG_TP varsToClose);
 
     const LiveRangeList* getLiveRangesForVar(unsigned int varNum) const;
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -302,7 +302,7 @@ enum RefCountState
 //
 // VariableLiveRange: Represent part of the life of a variable. A
 //      variable lives in a location (represented with struct "siVarLoc")
-//      between two assembly offsets.
+//      between two native offsets.
 //
 // Notes:
 //    We use emitLocation and not NATTIVE_OFFSET because location

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -325,8 +325,10 @@ public:
     emitLocation               m_EndEmitLocation;   // last position where "m_VarLocation" is valid
     CodeGenInterface::siVarLoc m_VarLocation;       // variable location
 
-    VariableLiveRange(CodeGenInterface::siVarLoc varHome, emitLocation startEmitLocation, emitLocation endEmitLocation)
-        : m_StartEmitLocation(startEmitLocation), m_EndEmitLocation(endEmitLocation), m_VarLocation(varHome)
+    VariableLiveRange(CodeGenInterface::siVarLoc varLocation,
+                      emitLocation               startEmitLocation,
+                      emitLocation               endEmitLocation)
+        : m_StartEmitLocation(startEmitLocation), m_EndEmitLocation(endEmitLocation), m_VarLocation(varLocation)
     {
     }
 
@@ -409,24 +411,22 @@ public:
 
     bool hasVariableLiveRangeOpen() const;
 
-    size_t getLiveRangesCount() const;
-
     const LiveRangeList* getLiveRanges() const;
 
-    void startLiveRangeFromEmitter(CodeGenInterface::siVarLoc varHome, emitter* emit) const;
+    void startLiveRangeFromEmitter(CodeGenInterface::siVarLoc varLocation, emitter* emit) const;
 
     void endLiveRangeAtEmitter(emitter* emit) const;
 
-    void updateLiveRangeAtEmitter(CodeGenInterface::siVarLoc varHome, emitter* emit) const;
+    void updateLiveRangeAtEmitter(CodeGenInterface::siVarLoc varLocation, emitter* emit) const;
 
 #ifdef DEBUG
     void dumpAllRegisterLiveRangesForBlock(emitter* emit, const CodeGenInterface* codeGen) const;
 
     void dumpRegisterLiveRangesForBlockBeforeCodeGenerated(const CodeGenInterface* codeGen) const;
 
-    bool hasVarHomesToDump() const;
+    bool hasVarLiveRangesToDump() const;
 
-    bool hasVarLocationsOfLastBlockToDump() const;
+    bool hasVarLiverRangesFromLastBlockToDump() const;
 
     void endBlockLiveRanges();
 #endif // DEBUG
@@ -464,7 +464,7 @@ public:
 
     ~VariableLiveKeeper();
 
-    unsigned int getLiveRangesCount() const;
+    size_t getLiveRangesCount() const;
 
     void siStartOrCloseVariableLiveRange(const LclVarDsc* varDsc, unsigned int varNum, bool isBorn, bool isDying);
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -373,7 +373,8 @@ class LiveRangeDumper
                                                  // reported from last call to EndBlock
 
 public:
-    LiveRangeDumper(const LiveRangeList* liveRanges);
+    LiveRangeDumper(const LiveRangeList* liveRanges)
+        : m_StartingLiveRange(liveRanges->end()), m_hasLiveRangestoDump(false){};
 
     // Make the dumper point to the last "VariableLiveRange" opened or nullptr if all are closed
     void resetDumper(const LiveRangeList* list);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -300,132 +300,6 @@ enum RefCountState
 #ifdef USING_VARIABLE_LIVE_RANGE
 //--------------------------------------------
 //
-// VariableLiveRange: Represent part of the life of a variable. A
-//      variable lives in a location (represented with struct "siVarLoc")
-//      between two native offsets.
-//
-// Notes:
-//    We use emitLocation and not NATTIVE_OFFSET because location
-//    is captured when code is being generated (genCodeForBBList
-//    and genGeneratePrologsAndEpilogs) but only after the whole
-//    method's code is generated can we obtain a final, fixed
-//    NATIVE_OFFSET representing the actual generated code offset.
-//    There is also a IL_OFFSET, but this is more accurate and the
-//    debugger is expecting assembly offsets.
-//    This class doesn't have behaviour attached to itself, it is
-//    just putting a name to a representation. It is used to build
-//    typedefs LiveRangeList and LiveRangeListIterator, which are
-//    basically a list of this class and a const_iterator of that
-//    list.
-//
-class VariableLiveRange
-{
-public:
-    emitLocation               m_StartEmitLocation; // first position from where "m_VarLocation" becomes valid
-    emitLocation               m_EndEmitLocation;   // last position where "m_VarLocation" is valid
-    CodeGenInterface::siVarLoc m_VarLocation;       // variable location
-
-    VariableLiveRange(CodeGenInterface::siVarLoc varLocation,
-                      emitLocation               startEmitLocation,
-                      emitLocation               endEmitLocation)
-        : m_StartEmitLocation(startEmitLocation), m_EndEmitLocation(endEmitLocation), m_VarLocation(varLocation)
-    {
-    }
-
-#ifdef DEBUG
-    // Dump "VariableLiveRange" when code has not been generated. We don't have the native code offset,
-    // but we do have "emitLocation"s and "siVarLoc".
-    void dumpVariableLiveRange(const CodeGenInterface* codeGen) const;
-
-    // Dump "VariableLiveRange" when code has been generated and we have the native code offset of each "emitLocation"
-    void dumpVariableLiveRange(emitter* emit, const CodeGenInterface* codeGen) const;
-#endif // DEBUG
-};
-
-typedef jitstd::list<VariableLiveRange> LiveRangeList;
-typedef LiveRangeList::const_iterator   LiveRangeListIterator;
-
-#ifdef DEBUG
-//--------------------------------------------
-//
-// LiveRangeDumper: Used for debugging purposes during code
-//  generation on genCodeForBBList. Keeps an iterator to the first
-//  edited/added "VariableLiveRange" of a variable during the
-//  generation of code of one block.
-//
-// Notes:
-//  The first "VariableLiveRange" reported for a variable during
-//  a BasicBlock is sent to "setDumperStartAt" so we can dump all
-//  the "VariableLiveRange"s from that one.
-//  After we dump all the "VariableLiveRange"s we call "reset" with
-//  the "liveRangeList" to set the barrier to nullptr or the last
-//  "VariableLiveRange" if it is opened.
-//  If no "VariableLiveRange" was edited/added during block,
-//  the iterator points to the end of variable's LiveRangeList.
-//
-class LiveRangeDumper
-{
-    // Iterator to the first edited/added position during actual block code generation. If last
-    // block had a closed "VariableLiveRange" (with a valid "m_EndEmitLocation") and not changes
-    // were applied to variable liveness, it points to the end of variable's LiveRangeList.
-    LiveRangeListIterator m_StartingLiveRange;
-    bool                  m_hasLiveRangestoDump; // True if a live range for this variable has been
-                                                 // reported from last call to EndBlock
-
-public:
-    LiveRangeDumper(const LiveRangeList* liveRanges)
-        : m_StartingLiveRange(liveRanges->end()), m_hasLiveRangestoDump(false){};
-
-    // Make the dumper point to the last "VariableLiveRange" opened or nullptr if all are closed
-    void resetDumper(const LiveRangeList* list);
-
-    // Make "LiveRangeDumper" instance points the last "VariableLiveRange" added so we can
-    // start dumping from there after the actual "BasicBlock"s code is generated.
-    void setDumperStartAt(const LiveRangeListIterator liveRangeIt);
-
-    // Return an iterator to the first "VariableLiveRange" edited/added during the current
-    // "BasicBlock"
-    LiveRangeListIterator getStartForDump() const;
-
-    // Return whether at least a "VariableLiveRange" was alive during the current "BasicBlock"'s
-    // code generation
-    bool hasLiveRangesToDump() const;
-};
-#endif // DEBUG
-
-//--------------------------------------------
-//
-// VariableLiveDescriptor: This class persist and update all the changes
-//  to the home of a variable. It has an instance of "LiveRangeList"
-//  and methods to report the start/end of a VariableLiveRange.
-//
-class VariableLiveDescriptor
-{
-    LiveRangeList* m_VariableLiveRanges; // the variable locations of this variable
-    INDEBUG(LiveRangeDumper* m_VariableLifeBarrier);
-
-public:
-    VariableLiveDescriptor(CompAllocator allocator);
-
-    bool           hasVariableLiveRangeOpen() const;
-    LiveRangeList* getLiveRanges() const;
-
-    void startLiveRangeFromEmitter(CodeGenInterface::siVarLoc varLocation, emitter* emit) const;
-    void endLiveRangeAtEmitter(emitter* emit) const;
-    void updateLiveRangeAtEmitter(CodeGenInterface::siVarLoc varLocation, emitter* emit) const;
-
-#ifdef DEBUG
-    void dumpAllRegisterLiveRangesForBlock(emitter* emit, const CodeGenInterface* codeGen) const;
-    void dumpRegisterLiveRangesForBlockBeforeCodeGenerated(const CodeGenInterface* codeGen) const;
-    bool hasVarLiveRangesToDump() const;
-    bool hasVarLiverRangesFromLastBlockToDump() const;
-    void endBlockLiveRanges();
-#endif // DEBUG
-};
-#endif // USING_VARIABLE_LIVE_RANGE
-
-//--------------------------------------------
-//
 // VariableLiveKeeper: Holds an array of "VariableLiveDescriptor", one for each variable
 //  whose location we track. It provides start/end/update/count operations over the
 //  "LiveRangeList" of any variable.
@@ -440,6 +314,134 @@ public:
 //
 class VariableLiveKeeper
 {
+public:
+    //--------------------------------------------
+    //
+    // VariableLiveRange: Represent part of the life of a variable. A
+    //      variable lives in a location (represented with struct "siVarLoc")
+    //      between two native offsets.
+    //
+    // Notes:
+    //    We use emitLocation and not NATTIVE_OFFSET because location
+    //    is captured when code is being generated (genCodeForBBList
+    //    and genGeneratePrologsAndEpilogs) but only after the whole
+    //    method's code is generated can we obtain a final, fixed
+    //    NATIVE_OFFSET representing the actual generated code offset.
+    //    There is also a IL_OFFSET, but this is more accurate and the
+    //    debugger is expecting assembly offsets.
+    //    This class doesn't have behaviour attached to itself, it is
+    //    just putting a name to a representation. It is used to build
+    //    typedefs LiveRangeList and LiveRangeListIterator, which are
+    //    basically a list of this class and a const_iterator of that
+    //    list.
+    //
+    class VariableLiveRange
+    {
+    public:
+        emitLocation               m_StartEmitLocation; // first position from where "m_VarLocation" becomes valid
+        emitLocation               m_EndEmitLocation;   // last position where "m_VarLocation" is valid
+        CodeGenInterface::siVarLoc m_VarLocation;       // variable location
+
+        VariableLiveRange(CodeGenInterface::siVarLoc varLocation,
+                          emitLocation               startEmitLocation,
+                          emitLocation               endEmitLocation)
+            : m_StartEmitLocation(startEmitLocation), m_EndEmitLocation(endEmitLocation), m_VarLocation(varLocation)
+        {
+        }
+
+#ifdef DEBUG
+        // Dump "VariableLiveRange" when code has not been generated. We don't have the native code offset,
+        // but we do have "emitLocation"s and "siVarLoc".
+        void dumpVariableLiveRange(const CodeGenInterface* codeGen) const;
+
+        // Dump "VariableLiveRange" when code has been generated and we have the native code offset of each
+        // "emitLocation"
+        void dumpVariableLiveRange(emitter* emit, const CodeGenInterface* codeGen) const;
+#endif // DEBUG
+    };
+
+    typedef jitstd::list<VariableLiveRange> LiveRangeList;
+    typedef LiveRangeList::const_iterator   LiveRangeListIterator;
+
+private:
+#ifdef DEBUG
+    //--------------------------------------------
+    //
+    // LiveRangeDumper: Used for debugging purposes during code
+    //  generation on genCodeForBBList. Keeps an iterator to the first
+    //  edited/added "VariableLiveRange" of a variable during the
+    //  generation of code of one block.
+    //
+    // Notes:
+    //  The first "VariableLiveRange" reported for a variable during
+    //  a BasicBlock is sent to "setDumperStartAt" so we can dump all
+    //  the "VariableLiveRange"s from that one.
+    //  After we dump all the "VariableLiveRange"s we call "reset" with
+    //  the "liveRangeList" to set the barrier to nullptr or the last
+    //  "VariableLiveRange" if it is opened.
+    //  If no "VariableLiveRange" was edited/added during block,
+    //  the iterator points to the end of variable's LiveRangeList.
+    //
+    class LiveRangeDumper
+    {
+        // Iterator to the first edited/added position during actual block code generation. If last
+        // block had a closed "VariableLiveRange" (with a valid "m_EndEmitLocation") and not changes
+        // were applied to variable liveness, it points to the end of variable's LiveRangeList.
+        LiveRangeListIterator m_StartingLiveRange;
+        bool                  m_hasLiveRangestoDump; // True if a live range for this variable has been
+                                                     // reported from last call to EndBlock
+
+    public:
+        LiveRangeDumper(const LiveRangeList* liveRanges)
+            : m_StartingLiveRange(liveRanges->end()), m_hasLiveRangestoDump(false){};
+
+        // Make the dumper point to the last "VariableLiveRange" opened or nullptr if all are closed
+        void resetDumper(const LiveRangeList* list);
+
+        // Make "LiveRangeDumper" instance points the last "VariableLiveRange" added so we can
+        // start dumping from there after the actual "BasicBlock"s code is generated.
+        void setDumperStartAt(const LiveRangeListIterator liveRangeIt);
+
+        // Return an iterator to the first "VariableLiveRange" edited/added during the current
+        // "BasicBlock"
+        LiveRangeListIterator getStartForDump() const;
+
+        // Return whether at least a "VariableLiveRange" was alive during the current "BasicBlock"'s
+        // code generation
+        bool hasLiveRangesToDump() const;
+    };
+#endif // DEBUG
+
+    //--------------------------------------------
+    //
+    // VariableLiveDescriptor: This class persist and update all the changes
+    //  to the home of a variable. It has an instance of "LiveRangeList"
+    //  and methods to report the start/end of a VariableLiveRange.
+    //
+    class VariableLiveDescriptor
+    {
+        LiveRangeList* m_VariableLiveRanges; // the variable locations of this variable
+        INDEBUG(LiveRangeDumper* m_VariableLifeBarrier);
+
+    public:
+        VariableLiveDescriptor(CompAllocator allocator);
+
+        bool           hasVariableLiveRangeOpen() const;
+        LiveRangeList* getLiveRanges() const;
+
+        void startLiveRangeFromEmitter(CodeGenInterface::siVarLoc varLocation, emitter* emit) const;
+        void endLiveRangeAtEmitter(emitter* emit) const;
+        void updateLiveRangeAtEmitter(CodeGenInterface::siVarLoc varLocation, emitter* emit) const;
+
+#ifdef DEBUG
+        void dumpAllRegisterLiveRangesForBlock(emitter* emit, const CodeGenInterface* codeGen) const;
+        void dumpRegisterLiveRangesForBlockBeforeCodeGenerated(const CodeGenInterface* codeGen) const;
+        bool hasVarLiveRangesToDump() const;
+        bool hasVarLiverRangesFromLastBlockToDump() const;
+        void endBlockLiveRanges();
+#endif // DEBUG
+    };
+
     unsigned int m_LiveDscCount;  // count of args, special args, and IL local variables to report home
     unsigned int m_LiveArgsCount; // count of arguments to report home
 
@@ -450,6 +452,7 @@ class VariableLiveKeeper
 
     bool m_LastBasicBlockHasBeenEmited; // When true no more siEndVariableLiveRange is considered.
                                         // No update/start happens when code has been generated.
+
 public:
     VariableLiveKeeper(unsigned int  totalLocalCount,
                        unsigned int  argsCount,
@@ -477,6 +480,7 @@ public:
     void dumpLvaVariableLiveRanges() const;
 #endif // DEBUG
 };
+#endif // USING_VARIABLE_LIVE_RANGE
 
 class LclVarDsc
 {
@@ -2076,11 +2080,13 @@ class Compiler
     */
 
 public:
+#ifdef USING_VARIABLE_LIVE_RANGE
     VariableLiveKeeper* varLiveKeeper; // Used to manage VariableLiveRanges of variables
 
     void initializeVariableLiveKeeper();
 
     VariableLiveKeeper* getVariableLiveKeeper() const;
+#endif // USING_VARIABLE_LIVE_RANGE
 
     hashBvGlobalData hbvGlobalData; // Used by the hashBv bitvector package.
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -324,7 +324,7 @@ public:
     CodeGenInterface::siVarLoc m_VarHome;           // variable home
 
     VariableLiveRange(CodeGenInterface::siVarLoc varHome, emitLocation startEmitLocation, emitLocation endEmitLocation)
-        : m_VarHome(varHome), m_StartEmitLocation(startEmitLocation), m_EndEmitLocation(endEmitLocation)
+        : m_StartEmitLocation(startEmitLocation), m_EndEmitLocation(endEmitLocation), m_VarHome(varHome)
     {
     }
 };

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -451,7 +451,10 @@ class VariableLiveKeeper
     bool m_LastBasicBlockHasBeenEmited; // When true no more siEndVariableLiveRange is considered.
                                         // No update/start happens when code has been generated.
 public:
-    VariableLiveKeeper(unsigned int totalLocalCount, unsigned int argsCount, Compiler* compiler);
+    VariableLiveKeeper(unsigned int  totalLocalCount,
+                       unsigned int  argsCount,
+                       Compiler*     compiler,
+                       CompAllocator allocator);
 
     // For tracking locations during code generation
     void siStartOrCloseVariableLiveRange(const LclVarDsc* varDsc, unsigned int varNum, bool isBorn, bool isDying);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -310,7 +310,7 @@ enum RefCountState
 //    and genGeneratePrologsAndEpilogs) but only after the whole
 //    method's code is generated can we obtain a final, fixed
 //    NATIVE_OFFSET representing the actual generated code offset.
-//    It is also IL_OFFSET, but this is more accurate and the
+//    There is also a IL_OFFSET, but this is more accurate and the
 //    debugger is expecting assembly offsets.
 //    This class doesn't have behaviour attached to itself, it is
 //    just putting a name to a representation. It is used to build
@@ -447,16 +447,16 @@ public:
 //
 class VariableLiveKeeper
 {
-    unsigned int lvLiveDscCount;  // count of args, special args, and IL local variables to report home
-    unsigned int lvLiveArgsCount; // count of arguments to report home
+    unsigned int m_LiveDscCount;  // count of args, special args, and IL local variables to report home
+    unsigned int m_LiveArgsCount; // count of arguments to report home
 
-    Compiler* compiler;
+    Compiler* m_Compiler;
 
     VariableLiveDescriptor* lvaLiveDsc; // Array of descriptors that manage VariableLiveRanges.
                                         // Its indices correspond to lvaTable indexes (or lvSlotNum).
 
-    bool lastBasicBlockHasBeenEmited; // When true no more siEndVariableLiveRange is considered.
-                                      // No update/start happens when code has been generated.
+    bool m_LastBasicBlockHasBeenEmited; // When true no more siEndVariableLiveRange is considered.
+                                        // No update/start happens when code has been generated.
 public:
     VariableLiveKeeper(unsigned int totalLocalCount, unsigned int argsCount, Compiler* compiler);
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -426,6 +426,8 @@ public:
 
     bool hasVarHomesToDump() const;
 
+    bool hasVarLocationsOfLastBlockToDump() const;
+
     void endBlockLiveRanges();
 #endif // DEBUG
 };
@@ -475,6 +477,7 @@ public:
     void siUpdateVariableLiveRange(const LclVarDsc* varDsc, unsigned int varNum);
 
     void siEndAllVariableLiveRange(VARSET_VALARG_TP varsToClose);
+    void siEndAllVariableLiveRange();
 
     const LiveRangeList* getLiveRangesForVar(unsigned int varNum) const;
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -402,31 +402,23 @@ public:
 class VariableLiveDescriptor
 {
     LiveRangeList* m_VariableLiveRanges; // the variable locations of this variable
-
     INDEBUG(LiveRangeDumper* m_VariableLifeBarrier);
 
 public:
     VariableLiveDescriptor(CompAllocator allocator);
 
-    bool hasVariableLiveRangeOpen() const;
-
+    bool                 hasVariableLiveRangeOpen() const;
     const LiveRangeList* getLiveRanges() const;
 
     void startLiveRangeFromEmitter(CodeGenInterface::siVarLoc varLocation, emitter* emit) const;
-
     void endLiveRangeAtEmitter(emitter* emit) const;
-
     void updateLiveRangeAtEmitter(CodeGenInterface::siVarLoc varLocation, emitter* emit) const;
 
 #ifdef DEBUG
     void dumpAllRegisterLiveRangesForBlock(emitter* emit, const CodeGenInterface* codeGen) const;
-
     void dumpRegisterLiveRangesForBlockBeforeCodeGenerated(const CodeGenInterface* codeGen) const;
-
     bool hasVarLiveRangesToDump() const;
-
     bool hasVarLiverRangesFromLastBlockToDump() const;
-
     void endBlockLiveRanges();
 #endif // DEBUG
 };
@@ -461,32 +453,24 @@ class VariableLiveKeeper
 public:
     VariableLiveKeeper(unsigned int totalLocalCount, unsigned int argsCount, Compiler* compiler);
 
-    size_t getLiveRangesCount() const;
-
+    // For tracking locations during code generation
     void siStartOrCloseVariableLiveRange(const LclVarDsc* varDsc, unsigned int varNum, bool isBorn, bool isDying);
-
     void siStartOrCloseVariableLiveRanges(VARSET_VALARG_TP varsIndexSet, bool isBorn, bool isDying);
-
     void siStartVariableLiveRange(const LclVarDsc* varDsc, unsigned int varNum);
-
     void siEndVariableLiveRange(unsigned int varNum);
-
     void siUpdateVariableLiveRange(const LclVarDsc* varDsc, unsigned int varNum);
-
     void siEndAllVariableLiveRange(VARSET_VALARG_TP varsToClose);
     void siEndAllVariableLiveRange();
 
     const LiveRangeList* getLiveRangesForVar(unsigned int varNum) const;
+    size_t getLiveRangesCount() const;
 
-    // For parameters variable locations on prolog
-
+    // For parameters locations on prolog
     void psiStartVariableLiveRange(CodeGenInterface::siVarLoc varLocation, unsigned int varNum);
-
     void psiClosePrologVariableRanges();
 
 #ifdef DEBUG
     void dumpBlockVariableLiveRanges(const BasicBlock* block);
-
     void dumpLvaVariableLiveRanges() const;
 #endif // DEBUG
 };

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -447,8 +447,8 @@ private:
 
     Compiler* m_Compiler;
 
-    VariableLiveDescriptor* lvaLiveDsc; // Array of descriptors that manage VariableLiveRanges.
-                                        // Its indices correspond to lvaTable indexes (or lvSlotNum).
+    VariableLiveDescriptor* m_vlrLiveDsc; // Array of descriptors that manage VariableLiveRanges.
+                                          // Its indices correspond to lvaTable indexes (or lvSlotNum).
 
     bool m_LastBasicBlockHasBeenEmited; // When true no more siEndVariableLiveRange is considered.
                                         // No update/start happens when code has been generated.

--- a/src/jit/compmemkind.h
+++ b/src/jit/compmemkind.h
@@ -54,6 +54,7 @@ CompMemKindMacro(RangeCheck)
 CompMemKindMacro(CopyProp)
 CompMemKindMacro(SideEffects)
 CompMemKindMacro(ObjectAllocator)
+CompMemKindMacro(VariableLiveRanges)
 //clang-format on
 
 #undef CompMemKindMacro

--- a/src/jit/ee_il_dll.cpp
+++ b/src/jit/ee_il_dll.cpp
@@ -655,7 +655,7 @@ void Compiler::eeSetLVinfo(unsigned                          which,
                            unsigned                          LVnum,
                            VarName                           name,
                            bool                              avail,
-                           const CodeGenInterface::siVarLoc* varLoc)
+                           const CodeGenInterface::siVarLoc& varLoc)
 {
     // ICorDebugInfo::VarLoc and CodeGenInterface::siVarLoc have to overlap
     // This is checked in siInit()
@@ -669,7 +669,7 @@ void Compiler::eeSetLVinfo(unsigned                          which,
         eeVars[which].startOffset = startOffs;
         eeVars[which].endOffset   = startOffs + length;
         eeVars[which].varNumber   = varNum;
-        eeVars[which].loc         = *varLoc;
+        eeVars[which].loc         = varLoc;
     }
 }
 

--- a/src/jit/ee_il_dll.cpp
+++ b/src/jit/ee_il_dll.cpp
@@ -914,7 +914,7 @@ void Compiler::eeDispVar(ICorDebugInfo::NativeVarInfo* var)
 void Compiler::eeDispVars(CORINFO_METHOD_HANDLE ftn, ULONG32 cVars, ICorDebugInfo::NativeVarInfo* vars)
 {
     printf("*************** Variable debug info\n");
-    printf("%d vars\n", cVars);
+    printf("%d live ranges\n", cVars);
     for (unsigned i = 0; i < cVars; i++)
     {
         eeDispVar(&vars[i]);

--- a/src/jit/ee_il_dll.cpp
+++ b/src/jit/ee_il_dll.cpp
@@ -652,9 +652,6 @@ void Compiler::eeSetLVinfo(unsigned                          which,
                            UNATIVE_OFFSET                    startOffs,
                            UNATIVE_OFFSET                    length,
                            unsigned                          varNum,
-                           unsigned                          LVnum,
-                           VarName                           name,
-                           bool                              avail,
                            const CodeGenInterface::siVarLoc& varLoc)
 {
     // ICorDebugInfo::VarLoc and CodeGenInterface::siVarLoc have to overlap

--- a/src/jit/jitstd/list.h
+++ b/src/jit/jitstd/list.h
@@ -52,8 +52,8 @@ public:
     {
     private:
         const_iterator(Node* ptr);
-        const_iterator();
     public:
+        const_iterator();
         const_iterator(const const_iterator& it);
         const_iterator(const typename list<T, Allocator>::iterator& it);
 

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -1256,6 +1256,14 @@ void LinearScan::recordVarLocationsAtStartOfBB(BasicBlock* bb)
                     compiler->compRegVarName(newRegNum));
             varDsc->lvRegNum = newRegNum;
             count++;
+
+            if (bb->bbPrev != nullptr && VarSetOps::IsMember(compiler, bb->bbPrev->bbLiveOut, varIndex))
+            {
+                // varDsc was alive on previous block end ("bb->bbPrev->bbLiveOut"), so it has an open
+                // "VariableLiveRange" which should change to be according "getInVarToRegMap"
+                VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
+                varLvKeeper->siUpdateVariableLiveRange(varDsc, varNum);
+            }
         }
         else if (newRegNum != REG_STK)
         {

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -1257,6 +1257,7 @@ void LinearScan::recordVarLocationsAtStartOfBB(BasicBlock* bb)
             varDsc->lvRegNum = newRegNum;
             count++;
 
+#ifdef USING_VARIABLE_LIVE_RANGE
             if (bb->bbPrev != nullptr && VarSetOps::IsMember(compiler, bb->bbPrev->bbLiveOut, varIndex))
             {
                 // varDsc was alive on previous block end ("bb->bbPrev->bbLiveOut"), so it has an open
@@ -1264,6 +1265,7 @@ void LinearScan::recordVarLocationsAtStartOfBB(BasicBlock* bb)
                 VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
                 varLvKeeper->siUpdateVariableLiveRange(varDsc, varNum);
             }
+#endif // USING_VARIABLE_LIVE_RANGE
         }
         else if (newRegNum != REG_STK)
         {

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -1262,8 +1262,7 @@ void LinearScan::recordVarLocationsAtStartOfBB(BasicBlock* bb)
             {
                 // varDsc was alive on previous block end ("bb->bbPrev->bbLiveOut"), so it has an open
                 // "VariableLiveRange" which should change to be according "getInVarToRegMap"
-                VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
-                varLvKeeper->siUpdateVariableLiveRange(varDsc, varNum);
+                compiler->getVariableLiveKeeper()->siUpdateVariableLiveRange(varDsc, varNum);
             }
 #endif // USING_VARIABLE_LIVE_RANGE
         }

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -499,6 +499,87 @@ CodeGenInterface::siVarLoc CodeGenInterface::getSiVarLoc(const LclVarDsc* varDsc
     return CodeGenInterface::siVarLoc(varDsc, baseReg, offset, isFramePointerUsed());
 }
 
+#if DEBUG
+void CodeGenInterface::dumpSiVarLoc(const siVarLoc* varLoc) const
+{
+    // "varLoc" cannot be null
+    noway_assert(varLoc != nullptr);
+
+    switch (varLoc->vlType)
+    {
+        case VLT_REG:
+        case VLT_REG_BYREF:
+        case VLT_REG_FP:
+            printf("%s", getRegName(varLoc->vlReg.vlrReg));
+            if (varLoc->vlType == VLT_REG_BYREF)
+            {
+                printf(" byref");
+            }
+            break;
+
+        case VLT_STK:
+        case VLT_STK_BYREF:
+            if ((int)varLoc->vlStk.vlsBaseReg != (int)ICorDebugInfo::REGNUM_AMBIENT_SP)
+            {
+                printf("%s[%d] (1 slot)", getRegName(varLoc->vlStk.vlsBaseReg), varLoc->vlStk.vlsOffset);
+            }
+            else
+            {
+                printf(STR_SPBASE "'[%d] (1 slot)", varLoc->vlStk.vlsOffset);
+            }
+            if (varLoc->vlType == VLT_REG_BYREF)
+            {
+                printf(" byref");
+            }
+            break;
+
+#ifndef _TARGET_AMD64_
+        case VLT_REG_REG:
+            printf("%s-%s", getRegName(varLoc->vlRegReg.vlrrReg1), getRegName(varLoc->vlRegReg.vlrrReg2));
+            break;
+
+        case VLT_REG_STK:
+            if ((int)varLoc->vlRegStk.vlrsStk.vlrssBaseReg != (int)ICorDebugInfo::REGNUM_AMBIENT_SP)
+            {
+                printf("%s-%s[%d]", getRegName(varLoc->vlRegStk.vlrsReg),
+                       getRegName(varLoc->vlRegStk.vlrsStk.vlrssBaseReg), varLoc->vlRegStk.vlrsStk.vlrssOffset);
+            }
+            else
+            {
+                printf("%s-" STR_SPBASE "'[%d]", getRegName(varLoc->vlRegStk.vlrsReg),
+                       varLoc->vlRegStk.vlrsStk.vlrssOffset);
+            }
+            break;
+
+        case VLT_STK_REG:
+            unreached(); // unexpected
+
+        case VLT_STK2:
+            if ((int)varLoc->vlStk2.vls2BaseReg != (int)ICorDebugInfo::REGNUM_AMBIENT_SP)
+            {
+                printf("%s[%d] (2 slots)", getRegName(varLoc->vlStk2.vls2BaseReg), varLoc->vlStk2.vls2Offset);
+            }
+            else
+            {
+                printf(STR_SPBASE "'[%d] (2 slots)", varLoc->vlStk2.vls2Offset);
+            }
+            break;
+
+        case VLT_FPSTK:
+            printf("ST(L-%d)", varLoc->vlFPstk.vlfReg);
+            break;
+
+        case VLT_FIXED_VA:
+            printf("fxd_va[%d]", varLoc->vlFixedVarArg.vlfvOffset);
+            break;
+#endif // !_TARGET_AMD64_
+
+        default:
+            unreached(); // unexpected
+    }
+}
+#endif
+
 #ifdef USING_SCOPE_INFO
 //------------------------------------------------------------------------
 // getSiVarLoc: Returns a "siVarLoc" instance representing the place where the variable

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -82,7 +82,7 @@ bool CodeGenInterface::siVarLoc::vlIsInReg(regNumber reg) const
     }
 }
 
-bool CodeGenInterface::siVarLoc::vlIsOnStk(regNumber reg, signed offset) const
+bool CodeGenInterface::siVarLoc::vlIsOnStack(regNumber reg, signed offset) const
 {
     regNumber actualReg;
 
@@ -128,6 +128,62 @@ bool CodeGenInterface::siVarLoc::vlIsOnStk(regNumber reg, signed offset) const
             assert(!"Bad locType");
             return false;
     }
+}
+
+bool CodeGenInterface::siVarLoc::vlIsOnStack() const
+{
+    switch (vlType)
+    {
+        case CodeGenInterface::VLT_STK:
+        case CodeGenInterface::VLT_STK2:
+        case CodeGenInterface::VLT_FPSTK:
+            return true;
+
+        default:
+            return false;
+    }
+}
+
+//------------------------------------------------------------------------
+// storeVariableOnRegisters: Convert the siVarLoc instance in a regsiter
+//  location using the given registers.
+//
+// Arguments:
+//    reg       - the first register where the variable is placed.
+//    otherReg  - the second register where the variable is placed
+//      or REG_NA if does not apply.
+//
+void CodeGenInterface::siVarLoc::storeVariableOnRegisters(regNumber reg, regNumber otherReg)
+{
+    if (otherReg == REG_NA)
+    {
+        // Only one register is used
+        vlType       = VLT_REG;
+        vlReg.vlrReg = reg;
+    }
+    else
+    {
+        // Two register are used
+        vlType            = VLT_REG_REG;
+        vlRegReg.vlrrReg1 = reg;
+        vlRegReg.vlrrReg2 = otherReg;
+    }
+}
+
+//------------------------------------------------------------------------
+// storeVariableOnStack: Convert the siVarLoc instance in a stack location
+//  with the given base register and stack offset.
+//
+// Arguments:
+//    stackBaseReg      - the base of the stack.
+//    varStackOffset    - the offset from the base where the variable is
+//      is placed.
+//
+void CodeGenInterface::siVarLoc::storeVariableOnStack(regNumber stackBaseReg, NATIVE_OFFSET varStackOffset)
+{
+    vlType           = VLT_STK;
+    vlStk.vlsBaseReg = stackBaseReg;
+    vlStk.vlsOffset  = varStackOffset;
 }
 
 //------------------------------------------------------------------------
@@ -1275,34 +1331,49 @@ void CodeGen::psiEndPrologScope(psiScope* scope)
  */
 
 //------------------------------------------------------------------------
-// psSetScopeOffset: Set the offset of the newScope to the offset of the LslVar
+// psiSetScopeOffset: Set the offset of the newScope to the offset of the LslVar
 //
 // Arguments:
 //    'newScope'  the new scope object whose offset is to be set to the lclVarDsc offset.
 //    'lclVarDsc' is an op that will now be contained by its parent.
-//
-//
-void CodeGen::psSetScopeOffset(psiScope* newScope, LclVarDsc* lclVarDsc)
+void CodeGen::psiSetScopeOffset(psiScope* newScope, const LclVarDsc* lclVarDsc) const
 {
     newScope->scRegister   = false;
     newScope->u2.scBaseReg = REG_SPBASE;
+    newScope->u2.scOffset  = psiGetVarStackOffset(lclVarDsc);
+}
+#endif // USING_SCOPE_INFO
+
+//------------------------------------------------------------------------
+// psiGetVarStackOffset: Return the offset of the lclVarDsc on the stack.
+//
+// Arguments:
+//    lclVarDsc - the LclVarDsc from whom the offset is asked.
+//
+NATIVE_OFFSET CodeGen::psiGetVarStackOffset(const LclVarDsc* lclVarDsc) const
+{
+    noway_assert(lclVarDsc != nullptr);
+
+    NATIVE_OFFSET stackOffset = 0;
 
 #ifdef _TARGET_AMD64_
     // scOffset = offset from caller SP - REGSIZE_BYTES
     // TODO-Cleanup - scOffset needs to be understood.  For now just matching with the existing definition.
-    newScope->u2.scOffset =
+    stackOffset =
         compiler->lvaToCallerSPRelativeOffset(lclVarDsc->lvStkOffs, lclVarDsc->lvFramePointerBased) + REGSIZE_BYTES;
 #else  // !_TARGET_AMD64_
     if (doubleAlignOrFramePointerUsed())
     {
         // REGSIZE_BYTES - for the pushed value of EBP
-        newScope->u2.scOffset = lclVarDsc->lvStkOffs - REGSIZE_BYTES;
+        stackOffset = lclVarDsc->lvStkOffs - REGSIZE_BYTES;
     }
     else
     {
-        newScope->u2.scOffset = lclVarDsc->lvStkOffs - genTotalFrameSize();
+        stackOffset = lclVarDsc->lvStkOffs - genTotalFrameSize();
     }
 #endif // !_TARGET_AMD64_
+
+    return stackOffset;
 }
 
 /*============================================================================
@@ -1310,45 +1381,48 @@ void CodeGen::psSetScopeOffset(psiScope* newScope, LclVarDsc* lclVarDsc)
 *============================================================================
 */
 
-/*****************************************************************************
- *                          psiBegProlog
- *
- * Initializes the PrologScopeInfo, and creates open scopes for all the
- * parameters of the method.
- */
-
+//------------------------------------------------------------------------
+// psiBegProlog: Initializes the PrologScopeInfo creating open psiScopes or
+//  VariableLiveRanges for all the parameters of the method depending on which
+//  flag is being used.
+//
 void CodeGen::psiBegProlog()
 {
     assert(compiler->compGeneratingProlog);
 
-    VarScopeDsc* varScope;
-
+#ifdef USING_SCOPE_INFO
     psiOpenScopeList.scNext = nullptr;
     psiOpenScopeLast        = &psiOpenScopeList;
     psiScopeLast            = &psiScopeList;
     psiScopeCnt             = 0;
+#endif // USING_SCOPE_INFO
 
     compiler->compResetScopeLists();
 
+    VarScopeDsc* varScope;
     while ((varScope = compiler->compGetNextEnterScope(0)) != nullptr)
     {
-        LclVarDsc* lclVarDsc1 = &compiler->lvaTable[varScope->vsdVarNum];
+        LclVarDsc* lclVarDsc = &compiler->lvaTable[varScope->vsdVarNum];
 
-        if (!lclVarDsc1->lvIsParam)
+        if (!lclVarDsc->lvIsParam)
         {
             continue;
         }
-
+#ifdef USING_SCOPE_INFO
         psiScope* newScope = psiNewPrologScope(varScope->vsdLVnum, varScope->vsdVarNum);
+#endif // USING_SCOPE_INFO
+#ifdef USING_VARIABLE_LIVE_RANGE
+        siVarLoc varHome;
+#endif // USING_VARIABLE_LIVE_RANGE
 
-        if (lclVarDsc1->lvIsRegArg)
+        if (lclVarDsc->lvIsRegArg)
         {
             bool isStructHandled = false;
 #if defined(UNIX_AMD64_ABI)
             SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR structDesc;
-            if (varTypeIsStruct(lclVarDsc1))
+            if (varTypeIsStruct(lclVarDsc))
             {
-                CORINFO_CLASS_HANDLE typeHnd = lclVarDsc1->lvVerTypeInfo.GetClassHandle();
+                CORINFO_CLASS_HANDLE typeHnd = lclVarDsc->lvVerTypeInfo.GetClassHandle();
                 assert(typeHnd != nullptr);
                 compiler->eeGetSystemVAmd64PassStructInRegisterDescriptor(typeHnd, &structDesc);
                 if (structDesc.passedInRegisters)
@@ -1362,11 +1436,11 @@ void CodeGen::psiBegProlog()
 
                         if (nCnt == 0)
                         {
-                            regNum = lclVarDsc1->lvArgReg;
+                            regNum = lclVarDsc->lvArgReg;
                         }
                         else if (nCnt == 1)
                         {
-                            otherRegNum = lclVarDsc1->lvOtherArgReg;
+                            otherRegNum = lclVarDsc->lvOtherArgReg;
                         }
                         else
                         {
@@ -1379,15 +1453,25 @@ void CodeGen::psiBegProlog()
                         assert(genMapRegNumToRegArgNum((nCnt == 0 ? regNum : otherRegNum), regType) != (unsigned)-1);
 #endif // DEBUG
                     }
-
+#ifdef USING_SCOPE_INFO
                     newScope->scRegister    = true;
                     newScope->u1.scRegNum   = (regNumberSmall)regNum;
                     newScope->u1.scOtherReg = (regNumberSmall)otherRegNum;
+#endif // USING_SCOPE_INFO
+
+#ifdef USING_VARIABLE_RANGE
+                    varHome.storeVariableOnRegisters(regNum, otherRegNum);
+#endif // USING_VARIABLE_RANGE
                 }
                 else
                 {
-                    // Stack passed argument. Get the offset from the  caller's frame.
-                    psSetScopeOffset(newScope, lclVarDsc1);
+// Stack passed argument. Get the offset from the  caller's frame.
+#ifdef USING_SCOPE_INFO
+                    psiSetScopeOffset(newScope, lclVarDsc);
+#endif // USING_SCOPE_INFO
+#ifdef USING_VARIABLE_LIVE_RANGE
+                    varHome.storeVariableOnStack(REG_SPBASE, psiGetVarStackOffset(lclVarDsc));
+#endif // USING_VARIABLE_LIVE_RANGE
                 }
 
                 isStructHandled = true;
@@ -1396,24 +1480,65 @@ void CodeGen::psiBegProlog()
             if (!isStructHandled)
             {
 #ifdef DEBUG
-                var_types regType = compiler->mangleVarArgsType(lclVarDsc1->TypeGet());
-                if (lclVarDsc1->lvIsHfaRegArg())
+                var_types regType = compiler->mangleVarArgsType(lclVarDsc->TypeGet());
+                if (lclVarDsc->lvIsHfaRegArg())
                 {
-                    regType = lclVarDsc1->GetHfaType();
+                    regType = lclVarDsc->GetHfaType();
                 }
-                assert(genMapRegNumToRegArgNum(lclVarDsc1->lvArgReg, regType) != (unsigned)-1);
+                assert(genMapRegNumToRegArgNum(lclVarDsc->lvArgReg, regType) != (unsigned)-1);
 #endif // DEBUG
 
+#ifdef USING_SCOPE_INFO
                 newScope->scRegister  = true;
-                newScope->u1.scRegNum = (regNumberSmall)lclVarDsc1->lvArgReg;
+                newScope->u1.scRegNum = (regNumberSmall)lclVarDsc->lvArgReg;
+#endif // USING_SCOPE_INFO
+#ifdef USING_VARIABLE_LIVE_RANGE
+                varHome.storeVariableOnRegisters(lclVarDsc->lvArgReg, REG_NA);
+#endif // USING_VARIABLE_LIVE_RANGE
             }
         }
         else
         {
-            psSetScopeOffset(newScope, lclVarDsc1);
+#ifdef USING_SCOPE_INFO
+            psiSetScopeOffset(newScope, lclVarDsc);
+#endif // USING_SCOPE_INFO
+#ifdef USING_VARIABLE_LIVE_RANGE
+            varHome.storeVariableOnStack(REG_SPBASE, psiGetVarStackOffset(lclVarDsc));
+#endif // USING_VARIABLE_LIVE_RANGE
         }
+
+#ifdef USING_VARIABLE_LIVE_RANGE
+        // Start a VariableLiveRange for this LclVarDsc on the built location
+        VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
+        varLvKeeper->psiStartVariableLiveRange(varHome, varScope->vsdVarNum);
+#endif // USING_VARIABLE_LIVE_RANGE
     }
 }
+
+//------------------------------------------------------------------------
+// psiEndProlog: Close all the open "psiScope" or "VariableLiveRanges"
+//  after prolog has been generated.
+//
+// Notes:
+//  This function is expected to be called after prolog code has been generated.
+//
+void CodeGen::psiEndProlog()
+{
+    assert(compiler->compGeneratingProlog);
+#ifdef USING_SCOPE_INFO
+    for (psiScope* scope = psiOpenScopeList.scNext; scope; scope = psiOpenScopeList.scNext)
+    {
+        psiEndPrologScope(scope);
+    }
+#endif
+
+#ifdef USING_VARIABLE_LIVE_RANGE
+    VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
+    varLiveKeeper->psiClosePrologVariableRanges();
+#endif // USING_VARIABLE_LIVE_RANGE
+}
+
+#ifdef USING_SCOPE_INFO
 
 /*****************************************************************************
  Enable this macro to get accurate prolog information for every instruction
@@ -1629,20 +1754,5 @@ void CodeGen::psiMoveToStack(unsigned varNum)
            !"Parameter scope not found (Assert doesnt always indicate error)");
 
 #endif // ACCURATE_PROLOG_DEBUG_INFO
-}
-
-/*****************************************************************************
- *                          psiEndProlog
- */
-
-void CodeGen::psiEndProlog()
-{
-    assert(compiler->compGeneratingProlog);
-    psiScope* scope;
-
-    for (scope = psiOpenScopeList.scNext; scope; scope = psiOpenScopeList.scNext)
-    {
-        psiEndPrologScope(scope);
-    }
 }
 #endif // USING_SCOPE_INFO

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -412,6 +412,37 @@ CodeGenInterface::siVarLoc::siVarLoc(const LclVarDsc* varDsc, regNumber baseReg,
     }
 }
 
+//------------------------------------------------------------------------
+// getSiVarLoc: Returns a "siVarLoc" instance representing the variable home.
+//
+// Arguments:
+//    varDsc       - the variable it is desired to build the "siVarLoc".
+//    stackLevel   - the stack variables in case frame is not hold by ebp
+//
+// Return Value:
+//    A "siVarLoc" representing the variable home, which could live
+//    in a register, an stack position, or a combination of both.
+//
+CodeGenInterface::siVarLoc CodeGenInterface::getSiVarLoc(const LclVarDsc* varDsc, unsigned int stackLevel) const
+{
+    // For stack vars, find the base register, and offset
+
+    regNumber baseReg;
+    signed    offset = varDsc->lvStkOffs;
+
+    if (!varDsc->lvFramePointerBased)
+    {
+        baseReg = REG_SPBASE;
+        offset += stackLevel;
+    }
+    else
+    {
+        baseReg = REG_FPBASE;
+    }
+
+    return CodeGenInterface::siVarLoc(varDsc, baseReg, offset, isFramePointerUsed());
+}
+
 #ifdef USING_SCOPE_INFO
 //------------------------------------------------------------------------
 // getSiVarLoc: Returns a "siVarLoc" instance representing the place where the variable

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -501,7 +501,7 @@ CodeGenInterface::siVarLoc CodeGenInterface::getSiVarLoc(const LclVarDsc* varDsc
     return CodeGenInterface::siVarLoc(varDsc, baseReg, offset, isFramePointerUsed());
 }
 
-#if DEBUG
+#ifdef DEBUG
 void CodeGenInterface::dumpSiVarLoc(const siVarLoc* varLoc) const
 {
     // "varLoc" cannot be null
@@ -1018,14 +1018,12 @@ void CodeGen::siBeginBlock(BasicBlock* block)
         siOpenScopesForNonTrackedVars(block, siLastEndOffs);
     }
 
-#ifdef USING_SCOPE_INFO
-#ifdef DEBUG
+#if defined(USING_SCOPE_INFO) && defined(DEBUG)
     if (verbose)
     {
         siDispOpenScopes();
     }
-#endif // DEBUG
-#endif // USING_SCOPE_INFO
+#endif // defined(USING_SCOPE_INFO) && defined(DEBUG)
 }
 
 //------------------------------------------------------------------------
@@ -1115,8 +1113,7 @@ void CodeGen::siOpenScopesForNonTrackedVars(const BasicBlock* block, unsigned in
                 compiler->getVariableLiveKeeper()->siStartVariableLiveRange(lclVarDsc, varScope->vsdVarNum);
 #endif // USING_VARIABLE_LIVE_RANGE
 
-#ifdef DEBUG
-#ifdef USING_SCOPE_INFO
+#if defined(DEBUG) && defined(USING_SCOPE_INFO)
                 if (VERBOSE)
                 {
                     printf("Scope info: >> new scope, VarNum=%u, tracked? %s, VarIndex=%u, bbLiveIn=%s ",
@@ -1125,10 +1122,10 @@ void CodeGen::siOpenScopesForNonTrackedVars(const BasicBlock* block, unsigned in
                     dumpConvertedVarSet(compiler, block->bbLiveIn);
                     printf("\n");
                 }
-#endif // USING_SCOPE_INFO
+#endif // defined(DEBUG) && defined(USING_SCOPE_INFO)
 
-                assert(!lclVarDsc->lvTracked || VarSetOps::IsMember(compiler, block->bbLiveIn, lclVarDsc->lvVarIndex));
-#endif // DEBUG
+                INDEBUG(assert(!lclVarDsc->lvTracked ||
+                               VarSetOps::IsMember(compiler, block->bbLiveIn, lclVarDsc->lvVarIndex)));
             }
             else
             {

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -1543,7 +1543,7 @@ void CodeGen::psiBegProlog()
         psiScope* newScope = psiNewPrologScope(varScope->vsdLVnum, varScope->vsdVarNum);
 #endif // USING_SCOPE_INFO
 #ifdef USING_VARIABLE_LIVE_RANGE
-        siVarLoc varHome;
+        siVarLoc varLocation;
 #endif // USING_VARIABLE_LIVE_RANGE
 
         if (lclVarDsc->lvIsRegArg)
@@ -1591,7 +1591,7 @@ void CodeGen::psiBegProlog()
 #endif // USING_SCOPE_INFO
 
 #ifdef USING_VARIABLE_RANGE
-                    varHome.storeVariableInRegisters(regNum, otherRegNum);
+                    varLocation.storeVariableInRegisters(regNum, otherRegNum);
 #endif // USING_VARIABLE_RANGE
                 }
                 else
@@ -1601,7 +1601,7 @@ void CodeGen::psiBegProlog()
                     psiSetScopeOffset(newScope, lclVarDsc);
 #endif // USING_SCOPE_INFO
 #ifdef USING_VARIABLE_LIVE_RANGE
-                    varHome.storeVariableOnStack(REG_SPBASE, psiGetVarStackOffset(lclVarDsc));
+                    varLocation.storeVariableOnStack(REG_SPBASE, psiGetVarStackOffset(lclVarDsc));
 #endif // USING_VARIABLE_LIVE_RANGE
                 }
 
@@ -1624,7 +1624,7 @@ void CodeGen::psiBegProlog()
                 newScope->u1.scRegNum = (regNumberSmall)lclVarDsc->lvArgReg;
 #endif // USING_SCOPE_INFO
 #ifdef USING_VARIABLE_LIVE_RANGE
-                varHome.storeVariableInRegisters(lclVarDsc->lvArgReg, REG_NA);
+                varLocation.storeVariableInRegisters(lclVarDsc->lvArgReg, REG_NA);
 #endif // USING_VARIABLE_LIVE_RANGE
             }
         }
@@ -1634,14 +1634,14 @@ void CodeGen::psiBegProlog()
             psiSetScopeOffset(newScope, lclVarDsc);
 #endif // USING_SCOPE_INFO
 #ifdef USING_VARIABLE_LIVE_RANGE
-            varHome.storeVariableOnStack(REG_SPBASE, psiGetVarStackOffset(lclVarDsc));
+            varLocation.storeVariableOnStack(REG_SPBASE, psiGetVarStackOffset(lclVarDsc));
 #endif // USING_VARIABLE_LIVE_RANGE
         }
 
 #ifdef USING_VARIABLE_LIVE_RANGE
         // Start a VariableLiveRange for this LclVarDsc on the built location
         VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
-        varLvKeeper->psiStartVariableLiveRange(varHome, varScope->vsdVarNum);
+        varLvKeeper->psiStartVariableLiveRange(varLocation, varScope->vsdVarNum);
 #endif // USING_VARIABLE_LIVE_RANGE
     }
 }

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -145,7 +145,7 @@ bool CodeGenInterface::siVarLoc::vlIsOnStack() const
 }
 
 //------------------------------------------------------------------------
-// storeVariableOnRegisters: Convert the siVarLoc instance in a regsiter
+// storeVariableInRegisters: Convert the siVarLoc instance in a regsiter
 //  location using the given registers.
 //
 // Arguments:
@@ -153,7 +153,7 @@ bool CodeGenInterface::siVarLoc::vlIsOnStack() const
 //    otherReg  - the second register where the variable is placed
 //      or REG_NA if does not apply.
 //
-void CodeGenInterface::siVarLoc::storeVariableOnRegisters(regNumber reg, regNumber otherReg)
+void CodeGenInterface::siVarLoc::storeVariableInRegisters(regNumber reg, regNumber otherReg)
 {
     if (otherReg == REG_NA)
     {
@@ -177,7 +177,7 @@ void CodeGenInterface::siVarLoc::storeVariableOnRegisters(regNumber reg, regNumb
 // Arguments:
 //    stackBaseReg      - the base of the stack.
 //    varStackOffset    - the offset from the base where the variable is
-//      is placed.
+//                        is placed.
 //
 void CodeGenInterface::siVarLoc::storeVariableOnStack(regNumber stackBaseReg, NATIVE_OFFSET varStackOffset)
 {
@@ -473,7 +473,9 @@ CodeGenInterface::siVarLoc::siVarLoc(const LclVarDsc* varDsc, regNumber baseReg,
 //
 // Arguments:
 //    varDsc       - the variable it is desired to build the "siVarLoc".
-//    stackLevel   - the stack variables in case frame is not hold by ebp
+//    stackLevel   - the current stack level. If the stack pointer changes in
+//                   the function, we must adjust stack pointer-based local
+//                   variable offsets to compensate.
 //
 // Return Value:
 //    A "siVarLoc" representing the variable home, which could live
@@ -552,7 +554,7 @@ void CodeGenInterface::dumpSiVarLoc(const siVarLoc* varLoc) const
             break;
 
         case VLT_STK_REG:
-            unreached(); // unexpected
+            unreached();
 
         case VLT_STK2:
             if ((int)varLoc->vlStk2.vls2BaseReg != (int)ICorDebugInfo::REGNUM_AMBIENT_SP)
@@ -575,7 +577,7 @@ void CodeGenInterface::dumpSiVarLoc(const siVarLoc* varLoc) const
 #endif // !_TARGET_AMD64_
 
         default:
-            unreached(); // unexpected
+            unreached();
     }
 }
 #endif
@@ -1541,7 +1543,7 @@ void CodeGen::psiBegProlog()
 #endif // USING_SCOPE_INFO
 
 #ifdef USING_VARIABLE_RANGE
-                    varHome.storeVariableOnRegisters(regNum, otherRegNum);
+                    varHome.storeVariableInRegisters(regNum, otherRegNum);
 #endif // USING_VARIABLE_RANGE
                 }
                 else
@@ -1574,7 +1576,7 @@ void CodeGen::psiBegProlog()
                 newScope->u1.scRegNum = (regNumberSmall)lclVarDsc->lvArgReg;
 #endif // USING_SCOPE_INFO
 #ifdef USING_VARIABLE_LIVE_RANGE
-                varHome.storeVariableOnRegisters(lclVarDsc->lvArgReg, REG_NA);
+                varHome.storeVariableInRegisters(lclVarDsc->lvArgReg, REG_NA);
 #endif // USING_VARIABLE_LIVE_RANGE
             }
         }

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -1589,9 +1589,9 @@ void CodeGen::psiBegProlog()
                     newScope->u1.scOtherReg = (regNumberSmall)otherRegNum;
 #endif // USING_SCOPE_INFO
 
-#ifdef USING_VARIABLE_RANGE
+#ifdef USING_VARIABLE_LIVE_RANGE
                     varLocation.storeVariableInRegisters(regNum, otherRegNum);
-#endif // USING_VARIABLE_RANGE
+#endif // USING_VARIABLE_LIVE_RANGE
                 }
                 else
                 {

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -896,6 +896,8 @@ void CodeGen::siInit()
     }
 #endif // FEATURE_EH_FUNCLETS
 
+    siLastEndOffs = 0;
+
 #ifdef USING_SCOPE_INFO
     siOpenScopeList.scNext = nullptr;
     siOpenScopeLast        = &siOpenScopeList;
@@ -904,7 +906,6 @@ void CodeGen::siInit()
     siScopeCnt = 0;
 
     VarSetOps::AssignNoCopy(compiler, siLastLife, VarSetOps::MakeEmpty(compiler));
-    siLastEndOffs = 0;
 
     if (compiler->info.compVarScopesCount == 0)
     {
@@ -1137,7 +1138,6 @@ void CodeGen::siOpenScopesForNonTrackedVars(const BasicBlock* block, unsigned in
     }
 }
 
-#ifdef USING_SCOPE_INFO
 /*****************************************************************************
  *                          siEndBlock
  *
@@ -1157,14 +1157,14 @@ void CodeGen::siEndBlock(BasicBlock* block)
     }
 #endif // FEATURE_EH_FUNCLETS
 
-#ifdef DEBUG
+#if defined(USING_SCOPE_INFO) && defined(DEBUG)
     if (verbose)
     {
         printf("\nScope info: end block " FMT_BB ", IL range ", block->bbNum);
         block->dspBlockILRange();
         printf("\n");
     }
-#endif // DEBUG
+#endif // defined(USING_SCOPE_INFO) && defined(DEBUG)
 
     unsigned endOffs = block->bbCodeOffsEnd;
 
@@ -1174,6 +1174,7 @@ void CodeGen::siEndBlock(BasicBlock* block)
         return;
     }
 
+#ifdef USING_SCOPE_INFO
     // If non-debuggable code, find all scopes which end over this block
     // and close them. For debuggable code, scopes will only end on block
     // boundaries.
@@ -1199,17 +1200,19 @@ void CodeGen::siEndBlock(BasicBlock* block)
             siEndScope(varNum);
         }
     }
+#endif // USING_SCOPE_INFO
 
     siLastEndOffs = endOffs;
 
-#ifdef DEBUG
+#if defined(USING_SCOPE_INFO) && defined(DEBUG)
     if (verbose)
     {
         siDispOpenScopes();
     }
-#endif
+#endif // defined(USING_SCOPE_INFO) && defined(DEBUG)
 }
 
+#ifdef USING_SCOPE_INFO
 //------------------------------------------------------------------------
 // siUpdate: Closes the "ScopeInfo" of the tracked variables that has become dead.
 //

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -176,8 +176,7 @@ void CodeGenInterface::siVarLoc::storeVariableInRegisters(regNumber reg, regNumb
 //
 // Arguments:
 //    stackBaseReg      - the base of the stack.
-//    varStackOffset    - the offset from the base where the variable is
-//                        is placed.
+//    varStackOffset    - the offset from the base where the variable is placed.
 //
 void CodeGenInterface::siVarLoc::storeVariableOnStack(regNumber stackBaseReg, NATIVE_OFFSET varStackOffset)
 {

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -1640,8 +1640,7 @@ void CodeGen::psiBegProlog()
 
 #ifdef USING_VARIABLE_LIVE_RANGE
         // Start a VariableLiveRange for this LclVarDsc on the built location
-        VariableLiveKeeper* varLvKeeper = compiler->getVariableLiveKeeper();
-        varLvKeeper->psiStartVariableLiveRange(varLocation, varScope->vsdVarNum);
+        compiler->getVariableLiveKeeper()->psiStartVariableLiveRange(varLocation, varScope->vsdVarNum);
 #endif // USING_VARIABLE_LIVE_RANGE
     }
 }
@@ -1664,8 +1663,7 @@ void CodeGen::psiEndProlog()
 #endif
 
 #ifdef USING_VARIABLE_LIVE_RANGE
-    VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
-    varLiveKeeper->psiClosePrologVariableRanges();
+    compiler->getVariableLiveKeeper()->psiClosePrologVariableRanges();
 #endif // USING_VARIABLE_LIVE_RANGE
 }
 

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -469,7 +469,7 @@ CodeGenInterface::siVarLoc::siVarLoc(const LclVarDsc* varDsc, regNumber baseReg,
 }
 
 //------------------------------------------------------------------------
-// getSiVarLoc: Returns a "siVarLoc" instance representing the variable home.
+// getSiVarLoc: Returns a "siVarLoc" instance representing the variable location.
 //
 // Arguments:
 //    varDsc       - the variable it is desired to build the "siVarLoc".
@@ -478,7 +478,7 @@ CodeGenInterface::siVarLoc::siVarLoc(const LclVarDsc* varDsc, regNumber baseReg,
 //                   variable offsets to compensate.
 //
 // Return Value:
-//    A "siVarLoc" representing the variable home, which could live
+//    A "siVarLoc" representing the variable location, which could live
 //    in a register, an stack position, or a combination of both.
 //
 CodeGenInterface::siVarLoc CodeGenInterface::getSiVarLoc(const LclVarDsc* varDsc, unsigned int stackLevel) const

--- a/src/jit/treelifeupdater.cpp
+++ b/src/jit/treelifeupdater.cpp
@@ -246,9 +246,11 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
 #endif // DEBUG
             }
 
+#ifdef USING_VARIABLE_LIVE_RANGE
             // For each of the LclVarDsc that are reporting change, variable or fields
             VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
             varLiveKeeper->siStartOrCloseVariableLiveRanges(&varDeltaSet, isBorn, isDying);
+#endif // USING_VARIABLE_LIVE_RANGE
 
 #ifdef USING_SCOPE_INFO
             compiler->codeGen->siUpdate();

--- a/src/jit/treelifeupdater.cpp
+++ b/src/jit/treelifeupdater.cpp
@@ -245,6 +245,11 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
                 }
 #endif // DEBUG
             }
+
+            // For each of the LclVarDsc that are reporting change, variable or fields
+            VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
+            varLiveKeeper->siStartOrCloseVariableLiveRanges(&varDeltaSet, isBorn, isDying);
+
 #ifdef USING_SCOPE_INFO
             compiler->codeGen->siUpdate();
 #endif // USING_SCOPE_INFO

--- a/src/jit/treelifeupdater.cpp
+++ b/src/jit/treelifeupdater.cpp
@@ -248,8 +248,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
 
 #ifdef USING_VARIABLE_LIVE_RANGE
             // For each of the LclVarDsc that are reporting change, variable or fields
-            VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
-            varLiveKeeper->siStartOrCloseVariableLiveRanges(varDeltaSet, isBorn, isDying);
+            compiler->getVariableLiveKeeper()->siStartOrCloseVariableLiveRanges(varDeltaSet, isBorn, isDying);
 #endif // USING_VARIABLE_LIVE_RANGE
 
 #ifdef USING_SCOPE_INFO

--- a/src/jit/treelifeupdater.cpp
+++ b/src/jit/treelifeupdater.cpp
@@ -249,7 +249,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
 #ifdef USING_VARIABLE_LIVE_RANGE
             // For each of the LclVarDsc that are reporting change, variable or fields
             VariableLiveKeeper* varLiveKeeper = compiler->getVariableLiveKeeper();
-            varLiveKeeper->siStartOrCloseVariableLiveRanges(&varDeltaSet, isBorn, isDying);
+            varLiveKeeper->siStartOrCloseVariableLiveRanges(varDeltaSet, isBorn, isDying);
 #endif // USING_VARIABLE_LIVE_RANGE
 
 #ifdef USING_SCOPE_INFO


### PR DESCRIPTION
This is a rephrasing of [other PR](https://github.com/dotnet/coreclr/pull/22770) that is quite huge.

I have splitted that main PR in different PRs:

1. [Adding comments](https://github.com/dotnet/coreclr/pull/23327): **not merged** and not included here.
2. [Moving gen stack level to code gen interface](https://github.com/dotnet/coreclr/pull/23328): **merged**.
3. [Adding const to functions that don't change or shouldn't change state](https://github.com/dotnet/coreclr/pull/23329): **merged**
4. [Adding a flag to able/disable scope info](https://github.com/dotnet/coreclr/pull/23298) **merged**

I am reporting arguments, special arguments and IL local variables. The integration has been checked from VS IDE.

I am writing a file for the documentation of the repository about reporting variable home.