### PR TITLE
Move AssemblyName to shared

### DIFF
--- a/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -173,7 +173,7 @@
     <Compile Include="$(BclSourcesRoot)\System\Object.CoreCLR.cs" />
     <Compile Include="$(BclSourcesRoot)\System\OleAutBinder.cs" Condition="'$(FeatureClassicCominterop)' == 'true'" />
     <Compile Include="$(BclSourcesRoot)\System\Reflection\Assembly.CoreCLR.cs" />
-    <Compile Include="$(BclSourcesRoot)\System\Reflection\AssemblyName.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Reflection\AssemblyName.CoreCLR.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Reflection\Associates.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Reflection\ConstructorInfo.CoreCLR.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Reflection\CustomAttribute.cs" />

--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -421,6 +421,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\AssemblyKeyFileAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\AssemblyKeyNameAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\AssemblyMetadataAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\AssemblyName.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\AssemblyNameFlags.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\AssemblyNameFormatter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\AssemblyProductAttribute.cs" />

--- a/src/System.Private.CoreLib/shared/System/Reflection/AssemblyName.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/AssemblyName.cs
@@ -4,14 +4,13 @@
 
 using System.Configuration.Assemblies;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Text;
 using CultureInfo = System.Globalization.CultureInfo;
 
 namespace System.Reflection
 {
-    public sealed class AssemblyName : ICloneable, IDeserializationCallback, ISerializable
+    public sealed partial class AssemblyName : ICloneable, IDeserializationCallback, ISerializable
     {
         // If you modify any of these fields, you must also update the 
         // AssemblyBaseObject structure in object.h
@@ -296,15 +295,6 @@ namespace System.Reflection
             return refName.Equals(defName, StringComparison.OrdinalIgnoreCase);
         }
 
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal extern void nInit(out RuntimeAssembly assembly, bool raiseResolveEvent);
-
-        internal void nInit()
-        {
-            RuntimeAssembly dummy = null;
-            nInit(out dummy, false);
-        }
-
         internal void SetProcArchIndex(PortableExecutableKinds pek, ImageFileMachine ifm)
         {
             ProcessorArchitecture = CalculateProcArchIndex(pek, ifm, _flags);
@@ -384,14 +374,6 @@ namespace System.Reflection
             _flags = flags;
             _strongNameKeyPair = keyPair;
         }
-
-        // This call opens and closes the file, but does not add the
-        // assembly to the domain.
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern AssemblyName nGetFileInformation(string s);
-
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private extern byte[] nGetPublicKeyToken();
 
         internal static string EscapeCodeBase(string codebase)
         {

--- a/src/System.Private.CoreLib/shared/System/Reflection/AssemblyName.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/AssemblyName.cs
@@ -37,18 +37,6 @@ namespace System.Reflection
             _flags = AssemblyNameFlags.None;
         }
 
-        public AssemblyName(string assemblyName)
-        {
-            if (assemblyName == null)
-                throw new ArgumentNullException(nameof(assemblyName));
-            if ((assemblyName.Length == 0) ||
-                (assemblyName[0] == '\0'))
-                throw new ArgumentException(SR.Format_StringZeroLength);
-
-            _name = assemblyName;
-            nInit();
-        }
-
         // Set and get the name of the assembly. If this is a weak Name
         // then it optionally contains a site. For strong assembly names, 
         // the name partitions up the strong name's namespace
@@ -169,16 +157,9 @@ namespace System.Reflection
             if (assemblyFile == null)
                 throw new ArgumentNullException(nameof(assemblyFile));
 
-            // Assembly.GetNameInternal() will not demand path discovery 
-            //  permission, so do that first.
-            string fullPath = Path.GetFullPath(assemblyFile);
-            return nGetFileInformation(fullPath);
+            return GetFileInformationCore(assemblyFile);
         }
 
-        // The public key that is used to verify an assemblies
-        // inclusion into the namespace. If the public key associated
-        // with the namespace cannot verify the assembly the assembly
-        // will fail to load.
         public byte[] GetPublicKey()
         {
             return _publicKey;
@@ -199,7 +180,7 @@ namespace System.Reflection
         public byte[] GetPublicKeyToken()
         {
             if (_publicKeyToken == null)
-                _publicKeyToken = nGetPublicKeyToken();
+                _publicKeyToken = ComputePublicKeyToken();
             return _publicKeyToken;
         }
 
@@ -250,7 +231,7 @@ namespace System.Reflection
                 if (this.Name == null)
                     return string.Empty;
                 // Do not call GetPublicKeyToken() here - that latches the result into AssemblyName which isn't a side effect we want.
-                byte[] pkt = _publicKeyToken ?? nGetPublicKeyToken();
+                byte[] pkt = _publicKeyToken ?? ComputePublicKeyToken();
                 return AssemblyNameFormatter.ComputeDisplayName(Name, Version, CultureName, pkt, Flags, ContentType);
             }
         }
@@ -293,50 +274,6 @@ namespace System.Reflection
             string refName = reference.Name ?? string.Empty;
             string defName = definition.Name ?? string.Empty;
             return refName.Equals(defName, StringComparison.OrdinalIgnoreCase);
-        }
-
-        internal void SetProcArchIndex(PortableExecutableKinds pek, ImageFileMachine ifm)
-        {
-            ProcessorArchitecture = CalculateProcArchIndex(pek, ifm, _flags);
-        }
-
-        internal static ProcessorArchitecture CalculateProcArchIndex(PortableExecutableKinds pek, ImageFileMachine ifm, AssemblyNameFlags flags)
-        {
-            if (((uint)flags & 0xF0) == 0x70)
-                return ProcessorArchitecture.None;
-
-            if ((pek & System.Reflection.PortableExecutableKinds.PE32Plus) == System.Reflection.PortableExecutableKinds.PE32Plus)
-            {
-                switch (ifm)
-                {
-                    case System.Reflection.ImageFileMachine.IA64:
-                        return ProcessorArchitecture.IA64;
-                    case System.Reflection.ImageFileMachine.AMD64:
-                        return ProcessorArchitecture.Amd64;
-                    case System.Reflection.ImageFileMachine.I386:
-                        if ((pek & System.Reflection.PortableExecutableKinds.ILOnly) == System.Reflection.PortableExecutableKinds.ILOnly)
-                            return ProcessorArchitecture.MSIL;
-                        break;
-                }
-            }
-            else
-            {
-                if (ifm == System.Reflection.ImageFileMachine.I386)
-                {
-                    if ((pek & System.Reflection.PortableExecutableKinds.Required32Bit) == System.Reflection.PortableExecutableKinds.Required32Bit)
-                        return ProcessorArchitecture.X86;
-
-                    if ((pek & System.Reflection.PortableExecutableKinds.ILOnly) == System.Reflection.PortableExecutableKinds.ILOnly)
-                        return ProcessorArchitecture.MSIL;
-
-                    return ProcessorArchitecture.X86;
-                }
-                if (ifm == System.Reflection.ImageFileMachine.ARM)
-                {
-                    return ProcessorArchitecture.Arm;
-                }
-            }
-            return ProcessorArchitecture.None;
         }
 
         internal void Init(string name,

--- a/src/System.Private.CoreLib/shared/System/Reflection/AssemblyName.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/AssemblyName.cs
@@ -131,19 +131,20 @@ namespace System.Reflection
         // Make a copy of this assembly name.
         public object Clone()
         {
-            AssemblyName name = new AssemblyName();
-            name.Init(_name,
-                      _publicKey,
-                      _publicKeyToken,
-                      _version,
-                      _cultureInfo,
-                      _hashAlgorithm,
-                      _versionCompatibility,
-                      _codeBase,
-                      _flags,
-                      _strongNameKeyPair);
-            name._hashForControl = _hashForControl;
-            name._hashAlgorithmForControl = _hashAlgorithmForControl;
+            var name = new AssemblyName
+            {
+                _name = _name,
+                _publicKey = (byte[])_publicKey?.Clone(),
+                _publicKeyToken = (byte[])_publicKeyToken?.Clone(),
+                _cultureInfo = _cultureInfo,
+                _version = (Version)_version?.Clone(),
+                _flags = _flags,
+                _codeBase = _codeBase,
+                _hashAlgorithm = _hashAlgorithm,
+                _versionCompatibility = _versionCompatibility,
+                _hashForControl = _hashForControl,
+                _hashAlgorithmForControl = _hashAlgorithmForControl
+            };
             return name;
         }
 
@@ -274,42 +275,6 @@ namespace System.Reflection
             string refName = reference.Name ?? string.Empty;
             string defName = definition.Name ?? string.Empty;
             return refName.Equals(defName, StringComparison.OrdinalIgnoreCase);
-        }
-
-        internal void Init(string name,
-                           byte[] publicKey,
-                           byte[] publicKeyToken,
-                           Version version,
-                           CultureInfo cultureInfo,
-                           AssemblyHashAlgorithm hashAlgorithm,
-                           AssemblyVersionCompatibility versionCompatibility,
-                           string codeBase,
-                           AssemblyNameFlags flags,
-                           StrongNameKeyPair keyPair) // Null if ref, matching Assembly if def
-        {
-            _name = name;
-
-            if (publicKey != null)
-            {
-                _publicKey = new byte[publicKey.Length];
-                Array.Copy(publicKey, 0, _publicKey, 0, publicKey.Length);
-            }
-
-            if (publicKeyToken != null)
-            {
-                _publicKeyToken = new byte[publicKeyToken.Length];
-                Array.Copy(publicKeyToken, 0, _publicKeyToken, 0, publicKeyToken.Length);
-            }
-
-            if (version != null)
-                _version = (Version)version.Clone();
-
-            _cultureInfo = cultureInfo;
-            _hashAlgorithm = hashAlgorithm;
-            _versionCompatibility = versionCompatibility;
-            _codeBase = codeBase;
-            _flags = flags;
-            _strongNameKeyPair = keyPair;
         }
 
         internal static string EscapeCodeBase(string codebase)

--- a/src/System.Private.CoreLib/src/System/Reflection/AssemblyName.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/AssemblyName.CoreCLR.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
+
+namespace System.Reflection
+{
+    public sealed partial class AssemblyName : ICloneable, IDeserializationCallback, ISerializable
+    {
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal extern void nInit(out RuntimeAssembly assembly, bool raiseResolveEvent);
+
+        internal void nInit()
+        {
+            nInit(out RuntimeAssembly dummy, false);
+        }
+
+        // This call opens and closes the file, but does not add the
+        // assembly to the domain.
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal static extern AssemblyName nGetFileInformation(string s);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private extern byte[] nGetPublicKeyToken();
+    }
+}

--- a/src/System.Private.CoreLib/src/System/Reflection/AssemblyName.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/AssemblyName.CoreCLR.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Configuration.Assemblies;
+using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
@@ -20,6 +22,29 @@ namespace System.Reflection
 
             _name = assemblyName;
             nInit(out RuntimeAssembly dummy, false);
+        }
+
+        internal AssemblyName(string name,
+            byte[] publicKey,
+            byte[] publicKeyToken,
+            Version version,
+            CultureInfo cultureInfo,
+            AssemblyHashAlgorithm hashAlgorithm,
+            AssemblyVersionCompatibility versionCompatibility,
+            string codeBase,
+            AssemblyNameFlags flags,
+            StrongNameKeyPair keyPair) // Null if ref, matching Assembly if def
+        {
+            _name = name;
+            _publicKey = (byte[])publicKey?.Clone();
+            _publicKeyToken = (byte[])publicKeyToken?.Clone();
+            _version = (Version)version?.Clone();
+            _cultureInfo = cultureInfo;
+            _hashAlgorithm = hashAlgorithm;
+            _versionCompatibility = versionCompatibility;
+            _codeBase = codeBase;
+            _flags = flags;
+            _strongNameKeyPair = keyPair;
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]

--- a/src/System.Private.CoreLib/src/System/Reflection/AssemblyName.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/AssemblyName.CoreCLR.cs
@@ -36,9 +36,9 @@ namespace System.Reflection
             StrongNameKeyPair keyPair) // Null if ref, matching Assembly if def
         {
             _name = name;
-            _publicKey = (byte[])publicKey?.Clone();
-            _publicKeyToken = (byte[])publicKeyToken?.Clone();
-            _version = (Version)version?.Clone();
+            _publicKey = publicKey;
+            _publicKeyToken = publicKeyToken;
+            _version = version;
             _cultureInfo = cultureInfo;
             _hashAlgorithm = hashAlgorithm;
             _versionCompatibility = versionCompatibility;
@@ -74,33 +74,33 @@ namespace System.Reflection
             if (((uint)flags & 0xF0) == 0x70)
                 return ProcessorArchitecture.None;
 
-            if ((pek & System.Reflection.PortableExecutableKinds.PE32Plus) == System.Reflection.PortableExecutableKinds.PE32Plus)
+            if ((pek & PortableExecutableKinds.PE32Plus) == PortableExecutableKinds.PE32Plus)
             {
                 switch (ifm)
                 {
-                    case System.Reflection.ImageFileMachine.IA64:
+                    case ImageFileMachine.IA64:
                         return ProcessorArchitecture.IA64;
-                    case System.Reflection.ImageFileMachine.AMD64:
+                    case ImageFileMachine.AMD64:
                         return ProcessorArchitecture.Amd64;
-                    case System.Reflection.ImageFileMachine.I386:
-                        if ((pek & System.Reflection.PortableExecutableKinds.ILOnly) == System.Reflection.PortableExecutableKinds.ILOnly)
+                    case ImageFileMachine.I386:
+                        if ((pek & PortableExecutableKinds.ILOnly) == PortableExecutableKinds.ILOnly)
                             return ProcessorArchitecture.MSIL;
                         break;
                 }
             }
             else
             {
-                if (ifm == System.Reflection.ImageFileMachine.I386)
+                if (ifm == ImageFileMachine.I386)
                 {
-                    if ((pek & System.Reflection.PortableExecutableKinds.Required32Bit) == System.Reflection.PortableExecutableKinds.Required32Bit)
+                    if ((pek & PortableExecutableKinds.Required32Bit) == PortableExecutableKinds.Required32Bit)
                         return ProcessorArchitecture.X86;
 
-                    if ((pek & System.Reflection.PortableExecutableKinds.ILOnly) == System.Reflection.PortableExecutableKinds.ILOnly)
+                    if ((pek & PortableExecutableKinds.ILOnly) == PortableExecutableKinds.ILOnly)
                         return ProcessorArchitecture.MSIL;
 
                     return ProcessorArchitecture.X86;
                 }
-                if (ifm == System.Reflection.ImageFileMachine.ARM)
+                if (ifm == ImageFileMachine.ARM)
                 {
                     return ProcessorArchitecture.Arm;
                 }

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -86,11 +86,9 @@ namespace System.Reflection
         // is returned.
         public override AssemblyName GetName(bool copiedName)
         {
-            AssemblyName an = new AssemblyName();
-
             string codeBase = GetCodeBase(copiedName);
 
-            an.Init(GetSimpleName(),
+            var an = new AssemblyName(GetSimpleName(),
                     GetPublicKey(),
                     null, // public key token
                     GetVersion(),

--- a/src/vm/assemblyspec.cpp
+++ b/src/vm/assemblyspec.cpp
@@ -587,7 +587,7 @@ void AssemblySpec::AssemblyNameInit(ASSEMBLYNAMEREF* pAsmName, PEImage* pImageIn
         IfFailThrow(pImageInfo->GetMDImport()->GetAssemblyProps(TokenFromRid(1, mdtAssembly), NULL, NULL, &hashAlgId, NULL, NULL, NULL));
     }
 
-    MethodDescCallSite init(METHOD__ASSEMBLY_NAME__INIT);
+    MethodDescCallSite init(METHOD__ASSEMBLY_NAME__CTOR);
     
     ARG_SLOT MethodArgs[] =
     {

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -536,7 +536,7 @@ FCFuncEnd()
 
 FCFuncStart(gAssemblyNameFuncs)
     FCFuncElement("nInit", AssemblyNameNative::Init)
-    FCFuncElement("nGetPublicKeyToken", AssemblyNameNative::GetPublicKeyToken)
+    FCFuncElement("ComputePublicKeyToken", AssemblyNameNative::GetPublicKeyToken)
     FCFuncElement("nGetFileInformation", AssemblyNameNative::GetFileInformation)
 FCFuncEnd()
 

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -120,7 +120,7 @@ DEFINE_FIELD_U(_hashAlgorithmForControl, AssemblyNameBaseObject, _hashAlgorithmF
 DEFINE_FIELD_U(_versionCompatibility,      AssemblyNameBaseObject, _versionCompatibility)
 DEFINE_FIELD_U(_flags,                     AssemblyNameBaseObject, _flags)
 DEFINE_CLASS(ASSEMBLY_NAME,         Reflection,             AssemblyName)
-DEFINE_METHOD(ASSEMBLY_NAME,        INIT,                   Init,                      IM_Str_ArrB_ArrB_Ver_CI_AHA_AVC_Str_ANF_SNKP_RetV)
+DEFINE_METHOD(ASSEMBLY_NAME,        CTOR,                   .ctor,                     IM_Str_ArrB_ArrB_Ver_CI_AHA_AVC_Str_ANF_SNKP_RetV)
 DEFINE_METHOD(ASSEMBLY_NAME,        SET_PROC_ARCH_INDEX,    SetProcArchIndex,          IM_PEK_IFM_RetV)
 
 DEFINE_CLASS_U(System,                 Version,                    VersionBaseObject)


### PR DESCRIPTION
I tried to reformat code in the second commit, let me know if I should roll it back (the first commit just moves few icalls to AssemblyName.CoreCLR.cs)
I replaced fields with auto properties (the type doesn't support binary serialization)

Main motivation is to implement https://github.com/mono/mono/blob/master/mcs/class/corlib/System.Reflection/AssemblyName.cs#L547-L550

/cc: @marek-safar @jkotas 