### PR TITLE
Improve performance of Memory<T>.Span property getter

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Memory.cs
+++ b/src/System.Private.CoreLib/shared/System/Memory.cs
@@ -12,6 +12,14 @@ using EditorBrowsableState = System.ComponentModel.EditorBrowsableState;
 
 using Internal.Runtime.CompilerServices;
 
+#if BIT64
+using nint = System.Int64;
+using nuint = System.UInt64;
+#else // BIT64
+using nint = System.Int32;
+using nuint = System.UInt32;
+#endif // BIT64
+
 namespace System
 {
     /// <summary>
@@ -372,12 +380,12 @@ namespace System
                     // least to be in-bounds when compared with the original Memory<T> instance, so using the span won't
                     // AV the process.
 
-                    int desiredStartIndex = _index & ReadOnlyMemory<T>.RemoveFlagsBitMask;
+                    nuint desiredStartIndex = (uint)_index & (uint)ReadOnlyMemory<T>.RemoveFlagsBitMask;
                     int desiredLength = _length;
 
 #if BIT64
                     // See comment in Span<T>.Slice for how this works.
-                    if ((ulong)(uint)desiredStartIndex + (ulong)(uint)desiredLength > (ulong)(uint)lengthOfUnderlyingSpan)
+                    if ((ulong)desiredStartIndex + (ulong)(uint)desiredLength > (ulong)(uint)lengthOfUnderlyingSpan)
                     {
                         ThrowHelper.ThrowArgumentOutOfRangeException();
                     }
@@ -388,7 +396,7 @@ namespace System
                     }
 #endif
 
-                    refToReturn = ref Unsafe.Add(ref refToReturn, desiredStartIndex);
+                    refToReturn = ref Unsafe.Add(ref refToReturn, (IntPtr)(void*)desiredStartIndex);
                     lengthOfUnderlyingSpan = desiredLength;
                 }
 

--- a/src/System.Private.CoreLib/shared/System/ReadOnlyMemory.cs
+++ b/src/System.Private.CoreLib/shared/System/ReadOnlyMemory.cs
@@ -12,6 +12,14 @@ using EditorBrowsableState = System.ComponentModel.EditorBrowsableState;
 
 using Internal.Runtime.CompilerServices;
 
+#if BIT64
+using nint = System.Int64;
+using nuint = System.UInt64;
+#else // BIT64
+using nint = System.Int32;
+using nuint = System.UInt32;
+#endif // BIT64
+
 namespace System
 {
     /// <summary>
@@ -294,12 +302,12 @@ namespace System
                     // least to be in-bounds when compared with the original Memory<T> instance, so using the span won't
                     // AV the process.
 
-                    int desiredStartIndex = _index & RemoveFlagsBitMask;
+                    nuint desiredStartIndex = (uint)_index & (uint)RemoveFlagsBitMask;
                     int desiredLength = _length;
 
 #if BIT64
                     // See comment in Span<T>.Slice for how this works.
-                    if ((ulong)(uint)desiredStartIndex + (ulong)(uint)desiredLength > (ulong)(uint)lengthOfUnderlyingSpan)
+                    if ((ulong)desiredStartIndex + (ulong)(uint)desiredLength > (ulong)(uint)lengthOfUnderlyingSpan)
                     {
                         ThrowHelper.ThrowArgumentOutOfRangeException();
                     }
@@ -310,7 +318,7 @@ namespace System
                     }
 #endif
 
-                    refToReturn = ref Unsafe.Add(ref refToReturn, desiredStartIndex);
+                    refToReturn = ref Unsafe.Add(ref refToReturn, (IntPtr)(void*)desiredStartIndex);
                     lengthOfUnderlyingSpan = desiredLength;
                 }
 


### PR DESCRIPTION
This is a small optimization to the `Memory<T>.Span` and `ReadOnlyMemory<T>.Span` property getters to reduce the overall codegen size and make the method slightly more efficient.

|                       Method |  Toolchain |     Mean |     Error |    StdDev |   Median | Ratio | RatioSD |
|----------------------------- |----------- |---------:|----------:|----------:|---------:|------:|--------:|
|  GetSpan_MemOfBytesFromArray | 3.0-master | 2.060 ms | 0.0402 ms | 0.0551 ms | 2.057 ms |  1.00 |    0.00 |
|  GetSpan_MemOfBytesFromArray |   memslice | 1.880 ms | 0.0278 ms | 0.0232 ms | 1.872 ms |  0.91 |    0.03 |
|                              |            |          |           |           |          |       |         |
|      GetSpan_MemOfBytesEmpty | 3.0-master | 1.411 ms | 0.0281 ms | 0.0764 ms | 1.387 ms |  1.00 |    0.00 |
|      GetSpan_MemOfBytesEmpty |   memslice | 1.354 ms | 0.0181 ms | 0.0160 ms | 1.355 ms |  0.98 |    0.03 |
|                              |            |          |           |           |          |       |         |
|  GetSpan_MemOfCharsFromArray | 3.0-master | 1.954 ms | 0.0312 ms | 0.0292 ms | 1.945 ms |  1.00 |    0.00 |
|  GetSpan_MemOfCharsFromArray |   memslice | 1.813 ms | 0.0192 ms | 0.0170 ms | 1.810 ms |  0.93 |    0.02 |
|                              |            |          |           |           |          |       |         |
| GetSpan_MemOfCharsFromString | 3.0-master | 1.736 ms | 0.0342 ms | 0.0589 ms | 1.724 ms |  1.00 |    0.00 |
| GetSpan_MemOfCharsFromString |   memslice | 1.582 ms | 0.0316 ms | 0.0483 ms | 1.574 ms |  0.91 |    0.04 |
|                              |            |          |           |           |          |       |         |
| GetSpan_MemOfCharsFromMemMgr | 3.0-master | 3.395 ms | 0.0392 ms | 0.0367 ms | 3.396 ms |  1.00 |    0.00 |
| GetSpan_MemOfCharsFromMemMgr |   memslice | 3.357 ms | 0.0533 ms | 0.0499 ms | 3.348 ms |  0.99 |    0.02 |
|                              |            |          |           |           |          |       |         |
|      GetSpan_MemOfCharsEmpty | 3.0-master | 1.341 ms | 0.0174 ms | 0.0154 ms | 1.341 ms |  1.00 |    0.00 |
|      GetSpan_MemOfCharsEmpty |   memslice | 1.340 ms | 0.0163 ms | 0.0153 ms | 1.344 ms |  1.00 |    0.02 |

x64 codegen before:

```asm
; everything before 'int desiredStartIndex = ...;' omitted
mov     eax,dword ptr [rsi+8]
and     eax,7FFFFFFFh
mov     edx,dword ptr [rsi+0Ch]
mov     ecx,eax  ; this is unnecessary
mov     r8d,edx
add     rcx,r8
mov     r8d,r14d
cmp     rcx,r8
ja      THROW_EXCEPTION
movsxd  rax,eax  ; this is unnecessary
add     rbp,rax
mov     r14d,edx
```

x64 codegen after:

```asm
; everything before 'nuint desiredStartIndex = ...;' omitted
mov     eax,dword ptr [rsi+8]
and     eax,7FFFFFFFh
mov     edx,dword ptr [rsi+0Ch]
mov     ecx,edx
add     rcx,rax
mov     r8d,r14d
cmp     rcx,r8
ja      THROW_EXCEPTION
add     rbp,rax
mov     r14d,edx
```

These optimizations take advantage of the JIT optimizations committed in https://github.com/dotnet/coreclr/commit/d5f638a1cd52fc2733e769e716d5a3a1d61fc804. In particular, this takes advantage of the fact that a 32-bit `and` operation on x64 will clear the upper 32 bits of the destination register, meaning that after the `and eax, 7FFFFFFFh` instruction we can immediately use `rax` without incurring the cost of any additional extension from 32-bit to 64-bit.

The "after" codegen is also 6 bytes smaller than the "before" codegen.