### PR TITLE
Reenable System.Runtime.Tests. for arm64.

### DIFF
--- a/tests/arm64/corefx_linux_test_exclusions.txt
+++ b/tests/arm64/corefx_linux_test_exclusions.txt
@@ -8,7 +8,6 @@ System.Net.NameResolution.Pal.Tests           # https://github.com/dotnet/corefx
 System.Net.Sockets.Tests                      # https://github.com/dotnet/coreclr/issues/21576 -- continuing flakiness
 System.Runtime.Numerics.Tests                 # https://github.com/dotnet/coreclr/issues/23242 -- timeout
 System.Runtime.Serialization.Formatters.Tests # https://github.com/dotnet/coreclr/issues/20246 -- timeout
-System.Runtime.Tests                          # https://github.com/dotnet/coreclr/issues/23444
 System.Text.RegularExpressions.Tests          # https://github.com/dotnet/coreclr/issues/17754 -- timeout -- JitMinOpts + Tiered only
 System.Threading.Tasks.Tests                  # https://github.com/dotnet/coreclr/issues/20706
 System.Threading.Tests                        # https://github.com/dotnet/coreclr/issues/20215

--- a/tests/arm64/corefx_test_exclusions.txt
+++ b/tests/arm64/corefx_test_exclusions.txt
@@ -5,5 +5,4 @@ System.IO.FileSystem.Tests                              # https://github.com/dot
 System.Management.Tests                                 # https://github.com/dotnet/corefx/issues/34030
 System.Net.HttpListener.Tests                           # https://github.com/dotnet/coreclr/issues/17584
 System.Net.Sockets.Tests                                # https://github.com/dotnet/coreclr/issues/23378
-System.Runtime.Tests                                    # https://github.com/dotnet/coreclr/issues/18914
 System.Text.RegularExpressions.Tests                    # https://github.com/dotnet/coreclr/issues/18912 -- timeout -- JitMinOpts only


### PR DESCRIPTION
The issue was fixed by https://github.com/dotnet/coreclr/pull/23627.

Closes #23444 and closes #18914.