### PR TITLE
Add option to only notify profiler of LOH allocations

### DIFF
--- a/src/inc/corprof.idl
+++ b/src/inc/corprof.idl
@@ -634,10 +634,14 @@ typedef enum
 
     COR_PRF_HIGH_REQUIRE_PROFILE_IMAGE              = 0,
 
+    // Enables the large object allocation monitoring according to the LOH threshold.
+    COR_PRF_HIGH_MONITOR_LARGEOBJECT_ALLOCATED      = 0x00000040,
+
     COR_PRF_HIGH_ALLOWABLE_AFTER_ATTACH             = COR_PRF_HIGH_IN_MEMORY_SYMBOLS_UPDATED | 
                                                       COR_PRF_HIGH_MONITOR_DYNAMIC_FUNCTION_UNLOADS | 
                                                       COR_PRF_HIGH_BASIC_GC |
-                                                      COR_PRF_HIGH_MONITOR_GC_MOVED_OBJECTS,
+                                                      COR_PRF_HIGH_MONITOR_GC_MOVED_OBJECTS |
+                                                      COR_PRF_HIGH_MONITOR_LARGEOBJECT_ALLOCATED,
 
     // MONITOR_IMMUTABLE represents all flags that may only be set during initialization.
     // Trying to change any of these flags elsewhere will result in a
@@ -3932,6 +3936,9 @@ interface ICorProfilerInfo10 : ICorProfilerInfo9
 
     // Given an ObjectID, determines whether it is in a read only segment.
     HRESULT IsFrozenObject(ObjectID objectId, BOOL *pbFrozen);
+
+    // Gets the value of the configured LOH Threshold.
+    HRESULT GetLOHObjectSizeThreshold(DWORD *pThreshold);
 }
 
 /*

--- a/src/inc/profilepriv.inl
+++ b/src/inc/profilepriv.inl
@@ -264,6 +264,21 @@ inline BOOL CORProfilerTrackAllocations()
             ((&g_profControlBlock)->dwEventMask & COR_PRF_MONITOR_OBJECT_ALLOCATED));
 }
 
+inline BOOL CORProfilerTrackLargeAllocations()
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        CANNOT_TAKE_LOCK;
+    }
+    CONTRACTL_END;
+
+    return
+            (CORProfilerPresent() &&
+            ((&g_profControlBlock)->dwEventMaskHigh & COR_PRF_HIGH_MONITOR_LARGEOBJECT_ALLOCATED));
+}
+
 inline BOOL CORProfilerEnableRejit()
 {
     CONTRACTL

--- a/src/pal/prebuilt/inc/corprof.h
+++ b/src/pal/prebuilt/inc/corprof.h
@@ -547,7 +547,8 @@ enum __MIDL___MIDL_itf_corprof_0000_0000_0006
         COR_PRF_HIGH_BASIC_GC	= 0x10,
         COR_PRF_HIGH_MONITOR_GC_MOVED_OBJECTS	= 0x20,
         COR_PRF_HIGH_REQUIRE_PROFILE_IMAGE	= 0,
-        COR_PRF_HIGH_ALLOWABLE_AFTER_ATTACH	= ( ( ( COR_PRF_HIGH_IN_MEMORY_SYMBOLS_UPDATED | COR_PRF_HIGH_MONITOR_DYNAMIC_FUNCTION_UNLOADS )  | COR_PRF_HIGH_BASIC_GC )  | COR_PRF_HIGH_MONITOR_GC_MOVED_OBJECTS ) ,
+        COR_PRF_HIGH_MONITOR_LARGEOBJECT_ALLOCATED	= 0x40,
+        COR_PRF_HIGH_ALLOWABLE_AFTER_ATTACH	= ( ( ( ( COR_PRF_HIGH_IN_MEMORY_SYMBOLS_UPDATED | COR_PRF_HIGH_MONITOR_DYNAMIC_FUNCTION_UNLOADS )  | COR_PRF_HIGH_BASIC_GC )  | COR_PRF_HIGH_MONITOR_GC_MOVED_OBJECTS )  | COR_PRF_HIGH_MONITOR_LARGEOBJECT_ALLOCATED ) ,
         COR_PRF_HIGH_MONITOR_IMMUTABLE	= COR_PRF_HIGH_DISABLE_TIERED_COMPILATION
     } 	COR_PRF_HIGH_MONITOR;
 
@@ -15195,6 +15196,9 @@ EXTERN_C const IID IID_ICorProfilerInfo10;
             ObjectID objectId,
             BOOL *pbFrozen) = 0;
         
+        virtual HRESULT STDMETHODCALLTYPE GetLOHObjectSizeThreshold( 
+            DWORD *pThreshold) = 0;
+        
     };
     
     
@@ -15793,6 +15797,10 @@ EXTERN_C const IID IID_ICorProfilerInfo10;
             ObjectID objectId,
             BOOL *pbFrozen);
         
+        HRESULT ( STDMETHODCALLTYPE *GetLOHObjectSizeThreshold )( 
+            ICorProfilerInfo10 * This,
+            DWORD *pThreshold);
+        
         END_INTERFACE
     } ICorProfilerInfo10Vtbl;
 
@@ -16100,6 +16108,9 @@ EXTERN_C const IID IID_ICorProfilerInfo10;
 
 #define ICorProfilerInfo10_IsFrozenObject(This,objectId,pbFrozen)	\
     ( (This)->lpVtbl -> IsFrozenObject(This,objectId,pbFrozen) ) 
+
+#define ICorProfilerInfo10_GetLOHObjectSizeThreshold(This,pThreshold)	\
+    ( (This)->lpVtbl -> GetLOHObjectSizeThreshold(This,pThreshold) ) 
 
 #endif /* COBJMACROS */
 

--- a/src/vm/eeprofinterfaces.inl
+++ b/src/vm/eeprofinterfaces.inl
@@ -23,5 +23,14 @@ FORCEINLINE BOOL TrackAllocations()
 #endif // PROFILING_SUPPORTED
 }
 
+FORCEINLINE BOOL TrackLargeAllocations()
+{
+#ifdef PROFILING_SUPPORTED
+    return CORProfilerTrackLargeAllocations();
+#else
+    return FALSE;
+#endif // PROFILING_SUPPORTED
+}
+
 
 #endif

--- a/src/vm/proftoeeinterfaceimpl.h
+++ b/src/vm/proftoeeinterfaceimpl.h
@@ -611,6 +611,8 @@ public:
 
     COM_METHOD IsFrozenObject(ObjectID objectId, BOOL *pbFrozen);
 
+    COM_METHOD GetLOHObjectSizeThreshold(DWORD *pThreshold);
+
     // end ICorProfilerInfo10
 
 protected:


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/24217.