### PR TITLE
JIT: ignore pinning of non-gc types

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -18929,22 +18929,28 @@ void Compiler::impInlineInitVars(InlineInfo* pInlineInfo)
         var_types type = (var_types)eeGetArgType(localsSig, &methInfo->locals, &isPinned);
 
         lclVarInfo[i + argCnt].lclHasLdlocaOp = false;
-        lclVarInfo[i + argCnt].lclIsPinned    = isPinned;
         lclVarInfo[i + argCnt].lclTypeInfo    = type;
 
         if (varTypeIsGC(type))
         {
+            if (isPinned)
+            {
+                JITDUMP("Inlinee local #%02u is pinned\n", i);
+                lclVarInfo[i + argCnt].lclIsPinned = true;
+
+                // Pinned locals may cause inlines to fail.
+                inlineResult->Note(InlineObservation::CALLEE_HAS_PINNED_LOCALS);
+                if (inlineResult->IsFailure())
+                {
+                    return;
+                }
+            }
+
             pInlineInfo->numberOfGcRefLocals++;
         }
-
-        if (isPinned)
+        else if (isPinned)
         {
-            // Pinned locals may cause inlines to fail.
-            inlineResult->Note(InlineObservation::CALLEE_HAS_PINNED_LOCALS);
-            if (inlineResult->IsFailure())
-            {
-                return;
-            }
+            JITDUMP("Ignoring pin on inlinee local #%02u -- not a GC type\n", i);
         }
 
         lclVarInfo[i + argCnt].lclVerTypeInfo = verParseArgSigToTypeInfo(&methInfo->locals, localsSig);

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -255,7 +255,19 @@ void Compiler::lvaInitTypeRef()
 
         lvaInitVarDsc(varDsc, varNum, corInfoType, typeHnd, localsSig, &info.compMethodInfo->locals);
 
-        varDsc->lvPinned  = ((corInfoTypeWithMod & CORINFO_TYPE_MOD_PINNED) != 0);
+        if ((corInfoTypeWithMod & CORINFO_TYPE_MOD_PINNED) != 0)
+        {
+            if ((corInfoType == CORINFO_TYPE_CLASS) || (corInfoType == CORINFO_TYPE_BYREF))
+            {
+                JITDUMP("Setting lvPinned for V%02u\n", varNum);
+                varDsc->lvPinned = 1;
+            }
+            else
+            {
+                JITDUMP("Ignoring pin for non-GC type V%02u\n", varNum);
+            }
+        }
+
         varDsc->lvOnFrame = true; // The final home for this local variable might be our local stack frame
 
         if (corInfoType == CORINFO_TYPE_CLASS)

--- a/tests/src/JIT/Regression/JitBlue/GitHub_23411/GitHub_23411.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_23411/GitHub_23411.il
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 .assembly extern System.Runtime { }
 .assembly extern System.Console { }
 .assembly extern System.Globalization { }

--- a/tests/src/JIT/Regression/JitBlue/GitHub_23950/GitHub_23950.il
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_23950/GitHub_23950.il
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib {}
+
+.assembly GitHub_23970 {}
+
+// Test that jit can inline method with a pinned pointer
+
+.class public sequential ansi sealed beforefieldinit Program
+	extends [mscorlib]System.Object
+{
+	.method private hidebysig static 
+		int32 Main (
+			string[] args
+		) cil managed 
+	{
+
+		.maxstack 1
+		.entrypoint
+		.locals init (
+			[0] int32
+		)
+		nop
+		ldc.i4.s 100
+		stloc.0
+		ldloca.s 0
+		call int32 Program::GetValueUnsafe(int32&)
+		ret
+	}
+
+	.method private hidebysig 
+		static int32 GetValueUnsafe (
+			int32& buffer
+		) cil managed 
+	{
+		.maxstack 3
+		.locals init (
+			[0] int32* pinned
+		)
+
+		ldarg.0
+		stloc.0
+		ldloc.0
+		ldind.i4
+		ret
+	}
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_23950/GitHub_23950.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_23950/GitHub_23950.ilproj
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GitHub_23950.il" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
We may see pin modifiers on locals that are not gc types.
Ignore these modifiers.

Closes #23950.

Also added a missing copyright header on an unrelated test.