### PR TITLE
If IPC connections fails, then remove active session.

### DIFF
--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -305,6 +305,8 @@ private:
     // The counterpart to WriteEvent which after the payload is constructed
     static void WriteEventInternal(EventPipeEvent &event, EventPipeEventPayload &payload, LPCGUID pActivityId = NULL, LPCGUID pRelatedActivityId = NULL);
 
+    static void DisableInternal(EventPipeSessionID id);
+
     // Enable the specified EventPipe session.
     static EventPipeSessionID Enable(
         LPCWSTR strOutputPath,

--- a/src/vm/eventpipefile.cpp
+++ b/src/vm/eventpipefile.cpp
@@ -66,6 +66,12 @@ EventPipeFile::~EventPipeFile()
     delete m_pSerializer;
 }
 
+bool EventPipeFile::HasErrors() const
+{
+    LIMITED_METHOD_CONTRACT;
+    return (m_pSerializer == nullptr) || m_pSerializer->HasWriteErrors();
+}
+
 void EventPipeFile::WriteEvent(EventPipeEventInstance &instance)
 {
     CONTRACTL

--- a/src/vm/eventpipefile.h
+++ b/src/vm/eventpipefile.h
@@ -22,6 +22,7 @@ public:
 
     void WriteEvent(EventPipeEventInstance &instance);
     void Flush();
+    bool HasErrors() const;
 
     const char *GetTypeName() override
     {

--- a/src/vm/fastserializer.cpp
+++ b/src/vm/fastserializer.cpp
@@ -188,7 +188,7 @@ void FastSerializer::WriteBuffer(BYTE *pBuffer, unsigned int length)
     EX_TRY
     {
         uint32_t outCount;
-        m_pStreamWriter->Write(pBuffer, length, outCount);
+        bool fSuccess = m_pStreamWriter->Write(pBuffer, length, outCount);
 
 #ifdef _DEBUG
         size_t prevPos = m_currentPos;
@@ -198,7 +198,7 @@ void FastSerializer::WriteBuffer(BYTE *pBuffer, unsigned int length)
         // This will cause us to stop writing to the file.
         // The file will still remain open until shutdown so that we don't
         // have to take a lock at this level when we touch the file stream.
-        m_writeErrorEncountered = (length != outCount);
+        m_writeErrorEncountered = (length != outCount) || !fSuccess;
 
 #ifdef _DEBUG
         _ASSERTE(m_writeErrorEncountered || (prevPos < m_currentPos));

--- a/src/vm/fastserializer.h
+++ b/src/vm/fastserializer.h
@@ -62,7 +62,7 @@ private:
 };
 
 //!
-//! Implements a StreamWriter for writing bytes to an File.
+//! Implements a StreamWriter for writing bytes to a File.
 //!
 class FileStreamWriter final : public StreamWriter
 {


### PR DESCRIPTION
## Before

If the connected client listening to events over IPC disconnects without previously sending a stop command, then

- The EventPipe session would stay active while silently failing to send data,
- Clients would not be able to reconnect (we currently support a single session)

## After

If the connected client listening to events over IPC disconnects without previously sending a stop command, then we remove the currently active session to allow for new connections.