### PR TITLE
If a delegate type is a WinRT delegate or a WinRT-projected delegate, allow default marshalling.

### DIFF
--- a/src/vm/mlinfo.cpp
+++ b/src/vm/mlinfo.cpp
@@ -2323,7 +2323,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
 
                         case NATIVE_TYPE_DEFAULT:
 #ifdef FEATURE_COMINTEROP
-                            if (m_ms == MARSHAL_SCENARIO_WINRT)
+                            if (m_ms == MARSHAL_SCENARIO_WINRT || m_pMT->IsProjectedFromWinRT() || WinRTTypeNameConverter::IsRedirectedType(m_pMT))
                             {
                                 m_type = MARSHAL_TYPE_INTERFACE;
                             }


### PR DESCRIPTION
When we changed the behavior of delegate marshalling to disallow users to marshal to the old `_Delegate` interface from the Mscorlib TLB in #23738, I missed a corner case where we might be marshalling for a WinRT event but might not be in a WinRT marshalling scenario, such subscribing to the `INotifyPropertyChanged.PropertyChanged` event. While I was working on cleaning up #23409, I found this bug.

This change allows any delegates that are WinRT delegates or are projected to/from WinRT delegates to marshal by default rules.