### PR TITLE
Fix MUSL ARM64 cross build

### DIFF
--- a/cross/toolchain.cmake
+++ b/cross/toolchain.cmake
@@ -76,8 +76,6 @@ if (CLR_CMAKE_COMPILER STREQUAL "Clang")
   add_compile_param(CROSS_LINK_FLAGS "--target=${TOOLCHAIN}")
 endif()
 
-add_compile_param(CROSS_LINK_FLAGS "-fuse-ld=gold")
-
 if(TARGET_ARCH_NAME STREQUAL "armel")
   if(DEFINED TIZEN_TOOLCHAIN) # For Tizen only
     add_compile_param(CROSS_LINK_FLAGS "-B${CROSS_ROOTFS}/usr/lib/gcc/${TIZEN_TOOLCHAIN}")

--- a/src/vm/arm64/asmhelpers.S
+++ b/src/vm/arm64/asmhelpers.S
@@ -1304,7 +1304,7 @@ LEAF_ENTRY JIT_Stelem_Ref, _TEXT
     beq     C_FUNC(JIT_Stelem_DoWrite)
 
     // Types didnt match but allow writing into an array of objects
-    ldr     x3, =g_pObjectClass
+    PREPARE_EXTERNAL_VAR g_pObjectClass, x3
     ldr     x3, [x3]  // x3 = *g_pObjectClass
     cmp     x3, x12   // array type matches with Object*
     beq     C_FUNC(JIT_Stelem_DoWrite)


### PR DESCRIPTION
There were two issues:
* the cross/toolchain.cmake was unconditionally setting the linker to ld.gold.
  This is not wanted in general and the ld.gold cannot link arm64 MUSL stuff
  correctly (it leaves a couple of TLS symbols as undefined)
* the src/vm/arm64/asmhelpers.S was referencing a global variable using absolute
  relocation, which is not allowed in shared libraries on MUSL based Linux distros.
