### PR TITLE
System.GC.AllocateUninitializedArray

### DIFF
--- a/src/System.Private.CoreLib/ILLinkTrim.xml
+++ b/src/System.Private.CoreLib/ILLinkTrim.xml
@@ -9,6 +9,8 @@
       <!-- Methods are used to register and unregister frozen segments. They are private and experimental. -->
       <method name="_RegisterFrozenSegment" />
       <method name="_UnregisterFrozenSegment" />
+      <!-- This is an internal API for now and is not yet used outside tests. -->
+      <method name="AllocateUninitializedArray" />
     </type>
     <!-- Properties and methods used by a debugger. -->
     <type fullname="System.Threading.Tasks.Task">

--- a/src/System.Private.CoreLib/src/System/GC.cs
+++ b/src/System.Private.CoreLib/src/System/GC.cs
@@ -648,14 +648,12 @@ namespace System
             }
         }
 
-
         // Skips zero-initialization of the array if possible. If T contains object references, 
         // the array is always zero-initialized.
         internal static T[] AllocateUninitializedArray<T>(int length)
         {
             if (length < 0)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.lengths, 0, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
-
 #if DEBUG
             // in DEBUG arrays of any length can be created uninitialized
 #else
@@ -670,7 +668,6 @@ namespace System
                 return new T[length];
             }
 #endif
-
             return (T[])AllocateNewArray(typeof(T[]).TypeHandle.Value, length, zeroingOptional: true);
         }
     }

--- a/src/System.Private.CoreLib/src/System/GC.cs
+++ b/src/System.Private.CoreLib/src/System/GC.cs
@@ -661,10 +661,12 @@ namespace System
             // in DEBUG arrays of any length can be created uninitialized
 #else
             // otherwise small arrays are allocated using `new[]` as that is generally faster.
+            //
             // The threshold was derived from various simulations. 
-            // As turned out the threshold depends on overal pattern of allocations and gradient around the number is shallow.
-            // As a result the and exact value of the threshold does not matter a lot and we chose 256.
-            if (Unsafe.SizeOf<T>() * length <= 256)
+            // As it turned out the threshold depends on overal pattern of all allocations and is typically in 200-300 byte range.
+            // The gradient around the number is shallow (there is no perf cliff) and the exact value of the threshold does not matter a lot.
+            // So it is 256 bytes including array header.
+            if (Unsafe.SizeOf<T>() * length < 256 - 3 * IntPtr.Size)
             {
                 return new T[length];
             }

--- a/src/System.Private.CoreLib/src/System/GC.cs
+++ b/src/System.Private.CoreLib/src/System/GC.cs
@@ -85,7 +85,7 @@ namespace System
 
         // NYI: generation, pinned, alignment
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern Array AllocateNewArray(IntPtr typeHandle, int length, bool clearMemory);
+        internal static extern Array AllocateNewArray(IntPtr typeHandle, int length, bool zeroingOptional);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern int GetGenerationWR(IntPtr handle);
@@ -670,7 +670,7 @@ namespace System
             }
 #endif
 
-            return (T[])AllocateNewArray(typeof(T[]).TypeHandle.Value, length, clearMemory: false);
+            return (T[])AllocateNewArray(typeof(T[]).TypeHandle.Value, length, zeroingOptional: true);
         }
     }
 }

--- a/src/System.Private.CoreLib/src/System/GC.cs
+++ b/src/System.Private.CoreLib/src/System/GC.cs
@@ -660,19 +660,35 @@ namespace System
         // otherwise specify a power of 2 value that's >= pointer size
         // the beginning of the payload of the object (&array[0]) will be aligned with this alignment.
         // static T[] AllocateArray<T>(int length, int generation = -1, bool pinned = false, int alignment = -1)
-        //
-        // TODO: VS  NYI generation, pinned, alignment. Probably should throw Unsupported?
-        public static T[] AllocateArray<T>(int length)
+        public static T[] AllocateArray<T>(int length, int generation = -1, bool pinned = false, int alignment = -1)
         {
+            // TODO: VS resources
+            if (generation != -1)
+                throw new NotSupportedException();
+
+            if (pinned)
+                throw new NotSupportedException();
+
+            if (alignment != -1)
+                throw new NotSupportedException();
+
             return AllocateArrayWorker<T>(length, clearMemory: true);
         }
 
         // Skips zero-initialization of the array if possible. If T contains object references, 
         // the array is always zero-initialized.
-        //
-        // TODO: VS  NYI generation, pinned, alignment. Probably should throw Unsupported?
-        public static T[] AllocateUninitializedArray<T>(int length)
+        public static T[] AllocateUninitializedArray<T>(int length, int generation = -1, bool pinned = false, int alignment = -1)
         {
+            // TODO: VS resources
+            if (generation != -1)
+                throw new NotSupportedException();
+
+            if (pinned)
+                throw new NotSupportedException();
+
+            if (alignment != -1)
+                throw new NotSupportedException();
+
             return AllocateArrayWorker<T>(length, clearMemory: false);
         }
 

--- a/src/System.Private.CoreLib/src/System/GC.cs
+++ b/src/System.Private.CoreLib/src/System/GC.cs
@@ -672,7 +672,10 @@ namespace System
             if (alignment != -1)
                 throw new NotSupportedException();
 
-            return AllocateArrayWorker<T>(length, clearMemory: true);
+            if (length < 0)
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.lengths, 0, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
+
+            return (T[])AllocateNewArray(typeof(T[]).TypeHandle.Value, length, clearMemory: true);
         }
 
         // Skips zero-initialization of the array if possible. If T contains object references, 
@@ -689,15 +692,10 @@ namespace System
             if (alignment != -1)
                 throw new NotSupportedException();
 
-            return AllocateArrayWorker<T>(length, clearMemory: false);
-        }
-
-        private static T[] AllocateArrayWorker<T>(int length, bool clearMemory)
-        {
             if (length < 0)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.lengths, 0, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
 
-            return (T[])AllocateNewArray(typeof(T).TypeHandle.Value, length, clearMemory);
+            return (T[])AllocateNewArray(typeof(T[]).TypeHandle.Value, length, clearMemory: false);
         }
     }
 }

--- a/src/System.Private.CoreLib/src/System/GC.cs
+++ b/src/System.Private.CoreLib/src/System/GC.cs
@@ -83,7 +83,6 @@ namespace System
         [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
         internal static extern int _EndNoGCRegion();
 
-        // NYI: generation, pinned, alignment
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern Array AllocateNewArray(IntPtr typeHandle, int length, bool zeroingOptional);
 

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -13447,13 +13447,16 @@ allocation_state gc_heap::try_allocate_more_space (alloc_context* acontext, size
             FIRE_EVENT(GCAllocationTick_V1, (uint32_t)etw_allocation_running_amount[etw_allocation_index],
                                             (gen_number == 0) ? gc_etw_alloc_soh : gc_etw_alloc_loh);
 #else
+
+#if defined(FEATURE_EVENT_TRACE)
+            // We are explicitly checking whether the event is enabled here.
             // Unfortunately some of the ETW macros do not check whether the ETW feature is enabled.
             // The ones that do are much less efficient.
-#if defined(FEATURE_EVENT_TRACE)
             if (EVENT_ENABLED(GCAllocationTick_V3))
             {
                 fire_etw_allocation_event (etw_allocation_running_amount[etw_allocation_index], gen_number, acontext->alloc_ptr);
             }
+
 #endif //FEATURE_EVENT_TRACE
 #endif //FEATURE_REDHAWK
             etw_allocation_running_amount[etw_allocation_index] = 0;

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -35021,6 +35021,11 @@ GCHeap::AllocAlign8Common(void* _hp, alloc_context* acontext, size_t size, uint3
                     // rest of the space should be correctly aligned for the real object.
                     newAlloc = (Object*)((uint8_t*)freeobj + Align(min_obj_size));
                     ASSERT(((size_t)newAlloc & 7) == desiredAlignment);
+                    if (flags & GC_ALLOC_ZEROING_OPTIONAL)
+                    {
+                        // clean the syncblock of the aligned object.
+                        *(((PTR_PTR)newAlloc)-1) = 0;
+                    }
                 }
                 freeobj->SetFree(min_obj_size);
             }

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -914,6 +914,7 @@ void updateGCShadow(Object** ptr, Object* val);
 #define GC_ALLOC_CONTAINS_REF 0x2
 #define GC_ALLOC_ALIGN8_BIAS 0x4
 #define GC_ALLOC_ALIGN8 0x8
+#define GC_ALLOC_ZEROING_OPTIONAL 0x10
 
 #if defined(USE_CHECKED_OBJECTREFS) && !defined(_NOVM)
 #define OBJECTREF_TO_UNCHECKED_OBJECTREF(objref)    (*((_UNCHECKED_OBJECTREF*)&(objref)))

--- a/src/gc/gcinterface.h
+++ b/src/gc/gcinterface.h
@@ -910,11 +910,30 @@ void updateGCShadow(Object** ptr, Object* val);
 #define GC_CALL_CHECK_APP_DOMAIN    0x4
 
 //flags for IGCHeapAlloc(...)
-#define GC_ALLOC_FINALIZE 0x1
-#define GC_ALLOC_CONTAINS_REF 0x2
-#define GC_ALLOC_ALIGN8_BIAS 0x4
-#define GC_ALLOC_ALIGN8 0x8
-#define GC_ALLOC_ZEROING_OPTIONAL 0x10
+enum GC_ALLOC_FLAGS
+{
+    GC_ALLOC_NO_FLAGS           = 0,
+    GC_ALLOC_FINALIZE           = 1,
+    GC_ALLOC_CONTAINS_REF       = 2,
+    GC_ALLOC_ALIGN8_BIAS        = 4,
+    GC_ALLOC_ALIGN8             = 8,
+    GC_ALLOC_ZEROING_OPTIONAL   = 16,
+};
+
+inline GC_ALLOC_FLAGS operator|(GC_ALLOC_FLAGS a, GC_ALLOC_FLAGS b)
+{return (GC_ALLOC_FLAGS)((int)a | (int)b);}
+
+inline GC_ALLOC_FLAGS operator&(GC_ALLOC_FLAGS a, GC_ALLOC_FLAGS b)
+{return (GC_ALLOC_FLAGS)((int)a & (int)b);}
+
+inline GC_ALLOC_FLAGS operator~(GC_ALLOC_FLAGS a)
+{return (GC_ALLOC_FLAGS)(~(int)a);}
+
+inline GC_ALLOC_FLAGS& operator|=(GC_ALLOC_FLAGS& a, GC_ALLOC_FLAGS b)
+{return (GC_ALLOC_FLAGS&)((int&)a |= (int)b);}
+
+inline GC_ALLOC_FLAGS& operator&=(GC_ALLOC_FLAGS& a, GC_ALLOC_FLAGS b)
+{return (GC_ALLOC_FLAGS&)((int&)a &= (int)b);}
 
 #if defined(USE_CHECKED_OBJECTREFS) && !defined(_NOVM)
 #define OBJECTREF_TO_UNCHECKED_OBJECTREF(objref)    (*((_UNCHECKED_OBJECTREF*)&(objref)))

--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -1219,7 +1219,8 @@ public:
 
     PER_HEAP
     CObjectHeader* allocate (size_t jsize,
-                             alloc_context* acontext);
+                             alloc_context* acontext,
+                             uint32_t flags);
 
 #ifdef MULTIPLE_HEAPS
     static
@@ -1241,7 +1242,7 @@ public:
     // Note: This is an instance method, but the heap instance is only used for
     // lowest_address and highest_address, which are currently the same accross all heaps.
     PER_HEAP
-    CObjectHeader* allocate_large_object (size_t size, int64_t& alloc_bytes);
+    CObjectHeader* allocate_large_object (size_t size, uint32_t flags, int64_t& alloc_bytes);
 
 #ifdef FEATURE_STRUCTALIGN
     PER_HEAP
@@ -1452,10 +1453,10 @@ protected:
     size_t limit_from_size (size_t size, size_t room, int gen_number,
                             int align_const);
     PER_HEAP
-    allocation_state try_allocate_more_space (alloc_context* acontext, size_t jsize,
+    allocation_state try_allocate_more_space (alloc_context* acontext, size_t jsize, uint32_t flags, 
                                               int alloc_generation_number);
     PER_HEAP_ISOLATED
-    BOOL allocate_more_space (alloc_context* acontext, size_t jsize,
+    BOOL allocate_more_space (alloc_context* acontext, size_t jsize, uint32_t flags, 
                               int alloc_generation_number);
 
     PER_HEAP
@@ -1470,6 +1471,7 @@ protected:
     BOOL a_fit_free_list_p (int gen_number, 
                             size_t size, 
                             alloc_context* acontext,
+                            uint32_t flags,
                             int align_const);
 
 #ifdef BACKGROUND_GC
@@ -1483,6 +1485,7 @@ protected:
     void bgc_loh_alloc_clr (uint8_t* alloc_start,
                             size_t size, 
                             alloc_context* acontext,
+                            uint32_t flags, 
                             int align_const, 
                             int lock_index,
                             BOOL check_used_p,
@@ -1524,6 +1527,7 @@ protected:
     PER_HEAP
     BOOL a_fit_free_list_large_p (size_t size, 
                                   alloc_context* acontext,
+                                  uint32_t flags, 
                                   int align_const);
 
     PER_HEAP
@@ -1531,12 +1535,14 @@ protected:
                               heap_segment* seg,
                               size_t size, 
                               alloc_context* acontext,
+                              uint32_t flags, 
                               int align_const,
                               BOOL* commit_failed_p);
     PER_HEAP
     BOOL loh_a_fit_segment_end_p (int gen_number,
                                   size_t size, 
                                   alloc_context* acontext,
+                                  uint32_t flags,
                                   int align_const,
                                   BOOL* commit_failed_p,
                                   oom_reason* oom_r);
@@ -1570,6 +1576,7 @@ protected:
     BOOL soh_try_fit (int gen_number,
                       size_t size, 
                       alloc_context* acontext,
+                      uint32_t flags,
                       int align_const,
                       BOOL* commit_failed_p,
                       BOOL* short_seg_end_p);
@@ -1577,6 +1584,7 @@ protected:
     BOOL loh_try_fit (int gen_number,
                       size_t size, 
                       alloc_context* acontext,
+                      uint32_t flags, 
                       int align_const,
                       BOOL* commit_failed_p,
                       oom_reason* oom_r);
@@ -1585,6 +1593,7 @@ protected:
     allocation_state allocate_small (int gen_number,
                                      size_t size, 
                                      alloc_context* acontext,
+                                     uint32_t flags,
                                      int align_const);
 
 #ifdef RECORD_LOH_STATE
@@ -1607,6 +1616,7 @@ protected:
     allocation_state allocate_large (int gen_number,
                                      size_t size, 
                                      alloc_context* acontext,
+                                     uint32_t flags, 
                                      int align_const);
 
     PER_HEAP_ISOLATED
@@ -1853,8 +1863,8 @@ protected:
     void adjust_limit (uint8_t* start, size_t limit_size, generation* gen,
                        int gen_number);
     PER_HEAP
-    void adjust_limit_clr (uint8_t* start, size_t limit_size,
-                           alloc_context* acontext, heap_segment* seg,
+    void adjust_limit_clr (uint8_t* start, size_t limit_size, size_t size,
+                           alloc_context* acontext, uint32_t flags, heap_segment* seg,
                            int align_const, int gen_number);
     PER_HEAP
     void  leave_allocation_segment (generation* gen);

--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -1450,7 +1450,7 @@ protected:
     void fire_etw_pin_object_event (uint8_t* object, uint8_t** ppObject);
 
     PER_HEAP
-    size_t limit_from_size (size_t size, size_t room, int gen_number,
+    size_t limit_from_size (size_t size, uint32_t flags, size_t room, int gen_number,
                             int align_const);
     PER_HEAP
     allocation_state try_allocate_more_space (alloc_context* acontext, size_t jsize, uint32_t flags, 

--- a/src/vm/comutilnative.cpp
+++ b/src/vm/comutilnative.cpp
@@ -1280,7 +1280,7 @@ FCIMPL3(Object*, GCInterface::AllocateNewArray, void* arrayTypeHandle, INT32 len
 
     HELPER_METHOD_FRAME_BEGIN_RET_0();
 
-    pRet = AllocateSzArray(arrayType, length, zeroingOptional? GC_ALLOC_ZEROING_OPTIONAL: GC_ALLOC_NO_FLAGS);
+    pRet = AllocateSzArray(arrayType, length, zeroingOptional ? GC_ALLOC_ZEROING_OPTIONAL : GC_ALLOC_NO_FLAGS);
 
     HELPER_METHOD_FRAME_END();
 

--- a/src/vm/comutilnative.cpp
+++ b/src/vm/comutilnative.cpp
@@ -1280,7 +1280,7 @@ FCIMPL3(Object*, GCInterface::AllocateNewArray, void* arrayTypeHandle, INT32 len
 
     HELPER_METHOD_FRAME_BEGIN_RET_0();
 
-    pRet = AllocateSzArray(arrayType, length, zeroingOptional);
+    pRet = AllocateSzArray(arrayType, length, zeroingOptional? GC_ALLOC_ZEROING_OPTIONAL: GC_ALLOC_NO_FLAGS);
 
     HELPER_METHOD_FRAME_END();
 

--- a/src/vm/comutilnative.cpp
+++ b/src/vm/comutilnative.cpp
@@ -1265,10 +1265,10 @@ FCIMPLEND
 **Returns: The allocated array.
 **Arguments: elementTypeHandle -> type of the element, 
 **           length -> number of elements, 
-**           clearMemory -> whether user prefer to skip clearing the content of the array.
+**           zeroingOptional -> whether caller prefers to skip clearing the content of the array, if possible.
 **Exceptions: IDS_EE_ARRAY_DIMENSIONS_EXCEEDED when size is too large. OOM if can't allocate.
 ==============================================================================*/
-FCIMPL3(Object*, GCInterface::AllocateNewArray, void* arrayTypeHandle, INT32 length, CLR_BOOL clearMemory)
+FCIMPL3(Object*, GCInterface::AllocateNewArray, void* arrayTypeHandle, INT32 length, CLR_BOOL zeroingOptional)
 {
     CONTRACTL {
         FCALL_CHECK;
@@ -1278,10 +1278,9 @@ FCIMPL3(Object*, GCInterface::AllocateNewArray, void* arrayTypeHandle, INT32 len
     OBJECTREF pRet = NULL;
     TypeHandle arrayType = TypeHandle::FromPtr(arrayTypeHandle);
 
-    HELPER_METHOD_FRAME_BEGIN_RET_1(pRet);
+    HELPER_METHOD_FRAME_BEGIN_RET_0();
 
-    //REVIEW: ArrayNative has a number of specialized helpers like for primitive arrays. Do we want smth similar?
-    pRet = AllocateSzArray(arrayType, length, /*zeroingOptional*/ !clearMemory);
+    pRet = AllocateSzArray(arrayType, length, zeroingOptional);
 
     HELPER_METHOD_FRAME_END();
 

--- a/src/vm/comutilnative.cpp
+++ b/src/vm/comutilnative.cpp
@@ -1268,7 +1268,7 @@ FCIMPLEND
 **           clearMemory -> whether user prefer to skip clearing the content of the array.
 **Exceptions: IDS_EE_ARRAY_DIMENSIONS_EXCEEDED when size is too large. OOM if can't allocate.
 ==============================================================================*/
-FCIMPL3(Object*, GCInterface::AllocateNewArray, void* elementTypeHandle, INT32 length, CLR_BOOL clearMemory)
+FCIMPL3(Object*, GCInterface::AllocateNewArray, void* arrayTypeHandle, INT32 length, CLR_BOOL clearMemory)
 {
     CONTRACTL {
         FCALL_CHECK;
@@ -1276,12 +1276,12 @@ FCIMPL3(Object*, GCInterface::AllocateNewArray, void* elementTypeHandle, INT32 l
     } CONTRACTL_END;
 
     OBJECTREF pRet = NULL;
-    TypeHandle elementType = TypeHandle::FromPtr(elementTypeHandle);
+    TypeHandle arrayType = TypeHandle::FromPtr(arrayTypeHandle);
 
     HELPER_METHOD_FRAME_BEGIN_RET_1(pRet);
 
     //REVIEW: ArrayNative has a number of specialized helpers like for primitive arrays. Do we want smth similar?
-    pRet = AllocateSzArray(elementType, length, /*zeroingOptional*/ !clearMemory);
+    pRet = AllocateSzArray(arrayType, length, /*zeroingOptional*/ !clearMemory);
 
     HELPER_METHOD_FRAME_END();
 

--- a/src/vm/comutilnative.cpp
+++ b/src/vm/comutilnative.cpp
@@ -1260,6 +1260,35 @@ FCIMPL0(INT64, GCInterface::GetAllocatedBytesForCurrentThread)
 }
 FCIMPLEND
 
+/*===============================AllocateNewArray===============================
+**Action: Allocates a new array object. Allows passing extra flags
+**Returns: The allocated array.
+**Arguments: elementTypeHandle -> type of the element, 
+**           length -> number of elements, 
+**           clearMemory -> whether user prefer to skip clearing the content of the array.
+**Exceptions: IDS_EE_ARRAY_DIMENSIONS_EXCEEDED when size is too large. OOM if can't allocate.
+==============================================================================*/
+FCIMPL3(Object*, GCInterface::AllocateNewArray, void* elementTypeHandle, INT32 length, CLR_BOOL clearMemory)
+{
+    CONTRACTL {
+        FCALL_CHECK;
+        PRECONDITION(length >= 0);
+    } CONTRACTL_END;
+
+    OBJECTREF pRet = NULL;
+    TypeHandle elementType = TypeHandle::FromPtr(elementTypeHandle);
+
+    HELPER_METHOD_FRAME_BEGIN_RET_1(pRet);
+
+    //REVIEW: ArrayNative has a number of specialized helpers like for primitive arrays. Do we want smth similar?
+    pRet = AllocateSzArray(elementType, length, /*zeroingOptional*/ !clearMemory);
+
+    HELPER_METHOD_FRAME_END();
+
+    return OBJECTREFToObject(pRet);
+}
+FCIMPLEND
+
 #ifdef FEATURE_BASICFREEZE
 
 /*===============================RegisterFrozenSegment===============================

--- a/src/vm/comutilnative.h
+++ b/src/vm/comutilnative.h
@@ -138,7 +138,9 @@ public:
     static FCDECL1(void,    ReRegisterForFinalize, Object *obj);
     static FCDECL2(int,     CollectionCount, INT32 generation, INT32 getSpecialGCCount);
     
-    static FCDECL0(INT64,    GetAllocatedBytesForCurrentThread);
+    static FCDECL0(INT64,   GetAllocatedBytesForCurrentThread);
+
+    static FCDECL3(Object*, AllocateNewArray, void* elementTypeHandle, INT32 length, CLR_BOOL clearMemory);
 
 #ifdef FEATURE_BASICFREEZE
     static

--- a/src/vm/comutilnative.h
+++ b/src/vm/comutilnative.h
@@ -140,7 +140,7 @@ public:
     
     static FCDECL0(INT64,   GetAllocatedBytesForCurrentThread);
 
-    static FCDECL3(Object*, AllocateNewArray, void* elementTypeHandle, INT32 length, CLR_BOOL clearMemory);
+    static FCDECL3(Object*, AllocateNewArray, void* elementTypeHandle, INT32 length, CLR_BOOL zeroingOptional);
 
 #ifdef FEATURE_BASICFREEZE
     static

--- a/src/vm/crossloaderallocatorhash.inl
+++ b/src/vm/crossloaderallocatorhash.inl
@@ -80,7 +80,7 @@ template <class TKey_, class TValue_>
 
     if (*pKeyValueStore == NULL)
     {
-        *pKeyValueStore = AllocatePrimitiveArray(ELEMENT_TYPE_I1, IsNull(value) ? sizeof(TKey) : sizeof(TKey) + sizeof(TValue), FALSE);
+        *pKeyValueStore = AllocatePrimitiveArray(ELEMENT_TYPE_I1, IsNull(value) ? sizeof(TKey) : sizeof(TKey) + sizeof(TValue));
         updatedKeyValueStore = true;
         TKey* pKeyLoc = (TKey*)((I1ARRAYREF)*pKeyValueStore)->GetDirectPointerToNonObjectElements();
         *pKeyLoc = key;
@@ -108,7 +108,7 @@ template <class TKey_, class TValue_>
                 COMPlusThrow(kOverflowException);
 
             // Allocate the new array.
-            I1ARRAYREF newKeyValueStore = (I1ARRAYREF)AllocatePrimitiveArray(ELEMENT_TYPE_I1, newSize*sizeof(TValue) + sizeof(TKey), FALSE);
+            I1ARRAYREF newKeyValueStore = (I1ARRAYREF)AllocatePrimitiveArray(ELEMENT_TYPE_I1, newSize*sizeof(TValue) + sizeof(TKey));
 
             // Since, AllocatePrimitiveArray may have triggered a GC, recapture all data pointers from GC objects
             void* pStartOfNewArray = newKeyValueStore->GetDirectPointerToNonObjectElements();

--- a/src/vm/customattribute.cpp
+++ b/src/vm/customattribute.cpp
@@ -170,7 +170,7 @@ CustomAttributeManagedValues Attribute::GetManagedCaValue(CaValue* pCaVal)
 
             if (length != (ULONG)-1)
             {
-                gc.array = (CaValueArrayREF)AllocateSzArray(MscorlibBinder::GetClass(CLASS__CUSTOM_ATTRIBUTE_ENCODED_ARGUMENT), length);
+                gc.array = (CaValueArrayREF)AllocateSzArray(TypeHandle(MscorlibBinder::GetClass(CLASS__CUSTOM_ATTRIBUTE_ENCODED_ARGUMENT)).MakeSZArray(), length);
                 CustomAttributeValue* pValues = gc.array->GetDirectPointerToNonObjectElements();
 
                 for (COUNT_T i = 0; i < length; i ++)

--- a/src/vm/customattribute.cpp
+++ b/src/vm/customattribute.cpp
@@ -170,7 +170,7 @@ CustomAttributeManagedValues Attribute::GetManagedCaValue(CaValue* pCaVal)
 
             if (length != (ULONG)-1)
             {
-                gc.array = (CaValueArrayREF)AllocateValueSzArray(MscorlibBinder::GetClass(CLASS__CUSTOM_ATTRIBUTE_ENCODED_ARGUMENT), length);
+                gc.array = (CaValueArrayREF)AllocateSzArray(MscorlibBinder::GetClass(CLASS__CUSTOM_ATTRIBUTE_ENCODED_ARGUMENT), length);
                 CustomAttributeValue* pValues = gc.array->GetDirectPointerToNonObjectElements();
 
                 for (COUNT_T i = 0; i < length; i ++)

--- a/src/vm/customattribute.cpp
+++ b/src/vm/customattribute.cpp
@@ -1310,7 +1310,7 @@ void COMCustomAttribute::ReadArray(Assembly *pCtorAssembly,
         TypeHandle arrayHandle = ClassLoader::LoadArrayTypeThrowing(th);
         if (arrayHandle.IsNull()) 
             goto badBlob;
-        *pArray = (BASEARRAYREF)AllocateArrayEx(arrayHandle, &bounds, 1);
+        *pArray = (BASEARRAYREF)AllocateSzArray(arrayHandle, bounds);
         BOOL fSuccess;
         switch (elementSize)
         {

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -782,6 +782,8 @@ FCFuncStart(gGCInterfaceFuncs)
 
     FCFuncElement("_GetAllocatedBytesForCurrentThread", GCInterface::GetAllocatedBytesForCurrentThread)
 
+    FCFuncElement("AllocateNewArray", GCInterface::AllocateNewArray)
+
 #ifdef FEATURE_BASICFREEZE
     QCFuncElement("_RegisterFrozenSegment", GCInterface::RegisterFrozenSegment)
     QCFuncElement("_UnregisterFrozenSegment", GCInterface::UnregisterFrozenSegment)

--- a/src/vm/fieldmarshaler.cpp
+++ b/src/vm/fieldmarshaler.cpp
@@ -2826,7 +2826,7 @@ VOID FieldMarshaler_FixedArray::UpdateCLRImpl(const VOID *pNativeValue, OBJECTRE
     CONTRACTL_END;
 
     // Allocate the value class array.
-    *ppProtectedCLRValue = AllocateArrayEx(m_arrayType.GetValue(), (INT32*)&m_numElems, 1);
+    *ppProtectedCLRValue = AllocateSzArray(m_arrayType.GetValue(), (INT32)m_numElems);
 
     // Marshal the contents from the native array to the managed array.
     const OleVariant::Marshaler *pMarshaler = OleVariant::GetMarshalerForVarType(m_vt, TRUE);        

--- a/src/vm/gchelpers.cpp
+++ b/src/vm/gchelpers.cpp
@@ -420,7 +420,7 @@ inline SIZE_T MaxArrayLength(SIZE_T componentSize)
     return (componentSize == 1) ? 0X7FFFFFC7 : 0X7FEFFFFF;
 }
 
-OBJECTREF AllocateSzArray(TypeHandle elementType, INT32 length, BOOL zeroingOptional)
+OBJECTREF AllocateSzArray(TypeHandle arrayType, INT32 length, BOOL zeroingOptional)
 {
     CONTRACTL {
         THROWS;
@@ -428,7 +428,7 @@ OBJECTREF AllocateSzArray(TypeHandle elementType, INT32 length, BOOL zeroingOpti
         MODE_COOPERATIVE; // returns an objref without pinning it => cooperative        
     } CONTRACTL_END;
 
-    return AllocateArrayEx(elementType.MakeSZArray(), &length, 1, FALSE,  zeroingOptional);
+    return AllocateArrayEx(arrayType, &length, 1, FALSE,  zeroingOptional);
 }
 
 void ThrowOutOfMemoryDimensionsExceeded()

--- a/src/vm/gchelpers.cpp
+++ b/src/vm/gchelpers.cpp
@@ -428,12 +428,11 @@ OBJECTREF AllocateSzArray(TypeHandle arrayType, INT32 cElements, BOOL zeroingOpt
         MODE_COOPERATIVE; // returns an objref without pinning it => cooperative        
     } CONTRACTL_END;
 
-    SetTypeHandleOnThreadForAlloc(arrayType);
-
     ArrayTypeDesc* arrayDesc = arrayType.AsArray();
     MethodTable* pArrayMT = arrayDesc->GetMethodTable();
+    SetTypeHandleOnThreadForAlloc(TypeHandle(pArrayMT));
 
-   _ASSERTE(pArrayMT->CheckInstanceActivated());
+    _ASSERTE(pArrayMT->CheckInstanceActivated());
     _ASSERTE(pArrayMT->GetInternalCorElementType() == ELEMENT_TYPE_SZARRAY);
     
     CorElementType elemType = pArrayMT->GetArrayElementType();

--- a/src/vm/gchelpers.h
+++ b/src/vm/gchelpers.h
@@ -20,10 +20,10 @@
 //
 //========================================================================
 
-OBJECTREF AllocateSzArray(TypeHandle elementType, INT32 length, BOOL zeroingOptional = FALSE);
+OBJECTREF AllocateSzArray(TypeHandle arrayType, INT32 length, BOOL zeroingOptional = FALSE);
     // The main Array allocation routine, can do multi-dimensional
 OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, BOOL bAllocateInLargeHeap = FALSE, BOOL zeroingOptional = FALSE);
-OBJECTREF AllocateArrayEx(TypeHandle arrayClass, INT32 *pArgs, DWORD dwNumArgs, BOOL bAllocateInLargeHeap = FALSE, BOOL zeroingOptional = FALSE);
+OBJECTREF AllocateArrayEx(TypeHandle arrayType, INT32 *pArgs, DWORD dwNumArgs, BOOL bAllocateInLargeHeap = FALSE, BOOL zeroingOptional = FALSE);
     // Optimized verion of above
 OBJECTREF FastAllocatePrimitiveArray(MethodTable* arrayType, DWORD cElements, BOOL bAllocateInLargeHeap = FALSE);
 

--- a/src/vm/gchelpers.h
+++ b/src/vm/gchelpers.h
@@ -22,8 +22,8 @@
 
 OBJECTREF AllocateSzArray(TypeHandle arrayType, INT32 length, BOOL zeroingOptional = FALSE);
     // The main Array allocation routine, can do multi-dimensional
-OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, BOOL bAllocateInLargeHeap = FALSE, BOOL zeroingOptional = FALSE);
-OBJECTREF AllocateArrayEx(TypeHandle arrayType, INT32 *pArgs, DWORD dwNumArgs, BOOL bAllocateInLargeHeap = FALSE, BOOL zeroingOptional = FALSE);
+OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, BOOL bAllocateInLargeHeap = FALSE);
+OBJECTREF AllocateArrayEx(TypeHandle arrayType, INT32 *pArgs, DWORD dwNumArgs, BOOL bAllocateInLargeHeap = FALSE);
     // Optimized verion of above
 OBJECTREF FastAllocatePrimitiveArray(MethodTable* arrayType, DWORD cElements, BOOL bAllocateInLargeHeap = FALSE);
 

--- a/src/vm/gchelpers.h
+++ b/src/vm/gchelpers.h
@@ -34,24 +34,7 @@ OBJECTREF AllocatePrimitiveArray(CorElementType type, DWORD cElements);
 // Allocate SD array of object types given an element type
 OBJECTREF AllocateObjectArray(DWORD cElements, TypeHandle ElementType, BOOL bAllocateInLargeHeap = FALSE);
 
-#if defined(_TARGET_X86_)
-// for x86, we generate efficient allocators for some special cases
-// these are called via inline wrappers that call the generated allocators
-// via function pointers.
-
-// Create a SD array of primitive types
-typedef HCCALL2_PTR(Object*, FastPrimitiveArrayAllocatorFuncPtr, CorElementType type, DWORD cElements);
-extern FastPrimitiveArrayAllocatorFuncPtr fastPrimitiveArrayAllocator;
-
-// Allocate SD array of object pointers.
-typedef HCCALL2_PTR(Object*, FastObjectArrayAllocatorFuncPtr, MethodTable *pArrayMT, DWORD cElements);
-extern FastObjectArrayAllocatorFuncPtr fastObjectArrayAllocator;
-
-// Allocate string
-typedef HCCALL1_PTR(StringObject*, FastStringAllocatorFuncPtr, DWORD cchArrayLength);
-extern FastStringAllocatorFuncPtr fastStringAllocator;
-#endif
-
+// Allocate a string
 STRINGREF AllocateString( DWORD cchStringLength );
 
 #ifdef FEATURE_UTF8STRING

--- a/src/vm/gchelpers.h
+++ b/src/vm/gchelpers.h
@@ -20,94 +20,45 @@
 //
 //========================================================================
 
-OBJECTREF AllocateSzArray(TypeHandle arrayType, INT32 length, BOOL zeroingOptional = FALSE);
-    // The main Array allocation routine, can do multi-dimensional
-OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, BOOL bAllocateInLargeHeap = FALSE);
-OBJECTREF AllocateArrayEx(TypeHandle arrayType, INT32 *pArgs, DWORD dwNumArgs, BOOL bAllocateInLargeHeap = FALSE);
-    // Optimized verion of above
-OBJECTREF FastAllocatePrimitiveArray(MethodTable* arrayType, DWORD cElements, BOOL bAllocateInLargeHeap = FALSE);
+// Allocate single-dimensional array given array type
+OBJECTREF AllocateSzArray(MethodTable *pArrayMT, INT32 length, GC_ALLOC_FLAGS flags = GC_ALLOC_NO_FLAGS, BOOL bAllocateInLargeHeap = FALSE);
+OBJECTREF AllocateSzArray(TypeHandle  arrayType, INT32 length, GC_ALLOC_FLAGS flags = GC_ALLOC_NO_FLAGS, BOOL bAllocateInLargeHeap = FALSE);
 
+// The main Array allocation routine, can do multi-dimensional
+OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, GC_ALLOC_FLAGS flags = GC_ALLOC_NO_FLAGS, BOOL bAllocateInLargeHeap = FALSE);
+OBJECTREF AllocateArrayEx(TypeHandle  arrayType, INT32 *pArgs, DWORD dwNumArgs, GC_ALLOC_FLAGS flags = GC_ALLOC_NO_FLAGS, BOOL bAllocateInLargeHeap = FALSE);
 
-#if defined(_TARGET_X86_)
-
-    // for x86, we generate efficient allocators for some special cases
-    // these are called via inline wrappers that call the generated allocators
-    // via function pointers.
-
-
-    // Create a SD array of primitive types
-typedef HCCALL2_PTR(Object*, FastPrimitiveArrayAllocatorFuncPtr, CorElementType type, DWORD cElements);
-
-extern FastPrimitiveArrayAllocatorFuncPtr fastPrimitiveArrayAllocator;
-
-    // The fast version always allocates in the normal heap
+// Create a SD array of primitive types given an element type
 OBJECTREF AllocatePrimitiveArray(CorElementType type, DWORD cElements);
 
-    // The slow version is distinguished via overloading by an additional parameter
-OBJECTREF AllocatePrimitiveArray(CorElementType type, DWORD cElements, BOOL bAllocateInLargeHeap);
+// Allocate SD array of object types given an element type
+OBJECTREF AllocateObjectArray(DWORD cElements, TypeHandle ElementType, BOOL bAllocateInLargeHeap = FALSE);
 
+#if defined(_TARGET_X86_)
+// for x86, we generate efficient allocators for some special cases
+// these are called via inline wrappers that call the generated allocators
+// via function pointers.
+
+// Create a SD array of primitive types
+typedef HCCALL2_PTR(Object*, FastPrimitiveArrayAllocatorFuncPtr, CorElementType type, DWORD cElements);
+extern FastPrimitiveArrayAllocatorFuncPtr fastPrimitiveArrayAllocator;
 
 // Allocate SD array of object pointers.
 typedef HCCALL2_PTR(Object*, FastObjectArrayAllocatorFuncPtr, MethodTable *pArrayMT, DWORD cElements);
-
 extern FastObjectArrayAllocatorFuncPtr fastObjectArrayAllocator;
 
-    // The fast version always allocates in the normal heap
-OBJECTREF AllocateObjectArray(DWORD cElements, TypeHandle ElementType);
-
-    // The slow version is distinguished via overloading by an additional parameter
-OBJECTREF AllocateObjectArray(DWORD cElements, TypeHandle ElementType, BOOL bAllocateInLargeHeap);
-
-
-    // Allocate string
+// Allocate string
 typedef HCCALL1_PTR(StringObject*, FastStringAllocatorFuncPtr, DWORD cchArrayLength);
-
 extern FastStringAllocatorFuncPtr fastStringAllocator;
+#endif
 
 STRINGREF AllocateString( DWORD cchStringLength );
 
-    // The slow version, implemented in gcscan.cpp
-STRINGREF SlowAllocateString( DWORD cchStringLength );
-
 #ifdef FEATURE_UTF8STRING
-UTF8STRINGREF SlowAllocateUtf8String( DWORD cchStringLength );
+UTF8STRINGREF AllocateUtf8String( DWORD cchStringLength );
 #endif // FEATURE_UTF8STRING
 
-#else
-
-// On other platforms, go to the (somewhat less efficient) implementations in gcscan.cpp
-
-    // Create a SD array of primitive types
-OBJECTREF AllocatePrimitiveArray(CorElementType type, DWORD cElements, BOOL bAllocateInLargeHeap = FALSE);
-
-    // Allocate SD array of object pointers
-OBJECTREF AllocateObjectArray(DWORD cElements, TypeHandle ElementType, BOOL bAllocateInLargeHeap = FALSE);
-
-STRINGREF SlowAllocateString( DWORD cchStringLength );
-
-#ifdef FEATURE_UTF8STRING
-UTF8STRINGREF SlowAllocateUtf8String( DWORD cchStringLength );
-#endif // FEATURE_UTF8STRING
-
-inline STRINGREF AllocateString( DWORD cchStringLength )
-{
-    WRAPPER_NO_CONTRACT;
-
-    return SlowAllocateString( cchStringLength );
-}
-
-#endif
-
-#ifdef FEATURE_UTF8STRING
-inline UTF8STRINGREF AllocateUtf8String(DWORD cchStringLength)
-{
-    WRAPPER_NO_CONTRACT;
-
-    return SlowAllocateUtf8String(cchStringLength);
-}
-#endif // FEATURE_UTF8STRING
-
-OBJECTREF DupArrayForCloning(BASEARRAYREF pRef, BOOL bAllocateInLargeHeap = FALSE);
+OBJECTREF DupArrayForCloning(BASEARRAYREF pRef);
 
 // The JIT requests the EE to specify an allocation helper to use at each new-site.
 // The EE makes this choice based on whether context boundaries may be involved,

--- a/src/vm/gchelpers.h
+++ b/src/vm/gchelpers.h
@@ -20,10 +20,10 @@
 //
 //========================================================================
 
-OBJECTREF AllocateValueSzArray(TypeHandle elementType, INT32 length);
+OBJECTREF AllocateSzArray(TypeHandle elementType, INT32 length, BOOL zeroingOptional = FALSE);
     // The main Array allocation routine, can do multi-dimensional
-OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, BOOL bAllocateInLargeHeap = FALSE);
-OBJECTREF AllocateArrayEx(TypeHandle arrayClass, INT32 *pArgs, DWORD dwNumArgs, BOOL bAllocateInLargeHeap = FALSE);
+OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, BOOL bAllocateInLargeHeap = FALSE, BOOL zeroingOptional = FALSE);
+OBJECTREF AllocateArrayEx(TypeHandle arrayClass, INT32 *pArgs, DWORD dwNumArgs, BOOL bAllocateInLargeHeap = FALSE, BOOL zeroingOptional = FALSE);
     // Optimized verion of above
 OBJECTREF FastAllocatePrimitiveArray(MethodTable* arrayType, DWORD cElements, BOOL bAllocateInLargeHeap = FALSE);
 

--- a/src/vm/i386/jitinterfacex86.cpp
+++ b/src/vm/i386/jitinterfacex86.cpp
@@ -1248,6 +1248,10 @@ void InitJITHelpers1()
         SetJitHelperFunction(CORINFO_HELP_NEWARR_1_VC, pMethodAddresses[4]);
         pMethodAddresses[5] = JIT_TrialAlloc::GenAllocArray((JIT_TrialAlloc::Flags)(flags|JIT_TrialAlloc::ALIGN8));
         SetJitHelperFunction(CORINFO_HELP_NEWARR_1_ALIGN8, pMethodAddresses[5]);
+
+        // If allocation logging is on, then we divert calls to FastAllocateString to an Ecall method, not this
+        // generated method. Find this workaround in Ecall::Init() in ecall.cpp.
+        ECall::DynamicallyAssignFCallImpl((PCODE) JIT_TrialAlloc::GenAllocString(flags), ECall::FastAllocateString);
     }
 
     // Replace static helpers with faster assembly versions

--- a/src/vm/i386/jitinterfacex86.cpp
+++ b/src/vm/i386/jitinterfacex86.cpp
@@ -779,10 +779,7 @@ HCIMPL2_RAW(Object*, UnframedAllocateObjectArray, MethodTable *pArrayMT, DWORD c
         MODE_COOPERATIVE;
     } CONTRACTL_END;
 
-    return OBJECTREFToObject(AllocateArrayEx(pArrayMT,
-                                               (INT32 *)(&cElements),
-                                               1,
-                                               FALSE));
+    return OBJECTREFToObject(AllocateSzArray(pArrayMT, cElements));
 }
 HCIMPLEND_RAW
 
@@ -798,7 +795,7 @@ HCIMPL2_RAW(Object*, UnframedAllocatePrimitiveArray, CorElementType type, DWORD 
         MODE_COOPERATIVE;
     } CONTRACTL_END;
 
-    return OBJECTREFToObject( AllocatePrimitiveArray(type, cElements, FALSE) );
+    return OBJECTREFToObject( AllocatePrimitiveArray(type, cElements) );
 }
 HCIMPLEND_RAW
 

--- a/src/vm/i386/jitinterfacex86.cpp
+++ b/src/vm/i386/jitinterfacex86.cpp
@@ -782,7 +782,6 @@ HCIMPL2_RAW(Object*, UnframedAllocateObjectArray, MethodTable *pArrayMT, DWORD c
     return OBJECTREFToObject(AllocateArrayEx(pArrayMT,
                                                (INT32 *)(&cElements),
                                                1,
-                                               FALSE,
                                                FALSE));
 }
 HCIMPLEND_RAW

--- a/src/vm/i386/jitinterfacex86.cpp
+++ b/src/vm/i386/jitinterfacex86.cpp
@@ -45,7 +45,6 @@ public:
         OBJ_ARRAY    = 0x4,
         ALIGN8       = 0x8,     // insert a dummy object to insure 8 byte alignment (until the next GC)
         ALIGN8OBJ    = 0x10,
-        NO_FRAME     = 0x20,    // call is from unmanaged code - don't try to put up a frame
     };
 
     static void *GenAllocSFast(Flags flags);
@@ -767,44 +766,6 @@ void *JIT_TrialAlloc::GenBox(Flags flags)
     return (void *)pStub->GetEntryPoint();
 }
 
-
-HCIMPL2_RAW(Object*, UnframedAllocateObjectArray, MethodTable *pArrayMT, DWORD cElements)
-{
-    // This isn't _really_ an FCALL and therefore shouldn't have the 
-    // SO_TOLERANT part of the FCALL_CONTRACT b/c it is not entered
-    // from managed code.
-    CONTRACTL {
-        THROWS;
-        GC_TRIGGERS;
-        MODE_COOPERATIVE;
-    } CONTRACTL_END;
-
-    return OBJECTREFToObject(AllocateSzArray(pArrayMT, cElements));
-}
-HCIMPLEND_RAW
-
-
-HCIMPL2_RAW(Object*, UnframedAllocatePrimitiveArray, CorElementType type, DWORD cElements)
-{
-    // This isn't _really_ an FCALL and therefore shouldn't have the 
-    // SO_TOLERANT part of the FCALL_CONTRACT b/c it is not entered
-    // from managed code.
-    CONTRACTL {
-        THROWS;
-        GC_TRIGGERS;
-        MODE_COOPERATIVE;
-    } CONTRACTL_END;
-
-    return OBJECTREFToObject( AllocatePrimitiveArray(type, cElements) );
-}
-HCIMPLEND_RAW
-
-HCIMPL1_RAW(PTR_MethodTable, UnframedGetTemplateMethodTable, ArrayTypeDesc *arrayDesc)
-{
-    return arrayDesc->GetTemplateMethodTable();
-}
-HCIMPLEND_RAW
-
 void *JIT_TrialAlloc::GenAllocArray(Flags flags)
 {
     STANDARD_VM_CONTRACT;
@@ -828,29 +789,6 @@ void *JIT_TrialAlloc::GenAllocArray(Flags flags)
 
     // push edx
     sl.X86EmitPushReg(kEDX);
-
-    if (flags & NO_FRAME)
-    {
-        if ((flags & OBJ_ARRAY) == 0)
-        {
-            // mov ecx,[g_pPredefinedArrayTypes+ecx*4]
-            sl.Emit8(0x8b);
-            sl.Emit16(0x8d0c);
-            sl.Emit32((int)(size_t)&g_pPredefinedArrayTypes);
-
-            // test ecx,ecx
-            sl.Emit16(0xc985);
-
-            // je noLock
-            sl.X86EmitCondJump(noLock, X86CondCode::kJZ);
-
-            sl.X86EmitPushReg(kEDX);
-            sl.X86EmitCall(sl.NewExternalCodeLabel((LPVOID)UnframedGetTemplateMethodTable), 0);
-            sl.X86EmitPopReg(kEDX);
-
-            sl.X86EmitMovRegReg(kECX, kEAX);
-        }
-    }
 
     // Do a conservative check here.  This is to avoid doing overflow checks within this function.  We'll
     // still have to do a size check before running through the body of EmitCore.  The way we do the check
@@ -976,28 +914,9 @@ void *JIT_TrialAlloc::GenAllocArray(Flags flags)
     // pop ecx - array method table
     sl.X86EmitPopReg(kECX);
 
-    CodeLabel * target;
-    if (flags & NO_FRAME)
-    {
-        if (flags & OBJ_ARRAY)
-        {
-            // Jump to the unframed helper
-            target = sl.NewExternalCodeLabel((LPVOID)UnframedAllocateObjectArray);
-            _ASSERTE(target->e.m_pExternalAddress);
-        }
-        else
-        {
-            // Jump to the unframed helper
-            target = sl.NewExternalCodeLabel((LPVOID)UnframedAllocatePrimitiveArray);
-            _ASSERTE(target->e.m_pExternalAddress);
-        }
-    }
-    else
-    {
-        // Jump to the framed helper
-        target = sl.NewExternalCodeLabel((LPVOID)JIT_NewArr1);
-        _ASSERTE(target->e.m_pExternalAddress);
-    }
+    // Jump to the framed helper
+    CodeLabel * target = sl.NewExternalCodeLabel((LPVOID)JIT_NewArr1);
+    _ASSERTE(target->e.m_pExternalAddress);
     sl.X86EmitNearJump(target);
 
     Stub *pStub = sl.Link(SystemDomain::GetGlobalLoaderAllocator()->GetExecutableHeap());
@@ -1084,31 +1003,14 @@ void *JIT_TrialAlloc::GenAllocString(Flags flags)
     // pop ecx - element count
     sl.X86EmitPopReg(kECX);
 
-    CodeLabel * target;
-    if (flags & NO_FRAME)
-    {
-        // Jump to the unframed helper
-        target = sl.NewExternalCodeLabel((LPVOID)UnframedAllocateString);
-    }
-    else
-    {
-        // Jump to the framed helper
-        target = sl.NewExternalCodeLabel((LPVOID)FramedAllocateString);
-    }
+    // Jump to the framed helper
+    CodeLabel * target = sl.NewExternalCodeLabel((LPVOID)FramedAllocateString);
     sl.X86EmitNearJump(target);
 
     Stub *pStub = sl.Link(SystemDomain::GetGlobalLoaderAllocator()->GetExecutableHeap());
 
     return (void *)pStub->GetEntryPoint();
 }
-
-
-FastStringAllocatorFuncPtr fastStringAllocator = UnframedAllocateString;
-
-FastObjectArrayAllocatorFuncPtr fastObjectArrayAllocator = UnframedAllocateObjectArray;
-
-FastPrimitiveArrayAllocatorFuncPtr fastPrimitiveArrayAllocator = UnframedAllocatePrimitiveArray;
-
 // For this helper,
 // If bCCtorCheck == true
 //          ECX contains the domain neutral module ID
@@ -1346,17 +1248,6 @@ void InitJITHelpers1()
         SetJitHelperFunction(CORINFO_HELP_NEWARR_1_VC, pMethodAddresses[4]);
         pMethodAddresses[5] = JIT_TrialAlloc::GenAllocArray((JIT_TrialAlloc::Flags)(flags|JIT_TrialAlloc::ALIGN8));
         SetJitHelperFunction(CORINFO_HELP_NEWARR_1_ALIGN8, pMethodAddresses[5]);
-
-        fastObjectArrayAllocator = (FastObjectArrayAllocatorFuncPtr)JIT_TrialAlloc::GenAllocArray((JIT_TrialAlloc::Flags)(flags|JIT_TrialAlloc::NO_FRAME|JIT_TrialAlloc::OBJ_ARRAY));
-        fastPrimitiveArrayAllocator = (FastPrimitiveArrayAllocatorFuncPtr)JIT_TrialAlloc::GenAllocArray((JIT_TrialAlloc::Flags)(flags|JIT_TrialAlloc::NO_FRAME));
-
-        // If allocation logging is on, then we divert calls to FastAllocateString to an Ecall method, not this
-        // generated method. Find this workaround in Ecall::Init() in ecall.cpp.
-        ECall::DynamicallyAssignFCallImpl((PCODE) JIT_TrialAlloc::GenAllocString(flags), ECall::FastAllocateString);
-
-        // generate another allocator for use from unmanaged code (won't need a frame)
-        fastStringAllocator = (FastStringAllocatorFuncPtr) JIT_TrialAlloc::GenAllocString((JIT_TrialAlloc::Flags)(flags|JIT_TrialAlloc::NO_FRAME));
-        //UnframedAllocateString;
     }
 
     // Replace static helpers with faster assembly versions

--- a/src/vm/i386/jitinterfacex86.cpp
+++ b/src/vm/i386/jitinterfacex86.cpp
@@ -780,9 +780,10 @@ HCIMPL2_RAW(Object*, UnframedAllocateObjectArray, MethodTable *pArrayMT, DWORD c
     } CONTRACTL_END;
 
     return OBJECTREFToObject(AllocateArrayEx(pArrayMT,
-                           (INT32 *)(&cElements),
-                           1,
-                           FALSE));
+                                               (INT32 *)(&cElements),
+                                               1,
+                                               FALSE,
+                                               FALSE));
 }
 HCIMPLEND_RAW
 

--- a/src/vm/ilmarshalers.cpp
+++ b/src/vm/ilmarshalers.cpp
@@ -4359,7 +4359,7 @@ FCIMPL4(void, MngdNativeArrayMarshaler::ConvertSpaceToManaged, MngdNativeArrayMa
         //
         // Allocate array
         //
-        SetObjectReference(pManagedHome, AllocateArrayEx(pThis->m_Array, &cElements, 1));
+        SetObjectReference(pManagedHome, AllocateSzArray(pThis->m_Array, cElements));
     }    
     HELPER_METHOD_FRAME_END();
 }
@@ -5392,7 +5392,7 @@ FCIMPL4(void, MngdHiddenLengthArrayMarshaler::ConvertSpaceToManaged, MngdHiddenL
     {
         TypeHandle elementType(pThis->m_pElementMT);
         TypeHandle arrayType = ClassLoader::LoadArrayTypeThrowing(elementType);
-        SetObjectReference(pManagedHome, AllocateArrayEx(arrayType, &cElements, 1));
+        SetObjectReference(pManagedHome, AllocateSzArray(arrayType, cElements));
     }
 
     HELPER_METHOD_FRAME_END();

--- a/src/vm/interpreter.cpp
+++ b/src/vm/interpreter.cpp
@@ -5995,7 +5995,7 @@ void Interpreter::NewArr()
         pArrayMT->CheckRunClassInitThrowing();
 
         INT32 size32 = (INT32)sz;
-        Object* newarray = OBJECTREFToObject(AllocateArrayEx(pArrayMT, &size32, 1));
+        Object* newarray = OBJECTREFToObject(AllocateSzArray(pArrayMT, size32));
 
         GCX_FORBID();
         OpStackTypeSet(stkInd, InterpreterType(CORINFO_TYPE_CLASS));

--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -553,7 +553,7 @@ class ArrayBase : public Object
     friend class GCHeap;
     friend class CObjectHeader;
     friend class Object;
-    friend OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, BOOL bAllocateInLargeHeap); 
+    friend OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, BOOL bAllocateInLargeHeap, BOOL zeroingOptional); 
     friend OBJECTREF FastAllocatePrimitiveArray(MethodTable* arrayType, DWORD cElements, BOOL bAllocateInLargeHeap);
     friend FCDECL2(Object*, JIT_NewArr1VC_MP_FastPortable, CORINFO_CLASS_HANDLE arrayMT, INT_PTR size);
     friend FCDECL2(Object*, JIT_NewArr1OBJ_MP_FastPortable, CORINFO_CLASS_HANDLE arrayMT, INT_PTR size);

--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -553,9 +553,8 @@ class ArrayBase : public Object
     friend class GCHeap;
     friend class CObjectHeader;
     friend class Object;
-    friend OBJECTREF AllocateSzArray(TypeHandle arrayType, INT32 length, BOOL zeroingOptional);
-    friend OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, BOOL bAllocateInLargeHeap); 
-    friend OBJECTREF FastAllocatePrimitiveArray(MethodTable* arrayType, DWORD cElements, BOOL bAllocateInLargeHeap);
+    friend OBJECTREF AllocateSzArray(MethodTable *pArrayMT, INT32 length, GC_ALLOC_FLAGS flags, BOOL bAllocateInLargeHeap);
+    friend OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, GC_ALLOC_FLAGS flags, BOOL bAllocateInLargeHeap); 
     friend FCDECL2(Object*, JIT_NewArr1VC_MP_FastPortable, CORINFO_CLASS_HANDLE arrayMT, INT_PTR size);
     friend FCDECL2(Object*, JIT_NewArr1OBJ_MP_FastPortable, CORINFO_CLASS_HANDLE arrayMT, INT_PTR size);
     friend class JIT_TrialAlloc;
@@ -722,7 +721,7 @@ class PtrArray : public ArrayBase
 {
     friend class GCHeap;
     friend class ClrDataAccess;
-    friend OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, BOOL bAllocateInLargeHeap); 
+    friend OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, DWORD flags, BOOL bAllocateInLargeHeap); 
     friend class JIT_TrialAlloc;
     friend class CheckAsmOffsets;
 

--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -553,7 +553,8 @@ class ArrayBase : public Object
     friend class GCHeap;
     friend class CObjectHeader;
     friend class Object;
-    friend OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, BOOL bAllocateInLargeHeap, BOOL zeroingOptional); 
+    friend OBJECTREF AllocateSzArray(TypeHandle arrayType, INT32 length, BOOL zeroingOptional);
+    friend OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, BOOL bAllocateInLargeHeap); 
     friend OBJECTREF FastAllocatePrimitiveArray(MethodTable* arrayType, DWORD cElements, BOOL bAllocateInLargeHeap);
     friend FCDECL2(Object*, JIT_NewArr1VC_MP_FastPortable, CORINFO_CLASS_HANDLE arrayMT, INT_PTR size);
     friend FCDECL2(Object*, JIT_NewArr1OBJ_MP_FastPortable, CORINFO_CLASS_HANDLE arrayMT, INT_PTR size);

--- a/src/vm/qcall.cpp
+++ b/src/vm/qcall.cpp
@@ -72,7 +72,7 @@ void QCall::ObjectHandleOnStack::SetGuidArray(const GUID * p, COUNT_T length)
     GCX_COOP();
 
     TypeHandle typeHandle = MscorlibBinder::GetClass(CLASS__GUID);
-    BASEARRAYREF arr = (BASEARRAYREF) AllocateSzArray(typeHandle, length);
+    BASEARRAYREF arr = (BASEARRAYREF) AllocateSzArray(typeHandle.MakeSZArray(), length);
     memcpyNoGCRefs(arr->GetDataPtr(), p, length * sizeof(GUID));
     Set(arr);
 }

--- a/src/vm/qcall.cpp
+++ b/src/vm/qcall.cpp
@@ -72,7 +72,7 @@ void QCall::ObjectHandleOnStack::SetGuidArray(const GUID * p, COUNT_T length)
     GCX_COOP();
 
     TypeHandle typeHandle = MscorlibBinder::GetClass(CLASS__GUID);
-    BASEARRAYREF arr = (BASEARRAYREF) AllocateValueSzArray(typeHandle, length);
+    BASEARRAYREF arr = (BASEARRAYREF) AllocateSzArray(typeHandle, length);
     memcpyNoGCRefs(arr->GetDataPtr(), p, length * sizeof(GUID));
     Set(arr);
 }

--- a/src/vm/runtimehandles.cpp
+++ b/src/vm/runtimehandles.cpp
@@ -764,7 +764,7 @@ PTRARRAYREF CopyRuntimeTypeHandles(TypeHandle * prgTH, FixupPointer<TypeHandle> 
     GCPROTECT_BEGIN(refArray);
     TypeHandle thRuntimeType = TypeHandle(MscorlibBinder::GetClass(arrayElemType));
     TypeHandle arrayHandle = ClassLoader::LoadArrayTypeThrowing(thRuntimeType, ELEMENT_TYPE_SZARRAY);
-    refArray = (PTRARRAYREF)AllocateArrayEx(arrayHandle, &numTypeHandles, 1);
+    refArray = (PTRARRAYREF)AllocateSzArray(arrayHandle, numTypeHandles);
 
     for (INT32 i = 0; i < numTypeHandles; i++)
     {
@@ -852,7 +852,7 @@ FCIMPL1(PtrArray*, RuntimeTypeHandle::GetInterfaces, ReflectClassBaseObject *pTy
         if (ifaceCount > 0)
         {            
             TypeHandle arrayHandle = ClassLoader::LoadArrayTypeThrowing(TypeHandle(g_pRuntimeTypeClass), ELEMENT_TYPE_SZARRAY);
-            refRetVal = (PTRARRAYREF)AllocateArrayEx(arrayHandle, &ifaceCount, 1);
+            refRetVal = (PTRARRAYREF)AllocateSzArray(arrayHandle, ifaceCount);
         
             // populate type array
             UINT i = 0;
@@ -1957,7 +1957,7 @@ FCIMPL3(Object *, SignatureNative::GetCustomModifiers, SignatureNative* pSignatu
         MethodTable *pMT = MscorlibBinder::GetClass(CLASS__TYPE);
         TypeHandle arrayHandle = ClassLoader::LoadArrayTypeThrowing(TypeHandle(pMT), ELEMENT_TYPE_SZARRAY);
 
-        gc.retVal = (PTRARRAYREF) AllocateArrayEx(arrayHandle, &cMods, 1);
+        gc.retVal = (PTRARRAYREF) AllocateSzArray(arrayHandle, cMods);
 
         while(cMods != 0)
         {
@@ -2107,7 +2107,7 @@ FCIMPL6(void, SignatureNative::GetSignature,
             INT32 nArgs = msig.NumFixedArgs();
             TypeHandle arrayHandle = ClassLoader::LoadArrayTypeThrowing(TypeHandle(g_pRuntimeTypeClass), ELEMENT_TYPE_SZARRAY);
 
-            PTRARRAYREF ptrArrayarguments = (PTRARRAYREF) AllocateArrayEx(arrayHandle, &nArgs, 1);
+            PTRARRAYREF ptrArrayarguments = (PTRARRAYREF) AllocateSzArray(arrayHandle, nArgs);
             gc.pSig->SetArgumentArray(ptrArrayarguments);
 
             for (INT32 i = 0; i < nArgs; i++) 
@@ -2509,7 +2509,7 @@ FCIMPL2(RuntimeMethodBody *, RuntimeMethodHandle::GetMethodBody, ReflectMethodOb
             // Allocate the array of exception clauses.
             INT32 cEh = (INT32)header.EHCount();
             const COR_ILMETHOD_SECT_EH* ehInfo = header.EH;
-            gc.TempArray = (BASEARRAYREF) AllocateArrayEx(thEHClauseArray, &cEh, 1);
+            gc.TempArray = (BASEARRAYREF) AllocateSzArray(thEHClauseArray, cEh);
 
             SetObjectReference((OBJECTREF*)&gc.MethodBodyObj->_exceptionClauses, gc.TempArray);
             
@@ -2545,7 +2545,7 @@ FCIMPL2(RuntimeMethodBody *, RuntimeMethodHandle::GetMethodBody, ReflectMethodOb
                                 &sigTypeContext, 
                                 MetaSig::sigLocalVars);
                 INT32 cLocals = metaSig.NumFixedArgs();
-                gc.TempArray  = (BASEARRAYREF) AllocateArrayEx(thLocalVariableArray, &cLocals, 1);
+                gc.TempArray  = (BASEARRAYREF) AllocateSzArray(thLocalVariableArray, cLocals);
                 SetObjectReference((OBJECTREF*)&gc.MethodBodyObj->_localVariables, gc.TempArray);
 
                 for (INT32 i = 0; i < cLocals; i ++)
@@ -2570,7 +2570,7 @@ FCIMPL2(RuntimeMethodBody *, RuntimeMethodHandle::GetMethodBody, ReflectMethodOb
             else
             {
                 INT32 cLocals = 0;
-                gc.TempArray  = (BASEARRAYREF) AllocateArrayEx(thLocalVariableArray, &cLocals, 1);
+                gc.TempArray  = (BASEARRAYREF) AllocateSzArray(thLocalVariableArray, cLocals);
                 SetObjectReference((OBJECTREF*)&gc.MethodBodyObj->_localVariables, gc.TempArray);
             }
         }

--- a/src/vm/typeparse.cpp
+++ b/src/vm/typeparse.cpp
@@ -1267,7 +1267,7 @@ TypeHandle TypeName::GetTypeFromAsm()
         if (cGenericArgs > 0)
         {
             TypeHandle arrayHandle = ClassLoader::LoadArrayTypeThrowing(TypeHandle(g_pRuntimeTypeClass), ELEMENT_TYPE_SZARRAY);
-            gc.refGenericArguments = (PTRARRAYREF)AllocateArrayEx(arrayHandle, &cGenericArgs, 1);
+            gc.refGenericArguments = (PTRARRAYREF)AllocateSzArray(arrayHandle, cGenericArgs);
         }
         // Instantiate generic arguments
         for (INT32 i = 0; i < cGenericArgs; i++)

--- a/tests/src/GC/API/GC/AllocateUninitializedArray.cs
+++ b/tests/src/GC/API/GC/AllocateUninitializedArray.cs
@@ -1,0 +1,129 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// Tests GC.Collect()
+
+using System;
+
+public class Test {
+
+
+    public static int Main() {
+        // allocate a bunch of SOH byte arrays and touch them.
+        var r = new Random(1234);
+        for (int i = 0; i < 10000; i++)
+        {
+            int size = r.Next(10000);
+            var arr = AllocUninitialized<byte>.Call(size);
+
+            if (size > 1)
+            {
+                arr[0] = 5;
+                arr[size - 1] = 17;
+                if (arr[0] != 5 || arr[size - 1] != 17)
+                {
+                    Console.WriteLine("Scenario 1 for GC.AllocUninitialized() failed!");
+                    return 1;
+                }
+            }
+        }
+
+        // allocate a bunch of LOH int arrays and touch them.
+        for (int i = 0; i < 1000; i++)
+        {
+            int size = r.Next(100000, 1000000);
+            var arr = AllocUninitialized<int>.Call(size);
+
+            arr[0] = 5;
+            arr[size - 1] = 17;
+            if (arr[0] != 5 || arr[size - 1] != 17)
+            {
+                Console.WriteLine("Scenario 2 for GC.AllocUninitialized() failed!");
+                return 1;
+            }
+        }
+
+        // allocate a string array
+        {
+            int i = 100;
+            var arr = AllocUninitialized<string>.Call(i);
+
+            arr[0] = "5";
+            arr[i - 1] = "17";
+            if (arr[0] != "5" || arr[i - 1] != "17")
+            {
+                Console.WriteLine("Scenario 3 for GC.AllocUninitialized() failed!");
+                return 1;
+            }
+        }
+
+        // allocate max size byte array
+        {
+            if (IntPtr.Size == 8)
+            {
+                int i = 0x7FFFFFC7;
+                var arr = AllocUninitialized<byte>.Call(i);
+
+                arr[0] = 5;
+                arr[i - 1] = 17;
+                if (arr[0] != 5 || arr[i - 1] != 17)
+                {
+                    Console.WriteLine("Scenario 4 for GC.AllocUninitialized() failed!");
+                    return 1;
+                }
+            }
+        }
+
+        // negative size
+        {
+            try
+            {
+                var arr = AllocUninitialized<byte>.Call(-1);
+
+                Console.WriteLine("Scenario 5 Expected exception!");
+                return 1;
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+            }
+        }
+
+        // too large
+        {
+            try
+            {
+                var arr = AllocUninitialized<double>.Call(int.MaxValue);
+
+                Console.WriteLine("Scenario 6 Expected exception!");
+                return 1;
+            }
+            catch (OutOfMemoryException)
+            {
+            }
+        }
+
+
+        Console.WriteLine("Test for GC.Collect() passed!");
+        return 100;
+    }
+
+    //TODO: This should be removed once the API is public.
+    static class AllocUninitialized<T>
+    {
+        public static Func<int, T[]> Call = (i) =>
+        {
+            // replace the stub with actual impl.
+            Call = (Func<int, T[]>)typeof(System.GC).
+            GetMethod("AllocateUninitializedArray",
+                bindingAttr: System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static,
+                binder: null,
+                new Type[] { typeof(int) },
+                modifiers: new System.Reflection.ParameterModifier[0]).
+            MakeGenericMethod(new Type[] { typeof(T) }).
+            CreateDelegate(typeof(Func<int, T[]>));
+
+            // call the impl.
+            return Call(i);
+        };
+    }
+}

--- a/tests/src/GC/API/GC/AllocateUninitializedArray.csproj
+++ b/tests/src/GC/API/GC/AllocateUninitializedArray.csproj
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>PdbOnly</DebugType>
+    <NoLogo>True</NoLogo>
+    <DefineConstants>$(DefineConstants);DESKTOP</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="AllocateUninitializedArray.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/JIT/Methodical/doublearray/dblarray3.cs
+++ b/tests/src/JIT/Methodical/doublearray/dblarray3.cs
@@ -99,7 +99,7 @@ internal class DblArray3
     public static void f3()
     {
         Array arr = Array.CreateInstance(typeof(double), 1000);
-        if (GC.GetGeneration(arr) != 0)
+        if (GC.GetGeneration(arr) != s_LOH_GEN)
         {
             Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
             throw new Exception();


### PR DESCRIPTION
Addresses: https://github.com/dotnet/corefx/issues/31787 
Also see: https://github.com/dotnet/coreclr/issues/17324, https://github.com/dotnet/coreclr/issues/17325, https://github.com/dotnet/corefx/issues/29101

=== Current design decisions:
* The proposed API (dotnet/corefx#31787) has several flags such as "pinned". This change only implements "do not clear" implicit contract of `AllocateUninitializedArray`. 
Other flags are not implemented and throw `NotSupported`. Need to decide whether this is appropriate from the API point of view.

* We will allow this API regardless of the size of the array and it will work the same. 
There will certainly be a threshold when it is not profitable due to overhead of API call vs `new T[size]`, so, when arrays are too short `AllocateUninitializedArray` will defer to `new T[]`.

* Internaly we use the general purpose `AllocateArrayEx` and just propagate the flags to GC. 
`AllocateArrayEx` is a bit heavier than what we need, since it handles all kind of cases such as multidimensional arrays and our case is relatively simple.
We should measure whether the overhead of the API is significant enough to have a faster path. `Array.CreateInstance` seems to have some specialization for simple cases. It is not clear whether it makes sense to do something similar here.

* We will not consider the "no clean" as an input to selecting LOH/SOH/generation. That will continue using existing metrics and tuning.
It does not seem that "no clean" arrays are necessarily long lived.
Besides the API proposal has separate flags to control the target generation anyways.

* We will not expand SOH allocations to the allocation quantum when asked not to clear. 
Otherwise the API would be effectively pointless for arrays shorter than 8K while it seems a reasonable scenario.

* For the purpose of testing I made `List<T>` and `StringBuilder` use this API and not clear underlying buffers. 
That is just for testing purposes and will not be merged.
It may yet be interesting to consider such approach, but not in this PR.


