### PR TITLE
[release/2.2] Add stack depth check to all Task continuations

### DIFF
--- a/src/mscorlib/src/System/Threading/Tasks/TaskScheduler.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/TaskScheduler.cs
@@ -186,12 +186,11 @@ namespace System.Threading.Tasks
             // Delegate cross-scheduler inlining requests to target scheduler
             if (ets != this && ets != null) return ets.TryRunInline(task, taskWasPreviouslyQueued);
 
-            StackGuard currentStackGuard;
             if ((ets == null) ||
                 (task.m_action == null) ||
                 task.IsDelegateInvoked ||
                 task.IsCanceled ||
-                (currentStackGuard = Task.CurrentStackGuard).TryBeginInliningScope() == false)
+                !RuntimeHelpers.TryEnsureSufficientExecutionStack())
             {
                 return false;
             }
@@ -199,28 +198,21 @@ namespace System.Threading.Tasks
             // Task class will still call into TaskScheduler.TryRunInline rather than TryExecuteTaskInline() so that 
             // 1) we can adjust the return code from TryExecuteTaskInline in case a buggy custom scheduler lies to us
             // 2) we maintain a mechanism for the TLS lookup optimization that we used to have for the ConcRT scheduler (will potentially introduce the same for TP)
-            bool bInlined = false;
-            try
+            if (TplEtwProvider.Log.IsEnabled())
             {
-                if (TplEtwProvider.Log.IsEnabled())
-                {
-                    task.FireTaskScheduledIfNeeded(this);
-                }
-                bInlined = TryExecuteTaskInline(task, taskWasPreviouslyQueued);
+                task.FireTaskScheduledIfNeeded(this);
             }
-            finally
-            {
-                currentStackGuard.EndInliningScope();
-            }
+
+            bool inlined = TryExecuteTaskInline(task, taskWasPreviouslyQueued);
 
             // If the custom scheduler returned true, we should either have the TASK_STATE_DELEGATE_INVOKED or TASK_STATE_CANCELED bit set
             // Otherwise the scheduler is buggy
-            if (bInlined && !(task.IsDelegateInvoked || task.IsCanceled))
+            if (inlined && !(task.IsDelegateInvoked || task.IsCanceled))
             {
                 throw new InvalidOperationException(SR.TaskScheduler_InconsistentStateAfterTryExecuteTaskInline);
             }
 
-            return bInlined;
+            return inlined;
         }
 
         /// <summary>


### PR DESCRIPTION
Port https://github.com/dotnet/coreclr/pull/23152 to release/2.2

Due to all of the file renames that have been made in master, cherry-pick didn't work, and I did a line-by-line manual port of the change.

#### Description

Currently Task has a stack depth check that avoids stack overflows on very deep stack continuation chains, but it only applies to Task.ContinueWith, not to other kinds of continuations. As await has been spreading far and wide, it has since become the dominant form of continuation, and this stack depth check doesn't currently apply to it.  In general this has been deemed fine, based on the idea that for "normal" code, the code that sets up the chain will have approximately the same depth as the code the executes the chain (e.g. calling into a bunch of nested async methods, the leaf yields, and then the continuation chain unwinds back through approximately the same stack depth).  However, because of how exceptions are handled, if an exception is thrown on a fairly deep stack, it can result in significantly more stack consumed as part of executing the continuation chain then setting it up, resulting in stack overflows while handling exceptions in async methods.

#### Customer Impact

Stack overflows / app crashes when async code with deep call stacks throw exceptions.

The customer can work around it by adding "await Task.Yield();" or similar at strategic points in their code, but figuring out where to do so can be very challenging, and likely also involves adding try/catch/finally blocks around the awaits on the problematic path.

[edit - danmosemsft ] Requested by major internal service.

#### Regression?

No.  We've just seen more customers hitting this as async/await gets propagated through significantly larger quantities of code.

#### Packaging reviewed? 

Change affects System.Private.CoreLib only.

#### Risk

The change itself is low risk in terms of code churn.  It just removes the existing "stack guard" mechanism and replaces it with a tried-and-true mechanism from the runtime, and then adds a call to that in one central location.  The main risk would be if some code somewhere somehow depended on an await continuation running synchronously and now it may end up running asynchronously (that was already possible, it's just now possible in additional situations).