### PR TITLE
Exclude PInvokes declared on other modules. We don't yet encode crossmodule references

### DIFF
--- a/src/vm/dllimport.cpp
+++ b/src/vm/dllimport.cpp
@@ -3403,14 +3403,6 @@ BOOL NDirect::MarshalingRequired(MethodDesc *pMD, PCCOR_SIGNATURE pSig /*= NULL*
         if (pMD->IsNDirect() && ((NDirectMethodDesc *)pMD)->IsClassConstructorTriggeredByILStub())
             return TRUE;
 
-        if (IsReadyToRunCompilation() && !pMD->GetModule()->IsInCurrentVersionBubble())
-        {
-            // FUTURE: ZapSig::EncodeMethod does not yet handle cross module references for ReadyToRun
-            // See zapsig.cpp around line 1217.
-            // Once this is implemented, we'll be able to inline pinvokes of extern methods declared in other modules (Ex: PresentationCore.dll)
-            return TRUE;
-        }
-
         callConv = sigInfo.GetCallConv();
     }
 

--- a/src/vm/dllimport.cpp
+++ b/src/vm/dllimport.cpp
@@ -3403,6 +3403,14 @@ BOOL NDirect::MarshalingRequired(MethodDesc *pMD, PCCOR_SIGNATURE pSig /*= NULL*
         if (pMD->IsNDirect() && ((NDirectMethodDesc *)pMD)->IsClassConstructorTriggeredByILStub())
             return TRUE;
 
+        if (IsReadyToRunCompilation() && !pMD->GetModule()->IsInCurrentVersionBubble())
+        {
+            // FUTURE: ZapSig::EncodeMethod does not yet handle cross module references for ReadyToRun
+            // See zapsig.cpp around line 1217.
+            // Once this is implemented, we'll be able to inline pinvokes of extern methods declared in other modules (Ex: PresentationCore.dll)
+            return TRUE;
+        }
+
         callConv = sigInfo.GetCallConv();
     }
 

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -3864,6 +3864,14 @@ BOOL ZapInfo::pInvokeMarshalingRequired(CORINFO_METHOD_HANDLE method,
         return TRUE; 
 #endif
 
+    if (IsReadyToRunCompilation() && !m_pImage->GetCompileInfo()->IsInCurrentVersionBubble(m_pEEJitInfo->getMethodModule(method)))
+    {
+        // FUTURE: ZapSig::EncodeMethod does not yet handle cross module references for ReadyToRun
+        // See zapsig.cpp around line 1217.
+        // Once this is implemented, we'll be able to inline pinvokes of extern methods declared in other modules (Ex: PresentationCore.dll)
+        return TRUE;
+    }
+
     return m_pEEJitInfo->pInvokeMarshalingRequired(method, sig);
 }
 


### PR DESCRIPTION
This is because of this code in ZapSig::EncodeMethod: 
https://github.com/dotnet/coreclr/blob/cd418635d5db40df67ffb45de74f61ca8df88207/src/vm/zapsig.cpp#L1217

I'm not trying to fix the encoding here, just special case "extern" methods declared on other modules (to unblock WPF scenarios... PresentationCore.dll and PresentationFramework.dll have that.

I'll fix cross module reference encoding later when I get a chance