### PR TITLE
Clean optVNConstantPropOnTree.

### DIFF
--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -2475,7 +2475,7 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
                         break;
 
                     default:
-                        // Can't optimize.
+                        // Do not support such optimization.
                         break;
                 }
             }
@@ -2484,15 +2484,15 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
 
         case TYP_REF:
         {
-            if (tree->TypeGet() != TYP_REF) // TODO seandree: what are other cases here?
-            {
-                // Can't optimize.
-                break;
-            }
-
             assert(vnStore->ConstantValue<size_t>(vnCns) == 0);
-
-            conValTree = gtNewIconNode(0, TYP_REF);
+            if (tree->TypeGet() == TYP_REF)
+            {
+                conValTree = gtNewIconNode(0, TYP_REF);
+            }
+            else
+            {
+                // Do not support such optimization (e.g byref(ref(0)).
+            }
         }
         break;
 
@@ -2537,15 +2537,20 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
                         break;
 
                     default:
-                        // Can't optimize.
+                        // Do not support (e.g. bool(const int)).
                         break;
                 }
             }
         }
         break;
 
+        case TYP_BYREF:
+            // Do not support const byref optimization.
+            break;
+
         default:
-            // Can't optimize.
+            // We do not record constants of other types.
+            unreached();
             break;
     }
 

--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -3923,6 +3923,8 @@ GenTree* Compiler::optAssertionProp_Update(GenTree* newTree, GenTree* tree, GenT
             // optAssertionPropMain(). It will reset the gtPrev and gtNext links for all nodes.
             newTree->gtNext = tree->gtNext;
 
+            // Old tree should not be referenced anymore.
+            DEBUG_DESTROY_NODE(tree);
         }
     }
 

--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -3897,7 +3897,8 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions, GenTree
 
 GenTree* Compiler::optAssertionProp_Update(GenTree* newTree, GenTree* tree, GenTreeStmt* stmt)
 {
-    noway_assert(newTree != nullptr);
+    assert(newTree != nullptr);
+    assert(tree != nullptr);
 
     if (stmt == nullptr)
     {
@@ -3908,33 +3909,20 @@ GenTree* Compiler::optAssertionProp_Update(GenTree* newTree, GenTree* tree, GenT
         noway_assert(!optLocalAssertionProp);
 
         // If newTree == tree then we modified the tree in-place otherwise we have to
-        // locate our parent node and update it so that it points to newTree
+        // locate our parent node and update it so that it points to newTree.
         if (newTree != tree)
         {
             GenTree** link = gtFindLink(stmt, tree);
-#ifdef DEBUG
-            if (link == nullptr)
-            {
-                noway_assert(!"gtFindLink failed!");
-                printf("\nCould not find parent of:\n");
-                gtDispTree(tree);
-                printf("\nIn this stmt:\n");
-                gtDispTree(stmt);
-            }
-#endif
             noway_assert(link != nullptr);
-            noway_assert(tree != nullptr);
-            if (link != nullptr)
-            {
-                // Replace the old operand with the newTree
-                *link = newTree;
 
-                // We only need to ensure that the gtNext field is set as it is used to traverse
-                // to the next node in the tree. We will re-morph this entire statement in
-                // optAssertionPropMain(). It will reset the gtPrev and gtNext links for all nodes.
+            // Replace the old operand with the newTree
+            *link = newTree;
 
-                newTree->gtNext = tree->gtNext;
-            }
+            // We only need to ensure that the gtNext field is set as it is used to traverse
+            // to the next node in the tree. We will re-morph this entire statement in
+            // optAssertionPropMain(). It will reset the gtPrev and gtNext links for all nodes.
+            newTree->gtNext = tree->gtNext;
+
         }
     }
 

--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -2388,8 +2388,8 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
     }
 
     // We want to use the Normal ValueNumber when checking for constants.
-    ValueNum vnCns = vnStore->VNConservativeNormalValue(tree->gtVNPair);
-    ValueNum vnLib = vnStore->VNLiberalNormalValue(tree->gtVNPair);
+    ValueNumPair vnPair = tree->gtVNPair;
+    ValueNum     vnCns  = vnStore->VNConservativeNormalValue(vnPair);
 
     // Check if node evaluates to a constant.
     if (!vnStore->IsVNConstant(vnCns))
@@ -2397,7 +2397,7 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
         return nullptr;
     }
 
-    GenTree* newTree = tree;
+    GenTree* conValTree = nullptr;
     switch (vnStore->TypeOfVN(vnCns))
     {
         case TYP_FLOAT:
@@ -2407,20 +2407,13 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
             if (tree->TypeGet() == TYP_INT)
             {
                 // Same sized reinterpretation of bits to integer
-                newTree = optPrepareTreeForReplacement(tree, tree);
-                tree->ChangeOperConst(GT_CNS_INT);
-                tree->gtIntCon.gtIconVal = *(reinterpret_cast<int*>(&value));
-                tree->gtVNPair           = ValueNumPair(vnLib, vnCns);
+                conValTree = gtNewIconNode(*(reinterpret_cast<int*>(&value)));
             }
             else
             {
                 // Implicit assignment conversion to float or double
                 assert(varTypeIsFloating(tree->TypeGet()));
-
-                newTree = optPrepareTreeForReplacement(tree, tree);
-                tree->ChangeOperConst(GT_CNS_DBL);
-                tree->gtDblCon.gtDconVal = value;
-                tree->gtVNPair           = ValueNumPair(vnLib, vnCns);
+                conValTree = gtNewDconNode(value, tree->TypeGet());
             }
             break;
         }
@@ -2431,21 +2424,13 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
 
             if (tree->TypeGet() == TYP_LONG)
             {
-                // Same sized reinterpretation of bits to long
-                newTree = optPrepareTreeForReplacement(tree, tree);
-                tree->ChangeOperConst(GT_CNS_NATIVELONG);
-                tree->gtIntConCommon.SetLngValue(*(reinterpret_cast<INT64*>(&value)));
-                tree->gtVNPair = ValueNumPair(vnLib, vnCns);
+                conValTree = gtNewLconNode(*(reinterpret_cast<INT64*>(&value)));
             }
             else
             {
                 // Implicit assignment conversion to float or double
                 assert(varTypeIsFloating(tree->TypeGet()));
-
-                newTree = optPrepareTreeForReplacement(tree, tree);
-                tree->ChangeOperConst(GT_CNS_DBL);
-                tree->gtDblCon.gtDconVal = value;
-                tree->gtVNPair           = ValueNumPair(vnLib, vnCns);
+                conValTree = gtNewDconNode(value, tree->TypeGet());
             }
             break;
         }
@@ -2460,9 +2445,7 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
                 // to be recorded as a relocation with the VM.
                 if (!opts.compReloc)
                 {
-                    newTree           = gtNewIconHandleNode(value, vnStore->GetHandleFlags(vnCns));
-                    newTree->gtVNPair = ValueNumPair(vnLib, vnCns);
-                    newTree           = optPrepareTreeForReplacement(tree, newTree);
+                    conValTree = gtNewIconHandleNode(value, vnStore->GetHandleFlags(vnCns));
                 }
             }
             else
@@ -2472,18 +2455,12 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
                 {
                     case TYP_INT:
                         // Implicit assignment conversion to smaller integer
-                        newTree = optPrepareTreeForReplacement(tree, tree);
-                        tree->ChangeOperConst(GT_CNS_INT);
-                        tree->gtIntCon.gtIconVal = (int)value;
-                        tree->gtVNPair           = ValueNumPair(vnLib, vnCns);
+                        conValTree = gtNewIconNode(static_cast<int>(value));
                         break;
 
                     case TYP_LONG:
                         // Same type no conversion required
-                        newTree = optPrepareTreeForReplacement(tree, tree);
-                        tree->ChangeOperConst(GT_CNS_NATIVELONG);
-                        tree->gtIntConCommon.SetLngValue(value);
-                        tree->gtVNPair = ValueNumPair(vnLib, vnCns);
+                        conValTree = gtNewLconNode(value);
                         break;
 
                     case TYP_FLOAT:
@@ -2494,32 +2471,30 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
 
                     case TYP_DOUBLE:
                         // Same sized reinterpretation of bits to double
-                        newTree = optPrepareTreeForReplacement(tree, tree);
-                        tree->ChangeOperConst(GT_CNS_DBL);
-                        tree->gtDblCon.gtDconVal = *(reinterpret_cast<double*>(&value));
-                        tree->gtVNPair           = ValueNumPair(vnLib, vnCns);
+                        conValTree = gtNewDconNode(*(reinterpret_cast<double*>(&value)));
                         break;
 
                     default:
-                        return nullptr;
+                        // Can't optimize.
+                        break;
                 }
             }
         }
         break;
 
         case TYP_REF:
-            if (tree->TypeGet() != TYP_REF)
+        {
+            if (tree->TypeGet() != TYP_REF) // TODO seandree: what are other cases here?
             {
-                return nullptr;
+                // Can't optimize.
+                break;
             }
 
             assert(vnStore->ConstantValue<size_t>(vnCns) == 0);
-            newTree = optPrepareTreeForReplacement(tree, tree);
-            tree->ChangeOperConst(GT_CNS_INT);
-            tree->gtIntCon.gtIconVal = 0;
-            tree->ClearIconHandleMask();
-            tree->gtVNPair = ValueNumPair(vnLib, vnCns);
-            break;
+
+            conValTree = gtNewIconNode(0, TYP_REF);
+        }
+        break;
 
         case TYP_INT:
         {
@@ -2531,9 +2506,7 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
                 // to be recorded as a relocation with the VM.
                 if (!opts.compReloc)
                 {
-                    newTree           = gtNewIconHandleNode(value, vnStore->GetHandleFlags(vnCns));
-                    newTree->gtVNPair = ValueNumPair(vnLib, vnCns);
-                    newTree           = optPrepareTreeForReplacement(tree, newTree);
+                    conValTree = gtNewIconHandleNode(value, vnStore->GetHandleFlags(vnCns));
                 }
             }
             else
@@ -2544,27 +2517,17 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
                     case TYP_REF:
                     case TYP_INT:
                         // Same type no conversion required
-                        newTree = optPrepareTreeForReplacement(tree, tree);
-                        tree->ChangeOperConst(GT_CNS_INT);
-                        tree->gtIntCon.gtIconVal = value;
-                        tree->ClearIconHandleMask();
-                        tree->gtVNPair = ValueNumPair(vnLib, vnCns);
+                        conValTree = gtNewIconNode(static_cast<int>(value));
                         break;
 
                     case TYP_LONG:
                         // Implicit assignment conversion to larger integer
-                        newTree = optPrepareTreeForReplacement(tree, tree);
-                        tree->ChangeOperConst(GT_CNS_NATIVELONG);
-                        tree->gtIntConCommon.SetLngValue(value);
-                        tree->gtVNPair = ValueNumPair(vnLib, vnCns);
+                        conValTree = gtNewLconNode(static_cast<int>(value));
                         break;
 
                     case TYP_FLOAT:
                         // Same sized reinterpretation of bits to float
-                        newTree = optPrepareTreeForReplacement(tree, tree);
-                        tree->ChangeOperConst(GT_CNS_DBL);
-                        tree->gtDblCon.gtDconVal = *(reinterpret_cast<float*>(&value));
-                        tree->gtVNPair           = ValueNumPair(vnLib, vnCns);
+                        conValTree = gtNewDconNode(*(reinterpret_cast<float*>(&value)), TYP_FLOAT);
                         break;
 
                     case TYP_DOUBLE:
@@ -2574,16 +2537,29 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
                         break;
 
                     default:
-                        return nullptr;
+                        // Can't optimize.
+                        break;
                 }
             }
         }
         break;
 
         default:
-            return nullptr;
+            // Can't optimize.
+            break;
     }
-    return newTree;
+
+    if (conValTree != nullptr)
+    {
+        // Were able to optimize, replace as COMMA(side_effects, const value tree);
+        conValTree->gtVNPair = vnPair;
+        return optPrepareTreeForReplacement(tree, conValTree);
+    }
+    else
+    {
+        // Was not able to optimize.
+        return nullptr;
+    }
 }
 
 /*******************************************************************************************************

--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -2485,13 +2485,10 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
         case TYP_REF:
         {
             assert(vnStore->ConstantValue<size_t>(vnCns) == 0);
+            // Support onle ref(ref(0)), do not support other forms (e.g byref(ref(0)).
             if (tree->TypeGet() == TYP_REF)
             {
                 conValTree = gtNewIconNode(0, TYP_REF);
-            }
-            else
-            {
-                // Do not support such optimization (e.g byref(ref(0)).
             }
         }
         break;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -6722,7 +6722,7 @@ public:
     fgWalkResult optVNConstantPropCurStmt(BasicBlock* block, GenTreeStmt* stmt, GenTree* tree);
     GenTree* optVNConstantPropOnJTrue(BasicBlock* block, GenTree* test);
     GenTree* optVNConstantPropOnTree(BasicBlock* block, GenTree* tree);
-    GenTree* optPrepareTreeForReplacement(GenTree* extractTree, GenTree* replaceTree);
+    GenTree* optExtractSideEffListFromConst(GenTree* tree);
 
     AssertionIndex GetAssertionCount()
     {

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -10506,14 +10506,14 @@ void Compiler::gtDispTree(GenTree*     tree,
     if (IsUninitialized(tree))
     {
         /* Value used to initalize nodes */
-        printf("Uninitialized tree node!");
+        printf("Uninitialized tree node!\n");
         return;
     }
 
     if (tree->gtOper >= GT_COUNT)
     {
         gtDispNode(tree, indentStack, msg, isLIR);
-        printf("Bogus operator!");
+        printf("Bogus operator!\n");
         return;
     }
 

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -7943,15 +7943,15 @@ GenTree* Compiler::gtGetThisArg(GenTreeCall* call)
 
         if (call->gtCallLateArgs)
         {
-            regNumber      thisReg         = REG_ARG_0;
             unsigned       argNum          = 0;
             fgArgTabEntry* thisArgTabEntry = gtArgEntryByArgNum(call, argNum);
             GenTree*       result          = thisArgTabEntry->node;
 
-#if !FEATURE_FIXED_OUT_ARGS
-            GenTree* lateArgs = call->gtCallLateArgs;
-            regList  list     = call->regArgList;
-            int      index    = 0;
+#if !FEATURE_FIXED_OUT_ARGS && defined(DEBUG)
+            regNumber thisReg  = REG_ARG_0;
+            GenTree*  lateArgs = call->gtCallLateArgs;
+            regList   list     = call->regArgList;
+            int       index    = 0;
             while (lateArgs != NULL)
             {
                 assert(lateArgs->gtOper == GT_LIST);
@@ -7959,16 +7959,13 @@ GenTree* Compiler::gtGetThisArg(GenTreeCall* call)
                 regNumber curArgReg = list[index];
                 if (curArgReg == thisReg)
                 {
-                    if (optAssertionPropagatedCurrentStmt)
-                        result = lateArgs->gtOp.gtOp1;
-
                     assert(result == lateArgs->gtOp.gtOp1);
                 }
 
                 lateArgs = lateArgs->gtOp.gtOp2;
                 index++;
             }
-#endif
+#endif // !FEATURE_FIXED_OUT_ARGS && defined(DEBUG)
             return result;
         }
     }


### PR DESCRIPTION
I was looking at unused variables in jit sources (see #23399, #23491) and found a suspicious code:
https://github.com/dotnet/coreclr/blob/29fabe7114d006af73ef768c529b4477b355a284/src/jit/gentree.cpp#L7946-L7971

where `thisReg` was unused if `FEATURE_FIXED_OUT_ARGS` was not true and `thisReg   = REG_ARG_0;` also looked unsafe, probably it should use `regNumber CodeGenInterface::genGetThisArgReg(GenTreeCall* call) const`, but it is not the main topic for this PR.

The block under `#if !FEATURE_FIXED_OUT_ARGS` looked unclear, from the first look I thought that it was debug only, but then I saw an assignment:
https://github.com/dotnet/coreclr/blob/29fabe7114d006af73ef768c529b4477b355a284/src/jit/gentree.cpp#L7962-L7963

it was not clear for me why for x86 (where `!FEATURE_FIXED_OUT_ARGS == true`) `fgArgTabEntry* thisArgTabEntry = gtArgEntryByArgNum(call, argNum);` did not give us the right value of `this` and on other platforms did.

So I looked in the history and confirmed that initially that was debug only block that checked `assert(result == lateArgs->gtOp.gtOp1);`  but then it was changed (DevDiv_276449) because of assert failure with such comment:

>   The assertion prop modifies the arg placeholder, therefore the result doesn't match the originally filled in lateArg. The fix is to track if it is modified for the current statement and if so replace result.

That placeholder modification described in the comment did not look good to me, because it could leave as with incorrect pointers in `call->fgArgInfo` and other places where we do not do this additional search and check.
I wanted to find where we do such modification and why it was x86 specific. We did this new assignment only under `optAssertionPropagated == true` that is set only in `optAssertionProp_Update`, so I decided to clean  `optAssertionProp_Update`(https://github.com/dotnet/coreclr/commit/b07b72627c9fe2807913df47451f9e26973d1023) and destroy the old tree in this function to catch where we can have wrong pointers (https://github.com/dotnet/coreclr/commit/04c7fa63a52d4405298fd4053e7be137eac6a042).

After that I caught an assert because of using a destroyed tree, the root cause for it was the code in `optVNConstantPropOnTree`, for example:
https://github.com/dotnet/coreclr/blob/29fabe7114d006af73ef768c529b4477b355a284/src/jit/assertionprop.cpp#L2410-L2413

`newTree = optPrepareTreeForReplacement(tree, tree)` could look like:
```
N011 (  1,  1) [001957] ------------                 /--*  LCL_VAR   int    V03 loc0         u:1 $c0 
N012 (  8,  5) [001960] ---X--------              /--*  GE        int    $14c
N010 (  3,  3) [001959] ---X--------              |  \--*  ARR_LENGTH int    $140 <- original
N009 (  1,  1) [001958] ------------              |     \--*  LCL_VAR   ref    V01 arg1         u:1 $80 <- original
               [002076] ---X--------              *  COMMA     int
N010 (  3,  3) [001959] ---X--------              \--*  ARR_LENGTH int    $140 <- duplicate
N009 (  1,  1) [001958] ------------                 \--*  LCL_VAR   ref    V01 arg1         u:1 $80 <- duplicate
```

that violated out NodesUniqueness concept and created situation where the new optimized tree used the old tree as a child. So I rewrote this function to create new constant trees instead of this hacks with old values, note this approach was already used for  some cases but not for all:
https://github.com/dotnet/coreclr/blob/29fabe7114d006af73ef768c529b4477b355a284/src/jit/assertionprop.cpp#L2457-L2467
So I cleaned `optVNConstantPropOnTree` (https://github.com/dotnet/coreclr/commit/c6dbbf050b2a532bfc3e1b0a228da4d42f5e79e9) and added some comments about unsupported cases that were not clear (https://github.com/dotnet/coreclr/commit/325bfa4890a069c4060116f81ef8753be3b828c9).

and finally changed the suspicious block back to `DEBUG` only with a goal to delete it after all tests pass.

There are no diffs (jit-diff x86/x64 -c/f crossgen/pmi).