### PR TITLE
Fix typo in Buffer.BlockCopy

### DIFF
--- a/src/vm/comutilnative.cpp
+++ b/src/vm/comutilnative.cpp
@@ -780,7 +780,7 @@ FCIMPL5(VOID, Buffer::BlockCopy, ArrayBase *src, int srcOffset, ArrayBase *dst, 
         {
             const CorElementType dstET = dst->GetArrayElementType();
             if (!CorTypeInfo::IsPrimitiveType_NoThrow(dstET))
-                FCThrowArgumentVoid(W("dest"), W("Arg_MustBePrimArray"));
+                FCThrowArgumentVoid(W("dst"), W("Arg_MustBePrimArray"));
         }
     }
 

--- a/tests/CoreFX/CoreFX.issues.json
+++ b/tests/CoreFX/CoreFX.issues.json
@@ -1293,6 +1293,10 @@
                     "name": "System.Tests.TimeSpanTests.Total_Days_Hours_Minutes_Seconds_Milliseconds",
                     "reason" : "https://github.com/dotnet/coreclr/pull/22040"
                 },
+                {
+                    "name": "System.Tests.BufferTests.BlockCopy_Invalid",
+                    "reason" : "https://github.com/dotnet/coreclr/pull/23636"
+                },
             ]
         }
     },


### PR DESCRIPTION
Once it's merged this test needs to be fixed as well: https://github.com/dotnet/corefx/blob/master/src/System.Runtime/tests/System/BufferTests.cs#L34
(line 34 expects ParamName="dst", [line 41](https://github.com/dotnet/corefx/blob/master/src/System.Runtime/tests/System/BufferTests.cs#L41) expects ParamName="dest").