### PR TITLE
Fix running JitBench on Linux

### DIFF
--- a/tests/src/performance/Scenario/JitBench/Benchmarks/WebAppBenchmarks.cs
+++ b/tests/src/performance/Scenario/JitBench/Benchmarks/WebAppBenchmarks.cs
@@ -275,7 +275,7 @@ namespace JitBench
         }
 
         private const string JitBenchRepoUrl = "https://github.com/aspnet/JitBench";
-        private const string JitBenchCommitSha1Id = "6bee730486f272d31f23f1033225090511f856f3";
+        private const string JitBenchCommitSha1Id = "e863c5f9543b4101c41fdd04730ca30684d1f913";
         private const string StoreDirName = ".store";
         private readonly Metric StartupMetric = new Metric("Startup", "ms");
         private readonly Metric FirstRequestMetric = new Metric("First Request", "ms");

--- a/tests/src/performance/Scenario/JitBench/Benchmarks/WebAppBenchmarks.cs
+++ b/tests/src/performance/Scenario/JitBench/Benchmarks/WebAppBenchmarks.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using System.Runtime.InteropServices;
 using Microsoft.Xunit.Performance.Api;
 
 namespace JitBench
@@ -99,11 +100,12 @@ namespace JitBench
         private async Task CreateStore(DotNetInstallation dotNetInstall, string outputDir, ITestOutputHelper output)
         {
             string tfm = DotNetSetup.GetTargetFrameworkMonikerForFrameworkVersion(dotNetInstall.FrameworkVersion);
-            string rid = $"win7-{dotNetInstall.Architecture}";
             string storeDirName = ".store";
-            await new ProcessRunner("powershell.exe", $".\\AspNet-GenerateStore.ps1 -InstallDir {storeDirName} -Architecture {dotNetInstall.Architecture} -Runtime {rid}")
+            await (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+                    new ProcessRunner("powershell.exe", $".\\AspNet-GenerateStore.ps1 -InstallDir {storeDirName} -Architecture {dotNetInstall.Architecture} -Runtime win7-{dotNetInstall.Architecture}") :
+                    new ProcessRunner("bash", $"./aspnet-generatestore.sh --install-dir {storeDirName} --architecture {dotNetInstall.Architecture} --runtime-id linux-{dotNetInstall.Architecture} -f {tfm} --fx-version {dotNetInstall.FrameworkVersion}"))
                 .WithWorkingDirectory(GetJitBenchRepoRootDir(outputDir))
-                .WithEnvironmentVariable("PATH", $"{dotNetInstall.DotNetDir};{Environment.GetEnvironmentVariable("PATH")}")
+                .WithEnvironmentVariable("PATH", $"{dotNetInstall.DotNetDir}{Path.PathSeparator}{Environment.GetEnvironmentVariable("PATH")}")
                 .WithEnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0")
                 .WithEnvironmentVariable("JITBENCH_TARGET_FRAMEWORK_MONIKER", tfm)
                 .WithEnvironmentVariable("JITBENCH_FRAMEWORK_VERSION", dotNetInstall.FrameworkVersion)

--- a/tests/src/performance/Scenario/JitBench/Runner/Benchmark.cs
+++ b/tests/src/performance/Scenario/JitBench/Runner/Benchmark.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -142,7 +142,7 @@ namespace JitBench
                 string[] args = new string[] { "--perf:collect", string.Join("+", run.MetricNames), "--perf:outputdir", run.OutputDir, "--perf:runid", run.BenchviewRunId };
                 using (var harness = new XunitPerformanceHarness(args))
                 {
-                    ProcessStartInfo startInfo = new ProcessStartInfo(run.DotNetInstallation.DotNetExe, (ExePath + " " + CommandLineArguments).Trim());
+                    ProcessStartInfo startInfo = new ProcessStartInfo(run.DotNetInstallation.DotNetExe, $"{ExePath} {CommandLineArguments}");
                     startInfo.WorkingDirectory = WorkingDirPath;
                     startInfo.RedirectStandardError = true;
                     startInfo.RedirectStandardOutput = true;

--- a/tests/src/performance/Scenario/JitBench/Utilities/DotNetSetup.cs
+++ b/tests/src/performance/Scenario/JitBench/Utilities/DotNetSetup.cs
@@ -215,7 +215,7 @@ namespace JitBench
 
         public static string GetRuntimeDownloadLink(string azureFeed, string version, string os, string arch)
         {
-            return string.Format("{0}/Runtime/{1}/dotnet-runtime-{1}-{2}-{3}.zip", azureFeed, version, os, arch);
+            return string.Format("{0}/Runtime/{1}/dotnet-runtime-{1}-{2}-{3}.{4}", azureFeed, version, os, arch, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "zip" : "tar.gz");
         }
 
         public static string GetSDKDownloadLink(string version, Architecture arch)
@@ -230,7 +230,7 @@ namespace JitBench
 
         public static string GetSDKDownloadLink(string azureFeed, string version, string os, string arch)
         {
-            return string.Format("{0}/Sdk/{1}/dotnet-sdk-{1}-{2}-{3}.zip", azureFeed, version, os, arch);
+            return string.Format("{0}/Sdk/{1}/dotnet-sdk-{1}-{2}-{3}.{4}", azureFeed, version, os, arch, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "zip" : "tar.gz");
         }
 
         public static string GetTargetFrameworkMonikerForFrameworkVersion(string runtimeVersion)

--- a/tests/src/performance/Scenario/JitBench/Utilities/FileTasks.cs
+++ b/tests/src/performance/Scenario/JitBench/Utilities/FileTasks.cs
@@ -15,8 +15,7 @@ namespace JitBench
     {
         public async static Task DownloadAndUnzip(string remotePath, string localExpandedDirPath, ITestOutputHelper output, bool deleteTempFiles=true)
         {
-            string tempFileNameBase = Guid.NewGuid().ToString();
-            string tempDownloadPath = Path.Combine(Path.GetTempPath(), tempFileNameBase + Path.GetExtension(remotePath));
+            string tempDownloadPath = Path.Combine(Path.GetTempPath(), Path.GetFileName(remotePath));
             Download(remotePath, tempDownloadPath, output);
             await Unzip(tempDownloadPath, localExpandedDirPath, output, true);
         }
@@ -51,8 +50,7 @@ namespace JitBench
                 bool deleteTar = deleteZippedFiles;
                 if(tempTarPath == null)
                 {
-                    string tempFileNameBase = Guid.NewGuid().ToString();
-                    tempTarPath = Path.Combine(Path.GetTempPath(), tempFileNameBase + ".tar");
+                    tempTarPath = Path.Combine(Path.GetTempPath(), zipPath.Substring(0, zipPath.Length - ".gz".Length));
                     deleteTar = true;
                 }
                 await UnGZip(zipPath, tempTarPath, output);


### PR DESCRIPTION
You can now do ` dotnet run -p tests/src/performance/Scenario/JitBench/unofficial_dotnet -c Release -- --perf:outputdir /tmp/jitbench --iterations 2 --benchmark "MusicStore"` and it just works.