### PR TITLE
Fix macro-redefined warnings caused by limits.h & float.h

### DIFF
--- a/src/debug/daccess/daccess.cpp
+++ b/src/debug/daccess/daccess.cpp
@@ -6321,9 +6321,9 @@ bool ClrDataAccess::ReportMem(TADDR addr, TSIZE_T size, bool fExpectSuccess /*= 
     while (size)
     {
         ULONG32 enumSize;
-        if (size > ULONG_MAX)
+        if (size > UINT32_MAX)
         {
-            enumSize = ULONG_MAX;
+            enumSize = UINT32_MAX;
         }
         else
         {

--- a/src/debug/di/divalue.cpp
+++ b/src/debug/di/divalue.cpp
@@ -4442,9 +4442,9 @@ HRESULT CordbHandleValue::GetSize(ULONG32 *pSize)
         return CORDBG_E_HANDLE_HAS_BEEN_DISPOSED;
     }
 
-    if (m_size > ULONG_MAX)
+    if (m_size > UINT32_MAX)
     {
-        *pSize = ULONG_MAX;
+        *pSize = UINT32_MAX;
         return (COR_E_OVERFLOW);
     }
 

--- a/src/debug/di/rspriv.h
+++ b/src/debug/di/rspriv.h
@@ -3973,7 +3973,7 @@ public:
 #if defined(DBG_TARGET_64BIT)
 #define MAX_ADDRESS     (_UI64_MAX)
 #else
-#define MAX_ADDRESS     (ULONG_MAX)
+#define MAX_ADDRESS     (_UI32_MAX)
 #endif
 #define MIN_ADDRESS     (0x0)
     CORDB_ADDRESS       m_minPatchAddr; //smallest patch in table
@@ -8684,9 +8684,9 @@ public:
         FAIL_IF_NEUTERED(this);
         VALIDATE_POINTER_TO_OBJECT(pSize, ULONG32 *);
 
-        if (m_size > ULONG_MAX)
+        if (m_size > UINT32_MAX)
         {
-            *pSize = ULONG_MAX;
+            *pSize = UINT32_MAX;
             return (COR_E_OVERFLOW);
         }
 

--- a/src/debug/di/symbolinfo.cpp
+++ b/src/debug/di/symbolinfo.cpp
@@ -260,7 +260,7 @@ STDMETHODIMP SymbolInfo::GetTypeDefProps (             // S_OK or error.
 
 
     SIZE_T cch=wcslen(classInfo->wszName)+1;
-    if (cch > ULONG_MAX)
+    if (cch > UINT32_MAX)
         return E_UNEXPECTED;
     *pchTypeDef=(ULONG)cch;
     
@@ -311,7 +311,7 @@ STDMETHODIMP SymbolInfo::GetMethodProps (
     
     *pClass=m_LastMethod.cls;
     SIZE_T cch=wcslen(m_LastMethod.wszName)+1;
-    if(cch > ULONG_MAX)
+    if(cch > UINT32_MAX)
         return E_UNEXPECTED;
     *pchMethod=(ULONG)cch;
     

--- a/src/inc/corprof.idl
+++ b/src/inc/corprof.idl
@@ -1550,7 +1550,7 @@ interface ICorProfilerCallback : IUnknown
      * GarbageCollectionFinished, all objects have been moved to their new locations, and
      * inspection may be done.
      *
-     * THIS CALLBACK IS OBSOLETE. It reports ranges for objects >4GB as ULONG_MAX 
+     * THIS CALLBACK IS OBSOLETE. It reports ranges for objects >4GB as UINT32_MAX
      * on 64-bit platforms. Use ICorProfilerCallback4::MovedReferences2 instead.
      */
     HRESULT MovedReferences(
@@ -2093,7 +2093,7 @@ interface ICorProfilerCallback2 : ICorProfilerCallback
      *      objectIDRangeStart[i] <= ObjectID < objectIDRangeStart[i] + cObjectIDRangeLength[i]
      * for 0 <= i < cMovedObjectIDRanges, then the ObjectID has survived the collection
      *
-     * THIS CALLBACK IS OBSOLETE. It reports ranges for objects >4GB as ULONG_MAX 
+     * THIS CALLBACK IS OBSOLETE. It reports ranges for objects >4GB as UINT32_MAX
      * on 64-bit platforms. Use ICorProfilerCallback4::SurvivingReferences2 instead.
      */
     HRESULT SurvivingReferences(

--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -517,9 +517,9 @@ struct BasicBlock : private LIR::Range
 #define BB_UNITY_WEIGHT 100 // how much a normal execute once block weights
 #define BB_LOOP_WEIGHT 8    // how much more loops are weighted
 #define BB_ZERO_WEIGHT 0
-#define BB_MAX_WEIGHT ULONG_MAX // we're using an 'unsigned' for the weight
-#define BB_VERY_HOT_WEIGHT 256  // how many average hits a BB has (per BBT scenario run) for this block
-                                // to be considered as very hot
+#define BB_MAX_WEIGHT UINT32_MAX // we're using an 'unsigned' for the weight
+#define BB_VERY_HOT_WEIGHT 256   // how many average hits a BB has (per BBT scenario run) for this block
+                                 // to be considered as very hot
 
     weight_t bbWeight; // The dynamic execution weight of this block
 

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -1789,8 +1789,8 @@ inline void LclVarDsc::incRefCnts(BasicBlock::weight_t weight, Compiler* comp, R
                 setLvRefCntWtd(newWeight, state);
             }
             else
-            { // On overflow we assign ULONG_MAX
-                setLvRefCntWtd(ULONG_MAX, state);
+            { // On overflow we assign UINT32_MAX
+                setLvRefCntWtd(UINT32_MAX, state);
             }
         }
     }

--- a/src/md/ceefilegen/ceesectionstring.cpp
+++ b/src/md/ceefilegen/ceesectionstring.cpp
@@ -73,7 +73,7 @@ StringTableEntry* CeeSectionString::createEntry(__in_z LPWSTR target, ULONG hash
     entry->m_hashId = hashId;
     entry->m_offset = dataLen();
     size_t len = (wcslen(target)+1) * sizeof(WCHAR);
-    if (len > ULONG_MAX) {
+    if (len > UINT32_MAX) {
         delete entry;
         return NULL;
     }

--- a/src/md/compiler/assemblymd_emit.cpp
+++ b/src/md/compiler/assemblymd_emit.cpp
@@ -308,7 +308,7 @@ STDMETHODIMP RegMeta::DefineExportedType(     // S_OK or error.
     // Split the name into name/namespace pair.
     ns::SplitInline(szNameUTF8, szTypeNamespaceUTF8, szTypeNameUTF8);
     
-    _ASSERTE(szName && dwExportedTypeFlags != ULONG_MAX && pmct);
+    _ASSERTE(szName && dwExportedTypeFlags != UINT32_MAX && pmct);
     _ASSERTE(TypeFromToken(tkImplementation) == mdtFile ||
               TypeFromToken(tkImplementation) == mdtAssemblyRef ||
               TypeFromToken(tkImplementation) == mdtExportedType ||
@@ -394,7 +394,7 @@ STDMETHODIMP RegMeta::DefineManifestResource( // S_OK or error.
     
     IfFailGo(m_pStgdb->m_MiniMd.PreUpdate());
     
-    _ASSERTE(szName && dwResourceFlags != ULONG_MAX && pmmr);
+    _ASSERTE(szName && dwResourceFlags != UINT32_MAX && pmmr);
     _ASSERTE(TypeFromToken(tkImplementation) == mdtFile ||
               TypeFromToken(tkImplementation) == mdtAssemblyRef ||
               tkImplementation == mdTokenNil);
@@ -646,7 +646,7 @@ HRESULT RegMeta::_SetAssemblyProps(     // S_OK or error.
     if (pbPublicKey)
         IfFailGo(m_pStgdb->m_MiniMd.PutBlob(TBL_Assembly, AssemblyRec::COL_PublicKey,
                                 pRecord, pbPublicKey, cbPublicKey));
-    if (ulHashAlgId != ULONG_MAX)
+    if (ulHashAlgId != UINT32_MAX)
         pRecord->SetHashAlgId(ulHashAlgId);
     IfFailGo(m_pStgdb->m_MiniMd.PutStringW(TBL_Assembly, AssemblyRec::COL_Name, pRecord, szName));
     if (pMetaData->usMajorVersion != USHRT_MAX)
@@ -713,7 +713,7 @@ HRESULT RegMeta::_SetAssemblyRefProps(  // S_OK or error.
     if (pbHashValue)
         IfFailGo(m_pStgdb->m_MiniMd.PutBlob(TBL_AssemblyRef, AssemblyRefRec::COL_HashValue,
                                     pRecord, pbHashValue, cbHashValue));
-    if (dwAssemblyRefFlags != ULONG_MAX)
+    if (dwAssemblyRefFlags != UINT32_MAX)
         pRecord->SetFlags(PrepareForSaving(dwAssemblyRefFlags));
 
     IfFailGo(UpdateENCLog(ar));
@@ -741,7 +741,7 @@ HRESULT RegMeta::_SetFileProps(         // S_OK or error.
     if (pbHashValue)
         IfFailGo(m_pStgdb->m_MiniMd.PutBlob(TBL_File, FileRec::COL_HashValue, pRecord,
                                     pbHashValue, cbHashValue));
-    if (dwFileFlags != ULONG_MAX)
+    if (dwFileFlags != UINT32_MAX)
         pRecord->SetFlags(dwFileFlags);
 
     IfFailGo(UpdateENCLog(file));
@@ -771,7 +771,7 @@ HRESULT RegMeta::_SetExportedTypeProps( // S_OK or error.
         _ASSERTE(TypeFromToken(tkTypeDef) == mdtTypeDef);
         pRecord->SetTypeDefId(tkTypeDef);
     }
-    if (dwExportedTypeFlags != ULONG_MAX)
+    if (dwExportedTypeFlags != UINT32_MAX)
         pRecord->SetFlags(dwExportedTypeFlags);
 
     IfFailGo(UpdateENCLog(ct));
@@ -797,9 +797,9 @@ HRESULT RegMeta::_SetManifestResourceProps(// S_OK or error.
     if (tkImplementation != mdTokenNil)
         IfFailGo(m_pStgdb->m_MiniMd.PutToken(TBL_ManifestResource,
                     ManifestResourceRec::COL_Implementation, pRecord, tkImplementation));
-    if (dwOffset != ULONG_MAX)
+    if (dwOffset != UINT32_MAX)
         pRecord->SetOffset(dwOffset);
-    if (dwResourceFlags != ULONG_MAX)
+    if (dwResourceFlags != UINT32_MAX)
         pRecord->SetFlags(dwResourceFlags);
 
     IfFailGo(UpdateENCLog(mr));

--- a/src/md/compiler/custattr_emit.cpp
+++ b/src/md/compiler/custattr_emit.cpp
@@ -1376,7 +1376,7 @@ HRESULT RegMeta::_HandleKnownCustomAttribute(    // S_OK or error.
 
         // Class packing and size.
         ULONG ulSize, ulPack;
-        ulPack = ulSize = ULONG_MAX;
+        ulPack = ulSize = UINT32_MAX;
         if (qNamedArgs[SL_Pack].val.type.tag)
         {    // Only 1,2,4,8,16,32,64,128 are legal values.
              ulPack = qNamedArgs[SL_Pack].val.u4;
@@ -1390,7 +1390,7 @@ HRESULT RegMeta::_HandleKnownCustomAttribute(    // S_OK or error.
                 IfFailGo(PostError(META_E_CA_INVALID_VALUE));
             ulSize = qNamedArgs[SL_Size].val.u4;
         }
-        if (ulPack!=ULONG_MAX || ulSize!=ULONG_MAX)
+        if (ulPack!=UINT32_MAX || ulSize!=UINT32_MAX)
             IfFailGo(_SetClassLayout(tkObj, ulPack, ulSize));
 
         // Class character set.

--- a/src/md/compiler/emit.cpp
+++ b/src/md/compiler/emit.cpp
@@ -228,7 +228,7 @@ STDMETHODIMP RegMeta::SetMethodImplFlags(     // [IN] S_OK or error.
     START_MD_PERF();
     LOCKWRITE();
 
-    _ASSERTE(TypeFromToken(md) == mdtMethodDef && dwImplFlags != ULONG_MAX);
+    _ASSERTE(TypeFromToken(md) == mdtMethodDef && dwImplFlags != UINT32_MAX);
 
     // Get the record.
     IfFailGo(m_pStgdb->m_MiniMd.GetMethodRecord(RidFromToken(md), &pMethodRec));
@@ -332,14 +332,14 @@ HRESULT RegMeta::_SetRVA(               // [IN] S_OK or error.
         pMethodRec->SetRVA(ulCodeRVA);
 
         // Do not set the flag value unless its valid.
-        if (dwImplFlags != ULONG_MAX)
+        if (dwImplFlags != UINT32_MAX)
             pMethodRec->SetImplFlags(static_cast<USHORT>(dwImplFlags));
 
         IfFailGo(UpdateENCLog(tk));
     }
     else            // TypeFromToken(tk) == mdtFieldDef
     {
-        _ASSERTE(dwImplFlags==0 || dwImplFlags==ULONG_MAX);
+        _ASSERTE(dwImplFlags==0 || dwImplFlags==UINT32_MAX);
 
         FieldRVARec     *pFieldRVARec;
         RID             iFieldRVA;
@@ -792,7 +792,7 @@ STDMETHODIMP RegMeta::SetClassLayout(
         // Iterate the list of fields...
         for (index = 0; rFieldOffsets[index].ridOfField != mdFieldDefNil; index++)
         {
-            if (rFieldOffsets[index].ulOffset != ULONG_MAX)
+            if (rFieldOffsets[index].ulOffset != UINT32_MAX)
             {
                 tkfd = TokenFromRid(rFieldOffsets[index].ridOfField, mdtFieldDef);
                 
@@ -843,9 +843,9 @@ HRESULT RegMeta::_SetClassLayout(       // S_OK or error.
     }
 
     // Set the data.
-    if (dwPackSize != ULONG_MAX)
+    if (dwPackSize != UINT32_MAX)
         pClassLayout->SetPackingSize(static_cast<USHORT>(dwPackSize));
-    if (ulClassSize != ULONG_MAX)
+    if (ulClassSize != UINT32_MAX)
         pClassLayout->SetClassSize(ulClassSize);
 
     // Create the log record for the non-token record.
@@ -1265,7 +1265,7 @@ STDMETHODIMP RegMeta::SetRVA(                 // [IN] S_OK or error.
     LOCKWRITE();
     
     IfFailGo(m_pStgdb->m_MiniMd.PreUpdate());
-    IfFailGo(_SetRVA(md, ulRVA, ULONG_MAX));    // 0xbaad
+    IfFailGo(_SetRVA(md, ulRVA, UINT32_MAX));    // 0xbaad
     
 ErrExit:
     STOP_MD_PERF(SetRVA);
@@ -1536,7 +1536,7 @@ STDMETHODIMP RegMeta::DefineUserString(       // S_OK or error.
     
     IfFailGo(m_pStgdb->m_MiniMd.PreUpdate());
     
-    _ASSERTE(pstk && szString && cchString != ULONG_MAX);
+    _ASSERTE(pstk && szString && cchString != UINT32_MAX);
 
 
     // Copy over the string to memory.
@@ -2156,7 +2156,7 @@ STDMETHODIMP RegMeta::SetMethodProps(         // S_OK or error.
     START_MD_PERF();
     LOCKWRITE();
     
-    if (dwMethodFlags != ULONG_MAX)
+    if (dwMethodFlags != UINT32_MAX)
     {
         // Make sure no one sets the reserved bits on the way in.
         _ASSERTE((dwMethodFlags & (mdReservedMask&~mdRTSpecialName)) == 0);
@@ -2239,7 +2239,7 @@ STDMETHODIMP RegMeta::SetPermissionSetProps(  // S_OK or error.
              TypeFromToken(tk) == mdtAssembly);
 
     // Check for valid Action.
-    if (dwAction == ULONG_MAX || dwAction == 0 || dwAction > dclMaximumValue)
+    if (dwAction == UINT32_MAX || dwAction == 0 || dwAction > dclMaximumValue)
         IfFailGo(E_INVALIDARG);
 
     IfFailGo(ImportHelper::FindPermission(&(m_pStgdb->m_MiniMd), tk, sAction, &tkPerm));
@@ -2366,7 +2366,7 @@ HRESULT RegMeta::_DefinePinvokeMap(     // Return hresult.
     }
     
     // Set the data.
-    if (dwMappingFlags != ULONG_MAX)
+    if (dwMappingFlags != UINT32_MAX)
         pRecord->SetMappingFlags(static_cast<USHORT>(dwMappingFlags));
     IfFailGo(m_pStgdb->m_MiniMd.PutStringW(TBL_ImplMap, ImplMapRec::COL_ImportName,
                                            pRecord, szImportName));
@@ -2418,7 +2418,7 @@ STDMETHODIMP RegMeta::SetPinvokeMap(          // Return code.
         IfFailGo(m_pStgdb->m_MiniMd.GetImplMapRecord(iRecord, &pRecord));
 
     // Set the data.
-    if (dwMappingFlags != ULONG_MAX)
+    if (dwMappingFlags != UINT32_MAX)
         pRecord->SetMappingFlags(static_cast<USHORT>(dwMappingFlags));
     if (szImportName)
         IfFailGo(m_pStgdb->m_MiniMd.PutStringW(TBL_ImplMap, ImplMapRec::COL_ImportName,
@@ -2541,7 +2541,7 @@ HRESULT RegMeta::DefineField(           // S_OK or error.
     IsGlobalMethodParent(&td);
     
     // Validate flags.
-    if (dwFieldFlags != ULONG_MAX)
+    if (dwFieldFlags != UINT32_MAX)
     {
         // fdHasFieldRVA is settable, but not re-settable by applications.
         _ASSERTE((dwFieldFlags & (fdReservedMask&~(fdHasFieldRVA|fdRTSpecialName))) == 0);
@@ -2773,7 +2773,7 @@ HRESULT RegMeta::DefineParam(
     LOCKWRITE();
 
     _ASSERTE(TypeFromToken(md) == mdtMethodDef && md != mdMethodDefNil &&
-             ulParamSeq != ULONG_MAX && ppd);
+             ulParamSeq != UINT32_MAX && ppd);
     
     IfFailGo(m_pStgdb->m_MiniMd.PreUpdate());
     
@@ -2852,7 +2852,7 @@ HRESULT RegMeta::SetFieldProps(           // S_OK or error.
     IfFailGo(m_pStgdb->m_MiniMd.PreUpdate());
     
     // Validate flags.
-    if (dwFieldFlags != ULONG_MAX)
+    if (dwFieldFlags != UINT32_MAX)
     {
         // fdHasFieldRVA is settable, but not re-settable by applications.
         _ASSERTE((dwFieldFlags & (fdReservedMask&~(fdHasFieldRVA|fdRTSpecialName))) == 0);

--- a/src/md/compiler/helper.cpp
+++ b/src/md/compiler/helper.cpp
@@ -188,7 +188,7 @@ HRESULT RegMeta::SetFieldLayoutHelper(  // Return hresult.
 
     LOCKWRITE();
 
-    if (ulOffset == ULONG_MAX)
+    if (ulOffset == UINT32_MAX)
     {
         // invalid argument
         IfFailGo( E_INVALIDARG );

--- a/src/md/compiler/import.cpp
+++ b/src/md/compiler/import.cpp
@@ -2748,7 +2748,7 @@ STDMETHODIMP RegMeta::GetParamForMethodIndex( // S_OK or error.
     START_MD_PERF();
     LOCKREAD();
     
-    _ASSERTE((TypeFromToken(md) == mdtMethodDef) && (ulParamSeq != ULONG_MAX) && (ppd != NULL));
+    _ASSERTE((TypeFromToken(md) == mdtMethodDef) && (ulParamSeq != UINT32_MAX) && (ppd != NULL));
     
     IfFailGo(_FindParamOfMethod(md, ulParamSeq, ppd));
 ErrExit:

--- a/src/md/compiler/regmeta_emit.cpp
+++ b/src/md/compiler/regmeta_emit.cpp
@@ -1187,12 +1187,12 @@ HRESULT RegMeta::_SetTypeDefProps(      // S_OK or error.
 
     _ASSERTE(TypeFromToken(td) == mdtTypeDef);
     _ASSERTE(TypeFromToken(tkExtends) == mdtTypeDef || TypeFromToken(tkExtends) == mdtTypeRef || TypeFromToken(tkExtends) == mdtTypeSpec ||
-                IsNilToken(tkExtends) || tkExtends == ULONG_MAX);
+                IsNilToken(tkExtends) || tkExtends == UINT32_MAX);
 
     // Get the record.
     IfFailGo(m_pStgdb->m_MiniMd.GetTypeDefRecord(RidFromToken(td), &pRecord));
 
-    if (dwTypeDefFlags != ULONG_MAX)
+    if (dwTypeDefFlags != UINT32_MAX)
     {
         // No one should try to set the reserved flags explicitly.
         _ASSERTE((dwTypeDefFlags & (tdReservedMask&~tdRTSpecialName)) == 0);
@@ -1203,7 +1203,7 @@ HRESULT RegMeta::_SetTypeDefProps(      // S_OK or error.
         // Set the flags.
         pRecord->SetFlags(dwTypeDefFlags);
     }
-    if (tkExtends != ULONG_MAX)
+    if (tkExtends != UINT32_MAX)
     {
         if (IsNilToken(tkExtends))
             tkExtends = mdTypeDefNil;
@@ -1460,7 +1460,7 @@ HRESULT RegMeta::_SetEventProps1(                // Return hresult.
     _ASSERTE(TypeFromToken(ev) == mdtEvent && RidFromToken(ev));
 
     IfFailGo(m_pStgdb->m_MiniMd.GetEventRecord(RidFromToken(ev), &pRecord));
-    if (dwEventFlags != ULONG_MAX)
+    if (dwEventFlags != UINT32_MAX)
     {
         // Don't let caller set reserved bits
         dwEventFlags &= ~evReservedMask;
@@ -1552,7 +1552,7 @@ HRESULT RegMeta::_SetPermissionSetProps(         // Return hresult.
     DeclSecurityRec *pRecord;
     HRESULT     hr = S_OK;
 
-    _ASSERTE(TypeFromToken(tkPerm) == mdtPermission && cbPermission != ULONG_MAX);
+    _ASSERTE(TypeFromToken(tkPerm) == mdtPermission && cbPermission != UINT32_MAX);
     _ASSERTE(dwAction && dwAction <= dclMaximumValue);
 
     IfFailGo(m_pStgdb->m_MiniMd.GetDeclSecurityRecord(RidFromToken(tkPerm), &pRecord));
@@ -1578,7 +1578,7 @@ HRESULT RegMeta::_DefineSetConstant(    // Return hresult.
     
 
     if ((dwCPlusTypeFlag != ELEMENT_TYPE_VOID && dwCPlusTypeFlag != ELEMENT_TYPE_END &&
-         dwCPlusTypeFlag != ULONG_MAX) &&
+         dwCPlusTypeFlag != UINT32_MAX) &&
         (pValue || (pValue == 0 && (dwCPlusTypeFlag == ELEMENT_TYPE_STRING ||
                                     dwCPlusTypeFlag == ELEMENT_TYPE_CLASS))))
     {
@@ -1646,7 +1646,7 @@ HRESULT RegMeta::_SetMethodProps(       // S_OK or error.
     IfFailGo(m_pStgdb->m_MiniMd.GetMethodRecord(RidFromToken(md), &pRecord));
 
     // Set the data.
-    if (dwMethodFlags != ULONG_MAX)
+    if (dwMethodFlags != UINT32_MAX)
     {
         // Preserve the reserved flags stored already and always keep the mdRTSpecialName
         dwMethodFlags |= (pRecord->GetFlags() & mdReservedMask);
@@ -1654,9 +1654,9 @@ HRESULT RegMeta::_SetMethodProps(       // S_OK or error.
         // Set the flags.
         pRecord->SetFlags(static_cast<USHORT>(dwMethodFlags));
     }
-    if (ulCodeRVA != ULONG_MAX)
+    if (ulCodeRVA != UINT32_MAX)
         pRecord->SetRVA(ulCodeRVA);
-    if (dwImplFlags != ULONG_MAX)
+    if (dwImplFlags != UINT32_MAX)
         pRecord->SetImplFlags(static_cast<USHORT>(dwImplFlags));
 
     IfFailGo(UpdateENCLog(md));
@@ -1689,11 +1689,11 @@ HRESULT RegMeta::_SetFieldProps(        // S_OK or error.
 
     // See if there is a Constant.
     if ((dwCPlusTypeFlag != ELEMENT_TYPE_VOID && dwCPlusTypeFlag != ELEMENT_TYPE_END &&
-         dwCPlusTypeFlag != ULONG_MAX) &&
+         dwCPlusTypeFlag != UINT32_MAX) &&
         (pValue || (pValue == 0 && (dwCPlusTypeFlag == ELEMENT_TYPE_STRING ||
                                     dwCPlusTypeFlag == ELEMENT_TYPE_CLASS))))
     {
-        if (dwFieldFlags == ULONG_MAX)
+        if (dwFieldFlags == UINT32_MAX)
             dwFieldFlags = pRecord->GetFlags();
         dwFieldFlags |= fdHasDefault;
 
@@ -1701,7 +1701,7 @@ HRESULT RegMeta::_SetFieldProps(        // S_OK or error.
     }
 
     // Set the flags.
-    if (dwFieldFlags != ULONG_MAX)
+    if (dwFieldFlags != UINT32_MAX)
     {
         if ( IsFdHasFieldRVA(dwFieldFlags) && !IsFdHasFieldRVA(pRecord->GetFlags()) ) 
         {
@@ -1753,24 +1753,24 @@ HRESULT RegMeta::_SetPropertyProps(      // S_OK or error.
 
     IfFailGo(m_pStgdb->m_MiniMd.GetPropertyRecord(RidFromToken(pr), &pRecord));
 
-    if (dwPropFlags != ULONG_MAX)
+    if (dwPropFlags != UINT32_MAX)
     {
         // Clear the reserved flags from the flags passed in.
         dwPropFlags &= (~prReservedMask);
     }
     // See if there is a constant.
     if ((dwCPlusTypeFlag != ELEMENT_TYPE_VOID && dwCPlusTypeFlag != ELEMENT_TYPE_END &&
-         dwCPlusTypeFlag != ULONG_MAX) &&
+         dwCPlusTypeFlag != UINT32_MAX) &&
         (pValue || (pValue == 0 && (dwCPlusTypeFlag == ELEMENT_TYPE_STRING ||
                                     dwCPlusTypeFlag == ELEMENT_TYPE_CLASS))))
     {
-        if (dwPropFlags == ULONG_MAX)
+        if (dwPropFlags == UINT32_MAX)
             dwPropFlags = pRecord->GetPropFlags();
         dwPropFlags |= prHasDefault;
         
         bHasDefault = true;
     }
-    if (dwPropFlags != ULONG_MAX)
+    if (dwPropFlags != UINT32_MAX)
     {
         // Preserve the reserved flags.
         dwPropFlags |= (pRecord->GetPropFlags() & prReservedMask);
@@ -1779,14 +1779,14 @@ HRESULT RegMeta::_SetPropertyProps(      // S_OK or error.
     }
 
     // store the getter (or clear out old one).
-    if (mdGetter != ULONG_MAX)
+    if (mdGetter != UINT32_MAX)
     {
         _ASSERTE(TypeFromToken(mdGetter) == mdtMethodDef || IsNilToken(mdGetter));
         IfFailGo(_DefineMethodSemantics(msGetter, mdGetter, pr, bClear));
     }
 
     // Store the setter (or clear out old one).
-    if (mdSetter != ULONG_MAX)
+    if (mdSetter != UINT32_MAX)
     {
         _ASSERTE(TypeFromToken(mdSetter) == mdtMethodDef || IsNilToken(mdSetter));
         IfFailGo(_DefineMethodSemantics(msSetter, mdSetter, pr, bClear));
@@ -1852,7 +1852,7 @@ HRESULT RegMeta::_SetParamProps(        // Return code.
         IfFailGo(m_pStgdb->m_MiniMd.PutStringW(TBL_Param, ParamRec::COL_Name, pRecord, szName));
     }
 
-    if (dwParamFlags != ULONG_MAX)
+    if (dwParamFlags != UINT32_MAX)
     {
         // No one should try to set the reserved flags explicitly.
         _ASSERTE((dwParamFlags & pdReservedMask) == 0);
@@ -1861,18 +1861,18 @@ HRESULT RegMeta::_SetParamProps(        // Return code.
     }
     // See if there is a constant.
     if ((dwCPlusTypeFlag != ELEMENT_TYPE_VOID && dwCPlusTypeFlag != ELEMENT_TYPE_END &&
-         dwCPlusTypeFlag != ULONG_MAX) &&
+         dwCPlusTypeFlag != UINT32_MAX) &&
         (pValue || (pValue == 0 && (dwCPlusTypeFlag == ELEMENT_TYPE_STRING ||
                                     dwCPlusTypeFlag == ELEMENT_TYPE_CLASS))))
     {
-        if (dwParamFlags == ULONG_MAX)
+        if (dwParamFlags == UINT32_MAX)
             dwParamFlags = pRecord->GetFlags();
         dwParamFlags |= pdHasDefault;
 
         bHasDefault = true;
     }
     // Set the flags.
-    if (dwParamFlags != ULONG_MAX)
+    if (dwParamFlags != UINT32_MAX)
     {
         // Preserve the reserved flags stored.
         dwParamFlags |= (pRecord->GetFlags() & pdReservedMask);

--- a/src/md/enc/mdinternalrw.cpp
+++ b/src/md/enc/mdinternalrw.cpp
@@ -2944,7 +2944,7 @@ HRESULT MDInternalRW::GetFieldOffset(
 
     IfFailGo(m_pStgdb->m_MiniMd.GetFieldLayoutRecord(iLayout, &pRec));
     *pulOffset = m_pStgdb->m_MiniMd.getOffSetOfFieldLayout(pRec);
-    _ASSERTE(*pulOffset != ULONG_MAX);
+    _ASSERTE(*pulOffset != UINT32_MAX);
 
 ErrExit:
     return hr;
@@ -2979,7 +2979,7 @@ HRESULT MDInternalRW::GetClassLayoutNext(
         {
             IfFailGo(m_pStgdb->m_MiniMd.GetFieldLayoutRecord(iLayout2, &pRec));
             *pulOffset = m_pStgdb->m_MiniMd.getOffSetOfFieldLayout(pRec);
-            _ASSERTE(*pulOffset != ULONG_MAX);
+            _ASSERTE(*pulOffset != UINT32_MAX);
             *pfd = fd;
             goto ErrExit;
         }

--- a/src/md/enc/metamodelrw.cpp
+++ b/src/md/enc/metamodelrw.cpp
@@ -1231,7 +1231,7 @@ CMiniMdRW::ComputeGrowLimits(
     else
     {
         // Tables are already large
-        m_maxRid = m_maxIx = ULONG_MAX;
+        m_maxRid = m_maxIx = UINT32_MAX;
         m_limIx = USHRT_MAX << 1;
         m_limRid = USHRT_MAX << 1; 
         m_eGrow = eg_grown;
@@ -4732,7 +4732,7 @@ CMiniMdRW::ExpandTables()
 
     // Remember that we've grown.
     m_eGrow = eg_grown;
-    m_maxRid = m_maxIx = ULONG_MAX;
+    m_maxRid = m_maxIx = UINT32_MAX;
 
 ErrExit:
     return hr;
@@ -5052,7 +5052,7 @@ CMiniMdRW::AddRecord(             // S_OK or error.
         if (m_maxRid > m_limRid && m_eGrow == eg_ok)
         {
             // OutputDebugStringA("Growing tables due to Record overflow.\n");
-            m_eGrow = eg_grow, m_maxRid = m_maxIx = ULONG_MAX;
+            m_eGrow = eg_grow, m_maxRid = m_maxIx = UINT32_MAX;
         }
     }
     ++m_Schema.m_cRecs[nTableIndex];
@@ -5370,7 +5370,7 @@ CMiniMdRW::PutString(   // S_OK or E_UNEXPECTED.
     
     hr = PutCol(m_TableDefs[ixTbl].m_pColDefs[ixCol], pvRecord, nStringIndex);
     
-    if (m_maxIx != ULONG_MAX)
+    if (m_maxIx != UINT32_MAX)
     {
         IfFailGo(m_StringHeap.GetAlignedSize(&nStringIndex));
     }
@@ -5380,7 +5380,7 @@ CMiniMdRW::PutString(   // S_OK or E_UNEXPECTED.
         if (m_maxIx > m_limIx && m_eGrow == eg_ok)
         {
             // OutputDebugStringA("Growing tables due to String overflow.\n");
-            m_eGrow = eg_grow, m_maxRid = m_maxIx = ULONG_MAX;
+            m_eGrow = eg_grow, m_maxRid = m_maxIx = UINT32_MAX;
         }
     }
     
@@ -5427,7 +5427,7 @@ CMiniMdRW::PutStringW(
 
     hr = PutCol(m_TableDefs[ixTbl].m_pColDefs[ixCol], pvRecord, nStringIndex);
     
-    if (m_maxIx != ULONG_MAX)
+    if (m_maxIx != UINT32_MAX)
     {
         IfFailGo(m_StringHeap.GetAlignedSize(&nStringIndex));
     }
@@ -5437,7 +5437,7 @@ CMiniMdRW::PutStringW(
         if (m_maxIx > m_limIx && m_eGrow == eg_ok)
         {
             // OutputDebugStringA("Growing tables due to String overflow.\n");
-            m_eGrow = eg_grow, m_maxRid = m_maxIx = ULONG_MAX;
+            m_eGrow = eg_grow, m_maxRid = m_maxIx = UINT32_MAX;
         }
     }
     
@@ -5471,7 +5471,7 @@ CMiniMdRW::PutGuid(     // S_OK or E_UNEXPECTED.
 
     hr = PutCol(m_TableDefs[ixTbl].m_pColDefs[ixCol], pvRecord, nIndex);
     
-    if (m_maxIx != ULONG_MAX)
+    if (m_maxIx != UINT32_MAX)
     {
         cbSize = m_GuidHeap.GetSize();
     }
@@ -5481,7 +5481,7 @@ CMiniMdRW::PutGuid(     // S_OK or E_UNEXPECTED.
         if (m_maxIx > m_limIx && m_eGrow == eg_ok)
         {
             // OutputDebugStringA("Growing tables due to GUID overflow.\n");
-            m_eGrow = eg_grow, m_maxRid = m_maxIx = ULONG_MAX;
+            m_eGrow = eg_grow, m_maxRid = m_maxIx = UINT32_MAX;
         }
     }
     
@@ -5594,7 +5594,7 @@ CMiniMdRW::PutBlob(
     
     hr = PutCol(m_TableDefs[ixTbl].m_pColDefs[ixCol], pvRecord, nBlobIndex);
     
-    if (m_maxIx != ULONG_MAX)
+    if (m_maxIx != UINT32_MAX)
     {
         IfFailGo(m_BlobHeap.GetAlignedSize(&nBlobIndex));
     }
@@ -5604,7 +5604,7 @@ CMiniMdRW::PutBlob(
         if (m_maxIx > m_limIx && m_eGrow == eg_ok)
         {
             // OutputDebugStringA("Growing tables due to Blob overflow.\n");
-            m_eGrow = eg_grow, m_maxRid = m_maxIx = ULONG_MAX;
+            m_eGrow = eg_grow, m_maxRid = m_maxIx = UINT32_MAX;
         }
     }
     
@@ -5651,7 +5651,7 @@ CMiniMdRW::AddChildRowIndirectForParent(
     {
         m_maxRid = m_Schema.m_cRecs[tblChild];
         if (m_maxRid > m_limRid && m_eGrow == eg_ok)
-            m_eGrow = eg_grow, m_maxIx = m_maxRid = ULONG_MAX;
+            m_eGrow = eg_grow, m_maxIx = m_maxRid = UINT32_MAX;
     }
     
     // Adjust the rest of the rows in the table.

--- a/src/md/runtime/mdinternalro.cpp
+++ b/src/md/runtime/mdinternalro.cpp
@@ -2182,7 +2182,7 @@ HRESULT MDInternalRO::GetFieldOffset(
 
     IfFailGo(m_LiteWeightStgdb.m_MiniMd.GetFieldLayoutRecord(iLayout, &pRec));
     *pulOffset = m_LiteWeightStgdb.m_MiniMd.getOffSetOfFieldLayout(pRec);
-    _ASSERTE(*pulOffset != ULONG_MAX);
+    _ASSERTE(*pulOffset != UINT32_MAX);
 
 ErrExit:
     return hr;
@@ -2215,7 +2215,7 @@ HRESULT MDInternalRO::GetClassLayoutNext(
         {
             IfFailGo(m_LiteWeightStgdb.m_MiniMd.GetFieldLayoutRecord(iLayout2, &pRec));
             *pulOffset = m_LiteWeightStgdb.m_MiniMd.getOffSetOfFieldLayout(pRec);
-            _ASSERTE(*pulOffset != ULONG_MAX);
+            _ASSERTE(*pulOffset != UINT32_MAX);
             *pfd = TokenFromRid(pLayout->m_ridFieldCur - 1, mdtFieldDef);
             goto ErrExit;
         }
@@ -2585,7 +2585,7 @@ HRESULT MDInternalRO::EnumAssociateInit(
     memset(phEnum, 0, sizeof(HENUMInternal));
 
     // There is no token kind!!!
-    phEnum->m_tkKind = ULONG_MAX;
+    phEnum->m_tkKind = UINT32_MAX;
 
     // output parameters have to be supplied
     _ASSERTE(TypeFromToken(evprop) == mdtEvent || TypeFromToken(evprop) == mdtProperty);

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -262,9 +262,7 @@ typedef char * va_list;
 #define INT_MAX       2147483647
 #define UINT_MAX      0xffffffff
 
-#define LONG_MIN    (-2147483647L - 1)
-//#define LONG_MAX      2147483647L
-//#define ULONG_MAX     0xffffffffUL
+// LONG_MIN, LONG_MAX, ULONG_MAX -- use INT32_MIN etc. instead.
 
 #define FLT_MAX 3.402823466e+38F
 #define DBL_MAX 1.7976931348623157e+308

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -37,6 +37,7 @@ Abstract:
 #define __PAL_H__
 
 #ifdef PAL_STDCPP_COMPAT
+#include <float.h>
 #include <limits.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -265,6 +266,9 @@ typedef char * va_list;
 //#define LONG_MAX      2147483647L
 //#define ULONG_MAX     0xffffffffUL
 
+#define FLT_MAX 3.402823466e+38F
+#define DBL_MAX 1.7976931348623157e+308
+
 #endif // !PAL_STDCPP_COMPAT
 
 /******************* PAL-Specific Entrypoints *****************************/
@@ -275,9 +279,6 @@ PALIMPORT
 BOOL
 PALAPI
 PAL_IsDebuggerPresent(VOID);
-
-#define FLT_MAX 3.402823466e+38F
-#define DBL_MAX 1.7976931348623157e+308
 
 /* minimum signed 64 bit value */
 #define _I64_MIN    (I64(-9223372036854775807) - 1)

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -262,7 +262,7 @@ typedef char * va_list;
 #define UINT_MAX      0xffffffff
 
 #define LONG_MIN    (-2147483647L - 1)
-#define LONG_MAX      2147483647L
+//#define LONG_MAX      2147483647L
 //#define ULONG_MAX     0xffffffffUL
 
 #endif // !PAL_STDCPP_COMPAT

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -263,7 +263,7 @@ typedef char * va_list;
 
 #define LONG_MIN    (-2147483647L - 1)
 #define LONG_MAX      2147483647L
-#define ULONG_MAX     0xffffffffUL
+//#define ULONG_MAX     0xffffffffUL
 
 #endif // !PAL_STDCPP_COMPAT
 

--- a/src/pal/inc/rt/atl.h
+++ b/src/pal/inc/rt/atl.h
@@ -229,11 +229,11 @@ class CComObject : public Base
 public:
 	typedef Base _BaseClass;
 
-	// Set refcount to -(LONG_MAX/2) to protect destruction and 
+	// Set refcount to -(INT32_MAX/2) to protect destruction and
 	// also catch mismatched Release in debug builds
 	~CComObject()
 	{
-		this->m_dwRef = -(LONG_MAX/2);
+		this->m_dwRef = -(INT32_MAX/2);
 	}
 	//If InternalAddRef or InternalRelease is undefined then your class
 	//doesn't derive from CComObjectRoot
@@ -297,7 +297,7 @@ public:
 	{
 #ifdef _DEBUG
 		LONG nRef = _ThreadModel::Decrement(&m_dwRef);
-		if (nRef < -(LONG_MAX / 2))
+		if (nRef < -(INT32_MAX / 2))
 		{
 			ATLASSERT(0);
 		}

--- a/src/pal/inc/rt/intsafe.h
+++ b/src/pal/inc/rt/intsafe.h
@@ -50,11 +50,6 @@
 
 #endif
 
-#define INT_MAX         2147483647
-//#define LONG_MAX        2147483647L
-#define USHRT_MAX       0xffff
-#define UINT_MAX        0xffffffff
-//#define ULONG_MAX       0xffffffffUL
 #define DWORD_MAX       0xffffffffUL
 
 //

--- a/src/pal/inc/rt/intsafe.h
+++ b/src/pal/inc/rt/intsafe.h
@@ -54,7 +54,7 @@
 #define LONG_MAX        2147483647L
 #define USHRT_MAX       0xffff
 #define UINT_MAX        0xffffffff
-#define ULONG_MAX       0xffffffffUL
+//#define ULONG_MAX       0xffffffffUL
 #define DWORD_MAX       0xffffffffUL
 
 //
@@ -612,7 +612,7 @@ ULongLongToULong(
     HRESULT hr = INTSAFE_E_ARITHMETIC_OVERFLOW;
     *pulResult = ULONG_ERROR;
     
-    if (ullOperand <= ULONG_MAX)
+    if (ullOperand <= _UI32_MAX)
     {
         *pulResult = (ULONG)ullOperand;
         hr = S_OK;

--- a/src/pal/inc/rt/intsafe.h
+++ b/src/pal/inc/rt/intsafe.h
@@ -51,7 +51,7 @@
 #endif
 
 #define INT_MAX         2147483647
-#define LONG_MAX        2147483647L
+//#define LONG_MAX        2147483647L
 #define USHRT_MAX       0xffff
 #define UINT_MAX        0xffffffff
 //#define ULONG_MAX       0xffffffffUL
@@ -350,7 +350,7 @@ UIntToLong(
     IN UINT Operand,
     OUT LONG* Result)
 {
-    if (Operand <= LONG_MAX)
+    if (Operand <= _I32_MAX)
     {
         *Result = (LONG)Operand;
         return S_OK;
@@ -503,7 +503,7 @@ ULongToLong(
     IN ULONG Operand,
     OUT LONG* Result)
 {
-    if (Operand <= LONG_MAX)
+    if (Operand <= _I32_MAX)
     {
         *Result = (LONG)Operand;
         return S_OK;
@@ -545,7 +545,7 @@ ULongLongToLong(
     IN ULONGLONG Operand,
     OUT LONG* Result)
 {
-    if (Operand <= LONG_MAX)
+    if (Operand <= _I32_MAX)
     {
         *Result = (LONG)Operand;
         return S_OK;

--- a/src/pal/src/cruntime/string.cpp
+++ b/src/pal/src/cruntime/string.cpp
@@ -114,7 +114,7 @@ Convert string to an unsigned long-integer value.
 
 Return Value
 
-strtoul returns the converted value, if any, or ULONG_MAX on
+strtoul returns the converted value, if any, or UINT32_MAX on
 overflow. It returns 0 if no conversion can be performed. errno is
 set to ERANGE if overflow or underflow occurs.
 
@@ -171,7 +171,7 @@ PAL_strtoul(const char *szNumber, char **pszEnd, int nBase)
     ulResult = strtoul(szNumber, pszEnd, nBase);
 
 #ifdef BIT64
-    if (ulResult > _UI32_MAX)
+    if (ulResult > UINT32_MAX)
     {
         char ch = *szNumber;
         while (isspace(ch))
@@ -183,7 +183,7 @@ PAL_strtoul(const char *szNumber, char **pszEnd, int nBase)
             to match Windows behavior. */
         if (ch != '-')
         {
-            ulResult = _UI32_MAX;
+            ulResult = UINT32_MAX;
             errno = ERANGE;
         }
     }

--- a/src/pal/src/cruntime/wchar.cpp
+++ b/src/pal/src/cruntime/wchar.cpp
@@ -244,7 +244,7 @@ Convert string to an unsigned long-integer value.
 
 Return Value
 
-wcstoul returns the converted value, if any, or ULONG_MAX on
+wcstoul returns the converted value, if any, or UINT32_MAX on
 overflow. It returns 0 if no conversion can be performed. errno is
 set to ERANGE if overflow or underflow occurs.
 
@@ -332,7 +332,7 @@ PAL_wcstoul(
     res = strtoul(s_nptr, &s_endptr, base);
 
 #ifdef BIT64
-    if (res > _UI32_MAX)
+    if (res > UINT32_MAX)
     {
         wchar_16 wc = *nptr;
         while (iswspace(wc))
@@ -344,7 +344,7 @@ PAL_wcstoul(
            to match Windows behavior. */
         if (wc != '-')
         {
-            res = _UI32_MAX;
+            res = UINT32_MAX;
             errno = ERANGE;
         }
     }

--- a/src/pal/tests/palsuite/c_runtime/wcstoul/test5/test5.cpp
+++ b/src/pal/tests/palsuite/c_runtime/wcstoul/test5/test5.cpp
@@ -33,9 +33,9 @@ int __cdecl main(int argc, char *argv[])
     errno = 0;
     l = wcstoul(overstr, &end, 10);
 
-    if (l != ULONG_MAX)
+    if (l != _UI32_MAX)
     {
-        Fail("ERROR: Expected wcstoul to return %u, got %u\n", ULONG_MAX, l);
+        Fail("ERROR: Expected wcstoul to return %u, got %u\n", _UI32_MAX, l);
     }
     if (end != overstr + 10)
     {
@@ -50,9 +50,9 @@ int __cdecl main(int argc, char *argv[])
     errno = 0;
     l = wcstoul(understr, &end, 10);
 
-    if (l != ULONG_MAX)
+    if (l != _UI32_MAX)
     {
-        Fail("ERROR: Expected wcstoul to return %u, got %u\n", ULONG_MAX, l);
+        Fail("ERROR: Expected wcstoul to return %u, got %u\n", _UI32_MAX, l);
     }
     if (end != understr + 2)
     {

--- a/src/utilcode/loaderheap.cpp
+++ b/src/utilcode/loaderheap.cpp
@@ -337,7 +337,7 @@ RangeList::RangeListBlock::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
         }
 
         size = range->end - range->start;
-        _ASSERTE( size < ULONG_MAX );    // ranges should be less than 4gig!
+        _ASSERTE( size < UINT32_MAX );    // ranges should be less than 4gig!
 
         // We can't be sure this entire range is mapped.  For example, the code:StubLinkStubManager
         // keeps track of all ranges in the code:BaseDomain::m_pStubHeap LoaderHeap, and 

--- a/src/utilcode/stgpool.cpp
+++ b/src/utilcode/stgpool.cpp
@@ -1904,7 +1904,7 @@ CInMemoryStream::Seek(
     STATIC_CONTRACT_FAULT; //E_OUTOFMEMORY;
 
     _ASSERTE(dwOrigin == STREAM_SEEK_SET || dwOrigin == STREAM_SEEK_CUR);
-    _ASSERTE(dlibMove.QuadPart <= static_cast<LONGLONG>(ULONG_MAX));
+    _ASSERTE(dlibMove.QuadPart <= static_cast<LONGLONG>(UINT32_MAX));
 
     if (dwOrigin == STREAM_SEEK_SET)
     {
@@ -1940,7 +1940,7 @@ CInMemoryStream::CopyTo(
     _ASSERTE(pcbRead == 0);
     _ASSERTE(pcbWritten == 0);
 
-    _ASSERTE(cb.QuadPart <= ULONG_MAX);
+    _ASSERTE(cb.QuadPart <= UINT32_MAX);
     ULONG       cbTotal = min(static_cast<ULONG>(cb.QuadPart), m_cbSize - m_cbCurrent);
     ULONG       cbRead=min(1024, cbTotal);
     CQuickBytes rBuf;

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -13089,7 +13089,7 @@ public:
     ULONG GetOriginalMDUpdateMode()
     {
         WRAPPER_NO_CONTRACT;
-        _ASSERTE(m_OriginalMDUpdateMode != LONG_MAX);
+        _ASSERTE(m_OriginalMDUpdateMode != ULONG_MAX);
         return m_OriginalMDUpdateMode;
     }
 private:

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -13037,7 +13037,7 @@ public:
     MDUpdateModeHolder()
     {
         m_pInternalEmitter = NULL;
-        m_OriginalMDUpdateMode = ULONG_MAX;
+        m_OriginalMDUpdateMode = UINT32_MAX;
     }
     ~MDUpdateModeHolder()
     {
@@ -13049,29 +13049,29 @@ public:
         LIMITED_METHOD_CONTRACT;
         HRESULT hr = S_OK;
         
-        _ASSERTE(updateMode != ULONG_MAX);
+        _ASSERTE(updateMode != UINT32_MAX);
         
         IfFailRet(pEmitter->QueryInterface(IID_IMDInternalEmit, (void **)&m_pInternalEmitter));
         _ASSERTE(m_pInternalEmitter != NULL);
         
         IfFailRet(m_pInternalEmitter->SetMDUpdateMode(updateMode, &m_OriginalMDUpdateMode));
-        _ASSERTE(m_OriginalMDUpdateMode != ULONG_MAX);
+        _ASSERTE(m_OriginalMDUpdateMode != UINT32_MAX);
         
         return hr;
     }
-    HRESULT Release(ULONG expectedPreviousUpdateMode = ULONG_MAX)
+    HRESULT Release(ULONG expectedPreviousUpdateMode = UINT32_MAX)
     {
         HRESULT hr = S_OK;
         
-        if (m_OriginalMDUpdateMode != ULONG_MAX)
+        if (m_OriginalMDUpdateMode != UINT32_MAX)
         {
             _ASSERTE(m_pInternalEmitter != NULL);
             ULONG previousUpdateMode;
             // Ignore the error when releasing
             hr = m_pInternalEmitter->SetMDUpdateMode(m_OriginalMDUpdateMode, &previousUpdateMode);
-            m_OriginalMDUpdateMode = ULONG_MAX;
+            m_OriginalMDUpdateMode = UINT32_MAX;
             
-            if (expectedPreviousUpdateMode != ULONG_MAX)
+            if (expectedPreviousUpdateMode != UINT32_MAX)
             {
                 if ((hr == S_OK) && (expectedPreviousUpdateMode != previousUpdateMode))
                 {
@@ -13089,7 +13089,7 @@ public:
     ULONG GetOriginalMDUpdateMode()
     {
         WRAPPER_NO_CONTRACT;
-        _ASSERTE(m_OriginalMDUpdateMode != ULONG_MAX);
+        _ASSERTE(m_OriginalMDUpdateMode != UINT32_MAX);
         return m_OriginalMDUpdateMode;
     }
 private:

--- a/src/vm/comdynamic.cpp
+++ b/src/vm/comdynamic.cpp
@@ -736,7 +736,7 @@ void QCALLTYPE COMDynamicWrite::SetConstantValue(QCall::ModuleHandle pModule, UI
     {
         hr = pRCW->GetEmitter()->SetFieldProps( 
             tk,                         // [IN] The FieldDef.
-            ULONG_MAX,                  // [IN] Field attributes.
+            UINT32_MAX,                 // [IN] Field attributes.
             valueCorType,               // [IN] Flag for the value type, selected ELEMENT_TYPE_*
             pValue,                     // [IN] Constant value.
             (ULONG) -1);                // [IN] Optional length.
@@ -745,7 +745,7 @@ void QCALLTYPE COMDynamicWrite::SetConstantValue(QCall::ModuleHandle pModule, UI
     {
         hr = pRCW->GetEmitter()->SetPropertyProps( 
             tk,                         // [IN] The PropertyDef.
-            ULONG_MAX,                  // [IN] Property attributes.
+            UINT32_MAX,                 // [IN] Property attributes.
             valueCorType,               // [IN] Flag for the value type, selected ELEMENT_TYPE_*
             pValue,                     // [IN] Constant value.
             (ULONG) -1,                 // [IN] Optional length.
@@ -758,7 +758,7 @@ void QCALLTYPE COMDynamicWrite::SetConstantValue(QCall::ModuleHandle pModule, UI
         hr = pRCW->GetEmitter()->SetParamProps( 
             tk,                   // [IN] The ParamDef.
             NULL,
-            ULONG_MAX,                  // [IN] Parameter attributes.
+            UINT32_MAX,                 // [IN] Parameter attributes.
             valueCorType,               // [IN] Flag for the value type, selected ELEMENT_TYPE_*
             pValue,                     // [IN] Constant value.
             (ULONG) -1);                // [IN] Optional length.

--- a/src/vm/commtmemberinfomap.cpp
+++ b/src/vm/commtmemberinfomap.cpp
@@ -525,7 +525,7 @@ void ComMTMemberInfoMap::SetupPropsForInterface(size_t sizeOfPtr)
     MethodDesc  *pMeth;                   // A MethodDesc.
     CQuickArray<int> rSlotMap;            // Array to map vtable slots.
     DWORD               nSlots;                                 // Number of vtable slots.
-    ULONG               ulComSlotMin    = ULONG_MAX;            // Find first COM+ slot.
+    ULONG               ulComSlotMin    = UINT32_MAX;           // Find first COM+ slot.
     ULONG               ulComSlotMax    = 0;                    // Find last COM+ slot.
     int                 bSlotRemap      = false;                // True if slots need to be mapped, due to holes.
     HRESULT             hr              = S_OK;

--- a/src/vm/eetoprofinterfaceimpl.cpp
+++ b/src/vm/eetoprofinterfaceimpl.cpp
@@ -5756,7 +5756,7 @@ HRESULT EEToProfInterfaceImpl::MovedReferences(GCReferencesData *pData)
 #ifdef BIT64
         // Recompute sizes as ULONGs for legacy callback
         for (ULONG i = 0; i < pData->curIdx; i++)
-            pData->arrULONG[i] = (pData->arrMemBlockSize[i] > ULONG_MAX) ? ULONG_MAX : (ULONG)pData->arrMemBlockSize[i];
+            pData->arrULONG[i] = (pData->arrMemBlockSize[i] > UINT32_MAX) ? UINT32_MAX : (ULONG)pData->arrMemBlockSize[i];
 #endif
 
         {
@@ -5786,7 +5786,7 @@ HRESULT EEToProfInterfaceImpl::MovedReferences(GCReferencesData *pData)
 #ifdef BIT64
         // Recompute sizes as ULONGs for legacy callback
         for (ULONG i = 0; i < pData->curIdx; i++)
-            pData->arrULONG[i] = (pData->arrMemBlockSize[i] > ULONG_MAX) ? ULONG_MAX : (ULONG)pData->arrMemBlockSize[i];
+            pData->arrULONG[i] = (pData->arrMemBlockSize[i] > UINT32_MAX) ? UINT32_MAX : (ULONG)pData->arrMemBlockSize[i];
 #endif
 
         {

--- a/src/vm/eventpipebuffermanager.cpp
+++ b/src/vm/eventpipebuffermanager.cpp
@@ -52,7 +52,7 @@ EventPipeBufferManager::EventPipeBufferManager(EventPipeSession* pSession, size_
     m_pCurrentBuffer = nullptr;
     m_pCurrentBufferList = nullptr;
 
-    m_maxSizeOfAllBuffers = Clamp((size_t)100 * 1024, maxSizeOfAllBuffers, (size_t)ULONG_MAX);
+    m_maxSizeOfAllBuffers = Clamp((size_t)100 * 1024, maxSizeOfAllBuffers, (size_t)UINT32_MAX);
 
     if (sequencePointAllocationBudget == 0)
     {

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -2844,7 +2844,7 @@ void ETW::TypeSystemLog::PostRegistrationInit()
             10          // Base 10 conversion
             );
 
-        if (dwCustomObjectAllocationEventsPerTypePerSec == ULONG_MAX)
+        if (dwCustomObjectAllocationEventsPerTypePerSec == UINT32_MAX)
             dwCustomObjectAllocationEventsPerTypePerSec = 0;
         if (dwCustomObjectAllocationEventsPerTypePerSec != 0)
         {

--- a/src/vm/proftoeeinterfaceimpl.cpp
+++ b/src/vm/proftoeeinterfaceimpl.cpp
@@ -1611,9 +1611,9 @@ HRESULT ProfToEEInterfaceImpl::GetObjectSize(ObjectID objectId, ULONG *pcSize)
             size = PtrAlign(size);
         }
 
-        if (size > ULONG_MAX)
+        if (size > UINT32_MAX)
         {
-            *pcSize = ULONG_MAX;
+            *pcSize = UINT32_MAX;
             return COR_E_OVERFLOW;
         }
         *pcSize = (ULONG)size; 

--- a/src/vm/rtlfunctions.h
+++ b/src/vm/rtlfunctions.h
@@ -45,7 +45,7 @@ PVOID DecodeDynamicFunctionTableContext (PVOID pvContext)
 }
 
 
-#define DYNAMIC_FUNCTION_TABLE_MAX_RANGE LONG_MAX
+#define DYNAMIC_FUNCTION_TABLE_MAX_RANGE INT32_MAX
 
 #endif // FEATURE_EH_FUNCLETS
 

--- a/src/vm/stublink.cpp
+++ b/src/vm/stublink.cpp
@@ -1351,7 +1351,7 @@ bool StubLinker::EmitUnwindInfo(Stub* pStub, int globalsize, LoaderHeap* pHeap)
 
     //
     // The RUNTIME_FUNCTION offsets are ULONGs.  If the region size is >
-    // ULONG_MAX, then we'll shift the base address to the next 4gb and
+    // UINT32_MAX, then we'll shift the base address to the next 4gb and
     // register a separate function table.
     //
     // But...RtlInstallFunctionTableCallback has a 2gb restriction...so

--- a/src/vm/stublink.cpp
+++ b/src/vm/stublink.cpp
@@ -1355,7 +1355,7 @@ bool StubLinker::EmitUnwindInfo(Stub* pStub, int globalsize, LoaderHeap* pHeap)
     // register a separate function table.
     //
     // But...RtlInstallFunctionTableCallback has a 2gb restriction...so
-    // make that LONG_MAX.
+    // make that INT32_MAX.
     //
 
     StubUnwindInfoHeader *pHeader = pStub->GetUnwindInfoHeader();

--- a/tests/src/Common/Platform/platformdefines.cpp
+++ b/tests/src/Common/Platform/platformdefines.cpp
@@ -378,7 +378,7 @@ HRESULT ULongLongToULong(ULONGLONG ullOperand, ULONG* pulResult)
     HRESULT hr = INTSAFE_E_ARITHMETIC_OVERFLOW;
     *pulResult = ULONG_ERROR;
     
-    if (ullOperand <= ULONG_MAX)
+    if (ullOperand <= UINT32_MAX)
     {
         *pulResult = (ULONG)ullOperand;
         hr = S_OK;

--- a/tests/src/Common/Platform/platformdefines.h
+++ b/tests/src/Common/Platform/platformdefines.h
@@ -66,10 +66,6 @@ typedef unsigned int ULONG, *PULONG;
 #define SUCCEEDED(_hr)          ((HRESULT)(_hr) >= 0)
 #define FAILED(_hr)             ((HRESULT)(_hr) < 0)
 
-//#ifdef ULONG_MAX
-//#undef ULONG_MAX
-//#endif
-//#define ULONG_MAX     0xffffffffUL
 #define CCH_BSTRMAX 0x7FFFFFFF  // 4 + (0x7ffffffb + 1 ) * 2 ==> 0xFFFFFFFC
 #define CB_BSTRMAX 0xFFFFFFFa   // 4 + (0xfffffff6 + 2) ==> 0xFFFFFFFC
 

--- a/tests/src/Common/Platform/platformdefines.h
+++ b/tests/src/Common/Platform/platformdefines.h
@@ -66,10 +66,10 @@ typedef unsigned int ULONG, *PULONG;
 #define SUCCEEDED(_hr)          ((HRESULT)(_hr) >= 0)
 #define FAILED(_hr)             ((HRESULT)(_hr) < 0)
 
-#ifdef ULONG_MAX
-#undef ULONG_MAX
-#endif
-#define ULONG_MAX     0xffffffffUL
+//#ifdef ULONG_MAX
+//#undef ULONG_MAX
+//#endif
+//#define ULONG_MAX     0xffffffffUL
 #define CCH_BSTRMAX 0x7FFFFFFF  // 4 + (0x7ffffffb + 1 ) * 2 ==> 0xFFFFFFFC
 #define CB_BSTRMAX 0xFFFFFFFa   // 4 + (0xfffffff6 + 2) ==> 0xFFFFFFFC
 


### PR DESCRIPTION
Fix macro-redefined warnings caused by limits.h & float.h

By this, we ignore conflicts with standard CHAR_BIT and *_MIN/*_MAX macros
when PAL_STDCPP_COMPAT is defined.

Bug: 20784