### PR TITLE
Tweaking some APIs according to user feedback.

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256_1.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Vector256_1.cs
@@ -105,13 +105,13 @@ namespace System.Runtime.Intrinsics
             {
                 if (typeof(T) == typeof(float))
                 {
-                    Vector256<float> result = Avx.Compare(this.AsSingle(), other.AsSingle(), FloatComparisonMode.EqualOrderedNonSignaling);
+                    Vector256<float> result = Avx.Compare(this.AsSingle(), other.AsSingle(), FloatComparisonMode.OrderedEqualNonSignaling);
                     return Avx.MoveMask(result) == 0b1111_1111; // We have one bit per element
                 }
 
                 if (typeof(T) == typeof(double))
                 {
-                    Vector256<double> result = Avx.Compare(this.AsDouble(), other.AsDouble(), FloatComparisonMode.EqualOrderedNonSignaling);
+                    Vector256<double> result = Avx.Compare(this.AsDouble(), other.AsDouble(), FloatComparisonMode.OrderedEqualNonSignaling);
                     return Avx.MoveMask(result) == 0b1111; // We have one bit per element
                 }
             }

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Avx2.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Avx2.PlatformNotSupported.cs
@@ -674,70 +674,131 @@ namespace System.Runtime.Intrinsics.X86
 
         /// <summary>
         /// __m256i _mm256_cvtepi8_epi16 (__m128i a)
-        ///   VPMOVSXBW ymm, xmm/m128
+        ///   VPMOVSXBW ymm, xmm
         /// </summary>
         public static Vector256<short> ConvertToVector256Int16(Vector128<sbyte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_cvtepu8_epi16 (__m128i a)
-        ///   VPMOVZXBW ymm, xmm/m128
+        ///   VPMOVZXBW ymm, xmm
         /// </summary>
         public static Vector256<ushort> ConvertToVector256UInt16(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
         public static Vector256<short> ConvertToVector256Int16(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_cvtepi8_epi32 (__m128i a)
-        ///   VPMOVSXBD ymm, xmm/m128
+        ///   VPMOVSXBD ymm, xmm
         /// </summary>
         public static Vector256<int> ConvertToVector256Int32(Vector128<sbyte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
-        /// __m256i _mm256_cvtepi16_epi32 (__m128i a)
-        ///   VPMOVSXWD ymm, xmm/m128
-        /// </summary>
-        public static Vector256<int> ConvertToVector256Int32(Vector128<short> value) { throw new PlatformNotSupportedException(); }
-        /// <summary>
         /// __m256i _mm256_cvtepu8_epi32 (__m128i a)
-        ///   VPMOVZXBD ymm, xmm/m128
+        ///   VPMOVZXBD ymm, xmm
         /// </summary>
         public static Vector256<uint> ConvertToVector256UInt32(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
         public static Vector256<int> ConvertToVector256Int32(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
+        /// __m256i _mm256_cvtepi16_epi32 (__m128i a)
+        ///   VPMOVSXWD ymm, xmm
+        /// </summary>
+        public static Vector256<int> ConvertToVector256Int32(Vector128<short> value) { throw new PlatformNotSupportedException(); }
+        /// <summary>
         /// __m256i _mm256_cvtepu16_epi32 (__m128i a)
-        ///   VPMOVZXWD ymm, xmm/m128
+        ///   VPMOVZXWD ymm, xmm
         /// </summary>
         public static Vector256<uint> ConvertToVector256UInt32(Vector128<ushort> value) { throw new PlatformNotSupportedException(); }
         public static Vector256<int> ConvertToVector256Int32(Vector128<ushort> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_cvtepi8_epi64 (__m128i a)
-        ///   VPMOVSXBQ ymm, xmm/m128
+        ///   VPMOVSXBQ ymm, xmm
         /// </summary>
         public static Vector256<long> ConvertToVector256Int64(Vector128<sbyte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
-        /// __m256i _mm256_cvtepi16_epi64 (__m128i a)
-        ///   VPMOVSXWQ ymm, xmm/m128
-        /// </summary>
-        public static Vector256<long> ConvertToVector256Int64(Vector128<short> value) { throw new PlatformNotSupportedException(); }
-        /// <summary>
-        /// __m256i _mm256_cvtepi32_epi64 (__m128i a)
-        ///   VPMOVSXDQ ymm, xmm/m128
-        /// </summary>
-        public static Vector256<long> ConvertToVector256Int64(Vector128<int> value) { throw new PlatformNotSupportedException(); }
-        /// <summary>
         /// __m256i _mm256_cvtepu8_epi64 (__m128i a)
-        ///   VPMOVZXBQ ymm, xmm/m128
+        ///   VPMOVZXBQ ymm, xmm
         /// </summary>
         public static Vector256<ulong> ConvertToVector256UInt64(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
         public static Vector256<long> ConvertToVector256Int64(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
+        /// __m256i _mm256_cvtepi16_epi64 (__m128i a)
+        ///   VPMOVSXWQ ymm, xmm
+        /// </summary>
+        public static Vector256<long> ConvertToVector256Int64(Vector128<short> value) { throw new PlatformNotSupportedException(); }
+        /// <summary>
         /// __m256i _mm256_cvtepu16_epi64 (__m128i a)
-        ///   VPMOVZXWQ ymm, xmm/m128
+        ///   VPMOVZXWQ ymm, xmm
         /// </summary>
         public static Vector256<ulong> ConvertToVector256UInt64(Vector128<ushort> value) { throw new PlatformNotSupportedException(); }
         public static Vector256<long> ConvertToVector256Int64(Vector128<ushort> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
+        /// __m256i _mm256_cvtepi32_epi64 (__m128i a)
+        ///   VPMOVSXDQ ymm, xmm
+        /// </summary>
+        public static Vector256<long> ConvertToVector256Int64(Vector128<int> value) { throw new PlatformNotSupportedException(); }
+        /// <summary>
         /// __m256i _mm256_cvtepu32_epi64 (__m128i a)
-        ///   VPMOVZXDQ ymm, xmm/m128
+        ///   VPMOVZXDQ ymm, xmm
         /// </summary>
         public static Vector256<ulong> ConvertToVector256UInt64(Vector128<uint> value) { throw new PlatformNotSupportedException(); }
         public static Vector256<long> ConvertToVector256Int64(Vector128<uint> value) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        ///   VPMOVSXBW ymm, m128
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector256<short> ConvertToVector256Int16(sbyte* address) { throw new PlatformNotSupportedException(); }
+        /// <summary>
+        ///   VPMOVZXBW ymm, m128
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector256<short> ConvertToVector256Int16(byte* address) { throw new PlatformNotSupportedException(); }
+        /// <summary>
+        ///   VPMOVSXBD ymm, m64
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector256<int> ConvertToVector256Int32(sbyte* address) { throw new PlatformNotSupportedException(); }
+        /// <summary>
+        ///   VPMOVZXBD ymm, m64
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector256<int> ConvertToVector256Int32(byte* address) { throw new PlatformNotSupportedException(); }
+        /// <summary>
+        ///   VPMOVSXWD ymm, m128
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector256<int> ConvertToVector256Int32(short* address) { throw new PlatformNotSupportedException(); }
+        /// <summary>
+        ///   VPMOVZXWD ymm, m128
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector256<int> ConvertToVector256Int32(ushort* address) { throw new PlatformNotSupportedException(); }
+        /// <summary>
+        ///   VPMOVSXBQ ymm, m32
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector256<long> ConvertToVector256Int64(sbyte* address) { throw new PlatformNotSupportedException(); }
+        /// <summary>
+        ///   VPMOVZXBQ ymm, m32
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector256<long> ConvertToVector256Int64(byte* address) { throw new PlatformNotSupportedException(); }
+        /// <summary>
+        ///   VPMOVSXWQ ymm, m64
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector256<long> ConvertToVector256Int64(short* address) { throw new PlatformNotSupportedException(); }
+        /// <summary>
+        ///   VPMOVZXWQ ymm, m64
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector256<long> ConvertToVector256Int64(ushort* address) { throw new PlatformNotSupportedException(); }
+        /// <summary>
+        ///   VPMOVSXDQ ymm, m128
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector256<long> ConvertToVector256Int64(int* address) { throw new PlatformNotSupportedException(); }
+        /// <summary>
+        ///   VPMOVZXDQ ymm, m128
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector256<long> ConvertToVector256Int64(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Avx2.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Avx2.PlatformNotSupported.cs
@@ -682,6 +682,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   VPMOVZXBW ymm, xmm/m128
         /// </summary>
         public static Vector256<ushort> ConvertToVector256UInt16(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
+        public static Vector256<short> ConvertToVector256Int16(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_cvtepi8_epi32 (__m128i a)
         ///   VPMOVSXBD ymm, xmm/m128
@@ -697,11 +698,13 @@ namespace System.Runtime.Intrinsics.X86
         ///   VPMOVZXBD ymm, xmm/m128
         /// </summary>
         public static Vector256<uint> ConvertToVector256UInt32(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
+        public static Vector256<int> ConvertToVector256Int32(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_cvtepu16_epi32 (__m128i a)
         ///   VPMOVZXWD ymm, xmm/m128
         /// </summary>
         public static Vector256<uint> ConvertToVector256UInt32(Vector128<ushort> value) { throw new PlatformNotSupportedException(); }
+        public static Vector256<int> ConvertToVector256Int32(Vector128<ushort> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_cvtepi8_epi64 (__m128i a)
         ///   VPMOVSXBQ ymm, xmm/m128
@@ -722,16 +725,19 @@ namespace System.Runtime.Intrinsics.X86
         ///   VPMOVZXBQ ymm, xmm/m128
         /// </summary>
         public static Vector256<ulong> ConvertToVector256UInt64(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
+        public static Vector256<long> ConvertToVector256Int64(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_cvtepu16_epi64 (__m128i a)
         ///   VPMOVZXWQ ymm, xmm/m128
         /// </summary>
         public static Vector256<ulong> ConvertToVector256UInt64(Vector128<ushort> value) { throw new PlatformNotSupportedException(); }
+        public static Vector256<long> ConvertToVector256Int64(Vector128<ushort> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m256i _mm256_cvtepu32_epi64 (__m128i a)
         ///   VPMOVZXDQ ymm, xmm/m128
         /// </summary>
         public static Vector256<ulong> ConvertToVector256UInt64(Vector128<uint> value) { throw new PlatformNotSupportedException(); }
+        public static Vector256<long> ConvertToVector256Int64(Vector128<uint> value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Avx2.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Avx2.cs
@@ -682,6 +682,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   VPMOVZXBW ymm, xmm/m128
         /// </summary>
         public static Vector256<ushort> ConvertToVector256UInt16(Vector128<byte> value) => ConvertToVector256UInt16(value);
+        public static Vector256<short> ConvertToVector256Int16(Vector128<byte> value) => ConvertToVector256Int16(value);
         /// <summary>
         /// __m256i _mm256_cvtepi8_epi32 (__m128i a)
         ///   VPMOVSXBD ymm, xmm/m128
@@ -697,11 +698,13 @@ namespace System.Runtime.Intrinsics.X86
         ///   VPMOVZXBD ymm, xmm/m128
         /// </summary>
         public static Vector256<uint> ConvertToVector256UInt32(Vector128<byte> value) => ConvertToVector256UInt32(value);
+        public static Vector256<int> ConvertToVector256Int32(Vector128<byte> value) => ConvertToVector256Int32(value);
         /// <summary>
         /// __m256i _mm256_cvtepu16_epi32 (__m128i a)
         ///   VPMOVZXWD ymm, xmm/m128
         /// </summary>
         public static Vector256<uint> ConvertToVector256UInt32(Vector128<ushort> value) => ConvertToVector256UInt32(value);
+        public static Vector256<int> ConvertToVector256Int32(Vector128<ushort> value) => ConvertToVector256Int32(value);
         /// <summary>
         /// __m256i _mm256_cvtepi8_epi64 (__m128i a)
         ///   VPMOVSXBQ ymm, xmm/m128
@@ -722,16 +725,19 @@ namespace System.Runtime.Intrinsics.X86
         ///   VPMOVZXBQ ymm, xmm/m128
         /// </summary>
         public static Vector256<ulong> ConvertToVector256UInt64(Vector128<byte> value) => ConvertToVector256UInt64(value);
+        public static Vector256<long> ConvertToVector256Int64(Vector128<byte> value) => ConvertToVector256Int64(value);
         /// <summary>
         /// __m256i _mm256_cvtepu16_epi64 (__m128i a)
         ///   VPMOVZXWQ ymm, xmm/m128
         /// </summary>
         public static Vector256<ulong> ConvertToVector256UInt64(Vector128<ushort> value) => ConvertToVector256UInt64(value);
+        public static Vector256<long> ConvertToVector256Int64(Vector128<ushort> value) => ConvertToVector256Int64(value);
         /// <summary>
         /// __m256i _mm256_cvtepu32_epi64 (__m128i a)
         ///   VPMOVZXDQ ymm, xmm/m128
         /// </summary>
         public static Vector256<ulong> ConvertToVector256UInt64(Vector128<uint> value) => ConvertToVector256UInt64(value);
+        public static Vector256<long> ConvertToVector256Int64(Vector128<uint> value) => ConvertToVector256Int64(value);
 
         /// <summary>
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Avx2.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Avx2.cs
@@ -674,70 +674,131 @@ namespace System.Runtime.Intrinsics.X86
 
         /// <summary>
         /// __m256i _mm256_cvtepi8_epi16 (__m128i a)
-        ///   VPMOVSXBW ymm, xmm/m128
+        ///   VPMOVSXBW ymm, xmm
         /// </summary>
         public static Vector256<short> ConvertToVector256Int16(Vector128<sbyte> value) => ConvertToVector256Int16(value);
         /// <summary>
         /// __m256i _mm256_cvtepu8_epi16 (__m128i a)
-        ///   VPMOVZXBW ymm, xmm/m128
+        ///   VPMOVZXBW ymm, xmm
         /// </summary>
         public static Vector256<ushort> ConvertToVector256UInt16(Vector128<byte> value) => ConvertToVector256UInt16(value);
         public static Vector256<short> ConvertToVector256Int16(Vector128<byte> value) => ConvertToVector256Int16(value);
         /// <summary>
         /// __m256i _mm256_cvtepi8_epi32 (__m128i a)
-        ///   VPMOVSXBD ymm, xmm/m128
+        ///   VPMOVSXBD ymm, xmm
         /// </summary>
         public static Vector256<int> ConvertToVector256Int32(Vector128<sbyte> value) => ConvertToVector256Int32(value);
         /// <summary>
-        /// __m256i _mm256_cvtepi16_epi32 (__m128i a)
-        ///   VPMOVSXWD ymm, xmm/m128
-        /// </summary>
-        public static Vector256<int> ConvertToVector256Int32(Vector128<short> value) => ConvertToVector256Int32(value);
-        /// <summary>
         /// __m256i _mm256_cvtepu8_epi32 (__m128i a)
-        ///   VPMOVZXBD ymm, xmm/m128
+        ///   VPMOVZXBD ymm, xmm
         /// </summary>
         public static Vector256<uint> ConvertToVector256UInt32(Vector128<byte> value) => ConvertToVector256UInt32(value);
         public static Vector256<int> ConvertToVector256Int32(Vector128<byte> value) => ConvertToVector256Int32(value);
         /// <summary>
+        /// __m256i _mm256_cvtepi16_epi32 (__m128i a)
+        ///   VPMOVSXWD ymm, xmm
+        /// </summary>
+        public static Vector256<int> ConvertToVector256Int32(Vector128<short> value) => ConvertToVector256Int32(value);
+        /// <summary>
         /// __m256i _mm256_cvtepu16_epi32 (__m128i a)
-        ///   VPMOVZXWD ymm, xmm/m128
+        ///   VPMOVZXWD ymm, xmm
         /// </summary>
         public static Vector256<uint> ConvertToVector256UInt32(Vector128<ushort> value) => ConvertToVector256UInt32(value);
         public static Vector256<int> ConvertToVector256Int32(Vector128<ushort> value) => ConvertToVector256Int32(value);
         /// <summary>
         /// __m256i _mm256_cvtepi8_epi64 (__m128i a)
-        ///   VPMOVSXBQ ymm, xmm/m128
+        ///   VPMOVSXBQ ymm, xmm
         /// </summary>
         public static Vector256<long> ConvertToVector256Int64(Vector128<sbyte> value) => ConvertToVector256Int64(value);
         /// <summary>
-        /// __m256i _mm256_cvtepi16_epi64 (__m128i a)
-        ///   VPMOVSXWQ ymm, xmm/m128
-        /// </summary>
-        public static Vector256<long> ConvertToVector256Int64(Vector128<short> value) => ConvertToVector256Int64(value);
-        /// <summary>
-        /// __m256i _mm256_cvtepi32_epi64 (__m128i a)
-        ///   VPMOVSXDQ ymm, xmm/m128
-        /// </summary>
-        public static Vector256<long> ConvertToVector256Int64(Vector128<int> value) => ConvertToVector256Int64(value);
-        /// <summary>
         /// __m256i _mm256_cvtepu8_epi64 (__m128i a)
-        ///   VPMOVZXBQ ymm, xmm/m128
+        ///   VPMOVZXBQ ymm, xmm
         /// </summary>
         public static Vector256<ulong> ConvertToVector256UInt64(Vector128<byte> value) => ConvertToVector256UInt64(value);
         public static Vector256<long> ConvertToVector256Int64(Vector128<byte> value) => ConvertToVector256Int64(value);
         /// <summary>
+        /// __m256i _mm256_cvtepi16_epi64 (__m128i a)
+        ///   VPMOVSXWQ ymm, xmm
+        /// </summary>
+        public static Vector256<long> ConvertToVector256Int64(Vector128<short> value) => ConvertToVector256Int64(value);
+        /// <summary>
         /// __m256i _mm256_cvtepu16_epi64 (__m128i a)
-        ///   VPMOVZXWQ ymm, xmm/m128
+        ///   VPMOVZXWQ ymm, xmm
         /// </summary>
         public static Vector256<ulong> ConvertToVector256UInt64(Vector128<ushort> value) => ConvertToVector256UInt64(value);
         public static Vector256<long> ConvertToVector256Int64(Vector128<ushort> value) => ConvertToVector256Int64(value);
         /// <summary>
+        /// __m256i _mm256_cvtepi32_epi64 (__m128i a)
+        ///   VPMOVSXDQ ymm, xmm
+        /// </summary>
+        public static Vector256<long> ConvertToVector256Int64(Vector128<int> value) => ConvertToVector256Int64(value);
+        /// <summary>
         /// __m256i _mm256_cvtepu32_epi64 (__m128i a)
-        ///   VPMOVZXDQ ymm, xmm/m128
+        ///   VPMOVZXDQ ymm, xmm
         /// </summary>
         public static Vector256<ulong> ConvertToVector256UInt64(Vector128<uint> value) => ConvertToVector256UInt64(value);
         public static Vector256<long> ConvertToVector256Int64(Vector128<uint> value) => ConvertToVector256Int64(value);
+
+        /// <summary>
+        ///   VPMOVSXBW ymm, m128
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector256<short> ConvertToVector256Int16(sbyte* address) => ConvertToVector256Int16(address);
+        /// <summary>
+        ///   VPMOVZXBW ymm, m128
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector256<short> ConvertToVector256Int16(byte* address) => ConvertToVector256Int16(address);
+        /// <summary>
+        ///   VPMOVSXBD ymm, m64
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector256<int> ConvertToVector256Int32(sbyte* address) => ConvertToVector256Int32(address);
+        /// <summary>
+        ///   VPMOVZXBD ymm, m64
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector256<int> ConvertToVector256Int32(byte* address) => ConvertToVector256Int32(address);
+        /// <summary>
+        ///   VPMOVSXWD ymm, m128
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector256<int> ConvertToVector256Int32(short* address) => ConvertToVector256Int32(address);
+        /// <summary>
+        ///   VPMOVZXWD ymm, m128
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector256<int> ConvertToVector256Int32(ushort* address) => ConvertToVector256Int32(address);
+        /// <summary>
+        ///   VPMOVSXBQ ymm, m32
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector256<long> ConvertToVector256Int64(sbyte* address) => ConvertToVector256Int64(address);
+        /// <summary>
+        ///   VPMOVZXBQ ymm, m32
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector256<long> ConvertToVector256Int64(byte* address) => ConvertToVector256Int64(address);
+        /// <summary>
+        ///   VPMOVSXWQ ymm, m64
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector256<long> ConvertToVector256Int64(short* address) => ConvertToVector256Int64(address);
+        /// <summary>
+        ///   VPMOVZXWQ ymm, m64
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector256<long> ConvertToVector256Int64(ushort* address) => ConvertToVector256Int64(address);
+        /// <summary>
+        ///   VPMOVSXDQ ymm, m128
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector256<long> ConvertToVector256Int64(int* address) => ConvertToVector256Int64(address);
+        /// <summary>
+        ///   VPMOVZXDQ ymm, m128
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector256<long> ConvertToVector256Int64(uint* address) => ConvertToVector256Int64(address);
 
         /// <summary>
         /// __m128i _mm256_extracti128_si256 (__m256i a, const int imm8)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Enums.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Enums.cs
@@ -10,17 +10,17 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// _CMP_EQ_OQ
         /// </summary>
-        EqualOrderedNonSignaling = 0,
+        OrderedEqualNonSignaling = 0,
 
         /// <summary>
         /// _CMP_LT_OS
         /// </summary>
-        LessThanOrderedSignaling = 1,
+        OrderedLessThanSignaling = 1,
 
         /// <summary>
         /// _CMP_LE_OS
         /// </summary>
-        LessThanOrEqualOrderedSignaling = 2,
+        OrderedLessThanOrEqualSignaling = 2,
 
         /// <summary>
         /// _CMP_UNORD_Q
@@ -30,17 +30,17 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// _CMP_NEQ_UQ
         /// </summary>
-        NotEqualUnorderedNonSignaling = 4,
+        UnorderedNotEqualNonSignaling = 4,
 
         /// <summary>
         /// _CMP_NLT_US
         /// </summary>
-        NotLessThanUnorderedSignaling = 5,
+        UnorderedNotLessThanSignaling = 5,
 
         /// <summary>
         /// _CMP_NLE_US
         /// </summary>
-        NotLessThanOrEqualUnorderedSignaling = 6,
+        UnorderedNotLessThanOrEqualSignaling = 6,
 
         /// <summary>
         /// _CMP_ORD_Q
@@ -50,57 +50,57 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// _CMP_EQ_UQ
         /// </summary>
-        EqualUnorderedNonSignaling = 8,
+        UnorderedEqualNonSignaling = 8,
 
         /// <summary>
         /// _CMP_NGE_US
         /// </summary>
-        NotGreaterThanOrEqualUnorderedSignaling = 9,
+        UnorderedNotGreaterThanOrEqualSignaling = 9,
 
         /// <summary>
         /// _CMP_NGT_US
         /// </summary>
-        NotGreaterThanUnorderedSignaling = 10,
+        UnorderedNotGreaterThanSignaling = 10,
 
         /// <summary>
         /// _CMP_FALSE_OQ
         /// </summary>
-        FalseOrderedNonSignaling = 11,
+        OrderedFalseNonSignaling = 11,
 
         /// <summary>
         /// _CMP_NEQ_OQ
         /// </summary>
-        NotEqualOrderedNonSignaling = 12,
+        OrderedNotEqualNonSignaling = 12,
 
         /// <summary>
         /// _CMP_GE_OS
         /// </summary>
-        GreaterThanOrEqualOrderedSignaling = 13,
+        OrderedGreaterThanOrEqualSignaling = 13,
 
         /// <summary>
         /// _CMP_GT_OS
         /// </summary>
-        GreaterThanOrderedSignaling = 14,
+        OrderedGreaterThanSignaling = 14,
 
         /// <summary>
         /// _CMP_TRUE_UQ
         /// </summary>
-        TrueUnorderedNonSignaling = 15,
+        UnorderedTrueNonSignaling = 15,
 
         /// <summary>
         /// _CMP_EQ_OS
         /// </summary>
-        EqualOrderedSignaling = 16,
+        OrderedEqualSignaling = 16,
 
         /// <summary>
         /// _CMP_LT_OQ
         /// </summary>
-        LessThanOrderedNonSignaling = 17,
+        OrderedLessThanNonSignaling = 17,
 
         /// <summary>
         /// _CMP_LE_OQ
         /// </summary>
-        LessThanOrEqualOrderedNonSignaling = 18,
+        OrderedLessThanOrEqualNonSignaling = 18,
 
         /// <summary>
         /// _CMP_UNORD_S
@@ -110,17 +110,17 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// _CMP_NEQ_US
         /// </summary>
-        NotEqualUnorderedSignaling = 20,
+        UnorderedNotEqualSignaling = 20,
 
         /// <summary>
         /// _CMP_NLT_UQ
         /// </summary>
-        NotLessThanUnorderedNonSignaling = 21,
+        UnorderedNotLessThanNonSignaling = 21,
 
         /// <summary>
         /// _CMP_NLE_UQ
         /// </summary>
-        NotLessThanOrEqualUnorderedNonSignaling = 22,
+        UnorderedNotLessThanOrEqualNonSignaling = 22,
 
         /// <summary>
         /// _CMP_ORD_S
@@ -130,41 +130,41 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         /// _CMP_EQ_US
         /// </summary>
-        EqualUnorderedSignaling = 24,
+        UnorderedEqualSignaling = 24,
 
         /// <summary>
         /// _CMP_NGE_UQ
         /// </summary>
-        NotGreaterThanOrEqualUnorderedNonSignaling = 25,
+        UnorderedNotGreaterThanOrEqualNonSignaling = 25,
 
         /// <summary>
         /// _CMP_NGT_UQ
         /// </summary>
-        NotGreaterThanUnorderedNonSignaling = 26,
+        UnorderedNotGreaterThanNonSignaling = 26,
 
         /// <summary>
         /// _CMP_FALSE_OS
         /// </summary>
-        FalseOrderedSignaling = 27,
+        OrderedFalseSignaling = 27,
 
         /// <summary>
         /// _CMP_NEQ_OS
         /// </summary>
-        NotEqualOrderedSignaling = 28,
+        OrderedNotEqualSignaling = 28,
 
         /// <summary>
         /// _CMP_GE_OQ
         /// </summary>
-        GreaterThanOrEqualOrderedNonSignaling = 29,
+        OrderedGreaterThanOrEqualNonSignaling = 29,
 
         /// <summary>
         /// _CMP_GT_OQ
         /// </summary>
-        GreaterThanOrderedNonSignaling = 30,
+        OrderedGreaterThanNonSignaling = 30,
 
         /// <summary>
         /// _CMP_TRUE_US
         /// </summary>
-        TrueUnorderedSignaling = 31,
+        UnorderedTrueSignaling = 31,
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse.PlatformNotSupported.cs
@@ -82,18 +82,21 @@ namespace System.Runtime.Intrinsics.X86
         ///   COMISS xmm, xmm/m32
         /// </summary>
         public static bool CompareEqualOrderedScalar(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static bool CompareScalarOrderedEqual(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_ucomieq_ss (__m128 a, __m128 b)
         ///   UCOMISS xmm, xmm/m32
         /// </summary>
         public static bool CompareEqualUnorderedScalar(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static bool CompareScalarUnorderedEqual(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128 _mm_cmpeq_ss (__m128 a,  __m128 b)
         ///   CMPSS xmm, xmm/m32, imm8(0)
         /// </summary>
         public static Vector128<float> CompareEqualScalar(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> CompareScalarEqual(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128 _mm_cmpgt_ps (__m128 a,  __m128 b)
@@ -106,18 +109,21 @@ namespace System.Runtime.Intrinsics.X86
         ///   COMISS xmm, xmm/m32
         /// </summary>
         public static bool CompareGreaterThanOrderedScalar(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static bool CompareScalarOrderedGreaterThan(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_ucomigt_ss (__m128 a, __m128 b)
         ///   UCOMISS xmm, xmm/m32
         /// </summary>
         public static bool CompareGreaterThanUnorderedScalar(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static bool CompareScalarUnorderedGreaterThan(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128 _mm_cmpgt_ss (__m128 a,  __m128 b)
         ///   CMPSS xmm, xmm/m32, imm8(6)
         /// </summary>
         public static Vector128<float> CompareGreaterThanScalar(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> CompareScalarGreaterThan(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128 _mm_cmpge_ps (__m128 a,  __m128 b)
@@ -130,18 +136,21 @@ namespace System.Runtime.Intrinsics.X86
         ///   COMISS xmm, xmm/m32
         /// </summary>
         public static bool CompareGreaterThanOrEqualOrderedScalar(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static bool CompareScalarOrderedGreaterThanOrEqual(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_ucomige_ss (__m128 a, __m128 b)
         ///   UCOMISS xmm, xmm/m32
         /// </summary>
         public static bool CompareGreaterThanOrEqualUnorderedScalar(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static bool CompareScalarUnorderedGreaterThanOrEqual(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128 _mm_cmpge_ss (__m128 a,  __m128 b)
         ///   CMPPS xmm, xmm/m32, imm8(5)
         /// </summary>
         public static Vector128<float> CompareGreaterThanOrEqualScalar(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> CompareScalarGreaterThanOrEqual(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128 _mm_cmplt_ps (__m128 a,  __m128 b)
@@ -154,18 +163,21 @@ namespace System.Runtime.Intrinsics.X86
         ///   COMISS xmm, xmm/m32
         /// </summary>
         public static bool CompareLessThanOrderedScalar(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static bool CompareScalarOrderedLessThan(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_ucomilt_ss (__m128 a, __m128 b)
         ///   UCOMISS xmm, xmm/m32
         /// </summary>
         public static bool CompareLessThanUnorderedScalar(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static bool CompareScalarUnorderedLessThan(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128 _mm_cmplt_ss (__m128 a,  __m128 b)
         ///   CMPSS xmm, xmm/m32, imm8(1)
         /// </summary>
         public static Vector128<float> CompareLessThanScalar(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> CompareScalarLessThan(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128 _mm_cmple_ps (__m128 a,  __m128 b)
@@ -178,18 +190,21 @@ namespace System.Runtime.Intrinsics.X86
         ///   COMISS xmm, xmm/m32
         /// </summary>
         public static bool CompareLessThanOrEqualOrderedScalar(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static bool CompareScalarOrderedLessThanOrEqual(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_ucomile_ss (__m128 a, __m128 b)
         ///   UCOMISS xmm, xmm/m32
         /// </summary>
         public static bool CompareLessThanOrEqualUnorderedScalar(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static bool CompareScalarUnorderedLessThanOrEqual(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128 _mm_cmple_ss (__m128 a,  __m128 b)
         ///   CMPSS xmm, xmm/m32, imm8(2)
         /// </summary>
         public static Vector128<float> CompareLessThanOrEqualScalar(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> CompareScalarLessThanOrEqual(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128 _mm_cmpneq_ps (__m128 a,  __m128 b)
@@ -202,18 +217,21 @@ namespace System.Runtime.Intrinsics.X86
         ///   COMISS xmm, xmm/m32
         /// </summary>
         public static bool CompareNotEqualOrderedScalar(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static bool CompareScalarOrderedNotEqual(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_ucomineq_ss (__m128 a, __m128 b)
         ///   UCOMISS xmm, xmm/m32
         /// </summary>
         public static bool CompareNotEqualUnorderedScalar(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static bool CompareScalarUnorderedNotEqual(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128 _mm_cmpneq_ss (__m128 a,  __m128 b)
         ///   CMPSS xmm, xmm/m32, imm8(4)
         /// </summary>
         public static Vector128<float> CompareNotEqualScalar(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> CompareScalarNotEqual(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128 _mm_cmpngt_ps (__m128 a,  __m128 b)
@@ -226,6 +244,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   CMPSS xmm, xmm/m32, imm8(2)
         /// </summary>
         public static Vector128<float> CompareNotGreaterThanScalar(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> CompareScalarNotGreaterThan(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128 _mm_cmpnge_ps (__m128 a,  __m128 b)
@@ -238,6 +257,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   CMPSS xmm, xmm/m32, imm8(1)
         /// </summary>
         public static Vector128<float> CompareNotGreaterThanOrEqualScalar(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> CompareScalarNotGreaterThanOrEqual(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128 _mm_cmpnlt_ps (__m128 a,  __m128 b)
@@ -250,6 +270,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   CMPSS xmm, xmm/m32, imm8(5)
         /// </summary>
         public static Vector128<float> CompareNotLessThanScalar(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> CompareScalarNotLessThan(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128 _mm_cmpnle_ps (__m128 a,  __m128 b)
@@ -262,6 +283,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   CMPSS xmm, xmm/m32, imm8(6)
         /// </summary>
         public static Vector128<float> CompareNotLessThanOrEqualScalar(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> CompareScalarNotLessThanOrEqual(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128 _mm_cmpord_ps (__m128 a,  __m128 b)
@@ -274,6 +296,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   CMPSS xmm, xmm/m32, imm8(7)
         /// </summary>
         public static Vector128<float> CompareOrderedScalar(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> CompareScalarOrdered(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128 _mm_cmpunord_ps (__m128 a,  __m128 b)
@@ -286,6 +309,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   CMPSS xmm, xmm/m32, imm8(3)
         /// </summary>
         public static Vector128<float> CompareUnorderedScalar(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> CompareScalarUnordered(Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_cvtss_si32 (__m128 a)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse.cs
@@ -84,18 +84,21 @@ namespace System.Runtime.Intrinsics.X86
         ///   COMISS xmm, xmm/m32
         /// </summary>
         public static bool CompareEqualOrderedScalar(Vector128<float> left, Vector128<float> right) => CompareEqualOrderedScalar(left, right);
+        public static bool CompareScalarOrderedEqual(Vector128<float> left, Vector128<float> right) => CompareScalarOrderedEqual(left, right);
 
         /// <summary>
         /// int _mm_ucomieq_ss (__m128 a, __m128 b)
         ///   UCOMISS xmm, xmm/m32
         /// </summary>
         public static bool CompareEqualUnorderedScalar(Vector128<float> left, Vector128<float> right) => CompareEqualUnorderedScalar(left, right);
+        public static bool CompareScalarUnorderedEqual(Vector128<float> left, Vector128<float> right) => CompareScalarUnorderedEqual(left, right);
 
         /// <summary>
         /// __m128 _mm_cmpeq_ss (__m128 a,  __m128 b)
         ///   CMPSS xmm, xmm/m32, imm8(0)
         /// </summary>
         public static Vector128<float> CompareEqualScalar(Vector128<float> left, Vector128<float> right) => CompareEqualScalar(left, right);
+        public static Vector128<float> CompareScalarEqual(Vector128<float> left, Vector128<float> right) => CompareScalarEqual(left, right);
 
         /// <summary>
         /// __m128 _mm_cmpgt_ps (__m128 a,  __m128 b)
@@ -108,18 +111,21 @@ namespace System.Runtime.Intrinsics.X86
         ///   COMISS xmm, xmm/m32
         /// </summary>
         public static bool CompareGreaterThanOrderedScalar(Vector128<float> left, Vector128<float> right) => CompareGreaterThanOrderedScalar(left, right);
+        public static bool CompareScalarOrderedGreaterThan(Vector128<float> left, Vector128<float> right) => CompareScalarOrderedGreaterThan(left, right);
 
         /// <summary>
         /// int _mm_ucomigt_ss (__m128 a, __m128 b)
         ///   UCOMISS xmm, xmm/m32
         /// </summary>
         public static bool CompareGreaterThanUnorderedScalar(Vector128<float> left, Vector128<float> right) => CompareGreaterThanUnorderedScalar(left, right);
+        public static bool CompareScalarUnorderedGreaterThan(Vector128<float> left, Vector128<float> right) => CompareScalarUnorderedGreaterThan(left, right);
 
         /// <summary>
         /// __m128 _mm_cmpgt_ss (__m128 a,  __m128 b)
         ///   CMPSS xmm, xmm/m32, imm8(6)
         /// </summary>
         public static Vector128<float> CompareGreaterThanScalar(Vector128<float> left, Vector128<float> right) => CompareGreaterThanScalar(left, right);
+        public static Vector128<float> CompareScalarGreaterThan(Vector128<float> left, Vector128<float> right) => CompareScalarGreaterThan(left, right);
 
         /// <summary>
         /// __m128 _mm_cmpge_ps (__m128 a,  __m128 b)
@@ -132,18 +138,21 @@ namespace System.Runtime.Intrinsics.X86
         ///   COMISS xmm, xmm/m32
         /// </summary>
         public static bool CompareGreaterThanOrEqualOrderedScalar(Vector128<float> left, Vector128<float> right) => CompareGreaterThanOrEqualOrderedScalar(left, right);
+        public static bool CompareScalarOrderedGreaterThanOrEqual(Vector128<float> left, Vector128<float> right) => CompareScalarOrderedGreaterThanOrEqual(left, right);
 
         /// <summary>
         /// int _mm_ucomige_ss (__m128 a, __m128 b)
         ///   UCOMISS xmm, xmm/m32
         /// </summary>
         public static bool CompareGreaterThanOrEqualUnorderedScalar(Vector128<float> left, Vector128<float> right) => CompareGreaterThanOrEqualUnorderedScalar(left, right);
+        public static bool CompareScalarUnorderedGreaterThanOrEqual(Vector128<float> left, Vector128<float> right) => CompareScalarUnorderedGreaterThanOrEqual(left, right);
 
         /// <summary>
         /// __m128 _mm_cmpge_ss (__m128 a,  __m128 b)
         ///   CMPPS xmm, xmm/m32, imm8(5)
         /// </summary>
         public static Vector128<float> CompareGreaterThanOrEqualScalar(Vector128<float> left, Vector128<float> right) => CompareGreaterThanOrEqualScalar(left, right);
+        public static Vector128<float> CompareScalarGreaterThanOrEqual(Vector128<float> left, Vector128<float> right) => CompareScalarGreaterThanOrEqual(left, right);
 
         /// <summary>
         /// __m128 _mm_cmplt_ps (__m128 a,  __m128 b)
@@ -156,18 +165,21 @@ namespace System.Runtime.Intrinsics.X86
         ///   COMISS xmm, xmm/m32
         /// </summary>
         public static bool CompareLessThanOrderedScalar(Vector128<float> left, Vector128<float> right) => CompareLessThanOrderedScalar(left, right);
+        public static bool CompareScalarOrderedLessThan(Vector128<float> left, Vector128<float> right) => CompareScalarOrderedLessThan(left, right);
 
         /// <summary>
         /// int _mm_ucomilt_ss (__m128 a, __m128 b)
         ///   UCOMISS xmm, xmm/m32
         /// </summary>
         public static bool CompareLessThanUnorderedScalar(Vector128<float> left, Vector128<float> right) => CompareLessThanUnorderedScalar(left, right);
+        public static bool CompareScalarUnorderedLessThan(Vector128<float> left, Vector128<float> right) => CompareScalarUnorderedLessThan(left, right);
 
         /// <summary>
         /// __m128 _mm_cmplt_ss (__m128 a,  __m128 b)
         ///   CMPSS xmm, xmm/m32, imm8(1)
         /// </summary>
         public static Vector128<float> CompareLessThanScalar(Vector128<float> left, Vector128<float> right) => CompareLessThanScalar(left, right);
+        public static Vector128<float> CompareScalarLessThan(Vector128<float> left, Vector128<float> right) => CompareScalarLessThan(left, right);
 
         /// <summary>
         /// __m128 _mm_cmple_ps (__m128 a,  __m128 b)
@@ -180,18 +192,21 @@ namespace System.Runtime.Intrinsics.X86
         ///   COMISS xmm, xmm/m32
         /// </summary>
         public static bool CompareLessThanOrEqualOrderedScalar(Vector128<float> left, Vector128<float> right) => CompareLessThanOrEqualOrderedScalar(left, right);
+        public static bool CompareScalarOrderedLessThanOrEqual(Vector128<float> left, Vector128<float> right) => CompareScalarOrderedLessThanOrEqual(left, right);
 
         /// <summary>
         /// int _mm_ucomile_ss (__m128 a, __m128 b)
         ///   UCOMISS xmm, xmm/m32
         /// </summary>
         public static bool CompareLessThanOrEqualUnorderedScalar(Vector128<float> left, Vector128<float> right) => CompareLessThanOrEqualUnorderedScalar(left, right);
+        public static bool CompareScalarUnorderedLessThanOrEqual(Vector128<float> left, Vector128<float> right) => CompareScalarUnorderedLessThanOrEqual(left, right);
 
         /// <summary>
         /// __m128 _mm_cmple_ss (__m128 a,  __m128 b)
         ///   CMPSS xmm, xmm/m32, imm8(2)
         /// </summary>
         public static Vector128<float> CompareLessThanOrEqualScalar(Vector128<float> left, Vector128<float> right) => CompareLessThanOrEqualScalar(left, right);
+        public static Vector128<float> CompareScalarLessThanOrEqual(Vector128<float> left, Vector128<float> right) => CompareScalarLessThanOrEqual(left, right);
 
         /// <summary>
         /// __m128 _mm_cmpneq_ps (__m128 a,  __m128 b)
@@ -204,18 +219,21 @@ namespace System.Runtime.Intrinsics.X86
         ///   COMISS xmm, xmm/m32
         /// </summary>
         public static bool CompareNotEqualOrderedScalar(Vector128<float> left, Vector128<float> right) => CompareNotEqualOrderedScalar(left, right);
+        public static bool CompareScalarOrderedNotEqual(Vector128<float> left, Vector128<float> right) => CompareScalarOrderedNotEqual(left, right);
 
         /// <summary>
         /// int _mm_ucomineq_ss (__m128 a, __m128 b)
         ///   UCOMISS xmm, xmm/m32
         /// </summary>
         public static bool CompareNotEqualUnorderedScalar(Vector128<float> left, Vector128<float> right) => CompareNotEqualUnorderedScalar(left, right);
+        public static bool CompareScalarUnorderedNotEqual(Vector128<float> left, Vector128<float> right) => CompareScalarUnorderedNotEqual(left, right);
 
         /// <summary>
         /// __m128 _mm_cmpneq_ss (__m128 a,  __m128 b)
         ///   CMPSS xmm, xmm/m32, imm8(4)
         /// </summary>
         public static Vector128<float> CompareNotEqualScalar(Vector128<float> left, Vector128<float> right) => CompareNotEqualScalar(left, right);
+        public static Vector128<float> CompareScalarNotEqual(Vector128<float> left, Vector128<float> right) => CompareScalarNotEqual(left, right);
 
         /// <summary>
         /// __m128 _mm_cmpngt_ps (__m128 a,  __m128 b)
@@ -228,6 +246,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   CMPSS xmm, xmm/m32, imm8(2)
         /// </summary>
         public static Vector128<float> CompareNotGreaterThanScalar(Vector128<float> left, Vector128<float> right) => CompareNotGreaterThanScalar(left, right);
+        public static Vector128<float> CompareScalarNotGreaterThan(Vector128<float> left, Vector128<float> right) => CompareScalarNotGreaterThan(left, right);
 
         /// <summary>
         /// __m128 _mm_cmpnge_ps (__m128 a,  __m128 b)
@@ -240,6 +259,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   CMPSS xmm, xmm/m32, imm8(1)
         /// </summary>
         public static Vector128<float> CompareNotGreaterThanOrEqualScalar(Vector128<float> left, Vector128<float> right) => CompareNotGreaterThanOrEqualScalar(left, right);
+        public static Vector128<float> CompareScalarNotGreaterThanOrEqual(Vector128<float> left, Vector128<float> right) => CompareScalarNotGreaterThanOrEqual(left, right);
 
         /// <summary>
         /// __m128 _mm_cmpnlt_ps (__m128 a,  __m128 b)
@@ -252,6 +272,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   CMPSS xmm, xmm/m32, imm8(5)
         /// </summary>
         public static Vector128<float> CompareNotLessThanScalar(Vector128<float> left, Vector128<float> right) => CompareNotLessThanScalar(left, right);
+        public static Vector128<float> CompareScalarNotLessThan(Vector128<float> left, Vector128<float> right) => CompareScalarNotLessThan(left, right);
 
         /// <summary>
         /// __m128 _mm_cmpnle_ps (__m128 a,  __m128 b)
@@ -264,6 +285,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   CMPSS xmm, xmm/m32, imm8(6)
         /// </summary>
         public static Vector128<float> CompareNotLessThanOrEqualScalar(Vector128<float> left, Vector128<float> right) => CompareNotLessThanOrEqualScalar(left, right);
+        public static Vector128<float> CompareScalarNotLessThanOrEqual(Vector128<float> left, Vector128<float> right) => CompareScalarNotLessThanOrEqual(left, right);
 
         /// <summary>
         /// __m128 _mm_cmpord_ps (__m128 a,  __m128 b)
@@ -276,6 +298,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   CMPSS xmm, xmm/m32, imm8(7)
         /// </summary>
         public static Vector128<float> CompareOrderedScalar(Vector128<float> left, Vector128<float> right) => CompareOrderedScalar(left, right);
+        public static Vector128<float> CompareScalarOrdered(Vector128<float> left, Vector128<float> right) => CompareScalarOrdered(left, right);
 
         /// <summary>
         /// __m128 _mm_cmpunord_ps (__m128 a,  __m128 b)
@@ -288,6 +311,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   CMPSS xmm, xmm/m32, imm8(3)
         /// </summary>
         public static Vector128<float> CompareUnorderedScalar(Vector128<float> left, Vector128<float> right) => CompareUnorderedScalar(left, right);
+        public static Vector128<float> CompareScalarUnordered(Vector128<float> left, Vector128<float> right) => CompareScalarUnordered(left, right);
 
         /// <summary>
         /// int _mm_cvtss_si32 (__m128 a)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse2.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse2.PlatformNotSupported.cs
@@ -301,21 +301,24 @@ namespace System.Runtime.Intrinsics.X86
 
         /// <summary>
         /// int _mm_comieq_sd (__m128d a, __m128d b)
-        ///   COMISS xmm, xmm/m64
+        ///   COMISD xmm, xmm/m64
         /// </summary>
         public static bool CompareEqualOrderedScalar(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static bool CompareScalarOrderedEqual(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_ucomieq_sd (__m128d a, __m128d b)
-        ///   UCOMISS xmm, xmm/m64
+        ///   UCOMISD xmm, xmm/m64
         /// </summary>
         public static bool CompareEqualUnorderedScalar(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static bool CompareScalarUnorderedEqual(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128d _mm_cmpeq_sd (__m128d a,  __m128d b)
         ///   CMPSD xmm, xmm/m64, imm8(0)
         /// </summary>
         public static Vector128<double> CompareEqualScalar(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> CompareScalarEqual(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm_cmpgt_epi8 (__m128i a,  __m128i b)
@@ -340,21 +343,24 @@ namespace System.Runtime.Intrinsics.X86
 
         /// <summary>
         /// int _mm_comigt_sd (__m128d a, __m128d b)
-        ///   COMISS xmm, xmm/m64
+        ///   COMISD xmm, xmm/m64
         /// </summary>
         public static bool CompareGreaterThanOrderedScalar(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static bool CompareScalarOrderedGreaterThan(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_ucomigt_sd (__m128d a, __m128d b)
-        ///   UCOMISS xmm, xmm/m64
+        ///   UCOMISD xmm, xmm/m64
         /// </summary>
         public static bool CompareGreaterThanUnorderedScalar(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static bool CompareScalarUnorderedGreaterThan(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128d _mm_cmpgt_sd (__m128d a,  __m128d b)
         ///   CMPSD xmm, xmm/m64, imm8(6)
         /// </summary>
         public static Vector128<double> CompareGreaterThanScalar(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> CompareScalarGreaterThan(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128d _mm_cmpge_pd (__m128d a,  __m128d b)
@@ -364,21 +370,24 @@ namespace System.Runtime.Intrinsics.X86
 
         /// <summary>
         /// int _mm_comige_sd (__m128d a, __m128d b)
-        ///   COMISS xmm, xmm/m64
+        ///   COMISD xmm, xmm/m64
         /// </summary>
         public static bool CompareGreaterThanOrEqualOrderedScalar(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static bool CompareScalarOrderedGreaterThanOrEqual(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_ucomige_sd (__m128d a, __m128d b)
-        ///   UCOMISS xmm, xmm/m64
+        ///   UCOMISD xmm, xmm/m64
         /// </summary>
         public static bool CompareGreaterThanOrEqualUnorderedScalar(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static bool CompareScalarUnorderedGreaterThanOrEqual(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128d _mm_cmpge_sd (__m128d a,  __m128d b)
         ///   CMPSD xmm, xmm/m64, imm8(5)
         /// </summary>
         public static Vector128<double> CompareGreaterThanOrEqualScalar(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> CompareScalarGreaterThanOrEqual(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm_cmplt_epi8 (__m128i a,  __m128i b)
@@ -403,21 +412,24 @@ namespace System.Runtime.Intrinsics.X86
 
         /// <summary>
         /// int _mm_comilt_sd (__m128d a, __m128d b)
-        ///   COMISS xmm, xmm/m64
+        ///   COMISD xmm, xmm/m64
         /// </summary>
         public static bool CompareLessThanOrderedScalar(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static bool CompareScalarOrderedLessThan(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_ucomilt_sd (__m128d a, __m128d b)
-        ///   UCOMISS xmm, xmm/m64
+        ///   UCOMISD xmm, xmm/m64
         /// </summary>
         public static bool CompareLessThanUnorderedScalar(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static bool CompareScalarUnorderedLessThan(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128d _mm_cmplt_sd (__m128d a,  __m128d b)
         ///   CMPSD xmm, xmm/m64, imm8(1)
         /// </summary>
         public static Vector128<double> CompareLessThanScalar(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> CompareScalarLessThan(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128d _mm_cmple_pd (__m128d a,  __m128d b)
@@ -427,21 +439,24 @@ namespace System.Runtime.Intrinsics.X86
 
         /// <summary>
         /// int _mm_comile_sd (__m128d a, __m128d b)
-        ///   COMISS xmm, xmm/m64
+        ///   COMISD xmm, xmm/m64
         /// </summary>
         public static bool CompareLessThanOrEqualOrderedScalar(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static bool CompareScalarOrderedLessThanOrEqual(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_ucomile_sd (__m128d a, __m128d b)
-        ///   UCOMISS xmm, xmm/m64
+        ///   UCOMISD xmm, xmm/m64
         /// </summary>
         public static bool CompareLessThanOrEqualUnorderedScalar(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static bool CompareScalarUnorderedLessThanOrEqual(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128d _mm_cmple_sd (__m128d a,  __m128d b)
         ///   CMPSD xmm, xmm/m64, imm8(2)
         /// </summary>
         public static Vector128<double> CompareLessThanOrEqualScalar(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> CompareScalarLessThanOrEqual(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128d _mm_cmpneq_pd (__m128d a,  __m128d b)
@@ -451,21 +466,24 @@ namespace System.Runtime.Intrinsics.X86
 
         /// <summary>
         /// int _mm_comineq_sd (__m128d a, __m128d b)
-        ///   COMISS xmm, xmm/m64
+        ///   COMISD xmm, xmm/m64
         /// </summary>
         public static bool CompareNotEqualOrderedScalar(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static bool CompareScalarOrderedNotEqual(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// int _mm_ucomineq_sd (__m128d a, __m128d b)
-        ///   UCOMISS xmm, xmm/m64
+        ///   UCOMISD xmm, xmm/m64
         /// </summary>
         public static bool CompareNotEqualUnorderedScalar(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static bool CompareScalarUnorderedNotEqual(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128d _mm_cmpneq_sd (__m128d a,  __m128d b)
         ///   CMPSD xmm, xmm/m64, imm8(4)
         /// </summary>
         public static Vector128<double> CompareNotEqualScalar(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> CompareScalarNotEqual(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128d _mm_cmpngt_pd (__m128d a,  __m128d b)
@@ -478,6 +496,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   CMPSD xmm, xmm/m64, imm8(2)
         /// </summary>
         public static Vector128<double> CompareNotGreaterThanScalar(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> CompareScalarNotGreaterThan(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128d _mm_cmpnge_pd (__m128d a,  __m128d b)
@@ -490,6 +509,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   CMPSD xmm, xmm/m64, imm8(1)
         /// </summary>
         public static Vector128<double> CompareNotGreaterThanOrEqualScalar(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> CompareScalarNotGreaterThanOrEqual(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128d _mm_cmpnlt_pd (__m128d a,  __m128d b)
@@ -502,6 +522,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   CMPSD xmm, xmm/m64, imm8(5)
         /// </summary>
         public static Vector128<double> CompareNotLessThanScalar(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> CompareScalarNotLessThan(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128d _mm_cmpnle_pd (__m128d a,  __m128d b)
@@ -514,6 +535,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   CMPSD xmm, xmm/m64, imm8(6)
         /// </summary>
         public static Vector128<double> CompareNotLessThanOrEqualScalar(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> CompareScalarNotLessThanOrEqual(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128d _mm_cmpord_pd (__m128d a,  __m128d b)
@@ -526,6 +548,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   CMPSD xmm, xmm/m64, imm8(7)
         /// </summary>
         public static Vector128<double> CompareOrderedScalar(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> CompareScalarOrdered(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128d _mm_cmpunord_pd (__m128d a,  __m128d b)
@@ -538,6 +561,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   CMPSD xmm, xmm/m64, imm8(3)
         /// </summary>
         public static Vector128<double> CompareUnorderedScalar(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> CompareScalarUnordered(Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128i _mm_cvtps_epi32 (__m128 a)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse2.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse2.cs
@@ -303,21 +303,24 @@ namespace System.Runtime.Intrinsics.X86
 
         /// <summary>
         /// int _mm_comieq_sd (__m128d a, __m128d b)
-        ///   COMISS xmm, xmm/m64
+        ///   COMISD xmm, xmm/m64
         /// </summary>
         public static bool CompareEqualOrderedScalar(Vector128<double> left, Vector128<double> right) => CompareEqualOrderedScalar(left, right);
+        public static bool CompareScalarOrderedEqual(Vector128<double> left, Vector128<double> right) => CompareScalarOrderedEqual(left, right);
 
         /// <summary>
         /// int _mm_ucomieq_sd (__m128d a, __m128d b)
-        ///   UCOMISS xmm, xmm/m64
+        ///   UCOMISD xmm, xmm/m64
         /// </summary>
         public static bool CompareEqualUnorderedScalar(Vector128<double> left, Vector128<double> right) => CompareEqualUnorderedScalar(left, right);
+        public static bool CompareScalarUnorderedEqual(Vector128<double> left, Vector128<double> right) => CompareScalarUnorderedEqual(left, right);
 
         /// <summary>
         /// __m128d _mm_cmpeq_sd (__m128d a,  __m128d b)
         ///   CMPSD xmm, xmm/m64, imm8(0)
         /// </summary>
         public static Vector128<double> CompareEqualScalar(Vector128<double> left, Vector128<double> right) => CompareEqualScalar(left, right);
+        public static Vector128<double> CompareScalarEqual(Vector128<double> left, Vector128<double> right) => CompareScalarEqual(left, right);
 
         /// <summary>
         /// __m128i _mm_cmpgt_epi8 (__m128i a,  __m128i b)
@@ -342,21 +345,24 @@ namespace System.Runtime.Intrinsics.X86
 
         /// <summary>
         /// int _mm_comigt_sd (__m128d a, __m128d b)
-        ///   COMISS xmm, xmm/m64
+        ///   COMISD xmm, xmm/m64
         /// </summary>
         public static bool CompareGreaterThanOrderedScalar(Vector128<double> left, Vector128<double> right) => CompareGreaterThanOrderedScalar(left, right);
+        public static bool CompareScalarOrderedGreaterThan(Vector128<double> left, Vector128<double> right) => CompareScalarOrderedGreaterThan(left, right);
 
         /// <summary>
         /// int _mm_ucomigt_sd (__m128d a, __m128d b)
-        ///   UCOMISS xmm, xmm/m64
+        ///   UCOMISD xmm, xmm/m64
         /// </summary>
         public static bool CompareGreaterThanUnorderedScalar(Vector128<double> left, Vector128<double> right) => CompareGreaterThanUnorderedScalar(left, right);
+        public static bool CompareScalarUnorderedGreaterThan(Vector128<double> left, Vector128<double> right) => CompareScalarUnorderedGreaterThan(left, right);
 
         /// <summary>
         /// __m128d _mm_cmpgt_sd (__m128d a,  __m128d b)
         ///   CMPSD xmm, xmm/m64, imm8(6)
         /// </summary>
         public static Vector128<double> CompareGreaterThanScalar(Vector128<double> left, Vector128<double> right) => CompareGreaterThanScalar(left, right);
+        public static Vector128<double> CompareScalarGreaterThan(Vector128<double> left, Vector128<double> right) => CompareScalarGreaterThan(left, right);
 
         /// <summary>
         /// __m128d _mm_cmpge_pd (__m128d a,  __m128d b)
@@ -366,21 +372,24 @@ namespace System.Runtime.Intrinsics.X86
 
         /// <summary>
         /// int _mm_comige_sd (__m128d a, __m128d b)
-        ///   COMISS xmm, xmm/m64
+        ///   COMISD xmm, xmm/m64
         /// </summary>
         public static bool CompareGreaterThanOrEqualOrderedScalar(Vector128<double> left, Vector128<double> right) => CompareGreaterThanOrEqualOrderedScalar(left, right);
+        public static bool CompareScalarOrderedGreaterThanOrEqual(Vector128<double> left, Vector128<double> right) => CompareScalarOrderedGreaterThanOrEqual(left, right);
 
         /// <summary>
         /// int _mm_ucomige_sd (__m128d a, __m128d b)
-        ///   UCOMISS xmm, xmm/m64
+        ///   UCOMISD xmm, xmm/m64
         /// </summary>
         public static bool CompareGreaterThanOrEqualUnorderedScalar(Vector128<double> left, Vector128<double> right) => CompareGreaterThanOrEqualUnorderedScalar(left, right);
+        public static bool CompareScalarUnorderedGreaterThanOrEqual(Vector128<double> left, Vector128<double> right) => CompareScalarUnorderedGreaterThanOrEqual(left, right);
 
         /// <summary>
         /// __m128d _mm_cmpge_sd (__m128d a,  __m128d b)
         ///   CMPSD xmm, xmm/m64, imm8(5)
         /// </summary>
         public static Vector128<double> CompareGreaterThanOrEqualScalar(Vector128<double> left, Vector128<double> right) => CompareGreaterThanOrEqualScalar(left, right);
+        public static Vector128<double> CompareScalarGreaterThanOrEqual(Vector128<double> left, Vector128<double> right) => CompareScalarGreaterThanOrEqual(left, right);
 
         /// <summary>
         /// __m128i _mm_cmplt_epi8 (__m128i a,  __m128i b)
@@ -405,21 +414,24 @@ namespace System.Runtime.Intrinsics.X86
 
         /// <summary>
         /// int _mm_comilt_sd (__m128d a, __m128d b)
-        ///   COMISS xmm, xmm/m64
+        ///   COMISD xmm, xmm/m64
         /// </summary>
         public static bool CompareLessThanOrderedScalar(Vector128<double> left, Vector128<double> right) => CompareLessThanOrderedScalar(left, right);
+        public static bool CompareScalarOrderedLessThan(Vector128<double> left, Vector128<double> right) => CompareScalarOrderedLessThan(left, right);
 
         /// <summary>
         /// int _mm_ucomilt_sd (__m128d a, __m128d b)
-        ///   UCOMISS xmm, xmm/m64
+        ///   UCOMISD xmm, xmm/m64
         /// </summary>
         public static bool CompareLessThanUnorderedScalar(Vector128<double> left, Vector128<double> right) => CompareLessThanUnorderedScalar(left, right);
+        public static bool CompareScalarUnorderedLessThan(Vector128<double> left, Vector128<double> right) => CompareScalarUnorderedLessThan(left, right);
 
         /// <summary>
         /// __m128d _mm_cmplt_sd (__m128d a,  __m128d b)
         ///   CMPSD xmm, xmm/m64, imm8(1)
         /// </summary>
         public static Vector128<double> CompareLessThanScalar(Vector128<double> left, Vector128<double> right) => CompareLessThanScalar(left, right);
+        public static Vector128<double> CompareScalarLessThan(Vector128<double> left, Vector128<double> right) => CompareScalarLessThan(left, right);
 
         /// <summary>
         /// __m128d _mm_cmple_pd (__m128d a,  __m128d b)
@@ -429,21 +441,24 @@ namespace System.Runtime.Intrinsics.X86
 
         /// <summary>
         /// int _mm_comile_sd (__m128d a, __m128d b)
-        ///   COMISS xmm, xmm/m64
+        ///   COMISD xmm, xmm/m64
         /// </summary>
         public static bool CompareLessThanOrEqualOrderedScalar(Vector128<double> left, Vector128<double> right) => CompareLessThanOrEqualOrderedScalar(left, right);
+        public static bool CompareScalarOrderedLessThanOrEqual(Vector128<double> left, Vector128<double> right) => CompareScalarOrderedLessThanOrEqual(left, right);
 
         /// <summary>
         /// int _mm_ucomile_sd (__m128d a, __m128d b)
-        ///   UCOMISS xmm, xmm/m64
+        ///   UCOMISD xmm, xmm/m64
         /// </summary>
         public static bool CompareLessThanOrEqualUnorderedScalar(Vector128<double> left, Vector128<double> right) => CompareLessThanOrEqualUnorderedScalar(left, right);
+        public static bool CompareScalarUnorderedLessThanOrEqual(Vector128<double> left, Vector128<double> right) => CompareScalarUnorderedLessThanOrEqual(left, right);
 
         /// <summary>
         /// __m128d _mm_cmple_sd (__m128d a,  __m128d b)
         ///   CMPSD xmm, xmm/m64, imm8(2)
         /// </summary>
         public static Vector128<double> CompareLessThanOrEqualScalar(Vector128<double> left, Vector128<double> right) => CompareLessThanOrEqualScalar(left, right);
+        public static Vector128<double> CompareScalarLessThanOrEqual(Vector128<double> left, Vector128<double> right) => CompareScalarLessThanOrEqual(left, right);
 
         /// <summary>
         /// __m128d _mm_cmpneq_pd (__m128d a,  __m128d b)
@@ -453,21 +468,24 @@ namespace System.Runtime.Intrinsics.X86
 
         /// <summary>
         /// int _mm_comineq_sd (__m128d a, __m128d b)
-        ///   COMISS xmm, xmm/m64
+        ///   COMISD xmm, xmm/m64
         /// </summary>
         public static bool CompareNotEqualOrderedScalar(Vector128<double> left, Vector128<double> right) => CompareNotEqualOrderedScalar(left, right);
+        public static bool CompareScalarOrderedNotEqual(Vector128<double> left, Vector128<double> right) => CompareScalarOrderedNotEqual(left, right);
 
         /// <summary>
         /// int _mm_ucomineq_sd (__m128d a, __m128d b)
-        ///   UCOMISS xmm, xmm/m64
+        ///   UCOMISD xmm, xmm/m64
         /// </summary>
         public static bool CompareNotEqualUnorderedScalar(Vector128<double> left, Vector128<double> right) => CompareNotEqualUnorderedScalar(left, right);
+        public static bool CompareScalarUnorderedNotEqual(Vector128<double> left, Vector128<double> right) => CompareScalarUnorderedNotEqual(left, right);
 
         /// <summary>
         /// __m128d _mm_cmpneq_sd (__m128d a,  __m128d b)
         ///   CMPSD xmm, xmm/m64, imm8(4)
         /// </summary>
         public static Vector128<double> CompareNotEqualScalar(Vector128<double> left, Vector128<double> right) => CompareNotEqualScalar(left, right);
+        public static Vector128<double> CompareScalarNotEqual(Vector128<double> left, Vector128<double> right) => CompareScalarNotEqual(left, right);
 
         /// <summary>
         /// __m128d _mm_cmpngt_pd (__m128d a,  __m128d b)
@@ -480,6 +498,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   CMPSD xmm, xmm/m64, imm8(2)
         /// </summary>
         public static Vector128<double> CompareNotGreaterThanScalar(Vector128<double> left, Vector128<double> right) => CompareNotGreaterThanScalar(left, right);
+        public static Vector128<double> CompareScalarNotGreaterThan(Vector128<double> left, Vector128<double> right) => CompareScalarNotGreaterThan(left, right);
 
         /// <summary>
         /// __m128d _mm_cmpnge_pd (__m128d a,  __m128d b)
@@ -492,6 +511,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   CMPSD xmm, xmm/m64, imm8(1)
         /// </summary>
         public static Vector128<double> CompareNotGreaterThanOrEqualScalar(Vector128<double> left, Vector128<double> right) => CompareNotGreaterThanOrEqualScalar(left, right);
+        public static Vector128<double> CompareScalarNotGreaterThanOrEqual(Vector128<double> left, Vector128<double> right) => CompareScalarNotGreaterThanOrEqual(left, right);
 
         /// <summary>
         /// __m128d _mm_cmpnlt_pd (__m128d a,  __m128d b)
@@ -504,6 +524,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   CMPSD xmm, xmm/m64, imm8(5)
         /// </summary>
         public static Vector128<double> CompareNotLessThanScalar(Vector128<double> left, Vector128<double> right) => CompareNotLessThanScalar(left, right);
+        public static Vector128<double> CompareScalarNotLessThan(Vector128<double> left, Vector128<double> right) => CompareScalarNotLessThan(left, right);
 
         /// <summary>
         /// __m128d _mm_cmpnle_pd (__m128d a,  __m128d b)
@@ -516,6 +537,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   CMPSD xmm, xmm/m64, imm8(6)
         /// </summary>
         public static Vector128<double> CompareNotLessThanOrEqualScalar(Vector128<double> left, Vector128<double> right) => CompareNotLessThanOrEqualScalar(left, right);
+        public static Vector128<double> CompareScalarNotLessThanOrEqual(Vector128<double> left, Vector128<double> right) => CompareScalarNotLessThanOrEqual(left, right);
 
         /// <summary>
         /// __m128d _mm_cmpord_pd (__m128d a,  __m128d b)
@@ -528,6 +550,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   CMPSD xmm, xmm/m64, imm8(7)
         /// </summary>
         public static Vector128<double> CompareOrderedScalar(Vector128<double> left, Vector128<double> right) => CompareOrderedScalar(left, right);
+        public static Vector128<double> CompareScalarOrdered(Vector128<double> left, Vector128<double> right) => CompareScalarOrdered(left, right);
 
         /// <summary>
         /// __m128d _mm_cmpunord_pd (__m128d a,  __m128d b)
@@ -540,6 +563,7 @@ namespace System.Runtime.Intrinsics.X86
         ///   CMPSD xmm, xmm/m64, imm8(3)
         /// </summary>
         public static Vector128<double> CompareUnorderedScalar(Vector128<double> left, Vector128<double> right) => CompareUnorderedScalar(left, right);
+        public static Vector128<double> CompareScalarUnordered(Vector128<double> left, Vector128<double> right) => CompareScalarUnordered(left, right);
 
         /// <summary>
         /// __m128i _mm_cvtps_epi32 (__m128 a)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse41.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse41.PlatformNotSupported.cs
@@ -181,64 +181,125 @@ namespace System.Runtime.Intrinsics.X86
 
         /// <summary>
         /// __m128i _mm_cvtepi8_epi16 (__m128i a)
-        ///   PMOVSXBW xmm, xmm/m64
+        ///   PMOVSXBW xmm, xmm
         /// </summary>
         public static Vector128<short> ConvertToVector128Int16(Vector128<sbyte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvtepu8_epi16 (__m128i a)
-        ///   PMOVZXBW xmm, xmm/m64
+        ///   PMOVZXBW xmm, xmm
         /// </summary>
         public static Vector128<short> ConvertToVector128Int16(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvtepi8_epi32 (__m128i a)
-        ///   PMOVSXBD xmm, xmm/m32
+        ///   PMOVSXBD xmm, xmm
         /// </summary>
         public static Vector128<int> ConvertToVector128Int32(Vector128<sbyte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvtepu8_epi32 (__m128i a)
-        ///   PMOVZXBD xmm, xmm/m32
+        ///   PMOVZXBD xmm, xmm
         /// </summary>
         public static Vector128<int> ConvertToVector128Int32(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvtepi16_epi32 (__m128i a)
-        ///   PMOVSXWD xmm, xmm/m64
+        ///   PMOVSXWD xmm, xmm
         /// </summary>
         public static Vector128<int> ConvertToVector128Int32(Vector128<short> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvtepu16_epi32 (__m128i a)
-        ///   PMOVZXWD xmm, xmm/m64
+        ///   PMOVZXWD xmm, xmm
         /// </summary>
         public static Vector128<int> ConvertToVector128Int32(Vector128<ushort> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvtepi8_epi64 (__m128i a)
-        ///   PMOVSXBQ xmm, xmm/m16
+        ///   PMOVSXBQ xmm, xmm
         /// </summary>
         public static Vector128<long> ConvertToVector128Int64(Vector128<sbyte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvtepu8_epi64 (__m128i a)
-        ///   PMOVZXBQ xmm, xmm/m16
+        ///   PMOVZXBQ xmm, xmm
         /// </summary>
         public static Vector128<long> ConvertToVector128Int64(Vector128<byte> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvtepi16_epi64 (__m128i a)
-        ///   PMOVSXWQ xmm, xmm/m32
+        ///   PMOVSXWQ xmm, xmm
         /// </summary>
         public static Vector128<long> ConvertToVector128Int64(Vector128<short> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvtepu16_epi64 (__m128i a)
-        ///   PMOVZXWQ xmm, xmm/m32
+        ///   PMOVZXWQ xmm, xmm
         /// </summary>
         public static Vector128<long> ConvertToVector128Int64(Vector128<ushort> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvtepi32_epi64 (__m128i a)
-        ///   PMOVSXDQ xmm, xmm/m64
+        ///   PMOVSXDQ xmm, xmm
         /// </summary>
         public static Vector128<long> ConvertToVector128Int64(Vector128<int> value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         /// __m128i _mm_cvtepu32_epi64 (__m128i a)
-        ///   PMOVZXDQ xmm, xmm/m64
+        ///   PMOVZXDQ xmm, xmm
         /// </summary>
         public static Vector128<long> ConvertToVector128Int64(Vector128<uint> value) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        ///   PMOVSXBW xmm, m64
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector128<short> ConvertToVector128Int16(sbyte* address) { throw new PlatformNotSupportedException(); }
+        /// <summary>
+        ///   PMOVZXBW xmm, m64
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector128<short> ConvertToVector128Int16(byte* address) { throw new PlatformNotSupportedException(); }
+        /// <summary>
+        ///   PMOVSXBD xmm, m32
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector128<int> ConvertToVector128Int32(sbyte* address) { throw new PlatformNotSupportedException(); }
+        /// <summary>
+        ///   PMOVZXBD xmm, m32
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector128<int> ConvertToVector128Int32(byte* address) { throw new PlatformNotSupportedException(); }
+        /// <summary>
+        ///   PMOVSXWD xmm, m64
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector128<int> ConvertToVector128Int32(short* address) { throw new PlatformNotSupportedException(); }
+        /// <summary>
+        ///   PMOVZXWD xmm, m64
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector128<int> ConvertToVector128Int32(ushort* address) { throw new PlatformNotSupportedException(); }
+        /// <summary>
+        ///   PMOVSXBQ xmm, m16
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector128<long> ConvertToVector128Int64(sbyte* address) { throw new PlatformNotSupportedException(); }
+        /// <summary>
+        ///   PMOVZXBQ xmm, m16
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector128<long> ConvertToVector128Int64(byte* address) { throw new PlatformNotSupportedException(); }
+        /// <summary>
+        ///   PMOVSXWQ xmm, m32
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector128<long> ConvertToVector128Int64(short* address) { throw new PlatformNotSupportedException(); }
+        /// <summary>
+        ///   PMOVZXWQ xmm, m32
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector128<long> ConvertToVector128Int64(ushort* address) { throw new PlatformNotSupportedException(); }
+        /// <summary>
+        ///   PMOVSXDQ xmm, m64
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector128<long> ConvertToVector128Int64(int* address) { throw new PlatformNotSupportedException(); }
+        /// <summary>
+        ///   PMOVZXDQ xmm, m64
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector128<long> ConvertToVector128Int64(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// __m128 _mm_dp_ps (__m128 a, __m128 b, const int imm8)

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse41.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/X86/Sse41.cs
@@ -183,64 +183,125 @@ namespace System.Runtime.Intrinsics.X86
 
         /// <summary>
         /// __m128i _mm_cvtepi8_epi16 (__m128i a)
-        ///   PMOVSXBW xmm, xmm/m64
+        ///   PMOVSXBW xmm, xmm
         /// </summary>
         public static Vector128<short> ConvertToVector128Int16(Vector128<sbyte> value) => ConvertToVector128Int16(value);
         /// <summary>
         /// __m128i _mm_cvtepu8_epi16 (__m128i a)
-        ///   PMOVZXBW xmm, xmm/m64
+        ///   PMOVZXBW xmm, xmm
         /// </summary>
         public static Vector128<short> ConvertToVector128Int16(Vector128<byte> value) => ConvertToVector128Int16(value);
         /// <summary>
         /// __m128i _mm_cvtepi8_epi32 (__m128i a)
-        ///   PMOVSXBD xmm, xmm/m32
+        ///   PMOVSXBD xmm, xmm
         /// </summary>
         public static Vector128<int> ConvertToVector128Int32(Vector128<sbyte> value) => ConvertToVector128Int32(value);
         /// <summary>
         /// __m128i _mm_cvtepu8_epi32 (__m128i a)
-        ///   PMOVZXBD xmm, xmm/m32
+        ///   PMOVZXBD xmm, xmm
         /// </summary>
         public static Vector128<int> ConvertToVector128Int32(Vector128<byte> value) => ConvertToVector128Int32(value);
         /// <summary>
         /// __m128i _mm_cvtepi16_epi32 (__m128i a)
-        ///   PMOVSXWD xmm, xmm/m64
+        ///   PMOVSXWD xmm, xmm
         /// </summary>
         public static Vector128<int> ConvertToVector128Int32(Vector128<short> value) => ConvertToVector128Int32(value);
         /// <summary>
         /// __m128i _mm_cvtepu16_epi32 (__m128i a)
-        ///   PMOVZXWD xmm, xmm/m64
+        ///   PMOVZXWD xmm, xmm
         /// </summary>
         public static Vector128<int> ConvertToVector128Int32(Vector128<ushort> value) => ConvertToVector128Int32(value);
         /// <summary>
         /// __m128i _mm_cvtepi8_epi64 (__m128i a)
-        ///   PMOVSXBQ xmm, xmm/m16
+        ///   PMOVSXBQ xmm, xmm
         /// </summary>
         public static Vector128<long> ConvertToVector128Int64(Vector128<sbyte> value) => ConvertToVector128Int64(value);
         /// <summary>
         /// __m128i _mm_cvtepu8_epi64 (__m128i a)
-        ///   PMOVZXBQ xmm, xmm/m16
+        ///   PMOVZXBQ xmm, xmm
         /// </summary>
         public static Vector128<long> ConvertToVector128Int64(Vector128<byte> value) => ConvertToVector128Int64(value);
         /// <summary>
         /// __m128i _mm_cvtepi16_epi64 (__m128i a)
-        ///   PMOVSXWQ xmm, xmm/m32
+        ///   PMOVSXWQ xmm, xmm
         /// </summary>
         public static Vector128<long> ConvertToVector128Int64(Vector128<short> value) => ConvertToVector128Int64(value);
         /// <summary>
         /// __m128i _mm_cvtepu16_epi64 (__m128i a)
-        ///   PMOVZXWQ xmm, xmm/m32
+        ///   PMOVZXWQ xmm, xmm
         /// </summary>
         public static Vector128<long> ConvertToVector128Int64(Vector128<ushort> value) => ConvertToVector128Int64(value);
         /// <summary>
         /// __m128i _mm_cvtepi32_epi64 (__m128i a)
-        ///   PMOVSXDQ xmm, xmm/m64
+        ///   PMOVSXDQ xmm, xmm
         /// </summary>
         public static Vector128<long> ConvertToVector128Int64(Vector128<int> value) => ConvertToVector128Int64(value);
         /// <summary>
         /// __m128i _mm_cvtepu32_epi64 (__m128i a)
-        ///   PMOVZXDQ xmm, xmm/m64
+        ///   PMOVZXDQ xmm, xmm
         /// </summary>
         public static Vector128<long> ConvertToVector128Int64(Vector128<uint> value) => ConvertToVector128Int64(value);
+
+        /// <summary>
+        ///   PMOVSXBW xmm, m64
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector128<short> ConvertToVector128Int16(sbyte* address) => ConvertToVector128Int16(address);
+        /// <summary>
+        ///   PMOVZXBW xmm, m64
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector128<short> ConvertToVector128Int16(byte* address) => ConvertToVector128Int16(address);
+        /// <summary>
+        ///   PMOVSXBD xmm, m32
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector128<int> ConvertToVector128Int32(sbyte* address) => ConvertToVector128Int32(address);
+        /// <summary>
+        ///   PMOVZXBD xmm, m32
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector128<int> ConvertToVector128Int32(byte* address) => ConvertToVector128Int32(address);
+        /// <summary>
+        ///   PMOVSXWD xmm, m64
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector128<int> ConvertToVector128Int32(short* address) => ConvertToVector128Int32(address);
+        /// <summary>
+        ///   PMOVZXWD xmm, m64
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector128<int> ConvertToVector128Int32(ushort* address) => ConvertToVector128Int32(address);
+        /// <summary>
+        ///   PMOVSXBQ xmm, m16
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector128<long> ConvertToVector128Int64(sbyte* address) => ConvertToVector128Int64(address);
+        /// <summary>
+        ///   PMOVZXBQ xmm, m16
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector128<long> ConvertToVector128Int64(byte* address) => ConvertToVector128Int64(address);
+        /// <summary>
+        ///   PMOVSXWQ xmm, m32
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector128<long> ConvertToVector128Int64(short* address) => ConvertToVector128Int64(address);
+        /// <summary>
+        ///   PMOVZXWQ xmm, m32
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector128<long> ConvertToVector128Int64(ushort* address) => ConvertToVector128Int64(address);
+        /// <summary>
+        ///   PMOVSXDQ xmm, m64
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector128<long> ConvertToVector128Int64(int* address) => ConvertToVector128Int64(address);
+        /// <summary>
+        ///   PMOVZXDQ xmm, m64
+        /// The native signature does not exist. We provide this additional overload for completeness.
+        /// </summary>
+        public static unsafe Vector128<long> ConvertToVector128Int64(uint* address) => ConvertToVector128Int64(address);
 
         /// <summary>
         /// __m128 _mm_dp_ps (__m128 a, __m128 b, const int imm8)


### PR DESCRIPTION
CC. @CarolEidt, @GrabYourPitchforks 

This handles the first part (CoreCLR side) of https://github.com/dotnet/corefx/issues/35768 and https://github.com/dotnet/corefx/issues/34881.

There will be a follow up PR in CoreFX updating the reference assembly and then a final PR against CoreCLR removing the outdated APIs and updating the tests. This is following the process we've done for prior tweaks to avoid "tearing" the API surface if something is snapped in between the various updates.

The first issue (35768) tracks us making the `Avx2.ConvertToVector256` overloads consistent with the `Sse41.ConvertToVector128` signatures and the corresponding native intrinsics. It also adds explicit APIs for the memory encoding since they are special and read partial vectors (but not single scalars) from memory.

The second issue (34881) tracks us updating various `Compare` methods to have consistent naming and trying to make those names less confusion.