### PR TITLE
[release/2.2][Port] Fix EventPipe EventHandle Caching for TraceLogging (#18355)

### DIFF
--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -531,6 +531,7 @@
     <Compile Include="$(BclSourcesRoot)\System\Diagnostics\Eventing\EventPipeEventDispatcher.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Diagnostics\Eventing\EventPipeEventProvider.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Diagnostics\Eventing\EventPipeMetadataGenerator.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Diagnostics\Eventing\TraceLogging\TraceLoggingEventHandleTable.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Diagnostics\Eventing\EventPipePayloadDecoder.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/NameInfo.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/NameInfo.cs
@@ -42,9 +42,6 @@ namespace System.Diagnostics.Tracing
         internal readonly int identity;
         internal readonly byte[] nameMetadata;
 
-#if FEATURE_PERFTRACING
-        private readonly object eventHandleCreationLock = new object();
-#endif
 
         public NameInfo(string name, EventTags tags, int typeMetadataSize)
         {
@@ -82,14 +79,14 @@ namespace System.Diagnostics.Tracing
         }
 
 #if FEATURE_PERFTRACING
-        public IntPtr GetOrCreateEventHandle(EventProvider provider, ConcurrentDictionary<int, IntPtr> eventHandleMap, EventDescriptor descriptor, TraceLoggingEventTypes eventTypes)
+        public IntPtr GetOrCreateEventHandle(EventProvider provider, TraceLoggingEventHandleTable eventHandleTable, EventDescriptor descriptor, TraceLoggingEventTypes eventTypes)
         {
-            IntPtr eventHandle = IntPtr.Zero;
-            if(!eventHandleMap.TryGetValue(descriptor.EventId, out eventHandle))
+            IntPtr eventHandle;
+            if ((eventHandle = eventHandleTable[descriptor.EventId]) == IntPtr.Zero)
             {
-                lock (eventHandleCreationLock)
+                lock (eventHandleTable)
                 {
-                    if (!eventHandleMap.TryGetValue(descriptor.EventId, out eventHandle))
+                    if ((eventHandle = eventHandleTable[descriptor.EventId]) == IntPtr.Zero)
                     {
                         byte[] metadataBlob = EventPipeMetadataGenerator.Instance.GenerateEventMetadata(
                             descriptor.EventId,
@@ -115,6 +112,9 @@ namespace System.Diagnostics.Tracing
                                     metadataLength);
                             }
                         }
+
+                        // Cache the event handle.
+                        eventHandleTable.SetEventHandle(descriptor.EventId, eventHandle);
                     }
                 }
             }

--- a/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
+++ b/src/mscorlib/shared/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
@@ -24,7 +24,6 @@ using System.Resources;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Collections.ObjectModel;
-using System.Collections.Concurrent;
 
 #if !ES_BUILD_AGAINST_DOTNET_V35
 using Contract = System.Diagnostics.Contracts.Contract;
@@ -49,7 +48,7 @@ namespace System.Diagnostics.Tracing
 #endif
 
 #if FEATURE_PERFTRACING
-        private ConcurrentDictionary<int, IntPtr> m_eventHandleMap = new ConcurrentDictionary<int, IntPtr>();
+        private readonly TraceLoggingEventHandleTable m_eventHandleTable = new TraceLoggingEventHandleTable();
 #endif
 
         /// <summary>
@@ -437,7 +436,7 @@ namespace System.Diagnostics.Tracing
             EventDescriptor descriptor = new EventDescriptor(identity, level, opcode, (long)keywords);
 
 #if FEATURE_PERFTRACING
-            IntPtr eventHandle = nameInfo.GetOrCreateEventHandle(m_eventPipeProvider, m_eventHandleMap, descriptor, eventTypes);
+            IntPtr eventHandle = nameInfo.GetOrCreateEventHandle(m_eventPipeProvider, m_eventHandleTable, descriptor, eventTypes);
             Debug.Assert(eventHandle != IntPtr.Zero);
 #else
             IntPtr eventHandle = IntPtr.Zero;
@@ -552,7 +551,7 @@ namespace System.Diagnostics.Tracing
                 }
 
 #if FEATURE_PERFTRACING
-                    IntPtr eventHandle = nameInfo.GetOrCreateEventHandle(m_eventPipeProvider, m_eventHandleMap, descriptor, eventTypes);
+                    IntPtr eventHandle = nameInfo.GetOrCreateEventHandle(m_eventPipeProvider, m_eventHandleTable, descriptor, eventTypes);
                     Debug.Assert(eventHandle != IntPtr.Zero);
 #else
                     IntPtr eventHandle = IntPtr.Zero;
@@ -621,7 +620,7 @@ namespace System.Diagnostics.Tracing
                     }
 
 #if FEATURE_PERFTRACING
-                    IntPtr eventHandle = nameInfo.GetOrCreateEventHandle(m_eventPipeProvider, m_eventHandleMap, descriptor, eventTypes);
+                    IntPtr eventHandle = nameInfo.GetOrCreateEventHandle(m_eventPipeProvider, m_eventHandleTable, descriptor, eventTypes);
                     Debug.Assert(eventHandle != IntPtr.Zero);
 #else
                     IntPtr eventHandle = IntPtr.Zero;

--- a/src/mscorlib/src/System/Diagnostics/Eventing/TraceLogging/TraceLoggingEventHandleTable.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/TraceLogging/TraceLoggingEventHandleTable.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+
+namespace System.Diagnostics.Tracing
+{
+#if FEATURE_PERFTRACING
+    /// <summary>
+    /// Per-EventSource data structure for caching EventPipe EventHandles associated with TraceLogging events.
+    /// </summary>
+    internal sealed class TraceLoggingEventHandleTable
+    {
+        private const int DefaultLength = 10;
+        private IntPtr[] m_innerTable;
+
+        internal TraceLoggingEventHandleTable()
+        {
+            m_innerTable = new IntPtr[DefaultLength];
+        }
+
+        internal IntPtr this[int eventID]
+        {
+            get
+            {
+                IntPtr ret = IntPtr.Zero;
+                IntPtr[] innerTable = Volatile.Read(ref m_innerTable);
+
+                if (eventID >= 0 && eventID < innerTable.Length)
+                {
+                    ret = innerTable[eventID];
+                }
+
+                return ret;
+            }
+        }
+
+        internal void SetEventHandle(int eventID, IntPtr eventHandle)
+        {
+            // Set operations must be serialized to ensure that re-size operations don't lose concurrent writes.
+            Debug.Assert(Monitor.IsEntered(this));
+
+            if (eventID >= m_innerTable.Length)
+            {
+                int newSize = m_innerTable.Length * 2;
+                if (newSize <= eventID)
+                {
+                    newSize = eventID + 1;
+                }
+
+                IntPtr[] newTable = new IntPtr[newSize];
+                Array.Copy(m_innerTable, 0, newTable, 0, m_innerTable.Length);
+                Volatile.Write(ref m_innerTable, newTable);
+            }
+
+            m_innerTable[eventID] = eventHandle;
+        }
+    }
+#endif
+}


### PR DESCRIPTION
#### Description

Enabling ETW or EventPipe tracing results in a unbound memory usage by the runtime.

 
#### Customer Impact

It impacts anyone using Azure customers using ASP.NET Core on App Service with Application Insights Profiler when ETW/EventPipe listeners are enabled.

 
#### Regression?

Yes, this is a regression. ETW scenario now shares some of the code of EventPipe, and this shared code introduced the bug where events were not properly cached. This results in a redundant allocation for the same event for as long as a session was recorded.


#### Risk

The risk is low. We checked this in a year ago and there have not been any issues reported with it. In addition, the code is only active when tracing is enabled.
I have manually tested the ETW and EventPipe scenarios reported and I can confirm that the bug is fixed (it is not on master branch neither), and I have stepped through the debugger to verify we do not keep allocating memory for the same event.


#### Issue

Fixes https://github.com/dotnet/coreclr/issues/23562
Originally at Microsoft/ApplicationInsights-dotnet#1102, and  https://github.com/aspnet/AspNetCore/issues/8648