### PR TITLE
Fix Debug.Assert in GenericDelegateCache

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/FutureFactory.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/FutureFactory.cs
@@ -2103,7 +2103,7 @@ namespace System.Threading.Tasks
             (Task<Task<TAntecedentResult>[]> wrappedAntecedents, object? state) =>
             {
                 wrappedAntecedents.NotifyDebuggerOfWaitCompletionIfNecessary();
-                Debug.Assert(state is Func<Task<TAntecedentResult>>);
+                Debug.Assert(state is Func<Task<TAntecedentResult>[], TResult>);
                 var func = (Func<Task<TAntecedentResult>[], TResult>)state;
                 return func(wrappedAntecedents.Result);
             };


### PR DESCRIPTION
The Debug.Assert is not matching what we're casting the value to, nor the generic parameters. Causing the JIT Perf tests to fail in the PR to merge to master:

```
Assertion Failed

   at System.Threading.Tasks.GenericDelegateCache`2.<>c.<.cctor>b__4_2(Task`1 wrappedAntecedents, Object state)
   at System.Threading.Tasks.ContinuationResultTaskFromResultTask`2.InnerInvoke()
   at System.Threading.Tasks.Task.<>c.<.cctor>b__274_0(Object obj)
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
   at System.Threading.Tasks.Task.ExecuteEntryUnsafe(Thread threadPoolThread)
   at System.Threading.Tasks.Task.ExecuteFromThreadPool(Thread threadPoolThread)
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback()
```

cc: @stephentoub @danmosemsft 