### PR TITLE
Fixes for tracking struct field sequences

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -7415,7 +7415,7 @@ DONE:
         FieldSeqNode* fldSeq = nullptr;
         if (GetZeroOffsetFieldMap()->Lookup(tree, &fldSeq))
         {
-            GetZeroOffsetFieldMap()->Set(copy, fldSeq);
+            fgAddFieldSeqForZeroOffset(copy, fldSeq);
         }
     }
 
@@ -17628,6 +17628,9 @@ FieldSeqNode* FieldSeqStore::Append(FieldSeqNode* a, FieldSeqNode* b)
     }
     else
     {
+        // We should never add a duplicate FieldSeqNode
+        assert(a != b);
+
         FieldSeqNode* tmp = Append(a->m_next, b);
         FieldSeqNode  fsn(a->m_fieldHnd, tmp);
         FieldSeqNode* res = nullptr;

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -1330,7 +1330,8 @@ GenTree* Compiler::impAssignStructPtr(GenTree*             destAddr,
 
         assert(OFFSETOF__CORINFO_TypedReference__dataPtr == 0);
         assert(destAddr->gtType == TYP_I_IMPL || destAddr->gtType == TYP_BYREF);
-        GetZeroOffsetFieldMap()->Set(destAddr, GetFieldSeqStore()->CreateSingleton(GetRefanyDataField()));
+        fgAddFieldSeqForZeroOffset(destAddr, GetFieldSeqStore()->CreateSingleton(GetRefanyDataField()));
+
         GenTree*       ptrSlot         = gtNewOperNode(GT_IND, TYP_I_IMPL, destAddr);
         GenTreeIntCon* typeFieldOffset = gtNewIconNode(OFFSETOF__CORINFO_TypedReference__type, TYP_I_IMPL);
         typeFieldOffset->gtFieldSeq    = GetFieldSeqStore()->CreateSingleton(GetRefanyTypeField());

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -6655,17 +6655,7 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
 #endif
 
         // We expect 'addr' to be an address at this point.
-        // But there are also cases where we can see a GT_LCL_FLD or a GT_LCL_VAR:
-        //
-        //     [001076] ----G-------              /--*  FIELD     long   m_constArray
-        //     [001072] ----G-------              |  \--*  ADDR      byref
-        //     [001073] ----G-------              |     \--*  FIELD     struct blob
-        //     [001074] ------------              |        \--*  ADDR      byref
-        //     [001075] ------------              |           \--*  LCL_VAR   struct V18 loc11
-        //
-        //
-        assert((addr->TypeGet() == TYP_BYREF) || (addr->TypeGet() == TYP_I_IMPL) || (addr->OperGet() == GT_LCL_FLD) ||
-               (addr->OperGet() == GT_LCL_VAR));
+        assert(addr->TypeGet() == TYP_BYREF || addr->TypeGet() == TYP_I_IMPL);
 
         // Since we don't make a constant zero to attach the field sequence to, associate it with the "addr" node.
         FieldSeqNode* fieldSeq =
@@ -6677,13 +6667,10 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
     GenTree* result = fgMorphSmpOp(tree, mac);
 
 #ifdef DEBUG
-    if (fldOffset == 0)
+    if (verbose)
     {
-        if (verbose)
-        {
-            printf("\nAfter calling fgMorphSmpOp (zero fldOffset case):\n");
-            gtDispTree(result);
-        }
+        printf("\nFinal value of Compiler::fgMorphField after calling fgMorphSmpOp:\n");
+        gtDispTree(result);
     }
 #endif
 
@@ -13517,7 +13504,7 @@ DONE_MORPHING_CHILDREN:
                         }
                         else
                         {
-                            // Append 'fieldSeq' to the exsisting one
+                            // Append 'fieldSeq' to the existing one
                             temp->AsLclFld()->gtFieldSeq =
                                 GetFieldSeqStore()->Append(temp->AsLclFld()->gtFieldSeq, fieldSeq);
                         }
@@ -18765,17 +18752,7 @@ private:
 void Compiler::fgAddFieldSeqForZeroOffset(GenTree* addr, FieldSeqNode* fieldSeqZero)
 {
     // We expect 'addr' to be an address at this point.
-    // But there are also cases where we can see a GT_LCL_FLD or a GT_LCL_VAR:
-    //
-    //     [001076] ----G-------              /--*  FIELD     long   m_constArray
-    //     [001072] ----G-------              |  \--*  ADDR      byref
-    //     [001073] ----G-------              |     \--*  FIELD     struct blob
-    //     [001074] ------------              |        \--*  ADDR      byref
-    //     [001075] ------------              |           \--*  LCL_VAR   struct V18 loc11
-    //
-    //
-    assert(addr->TypeGet() == TYP_BYREF || addr->TypeGet() == TYP_I_IMPL || addr->OperGet() == GT_LCL_FLD ||
-           addr->OperGet() == GT_LCL_VAR);
+    assert(addr->TypeGet() == TYP_BYREF || addr->TypeGet() == TYP_I_IMPL);
 
     FieldSeqNode* fieldSeqUpdate   = fieldSeqZero;
     GenTree*      fieldSeqNode     = addr;

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -13478,35 +13478,38 @@ DONE_MORPHING_CHILDREN:
                 // lclVar and must not extend beyond the end of the lclVar.
                 if ((ival1 >= 0) && ((ival1 + genTypeSize(typ)) <= varSize))
                 {
+                    GenTreeLclFld* lclFld;
+
                     // We will turn a GT_LCL_VAR into a GT_LCL_FLD with an gtLclOffs of 'ival'
                     // or if we already have a GT_LCL_FLD we will adjust the gtLclOffs by adding 'ival'
                     // Then we change the type of the GT_LCL_FLD to match the orginal GT_IND type.
                     //
                     if (temp->OperGet() == GT_LCL_FLD)
                     {
-                        temp->AsLclFld()->gtLclOffs += (unsigned short)ival1;
-                        temp->AsLclFld()->gtFieldSeq =
-                            GetFieldSeqStore()->Append(temp->AsLclFld()->gtFieldSeq, fieldSeq);
+                        lclFld = temp->AsLclFld();
+                        lclFld->gtLclOffs += (unsigned short)ival1;
+                        lclFld->gtFieldSeq = GetFieldSeqStore()->Append(lclFld->gtFieldSeq, fieldSeq);
                     }
                     else // we have a GT_LCL_VAR
                     {
                         assert(temp->OperGet() == GT_LCL_VAR);
-                        temp->ChangeOper(GT_LCL_FLD); // Note that this typically makes the gtFieldSeq "NotAField"...
-                        temp->AsLclFld()->gtLclOffs = (unsigned short)ival1;
+                        temp->ChangeOper(GT_LCL_FLD); // Note that this typically makes the gtFieldSeq "NotAField",
+                        // unless there is a zero filed offset associated with 'temp'.
+                        lclFld            = temp->AsLclFld();
+                        lclFld->gtLclOffs = (unsigned short)ival1;
 
-                        if (temp->AsLclFld()->gtFieldSeq == FieldSeqStore::NotAField())
+                        if (lclFld->gtFieldSeq == FieldSeqStore::NotAField())
                         {
                             if (fieldSeq != nullptr)
                             {
                                 // If it does represent a field, note that.
-                                temp->AsLclFld()->gtFieldSeq = fieldSeq;
+                                lclFld->gtFieldSeq = fieldSeq;
                             }
                         }
                         else
                         {
                             // Append 'fieldSeq' to the existing one
-                            temp->AsLclFld()->gtFieldSeq =
-                                GetFieldSeqStore()->Append(temp->AsLclFld()->gtFieldSeq, fieldSeq);
+                            lclFld->gtFieldSeq = GetFieldSeqStore()->Append(lclFld->gtFieldSeq, fieldSeq);
                         }
                     }
                     temp->gtType      = tree->gtType;

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -2351,7 +2351,7 @@ public:
                 // If it has a zero-offset field seq, copy annotation to the ref
                 if (hasZeroMapAnnotation)
                 {
-                    m_pCompiler->GetZeroOffsetFieldMap()->Set(ref, fldSeq);
+                    m_pCompiler->fgAddFieldSeqForZeroOffset(ref, fldSeq);
                 }
 
                 /* Create a comma node for the CSE assignment */
@@ -2392,7 +2392,7 @@ public:
             // If it has a zero-offset field seq, copy annotation.
             if (hasZeroMapAnnotation)
             {
-                m_pCompiler->GetZeroOffsetFieldMap()->Set(cse, fldSeq);
+                m_pCompiler->fgAddFieldSeqForZeroOffset(cse, fldSeq);
             }
 
             assert(m_pCompiler->fgRemoveRestOfBlock == false);

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -7510,17 +7510,6 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                             ValueNum      arrVN  = funcApp.m_args[1];
                             ValueNum      inxVN  = funcApp.m_args[2];
                             FieldSeqNode* fldSeq = vnStore->FieldSeqVNToFieldSeq(funcApp.m_args[3]);
-
-                            if (arg->gtOper != GT_LCL_VAR)
-                            {
-                                // Does the child of the GT_IND 'arg' have an associated zero-offset field sequence?
-                                FieldSeqNode* addrFieldSeq = nullptr;
-                                if (GetZeroOffsetFieldMap()->Lookup(arg, &addrFieldSeq))
-                                {
-                                    fldSeq = GetFieldSeqStore()->Append(addrFieldSeq, fldSeq);
-                                }
-                            }
-
 #ifdef DEBUG
                             if (verbose)
                             {


### PR DESCRIPTION
Fixes for Zero Offset field sequence tracking

 - A GT_LCL_VAR may have a zeroOffset field
 - Add an assert to prevent building field sequences with duplicates
 - Fix fgMorphField when we have a zero offset field

Improve fgAddFieldSeqForZeroOffset
 - Add JItDump info
 - Handle GT_LCL_FLD