### PR TITLE
Treat WinMDs as having been loaded in the default ALC for AssemblyLoadContext.GetLoadContext

### DIFF
--- a/src/vm/assemblynative.cpp
+++ b/src/vm/assemblynative.cpp
@@ -1331,7 +1331,10 @@ INT_PTR QCALLTYPE AssemblyNative::GetLoadContextForAssembly(QCall::AssemblyHandl
     // We should have a load context binder at this point.
     _ASSERTE(pOpaqueBinder != nullptr);
 
-    if (!AreSameBinderInstance(pTPABinder, pOpaqueBinder))
+    // the TPA binder uses the default ALC
+    // WinRT assemblies (bound using the WinRT binder) don't actually have an ALC,
+    // so treat them the same as if they were loaded into the TPA ALC in this case.
+    if (!AreSameBinderInstance(pTPABinder, pOpaqueBinder) && !AreSameBinderInstance(pCurDomain->GetWinRtBinder(), pOpaqueBinder))
     {
         // Only CLRPrivBinderAssemblyLoadContext instance contains the reference to its
         // corresponding managed instance.

--- a/src/vm/assemblynative.cpp
+++ b/src/vm/assemblynative.cpp
@@ -1334,7 +1334,11 @@ INT_PTR QCALLTYPE AssemblyNative::GetLoadContextForAssembly(QCall::AssemblyHandl
     // the TPA binder uses the default ALC
     // WinRT assemblies (bound using the WinRT binder) don't actually have an ALC,
     // so treat them the same as if they were loaded into the TPA ALC in this case.
+#ifdef FEATURE_COMINTEROP
     if (!AreSameBinderInstance(pTPABinder, pOpaqueBinder) && !AreSameBinderInstance(pCurDomain->GetWinRtBinder(), pOpaqueBinder))
+#else
+    if (!AreSameBinderInstance(pTPABinder, pOpaqueBinder))
+#endif // FEATURE_COMINTEROP
     {
         // Only CLRPrivBinderAssemblyLoadContext instance contains the reference to its
         // corresponding managed instance.


### PR DESCRIPTION
Fixes #23583 

There is currently no way to load a WinMD into an ALC and all WinMD dependencies are loaded into the default ALC, so from a user perspective, this is effectively correct.

With #23402 this will change slightly (a WinMD will still be loaded by the WinRT binder but its dependencies can be loaded into an isolated ALC), so we might want to do different behavior then.