### PR TITLE
Improve the performance of the type loader

### DIFF
--- a/src/vm/assemblyname.cpp
+++ b/src/vm/assemblyname.cpp
@@ -88,10 +88,10 @@ FCIMPL1(Object*, AssemblyNameNative::ToString, Object* refThisUNSAFE)
     if (pThis == NULL)
         COMPlusThrow(kNullReferenceException, W("NullReference_This"));
 
-    StackingAllocatorHolder sah(&pThread->m_MarshalAlloc); //hold checkpoint for autorelease
+    ACQUIRE_STACKING_ALLOCATOR(pStackingAllocator);
 
     AssemblySpec spec;
-    spec.InitializeSpec(sah.GetStackingAllocator(), (ASSEMBLYNAMEREF*) &pThis, FALSE); 
+    spec.InitializeSpec(pStackingAllocator, (ASSEMBLYNAMEREF*) &pThis, FALSE); 
 
     StackSString name;
     spec.GetFileOrDisplayName(ASM_DISPLAYF_VERSION |
@@ -161,10 +161,10 @@ FCIMPL3(void, AssemblyNameNative::Init, Object * refThisUNSAFE, OBJECTREF * pAss
     if (pThis == NULL)
         COMPlusThrow(kNullReferenceException, W("NullReference_This"));
 
-    StackingAllocatorHolder sah(&GetThread()->m_MarshalAlloc); //hold checkpoint for autorelease
+    ACQUIRE_STACKING_ALLOCATOR(pStackingAllocator);
 
     AssemblySpec spec;
-    hr = spec.InitializeSpec(sah.GetStackingAllocator(), (ASSEMBLYNAMEREF *) &pThis, TRUE); 
+    hr = spec.InitializeSpec(pStackingAllocator, (ASSEMBLYNAMEREF *) &pThis, TRUE); 
 
     if (SUCCEEDED(hr))
     {

--- a/src/vm/assemblyname.cpp
+++ b/src/vm/assemblyname.cpp
@@ -88,12 +88,10 @@ FCIMPL1(Object*, AssemblyNameNative::ToString, Object* refThisUNSAFE)
     if (pThis == NULL)
         COMPlusThrow(kNullReferenceException, W("NullReference_This"));
 
-    Thread *pThread = GetThread();
-
-    CheckPointHolder cph(pThread->m_MarshalAlloc.GetCheckpoint()); //hold checkpoint for autorelease
+    StackingAllocatorHolder sah(&pThread->m_MarshalAlloc); //hold checkpoint for autorelease
 
     AssemblySpec spec;
-    spec.InitializeSpec(&(pThread->m_MarshalAlloc), (ASSEMBLYNAMEREF*) &pThis, FALSE); 
+    spec.InitializeSpec(sah.GetStackingAllocator(), (ASSEMBLYNAMEREF*) &pThis, FALSE); 
 
     StackSString name;
     spec.GetFileOrDisplayName(ASM_DISPLAYF_VERSION |
@@ -163,12 +161,10 @@ FCIMPL3(void, AssemblyNameNative::Init, Object * refThisUNSAFE, OBJECTREF * pAss
     if (pThis == NULL)
         COMPlusThrow(kNullReferenceException, W("NullReference_This"));
 
-    Thread * pThread = GetThread();
-
-    CheckPointHolder cph(pThread->m_MarshalAlloc.GetCheckpoint()); //hold checkpoint for autorelease
+    StackingAllocatorHolder sah(&GetThread()->m_MarshalAlloc); //hold checkpoint for autorelease
 
     AssemblySpec spec;
-    hr = spec.InitializeSpec(&(pThread->m_MarshalAlloc), (ASSEMBLYNAMEREF *) &pThis, TRUE); 
+    hr = spec.InitializeSpec(sah.GetStackingAllocator(), (ASSEMBLYNAMEREF *) &pThis, TRUE); 
 
     if (SUCCEEDED(hr))
     {

--- a/src/vm/assemblynative.cpp
+++ b/src/vm/assemblynative.cpp
@@ -62,7 +62,7 @@ FCIMPL6(Object*, AssemblyNative::Load, AssemblyNameBaseObject* assemblyNameUNSAF
     if (gc.assemblyName == NULL)
         COMPlusThrow(kArgumentNullException, W("ArgumentNull_AssemblyName"));
 
-    StackingAllocatorHolder sah(&GetThread()->m_MarshalAlloc); //hold checkpoint for autorelease
+    ACQUIRE_STACKING_ALLOCATOR(pStackingAllocator);
 
     DomainAssembly * pParentAssembly = NULL;
     Assembly * pRefAssembly = NULL;
@@ -94,7 +94,7 @@ FCIMPL6(Object*, AssemblyNative::Load, AssemblyNameBaseObject* assemblyNameUNSAF
 
     // Initialize spec
     AssemblySpec spec;
-    spec.InitializeSpec(&(pThread->m_MarshalAlloc), 
+    spec.InitializeSpec(pStackingAllocator, 
                         &gc.assemblyName,
                         FALSE);
     
@@ -104,7 +104,7 @@ FCIMPL6(Object*, AssemblyNative::Load, AssemblyNameBaseObject* assemblyNameUNSAF
     }
     
     if (gc.codeBase != NULL)
-        spec.SetCodeBase(sah.GetStackingAllocator(), &gc.codeBase);
+        spec.SetCodeBase(pStackingAllocator, &gc.codeBase);
 
     if (pParentAssembly != NULL)
         spec.SetParentAssembly(pParentAssembly);

--- a/src/vm/assemblynative.cpp
+++ b/src/vm/assemblynative.cpp
@@ -62,8 +62,7 @@ FCIMPL6(Object*, AssemblyNative::Load, AssemblyNameBaseObject* assemblyNameUNSAF
     if (gc.assemblyName == NULL)
         COMPlusThrow(kArgumentNullException, W("ArgumentNull_AssemblyName"));
 
-    Thread * pThread = GetThread();
-    CheckPointHolder cph(pThread->m_MarshalAlloc.GetCheckpoint()); //hold checkpoint for autorelease
+    StackingAllocatorHolder sah(&GetThread()->m_MarshalAlloc); //hold checkpoint for autorelease
 
     DomainAssembly * pParentAssembly = NULL;
     Assembly * pRefAssembly = NULL;
@@ -105,7 +104,7 @@ FCIMPL6(Object*, AssemblyNative::Load, AssemblyNameBaseObject* assemblyNameUNSAF
     }
     
     if (gc.codeBase != NULL)
-        spec.SetCodeBase(&(pThread->m_MarshalAlloc), &gc.codeBase);
+        spec.SetCodeBase(sah.GetStackingAllocator(), &gc.codeBase);
 
     if (pParentAssembly != NULL)
         spec.SetParentAssembly(pParentAssembly);

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -6539,9 +6539,8 @@ void Module::FixupVTables()
             cVtableThunks += pFixupTable[iFixup].Count;
     }
 
-    Thread *pThread = GetThread();
-    StackingAllocator *pAlloc = &pThread->m_MarshalAlloc;
-    CheckPointHolder cph(pAlloc->GetCheckpoint());
+    StackingAllocatorHolder sah(&GetThread()->m_MarshalAlloc);
+    StackingAllocator *pAlloc = sah.GetStackingAllocator();
 
     // Allocate the working array of tokens.
     cMethodsToLoad = cVtableThunks;

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -6539,8 +6539,7 @@ void Module::FixupVTables()
             cVtableThunks += pFixupTable[iFixup].Count;
     }
 
-    StackingAllocatorHolder sah(&GetThread()->m_MarshalAlloc);
-    StackingAllocator *pAlloc = sah.GetStackingAllocator();
+    ACQUIRE_STACKING_ALLOCATOR(pAlloc);
 
     // Allocate the working array of tokens.
     cMethodsToLoad = cVtableThunks;

--- a/src/vm/class.cpp
+++ b/src/vm/class.cpp
@@ -293,8 +293,8 @@ VOID EEClass::FixupFieldDescForEnC(MethodTable * pMT, EnCFieldDesc *pFD, mdField
     // MethodTableBuilder uses the stacking allocator for most of it's
     // working memory requirements, so this makes sure to free the memory
     // once this function is out of scope.
-    StackingAllocator *pStackingAllocator = &GetThread()->m_MarshalAlloc;
-    CheckPointHolder cph(pStackingAllocator->GetCheckpoint());
+    StackingAllocatorHolder sah(&GetThread()->m_MarshalAlloc);
+    StackingAllocator *pStackingAllocator = sah.GetStackingAllocator();
 
     MethodTableBuilder::bmtMetaDataInfo bmtMetaData;
     bmtMetaData.cFields = 1;
@@ -604,10 +604,12 @@ HRESULT EEClass::AddMethod(MethodTable * pMT, mdMethodDef methodDef, RVA newRVA,
     // Get the new MethodDesc (Note: The method desc memory is zero initialized)
     MethodDesc *pNewMD = pChunk->GetFirstMethodDesc();
 
+    StackingAllocatorHolder sah(&GetThread()->m_MarshalAlloc);
+
     // Initialize the new MethodDesc
     MethodTableBuilder builder(pMT,
                                pClass,
-                               &GetThread()->m_MarshalAlloc,
+                               sah.GetStackingAllocator(),
                                &dummyAmTracker);
     EX_TRY
     {

--- a/src/vm/class.cpp
+++ b/src/vm/class.cpp
@@ -293,8 +293,7 @@ VOID EEClass::FixupFieldDescForEnC(MethodTable * pMT, EnCFieldDesc *pFD, mdField
     // MethodTableBuilder uses the stacking allocator for most of it's
     // working memory requirements, so this makes sure to free the memory
     // once this function is out of scope.
-    StackingAllocatorHolder sah(&GetThread()->m_MarshalAlloc);
-    StackingAllocator *pStackingAllocator = sah.GetStackingAllocator();
+    ACQUIRE_STACKING_ALLOCATOR(pStackingAllocator);
 
     MethodTableBuilder::bmtMetaDataInfo bmtMetaData;
     bmtMetaData.cFields = 1;
@@ -604,12 +603,12 @@ HRESULT EEClass::AddMethod(MethodTable * pMT, mdMethodDef methodDef, RVA newRVA,
     // Get the new MethodDesc (Note: The method desc memory is zero initialized)
     MethodDesc *pNewMD = pChunk->GetFirstMethodDesc();
 
-    StackingAllocatorHolder sah(&GetThread()->m_MarshalAlloc);
+    ACQUIRE_STACKING_ALLOCATOR(pStackingAllocator);
 
     // Initialize the new MethodDesc
     MethodTableBuilder builder(pMT,
                                pClass,
-                               sah.GetStackingAllocator(),
+                               pStackingAllocator,
                                &dummyAmTracker);
     EX_TRY
     {

--- a/src/vm/class.cpp
+++ b/src/vm/class.cpp
@@ -293,7 +293,8 @@ VOID EEClass::FixupFieldDescForEnC(MethodTable * pMT, EnCFieldDesc *pFD, mdField
     // MethodTableBuilder uses the stacking allocator for most of it's
     // working memory requirements, so this makes sure to free the memory
     // once this function is out of scope.
-    CheckPointHolder cph(GetThread()->m_MarshalAlloc.GetCheckpoint());
+    StackingAllocator *pStackingAllocator = &GetThread()->m_MarshalAlloc;
+    CheckPointHolder cph(pStackingAllocator->GetCheckpoint());
 
     MethodTableBuilder::bmtMetaDataInfo bmtMetaData;
     bmtMetaData.cFields = 1;
@@ -357,7 +358,7 @@ VOID EEClass::FixupFieldDescForEnC(MethodTable * pMT, EnCFieldDesc *pFD, mdField
 
     BaseDomain * pDomain = pMT->GetDomain();
     MethodTableBuilder builder(pMT, pClass,
-                               &GetThread()->m_MarshalAlloc,
+                               pStackingAllocator,
                                &dummyAmTracker);
 
     MethodTableBuilder::bmtGenericsInfo genericsInfo;

--- a/src/vm/classcompat.cpp
+++ b/src/vm/classcompat.cpp
@@ -227,8 +227,6 @@ InteropMethodTableData *MethodTableBuilder::BuildInteropVTable(AllocMemTracker *
 #endif // _DEBUG
 
     //Get Check Point for the thread-based allocator
-    Thread *pThread = GetThread();
-    CheckPointHolder cph(pThread->m_MarshalAlloc.GetCheckpoint()); //hold checkpoint for autorelease
 
     HRESULT hr = S_OK;
     Module *pModule = pThisMT->GetModule();
@@ -349,19 +347,19 @@ InteropMethodTableData *MethodTableBuilder::BuildInteropVTable(AllocMemTracker *
         // The interop data for the VTable for COM Interop backward compatibility
 
         // Allocate space to hold on to the MethodDesc for each entry
-        bmtVT.ppSDVtable = new (&pThread->m_MarshalAlloc) InteropMethodTableSlotData*[bmtVT.dwMaxVtableSize];
+        bmtVT.ppSDVtable = new (GetStackingAllocator()) InteropMethodTableSlotData*[bmtVT.dwMaxVtableSize];
         ZeroMemory(bmtVT.ppSDVtable, bmtVT.dwMaxVtableSize * sizeof(InteropMethodTableSlotData*));
 
         // Allocate space to hold on to the MethodDesc for each entry
-        bmtVT.ppSDNonVtable = new (&pThread->m_MarshalAlloc) InteropMethodTableSlotData*[NumDeclaredMethods()];
+        bmtVT.ppSDNonVtable = new (GetStackingAllocator()) InteropMethodTableSlotData*[NumDeclaredMethods()];
         ZeroMemory(bmtVT.ppSDNonVtable , sizeof(InteropMethodTableSlotData*)*NumDeclaredMethods());
 
 
         DWORD cMaxEntries = (bmtVT.dwMaxVtableSize * 2) + (NumDeclaredMethods() * 2);
-        InteropMethodTableSlotData *pInteropData = new (&pThread->m_MarshalAlloc) InteropMethodTableSlotData[cMaxEntries];
+        InteropMethodTableSlotData *pInteropData = new (GetStackingAllocator()) InteropMethodTableSlotData[cMaxEntries];
         memset(pInteropData, 0, cMaxEntries * sizeof(InteropMethodTableSlotData));
 
-        bmtVT.pInteropData = new (&pThread->m_MarshalAlloc) InteropMethodTableSlotDataMap(pInteropData, cMaxEntries);
+        bmtVT.pInteropData = new (GetStackingAllocator()) InteropMethodTableSlotDataMap(pInteropData, cMaxEntries);
 
         // Initialize the map with parent information
         if (bmtParent.pParentMethodTable != NULL)
@@ -632,7 +630,7 @@ VOID MethodTableBuilder::BuildInteropVTable_InterfaceList(
         Module *pModule = GetModule();
 
         // Allocate the BuildingInterfaceList table
-        *ppBuildingInterfaceList = new(&pThread->m_MarshalAlloc) BuildingInterfaceInfo_t[cAllInterfaces];
+        *ppBuildingInterfaceList = new(GetStackingAllocator()) BuildingInterfaceInfo_t[cAllInterfaces];
         BuildingInterfaceInfo_t *pInterfaceBuildInfo = *ppBuildingInterfaceList;
 
         while (pMDImport->EnumNext(&hEnumInterfaceImpl, &ii))
@@ -836,13 +834,10 @@ VOID MethodTableBuilder::BuildInteropVTable_PlaceMembers(
                         slotNum = (WORD) pItfMD->GetSlot();
                         if (bmtInterface->pppInterfaceImplementingMD[j] == NULL)
                         {
-                            Thread *pThread = GetThread();
-                            StackingAllocator * pAlloc = &pThread->m_MarshalAlloc;
-
-                            bmtInterface->pppInterfaceImplementingMD[j] = new (pAlloc) MethodDesc * [pInterface->GetNumVirtuals()];
+                            bmtInterface->pppInterfaceImplementingMD[j] = new (GetStackingAllocator()) MethodDesc * [pInterface->GetNumVirtuals()];
                             memset(bmtInterface->pppInterfaceImplementingMD[j], 0, sizeof(MethodDesc *) * pInterface->GetNumVirtuals());
 
-                            bmtInterface->pppInterfaceDeclaringMD[j] = new (pAlloc) MethodDesc * [pInterface->GetNumVirtuals()];
+                            bmtInterface->pppInterfaceDeclaringMD[j] = new (GetStackingAllocator()) MethodDesc * [pInterface->GetNumVirtuals()];
                             memset(bmtInterface->pppInterfaceDeclaringMD[j], 0, sizeof(MethodDesc *) * pInterface->GetNumVirtuals());
                         }
 
@@ -1084,7 +1079,7 @@ VOID MethodTableBuilder::BuildInteropVTable_ResolveInterfaces(
     }
 
     // Create a fully expanded map of all interfaces we implement
-    bmtInterface->pInterfaceMap = new (&pThread->m_MarshalAlloc) InterfaceInfo_t[bmtInterface->dwMaxExpandedInterfaces];
+    bmtInterface->pInterfaceMap = new (pStackingAllocator) InterfaceInfo_t[bmtInterface->dwMaxExpandedInterfaces];
 
     // # slots of largest interface
     bmtInterface->dwLargestInterfaceSize = 0;
@@ -1100,9 +1095,9 @@ VOID MethodTableBuilder::BuildInteropVTable_ResolveInterfaces(
         // This is needed later - for each interface, we get the MethodDesc pointer for each
         // method.  We need to be able to persist at most one interface at a time, so we
         // need enough memory for the largest interface.
-        bmtInterface->ppInterfaceMethodDescList = new (&pThread->m_MarshalAlloc) MethodDesc*[bmtInterface->dwLargestInterfaceSize];
+        bmtInterface->ppInterfaceMethodDescList = new (GetStackingAllocator()) MethodDesc*[bmtInterface->dwLargestInterfaceSize];
 
-        bmtInterface->ppInterfaceDeclMethodDescList = new (&pThread->m_MarshalAlloc) MethodDesc*[bmtInterface->dwLargestInterfaceSize];
+        bmtInterface->ppInterfaceDeclMethodDescList = new (GetStackingAllocator()) MethodDesc*[bmtInterface->dwLargestInterfaceSize];
     }
 
     EEClass *pParentClass = (IsInterface() || bmtParent->pParentMethodTable == NULL) ? NULL : bmtParent->pParentMethodTable->GetClass();
@@ -1134,10 +1129,10 @@ VOID MethodTableBuilder::BuildInteropVTable_ResolveInterfaces(
 
     bmtVT->wCurrentNonVtableSlot      = 0;
 
-    bmtInterface->pppInterfaceImplementingMD = (MethodDesc ***) pThread->m_MarshalAlloc.Alloc(S_UINT32(sizeof(MethodDesc *)) * S_UINT32(bmtInterface->dwMaxExpandedInterfaces));
+    bmtInterface->pppInterfaceImplementingMD = (MethodDesc ***) GetStackingAllocator()->Alloc(S_UINT32(sizeof(MethodDesc *)) * S_UINT32(bmtInterface->dwMaxExpandedInterfaces));
     memset(bmtInterface->pppInterfaceImplementingMD, 0, sizeof(MethodDesc *) * bmtInterface->dwMaxExpandedInterfaces);
 
-    bmtInterface->pppInterfaceDeclaringMD = (MethodDesc ***) pThread->m_MarshalAlloc.Alloc(S_UINT32(sizeof(MethodDesc *)) * S_UINT32(bmtInterface->dwMaxExpandedInterfaces));
+    bmtInterface->pppInterfaceDeclaringMD = (MethodDesc ***) GetStackingAllocator()->Alloc(S_UINT32(sizeof(MethodDesc *)) * S_UINT32(bmtInterface->dwMaxExpandedInterfaces));
     memset(bmtInterface->pppInterfaceDeclaringMD, 0, sizeof(MethodDesc *) * bmtInterface->dwMaxExpandedInterfaces);
 
     return;
@@ -1555,8 +1550,8 @@ VOID MethodTableBuilder::BuildInteropVTable_PlaceMethodImpls(
 
     // Allocate some temporary storage. The number of overrides for a single method impl
     // cannot be greater then the number of vtable slots. 
-    DWORD* slots = (DWORD*) new (&GetThread()->m_MarshalAlloc) DWORD[bmtVT->wCurrentVtableSlot];
-    MethodDesc **replaced = new (&GetThread()->m_MarshalAlloc) MethodDesc*[bmtVT->wCurrentVtableSlot];
+    DWORD* slots = (DWORD*) new (GetStackingAllocator()) DWORD[bmtVT->wCurrentVtableSlot];
+    MethodDesc **replaced = new (GetStackingAllocator()) MethodDesc*[bmtVT->wCurrentVtableSlot];
 
     while(pIndex < bmtMethodImpl->pIndex) {
 
@@ -1761,7 +1756,7 @@ VOID MethodTableBuilder::BuildInteropVTable_PlaceInterfaceDeclaration(
                 if(bmtInterface->pdwOriginalStart == NULL)
                 {
                     Thread *pThread = GetThread();
-                    bmtInterface->pdwOriginalStart = new (&pThread->m_MarshalAlloc) DWORD[bmtInterface->dwMaxExpandedInterfaces];
+                    bmtInterface->pdwOriginalStart = new (GetStackingAllocator()) DWORD[bmtInterface->dwMaxExpandedInterfaces];
                     memset(bmtInterface->pdwOriginalStart, 0, sizeof(DWORD)*bmtInterface->dwMaxExpandedInterfaces);
                 }
 
@@ -2080,7 +2075,7 @@ VOID    MethodTableBuilder::EnumerateMethodImpls()
         //
         // Allocate the structures to keep track of the token pairs
         //
-        bmtMethodImpl->rgMethodImplTokens = new (&GetThread()->m_MarshalAlloc)
+        bmtMethodImpl->rgMethodImplTokens = new (GetStackingAllocator())
             bmtMethodImplInfo::MethodImplTokenPair[bmtMethodImpl->dwNumberMethodImpls];
             
         // Iterate through each MethodImpl declared on this class
@@ -2137,8 +2132,8 @@ VOID    MethodTableBuilder::EnumerateMethodImpls()
         //
         // Allocate the structures to keep track of the impl matches
         //
-        bmtMethodImpl->pMethodDeclSubsts = new (&GetThread()->m_MarshalAlloc) Substitution[bmtMethodImpl->dwNumberMethodImpls]; 
-        bmtMethodImpl->rgEntries = new (&GetThread()->m_MarshalAlloc) bmtMethodImplInfo::Entry[bmtMethodImpl->dwNumberMethodImpls];
+        bmtMethodImpl->pMethodDeclSubsts = new (GetStackingAllocator()) Substitution[bmtMethodImpl->dwNumberMethodImpls]; 
+        bmtMethodImpl->rgEntries = new (GetStackingAllocator()) bmtMethodImplInfo::Entry[bmtMethodImpl->dwNumberMethodImpls];
 
         // These are used for verification
         maxRidMD = pMDInternalImport->GetCountWithTokenKind(mdtMethodDef);
@@ -2309,7 +2304,6 @@ VOID    MethodTableBuilder::EnumerateClassMethods()
 
     HRESULT hr = S_OK;
     DWORD i;
-    Thread *pThread = GetThread();
     IMDInternalImport *pMDInternalImport = bmtType->pMDImport;
     mdToken tok;
     DWORD dwMemberAttrs;
@@ -2346,16 +2340,16 @@ VOID    MethodTableBuilder::EnumerateClassMethods()
     // Allocate an array to contain the method tokens as well as information about the methods.
     bmtMethod->cMethAndGaps = bmtMethod->hEnumMethod.EnumGetCount();
 
-    bmtMethod->rgMethodTokens = new (&pThread->m_MarshalAlloc) mdToken[bmtMethod->cMethAndGaps]; 
-    bmtMethod->rgMethodRVA = new (&pThread->m_MarshalAlloc) ULONG[bmtMethod->cMethAndGaps]; 
-    bmtMethod->rgMethodAttrs = new (&pThread->m_MarshalAlloc) DWORD[bmtMethod->cMethAndGaps]; 
-    bmtMethod->rgMethodImplFlags = new (&pThread->m_MarshalAlloc) DWORD[bmtMethod->cMethAndGaps]; 
-    bmtMethod->rgMethodClassifications = new (&pThread->m_MarshalAlloc) DWORD[bmtMethod->cMethAndGaps]; 
+    bmtMethod->rgMethodTokens = new (GetStackingAllocator()) mdToken[bmtMethod->cMethAndGaps]; 
+    bmtMethod->rgMethodRVA = new (GetStackingAllocator()) ULONG[bmtMethod->cMethAndGaps]; 
+    bmtMethod->rgMethodAttrs = new (GetStackingAllocator()) DWORD[bmtMethod->cMethAndGaps]; 
+    bmtMethod->rgMethodImplFlags = new (GetStackingAllocator()) DWORD[bmtMethod->cMethAndGaps]; 
+    bmtMethod->rgMethodClassifications = new (GetStackingAllocator()) DWORD[bmtMethod->cMethAndGaps]; 
 
-    bmtMethod->rgszMethodName = new (&pThread->m_MarshalAlloc) LPCSTR[bmtMethod->cMethAndGaps];
+    bmtMethod->rgszMethodName = new (GetStackingAllocator()) LPCSTR[bmtMethod->cMethAndGaps];
 
-    bmtMethod->rgMethodImpl = new (&pThread->m_MarshalAlloc) BYTE[bmtMethod->cMethAndGaps]; 
-    bmtMethod->rgMethodType = new (&pThread->m_MarshalAlloc) BYTE[bmtMethod->cMethAndGaps]; 
+    bmtMethod->rgMethodImpl = new (GetStackingAllocator()) BYTE[bmtMethod->cMethAndGaps]; 
+    bmtMethod->rgMethodType = new (GetStackingAllocator()) BYTE[bmtMethod->cMethAndGaps]; 
 
     enum { SeenCtor = 1, SeenInvoke = 2, SeenBeginInvoke = 4, SeenEndInvoke = 8};
     unsigned delegateMethodsSeen = 0;
@@ -2961,10 +2955,8 @@ VOID    MethodTableBuilder::AllocateMethodWorkingMemory()
     CONTRACTL_END;
 
     DWORD i;
-    Thread *pThread = GetThread();
-
     // Allocate a MethodDesc* for each method (needed later when doing interfaces), and a FieldDesc* for each field
-    bmtMethod->ppMethodDescList = new (&pThread->m_MarshalAlloc) MethodDesc*[NumDeclaredMethods()];
+    bmtMethod->ppMethodDescList = new (GetStackingAllocator()) MethodDesc*[NumDeclaredMethods()];
     ZeroMemory(bmtMethod->ppMethodDescList, NumDeclaredMethods() * sizeof(MethodDesc *));
 
     // Create a temporary function table (we don't know how large the vtable will be until the very end,
@@ -2979,7 +2971,7 @@ VOID    MethodTableBuilder::AllocateMethodWorkingMemory()
     if (IsValueClass())
     {
         bmtVT->dwMaxVtableSize += NumDeclaredMethods();
-        bmtMethod->ppUnboxMethodDescList = new (&pThread->m_MarshalAlloc) MethodDesc*[NumDeclaredMethods()];
+        bmtMethod->ppUnboxMethodDescList = new (GetStackingAllocator()) MethodDesc*[NumDeclaredMethods()];
         ZeroMemory(bmtMethod->ppUnboxMethodDescList, NumDeclaredMethods() * sizeof(MethodDesc*));
     }
 
@@ -2997,13 +2989,13 @@ VOID    MethodTableBuilder::AllocateMethodWorkingMemory()
     }
 
     // Allocate the temporary vtable
-    bmtVT->pVtable = new (&pThread->m_MarshalAlloc)PCODE [bmtVT->dwMaxVtableSize];
+    bmtVT->pVtable = new (GetStackingAllocator())PCODE [bmtVT->dwMaxVtableSize];
     ZeroMemory(bmtVT->pVtable, bmtVT->dwMaxVtableSize * sizeof(PCODE));
-    bmtVT->pVtableMD = new (&pThread->m_MarshalAlloc) MethodDesc*[bmtVT->dwMaxVtableSize];
+    bmtVT->pVtableMD = new (GetStackingAllocator()) MethodDesc*[bmtVT->dwMaxVtableSize];
     ZeroMemory(bmtVT->pVtableMD, bmtVT->dwMaxVtableSize * sizeof(MethodDesc*));
 
     // Allocate the temporary non-vtable
-    bmtVT->pNonVtableMD = new (&pThread->m_MarshalAlloc) MethodDesc*[NumDeclaredMethods()];
+    bmtVT->pNonVtableMD = new (GetStackingAllocator()) MethodDesc*[NumDeclaredMethods()];
     ZeroMemory(bmtVT->pNonVtableMD, sizeof(MethodDesc*) * NumDeclaredMethods());
 
     if (bmtParent->pParentMethodTable != NULL)
@@ -3066,7 +3058,7 @@ VOID    MethodTableBuilder::AllocateMethodWorkingMemory()
     if (NumDeclaredMethods() > 0)
     {
         bmtParent->ppParentMethodDescBuf = (MethodDesc **)
-            pThread->m_MarshalAlloc.Alloc(S_UINT32(2) * S_UINT32(NumDeclaredMethods()) *
+            GetStackingAllocator()->Alloc(S_UINT32(2) * S_UINT32(NumDeclaredMethods()) *
                                           S_UINT32(sizeof(MethodDesc*)));
 
         bmtParent->ppParentMethodDescBufPtr = bmtParent->ppParentMethodDescBuf;
@@ -3532,10 +3524,9 @@ MethodNameHash *MethodTableBuilder::CreateMethodChainHash(MethodTable *pMT)
 {
     STANDARD_VM_CONTRACT;
 
-    Thread *pThread = GetThread();
-    MethodNameHash *pHash = new (&pThread->m_MarshalAlloc) MethodNameHash();
+    MethodNameHash *pHash = new (GetStackingAllocator()) MethodNameHash();
 
-    pHash->Init(pMT->GetNumVirtuals(), &(pThread->m_MarshalAlloc));
+    pHash->Init(pMT->GetNumVirtuals(), GetStackingAllocator());
 
     MethodTable::MethodIterator it(pMT);
     for (;it.IsValid(); it.Next())

--- a/src/vm/classcompat.cpp
+++ b/src/vm/classcompat.cpp
@@ -1079,7 +1079,7 @@ VOID MethodTableBuilder::BuildInteropVTable_ResolveInterfaces(
     }
 
     // Create a fully expanded map of all interfaces we implement
-    bmtInterface->pInterfaceMap = new (pStackingAllocator) InterfaceInfo_t[bmtInterface->dwMaxExpandedInterfaces];
+    bmtInterface->pInterfaceMap = new (GetStackingAllocator()) InterfaceInfo_t[bmtInterface->dwMaxExpandedInterfaces];
 
     // # slots of largest interface
     bmtInterface->dwLargestInterfaceSize = 0;

--- a/src/vm/classcompat.h
+++ b/src/vm/classcompat.h
@@ -200,11 +200,12 @@ public:
 class MethodTableBuilder
 {
 public:
-    MethodTableBuilder(MethodTable * pMT) 
+    MethodTableBuilder(MethodTable * pMT, StackingAllocator *pStackingAllocator) 
     {
         LIMITED_METHOD_CONTRACT;
         m_pHalfBakedMT = pMT;
         m_pHalfBakedClass = pMT->GetClass();
+        m_pStackingAllocator = pStackingAllocator;
         NullBMTData();
     }
 public:
@@ -241,6 +242,9 @@ private:
     // <NICE> Get rid of this.</NICE>
     EEClass *m_pHalfBakedClass;
     MethodTable * m_pHalfBakedMT;
+    StackingAllocator *m_pStackingAllocator;
+
+    StackingAllocator* GetStackingAllocator() { return m_pStackingAllocator; }
 
     // GetHalfBakedClass: The EEClass you get back from this function may not have all its fields filled in yet.
     // Thus you have to make sure that the relevant item which you are accessing has

--- a/src/vm/eehash.h
+++ b/src/vm/eehash.h
@@ -104,6 +104,7 @@ public:
     // should fall back to the slow GetValue if GetValueSpeculative returns false.
     // Assumes that we are in cooperative mode already. For performance-sensitive codepaths.
     BOOL            GetValueSpeculative(KeyType pKey, HashDatum *pData);
+    BOOL            GetValueSpeculative(KeyType pKey, HashDatum *pData, DWORD hashValue);
 
     DWORD           GetHash(KeyType Key);
     DWORD           GetCount();

--- a/src/vm/eehash.inl
+++ b/src/vm/eehash.inl
@@ -510,6 +510,32 @@ FORCEINLINE BOOL EEHashTableBase<KeyType, Helper, bDefaultCopyIsDeep>::GetValueS
 }
 
 template <class KeyType, class Helper, BOOL bDefaultCopyIsDeep>
+FORCEINLINE BOOL EEHashTableBase<KeyType, Helper, bDefaultCopyIsDeep>::GetValueSpeculative(KeyType pKey, HashDatum *pData, DWORD hashValue)
+{
+    CONTRACTL
+    {
+        WRAPPER(THROWS);
+        WRAPPER(GC_NOTRIGGER);
+#ifdef MODE_COOPERATIVE     // This header file sees contract.h, not eecontract.h - what a kludge!
+        MODE_COOPERATIVE;
+#endif
+    }
+    CONTRACTL_END
+
+    EEHashEntry_t *pItem = FindItemSpeculative(pKey, hashValue);
+
+    if (pItem != NULL)
+    {
+        *pData = pItem->Data;
+        return TRUE;
+    }
+    else
+    {
+        return FALSE;
+    }
+}
+
+template <class KeyType, class Helper, BOOL bDefaultCopyIsDeep>
 EEHashEntry_t *EEHashTableBase<KeyType, Helper, bDefaultCopyIsDeep>::FindItem(KeyType pKey)
 {
     CONTRACTL

--- a/src/vm/methodtable.cpp
+++ b/src/vm/methodtable.cpp
@@ -8448,11 +8448,9 @@ InteropMethodTableData *MethodTable::CreateComInteropData(AllocMemTracker *pamTr
         PRECONDITION(GetParentMethodTable() == NULL || GetParentMethodTable()->LookupComInteropData() != NULL);
     } CONTRACTL_END;
 
-    Thread *pThread = GetThread();
-    StackingAllocator *pStackingAllocator = &pThread->m_MarshalAlloc;
-    CheckPointHolder cph(pStackingAllocator->GetCheckpoint()); //hold checkpoint for autorelease
+    StackingAllocatorHolder sah(&GetThread()->m_MarshalAlloc);
 
-    ClassCompat::MethodTableBuilder builder(this, pStackingAllocator);
+    ClassCompat::MethodTableBuilder builder(this, sah.GetStackingAllocator());
 
     InteropMethodTableData *pData = builder.BuildInteropVTable(pamTracker);
     _ASSERTE(pData);

--- a/src/vm/methodtable.cpp
+++ b/src/vm/methodtable.cpp
@@ -8448,9 +8448,9 @@ InteropMethodTableData *MethodTable::CreateComInteropData(AllocMemTracker *pamTr
         PRECONDITION(GetParentMethodTable() == NULL || GetParentMethodTable()->LookupComInteropData() != NULL);
     } CONTRACTL_END;
 
-    StackingAllocatorHolder sah(&GetThread()->m_MarshalAlloc);
+    ACQUIRE_STACKING_ALLOCATOR(pStackingAllocator);
 
-    ClassCompat::MethodTableBuilder builder(this, sah.GetStackingAllocator());
+    ClassCompat::MethodTableBuilder builder(this, pStackingAllocator);
 
     InteropMethodTableData *pData = builder.BuildInteropVTable(pamTracker);
     _ASSERTE(pData);

--- a/src/vm/methodtable.cpp
+++ b/src/vm/methodtable.cpp
@@ -8448,7 +8448,11 @@ InteropMethodTableData *MethodTable::CreateComInteropData(AllocMemTracker *pamTr
         PRECONDITION(GetParentMethodTable() == NULL || GetParentMethodTable()->LookupComInteropData() != NULL);
     } CONTRACTL_END;
 
-    ClassCompat::MethodTableBuilder builder(this);
+    Thread *pThread = GetThread();
+    StackingAllocator *pStackingAllocator = &pThread->m_MarshalAlloc;
+    CheckPointHolder cph(pStackingAllocator->GetCheckpoint()); //hold checkpoint for autorelease
+
+    ClassCompat::MethodTableBuilder builder(this, pStackingAllocator);
 
     InteropMethodTableData *pData = builder.BuildInteropVTable(pamTracker);
     _ASSERTE(pData);

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -9017,9 +9017,8 @@ MethodTableBuilder::LoadExactInterfaceMap(MethodTable *pMT)
 
         // First we do a GetCheckpoint for the thread-based allocator.  ExpandExactInheritedInterfaces allocates substitution chains
         // on the thread allocator rather than on the stack.
-        Thread * pThread = GetThread();
-        StackingAllocator *pStackingAllocator = &pThread->m_MarshalAlloc;
-        CheckPointHolder cph(pStackingAllocator->GetCheckpoint()); //hold checkpoint for autorelease
+        StackingAllocatorHolder sah(&GetThread()->m_MarshalAlloc);
+        StackingAllocator *pStackingAllocator = sah.GetStackingAllocator();
 
         // ***********************************************************
         // ****** This must be consistent with code:ExpandApproxInterface etc. *******
@@ -12013,8 +12012,6 @@ ClassLoader::CreateTypeHandleForTypeDefThrowing(
 
     MethodTable * pMT = NULL;
 
-    Thread * pThread = GetThread();
-
     MethodTable * pParentMethodTable = NULL;
     SigPointer    parentInst;
     mdTypeDef     tdEnclosing = mdTypeDefNil;
@@ -12037,8 +12034,8 @@ ClassLoader::CreateTypeHandleForTypeDefThrowing(
     // used during class loading.
     // <NICE> Ideally a debug/checked build should pass around tokens indicating the Checkpoint
     // being used and check these dynamically </NICE>
-    StackingAllocator *pStackingAllocator = &pThread->m_MarshalAlloc;
-    CheckPointHolder cph(pStackingAllocator->GetCheckpoint()); //hold checkpoint for autorelease
+    StackingAllocatorHolder sah(&GetThread()->m_MarshalAlloc); //hold checkpoint for autorelease
+    StackingAllocator *pStackingAllocator = sah.GetStackingAllocator();
     
     // Gather up generics info
     MethodTableBuilder::GatherGenericsInfo(pModule, cl, inst, &genericsInfo);

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -2662,7 +2662,7 @@ MethodTableBuilder::EnumerateClassMethods()
         }
 
         // Signature validation
-        if (!GetModule()->IsSystem())
+        if (!bmtProp->fNoSanityChecks)
         {
             hr = validateTokenSig(tok,pMemberSignature,cMemberSignature,dwMemberAttrs,pMDInternalImport);
             if (FAILED(hr))
@@ -2851,8 +2851,8 @@ MethodTableBuilder::EnumerateClassMethods()
         // But first - minimal flags validity checks
         //
         // No methods in Enums!
-#ifndef _DEBUG // Don't run the minimal validity checks for the system dll (except in debug builds so we don't build a bad system dll)
-        if (!GetModule()->IsSystem())
+#ifndef _DEBUG // Don't run the minimal validity checks for the system dll/r2r dlls (except in debug builds so we don't build a bad system dll)
+        if (!bmtProp->fNoSanityChecks)
 #endif
         {
             if (fIsClassEnum)
@@ -9078,7 +9078,9 @@ MethodTableBuilder::LoadExactInterfaceMap(MethodTable *pMT)
         // If there are any __Canon instances in the type argument list, then we defer the
         // ambiguity checking until an exact instantiation.
         // As the C# compiler won't allow an ambiguous generic interface to be generated, we don't
-        // need this logic for CoreLib
+        // need this logic for CoreLib. We can't use the sanity checks flag here, as these ambiguities
+        // are specified to the exact instantiation in use, not just whether or not normal the type is
+        // well formed in metadata.
         if (!pMT->IsSharedByGenericInstantiations() && !pMT->GetModule()->IsSystem())
         {
             // There are no __Canon types in the instantiation, so do ambiguity check.

--- a/src/vm/methodtablebuilder.h
+++ b/src/vm/methodtablebuilder.h
@@ -123,7 +123,8 @@ public:
     static void GatherGenericsInfo(Module *pModule,
                                    mdTypeDef cl,
                                    Instantiation inst,
-                                   bmtGenericsInfo *bmtGenericsInfo);
+                                   bmtGenericsInfo *bmtGenericsInfo,
+                                   StackingAllocator *pStackingAllocator);
 
     MethodTable *
     BuildMethodTableThrowing(
@@ -2426,7 +2427,8 @@ private:
         bmtExactInterfaceInfo *     bmtInfo, 
         MethodTable *               pIntf, 
         const Substitution *        pSubstForTypeLoad_OnStack,  // Allocated on stack!
-        const Substitution *        pSubstForComparing_OnStack  // Allocated on stack!
+        const Substitution *        pSubstForComparing_OnStack, // Allocated on stack!
+        StackingAllocator *         pStackingAllocator
         COMMA_INDEBUG(MethodTable * dbg_pClassMT));
     
 public:
@@ -2444,7 +2446,8 @@ public:
         bmtExactInterfaceInfo * bmtInfo, 
         MethodTable *           pParentMT, 
         const Substitution *    pSubstForTypeLoad, 
-        Substitution *          pSubstForComparing);
+        Substitution *          pSubstForComparing,
+        StackingAllocator *     pStackingAllocator);
 
 public: 
     // --------------------------------------------------------------------------------------------
@@ -2469,7 +2472,8 @@ public:
         bmtInterfaceAmbiguityCheckInfo *,
         Module *pModule, 
         mdToken typeDef,  
-        const Substitution *pSubstChain);
+        const Substitution *pSubstChain,
+        StackingAllocator *pStackingAllocator);
 
 private:
     static void

--- a/src/vm/methodtablebuilder.h
+++ b/src/vm/methodtablebuilder.h
@@ -2438,7 +2438,8 @@ public:
         Module *                    pModule, 
         mdToken                     typeDef, 
         const Substitution *        pSubstForTypeLoad, 
-        Substitution *              pSubstForComparing 
+        Substitution *              pSubstForComparing,
+        StackingAllocator *     pStackingAllocator
         COMMA_INDEBUG(MethodTable * dbg_pClassMT));
     
     static void
@@ -2480,7 +2481,8 @@ private:
     InterfaceAmbiguityCheck(
         bmtInterfaceAmbiguityCheckInfo *,
         const Substitution *pSubstChain, 
-        MethodTable *pIntfMT);
+        MethodTable *pIntfMT,
+        StackingAllocator *pStackingAllocator);
 
 public:
     static void

--- a/src/vm/stackingallocator.cpp
+++ b/src/vm/stackingallocator.cpp
@@ -52,7 +52,6 @@ StackingAllocator::StackingAllocator()
 
     m_FirstBlock = NULL;
     m_FirstFree = NULL;
-    m_InitialBlock = NULL;
     m_DeferredFreeBlock = NULL;
 
 #ifdef _DEBUG
@@ -274,7 +273,7 @@ void StackingAllocator::Collapse(void *CheckpointMarker)
 
     // Special case collapsing back to the initial checkpoint.
     if (c == &s_initialCheckpoint || c->m_OldBlock == NULL) {
-        Clear(m_InitialBlock);
+        Clear(&m_InitialBlock.m_InitialBlockHeader);
         Init(false);
 
         // confirm no buffer overruns

--- a/src/vm/stackingallocator.cpp
+++ b/src/vm/stackingallocator.cpp
@@ -63,9 +63,15 @@ StackingAllocator::StackingAllocator()
         m_MaxAlloc = 0;
 #endif
 
-    Init(true);
+    Init();
 }
 
+StackingAllocator::InitialStackBlock::InitialStackBlock()
+{
+    m_initialBlockHeader.m_Next = NULL;
+    m_initialBlockHeader.m_Length = sizeof(m_dataSpace);
+    INDEBUG(m_initialBlockHeader.m_Sentinal = 0);
+}
 
 StackingAllocator::~StackingAllocator()
 {
@@ -77,7 +83,7 @@ StackingAllocator::~StackingAllocator()
     }
     CONTRACTL_END;
 
-    Clear(NULL);
+    Clear(&m_InitialBlock.m_initialBlockHeader);
  
     if (m_DeferredFreeBlock)
     {
@@ -94,8 +100,32 @@ StackingAllocator::~StackingAllocator()
 #endif
 }
 
+void StackingAllocator::Init()
+{
+    WRAPPER_NO_CONTRACT;
+
+    m_FirstBlock = &m_InitialBlock.m_initialBlockHeader;
+    m_FirstFree = m_FirstBlock->GetData();
+    _ASSERTE((void*)m_FirstFree == (void*)m_InitialBlock.m_dataSpace);
+    m_BytesLeft = static_cast<unsigned>(m_FirstBlock->m_Length);
+}
+
 // Lightweight initial checkpoint
 Checkpoint StackingAllocator::s_initialCheckpoint;
+
+void StackingAllocator::StoreCheckpoint(Checkpoint *c)
+{
+    LIMITED_METHOD_CONTRACT;
+
+#ifdef _DEBUG
+    m_CheckpointDepth++;
+    m_Checkpoints++;
+#endif
+
+    // Record previous allocator state in it.
+    c->m_OldBlock = m_FirstBlock;
+    c->m_OldBytesLeft = m_BytesLeft;
+}
 
 void *StackingAllocator::GetCheckpoint()
 {
@@ -113,7 +143,7 @@ void *StackingAllocator::GetCheckpoint()
     // a special marker, s_initialCheckpoint). This is because we know how to restore the
     // allocator state on a Collapse without having to store any additional
     // context info.
-    if ((m_InitialBlock == NULL) || (m_FirstFree == m_InitialBlock->m_Data))
+    if (m_FirstFree == m_InitialBlock.m_dataSpace)
         return &s_initialCheckpoint;
 
     // Remember the current allocator state.
@@ -171,9 +201,7 @@ bool StackingAllocator::AllocNewBlockForBytes(unsigned n)
         // limit of MinBlockSize and an upper limit of MaxBlockSize. If the
         // request is larger than MaxBlockSize then allocate exactly that
         // amount.
-        // Additionally, if we don't have an initial block yet, use an increased
-        // lower bound for the size, since we intend to cache this block.
-        unsigned lower = m_InitialBlock ? MinBlockSize : InitBlockSize;
+        unsigned lower = MinBlockSize;
         size_t allocSize = sizeof(StackBlock) + max(n, min(max(n * 4, lower), MaxBlockSize));
 
         // Allocate the block.
@@ -191,19 +219,11 @@ bool StackingAllocator::AllocNewBlockForBytes(unsigned n)
 #endif
      }
 
-     // If this is the first block allocated, we record that fact since we
-     // intend to cache it.
-     if (m_InitialBlock == NULL)
-     {
-         _ASSERTE((m_FirstBlock == NULL) && (m_FirstFree == NULL) && (m_BytesLeft == 0));
-         m_InitialBlock = b;
-     }
-
      // Link new block to head of block chain and update internal state to
      // start allocating from this new block.
      b->m_Next = m_FirstBlock;
      m_FirstBlock = b;
-     m_FirstFree = b->m_Data;
+     m_FirstFree = b->GetData();
      // the cast below is safe because b->m_Length is less than MaxBlockSize (4096)
      m_BytesLeft = static_cast<unsigned>(b->m_Length);
 
@@ -273,8 +293,8 @@ void StackingAllocator::Collapse(void *CheckpointMarker)
 
     // Special case collapsing back to the initial checkpoint.
     if (c == &s_initialCheckpoint || c->m_OldBlock == NULL) {
-        Clear(&m_InitialBlock.m_InitialBlockHeader);
-        Init(false);
+        Clear(&m_InitialBlock.m_initialBlockHeader);
+        Init();
 
         // confirm no buffer overruns
         INDEBUG(Validate(m_FirstBlock, m_FirstFree));
@@ -294,33 +314,71 @@ void StackingAllocator::Collapse(void *CheckpointMarker)
 
     // Restore former allocator state.
     m_FirstBlock = pOldBlock;
-    m_FirstFree = &pOldBlock->m_Data[pOldBlock->m_Length - iOldBytesLeft];
+    m_FirstFree = &pOldBlock->GetData()[pOldBlock->m_Length - iOldBytesLeft];
     m_BytesLeft = iOldBytesLeft;
 
     // confirm no buffer overruns
     INDEBUG(Validate(m_FirstBlock, m_FirstFree));
 }
 
-void StackingAllocator::ClearUnallocated()
+#ifdef _DEBUG
+void StackingAllocator::Validate(StackBlock *block, void* spot)
 {
-    WRAPPER_NO_CONTRACT;
-    if (m_DeferredFreeBlock != NULL)
-    {
-        delete [] (char *)m_DeferredFreeBlock;
-        m_DeferredFreeBlock = NULL;
-    }
+    LIMITED_METHOD_CONTRACT;
 
-    if ((m_FirstBlock == m_InitialBlock) && (m_InitialBlock != NULL) && (m_BytesLeft == m_InitialBlock->m_Length))
+    if (!block) 
+        return;
+    _ASSERTE(m_InitialBlock.m_initialBlockHeader.m_Length == sizeof(m_InitialBlock.m_dataSpace));
+    Sentinal* ptr = block->m_Sentinal;
+    _ASSERTE(spot);
+    while(ptr >= spot)
     {
-        // There are no active allocations on this allocator, free the initial block too
-        delete [] (char *)m_InitialBlock;
-        m_FirstBlock = NULL;
-        m_InitialBlock = NULL;
-        m_FirstFree = NULL;
-        m_BytesLeft = 0;
+            // If this assert goes off then someone overwrote their buffer!
+            // A common candidate is PINVOKE buffer run.  To confirm look
+            // up on the stack for NDirect.* Look for the MethodDesc
+            // associated with it.  Be very suspicious if it is one that
+            // has a return string buffer!.  This usually means the end
+            // programmer did not allocate a big enough buffer before passing
+            // it to the PINVOKE method.
+        if (ptr->m_Marker1 != Sentinal::marker1Val)
+            _ASSERTE(!"Memory overrun!! May be bad buffer passed to PINVOKE. turn on logging LF_STUBS level 6 to find method");
+        ptr = ptr->m_Next;
+    }
+    block->m_Sentinal = ptr;
+}
+#endif // _DEBUG
+
+void StackingAllocator::Clear(StackBlock *ToBlock)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    StackBlock *p = m_FirstBlock;
+    StackBlock *q;
+
+    _ASSERTE(ToBlock != NULL);
+
+    while (p != ToBlock)
+    {
+        PREFAST_ASSUME(p != NULL);
+        
+        q = p;
+        p = p->m_Next;
+
+        INDEBUG(Validate(q, q));
+
+        // we don't give the tail block back to the OS
+        // because we can get into situations where we're growing
+        // back and forth over a single seam for a tiny alloc
+        // and the perf is a disaster -- VSWhidbey #100462
+        if (m_DeferredFreeBlock != NULL)
+        {
+            delete [] (char *)m_DeferredFreeBlock;
+        }
+
+        m_DeferredFreeBlock = q;
+        m_DeferredFreeBlock->m_Next = NULL;
     }
 }
-
 void * __cdecl operator new(size_t n, StackingAllocator * alloc)
 {
     STATIC_CONTRACT_THROWS;
@@ -383,3 +441,24 @@ void * __cdecl operator new[](size_t n, StackingAllocator * alloc, const NoThrow
     return alloc->UnsafeAllocNoThrow((unsigned)n);
 }
 
+StackingAllocatorHolder::~StackingAllocatorHolder()
+{
+    m_pStackingAllocator->Collapse(m_checkpointMarker);
+    if (m_owner)
+    {
+        m_thread->m_stackLocalAllocator = NULL;
+        m_pStackingAllocator->~StackingAllocator();
+    }
+}
+
+StackingAllocatorHolder::StackingAllocatorHolder(StackingAllocator *pStackingAllocator, Thread *pThread, bool owner) :
+    m_pStackingAllocator(pStackingAllocator),
+    m_checkpointMarker(pStackingAllocator->GetCheckpoint()),
+    m_thread(pThread),
+    m_owner(owner)
+{
+    if (m_owner)
+    {
+        m_thread->m_stackLocalAllocator = pStackingAllocator;
+    }
+}

--- a/src/vm/stackingallocator.cpp
+++ b/src/vm/stackingallocator.cpp
@@ -302,6 +302,25 @@ void StackingAllocator::Collapse(void *CheckpointMarker)
     INDEBUG(Validate(m_FirstBlock, m_FirstFree));
 }
 
+void StackingAllocator::ClearUnallocated()
+{
+    WRAPPER_NO_CONTRACT;
+    if (m_DeferredFreeBlock != NULL)
+    {
+        delete [] (char *)m_DeferredFreeBlock;
+        m_DeferredFreeBlock = NULL;
+    }
+
+    if ((m_FirstBlock == m_InitialBlock) && (m_InitialBlock != NULL) && (m_BytesLeft == m_InitialBlock->m_Length))
+    {
+        // There are no active allocations on this allocator, free the initial block too
+        delete [] (char *)m_InitialBlock;
+        m_FirstBlock = NULL;
+        m_InitialBlock = NULL;
+        m_FirstFree = NULL;
+        m_BytesLeft = 0;
+    }
+}
 
 void * __cdecl operator new(size_t n, StackingAllocator * alloc)
 {

--- a/src/vm/stackingallocator.h
+++ b/src/vm/stackingallocator.h
@@ -80,9 +80,9 @@ public:
 
     enum
     {
-        MinBlockSize    = 128,
-        MaxBlockSize    = 4096,
-        InitBlockSize   = 512      
+        MinBlockSize    = 0x8000,
+        MaxBlockSize    = 0x8000,
+        InitBlockSize   = 0x8000
     };
 
 #ifndef DACCESS_COMPILE
@@ -196,6 +196,26 @@ public:
 
     void* UnsafeAllocSafeThrow(UINT32 size);
     void* UnsafeAlloc(UINT32 size);
+    void ClearUnallocated()
+    {
+        WRAPPER_NO_CONTRACT;
+        if (m_DeferredFreeBlock != NULL)
+        {
+            delete [] (char *)m_DeferredFreeBlock;
+            m_DeferredFreeBlock = NULL;
+        }
+
+        if ((m_FirstBlock == m_InitialBlock) && (m_BytesLeft == m_InitialBlock->m_Length))
+        {
+            // There are no active allocations on this allocator, free the initial block too
+            delete [] (char *)m_InitialBlock;
+            m_FirstBlock = NULL;
+            m_InitialBlock = NULL;
+            m_FirstFree = NULL;
+            m_BytesLeft = 0;
+        }
+    }
+    
 private:
 
     bool AllocNewBlockForBytes(unsigned n);

--- a/src/vm/stackingallocator.h
+++ b/src/vm/stackingallocator.h
@@ -196,25 +196,7 @@ public:
 
     void* UnsafeAllocSafeThrow(UINT32 size);
     void* UnsafeAlloc(UINT32 size);
-    void ClearUnallocated()
-    {
-        WRAPPER_NO_CONTRACT;
-        if (m_DeferredFreeBlock != NULL)
-        {
-            delete [] (char *)m_DeferredFreeBlock;
-            m_DeferredFreeBlock = NULL;
-        }
-
-        if ((m_FirstBlock == m_InitialBlock) && (m_BytesLeft == m_InitialBlock->m_Length))
-        {
-            // There are no active allocations on this allocator, free the initial block too
-            delete [] (char *)m_InitialBlock;
-            m_FirstBlock = NULL;
-            m_InitialBlock = NULL;
-            m_FirstFree = NULL;
-            m_BytesLeft = 0;
-        }
-    }
+    void ClearUnallocated();
     
 private:
 

--- a/src/vm/stackingallocator.h
+++ b/src/vm/stackingallocator.h
@@ -228,9 +228,21 @@ private :
   Thread *pThread__ACQUIRE_STACKING_ALLOCATOR = GetThread(); \
   StackingAllocator *stackingAllocatorName = pThread__ACQUIRE_STACKING_ALLOCATOR->m_stackLocalAllocator; \
   bool allocatorOwner__ACQUIRE_STACKING_ALLOCATOR = false; \
+  NewHolder<StackingAllocator> heapAllocatedStackingBuffer__ACQUIRE_STACKING_ALLOCATOR; \
+\
   if (stackingAllocatorName == NULL) \
   { \
-      stackingAllocatorName = new (_alloca(sizeof(StackingAllocator))) StackingAllocator; \
+      if (pThread__ACQUIRE_STACKING_ALLOCATOR->CheckCanUseStackAlloc()) \
+      { \
+          stackingAllocatorName = new (_alloca(sizeof(StackingAllocator))) StackingAllocator; \
+      } \
+      else \
+      {\
+          stackingAllocatorName = new (nothrow) StackingAllocator; \
+          if (stackingAllocatorName == NULL) \
+              ThrowOutOfMemory(); \
+          heapAllocatedStackingBuffer__ACQUIRE_STACKING_ALLOCATOR = stackingAllocatorName; \
+      }\
       allocatorOwner__ACQUIRE_STACKING_ALLOCATOR = true; \
   } \
   StackingAllocatorHolder sah_ACQUIRE_STACKING_ALLOCATOR(stackingAllocatorName, pThread__ACQUIRE_STACKING_ALLOCATOR, allocatorOwner__ACQUIRE_STACKING_ALLOCATOR)

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -6437,10 +6437,8 @@ BOOL Thread::SetStackLimits(SetStackLimitScope scope)
             m_CacheStackSufficientExecutionLimit = reinterpret_cast<UINT_PTR>(m_CacheStackBase);
         }
 
-        // Compute the limit used by EnsureSufficientExecutionStack and cache it on the thread. This minimum stack size should
-        // be sufficient to allow a typical non-recursive call chain to execute, including potential exception handling and
-        // garbage collection. Used for probing for available stack space through RuntimeImports.EnsureSufficientExecutionStack,
-        // among other things.
+        // Compute the limit used by CheckCanUseStackAllocand cache it on the thread. This minimum stack size should
+        // be sufficient to avoid all significant risk of a moderate size stack alloc interfering with application behavior
         const UINT_PTR StackAllocNonRiskyExecutionStackSize = 512 * 1024;
         _ASSERTE(m_CacheStackBase >= m_CacheStackLimit);
         if ((reinterpret_cast<UINT_PTR>(m_CacheStackBase) - reinterpret_cast<UINT_PTR>(m_CacheStackLimit)) >

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -8118,8 +8118,6 @@ void Thread::InternalReset(BOOL fNotFinalizerThread, BOOL fThreadObjectResetNeed
         nPriority = ResetManagedThreadObject(nPriority);
     }
 
-    //m_MarshalAlloc.Collapse(NULL);
-
     if (fResetAbort && IsAbortRequested()) {
         UnmarkThreadForAbort(TAR_ALL);
     }

--- a/src/vm/threads.h
+++ b/src/vm/threads.h
@@ -275,7 +275,7 @@ public:
     BOOL IsAddressInStack (PTR_VOID addr) const { return TRUE; }
     static BOOL IsAddressInCurrentStack (PTR_VOID addr) { return TRUE; }
 
-    StackingAllocator    m_MarshalAlloc;
+    StackingAllocator*    m_stackLocalAllocator = NULL;
 
  private:
     LoadLevelLimiter *m_pLoadLimiter;
@@ -438,15 +438,6 @@ public:
 
     DWORD       m_dwLastError;
 };
-
-inline void DoReleaseCheckpoint(void *checkPointMarker)
-{
-    WRAPPER_NO_CONTRACT;
-    GetThread()->m_MarshalAlloc.Collapse(checkPointMarker);
-}
-
-// CheckPointHolder : Back out to a checkpoint on the thread allocator.
-typedef Holder<void*, DoNothing,DoReleaseCheckpoint> CheckPointHolder;
 
 class AVInRuntimeImplOkayHolder
 {
@@ -1691,7 +1682,7 @@ public:
     // is started using a CheckPointHolder and GetCheckpoint, and this region can then be used for allocations
     // from that point onwards, and then all memory is reclaimed when the static scope for the
     // checkpoint is exited by the running thread.
-    StackingAllocator    m_MarshalAlloc;
+    StackingAllocator*    m_stackLocalAllocator = NULL;
 
     // Flags used to indicate tasks the thread has to do.
     ThreadTasks          m_ThreadTasks;
@@ -6335,20 +6326,6 @@ if (g_pConfig->GetGCStressLevel() && g_pConfig->FastGCStressLevel() > 1) {   \
 #define CLEANSTACKFORFASTGCSTRESS()
 
 #endif  // _DEBUG
-
-
-
-
-inline void DoReleaseCheckpoint(void *checkPointMarker)
-{
-    WRAPPER_NO_CONTRACT;
-    GetThread()->m_MarshalAlloc.Collapse(checkPointMarker);
-}
-
-
-// CheckPointHolder : Back out to a checkpoint on the thread allocator.
-typedef Holder<void*, DoNothing, DoReleaseCheckpoint> CheckPointHolder;
-
 
 #ifdef _DEBUG_IMPL
 // Holder for incrementing the ForbidGCLoaderUse counter.

--- a/src/vm/threads.h
+++ b/src/vm/threads.h
@@ -276,6 +276,7 @@ public:
     static BOOL IsAddressInCurrentStack (PTR_VOID addr) { return TRUE; }
 
     StackingAllocator*    m_stackLocalAllocator = NULL;
+    bool CheckCanUseStackAlloc() { return true; }
 
  private:
     LoadLevelLimiter *m_pLoadLimiter;
@@ -3281,6 +3282,16 @@ public:
     // and GetCachedStackBase for the cached values on this Thread.
     static void * GetStackLowerBound();
     static void * GetStackUpperBound();
+
+    bool CheckCanUseStackAlloc()
+    {
+        int local;
+        UINT_PTR current = reinterpret_cast<UINT_PTR>(&local);
+        UINT_PTR limit = GetCachedStackStackAllocNonRiskyExecutionLimit();
+        return (current > limit);
+    }
+#else // DACCESS_COMPILE
+    bool CheckCanUseStackAlloc() { return true; }
 #endif
 
     enum SetStackLimitScope { fAll, fAllowableOnly };
@@ -3294,6 +3305,7 @@ public:
     PTR_VOID GetCachedStackBase() {LIMITED_METHOD_DAC_CONTRACT;  return m_CacheStackBase; }
     PTR_VOID GetCachedStackLimit() {LIMITED_METHOD_DAC_CONTRACT;  return m_CacheStackLimit;}
     UINT_PTR GetCachedStackSufficientExecutionLimit() {LIMITED_METHOD_DAC_CONTRACT; return m_CacheStackSufficientExecutionLimit;}
+    UINT_PTR GetCachedStackStackAllocNonRiskyExecutionLimit() {LIMITED_METHOD_DAC_CONTRACT; return m_CacheStackStackAllocNonRiskyExecutionLimit;}
 
 private:
     // Access the base and limit of the stack. (I.e. the memory ranges that the thread has reserved for its stack).
@@ -3304,6 +3316,7 @@ private:
     PTR_VOID    m_CacheStackBase;
     PTR_VOID    m_CacheStackLimit;
     UINT_PTR    m_CacheStackSufficientExecutionLimit;
+    UINT_PTR    m_CacheStackStackAllocNonRiskyExecutionLimit;
 
 #define HARD_GUARD_REGION_SIZE GetOsPageSize()
 

--- a/src/vm/threadsuspend.cpp
+++ b/src/vm/threadsuspend.cpp
@@ -2970,6 +2970,7 @@ void Thread::PulseGCMode()
     if (PreemptiveGCDisabled() && CatchAtSafePoint())
     {
         EnablePreemptiveGC();
+        m_MarshalAlloc.ClearUnallocated();
         DisablePreemptiveGC();
     }
 }

--- a/src/vm/threadsuspend.cpp
+++ b/src/vm/threadsuspend.cpp
@@ -2970,7 +2970,6 @@ void Thread::PulseGCMode()
     if (PreemptiveGCDisabled() && CatchAtSafePoint())
     {
         EnablePreemptiveGC();
-        m_MarshalAlloc.ClearUnallocated();
         DisablePreemptiveGC();
     }
 }


### PR DESCRIPTION
- Disable interface ambiguity checks in Corelib
- Improve StackingAllocator perf
  - Increase size of allocation blocks
  - Cleanup allocation blocks comletely on gc suspension
- Check for presence of generic parameters to methods in a more efficient manner
  - Querying the count of GenericParameter records requires a binary search in the GenericParams table
  - Checking the generic flag on the method signature is effectively free
- Skip unnecessary checks in EnumerateClassMethods for corelib
- Use slightly faster hashtable functions in StringLiteralMap
  - Remove pointless string literal entry hash table search