### PR TITLE
Disable a couple of S.R.InteropServices tests

### DIFF
--- a/tests/CoreFX/CoreFX.issues.json
+++ b/tests/CoreFX/CoreFX.issues.json
@@ -1065,6 +1065,14 @@
                 {
                     "name": "System.Runtime.InteropServices.Tests.StringToHGlobalAutoTests.StringToHGlobalAuto_NonNullString_Roundtrips",
                     "reason": "https://github.com/dotnet/coreclr/pull/23664"
+                },
+                {
+                    "name": "System.Runtime.InteropServices.Tests.ThrowExceptionForHRTests.ThrowExceptionForHR_NoErrorInfo_ReturnsValidException",
+                    "reason": "outdated"
+                },
+                {
+                    "name": "System.Runtime.InteropServices.Tests.ThrowExceptionForHRTests.ThrowExceptionForHR_ErrorInfo_ReturnsValidException",
+                    "reason": "outdated"
                 }
             ]
         }


### PR DESCRIPTION
- It looks like these are running in outdated snapshots:
  - https://ci.dot.net/job/dotnet_coreclr/job/master/job/x64_checked_ubuntu_corefx_innerloop_prtest/9973/
  - https://ci.dot.net/job/dotnet_coreclr/job/master/job/x64_checked_ubuntu_corefx_innerloop_prtest/10012/
- Disabled the two tests that were fixed in PR https://github.com/dotnet/corefx/pull/34968 to get CI clean