### PR TITLE
Add config value for JitHost Slab cache maximum size

### DIFF
--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -369,6 +369,8 @@ RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_StackSamplingNumMethods, W("StackSamplingNu
 RETAIL_CONFIG_STRING_INFO_EX(INTERNAL_AltJitNgen, W("AltJitNgen"), "Enables AltJit for NGEN and selectively limits it to the specified methods.", CLRConfig::REGUTIL_default)
 #endif // defined(ALLOW_SXS_JIT_NGEN)
 
+RETAIL_CONFIG_DWORD_INFO(EXTERNAL_JitHostMaxSlabCache, W("JitHostMaxSlabCache"), 0x1000000, "Sets jit host max slab cache size, 16MB default")
+
 RETAIL_CONFIG_DWORD_INFO_DIRECT_ACCESS(EXTERNAL_JitOptimizeType, W("JitOptimizeType"), "")
 RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_JitPrintInlinedMethods, W("JitPrintInlinedMethods"), 0, "", CLRConfig::REGUTIL_default)
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_JitTelemetry, W("JitTelemetry"), 1, "If non-zero, gather JIT telemetry data")

--- a/src/vm/eeconfig.cpp
+++ b/src/vm/eeconfig.cpp
@@ -211,6 +211,8 @@ HRESULT EEConfig::Init()
     dwSpinRetryCount = 0xA;
     dwMonitorSpinCount = 0;
 
+    dwJitHostMaxSlabCache = 0;
+
     iJitOptimizeType = OPT_DEFAULT;
     fJitFramed = false;
     fJitAlignLoops = false;
@@ -1002,6 +1004,8 @@ HRESULT EEConfig::sync()
     dwSpinLimitConstant = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_SpinLimitConstant);
     dwSpinRetryCount = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_SpinRetryCount);
     dwMonitorSpinCount = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_Monitor_SpinCount);
+
+    dwJitHostMaxSlabCache = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_JitHostMaxSlabCache);
 
     fJitFramed = (GetConfigDWORD_DontUse_(CLRConfig::UNSUPPORTED_JitFramed, fJitFramed) != 0);
     fJitAlignLoops = (GetConfigDWORD_DontUse_(CLRConfig::UNSUPPORTED_JitAlignLoops, fJitAlignLoops) != 0);

--- a/src/vm/eeconfig.h
+++ b/src/vm/eeconfig.h
@@ -272,6 +272,8 @@ public:
     DWORD         MonitorSpinCount(void)          const {LIMITED_METHOD_CONTRACT;  return dwMonitorSpinCount; }
 
     // Jit-config
+
+    DWORD         JitHostMaxSlabCache(void)         const {LIMITED_METHOD_CONTRACT;  return dwJitHostMaxSlabCache; }
     
     unsigned int  GenOptimizeType(void)             const {LIMITED_METHOD_CONTRACT;  return iJitOptimizeType; }
     bool          JitFramed(void)                   const {LIMITED_METHOD_CONTRACT;  return fJitFramed; }
@@ -781,6 +783,8 @@ private: //----------------------------------------------------------------
     bool fInited;                   // have we synced to the registry at least once?
 
     // Jit-config
+
+    DWORD dwJitHostMaxSlabCache; // max size for jit host slab cache
 
     bool fJitFramed;           // Enable/Disable EBP based frames
     bool fJitAlignLoops;       // Enable/Disable loop alignment

--- a/src/vm/jithost.cpp
+++ b/src/vm/jithost.cpp
@@ -119,7 +119,7 @@ void JitHost::freeSlab(void* slab, size_t actualSize)
     {
         CrstHolder lock(&m_jitSlabAllocatorCrst);
 
-        if (m_totalCached < 0x1000000) // Do not cache more than 16MB
+        if (m_totalCached < g_pConfig->JitHostMaxSlabCache()) // Do not cache more than maximum allowed value
         {
             m_totalCached += actualSize;
 


### PR DESCRIPTION
This change allows to tune cache size, reduction of which allows to reduce Private_Dirty memory of Tizen Xamarin applications on 1.2 Mb in average.

cc @alpencolt @alexander-aksenov