### PR TITLE
Fix failures caused by ICU regression

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Globalization/CalendarData.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CalendarData.Unix.cs
@@ -39,7 +39,11 @@ namespace System.Globalization
             // TODO-NULLABLE: these can return null but are later replaced with String.Empty or other non-nullable value
             result &= GetCalendarInfo(localeName, calendarId, CalendarDataType.NativeName, out this.sNativeName!);
             result &= GetCalendarInfo(localeName, calendarId, CalendarDataType.MonthDay, out this.sMonthDay!);
-            this.sMonthDay = NormalizeDatePattern(this.sMonthDay);
+
+            if (this.sMonthDay != null)
+            {
+                this.sMonthDay = NormalizeDatePattern(this.sMonthDay);
+            }
 
             result &= EnumDatePatterns(localeName, calendarId, CalendarDataType.ShortDates, out this.saShortDates!);
             result &= EnumDatePatterns(localeName, calendarId, CalendarDataType.LongDates, out this.saLongDates!);

--- a/src/System.Private.CoreLib/shared/System/Globalization/CalendarData.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CalendarData.cs
@@ -112,7 +112,8 @@ namespace System.Globalization
 
             if (!LoadCalendarDataFromSystem(localeName, calendarId))
             {
-                Debug.Fail("[CalendarData] LoadCalendarDataFromSystem call isn't expected to fail for calendar " + calendarId + " locale " + localeName);
+                // LoadCalendarDataFromSystem sometimes can fail on Linux if the installed ICU package is missing some resources.
+                // The ICU package can miss some resources in some cases like if someone compile and build the ICU package manually or ICU has a regression.
 
                 // Something failed, try invariant for missing parts
                 // This is really not good, but we don't want the callers to crash.


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/37098

.NET Core depends on ICU when running on Linux/OSX. Recently some people raised some failure on the framework stack. After investigation we found a regression in ICU which is the root cause of this failure. The regression is, when calling ICU to get some date patterns/properties, in some cases ICU return error code U_MISSING_RESOURCE_ERROR. Although the framework code written to fallback to some invariant values at that time, but we had some wrong line of code which assumed we never fail and trying to access the returned value without checking. That cause the framework to throw NullReferenceException.

The fix here is to make the framework resilient against such cases and continue to run nicely. I have contact ICU support members and I learned there is similar issue tracked in ICU repo https://unicode-org.atlassian.net/browse/ICU-20558