### PR TITLE
Fix precompiling CoreRoot overlay with crossgen for Windows arm/arm64

### DIFF
--- a/build-test.cmd
+++ b/build-test.cmd
@@ -358,7 +358,7 @@ if exist "%CORE_ROOT%" rd /s /q "%CORE_ROOT%"
 if exist "%CORE_ROOT_STAGE%" rd /s /q "%CORE_ROOT_STAGE%"
 md "%CORE_ROOT%"
 md "%CORE_ROOT_STAGE%"
-xcopy "%__BinDir%" "%CORE_ROOT_STAGE%"
+xcopy /s "%__BinDir%" "%CORE_ROOT_STAGE%"
 
 REM =========================================================================================
 REM ===
@@ -562,7 +562,11 @@ echo "%2" | findstr /b "xunit." >nul && (
   exit /b 0
 )
 
-"%CORE_ROOT_STAGE%\crossgen.exe" /Platform_Assemblies_Paths "%CORE_ROOT%" /in "%1" /out "%CORE_ROOT%/temp.ni.dll" >nul 2>nul
+set __CrossgenExe="%CORE_ROOT_STAGE%\crossgen.exe"
+if /i "%__BuildArch%" == "arm" ( set __CrossgenExe="%CORE_ROOT_STAGE%\x86\crossgen.exe" )
+if /i "%__BuildArch%" == "arm64" ( set __CrossgenExe="%CORE_ROOT_STAGE%\x64\crossgen.exe" )
+
+"%__CrossgenExe%" /Platform_Assemblies_Paths "%CORE_ROOT%" /in "%1" /out "%CORE_ROOT%/temp.ni.dll" >nul 2>nul
 set /a __exitCode = %errorlevel%
 if "%__exitCode%" == "-2146230517" (
     echo %2 is not a managed assembly.
@@ -570,7 +574,7 @@ if "%__exitCode%" == "-2146230517" (
 )
 
 if %__exitCode% neq 0 (
-    echo Unable to precompile %2
+    echo Unable to precompile %2, Exit Code is %__exitCode%
     exit /b 0
 )
 


### PR DESCRIPTION
This is an existing issue in the Windows scripts that I found while adding FX pre-compilation for Linux.
/cc: @RussKeldorph @echesakovMSFT 