### PR TITLE
Use delete [] on array types

### DIFF
--- a/src/debug/di/process.cpp
+++ b/src/debug/di/process.cpp
@@ -7300,7 +7300,7 @@ HRESULT CordbProcess::WriteMemory(CORDB_ADDRESS address, DWORD size,
         if (bufferCopy != NULL)
         {
             memmove(buffer, bufferCopy, size);
-            delete bufferCopy;
+            delete [] bufferCopy;
         }
     }
 

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -19305,7 +19305,7 @@ recheck:
                 uint8_t** tmp = new (nothrow) uint8_t* [new_size];
                 if (tmp)
                 {
-                    delete background_mark_stack_array;
+                    delete [] background_mark_stack_array;
                     background_mark_stack_array = tmp;
                     background_mark_stack_array_length = new_size;
                     background_mark_stack_tos = background_mark_stack_array;

--- a/src/ilasm/assembler.cpp
+++ b/src/ilasm/assembler.cpp
@@ -1780,7 +1780,7 @@ mdToken Assembler::MakeMemberRef(mdToken cr, __in __nullterminated char* pszMemb
             }
         }
         //if(m_fOBJ)    m_pCurMethod->m_TRDList.PUSH(new TokenRelocDescr(m_CurPC,mr));
-        delete pszMemberName;
+        delete [] pszMemberName;
         delete sig;
     }
     return mr;
@@ -2164,7 +2164,7 @@ void Assembler::EmitBytes(BYTE *p, unsigned len)
 
 
         memcpy(pb,m_pOutputBuffer,m_CurPC);
-        delete m_pOutputBuffer;
+        delete [] m_pOutputBuffer;
         m_pOutputBuffer = pb;
         m_pCurOutputPos = &m_pOutputBuffer[m_CurPC];
         m_pEndOutputPos = &m_pOutputBuffer[newlen];

--- a/src/inc/outstring.h
+++ b/src/inc/outstring.h
@@ -36,7 +36,7 @@ public:
         end = &start[initialAlloc];
     }
     
-    ~OutString() { delete start; }
+    ~OutString() { delete [] start; }
     
     // shortcut for printing decimal  
     OutString& operator<<(int i) { return(dec(i)); }

--- a/src/vm/eventpipeeventsource.cpp
+++ b/src/vm/eventpipeeventsource.cpp
@@ -57,7 +57,7 @@ EventPipeEventSource::EventPipeEventSource()
 
     // Delete the metadata after the event is created.
     // The metadata blob will be copied into EventPipe-owned memory.
-    delete(pMetadata);
+    delete [] pMetadata;
 }
 
 EventPipeEventSource::~EventPipeEventSource()


### PR DESCRIPTION
Calling delete on types allocated with new[] leads to undefined behaviour.