### PR TITLE
Add a destructor for sos::GCHeap

### DIFF
--- a/src/ToolBox/SOS/Strike/sos.cpp
+++ b/src/ToolBox/SOS/Strike/sos.cpp
@@ -795,6 +795,11 @@ namespace sos
         }
     }
 
+    GCHeap::~GCHeap()
+    {
+        delete [] mHeaps;
+    }
+
     ObjectIterator GCHeap::WalkHeap(TADDR start, TADDR stop) const
     {
         return ObjectIterator(mHeaps, mNumHeaps, start, stop);

--- a/src/ToolBox/SOS/Strike/sos.h
+++ b/src/ToolBox/SOS/Strike/sos.h
@@ -752,6 +752,8 @@ namespace sos
          */
         GCHeap();
 
+        ~GCHeap();
+
         /* Returns an ObjectIterator which allows you to walk the objects on the managed heap.
          * This ObjectIterator is valid for the duration of the GCHeap's lifetime.  Note that
          * if you specify an address at which you wish to start walking the heap it need


### PR DESCRIPTION
The constructor allocates memory via `new []`. It should be freed up via `delete []` by a destructor to avoid a memory leak.

(I am not familiar with this codebase, so I would appreciate it if someone can review this change with the assumption that it is broken.)