### PR TITLE
Add missing check for UTF-16 low surrogate char at start of buffer

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Text/Unicode/Utf16Utility.Validation.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/Unicode/Utf16Utility.Validation.cs
@@ -325,15 +325,15 @@ namespace System.Text.Unicode
                             // or palignr available to us, we'll do this as a loop. We won't look at
                             // the very last high surrogate char element since we don't yet know if
                             // the next vector read will have a low surrogate char element.
+                            
+                            if (lowSurrogateChars[0] != 0)
+                            {
+                                goto Error; // error: start of buffer contains standalone low surrogate char
+                            }
 
                             ushort surrogatePairsCount = 0;
                             for (int i = 0; i < Vector<ushort>.Count - 1; i++)
                             {
-                                if (lowSurrogateChars[0] != 0)
-                                {
-                                    goto NonVectorizedLoop; // error: start of buffer contains standalone low surrogate char
-                                }
-
                                 surrogatePairsCount -= highSurrogateChars[i]; // turns into +1 or +0
                                 if (highSurrogateChars[i] != lowSurrogateChars[i + 1])
                                 {

--- a/src/System.Private.CoreLib/shared/System/Text/Unicode/Utf16Utility.Validation.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/Unicode/Utf16Utility.Validation.cs
@@ -329,6 +329,11 @@ namespace System.Text.Unicode
                             ushort surrogatePairsCount = 0;
                             for (int i = 0; i < Vector<ushort>.Count - 1; i++)
                             {
+                                if (lowSurrogateChars[0] != 0)
+                                {
+                                    goto NonVectorizedLoop; // error: start of buffer contains standalone low surrogate char
+                                }
+
                                 surrogatePairsCount -= highSurrogateChars[i]; // turns into +1 or +0
                                 if (highSurrogateChars[i] != lowSurrogateChars[i + 1])
                                 {


### PR DESCRIPTION
(Found by the fuzzing run. Regression in Preview 5.)

The method `Encoding.UTF8.GetByteCount(chars)` can sometimes return an incorrect value if __all__ of the following conditions hold:

* The first character of the UTF-16 input string must be a standalone low surrogate code unit, or all characters in the string before this standalone low surrogate code unit must have been ASCII characters. (There are other variations on this pattern, but this is the easiest way to trigger the bug.)
* Including this standalone UTF-16 low surrogate code unit, enough data remains in the input string to fill a `Vector<ushort>`.
* A custom replacement fallback mechanism has been set on the `UTF8Encoding` instance.
* SSE2 is not available, perhaps because the application has been precompiled using crossgen or because the current arch is not x86-based.

The easiest way to repro the issue is to run the below console application with the environment variable `COMPLUS_ENABLESSE2=0` set.

```cs
static void Main(string[] args)
{
    var encoding = Encoding.GetEncoding("utf-8", new EncoderReplacementFallback("BAD!"), DecoderFallback.ExceptionFallback);
    char[] chars = new char[Vector<ushort>.Count];
    chars[0] = '\uD800';
    Console.WriteLine(encoding.GetByteCount(chars));    // outputs '11', this is correct

    chars[0] = '\uDC00';
    Console.WriteLine(encoding.GetByteCount(chars));    // outputs '10', should be '11'
    return;
}
```

This is very similar to https://github.com/dotnet/coreclr/pull/24235 in terms of how it affects real-world applications. First, the bug manifests only in the "count the number of output bytes" step of the `GetBytes` method. The actual transcoding operation (where the output array is populated) does not have the same bug.

Second, the bug does not manifest unless the fallback mechanism has been replaced on the `UTF8Encoding` instance. The reason for this is that the byte counting step incorrectly reports that the invalid standalone UTF-16 surrogate code unit `U+DC00` would fall into the range of scalar values which requires 3 output UTF-8 bytes (`U+0800..U+FFFF`). Since the default replacement mechanism is to replace standalone surrogate code units with the replacement character `U+FFFD` - which is already 3 UTF-8 bytes - the count ends up being correct anyway.

Third, the input must already be malformed in a very particular fashion. It's extraordinarily difficult for malformed UTF-16 data to make its way into an application using Framework-provided APIs via a networking layer. An app running as a network-facing service would need to go out of its way to allow malformed input to make its way into the system, and in doing so they've almost certainly introduced other security vulnerabilites into the app. (It may be more viable to send malformed input via RPC to an app running on the same machine.)

Finally, the application must be targeting ARM, or the environment variable which disables SSE2 intrinsics must have been set, or the application must be using crossgen precompilation (which would disable hardware intrinsics entirely).

For the above reasons I'm not pushing for this to be cherry-picked into the Preview 5 branch.