### PR TITLE
Workaround users having strongly typed HRESULTs on instance methods such as PreserveSig'd COM members

### DIFF
--- a/src/vm/mlinfo.cpp
+++ b/src/vm/mlinfo.cpp
@@ -2753,7 +2753,6 @@ MarshalInfo::MarshalInfo(Module* pModule,
                         // (returning small value types by value in registers) is already done in JIT64.
                         if (        !m_byref   // Permit register-sized structs as return values
                                  && !isParam
-                                 && !onInstanceMethod
                                  && CorIsPrimitiveType(m_pMT->GetInternalCorElementType())
                                  && !IsUnmanagedValueTypeReturnedByRef(nativeSize)
                                  && managedSize <= sizeof(void*)

--- a/src/vm/mlinfo.cpp
+++ b/src/vm/mlinfo.cpp
@@ -1645,29 +1645,8 @@ MarshalInfo::MarshalInfo(Module* pModule,
     // "un-normalized" signature type. It has to be verified that all the value types
     // that have been normalized away have default marshaling or MarshalAs(Struct).
     // In addition, the nativeType must be updated with the type of the real primitive inside.
-    // We don't normalize on return values of member functions since struct return values need to be treated as structures.
-    if (isParam || !onInstanceMethod)
-    {
-        VerifyAndAdjustNormalizedType(pModule, sig, pTypeContext, &mtype, &nativeType);
-    }
-    else
-    {
-        SigPointer sigtmp = sig;
-        CorElementType closedElemType = sigtmp.PeekElemTypeClosed(pModule, pTypeContext);
-        if (closedElemType == ELEMENT_TYPE_VALUETYPE)
-        {
-            TypeHandle th = sigtmp.GetTypeHandleThrowing(pModule, pTypeContext); 
-            // If the return type of an instance method is a value-type we need the actual return type.
-            // However, if the return type is an enum, we can normalize it.
-            if (!th.IsEnum())
-            {
-                mtype = closedElemType;
-            }
-        }
-
-    }
+    VerifyAndAdjustNormalizedType(pModule, sig, pTypeContext, &mtype, &nativeType);
 #endif // _TARGET_X86_
-
 
     if (nativeType == NATIVE_TYPE_CUSTOMMARSHALER)
     {

--- a/tests/src/Interop/PInvoke/Miscellaneous/ThisCall/ThisCallNative.cpp
+++ b/tests/src/Interop/PInvoke/Miscellaneous/ThisCall/ThisCallNative.cpp
@@ -48,6 +48,11 @@ public:
     {
         return {(int)height};
     }
+
+    virtual int GetInt(int i)
+    {
+        return i;
+    }
 };
 
 

--- a/tests/src/Interop/PInvoke/Miscellaneous/ThisCall/ThisCallTest.cs
+++ b/tests/src/Interop/PInvoke/Miscellaneous/ThisCall/ThisCallTest.cs
@@ -17,6 +17,7 @@ unsafe class ThisCallNative
             public IntPtr getSize;
             public IntPtr getWidth;
             public IntPtr getHeightAsInt;
+            public IntPtr getInt;
         }
 
         public VtableLayout* vtable;
@@ -31,12 +32,29 @@ unsafe class ThisCallNative
         public float height;
     }
 
+    [StructLayout(LayoutKind.Explicit)]
     public struct Width
     {
+        // Add a duplicate field so we can still test a 4-byte HFA return type being passed byref
+        // without hitting our workaround for single-field struct returns on instance methods.
+        [FieldOffset(0)]
+        private float dummyField;
+        [FieldOffset(0)]
         public float width;
     }
 
-    public struct IntWrapper
+    [StructLayout(LayoutKind.Explicit)]
+    public struct HeightAsInt
+    {
+        // Add a duplicate field so we can still test a 4-byte non HFA return type being passed byref
+        // without hitting our workaround for single-field struct returns on instance methods.
+        [FieldOffset(0)]
+        private int dummyField;
+        [FieldOffset(0)]
+        public int i;
+    }
+
+    public struct StructWrappingSingleInt
     {
         public int i;
     }
@@ -46,7 +64,12 @@ unsafe class ThisCallNative
     [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
     public delegate Width GetWidthFn(C* c);
     [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
-    public delegate IntWrapper GetHeightAsIntFn(C* c);
+    public delegate HeightAsInt GetHeightAsIntFn(C* c);
+
+    // We specifically don't want to match the return type here so that we can correctly test
+    // the workaround.
+    [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+    public delegate StructWrappingSingleInt GetIntFn(C* c, int value);
 
     [DllImport(nameof(ThisCallNative))]
     public static extern C* CreateInstanceOfC(float width, float height);
@@ -64,6 +87,7 @@ class ThisCallTest
             Test8ByteHFA(instance);
             Test4ByteHFA(instance);
             Test4ByteNonHFA(instance);
+            TestSingleFieldStructReturnWorkaround(instance);
         }
         catch (System.Exception ex)
         {
@@ -96,8 +120,18 @@ class ThisCallTest
     {
         ThisCallNative.GetHeightAsIntFn callback = Marshal.GetDelegateForFunctionPointer<ThisCallNative.GetHeightAsIntFn>(instance->vtable->getHeightAsInt);
 
-        ThisCallNative.IntWrapper result = callback(instance);
+        ThisCallNative.HeightAsInt result = callback(instance);
 
         Assert.AreEqual((int)instance->height, result.i);
+    }
+
+    private static unsafe void TestSingleFieldStructReturnWorkaround(ThisCallNative.C* instance)
+    {
+        ThisCallNative.GetIntFn callback = Marshal.GetDelegateForFunctionPointer<ThisCallNative.GetIntFn>(instance->vtable->getInt);
+
+        int value = 42;
+        ThisCallNative.StructWrappingSingleInt result = callback(instance, value);
+
+        Assert.AreEqual(value, result.i);
     }
 }


### PR DESCRIPTION
Some of our users (such as WPF), use a struct to wrap their HRESULT return types on COM members when they use `PreserveSig`. When we updated CoreCLR to correctly handle the Windows calling convention, we broke this behavior.

This PR adds a workaround to marshal structs that have only one member that is a (struct that has only one member of a...) primitive type as though it was the primitive type.

Add tests verifying behavior.

cc: @jeffschwMSFT @davidwrighton