### PR TITLE
JIT: handle pinned pointers in inlinee

### DIFF
--- a/src/jit/inline.h
+++ b/src/jit/inline.h
@@ -595,11 +595,11 @@ struct InlineInfo
     int           lclTmpNum[MAX_INL_LCLS];                     // map local# -> temp# (-1 if unused)
     InlLclVarInfo lclVarInfo[MAX_INL_LCLS + MAX_INL_ARGS + 1]; // type information from local sig
 
-    unsigned numberOfGcRefLocals; // Number of TYP_REF and TYP_BYREF locals
+    unsigned numberOfMustNullLocals; // Number of TYP_REF, TYP_BYREF, and pinned TYP_PTR locals
 
-    bool HasGcRefLocals() const
+    bool HasMustNullLocals() const
     {
-        return numberOfGcRefLocals > 0;
+        return numberOfMustNullLocals > 0;
     }
 
     bool     thisDereferencedFirst;

--- a/tests/src/JIT/Regression/JitBlue/GitHub_23411/GitHub_23411.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_23411/GitHub_23411.il
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 .assembly extern System.Runtime { }
 .assembly extern System.Console { }
 .assembly extern System.Globalization { }

--- a/tests/src/JIT/Regression/JitBlue/GitHub_23950/GitHub_23950.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_23950/GitHub_23950.il
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib {}
+
+.assembly GitHub_23970 {}
+
+// Test that jit can inline method with a pinned pointer
+
+.class public sequential ansi sealed beforefieldinit Program
+	extends [mscorlib]System.Object
+{
+	.method private hidebysig static 
+		int32 Main (
+			string[] args
+		) cil managed 
+	{
+
+		.maxstack 1
+		.entrypoint
+		.locals init (
+			[0] int32
+		)
+		nop
+		ldc.i4.s 100
+		stloc.0
+		ldloca.s 0
+		call int32 Program::GetValueUnsafe(int32&)
+		ret
+	}
+
+	.method private hidebysig 
+		static int32 GetValueUnsafe (
+			int32& buffer
+		) cil managed 
+	{
+		.maxstack 3
+		.locals init (
+			[0] int32* pinned
+		)
+
+		ldarg.0
+		stloc.0
+		ldloc.0
+		ldind.i4
+		ret
+	}
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_23950/GitHub_23950.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_23950/GitHub_23950.ilproj
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_23950.il" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
We may see pins on locals that are not gc types. Handle this case.

Closes #23950.

Also added a missing copyright header on an unrelated test.