### PR TITLE
JIT: update byref null check logic to handle field chains

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -11918,6 +11918,10 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac)
             switch (tree->gtOper)
             {
                 case GT_ADDR:
+                    // A non-null mac here implies this node is part of an address computation.
+                    // If so, we need to pass the existing mac down to the child node.
+                    //
+                    // Otherwise, use a new mac.
                     if (subMac1 == nullptr)
                     {
                         subMac1         = &subIndMac1;
@@ -11933,12 +11937,11 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac)
                 case GT_BLK:
                 case GT_DYN_BLK:
                 case GT_IND:
-                    // If this node is part of an address computation, propagate
-                    // the existing mac.
+                    // A non-null mac here implies this node is part of an address computation (the tree parent is
+                    // GT_ADDR).
+                    // If so, we need to pass the existing mac down to the child node.
                     //
-                    // We can't check for this exactly, but a non-null mac is a
-                    // reasonable approximation for "this node is part of an
-                    // address computation".
+                    // Otherwise, use a new mac.
                     if (subMac1 == nullptr)
                     {
                         subMac1 = &subIndMac1;

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -11977,16 +11977,16 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac)
             }
         }
 
-        // If gtOp1 is a GT_FIELD, we need to pass down the mac if
-        // its parent is GT_ADDR, since the address of the field
+        // If op1 is a GT_FIELD or indir, we need to pass down the mac if
+        // its parent is GT_ADDR, since the address of op1
         // is part of an ongoing address computation. Otherwise
         // op1 represents the value of the field and so any address
         // calculations it does are in a new context.
-        if ((op1->gtOper == GT_FIELD) && (tree->gtOper != GT_ADDR))
+        if (((op1->gtOper == GT_FIELD) || op1->OperIsIndir()) && (tree->gtOper != GT_ADDR))
         {
             subMac1 = nullptr;
 
-            // The impact of this field's value to any ongoing
+            // The impact of op1's value to any ongoing
             // address computation is handled below when looking
             // at op2.
         }
@@ -12087,11 +12087,11 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac)
                 break;
         }
 
-        // If gtOp2 is a GT_FIELD, we must be taking its value,
+        // If op2 is a GT_FIELD or indir, we must be taking its value,
         // so it should evaluate its address in a new context.
-        if (op2->gtOper == GT_FIELD)
+        if ((op2->gtOper == GT_FIELD) || op2->OperIsIndir())
         {
-            // The impact of this field's value to any ongoing
+            // The impact of op2's value to any ongoing
             // address computation is handled above when looking
             // at op1.
             mac = nullptr;

--- a/tests/src/JIT/Regression/JitBlue/GitHub_23791/GitHub_23791.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_23791/GitHub_23791.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+using System;
+using System.Runtime.CompilerServices;
+
+// The jit should null check 'this' in NextElement
+
+unsafe struct GitHub_23791
+{
+    fixed byte A[10];
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    byte NextElement(int i) => A[1+i];
+
+    static int Main() 
+    {
+        int result = -1;
+        GitHub_23791* x = null;
+        bool threw = true;
+
+        try
+        {
+            byte t = x->NextElement(100000);
+            threw = false;
+        }
+        catch (NullReferenceException)
+        {
+            result = 100;
+        }
+
+        if (!threw)
+        {
+            Console.WriteLine($"FAIL: did not throw an exception");
+        }
+
+        return result;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_23791/GitHub_23791.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_23791/GitHub_23791.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{2649FAFE-07BF-4F93-8120-BA9A69285ABB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
The jit was not properly accumulating offsets when figuring out if a byref
should be null checked.

Use ~~GTF_DONT_CSE~~ a non-null MorphAddressContext as indication that
GT_FIELD and GT_IND nodes are actually part of an ongoing address computation.
During field morphing propagate the current address context to the child node,
instead of starting a new one.

Fixes #23791.