### PR TITLE
Enable fine-grained and universal exclusions for CoreFX tests

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -2169,8 +2169,9 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                                 def workspaceRelativeFxRoot = "_/fx"
                                 def absoluteFxRoot = "%WORKSPACE%\\_\\fx"
                                 def fxBranch = getFxBranch(branch)
+                                def exclusionRspPath = "%WORKSPACE%\\tests\\scripts\\run-corefx-tests-exclusions.txt"
 
-                                buildCommands += "python -u %WORKSPACE%\\tests\\scripts\\run-corefx-tests.py -arch ${arch} -ci_arch ${architecture} -build_type ${configuration} -fx_root ${absoluteFxRoot} -fx_branch ${fxBranch} -env_script ${envScriptPath}"
+                                buildCommands += "python -u %WORKSPACE%\\tests\\scripts\\run-corefx-tests.py -arch ${arch} -ci_arch ${architecture} -build_type ${configuration} -fx_root ${absoluteFxRoot} -fx_branch ${fxBranch} -env_script ${envScriptPath} -exclusion_rsp_file ${exclusionRspPath}"
 
                                 // Archive and process (only) the test results
                                 Utilities.addArchival(newJob, "${workspaceRelativeFxRoot}/artifacts/bin/**/testResults.xml", "", /* doNotFailIfNothingArchived */ true, /* archiveOnlyIfSuccessful */ false)
@@ -2403,8 +2404,9 @@ def static calculateBuildCommands(def newJob, def scenario, def branch, def isPR
                             def workspaceRelativeFxRoot = "_/fx"
                             def absoluteFxRoot = "\$WORKSPACE/${workspaceRelativeFxRoot}"
                             def fxBranch = getFxBranch(branch)
+                            def exclusionRspPath = "\$WORKSPACE%/tests/scripts/run-corefx-tests-exclusions.txt"
 
-                            buildCommands += "python -u \$WORKSPACE/tests/scripts/run-corefx-tests.py -arch ${architecture} -ci_arch ${architecture} -build_type ${configuration} -fx_root ${absoluteFxRoot} -fx_branch ${fxBranch} -env_script ${scriptFileName}"
+                            buildCommands += "python -u \$WORKSPACE/tests/scripts/run-corefx-tests.py -arch ${architecture} -ci_arch ${architecture} -build_type ${configuration} -fx_root ${absoluteFxRoot} -fx_branch ${fxBranch} -env_script ${scriptFileName} -exclusion_rsp_file ${exclusionRspPath}"
 
                             // Archive and process (only) the test results
                             Utilities.addArchival(newJob, "${workspaceRelativeFxRoot}/artifacts/bin/**/testResults.xml", "", /* doNotFailIfNothingArchived */ true, /* archiveOnlyIfSuccessful */ false)
@@ -2989,7 +2991,8 @@ def static CreateWindowsArmTestJob(def dslFactory, def project, def architecture
                 def corefx_runtime_path   = "%WORKSPACE%\\_\\fx\\artifacts\\bin\\testhost\\netcoreapp-Windows_NT-Release-${architecture}"
                 def corefx_tests_dir      = "%WORKSPACE%\\_\\fx\\artifacts\\bin\\tests"
                 def corefx_exclusion_file = "%WORKSPACE%\\tests\\${architecture}\\corefx_test_exclusions.txt"
-                batchFile("call %WORKSPACE%\\tests\\scripts\\run-corefx-tests.bat ${corefx_runtime_path} ${corefx_tests_dir} ${corefx_exclusion_file} ${architecture}")
+                def exclusionRspPath      = "%WORKSPACE%\\tests\\scripts\\run-corefx-tests-exclusions.txt"
+                batchFile("call %WORKSPACE%\\tests\\scripts\\run-corefx-tests.bat ${corefx_runtime_path} ${corefx_tests_dir} ${corefx_exclusion_file} ${architecture} ${exclusionRspPath}")
 
             } else { // !isCoreFxScenario(scenario)
 
@@ -3374,8 +3377,9 @@ python -u \${WORKSPACE}/tests/scripts/run-pmi-diffs.py -arch ${architecture} -ci
                 shell("tar -czf dasm.${os}.${architecture}.${configuration}.tgz ./_/pmi/asm")
             }
             else if (doCoreFxTesting) {
+                def exclusionRspPath = "\${WORKSPACE}/tests/scripts/run-corefx-tests-exclusions.txt"
                 shell("""\
-\${WORKSPACE}/tests/scripts/run-corefx-tests.sh --test-exclude-file \${WORKSPACE}/tests/${architecture}/corefx_linux_test_exclusions.txt --runtime \${WORKSPACE}/${workspaceRelativeFxRootLinux}/artifacts/bin/testhost/netcoreapp-Linux-Release-${architecture} --arch ${architecture} --corefx-tests \${WORKSPACE}/${workspaceRelativeFxRootLinux}/artifacts/bin --configurationGroup Release""")
+\${WORKSPACE}/tests/scripts/run-corefx-tests.sh --test-exclude-file \${WORKSPACE}/tests/${architecture}/corefx_linux_test_exclusions.txt --runtime \${WORKSPACE}/${workspaceRelativeFxRootLinux}/artifacts/bin/testhost/netcoreapp-Linux-Release-${architecture} --arch ${architecture} --corefx-tests \${WORKSPACE}/${workspaceRelativeFxRootLinux}/artifacts/bin --configurationGroup Release --exclusion-rsp-file ${exclusionRspPath}""")
             }
             else {
                 def runScript = "${dockerCmd}./tests/runtest.sh"

--- a/tests/scripts/run-corefx-tests-exclusions.txt
+++ b/tests/scripts/run-corefx-tests-exclusions.txt
@@ -1,0 +1,14 @@
+# This is a "response file" used to pass fine-grained test exclusions to the
+# corefx xunit test wrapper scripts, RunTests.cmd or RunTests.sh. Lines here
+# should be in a format that xunit understands. Lines beginning with '#' are
+# comment lines and are ignored.
+#
+# Please list a GitHub issue for every exclusion.
+
+# https://github.com/dotnet/coreclr/issues/24159
+-nomethod "System.Buffers.Tests.ArrayBufferWriterTests_Byte.Advance"
+-nomethod "System.Buffers.Tests.ArrayBufferWriterTests_Char.Advance"
+
+# https://github.com/dotnet/coreclr/issues/22442
+-nomethod "Microsoft.Win32.SystemEventsTests.CreateTimerTests.ConcurrentTimers"
+-nomethod "Microsoft.Win32.SystemEventsTests.SessionSwitchTests.SignalsSessionSwitch"

--- a/tests/scripts/run-corefx-tests.bat
+++ b/tests/scripts/run-corefx-tests.bat
@@ -18,6 +18,8 @@ echo ^<tests dir^>           -- Path to corefx test tree, e.g., _\fx\bin\tests
 echo ^<test exclusion file^> -- Path to test exclusion file, e.g., C:\coreclr\tests\arm\corefx_test_exclusions.txt
 echo ^<architecture^>        -- Architecture to run, either ARM or ARM64. (We can't depend on PROCESSOR_ARCHITECTURE because
 echo                            the batch script might be invoked with an ARM64 CMD but we need to run ARM.)
+echo ^<exclusion rsp file^>  -- Path to test exclusion response file, passed to RunTests.cmd and then xunit, e.g.,
+echo                            C:\coreclr\tests\scripts\run-corefx-tests-exclusions.txt
 echo.
 echo The ^<test exclusion file^> is a file with a list of assemblies for which the
 echo tests should not be run. This allows excluding failing tests by excluding the
@@ -28,22 +30,26 @@ echo.
 echo     System.Console.Tests
 echo     System.Data.SqlClient.Tests
 echo     System.Diagnostics.Process.Tests
+echo.
+echo The ^<exclusion rsp file^> is in the form expected by xunit.console.dll as a response file.
 goto :eof
 
 :start
-if "%4"=="" goto usage
-if not "%5"=="" goto usage
+if "%5"=="" goto usage
+if not "%6"=="" goto usage
 
 set _runtime_path=%1
 set _tests_dir=%2
 set _exclusion_file=%3
 set _architecture=%4
+set _exclusion_rsp_file=%5
 
 echo Running CoreFX tests
 echo Using runtime: %_runtime_path%
 echo Using tests: %_tests_dir%
 echo Using test exclusion file: %_exclusion_file%
 echo Using architecture: %_architecture%
+echo Using exclusion response file: %_exclusion_rsp_file%
 
 set _pass=0
 set _fail=0
@@ -81,7 +87,7 @@ if %errorlevel% EQU 0 (
     echo COREFX TEST %_t3% EXCLUDED
     set /A _skipped=_skipped + 1
 ) else (
-    call :run %1\RunTests.cmd --runtime-path %_runtime_path%
+    call :run %1\RunTests.cmd --runtime-path %_runtime_path% --rsp-file %_exclusion_rsp_file%
 )
 goto :eof
 

--- a/tests/scripts/run-corefx-tests.sh
+++ b/tests/scripts/run-corefx-tests.sh
@@ -327,9 +327,9 @@ run_test()
 
     echo
     echo "Running tests in $dirName"
-    echo "${TimeoutTool}./RunTests.sh --runtime-path $Runtime"
+    echo "${TimeoutTool}./RunTests.sh --runtime-path $Runtime --rsp-file $ExclusionRspFile"
     echo
-    ${TimeoutTool}./RunTests.sh --runtime-path "$Runtime"
+    ${TimeoutTool}./RunTests.sh --runtime-path "$Runtime" --rsp-file "$ExclusionRspFile"
     exitCode=$?
 
     if [ $exitCode -ne 0 ] ; then
@@ -457,6 +457,10 @@ do
 
         --test-exclude-file)
             TestExcludeFile=$2
+            ;;
+
+        --exclusion-rsp-file)
+            ExclusionRspFile=$2
             ;;
 
         --timeout)


### PR DESCRIPTION
One problem we've had in coreclr Jenkins when running corefx
tests (in the coreclr outerloop runs -- the ones using the
run-corefx-tests.py harness) is the inability to exclude
failing tests for x86 or x64, and the inability to have
fine-grained exclusions. This has led to problems like
https://github.com/dotnet/coreclr/issues/22442 where
virtually all Windows x86 and x64 corefx runs fail due to
timeouts. And issues like https://github.com/dotnet/coreclr/issues/24159
where all corefx test legs fail, and we have no control
over exclusions to get them all passing again quickly.

Now that the corefx RunTests.cmd/sh wrapper scripts
parse named arguments, including a response file that
is passed on to xunit, and also that the corefx used
xunit has support for this response file as well as
fine-grained exclusions (per-method/per-class/per-namespace),
we can take advantage of it.

This change adds a single, global, corefx xunit exclusion
response file, that will be used for all platforms. Since this
run-corefx-tests.py mechanism is not expected to live much longer,
this seems sufficient.