### PR TITLE
Use BYOC pools in finalize-publish.yml

### DIFF
--- a/eng/finalize-publish.yml
+++ b/eng/finalize-publish.yml
@@ -16,7 +16,8 @@ jobs:
     parameters:
       configuration: Release
       pool:
-        name: dotnet-internal-temp
+        name: NetCoreInternal-Int-Pool
+        queue: BuildPool.Windows.10.Amd64.VS2017
       dependsOn: ${{ parameters.dependsOn }}
   # Update dotnet/versions
   - job: Finalize_Publish_Versions
@@ -24,7 +25,8 @@ jobs:
     dependsOn:
     - Asset_Registry_Publish
     pool:
-      name: Hosted VS2017
+      name: NetCoreInternal-Int-Pool
+      queue: BuildPool.Windows.10.Amd64.VS2017
     variables:
       - group: DotNet-Versions-Publish
     steps:

--- a/eng/finalize-publish.yml
+++ b/eng/finalize-publish.yml
@@ -25,8 +25,7 @@ jobs:
     dependsOn:
     - Asset_Registry_Publish
     pool:
-      name: NetCoreInternal-Int-Pool
-      queue: BuildPool.Windows.10.Amd64.VS2017
+      name: Hosted VS2017
     variables:
       - group: DotNet-Versions-Publish
     steps:


### PR DESCRIPTION
See https://github.com/dotnet/coreclr/pull/23501#issuecomment-479993414 

@sdmaclea Since you setup a pool for `Finalize_Publish_Versions` job in https://github.com/dotnet/coreclr/commit/51d033897eb5663ea8bab53704406d9fd82af98f - is there any reason why this is `Hosted VS2017`? Should we use BYOC internal pools instead?