### PR TITLE
Fix issue #23943

### DIFF
--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -8422,9 +8422,8 @@ BYTE* emitter::emitOutputLoadLabel(BYTE* dst, BYTE* srcAddr, BYTE* dstAddr, inst
     {
         // adrp x, [rel page addr] -- compute page address: current page addr + rel page addr
         assert(fmt == IF_LARGEADR);
-        ssize_t relPageAddr =
-            (((ssize_t)dstAddr & 0xFFFFFFFFFFFFF000LL) - ((ssize_t)srcAddr & 0xFFFFFFFFFFFFF000LL)) >> 12;
-        dst = emitOutputShortAddress(dst, INS_adrp, IF_DI_1E, relPageAddr, dstReg);
+        ssize_t relPageAddr = computeRelPageAddr((size_t)dstAddr, (size_t)srcAddr);
+        dst                 = emitOutputShortAddress(dst, INS_adrp, IF_DI_1E, relPageAddr, dstReg);
 
         // add x, x, page offs -- compute address = page addr + page offs
         ssize_t imm12 = (ssize_t)dstAddr & 0xFFF; // 12 bits
@@ -8524,8 +8523,7 @@ BYTE* emitter::emitOutputLJ(insGroup* ig, BYTE* dst, instrDesc* i)
             {
                 // adrp x, [rel page addr] -- compute page address: current page addr + rel page addr
                 assert(fmt == IF_LARGELDC);
-                ssize_t relPageAddr =
-                    (((ssize_t)dstAddr & 0xFFFFFFFFFFFFF000LL) - ((ssize_t)srcAddr & 0xFFFFFFFFFFFFF000LL)) >> 12;
+                ssize_t relPageAddr = computeRelPageAddr((size_t)dstAddr, (size_t)srcAddr);
                 if (isVectorRegister(dstReg))
                 {
                     // Update addrReg with the reserved integer register

--- a/src/jit/emitarm64.h
+++ b/src/jit/emitarm64.h
@@ -669,6 +669,11 @@ static bool isValidImmCond(ssize_t imm);
 static bool isValidImmCondFlags(ssize_t imm);
 static bool isValidImmCondFlagsImm5(ssize_t imm);
 
+inline static ssize_t computeRelPageAddr(size_t dstAddr, size_t srcAddr)
+{
+    return (dstAddr >> 12) - (srcAddr >> 12);
+}
+
 /************************************************************************/
 /*           The public entry points to output instructions             */
 /************************************************************************/

--- a/src/jit/emitarm64.h
+++ b/src/jit/emitarm64.h
@@ -669,6 +669,7 @@ static bool isValidImmCond(ssize_t imm);
 static bool isValidImmCondFlags(ssize_t imm);
 static bool isValidImmCondFlagsImm5(ssize_t imm);
 
+// Computes page "delta" between two addresses
 inline static ssize_t computeRelPageAddr(size_t dstAddr, size_t srcAddr)
 {
     return (dstAddr >> 12) - (srcAddr >> 12);


### PR DESCRIPTION
The issue https://github.com/dotnet/coreclr/issues/23943 is due to literal `0xFFFFFFFFFFFFF000LL` being **long long unsigned int** and using as if it were **long long int**.

https://github.com/dotnet/coreclr/blob/77a5f9cef77c34db739bb3c13bfd091c693a12d4/src/jit/emitarm64.cpp#L8425-L8427

All the following expressions
* `0xFFFFFFFFFFFFF000LL`
* `((ssize_t)dstAddr & 0xFFFFFFFFFFFFF000LL)`
* `((ssize_t)srcAddr & 0xFFFFFFFFFFFFF000LL)` 
* `(((ssize_t)dstAddr & 0xFFFFFFFFFFFFF000LL) - ((ssize_t)srcAddr & 0xFFFFFFFFFFFFF000LL))` 

have **long long unsigned int** type (see https://godbolt.org/z/Z443bf).

Consequently, C++ compiler uses **lsr** instruction instead of **asr** instruction for shifting 12 bits to the right.

This can be seen from the generated assembly for the expression computing `relPageAddr`

```asm
  244978:       9274ce88        and     x8, x20, #0xfffffffffffff000
  24497c:       9274cec9        and     x9, x22, #0xfffffffffffff000
  244980:       cb090108        sub     x8, x8, x9
  244984:       d34cfd04        lsr     x4, x8, #12
```

With this changes (introducing and using `computeRelPageAddr` function) the corresponding expression for `relPageAddr` will be
```asm
  244978:       d34cfe88        lsr     x8, x20, #12
  24497c:       cb563104        sub     x4, x8, x22, lsr #12
```


Fixes issue #23943 