### PR TITLE
Update maximum allowed arm prolog size

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -3849,7 +3849,9 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
 
         // Generate:
         //
-        //      mov rOffset, -pageSize
+        //      mov rOffset, -pageSize    // On arm, this turns out to be "movw r1, 0xf000; sxth r1, r1".
+        //                                // We could save 4 bytes in the prolog by using "movs r1, 0" at the
+        //                                // runtime expense of running a useless first loop iteration.
         //      mov rLimit, -frameSize
         // loop:
         //      ldr rTemp, [sp + rOffset] // rTemp = wzr on ARM64

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -1374,7 +1374,7 @@ protected:
     void emitDispClsVar(CORINFO_FIELD_HANDLE fldHnd, ssize_t offs, bool reloc = false);
     void emitDispFrameRef(int varx, int disp, int offs, bool asmfm);
     void emitDispInsOffs(unsigned offs, bool doffs);
-    void emitDispInsHex(BYTE* code, size_t sz);
+    void emitDispInsHex(instrDesc* id, BYTE* code, size_t sz);
 
 #else // !DEBUG
 #define emitVarRefOffs 0

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -6778,7 +6778,7 @@ void emitter::emitDispGC(emitAttr attr)
  *  Display (optionally) the instruction encoding in hex
  */
 
-void emitter::emitDispInsHex(BYTE* code, size_t sz)
+void emitter::emitDispInsHex(instrDesc* id, BYTE* code, size_t sz)
 {
     // We do not display the instruction hex if we want diff-able disassembly
     if (!emitComp->opts.disDiffable)
@@ -6790,6 +6790,27 @@ void emitter::emitDispInsHex(BYTE* code, size_t sz)
         else if (sz == 4)
         {
             printf("  %04X %04X", (*((unsigned short*)(code + 0))), (*((unsigned short*)(code + 2))));
+        }
+        else
+        {
+            assert(sz == 0);
+
+            // At least display the encoding size of the instruction, even if not displaying its actual encoding.
+            insSize isz = emitInsSize(id->idInsFmt());
+            switch (isz)
+            {
+                case ISZ_16BIT:
+                    printf("  2B");
+                    break;
+                case ISZ_32BIT:
+                    printf("  4B");
+                    break;
+                case ISZ_48BIT:
+                    printf("  6B");
+                    break;
+                default:
+                    unreached();
+            }
         }
     }
 }
@@ -6822,7 +6843,7 @@ void emitter::emitDispInsHelp(
 
     /* Display the instruction hex code */
 
-    emitDispInsHex(code, sz);
+    emitDispInsHex(id, code, sz);
 
     printf("      ");
 

--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -10698,7 +10698,7 @@ void emitter::emitDispAddrRRExt(regNumber reg1, regNumber reg2, insOpts opt, boo
  *  Display (optionally) the instruction encoding in hex
  */
 
-void emitter::emitDispInsHex(BYTE* code, size_t sz)
+void emitter::emitDispInsHex(instrDesc* id, BYTE* code, size_t sz)
 {
     // We do not display the instruction hex if we want diff-able disassembly
     if (!emitComp->opts.disDiffable)
@@ -10709,6 +10709,7 @@ void emitter::emitDispInsHex(BYTE* code, size_t sz)
         }
         else
         {
+            assert(sz == 0);
             printf("              ");
         }
     }
@@ -10742,7 +10743,7 @@ void emitter::emitDispIns(
 
     /* Display the instruction hex code */
 
-    emitDispInsHex(pCode, sz);
+    emitDispInsHex(id, pCode, sz);
 
     printf("      ");
 

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -8049,7 +8049,7 @@ void emitter::emitDispShift(instruction ins, int cnt)
  *  Display (optionally) the bytes for the instruction encoding in hex
  */
 
-void emitter::emitDispInsHex(BYTE* code, size_t sz)
+void emitter::emitDispInsHex(instrDesc* id, BYTE* code, size_t sz)
 {
     // We do not display the instruction hex if we want diff-able disassembly
     if (!emitComp->opts.disDiffable)
@@ -8216,7 +8216,7 @@ void emitter::emitDispIns(
     {
         /* Display the instruction hex code */
 
-        emitDispInsHex(code, sz);
+        emitDispInsHex(id, code, sz);
     }
 
     /* Display the instruction name */

--- a/src/jit/unwind.h
+++ b/src/jit/unwind.h
@@ -20,8 +20,8 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // You can increase this "max" number if necessary.
 
 #if defined(_TARGET_ARM_)
-const unsigned MAX_PROLOG_SIZE_BYTES = 40;
-const unsigned MAX_EPILOG_SIZE_BYTES = 40;
+const unsigned MAX_PROLOG_SIZE_BYTES = 44;
+const unsigned MAX_EPILOG_SIZE_BYTES = 44;
 #define UWC_END 0xFF // "end" unwind code
 #define UW_MAX_FRAGMENT_SIZE_BYTES (1U << 19)
 #define UW_MAX_CODE_WORDS_COUNT 15      // Max number that can be encoded in the "Code Words" field of the .pdata record


### PR DESCRIPTION
Change #23715 changed the localloc stack probe loop to load a
negative constant instead of zero to start the probing loop.
This increased the size of the probing loop, and hence the
size of the maximum prolog, by 4 bytes. Bump the assert on
the maximum size to match.

Note that as the comment says, the maximum size there is not
actually a maximum (it was originally), it is just to alert
us when the maximum generated prolog size has gone up.

Fixes #23920

Also, when dumping an arm instruction, and when we don't have the actual
code bytes (such as during code generation, as opposed to emission),
display the (current) instruction size, either 2 bytes (2B),
4 bytes (4B), or 6 bytes (6B).