### PR TITLE
Make MarshalAsAttribute partial

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/MarshalAsAttribute.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/MarshalAsAttribute.cs
@@ -5,7 +5,7 @@
 namespace System.Runtime.InteropServices
 {
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Field | AttributeTargets.ReturnValue, Inherited = false)]
-    public sealed class MarshalAsAttribute : Attribute
+    public sealed partial class MarshalAsAttribute : Attribute
     {
         public MarshalAsAttribute(UnmanagedType unmanagedType)
         {


### PR DESCRIPTION
Mono runtime uses this attribute in C thus we need to sync [layouts](https://github.com/mono/mono/blob/master/mono/metadata/object-internals.h#L1512-L1524).
so I want to add `[StructLayout(LayoutKind.Sequential)]` for Mono.

Current auto-layout for this attribute is:
```
Type layout for 'MarshalAsAttribute'
Size: 56 bytes. Paddings: 2 bytes (%3 of empty space)
|=======================================================|
| Object Header (8 bytes)                               |
|-------------------------------------------------------|
| Method Table Ptr (8 bytes)                            |
|=======================================================|
|   0-7: Type SafeArrayUserDefinedSubType (8 bytes)     |
|-------------------------------------------------------|
|  8-15: String MarshalType (8 bytes)                   |
|-------------------------------------------------------|
| 16-23: Type MarshalTypeRef (8 bytes)                  |
|-------------------------------------------------------|
| 24-31: String MarshalCookie (8 bytes)                 |
|-------------------------------------------------------|
| 32-35: UnmanagedType <Value>k__BackingField (4 bytes) |
|-------------------------------------------------------|
| 36-39: VarEnum SafeArraySubType (4 bytes)             |
|-------------------------------------------------------|
| 40-43: Int32 IidParameterIndex (4 bytes)              |
|-------------------------------------------------------|
| 44-47: UnmanagedType ArraySubType (4 bytes)           |
|-------------------------------------------------------|
| 48-51: Int32 SizeConst (4 bytes)                      |
|-------------------------------------------------------|
| 52-53: Int16 SizeParamIndex (2 bytes)                 |
|-------------------------------------------------------|
| 54-55: padding (2 bytes)                              |
|=======================================================|
```

cc: @marek-safar @jkotas 