### PR TITLE
Support simple assembly name in startup hook

### DIFF
--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -1264,9 +1264,6 @@
   <data name="Argument_InvalidSerializedString" xml:space="preserve">
     <value>The specified serialized string '{0}' is not supported.</value>
   </data>
-  <data name="Argument_InvalidStartupHookSyntax" xml:space="preserve">
-    <value>The syntax of the startup hook variable was invalid.</value>
-  </data>
   <data name="Argument_InvalidStartupHookSignature" xml:space="preserve">
     <value>The signature of the startup hook '{0}' in assembly '{1}' was invalid. It must be 'public static void Initialize()'.</value>
   </data>

--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -3754,4 +3754,10 @@
   <data name="Serialization_DangerousDeserialization_Switch" xml:space="preserve">
     <value>An action was attempted during deserialization that could lead to a security vulnerability. The action has been aborted. To allow the action, set the '{0}' AppContext switch to true.</value>
   </data>
+  <data name="Argument_InvalidStartupHookSimpleAssemblyName" xml:space="preserve">
+    <value>The startup hook simple assembly name '{0}' is invalid. It must be a valid assembly name and it may not contain directory separator, space or comma characters and must not end with '.dll'.</value>
+  </data>
+  <data name="Argument_StartupHookAssemblyLoadFailed" xml:space="preserve">
+    <value>Startup hook assembly '{0}' failed to load. See inner exception for details.</value>
+  </data>
 </root>

--- a/src/System.Private.CoreLib/src/System/StartupHookProvider.cs
+++ b/src/System.Private.CoreLib/src/System/StartupHookProvider.cs
@@ -50,7 +50,7 @@ namespace System
                 string startupHookPart = startupHookParts[i];
                 if (string.IsNullOrEmpty(startupHookPart))
                 {
-                    throw new ArgumentException(SR.Argument_InvalidStartupHookSyntax);
+                    continue;
                 }
 
                 if (Path.IsPathFullyQualified(startupHookPart))

--- a/src/System.Private.CoreLib/src/System/StartupHookProvider.cs
+++ b/src/System.Private.CoreLib/src/System/StartupHookProvider.cs
@@ -50,6 +50,7 @@ namespace System
                 string startupHookPart = startupHookParts[i];
                 if (string.IsNullOrEmpty(startupHookPart))
                 {
+                    // Leave the slot in startupHooks empty (nulls for everything). This is simpler than shifting and resizing the array.
                     continue;
                 }
 
@@ -98,8 +99,6 @@ namespace System
         // "static void Initialize()" method.
         private static void CallStartupHook(StartupHookNameOrPath startupHook)
         {
-            Debug.Assert(startupHook.Path != null || startupHook.AssemblyName != null);
-
             Assembly assembly;
             try
             {
@@ -108,10 +107,15 @@ namespace System
                     Debug.Assert(Path.IsPathFullyQualified(startupHook.Path));
                     assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(startupHook.Path);
                 }
-                else
+                else if (startupHook.AssemblyName != null)
                 {
                     Debug.Assert(startupHook.AssemblyName != null);
                     assembly = AssemblyLoadContext.Default.LoadFromAssemblyName(startupHook.AssemblyName);
+                }
+                else
+                {
+                    // Empty slot - skip it
+                    return;
                 }
             }
             catch (Exception assemblyLoadException)

--- a/src/System.Private.CoreLib/src/System/StartupHookProvider.cs
+++ b/src/System.Private.CoreLib/src/System/StartupHookProvider.cs
@@ -13,15 +13,6 @@ namespace System
     {
         private const string StartupHookTypeName = "StartupHook";
         private const string InitializeMethodName = "Initialize";
-
-        private static readonly char[] s_disallowedSimpleAssemblyNameChars = new char[]
-        {
-            Path.DirectorySeparatorChar,
-            Path.AltDirectorySeparatorChar,
-            ' ',
-            ','
-        };
-
         private const string DisallowedSimpleAssemblyNameSuffix = ".dll";
 
         private struct StartupHookNameOrPath
@@ -43,6 +34,14 @@ namespace System
                 return;
             }
 
+            char[] disallowedSimpleAssemblyNameChars = new char[]
+            {
+                Path.DirectorySeparatorChar,
+                Path.AltDirectorySeparatorChar,
+                ' ',
+                ','
+            };
+
             // Parse startup hooks variable
             string[] startupHookParts = startupHooksVariable.Split(Path.PathSeparator);
             StartupHookNameOrPath[] startupHooks = new StartupHookNameOrPath[startupHookParts.Length];
@@ -63,9 +62,9 @@ namespace System
                     // The intent here is to only support simple assembly names, but AssemblyName .ctor accepts
                     // lot of other forms (fully qualified assembly name, strings which look like relative paths and so on).
                     // So add a check on top which will disallow any directory separator, space or comma in the assembly name.
-                    for (int j = 0; j < s_disallowedSimpleAssemblyNameChars.Length; j++)
+                    for (int j = 0; j < disallowedSimpleAssemblyNameChars.Length; j++)
                     {
-                        if (startupHookPart.Contains(s_disallowedSimpleAssemblyNameChars[j]))
+                        if (startupHookPart.Contains(disallowedSimpleAssemblyNameChars[j]))
                         {
                             throw new ArgumentException(SR.Format(SR.Argument_InvalidStartupHookSimpleAssemblyName, startupHookPart));
                         }


### PR DESCRIPTION
Implements support for using simple assembly names in the startup hook environment variable.
The code first tests if the value is a fully qualified path, and if so, will load the assembly by path.
If it's not, it will parse the value with `new AssemblyName`. If that works, it will load the assembly by name.

Note that the code still blocks relative assembly paths, as those will not parse as assembly names.

The change is a bit larger to avoid parsing the assembly name twice.

Tests will be added in the core-setup repo, since all the existing startup hook tests are there as well.

Fixes #23343 