### PR TITLE
Disable _il_relthread-race test under GCStress

### DIFF
--- a/tests/src/JIT/Methodical/tailcall/Desktop/_il_relthread-race.csproj
+++ b/tests/src/JIT/Methodical/tailcall/Desktop/_il_relthread-race.csproj
@@ -11,8 +11,9 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
 
-    <!-- NOTE: this test simply takes too long to complete under heap verify. It is not fundamentally incompatible. -->
+    <!-- NOTE: this test simply takes too long to complete under heap verify or GCStress. It is not fundamentally incompatible. -->
     <HeapVerifyIncompatible>true</HeapVerifyIncompatible>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
It takes too long, and times out in CI.

Fixes #24172