### PR TITLE
Compile JIT sources with /W4

### DIFF
--- a/src/inc/yieldprocessornormalized.h
+++ b/src/inc/yieldprocessornormalized.h
@@ -101,7 +101,7 @@ FORCEINLINE void YieldProcessorNormalized(const YieldProcessorNormalizationInfo 
     {
         // On platforms with a small SIZE_T, prevent overflow on the multiply below. normalizationInfo.yieldsPerNormalizedYield
         // is limited to MinNsPerNormalizedYield by InitializeYieldProcessorNormalized().
-        const unsigned int MaxCount = (unsigned int)SIZE_MAX / MinNsPerNormalizedYield;
+        const unsigned int MaxCount = UINT_MAX / MinNsPerNormalizedYield;
         if (count > MaxCount)
         {
             count = MaxCount;
@@ -147,7 +147,7 @@ FORCEINLINE void YieldProcessorNormalizedForPreSkylakeCount(
     {
         // On platforms with a small SIZE_T, prevent overflow on the multiply below. normalizationInfo.yieldsPerNormalizedYield
         // is limited to MinNsPerNormalizedYield by InitializeYieldProcessorNormalized().
-        const unsigned int MaxCount = (unsigned int)SIZE_MAX / MinNsPerNormalizedYield;
+        const unsigned int MaxCount = UINT_MAX / MinNsPerNormalizedYield;
         if (preSkylakeCount > MaxCount)
         {
             preSkylakeCount = MaxCount;

--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -9,6 +9,8 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   add_compile_options(-Wno-error)
 endif()
 
+add_compile_options($<$<CXX_COMPILER_ID:MSVC>:-W4>)
+
 if (CLR_CMAKE_TARGET_ARCH_AMD64 OR CLR_CMAKE_TARGET_ARCH_ARM64 OR (CLR_CMAKE_TARGET_ARCH_I386 AND NOT CLR_CMAKE_PLATFORM_UNIX))
   add_definitions(-DFEATURE_SIMD)
   add_definitions(-DFEATURE_HW_INTRINSICS)

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7439,8 +7439,8 @@ private:
 #endif // _TARGET_ARM_
 
 #if defined(_TARGET_UNIX_)
-    int mapRegNumToDwarfReg(regNumber reg);
-    void createCfiCode(FuncInfoDsc* func, UCHAR codeOffset, UCHAR opcode, USHORT dwarfReg, INT offset = 0);
+    short mapRegNumToDwarfReg(regNumber reg);
+    void createCfiCode(FuncInfoDsc* func, UNATIVE_OFFSET codeOffset, UCHAR opcode, short dwarfReg, INT offset = 0);
     void unwindPushPopCFI(regNumber reg);
     void unwindBegPrologCFI();
     void unwindPushPopMaskCFI(regMaskTP regMask, bool isFloat);

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -18036,9 +18036,9 @@ bool GenTreeHWIntrinsic::OperIsMemoryLoadOrStore()
 {
 #ifdef _TARGET_XARCH_
     return OperIsMemoryLoad() || OperIsMemoryStore();
-#else  // _TARGET_XARCH_
+#else
     return false;
-#endif // _TARGET_XARCH_
+#endif
 }
 
 #endif // FEATURE_HW_INTRINSICS

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -18036,8 +18036,9 @@ bool GenTreeHWIntrinsic::OperIsMemoryLoadOrStore()
 {
 #ifdef _TARGET_XARCH_
     return OperIsMemoryLoad() || OperIsMemoryStore();
-#endif // _TARGET_XARCH_
+#else  // _TARGET_XARCH_
     return false;
+#endif // _TARGET_XARCH_
 }
 
 #endif // FEATURE_HW_INTRINSICS

--- a/src/jit/hashbv.cpp
+++ b/src/jit/hashbv.cpp
@@ -793,15 +793,16 @@ void hashBv::setBit(indexType index)
 {
     assert(index >= 0);
     assert(this->numNodes == this->getNodeCount());
-    hashBvNode* result = nullptr;
 
     indexType baseIndex = index & ~(BITS_PER_NODE - 1);
     indexType base      = index - baseIndex;
     indexType elem      = base / BITS_PER_ELEMENT;
     indexType posi      = base % BITS_PER_ELEMENT;
 
+    hashBvNode* result = nodeArr[0];
+
     // this should be the 99% case :  when there is only one node in the structure
-    if ((result = nodeArr[0]) && result->baseIndex == baseIndex)
+    if ((result != nullptr) && (result->baseIndex == baseIndex))
     {
         result->elements[elem] |= indexType(1) << posi;
         return;

--- a/src/jit/hwintrinsiccodegenxarch.cpp
+++ b/src/jit/hwintrinsiccodegenxarch.cpp
@@ -174,7 +174,7 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
                 if ((ival != -1) && varTypeIsFloating(baseType))
                 {
                     assert((ival >= 0) && (ival <= 127));
-                    genHWIntrinsic_R_R_RM_I(node, ins, ival);
+                    genHWIntrinsic_R_R_RM_I(node, ins, static_cast<int8_t>(ival));
                 }
                 else if (category == HW_Category_MemoryLoad)
                 {

--- a/src/jit/hwintrinsicxarch.cpp
+++ b/src/jit/hwintrinsicxarch.cpp
@@ -117,7 +117,6 @@ static InstructionSet X64VersionOfIsa(InstructionSet isa)
             return InstructionSet_POPCNT_X64;
         default:
             unreached();
-            return InstructionSet_ILLEGAL;
     }
 }
 
@@ -396,10 +395,7 @@ GenTree* HWIntrinsicInfo::lookupLastOp(const GenTreeHWIntrinsic* node)
         }
 
         default:
-        {
             unreached();
-            return nullptr;
-        }
     }
 }
 
@@ -660,7 +656,6 @@ GenTree* Compiler::impNonConstFallback(NamedIntrinsic intrinsic, var_types simdT
 
         default:
             unreached();
-            return nullptr;
     }
 }
 
@@ -904,9 +899,9 @@ GenTree* Compiler::impHWIntrinsic(NamedIntrinsic        intrinsic,
 
                 op3 = addRangeCheckIfNeeded(intrinsic, op3, mustExpand);
 
-                argType = JITtype2varType(strip(info.compCompHnd->getArgType(sig, arg2, &argClass)));
-                op2     = getArgForHWIntrinsic(argType, argClass);
-                var_types op2Type;
+                argType           = JITtype2varType(strip(info.compCompHnd->getArgType(sig, arg2, &argClass)));
+                op2               = getArgForHWIntrinsic(argType, argClass);
+                var_types op2Type = TYP_UNDEF;
                 if (intrinsic == NI_AVX2_GatherVector128 || intrinsic == NI_AVX2_GatherVector256)
                 {
                     assert(varTypeIsSIMD(op2->TypeGet()));
@@ -1941,10 +1936,7 @@ GenTree* Compiler::impBMI1OrBMI2Intrinsic(NamedIntrinsic        intrinsic,
         }
 
         default:
-        {
             unreached();
-            return nullptr;
-        }
     }
 }
 

--- a/src/jit/unwind.cpp
+++ b/src/jit/unwind.cpp
@@ -120,9 +120,10 @@ void Compiler::unwindGetFuncLocations(FuncInfoDsc*             func,
 
 #if defined(_TARGET_UNIX_)
 
-void Compiler::createCfiCode(FuncInfoDsc* func, UCHAR codeOffset, UCHAR cfiOpcode, USHORT dwarfReg, INT offset)
+void Compiler::createCfiCode(FuncInfoDsc* func, UNATIVE_OFFSET codeOffset, UCHAR cfiOpcode, short dwarfReg, INT offset)
 {
-    CFI_CODE cfiEntry(codeOffset, cfiOpcode, dwarfReg, offset);
+    noway_assert(static_cast<UCHAR>(codeOffset) == codeOffset);
+    CFI_CODE cfiEntry(static_cast<UCHAR>(codeOffset), cfiOpcode, dwarfReg, offset);
     func->cfiCodes->push_back(cfiEntry);
 }
 
@@ -130,9 +131,8 @@ void Compiler::unwindPushPopCFI(regNumber reg)
 {
     assert(compGeneratingProlog);
 
-    FuncInfoDsc* func     = funCurrentFunc();
-    unsigned int cbProlog = unwindGetCurrentOffset(func);
-    noway_assert((BYTE)cbProlog == cbProlog);
+    FuncInfoDsc*   func     = funCurrentFunc();
+    UNATIVE_OFFSET cbProlog = unwindGetCurrentOffset(func);
 
     regMaskTP relOffsetMask = RBM_CALLEE_SAVED
 #if defined(UNIX_AMD64_ABI) && ETW_EBP_FRAMED
@@ -205,12 +205,11 @@ void Compiler::unwindPushPopMaskCFI(regMaskTP regMask, bool isFloat)
 void Compiler::unwindAllocStackCFI(unsigned size)
 {
     assert(compGeneratingProlog);
-    FuncInfoDsc* func     = funCurrentFunc();
-    unsigned int cbProlog = 0;
+    FuncInfoDsc*   func     = funCurrentFunc();
+    UNATIVE_OFFSET cbProlog = 0;
     if (compGeneratingProlog)
     {
         cbProlog = unwindGetCurrentOffset(func);
-        noway_assert((BYTE)cbProlog == cbProlog);
     }
     createCfiCode(func, cbProlog, CFI_ADJUST_CFA_OFFSET, DWARF_REG_ILLEGAL, size);
 }
@@ -225,9 +224,8 @@ void Compiler::unwindAllocStackCFI(unsigned size)
 void Compiler::unwindSetFrameRegCFI(regNumber reg, unsigned offset)
 {
     assert(compGeneratingProlog);
-    FuncInfoDsc* func     = funCurrentFunc();
-    unsigned int cbProlog = unwindGetCurrentOffset(func);
-    noway_assert((BYTE)cbProlog == cbProlog);
+    FuncInfoDsc*   func     = funCurrentFunc();
+    UNATIVE_OFFSET cbProlog = unwindGetCurrentOffset(func);
 
     createCfiCode(func, cbProlog, CFI_DEF_CFA_REGISTER, mapRegNumToDwarfReg(reg));
     if (offset != 0)

--- a/src/jit/unwindamd64.cpp
+++ b/src/jit/unwindamd64.cpp
@@ -18,9 +18,9 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 #if defined(_TARGET_AMD64_)
 #ifdef UNIX_AMD64_ABI
-int Compiler::mapRegNumToDwarfReg(regNumber reg)
+short Compiler::mapRegNumToDwarfReg(regNumber reg)
 {
-    int dwarfReg = DWARF_REG_ILLEGAL;
+    short dwarfReg = DWARF_REG_ILLEGAL;
 
     switch (reg)
     {
@@ -457,7 +457,6 @@ void Compiler::unwindSaveRegCFI(regNumber reg, unsigned offset)
         FuncInfoDsc* func = funCurrentFunc();
 
         unsigned int cbProlog = unwindGetCurrentOffset(func);
-        noway_assert((BYTE)cbProlog == cbProlog);
         createCfiCode(func, cbProlog, CFI_REL_OFFSET, mapRegNumToDwarfReg(reg), offset);
     }
 }

--- a/src/jit/unwindarm.cpp
+++ b/src/jit/unwindarm.cpp
@@ -17,9 +17,9 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #endif
 
 #if defined(_TARGET_ARM_) && defined(_TARGET_UNIX_)
-int Compiler::mapRegNumToDwarfReg(regNumber reg)
+short Compiler::mapRegNumToDwarfReg(regNumber reg)
 {
-    int dwarfReg = DWARF_REG_ILLEGAL;
+    short dwarfReg = DWARF_REG_ILLEGAL;
 
     switch (reg)
     {

--- a/src/jit/unwindarm64.cpp
+++ b/src/jit/unwindarm64.cpp
@@ -19,9 +19,9 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #if defined(_TARGET_ARM64_)
 
 #if defined(_TARGET_UNIX_)
-int Compiler::mapRegNumToDwarfReg(regNumber reg)
+short Compiler::mapRegNumToDwarfReg(regNumber reg)
 {
-    int dwarfReg = DWARF_REG_ILLEGAL;
+    short dwarfReg = DWARF_REG_ILLEGAL;
 
     NYI("CFI codes");
 

--- a/src/jit/unwindx86.cpp
+++ b/src/jit/unwindx86.cpp
@@ -21,9 +21,9 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #endif // _TARGET_X86_
 
 #if defined(_TARGET_UNIX_)
-int Compiler::mapRegNumToDwarfReg(regNumber reg)
+short Compiler::mapRegNumToDwarfReg(regNumber reg)
 {
-    int dwarfReg = DWARF_REG_ILLEGAL;
+    short dwarfReg = DWARF_REG_ILLEGAL;
 
     NYI("CFI codes");
 


### PR DESCRIPTION
This enables VC++'s `/W4` for JIT sources. In addition to helping catching potential coding issues this also matches what the internal .NET Framework builds seem to use so it prevents code going in that compiles fine in CoreCLR and fails in the internal build.

Apart from `/W4` it looks like the internal build uses similar compilation options, except for some unknown `guard` options.
