### PR TITLE
Fix interop test cases to pass doubles for native varargs

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -74,6 +74,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/tracing/keyword/TwoKeywords/TwoKeywords/*">
             <Issue>23224, often fails with timeout in release</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/tracecontrol/tracecontrol/*">
+            <Issue>20299</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- All Unix targets -->
@@ -256,28 +259,6 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/tracevalidation/inducedgc/inducedgc/*">
             <Issue>23124</Issue>
-        </ExcludeList>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(XunitTestBinBase)' != ''">
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/tracecontrol/tracecontrol/*">
-            <Issue>20299</Issue>
-        </ExcludeList>
-    </ItemGroup>
-
-    <!-- Windows specific excludes -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TargetsWindows)' == 'true'">
-         <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/mcc/interop/mcc_i11/*">
-            <Issue>22974</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/mcc/interop/mcc_i10/*">
-            <Issue>22974</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/mcc/interop/mcc_i12/*">
-            <Issue>22974</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/mcc/interop/mcc_i13/*">
-            <Issue>22974</Issue>
         </ExcludeList>
     </ItemGroup>
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i10.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i10.il
@@ -13,7 +13,7 @@
   .class MyClass
   {
     .method assembly static pinvokeimpl("native_i1c" as "#1" cdecl) 
-        vararg valuetype MCCTest.VType1 Sum(float32) cil managed preservesig {
+        vararg valuetype MCCTest.VType1 Sum(float64) cil managed preservesig {
     }
 
     .method private static int32 Main(string[] args)
@@ -39,19 +39,19 @@
       ldc.r8     12
       ldc.r8     1
       neg
-      call       vararg valuetype MCCTest.VType1 MCCTest.MyClass::Sum(float32, ..., 
-																		float32, 
-																		float32, 
-																		float32, 
-																		float32, 
-																		float32, 
-																		float32, 
-																		float32, 
-																		float32, 
-																		float32, 
-																		float32, 
-																		float32, 
-																		float32)
+      call       vararg valuetype MCCTest.VType1 MCCTest.MyClass::Sum(float64, ...,
+																		float64,
+																		float64,
+																		float64,
+																		float64,
+																		float64,
+																		float64,
+																		float64,
+																		float64,
+																		float64,
+																		float64,
+																		float64,
+																		float64)
 
       stloc.s    res
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i11.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i11.il
@@ -15,7 +15,7 @@
   .class MyClass
   {
     .method assembly static pinvokeimpl("native_i1c.dll" as "#1" cdecl)
-       vararg valuetype MCCTest.VType1 Sum(float32) cil managed preservesig {
+       vararg valuetype MCCTest.VType1 Sum(float64) cil managed preservesig {
     }
 
     .method private static int32 Main(string[] args)
@@ -27,34 +27,34 @@
         [1] int32 rc
       )
 
-      ldc.r4     1
-      ldc.r4     2
-      ldc.r4     3
-      ldc.r4     4
-      ldc.r4     5
-      ldc.r4     6
-      ldc.r4     7
-      ldc.r4     8
-      ldc.r4     9
-      ldc.r4     10
-      ldc.r4     11
-      ldc.r4     12
-      ldc.r4     1
+      ldc.r8     1
+      ldc.r8     2
+      ldc.r8     3
+      ldc.r8     4
+      ldc.r8     5
+      ldc.r8     6
+      ldc.r8     7
+      ldc.r8     8
+      ldc.r8     9
+      ldc.r8     10
+      ldc.r8     11
+      ldc.r8     12
+      ldc.r8     1
       neg
-      ldftn      vararg valuetype MCCTest.VType1 MCCTest.MyClass::Sum(float32)
-      calli      vararg valuetype MCCTest.VType1(float32, ...,
-                                                    float32,
-                                                    float32,
-                                                    float32,
-                                                    float32,
-                                                    float32,
-                                                    float32,
-                                                    float32,
-                                                    float32,
-                                                    float32,
-                                                    float32,
-                                                    float32,
-                                                    float32)
+      ldftn      vararg valuetype MCCTest.VType1 MCCTest.MyClass::Sum(float64)
+      calli      vararg valuetype MCCTest.VType1(float64, ...,
+                                                    float64,
+                                                    float64,
+                                                    float64,
+                                                    float64,
+                                                    float64,
+                                                    float64,
+                                                    float64,
+                                                    float64,
+                                                    float64,
+                                                    float64,
+                                                    float64,
+                                                    float64)
       stloc.s    res
 
       // Check Result

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i12.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i12.il
@@ -15,40 +15,40 @@
   .class MyClass
   {
     .method assembly static pinvokeimpl("native_i1c.dll" as "#1" cdecl)
-        vararg valuetype MCCTest.VType1 Sum(float32) cil managed preservesig {
+        vararg valuetype MCCTest.VType1 Sum(float64) cil managed preservesig {
     }
 
     .method private valuetype MCCTest.VType1 GetSum()
     {
       .maxstack  64
-      ldc.r4     1
-      ldc.r4     2
-      ldc.r4     3
-      ldc.r4     4
-      ldc.r4     5
-      ldc.r4     6
-      ldc.r4     7
-      ldc.r4     8
-      ldc.r4     9
-      ldc.r4     10
-      ldc.r4     11
-      ldc.r4     12
-      ldc.r4     1
+      ldc.r8     1
+      ldc.r8     2
+      ldc.r8     3
+      ldc.r8     4
+      ldc.r8     5
+      ldc.r8     6
+      ldc.r8     7
+      ldc.r8     8
+      ldc.r8     9
+      ldc.r8     10
+      ldc.r8     11
+      ldc.r8     12
+      ldc.r8     1
       neg
       tail.
-      call       vararg valuetype MCCTest.VType1 MCCTest.MyClass::Sum(float32, ...,
-                                                                        float32,
-                                                                        float32,
-                                                                        float32,
-                                                                        float32,
-                                                                        float32,
-                                                                        float32,
-                                                                        float32,
-                                                                        float32,
-                                                                        float32,
-                                                                        float32,
-                                                                        float32,
-                                                                        float32)
+      call       vararg valuetype MCCTest.VType1 MCCTest.MyClass::Sum(float64, ...,
+                                                                        float64,
+                                                                        float64,
+                                                                        float64,
+                                                                        float64,
+                                                                        float64,
+                                                                        float64,
+                                                                        float64,
+                                                                        float64,
+                                                                        float64,
+                                                                        float64,
+                                                                        float64,
+                                                                        float64)
         ret
     }
 

--- a/tests/src/JIT/jit64/mcc/interop/mcc_i13.il
+++ b/tests/src/JIT/jit64/mcc/interop/mcc_i13.il
@@ -15,45 +15,45 @@
   .class MyClass
   {
     .method assembly static pinvokeimpl("native_i1c.dll" as "#1" cdecl)
-        vararg valuetype MCCTest.VType1 Sum(float32) cil managed preservesig {
+        vararg valuetype MCCTest.VType1 Sum(float64) cil managed preservesig {
     }
 
     .method private valuetype MCCTest.VType1 GetSum()
     {
       .maxstack  64
-      ldc.r4     1
-      ldc.r4     2
-      ldc.r4     3
-      ldc.r4     4
-      ldc.r4     5
-      ldc.r4     6
-      ldc.r4     7
-      ldc.r4     8
-      ldc.r4     9
-      ldc.r4     10
-      ldc.r4     11
-      ldc.r4     12
-      ldc.r4     1
+      ldc.r8     1
+      ldc.r8     2
+      ldc.r8     3
+      ldc.r8     4
+      ldc.r8     5
+      ldc.r8     6
+      ldc.r8     7
+      ldc.r8     8
+      ldc.r8     9
+      ldc.r8     10
+      ldc.r8     11
+      ldc.r8     12
+      ldc.r8     1
       neg
-      call       vararg valuetype MCCTest.VType1 MCCTest.MyClass::GetSum2(float32, ...,
-                                                                            float32,
-                                                                            float32,
-                                                                            float32,
-                                                                            float32,
-                                                                            float32,
-                                                                            float32,
-                                                                            float32,
-                                                                            float32,
-                                                                            float32,
-                                                                            float32,
-                                                                            float32,
-                                                                            float32)
+      call       vararg valuetype MCCTest.VType1 MCCTest.MyClass::GetSum2(float64, ...,
+                                                                            float64,
+                                                                            float64,
+                                                                            float64,
+                                                                            float64,
+                                                                            float64,
+                                                                            float64,
+                                                                            float64,
+                                                                            float64,
+                                                                            float64,
+                                                                            float64,
+                                                                            float64,
+                                                                            float64)
         ret
     }
 
-    .method private static vararg valuetype MCCTest.VType1 GetSum2(float32)
+    .method private static vararg valuetype MCCTest.VType1 GetSum2(float64)
     {
-      jmp   vararg valuetype MCCTest.VType1 MCCTest.MyClass::Sum(float32)
+      jmp   vararg valuetype MCCTest.VType1 MCCTest.MyClass::Sum(float64)
     }
 
     .method public specialname rtspecialname instance void  .ctor()


### PR DESCRIPTION
Remove these tests from the windows exclude list. Also move one
other exclude entry from its own section into the general exclude list.

Closes #22974