### PR TITLE
Don't return value types as const

### DIFF
--- a/src/inc/formattype.cpp
+++ b/src/inc/formattype.cpp
@@ -86,7 +86,7 @@ static void appendStrNum(CQuickBytes *out, int num) {
     appendStr(out, buff);   
 }
 
-const PCCOR_SIGNATURE PrettyPrintSignature(
+PCCOR_SIGNATURE PrettyPrintSignature(
     PCCOR_SIGNATURE typePtr,            // type to convert,     
     unsigned typeLen,                   // the lenght of 'typePtr' 
     const char* name,                   // can be "", the name of the method for this sig 0 means local var sig 
@@ -184,7 +184,7 @@ const char* PrettyPrintSig(
 // Converts a com signature to a printable signature.
 // Note that return value is pointing at the CQuickBytes buffer, 
 
-const PCCOR_SIGNATURE PrettyPrintSignature(
+PCCOR_SIGNATURE PrettyPrintSignature(
     PCCOR_SIGNATURE typePtr,    // type to convert,     
     unsigned typeLen,           // the lenght of 'typePtr' 
     const char* name,           // can be "", the name of the method for this sig 0 means local var sig 

--- a/src/vm/eventpipeeventinstance.h
+++ b/src/vm/eventpipeeventinstance.h
@@ -41,7 +41,7 @@ public:
         return m_pEvent;
     }
 
-    const LARGE_INTEGER* const GetTimeStamp() const
+    const LARGE_INTEGER* GetTimeStamp() const
     {
         LIMITED_METHOD_CONTRACT;
 
@@ -69,21 +69,21 @@ public:
         return m_threadID;
     }
 
-    const GUID* const GetActivityId() const
+    const GUID* GetActivityId() const
     {
         LIMITED_METHOD_CONTRACT;
 
         return &m_activityId;
     }
 
-    const GUID* const GetRelatedActivityId() const
+    const GUID* GetRelatedActivityId() const
     {
         LIMITED_METHOD_CONTRACT;
 
         return &m_relatedActivityId;
     }
 
-    const BYTE* const GetData() const
+    const BYTE* GetData() const
     {
         LIMITED_METHOD_CONTRACT;
 


### PR DESCRIPTION
These types are value types; they are returned by copying. Marking the
return type as const has no effect: since the value is copied, the
caller can modify it anyway.

This resolves all the -Wignored-qualifiers warnings produced by clang 7
(when those warnings are explicitly enabled).