### PR TITLE
Mark test GitHub_18582 as optimization sensitive

### DIFF
--- a/tests/src/JIT/Regression/JitBlue/GitHub_18582/GitHub_18582.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_18582/GitHub_18582.csproj
@@ -27,6 +27,7 @@
   <PropertyGroup>
     <DebugType></DebugType>
     <Optimize>True</Optimize>
+    <JitOptimizationSensitive>True</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GitHub_18582.cs" />


### PR DESCRIPTION
Jitstress on OSX will turn on cloning stress in `Test` and cause stack overflows
cloning the large `GT_LIST` subtree of the call.

See issue #23346.