### PR TITLE
Fix Arm64 UpperVector save/restore

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -4904,9 +4904,8 @@ void CodeGen::genSIMDIntrinsicSetItem(GenTreeSIMD* simdNode)
 //    When a 16-byte SIMD value is live across a call, the register allocator will use this intrinsic
 //    to cause the upper half to be saved.  It will first attempt to find another, unused, callee-save
 //    register.  If such a register cannot be found, it will save it to an available caller-save register.
-//    In that case, this node will be marked GTF_SPILL, which will cause genProduceReg to save the 8 byte
-//    value to the stack.  (Note that if there are no caller-save registers available, the entire 16 byte
-//    value will be spilled to the stack.)
+//    In that case, this node will be marked GTF_SPILL, which will cause this method to save
+//    the upper half to the lclVar's home location.
 //
 void CodeGen::genSIMDIntrinsicUpperSave(GenTreeSIMD* simdNode)
 {
@@ -4921,7 +4920,23 @@ void CodeGen::genSIMDIntrinsicUpperSave(GenTreeSIMD* simdNode)
     assert(targetReg != REG_NA);
     getEmitter()->emitIns_R_R_I_I(INS_mov, EA_8BYTE, targetReg, op1Reg, 0, 1);
 
-    genProduceReg(simdNode);
+    if ((simdNode->gtFlags & GTF_SPILL) != 0)
+    {
+        // This is not a normal spill; we'll spill it to the lclVar location.
+        // The localVar must have a stack home.
+        unsigned   varNum = op1->AsLclVarCommon()->gtLclNum;
+        LclVarDsc* varDsc = compiler->lvaGetDesc(varNum);
+        assert(varDsc->lvOnFrame);
+        // We want to store this to the upper 8 bytes of this localVar's home.
+        int offset = 8;
+
+        emitAttr attr = emitTypeSize(TYP_SIMD8);
+        getEmitter()->emitIns_S_R(INS_str, attr, targetReg, varNum, offset);
+    }
+    else
+    {
+        genProduceReg(simdNode);
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -4939,11 +4954,7 @@ void CodeGen::genSIMDIntrinsicUpperSave(GenTreeSIMD* simdNode)
 //    have their home register, this node has its targetReg on the lclVar child, and its source
 //    on the simdNode.
 //    Regarding spill, please see the note above on genSIMDIntrinsicUpperSave.  If we have spilled
-//    an upper-half to a caller save register, this node will be marked GTF_SPILLED.  However, unlike
-//    most spill scenarios, the saved tree will be different from the restored tree, but the spill
-//    restore logic, which is triggered by the call to genConsumeReg, requires us to provide the
-//    spilled tree (saveNode) in order to perform the reload.  We can easily find that tree,
-//    as it is in the spill descriptor for the register from which it was saved.
+//    an upper-half to the lclVar's home location, this node will be marked GTF_SPILLED.
 //
 void CodeGen::genSIMDIntrinsicUpperRestore(GenTreeSIMD* simdNode)
 {
@@ -4959,9 +4970,14 @@ void CodeGen::genSIMDIntrinsicUpperRestore(GenTreeSIMD* simdNode)
     assert(srcReg != REG_NA);
     if (simdNode->gtFlags & GTF_SPILLED)
     {
-        GenTree* saveNode = regSet.rsSpillDesc[srcReg]->spillTree;
-        noway_assert(saveNode != nullptr && (saveNode->gtRegNum == srcReg));
-        genConsumeReg(saveNode);
+        // The localVar must have a stack home.
+        LclVarDsc* varDsc = compiler->lvaGetDesc(varNum);
+        assert(varDsc->lvOnFrame);
+        // We will load this from the upper 8 bytes of this localVar's home.
+        int offset = 8;
+
+        emitAttr attr = emitTypeSize(TYP_SIMD8);
+        getEmitter()->emitIns_R_S(INS_ldr, attr, srcReg, varNum, offset);
     }
     getEmitter()->emitIns_R_R_I_I(INS_mov, EA_8BYTE, lclVarReg, srcReg, 1, 0);
 }

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -7064,7 +7064,7 @@ void LinearScan::resolveRegisters()
                                 // These have no associated Restore, as we always spill if the vector is
                                 // in a register when this is encountered.
                                 // The nextRefPosition we're interested in (where we may need to insert a
-                                // reload or flag as GTF_NOREG_AT_USE is the subsequent RefPosition.
+                                // reload or flag as GTF_NOREG_AT_USE) is the subsequent RefPosition.
                                 assert(!currentInterval->isLocalVar);
                                 nextRefPosition = nextRefPosition->nextRefPosition;
                                 assert(nextRefPosition->refType != RefTypeUpperVectorSave);

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -7076,7 +7076,7 @@ void LinearScan::resolveRegisters()
                                 if (nextRefPosition->assignedReg() != REG_NA)
                                 {
                                     insertCopyOrReload(block, treeNode, currentRefPosition->getMultiRegIdx(),
-                                        nextRefPosition);
+                                                       nextRefPosition);
                                 }
                                 else
                                 {

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -5681,8 +5681,8 @@ void LinearScan::allocateRegisters()
 
 #ifdef DEBUG
                 // Under stress mode, don't attempt to allocate a reg to
-                // reg optional ref position.
-                if (allocateReg && regOptionalNoAlloc())
+                // reg optional ref position, unless it's a ParamDef.
+                if (allocateReg && regOptionalNoAlloc() && (currentRefPosition->refType != RefTypeParamDef))
                 {
                     allocateReg = false;
                 }

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3331,7 +3331,7 @@ bool LinearScan::isRegInUse(RegRecord* regRec, RefPosition* refPosition)
         // because we'll always find something with a later nextLocation, but it can happen in stress when
         // we have LSRA_SELECT_NEAREST.
         if ((nextAssignedRef != nullptr) && isRefPositionActive(nextAssignedRef, refPosition->nodeLocation) &&
-            nextAssignedRef->RequiresRegister())
+            !nextAssignedRef->RegOptional())
         {
             return true;
         }
@@ -3693,21 +3693,21 @@ regNumber LinearScan::allocateBusyReg(Interval* current, RefPosition* refPositio
                 {
                     if (nextRefPosition2 != nullptr)
                     {
-                        assert(!nextRefPosition->RequiresRegister() || !nextRefPosition2->RequiresRegister());
+                        assert(nextRefPosition->RegOptional() || nextRefPosition2->RegOptional());
                     }
                     else
                     {
-                        assert(!nextRefPosition->RequiresRegister());
+                        assert(nextRefPosition->RegOptional());
                     }
                 }
                 else
                 {
-                    assert(nextRefPosition2 != nullptr && !nextRefPosition2->RequiresRegister());
+                    assert(nextRefPosition2 != nullptr && nextRefPosition2->RegOptional());
                 }
 #else  // !_TARGET_ARM_
                 Interval*    assignedInterval = farthestRefPhysRegRecord->assignedInterval;
                 RefPosition* nextRefPosition  = assignedInterval->getNextRefPosition();
-                assert(!nextRefPosition->RequiresRegister());
+                assert(nextRefPosition->RegOptional());
 #endif // !_TARGET_ARM_
             }
         }
@@ -4020,7 +4020,7 @@ void LinearScan::spillInterval(Interval* interval, RefPosition* fromRefPosition,
     {
         // If not allocated a register, Lcl var def/use ref positions even if reg optional
         // should be marked as spillAfter.
-        if (!fromRefPosition->RequiresRegister() && !(interval->isLocalVar && fromRefPosition->IsActualRef()))
+        if (fromRefPosition->RegOptional() && !(interval->isLocalVar && fromRefPosition->IsActualRef()))
         {
             fromRefPosition->registerAssignment = RBM_NONE;
         }
@@ -4952,17 +4952,8 @@ void LinearScan::processBlockEndLocations(BasicBlock* currentBlock)
             outVarToRegMap[varIndex] = REG_STK;
         }
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
-        // Restore any partially-spilled large vector locals.
-        if (varTypeNeedsPartialCalleeSave(interval->registerType) && interval->isPartiallySpilled)
-        {
-            Interval* upperInterval = getUpperVectorInterval(varIndex);
-            if (interval->isActive && allocationPassComplete)
-            {
-                insertUpperVectorRestore(nullptr, upperInterval, currentBlock);
-            }
-            upperInterval->isActive      = false;
-            interval->isPartiallySpilled = false;
-        }
+        // Ensure that we have no partially-spilled large vector locals.
+        assert(!varTypeNeedsPartialCalleeSave(interval->registerType) || !interval->isPartiallySpilled);
 #endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
     }
     INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_END_BB));
@@ -5678,6 +5669,16 @@ void LinearScan::allocateRegisters()
                     allocateReg = false;
                 }
 
+#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE && defined(_TARGET_XARCH_)
+                // We can also avoid allocating a register (in fact we don't want to) if we have
+                // an UpperVectorRestore on xarch where the value is on the stack.
+                if ((currentRefPosition->refType == RefTypeUpperVectorRestore) && (currentInterval->physReg == REG_NA))
+                {
+                    assert(currentRefPosition->regOptional);
+                    allocateReg = false;
+                }
+#endif
+
 #ifdef DEBUG
                 // Under stress mode, don't attempt to allocate a reg to
                 // reg optional ref position.
@@ -5698,7 +5699,7 @@ void LinearScan::allocateRegisters()
             // then find a register to spill
             if (assignedRegister == REG_NA)
             {
-                bool isAllocatable = currentRefPosition->IsActualRef() || currentRefPosition->RegOptional();
+                bool isAllocatable = currentRefPosition->IsActualRef();
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE && defined(_TARGET_ARM64_)
                 if (currentInterval->isUpperVector)
                 {
@@ -6022,7 +6023,7 @@ void LinearScan::resolveLocalRef(BasicBlock* block, GenTree* treeNode, RefPositi
 
     if (currentRefPosition->registerAssignment == RBM_NONE)
     {
-        assert(!currentRefPosition->RequiresRegister());
+        assert(currentRefPosition->RegOptional());
         assert(interval->isSpilled);
 
         varDsc->lvRegNum = REG_STK;
@@ -6362,19 +6363,20 @@ void LinearScan::insertCopyOrReload(BasicBlock* block, GenTree* tree, unsigned m
 //
 void LinearScan::insertUpperVectorSave(GenTree*     tree,
                                        RefPosition* refPosition,
-                                       Interval*    upperInterval,
+                                       Interval*    upperVectorInterval,
                                        BasicBlock*  block)
 {
-    Interval* lclVarInterval = upperInterval->relatedInterval;
+    JITDUMP("Inserting UpperVectorSave for RP #%d before %d.%s:\n", refPosition->rpNum, tree->gtTreeID,
+            GenTree::OpName(tree->gtOper));
+    Interval* lclVarInterval = upperVectorInterval->relatedInterval;
     assert(lclVarInterval->isLocalVar == true);
+    assert(refPosition->getInterval() == upperVectorInterval);
     regNumber lclVarReg = lclVarInterval->physReg;
     if (lclVarReg == REG_NA)
     {
         return;
     }
 
-    Interval* upperVectorInterval = refPosition->getInterval();
-    assert(upperVectorInterval->relatedInterval == lclVarInterval);
     LclVarDsc* varDsc = compiler->lvaTable + lclVarInterval->varNum;
     assert(varTypeNeedsPartialCalleeSave(varDsc->lvType));
     assert((genRegMask(lclVarReg) & RBM_FLT_CALLEE_SAVED) != RBM_NONE);
@@ -6406,7 +6408,7 @@ void LinearScan::insertUpperVectorSave(GenTree*     tree,
     if (spillToMem)
     {
         simdNode->gtFlags |= GTF_SPILL;
-        upperVectorInterval->physReg = REG_STK;
+        upperVectorInterval->physReg = REG_NA;
     }
     else
     {
@@ -6415,6 +6417,8 @@ void LinearScan::insertUpperVectorSave(GenTree*     tree,
     }
 
     blockRange.InsertBefore(tree, LIR::SeqTree(compiler, simdNode));
+    DISPTREE(simdNode);
+    JITDUMP("\n");
 }
 
 //------------------------------------------------------------------------
@@ -6431,8 +6435,12 @@ void LinearScan::insertUpperVectorSave(GenTree*     tree,
 //    In the case where 'tree' is non-null, we will insert the restore just prior to
 //    its use, in order to ensure the proper ordering.
 //
-void LinearScan::insertUpperVectorRestore(GenTree* tree, Interval* upperVectorInterval, BasicBlock* block)
+void LinearScan::insertUpperVectorRestore(GenTree*     tree,
+                                          RefPosition* refPosition,
+                                          Interval*    upperVectorInterval,
+                                          BasicBlock*  block)
 {
+    JITDUMP("Adding UpperVectorRestore for RP #%d ", refPosition->rpNum);
     Interval* lclVarInterval = upperVectorInterval->relatedInterval;
     assert(lclVarInterval->isLocalVar == true);
     regNumber lclVarReg = lclVarInterval->physReg;
@@ -6455,15 +6463,17 @@ void LinearScan::insertUpperVectorRestore(GenTree* tree, Interval* upperVectorIn
     regNumber restoreReg = upperVectorInterval->physReg;
     SetLsraAdded(simdNode);
 
-    if (upperVectorInterval->physReg == REG_NA)
+    if (restoreReg == REG_NA)
     {
         // We need a stack location for this.
         assert(lclVarInterval->isSpilled);
-        simdNode->gtFlags |= GTF_SPILLED;
 #ifdef _TARGET_AMD64_
+        assert(refPosition->assignedReg() == REG_NA);
         simdNode->gtFlags |= GTF_NOREG_AT_USE;
 #else
-        assert(!"We require a register for Arm64 UpperVectorRestore");
+        simdNode->gtFlags |= GTF_SPILLED;
+        assert(refPosition->assignedReg() != REG_NA);
+        restoreReg = refPosition->assignedReg();
 #endif
     }
     simdNode->gtRegNum = restoreReg;
@@ -6472,8 +6482,7 @@ void LinearScan::insertUpperVectorRestore(GenTree* tree, Interval* upperVectorIn
     JITDUMP("Adding UpperVectorRestore ");
     if (tree != nullptr)
     {
-        JITDUMP("after:\n");
-        DISPTREE(tree);
+        JITDUMP("before %d.%s:\n", tree->gtTreeID, GenTree::OpName(tree->gtOper));
         LIR::Use treeUse;
         bool     foundUse = blockRange.TryGetUse(tree, &treeUse);
         assert(foundUse);
@@ -6937,8 +6946,6 @@ void LinearScan::resolveRegisters()
             }
             else if (currentRefPosition->refType == RefTypeUpperVectorRestore)
             {
-                // The treeNode is a use of the large vector lclVar.
-                noway_assert(treeNode != nullptr);
                 // Since we don't do partial restores of tree temp intervals, this must be an upperVector.
                 Interval* interval         = currentRefPosition->getInterval();
                 Interval* localVarInterval = interval->relatedInterval;
@@ -6949,7 +6956,7 @@ void LinearScan::resolveRegisters()
                     assert((localVarInterval->assignedReg != nullptr) &&
                            (localVarInterval->assignedReg->regNum == localVarInterval->physReg) &&
                            (localVarInterval->assignedReg->assignedInterval == localVarInterval));
-                    insertUpperVectorRestore(treeNode, interval, block);
+                    insertUpperVectorRestore(treeNode, currentRefPosition, interval, block);
                 }
                 localVarInterval->isPartiallySpilled = false;
             }
@@ -6962,7 +6969,8 @@ void LinearScan::resolveRegisters()
                 // This is either a use, a dead def, or a field of a struct
                 Interval* interval = currentRefPosition->getInterval();
                 assert(currentRefPosition->refType == RefTypeUse ||
-                       currentRefPosition->registerAssignment == RBM_NONE || interval->isStructField);
+                       currentRefPosition->registerAssignment == RBM_NONE || interval->isStructField ||
+                       interval->IsUpperVector());
 
                 // TODO-Review: Need to handle the case where any of the struct fields
                 // are reloaded/spilled at this use
@@ -7043,36 +7051,46 @@ void LinearScan::resolveRegisters()
                         // If the value is reloaded or moved to a different register, we need to insert
                         // a node to hold the register to which it should be reloaded
                         RefPosition* nextRefPosition = currentRefPosition->nextRefPosition;
-                        assert(nextRefPosition != nullptr);
+                        noway_assert(nextRefPosition != nullptr);
                         if (INDEBUG(alwaysInsertReload() ||)
                                 nextRefPosition->assignedReg() != currentRefPosition->assignedReg())
                         {
-                            if (!currentRefPosition->getInterval()->isLocalVar)
+#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+                            // Note that we asserted above that this is an Interval RefPosition.
+                            Interval* currentInterval = currentRefPosition->getInterval();
+                            if (!currentInterval->isUpperVector && nextRefPosition->refType == RefTypeUpperVectorSave)
                             {
-                                while ((nextRefPosition != nullptr) &&
-                                       (nextRefPosition->refType == RefTypeUpperVectorSave))
+                                // The currentRefPosition is a spill of a tree temp.
+                                // These have no associated Restore, as we always spill if the vector is
+                                // in a register when this is encountered.
+                                // The nextRefPosition we're interested in (where we may need to insert a
+                                // reload or flag as GTF_NOREG_AT_USE is the subsequent RefPosition.
+                                assert(!currentInterval->isLocalVar);
+                                nextRefPosition = nextRefPosition->nextRefPosition;
+                                assert(nextRefPosition->refType != RefTypeUpperVectorSave);
+                            }
+                            // UpperVector intervals may have unique assignments at each reference.
+                            if (!currentInterval->isUpperVector)
+#endif
+                            {
+                                if (nextRefPosition->assignedReg() != REG_NA)
                                 {
-                                    nextRefPosition = nextRefPosition->nextRefPosition;
+                                    insertCopyOrReload(block, treeNode, currentRefPosition->getMultiRegIdx(),
+                                        nextRefPosition);
                                 }
-                            }
-                            noway_assert(nextRefPosition != nullptr);
-                            if (nextRefPosition->assignedReg() != REG_NA)
-                            {
-                                insertCopyOrReload(block, treeNode, currentRefPosition->getMultiRegIdx(),
-                                                   nextRefPosition);
-                            }
-                            else
-                            {
-                                assert(nextRefPosition->RegOptional());
-
-                                // In case of tree temps, if def is spilled and use didn't
-                                // get a register, set a flag on tree node to be treated as
-                                // contained at the point of its use.
-                                if (currentRefPosition->spillAfter && currentRefPosition->refType == RefTypeDef &&
-                                    nextRefPosition->refType == RefTypeUse)
+                                else
                                 {
-                                    assert(nextRefPosition->treeNode == nullptr);
-                                    treeNode->gtFlags |= GTF_NOREG_AT_USE;
+                                    assert(nextRefPosition->RegOptional());
+
+                                    // In case of tree temps, if def is spilled and use didn't
+                                    // get a register, set a flag on tree node to be treated as
+                                    // contained at the point of its use.
+                                    if (currentRefPosition->spillAfter && currentRefPosition->refType == RefTypeDef &&
+                                        nextRefPosition->refType == RefTypeUse)
+                                    {
+                                        assert(nextRefPosition->treeNode == nullptr);
+                                        treeNode->gtFlags |= GTF_NOREG_AT_USE;
+                                    }
                                 }
                             }
                         }
@@ -9724,14 +9742,16 @@ void LinearScan::dumpRegRecordHeader()
            "Use, Fixd) followed by a '*' if it is a last use, and a 'D' if it is delayRegFree, and then the\n"
            "action taken during allocation (e.g. Alloc a new register, or Keep an existing one).\n"
            "The subsequent columns show the Interval occupying each register, if any, followed by 'a' if it is\n"
-           "active, and 'i'if it is inactive.  Columns are only printed up to the last modifed register, which\n"
-           "may increase during allocation, in which case additional columns will appear.  Registers which are\n"
-           "not marked modified have ---- in their column.\n\n");
+           "active, a 'p' if it is a large vector that has been partially spilled, and 'i'if it is inactive.\n"
+           "Columns are only printed up to the last modifed register, which may increase during allocation,"
+           "in which case additional columns will appear.  \n"
+           "Registers which are not marked modified have ---- in their column.\n\n");
 
     // First, determine the width of each register column (which holds a reg name in the
     // header, and an interval name in each subsequent row).
     int intervalNumberWidth = (int)log10((double)intervals.size()) + 1;
-    // The regColumnWidth includes the identifying character (I or V) and an 'i' or 'a' (inactive or active)
+    // The regColumnWidth includes the identifying character (I or V) and an 'i', 'p' or 'a' (inactive,
+    // partially-spilled or active)
     regColumnWidth = intervalNumberWidth + 2;
     if (regColumnWidth < 4)
     {
@@ -9897,6 +9917,12 @@ void LinearScan::dumpRegRecords()
             {
                 dumpIntervalName(interval);
                 char activeChar = interval->isActive ? 'a' : 'i';
+#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+                if (interval->isPartiallySpilled)
+                {
+                    activeChar = 'p';
+                }
+#endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
                 printf("%c", activeChar);
             }
             else if (regRecord.isBusyUntilNextKill)
@@ -10471,9 +10497,22 @@ void LinearScan::verifyFinalAllocation()
                     {
                         regRecord->assignedInterval = nullptr;
                     }
+#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+                    else if (interval->isUpperVector && !currentRefPosition->RegOptional())
+                    {
+                        // These only require a register if they are not RegOptional, and their lclVar
+                        // interval is living in a register and not already partially spilled.
+                        if ((currentRefPosition->refType == RefTypeUpperVectorSave) ||
+                            (currentRefPosition->refType == RefTypeUpperVectorRestore))
+                        {
+                            Interval* lclVarInterval = interval->relatedInterval;
+                            assert((lclVarInterval->physReg == REG_NA) || lclVarInterval->isPartiallySpilled);
+                        }
+                    }
+#endif
                     else
                     {
-                        assert(!currentRefPosition->RequiresRegister());
+                        assert(currentRefPosition->RegOptional());
                     }
                 }
             }

--- a/src/jit/lsrabuild.cpp
+++ b/src/jit/lsrabuild.cpp
@@ -1407,8 +1407,8 @@ void LinearScan::buildUpperVectorSaveRefPositions(GenTree* tree, LsraLocation cu
             // In the rare case where such an interval is live across nested calls, we don't need to insert another.
             if (listNode->ref->getInterval()->recentRefPosition->refType != RefTypeUpperVectorSave)
             {
-                RefPosition* pos = newRefPosition(listNode->ref->getInterval(), currentLoc, RefTypeUpperVectorSave, tree,
-                                                  RBM_FLT_CALLEE_SAVED);
+                RefPosition* pos = newRefPosition(listNode->ref->getInterval(), currentLoc, RefTypeUpperVectorSave,
+                                                  tree, RBM_FLT_CALLEE_SAVED);
             }
         }
     }

--- a/src/jit/lsrabuild.cpp
+++ b/src/jit/lsrabuild.cpp
@@ -1404,11 +1404,40 @@ void LinearScan::buildUpperVectorSaveRefPositions(GenTree* tree, LsraLocation cu
     {
         if (varTypeNeedsPartialCalleeSave(listNode->treeNode->TypeGet()))
         {
-            RefPosition* pos = newRefPosition(listNode->ref->getInterval(), currentLoc, RefTypeUpperVectorSave, tree,
-                                              RBM_FLT_CALLEE_SAVED);
+            // In the rare case where such an interval is live across nested calls, we don't need to insert another.
+            if (listNode->ref->getInterval()->recentRefPosition->refType != RefTypeUpperVectorSave)
+            {
+                RefPosition* pos = newRefPosition(listNode->ref->getInterval(), currentLoc, RefTypeUpperVectorSave, tree,
+                                                  RBM_FLT_CALLEE_SAVED);
+            }
         }
     }
 }
+
+//------------------------------------------------------------------------
+// buildUpperVectorRestoreRefPosition - Create a RefPosition for restoring
+//                                      the upper half of a large vector.
+//
+// Arguments:
+//    lclVarInterval - A lclVarInterval that is live at 'currentLoc'
+//    currentLoc     - The current location for which we're building RefPositions
+//    node           - The node, if any, that the restore would be inserted before.
+//                     If null, the restore will be inserted at the end of the block.
+//
+void LinearScan::buildUpperVectorRestoreRefPosition(Interval* lclVarInterval, LsraLocation currentLoc, GenTree* node)
+{
+    if (lclVarInterval->isPartiallySpilled)
+    {
+        unsigned     varIndex            = lclVarInterval->getVarIndex(compiler);
+        Interval*    upperVectorInterval = getUpperVectorInterval(varIndex);
+        RefPosition* pos = newRefPosition(upperVectorInterval, currentLoc, RefTypeUpperVectorRestore, node, RBM_NONE);
+        lclVarInterval->isPartiallySpilled = false;
+#ifdef _TARGET_XARCH_
+        pos->regOptional = true;
+#endif
+    }
+}
+
 #endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
 
 #ifdef DEBUG
@@ -1749,6 +1778,7 @@ void LinearScan::insertZeroInitRefPositions()
                 GenTree*     firstNode = getNonEmptyBlock(compiler->fgFirstBB)->firstNode();
                 RefPosition* pos =
                     newRefPosition(interval, MinLocation, RefTypeZeroInit, firstNode, allRegs(interval->registerType));
+                pos->setRegOptional(true);
                 varDsc->lvMustInit = true;
             }
             else
@@ -1983,6 +2013,7 @@ void LinearScan::buildIntervals()
                 assignPhysReg(inArgReg, interval);
             }
             RefPosition* pos = newRefPosition(interval, MinLocation, RefTypeParamDef, nullptr, mask);
+            pos->setRegOptional(true);
         }
         else if (varTypeIsStruct(argDsc->lvType))
         {
@@ -1996,6 +2027,7 @@ void LinearScan::buildIntervals()
                     Interval*    interval = getIntervalForLocalVar(fieldVarDsc->lvVarIndex);
                     RefPosition* pos =
                         newRefPosition(interval, MinLocation, RefTypeParamDef, nullptr, allRegs(TypeGet(fieldVarDsc)));
+                    pos->setRegOptional(true);
                 }
             }
         }
@@ -2110,6 +2142,7 @@ void LinearScan::buildIntervals()
                         Interval*    interval = getIntervalForLocalVar(varIndex);
                         RefPosition* pos      = newRefPosition(interval, currentLoc, RefTypeDummyDef, nullptr,
                                                           allRegs(interval->registerType));
+                        pos->setRegOptional(true);
                     }
                 }
                 JITDUMP("Finished creating dummy definitions\n\n");
@@ -2154,15 +2187,17 @@ void LinearScan::buildIntervals()
         }
 
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
-        // At the end of each block, we'll restore any upperVectors, so reset isPartiallySpilled on all of them.
+        // At the end of each block, create upperVectorRestores for any largeVectorVars that may be
+        // partiallySpilled (during the build phase all intervals will be marked isPartiallySpilled if
+        // they *may) be partially spilled at any point.
         if (enregisterLocalVars)
         {
             VarSetOps::Iter largeVectorVarsIter(compiler, largeVectorVars);
             unsigned        largeVectorVarIndex = 0;
             while (largeVectorVarsIter.NextElem(&largeVectorVarIndex))
             {
-                Interval* lclVarInterval           = getIntervalForLocalVar(largeVectorVarIndex);
-                lclVarInterval->isPartiallySpilled = false;
+                Interval* lclVarInterval = getIntervalForLocalVar(largeVectorVarIndex);
+                buildUpperVectorRestoreRefPosition(lclVarInterval, currentLoc, nullptr);
             }
         }
 #endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
@@ -2230,6 +2265,7 @@ void LinearScan::buildIntervals()
                     Interval*    interval = getIntervalForLocalVar(varIndex);
                     RefPosition* pos =
                         newRefPosition(interval, currentLoc, RefTypeExpUse, nullptr, allRegs(interval->registerType));
+                    pos->setRegOptional(true);
                     JITDUMP(" V%02u", varNum);
                 }
                 JITDUMP("\n");
@@ -2286,6 +2322,7 @@ void LinearScan::buildIntervals()
                 Interval*    interval = getIntervalForLocalVar(varDsc->lvVarIndex);
                 RefPosition* pos =
                     newRefPosition(interval, currentLoc, RefTypeExpUse, nullptr, allRegs(interval->registerType));
+                pos->setRegOptional(true);
             }
         }
 
@@ -2301,6 +2338,7 @@ void LinearScan::buildIntervals()
                     Interval*    interval = getIntervalForLocalVar(varDsc->lvVarIndex);
                     RefPosition* pos =
                         newRefPosition(interval, currentLoc, RefTypeExpUse, nullptr, allRegs(interval->registerType));
+                    pos->setRegOptional(true);
                 }
             }
         }
@@ -2633,17 +2671,7 @@ RefPosition* LinearScan::BuildUse(GenTree* operand, regMaskTP candidates, int mu
             VarSetOps::RemoveElemD(compiler, currentLiveVars, varIndex);
         }
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
-        if (interval->isPartiallySpilled)
-        {
-            unsigned     varIndex            = interval->getVarIndex(compiler);
-            Interval*    upperVectorInterval = getUpperVectorInterval(varIndex);
-            RefPosition* pos =
-                newRefPosition(upperVectorInterval, currentLoc, RefTypeUpperVectorRestore, operand, RBM_NONE);
-            interval->isPartiallySpilled = false;
-#ifdef _TARGET_XARCH_
-            pos->regOptional = true;
-#endif
-        }
+        buildUpperVectorRestoreRefPosition(interval, currentLoc, operand);
 #endif
     }
     else

--- a/src/jit/simdcodegenxarch.cpp
+++ b/src/jit/simdcodegenxarch.cpp
@@ -3086,8 +3086,7 @@ void CodeGen::genSIMDIntrinsicUpperRestore(GenTreeSIMD* simdNode)
     regNumber srcReg    = simdNode->gtRegNum;
     regNumber lclVarReg = genConsumeReg(op1);
     assert(lclVarReg != REG_NA);
-    assert(srcReg != REG_NA);
-    if (srcReg != REG_STK)
+    if (srcReg != REG_NA)
     {
         getEmitter()->emitIns_R_R_R_I(INS_vinsertf128, EA_32BYTE, lclVarReg, lclVarReg, srcReg, 0x01);
     }

--- a/tests.out
+++ b/tests.out
@@ -1,2 +1,0 @@
-python "E:\git3\coreclr\tests\runtest.py" -arch x64 -build_type Checked -test_env E:\Test\testenv.cmd --generate_layout
-Error, incorrect core_root location.

--- a/tests.out
+++ b/tests.out
@@ -1,0 +1,2 @@
+python "E:\git3\coreclr\tests\runtest.py" -arch x64 -build_type Checked -test_env E:\Test\testenv.cmd --generate_layout
+Error, incorrect core_root location.

--- a/tests/src/JIT/Regression/JitBlue/GitHub_23885/GitHub_23885.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_23885/GitHub_23885.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Numerics;
+
+public class GitHub_23885
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void dummy(Vector<ulong> v1, Vector<ulong> v2, Vector<ulong> v3, Vector<ulong> v4,
+                      Vector<ulong> v5, Vector<ulong> v6, Vector<ulong> v7, Vector<ulong> v8)
+    {
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void CreateVectors()
+    {
+        Vector<ulong> vA = new Vector<ulong>((ulong)0xa);
+        Vector<ulong> vB = new Vector<ulong>((ulong)0xb);
+        Vector<ulong> vC = new Vector<ulong>((ulong)0xc);
+        Vector<ulong> vD = new Vector<ulong>((ulong)0xd);
+        Vector<ulong> vE = new Vector<ulong>((ulong)0xe);
+        Vector<ulong> vF = new Vector<ulong>((ulong)0xf);
+        Vector<ulong> vG = new Vector<ulong>((ulong)0x8);
+        Vector<ulong> vH = new Vector<ulong>((ulong)0x9);
+        dummy(vA, vB, vC, vD, vE, vF, vG, vH);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static double GetDouble()
+    {
+        return 1.0;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void ConsumeDouble(double d)
+    {
+    }
+
+    static int Main(string[] args)
+    {
+        int returnVal = 100;
+
+        // Define a non-SIMD floating point value so that we've got an odd number of
+        // callee-save floating-point/vector registers remaining.
+        double d = GetDouble();
+
+        // Declare and initialize a bunch of vectors.
+        Vector<ulong> xA = Vector<ulong>.One;
+        Vector<ulong> xB = Vector<ulong>.One;
+        Vector<ulong> xC = Vector<ulong>.One;
+        Vector<ulong> xD = Vector<ulong>.One;
+        Vector<ulong> xE = Vector<ulong>.One;
+        Vector<ulong> xF = Vector<ulong>.One;
+
+        // Use d a few times to give it more weight than the SIMD values.
+        ConsumeDouble((d * d) + d);
+        d = d * GetDouble();
+
+        // Use the vectors in computation to give them some weight.
+        xA = xB + xC + xD + xE + xF;
+        xB = xA + xC + xD + xE + xF;
+        xC = xA + xB + xD + xE + xF;
+        xD = xA + xC + xC + xE + xF;
+        xE = xA + xC + xD + xD + xF;
+        xF = xA + xC + xD + xE + xE;
+
+        ConsumeDouble((d * d) + d);
+        d = d * GetDouble();
+
+        CreateVectors();
+
+        Console.WriteLine("{0} {1} {2} {3} {4} {5}", xA, xB, xC, xD, xE, xF);
+        if (!xA.Equals(new Vector<ulong>((ulong)5)) || !xB.Equals(new Vector<ulong>((ulong)9)) || !xC.Equals(new Vector<ulong>((ulong)17)) ||
+            !xD.Equals(new Vector<ulong>((ulong)41)) || !xE.Equals(new Vector<ulong>((ulong)105)) || !xF.Equals(new Vector<ulong>((ulong)273)))
+        {
+            returnVal = -1;
+        }
+
+        // Now, create more vectors, so that even more will be spilled aross the next call.
+        Vector<ulong> xG = Vector<ulong>.Zero;
+        Vector<ulong> xH = Vector<ulong>.Zero;
+        Vector<ulong> xI = Vector<ulong>.Zero;
+
+        CreateVectors();
+
+        Console.WriteLine("{0} {1} {2} {3} {4} {5} {6} {7} {8}", xA, xB, xC, xD, xE, xF, xG, xH, xI);
+
+        ConsumeDouble((d * d) + d);
+        d = d * GetDouble();
+
+        if (!xA.Equals(new Vector<ulong>((ulong)5)) || !xB.Equals(new Vector<ulong>((ulong)9)) || !xC.Equals(new Vector<ulong>((ulong)17)) ||
+            !xD.Equals(new Vector<ulong>((ulong)41)) || !xE.Equals(new Vector<ulong>((ulong)105)) || !xF.Equals(new Vector<ulong>((ulong)273)) ||
+            !xG.Equals(Vector<ulong>.Zero) || !xH.Equals(Vector<ulong>.Zero) || !xI.Equals(Vector<ulong>.Zero))
+        {
+            returnVal = -1;
+        }
+
+        return returnVal;
+    }
+}
+

--- a/tests/src/JIT/Regression/JitBlue/GitHub_23885/GitHub_23885.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_23885/GitHub_23885.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Change the general handling of end-of-block restores so that we always have a RefPosition on which to allocate the register needed on Arm64.

Fix #23885