### PR TITLE
Fix handling of negative numbers in ThreadPool.SetMin/MaxThreads

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/ThreadPool.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadPool.CoreCLR.cs
@@ -208,7 +208,10 @@ namespace System.Threading
 
         public static bool SetMaxThreads(int workerThreads, int completionPortThreads)
         {
-            return SetMaxThreadsNative(workerThreads, completionPortThreads);
+            return
+                workerThreads >= 0 &&
+                completionPortThreads >= 0 &&
+                SetMaxThreadsNative(workerThreads, completionPortThreads);
         }
 
         public static void GetMaxThreads(out int workerThreads, out int completionPortThreads)
@@ -218,7 +221,10 @@ namespace System.Threading
 
         public static bool SetMinThreads(int workerThreads, int completionPortThreads)
         {
-            return SetMinThreadsNative(workerThreads, completionPortThreads);
+            return
+                workerThreads >= 0 &&
+                completionPortThreads >= 0 &&
+                SetMinThreadsNative(workerThreads, completionPortThreads);
         }
 
         public static void GetMinThreads(out int workerThreads, out int completionPortThreads)

--- a/tests/CoreFX/CoreFX.issues.json
+++ b/tests/CoreFX/CoreFX.issues.json
@@ -967,7 +967,7 @@
             "classes": null,
             "methods": [
                 {
-                    "name": "System.Threading.ThreadPools.Tests.SetMinMaxThreadsTest",
+                    "name": "System.Threading.ThreadPools.Tests.ThreadPoolTests.SetMinMaxThreadsTest",
                     "reason": "https://github.com/dotnet/corefx/issues/36885"
                 }
             ]

--- a/tests/CoreFX/CoreFX.issues.json
+++ b/tests/CoreFX/CoreFX.issues.json
@@ -960,6 +960,20 @@
         }
     },
     {
+        "name": "System.Threading.ThreadPool.Tests",
+        "enabled": true,
+        "exclusions": {
+            "namespaces": null,
+            "classes": null,
+            "methods": [
+                {
+                    "name": "System.Threading.ThreadPools.Tests.SetMinMaxThreadsTest",
+                    "reason": "https://github.com/dotnet/corefx/issues/36885"
+                }
+            ]
+        }
+    },
+    {
         "name": "System.Memory.Tests",
         "enabled": true,
         "exclusions": {


### PR DESCRIPTION
cc: @kouvel, @filipnavara 
Contributes to https://github.com/dotnet/corefx/issues/36885