### PR TITLE
Improve support for `--cpus` to Docker CLI

### DIFF
--- a/src/gc/env/gcenv.os.h
+++ b/src/gc/env/gcenv.os.h
@@ -372,7 +372,7 @@ public:
     // Get number of processors assigned to the current process
     // Return:
     //  The number of processors
-    static uint32_t GetCurrentProcessCpuCount();
+    static uint32_t GetCurrentProcessCpuCount(bool withCpuLimit = false);
 
     // Sets the calling thread's affinity to only run on the processor specified.
     // Parameters:

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -34103,7 +34103,7 @@ HRESULT GCHeap::Initialize()
 
     nhp_from_config = static_cast<uint32_t>(GCConfig::GetHeapCount());
     
-    uint32_t nhp_from_process = GCToOSInterface::GetCurrentProcessCpuCount();
+    uint32_t nhp_from_process = GCToOSInterface::GetCurrentProcessCpuCount(true);
 
     if (nhp_from_config)
     {

--- a/src/gc/windows/gcenv.windows.cpp
+++ b/src/gc/windows/gcenv.windows.cpp
@@ -1011,7 +1011,7 @@ const AffinitySet* GCToOSInterface::SetGCThreadsAffinitySet(uintptr_t configAffi
 // Get number of processors assigned to the current process
 // Return:
 //  The number of processors
-uint32_t GCToOSInterface::GetCurrentProcessCpuCount()
+uint32_t GCToOSInterface::GetCurrentProcessCpuCount(bool withCpuLimit)
 {
     static int cCPUs = 0;
 

--- a/src/inc/utilcode.h
+++ b/src/inc/utilcode.h
@@ -1413,7 +1413,7 @@ public:
     }
 };
 
-int GetCurrentProcessCpuCount();
+int GetCurrentProcessCpuCount(bool withCpuLimit = false);
 DWORD_PTR GetCurrentProcessCpuMask();
 
 uint32_t GetOsPageSize();

--- a/src/utilcode/util.cpp
+++ b/src/utilcode/util.cpp
@@ -1191,7 +1191,7 @@ BOOL CPUGroupInfo::GetCPUGroupRange(WORD group_number, WORD* group_begin, WORD* 
 //******************************************************************************
 // Returns the number of processors that a process has been configured to run on
 //******************************************************************************
-int GetCurrentProcessCpuCount()
+int GetCurrentProcessCpuCount(bool withCpuLimit)
 {
     CONTRACTL
     {
@@ -1236,7 +1236,7 @@ int GetCurrentProcessCpuCount()
 #ifdef FEATURE_PAL
     uint32_t cpuLimit;
 
-    if (PAL_GetCpuLimit(&cpuLimit) && cpuLimit < count)
+    if (withCpuLimit && PAL_GetCpuLimit(&cpuLimit) && cpuLimit < count)
         count = cpuLimit;
 #endif
 

--- a/src/vm/gcenv.os.cpp
+++ b/src/vm/gcenv.os.cpp
@@ -476,14 +476,14 @@ const AffinitySet* GCToOSInterface::SetGCThreadsAffinitySet(uintptr_t configAffi
 // Get number of processors assigned to the current process
 // Return:
 //  The number of processors
-uint32_t GCToOSInterface::GetCurrentProcessCpuCount()
+uint32_t GCToOSInterface::GetCurrentProcessCpuCount(bool withCpuLimit)
 {
     LIMITED_METHOD_CONTRACT;
 
     // GetCurrentProcessCpuCount only returns up to 64 procs.
     return CPUGroupInfo::CanEnableGCCPUGroups() ?
                 GCToOSInterface::GetTotalProcessorCount():
-                ::GetCurrentProcessCpuCount();
+                ::GetCurrentProcessCpuCount(withCpuLimit);
 }
 
 // Return the size of the user-mode portion of the virtual address space of this process.

--- a/src/vm/simplerwlock.hpp
+++ b/src/vm/simplerwlock.hpp
@@ -148,7 +148,8 @@ public:
         } CONTRACTL_END;
 
         m_RWLock = 0;
-        m_spinCount = (GetCurrentProcessCpuCount() == 1) ? 0 : 4000;
+        // Passing false here reduces ASP.NET Core Plaintext benchmark results from 1.2M to 0.8M RPS.
+        m_spinCount = (GetCurrentProcessCpuCount(true) == 1) ? 0 : 4000;
         m_WriterWaiting = FALSE;
 
 #ifdef _DEBUG


### PR DESCRIPTION
This focuses on better supporting Docker CLI's parameter `--cpus`, which limits the amount of CPU time available to the container (ex: 1.8 means 180% CPU time, ie on 2 cores 90% for each core, on 4 cores 45% on each core, etc.)

All the runtime components depending on the number of processors available are:
 - ThreadPool
 - GC
 - `Environment.ProcessorCount` via `SystemNative::GetProcessorCount`
 - `SimpleRWLock::m_spinCount`
 - `BaseDomain::m_iNumberOfProcessors` (it's used to determine the GC heap to affinitize to)

All the above components take advantage of `--cpus` via `CGroup::GetCpuLimit` with #12797, allowing to optimize performance in a container/machine with limited resources. This makes sure the runtime components makes the best use of available resources.

In the case of `Environment.ProcessorCount`, the behavior is such that passing `--cpus=1.5` on a machine with 8 processors will return `1`  as shown in #22302 (comment). This behavior is not consistent with [Windows Job Objects](https://docs.microsoft.com/en-us/windows/desktop/api/winnt/ns-winnt-jobobject_cpu_rate_control_information) which still returns the number of processors for the container/machine even if it only gets parts of the total number of cycles.

This behavior is erroneous because the container still has access to the full range of processors on the machine, and only its _processor time_ is limited. For example, in the case of a 4 processors machine, with a value of `--cpus=1.8`, there can be 4 threads running in parallel even though each thread will only get `1.8 / 8 = .45` or 45% of all cycles of each processor.

The work consist in reverting the behavior of `SystemNative::GetProcessorCount` to pre #12797.