### PR TITLE
Normalize directory separators before calling LoadLibrary

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -352,8 +352,6 @@ namespace System.Runtime.Loader
                 throw new ArgumentException(SR.Argument_AbsolutePathRequired, nameof(unmanagedDllPath));
             }
             
-            unmanagedDllPath = PathInternal.RemoveRelativeSegments(unmanagedDllPath, PathInternal.GetRootLength(unmanagedDllPath));
-
             return InternalLoadUnmanagedDllFromPath(unmanagedDllPath);
         }
 

--- a/src/System.Private.CoreLib/shared/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -351,7 +351,7 @@ namespace System.Runtime.Loader
             {
                 throw new ArgumentException(SR.Argument_AbsolutePathRequired, nameof(unmanagedDllPath));
             }
-            
+
             return InternalLoadUnmanagedDllFromPath(unmanagedDllPath);
         }
 

--- a/src/System.Private.CoreLib/shared/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -351,6 +351,8 @@ namespace System.Runtime.Loader
             {
                 throw new ArgumentException(SR.Argument_AbsolutePathRequired, nameof(unmanagedDllPath));
             }
+            
+            unmanagedDllPath = PathInternal.RemoveRelativeSegments(unmanagedDllPath, PathInternal.GetRootLength(unmanagedDllPath));
 
             return InternalLoadUnmanagedDllFromPath(unmanagedDllPath);
         }

--- a/src/utilcode/longfilepathwrappers.cpp
+++ b/src/utilcode/longfilepathwrappers.cpp
@@ -30,6 +30,10 @@ public:
         static BOOL IsDevice(SString & path);
 
         static HRESULT NormalizePath(SString& path);
+
+#ifndef FEATURE_PAL
+        static void NormalizeDirectorySeparators(SString& path);
+#endif
 };
 
 HMODULE
@@ -59,6 +63,7 @@ LoadLibraryExWrapper(
 #ifndef FEATURE_PAL
             //Adding the assert to ensure relative paths which are not just filenames are not used for LoadLibrary Calls
             _ASSERTE(!LongFile::IsPathNotFullyQualified(path) || !LongFile::ContainsDirectorySeparator(path));
+            LongFile::NormalizeDirectorySeparators(path);
 #endif //FEATURE_PAL
 
             ret = LoadLibraryExW(path.GetUnicode(), hFile, dwFlags);
@@ -1172,6 +1177,17 @@ const WCHAR* LongFile::ExtendedPrefix = W("\\\\?\\");
 const WCHAR* LongFile::DevicePathPrefix = W("\\\\.\\");
 const WCHAR* LongFile::UNCExtendedPathPrefix = W("\\\\?\\UNC\\");
 const WCHAR* LongFile::UNCPathPrefix = UNCPATHPREFIX;
+
+void LongFile::NormalizeDirectorySeparators(SString& path)
+{
+    for(SString::Iterator i = path.Begin(); i < path.End(); ++i)
+    {
+        if (*i == AltDirectorySeparatorChar)
+        {
+            path.Replace(i, DirectorySeparatorChar);
+        }
+    }
+}
 
 BOOL LongFile::IsExtended(SString & path)
 {


### PR DESCRIPTION
Fixes #22094