### PR TITLE
Make tracelogging GCStressIncompatible.

### DIFF
--- a/tests/src/tracing/tracevalidation/tracelogging/tracelogging.csproj
+++ b/tests/src/tracing/tracevalidation/tracelogging/tracelogging.csproj
@@ -9,6 +9,7 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <GCStressIncompatible>true</GCStressIncompatible>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
The test fails on different platforms in both test systems with:
`Assert failure(PID 16094 [0x00003ede], Thread: 16094 [0x3ede]): CORProfilerStackSnapshotEnabled() || !IsStackWalkerThread()
`
[Example 1 arm64](https://ci.dot.net/job/dotnet_coreclr/job/master/job/jitstress/job/arm64_cross_checked_ubuntu16.04_r2r_gcstress15_tst/23/testReport/tracing_tracevalidation/_tracelogging_tracelogging_tracelogging_/_tracelogging_tracelogging_tracelogging_sh/), [example 2 x64](https://ci.dot.net/job/dotnet_coreclr/job/master/job/jitstress/job/x64_checked_centos7.1_r2r_gcstress15_tst/130/testReport/tracing_tracevalidation/_tracelogging_tracelogging_tracelogging_/_tracelogging_tracelogging_tracelogging_sh/), [example 3 ADO](https://dev.azure.com/dnceng/public/_build/results?buildId=137838&view=ms.vss-test-web.build-test-results-tab)


Link #17480, cc @brianrob 