### PR TITLE
Nullable: make Object.ToString() return nullable

### DIFF
--- a/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -25,7 +25,9 @@
     <CLSCompliant>true</CLSCompliant>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>649,1573,1591,0419,BCL0020</NoWarn> <!-- Remove BCL0020 once https://github.com/dotnet/arcade/pull/2158 is available -->
+    <!-- Remove BCL0020 once https://github.com/dotnet/arcade/pull/2158 is available 
+         Remove CS8608 once https://github.com/dotnet/roslyn/issues/23268 is resolved -->
+    <NoWarn>649,1573,1591,0419,BCL0020,CS8609</NoWarn>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <SignAssembly>true</SignAssembly>
     <DelaySign>true</DelaySign>

--- a/src/System.Private.CoreLib/shared/System/Globalization/HijriCalendar.Win32.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/HijriCalendar.Win32.cs
@@ -55,10 +55,10 @@ namespace System.Globalization
                 }
 
                 int hijriAdvance = 0;
-                string str = value.ToString();
+                string? str = value.ToString();
                 if (string.Compare(str, 0, HijriAdvanceRegKeyEntry, 0, HijriAdvanceRegKeyEntry.Length, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    if (str.Length == HijriAdvanceRegKeyEntry.Length)
+                    if (str!.Length == HijriAdvanceRegKeyEntry.Length)
                         hijriAdvance = -1;
                     else
                     {

--- a/src/System.Private.CoreLib/shared/System/Object.cs
+++ b/src/System.Private.CoreLib/shared/System/Object.cs
@@ -36,7 +36,7 @@ namespace System
 
         // Returns a String which represents the object instance.  The default
         // for an object is to return the fully qualified name of the class.
-        public virtual string ToString()
+        public virtual string? ToString()
         {
             return GetType().ToString();
         }

--- a/src/System.Private.CoreLib/shared/System/String.Manipulation.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Manipulation.cs
@@ -34,14 +34,7 @@ namespace System
             }
         }
 
-        public static string Concat(object? arg0)
-        {
-            if (arg0 == null)
-            {
-                return string.Empty;
-            }
-            return arg0.ToString();
-        }
+        public static string Concat(object? arg0) => arg0?.ToString() ?? string.Empty;
 
         public static string Concat(object? arg0, object? arg1)
         {


### PR DESCRIPTION
@krwq with this warn disabled you should be able to now annotate overrides correctly, the ones you had to workaround in you previous PRs.

cc: @jaredpar @jcouv @terrajobst 