### PR TITLE
Run CoreFX baseline arm/arm64 Windows/Ubuntu daily.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1527,6 +1527,9 @@ def static addNonPRTriggers(def job, def branch, def isPR, def architecture, def
                     // These jobs are very fast on Linux/arm64 hardware, so run them daily.
                     addPeriodicTriggerHelper(job, '@daily')
                 }
+                else if (scenario == 'corefx_baseline') {
+                    addPeriodicTriggerHelper(job, '@daily')
+                }
                 else {
                     addPeriodicTriggerHelper(job, '@weekly')
                 }


### PR DESCRIPTION
These jobs take ~1 hour each (except windows x64/x86 where we have contracts)  and we can allow to run them more often.
We need more data for flaky issues and to track new regressions.

Affected legs:
https://ci.dot.net/job/dotnet_coreclr/job/master/job/jitstress/job/arm_cross_checked_windows_nt_corefx_baseline_bld/
https://ci.dot.net/job/dotnet_coreclr/job/master/job/jitstress/job/x64_checked_ubuntu_corefx_baseline/
https://ci.dot.net/job/dotnet_coreclr/job/master/job/jitstress/job/x64_checked_windows_nt_corefx_baseline/
https://ci.dot.net/job/dotnet_coreclr/job/master/job/jitstress/job/x86_checked_windows_nt_corefx_baseline/
https://ci.dot.net/job/dotnet_coreclr/job/master/job/jitstress/job/arm64_cross_checked_windows_nt_corefx_baseline_bld/
https://ci.dot.net/job/dotnet_coreclr/job/master/job/jitstress/job/arm64_cross_checked_ubuntu16.04_corefx_baseline/
https://ci.dot.net/job/dotnet_coreclr/job/master/job/jitstress/job/arm64_cross_checked_windows_nt_corefx_baseline_bld/
https://ci.dot.net/job/dotnet_coreclr/job/master/job/jitstress/job/arm_cross_checked_ubuntu_corefx_baseline/

