### PR TITLE
Nullable: Internal.IO(Namespace),  TraceLoggingEventHandleTable (Type)

### DIFF
--- a/src/System.Private.CoreLib/shared/Internal/IO/File.Unix.cs
+++ b/src/System.Private.CoreLib/shared/Internal/IO/File.Unix.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace Internal.IO
 {
     internal static partial class File

--- a/src/System.Private.CoreLib/shared/Internal/IO/File.Windows.cs
+++ b/src/System.Private.CoreLib/shared/Internal/IO/File.Windows.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
 using Microsoft.Win32;
 using Microsoft.Win32.SafeHandles;
 using System.IO;

--- a/src/System.Private.CoreLib/shared/Internal/IO/File.cs
+++ b/src/System.Private.CoreLib/shared/Internal/IO/File.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
 using System;
 using System.Diagnostics;
 using System.Security;
@@ -19,7 +20,7 @@ namespace Internal.IO
         // given by the specified path exists; otherwise, the result is
         // false.  Note that if path describes a directory,
         // Exists will return true.
-        public static bool Exists(string path)
+        public static bool Exists(string? path)
         {
             try
             {

--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/TraceLogging/TraceLoggingEventHandleTable.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/TraceLogging/TraceLoggingEventHandleTable.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
 using System.Threading;
 
 namespace System.Diagnostics.Tracing


### PR DESCRIPTION
Adding null annotation for couple of Internal.IO (left in stephens PR) And System.Diagnostics.Eventing.

Keeping it small as it is my first pr for annotations