### PR TITLE
Delete simple unused vars2

### DIFF
--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -2327,9 +2327,9 @@ emitter::code_t emitter::emitInsCode(instruction ins, insFormat fmt)
     unsigned R = bmImm.immR;
     unsigned S = bmImm.immS;
 
-    unsigned elemWidth = 64; // used when immN == 1
+    unsigned elemWidth = 64; // used when N == 1
 
-    if (bmImm.immN == 0) // find the smaller elemWidth when immN == 0
+    if (N == 0) // find the smaller elemWidth when N == 0
     {
         // Scan S for the highest bit not set
         elemWidth = 32;
@@ -3393,9 +3393,8 @@ void emitter::emitIns_I(instruction ins, emitAttr attr, ssize_t imm)
 
 void emitter::emitIns_R(instruction ins, emitAttr attr, regNumber reg)
 {
-    emitAttr   size = EA_SIZE(attr);
-    insFormat  fmt  = IF_NONE;
-    instrDesc* id   = nullptr;
+    insFormat  fmt = IF_NONE;
+    instrDesc* id  = nullptr;
 
     /* Figure out the encoding format of the instruction */
     switch (ins)
@@ -3537,7 +3536,6 @@ void emitter::emitIns_R_I(instruction ins, emitAttr attr, regNumber reg, ssize_t
                 ssize_t  imm8 = 0;
                 unsigned pos  = 0;
                 canEncode     = true;
-                bool failed   = false;
                 while (uimm != 0)
                 {
                     INT64 loByte = uimm & 0xFF;
@@ -6089,8 +6087,7 @@ void emitter::emitIns_R_R_R_R(
 
 void emitter::emitIns_R_COND(instruction ins, emitAttr attr, regNumber reg, insCond cond)
 {
-    emitAttr     size = EA_SIZE(attr);
-    insFormat    fmt  = IF_NONE;
+    insFormat    fmt = IF_NONE;
     condFlagsImm cfi;
     cfi.immCFVal = 0;
 
@@ -6132,8 +6129,7 @@ void emitter::emitIns_R_COND(instruction ins, emitAttr attr, regNumber reg, insC
 
 void emitter::emitIns_R_R_COND(instruction ins, emitAttr attr, regNumber reg1, regNumber reg2, insCond cond)
 {
-    emitAttr     size = EA_SIZE(attr);
-    insFormat    fmt  = IF_NONE;
+    insFormat    fmt = IF_NONE;
     condFlagsImm cfi;
     cfi.immCFVal = 0;
 
@@ -6178,8 +6174,7 @@ void emitter::emitIns_R_R_COND(instruction ins, emitAttr attr, regNumber reg1, r
 void emitter::emitIns_R_R_R_COND(
     instruction ins, emitAttr attr, regNumber reg1, regNumber reg2, regNumber reg3, insCond cond)
 {
-    emitAttr     size = EA_SIZE(attr);
-    insFormat    fmt  = IF_NONE;
+    insFormat    fmt = IF_NONE;
     condFlagsImm cfi;
     cfi.immCFVal = 0;
 
@@ -6229,8 +6224,7 @@ void emitter::emitIns_R_R_R_COND(
 void emitter::emitIns_R_R_FLAGS_COND(
     instruction ins, emitAttr attr, regNumber reg1, regNumber reg2, insCflags flags, insCond cond)
 {
-    emitAttr     size = EA_SIZE(attr);
-    insFormat    fmt  = IF_NONE;
+    insFormat    fmt = IF_NONE;
     condFlagsImm cfi;
     cfi.immCFVal = 0;
 
@@ -6274,8 +6268,7 @@ void emitter::emitIns_R_R_FLAGS_COND(
 void emitter::emitIns_R_I_FLAGS_COND(
     instruction ins, emitAttr attr, regNumber reg, int imm, insCflags flags, insCond cond)
 {
-    emitAttr     size = EA_SIZE(attr);
-    insFormat    fmt  = IF_NONE;
+    insFormat    fmt = IF_NONE;
     condFlagsImm cfi;
     cfi.immCFVal = 0;
 
@@ -6876,7 +6869,6 @@ void emitter::emitIns_R_C(
 
     emitAttr      size = EA_SIZE(attr);
     insFormat     fmt  = IF_NONE;
-    int           disp = 0;
     instrDescJmp* id   = emitNewInstrJmp();
 
     switch (ins)
@@ -9071,14 +9063,13 @@ unsigned emitter::emitOutputCall(insGroup* ig, BYTE* dst, instrDesc* id, code_t 
 
 size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 {
-    BYTE*         dst  = *dp;
-    BYTE*         odst = dst;
-    code_t        code = 0;
-    size_t        sz   = emitGetInstrDescSize(id); // TODO-ARM64-Cleanup: on ARM, this is set in each case. why?
-    instruction   ins  = id->idIns();
-    insFormat     fmt  = id->idInsFmt();
-    emitAttr      size = id->idOpSize();
-    unsigned char callInstrSize = 0;
+    BYTE*       dst  = *dp;
+    BYTE*       odst = dst;
+    code_t      code = 0;
+    size_t      sz   = emitGetInstrDescSize(id); // TODO-ARM64-Cleanup: on ARM, this is set in each case. why?
+    instruction ins  = id->idIns();
+    insFormat   fmt  = id->idInsFmt();
+    emitAttr    size = id->idOpSize();
 
 #ifdef DEBUG
 #if DUMP_GC_TABLES
@@ -9089,8 +9080,6 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 #endif // DEBUG
 
     assert(REG_NA == (int)REG_NA);
-
-    VARSET_TP GCvars(VarSetOps::UninitVal());
 
     /* What instruction format have we got? */
 
@@ -11705,8 +11694,6 @@ void emitter::emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataR
 
 regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, GenTree* src)
 {
-    regNumber result = REG_NA;
-
     // dst can only be a reg
     assert(!dst->isContained());
 
@@ -11737,8 +11724,6 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
 
 regNumber emitter::emitInsTernary(instruction ins, emitAttr attr, GenTree* dst, GenTree* src1, GenTree* src2)
 {
-    regNumber result = REG_NA;
-
     // dst can only be a reg
     assert(!dst->isContained());
 

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -496,8 +496,6 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
     noway_assert(jumpCnt >= 2);
 
     // Spill the argument to the switch node into a local so that it can be used later.
-    unsigned blockWeight = originalSwitchBB->getBBWeight(comp);
-
     LIR::Use use(switchBBRange, &(node->gtOp.gtOp1), node);
     ReplaceWithLclVar(use);
 
@@ -508,9 +506,8 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
     assert(node->gtOper == GT_SWITCH);
     GenTree* temp = node->gtOp.gtOp1;
     assert(temp->gtOper == GT_LCL_VAR);
-    unsigned   tempLclNum  = temp->gtLclVarCommon.gtLclNum;
-    LclVarDsc* tempVarDsc  = comp->lvaTable + tempLclNum;
-    var_types  tempLclType = temp->TypeGet();
+    unsigned  tempLclNum  = temp->gtLclVarCommon.gtLclNum;
+    var_types tempLclType = temp->TypeGet();
 
     BasicBlock* defaultBB   = jumpTab[jumpCnt - 1];
     BasicBlock* followingBB = originalSwitchBB->bbNext;
@@ -2040,8 +2037,7 @@ void Lowering::LowerFastTailCall(GenTreeCall* call)
                 // This should not be a GT_PHI_ARG.
                 assert(treeNode->OperGet() != GT_PHI_ARG);
 
-                GenTreeLclVarCommon* lcl    = treeNode->AsLclVarCommon();
-                LclVarDsc*           lclVar = &comp->lvaTable[lcl->gtLclNum];
+                GenTreeLclVarCommon* lcl = treeNode->AsLclVarCommon();
 
                 // Fast tail calling criteria permits passing of structs of size 1, 2, 4 and 8 as args.
                 // It is possible that the callerArgLclNum corresponds to such a struct whose stack slot
@@ -2562,11 +2558,11 @@ GenTree* Lowering::OptimizeConstCompare(GenTree* cmp)
 
 #if defined(_TARGET_XARCH_) || defined(_TARGET_ARM64_)
     GenTree*       op1      = cmp->gtGetOp1();
-    var_types      op1Type  = op1->TypeGet();
     GenTreeIntCon* op2      = cmp->gtGetOp2()->AsIntCon();
     ssize_t        op2Value = op2->IconValue();
 
 #ifdef _TARGET_XARCH_
+    var_types op1Type = op1->TypeGet();
     if (IsContainableMemoryOp(op1) && varTypeIsSmall(op1Type) && genSmallTypeCanRepresentValue(op1Type, op2Value))
     {
         //
@@ -3837,7 +3833,6 @@ GenTree* Lowering::LowerNonvirtPinvokeCall(GenTreeCall* call)
     // platform. They may be changed in the future such that they preserve all register values.
 
     GenTree* result = nullptr;
-    void*    addr   = nullptr;
 
     // assert we have seen one of these
     noway_assert(comp->info.compCallUnmanaged != 0);
@@ -4189,8 +4184,6 @@ bool Lowering::AreSourcesPossiblyModifiedLocals(GenTree* addr, GenTree* base, Ge
 {
     assert(addr != nullptr);
 
-    unsigned markCount = 0;
-
     SideEffectSet baseSideEffects;
     if (base != nullptr)
     {
@@ -4338,8 +4331,6 @@ GenTree* Lowering::TryCreateAddrMode(LIR::Use&& use, bool isIndir)
         return addr;
     }
 
-    GenTree* arrLength = nullptr;
-
     JITDUMP("Addressing mode:\n");
     JITDUMP("  Base\n    ");
     DISPNODE(base);
@@ -4399,8 +4390,6 @@ GenTree* Lowering::TryCreateAddrMode(LIR::Use&& use, bool isIndir)
 //
 GenTree* Lowering::LowerAdd(GenTree* node)
 {
-    GenTree* next = node->gtNext;
-
 #ifndef _TARGET_ARMARCH_
     if (varTypeIsIntegralOrI(node))
     {
@@ -4455,7 +4444,6 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
     assert(divMod->OperGet() != GT_UMOD);
 #endif // _TARGET_ARM64_
 
-    GenTree* next     = divMod->gtNext;
     GenTree* dividend = divMod->gtGetOp1();
     GenTree* divisor  = divMod->gtGetOp2();
 
@@ -4829,9 +4817,6 @@ GenTree* Lowering::LowerConstIntDivOrMod(GenTree* node)
 
     // We need to use the dividend node multiple times so its value needs to be
     // computed once and stored in a temp variable.
-
-    unsigned curBBWeight = comp->compCurBB->getBBWeight(comp);
-
     LIR::Use opDividend(BlockRange(), &divMod->gtOp.gtOp1, divMod);
     dividend = ReplaceWithLclVar(opDividend);
 
@@ -4908,10 +4893,7 @@ GenTree* Lowering::LowerConstIntDivOrMod(GenTree* node)
 GenTree* Lowering::LowerSignedDivOrMod(GenTree* node)
 {
     assert((node->OperGet() == GT_DIV) || (node->OperGet() == GT_MOD));
-    GenTree* next     = node->gtNext;
-    GenTree* divMod   = node;
-    GenTree* dividend = divMod->gtGetOp1();
-    GenTree* divisor  = divMod->gtGetOp2();
+    GenTree* next = node->gtNext;
 
     if (varTypeIsIntegral(node->TypeGet()))
     {
@@ -5068,9 +5050,8 @@ void Lowering::WidenSIMD12IfNecessary(GenTreeLclVarCommon* node)
 GenTree* Lowering::LowerArrElem(GenTree* node)
 {
     // This will assert if we don't have an ArrElem node
-    GenTreeArrElem*     arrElem     = node->AsArrElem();
-    const unsigned char rank        = arrElem->gtArrElem.gtArrRank;
-    const unsigned      blockWeight = m_block->getBBWeight(comp);
+    GenTreeArrElem*     arrElem = node->AsArrElem();
+    const unsigned char rank    = arrElem->gtArrElem.gtArrRank;
 
     JITDUMP("Lowering ArrElem\n");
     JITDUMP("============\n");
@@ -5088,8 +5069,6 @@ GenTree* Lowering::LowerArrElem(GenTree* node)
 
     GenTree* arrObjNode = arrElem->gtArrObj;
     assert(arrObjNode->IsLocal());
-
-    LclVarDsc* const varDsc = &comp->lvaTable[arrElem->gtArrObj->AsLclVarCommon()->gtLclNum];
 
     GenTree* insertionPoint = arrElem;
 

--- a/src/jit/lowerarmarch.cpp
+++ b/src/jit/lowerarmarch.cpp
@@ -616,15 +616,12 @@ void Lowering::ContainCheckIndir(GenTreeIndir* indirNode)
     bool     makeContained = true;
     if ((addr->OperGet() == GT_LEA) && IsSafeToContainMem(indirNode, addr))
     {
-        GenTreeAddrMode* lea   = addr->AsAddrMode();
-        GenTree*         base  = lea->Base();
-        GenTree*         index = lea->Index();
-        int              cns   = lea->Offset();
-
 #ifdef _TARGET_ARM_
         // ARM floating-point load/store doesn't support a form similar to integer
         // ldr Rdst, [Rbase + Roffset] with offset in a register. The only supported
         // form is vldr Rdst, [Rbase + imm] with a more limited constraint on the imm.
+        GenTreeAddrMode* lea = addr->AsAddrMode();
+        int              cns = lea->Offset();
         if (lea->HasIndex() || !emitter::emitIns_valid_imm_for_vldst_offset(cns))
         {
             if (indirNode->OperGet() == GT_STOREIND)
@@ -870,10 +867,9 @@ void Lowering::ContainCheckSIMD(GenTreeSIMD* simdNode)
 //
 void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
 {
-    NamedIntrinsic  intrinsicID = node->gtHWIntrinsicId;
-    GenTreeArgList* argList     = nullptr;
-    GenTree*        op1         = node->gtOp.gtOp1;
-    GenTree*        op2         = node->gtOp.gtOp2;
+    GenTreeArgList* argList = nullptr;
+    GenTree*        op1     = node->gtOp.gtOp1;
+    GenTree*        op2     = node->gtOp.gtOp2;
 
     if (op1->OperIs(GT_LIST))
     {

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -145,12 +145,11 @@ void Lowering::LowerStoreIndir(GenTreeIndir* node)
 //
 void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
 {
-    GenTree*  dstAddr       = blkNode->Addr();
-    unsigned  size          = blkNode->gtBlkSize;
-    GenTree*  source        = blkNode->Data();
-    Compiler* compiler      = comp;
-    GenTree*  srcAddrOrFill = nullptr;
-    bool      isInitBlk     = blkNode->OperIsInitBlkOp();
+    GenTree* dstAddr       = blkNode->Addr();
+    unsigned size          = blkNode->gtBlkSize;
+    GenTree* source        = blkNode->Data();
+    GenTree* srcAddrOrFill = nullptr;
+    bool     isInitBlk     = blkNode->OperIsInitBlkOp();
 
     if (!isInitBlk)
     {
@@ -593,7 +592,6 @@ void Lowering::LowerPutArgStk(GenTreePutArgStk* putArgStk)
     }
 
 #ifdef FEATURE_PUT_STRUCT_ARG_STK
-    GenTree* dst     = putArgStk;
     GenTree* srcAddr = nullptr;
 
     bool haveLocalAddr = false;
@@ -615,7 +613,7 @@ void Lowering::LowerPutArgStk(GenTreePutArgStk* putArgStk)
     // it might be the right thing to do.
 
     // This threshold will decide from using the helper or let the JIT decide to inline
-    // a code sequence of its choice.
+    // a code sequence of its choice, but currently we use CPBLK_UNROLL_LIMIT, see #20549.
     ssize_t helperThreshold = max(CPBLK_MOVS_LIMIT, CPBLK_UNROLL_LIMIT);
     ssize_t size            = putArgStk->gtNumSlots * TARGET_POINTER_SIZE;
 
@@ -1765,11 +1763,11 @@ void Lowering::ContainCheckDivOrMod(GenTreeOp* node)
         return;
     }
 
-    GenTree* dividend = node->gtGetOp1();
-    GenTree* divisor  = node->gtGetOp2();
+    GenTree* divisor = node->gtGetOp2();
 
     bool divisorCanBeRegOptional = true;
 #ifdef _TARGET_X86_
+    GenTree* dividend = node->gtGetOp1();
     if (dividend->OperGet() == GT_LONG)
     {
         divisorCanBeRegOptional = false;

--- a/src/jit/lsraarm64.cpp
+++ b/src/jit/lsraarm64.cpp
@@ -46,7 +46,6 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 int LinearScan::BuildNode(GenTree* tree)
 {
     assert(!tree->isContained());
-    Interval* prefSrcInterval = nullptr;
     int       srcCount;
     int       dstCount      = 0;
     regMaskTP dstCandidates = RBM_NONE;
@@ -55,8 +54,6 @@ int LinearScan::BuildNode(GenTree* tree)
 
     // Reset the build-related members of LinearScan.
     clearBuildState();
-
-    RegisterType registerType = TypeGet(tree);
 
     // Set the default dstCount. This may be modified below.
     if (tree->IsValue())
@@ -603,11 +600,8 @@ int LinearScan::BuildNode(GenTree* tree)
             GenTreeBoundsChk* node = tree->AsBoundsChk();
             // Consumes arrLen & index - has no result
             assert(dstCount == 0);
-
-            GenTree* intCns = nullptr;
-            GenTree* other  = nullptr;
-            srcCount        = BuildOperandUses(tree->AsBoundsChk()->gtIndex);
-            srcCount += BuildOperandUses(tree->AsBoundsChk()->gtArrLen);
+            srcCount = BuildOperandUses(node->gtIndex);
+            srcCount += BuildOperandUses(node->gtArrLen);
         }
         break;
 
@@ -1007,7 +1001,6 @@ int LinearScan::BuildHWIntrinsic(GenTreeHWIntrinsic* intrinsicTree)
         op1 = op1->AsArgList()->Current();
     }
 
-    int  dstCount       = intrinsicTree->IsValue() ? 1 : 0;
     bool op2IsDelayFree = false;
     bool op3IsDelayFree = false;
 

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -46,8 +46,6 @@ int LinearScan::BuildIndir(GenTreeIndir* indirTree)
         return srcCount;
     }
 
-    bool isStore = (indirTree->gtOper == GT_STOREIND);
-
     GenTree* addr  = indirTree->Addr();
     GenTree* index = nullptr;
     int      cns   = 0;

--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -1326,7 +1326,6 @@ void CodeGen::psiBegProlog()
                     regNumber otherRegNum = REG_NA;
                     for (unsigned nCnt = 0; nCnt < structDesc.eightByteCount; nCnt++)
                     {
-                        unsigned  len     = structDesc.eightByteSizes[nCnt];
                         var_types regType = TYP_UNDEF;
 
                         if (nCnt == 0)

--- a/src/jit/simd.cpp
+++ b/src/jit/simd.cpp
@@ -2481,7 +2481,6 @@ GenTree* Compiler::impSIMDIntrinsic(OPCODE                opcode,
                 unsigned initCount    = argCount - 1;
                 unsigned elementCount = getSIMDVectorLength(size, baseType);
                 noway_assert(initCount == elementCount);
-                GenTree* nextArg = op2;
 
                 // Build a GT_LIST with the N values.
                 // We must maintain left-to-right order of the args, but we will pop
@@ -2490,7 +2489,6 @@ GenTree* Compiler::impSIMDIntrinsic(OPCODE                opcode,
                 GenTree* list              = nullptr;
                 GenTree* firstArg          = nullptr;
                 GenTree* prevArg           = nullptr;
-                int      offset            = 0;
                 bool     areArgsContiguous = true;
                 for (unsigned i = 0; i < initCount; i++)
                 {
@@ -2651,7 +2649,6 @@ GenTree* Compiler::impSIMDIntrinsic(OPCODE                opcode,
             assert(op2->TypeGet() == TYP_REF);
             GenTree* arrayRefForArgChk = op2;
             GenTree* argRngChk         = nullptr;
-            GenTree* asg               = nullptr;
             if ((arrayRefForArgChk->gtFlags & GTF_SIDE_EFFECT) != 0)
             {
                 op2 = fgInsertCommaFormTemp(&arrayRefForArgChk);
@@ -2756,7 +2753,6 @@ GenTree* Compiler::impSIMDIntrinsic(OPCODE                opcode,
             //    op2 - VSmall
             //    op1 - byref of VLarge
             assert(baseType == TYP_FLOAT);
-            unsigned elementByteCount = 4;
 
             GenTree* op4 = nullptr;
             if (argCount == 4)

--- a/src/jit/simdcodegenxarch.cpp
+++ b/src/jit/simdcodegenxarch.cpp
@@ -3079,7 +3079,6 @@ void CodeGen::genSIMDIntrinsicUpperRestore(GenTreeSIMD* simdNode)
     assert(op1->IsLocal() && op1->TypeGet() == TYP_SIMD32);
     regNumber srcReg    = simdNode->gtRegNum;
     regNumber lclVarReg = genConsumeReg(op1);
-    unsigned  varNum    = op1->AsLclVarCommon()->gtLclNum;
     assert(lclVarReg != REG_NA);
     assert(srcReg != REG_NA);
     if (simdNode->gtFlags & GTF_SPILLED)

--- a/src/jit/ssabuilder.cpp
+++ b/src/jit/ssabuilder.cpp
@@ -1870,9 +1870,9 @@ void Compiler::JitTestCheckSSA()
     for (NodeToTestDataMap::KeyIterator ki = testData->Begin(); !ki.Equal(testData->End()); ++ki)
     {
         TestLabelAndNum tlAndN;
-        GenTree*        node = ki.Get();
-        bool            b    = testData->Lookup(node, &tlAndN);
-        assert(b);
+        GenTree*        node       = ki.Get();
+        bool            nodeExists = testData->Lookup(node, &tlAndN);
+        assert(nodeExists);
         if (tlAndN.m_tl == TL_SsaName)
         {
             if (node->OperGet() != GT_LCL_VAR)
@@ -1911,7 +1911,8 @@ void Compiler::JitTestCheckSSA()
                 }
                 // The mapping(s) must be one-to-one: if the label has a mapping, then the ssaNm must, as well.
                 ssize_t num2;
-                bool    b = ssaToLabel->Lookup(ssaNm, &num2);
+                bool    ssaExists = ssaToLabel->Lookup(ssaNm, &num2);
+                assert(ssaExists);
                 // And the mappings must be the same.
                 if (tlAndN.m_num != num2)
                 {

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -5923,8 +5923,6 @@ void Compiler::fgValueNumberBlock(BasicBlock* blk)
     compCurStmtNum = blk->bbStmtNum - 1; // Set compCurStmtNum
 #endif
 
-    unsigned outerLoopNum = BasicBlock::NOT_IN_LOOP;
-
     // First: visit phi's.  If "newVNForPhis", give them new VN's.  If not,
     // first check to see if all phi args have the same value.
     GenTree* firstNonPhi = blk->FirstNonPhiDef();
@@ -7849,7 +7847,6 @@ void Compiler::fgValueNumberTree(GenTree* tree)
             // can recognize redundant loads with no stores between them.
             GenTree*             addr         = tree->AsIndir()->Addr();
             GenTreeLclVarCommon* lclVarTree   = nullptr;
-            FieldSeqNode*        fldSeq1      = nullptr;
             FieldSeqNode*        fldSeq2      = nullptr;
             GenTree*             obj          = nullptr;
             GenTree*             staticOffset = nullptr;
@@ -7890,9 +7887,6 @@ void Compiler::fgValueNumberTree(GenTree* tree)
 
                 ValueNum      inxVN  = ValueNumStore::NoVN;
                 FieldSeqNode* fldSeq = nullptr;
-
-                // GenTree* addr = tree->gtOp.gtOp1;
-                ValueNum addrVN = addrNvnp.GetLiberal();
 
                 // Try to parse it.
                 GenTree* arr = nullptr;
@@ -9749,7 +9743,8 @@ void Compiler::JitTestCheckVN()
                 }
                 // The mapping(s) must be one-to-one: if the label has a mapping, then the ssaNm must, as well.
                 ssize_t num2;
-                bool    b = vnToLabel->Lookup(vn, &num2);
+                bool    found = vnToLabel->Lookup(vn, &num2);
+                assert(found);
                 // And the mappings must be the same.
                 if (tlAndN.m_num != num2)
                 {


### PR DESCRIPTION
#23481 was reverted, try to merge this again without `hwintrinsiccodegenxarch.cpp` that is actively changing now.