### PR TITLE
Add 'SetNotificationForWaitCompletion' to ILLinkTrim.xml

### DIFF
--- a/src/System.Private.CoreLib/ILLinkTrim.xml
+++ b/src/System.Private.CoreLib/ILLinkTrim.xml
@@ -15,6 +15,7 @@
       <property name="ParentForDebugger" />
       <property name="StateFlagsForDebugger" />
       <method name="GetDelegateContinuationsForDebugger" />
+      <method name="SetNotificationForWaitCompletion" />
     </type>
     <type fullname="System.Threading.ThreadPool">
       <method name="GetQueuedWorkItemsForDebugger" />
@@ -36,6 +37,7 @@
     </type>
     <type fullname="System.Runtime.CompilerServices.AsyncTaskMethodBuilder*">
       <property name="ObjectIdForDebugger" />
+      <method name="SetNotificationForWaitCompletion" />
     </type>
     <type fullname="System.Threading.Tasks.Task">
       <!-- Methods is used by VS Tasks Window. -->


### PR DESCRIPTION
SetNotificationForWaitCompletion is meant to be func-eval'ed by the debugger to enable async step out. But this method was being removed by the IL linker. This adds it back.