### PR TITLE
Fix WaitHandle.WaitAll arg validation

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/WaitHandle.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/WaitHandle.cs
@@ -265,7 +265,7 @@ namespace System.Threading
             }
         }
 
-        private static int WaitMultiple(ReadOnlySpan<WaitHandle> waitHandles, bool waitAll, int millisecondsTimeout)
+        private static int WaitMultiple(WaitHandle[] waitHandles, bool waitAll, int millisecondsTimeout)
         {
             if (waitHandles == null)
             {


### PR DESCRIPTION
A recent change looks to have broken WaitHandle.WaitAll's validation of its waitHandle parameter.  By using a span instead of an array, the check for null became a nop.  This doesn't actually cause the wrong exception to be thrown, because the subsequent Length == 0 check picks it up, but with the wrong error message.

cc: @jkotas, @filipnavara 

EDIT: It's not actually broken. Just unnecessary work going through a span for a null comparison.