### PR TITLE
Fix test for 64-bit platforms

### DIFF
--- a/tests/src/JIT/Methodical/largeframes/skip4/skippage4.cs
+++ b/tests/src/JIT/Methodical/largeframes/skip4/skippage4.cs
@@ -18,7 +18,7 @@ namespace BigFrames
     {
         [FieldOffset(0)]
         public int i1;
-        [FieldOffset(65500)]
+        [FieldOffset(65496)] // Must be 8-byte aligned for test to work on 64-bit platforms.
         public Object o1;
     }
 


### PR DESCRIPTION
Object type in structs apparently must be 8 byte aligned.

Fixes #23986