### PR TITLE
[WIP] Add corefx tests to coreclr test runs.

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -23,6 +23,10 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>f9decfe63aadb21139c048ce3ea43982982e5000</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="2.2.0-beta.19162.7">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>443dea11f8649fe12fedf60cfab0a4b2b20bd153</Sha>
+    </Dependency>
     <Dependency Name="optimization.IBC.CoreCLR" Version="99.99.99-master-20190313.3">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>
       <Sha>4f9d0ecf2b8151859fd2bd0734af32ea59258a3d</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,9 +9,11 @@
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
     <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.19179.4</MicrosoftDotNetXUnitConsoleRunnerVersion>
     <MicrosoftNetFrameworkReferenceAssembliesVersion>1.0.0-alpha-004</MicrosoftNetFrameworkReferenceAssembliesVersion>
+
     <MicrosoftPrivateCoreFxNETCoreAppVersion>4.6.0-preview5.19214.16</MicrosoftPrivateCoreFxNETCoreAppVersion>
     <MicrosoftNETCorePlatformsVersion>3.0.0-preview5.19214.16</MicrosoftNETCorePlatformsVersion>
     <MicrosoftNETCoreAppVersion>3.0.0-preview5-27614-10</MicrosoftNETCoreAppVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>2.2.0-beta.19162.7</MicrosoftDotNetBuildTasksFeedVersion>
     <optimizationIBCCoreCLRVersion>99.99.99-master-20190313.3</optimizationIBCCoreCLRVersion>
     <optimizationPGOCoreCLRVersion>99.99.99-master-20190313.3</optimizationPGOCoreCLRVersion>
   </PropertyGroup>

--- a/eng/helixcorefxtests.proj
+++ b/eng/helixcorefxtests.proj
@@ -17,9 +17,7 @@
     <HelixConfiguration>$(__BuildType)</HelixConfiguration>
 
     <!--
-      TODO: these should be moved to Directory.Build.props (from dir.props)
-      So dir.props doesn't need to be included. It wouldn't work anyway because it uses BuildOS, BuildArch and
-      BuildType, etc. instead of __BuildOS, __BuildArch, etc. to set the properties.
+      TODO: ProjectDir, RootBinDir, TestWorkingDir, and TargetsWindows are global properties set in dir.props, remove the property assignment here when we port to arcade.
      -->
     <ProjectDir Condition="'$(__ProjectDir)'==''">$(MSBuildThisFileDirectory)..\</ProjectDir>
     <RootBinDir Condition="'$(__RootBinDir)'==''">$(ProjectDir)bin\</RootBinDir>

--- a/eng/helixcorefxtests.proj
+++ b/eng/helixcorefxtests.proj
@@ -1,0 +1,111 @@
+<Project InitialTargets="BuildHelixWorkItems" Sdk="Microsoft.DotNet.Helix.Sdk">
+  <Import Project="$(NuGetPackageRoot)microsoft.dotnet.build.tasks.feed\$(MicrosoftDotNetBuildTasksFeedVersion)\build\Microsoft.DotNet.Build.Tasks.Feed.targets" />
+
+  <PropertyGroup>
+    <!-- Set the TargetFramework just to make the SDK happy -->
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Creator>$(_Creator)</Creator>
+    <HelixAccessToken>$(_HelixAccessToken)</HelixAccessToken>
+    <HelixBuild>$(_HelixBuild)</HelixBuild>
+    <HelixSource>$(_HelixSource)</HelixSource>
+    <HelixTargetQueues>$(_HelixTargetQueues)</HelixTargetQueues>
+    <HelixType>$(_HelixType)</HelixType>
+    <HelixArchitecture>$(__BuildArch)</HelixArchitecture>
+    <HelixConfiguration>$(__BuildType)</HelixConfiguration>
+
+    <!--
+      TODO: these should be moved to Directory.Build.props (from dir.props)
+      So dir.props doesn't need to be included. It wouldn't work anyway because it uses BuildOS, BuildArch and
+      BuildType, etc. instead of __BuildOS, __BuildArch, etc. to set the properties.
+     -->
+    <ProjectDir Condition="'$(__ProjectDir)'==''">$(MSBuildThisFileDirectory)..\</ProjectDir>
+    <RootBinDir Condition="'$(__RootBinDir)'==''">$(ProjectDir)bin\</RootBinDir>
+    <TestWorkingDir Condition="'$(__TestWorkingDir)'==''">$(RootBinDir)tests\$(__BuildOS).$(__BuildArch).$(__BuildType)\</TestWorkingDir>
+    <TargetsWindows Condition="'$(__BuildOS)' == 'Windows_NT'">true</TargetsWindows>
+
+    <TestHostRootPath>$(TestWorkingDir)testhost\</TestHostRootPath>
+    <TestArchiveRuntimeRoot>$(TestWorkingDir)helix\</TestArchiveRuntimeRoot>
+    <TestArchiveRuntimeFile>$(TestArchiveRuntimeRoot)testhost-runtime.zip</TestArchiveRuntimeFile>
+    <HelixCorrelationPayload></HelixCorrelationPayload>
+
+    <EnableAzurePipelinesReporter>$(_PublishTestResults)</EnableAzurePipelinesReporter>
+    <EnableAzurePipelinesReporter Condition=" '$(EnableAzurePipelinesReporter)' == '' ">false</EnableAzurePipelinesReporter>
+    <EnableXUnitReporter>true</EnableXUnitReporter>
+    <FailOnMissionControlTestFailure>true</FailOnMissionControlTestFailure>
+    <FailOnWorkItemFailure>true</FailOnWorkItemFailure>
+
+    <TimeoutInSeconds Condition="'$(TimeoutInSeconds)' == ''">600</TimeoutInSeconds>
+    <CommandTimeoutSpan>$([System.TimeSpan]::FromSeconds($(TimeoutInSeconds)))</CommandTimeoutSpan>
+    <MaxRetryCount Condition="'$(MaxRetryCount)' == ''">4</MaxRetryCount>
+    <WaitForWorkItemCompletion>true</WaitForWorkItemCompletion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AdditionalRunArguments>-notrait category=OuterLoop -notrait category=RequiresElevation</AdditionalRunArguments>
+    <!--
+      For windows we need to use call, since the command is going to be called from a bat script created by Helix
+      and we exit /b at the end of RunTests.cmd, Helix runs some other commands after ours within the bat script,
+      if we don't use call, then we cause the parent script to exit, and anything after will not be executed.
+      The arguments passed in to the run script in order are the runtime directory, the dotnet root directory (for
+      helix submissions same as the runtime directory) and the global tools directory.
+    -->
+    <HelixCommand Condition="'$(TargetsWindows)' == 'true'">call RunTests.cmd %HELIX_CORRELATION_PAYLOAD% %HELIX_CORRELATION_PAYLOAD% %HELIX_CORRELATION_PAYLOAD%\tools "$(AdditionalRunArguments)"</HelixCommand>
+    <HelixCommand Condition="'$(TargetsWindows)' != 'true'">./RunTests.sh $HELIX_CORRELATION_PAYLOAD $HELIX_CORRELATION_PAYLOAD $HELIX_CORRELATION_PAYLOAD/tools "$(AdditionalRunArguments)"</HelixCommand>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <TestArchiveRuntimeInputs Include="$(TestHostRootPath)**/*" />
+  </ItemGroup>
+
+  <Target Name="CompressRuntimeDirectory"
+          Inputs="@(TestArchiveRuntimeInputs)"
+          Outputs="$(TestArchiveRuntimeFile)">
+
+    <MakeDir Directories="$(TestArchiveRuntimeRoot)" />
+
+    <ZipDirectory
+        SourceDirectory="$(TestHostRootPath)"
+        DestinationFile="$(TestArchiveRuntimeFile)"
+        Overwrite="true" />
+
+    <Message Importance="High" Text="Zipped correlation payload into $(TestArchiveRuntimeFile)" />
+  </Target>
+
+  <PropertyGroup>
+    <TestAssetBlobFeedUrl>https://dotnetfeed.blob.core.windows.net/dotnet-core</TestAssetBlobFeedUrl>
+  </PropertyGroup>
+
+  <Target Name="GetTestAssetManifest" 
+          Returns="@(TestAssetBlobInfos)">
+
+    <PropertyGroup>
+      <_TargetGroup>netcoreapp</_TargetGroup>
+      <_AssetManifestPath>$(TestAssetBlobFeedUrl)/corefx-tests/$(MicrosoftPrivateCoreFxNETCoreAppVersion)/$(__BuildOS).$(__BuildArch)/$(_TargetGroup)/corefx-test-assets.xml</_AssetManifestPath>
+    </PropertyGroup>
+
+    <ParseBuildManifest AssetManifestPath="$(_AssetManifestPath)">
+      <Output TaskParameter="BlobInfos" ItemName="TestAssetBlobInfos" />
+    </ParseBuildManifest>
+  </Target>
+
+  <Target Name="BuildHelixWorkItems"
+          Inputs="$(TestArchiveRuntimeFile);@(TestAssetBlobInfos)"
+          Outputs="@(HelixCorrelationPayload);@(HelixWorkItem)"
+          DependsOnTargets="CompressRuntimeDirectory;GetTestAssetManifest">
+
+    <ItemGroup>
+      <HelixCorrelationPayload Include="$(TestArchiveRuntimeFile)" />
+
+      <HelixWorkItem Include="@(TestAssetBlobInfos -> '%(FileName)')">
+        <PayloadUri>$(TestAssetBlobFeedUrl)/%(Identity)</PayloadUri>
+        <Command>$(HelixCommand)</Command>
+        <Timeout>$(CommandTimeoutSpan)</Timeout>
+      </HelixWorkItem>
+    </ItemGroup>
+
+    <Message Importance="High" Text="@(HelixWorkItem -> '%(PayloadUri)')" />
+  </Target>
+</Project>

--- a/eng/send-to-helix-step.yml
+++ b/eng/send-to-helix-step.yml
@@ -15,7 +15,7 @@ parameters:
   timeoutPerTestCollectionInMinutes: ''
   timeoutPerTestInMinutes: ''
   runCrossGen: ''
-  helixProjectFile: ''
+  helixProjectArguments: ''
 
 steps:
 - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
@@ -25,7 +25,7 @@ steps:
     ${{ if ne(parameters.condition, '') }}:
       condition: ${{ parameters.condition }}
 
-  - powershell: eng\common\msbuild.ps1 -ci ${{ parameters.helixProjectFile }} /maxcpucount /bl:$(Build.SourcesDirectory)/bin/Logs/SendToHelix.binlog
+  - powershell: eng\common\msbuild.ps1 -ci ${{ parameters.helixProjectArguments }} /maxcpucount /bl:$(Build.SourcesDirectory)/bin/Logs/SendToHelix.binlog
     displayName: ${{ parameters.displayName }}
     ${{ if ne(parameters.condition, '') }}:
       condition: ${{ parameters.condition }}
@@ -60,7 +60,7 @@ steps:
         # Arcade uses this SDK instead of trying to restore one.
         DotNetCoreSdkDir: /usr/local/dotnet
 
-  - script: ./eng/common/msbuild.sh --ci ${{ parameters.helixProjectFile }} /maxcpucount /bl:$(Build.SourcesDirectory)/bin/Logs/SendToHelix.binlog
+  - script: ./eng/common/msbuild.sh --ci ${{ parameters.helixProjectArguments }} /maxcpucount /bl:$(Build.SourcesDirectory)/bin/Logs/SendToHelix.binlog
     displayName: ${{ parameters.displayName }}
     ${{ if ne(parameters.condition, '') }}:
       condition: ${{ parameters.condition }}

--- a/eng/send-to-helix-step.yml
+++ b/eng/send-to-helix-step.yml
@@ -15,10 +15,16 @@ parameters:
   timeoutPerTestCollectionInMinutes: ''
   timeoutPerTestInMinutes: ''
   runCrossGen: ''
+  helixProjectFile: ''
 
 steps:
 - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-  - powershell: eng\common\msbuild.ps1 -ci tests\helixpublishwitharcade.proj /maxcpucount
+  - powershell: eng\common\build.ps1 /p:DotNetPublishToBlobFeed=true -ci -restore -projects $(Build.SourcesDirectory)\eng\empty.proj
+    displayName: Restore blob feed tasks
+    ${{ if ne(parameters.condition, '') }}:
+      condition: ${{ parameters.condition }}
+
+  - powershell: eng\common\msbuild.ps1 -ci ${{ parameters.helixProjectFile }} /maxcpucount /bl:$(Build.SourcesDirectory)/bin/Logs/SendToHelix.binlog
     displayName: ${{ parameters.displayName }}
     ${{ if ne(parameters.condition, '') }}:
       condition: ${{ parameters.condition }}
@@ -39,9 +45,20 @@ steps:
       _TimeoutPerTestInMinutes: ${{ parameters.timeoutPerTestInMinutes }}
       ${{ if eq(parameters.publishTestResults, 'true') }}:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      # TODO: remove NUGET_PACKAGES once https://github.com/dotnet/arcade/issues/1578 is fixed
+      NUGET_PACKAGES: $(Build.SourcesDirectory)\.packages 
 
 - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-  - script: ./eng/common/msbuild.sh --ci tests/helixpublishwitharcade.proj /maxcpucount
+  - script: ./eng/common/build.sh /p:DotNetPublishToBlobFeed=true --ci --restore --projects $(Build.SourcesDirectory)/eng/empty.proj
+    displayName: Restore blob feed tasks
+    ${{ if ne(parameters.condition, '') }}:
+      condition: ${{ parameters.condition }}
+    ${{ if eq(parameters.osGroup, 'FreeBSD') }}:
+      env:
+        # Arcade uses this SDK instead of trying to restore one.
+        DotNetCoreSdkDir: /usr/local/dotnet
+
+  - script: ./eng/common/msbuild.sh --ci ${{ parameters.helixProjectFile }} /maxcpucount /bl:$(Build.SourcesDirectory)/bin/Logs/SendToHelix.binlog
     displayName: ${{ parameters.displayName }}
     ${{ if ne(parameters.condition, '') }}:
       condition: ${{ parameters.condition }}
@@ -62,3 +79,5 @@ steps:
       _TimeoutPerTestInMinutes: ${{ parameters.timeoutPerTestInMinutes }}
       ${{ if eq(parameters.publishTestResults, 'true') }}:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      # TODO: remove NUGET_PACKAGES once https://github.com/dotnet/arcade/issues/1578 is fixed
+      NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages

--- a/eng/send-to-helix-step.yml
+++ b/eng/send-to-helix-step.yml
@@ -19,6 +19,7 @@ parameters:
 
 steps:
 - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+  # TODO: Remove and consolidate this when we move to arcade via init-tools.cmd.
   - powershell: eng\common\build.ps1 /p:DotNetPublishToBlobFeed=true -ci -restore -projects $(Build.SourcesDirectory)\eng\empty.proj
     displayName: Restore blob feed tasks
     ${{ if ne(parameters.condition, '') }}:
@@ -49,6 +50,7 @@ steps:
       NUGET_PACKAGES: $(Build.SourcesDirectory)\.packages 
 
 - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
+  # TODO: Remove and consolidate this when we move to arcade via init-tools.sh.
   - script: ./eng/common/build.sh /p:DotNetPublishToBlobFeed=true --ci --restore --projects $(Build.SourcesDirectory)/eng/empty.proj
     displayName: Restore blob feed tasks
     ${{ if ne(parameters.condition, '') }}:

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -192,9 +192,9 @@ jobs:
 
         # Sets up the template to run the corefx tests
         ${{ if eq(parameters.corefxTests, true) }}:
-          helixProjectFile: 'eng/helixcorefxtests.proj /t:Test /p:ArcadeBuild=True'
+          helixProjectArguments: 'eng/helixcorefxtests.proj /t:Test /p:ArcadeBuild=True'
         ${{ if eq(parameters.corefxTests, false) }}:
-          helixProjectFile: 'tests/helixpublishwitharcade.proj'
+          helixProjectArguments: 'tests/helixpublishwitharcade.proj'
 
         ${{ if in(parameters.testGroup, 'innerloop', 'outerloop') }}:
           scenarios:

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -7,6 +7,8 @@ parameters:
   readyToRun: false
   helixQueues: ''
   crossrootfsDir: ''
+  # If true, run the corefx tests instead of the coreclr ones
+  corefxTests: false
 
 ### Test job
 
@@ -126,7 +128,7 @@ jobs:
     - template: /eng/send-to-helix-step.yml
       parameters:
         displayName: Send tests to Helix
-        buildConfig: ${{ parameters.buildConfig }}
+        buildConfig: $(buildConfigUpper)
         archType: ${{ parameters.archType }}
         osGroup: ${{ parameters.osGroup }}
 
@@ -177,6 +179,12 @@ jobs:
           # Access token variable for internal project from the
           # DotNet-HelixApi-Access variable group
           helixAccessToken: $(HelixApiAccessToken)
+
+        # Sets up the template to run the corefx tests
+        ${{ if eq(parameters.corefxTests, 'true') }}:
+          helixProjectFile: 'eng/helixcorefxtests.proj /t:Test /p:ArcadeBuild=True'
+        ${{ if ne(parameters.corefxTests, 'true') }}:
+          helixProjectFile: 'tests/helixpublishwitharcade.proj'
 
         ${{ if in(parameters.testGroup, 'innerloop', 'outerloop') }}:
           scenarios:

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -70,6 +70,16 @@ jobs:
       - name: clangArg
         value: '-clang5.0'
 
+    - name: testhostArg
+      value: ''
+    - ${{ if eq(parameters.corefxTests, true) }}:
+      - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
+        - name: testhostArg
+          value: 'generatetesthostonly'
+      - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+        - name: testhostArg
+          value: 'buildtesthostonly'
+
     # FreeBSD test jobs are disabled since we don't have any FreeBSD helix queues.
     ${{ if eq(parameters.osGroup, 'FreeBSD') }}:
       condition: false
@@ -117,10 +127,10 @@ jobs:
     # Build tests
     # TODO: enable crossgen in build-test.sh
     - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-      - script: ./build-test.sh $(buildConfig) $(archType) $(crossArg) $(priorityArg) $(crossgenArg) $(clangArg)
+      - script: ./build-test.sh $(buildConfig) $(archType) $(crossArg) $(priorityArg) $(crossgenArg) $(clangArg) $(testhostArg)
         displayName: Build tests
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-      - script: build-test.cmd $(buildConfig) $(archType) $(priorityArg) $(crossgenArg)
+      - script: build-test.cmd $(buildConfig) $(archType) $(priorityArg) $(crossgenArg) $(testhostArg)
         displayName: Build tests
 
 
@@ -181,9 +191,9 @@ jobs:
           helixAccessToken: $(HelixApiAccessToken)
 
         # Sets up the template to run the corefx tests
-        ${{ if eq(parameters.corefxTests, 'true') }}:
+        ${{ if eq(parameters.corefxTests, true) }}:
           helixProjectFile: 'eng/helixcorefxtests.proj /t:Test /p:ArcadeBuild=True'
-        ${{ if ne(parameters.corefxTests, 'true') }}:
+        ${{ if eq(parameters.corefxTests, false) }}:
           helixProjectFile: 'tests/helixpublishwitharcade.proj'
 
         ${{ if in(parameters.testGroup, 'innerloop', 'outerloop') }}:


### PR DESCRIPTION
This is still a work-in-progress. The test-job.yml template now has
a new flag "corefxTests" that can be set to enable corefx tests instead
of the coreclr ones. This flag can be passed through the platform-matrix.yml
template as a jobParameter.

There is no filtering done yet so there are lots of failures.

This change is waiting for an arcade change that allows arguments/traits
be passed to the runtest scripts to do filtering.

The last piece of this work is writing a build task that processes the
tests\corefx\corefx.issues.json file and creates the notraits/traits
arguments for each test. This build task can be based on the old corefx
test runner here: tests\src\Common\CoreFX\TestFileSetup.

Summary of the steps involved:

1) Select the helix .proj file to use based on the "corefxTests" flag (in test-job.yml)
2) Restore the blob feed build task: Microsoft.DotNet.Build.Tasks.Feed (in send-to-helix-step.yml)
3) Execute the helix msbuild file helixcorefxtests.proj (in send-to-helix-step.yml)
4) Run the CompressRuntimeDirectory target to zip up the "testhost" directory for the helix correlation payload (helixcorefxtests.proj)
5) Run the GetTestAssetManifest target to download and process the list of test asset zips (helixcorefxtests.proj)
6) Run the new build task to process the corefx.issues.json test filtering (not done yet).
7) Run the BuildTestAssetManifest target to build the HelixWorkItems from the test asset list (helixcorefxtests.proj)