### PR TITLE
Disable COM native-client tests on IL round-trip

### DIFF
--- a/tests/src/Interop/COM/NativeClients/DefaultInterfaces.csproj
+++ b/tests/src/Interop/COM/NativeClients/DefaultInterfaces.csproj
@@ -5,6 +5,7 @@
     <IgnoreCoreCLRTestLibraryDependency>true</IgnoreCoreCLRTestLibraryDependency>
     <CLRTestScriptLocalCoreShim>true</CLRTestScriptLocalCoreShim>
     <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
+    <IlrtTestKind>BuildOnly</IlrtTestKind>
 
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>

--- a/tests/src/Interop/COM/NativeClients/Licensing.csproj
+++ b/tests/src/Interop/COM/NativeClients/Licensing.csproj
@@ -5,6 +5,7 @@
     <IgnoreCoreCLRTestLibraryDependency>true</IgnoreCoreCLRTestLibraryDependency>
     <CLRTestScriptLocalCoreShim>true</CLRTestScriptLocalCoreShim>
     <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
+    <IlrtTestKind>BuildOnly</IlrtTestKind>
 
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>

--- a/tests/src/Interop/COM/NativeClients/Primitives.csproj
+++ b/tests/src/Interop/COM/NativeClients/Primitives.csproj
@@ -5,6 +5,7 @@
     <IgnoreCoreCLRTestLibraryDependency>true</IgnoreCoreCLRTestLibraryDependency>
     <CLRTestScriptLocalCoreShim>true</CLRTestScriptLocalCoreShim>
     <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
+    <IlrtTestKind>BuildOnly</IlrtTestKind>
 
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>


### PR DESCRIPTION
Disable tests that are failing in #23427. The failures aren't reproducable outside of Jenkins.

Fixes #23427
