### PR TITLE
Remove unused offset calculation

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/Utf8Parser.Date.Default.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/Utf8Parser.Date.Default.cs
@@ -83,12 +83,6 @@ namespace System.Buffers.Text
                 offsetMinutes = (int)(digit1 * 10 + digit2);
             }
 
-            TimeSpan offset = new TimeSpan(hours: offsetHours, minutes: offsetMinutes, seconds: 0);
-            if (sign == Utf8Constants.Minus)
-            {
-                offset = -offset;
-            }
-
             if (!TryCreateDateTimeOffset(dateTime: dateTime, offsetNegative: sign == Utf8Constants.Minus, offsetHours: offsetHours, offsetMinutes: offsetMinutes, out value))
             {
                 bytesConsumed = 0;


### PR DESCRIPTION
Utf8Parser has a redundant calculation of date time offset.

Fix #21834