### PR TITLE
[System.Globalization.Native] Fix small issues in CloneCollatorWithOptions and GetCollatorFromSortHandle

### DIFF
--- a/src/corefx/System.Globalization.Native/pal_collation.c
+++ b/src/corefx/System.Globalization.Native/pal_collation.c
@@ -143,7 +143,7 @@ static int AddItem(UCharList* list, const UChar item)
     if (size >= list->capacity)
     {
         list->capacity *= 2;
-        UChar* ptr = (UChar*)realloc(list->items, list->capacity * sizeof(UChar*));
+        UChar* ptr = (UChar*)realloc(list->items, list->capacity * sizeof(UChar));
         if (ptr == NULL)
         {
             return FALSE;
@@ -188,14 +188,13 @@ static UCharList* GetCustomRules(int32_t options, UColAttributeValue strength, i
     // Use 512 as the starting size, so the customRules won't have to grow if we are just
     // doing the KanaType custom rule.
     customRules->capacity = 512;
-    customRules->items = calloc(customRules->capacity, sizeof(UChar));
+    customRules->size = 0;
+    customRules->items = malloc(customRules->capacity * sizeof(UChar));
     if (customRules->items == NULL)
     {
         free(customRules);
         return NULL;
     }
-
-    customRules->size = 0;
 
     if (needsIgnoreKanaTypeCustomRule || needsNotIgnoreKanaTypeCustomRule)
     {
@@ -280,7 +279,7 @@ UCollator* CloneCollatorWithOptions(const UCollator* pCollator, int32_t options,
 
     UCollator* pClonedCollator;
     UCharList* customRules = GetCustomRules(options, strength, isIgnoreSymbols);
-    if (customRules == NULL)
+    if (customRules == NULL || customRules->size == 0)
     {
         pClonedCollator = ucol_safeClone(pCollator, NULL, NULL, pErr);
     }
@@ -305,8 +304,8 @@ UCollator* CloneCollatorWithOptions(const UCollator* pCollator, int32_t options,
 
         pClonedCollator = ucol_openRules(completeRules, completeRulesLength, UCOL_DEFAULT, strength, NULL, pErr);
         free(completeRules);
-        free(customRules);
     }
+    free(customRules);
 
     if (isIgnoreSymbols)
     {

--- a/src/corefx/System.Globalization.Native/pal_collation.c
+++ b/src/corefx/System.Globalization.Native/pal_collation.c
@@ -158,7 +158,10 @@ static UCharList* GetCustomRules(int32_t options, UColAttributeValue strength, i
 
     // If we need to create customRules, the KanaType custom rule will be 88 kana characters * 4 = 352 chars long
     // and the Width custom rule will be at most 212 halfwidth characters * 5 = 1060 chars long.
-    int capacity = 88 * 4 + g_HalfFullCharsLength * 5;
+    int capacity = 
+        ((needsIgnoreKanaTypeCustomRule || needsNotIgnoreKanaTypeCustomRule) ? 4 * (hiraganaEnd - hiraganaStart + 1) : 0) +
+        ((needsIgnoreWidthCustomRule || needsNotIgnoreWidthCustomRule) ? 5 * g_HalfFullCharsLength : 0);
+
     UChar* items;
     customRules->items = items = malloc(capacity * sizeof(UChar));
     if (customRules->items == NULL)
@@ -332,11 +335,13 @@ static int CanIgnoreAllCollationElements(const UCollator* pColl, const UChar* lp
 
 void CreateSortHandle(SortHandle** ppSortHandle)
 {
-    *ppSortHandle = (SortHandle*)calloc(1, sizeof(SortHandle));
+    *ppSortHandle = (SortHandle*)malloc(sizeof(SortHandle));
     if ((*ppSortHandle) == NULL)
     {
         return;
     }
+
+    memset(*ppSortHandle, 0, sizeof(SortHandle));
 
     int result = pthread_mutex_init(&(*ppSortHandle)->collatorsLockObject, NULL);
     if (result != 0)

--- a/src/corefx/System.Globalization.Native/pal_collation.c
+++ b/src/corefx/System.Globalization.Native/pal_collation.c
@@ -158,8 +158,6 @@ static UCharList* GetCustomRules(int32_t options, UColAttributeValue strength, i
 
     // If we need to create customRules, the KanaType custom rule will be 88 kana characters * 4 = 352 chars long
     // and the Width custom rule will be at most 212 halfwidth characters * 5 = 1060 chars long.
-    // Use 512 as the starting size, so the customRules won't have to grow if we are just
-    // doing the KanaType custom rule.
     int capacity = 88 * 4 + g_HalfFullCharsLength * 5;
     UChar* items;
     customRules->items = items = malloc(capacity * sizeof(UChar));


### PR DESCRIPTION
The collator object returned by `CloneCollatorWithOptions` is cached so this is not a performance critical path. However, some mistakes were made in PR #22378 that made it perform a little less efficiently than it used to.

The performance-critical path in `GetCollatorFromSortHandle` was using binary search trees for something that could have been handled much easier with a small 32-entry lookup table. This is alternative fix to #24099 for an observed performance regression.

/cc @janvorli @stephentoub @jkotas 