### PR TITLE
Remove Fedora runs.

### DIFF
--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -156,13 +156,12 @@ jobs:
             asArray:
             - Ubuntu.1804.Amd64.Open
           ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-            asString: 'Debian.9.Amd64.Open,Ubuntu.1604.Amd64.Open,Ubuntu.1804.Amd64.Open,Centos.7.Amd64.Open,Fedora.28.Amd64.Open,RedHat.7.Amd64.Open'
+            asString: 'Debian.9.Amd64.Open,Ubuntu.1604.Amd64.Open,Ubuntu.1804.Amd64.Open,Centos.7.Amd64.Open,RedHat.7.Amd64.Open'
             asArray:
             - Debian.9.Amd64.Open
             - Ubuntu.1604.Amd64.Open
             - Ubuntu.1804.Amd64.Open
             - Centos.7.Amd64.Open
-            - Fedora.28.Amd64.Open
             - RedHat.7.Amd64.Open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             asString: 'Debian.9.Amd64,Ubuntu.1604.Amd64,Ubuntu.1804.Amd64,Centos.7.Amd64,Fedora.28.Amd64,RedHat.7.Amd64'


### PR DESCRIPTION
GCStress fails there because it can't use external disasembler when it is available in CoreRoot.

[Example ](https://dev.azure.com/dnceng/public/_build/results?buildId=137838&view=ms.vss-test-web.build-test-results-tab)(scroll down to `Linux x64 Checked gcstress0xc @ Fedora.28.Amd64.Open`).