### PR TITLE
Remove dlclose call to unload CoreCLR

### DIFF
--- a/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
+++ b/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
@@ -466,11 +466,6 @@ int ExecuteManagedAssembly(
                 }
             }
         }
-
-        if (dlclose(coreclrLib) != 0)
-        {
-            fprintf(stderr, "Warning - dlclose failed\n");
-        }
     }
     else
     {


### PR DESCRIPTION
@jkotas commented 2 years ago in https://github.com/dotnet/coreclr/issues/12266#issuecomment-308484006

> Yes, the dlclose call should be removed.

Is that still true?