### PR TITLE
Don't denormalize enum return values on instance methods on x86.

### DIFF
--- a/src/vm/mlinfo.cpp
+++ b/src/vm/mlinfo.cpp
@@ -1654,14 +1654,14 @@ MarshalInfo::MarshalInfo(Module* pModule,
     {
         SigPointer sigtmp = sig;
         CorElementType closedElemType = sigtmp.PeekElemTypeClosed(pModule, pTypeContext);
-        if(closedElemType == ELEMENT_TYPE_VALUETYPE)
+        if (closedElemType == ELEMENT_TYPE_VALUETYPE)
         {
             TypeHandle th = sigtmp.GetTypeHandleThrowing(pModule, pTypeContext); 
             // If the return type of an instance method is a value-type we need the actual return type.
             // However, if the return type is an enum, we can normalize it.
             if (!th.IsEnum())
             {
-                mtype = sig.PeekElemTypeClosed(pModule, pTypeContext);
+                mtype = closedElemType;
             }
         }
 

--- a/src/vm/mlinfo.cpp
+++ b/src/vm/mlinfo.cpp
@@ -1652,7 +1652,19 @@ MarshalInfo::MarshalInfo(Module* pModule,
     }
     else
     {
-        mtype = sig.PeekElemTypeClosed(pModule, pTypeContext);
+        SigPointer sigtmp = sig;
+        CorElementType closedElemType = sigtmp.PeekElemTypeClosed(pModule, pTypeContext);
+        if(closedElemType == ELEMENT_TYPE_VALUETYPE)
+        {
+            TypeHandle th = sigtmp.GetTypeHandleThrowing(pModule, pTypeContext); 
+            // If the return type of an instance method is a value-type we need the actual return type.
+            // However, if the return type is an enum, we can normalize it.
+            if (!th.IsEnum())
+            {
+                mtype = sig.PeekElemTypeClosed(pModule, pTypeContext);
+            }
+        }
+
     }
 #endif // _TARGET_X86_
 


### PR DESCRIPTION
Enums need to be treated as their underlying type so they are correctly categorized and marshalled.

Fixes dotnet/corefx#36687