### PR TITLE
Match managed DetermineLibraryNameVariations implementation to native DetermineLibNameVariations implementation.

### DIFF
--- a/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyDependencyResolver.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyDependencyResolver.cs
@@ -232,6 +232,8 @@ namespace System.Runtime.Loader
             yield return new LibraryNameVariation(string.Empty, string.Empty);
 
             if (isRelativePath &&
+                libName.Contains('.') &&
+                !libName.EndsWith('.') &&
                 !libName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) &&
                 !libName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
             {
@@ -294,15 +296,6 @@ namespace System.Runtime.Loader
                         yield return new LibraryNameVariation(LibraryNamePrefix, string.Empty);
                     }
                 }
-            }
-
-            yield return new LibraryNameVariation(string.Empty, string.Empty);
-
-            if (isRelativePath &&
-                !libName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) &&
-                !libName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
-            {
-                yield return new LibraryNameVariation(string.Empty, LibraryNameSuffix);
             }
         }
 #endif

--- a/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyDependencyResolver.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyDependencyResolver.cs
@@ -232,8 +232,6 @@ namespace System.Runtime.Loader
             yield return new LibraryNameVariation(string.Empty, string.Empty);
 
             if (isRelativePath &&
-                libName.Contains('.') &&
-                !libName.EndsWith('.') &&
                 !libName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) &&
                 !libName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyDependencyResolver.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyDependencyResolver.cs
@@ -259,7 +259,7 @@ namespace System.Runtime.Loader
             else
             {
                 bool containsSuffix = false;
-                int indexOfSuffix = libName.IndexOf(LibraryNameSuffix);
+                int indexOfSuffix = libName.IndexOf(LibraryNameSuffix, StringComparison.OrdinalIgnoreCase);
                 if (indexOfSuffix >= 0)
                 {
                     indexOfSuffix += LibraryNameSuffix.Length;


### PR DESCRIPTION
Fixes #24187 