### PR TITLE
Emit event for calls to ReadyToRunInfo::GetEntryPoint.

### DIFF
--- a/src/inc/eventtracebase.h
+++ b/src/inc/eventtracebase.h
@@ -578,6 +578,7 @@ namespace ETW
             BOOL fSendILToNativeMapEvent,
             BOOL fGetReJitIDs);
         static VOID SendEventsForNgenMethods(Module *pModule, DWORD dwEventOptions);
+        static VOID SendR2RGetEntryPointEvent(MethodDesc *pMethodDesc, PCODE pEntryPoint);
         static VOID SendMethodJitStartEvent(MethodDesc *pMethodDesc, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL);
         static VOID SendMethodILToNativeMapEvent(MethodDesc * pMethodDesc, DWORD dwEventOptions, SIZE_T pCode, ReJITID rejitID);
         static VOID SendMethodEvent(MethodDesc *pMethodDesc, DWORD dwEventOptions, BOOL bIsJit, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL, SIZE_T pCode = 0, ReJITID rejitID = 0, BOOL bProfilerRejectedPrecompiledCode = FALSE, BOOL bReadyToRunRejectedPrecompiledCode = FALSE);
@@ -604,6 +605,7 @@ namespace ETW
 
         }MethodStructs;
 
+        static VOID GetR2RGetEntryPoint(MethodDesc *pMethodDesc, PCODE pEntryPoint);
         static VOID MethodJitting(MethodDesc *pMethodDesc, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL);
         static VOID MethodJitted(MethodDesc *pMethodDesc, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL, SIZE_T pCode = 0, ReJITID rejitID = 0, BOOL bProfilerRejectedPrecompiledCode = FALSE, BOOL bReadyToRunRejectedPrecompiledCode = FALSE);
         static VOID StubInitialized(ULONGLONG ullHelperStartAddress, LPCWSTR pHelperName);
@@ -613,6 +615,7 @@ namespace ETW
         static VOID DynamicMethodDestroyed(MethodDesc *pMethodDesc);
 #else // FEATURE_EVENT_TRACE
     public:
+        static VOID GetR2RGetEntryPoint(MethodDesc *pMethodDesc, PCODE pEntryPoint) {};
         static VOID MethodJitting(MethodDesc *pMethodDesc, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL) {};
         static VOID MethodJitted(MethodDesc *pMethodDesc, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL, SIZE_T pCode = 0, ReJITID rejitID = 0, BOOL bProfilerRejectedPrecompiledCode = FALSE, BOOL bReadyToRunRejectedPrecompiledCode = FALSE) {};
         static VOID StubInitialized(ULONGLONG ullHelperStartAddress, LPCWSTR pHelperName) {};

--- a/src/inc/eventtracebase.h
+++ b/src/inc/eventtracebase.h
@@ -578,7 +578,6 @@ namespace ETW
             BOOL fSendILToNativeMapEvent,
             BOOL fGetReJitIDs);
         static VOID SendEventsForNgenMethods(Module *pModule, DWORD dwEventOptions);
-        static VOID SendR2RGetEntryPointEvent(MethodDesc *pMethodDesc, PCODE pEntryPoint);
         static VOID SendMethodJitStartEvent(MethodDesc *pMethodDesc, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL);
         static VOID SendMethodILToNativeMapEvent(MethodDesc * pMethodDesc, DWORD dwEventOptions, SIZE_T pCode, ReJITID rejitID);
         static VOID SendMethodEvent(MethodDesc *pMethodDesc, DWORD dwEventOptions, BOOL bIsJit, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL, SIZE_T pCode = 0, ReJITID rejitID = 0, BOOL bProfilerRejectedPrecompiledCode = FALSE, BOOL bReadyToRunRejectedPrecompiledCode = FALSE);

--- a/src/vm/ClrEtwAll.man
+++ b/src/vm/ClrEtwAll.man
@@ -1657,15 +1657,19 @@
 
                     <template tid="R2RGetEntryPoint">
                         <data name="MethodID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="MethodNamespace" inType="win:UnicodeString" />
                         <data name="MethodName" inType="win:UnicodeString" />
+                        <data name="MethodSignature" inType="win:UnicodeString" />
                         <data name="EntryPoint" inType="win:UInt64" outType="win:HexInt64" />
                         <data name="ClrInstanceID" inType="win:UInt16" />
                         <UserData>
                             <R2RGetEntryPoint xmlns="myNs">
                                 <MethodID> %1 </MethodID>
-                                <MethodName> %2 </MethodName>
-                                <EntryPoint> %3 </EntryPoint>
-                                <ClrInstanceID> %4 </ClrInstanceID>
+                                <MethodNamespace> %2 </MethodNamespace>
+                                <MethodName> %3 </MethodName>
+                                <MethodSignature> %4 </MethodSignature>
+                                <EntryPoint> %5 </EntryPoint>
+                                <ClrInstanceID> %6 </ClrInstanceID>
                             </R2RGetEntryPoint>
                         </UserData>
                     </template>

--- a/src/vm/ClrEtwAll.man
+++ b/src/vm/ClrEtwAll.man
@@ -1655,6 +1655,21 @@
                         </UserData>
                     </template>
 
+                    <template tid="R2RGetEntryPoint">
+                        <data name="MethodID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="MethodName" inType="win:UnicodeString" />
+                        <data name="EntryPoint" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <UserData>
+                            <R2RGetEntryPoint xmlns="myNs">
+                                <MethodID> %1 </MethodID>
+                                <MethodName> %2 </MethodName>
+                                <EntryPoint> %3 </EntryPoint>
+                                <ClrInstanceID> %4 </ClrInstanceID>
+                            </R2RGetEntryPoint>
+                        </UserData>
+                    </template>
+
                     <template tid="MethodLoadUnloadVerbose">
                         <data name="MethodID" inType="win:UInt64" outType="win:HexInt64" />
                         <data name="ModuleID" inType="win:UInt64" outType="win:HexInt64" />
@@ -2968,6 +2983,11 @@
                            keywords ="JitKeyword NGenKeyword" opcode="MethodLoad"
                            task="CLRMethod"
                            symbol="MethodLoad_V2" message="$(string.RuntimePublisher.MethodLoad_V2EventMessage)"/>
+
+                    <event value="159" version="0" level="win:Verbose" template="R2RGetEntryPoint"
+                           keywords ="NGenKeyword" opcode="MethodLoad"
+                           task="CLRMethod"
+                           symbol="R2RGetEntryPoint" message="$(string.RuntimePublisher.R2RGetEntryPointEventMessage)"/>
 
                     <event value="142" version="0" level="win:Informational"  template="MethodLoadUnload"
                            keywords ="JitKeyword NGenKeyword" opcode="MethodUnload"
@@ -6393,6 +6413,7 @@
                 <string id="RuntimePublisher.MethodLoadEventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6" />
                 <string id="RuntimePublisher.MethodLoad_V1EventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6;%nClrInstanceID=%7" />
                 <string id="RuntimePublisher.MethodLoad_V2EventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6;%nClrInstanceID=%7;%nReJITID=%8" />
+                <string id="RuntimePublisher.R2RGetEntryPointEventMessage" value="MethodID=%1;%nMethodName=%2;%nEntryPoint=%3;%nClrInstanceID=%4" />
                 <string id="RuntimePublisher.MethodLoadVerboseEventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6;%nMethodNamespace=%7;%nMethodName=%8;%nMethodSignature=%9" />
                 <string id="RuntimePublisher.MethodLoadVerbose_V1EventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6;%nMethodNamespace=%7;%nMethodName=%8;%nMethodSignature=%9;%nClrInstanceID=%10" />
                 <string id="RuntimePublisher.MethodLoadVerbose_V2EventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6;%nMethodNamespace=%7;%nMethodName=%8;%nMethodSignature=%9;%nClrInstanceID=%10;%nReJITID=%11" />

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -5204,6 +5204,23 @@ HRESULT ETW::CodeSymbolLog::ReadInMemorySymbols(
     return S_OK;
 }
 
+VOID ETW::MethodLog::GetR2RGetEntryPoint(MethodDesc *pMethodDesc, PCODE pEntryPoint)
+{
+    CONTRACTL{
+        NOTHROW;
+        GC_TRIGGERS;
+    } CONTRACTL_END;
+
+    EX_TRY
+    {
+        if (ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_Context, R2RGetEntryPoint))
+        {
+            ETW::MethodLog::SendR2RGetEntryPointEvent(pMethodDesc, pEntryPoint);
+        }
+
+    } EX_CATCH{ } EX_END_CATCH(SwallowAllExceptions);
+}
+
 /*******************************************************/
 /* This is called by the runtime when a method is jitted completely */
 /*******************************************************/
@@ -6158,6 +6175,25 @@ VOID ETW::LoaderLog::SendModuleEvent(Module *pModule, DWORD dwEventOptions, BOOL
             SendModuleRange(pModule, dwEventOptions);
         }
     }
+}
+
+VOID ETW::MethodLog::SendR2RGetEntryPointEvent(MethodDesc *pMethodDesc, PCODE pEntryPoint)
+{
+    CONTRACTL{
+        THROWS;
+        GC_TRIGGERS;
+    } CONTRACTL_END;
+
+    SString tNamespace, tMethodName, tMethodSignature;
+    pMethodDesc->GetMethodInfo(tNamespace, tMethodName, tMethodSignature);
+
+    FireEtwR2RGetEntryPoint(
+        (UINT64)pMethodDesc,
+        (PCWSTR)tNamespace.GetUnicode(),
+        (PCWSTR)tMethodName.GetUnicode(),
+        (PCWSTR)tMethodSignature.GetUnicode(),
+        pEntryPoint,
+        GetClrInstanceId());
 }
 
 /*****************************************************************/

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -5211,23 +5211,23 @@ VOID ETW::MethodLog::GetR2RGetEntryPoint(MethodDesc *pMethodDesc, PCODE pEntryPo
         GC_TRIGGERS;
     } CONTRACTL_END;
 
-    EX_TRY
+    if (ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_Context, R2RGetEntryPoint))
     {
-        if (ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_Context, R2RGetEntryPoint))
+        EX_TRY
         {
-            SString tNamespace, tMethodName, tMethodSignature;
-            pMethodDesc->GetMethodInfo(tNamespace, tMethodName, tMethodSignature);
+                SString tNamespace, tMethodName, tMethodSignature;
+                pMethodDesc->GetMethodInfo(tNamespace, tMethodName, tMethodSignature);
 
-            FireEtwR2RGetEntryPoint(
-                (UINT64)pMethodDesc,
-                (PCWSTR)tNamespace.GetUnicode(),
-                (PCWSTR)tMethodName.GetUnicode(),
-                (PCWSTR)tMethodSignature.GetUnicode(),
-                pEntryPoint,
-                GetClrInstanceId());
-        }
+                FireEtwR2RGetEntryPoint(
+                    (UINT64)pMethodDesc,
+                    (PCWSTR)tNamespace.GetUnicode(),
+                    (PCWSTR)tMethodName.GetUnicode(),
+                    (PCWSTR)tMethodSignature.GetUnicode(),
+                    pEntryPoint,
+                    GetClrInstanceId());
 
-    } EX_CATCH{ } EX_END_CATCH(SwallowAllExceptions);
+        } EX_CATCH{ } EX_END_CATCH(SwallowAllExceptions);
+    }
 }
 
 /*******************************************************/

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -5215,7 +5215,16 @@ VOID ETW::MethodLog::GetR2RGetEntryPoint(MethodDesc *pMethodDesc, PCODE pEntryPo
     {
         if (ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_Context, R2RGetEntryPoint))
         {
-            ETW::MethodLog::SendR2RGetEntryPointEvent(pMethodDesc, pEntryPoint);
+            SString tNamespace, tMethodName, tMethodSignature;
+            pMethodDesc->GetMethodInfo(tNamespace, tMethodName, tMethodSignature);
+
+            FireEtwR2RGetEntryPoint(
+                (UINT64)pMethodDesc,
+                (PCWSTR)tNamespace.GetUnicode(),
+                (PCWSTR)tMethodName.GetUnicode(),
+                (PCWSTR)tMethodSignature.GetUnicode(),
+                pEntryPoint,
+                GetClrInstanceId());
         }
 
     } EX_CATCH{ } EX_END_CATCH(SwallowAllExceptions);
@@ -6175,25 +6184,6 @@ VOID ETW::LoaderLog::SendModuleEvent(Module *pModule, DWORD dwEventOptions, BOOL
             SendModuleRange(pModule, dwEventOptions);
         }
     }
-}
-
-VOID ETW::MethodLog::SendR2RGetEntryPointEvent(MethodDesc *pMethodDesc, PCODE pEntryPoint)
-{
-    CONTRACTL{
-        THROWS;
-        GC_TRIGGERS;
-    } CONTRACTL_END;
-
-    SString tNamespace, tMethodName, tMethodSignature;
-    pMethodDesc->GetMethodInfo(tNamespace, tMethodName, tMethodSignature);
-
-    FireEtwR2RGetEntryPoint(
-        (UINT64)pMethodDesc,
-        (PCWSTR)tNamespace.GetUnicode(),
-        (PCWSTR)tMethodName.GetUnicode(),
-        (PCWSTR)tMethodSignature.GetUnicode(),
-        pEntryPoint,
-        GetClrInstanceId());
 }
 
 /*****************************************************************/

--- a/src/vm/readytoruninfo.cpp
+++ b/src/vm/readytoruninfo.cpp
@@ -673,6 +673,11 @@ PCODE ReadyToRunInfo::GetEntryPoint(MethodDesc * pMD, PrepareCodeConfig* pConfig
     STANDARD_VM_CONTRACT;
 
     PCODE pEntryPoint = NULL;
+#ifndef CROSSGEN_COMPILE
+#ifdef PROFILING_SUPPORTED
+    BOOL fShouldSearchCache = TRUE;
+#endif // PROFILING_SUPPORTED
+#endif // CROSSGEN_COMPILE
     mdToken token = pMD->GetMemberDef();
     int rid = RidFromToken(token);
     if (rid == 0)
@@ -714,7 +719,6 @@ PCODE ReadyToRunInfo::GetEntryPoint(MethodDesc * pMD, PrepareCodeConfig* pConfig
 
 #ifndef CROSSGEN_COMPILE
 #ifdef PROFILING_SUPPORTED
-        BOOL fShouldSearchCache = TRUE;
         {
             BEGIN_PIN_PROFILER(CORProfilerTrackCacheSearches());
             g_profControlBlock.pProfInterface->

--- a/src/vm/readytoruninfo.cpp
+++ b/src/vm/readytoruninfo.cpp
@@ -794,7 +794,10 @@ PCODE ReadyToRunInfo::GetEntryPoint(MethodDesc * pMD, PrepareCodeConfig* pConfig
     }
 
 done:
-    ETW::MethodLog::GetR2RGetEntryPoint(pMD, pEntryPoint);
+    if (ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_Context, R2RGetEntryPoint))
+    {
+        ETW::MethodLog::GetR2RGetEntryPoint(pMD, pEntryPoint);
+    }
     return pEntryPoint;
 }
 

--- a/src/vm/readytoruninfo.cpp
+++ b/src/vm/readytoruninfo.cpp
@@ -794,13 +794,7 @@ PCODE ReadyToRunInfo::GetEntryPoint(MethodDesc * pMD, PrepareCodeConfig* pConfig
     }
 
 done:
-    if(ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_Context, R2RGetEntryPoint))
-    {
-        SString fullMethodSignature;
-        pMD->GetFullMethodInfo(fullMethodSignature);
-        FireEtwR2RGetEntryPoint((UINT64)pMD, fullMethodSignature.GetUnicode(), pEntryPoint, GetClrInstanceId());
-    }
-
+    ETW::MethodLog::GetR2RGetEntryPoint(pMD, pEntryPoint);
     return pEntryPoint;
 }
 


### PR DESCRIPTION
Adds a new R2RGetEntryPoint event for use in diagnosing R2R method lookup behavior.  As an example, I used this event to help diagnose #23640.