### PR TITLE
Remove exclusion for System.Threading.Tasks.Tests

### DIFF
--- a/tests/arm64/corefx_linux_test_exclusions.txt
+++ b/tests/arm64/corefx_linux_test_exclusions.txt
@@ -9,5 +9,4 @@ System.Net.Sockets.Tests                      # https://github.com/dotnet/corecl
 System.Runtime.Numerics.Tests                 # https://github.com/dotnet/coreclr/issues/23242 -- timeout
 System.Runtime.Serialization.Formatters.Tests # https://github.com/dotnet/coreclr/issues/20246 -- timeout
 System.Text.RegularExpressions.Tests          # https://github.com/dotnet/coreclr/issues/17754 -- timeout -- JitMinOpts + Tiered only
-System.Threading.Tasks.Tests                  # https://github.com/dotnet/coreclr/issues/20706
 System.Threading.Tests                        # https://github.com/dotnet/coreclr/issues/20215

--- a/tests/arm64/corefx_test_exclusions.txt
+++ b/tests/arm64/corefx_test_exclusions.txt
@@ -6,3 +6,4 @@ System.Management.Tests                                 # https://github.com/dot
 System.Net.HttpListener.Tests                           # https://github.com/dotnet/coreclr/issues/17584
 System.Net.Sockets.Tests                                # https://github.com/dotnet/coreclr/issues/23378
 System.Text.RegularExpressions.Tests                    # https://github.com/dotnet/coreclr/issues/18912 -- timeout -- JitMinOpts only
+System.Threading.Tasks.Tests                            # https://github.com/dotnet/corefx/pull/36645

--- a/tests/arm64/corefx_test_exclusions.txt
+++ b/tests/arm64/corefx_test_exclusions.txt
@@ -6,4 +6,3 @@ System.Management.Tests                                 # https://github.com/dot
 System.Net.HttpListener.Tests                           # https://github.com/dotnet/coreclr/issues/17584
 System.Net.Sockets.Tests                                # https://github.com/dotnet/coreclr/issues/23378
 System.Text.RegularExpressions.Tests                    # https://github.com/dotnet/coreclr/issues/18912 -- timeout -- JitMinOpts only
-System.Threading.Tasks.Tests                            # https://github.com/dotnet/corefx/pull/36645


### PR DESCRIPTION
There was a race in the test, which causes failures in various stress runs. 
The failure was addressed in dotnet/corefx#36645  

Since the stress tests use up to date corefx bits, the exclusion is no longer necessary.