### PR TITLE
Fix rounding to UINT32_MAX

### DIFF
--- a/src/gc/unix/cgroup.cpp
+++ b/src/gc/unix/cgroup.cpp
@@ -118,17 +118,10 @@ public:
             *val = 1;
             return true;
         }
-        
-        cpu_count = (double) quota / period;
-        if (cpu_count < UINT32_MAX - 1)
-        {
-            // round up
-            *val = (uint32_t)(cpu_count + 0.999999999);
-        }
-        else
-        {
-            *val = UINT32_MAX;
-        }
+
+        // Calculate cpu count based on quota and round it up
+        cpu_count = (double) quota / period  + 0.999999999;
+        *val = (cpu_count < UINT32_MAX) ? (uint32_t)cpu_count : UINT32_MAX;
 
         return true;
     }

--- a/src/pal/src/misc/cgroup.cpp
+++ b/src/pal/src/misc/cgroup.cpp
@@ -107,16 +107,9 @@ public:
             return true;
         }
 
-        cpu_count = (double) quota / period;
-        if (cpu_count < UINT_MAX - 1)
-        {
-            // round up
-            *val = (UINT)(cpu_count + 0.999999999);
-        }
-        else
-        {
-            *val = UINT_MAX;
-        }
+        // Calculate cpu count based on quota and round it up
+        cpu_count = (double) quota / period  + 0.999999999;
+        *val = (cpu_count < UINT_MAX) ? (UINT)cpu_count : UINT_MAX;
 
         return true;
     }


### PR DESCRIPTION
In case you would have UINT32_MAX - 1 CPUs, you would round up to return UINT32_MAX CPUs.