### PR TITLE
Fix NUMA node for heap when NUMA is not available

### DIFF
--- a/src/gc/windows/gcenv.windows.cpp
+++ b/src/gc/windows/gcenv.windows.cpp
@@ -1332,20 +1332,20 @@ bool GCToOSInterface::GetProcessorForHeap(uint16_t heap_number, uint16_t* proc_n
         GroupProcNo groupProcNo(gn, gpn);
         *proc_no = groupProcNo.GetCombinedValue();
 
+        PROCESSOR_NUMBER procNumber;
+
+        if (CanEnableGCCPUGroups())
+        {
+            procNumber.Group = gn;
+        }
+        else
+        {
+            // Get the current processor group
+            GetCurrentProcessorNumberEx(&procNumber);
+        }
+
         if (GCToOSInterface::CanEnableGCNumaAware())
         {
-            PROCESSOR_NUMBER procNumber;
-
-            if (CanEnableGCCPUGroups())
-            {
-                procNumber.Group = gn;
-            }
-            else
-            {
-                // Get the current processor group
-                GetCurrentProcessorNumberEx(&procNumber);
-            }
-
             procNumber.Number   = (BYTE)gpn;
             procNumber.Reserved = 0;
 
@@ -1356,7 +1356,7 @@ bool GCToOSInterface::GetProcessorForHeap(uint16_t heap_number, uint16_t* proc_n
         }
         else
         {   // no numa setting, each cpu group is treated as a node
-            *node_no = groupProcNo.GetGroup();
+            *node_no = procNumber.Group;
         }
     }
 

--- a/src/vm/gcenv.os.cpp
+++ b/src/vm/gcenv.os.cpp
@@ -982,20 +982,20 @@ bool GCToOSInterface::GetProcessorForHeap(uint16_t heap_number, uint16_t* proc_n
         GroupProcNo groupProcNo(gn, gpn);
         *proc_no = groupProcNo.GetCombinedValue();
 
+        PROCESSOR_NUMBER procNumber;
+
+        if (CPUGroupInfo::CanEnableGCCPUGroups())
+        {
+            procNumber.Group = gn;
+        }
+        else
+        {
+            // Get the current processor group
+            GetCurrentProcessorNumberEx(&procNumber);
+        }
+
         if (GCToOSInterface::CanEnableGCNumaAware())
         {
-            PROCESSOR_NUMBER procNumber;
-
-            if (CPUGroupInfo::CanEnableGCCPUGroups())
-            {
-                procNumber.Group = gn;
-            }
-            else
-            {
-                // Get the current processor group
-                GetCurrentProcessorNumberEx(&procNumber);
-            }
-
             procNumber.Number   = (BYTE)gpn;
             procNumber.Reserved = 0;
 
@@ -1006,7 +1006,7 @@ bool GCToOSInterface::GetProcessorForHeap(uint16_t heap_number, uint16_t* proc_n
         }
         else
         {   // no numa setting, each cpu group is treated as a node
-            *node_no = groupProcNo.GetGroup();
+            *node_no = procNumber.Group;
         }
 #else // !FEATURE_PAL
         *proc_no = procIndex;


### PR DESCRIPTION
The recent refactoring of the GCToOSInterface::GetProcessorForHeap has
accidentally changed the NUMA node returned in case NUMA is disabled
(either via the COMPlus_GCNumaAware or due to the fact that there is
just a single NUMA node on the system) and the CPU groups are disabled.
Before that refactoring, the code was incorrectly returning 0 as the
NUMA node when CPU groups were disabled no matter whether NUMA was
enabled or disabled. The refactoring fixed that by returning the
current CPU group number for the case when NUMA was enabled, however
it still returned incorrect value, this time GroupProcNo::NoGroup as
the NUMA node number in case NUMA was disabled.

The effect of this is that VirtualAllocExNuma fails (due to the nndpreferred being 
larger than the max numa nodes supported by Windows) and we fall back to 
regular VirtualAlloc. This happens only in gc_heap::virtual_alloc_commit_for_heap,
we don't pass numa node to CToOSInterface::VirtualCommit at other places.

This change fixes it by returning the current group number in this case.