### PR TITLE
Removing EventPipe file polling (EventPipeController+Timer)

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/Timer.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Timer.cs
@@ -470,14 +470,8 @@ namespace System.Threading
                 }
                 else
                 {
-                    if (
-#if CORECLR
-                        // Don't emit this event during EventPipeController.  This avoids initializing FrameworkEventSource during start-up which is expensive relative to the rest of start-up.
-                        !EventPipeController.Initializing &&
-#endif
-                        FrameworkEventSource.Log.IsEnabled(EventLevel.Informational, FrameworkEventSource.Keywords.ThreadTransfer))
+                    if (FrameworkEventSource.Log.IsEnabled(EventLevel.Informational, FrameworkEventSource.Keywords.ThreadTransfer))
                         FrameworkEventSource.Log.ThreadTransferSendObj(this, 1, string.Empty, true, (int)dueTime, (int)period);
-
                     success = _associatedTimerQueue.UpdateTimer(this, dueTime, period);
                 }
             }

--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeController.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeController.cs
@@ -197,7 +197,7 @@ namespace System.Diagnostics.Tracing
         {
             get
             {
-                string? stringValue = CompatibilitySwitch.GetValueInternal("EnableEventPipe");
+                string? stringValue = CompatibilitySwitch.GetValueInternal("EventPipeCircularMB");
                 if ((stringValue == null) || (!uint.TryParse(stringValue, out uint value)))
                 {
                     value = DefaultCircularBufferMB;

--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeController.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeController.cs
@@ -13,12 +13,10 @@ namespace System.Diagnostics.Tracing
     /// Simple out-of-process listener for controlling EventPipe.
     /// The following environment variables are used to configure EventPipe:
     ///  - COMPlus_EnableEventPipe=1 : Enable EventPipe immediately for the life of the process.
-    ///  - COMPlus_EnableEventPipe=4 : Enables this controller and creates a thread to listen for enable/disable events.
     ///  - COMPlus_EventPipeConfig : Provides the configuration in xperf string form for which providers/keywords/levels to be enabled.
     ///                              If not specified, the default configuration is used.
     ///  - COMPlus_EventPipeOutputFile : The full path to the netperf file to be written.
     ///  - COMPlus_EventPipeCircularMB : The size in megabytes of the circular buffer.
-    /// NOTE: If COMPlus_EnableEventPipe != 4 then this listener is not created and does not add any overhead to the process.
     /// </summary>
     internal static class EventPipeController
     {

--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeController.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeController.cs
@@ -37,16 +37,11 @@ namespace System.Diagnostics.Tracing
 
         private static bool IsControllerInitialized { get; set; } = false;
 
-        // Initialization flag used to avoid initializing FrameworkEventSource on the startup path.
-        internal static bool Initializing { get; private set; }
-
         internal static void Initialize()
         {
             // Don't allow failures to propagate upstream.  Ensure program correctness without tracing.
             try
             {
-                Initializing = true;
-
                 if (!IsControllerInitialized)
                 {
                     if (Config_EnableEventPipe > 0)
@@ -56,17 +51,12 @@ namespace System.Diagnostics.Tracing
                         EventPipe.Enable(BuildConfigFromEnvironment());
                     }
 
-                    // If enable is explicitly set to 0, then don't start the controller (to avoid overhead).
                     RuntimeEventSource.Initialize();
 
                     IsControllerInitialized = true;
                 }
             }
             catch { }
-            finally
-            {
-                Initializing = false;
-            }
         }
 
         private static EventPipeConfiguration BuildConfigFromEnvironment()


### PR DESCRIPTION
This feature was a temporary workaround to enable/disable tracing from out-of-proc by dropping a config file in a location where the runtime could find, but it has been superseded in favor of EventPipe using IPC and dotnet-trace.