### PR TITLE
[System.Globalization.Native] Fix regressions from #22378 and #22390

### DIFF
--- a/src/corefx/System.Globalization.Native/pal_alloc.h
+++ b/src/corefx/System.Globalization.Native/pal_alloc.h
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include <stdlib.h>
+#include <stdint.h>
+
+static void *pal_allocarray(size_t numMembers, size_t count)
+{
+    if (numMembers == 0 || count == 0)
+        return NULL;
+    if (SIZE_MAX / numMembers < count)
+        return NULL;
+    return malloc(numMembers * count);
+}
+
+static void *pal_reallocarray(void *ptr, size_t numMembers, size_t count)
+{
+    if (numMembers == 0 || count == 0)
+        return NULL;
+    if (SIZE_MAX / numMembers < count)
+        return NULL;
+    return realloc(ptr, numMembers * count);
+}

--- a/src/corefx/System.Globalization.Native/pal_calendarData.c
+++ b/src/corefx/System.Globalization.Native/pal_calendarData.c
@@ -224,7 +224,7 @@ static int InvokeCallbackForDatePattern(const char* locale,
     UErrorCode ignore = U_ZERO_ERROR;
     int32_t patternLen = udat_toPattern(pFormat, FALSE, NULL, 0, &ignore) + 1;
 
-    UChar* pattern = calloc(patternLen, sizeof(UChar));
+    UChar* pattern = malloc(patternLen * sizeof(UChar));
     if (pattern == NULL)
     {
         udat_close(pFormat);
@@ -232,6 +232,7 @@ static int InvokeCallbackForDatePattern(const char* locale,
     }
 
     udat_toPattern(pFormat, FALSE, pattern, patternLen, &err);
+    pattern[patternLen - 1] = 0;
     udat_close(pFormat);
 
     if (U_SUCCESS(err))
@@ -264,7 +265,7 @@ static int InvokeCallbackForDateTimePattern(const char* locale,
     UErrorCode ignore = U_ZERO_ERROR;
     int32_t patternLen = udatpg_getBestPattern(pGenerator, patternSkeleton, -1, NULL, 0, &ignore) + 1;
 
-    UChar* bestPattern = calloc(patternLen, sizeof(UChar));
+    UChar* bestPattern = malloc(patternLen * sizeof(UChar));
     if (bestPattern == NULL)
     {
         udatpg_close(pGenerator);
@@ -272,6 +273,7 @@ static int InvokeCallbackForDateTimePattern(const char* locale,
     }
 
     udatpg_getBestPattern(pGenerator, patternSkeleton, -1, bestPattern, patternLen, &err);
+    bestPattern[patternLen - 1] = 0;
     udatpg_close(pGenerator);
 
     if (U_SUCCESS(err))
@@ -332,7 +334,7 @@ static int32_t EnumSymbols(const char* locale,
         }
         else
         {
-            symbolBuf = calloc(symbolLen, sizeof(UChar));
+            symbolBuf = malloc(symbolLen * sizeof(UChar));
             if (symbolBuf == NULL)
             {
                 err = U_MEMORY_ALLOCATION_ERROR;
@@ -341,6 +343,7 @@ static int32_t EnumSymbols(const char* locale,
         }
 
         udat_getSymbols(pFormat, type, i, symbolBuf, symbolLen, &err);
+        symbolBuf[symbolLen - 1] = 0;
 
         if (U_SUCCESS(err))
         {

--- a/src/corefx/System.Globalization.Native/pal_calendarData.c
+++ b/src/corefx/System.Globalization.Native/pal_calendarData.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <strings.h>
 
+#include "pal_alloc.h"
 #include "pal_calendarData.h"
 
 #define GREGORIAN_NAME "gregorian"
@@ -224,7 +225,7 @@ static int InvokeCallbackForDatePattern(const char* locale,
     UErrorCode ignore = U_ZERO_ERROR;
     int32_t patternLen = udat_toPattern(pFormat, FALSE, NULL, 0, &ignore) + 1;
 
-    UChar* pattern = malloc(patternLen * sizeof(UChar));
+    UChar* pattern = pal_allocarray(patternLen, sizeof(UChar));
     if (pattern == NULL)
     {
         udat_close(pFormat);
@@ -265,7 +266,7 @@ static int InvokeCallbackForDateTimePattern(const char* locale,
     UErrorCode ignore = U_ZERO_ERROR;
     int32_t patternLen = udatpg_getBestPattern(pGenerator, patternSkeleton, -1, NULL, 0, &ignore) + 1;
 
-    UChar* bestPattern = malloc(patternLen * sizeof(UChar));
+    UChar* bestPattern = pal_allocarray(patternLen, sizeof(UChar));
     if (bestPattern == NULL)
     {
         udatpg_close(pGenerator);
@@ -334,7 +335,7 @@ static int32_t EnumSymbols(const char* locale,
         }
         else
         {
-            symbolBuf = malloc(symbolLen * sizeof(UChar));
+            symbolBuf = pal_allocarray(symbolLen, sizeof(UChar));
             if (symbolBuf == NULL)
             {
                 err = U_MEMORY_ALLOCATION_ERROR;

--- a/src/corefx/System.Globalization.Native/pal_collation.c
+++ b/src/corefx/System.Globalization.Native/pal_collation.c
@@ -444,11 +444,15 @@ const UCollator* GetCollatorFromSortHandle(SortHandle* pSortHandle, int32_t opti
 
         TCollatorMap* map = (TCollatorMap*)malloc(sizeof(TCollatorMap));
         map->key = options;
-        void* entry = tsearch(map, &pSortHandle->collatorsPerOptionRoot, TreeComparer);
-        if ((*(TCollatorMap**)entry) == map)
+        // tfind on glibc is significantly faster than tsearch and we expect
+        // to hit the cache here often so it's benefitial to prefer lookup time
+        // over addition time
+        void* entry = tfind(map, &pSortHandle->collatorsPerOptionRoot, TreeComparer);
+        if (entry == NULL)
         {
             pCollator = CloneCollatorWithOptions(pSortHandle->regular, options, pErr);
             map->UCollator = pCollator;
+            tsearch(map, &pSortHandle->collatorsPerOptionRoot, TreeComparer);
         }
         else
         {

--- a/src/corefx/System.Globalization.Native/pal_localeNumberData.c
+++ b/src/corefx/System.Globalization.Native/pal_localeNumberData.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "pal_alloc.h"
 #include "pal_localeNumberData.h"
 
 // invariant character definitions used by ICU
@@ -86,13 +87,13 @@ static char* NormalizeNumericPattern(const UChar* srcPattern, int isNegative)
     if (isNegative && !minusAdded)
     {
         size_t length = (iEnd - iStart) + 2;
-        destPattern = malloc(length * sizeof(char));
+        destPattern = pal_allocarray(length, sizeof(char));
         destPattern[index++] = '-';
     }
     else
     {
         size_t length = (iEnd - iStart) + 1;
-        destPattern = malloc(length * sizeof(char));
+        destPattern = pal_allocarray(length, sizeof(char));
     }
 
     for (int i = iStart; i <= iEnd; i++)
@@ -166,7 +167,7 @@ static int GetNumericPattern(const UNumberFormat* pNumberFormat,
     UErrorCode ignore = U_ZERO_ERROR;
     int32_t icuPatternLength = unum_toPattern(pNumberFormat, FALSE, NULL, 0, &ignore) + 1;
 
-    UChar* icuPattern = malloc(icuPatternLength * sizeof(UChar));
+    UChar* icuPattern = pal_allocarray(icuPatternLength, sizeof(UChar));
     if (icuPattern == NULL)
     {
         return U_MEMORY_ALLOCATION_ERROR;

--- a/src/corefx/System.Globalization.Native/pal_localeNumberData.c
+++ b/src/corefx/System.Globalization.Native/pal_localeNumberData.c
@@ -86,13 +86,13 @@ static char* NormalizeNumericPattern(const UChar* srcPattern, int isNegative)
     if (isNegative && !minusAdded)
     {
         size_t length = (iEnd - iStart) + 2;
-        destPattern = calloc(length, sizeof(char));
+        destPattern = malloc(length * sizeof(char));
         destPattern[index++] = '-';
     }
     else
     {
         size_t length = (iEnd - iStart) + 1;
-        destPattern = calloc(length, sizeof(char));
+        destPattern = malloc(length * sizeof(char));
     }
 
     for (int i = iStart; i <= iEnd; i++)
@@ -142,6 +142,8 @@ static char* NormalizeNumericPattern(const UChar* srcPattern, int isNegative)
         }
     }
 
+    destPattern[index] = 0;
+
     return destPattern;
 }
 
@@ -164,7 +166,7 @@ static int GetNumericPattern(const UNumberFormat* pNumberFormat,
     UErrorCode ignore = U_ZERO_ERROR;
     int32_t icuPatternLength = unum_toPattern(pNumberFormat, FALSE, NULL, 0, &ignore) + 1;
 
-    UChar* icuPattern = calloc(icuPatternLength, sizeof(UChar));
+    UChar* icuPattern = malloc(icuPatternLength * sizeof(UChar));
     if (icuPattern == NULL)
     {
         return U_MEMORY_ALLOCATION_ERROR;
@@ -173,6 +175,7 @@ static int GetNumericPattern(const UNumberFormat* pNumberFormat,
     UErrorCode err = U_ZERO_ERROR;
 
     unum_toPattern(pNumberFormat, FALSE, icuPattern, icuPatternLength, &err);
+    icuPattern[icuPatternLength - 1] = 0;
 
     assert(U_SUCCESS(err));
 

--- a/src/corefx/System.Globalization.Native/pal_localeStringData.c
+++ b/src/corefx/System.Globalization.Native/pal_localeStringData.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "pal_alloc.h"
 #include "pal_localeStringData.h"
 
 /*
@@ -77,7 +78,7 @@ static UErrorCode GetLocaleIso639LanguageTwoLetterName(const char* locale, UChar
     UErrorCode status = U_ZERO_ERROR, ignore = U_ZERO_ERROR;
     int32_t length = uloc_getLanguage(locale, NULL, 0, &ignore) + 1;
 
-    char* buf = malloc(length * sizeof(char));
+    char* buf = pal_allocarray(length, sizeof(char));
     if (buf == NULL)
     {
         return U_MEMORY_ALLOCATION_ERROR;
@@ -121,7 +122,7 @@ static UErrorCode GetLocaleIso3166CountryName(const char* locale, UChar* value, 
     UErrorCode status = U_ZERO_ERROR, ignore = U_ZERO_ERROR;
     int32_t length = uloc_getCountry(locale, NULL, 0, &ignore) + 1;
 
-    char* buf = malloc(length * sizeof(char));
+    char* buf = pal_allocarray(length, sizeof(char));
     if (buf == NULL)
     {
         return U_MEMORY_ALLOCATION_ERROR;

--- a/src/corefx/System.Globalization.Native/pal_localeStringData.c
+++ b/src/corefx/System.Globalization.Native/pal_localeStringData.c
@@ -77,13 +77,14 @@ static UErrorCode GetLocaleIso639LanguageTwoLetterName(const char* locale, UChar
     UErrorCode status = U_ZERO_ERROR, ignore = U_ZERO_ERROR;
     int32_t length = uloc_getLanguage(locale, NULL, 0, &ignore) + 1;
 
-    char* buf = calloc(length, sizeof(char));
+    char* buf = malloc(length * sizeof(char));
     if (buf == NULL)
     {
         return U_MEMORY_ALLOCATION_ERROR;
     }
 
     uloc_getLanguage(locale, buf, length, &status);
+    buf[length - 1] = 0;
     u_charsToUChars_safe(buf, value, valueLength, &status);
     free(buf);
 
@@ -120,13 +121,14 @@ static UErrorCode GetLocaleIso3166CountryName(const char* locale, UChar* value, 
     UErrorCode status = U_ZERO_ERROR, ignore = U_ZERO_ERROR;
     int32_t length = uloc_getCountry(locale, NULL, 0, &ignore) + 1;
 
-    char* buf = calloc(length, sizeof(char));
+    char* buf = malloc(length * sizeof(char));
     if (buf == NULL)
     {
         return U_MEMORY_ALLOCATION_ERROR;
     }
 
     uloc_getCountry(locale, buf, length, &status);
+    buf[length - 1] = 0;
     u_charsToUChars_safe(buf, value, valueLength, &status);
     free(buf);
 


### PR DESCRIPTION
Address few regressions from #22378. Avoid using `calloc` in order to remove overhead from unnecessary zeroing of memory.

Fix reallocation in `AddItem` (pal_collation.c) to prevent accidental overflow and to use correct element size. Previously it allocated more memory due to incorrectly multiplying by `sizeof(UChar*)` instead of `sizeof(UChar)`.

Fix performance regression from #22390 (tracked in https://github.com/aspnet/AspNetCore/issues/9404). `tsearch` performance on glibc is vastly inferior to `tfind` so prefer to use the later. On macOS the performance of either approach was nearly identical.