### PR TITLE
PermissionSet: follow netfx more in order to avoid workarounds with nullable

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Security/PermissionSet.cs
+++ b/src/System.Private.CoreLib/shared/System/Security/PermissionSet.cs
@@ -24,8 +24,8 @@ namespace System.Security
         public void Assert() { }
         public bool ContainsNonCodeAccessPermissions() { return false; }
         [Obsolete]
-        public static byte[] ConvertPermissionSet(string inFormat, byte[] inData, string outFormat) { return null; }
-        public virtual PermissionSet Copy() { return default(PermissionSet); }
+        public static byte[] ConvertPermissionSet(string inFormat, byte[] inData, string outFormat) { throw new NotImplementedException(); }
+        public virtual PermissionSet Copy() { return new PermissionSet(this); }
         public virtual void CopyTo(Array array, int index) { }
         public void Demand() { }
         [Obsolete]


### PR DESCRIPTION
Addressing feedback from https://github.com/dotnet/coreclr/pull/23623 but extracting IL changes separately to avoid IL diffing noise and be able to easier isolate issues in case of regressions.