### PR TITLE
Add test coverage for static members on interfaces

### DIFF
--- a/tests/src/Regressions/coreclr/15647/interfacestatics.il
+++ b/tests/src/Regressions/coreclr/15647/interfacestatics.il
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly interfacestatics { }
+
+.assembly extern System.Runtime { }
+
+.class interface IFoo<T>
+{
+  .field public static class [System.Runtime]System.Type O
+
+  .method public static specialname rtspecialname void .cctor()
+  {
+    ldtoken !T[]
+    call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    stsfld class [System.Runtime]System.Type class IFoo<!T>::O
+    ret
+  }
+
+  .method public static class [System.Runtime]System.Type GimmeT()
+  {
+    ldtoken !T[0...]
+    call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    ret
+  }
+
+  .method public static class [System.Runtime]System.Type GimmeU<U>()
+  {
+    ldtoken !!U
+    call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    ret
+  }
+
+  .method public static class [System.Runtime]System.Type GimmeU_T<U>()
+  {
+    call class [System.Runtime]System.Type class IFoo<!!U>::GimmeT()
+    ret
+  }
+}
+
+.method static hidebysig int32 Main()
+{
+  .entrypoint
+
+  ldsfld class [System.Runtime]System.Type class IFoo<object>::O
+  ldtoken object[]
+  call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)    
+  ceq
+  brtrue IFoo_object_O_Okay
+  ldc.i4.1
+  ret
+
+IFoo_object_O_Okay:
+  ldsfld class [System.Runtime]System.Type class IFoo<string>::O
+  ldtoken string[]
+  call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)    
+  ceq
+  brtrue IFoo_string_O_Okay
+  ldc.i4.2
+  ret
+
+IFoo_string_O_Okay:
+  call class [System.Runtime]System.Type class IFoo<object>::GimmeT()
+  ldtoken object[0...]
+  call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)    
+  ceq
+  brtrue IFoo_object_Gimme_T_Okay
+  ldc.i4.3
+  ret
+
+IFoo_object_Gimme_T_Okay:
+  call class [System.Runtime]System.Type class IFoo<object>::GimmeU<string>()
+  ldtoken string
+  call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)    
+  ceq
+  brtrue IFoo_object_Gimme_U_Okay
+  ldc.i4.4
+  ret
+
+IFoo_object_Gimme_U_Okay:
+  call class [System.Runtime]System.Type class IFoo<object>::GimmeU_T<string>()
+  ldtoken string[0...]
+  call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)    
+  ceq
+  brtrue IFoo_object_Gimme_U_T_Okay
+  ldc.i4.5
+  ret
+
+IFoo_object_Gimme_U_T_Okay:
+
+  ldc.i4 100
+  ret
+}

--- a/tests/src/Regressions/coreclr/15647/interfacestatics.ilproj
+++ b/tests/src/Regressions/coreclr/15647/interfacestatics.ilproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>interfacestatics</AssemblyName>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{85DFC527-4DB1-595E-A7D7-E94EE1F8140D}</ProjectGuid>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="interfacestatics.il" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/tests/src/reflection/StaticInterfaceMembers/consumer.cs
+++ b/tests/src/reflection/StaticInterfaceMembers/consumer.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+
+class Program
+{
+    static int Main()
+    {
+        {
+            FieldInfo fi = typeof(IFoo<object>).GetField("O");
+            object val = fi.GetValue(null);
+            if (!object.ReferenceEquals(val, typeof(object[])))
+                throw new Exception();
+        }
+
+        {
+            MethodInfo mi = typeof(IFoo<string>).GetMethod("GimmeT");
+            object val = mi.Invoke(null, Array.Empty<object>());
+            if (!object.ReferenceEquals(val, typeof(string)))
+                throw new Exception();
+        }
+
+        {
+            MethodInfo mi = typeof(IFoo<object>).GetMethod("GimmeU").MakeGenericMethod(typeof(string));
+            object val = mi.Invoke(null, Array.Empty<object>());
+            if (!object.ReferenceEquals(val, typeof(string)))
+                throw new Exception();
+        }
+
+        return 100;
+    }
+}

--- a/tests/src/reflection/StaticInterfaceMembers/consumer.csproj
+++ b/tests/src/reflection/StaticInterfaceMembers/consumer.csproj
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="consumer.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="provider.ilproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <NoWarn Include="42016,42020,42025,42024" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/reflection/StaticInterfaceMembers/provider.il
+++ b/tests/src/reflection/StaticInterfaceMembers/provider.il
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly provider { }
+
+.assembly extern mscorlib { }
+
+.class interface public IFoo<T>
+{
+  .field public static class [mscorlib]System.Type O
+
+  .method public static specialname rtspecialname void .cctor()
+  {
+    ldtoken !T[]
+    call class [mscorlib]System.Type class [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+    stsfld class [mscorlib]System.Type class IFoo<!T>::O
+    ret
+  }
+
+  .method public static class [mscorlib]System.Type GimmeT()
+  {
+    ldtoken !T
+    call class [mscorlib]System.Type class [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+    ret
+  }
+
+  .method public static class [mscorlib]System.Type GimmeU<U>()
+  {
+    ldtoken !!U
+    call class [mscorlib]System.Type class [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+    ret
+  }
+}

--- a/tests/src/reflection/StaticInterfaceMembers/provider.ilproj
+++ b/tests/src/reflection/StaticInterfaceMembers/provider.ilproj
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="provider.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
This has been supported since v1 but we don't have much test coverage.

C# is going to enable interfaces to have static members and static constructors so we better start testing it.

Fixes #15647.