### PR TITLE
Add --runtime-path to CoreFX test runner.

### DIFF
--- a/tests/scripts/run-corefx-tests.bat
+++ b/tests/scripts/run-corefx-tests.bat
@@ -81,7 +81,7 @@ if %errorlevel% EQU 0 (
     echo COREFX TEST %_t3% EXCLUDED
     set /A _skipped=_skipped + 1
 ) else (
-    call :run %1\RunTests.cmd %_runtime_path%
+    call :run %1\RunTests.cmd --runtime-path %_runtime_path%
 )
 goto :eof
 

--- a/tests/scripts/run-corefx-tests.sh
+++ b/tests/scripts/run-corefx-tests.sh
@@ -327,9 +327,9 @@ run_test()
 
     echo
     echo "Running tests in $dirName"
-    echo "${TimeoutTool}./RunTests.sh $Runtime"
+    echo "${TimeoutTool}./RunTests.sh --runtime-path $Runtime"
     echo
-    ${TimeoutTool}./RunTests.sh "$Runtime"
+    ${TimeoutTool}./RunTests.sh --runtime-path "$Runtime"
     exitCode=$?
 
     if [ $exitCode -ne 0 ] ; then


### PR DESCRIPTION
corefx arm32 ubuntu testing is blocked by https://github.com/dotnet/core-eng/issues/6014#event-2283234371