### PR TITLE
Correct iterator in JIT

### DIFF
--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -1206,9 +1206,9 @@ void CodeGen::genNumberOperandUse(GenTree* const operand, int& useNum) const
     }
     else
     {
-        for (GenTree* operand : operand->Operands())
+        for (GenTree* op : operand->Operands())
         {
-            genNumberOperandUse(operand, useNum);
+            genNumberOperandUse(op, useNum);
         }
     }
 }


### PR DESCRIPTION
Correct iterator in genNumberOperandUse as operand is both used for loop value and also for finding the Operands()

Use of uninitialised value of size 8
GenTree::OperGet() const (gentree.h:366)
GenTreeUseEdgeIterator::GenTreeUseEdgeIterator(GenTree*) (gentree.cpp:8394)
GenTreeOperandIterator::GenTreeOperandIterator(GenTree*) (gentree.h:2291)
GenTree::OperandsBegin() (gentree.cpp:8977)
GenTree::Operands() (gentree.cpp:8987)
CodeGen::genNumberOperandUse(GenTree*, int&) const (codegenlinear.cpp:1209)
CodeGen::genCodeForBBlist() (codegenlinear.cpp:405)
CodeGen::genGenerateCode(void**, unsigned int*) (codegencommon.cpp:2147)
