### PR TITLE
Fix a ZeroMemory call in methodcontext.cpp

### DIFF
--- a/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -2535,8 +2535,8 @@ void MethodContext::recGetArgType(CORINFO_SIG_INFO*       sig,
         GetArgType = new LightWeightMap<GetArgTypeValue, Agnostic_GetArgType_Value>();
 
     GetArgTypeValue key;
-    ZeroMemory(&key, sizeof(GetArgType)); // We use the input structs as a key and use memcmp to compare.. so
-                                          // we need to zero out padding too
+    ZeroMemory(&key, sizeof(key)); // We use the input structs as a key and use memcmp to compare.. so
+                                   // we need to zero out padding too
     // Only setting values for things the EE seems to pay attention to... this is necessary since some of the values
     // are unset and fail our precise comparisons ...
     key.flags                  = (DWORD)sig->flags;


### PR DESCRIPTION
The argument is of type `GetArgTypeValue` and so the `sizeof()` should be
done on `GetArgTypeValue`, not on the different type `GetArgType`.