### PR TITLE
Fix19817

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Reflection/Assembly.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Assembly.cs
@@ -205,7 +205,14 @@ namespace System.Reflection
             if (partialName == null)
                 throw new ArgumentNullException(nameof(partialName));
 
-            return Load(partialName);
+            try
+            {
+                return Load(partialName);
+            }
+            catch (FileNotFoundException)
+            {
+                return null;
+            }
         }
 
         // Loads the assembly with a COFF based IMAGE containing

--- a/src/System.Private.CoreLib/shared/System/Reflection/Assembly.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Assembly.cs
@@ -205,6 +205,9 @@ namespace System.Reflection
             if (partialName == null)
                 throw new ArgumentNullException(nameof(partialName));
 
+            if ((partialName.Length == 0) || (partialName[0] == '\0'))
+                throw new ArgumentException(SR.Format_StringZeroLength, nameof(partialName));
+
             try
             {
                 return Load(partialName);


### PR DESCRIPTION
Assembly.LoadFromPartialName(string) should not throw FileNotFoundException
rather it should return null.

Fixes #19817