### PR TITLE
Fix arm altjit asm diffs

### DIFF
--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -12279,8 +12279,7 @@ CorJitResult invokeCompileMethodHelper(EEJitManager *jitMgr,
         // If we failed to jit, then fall back to the primary Jit.
         if (FAILED(ret))
         {
-            // Consider adding this call:
-            //      ((CEEJitInfo*)comp)->BackoutJitData(jitMgr);
+            ((CEEJitInfo*)comp)->BackoutJitData(jitMgr);
             ((CEEJitInfo*)comp)->ResetForJitRetry();
             ret = CORJIT_SKIPPED;
         }


### PR DESCRIPTION
At shutdown, the VM iterates over generated code as part of ETW
"rundown". This currently includes altjit generated code. It calls
functions which interprets the code as native code, e.g., arm32
GC info as x86 GC info.

The fix is to make a call to BackoutJitData(), which was already
suggested in the comments. This removes the altjit generated code
from the "nibble map", and hence from the iteration.

Fixes #23393