### PR TITLE
Fix AssemblyName cache hash and key

### DIFF
--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -25,7 +25,9 @@ namespace System.Reflection
         private event ModuleResolveEventHandler _ModuleResolve;
         private string? m_fullname;
         private object? m_syncRoot;   // Used to keep collectible types alive and as the syncroot for reflection.emit
+#pragma warning disable 169
         private IntPtr m_assembly;    // slack for ptr datum on unmanaged side
+#pragma warning restore 169
 
         #endregion
 

--- a/src/binder/assemblyname.cpp
+++ b/src/binder/assemblyname.cpp
@@ -486,6 +486,15 @@ Exit:
         {
             dwUseIdentityFlags &= ~AssemblyIdentity::IDENTITY_FLAG_CONTENT_TYPE;
         }
+        if ((dwIncludeFlags & INCLUDE_PUBLIC_KEY_TOKEN) == 0)
+        {
+            dwUseIdentityFlags &= ~AssemblyIdentity::IDENTITY_FLAG_PUBLIC_KEY;
+            dwUseIdentityFlags &= ~AssemblyIdentity::IDENTITY_FLAG_PUBLIC_KEY_TOKEN;
+        }
+        if ((dwIncludeFlags & EXCLUDE_CULTURE) != 0)
+        {
+            dwUseIdentityFlags &= ~AssemblyIdentity::IDENTITY_FLAG_CULTURE;
+        }
 
         dwHash ^= static_cast<DWORD>(HashCaseInsensitive(GetSimpleName()));
         dwHash = _rotl(dwHash, 4);

--- a/src/vm/assemblynative.cpp
+++ b/src/vm/assemblynative.cpp
@@ -78,18 +78,18 @@ FCIMPL6(Object*, AssemblyNative::Load, AssemblyNameBaseObject* assemblyNameUNSAF
     else
     {
         // Compute parent assembly
-        if (gc.requestingAssembly == NULL)
-        {
-            pRefAssembly = SystemDomain::GetCallersAssembly(stackMark);
-        }
-        else
+        if (gc.requestingAssembly != NULL)
         {
             pRefAssembly = gc.requestingAssembly->GetAssembly();
+        }
+        else if (ptrLoadContextBinder == NULL)
+        {
+            pRefAssembly = SystemDomain::GetCallersAssembly(stackMark);
         }
         
         if (pRefAssembly)
         {
-            pParentAssembly= pRefAssembly->GetDomainAssembly();
+            pParentAssembly = pRefAssembly->GetDomainAssembly();
         }
     }
 

--- a/tests/CoreFX/CoreFX.issues.json
+++ b/tests/CoreFX/CoreFX.issues.json
@@ -1150,6 +1150,20 @@
         }
     },
     {
+        "name": "System.Runtime.Loader.DefaultContext.Tests",
+        "enabled": true,
+        "exclusions": {
+            "namespaces": null,
+            "classes": null,
+            "methods": [
+                {
+                    "name" : "System.Runtime.Loader.Tests.DefaultLoadContextTests.LoadInDefaultContext",
+                    "reason" : "Waiting for https://github.com/dotnet/corefx/pull/37071"
+                }
+            ]
+        }
+    },
+    {
         "name": "System.Runtime.Loader.Tests",
         "enabled": true,
         "exclusions": {

--- a/tests/src/Loader/ContextualReflection/ContextualReflection.cs
+++ b/tests/src/Loader/ContextualReflection/ContextualReflection.cs
@@ -751,7 +751,6 @@ namespace ContextualReflectionTest
             TestMockAssemblyThrows();
         }
 
-        [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public void RunTestsIsolated()
         {
             VerifyIsolationAlc();

--- a/tests/src/Loader/ContextualReflection/ContextualReflection.cs
+++ b/tests/src/Loader/ContextualReflection/ContextualReflection.cs
@@ -321,6 +321,9 @@ namespace ContextualReflectionTest
         {
             TestAssemblyLoad(isolated, (string assemblyName) => Assembly.Load(assemblyName));
             TestAssemblyLoad(isolated, (string assemblyName) => Assembly.Load(new AssemblyName(assemblyName)));
+#pragma warning disable 618
+            TestAssemblyLoad(isolated, (string assemblyName) => Assembly.LoadWithPartialName(assemblyName));
+#pragma warning restore 618
         }
 
         void TestAssemblyLoad(bool isolated, Func<string, Assembly> assemblyLoad)

--- a/tests/src/Loader/ContextualReflection/ContextualReflectionDependency.cs
+++ b/tests/src/Loader/ContextualReflection/ContextualReflectionDependency.cs
@@ -16,7 +16,6 @@ namespace ContextualReflectionTest
         Assembly alcAssembly { get; }
         Type alcProgramType { get; }
         IProgram alcProgramInstance { get; }
-        [MethodImplAttribute(MethodImplOptions.NoInlining)]
         void RunTestsIsolated();
     }
 


### PR DESCRIPTION
Fixes #24135

* `AssemblyName::Hash(DWORD dwIncludeFlags)` was including should be ignored attributes in its hash.
* `AssemblyNative::Load` was using stackMark in a case where it wasn't needed.
* Compiler started erroring because `RuntimeAssembly.m_assembly` was unsused in C#.  It is used in native code.  Disable the warning.
* Add ContextualReflection `LoadWithPartialName` test case.
* Remove unnecessary `NoInlining` attribute
* Disable broken CoreFX test case dotnet/corefx#37071
