### PR TITLE
Fix GetObjectReferences API when caller doesn't zero the param

### DIFF
--- a/src/vm/proftoeeinterfaceimpl.cpp
+++ b/src/vm/proftoeeinterfaceimpl.cpp
@@ -6836,6 +6836,7 @@ HRESULT ProfToEEInterfaceImpl::GetObjectReferences(ObjectID objectId, ULONG32 cN
     {
         if (cNumReferences == 0)
         {
+            *pcNumReferences = 0;
             GCHeapUtilities::GetGCHeap()->DiagWalkObject(pBO, &CountContainedObjectRef, (void*)pcNumReferences);
         }
         else


### PR DESCRIPTION
Found it while writing unit tests.

cc @davmason @noahfalk 