### PR TITLE
Improve RuntimeHelpers.GetSubArray

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.Serialization;
+using Internal.Runtime.CompilerServices;
 
 namespace System.Runtime.CompilerServices
 {
@@ -13,22 +14,37 @@ namespace System.Runtime.CompilerServices
         public delegate void CleanupCode(object userData, bool exceptionThrown);
 
         /// <summary>
-        /// GetSubArray helper method for the compiler to slice an array using a range.
+        /// Slices the specified array using the specified range.
         /// </summary>
         public static T[] GetSubArray<T>(T[] array, Range range)
         {
-            Type elementType = array.GetType().GetElementType();
-            Span<T> source = array.AsSpan(range);
-
-            if (elementType.IsValueType)
+            if (array == null)
             {
-                return source.ToArray();
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+            }
+
+            Range.OffsetAndLength offLen = range.GetOffsetAndLength(array.Length);
+            if (offLen.Length == 0)
+            {
+                return Array.Empty<T>();
+            }
+
+            if (default(T) != null || typeof(T[]) == array.GetType())
+            {
+                // We know the type of the array to be exactly T[].
+                var dest = new T[offLen.Length];
+                Buffer.Memmove(
+                    ref Unsafe.As<byte, T>(ref dest.GetRawSzArrayData()),
+                    ref Unsafe.Add(ref Unsafe.As<byte, T>(ref array.GetRawSzArrayData()), offLen.Offset),
+                    (uint)offLen.Length);
+                return dest;
             }
             else
             {
-                T[] newArray = (T[])Array.CreateInstance(elementType, source.Length);
-                source.CopyTo(newArray);
-                return newArray;
+                // The array is actually a U[] where U:T.
+                T[] dest = (T[])Array.CreateInstance(array.GetType().GetElementType(), offLen.Length);
+                Array.Copy(array, offLen.Offset, dest, 0, offLen.Length);
+                return dest;
             }
         }
 

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -24,14 +24,16 @@ namespace System.Runtime.CompilerServices
             }
 
             Range.OffsetAndLength offLen = range.GetOffsetAndLength(array.Length);
-            if (offLen.Length == 0)
-            {
-                return Array.Empty<T>();
-            }
 
             if (default(T) != null || typeof(T[]) == array.GetType())
             {
                 // We know the type of the array to be exactly T[].
+
+                if (offLen.Length == 0)
+                {
+                    return Array.Empty<T>();
+                }
+
                 var dest = new T[offLen.Length];
                 Buffer.Memmove(
                     ref Unsafe.As<byte, T>(ref dest.GetRawSzArrayData()),


### PR DESCRIPTION
This change does three things.

First, it fixes `GetSubArray` to work when the supplied array is actually a `U[]` where `U : T`.  Currently this case ends up throwing an exception inside of span, which doesn't like working with arrays covariantly.

Second, it fixes argument validation so that we throw an `ArgumentNullException` if the input array is null rather than `NullReferenceException`.

Third, it improves the performance of `GetSubArray` for the 95% common case where either `T` is a value type or the type of the array matches the `T` type specified.

Before:
```
         Method |      Mean |     Error |   StdDev |  Gen 0 | Allocated |
--------------- |----------:|----------:|---------:|-------:|----------:|
   ByteSubArray |  44.21 ns | 0.9510 ns | 1.481 ns | 0.0151 |      32 B |
 StringSubArray | 154.41 ns | 3.0687 ns | 2.720 ns | 0.0224 |      48 B |
 ObjectSubArray |        NA |        NA |       NA |    N/A |       N/A |
```

After:
```
         Method |      Mean |     Error |    StdDev |  Gen 0 | Allocated |
--------------- |----------:|----------:|----------:|-------:|----------:|
   ByteSubArray |  20.47 ns | 0.4621 ns | 0.5845 ns | 0.0153 |      32 B |
 StringSubArray |  33.35 ns | 0.7216 ns | 1.1446 ns | 0.0229 |      48 B |
 ObjectSubArray | 137.37 ns | 2.8155 ns | 5.4245 ns | 0.0229 |      48 B |
```

Benchmark:
```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Attributes.Jobs;
using BenchmarkDotNet.Running;
using System;
using System.Runtime.CompilerServices;

[MemoryDiagnoser]
[InProcess]
public class Benchmark
{
    private static void Main() => BenchmarkRunner.Run<Benchmark>();

    private readonly static byte[] s_bytes = new byte[] { 1, 2, 3, 4, 5 };
    private readonly static string[] s_strings = new string[] { "1", "2", "3", "4", "5" };

    [Benchmark] public byte[] ByteSubArray() => RuntimeHelpers.GetSubArray(s_bytes, new Range(new Index(1), new Index(1, true)));
    [Benchmark] public string[] StringSubArray() => RuntimeHelpers.GetSubArray(s_strings, new Range(new Index(1), new Index(1, true)));
    [Benchmark] public object[] ObjectSubArray() => RuntimeHelpers.GetSubArray<object>(s_strings, new Range(new Index(1), new Index(1, true)));
}
```

cc: @tarekgh, @GrabYourPitchforks, @jkotas, @agocke 