### PR TITLE
Revert perf optimization in Trim(Span)

### DIFF
--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.Trim.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.Trim.cs
@@ -18,7 +18,7 @@ namespace System
         {
             ReadOnlySpan<T> span = memory.Span;
             int start = ClampStart(span, trimElement);
-            int length = ClampEnd(span, start + 1, trimElement);
+            int length = ClampEnd(span, start, trimElement);
             return memory.Slice(start, length);
         }
 
@@ -50,7 +50,7 @@ namespace System
         {
             ReadOnlySpan<T> span = memory.Span;
             int start = ClampStart(span, trimElement);
-            int length = ClampEnd(span, start + 1, trimElement);
+            int length = ClampEnd(span, start, trimElement);
             return memory.Slice(start, length);
         }
 
@@ -81,7 +81,7 @@ namespace System
             where T : IEquatable<T>
         {
             int start = ClampStart(span, trimElement);
-            int length = ClampEnd(span, start + 1, trimElement);
+            int length = ClampEnd(span, start, trimElement);
             return span.Slice(start, length);
         }
 
@@ -112,7 +112,7 @@ namespace System
             where T : IEquatable<T>
         {
             int start = ClampStart(span, trimElement);
-            int length = ClampEnd(span, start + 1, trimElement);
+            int length = ClampEnd(span, start, trimElement);
             return span.Slice(start, length);
         }
 
@@ -220,7 +220,7 @@ namespace System
             {
                 ReadOnlySpan<T> span = memory.Span;
                 int start = ClampStart(span, trimElements);
-                int length = ClampEnd(span, start + 1, trimElements);
+                int length = ClampEnd(span, start, trimElements);
                 return memory.Slice(start, length);
             }
 
@@ -292,7 +292,7 @@ namespace System
             {
                 ReadOnlySpan<T> span = memory.Span;
                 int start = ClampStart(span, trimElements);
-                int length = ClampEnd(span, start + 1, trimElements);
+                int length = ClampEnd(span, start, trimElements);
                 return memory.Slice(start, length);
             }
 
@@ -364,7 +364,7 @@ namespace System
             if (trimElements.Length > 1)
             {
                 int start = ClampStart(span, trimElements);
-                int length = ClampEnd(span, start + 1, trimElements);
+                int length = ClampEnd(span, start, trimElements);
                 return span.Slice(start, length);
             }
 
@@ -435,7 +435,7 @@ namespace System
             if (trimElements.Length > 1)
             {
                 int start = ClampStart(span, trimElements);
-                int length = ClampEnd(span, start + 1, trimElements);
+                int length = ClampEnd(span, start, trimElements);
                 return span.Slice(start, length);
             }
 
@@ -547,7 +547,7 @@ namespace System
         {
             ReadOnlySpan<char> span = memory.Span;
             int start = ClampStart(span);
-            int length = ClampEnd(span, start + 1);
+            int length = ClampEnd(span, start);
             return memory.Slice(start, length);
         }
 
@@ -573,7 +573,7 @@ namespace System
         {
             ReadOnlySpan<char> span = memory.Span;
             int start = ClampStart(span);
-            int length = ClampEnd(span, start + 1);
+            int length = ClampEnd(span, start);
             return memory.Slice(start, length);
         }
 
@@ -803,7 +803,7 @@ namespace System
         public static Span<char> Trim(this Span<char> span)
         {
             int start = ClampStart(span);
-            int length = ClampEnd(span, start + 1);
+            int length = ClampEnd(span, start);
             return span.Slice(start, length);
         }
 


### PR DESCRIPTION
This [optimization](https://github.com/grant-d/coreclr/commit/ee5f321368daa6fe64226a3dd287285eb97b43bd#diff-cc88fbaa6077c440a3e08374eb41c5ea) in [this PR](https://github.com/dotnet/coreclr/pull/22798) broke several units that were previously working.

Local testing confirms **undoing optimization is successful** - tests all pass again.

This PR simply fixes the issue. We can look at re-optimization in a separate PR.

More detail [here](https://github.com/dotnet/corefx/pull/35576#discussion_r272431304)

cc @ahsonkhan 