### PR TITLE
Tighten GC mode assertion for EventPipe::Enable()

### DIFF
--- a/src/vm/diagnosticserver.cpp
+++ b/src/vm/diagnosticserver.cpp
@@ -20,7 +20,7 @@ static DWORD WINAPI DiagnosticsServerThread(LPVOID lpThreadParameter)
     {
         NOTHROW;
         GC_TRIGGERS;
-        MODE_ANY;
+        MODE_PREEMPTIVE;
         PRECONDITION(lpThreadParameter != nullptr);
     }
     CONTRACTL_END;

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -244,7 +244,7 @@ EventPipeSessionID EventPipe::Enable(
     {
         THROWS;
         GC_TRIGGERS;
-        MODE_ANY;
+        MODE_PREEMPTIVE;
         PRECONDITION(circularBufferSizeInMB > 0);
         PRECONDITION(profilerSamplingRateInNanoseconds > 0);
         PRECONDITION(numProviders > 0 && pProviders != nullptr);
@@ -276,7 +276,7 @@ EventPipeSessionID EventPipe::Enable(
     {
         THROWS;
         GC_TRIGGERS;
-        MODE_ANY;
+        MODE_PREEMPTIVE;
         PRECONDITION(pSession != nullptr);
         PRECONDITION(GetLock()->OwnedByCurrentThread());
     }

--- a/src/vm/eventpipefile.cpp
+++ b/src/vm/eventpipefile.cpp
@@ -15,7 +15,7 @@ EventPipeFile::EventPipeFile(StreamWriter *pStreamWriter) : FastSerializableObje
     {
         THROWS;
         GC_TRIGGERS;
-        MODE_ANY;
+        MODE_PREEMPTIVE;
     }
     CONTRACTL_END;
 

--- a/src/vm/eventpipeprotocolhelper.cpp
+++ b/src/vm/eventpipeprotocolhelper.cpp
@@ -73,7 +73,7 @@ void EventPipeProtocolHelper::StopTracing(IpcStream *pStream)
     {
         THROWS;
         GC_TRIGGERS;
-        MODE_ANY;
+        MODE_PREEMPTIVE;
         PRECONDITION(pStream != nullptr);
     }
     CONTRACTL_END;
@@ -118,7 +118,7 @@ void EventPipeProtocolHelper::CollectTracing(IpcStream *pStream)
     {
         THROWS;
         GC_TRIGGERS;
-        MODE_ANY;
+        MODE_PREEMPTIVE;
         PRECONDITION(pStream != nullptr);
     }
     CONTRACTL_END;

--- a/src/vm/fastserializer.cpp
+++ b/src/vm/fastserializer.cpp
@@ -18,7 +18,7 @@ IpcStreamWriter::IpcStreamWriter(uint64_t id, IpcStream *pStream) : _pStream(pSt
     {
         NOTHROW;
         GC_TRIGGERS;
-        MODE_ANY;
+        MODE_PREEMPTIVE;
         PRECONDITION(_pStream != nullptr);
     }
     CONTRACTL_END;
@@ -73,7 +73,7 @@ FileStreamWriter::FileStreamWriter(const SString &outputFilePath)
     {
         THROWS;
         GC_TRIGGERS;
-        MODE_ANY;
+        MODE_PREEMPTIVE;
     }
     CONTRACTL_END;
     m_pFileStream = new CFileStream();
@@ -126,7 +126,7 @@ FastSerializer::FastSerializer(StreamWriter *pStreamWriter) : m_pStreamWriter(pS
     {
         THROWS;
         GC_TRIGGERS;
-        MODE_ANY;
+        MODE_PREEMPTIVE;
         PRECONDITION(m_pStreamWriter != NULL);
     }
     CONTRACTL_END;
@@ -268,7 +268,7 @@ void FastSerializer::WriteFileHeader()
     {
         NOTHROW;
         GC_NOTRIGGER;
-        MODE_ANY;
+        MODE_PREEMPTIVE;
     }
     CONTRACTL_END;
 


### PR DESCRIPTION
According to the [documentation](https://github.com/dotnet/coreclr/blob/0c88c2e67260ddcb1d400eb6adda19de627998f5/Documentation/mscorlib.md#calling-from-managed-to-native-code), QCALL involves a proper PInvoke transition frame, which means unless explicitly switched, the native code paths are in preemptive mode. That gives us an opportunity to tighten the asserts. Tightening the assert allows us to catch current bugs, prevent future regressions and better (live) document what the mode is supposed to be.

As far as I understand, `EventPipe::Enable()` could happen only if it is triggered in managed code through QCALL or from IPC (which is purely native code), therefore we can assert native code that is used only for `EventPipe::Enable()` has to be in preemptive mode. This analysis forms the basis of this PR, so if this is incorrect, feel free to comment on this analysis.

I proved (though tedious manual static code analysis) that the functions I changed are called only in the `EventPipe::Enable()`. Feel free to comment if you found the code I changed could be called by other code-path, because if that's the case, my assumption might be wrong. It might not capture all calls that are involved only in `EventPipe::Enable()`, so feel free to point those out as well.

For calls that are used in `EventPipe::Write()` cannot be tightened because we knew it might be called directly (through the code generator) in random places in the runtime where it might already be in cooperative mode (I was able to prove in some case `EventPipe::Write()` is indeed called by thread in cooperative mode. (Those calls should be scrutinized for their potential to block GC). 