### PR TITLE
Fix CMake warning about clrjit.exports.in file when using Ninja generator

### DIFF
--- a/functions.cmake
+++ b/functions.cmake
@@ -86,11 +86,7 @@ function(preprocess_def_file inputFilename outputFilename)
                               PROPERTIES GENERATED TRUE)
 endfunction()
 
-function(generate_exports_file)
-  set(INPUT_LIST ${ARGN})
-  list(GET INPUT_LIST -1 outputFilename)
-  list(REMOVE_AT INPUT_LIST -1)
-
+function(generate_exports_file INPUT_FILE OUTPUT_FILE)
   if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
     set(AWK_SCRIPT generateexportedsymbols.awk)
   else()
@@ -98,9 +94,9 @@ function(generate_exports_file)
   endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 
   add_custom_command(
-    OUTPUT ${outputFilename}
-    COMMAND ${AWK} -f ${CMAKE_SOURCE_DIR}/${AWK_SCRIPT} ${INPUT_LIST} >${outputFilename}
-    DEPENDS ${INPUT_LIST} ${CMAKE_SOURCE_DIR}/${AWK_SCRIPT}
+    OUTPUT ${OUTPUT_FILE}
+    COMMAND ${AWK} -f ${CMAKE_SOURCE_DIR}/${AWK_SCRIPT} ${INPUT_FILE} >${OUTPUT_FILE}
+    DEPENDS ${INPUT_FILE} ${CMAKE_SOURCE_DIR}/${AWK_SCRIPT}
     COMMENT "Generating exports file ${outputFilename}"
   )
   set_source_files_properties(${outputFilename}

--- a/functions.cmake
+++ b/functions.cmake
@@ -86,7 +86,7 @@ function(preprocess_def_file inputFilename outputFilename)
                               PROPERTIES GENERATED TRUE)
 endfunction()
 
-function(generate_exports_file INPUT_FILE OUTPUT_FILE)
+function(generate_exports_file inputFilename outputFilename)
   if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
     set(AWK_SCRIPT generateexportedsymbols.awk)
   else()
@@ -94,9 +94,9 @@ function(generate_exports_file INPUT_FILE OUTPUT_FILE)
   endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 
   add_custom_command(
-    OUTPUT ${OUTPUT_FILE}
-    COMMAND ${AWK} -f ${CMAKE_SOURCE_DIR}/${AWK_SCRIPT} ${INPUT_FILE} >${OUTPUT_FILE}
-    DEPENDS ${INPUT_FILE} ${CMAKE_SOURCE_DIR}/${AWK_SCRIPT}
+    OUTPUT ${outputFilename}
+    COMMAND ${AWK} -f ${CMAKE_SOURCE_DIR}/${AWK_SCRIPT} ${inputFilename} >${outputFilename}
+    DEPENDS ${inputFilename} ${CMAKE_SOURCE_DIR}/${AWK_SCRIPT}
     COMMENT "Generating exports file ${outputFilename}"
   )
   set_source_files_properties(${outputFilename}

--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -275,7 +275,7 @@ else()
   clr_unknown_arch()
 endif()
 
-set( SOURCES
+set(SOURCES
   ${JIT_SOURCES}
   ${JIT_HEADERS}
   ${JIT_RESOURCES}
@@ -291,27 +291,19 @@ convert_to_absolute_path(JIT_ARM_SOURCES ${JIT_ARM_SOURCES})
 convert_to_absolute_path(JIT_I386_SOURCES ${JIT_I386_SOURCES})
 convert_to_absolute_path(JIT_ARM64_SOURCES ${JIT_ARM64_SOURCES})
 
-set (CLRJIT_EXPORTS ${CMAKE_CURRENT_LIST_DIR}/ClrJit.exports)
 
 if(WIN32)
   add_precompiled_header(jitpch.h ../jitpch.cpp SOURCES)
+  set(CLRJIT_EXPORTS ${CMAKE_CURRENT_LIST_DIR}/ClrJit.exports)
   set(JIT_EXPORTS_FILE ${CMAKE_CURRENT_BINARY_DIR}/ClrJit.exports.def)
   preprocess_def_file (${CLRJIT_EXPORTS} ${JIT_EXPORTS_FILE})
 
   set(SHARED_LIB_SOURCES ${SOURCES} ${JIT_EXPORTS_FILE})
 else()
-  set(JIT_EXPORTS_IN_FILE ${CMAKE_CURRENT_BINARY_DIR}/clrjit.exports.in)
-  set (CLRJIT_PAL_EXPORTS ${CMAKE_CURRENT_LIST_DIR}/ClrJit.PAL.exports)
-
-  find_program(CAT cat)
-  add_custom_command(
-    OUTPUT ${JIT_EXPORTS_IN_FILE}
-    COMMAND ${CAT} ${CLRJIT_EXPORTS} ${CLRJIT_PAL_EXPORTS} > ${JIT_EXPORTS_IN_FILE}
-    DEPENDS ${CLRJIT_EXPORTS} ${CLRJIT_PAL_EXPORTS}
-  )
+  set(CLRJIT_EXPORTS ${CMAKE_CURRENT_LIST_DIR}/ClrJit.PAL.exports)
 
   set(JIT_EXPORTS_FILE ${CMAKE_CURRENT_BINARY_DIR}/clrjit.exports)
-  generate_exports_file(${JIT_EXPORTS_IN_FILE} ${JIT_EXPORTS_FILE})
+  generate_exports_file(${CLRJIT_EXPORTS} ${JIT_EXPORTS_FILE})
 
   if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL FreeBSD OR CMAKE_SYSTEM_NAME STREQUAL NetBSD)
     # This is required to force using our own PAL, not one that we are loaded with.

--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -295,20 +295,8 @@ set (CLRJIT_EXPORTS ${CMAKE_CURRENT_LIST_DIR}/ClrJit.exports)
 
 if(WIN32)
   add_precompiled_header(jitpch.h ../jitpch.cpp SOURCES)
-
-  # Create .def file containing a list of exports preceeded by
-  # 'EXPORTS'.  The file "ClrJit.exports" already contains the list, so we
-  # massage it into the correct format here to create "ClrJit.exports.def".
   set(JIT_EXPORTS_FILE ${CMAKE_CURRENT_BINARY_DIR}/ClrJit.exports.def)
-  set(JIT_EXPORTS_FILE_TEMP ${JIT_EXPORTS_FILE}.txt)
-  file(READ ${CLRJIT_EXPORTS} exports_list)
-  file(WRITE ${JIT_EXPORTS_FILE_TEMP} "LIBRARY CLRJIT\n")
-  file(APPEND ${JIT_EXPORTS_FILE_TEMP} "EXPORTS\n")
-  file(APPEND ${JIT_EXPORTS_FILE_TEMP} ${exports_list})
-
-  # Copy the file only if it has changed.
-  execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
-    ${JIT_EXPORTS_FILE_TEMP} ${JIT_EXPORTS_FILE})
+  preprocess_def_file (${CLRJIT_EXPORTS} ${JIT_EXPORTS_FILE})
 
   set(SHARED_LIB_SOURCES ${SOURCES} ${JIT_EXPORTS_FILE})
 else()

--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -291,6 +291,8 @@ convert_to_absolute_path(JIT_ARM_SOURCES ${JIT_ARM_SOURCES})
 convert_to_absolute_path(JIT_I386_SOURCES ${JIT_I386_SOURCES})
 convert_to_absolute_path(JIT_ARM64_SOURCES ${JIT_ARM64_SOURCES})
 
+set (CLRJIT_EXPORTS ${CMAKE_CURRENT_LIST_DIR}/ClrJit.exports)
+
 if(WIN32)
   add_precompiled_header(jitpch.h ../jitpch.cpp SOURCES)
 
@@ -299,7 +301,7 @@ if(WIN32)
   # massage it into the correct format here to create "ClrJit.exports.def".
   set(JIT_EXPORTS_FILE ${CMAKE_CURRENT_BINARY_DIR}/ClrJit.exports.def)
   set(JIT_EXPORTS_FILE_TEMP ${JIT_EXPORTS_FILE}.txt)
-  file(READ "ClrJit.exports" exports_list)
+  file(READ ${CLRJIT_EXPORTS} exports_list)
   file(WRITE ${JIT_EXPORTS_FILE_TEMP} "LIBRARY CLRJIT\n")
   file(APPEND ${JIT_EXPORTS_FILE_TEMP} "EXPORTS\n")
   file(APPEND ${JIT_EXPORTS_FILE_TEMP} ${exports_list})
@@ -311,11 +313,14 @@ if(WIN32)
   set(SHARED_LIB_SOURCES ${SOURCES} ${JIT_EXPORTS_FILE})
 else()
   set(JIT_EXPORTS_IN_FILE ${CMAKE_CURRENT_BINARY_DIR}/clrjit.exports.in)
-  file(READ "${CMAKE_CURRENT_LIST_DIR}/ClrJit.exports" jit_exports)
-  file(READ "${CMAKE_CURRENT_LIST_DIR}/ClrJit.PAL.exports" pal_exports)
-  file(WRITE ${JIT_EXPORTS_IN_FILE} ${jit_exports})
-  file(APPEND ${JIT_EXPORTS_IN_FILE} "\n")
-  file(APPEND ${JIT_EXPORTS_IN_FILE} ${pal_exports})
+  set (CLRJIT_PAL_EXPORTS ${CMAKE_CURRENT_LIST_DIR}/ClrJit.PAL.exports)
+
+  find_program(CAT cat)
+  add_custom_command(
+    OUTPUT ${JIT_EXPORTS_IN_FILE}
+    COMMAND ${CAT} ${CLRJIT_EXPORTS} ${CLRJIT_PAL_EXPORTS} > ${JIT_EXPORTS_IN_FILE}
+    DEPENDS ${CLRJIT_EXPORTS} ${CLRJIT_PAL_EXPORTS}
+  )
 
   set(JIT_EXPORTS_FILE ${CMAKE_CURRENT_BINARY_DIR}/clrjit.exports)
   generate_exports_file(${JIT_EXPORTS_IN_FILE} ${JIT_EXPORTS_FILE})

--- a/src/jit/ClrJit.PAL.exports
+++ b/src/jit/ClrJit.PAL.exports
@@ -1,3 +1,6 @@
+getJit
+jitStartup
+sxsJitStartup
 DllMain
 PAL_RegisterModule
 PAL_UnregisterModule

--- a/src/jit/ClrJit.exports
+++ b/src/jit/ClrJit.exports
@@ -1,3 +1,8 @@
-getJit
-jitStartup
-sxsJitStartup
+; Licensed to the .NET Foundation under one or more agreements.
+; The .NET Foundation licenses this file to you under the MIT license.
+; See the LICENSE file in the project root for more information.
+
+EXPORTS
+    getJit
+    jitStartup
+    sxsJitStartup

--- a/src/jit/armelnonjit/CMakeLists.txt
+++ b/src/jit/armelnonjit/CMakeLists.txt
@@ -41,6 +41,8 @@ if(WIN32)
   add_definitions(-DFX_VER_INTERNALNAME_STR=armelnonjit.dll)
 endif(WIN32)
 
+set_source_files_properties(${JIT_EXPORTS_FILE} PROPERTIES GENERATED TRUE)
+
 add_library_clr(armelnonjit
    SHARED
    ${SHARED_LIB_SOURCES}

--- a/src/jit/dll/CMakeLists.txt
+++ b/src/jit/dll/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(ClrJit)
 
+set_source_files_properties(${JIT_EXPORTS_FILE} PROPERTIES GENERATED TRUE)
+
 if(CLR_CMAKE_PLATFORM_UNIX)
     add_compile_options(-fPIC)
 

--- a/src/jit/linuxnonjit/CMakeLists.txt
+++ b/src/jit/linuxnonjit/CMakeLists.txt
@@ -27,6 +27,8 @@ if(WIN32)
   add_definitions(-DFX_VER_INTERNALNAME_STR=linuxnonjit.dll)
 endif(WIN32)
 
+set_source_files_properties(${JIT_EXPORTS_FILE} PROPERTIES GENERATED TRUE)
+
 add_library_clr(linuxnonjit
    SHARED
    ${SHARED_LIB_SOURCES}

--- a/src/jit/protojit/CMakeLists.txt
+++ b/src/jit/protojit/CMakeLists.txt
@@ -13,6 +13,8 @@ if(WIN32)
   add_definitions(-DFX_VER_INTERNALNAME_STR=protojit.dll)
 endif(WIN32)
 
+set_source_files_properties(${JIT_EXPORTS_FILE} PROPERTIES GENERATED TRUE)
+
 add_library_clr(protojit
    SHARED
    ${SHARED_LIB_SOURCES}

--- a/src/jit/protononjit/CMakeLists.txt
+++ b/src/jit/protononjit/CMakeLists.txt
@@ -39,6 +39,8 @@ if(WIN32)
   add_definitions(-DFX_VER_INTERNALNAME_STR=protononjit.dll)
 endif(WIN32)
 
+set_source_files_properties(${JIT_EXPORTS_FILE} PROPERTIES GENERATED TRUE)
+
 add_library_clr(protononjit
    SHARED
    ${SHARED_LIB_SOURCES}

--- a/src/jit/standalone/CMakeLists.txt
+++ b/src/jit/standalone/CMakeLists.txt
@@ -12,6 +12,8 @@ if(WIN32)
   add_definitions(-DFX_VER_INTERNALNAME_STR=clrjit.dll)
 endif(WIN32)
 
+set_source_files_properties(${JIT_EXPORTS_FILE} PROPERTIES GENERATED TRUE)
+
 add_library_clr(clrjit
    SHARED
    ${SHARED_LIB_SOURCES}


### PR DESCRIPTION
CMake was having issues determining that the `clrjit.exports.in` file was generated by CMake for the Ninja build system. I've moved the generation into a custom command and out of the configure step.

Additionally this change makes the generation of clrjit.exports.in not break incremental build/install when using ninja. It also only writes `clrjit.exports.in` when inputs change instead of on every build.

Refactor `generate_exports_file` to explicitly accept two parameters since that's all that the AWK script supports and that's all that any usages use.