### PR TITLE
Fix crash after unload with server GC

### DIFF
--- a/src/vm/domainfile.cpp
+++ b/src/vm/domainfile.cpp
@@ -2406,6 +2406,12 @@ void DomainAssembly::EnumStaticGCRefs(promote_func* fn, ScanContext* sc)
          GCHeapUtilities::IsServerHeap()   &&
          IsGCSpecialThread());
 
+    if (IsCollectible())
+    {
+        // Collectible assemblies have statics stored in managed arrays, so they don't need special handlings
+        return;
+    }
+
     DomainModuleIterator i = IterateModules(kModIterIncludeLoaded);
     while (i.Next())
     {


### PR DESCRIPTION
When server GC is on, the DomainAssembly::EnumStaticGCRefs is called to
enumerate GC statics. For collectible assemblies, the GC statics are
stored in managed arrays and so there is no need for a special
enumeration of the GC statics. Attempt to do that was causing a crash
due to the fact that the corresponding DomainLocalModule::m_pGCStatics
is always NULL for collectible assemblies and we were trying to access
it.

Close #24140