### PR TITLE
Group XUnitWrapper.dll into the same Payloads when submit to Helix

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,6 +7,7 @@
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
+    <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.19179.4</MicrosoftDotNetXUnitConsoleRunnerVersion>
     <MicrosoftNetFrameworkReferenceAssembliesVersion>1.0.0-alpha-004</MicrosoftNetFrameworkReferenceAssembliesVersion>
     <MicrosoftPrivateCoreFxNETCoreAppVersion>4.6.0-preview5.19208.1</MicrosoftPrivateCoreFxNETCoreAppVersion>
     <MicrosoftNETCorePlatformsVersion>3.0.0-preview5.19208.1</MicrosoftNETCorePlatformsVersion>
@@ -16,6 +17,7 @@
   </PropertyGroup>
   <!--Package names-->
   <PropertyGroup>
+    <MicrosoftDotNetXUnitConsoleRunnerPackage>Microsoft.DotNet.XUnitConsoleRunner</MicrosoftDotNetXUnitConsoleRunnerPackage>
     <MicrosoftPrivateCoreFxNETCoreAppPackage>Microsoft.Private.CoreFx.NETCoreApp</MicrosoftPrivateCoreFxNETCoreAppPackage>
     <MicrosoftNETCorePlatformsPackage>Microsoft.NETCore.Platforms</MicrosoftNETCorePlatformsPackage>
     <MicrosoftNETCoreAppPackage>Microsoft.NETCore.App</MicrosoftNETCoreAppPackage>

--- a/tests/helixpublishwitharcade.proj
+++ b/tests/helixpublishwitharcade.proj
@@ -10,10 +10,6 @@
        that will run in parallel. -->
 
   <Target Name="RunInParallelForEachScenario">
-    <ItemGroup>
-      <_Scenarios Include="$(_Scenarios.Split(','))" />
-    </ItemGroup>
-
     <PropertyGroup>
       <!-- This specifies what properties are needed to be passed down as global properties to a child project. -->
 
@@ -34,9 +30,12 @@
       </_PropertiesToPass>
     </PropertyGroup>
 
-    <ItemGroup>
-      <!-- MSBuild creates a new instance of the project for each %(_Scenarios.Identity) and can build them in parallel. -->
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="PreparePayloadsDirectories" Properties="Scenarios=$(_Scenarios)" StopOnFirstFailure="true" />
 
+    <ItemGroup>
+      <_Scenarios Include="$(_Scenarios.Split(','))" />
+
+      <!-- MSBuild creates a new instance of the project for each %(_Scenarios.Identity) and can build them in parallel. -->
       <_ProjectsToBuild Include="$(MSBuildProjectFile)">
         <AdditionalProperties>$(_PropertiesToPass);Scenario=%(_Scenarios.Identity)</AdditionalProperties>
       </_ProjectsToBuild>
@@ -44,39 +43,106 @@
 
     <PropertyGroup>
       <_BuildInParallel>false</_BuildInParallel>
-      <_BuildInParallel Condition=" '@(_ProjectsToBuild->Count())' > '1' ">true</_BuildInParallel>
+      <_BuildInParallel Condition=" '@(_ProjectsToBuild->Count())' &gt; '1' ">true</_BuildInParallel>
     </PropertyGroup>
 
-    <MSBuild Projects="@(_ProjectsToBuild)" Targets="CreateTestEnvFiles" StopOnFirstFailure="true" />
     <MSBuild Projects="@(_ProjectsToBuild)" Targets="Test" BuildInParallel="$(_BuildInParallel)" StopOnFirstFailure="false" Properties="UsesHelixSdk=true" />
   </Target>
 
-  <Import Project="..\dir.props" />
+  <Import Project="src\dir.props" />
 
   <PropertyGroup>
-    <CoreRootDir>$(TestWorkingDir)Tests\Core_Root</CoreRootDir>
+    <BinDir>$([MSBuild]::NormalizeDirectory($(BinDir)))</BinDir>
+    <CoreRootDirectory>$(BinDir)Tests\Core_Root\</CoreRootDirectory>
+    <PayloadsRootDirectory>$(BinDir)Payloads\</PayloadsRootDirectory>
     <TestEnvFileName Condition=" '$(TargetsWindows)' == 'true' ">SetStressModes_$(Scenario).cmd</TestEnvFileName>
     <TestEnvFileName Condition=" '$(TargetsWindows)' != 'true' ">SetStressModes_$(Scenario).sh</TestEnvFileName>
   </PropertyGroup>
 
-  <ItemGroup>
-    <XUnitWrapperDll Include="$(TestWorkingDir)\**\*.XUnitWrapper.dll">
-      <FileDirectory>%(RootDir)%(Directory)</FileDirectory>
-      <File>%(FileName)%(Extension)</File>
-    </XUnitWrapperDll>
-  </ItemGroup>
+  <Import Project="testgrouping.proj" />
 
-  <Target Name="CreateTestEnvFiles">
+  <Target Name="DiscoverAllXUnitWrappers">
+    <ItemGroup>
+      <_XUnitWrapperDll Include="%(TestGrouping.XUnitWrapperDll)" Condition="Exists('%(XUnitWrapperDll)')">
+        <PayloadGroup>%(TestGroup)</PayloadGroup>
+      </_XUnitWrapperDll>
+      <_XUnitWrapperDll Include="@(XUnitWrapperGrouping)" />
 
-    <!-- This target creates one __TestEnv file for each XUnitWrapper. -->
+      <!-- This adds the remaining *.XUnitWrapper.dll files in BinDir unless
+           1) they are in PayloadsRootDirectory or
+           2) they are grouped by XUnitWrapperGrouping. -->
+      <_XUnitWrapperDll Include="$(BinDir)**\*.XUnitWrapper.dll" Exclude="$(PayloadsRootDirectory)**\*.XUnitWrapper.dll;@(XUnitWrapperGrouping->Metadata('FullPath'))">
+         <PayloadGroup></PayloadGroup>
+      </_XUnitWrapperDll>
+
+      <!-- Assign "default" value of PayloadGroup metadata. -->
+      <_XUnitWrapperDll Update="@(_XUnitWrapperDll)">
+         <PayloadGroup Condition="'%(PayloadGroup)' == ''">$([MSBuild]::ValueOrDefault(%(FileName),'').Replace('.XUnitWrapper',''))</PayloadGroup>
+      </_XUnitWrapperDll>
+
+      <_XUnitWrapperDll Update="@(_XUnitWrapperDll)">
+        <FileDirectory>%(RootDir)%(Directory)</FileDirectory>
+        <File>%(FileName)%(Extension)</File>
+      </_XUnitWrapperDll>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="PreparePayloadDirectory" Outputs="%(_XUnitWrapperDll.File)%(PayloadGroup)" DependsOnTargets="DiscoverAllXUnitWrappers">
+    <PropertyGroup>
+      <_FileDirectory>%(_XUnitWrapperDll.FileDirectory)</_FileDirectory>
+      <_PayloadGroup>%(_XUnitWrapperDll.PayloadGroup)</_PayloadGroup>
+      <_XUnitWrapperDll>%(_XUnitWrapperDll.FullPath)</_XUnitWrapperDll>
+    </PropertyGroup>
 
     <ItemGroup>
-      <_ProjectsToBuild Include=".\testenvironment.proj">
-        <Properties>Scenario=$(Scenario);TestEnvFileName=%(XUnitWrapperDll.FileDirectory)$(TestEnvFileName);TargetsWindows=$(TargetsWindows)</Properties>
+      <_TestGroupingRelevant Include="@(TestGrouping->WithMetadataValue('XUnitWrapperDll',$(_XUnitWrapperDll))->Metadata('FullPath'))" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_TestGroupingExists>@(_TestGroupingRelevant->AnyHaveMetadataValue('TestGroup','$(_PayloadGroup)'))</_TestGroupingExists>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_PayloadFiles Include="$(_FileDirectory)**" Exclude="@(_TestGroupingRelevant)" Condition="'$(_TestGroupingExists)' != 'true'" />
+      <_PayloadFiles Include="@(_TestGroupingRelevant->WithMetadataValue('TestGroup','$(_PayloadGroup)')->DistinctWithCase())" Condition="'$(_TestGroupingExists)' == 'true'" />
+      <_PayloadFiles Include="$(_FileDirectory)*" Condition="'$(_TestGroupingExists)' == 'true'" />
+
+      <_PayloadFiles Update="@(_PayloadFiles)">
+        <!-- Never use [MSBuild]::MakeRelative here! We have some files containing Unicode characters in their %(FullPath) and
+             MakeRelative function calls Escape function internally that replaces all the Unicode characters with %<xx>. -->
+        <FileRelativeToPayloadsRootDirectory>$(_PayloadGroup)\$([System.IO.Path]::GetRelativePath($(BinDir), %(FullPath)))</FileRelativeToPayloadsRootDirectory>
+      </_PayloadFiles>
+    </ItemGroup>
+
+    <Copy SourceFiles="@(_PayloadFiles)" DestinationFiles="@(_PayloadFiles->'$(PayloadsRootDirectory)%(FileRelativeToPayloadsRootDirectory)')" />
+  </Target>
+
+  <Target Name="CreateTestEnvFiles">
+    <!-- This target creates one __TestEnv file for each combination of %(_PayloadGroups.Identity) and $(Scenario). -->
+
+    <ItemGroup>
+      <_PayloadGroups Include="$(PayloadGroups)" />
+      <_ProjectsToBuild Include="testenvironment.proj">
+        <Properties>Scenario=$(Scenario);TestEnvFileName=$(PayloadsRootDirectory)%(_PayloadGroups.Identity)\$(TestEnvFileName);TargetsWindows=$(TargetsWindows)</Properties>
       </_ProjectsToBuild>
     </ItemGroup>
 
     <MSBuild Projects="@(_ProjectsToBuild)" Targets="CreateTestEnvFile" StopOnFirstFailure="true" />
+  </Target>
+
+  <Target Name="PreparePayloadsDirectories" DependsOnTargets="PreparePayloadDirectory">
+    <PropertyGroup>
+      <_PayloadGroups>@(_XUnitWrapperDll->Metadata('PayloadGroup')->DistinctWithCase())</_PayloadGroups>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_Scenario Include="$(_Scenarios.Split(','))" />
+      <_ProjectsToBuild Include="$(MSBuildProjectFile)">
+        <AdditionalProperties>Scenario=%(_Scenario.Identity);PayloadGroups=$(_PayloadGroups)</AdditionalProperties>
+      </_ProjectsToBuild>
+    </ItemGroup>
+
+    <MSBuild Projects="@(_ProjectsToBuild)" Targets="CreateTestEnvFiles" StopOnFirstFailure="true" />
   </Target>
 
   <PropertyGroup>
@@ -93,7 +159,7 @@
     <TestRunNamePrefix Condition=" '$(Scenario)' != 'normal' ">$(BuildOS) $(BuildArch) $(BuildType) $(Scenario) @ </TestRunNamePrefix>
     <TimeoutPerTestInMilliseconds Condition=" '$(TimeoutPerTestInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestInMinutes)).TotalMilliseconds)</TimeoutPerTestInMilliseconds>
     <WaitForWorkItemCompletion>true</WaitForWorkItemCompletion>
-    <XUnitRunnerArgs>-parallel collections -nocolor -noshadow -xml testResults.xml -notrait category=outerloop -notrait category=failing</XUnitRunnerArgs>
+    <XUnitRunnerArgs>-parallel collections -nocolor -noshadow -xml testResults.xml</XUnitRunnerArgs>
   </PropertyGroup>
 
   <!-- WARNING: HelixPreCommand ItemGroup is intentionally minimal and should be kept that way. -->
@@ -128,11 +194,26 @@
     <XUnitRunnerDll>$CORE_ROOT/xunit.console.dll</XUnitRunnerDll>
   </PropertyGroup>
 
-  <ItemGroup>
-    <HelixCorrelationPayload Include="$(CoreRootDir)" />
-    <HelixWorkItem Include="@(XUnitWrapperDll->'%(FileName)'->Replace('.XUnitWrapper', ''))">
-      <PayloadDirectory>%(FileDirectory)</PayloadDirectory>
-      <Command>$(CoreRun) $(XUnitRunnerDll) %(File) $(XUnitRunnerArgs)</Command>
+  <ItemGroup Condition=" '$(UsesHelixSdk)' == 'true' ">
+    <HelixCorrelationPayload Include="$(CoreRootDirectory)" />
+
+    <Payloads Include="$([System.IO.Directory]::GetDirectories($(PayloadsRootDirectory)))" Condition="Exists('$(PayloadsRootDirectory)')" />
+    <Payloads Update="@(Payloads)">
+      <PayloadGroup>$([MSBuild]::MakeRelative($(PayloadsRootDirectory), %(FullPath)))</PayloadGroup>
+      <PayloadDirectory>%(FullPath)</PayloadDirectory>
+      <XUnitWrapperDlls>$([System.String]::Join(' ', $([System.IO.Directory]::GetFiles(%(FullPath), '*.XUnitWrapper.dll', SearchOption.AllDirectories))).Replace($([MSBuild]::EnsureTrailingSlash(%(FullPath))),''))</XUnitWrapperDlls>
+    </Payloads>
+
+    <Payloads Update="@(Payloads)">
+      <TestGroup>%(PayloadGroup)</TestGroup>
+      <!-- When Payload contains more than one *.XUnitWrapper.dll TestGroup should not be specified. -->
+      <TestGroup Condition=" $([MSBuild]::ValueOrDefault(%(XUnitWrapperDlls), '').IndexOf('.XUnitWrapper.dll')) != $([MSBuild]::ValueOrDefault(%(XUnitWrapperDlls), '').LastIndexOf('.XUnitWrapper.dll')) "></TestGroup>
+    </Payloads>
+
+    <HelixWorkItem Include="@(Payloads->Metadata('PayloadGroup'))">
+      <PayloadDirectory>%(PayloadDirectory)</PayloadDirectory>
+      <Command>$(CoreRun) $(XUnitRunnerDll) %(XUnitWrapperDlls) $(XUnitRunnerArgs)</Command>
+      <Command Condition=" '%(TestGroup)' != '' ">$(CoreRun) $(XUnitRunnerDll) %(XUnitWrapperDlls) $(XUnitRunnerArgs) -trait TestGroup=%(TestGroup)</Command>
       <Timeout Condition=" '$(TimeoutPerTestCollectionInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestCollectionInMinutes)))</Timeout>
     </HelixWorkItem>
   </ItemGroup>

--- a/tests/helixpublishwitharcade.proj
+++ b/tests/helixpublishwitharcade.proj
@@ -30,6 +30,7 @@
       </_PropertiesToPass>
     </PropertyGroup>
 
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="PrepareCorrelationPayloadDirectory" />
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="PreparePayloadsDirectories" Properties="Scenarios=$(_Scenarios)" StopOnFirstFailure="true" />
 
     <ItemGroup>
@@ -115,6 +116,16 @@
     </ItemGroup>
 
     <Copy SourceFiles="@(_PayloadFiles)" DestinationFiles="@(_PayloadFiles->'$(PayloadsRootDirectory)%(FileRelativeToPayloadsRootDirectory)')" />
+  </Target>
+
+  <Target Name="PrepareCorrelationPayloadDirectory">
+    <MSBuild Projects="xunitconsolerunner.depproj" Targets="Restore" />
+
+    <ItemGroup>
+      <_XUnitConsoleRunnerFiles Include="$(PackagesDir)$(MicrosoftDotNetXUnitConsoleRunnerPackage.ToLower())\$(MicrosoftDotNetXUnitConsoleRunnerVersion)\**\xunit.console.*" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(_XUnitConsoleRunnerFiles)" DestinationFolder="$(CoreRootDirectory)" />
   </Target>
 
   <Target Name="CreateTestEnvFiles">

--- a/tests/helixpublishwitharcade.proj
+++ b/tests/helixpublishwitharcade.proj
@@ -80,17 +80,12 @@
       <_XUnitWrapperDll Update="@(_XUnitWrapperDll)">
          <PayloadGroup Condition="'%(PayloadGroup)' == ''">$([MSBuild]::ValueOrDefault(%(FileName),'').Replace('.XUnitWrapper',''))</PayloadGroup>
       </_XUnitWrapperDll>
-
-      <_XUnitWrapperDll Update="@(_XUnitWrapperDll)">
-        <FileDirectory>%(RootDir)%(Directory)</FileDirectory>
-        <File>%(FileName)%(Extension)</File>
-      </_XUnitWrapperDll>
     </ItemGroup>
   </Target>
 
-  <Target Name="PreparePayloadDirectory" Outputs="%(_XUnitWrapperDll.File)%(PayloadGroup)" DependsOnTargets="DiscoverAllXUnitWrappers">
+  <Target Name="PreparePayloadDirectory" Outputs="%(_XUnitWrapperDll.FileName)%(PayloadGroup)" DependsOnTargets="DiscoverAllXUnitWrappers">
     <PropertyGroup>
-      <_FileDirectory>%(_XUnitWrapperDll.FileDirectory)</_FileDirectory>
+      <_FileDirectory>%(_XUnitWrapperDll.RootDir)%(Directory)</_FileDirectory>
       <_PayloadGroup>%(_XUnitWrapperDll.PayloadGroup)</_PayloadGroup>
       <_XUnitWrapperDll>%(_XUnitWrapperDll.FullPath)</_XUnitWrapperDll>
     </PropertyGroup>

--- a/tests/helixpublishwitharcade.proj
+++ b/tests/helixpublishwitharcade.proj
@@ -73,6 +73,7 @@
            1) they are in PayloadsRootDirectory or
            2) they are grouped by XUnitWrapperGrouping. -->
       <_XUnitWrapperDll Include="$(BinDir)**\*.XUnitWrapper.dll" Exclude="$(PayloadsRootDirectory)**\*.XUnitWrapper.dll;@(XUnitWrapperGrouping->Metadata('FullPath'))">
+         <!-- Set PayloadGroup to empty string, so we can update _XUnitWrapperDll items with no PayloadGroup to default value. Unfortunatelly, we can't do this right here. -->
          <PayloadGroup></PayloadGroup>
       </_XUnitWrapperDll>
 
@@ -99,7 +100,9 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <!-- If no TestGrouping is defined, all the files under $(_FileDirectory) and its subdirectories goes to the PayloadDirectory. -->
       <_PayloadFiles Include="$(_FileDirectory)**" Exclude="@(_TestGroupingRelevant)" Condition="'$(_TestGroupingExists)' != 'true'" />
+      <!-- If there is a TestGrouping, then take only the files that belong to the TestGroup == $(_PayloadGroup). -->
       <_PayloadFiles Include="@(_TestGroupingRelevant->WithMetadataValue('TestGroup','$(_PayloadGroup)')->DistinctWithCase())" Condition="'$(_TestGroupingExists)' == 'true'" />
       <_PayloadFiles Include="$(_FileDirectory)*" Condition="'$(_TestGroupingExists)' == 'true'" />
 

--- a/tests/runtest.proj
+++ b/tests/runtest.proj
@@ -230,6 +230,7 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
       <AllCMDs Include="@(AllCMDsPresent)" Exclude="@(AllCMDExcludeFilter)"/>
 
       <AllCommands Include="@(AllCMDs)" >
+        <_DisplayName>$([MSBuild]::MakeRelative($(XunitTestBinBase), %(AllCMDs.FullPath)))</_DisplayName>
         <_FactName Condition="'$(RunningOnUnix)' != 'true'" >$([System.String]::Copy('%(AllCMDs.FullPath)').Replace("$(_CMDDIR)",'').Replace(".","_").Replace("\","_").Replace("-","_"))</_FactName>
         <_ClassName Condition="'$(RunningOnUnix)' != 'true'" >$([System.String]::Copy('%(AllCMDs.FullPath)').Replace("$(_CMDDIR)",'').Replace("cmd","").Replace(".","_").Replace("\","_").Replace("-","_"))</_ClassName>
         <_FactName Condition="'$(RunningOnUnix)' == 'true'" >$([System.String]::Copy('%(AllCMDs.FullPath)').Replace("$(_CMDDIR)",'').Replace(".","_").Replace("/","_").Replace("-","_"))</_FactName>
@@ -240,7 +241,7 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
 
         public class %(AllCommands._ClassName)
         {
-            [Fact]
+            [Fact(DisplayName=@"%(AllCommands._DisplayName)")]
             public void %(AllCommands._FactName)()
             {
                 int ret = -100%3B

--- a/tests/runtest.proj
+++ b/tests/runtest.proj
@@ -147,6 +147,8 @@ $(_XunitEpilog)
     <MSBuild Projects="$(XunitWrapperSrcDir)\$(XunitWrapper).csproj" Targets="Restore;Build" />
   </Target>
 
+  <Import Project="testgrouping.proj" />
+
   <Target Name="CreateXunitFacts">
     <!-- NOTE! semicolons must be escaped with %3B boooo -->
 
@@ -215,10 +217,6 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
       </_XunitEpilog>
     </PropertyGroup>
 
-    <ItemGroup>
-      <CanonicalExcludeList Include="%(ExcludeList.FullPath)" Condition="$(HaveExcludes)"/>
-    </ItemGroup>
-
     <PropertyGroup>
       <TestExecutableReplacement Condition="'$(TargetsWindows)' != 'true' ">testExecutable = testExecutable.Replace("\\", "/")%3B</TestExecutableReplacement>
     </PropertyGroup>
@@ -226,23 +224,31 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
     <ItemGroup>
       <AllCMDsPresent Include="$(_CMDDIR)\**\*.cmd" Condition="'$(RunningOnUnix)' != 'true'" />
       <AllCMDsPresent Include="$(_CMDDIR)\**\*.sh" Condition="'$(RunningOnUnix)' == 'true'" />
-      <AllCMDExcludeFilter Include="@(CanonicalExcludeList)" Condition="$(HaveExcludes)"/>
-      <AllCMDs Include="@(AllCMDsPresent)" Exclude="@(AllCMDExcludeFilter)"/>
-
-      <AllCommands Include="@(AllCMDs)" >
-        <_DisplayName>$([MSBuild]::MakeRelative($(XunitTestBinBase), %(AllCMDs.FullPath)))</_DisplayName>
-        <_FactName Condition="'$(RunningOnUnix)' != 'true'" >$([System.String]::Copy('%(AllCMDs.FullPath)').Replace("$(_CMDDIR)",'').Replace(".","_").Replace("\","_").Replace("-","_"))</_FactName>
-        <_ClassName Condition="'$(RunningOnUnix)' != 'true'" >$([System.String]::Copy('%(AllCMDs.FullPath)').Replace("$(_CMDDIR)",'').Replace("cmd","").Replace(".","_").Replace("\","_").Replace("-","_"))</_ClassName>
-        <_FactName Condition="'$(RunningOnUnix)' == 'true'" >$([System.String]::Copy('%(AllCMDs.FullPath)').Replace("$(_CMDDIR)",'').Replace(".","_").Replace("/","_").Replace("-","_"))</_FactName>
-        <_ClassName Condition="'$(RunningOnUnix)' == 'true'" >$([System.String]::Copy('%(AllCMDs.FullPath)').Replace("$(_CMDDIR)",'').Replace("sh","").Replace(".","_").Replace("/","_").Replace("-","_"))</_ClassName>
-
-        <_XunitFact >
+      <TestGroupingDistinctWithCase Include="@(TestGrouping->Metadata('FullPath')->DistinctWithCase())" />
+      <TestGroupingNotRelevant Include="@(TestGroupingDistinctWithCase)" Exclude="@(AllCMDsPresent)" />
+      <GroupedCMDs Include="@(TestGroupingDistinctWithCase)" Exclude="@(TestGroupingNotRelevant)" />
+      <GroupedCMDs Include="@(AllCMDsPresent)" Exclude="@(GroupedCMDs)">
+        <TestGroup>$(Category)</TestGroup>
+      </GroupedCMDs>
+      <AllCMDExcludeFilter Include="@(ExcludeList->Metadata('FullPath'))" Condition="$(HaveExcludes)" />
+      <AllCMDs Include="@(GroupedCMDs)" Exclude="@(AllCMDExcludeFilter)">
+        <RelativeToCMDDIR>$([MSBuild]::MakeRelative($(_CMDDIR), %(FullPath)))</RelativeToCMDDIR>
+      </AllCMDs>
+      <AllCommands Include="@(AllCMDs)" Condition="@(AllCMDs->Count()) &gt; 0">
+        <DisplayName>$([MSBuild]::MakeRelative($(XunitTestBinBase), %(AllCMDs.FullPath)))</DisplayName>
+        <FactName Condition="'$(RunningOnUnix)' != 'true'" >_$([MSBuild]::ValueOrDefault(%(AllCMDs.RelativeToCMDDIR),"").Replace(".","_").Replace("\","_").Replace("-","_"))</FactName>
+        <ClassName Condition="'$(RunningOnUnix)' != 'true'" >_$([MSBuild]::ValueOrDefault(%(AllCMDs.RelativeToCMDDIR),"").Replace("cmd","").Replace(".","_").Replace("\","_").Replace("-","_"))</ClassName>
+        <FactName Condition="'$(RunningOnUnix)' == 'true'" >_$([MSBuild]::ValueOrDefault(%(AllCMDs.RelativeToCMDDIR),"").Replace(".","_").Replace("/","_").Replace("-","_"))</FactName>
+        <ClassName Condition="'$(RunningOnUnix)' == 'true'" >_$([MSBuild]::ValueOrDefault(%(AllCMDs.RelativeToCMDDIR), '').Replace('sh','').Replace('.','_').Replace('/','_').Replace('-','_'))</ClassName>
+        <TestGroup>%(AllCMDs.TestGroup)</TestGroup>
+        <XUnitFact >
           <![CDATA[
 
-        public class %(AllCommands._ClassName)
+        public class %(AllCommands.ClassName)
         {
-            [Fact(DisplayName=@"%(AllCommands._DisplayName)")]
-            public void %(AllCommands._FactName)()
+            [Fact(DisplayName=@"%(AllCommands.DisplayName)")]
+            [Trait("TestGroup", "%(AllCommands.TestGroup)")]
+            public void %(AllCommands.FactName)()
             {
                 int ret = -100%3B
                 string outputFile = null%3B
@@ -311,9 +317,9 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
        }
 
         ]]>
-        </_XunitFact>
+        </XUnitFact>
       </AllCommands>
-      <AllXUnitFacts Include= "%(AllCommands._XunitFact)" />
+      <AllXUnitFacts Include= "@(AllCommands->Metadata(XUnitFact))" />
     </ItemGroup>
   </Target>
 

--- a/tests/testgrouping.proj
+++ b/tests/testgrouping.proj
@@ -1,0 +1,119 @@
+<Project>
+  <ItemGroup>
+    <TestGrouping Include="$(BinDir)baseservices\threading\generics\**">
+      <TestGroup>baseservices.threading.generics</TestGroup>
+      <XUnitWrapperDll>$(BinDir)baseservices\threading\baseservices.threading.XUnitWrapper.dll</XUnitWrapperDll>
+    </TestGrouping>
+
+    <TestGrouping Include="$(BinDir)JIT\jit64\hfa\**">
+      <TestGroup>JIT.jit64.hfa</TestGroup>
+      <XUnitWrapperDll>$(BinDir)JIT\jit64\JIT.jit64.XUnitWrapper.dll</XUnitWrapperDll>
+    </TestGrouping>
+
+    <TestGrouping Condition="'$(BuildOS)' == 'Windows_NT'" Include="$(BinDir)JIT\jit64\mcc\**">
+      <TestGroup>JIT.jit64.mcc</TestGroup>
+      <XUnitWrapperDll>$(BinDir)JIT\jit64\JIT.jit64.XUnitWrapper.dll</XUnitWrapperDll>
+    </TestGrouping>
+
+    <TestGrouping Include="$(BinDir)JIT\jit64\opt\**">
+      <TestGroup>JIT.jit64.opt</TestGroup>
+      <XUnitWrapperDll>$(BinDir)JIT\jit64\JIT.jit64.XUnitWrapper.dll</XUnitWrapperDll>
+    </TestGrouping>
+
+    <TestGrouping Include="$(BinDir)JIT\jit64\valuetypes\**">
+      <TestGroup>JIT.jit64.valuetypes</TestGroup>
+      <XUnitWrapperDll>$(BinDir)JIT\jit64\JIT.jit64.XUnitWrapper.dll</XUnitWrapperDll>
+    </TestGrouping>
+
+    <TestGrouping Include="$(BinDir)JIT\Methodical\a*\**;
+                           $(BinDir)JIT\Methodical\b*\**;
+                           $(BinDir)JIT\Methodical\c*\**;
+                           $(BinDir)JIT\Methodical\d*\**;
+                           $(BinDir)JIT\Methodical\A*\**;
+                           $(BinDir)JIT\Methodical\B*\**;
+                           $(BinDir)JIT\Methodical\C*\**;
+                           $(BinDir)JIT\Methodical\D*\**">
+      <TestGroup>JIT.Methodical.a-dA-D</TestGroup>
+      <XUnitWrapperDll>$(BinDir)JIT\Methodical\JIT.Methodical.XUnitWrapper.dll</XUnitWrapperDll>
+    </TestGrouping>
+
+    <TestGrouping Include="$(BinDir)JIT\Methodical\eh\**">
+      <TestGroup>JIT.Methodical.eh</TestGroup>
+      <XUnitWrapperDll>$(BinDir)JIT\Methodical\JIT.Methodical.XUnitWrapper.dll</XUnitWrapperDll>
+    </TestGrouping>
+
+    <TestGrouping Include="$(BinDir)JIT\Methodical\e*\**;
+                           $(BinDir)JIT\Methodical\E*\**"
+                  Exclude="$(BinDir)JIT\Methodical\eh\**">
+      <TestGroup>JIT.Methodical.e-iE-I</TestGroup>
+      <XUnitWrapperDll>$(BinDir)JIT\Methodical\JIT.Methodical.XUnitWrapper.dll</XUnitWrapperDll>
+    </TestGrouping>
+
+    <TestGrouping Include="$(BinDir)JIT\Methodical\f*\**;
+                           $(BinDir)JIT\Methodical\g*\**;
+                           $(BinDir)JIT\Methodical\h*\**;
+                           $(BinDir)JIT\Methodical\i*\**;
+                           $(BinDir)JIT\Methodical\F*\**;
+                           $(BinDir)JIT\Methodical\G*\**;
+                           $(BinDir)JIT\Methodical\H*\**;
+                           $(BinDir)JIT\Methodical\I*\**">
+      <TestGroup>JIT.Methodical.e-iE-I</TestGroup>
+      <XUnitWrapperDll>$(BinDir)JIT\Methodical\JIT.Methodical.XUnitWrapper.dll</XUnitWrapperDll>
+    </TestGrouping>
+
+    <TestGrouping Include="$(BinDir)JIT\Regression\CLR-x86-JIT\V1-M09*\**;
+                           $(BinDir)JIT\Regression\CLR-x86-JIT\V1-M10*\**;
+                           $(BinDir)JIT\Regression\CLR-x86-JIT\V1-M11*\**">
+      <TestGroup>JIT.Regression.CLR-x86-JIT.V1-M09-M11</TestGroup>
+      <XUnitWrapperDll>$(BinDir)JIT\Regression\JIT.Regression.XUnitWrapper.dll</XUnitWrapperDll>
+    </TestGrouping>
+
+    <TestGrouping Include="$(BinDir)JIT\Regression\CLR-x86-JIT\V1-M12*\**;
+                           $(BinDir)JIT\Regression\CLR-x86-JIT\V1-M13*\**">
+      <TestGroup>JIT.Regression.CLR-x86-JIT.V1-M12-M13</TestGroup>
+      <XUnitWrapperDll>$(BinDir)JIT\Regression\JIT.Regression.XUnitWrapper.dll</XUnitWrapperDll>
+    </TestGrouping>
+
+    <TestGrouping Include="$(BinDir)Loader\classloader\generics\**">
+      <TestGroup>Loader.classloader.generics</TestGroup>
+      <XUnitWrapperDll>$(BinDir)Loader\classloader\Loader.classloader.XUnitWrapper.dll</XUnitWrapperDll>
+    </TestGrouping>
+
+    <TestGrouping Include="$(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest?\**;
+                           $(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest??\**;
+                           $(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1??\**;
+                           $(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest2??\**">
+      <TestGroup>Loader.classloader.TypeGeneratorTests.TypeGeneratorTest0-299</TestGroup>
+      <XUnitWrapperDll>$(BinDir)Loader\classloader\Loader.classloader.XUnitWrapper.dll</XUnitWrapperDll>
+    </TestGrouping>
+
+    <TestGrouping Include="$(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest3??\**;
+                           $(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest4??\**;
+                           $(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest5??\**">
+      <TestGroup>Loader.classloader.TypeGeneratorTests.TypeGeneratorTest300-599</TestGroup>
+      <XUnitWrapperDll>$(BinDir)Loader\classloader\Loader.classloader.XUnitWrapper.dll</XUnitWrapperDll>
+    </TestGrouping>
+
+    <TestGrouping Include="$(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest6??\**;
+                           $(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest7??\**;
+                           $(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest8??\**">
+      <TestGroup>Loader.classloader.TypeGeneratorTests.TypeGeneratorTest600-899</TestGroup>
+      <XUnitWrapperDll>$(BinDir)Loader\classloader\Loader.classloader.XUnitWrapper.dll</XUnitWrapperDll>
+    </TestGrouping>
+
+    <TestGrouping Include="$(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest9??\**;
+                           $(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest10??\**;
+                           $(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest11??\**">
+      <TestGroup>Loader.classloader.TypeGeneratorTests.TypeGeneratorTest900-1199</TestGroup>
+      <XUnitWrapperDll>$(BinDir)Loader\classloader\Loader.classloader.XUnitWrapper.dll</XUnitWrapperDll>
+    </TestGrouping>
+
+    <TestGrouping Include="$(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest12??\**;
+                           $(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest13??\**;
+                           $(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest14??\**;
+                           $(BinDir)Loader\classloader\TypeGeneratorTests\TypeGeneratorTest1500\**">
+      <TestGroup>Loader.classloader.TypeGeneratorTests.TypeGeneratorTest1200-1500</TestGroup>
+      <XUnitWrapperDll>$(BinDir)Loader\classloader\Loader.classloader.XUnitWrapper.dll</XUnitWrapperDll>
+    </TestGrouping>
+  </ItemGroup>
+</Project>

--- a/tests/testgrouping.proj
+++ b/tests/testgrouping.proj
@@ -115,5 +115,41 @@
       <TestGroup>Loader.classloader.TypeGeneratorTests.TypeGeneratorTest1200-1500</TestGroup>
       <XUnitWrapperDll>$(BinDir)Loader\classloader\Loader.classloader.XUnitWrapper.dll</XUnitWrapperDll>
     </TestGrouping>
+
+    <XUnitWrapperGrouping Include="$(BinDir)baseservices\compilerservices\*.XUnitWrapper.dll;
+                                   $(BinDir)baseservices\exceptions\*.XUnitWrapper.dll;
+                                   $(BinDir)baseservices\multidimmarray\*.XUnitWrapper.dll;
+                                   $(BinDir)baseservices\TieredCompilation\*.XUnitWrapper.dll;
+                                   $(BinDir)baseservices\typeequivalence\*.XUnitWrapper.dll;
+                                   $(BinDir)baseservices\varargs\*.XUnitWrapper.dll;
+                                   $(BinDir)CoreMangLib\**\*.XUnitWrapper.dll;
+                                   $(BinDir)Exceptions\**\*.XUnitWrapper.dll;
+                                   $(BinDir)GC\**\*.XUnitWrapper.dll;
+                                   $(BinDir)hosting\**\*.XUnitWrapper.dll;
+                                   $(BinDir)ilasm\**\*.XUnitWrapper.dll;
+                                   $(BinDir)Loader\**\*.XUnitWrapper.dll;
+                                   $(BinDir)managed\**\*.XUnitWrapper.dll;
+                                   $(BinDir)readytorun\**\*.XUnitWrapper.dll;
+                                   $(BinDir)reflection\**\*.XUnitWrapper.dll;
+                                   $(BinDir)Regressions\**\*.XUnitWrapper.dll;
+                                   $(BinDir)tracing\**\*.XUnitWrapper.dll"
+                          Exclude="$(BinDir)Loader\classloader\Loader.classloader.XUnitWrapper.dll">
+      <PayloadGroup>PayloadGroup0</PayloadGroup>
+    </XUnitWrapperGrouping>
+
+    <XUnitWrapperGrouping Include="$(BinDir)Interop\**\Interop.*.XUnitWrapper.dll">
+      <PayloadGroup>Interop</PayloadGroup>
+    </XUnitWrapperGrouping>
+
+    <XUnitWrapperGrouping Include="$(BinDir)JIT\BBT\*.XUnitWrapper.dll;
+                                   $(BinDir)JIT\CheckProjects\*.XUnitWrapper.dll;
+                                   $(BinDir)JIT\Intrinsics\*.XUnitWrapper.dll;
+                                   $(BinDir)JIT\opt\*.XUnitWrapper.dll;
+                                   $(BinDir)JIT\Performance\*.XUnitWrapper.dll;
+                                   $(BinDir)JIT\RyuJIT\*.XUnitWrapper.dll;
+                                   $(BinDir)JIT\SIMD\*.XUnitWrapper.dll;
+                                   $(BinDir)JIT\superpmi\*.XUnitWrapper.dll">
+      <PayloadGroup>JIT</PayloadGroup>
+    </XUnitWrapperGrouping>
   </ItemGroup>
 </Project>

--- a/tests/xunitconsolerunner.depproj
+++ b/tests/xunitconsolerunner.depproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="src\dir.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="$(MicrosoftDotNetXUnitConsoleRunnerPackage)" Version="$(MicrosoftDotNetXUnitConsoleRunnerVersion)" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This PR changes the way we are submitting workitems to Helix
1. Some of the long running XUnitWrappers are split into separate collections of tests. For example, Loader.classloader is split into Loader.classloader.TypeGeneratorTests.TypeGeneratorTest0-299, Loader.classloader.TypeGeneratorTests.TypeGeneratorTest300-599 etc and submitted as separate Helix workitems.
2. Some of the short running XUnitWrappers (that take seconds to finish) are grouped together and submitted as one Helix workitem (e.g. PayloadGroup0)

Overall, this reduces number of Helix workitems submitted by Pri1 CI job from 90 to 29 while also descreases running time for the longest Helix workitem as follows:

| Architecture | Configuration | OperatingSystem | Longest running Helix workitem (seconds) - Before | Longest running Helix workitem (seconds) - After |
| --- | --- | --- | --- | --- |
| x64 | Checked | Alpine.38.Amd64.Open | Loader.classloader (877s) | PayloadGroup0 (421s)
| x64 | Checked-no_tiered_compilation | Alpine.38.Amd64.Open | Loader.classloader (884s) | PayloadGroup0 (390s)
| x64 | Checked | OSX.1013.Amd64.Open | Loader.classloader (1339s) | PayloadGroup0 (533s)
| x64 | Checked-no_tiered_compilation | OSX.1013.Amd64.Open | Loader.classloader (1253s) |PayloadGroup0 (512s)
| x64 | Checked | Ubuntu.1804.Amd64.Open | Loader.classloader (886s) | PayloadGroup0 (370s)
| x64 | Checked-no_tiered_compilation | Ubuntu.1804.Amd64.Open | Loader.classloader (786s) | PayloadGroup0 (373s)
| arm64 | Checked | Ubuntu.1804.Arm64.Open | JIT.jit64 (314s) | JIT.Methodical (451s)
| arm64 | Checked-no_tiered_compilation | Ubuntu.1804.Arm64.Open | JIT.jit64 (309s) | JIT.jit64.opt (308s)
| x64 | Checked | Windows.10.Amd64.Open | Loader.classloader **(2889s)** | PayloadGroup0 (942s)
| x64 | Checked-no_tiered_compilation | Windows.10.Amd64.Open | Loader.classloader **(2810s)** | PayloadGroup0 (1085s)
| x86 | Checked | Windows.10.Amd64.Open | Loader.classloader **(3596s)** | PayloadGroup0 (1289s)
| x86 | Checked-no_tiered_compilation | Windows.10.Amd64.Open | Loader.classloader **(3668s)** | PayloadGroup0 (1279s)

I am working on gathering the statistics for Ubuntu.1804.Arm32 since the queue was enabled only yesterday.