### PR TITLE
Fix lsraBlockEpoch check.

### DIFF
--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -1397,6 +1397,10 @@ private:
     int compareBlocksForSequencing(BasicBlock* block1, BasicBlock* block2, bool useBlockWeights);
     BasicBlockList* blockSequenceWorkList;
     bool            blockSequencingDone;
+#ifdef DEBUG
+    // LSRA must not change number of blocks and blockEpoch that it initializes at start.
+    unsigned blockEpoch;
+#endif // DEBUG
     void addToBlockSequenceWorkList(BlockSet sequencedBlockSet, BasicBlock* block, BlockSet& predSet);
     void removeFromBlockSequenceWorkList(BasicBlockList* listNode, BasicBlockList* prevNode);
     BasicBlock* getNextCandidateFromWorkList();


### PR DESCRIPTION
There were 2 errors in my old change #11233:
1. an assignment inside a noway assert: `noway_assert(lsraBlockEpoch = compiler->GetCurBasicBlockEpoch());`, so it was not checking anything;
2. `lsraBlockEpoch` was initizalized too early before we called `buildIntervals` that set `blockSequencingDone` and called `compiler->EnsureBasicBlockEpoch();` and  initialized `bbVisitedSet = BlockSetOps::MakeEmpty(compiler);`.

Fix both errors and add an additional check that we set `blockSequencingDone` only once.