### PR TITLE
Add PAL exports to DAC and remove linkage of PAL from static utility library

### DIFF
--- a/src/dlls/mscordac/mscordac_unixexports.src
+++ b/src/dlls/mscordac/mscordac_unixexports.src
@@ -112,6 +112,7 @@ nativeStringResourceTable_mscorrc_debug
 #GetCurrentDirectoryW
 #GetCurrentProcess
 #GetCurrentProcessId
+#GetCurrentProcessorNumberEx
 #GetCurrentThreadId
 #GetEnvironmentVariableA
 #GetEnvironmentVariableW
@@ -119,9 +120,12 @@ nativeStringResourceTable_mscorrc_debug
 #GetFileAttributesW
 #GetFileSize
 #GetFullPathNameW
+#GetLogicalProcessorInformationEx
 #GetLastError
 #GetLongPathNameW
 #GetModuleFileNameW
+#GetNumaHighestNodeNumber
+#GetNumaProcessorNodeEx
 #GetProcAddress
 #GetProcessAffinityMask
 #GetProcessHeap
@@ -133,6 +137,7 @@ nativeStringResourceTable_mscorrc_debug
 #GetTempFileNameW
 #GetTempPathA
 #GetTempPathW
+#GetThreadGroupAffinity
 #HeapAlloc
 #HeapFree
 #HeapSetInformation
@@ -168,6 +173,7 @@ nativeStringResourceTable_mscorrc_debug
 #SetFilePointer
 #SetLastError
 #SetErrorMode
+#SetThreadGroupAffinity
 #Sleep
 #SleepEx
 #SwitchToThread
@@ -179,6 +185,7 @@ nativeStringResourceTable_mscorrc_debug
 #TlsGetValue
 #TlsSetValue
 #VirtualAlloc
+#VirtualAllocExNuma
 #VirtualFree
 #VirtualProtect
 #VirtualQuery

--- a/src/utilcode/staticnohost/CMakeLists.txt
+++ b/src/utilcode/staticnohost/CMakeLists.txt
@@ -9,7 +9,4 @@ add_library_clr(utilcodestaticnohost STATIC ${UTILCODE_STATICNOHOST_SOURCES})
 
 if(CLR_CMAKE_PLATFORM_UNIX)
   target_link_libraries(utilcodestaticnohost  nativeresourcestring)
-  if(CLR_CMAKE_PLATFORM_DARWIN)
-    target_link_libraries(utilcodestaticnohost  coreclrpal)
-  endif(CLR_CMAKE_PLATFORM_DARWIN)
 endif(CLR_CMAKE_PLATFORM_UNIX)


### PR DESCRIPTION
As explained in #23924, #22861 introduced a dependency in PAL APIs in the util library, which gets transitively linked in the DBI. Replicating Jan's suggested fix, we take the additional APIs needed from the PAL by exporting them on the DAC. The list looks a bit different as there's been some churn in master, which changes the exports needed, but this is a more conservative approach than taking the closure of commits needed for the other commit to be picked into this branch.

I verified this fixes the process attach for OSX and that it causes no issues on Linux-x64 on the customer scenarios that reported it. 

cc: @mmitche @tommcdon