### PR TITLE
Remove the MultiFileSec option from EventPipe.

### DIFF
--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipe.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipe.cs
@@ -87,7 +87,6 @@ namespace System.Diagnostics.Tracing
         private uint m_circularBufferSizeInMB;
         private List<EventPipeProviderConfiguration> m_providers;
         private TimeSpan m_minTimeBetweenSamples = TimeSpan.FromMilliseconds(1);
-        private ulong m_multiFileTraceLengthInSeconds = 0;
 
         internal EventPipeConfiguration(
             string outputFile,
@@ -114,11 +113,6 @@ namespace System.Diagnostics.Tracing
         internal uint CircularBufferSizeInMB
         {
             get { return m_circularBufferSizeInMB; }
-        }
-
-        internal ulong MultiFileTraceLengthInSeconds
-        {
-            get { return m_multiFileTraceLengthInSeconds; }
         }
 
         internal EventPipeProviderConfiguration[] Providers
@@ -168,11 +162,6 @@ namespace System.Diagnostics.Tracing
 
             m_minTimeBetweenSamples = minTimeBetweenSamples;
         }
-
-        internal void SetMultiFileTraceLength(ulong traceLengthInSeconds)
-        {
-            m_multiFileTraceLengthInSeconds = traceLengthInSeconds;
-        }
     }
 
     internal static class EventPipe
@@ -198,8 +187,7 @@ namespace System.Diagnostics.Tracing
                 configuration.CircularBufferSizeInMB,
                 (ulong)configuration.ProfilerSamplingRateInNanoseconds,
                 providers,
-                (uint)providers.Length,
-                configuration.MultiFileTraceLengthInSeconds);
+                (uint)providers.Length);
         }
 
         internal static void Disable()
@@ -219,8 +207,7 @@ namespace System.Diagnostics.Tracing
             uint circularBufferSizeInMB,
             ulong profilerSamplingRateInNanoseconds,
             EventPipeProviderConfiguration[] providers,
-            uint numProviders,
-            ulong multiFileTraceLengthInSeconds);
+            uint numProviders);
 
         [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
         internal static extern void Disable(UInt64 sessionID);

--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeController.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeController.cs
@@ -46,7 +46,6 @@ namespace System.Diagnostics.Tracing
         private const string ConfigKey_CircularMB = "CircularMB";
         private const string ConfigKey_OutputPath = "OutputPath";
         private const string ConfigKey_ProcessID = "ProcessID";
-        private const string ConfigKey_MultiFileSec = "MultiFileSec";
 
         // The default set of providers/keywords/levels.  Used if an alternative configuration is not specified.
         private static EventPipeProviderConfiguration[] DefaultProviderConfiguration => new EventPipeProviderConfiguration[]
@@ -170,7 +169,6 @@ namespace System.Diagnostics.Tracing
             string strProviderConfig = null;
             string strCircularMB = null;
             string strProcessID = null;
-            string strMultiFileSec = null;
 
             // Split the configuration entries by line.
             string[] configEntries = strConfigContents.Split(new string[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
@@ -200,10 +198,6 @@ namespace System.Diagnostics.Tracing
                     {
                         strProcessID = entryComponents[1];
                     }
-                    else if (key.Equals(ConfigKey_MultiFileSec))
-                    {
-                        strMultiFileSec = entryComponents[1];
-                    }
                 }
             }
 
@@ -224,13 +218,6 @@ namespace System.Diagnostics.Tracing
                 throw new ArgumentNullException(nameof(outputPath));
             }
 
-            // Check to see if MultiFileSec is specified.
-            ulong multiFileSec = 0;
-            if (!string.IsNullOrEmpty(strMultiFileSec))
-            {
-                multiFileSec = Convert.ToUInt64(strMultiFileSec);
-            }
-
             // Build the full path to the trace file.
             string traceFileName = BuildTraceFileName();
             string outputFile = Path.Combine(outputPath, traceFileName);
@@ -244,7 +231,6 @@ namespace System.Diagnostics.Tracing
 
             // Initialize a new configuration object.
             EventPipeConfiguration config = new EventPipeConfiguration(outputFile, circularMB);
-            config.SetMultiFileTraceLength(multiFileSec);
 
             // Set the provider configuration if specified.
             if (!string.IsNullOrEmpty(strProviderConfig))

--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeEventDispatcher.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeEventDispatcher.cs
@@ -110,7 +110,7 @@ namespace System.Diagnostics.Tracing
                 new EventPipeProviderConfiguration(NativeRuntimeEventSource.EventSourceName, (ulong) aggregatedKeywords, (uint) highestLevel, null)
             };
 
-            m_sessionID = EventPipeInternal.Enable(null, 1024, 1, providerConfiguration, 1, 0);
+            m_sessionID = EventPipeInternal.Enable(null, 1024, 1, providerConfiguration, 1);
             Debug.Assert(m_sessionID != 0);
 
             // Get the session information that is required to properly dispatch events.

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -255,8 +255,7 @@ public:
         uint32_t circularBufferSizeInMB,
         uint64_t profilerSamplingRateInNanoseconds,
         const EventPipeProviderConfiguration *pProviders,
-        uint32_t numProviders,
-        uint64_t multiFileTraceLengthInSeconds);
+        uint32_t numProviders);
 
     static EventPipeSessionID Enable(
         IpcStream *pStream,
@@ -313,27 +312,15 @@ private:
     // Enable the specified EventPipe session.
     static EventPipeSessionID Enable(
         EventPipeSession *const pSession,
-        WAITORTIMERCALLBACK callback,
-        DWORD dueTime,
-        DWORD period);
+        WAITORTIMERCALLBACK callback = nullptr,
+        DWORD dueTime = 0,
+        DWORD period = 0);
 
     static void CreateFlushTimerCallback(WAITORTIMERCALLBACK Callback, DWORD DueTime, DWORD Period);
 
     static void DeleteFlushTimerCallback();
 
-    // Performs one polling operation to determine if it is necessary to switch to a new file.
-    // If the polling operation decides it is time, it will perform the switch.
-    // Called directly from the timer when the timer is triggered.
-    static void WINAPI SwitchToNextFileTimerCallback(PVOID parameter, BOOLEAN timerFired);
-
     static void WINAPI FlushTimer(PVOID parameter, BOOLEAN timerFired);
-
-    // If event pipe has been configured to write multiple files, switch to the next file.
-    static void SwitchToNextFile();
-
-    // Generate the file path for the next trace file.
-    // This is used when event pipe has been configured to create multiple trace files with a specified maximum length of time.
-    static void GetNextFilePath(SString &nextTraceFilePath);
 
     // Callback function for the stack walker.  For each frame walked, this callback is invoked.
     static StackWalkAction StackWalkCallback(CrawlFrame *pCf, StackContents *pData);
@@ -358,14 +345,11 @@ private:
     static EventPipeConfiguration *s_pConfig;
     static EventPipeSession *s_pSession;
     static EventPipeBufferManager *s_pBufferManager;
-    static LPCWSTR s_pOutputPath;
-    static unsigned long s_nextFileIndex;
     static EventPipeFile *s_pFile;
     static EventPipeEventSource *s_pEventSource;
     static LPCWSTR s_pCommandLine;
     static HANDLE s_fileSwitchTimerHandle;
     static ULONGLONG s_lastFlushSwitchTime;
-    static uint64_t s_multiFileTraceLengthInSeconds;
 };
 
 struct EventPipeProviderConfiguration

--- a/src/vm/eventpipeinternal.cpp
+++ b/src/vm/eventpipeinternal.cpp
@@ -22,8 +22,7 @@ UINT64 QCALLTYPE EventPipeInternal::Enable(
     UINT32 circularBufferSizeInMB,
     INT64 profilerSamplingRateInNanoseconds,
     EventPipeProviderConfiguration *pProviders,
-    UINT32 numProviders,
-    UINT64 multiFileTraceLengthInSeconds)
+    UINT32 numProviders)
 {
     QCALL_CONTRACT;
 
@@ -36,8 +35,7 @@ UINT64 QCALLTYPE EventPipeInternal::Enable(
             circularBufferSizeInMB,
             profilerSamplingRateInNanoseconds,
             pProviders,
-            numProviders,
-            multiFileTraceLengthInSeconds);
+            numProviders);
     }
     END_QCALL;
 

--- a/src/vm/eventpipeinternal.h
+++ b/src/vm/eventpipeinternal.h
@@ -49,8 +49,7 @@ public:
         UINT32 circularBufferSizeInMB,
         INT64 profilerSamplingRateInNanoseconds,
         EventPipeProviderConfiguration *pProviders,
-        UINT32 numProviders,
-        UINT64 multiFileTraceLengthInSeconds);
+        UINT32 numProviders);
 
     //! TODO: Add a ListActiveSessions to get the live SessionID in order to Disable?
 

--- a/src/vm/eventpipeprotocolhelper.cpp
+++ b/src/vm/eventpipeprotocolhelper.cpp
@@ -74,7 +74,7 @@ void EventPipeProtocolHelper::EnableFileTracingEventHandler(IpcStream *pStream)
 
     // The protocol buffer is defined as:
     // X, Y, Z means encode bytes for X followed by bytes for Y followed by bytes for Z
-    // message = uint circularBufferMB, ulong multiFileTraceLength, string outputPath, array<provider_config> providers
+    // message = uint circularBufferMB, string outputPath, array<provider_config> providers
     // uint = 4 little endian bytes
     // ulong = 8 little endian bytes
     // wchar = 2 little endian bytes, UTF16 encoding
@@ -84,13 +84,11 @@ void EventPipeProtocolHelper::EnableFileTracingEventHandler(IpcStream *pStream)
 
     LPCWSTR strOutputPath;
     uint32_t circularBufferSizeInMB = EventPipeProtocolHelper::DefaultCircularBufferMB;
-    uint64_t multiFileTraceLengthInSeconds = EventPipeProtocolHelper::DefaultMultiFileTraceLengthInSeconds;
     CQuickArray<EventPipeProviderConfiguration> providerConfigs;
 
     uint8_t *pBufferCursor = buffer;
     uint32_t bufferLen = nNumberOfBytesRead;
     if (!TryParse(pBufferCursor, bufferLen, circularBufferSizeInMB) ||
-        !TryParse(pBufferCursor, bufferLen, multiFileTraceLengthInSeconds) ||
         !TryParseString(pBufferCursor, bufferLen, strOutputPath) ||
         !TryParseProviderConfiguration(pBufferCursor, bufferLen, providerConfigs))
     {
@@ -103,12 +101,11 @@ void EventPipeProtocolHelper::EnableFileTracingEventHandler(IpcStream *pStream)
     if (providerConfigs.Size() > 0)
     {
         sessionId = EventPipe::Enable(
-            strOutputPath,                                 // outputFile
-            circularBufferSizeInMB,                        // circularBufferSizeInMB
-            DefaultProfilerSamplingRateInNanoseconds,      // ProfilerSamplingRateInNanoseconds
-            providerConfigs.Ptr(),                         // pConfigs
-            static_cast<uint32_t>(providerConfigs.Size()), // numConfigs
-            multiFileTraceLengthInSeconds);                // multiFileTraceLengthInSeconds
+            strOutputPath,                                  // outputFile
+            circularBufferSizeInMB,                         // circularBufferSizeInMB
+            DefaultProfilerSamplingRateInNanoseconds,       // ProfilerSamplingRateInNanoseconds
+            providerConfigs.Ptr(),                          // pConfigs
+            static_cast<uint32_t>(providerConfigs.Size())); // numConfigs
     }
 
     uint32_t nBytesWritten = 0;
@@ -191,7 +188,7 @@ void EventPipeProtocolHelper::AttachTracingEventHandler(IpcStream *pStream)
 
     // The protocol buffer is defined as:
     // X, Y, Z means encode bytes for X followed by bytes for Y followed by bytes for Z
-    // message = uint circularBufferMB, ulong multiFileTraceLength, string outputPath, array<provider_config> providers
+    // message = uint circularBufferMB, string outputPath, array<provider_config> providers
     // uint = 4 little endian bytes
     // wchar = 2 little endian bytes, UTF16 encoding
     // array<T> = uint length, length # of Ts
@@ -200,13 +197,11 @@ void EventPipeProtocolHelper::AttachTracingEventHandler(IpcStream *pStream)
 
     LPCWSTR strOutputPath;
     uint32_t circularBufferSizeInMB = EventPipeProtocolHelper::DefaultCircularBufferMB;
-    uint64_t multiFileTraceLengthInSeconds = EventPipeProtocolHelper::DefaultMultiFileTraceLengthInSeconds;
     CQuickArray<EventPipeProviderConfiguration> providerConfigs;
 
     uint8_t *pBufferCursor = buffer;
     uint32_t bufferLen = nNumberOfBytesRead;
     if (!TryParse(pBufferCursor, bufferLen, circularBufferSizeInMB) ||
-        !TryParse(pBufferCursor, bufferLen, multiFileTraceLengthInSeconds) ||
         !TryParseString(pBufferCursor, bufferLen, strOutputPath) ||
         !TryParseProviderConfiguration(pBufferCursor, bufferLen, providerConfigs))
     {

--- a/src/vm/eventpipeprotocolhelper.h
+++ b/src/vm/eventpipeprotocolhelper.h
@@ -23,7 +23,6 @@ public:
 
 private:
     const static uint32_t DefaultCircularBufferMB = 1024; // 1 GB
-    const static uint64_t DefaultMultiFileTraceLengthInSeconds = 0;
     const static uint32_t DefaultProfilerSamplingRateInNanoseconds = 1000000; // 1 msec.
     const static uint32_t IpcStreamReadBufferSize = 8192;
 


### PR DESCRIPTION
This option was a pseudo mechanism to fake "streaming" events out-of-proc.
The idea was to have EventPipe creating files every N seconds, with event data up to that point. Thus, external processes could read these files in an attempt to get "read-time" data.
Now, we actually have streaming of event through IPC channels.