### PR TITLE
Don't null out references in Stream/BinaryReader/Writer

### DIFF
--- a/src/System.Private.CoreLib/shared/System/IO/BinaryWriter.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/BinaryWriter.cs
@@ -18,9 +18,9 @@ namespace System.IO
         public static readonly BinaryWriter Null = new BinaryWriter();
 
         protected Stream OutStream;
-        private byte[] _buffer;    // temp space for writing primitives to.
-        private Encoding _encoding;
-        private Encoder _encoder;
+        private readonly byte[] _buffer;    // temp space for writing primitives to.
+        private readonly Encoding _encoding;
+        private readonly Encoder _encoder;
 
         private bool _leaveOpen;
 

--- a/tests/CoreFX/CoreFX.issues.json
+++ b/tests/CoreFX/CoreFX.issues.json
@@ -740,6 +740,32 @@
         }
     },
     {
+        "name": "System.IO.Tests",
+        "enabled": true,
+        "exclusions": {
+            "namespaces": null,
+            "classes": null,
+            "methods": [
+                {
+                    "name": "System.IO.Tests.CloseTests.AfterDisposeThrows",
+                    "reason": "Readers/writers changed to not null out base stream on dispose"
+                },
+                {
+                    "name": "System.IO.Tests.CloseTests.AfterCloseThrows",
+                    "reason": "Readers/writers changed to not null out base stream on dispose"
+                },
+                {
+                    "name": "System.IO.Tests.StreamWriterWithBufferedStream_CloseTests.AfterDisposeThrows",
+                    "reason": "Readers/writers changed to not null out base stream on dispose"
+                },
+                {
+                    "name": "System.IO.Tests.StreamWriterWithBufferedStream_CloseTests.AfterCloseThrows",
+                    "reason": "Readers/writers changed to not null out base stream on dispose"
+                }
+            ]
+        }
+    },
+    {
         "name": "System.IO.FileSystem.Tests",
         "enabled": true,
         "exclusions": {


### PR DESCRIPTION
These types null out some fields on Dispose, and some of those fields are accessible directly via exposed properties, which means that nulling them out would either force us to annotate those properties as being nullable or would require us to lie about them being nullable.  Nulling them out also makes it easier to accidentally null ref in the implementation, and prevents us from making the fields readonly.

It should be exceedingly rare that you dispose of one of these objects and then keep it alive while also being concerned about keeping alive the other helper objects the type uses.  So this change just uses a separate flag to track disposal, and avoids nulling out the fields, which is not a common practice elsewhere in the framework.

This will be a visible change in that after Dispose, properties like StreamWriter.BaseStream/Encoding will now return the stream/encoding rather than null.  In theory that could break someone if they were using those properties to determine whether the writer had been disposed, but that seems unlikely / similar fallout from most any bug fix, and objects generally aren't supposed to be touched after Dispose, anyway.

cc: @jkotas, @JeremyKuhne, @dotnet/nullablefc 