### PR TITLE
Null-terminate buffers that strncpy writes to

### DIFF
--- a/src/corefx/System.Globalization.Native/pal_calendarData.c
+++ b/src/corefx/System.Globalization.Native/pal_calendarData.c
@@ -305,6 +305,8 @@ static int32_t EnumSymbols(const char* locale,
 
     char localeWithCalendarName[ULOC_FULLNAME_CAPACITY];
     strncpy(localeWithCalendarName, locale, ULOC_FULLNAME_CAPACITY);
+    localeWithCalendarName[ULOC_FULLNAME_CAPACITY - 1] = 0;
+
     uloc_setKeywordValue("calendar", GetCalendarName(calendarId), localeWithCalendarName, ULOC_FULLNAME_CAPACITY, &err);
 
     UCalendar* pCalendar = ucal_open(NULL, 0, localeWithCalendarName, UCAL_DEFAULT, &err);
@@ -412,6 +414,7 @@ static int32_t EnumAbbrevEraNames(const char* locale,
     char* parentNamePtr = parentNameBuf;
 
     strncpy(localeNamePtr, locale, ULOC_FULLNAME_CAPACITY);
+    localeNamePtr[ULOC_FULLNAME_CAPACITY - 1] = 0;
 
     while (TRUE)
     {


### PR DESCRIPTION
It is possible that the string being copied is so large that `strncpy` fills up the destination array and does not write any null characters to it. That will lead to buffer overflows. Work around that by always writing a null character at the end of the destination array.