### PR TITLE
Changing DIM Test to run on mono either

### DIFF
--- a/tests/src/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained2.il
+++ b/tests/src/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained2.il
@@ -62,18 +62,18 @@
 
   ldarga.s 0
   constrained. !!T
-  callvirt instance int32 class IAdder`1<string>::PlusPlus()
+  callvirt instance int32 class IAdder`1<!!U>::PlusPlus()
   ldarga.s 0
   constrained. !!T
-  callvirt instance int32 class IAdder`1<string>::PlusPlus()
+  callvirt instance int32 class IAdder`1<!!U>::PlusPlus()
   add
-
+  
   ldarga.s 0
   constrained. !!T
-  callvirt instance int32 class IAdder`1<!!U>::PlusPlus()
+  callvirt instance int32 class IAdder`1<string>::PlusPlus()
   ldarga.s 0
   constrained. !!T
-  callvirt instance int32 class IAdder`1<!!U>::PlusPlus()
+  callvirt instance int32 class IAdder`1<string>::PlusPlus()
   add
 
   add

--- a/tests/src/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained2.il
+++ b/tests/src/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained2.il
@@ -67,7 +67,7 @@
   constrained. !!T
   callvirt instance int32 class IAdder`1<!!U>::PlusPlus()
   add
-  
+
   ldarga.s 0
   constrained. !!T
   callvirt instance int32 class IAdder`1<string>::PlusPlus()

--- a/tests/src/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained2_gm.il
+++ b/tests/src/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained2_gm.il
@@ -67,7 +67,7 @@
   constrained. !!T
   callvirt instance int32 class IAdder`1<!!U>::PlusPlus<object>()
   add
-  
+
   ldarga.s 0
   constrained. !!T
   callvirt instance int32 class IAdder`1<string>::PlusPlus<object>()

--- a/tests/src/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained2_gm.il
+++ b/tests/src/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained2_gm.il
@@ -62,18 +62,18 @@
 
   ldarga.s 0
   constrained. !!T
-  callvirt instance int32 class IAdder`1<string>::PlusPlus<object>()
+  callvirt instance int32 class IAdder`1<!!U>::PlusPlus<object>()
   ldarga.s 0
   constrained. !!T
-  callvirt instance int32 class IAdder`1<string>::PlusPlus<object>()
+  callvirt instance int32 class IAdder`1<!!U>::PlusPlus<object>()
   add
-
+  
   ldarga.s 0
   constrained. !!T
-  callvirt instance int32 class IAdder`1<!!U>::PlusPlus<object>()
+  callvirt instance int32 class IAdder`1<string>::PlusPlus<object>()
   ldarga.s 0
   constrained. !!T
-  callvirt instance int32 class IAdder`1<!!U>::PlusPlus<object>()
+  callvirt instance int32 class IAdder`1<string>::PlusPlus<object>()
   add
 
   add


### PR DESCRIPTION
Changing the test to run on runtimes that supports lookups with runtime determined boxing and on runtimes that doesn't support.
Discussed with Michal Strehovsky.