### PR TITLE
Match BOX idioms early in the importer

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3569,6 +3569,7 @@ protected:
 
     GenTree* impImportLdvirtftn(GenTree* thisPtr, CORINFO_RESOLVED_TOKEN* pResolvedToken, CORINFO_CALL_INFO* pCallInfo);
 
+    int impBoxPatternMatch(CORINFO_RESOLVED_TOKEN* pResolvedToken, const BYTE* codeAddr, const BYTE* codeEndp);
     void impImportAndPushBox(CORINFO_RESOLVED_TOKEN* pResolvedToken);
 
     void impImportNewObjArray(CORINFO_RESOLVED_TOKEN* pResolvedToken, CORINFO_CALL_INFO* pCallInfo);


### PR DESCRIPTION
This avoids some of the surprise allocations mentioned in https://github.com/dotnet/coreclr/pull/22984, and helps with downstream optimizations in some cases.