### PR TITLE
Postponing the managed callback so that they are called after the lock acquisition

### DIFF
--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -234,6 +234,8 @@ public:
 
 typedef UINT64 EventPipeSessionID;
 
+class EventPipeProviderCallbackDataQueue;
+
 class EventPipe
 {
     // Declare friends.
@@ -272,6 +274,8 @@ public:
     // Create a provider.
     static EventPipeProvider *CreateProvider(const SString &providerName, EventPipeCallback pCallbackFunction = NULL, void *pCallbackData = NULL);
 
+    static EventPipeProvider *CreateProvider(const SString &providerName, EventPipeCallback pCallbackFunction, void *pCallbackData, EventPipeProviderCallbackDataQueue* pEventPipeProviderCallbackDataQueue);
+
     // Get a provider.
     static EventPipeProvider *GetProvider(const SString &providerName);
 
@@ -305,14 +309,15 @@ private:
     // The counterpart to WriteEvent which after the payload is constructed
     static void WriteEventInternal(EventPipeEvent &event, EventPipeEventPayload &payload, LPCGUID pActivityId = NULL, LPCGUID pRelatedActivityId = NULL);
 
-    static void DisableInternal(EventPipeSessionID id);
+    static void DisableInternal(EventPipeSessionID id, EventPipeProviderCallbackDataQueue* pEventPipeProviderCallbackDataQueue);
 
     // Enable the specified EventPipe session.
     static EventPipeSessionID Enable(
         LPCWSTR strOutputPath,
         EventPipeSession *const pSession,
         EventPipeSessionType sessionType,
-        IpcStream *const pStream);
+        IpcStream *const pStream,
+        EventPipeProviderCallbackDataQueue* pEventPipeProviderCallbackDataQueue);
 
     static void CreateFlushTimerCallback();
 

--- a/src/vm/eventpipeconfiguration.h
+++ b/src/vm/eventpipeconfiguration.h
@@ -26,6 +26,36 @@ enum class EventPipeEventLevel
     Verbose
 };
 
+struct EventPipeProviderCallbackData
+{
+    LPCWSTR pFilterData;
+    EventPipeCallback pCallbackFunction;
+    bool enabled;
+    INT64 keywords;
+    EventPipeEventLevel providerLevel;
+    void* pCallbackData;
+};
+
+struct EventPipeProviderCallbackDataNode
+{
+    EventPipeProviderCallbackData* value;
+    EventPipeProviderCallbackDataNode* prev;
+};
+
+class EventPipeProviderCallbackDataQueue
+{
+public:
+    EventPipeProviderCallbackDataQueue();
+
+    void Enqueue(EventPipeProviderCallbackData* pEventPipeProviderCallbackData);
+
+    bool TryDequeue(EventPipeProviderCallbackData* pEventPipeProviderCallbackData);
+
+private:
+    EventPipeProviderCallbackDataNode* front;
+    EventPipeProviderCallbackDataNode* back;
+};
+
 class EventPipeConfiguration
 {
 public:
@@ -36,13 +66,13 @@ public:
     void Initialize();
 
     // Create a new provider.
-    EventPipeProvider *CreateProvider(const SString &providerName, EventPipeCallback pCallbackFunction, void *pCallbackData);
+    EventPipeProvider *CreateProvider(const SString &providerName, EventPipeCallback pCallbackFunction, void *pCallbackData, EventPipeProviderCallbackDataQueue* pEventPipeProviderCallbackDataQueue);
 
     // Delete a provider.
     void DeleteProvider(EventPipeProvider *pProvider);
 
     // Register a provider.
-    bool RegisterProvider(EventPipeProvider &provider);
+    bool RegisterProvider(EventPipeProvider &provider, EventPipeProviderCallbackDataQueue* pEventPipeProviderCallbackDataQueue);
 
     // Unregister a provider.
     bool UnregisterProvider(EventPipeProvider &provider);
@@ -64,10 +94,10 @@ public:
     size_t GetCircularBufferSize() const;
 
     // Enable a session in the event pipe.
-    void Enable(EventPipeSession *pSession);
+    void Enable(EventPipeSession *pSession, EventPipeProviderCallbackDataQueue* pEventPipeProviderCallbackDataQueue);
 
     // Disable a session in the event pipe.
-    void Disable(EventPipeSession *pSession);
+    void Disable(EventPipeSession *pSession, EventPipeProviderCallbackDataQueue* pEventPipeProviderCallbackDataQueue);
 
     // Get the status of the event pipe.
     bool Enabled() const;
@@ -76,7 +106,7 @@ public:
     bool RundownEnabled() const;
 
     // Enable rundown using the specified configuration.
-    void EnableRundown(EventPipeSession *pSession);
+    void EnableRundown(EventPipeSession *pSession, EventPipeProviderCallbackDataQueue* pEventPipeProviderCallbackDataQueue);
 
     // Get the event used to write metadata to the event stream.
     EventPipeEventInstance *BuildEventMetadataEvent(EventPipeEventInstance &sourceInstance, unsigned int metdataId);

--- a/src/vm/eventpipeprovider.h
+++ b/src/vm/eventpipeprovider.h
@@ -78,13 +78,16 @@ private:
 
     // Set the provider configuration (enable and disable sets of events).
     // This is called by EventPipeConfiguration.
-    void SetConfiguration(bool providerEnabled, INT64 keywords, EventPipeEventLevel providerLevel, LPCWSTR pFilterData);
+    EventPipeProviderCallbackData SetConfiguration(bool providerEnabled, INT64 keywords, EventPipeEventLevel providerLevel, LPCWSTR pFilterData);
 
     // Refresh the runtime state of all events.
     void RefreshAllEvents();
 
+    // Prepare the data required for invoking callback
+    EventPipeProviderCallbackData PrepareCallbackData(LPCWSTR pFilterData);
+
     // Invoke the provider callback.
-    void InvokeCallback(LPCWSTR pFilterData);
+    static void InvokeCallback(EventPipeProviderCallbackData eventPipeProviderCallbackData);
 
     // Specifies whether or not the provider was deleted, but that deletion
     // was deferred until after tracing is stopped.

--- a/src/vm/sampleprofiler.cpp
+++ b/src/vm/sampleprofiler.cpp
@@ -36,7 +36,7 @@ HINSTANCE SampleProfiler::s_hMultimediaLib = NULL;
 typedef MMRESULT (WINAPI *TimePeriodFnPtr) (UINT uPeriod);
 #endif //FEATURE_PAL
 
-void SampleProfiler::Enable()
+void SampleProfiler::Enable(EventPipeProviderCallbackDataQueue* pEventPipeProviderCallbackDataQueue)
 {
     CONTRACTL
     {
@@ -53,7 +53,7 @@ void SampleProfiler::Enable()
 
     if(s_pEventPipeProvider == NULL)
     {
-        s_pEventPipeProvider = EventPipe::CreateProvider(SL(s_providerName));
+        s_pEventPipeProvider = EventPipe::CreateProvider(SL(s_providerName), nullptr, nullptr, pEventPipeProviderCallbackDataQueue);
         s_pThreadTimeEvent = s_pEventPipeProvider->AddEvent(
             0, /* eventID */
             0, /* keywords */

--- a/src/vm/sampleprofiler.h
+++ b/src/vm/sampleprofiler.h
@@ -26,7 +26,7 @@ class SampleProfiler
     public:
 
         // Enable profiling.
-        static void Enable();
+        static void Enable(EventPipeProviderCallbackDataQueue* pEventPipeProviderCallbackDataQueue);
 
         // Disable profiling.
         static void Disable();


### PR DESCRIPTION
In the current code, when `EventPipeProvider::SetConfiguration(...)` is called, it invokes a callback. The callback might be anything, including, but not limited to, being managed code, trigger gc, write more events, and so on. 

Right now, the callback is invoked while `EventPipe::GetLock()` is held, leading to the potential to deadlocks. Let say it attempts to acquires a managed lock `A` during the callback, while another thread already held managed lock `A` and will not relinquish until something involving `EventPipe::GetLock()` is done (such as enabling a provider), then we will have a deadlock. We cannot blame the user's code since it is not aware of the existence of `EventPipe::GetLock()`.

A possible solution to the problem is to ensure the callback is invoked without holding the lock. The change achieves this by accumulating all the callback data and invokes them after the lock is relinquished. This removes the possibility that a managed lock is taken after `EventPipe::GetLock()`, at the cost of a slightly modified behavior that the callbacks are invoked slightly later than it was.

