### PR TITLE
Disable 2 GC tests under HeapVerify for arm64

### DIFF
--- a/tests/src/GC/Regressions/v2.0-rtm/494226/494226.csproj
+++ b/tests/src/GC/Regressions/v2.0-rtm/494226/494226.csproj
@@ -10,7 +10,7 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <GCStressIncompatible>true</GCStressIncompatible>
-    <HeapVerifyIncompatible Condition="'$(Platform)' == 'x86' or '$(Platform)' == 'arm'">true</HeapVerifyIncompatible>
+    <HeapVerifyIncompatible Condition="'$(Platform)' == 'x86' or '$(Platform)' == 'arm' or '$(Platform)' == 'arm64'">true</HeapVerifyIncompatible>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/GC/Scenarios/ServerModel/servermodel.csproj
+++ b/tests/src/GC/Scenarios/ServerModel/servermodel.csproj
@@ -11,7 +11,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <CLRTestExecutionArguments>/numrequests:100</CLRTestExecutionArguments>
     <GCStressIncompatible>true</GCStressIncompatible>
-    <HeapVerifyIncompatible Condition="'$(Platform)' == 'x86' or '$(Platform)' == 'arm'">true</HeapVerifyIncompatible>
+    <HeapVerifyIncompatible Condition="'$(Platform)' == 'x86' or '$(Platform)' == 'arm' or '$(Platform)' == 'arm64'">true</HeapVerifyIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
They fail due to timeout with `COMPlus_HeapVerify=1` on arm64.

They were already being disabled for HeapVerify for x86 and arm32.

Fixes #24175