### PR TITLE
Update container for musl_arm64 cross build. Add Alpine.38.Arm64.Open Helix queue

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ resources:
     image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.6-WithNode-f4d3fe3-20181220200247
 
   - container: musl_arm64_build_image
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-alpine10fcdcf-20190208200917
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-alpine-406629a-20190403203438
 
   - container: centos7_x64_build_image
     image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-d485f41-20173404063424

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -94,7 +94,8 @@ jobs:
         osIdentifier: Linux_musl
         containerName: musl_arm64_build_image
         helixQueues:
-        # TODO: enable (Alpine.38.Arm64.Open) once https://github.com/dotnet/coreclr/issues/23621 is resolved
+        - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          - (Alpine.38.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-46e69dd-20190313223330
         - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           - (Alpine.38.Arm64)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-46e69dd-20190313223330
         crossrootfsDir: '/crossrootfs/arm64'


### PR DESCRIPTION
@janvorli fixed Alpine ARM64 image we use for crossbuild in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/112

Use this image in coreclr-ci and also add Alpine.38.Arm64.Open Helix queue

Fixes #23621