### PR TITLE
Add more asserts for the EventPipeBufferManager consumers

### DIFF
--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -891,6 +891,7 @@ EventPipeEventInstance *EventPipe::GetNextEvent()
         THROWS;
         GC_TRIGGERS;
         MODE_PREEMPTIVE;
+        PRECONDITION(!GetLock()->OwnedByCurrentThread());
     }
     CONTRACTL_END;
 

--- a/src/vm/eventpipebuffermanager.cpp
+++ b/src/vm/eventpipebuffermanager.cpp
@@ -415,6 +415,7 @@ void EventPipeBufferManager::WriteAllBuffersToFile(EventPipeFile *pFile, LARGE_I
         GC_NOTRIGGER;
         MODE_ANY;
         PRECONDITION(pFile != nullptr);
+        PRECONDITION(EventPipe::GetLock()->OwnedByCurrentThread());
     }
     CONTRACTL_END;
 
@@ -488,6 +489,7 @@ EventPipeEventInstance* EventPipeBufferManager::GetNextEvent()
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
+        PRECONDITION(!EventPipe::GetLock()->OwnedByCurrentThread());
     }
     CONTRACTL_END;
 


### PR DESCRIPTION
Here is what I think is correct about the `EventPipe::GetLock()` status in the various places where we read events from the buffers.

If I am right, I am wondering what would happen if `EventPipeBufferManager::GetNextEvent()` and `EventPipe::Disable()` are running at the same time?