### PR TITLE
Fix OSX debugging

### DIFF
--- a/src/dlls/mscordac/mscordac_unixexports.src
+++ b/src/dlls/mscordac/mscordac_unixexports.src
@@ -30,6 +30,8 @@ nativeStringResourceTable_mscorrc_debug
 #PAL__flushall
 #PAL_free
 #PAL_fwprintf
+#PAL_GetLogicalCpuCountFromOS
+#PAL_GetNumaProcessorNode
 #PAL_GetPALDirectoryW
 #PAL_GetResourceString
 #PAL_get_stdout
@@ -122,6 +124,7 @@ nativeStringResourceTable_mscorrc_debug
 #GetLastError
 #GetLongPathNameW
 #GetModuleFileNameW
+#GetNumaHighestNodeNumber
 #GetProcAddress
 #GetProcessHeap
 #GetShortPathNameW
@@ -178,6 +181,7 @@ nativeStringResourceTable_mscorrc_debug
 #TlsGetValue
 #TlsSetValue
 #VirtualAlloc
+#VirtualAllocExNuma
 #VirtualFree
 #VirtualProtect
 #VirtualQuery

--- a/src/utilcode/staticnohost/CMakeLists.txt
+++ b/src/utilcode/staticnohost/CMakeLists.txt
@@ -9,7 +9,4 @@ add_library_clr(utilcodestaticnohost STATIC ${UTILCODE_STATICNOHOST_SOURCES})
 
 if(CLR_CMAKE_PLATFORM_UNIX)
   target_link_libraries(utilcodestaticnohost  nativeresourcestring)
-  if(CLR_CMAKE_PLATFORM_DARWIN)
-    target_link_libraries(utilcodestaticnohost  coreclrpal)
-  endif(CLR_CMAKE_PLATFORM_DARWIN)
 endif(CLR_CMAKE_PLATFORM_UNIX)


### PR DESCRIPTION
A recent change has incorrectly added dependency on libcoreclrpal.a to
libutilcodenohost.a. This in turn, due to the transitive propagation of
dependencies, caused the libmscordbi to be linked with libcoreclrpal.a.
So libmscordbi contained its own PAL after that change, which is wrong.
libmscordbi should depend on PAL APIs through libmscordaccore that
exports the symbols it needs for it in order to keep just one PAL in the
process.

The fix is to remove the libcoreclrpal.a dependency and export few
new symbols from libmscordaccore instead.