### PR TITLE
Partially improve support for `--cpus` from Docker CLI

### DIFF
--- a/src/gc/unix/cgroup.cpp
+++ b/src/gc/unix/cgroup.cpp
@@ -102,7 +102,7 @@ public:
     {
         long long quota;
         long long period;
-        long long cpu_count;
+        double cpu_count;
 
         quota = ReadCpuCGroupValue(CFS_QUOTA_FILENAME);
         if (quota <= 0)
@@ -119,10 +119,11 @@ public:
             return true;
         }
         
-        cpu_count = quota / period;
-        if (cpu_count < UINT32_MAX)
+        cpu_count = (double) quota / period;
+        if (cpu_count < UINT32_MAX - 1)
         {
-            *val = cpu_count;
+            // round up
+            *val = (uint32_t)(cpu_count + 0.999999999);
         }
         else
         {

--- a/src/pal/src/misc/cgroup.cpp
+++ b/src/pal/src/misc/cgroup.cpp
@@ -90,7 +90,7 @@ public:
     {
         long long quota;
         long long period;
-        long long cpu_count;
+        double cpu_count;
 
         quota = ReadCpuCGroupValue(CFS_QUOTA_FILENAME);
         if (quota <= 0)
@@ -106,11 +106,12 @@ public:
             *val = 1;
             return true;
         }
-        
-        cpu_count = quota / period;
-        if (cpu_count < UINT_MAX)
+
+        cpu_count = (double) quota / period;
+        if (cpu_count < UINT_MAX - 1)
         {
-            *val = cpu_count;
+            // round up
+            *val = (UINT)(cpu_count + 0.999999999);
         }
         else
         {

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -2524,6 +2524,12 @@ PAL_GetCPUBusyTime(
         {
             return 0;
         }
+
+        UINT cpuLimit;
+        if (PAL_GetCpuLimit(&cpuLimit) && cpuLimit < dwNumberOfProcessors)
+        {
+            dwNumberOfProcessors = cpuLimit;
+        }
     }
 
     if (getrusage(RUSAGE_SELF, &resUsage) == -1)


### PR DESCRIPTION
This focuses on better supporting Docker CLI's parameter `--cpus`, which limits the amount of CPU time available to the container (ex: 1.8 means 180% CPU time, ie on 2 cores 90% for each core, on 4 cores 45% on each core, etc.) in the case of the ThreadPool and in the case of calculating the CPU limit.