### PR TITLE
Enable R2R testing in PRs. Workaround an issue with custom xunit.console.dll runner.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -221,6 +221,21 @@ jobs:
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress0x3-gcstress0xc') }}:
           testGroup: outerloop-gcstress0x3-gcstress0xc
 
+# The ReadyToRun test jobs that are triggered by default from a PR.
+- ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
+  - template: eng/platform-matrix.yml
+    parameters:
+      jobTemplate: test-job.yml
+      buildConfig: checked
+      platforms:
+      - Linux_x64
+      - OSX_x64
+      - Windows_NT_x64
+      - Windows_NT_x86
+      jobParameters:
+        readyToRun: true
+        testGroup: innerloop
+
 # CI
 - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
   - template: eng/platform-matrix.yml

--- a/build-test.cmd
+++ b/build-test.cmd
@@ -557,6 +557,11 @@ if /I "%2" == "mscorlib.ni.dll" exit /b 0
 REM don't precompile anything from CoreCLR
 if /I exist %CORE_ROOT_STAGE%\%2 exit /b 0
 
+REM Don't precompile xunit.* files
+echo "%2" | findstr /b "xunit." >nul && (
+  exit /b 0
+)
+
 "%CORE_ROOT_STAGE%\crossgen.exe" /Platform_Assemblies_Paths "%CORE_ROOT%" /in "%1" /out "%CORE_ROOT%/temp.ni.dll" >nul 2>nul
 set /a __exitCode = %errorlevel%
 if "%__exitCode%" == "-2146230517" (

--- a/build-test.sh
+++ b/build-test.sh
@@ -176,7 +176,8 @@ precompile_coreroot_fx()
 
     local overlayDir=$CORE_ROOT
 
-    filesToPrecompile=$(find -L $overlayDir -iname \*.dll -not -iname \*.ni.dll -not -iname \*-ms-win-\* -not -iname xunit.\* -type f )
+    # TODO: Remove System.Xml.XDocument.dll exclusion - it was added because "custom" xunit.console.dll fails when running from Core_Root with crossgen-d framework.
+    filesToPrecompile=$(find -L $overlayDir -iname \*.dll -not -iname \*.ni.dll -not -iname \*-ms-win-\* -not -iname xunit.\* -not -name System.Xml.XDocument.dll -type f)
     for fileToPrecompile in ${filesToPrecompile}
     do
         local filename=${fileToPrecompile}

--- a/build-test.sh
+++ b/build-test.sh
@@ -176,7 +176,7 @@ precompile_coreroot_fx()
 
     local overlayDir=$CORE_ROOT
 
-    filesToPrecompile=$(find -L $overlayDir -iname \*.dll -not -iname \*.ni.dll -not -iname \*-ms-win-\* -type f )
+    filesToPrecompile=$(find -L $overlayDir -iname \*.dll -not -iname \*.ni.dll -not -iname \*-ms-win-\* -not -iname xunit.\* -type f )
     for fileToPrecompile in ${filesToPrecompile}
     do
         local filename=${fileToPrecompile}


### PR DESCRIPTION
This enables ReadyToRun testing running aganst pull requests for:
- Linux_x64 
- OSX_x64 
- Windows_NT_x64
- Windows_NT_x86

Also excludes xunit.* files from being crossgen-d.

An issue we saw in https://github.com/dotnet/coreclr/issues/20797 and https://github.com/dotnet/coreclr/pull/20975 now happens again here. 

I will work on the permanent solution for the issue. 
However, we need to get R2R testing on Linux/macOS green asap, so temporary excluding **System.Xml.XDocument.dll** to workaround this.