### PR TITLE
Make sure variable live range for prolog is reported first

### DIFF
--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -706,7 +706,7 @@ public:
             void dumpAllRegisterLiveRangesForBlock(emitter* emit, const CodeGenInterface* codeGen) const;
             void dumpRegisterLiveRangesForBlockBeforeCodeGenerated(const CodeGenInterface* codeGen) const;
             bool hasVarLiveRangesToDump() const;
-            bool hasVarLiverRangesFromLastBlockToDump() const;
+            bool hasVarLiveRangesFromLastBlockToDump() const;
             void endBlockLiveRanges();
 #endif // DEBUG
         };
@@ -718,6 +718,9 @@ public:
 
         VariableLiveDescriptor* m_vlrLiveDsc; // Array of descriptors that manage VariableLiveRanges.
                                               // Its indices correspond to lvaTable indexes (or lvSlotNum).
+
+        VariableLiveDescriptor* m_vlrLiveDscForProlog; // Array of descriptors that manage VariableLiveRanges.
+                                                       // Its indices correspond to lvaTable indexes (or lvSlotNum).
 
         bool m_LastBasicBlockHasBeenEmited; // When true no more siEndVariableLiveRange is considered.
                                             // No update/start happens when code has been generated.
@@ -737,7 +740,8 @@ public:
         void siEndAllVariableLiveRange(VARSET_VALARG_TP varsToClose);
         void siEndAllVariableLiveRange();
 
-        LiveRangeList* getLiveRangesForVar(unsigned int varNum) const;
+        LiveRangeList* getLiveRangesForVarForBody(unsigned int varNum) const;
+        LiveRangeList* getLiveRangesForVarForProlog(unsigned int varNum) const;
         size_t getLiveRangesCount() const;
 
         // For parameters locations on prolog


### PR DESCRIPTION
This is a follow-up of @BrianBohe work.

When we are reporting the variable live range under `USING_VARIABLE_LIVE_RANGE`, we were reporting the live ranges related to prolog later than what we would have done under `USING_SCOPE_INFO`. Ideally, we should report the live ranges in prolog first.

The change passes the CI with both `USING_VARIABLE_LIVE_RANGE` on and off, and current it is in the OFF state, this change is ready to be merged.

@BruceForstall 