### PR TITLE
Fix incorrect thread affinitization

### DIFF
--- a/src/pal/src/thread/thread.cpp
+++ b/src/pal/src/thread/thread.cpp
@@ -2948,13 +2948,8 @@ PAL_SetCurrentThreadAffinity(WORD procNo)
     cpu_set_t cpuSet;
     CPU_ZERO(&cpuSet);
 
-    int st = pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuSet);
-
-    if (st == 0)
-    {
-        CPU_SET(procNo, &cpuSet);
-        st = pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuSet);
-    }
+    CPU_SET(procNo, &cpuSet);
+    int st = pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuSet);
 
     return st == 0;
 #else  // HAVE_PTHREAD_GETAFFINITY_NP


### PR DESCRIPTION
The PAL_SetCurrentThreadAffinity was incorrectly adding the specified processor
to the current thread affinity set instead of setting the affinity to only
the processor specified.
It was causing 20% performance hit in aspnet benchmarks on machines with
many cores.
This ~~change~~ issue crept in when I was refactoring the related code while removing
CPU groups emulation.