### PR TITLE
JIT: don't treat whitespace as separator in assembly name lists

### DIFF
--- a/src/jit/utils.cpp
+++ b/src/jit/utils.cpp
@@ -1469,7 +1469,8 @@ void HelperCallProperties::init()
 // The string should be of the form
 // MyAssembly
 // MyAssembly;mscorlib;System
-// MyAssembly;mscorlib System
+//
+// You must use ';' as a separator; whitespace no longer works
 
 AssemblyNamesList2::AssemblyNamesList2(const wchar_t* list, HostAllocator alloc) : m_alloc(alloc)
 {
@@ -1481,12 +1482,9 @@ AssemblyNamesList2::AssemblyNamesList2(const wchar_t* list, HostAllocator alloc)
     {
         WCHAR curChar = *listWalk;
 
-        if (iswspace(curChar) || curChar == W(';') || curChar == W('\0'))
+        if (curChar == W(';') || curChar == W('\0'))
         {
-            //
-            // Found white-space
-            //
-
+            // Found separator or end of string
             if (nameStart)
             {
                 // Found the end of the current name; add a new assembly name to the list.


### PR DESCRIPTION
Only recognize ";" as a separator, so that we can support exclusions or inclusions
of assemblies whose names include spaces.

Impacts the altjit exclude list, and the disasm include list.

Addresses dotnet/jitutils#200.