### PR TITLE
Delete fgArgTabEntry::node

### DIFF
--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -3726,13 +3726,13 @@ GenTree* Compiler::optAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCal
             call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_CHKCASTANY) ||
             call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_CHKCASTCLASS_SPECIAL))
         {
-            GenTree* arg1 = gtArgEntryByArgNum(call, 1)->node;
+            GenTree* arg1 = gtArgEntryByArgNum(call, 1)->GetNode();
             if (arg1->gtOper != GT_LCL_VAR)
             {
                 return nullptr;
             }
 
-            GenTree* arg2 = gtArgEntryByArgNum(call, 0)->node;
+            GenTree* arg2 = gtArgEntryByArgNum(call, 0)->GetNode();
 
             unsigned index = optAssertionIsSubtype(arg1, arg2, assertions);
             if (index != NO_ASSERTION_INDEX)

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -7008,7 +7008,7 @@ void Compiler::compCallArgStats()
 
                 argTotalCalls++;
 
-                if (!call->gtCall.gtCallObjp)
+                if (call->AsCall()->gtCallThisArg == nullptr)
                 {
                     if (call->gtCall.gtCallType == CT_HELPER)
                     {

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -10151,9 +10151,9 @@ public:
             {
                 GenTreeCall* const call = node->AsCall();
 
-                if (call->gtCallObjp != nullptr)
+                if (call->gtCallThisArg != nullptr)
                 {
-                    result = WalkTree(&call->gtCallObjp, call);
+                    result = WalkTree(&call->gtCallThisArg->NodeRef(), call);
                     if (result == fgWalkResult::WALK_ABORT)
                     {
                         return result;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1333,8 +1333,7 @@ struct fgArgTabEntry
 {
     GenTree* node;         // Initially points to `use`'s node, but if the argument is replaced with an GT_ASG or
                            // placeholder it will point at the actual argument node in the gtCallLateArgs list.
-    GenTreeCall::Use* use; // Points at the GenTreeCall::Use in the gtCallArgs for this argument
-                           // or nullptr for the `this` argument which does not have a corresponding GenTreeCall::Use.
+    GenTreeCall::Use* use; // Points to the argument's GenTreeCall::Use in gtCallArgs or gtCallThisArg.
 
     unsigned argNum; // The original argument number, also specifies the required argument evaluation order from the IL
 
@@ -2596,7 +2595,6 @@ public:
     static fgArgTabEntry* gtArgEntryByNode(GenTreeCall* call, GenTree* node);
     fgArgTabEntry* gtArgEntryByLateArgIndex(GenTreeCall* call, unsigned lateArgInx);
     static GenTree* gtArgNodeByLateArgInx(GenTreeCall* call, unsigned lateArgInx);
-    bool gtArgIsThisPtr(fgArgTabEntry* argEntry);
 
     GenTree* gtNewAssignNode(GenTree* dst, GenTree* src);
 

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -4412,7 +4412,7 @@ void GenTree::VisitOperands(TVisitor visitor)
         case GT_CALL:
         {
             GenTreeCall* const call = this->AsCall();
-            if ((call->gtCallObjp != nullptr) && (visitor(call->gtCallObjp) == VisitResult::Abort))
+            if ((call->gtCallThisArg != nullptr) && (visitor(call->gtCallThisArg->GetNode()) == VisitResult::Abort))
             {
                 return;
             }

--- a/src/jit/earlyprop.cpp
+++ b/src/jit/earlyprop.cpp
@@ -85,7 +85,7 @@ GenTree* Compiler::getArrayLengthFromAllocation(GenTree* tree)
                 call->gtCallMethHnd == eeFindHelper(CORINFO_HELP_NEWARR_1_ALIGN8))
             {
                 // This is an array allocation site. Grab the array length node.
-                return gtArgEntryByArgNum(call, 1)->node;
+                return gtArgEntryByArgNum(call, 1)->GetNode();
             }
         }
     }
@@ -127,7 +127,7 @@ GenTree* Compiler::getObjectHandleNodeFromAllocation(GenTree* tree)
             {
                 // This is an object allocation site. Return the runtime type handle node.
                 fgArgTabEntry* argTabEntry = gtArgEntryByArgNum(call, 0);
-                return argTabEntry->node;
+                return argTabEntry->GetNode();
             }
         }
     }

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -7461,7 +7461,7 @@ GenTree* Compiler::fgOptimizeDelegateConstructor(GenTreeCall*            call,
             {
                 JITDUMP("optimized\n");
 
-                GenTree*             thisPointer       = call->gtCallObjp;
+                GenTree*             thisPointer       = call->gtCallThisArg->GetNode();
                 GenTree*             targetObjPointers = call->gtCallArgs->GetNode();
                 GenTreeCall::Use*    helperArgs        = nullptr;
                 CORINFO_LOOKUP       pLookup;
@@ -7495,7 +7495,7 @@ GenTree* Compiler::fgOptimizeDelegateConstructor(GenTreeCall*            call,
         {
             JITDUMP("optimized\n");
 
-            GenTree*          thisPointer       = call->gtCallObjp;
+            GenTree*          thisPointer       = call->gtCallThisArg->GetNode();
             GenTree*          targetObjPointers = call->gtCallArgs->GetNode();
             GenTreeCall::Use* helperArgs        = gtNewCallArgs(thisPointer, targetObjPointers);
 
@@ -18781,9 +18781,9 @@ void Compiler::fgSetTreeSeqHelper(GenTree* tree, bool isLIR)
         case GT_CALL:
 
             /* We'll evaluate the 'this' argument value first */
-            if (tree->gtCall.gtCallObjp)
+            if (tree->AsCall()->gtCallThisArg != nullptr)
             {
-                fgSetTreeSeqHelper(tree->gtCall.gtCallObjp, isLIR);
+                fgSetTreeSeqHelper(tree->AsCall()->gtCallThisArg->GetNode(), isLIR);
             }
 
             for (GenTreeCall::Use& use : tree->AsCall()->Args())
@@ -21320,12 +21320,12 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
 
                 call = tree->AsCall();
 
-                if (call->gtCallObjp)
+                if (call->gtCallThisArg != nullptr)
                 {
-                    fgDebugCheckFlags(call->gtCallObjp);
-                    chkFlags |= (call->gtCallObjp->gtFlags & GTF_SIDE_EFFECT);
+                    fgDebugCheckFlags(call->gtCallThisArg->GetNode());
+                    chkFlags |= (call->gtCallThisArg->GetNode()->gtFlags & GTF_SIDE_EFFECT);
 
-                    if (call->gtCallObjp->gtFlags & GTF_ASG)
+                    if ((call->gtCallThisArg->GetNode()->gtFlags & GTF_ASG) != 0)
                     {
                         treeFlags |= GTF_ASG;
                     }

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -6219,19 +6219,9 @@ fgArgTabEntry* Compiler::gtArgEntryByNode(GenTreeCall* call, GenTree* node)
         {
             return curArgTabEntry;
         }
-        else if (curArgTabEntry->use != nullptr)
+        else if (curArgTabEntry->use->GetNode() == node)
         {
-            if (curArgTabEntry->use->GetNode() == node)
-            {
-                return curArgTabEntry;
-            }
-        }
-        else // (curArgTabEntry->parent == NULL)
-        {
-            if ((call->gtCallThisArg != nullptr) && (call->gtCallThisArg->GetNode() == node))
-            {
-                return curArgTabEntry;
-            }
+            return curArgTabEntry;
         }
     }
     noway_assert(!"gtArgEntryByNode: node not found");
@@ -6292,15 +6282,6 @@ GenTree* Compiler::gtArgNodeByLateArgInx(GenTreeCall* call, unsigned lateArgInx)
     }
     noway_assert(argx != nullptr);
     return argx;
-}
-
-/*****************************************************************************
- *
- *  Given an fgArgTabEntry*, return true if it is the 'this' pointer argument.
- */
-bool Compiler::gtArgIsThisPtr(fgArgTabEntry* argEntry)
-{
-    return (argEntry->use == nullptr);
 }
 
 /*****************************************************************************
@@ -11359,7 +11340,7 @@ void Compiler::gtGetLateArgMsg(
     else
 #endif
     {
-        if (gtArgIsThisPtr(curArgTabEntry))
+        if (curArgTabEntry->use == call->gtCallThisArg)
         {
             sprintf_s(bufp, bufLength, "this in %s%c", compRegVarName(argReg), 0);
         }

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -1053,9 +1053,8 @@ void GenTreeCall::ReplaceCallOperand(GenTree** useEdge, GenTree* replacement)
         {
             assert((replacement->gtFlags & GTF_LATE_ARG) == 0);
 
-            fgArgTabEntry* fp = Compiler::gtArgEntryByNode(this, originalOperand);
-            assert(fp->node == originalOperand);
-            fp->node = replacement;
+            fgArgTabEntry* fp = Compiler::gtArgEntryByNode(this, replacement);
+            assert(fp->GetNode() == replacement);
         }
     }
 }
@@ -6215,7 +6214,7 @@ fgArgTabEntry* Compiler::gtArgEntryByNode(GenTreeCall* call, GenTree* node)
     {
         curArgTabEntry = argTable[i];
 
-        if (curArgTabEntry->node == node)
+        if (curArgTabEntry->GetNode() == node)
         {
             return curArgTabEntry;
         }
@@ -8056,7 +8055,7 @@ GenTree* Compiler::gtGetThisArg(GenTreeCall* call)
     {
         unsigned       argNum          = 0;
         fgArgTabEntry* thisArgTabEntry = gtArgEntryByArgNum(call, argNum);
-        GenTree*       result          = thisArgTabEntry->node;
+        GenTree*       result          = thisArgTabEntry->GetNode();
 
         // Assert if we used DEBUG_DESTROY_NODE.
         assert(result->gtOper != GT_COUNT);

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -3317,6 +3317,7 @@ struct GenTreeCall final : public GenTree
     public:
         Use(GenTree* node, Use* next = nullptr) : m_node(node), m_next(next)
         {
+            assert(node != nullptr);
         }
 
         GenTree*& NodeRef()
@@ -3326,6 +3327,7 @@ struct GenTreeCall final : public GenTree
 
         GenTree* GetNode() const
         {
+            assert(m_node != nullptr);
             return m_node;
         }
 

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -3407,11 +3407,11 @@ struct GenTreeCall final : public GenTree
         }
     };
 
-    GenTree* gtCallObjp;     // The instance argument ('this' pointer)
-    Use*     gtCallArgs;     // The list of arguments in original evaluation order
-    Use*     gtCallLateArgs; // On x86:     The register arguments in an optimal order
-                             // On ARM/x64: - also includes any outgoing arg space arguments
-                             //             - that were evaluated into a temp LclVar
+    Use* gtCallThisArg;  // The instance argument ('this' pointer)
+    Use* gtCallArgs;     // The list of arguments in original evaluation order
+    Use* gtCallLateArgs; // On x86:     The register arguments in an optimal order
+                         // On ARM/x64: - also includes any outgoing arg space arguments
+                         //             - that were evaluated into a temp LclVar
     fgArgInfo* fgArgInfo;
 
     UseList Args()

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -4024,6 +4024,8 @@ struct GenTreeCall final : public GenTree
 
     bool AreArgsComplete() const;
 
+    static bool Equals(GenTreeCall* c1, GenTreeCall* c2);
+
     GenTreeCall(var_types type) : GenTree(GT_CALL, type)
     {
         fgArgInfo = nullptr;

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -3372,6 +3372,11 @@ struct GenTreeCall final : public GenTree
             return m_use;
         }
 
+        Use* GetUse() const
+        {
+            return m_use;
+        }
+
         UseIterator& operator++()
         {
             m_use = m_use->GetNext();

--- a/src/jit/gschecks.cpp
+++ b/src/jit/gschecks.cpp
@@ -190,10 +190,11 @@ Compiler::fgWalkResult Compiler::gsMarkPtrsAndAssignGroups(GenTree** pTree, fgWa
             newState.isUnderIndir = false;
             newState.isAssignSrc  = false;
             {
-                if (tree->gtCall.gtCallObjp)
+                if (tree->AsCall()->gtCallThisArg != nullptr)
                 {
                     newState.isUnderIndir = true;
-                    comp->fgWalkTreePre(&tree->gtCall.gtCallObjp, gsMarkPtrsAndAssignGroups, (void*)&newState);
+                    comp->fgWalkTreePre(&tree->AsCall()->gtCallThisArg->NodeRef(), gsMarkPtrsAndAssignGroups,
+                                        (void*)&newState);
                 }
 
                 for (GenTreeCall::Use& use : tree->AsCall()->Args())

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1491,9 +1491,9 @@ GenTree* Lowering::LowerFloatArgReg(GenTree* arg, regNumber regNum)
 void Lowering::LowerArgsForCall(GenTreeCall* call)
 {
     JITDUMP("objp:\n======\n");
-    if (call->gtCallObjp)
+    if (call->gtCallThisArg != nullptr)
     {
-        LowerArg(call, &call->gtCallObjp);
+        LowerArg(call, &call->gtCallThisArg->NodeRef());
     }
 
     JITDUMP("\nargs:\n======\n");
@@ -5429,9 +5429,9 @@ void Lowering::CheckCallArg(GenTree* arg)
 //
 void Lowering::CheckCall(GenTreeCall* call)
 {
-    if (call->gtCallObjp != nullptr)
+    if (call->gtCallThisArg != nullptr)
     {
-        CheckCallArg(call->gtCallObjp);
+        CheckCallArg(call->gtCallThisArg->GetNode());
     }
 
     for (GenTreeCall::Use& use : call->Args())

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1007,8 +1007,7 @@ GenTree* Lowering::NewPutArg(GenTreeCall* call, GenTree* arg, fgArgTabEntry* inf
     assert(arg != nullptr);
     assert(info != nullptr);
 
-    GenTree* putArg         = nullptr;
-    bool     updateArgTable = true;
+    GenTree* putArg = nullptr;
 
     bool isOnStack = true;
     isOnStack      = info->regNum == REG_STK;
@@ -1225,10 +1224,6 @@ GenTree* Lowering::NewPutArg(GenTreeCall* call, GenTree* arg, fgArgTabEntry* inf
     {
         putArg->gtFlags |= GTF_LATE_ARG;
     }
-    else if (updateArgTable)
-    {
-        info->node = putArg;
-    }
     return putArg;
 }
 
@@ -1269,7 +1264,7 @@ void Lowering::LowerArg(GenTreeCall* call, GenTree** ppArg)
     }
 
     fgArgTabEntry* info = comp->gtArgEntryByNode(call, arg);
-    assert(info->node == arg);
+    assert(info->GetNode() == arg);
     var_types type = arg->TypeGet();
 
     if (varTypeIsSmall(type))
@@ -1309,8 +1304,9 @@ void Lowering::LowerArg(GenTreeCall* call, GenTree** ppArg)
         GenTreeUnOp* bitcast = new (comp, GT_BITCAST) GenTreeOp(GT_BITCAST, TYP_LONG, arg, nullptr);
         BlockRange().InsertAfter(arg, bitcast);
 
-        info->node = *ppArg = arg = bitcast;
-        type                      = TYP_LONG;
+        *ppArg = arg = bitcast;
+        assert(info->GetNode() == arg);
+        type = TYP_LONG;
     }
 #endif // defined(_TARGET_X86_)
 #endif // defined(FEATURE_SIMD)
@@ -1337,8 +1333,8 @@ void Lowering::LowerArg(GenTreeCall* call, GenTree** ppArg)
 
             BlockRange().InsertBefore(arg, putArg);
             BlockRange().Remove(arg);
-            *ppArg     = fieldList;
-            info->node = fieldList;
+            *ppArg = fieldList;
+            assert(info->GetNode() == fieldList);
         }
         else
         {
@@ -2243,16 +2239,16 @@ GenTree* Lowering::LowerTailCallViaHelper(GenTreeCall* call, GenTree* callTarget
 #ifdef DEBUG
     argEntry = comp->gtArgEntryByArgNum(call, 0);
     assert(argEntry != nullptr);
-    assert(argEntry->node->gtOper == GT_PUTARG_REG);
-    GenTree* firstArg = argEntry->node->gtOp.gtOp1;
+    assert(argEntry->GetNode()->OperIs(GT_PUTARG_REG));
+    GenTree* firstArg = argEntry->GetNode()->AsUnOp()->gtGetOp1();
     assert(firstArg->gtOper == GT_CNS_INT);
 #endif
 
     // Replace second arg by callTarget.
     argEntry = comp->gtArgEntryByArgNum(call, 1);
     assert(argEntry != nullptr);
-    assert(argEntry->node->gtOper == GT_PUTARG_REG);
-    GenTree* secondArg = argEntry->node->gtOp.gtOp1;
+    assert(argEntry->GetNode()->OperIs(GT_PUTARG_REG));
+    GenTree* secondArg = argEntry->GetNode()->AsUnOp()->gtGetOp1();
 
     ContainCheckRange(callTargetRange);
     BlockRange().InsertAfter(secondArg, std::move(callTargetRange));
@@ -2263,7 +2259,7 @@ GenTree* Lowering::LowerTailCallViaHelper(GenTreeCall* call, GenTree* callTarget
 
     BlockRange().Remove(std::move(secondArgRange));
 
-    argEntry->node->gtOp.gtOp1 = callTarget;
+    argEntry->GetNode()->AsUnOp()->gtOp1 = callTarget;
 
 #elif defined(_TARGET_X86_)
 
@@ -2282,8 +2278,7 @@ GenTree* Lowering::LowerTailCallViaHelper(GenTreeCall* call, GenTree* callTarget
     // arg 0 == callTarget.
     argEntry = comp->gtArgEntryByArgNum(call, numArgs - 1);
     assert(argEntry != nullptr);
-    assert(argEntry->node->gtOper == GT_PUTARG_STK);
-    GenTree* arg0 = argEntry->node->gtOp.gtOp1;
+    GenTree* arg0 = argEntry->GetNode()->AsPutArgStk()->gtGetOp1();
 
     ContainCheckRange(callTargetRange);
     BlockRange().InsertAfter(arg0, std::move(callTargetRange));
@@ -2293,13 +2288,12 @@ GenTree* Lowering::LowerTailCallViaHelper(GenTreeCall* call, GenTree* callTarget
     assert(isClosed);
     BlockRange().Remove(std::move(secondArgRange));
 
-    argEntry->node->gtOp.gtOp1 = callTarget;
+    argEntry->GetNode()->AsPutArgStk()->gtOp1 = callTarget;
 
     // arg 1 == flags
     argEntry = comp->gtArgEntryByArgNum(call, numArgs - 2);
     assert(argEntry != nullptr);
-    assert(argEntry->node->gtOper == GT_PUTARG_STK);
-    GenTree* arg1 = argEntry->node->gtOp.gtOp1;
+    GenTree* arg1 = argEntry->GetNode()->AsPutArgStk()->gtGetOp1();
     assert(arg1->gtOper == GT_CNS_INT);
 
     ssize_t tailCallHelperFlags = 1 |                                  // always restore EDI,ESI,EBX
@@ -2309,8 +2303,7 @@ GenTree* Lowering::LowerTailCallViaHelper(GenTreeCall* call, GenTree* callTarget
     // arg 2 == numberOfNewStackArgsWords
     argEntry = comp->gtArgEntryByArgNum(call, numArgs - 3);
     assert(argEntry != nullptr);
-    assert(argEntry->node->gtOper == GT_PUTARG_STK);
-    GenTree* arg2 = argEntry->node->gtOp.gtOp1;
+    GenTree* arg2 = argEntry->GetNode()->AsPutArgStk()->gtGetOp1();
     assert(arg2->gtOper == GT_CNS_INT);
 
     arg2->gtIntCon.gtIconVal = nNewStkArgsWords;
@@ -2319,8 +2312,7 @@ GenTree* Lowering::LowerTailCallViaHelper(GenTreeCall* call, GenTree* callTarget
     // arg 3 == numberOfOldStackArgsWords
     argEntry = comp->gtArgEntryByArgNum(call, numArgs - 4);
     assert(argEntry != nullptr);
-    assert(argEntry->node->gtOper == GT_PUTARG_STK);
-    GenTree* arg3 = argEntry->node->gtOp.gtOp1;
+    GenTree* arg3 = argEntry->GetNode()->AsPutArgStk()->gtGetOp1();
     assert(arg3->gtOper == GT_CNS_INT);
 #endif // DEBUG
 
@@ -3264,7 +3256,7 @@ GenTree* Lowering::LowerDelegateInvoke(GenTreeCall* call)
 #endif // !_TARGET_X86_
 
         fgArgTabEntry* thisArgTabEntry = comp->gtArgEntryByArgNum(call, argNum);
-        thisArgNode                    = thisArgTabEntry->node;
+        thisArgNode                    = thisArgTabEntry->GetNode();
     }
     else
     {
@@ -4065,8 +4057,8 @@ GenTree* Lowering::LowerVirtualVtableCall(GenTreeCall* call)
     // get a reference to the thisPtr being passed
     fgArgTabEntry* argEntry = comp->gtArgEntryByArgNum(call, thisPtrArgNum);
     assert(argEntry->regNum == thisPtrArgReg);
-    assert(argEntry->node->gtOper == GT_PUTARG_REG);
-    GenTree* thisPtr = argEntry->node->gtOp.gtOp1;
+    assert(argEntry->GetNode()->OperIs(GT_PUTARG_REG));
+    GenTree* thisPtr = argEntry->GetNode()->AsUnOp()->gtGetOp1();
 
     // If what we are passing as the thisptr is not already a local, make a new local to place it in
     // because we will be creating expressions based on it.
@@ -4083,7 +4075,7 @@ GenTree* Lowering::LowerVirtualVtableCall(GenTreeCall* call)
             vtableCallTemp = comp->lvaGrabTemp(true DEBUGARG("virtual vtable call"));
         }
 
-        LIR::Use thisPtrUse(BlockRange(), &(argEntry->node->gtOp.gtOp1), argEntry->node);
+        LIR::Use thisPtrUse(BlockRange(), &(argEntry->GetNode()->AsUnOp()->gtOp1), argEntry->GetNode());
         ReplaceWithLclVar(thisPtrUse, vtableCallTemp);
 
         lclNum = vtableCallTemp;

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -962,9 +962,9 @@ fgArgInfo::fgArgInfo(GenTreeCall* newCall, GenTreeCall* oldCall)
         {
             for (unsigned i = 0; i < argTableSize; i++)
             {
-                if (argTable[i]->use == &(*oldUse))
+                if (argTable[i]->use == oldUse.GetUse())
                 {
-                    argTable[i]->use = &(*newUse);
+                    argTable[i]->use = newUse.GetUse();
                     break;
                 }
             }
@@ -979,9 +979,9 @@ fgArgInfo::fgArgInfo(GenTreeCall* newCall, GenTreeCall* oldCall)
         {
             for (unsigned i = 0; i < argTableSize; i++)
             {
-                if (argTable[i]->lateUse == &(*oldUse))
+                if (argTable[i]->lateUse == oldUse.GetUse())
                 {
-                    argTable[i]->lateUse = &(*newUse);
+                    argTable[i]->lateUse = newUse.GetUse();
                     break;
                 }
             }

--- a/src/jit/stacklevelsetter.cpp
+++ b/src/jit/stacklevelsetter.cpp
@@ -246,7 +246,7 @@ unsigned StackLevelSetter::PopArgumentsFromCall(GenTreeCall* call)
             fgArgTabEntry* argTab = argInfo->ArgTable()[i];
             if (argTab->numSlots != 0)
             {
-                GenTree* node = argTab->node;
+                GenTree* node = argTab->GetNode();
                 assert(node->OperIsPutArgStkOrSplit());
 
                 GenTreePutArgStk* putArg = node->AsPutArgStk();


### PR DESCRIPTION
This replace the `GenTree* fgArgTabEntry::node` pointer with a pointer to the late arg (use). This way the node pointer can still be obtained from either `fgArgTabEntry::use` or `fgArgTabEntry::lateUse` and we no longer need to special case operand replacement (with the exception of preserving `GTF_LATE_ARG`).

Contributes to #26307

The extra `Use` for the `this` arg does increase memory usage a bit, by around 0.05%. I think it's definitely worth it. And we could recover some of that if we eventually move the `this` arg to the normal arg list so that `GenTreeCall` (and all large nodes) becomes one pointer smaller.

No diffs. (crossgen/PMI x86/x64 and altjit arm32/arm64)