### PR TITLE
Improve Precision to 10 microseconds in timespan

### DIFF
--- a/src/System.Private.CoreLib/shared/System/TimeSpan.cs
+++ b/src/System.Private.CoreLib/shared/System/TimeSpan.cs
@@ -239,11 +239,10 @@ namespace System
         {
             if (double.IsNaN(value))
                 throw new ArgumentException(SR.Arg_CannotBeNaN);
-            double tmp = value * scale;
-            double millis = tmp + (value >= 0 ? 0.5 : -0.5);
+            double millis = value * scale;
             if ((millis > long.MaxValue / TicksPerMillisecond) || (millis < long.MinValue / TicksPerMillisecond))
                 throw new OverflowException(SR.Overflow_TimeSpanTooLong);
-            return new TimeSpan((long)millis * TicksPerMillisecond);
+            return new TimeSpan((long)(millis * TicksPerMillisecond));
         }
 
         public static TimeSpan FromMilliseconds(double value)

--- a/src/System.Private.CoreLib/shared/System/TimeSpan.cs
+++ b/src/System.Private.CoreLib/shared/System/TimeSpan.cs
@@ -196,7 +196,7 @@ namespace System
 
         public static TimeSpan FromDays(double value)
         {
-            return Interval(value, MillisPerDay);
+            return Interval(value, TicksPerDay);
         }
 
         public TimeSpan Duration()
@@ -232,27 +232,27 @@ namespace System
 
         public static TimeSpan FromHours(double value)
         {
-            return Interval(value, MillisPerHour);
+            return Interval(value, TicksPerHour);
         }
 
-        private static TimeSpan Interval(double value, int scale)
+        private static TimeSpan Interval(double value, double scale)
         {
             if (double.IsNaN(value))
                 throw new ArgumentException(SR.Arg_CannotBeNaN);
             double millis = value * scale;
-            if ((millis > long.MaxValue / TicksPerMillisecond) || (millis < long.MinValue / TicksPerMillisecond))
+            if ((millis > long.MaxValue) || (millis < long.MinValue))
                 throw new OverflowException(SR.Overflow_TimeSpanTooLong);
-            return new TimeSpan((long)(millis * TicksPerMillisecond));
+            return new TimeSpan((long)millis);
         }
 
         public static TimeSpan FromMilliseconds(double value)
         {
-            return Interval(value, 1);
+            return Interval(value, TicksPerMillisecond);
         }
 
         public static TimeSpan FromMinutes(double value)
         {
-            return Interval(value, MillisPerMinute);
+            return Interval(value, TicksPerMinute);
         }
 
         public TimeSpan Negate()
@@ -264,7 +264,7 @@ namespace System
 
         public static TimeSpan FromSeconds(double value)
         {
-            return Interval(value, MillisPerSecond);
+            return Interval(value, TicksPerSecond);
         }
 
         public TimeSpan Subtract(TimeSpan ts)

--- a/tests/CoreFX/CoreFX.issues.json
+++ b/tests/CoreFX/CoreFX.issues.json
@@ -1016,6 +1016,40 @@
         }
     },
     {
+        "name": "System.Runtime",
+        "enabled": true,
+        "exclusions": {
+            "namespaces": null,
+            "classes": null,
+            "methods": [
+                {
+                    "name": "System.Tests.TimeSpanTests.FromMilliseconds",
+                    "reason": "The test will be enabled after https://github.com/dotnet/corefx/pull/37235"
+                },
+                {
+                    "name": "System.Tests.TimeSpanTests.FromMilliseconds_Invalid",
+                    "reason": "The test will be enabled after https://github.com/dotnet/corefx/pull/37235"
+                },
+                {
+                    "name": "System.Tests.TimeSpanTests.NamedMultiplication",
+                    "reason": "The test will be enabled after https://github.com/dotnet/corefx/pull/37235"
+                },
+                {
+                    "name": "System.Tests.TimeSpanTests.Multiplication",
+                    "reason": "The test will be enabled after https://github.com/dotnet/corefx/pull/37235"
+                },
+                {
+                    "name": "System.Tests.TimeSpanTests.Division",
+                    "reason": "The test will be enabled after https://github.com/dotnet/corefx/pull/37235"
+                },
+                {
+                    "name": "System.Tests.TimeSpanTests.NamedDivision",
+                    "reason": "The test will be enabled after https://github.com/dotnet/corefx/pull/37235"
+                },
+            ]
+        }
+    },
+    {
         "name": "System.Runtime.Extensions.Tests",
         "enabled": true,
         "exclusions": {

--- a/tests/CoreFX/CoreFX.issues.json
+++ b/tests/CoreFX/CoreFX.issues.json
@@ -1046,6 +1046,82 @@
                     "name": "System.Tests.TimeSpanTests.NamedDivision",
                     "reason": "The test will be enabled after https://github.com/dotnet/corefx/pull/37235"
                 },
+                {
+                    "name": "System.Text.Tests.StringBuilderTests.Equals",
+                    "reason": "Because of a change in StringBuilder, this test is outdated."
+                },
+                {
+                    "name": "System.Tests.DecimalTests.Remainder",
+                    "reason": "https://github.com/dotnet/coreclr/issues/12605"
+                },
+                {
+                    "name": "System.Tests.DecimalTests.Remainder_Invalid",
+                    "reason": "https://github.com/dotnet/coreclr/issues/12605"
+                },
+                {
+                    "name": "System.Tests.DecimalTests+BigIntegerMod.Test",
+                    "reason": "https://github.com/dotnet/coreclr/issues/12605"
+                },
+                {
+                    "name": "System.Tests.DecimalTests.Round_InvalidMidpointRounding_ThrowsArgumentException",
+                    "reason": "outdated"
+                },
+                {
+                    "name": "System.Tests.ArrayTests.Copy",
+                    "reason": "Needs updates for XUnit 2.4"
+                },
+                {
+                    "name": "System.Tests.ArraySegment_Tests.CopyTo_Invalid",
+                    "reason": "Needs parameter name updated to 'destination'."
+                },
+                {
+                    "name": "System.Tests.TimeSpanTests.Parse_Invalid",
+                    "reason": "Temporary disabling till merging the PR https://github.com/dotnet/corefx/pull/34561"
+                },
+                {
+                    "name": "System.Tests.TimeSpanTests.Parse_Span",
+                    "reason": "Temporary disabling till merging the PR https://github.com/dotnet/corefx/pull/34561"
+                },
+                {
+                    "name": "System.Tests.TimeSpanTests.Parse_Span_Invalid",
+                    "reason": "Temporary disabling till merging the PR https://github.com/dotnet/corefx/pull/34561"
+                },
+                {
+                    "name": "System.Tests.TimeSpanTests.Parse",
+                    "reason": "Temporary disabling till merging the PR https://github.com/dotnet/corefx/pull/34561"
+                },
+                {
+                    "name": "System.Tests.SingleTests.Test_ToString",
+                    "reason" : "https://github.com/dotnet/coreclr/pull/22040"
+                },
+                {
+                    "name": "System.Tests.SingleTests.TryFormat",
+                    "reason" : "https://github.com/dotnet/coreclr/pull/22040"
+                },
+                {
+                    "name": "System.Tests.DoubleTests.Test_ToString",
+                    "reason" : "https://github.com/dotnet/coreclr/pull/22040"
+                },
+                {
+                    "name": "System.Tests.DoubleTests.TryFormat",
+                    "reason" : "https://github.com/dotnet/coreclr/pull/22040"
+                },
+                {
+                    "name": "System.Tests.TimeSpanTests.Total_Days_Hours_Minutes_Seconds_Milliseconds",
+                    "reason" : "https://github.com/dotnet/coreclr/pull/22040"
+                },
+                {
+                    "name": "System.Tests.BufferTests.BlockCopy_Invalid",
+                    "reason": "https://github.com/dotnet/coreclr/pull/23636"
+                },
+                {
+                    "name": "System.Tests.VersionTests.Comparisons_NullArgument_ThrowsArgumentNullException",
+                    "reason":  "Version was improved to no longer throw from comparison operators"
+                },
+                {
+                    "name" : "System.Tests.ActivatorNetcoreTests.CreateInstanceAssemblyResolve",
+                    "reason" : "Waiting for https://github.com/dotnet/corefx/pull/37080"
+                }
             ]
         }
     },
@@ -1374,92 +1450,6 @@
                 }
             ],
             "methods": null
-        }
-    },
-    {
-        "name": "System.Runtime.Tests",
-        "enabled": true,
-        "exclusions": {
-            "namespaces": null,
-            "classes": null,
-            "methods": [
-                {
-                    "name": "System.Text.Tests.StringBuilderTests.Equals",
-                    "reason": "Because of a change in StringBuilder, this test is outdated."
-                },
-                {
-                    "name": "System.Tests.DecimalTests.Remainder",
-                    "reason": "https://github.com/dotnet/coreclr/issues/12605"
-                },
-                {
-                    "name": "System.Tests.DecimalTests.Remainder_Invalid",
-                    "reason": "https://github.com/dotnet/coreclr/issues/12605"
-                },
-                {
-                    "name": "System.Tests.DecimalTests+BigIntegerMod.Test",
-                    "reason": "https://github.com/dotnet/coreclr/issues/12605"
-                },
-                {
-                    "name": "System.Tests.DecimalTests.Round_InvalidMidpointRounding_ThrowsArgumentException",
-                    "reason": "outdated"
-                }, 
-                {
-                    "name": "System.Tests.ArrayTests.Copy",
-                    "reason": "Needs updates for XUnit 2.4"
-                },
-                {
-                    "name": "System.Tests.ArraySegment_Tests.CopyTo_Invalid",
-                    "reason": "Needs parameter name updated to 'destination'."
-                },
-                {
-                    "name": "System.Tests.TimeSpanTests.Parse_Invalid",
-                    "reason": "Temporary disabling till merging the PR https://github.com/dotnet/corefx/pull/34561"
-                },
-                {
-                    "name": "System.Tests.TimeSpanTests.Parse_Span",
-                    "reason": "Temporary disabling till merging the PR https://github.com/dotnet/corefx/pull/34561"
-                },
-                {
-                    "name": "System.Tests.TimeSpanTests.Parse_Span_Invalid",
-                    "reason": "Temporary disabling till merging the PR https://github.com/dotnet/corefx/pull/34561"
-                },
-                {
-                    "name": "System.Tests.TimeSpanTests.Parse",
-                    "reason": "Temporary disabling till merging the PR https://github.com/dotnet/corefx/pull/34561"
-                },
-                {
-                    "name": "System.Tests.SingleTests.Test_ToString",
-                    "reason" : "https://github.com/dotnet/coreclr/pull/22040"
-                },
-                {
-                    "name": "System.Tests.SingleTests.TryFormat",
-                    "reason" : "https://github.com/dotnet/coreclr/pull/22040"
-                },
-                {
-                    "name": "System.Tests.DoubleTests.Test_ToString",
-                    "reason" : "https://github.com/dotnet/coreclr/pull/22040"
-                },
-                {
-                    "name": "System.Tests.DoubleTests.TryFormat",
-                    "reason" : "https://github.com/dotnet/coreclr/pull/22040"
-                },
-                {
-                    "name": "System.Tests.TimeSpanTests.Total_Days_Hours_Minutes_Seconds_Milliseconds",
-                    "reason" : "https://github.com/dotnet/coreclr/pull/22040"
-                },
-                {
-                    "name": "System.Tests.BufferTests.BlockCopy_Invalid",
-                    "reason": "https://github.com/dotnet/coreclr/pull/23636"
-                },
-                {
-                    "name": "System.Tests.VersionTests.Comparisons_NullArgument_ThrowsArgumentNullException",
-                    "reason":  "Version was improved to no longer throw from comparison operators"
-                },
-                {
-                    "name" : "System.Tests.ActivatorNetcoreTests.CreateInstanceAssemblyResolve",
-                    "reason" : "Waiting for https://github.com/dotnet/corefx/pull/37080"
-                }
-            ]
         }
     },
     {

--- a/tests/CoreFX/CoreFX.issues.json
+++ b/tests/CoreFX/CoreFX.issues.json
@@ -1016,7 +1016,7 @@
         }
     },
     {
-        "name": "System.Runtime",
+        "name": "System.Runtime.Tests",
         "enabled": true,
         "exclusions": {
             "namespaces": null,


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/32430
Related corefx PR https://github.com/dotnet/corefx/pull/37235

```
double millis = tmp + (value >= 0 ? 0.5 : -0.5);
```

This line was added  because casting double to long was dropping the decimal part and we expect it to rounded off. This wont be the case anymore.