### PR TITLE
When large pages are enabled, only reserve/commit 1x seg size for LOH

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -2819,7 +2819,7 @@ GCSpinLock gc_heap::gc_lock;
 
 size_t gc_heap::eph_gen_starts_size = 0;
 heap_segment* gc_heap::segment_standby_list;
-size_t        gc_heap::use_large_pages_p = 0;
+bool          gc_heap::use_large_pages_p = 0;
 size_t        gc_heap::last_gc_index = 0;
 #ifdef SEG_MAPPING_TABLE
 size_t        gc_heap::min_segment_size = 0;
@@ -10014,12 +10014,9 @@ HRESULT gc_heap::initialize_gc (size_t segment_size,
     block_count = 1;
 #endif //MULTIPLE_HEAPS
 
-    use_large_pages_p = false;
-
     if (heap_hard_limit)
     {
         check_commit_cs.Initialize();
-        use_large_pages_p = GCConfig::GetGCLargePages();
     }
 
     if (!reserve_initial_memory(segment_size,heap_size,block_count,use_large_pages_p))
@@ -34197,7 +34194,8 @@ HRESULT GCHeap::Initialize()
     {
         seg_size = gc_heap::get_segment_size_hard_limit (&nhp, (nhp_from_config == 0));
         gc_heap::soh_segment_size = seg_size;
-        large_seg_size = seg_size * 2;
+        gc_heap::use_large_pages_p = GCConfig::GetGCLargePages();
+        large_seg_size = gc_heap::use_large_pages_p ? seg_size : seg_size * 2;
     }
     else
     {

--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -3155,7 +3155,7 @@ public:
 
     // This is if large pages should be used.
     PER_HEAP_ISOLATED
-    size_t use_large_pages_p;
+    bool use_large_pages_p;
 
     PER_HEAP_ISOLATED
     size_t last_gc_index;


### PR DESCRIPTION
When large pages are enabled, we must commit everything we reserve.
Previously we reserved 2x the segment size for LOH. This is a problem
with large pages where we must commit everything we reserve.

Thanks to https://github.com/dotnet/coreclr/pull/24081 this does not
cause performance regression with large pages; but without large pages
we were seeing regressions when the loh_seg_size was reduced. So this
change will only take effect when large pages are enabled.