### PR TITLE
Fix incorrect EHCount calculation

### DIFF
--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
@@ -717,8 +717,7 @@ namespace System.Reflection.Emit
             stackSize = m_stackSize;
             if (m_exceptionHeader != null && m_exceptionHeader.Length != 0)
             {
-                // If length < 4, fail. Below pattern elides future bounds checks in method.
-                if (3 >= (uint)m_exceptionHeader.Length)
+                if (m_exceptionHeader.Length < 4)
                     throw new FormatException();
 
                 byte header = m_exceptionHeader[0];

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
@@ -725,13 +725,12 @@ namespace System.Reflection.Emit
 
                 if ((header & 0x40) != 0) // Fat
                 {
-                    Span<byte> size = stackalloc byte[4];
-                    size[0] = m_exceptionHeader[1]; // n.b. this is a 24-bit integer, not a 32-bit integer
-                    size[1] = m_exceptionHeader[2];
-                    size[2] = m_exceptionHeader[3];
-                    size[3] = 0;
+                    // Positions 1..3 of m_exceptionHeader are a 24-bit little-endian integer.
+                    int size = m_exceptionHeader[3] << 16;
+                    size |= m_exceptionHeader[2] << 8;
+                    size |= m_exceptionHeader[1];
 
-                    EHCount = (BitConverter.ToInt32(size) - 4) / 24;
+                    EHCount = (size - 4) / 24;
                 }
                 else
                     EHCount = (m_exceptionHeader[1] - 2) / 12;


### PR DESCRIPTION
https://github.com/dotnet/coreclr/pull/23833 accidentally introduced a bug in `DynamicMethod` due to an incorrect calculation being used to compute the _EHCount_ value. The incoming value is actually stored in 24 bits, not 32 bits, and we were reading an extra byte and corrupting the actual _EHCount_ value when writing it to the IL stream.

Also unblocks CI at https://github.com/dotnet/corefx/pull/36922.