### PR TITLE
Work around #23583

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -145,7 +145,16 @@ namespace System.Runtime.Loader
             {
                 foreach (Assembly a in GetLoadedAssemblies())
                 {
-                    AssemblyLoadContext alc = GetLoadContext(a);
+                    AssemblyLoadContext alc;
+                    try
+                    {
+                        alc = GetLoadContext(a);
+                    }
+                    catch
+                    {
+                        // GetLoadContext is sometimes throwing an AV
+                        continue;
+                    }
 
                     if (alc == this)
                     {


### PR DESCRIPTION
Add try/catch block around GetLoadContext which sometimes is throwing an AV

This is a workaround for #23583 

/cc @jkotas @janvorli 