### PR TITLE
Fix invalid-noreturn warning for __CorHlprThrowOOM in corhlpr.h

### DIFF
--- a/src/inc/check.h
+++ b/src/inc/check.h
@@ -15,6 +15,7 @@
 
 #include "static_assert.h"
 #include "daccess.h"
+#include "unreachable.h"
 
 #ifdef _DEBUG
 
@@ -556,19 +557,6 @@ CHECK CheckValue(TYPENAME &val)
 #define UNREACHABLE_MSG_RET(_message) UNREACHABLE_MSG(_message)
 
 #endif // __llvm__ else
-
-#if defined(_MSC_VER) || defined(_PREFIX_)
-#if defined(_TARGET_AMD64_)
-// Empty methods that consist of UNREACHABLE() result in a zero-sized declspec(noreturn) method
-// which causes the pdb file to make the next method declspec(noreturn) as well, thus breaking BBT
-// Remove when we get a VC compiler that fixes VSW 449170
-# define __UNREACHABLE() DebugBreak(); __assume(0);
-#else
-# define __UNREACHABLE() __assume(0)
-#endif
-#else
-#define __UNREACHABLE() __builtin_unreachable()
-#endif
 
 #ifdef _DEBUG_IMPL
 

--- a/src/inc/corhlpr.h
+++ b/src/inc/corhlpr.h
@@ -21,6 +21,7 @@
 #include "cor.h"
 #include "corhdr.h"
 #include "corerror.h"
+#include "unreachable.h"
 
 // This header is consumed both within the runtime and externally. In the former
 // case we need to wrap memory allocations, in the latter there is no
@@ -43,6 +44,7 @@ inline void DECLSPEC_NORETURN THROW_OUT_OF_MEMORY()
 static inline void DECLSPEC_NORETURN __CorHlprThrowOOM()
 {
     RaiseException(STATUS_NO_MEMORY, 0, 0, NULL);
+    __UNREACHABLE();
 }
 static inline BYTE *__CorHlprNewThrows(size_t bytes)
 {

--- a/src/inc/gcinfodecoder.h
+++ b/src/inc/gcinfodecoder.h
@@ -138,12 +138,6 @@ inline BOOL IS_ALIGNED( void* val, size_t alignment )
 
 #endif
 
-// Stuff from check.h:
-
-#ifndef UNREACHABLE
-#define UNREACHABLE() __assume(0)
-#endif
-
 // Stuff from eetwain.h:
 
 #ifndef _EETWAIN_H

--- a/src/inc/unreachable.h
+++ b/src/inc/unreachable.h
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ---------------------------------------------------------------------------
+// unreachable.h
+// ---------------------------------------------------------------------------
+
+
+#ifndef __UNREACHABLE_H__
+#define __UNREACHABLE_H__
+
+#if defined(_MSC_VER) || defined(_PREFIX_)
+#if defined(_TARGET_AMD64_)
+// Empty methods that consist of UNREACHABLE() result in a zero-sized declspec(noreturn) method
+// which causes the pdb file to make the next method declspec(noreturn) as well, thus breaking BBT
+// Remove when we get a VC compiler that fixes VSW 449170
+# define __UNREACHABLE() do { DebugBreak(); __assume(0); } while (0)
+#else
+# define __UNREACHABLE() __assume(0)
+#endif
+#else
+#define __UNREACHABLE() __builtin_unreachable()
+#endif
+
+#endif // __UNREACHABLE_H__
+


### PR DESCRIPTION
Fix invalid-noreturn warning for __CorHlprThrowOOM in corhlpr.h

It's done by using #pragma diagnostic to ignore the following:
```
  warning: function declared 'noreturn' should not return
```