### PR TITLE
Fix accidental non-collectible context unloading

### DIFF
--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -1930,9 +1930,6 @@
   <data name="ArrayTypeMismatch_ConstrainedCopy" xml:space="preserve">
     <value>Array.ConstrainedCopy will only work on array types that are provably compatible, without any form of boxing, unboxing, widening, or casting of each array element.  Change the array types (i.e., copy a Derived[] to a Base[]), or use a mitigation strategy in the CER for Array.Copy's less powerful reliability contract, such as cloning the array or throwing away the potentially corrupt destination array.</value>
   </data>
-  <data name="AssemblyLoadContext_Constructor_CannotInstantiateWhileUnloading" xml:space="preserve">
-    <value>Cannot instantiate AssemblyLoadContext while the current process is exiting.</value>
-  </data>
   <data name="AssemblyLoadContext_Unload_CannotUnloadIfNotCollectible" xml:space="preserve">
     <value>Cannot unload non-collectible AssemblyLoadContext.</value>
   </data>


### PR DESCRIPTION
The OnProcessExit was iterating over the s_contextsToUnload and calling
Unload on each of the contexts. However the s_contextsToUnload is a
misnomer, it contains all the contexts, both collectible and
non-collectible ones. So we were calling Unload on non-collectible
contexts too there. That resulted in InvalidOperationException being
thrown from the OnProcessExit.

This change fixes that by calling unload only on ALCs whose
IsCollectible returns true. It also renames the s_contextsToUnload to
s_allContexts.

Close #22902