### PR TITLE
Updating System.Numerics.Vector<T> to use the readonly members feature.

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Numerics/Vector.cs
+++ b/src/System.Private.CoreLib/shared/System/Numerics/Vector.cs
@@ -817,7 +817,7 @@ namespace System.Numerics
         /// <exception cref="ArgumentNullException">If the destination array is null</exception>
         /// <exception cref="ArgumentException">If number of elements in source vector is greater than those available in destination array</exception>
         [Intrinsic]
-        public unsafe void CopyTo(T[] destination)
+        public unsafe readonly void CopyTo(T[] destination)
         {
             CopyTo(destination, 0);
         }
@@ -831,7 +831,7 @@ namespace System.Numerics
         /// <exception cref="ArgumentOutOfRangeException">If index is greater than end of the array or index is less than zero</exception>
         /// <exception cref="ArgumentException">If number of elements in source vector is greater than those available in destination array</exception>
         [Intrinsic]
-        public unsafe void CopyTo(T[] destination, int startIndex)
+        public unsafe readonly void CopyTo(T[] destination, int startIndex)
         {
             if (destination == null)
             {
@@ -1104,7 +1104,7 @@ namespace System.Numerics
         /// <summary>
         /// Returns the element at the given index.
         /// </summary>
-        public unsafe T this[int index]
+        public unsafe readonly T this[int index]
         {
             [Intrinsic]
             get
@@ -1196,7 +1196,7 @@ namespace System.Numerics
         /// <param name="obj">The Object to compare against.</param>
         /// <returns>True if the Object is equal to this vector; False otherwise.</returns>
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
-        public override bool Equals(object? obj)
+        public override readonly bool Equals(object? obj)
         {
             if (!(obj is Vector<T>))
             {
@@ -1211,7 +1211,7 @@ namespace System.Numerics
         /// <param name="other">The vector to compare this instance to.</param>
         /// <returns>True if the other vector is equal to this instance; False otherwise.</returns>
         [Intrinsic]
-        public bool Equals(Vector<T> other)
+        public readonly bool Equals(Vector<T> other)
         {
             if (Vector.IsHardwareAccelerated)
             {
@@ -1343,7 +1343,7 @@ namespace System.Numerics
         /// Returns the hash code for this instance.
         /// </summary>
         /// <returns>The hash code.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             int hash = 0;
 
@@ -1553,7 +1553,7 @@ namespace System.Numerics
         /// Returns a String representing this vector.
         /// </summary>
         /// <returns>The string representation.</returns>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return ToString("G", CultureInfo.CurrentCulture);
         }
@@ -1563,7 +1563,7 @@ namespace System.Numerics
         /// </summary>
         /// <param name="format">The format of individual elements.</param>
         /// <returns>The string representation.</returns>
-        public string ToString(string? format)
+        public readonly string ToString(string? format)
         {
             return ToString(format, CultureInfo.CurrentCulture);
         }
@@ -1575,7 +1575,7 @@ namespace System.Numerics
         /// <param name="format">The format of individual elements.</param>
         /// <param name="formatProvider">The format provider to use when formatting elements.</param>
         /// <returns>The string representation.</returns>
-        public string ToString(string? format, IFormatProvider? formatProvider)
+        public readonly string ToString(string? format, IFormatProvider? formatProvider)
         {
             StringBuilder sb = new StringBuilder();
             string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;

--- a/src/System.Private.CoreLib/shared/System/Numerics/Vector.tt
+++ b/src/System.Private.CoreLib/shared/System/Numerics/Vector.tt
@@ -334,7 +334,7 @@ namespace System.Numerics
         /// <exception cref="ArgumentNullException">If the destination array is null</exception>
         /// <exception cref="ArgumentException">If number of elements in source vector is greater than those available in destination array</exception>
         [Intrinsic]
-        public unsafe void CopyTo(T[] destination)
+        public unsafe readonly void CopyTo(T[] destination)
         {
             CopyTo(destination, 0);
         }
@@ -348,7 +348,7 @@ namespace System.Numerics
         /// <exception cref="ArgumentOutOfRangeException">If index is greater than end of the array or index is less than zero</exception>
         /// <exception cref="ArgumentException">If number of elements in source vector is greater than those available in destination array</exception>
         [Intrinsic]
-        public unsafe void CopyTo(T[] destination, int startIndex)
+        public unsafe readonly void CopyTo(T[] destination, int startIndex)
         {
             if (destination == null)
             {
@@ -415,7 +415,7 @@ namespace System.Numerics
         /// <summary>
         /// Returns the element at the given index.
         /// </summary>
-        public unsafe T this[int index]
+        public unsafe readonly T this[int index]
         {
             [Intrinsic]
             get
@@ -451,7 +451,7 @@ namespace System.Numerics
         /// <param name="obj">The Object to compare against.</param>
         /// <returns>True if the Object is equal to this vector; False otherwise.</returns>
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
-        public override bool Equals(object? obj)
+        public override readonly bool Equals(object? obj)
         {
             if (!(obj is Vector<T>))
             {
@@ -466,7 +466,7 @@ namespace System.Numerics
         /// <param name="other">The vector to compare this instance to.</param>
         /// <returns>True if the other vector is equal to this instance; False otherwise.</returns>
         [Intrinsic]
-        public bool Equals(Vector<T> other)
+        public readonly bool Equals(Vector<T> other)
         {
             if (Vector.IsHardwareAccelerated)
             {
@@ -524,7 +524,7 @@ namespace System.Numerics
         /// Returns the hash code for this instance.
         /// </summary>
         /// <returns>The hash code.</returns>
-        public override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             int hash = 0;
 
@@ -582,7 +582,7 @@ namespace System.Numerics
         /// Returns a String representing this vector.
         /// </summary>
         /// <returns>The string representation.</returns>
-        public override string ToString()
+        public override readonly string ToString()
         {
             return ToString("G", CultureInfo.CurrentCulture);
         }
@@ -592,7 +592,7 @@ namespace System.Numerics
         /// </summary>
         /// <param name="format">The format of individual elements.</param>
         /// <returns>The string representation.</returns>
-        public string ToString(string? format)
+        public readonly string ToString(string? format)
         {
             return ToString(format, CultureInfo.CurrentCulture);
         }
@@ -604,7 +604,7 @@ namespace System.Numerics
         /// <param name="format">The format of individual elements.</param>
         /// <param name="formatProvider">The format provider to use when formatting elements.</param>
         /// <returns>The string representation.</returns>
-        public string ToString(string? format, IFormatProvider? formatProvider)
+        public readonly string ToString(string? format, IFormatProvider? formatProvider)
         {
             StringBuilder sb = new StringBuilder();
             string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;


### PR DESCRIPTION
This handles dotnet/corefx#36586 for the System.Numerics.Vector types in corelib (the change for types in CoreFX was https://github.com/dotnet/corefx/pull/36702).