### PR TITLE
Fix verification of 3-byte UTF-8 sequence followed by non-ASCII byte

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Text/Unicode/Utf8Utility.Validation.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/Unicode/Utf8Utility.Validation.cs
@@ -390,16 +390,16 @@ namespace System.Text.Unicode
                         // Can't extract this check into its own helper method because JITter produces suboptimal
                         // assembly, even with aggressive inlining.
 
-                        // Code below becomes 5 instructions: test, jz, add, test, jz
+                        // Code below becomes 5 instructions: test, jz, lea, test, jz
 
-                        if (((thisDWord & 0x0000_200Fu) == 0) || (((thisDWord -= 0x0000_200Du) & 0x0000_200Fu) == 0))
+                        if (((thisDWord & 0x0000_200Fu) == 0) || (((thisDWord - 0x0000_200Du) & 0x0000_200Fu) == 0))
                         {
                             goto Error; // overlong or surrogate
                         }
                     }
                     else
                     {
-                        if (((thisDWord & 0x0F20_0000u) == 0) || (((thisDWord -= 0x0D20_0000u) & 0x0F20_0000u) == 0))
+                        if (((thisDWord & 0x0F20_0000u) == 0) || (((thisDWord - 0x0D20_0000u) & 0x0F20_0000u) == 0))
                         {
                             goto Error; // overlong or surrogate
                         }


### PR DESCRIPTION
(Caught while fuzzing the UTF-8 validation logic. This is a regression in Preview 5.)

In the UTF-8 validation logic, the "overlong or surrogate 3-byte sequence?" check was also modifying the value of `thisDWord`, which was causing the ASCII draining logic (around 20 lines below this change) to return the wrong value.

Consider the input sequence `[ E7 8B 80 80 ]`. The first three bytes are the well-formed UTF-8 sequence corresponding to the scalar value `U+72C0` (狀); the last byte is an invalid standalone `[ 80 ]`.

At the start of the loop, this is read into a DWORD in machine-endian order and undergoes the following transformations.

```txt
0x80_80_8B_E7     ; original DWORD read
0x80_80_0B_27     ; check for 2-byte sequence (this check will fail and we'll move on)
0x80_00_0B_07     ; check for 3-byte sequence (this check will succeed)
0x7F_FF_EA_FA     ; inadvertent mutation while checking for surrogate sequence
```

We wanted to leave the most significant bit unperturbed so that we could smear its value while performing the ASCII draining logic, but due to the subtraction operation we inadvertently clear the high bit due to the arithmetic carry. The end result is that the ASCII drain logic treats the final byte as an ASCII byte instead of as a non-ASCII byte, causing APIs like `Encoding.UTF8.GetCharCount` to return the wrong value or `Encoding.UTF8.GetString` to throw unexpectedly.

The fix is to replace `-=` with `-` in the conditional check, which will ensure the high bit remains untouched. We could also have written `thisDWord += 0x0080_0000u - 0x0000_200Du`, which would have left the high bit untouched while still only requiring a single register (results in `add` instead of `lea`), but the PR as currently submitted seemed cleaner.

I _believe_ these methods will only fail if a developer has instantiated the encoder with a `DecoderReplacementFallback` whose replacement string is 0 or 2+ characters, which is not a common operation. So this shouldn't affect the majority of application developers.

I don't believe the transcoding logic is affected by this bug. It seems to affect only the validation / character counting logic, and only when a custom replacement fallback is in use. `Encoding.UTF8.GetString(...)` will still always return a correct value as far as I can tell.