### PR TITLE
Fix resource loading

### DIFF
--- a/src/utilcode/pedecoder.cpp
+++ b/src/utilcode/pedecoder.cpp
@@ -1801,12 +1801,6 @@ DWORD PEDecoder::ReadResourceDictionary(DWORD rvaOfResourceSection, DWORD rva, L
 
     IMAGE_RESOURCE_DIRECTORY *pResourceDirectory = (IMAGE_RESOURCE_DIRECTORY *)GetRvaData(rva);
 
-    if (pResourceDirectory->MajorVersion != 4)
-        return 0;
-
-    if (pResourceDirectory->MinorVersion != 0)
-        return 0;
-
     // Check to see if entire resource dictionary is accessible
     if (!CheckRva(rva + sizeof(IMAGE_RESOURCE_DIRECTORY), 
                        (sizeof(IMAGE_RESOURCE_DIRECTORY_ENTRY) * pResourceDirectory->NumberOfNamedEntries) +


### PR DESCRIPTION
- Some resources are generated without setting a Major/Minor version in the resource directory
- This is legal, and we shouldn't skip parsing the resource
