### PR TITLE
Clean up AssemblyLoadContext30Extensions test

### DIFF
--- a/tests/src/Loader/AssemblyLoadContext30Extensions/AssemblyLoadContext30Extensions.cs
+++ b/tests/src/Loader/AssemblyLoadContext30Extensions/AssemblyLoadContext30Extensions.cs
@@ -6,8 +6,6 @@ using System.Reflection;
 using System.Runtime.Loader;
 using System.IO;
 
-using Console = Internal.Console;
-
 namespace My
 {
     public class CustomAssemblyLoadContext : AssemblyLoadContext
@@ -119,7 +117,6 @@ public class Program
 
     public static void AssemblyLoadByteArrayName()
     {
-#if ReadAllBytes // System.IO.File.ReadAllBytes is not found when ReferenceSystemPrivateCoreLib is true
         try
         {
             Console.WriteLine("AssemblyLoadByteArrayName()");
@@ -138,7 +135,7 @@ public class Program
             Assert(alc.GetType().ToString() == "System.Runtime.Loader.IndividualAssemblyLoadContext");
 
             Console.WriteLine(alc.ToString());
-            Assert(alc.ToString().Contains("\"Default"));
+            Assert(alc.ToString().Contains("\"Assembly.Load(byte[], ...)\""));
             Assert(alc.ToString().Contains("\" System.Runtime.Loader.IndividualAssemblyLoadContext"));
             Assert(alc.ToString().Contains(" #"));
         }
@@ -146,7 +143,6 @@ public class Program
         {
             Assert(false, e.ToString());
         }
-#endif
     }
 
     public static void CustomWOName()

--- a/tests/src/Loader/AssemblyLoadContext30Extensions/AssemblyLoadContext30Extensions.csproj
+++ b/tests/src/Loader/AssemblyLoadContext30Extensions/AssemblyLoadContext30Extensions.csproj
@@ -10,7 +10,6 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <ReferenceSystemPrivateCoreLib>true</ReferenceSystemPrivateCoreLib>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">


### PR DESCRIPTION
Build test against corefx ref facade
Enable Assembly.Load(byte[], ...) test