### PR TITLE
[JIT] Remove extra bound checks for explicit range checks

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -6851,6 +6851,10 @@ public:
     void optObtainLoopCloningOpts(LoopCloneContext* context);
     bool optIsLoopClonable(unsigned loopInd);
 
+    bool optExtractUniqueBBFromCondScope(BasicBlock*                  bbCond,
+                                         jitstd::vector<BasicBlock*>* extracted,
+                                         bool                         isReversedCond = false);
+
     bool optCanCloneLoops();
 
 #ifdef DEBUG

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -5199,7 +5199,7 @@ bool Compiler::optExtractUniqueBBFromCondScope(BasicBlock*                  bbCo
         for (BasicBlock* bbToAnalysis : recTemp)
         {
             // We do not analysis again that marked as true in records
-            if (recFlow.Lookup(bbToAnalysis) || !recFlow[bbToAnalysis])
+            if (!recFlow[bbToAnalysis])
             {
                 recNext.push_back(bbToAnalysis);
             }

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -5086,6 +5086,13 @@ bool Compiler::optExtractUniqueBBFromCondScope(BasicBlock*                  bbCo
     BasicBlock* bbFalse = bbCond->bbJumpDest;
     BasicBlock* bbTrue  = bbCond->bbNext;
 
+#ifdef _DEBUG
+    if (verbose)
+    {
+        printf("Finding unique paths flows from " FMT_BB ", \n", bbCond->bbNum);
+    }
+#endif
+
     if (isReversedCond)
     {
         std::swap(bbFalse, bbTrue);
@@ -5112,6 +5119,13 @@ bool Compiler::optExtractUniqueBBFromCondScope(BasicBlock*                  bbCo
                     {
                         recFlow.Set(bbFlowTo, true, BlkSet::SetKind::Overwrite);
                         recTemp.push_back(bbFlowTo);
+
+#ifdef _DEBUG
+                        if (verbose)
+                        {
+                            printf("  found path for " FMT_BB ", \n", bbFlowTo->bbNum);
+                        }
+#endif
                     }
                     else
                     {
@@ -5128,6 +5142,12 @@ bool Compiler::optExtractUniqueBBFromCondScope(BasicBlock*                  bbCo
                     {
                         recFlow.Set(bbFlowTo, true, BlkSet::SetKind::Overwrite);
                         recTemp.push_back(bbFlowTo);
+#ifdef _DEBUG
+                        if (verbose)
+                        {
+                            printf("  found path for " FMT_BB ", \n", bbFlowTo->bbNum);
+                        }
+#endif
                     }
                     else
                     {
@@ -5144,6 +5164,12 @@ bool Compiler::optExtractUniqueBBFromCondScope(BasicBlock*                  bbCo
                     {
                         recFlow.Set(bbFlowToF, true, BlkSet::SetKind::Overwrite);
                         recTemp.push_back(bbFlowToF);
+#ifdef _DEBUG
+                        if (verbose)
+                        {
+                            printf("  found path for " FMT_BB ", \n", bbFlowToF->bbNum);
+                        }
+#endif
                     }
                     else
                     {
@@ -5176,6 +5202,12 @@ bool Compiler::optExtractUniqueBBFromCondScope(BasicBlock*                  bbCo
                         {
                             recFlow.Set(bbFlowTo, true, BlkSet::SetKind::Overwrite);
                             recTemp.push_back(bbFlowTo);
+#ifdef _DEBUG
+                            if (verbose)
+                            {
+                                printf("  found path to " FMT_BB ", \n", bbFlowTo->bbNum);
+                            }
+#endif
                         }
                         else
                         {
@@ -5207,11 +5239,24 @@ bool Compiler::optExtractUniqueBBFromCondScope(BasicBlock*                  bbCo
         recTemp.clear();
     }
 
+#ifdef _DEBUG
+    if (verbose)
+    {
+        printf(FMT_BB " can uniquely flows to \n", bbCond->bbNum);
+    }
+#endif
+
     for (auto iter = recFlow.Begin(); !iter.Equal(recFlow.End()); iter.Next())
     {
         if (iter.GetValue() == true)
         {
             extracted->push_back(iter.Get());
+#ifdef _DEBUG
+            if (verbose)
+            {
+                printf("  -" FMT_BB ", \n", bbCond->bbNum);
+            }
+#endif
         }
     }
 

--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -239,6 +239,9 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, GenTreeStmt* stmt, GenTre
 
             break;
         }
+        
+        default:
+            break;
     }
 }
 

--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -413,7 +413,7 @@ void RangeCheck::OptimizeRangeCheckWithExplicitCheck(BasicBlock*  block,
 
     for (BasicBlock* bbIter : extracted)
     {
-        for (GenTreeStmt* gtStmtIter = bbIter->bbTreeList->AsStmt(); gtStmtIter; gtStmtIter = gtStmtIter->gtNextStmt)
+        for (GenTreeStmt* gtStmtIter = bbIter->firstStmt(); gtStmtIter != nullptr; gtStmtIter = gtStmtIter->getNextStmt())
         {
             for (GenTree* gtTreeIter = gtStmtIter->gtStmtList; gtTreeIter; gtTreeIter = gtTreeIter->gtNext)
             {

--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -208,7 +208,7 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, GenTreeStmt* stmt, GenTre
             GenTree*   gtCmpLen = gtCmp->gtGetOp1();
             GenTree*   gtCmpCns = gtCmp->gtGetOp2IfPresent();
 
-            // The compare expression can be comma because of CSE expansion. extract effeictive value before checking it
+            // The compare expression can be comma because of CSE expansion. extract effective value before checking it
             if (gtCmpLen->OperIs(GT_COMMA))
             {
                 GenTree* cmmOp1 = gtCmpLen->gtGetOp1();
@@ -227,8 +227,6 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, GenTreeStmt* stmt, GenTre
                 }
             }
 
-            // The target comparer should contains GTF_ARRLEN_ARR_IDX flags which is mean this local variable is length
-            // also check that this is kind of explicit range checking
             if (gtCmpCns == nullptr || !gtCmpCns->OperIs(GT_CNS_INT) || !gtCmpLen->OperIs(GT_ARR_LENGTH))
             {
                 break;

--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -239,7 +239,7 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, GenTreeStmt* stmt, GenTre
 
             break;
         }
-        
+
         default:
             break;
     }

--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -413,7 +413,8 @@ void RangeCheck::OptimizeRangeCheckWithExplicitCheck(BasicBlock*  block,
 
     for (BasicBlock* bbIter : extracted)
     {
-        for (GenTreeStmt* gtStmtIter = bbIter->firstStmt(); gtStmtIter != nullptr; gtStmtIter = gtStmtIter->getNextStmt())
+        for (GenTreeStmt* gtStmtIter = bbIter->firstStmt(); gtStmtIter != nullptr;
+             gtStmtIter              = gtStmtIter->getNextStmt())
         {
             for (GenTree* gtTreeIter = gtStmtIter->gtStmtList; gtTreeIter; gtTreeIter = gtTreeIter->gtNext)
             {

--- a/src/jit/rangecheck.h
+++ b/src/jit/rangecheck.h
@@ -465,6 +465,12 @@ public:
     // contain the tree.
     void OptimizeRangeCheck(BasicBlock* block, GenTreeStmt* stmt, GenTree* tree);
 
+    void OptimizeRangeCheckWithAssertion(BasicBlock* block, GenTreeStmt* stmt, GenTree* treeParent);
+    void OptimizeRangeCheckWithExplicitCheck(BasicBlock*  block,
+                                             GenTreeStmt* stmt,
+                                             GenTree*     treeParent,
+                                             unsigned int arrVn);
+
     // Given the index expression try to find its range.
     // The range of a variable depends on its rhs which in turn depends on its constituent variables.
     // The "path" is the path taken in the search for the rhs' range and its constituents' range.

--- a/tests/src/JIT/RangeCheck/rangecheck1.cs
+++ b/tests/src/JIT/RangeCheck/rangecheck1.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+using System;
+namespace RangeCheck
+{
+    internal class RC1
+    {
+        public static int Main(String[] args)
+        {
+            int[] testArr = {0, 0, 0, 10, 10, 10, 10, 10, 10, 10};
+
+            if (testArr.Length > 5)
+            {
+                testArr[0] = 10;
+            }
+
+            if (testArr.Length > 10)
+            {
+                testArr[10] = 10;
+            }
+
+            if (testArr.Length > 0 && testArr[0] == 10)
+            {
+                testArr[1] = 10;
+            }
+            else
+            {
+                try 
+                {
+                    testArr[10] = 10;
+                    return 101;
+                }
+                catch(Exception e)
+                {
+                    
+                }
+            }
+
+            if (testArr.Length < 3)
+            {
+                return 101;
+            }
+            else
+            {
+                testArr[2] = 10;
+            }
+
+            int result = 0;
+            foreach(int i in testArr)
+            {
+                result += i;
+            }
+
+            return result;
+        }
+    }
+}
+

--- a/tests/src/JIT/RangeCheck/rangecheck1.csproj
+++ b/tests/src/JIT/RangeCheck/rangecheck1.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{34026C3E-193C-45CF-B55D-8FAB068D4F79}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+    <Optimize>False</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="rangecheck1.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Original PR https://github.com/dotnet/coreclr/pull/22848 and rebased because of `optRemoveRangeCheck`

Currently, removing bound checks for explicit array(includes buffer, char[], string, array like etcs.) range check on some major patterns.

such as
```
if (array.Length > 0)
{
    // Some (array) use expressions.
}
```

The explicit range check removal will be triggered if only the code scope of if expression is only can reach with if expressions, which means there is no Side-Effect on that code scope.

Related to #19620

