### PR TITLE
Fix optAssertionProp_Update.

### DIFF
--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -3905,9 +3905,18 @@ GenTree* Compiler::optAssertionProp_Update(GenTree* newTree, GenTree* tree, GenT
             GenTree**    useEdge  = linkData.result;
             GenTree*     parent   = linkData.parent;
             noway_assert(useEdge != nullptr);
-            assert(parent != nullptr);
 
-            parent->ReplaceOperand(useEdge, newTree);
+            if (parent != nullptr)
+            {
+                parent->ReplaceOperand(useEdge, newTree);
+            }
+            else
+            {
+                // If there's no parent, the tree being replaced is the root of the
+                // statement.
+                assert((stmt->gtStmtExpr == tree) && (&stmt->gtStmtExpr == useEdge));
+                stmt->gtStmtExpr = newTree;
+            }
 
             // We only need to ensure that the gtNext field is set as it is used to traverse
             // to the next node in the tree. We will re-morph this entire statement in

--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -3901,7 +3901,8 @@ GenTree* Compiler::optAssertionProp_Update(GenTree* newTree, GenTree* tree, GenT
         // locate our parent node and update it so that it points to newTree.
         if (newTree != tree)
         {
-            GenTree** link = gtFindLink(stmt, tree);
+            FindLinkData linkData = gtFindLink(stmt, tree);
+            GenTree**    link     = linkData.result;
             noway_assert(link != nullptr);
 
             // Replace the old operand with the newTree

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2994,7 +2994,14 @@ public:
     static fgWalkPreFn gtMarkColonCond;
     static fgWalkPreFn gtClearColonCond;
 
-    GenTree** gtFindLink(GenTreeStmt* stmt, GenTree* node);
+    struct FindLinkData
+    {
+        GenTree*  nodeToFind;
+        GenTree** result;
+        GenTree*  parent;
+    };
+
+    FindLinkData gtFindLink(GenTreeStmt* stmt, GenTree* node);
     bool gtHasCatchArg(GenTree* tree);
 
     typedef ArrayStack<GenTree*> GenTreeStack;

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -7948,6 +7948,9 @@ GenTree* Compiler::gtGetThisArg(GenTreeCall* call)
             fgArgTabEntry* thisArgTabEntry = gtArgEntryByArgNum(call, argNum);
             GenTree*       result          = thisArgTabEntry->node;
 
+            // Assert if we used DEBUG_DESTROY_NODE.
+            assert(result->gtOper != GT_COUNT);
+
 #if !FEATURE_FIXED_OUT_ARGS && defined(DEBUG)
             // Check that call->fgArgInfo used in gtArgEntryByArgNum was not
             // left outdated by assertion propogation updates.
@@ -7972,6 +7975,7 @@ GenTree* Compiler::gtGetThisArg(GenTreeCall* call)
                 index++;
             }
 #endif // !FEATURE_FIXED_OUT_ARGS && defined(DEBUG)
+
             return result;
         }
     }
@@ -15162,42 +15166,37 @@ Compiler::fgWalkResult Compiler::gtClearColonCond(GenTree** pTree, fgWalkData* d
     return WALK_CONTINUE;
 }
 
-struct FindLinkData
-{
-    GenTree*  nodeToFind;
-    GenTree** result;
-};
-
 /*****************************************************************************
  *
  *  Callback used by the tree walker to implement fgFindLink()
  */
 static Compiler::fgWalkResult gtFindLinkCB(GenTree** pTree, Compiler::fgWalkData* cbData)
 {
-    FindLinkData* data = (FindLinkData*)cbData->pCallbackData;
+    Compiler::FindLinkData* data = (Compiler::FindLinkData*)cbData->pCallbackData;
     if (*pTree == data->nodeToFind)
     {
         data->result = pTree;
+        data->parent = cbData->parent;
         return Compiler::WALK_ABORT;
     }
 
     return Compiler::WALK_CONTINUE;
 }
 
-GenTree** Compiler::gtFindLink(GenTreeStmt* stmt, GenTree* node)
+Compiler::FindLinkData Compiler::gtFindLink(GenTreeStmt* stmt, GenTree* node)
 {
-    FindLinkData data = {node, nullptr};
+    FindLinkData data = {node, nullptr, nullptr};
 
     fgWalkResult result = fgWalkTreePre(&stmt->gtStmtExpr, gtFindLinkCB, &data);
 
     if (result == WALK_ABORT)
     {
         assert(data.nodeToFind == *data.result);
-        return data.result;
+        return data;
     }
     else
     {
-        return nullptr;
+        return {node, nullptr, nullptr};
     }
 }
 

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -2364,7 +2364,8 @@ public:
             // Walk the statement 'stmt' and find the pointer
             // in the tree is pointing to 'exp'
             //
-            GenTree** link = m_pCompiler->gtFindLink(stmt, exp);
+            Compiler::FindLinkData linkData = m_pCompiler->gtFindLink(stmt, exp);
+            GenTree**              link     = linkData.result;
 
 #ifdef DEBUG
             if (link == nullptr)

--- a/tests/src/JIT/Regression/JitBlue/GitHub_24185/GitHub_24185.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_24185/GitHub_24185.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+// The test shows recursive assertion propogation in one statement.
+
+namespace GitHub_24185
+{
+    public class Program
+    {
+        static int Main(string[] args)
+        {
+            try
+            {
+                throw new AggregateException(new Exception("A random exception1"), new Exception("A random exception2"));
+            }
+            catch (Exception e)
+            {
+                // Each expression in this condition checks that `e` is not null and checks its type.
+                // This information should be calculated once and propogated by assertion propogation.
+                if (!(e is AggregateException) ||                    
+                    !((((AggregateException)e).InnerExceptions[0] is ArgumentException) 
+                    || ((AggregateException)e).InnerExceptions[0] is AggregateException))
+                {
+                    return 100;
+                }
+
+            }
+            return 0;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_24185/GitHub_24185.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_24185/GitHub_24185.csproj
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
736291405a: Add few comments and format `gtGetThisArg`.

332bd2ec8a: Change `gtFindLink` to return the parent in addition to the link.

6418fcf88c: Fix parent's links in `fgArgInfo` in optAssertionProp_Update. <- **this change fixes the issue.**

e5decb744c: Add a repro test.

0bf52e4304: Use `ReplaceOperand`.

Fixes #24185