### PR TITLE
Helix telemetry fixes

### DIFF
--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -15,6 +15,7 @@ jobs:
     archType: ${{ parameters.archType }}
     osGroup: ${{ parameters.osGroup }}
     osIdentifier: ${{ parameters.osIdentifier }}
+    helixType: 'build/product/'
     enableMicrobuild: true
 
     # Compute job name from template parameters
@@ -68,8 +69,6 @@ jobs:
       # Variables used by arcade to gather asset manifests
       - name: _DotNetPublishToBlobFeed
         value: true
-      - name: _BuildConfig
-        value: $(buildConfigUpper)
     - name: officialBuildIdArg
       value: ''
     - name: ibcOptimizeArg

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -43,8 +43,11 @@ parameters:
   # Optional: enable sending telemetry
   enableTelemetry: false
 
-  # Optional: define the helix repo for telemeetry (example: 'dotnet/arcade')
+  # Optional: define the helix repo for telemetry (example: 'dotnet/arcade')
   helixRepo: ''
+
+  # Optional: define the helix type for telemetry (example: 'build/product/')
+  helixType: ''
 
   # Required: name of the job
   name: ''
@@ -122,6 +125,8 @@ jobs:
       displayName: 'Send Helix Start Telemetry'
       inputs:
         helixRepo: ${{ parameters.helixRepo }}
+        ${{ if ne(parameters.helixType, '') }}:
+          helixType: ${{ parameters.helixType }}
         buildConfig: $(_BuildConfig)
         runAsPublic: ${{ parameters.runAsPublic }}
       continueOnError: ${{ parameters.continueOnError }}

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -20,6 +20,7 @@ jobs:
     archType: ${{ parameters.archType }}
     osGroup: ${{ parameters.osGroup }}
     osIdentifier: ${{ parameters.osIdentifier }}
+    helixType: 'build/tests/'
 
     # Compute job name from template parameters
     ${{ if and(eq(parameters.testGroup, 'innerloop'), eq(parameters.readyToRun, false)) }}:
@@ -113,7 +114,6 @@ jobs:
 
 
     # Build tests
-    # TODO: enable crossgen in build-test.sh
     - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
       - script: ./build-test.sh $(buildConfig) $(archType) $(crossArg) $(priorityArg) $(crossgenArg) $(clangArg)
         displayName: Build tests
@@ -134,13 +134,7 @@ jobs:
           creator: $(Build.DefinitionName)
 
         helixBuild: $(Build.BuildNumber)
-
-        ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
-          helixSource: official/dotnet/coreclr/$(Build.SourceBranch)
-        ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
-          helixSource: pr/dotnet/coreclr/$(Build.SourceBranch)
-        ${{ if and(eq(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
-          helixSource: ci/dotnet/coreclr/$(Build.SourceBranch)
+        helixSource: $(_HelixSource)
 
         ${{ if eq(parameters.readyToRun, false) }}:
           helixType: 'test/functional/cli/'

--- a/eng/xplat-job.yml
+++ b/eng/xplat-job.yml
@@ -5,6 +5,7 @@ parameters:
   osIdentifier: ''
   name: ''
   displayName: ''
+  helixType: '(unspecified)'
   condition: ''
   dependsOn: ''
   containerName: ''
@@ -28,9 +29,10 @@ jobs:
     dependsOn: ${{ parameters.dependsOn }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
 
-    # Send telemetry for official builds
-    enableTelemetry: ${{ and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}
+    # Send telemetry for all builds
+    enableTelemetry: true
     helixRepo: 'dotnet/coreclr'
+    helixType: ${{ parameters.helixType }}
 
     enableMicrobuild: ${{ parameters.enableMicrobuild }}
 
@@ -104,6 +106,9 @@ jobs:
       - name: buildConfigUpper
         value: 'Release'
 
+    - name: _BuildConfig
+      value: $(buildConfigUpper)
+
     - name: archType
       value: ${{ parameters.archType }}
 
@@ -113,6 +118,16 @@ jobs:
     - name: osIdentifier
       value: ${{ parameters.osIdentifier }}
       
+    - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+      - name: _HelixSource
+        value: official/dotnet/coreclr/$(Build.SourceBranch)
+    - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+      - name: _HelixSource
+        value: pr/dotnet/coreclr/$(Build.SourceBranch)
+    - ${{ if and(eq(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+      - name: _HelixSource
+        value: ci/dotnet/coreclr/$(Build.SourceBranch)
+
     - ${{ if ne(parameters.crossrootfsDir, '') }}:
       - name: crossArg
         value: 'cross'


### PR DESCRIPTION
- Enable telemetry unconditionally
- Set the `_BuildConfig` variable in `xplat-job.yml` so it is available to
  both product and test builds.
- Set the Helix `Type` parameter explicitly to distinguish product and test builds
- Set the Helix `Source` parameter for builds as well as test jobs

The change to `job.yml` is from dotnet/arcade#2620.