### PR TITLE
Optimized instance creation via activator

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Activator.RuntimeType.cs
+++ b/src/System.Private.CoreLib/shared/System/Activator.RuntimeType.cs
@@ -218,19 +218,16 @@ namespace System
 
                 ConstructorInfo? runtimeCtorInfo = RuntimeType.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, Type.EmptyTypes, null);
 
-                if (IsValueType)
+                if (runtimeCtorInfo != null && runtimeCtorInfo.IsPublic)
                 {
-                    if (runtimeCtorInfo != null && runtimeCtorInfo.IsPublic)
+                    if (IsValueType)
                         ConstructStruct = CreateDelegate<StructConstructor<T>>(runtimeCtorInfo);
                     else
-                        IsNotActivatable = runtimeCtorInfo != null;
+                        ConstructClass = CreateDelegate<ClassConstructor<T>>(runtimeCtorInfo);
                 }
                 else
                 {
-                    if (runtimeCtorInfo != null && runtimeCtorInfo.IsPublic)
-                        ConstructClass = CreateDelegate<ClassConstructor<T>>(runtimeCtorInfo);
-                    else
-                        IsNotActivatable = true;
+                    IsNotActivatable = !(IsValueType && runtimeCtorInfo == null);
                 }
             }
         }


### PR DESCRIPTION
Fixes #7592.
Fixes #16621.

Unfortunately, I wasn't able to run benchmarks and even tests. An application fails with a `NullReferenceException` and I can't understand why it happens:

```
Unhandled Exception: System.NullReferenceException: Object reference not set to an instance of an object.
   at BenchmarkDotNet.Characteristics.CharacteristicObject.ApplyCore(CharacteristicObject other, IEnumerable`1 characteristicsToApply)
   at BenchmarkDotNet.Characteristics.CharacteristicObject.UnfreezeCopyCore()
   at BenchmarkDotNet.ConsoleArguments.ConfigParser.CreateConfig(CommandLineOptions options, IConfig globalConfig)
   at BenchmarkDotNet.ConsoleArguments.ConfigParser.<>c__DisplayClass4_0.<Parse>b__0(CommandLineOptions options)
   at CommandLine.ParserResultExtensions.WithParsed[T](ParserResult`1 result, Action`1 action)
   at BenchmarkDotNet.ConsoleArguments.ConfigParser.Parse(String[] args, ILogger logger, IConfig globalConfig)
   at BenchmarkDotNet.Running.BenchmarkSwitcher.RunWithDirtyAssemblyResolveHelper(String[] args, IConfig config)
   at BenchmarkDotNet.Running.BenchmarkSwitcher.Run(String[] args, IConfig config)
   at Npgsql.Benchmarks.Program.Main(String[] args)
```

```csharp
[Config(typeof(Config))]
[MemoryDiagnoser]
[InProcess]
public class ActivatorTests
{
    public class Config : ManualConfig
    {
        public Config() => Add(StatisticColumn.OperationsPerSecond);
    }

    [Benchmark]
    public Address CreateClass() => Activator.CreateInstance<Address>();

    [Benchmark]
    public Coordinates CreateStruct() => Activator.CreateInstance<Coordinates>();
}

public class Address
{
    public string Street { get; set; }
    public string City { get; set; }
    public int Zip { get; set; }
}

public struct Coordinates
{
    public double Latitude { get; set; }
    public double Longitude { get; set; }
}
```

I had no other exceptions while debugging. Anyway, I moved implementation into the benchmark (`Allocate` was replaced by `GetUninitializedObject`) and ran it on the official .NET Core 3 preview 3. There is a little performance degradation in the class initialization case, but for value types there is 5 time boost and zero memory allocation.

Any help with debugging is very appreciated.

/cc @GrabYourPitchforks @jkotas 