### PR TITLE
Renaming 'failure' in counter tests

### DIFF
--- a/tests/src/tracing/eventcounter/incrementingpollingcounter.cs
+++ b/tests/src/tracing/eventcounter/incrementingpollingcounter.cs
@@ -19,11 +19,11 @@ namespace BasicEventSourceTests
         [EventSource(Name = "SimpleEventSource")]
         private sealed class SimpleEventSource : EventSource
         {
-            private object _failureCounter;
+            private object _mockedCounter;
 
-            public SimpleEventSource(Func<double> getFailureCount, Type IncrementingPollingCounterType)
+            public SimpleEventSource(Func<double> getMockedCount, Type IncrementingPollingCounterType)
             {
-                _failureCounter = Activator.CreateInstance(IncrementingPollingCounterType, "failureCount", this, getFailureCount);    
+                _mockedCounter = Activator.CreateInstance(IncrementingPollingCounterType, "failureCount", this, getMockedCount);    
             }
         }
 
@@ -91,12 +91,12 @@ namespace BasicEventSourceTests
         }
 
 
-        public static int failureCountCalled = 0;
+        public static int mockedCountCalled = 0;
 
-        public static double getFailureCount()
+        public static double getMockedCount()
         {
-            failureCountCalled++;
-            return failureCountCalled;
+            mockedCountCalled++;
+            return mockedCountCalled;
         }
         public static int Main(string[] args)
         {
@@ -117,12 +117,12 @@ namespace BasicEventSourceTests
                     return 1;
                 }
 
-                SimpleEventSource eventSource = new SimpleEventSource(getFailureCount, IncrementingPollingCounterType);
+                SimpleEventSource eventSource = new SimpleEventSource(getMockedCount, IncrementingPollingCounterType);
 
                 // Want to sleep for 5000 ms to get some counters piling up.
                 Thread.Sleep(5000);
 
-                if (!myListener.Failed && failureCountCalled > 0)
+                if (!myListener.Failed && mockedCountCalled > 0)
                 {
                     Console.WriteLine("Test Passed");
                     return 100;    

--- a/tests/src/tracing/eventcounter/pollingcounter.cs
+++ b/tests/src/tracing/eventcounter/pollingcounter.cs
@@ -22,10 +22,10 @@ namespace BasicEventSourceTests
             private object _failureCounter;
             private object _successCounter;
 
-            public SimpleEventSource(Func<double> getFailureCount, Func<double> getSuccessCount, Type PollingCounterType)
+            public SimpleEventSource(Func<double> getMockedCount, Func<double> getSuccessCount, Type PollingCounterType)
             {
                 _failureCounter = Activator.CreateInstance(PollingCounterType, "failureCount", this, getSuccessCount);
-                _successCounter = Activator.CreateInstance(PollingCounterType, "successCount", this, getFailureCount);
+                _successCounter = Activator.CreateInstance(PollingCounterType, "successCount", this, getMockedCount);
             }
         }
 
@@ -112,9 +112,9 @@ namespace BasicEventSourceTests
                         }
                         else if (name.Equals("successCount"))
                         {
-                            if (Int32.Parse(mean) != failureCountCalled)
+                            if (Int32.Parse(mean) != mockedCountCalled)
                             {
-                                Console.WriteLine($"Mean is not what we expected: {mean} vs {failureCountCalled}");
+                                Console.WriteLine($"Mean is not what we expected: {mean} vs {mockedCountCalled}");
                             }
                         }
 
@@ -137,13 +137,13 @@ namespace BasicEventSourceTests
         }
 
 
-        public static int failureCountCalled = 0;
+        public static int mockedCountCalled = 0;
         public static int successCountCalled = 0;
 
-        public static double getFailureCount()
+        public static double getMockedCount()
         {
-            failureCountCalled++;
-            return failureCountCalled;
+            mockedCountCalled++;
+            return mockedCountCalled;
         }
 
         public static double getSuccessCount()
@@ -171,12 +171,12 @@ namespace BasicEventSourceTests
                     return 1;
                 }
 
-                SimpleEventSource eventSource = new SimpleEventSource(getFailureCount, getSuccessCount, PollingCounterType);
+                SimpleEventSource eventSource = new SimpleEventSource(getMockedCount, getSuccessCount, PollingCounterType);
 
                 // Want to sleep for 5000 ms to get some counters piling up.
                 Thread.Sleep(5000);
 
-                if (myListener.FailureEventCount > 0 && myListener.SuccessEventCount > 0 && !myListener.Failed && (failureCountCalled > 0 && successCountCalled > 0))
+                if (myListener.FailureEventCount > 0 && myListener.SuccessEventCount > 0 && !myListener.Failed && (mockedCountCalled > 0 && successCountCalled > 0))
                 {
                     Console.WriteLine("Test Passed");
                     return 100;    


### PR DESCRIPTION
This is just renaming the term "failure" in tests for PollingCounter and IncrementingPollingCounter to avoid confusion with *actual* test failures. 