### PR TITLE
Adding more coverage for the AES hwintrinsic tests.

### DIFF
--- a/src/jit/instr.cpp
+++ b/src/jit/instr.cpp
@@ -1100,12 +1100,6 @@ void CodeGen::inst_RV_TT_IV(instruction ins, emitAttr attr, regNumber reg1, GenT
                 {
                     varNum = addr->AsLclVarCommon()->GetLclNum();
                     offset = 0;
-
-                    // Ensure that all the GenTreeIndir values are set to their defaults.
-                    assert(!memIndir->HasIndex());
-                    assert(memIndir->Scale() == 1);
-                    assert(memIndir->Offset() == 0);
-
                     break;
                 }
 

--- a/tests/src/JIT/HardwareIntrinsics/X86/Aes/DecryptLast.Byte.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Aes/DecryptLast.Byte.cs
@@ -21,7 +21,7 @@ namespace JIT.HardwareIntrinsics.X86
     {
         private static void DecryptLastByte()
         {
-            var test = new SimpleBinaryOpTest__DecryptLastByte();
+            var test = new AesBinaryOpTest__DecryptLastByte();
 
             if (test.IsSupported)
             {
@@ -52,6 +52,12 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates passing a static member works
                 test.RunClsVarScenario();
 
+                if (Aes.IsSupported)
+                {
+                    // Validates passing a static member works, using pinning and Load
+                    test.RunClsVarScenario_Load();
+                }
+
                 // Validates passing a local works, using Unsafe.Read
                 test.RunLclVarScenario_UnsafeRead();
 
@@ -67,14 +73,38 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates passing the field of a local class works
                 test.RunClassLclFldScenario();
 
+                if (Aes.IsSupported)
+                {
+                    // Validates passing the field of a local class works, using pinning and Load
+                    test.RunClassLclFldScenario_Load();
+                }
+
                 // Validates passing an instance member of a class works
                 test.RunClassFldScenario();
+
+                if (Aes.IsSupported)
+                {
+                    // Validates passing an instance member of a class works, using pinning and Load
+                    test.RunClassFldScenario_Load();
+                }
 
                 // Validates passing the field of a local struct works
                 test.RunStructLclFldScenario();
 
+                if (Aes.IsSupported)
+                {
+                    // Validates passing the field of a local struct works, using pinning and Load
+                    test.RunStructLclFldScenario_Load();
+                }
+
                 // Validates passing an instance member of a struct works
                 test.RunStructFldScenario();
+
+                if (Aes.IsSupported)
+                {
+                    // Validates passing an instance member of a struct works, using pinning and Load
+                    test.RunStructFldScenario_Load();
+                }
             }
             else
             {
@@ -89,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
         }
     }
 
-    public sealed unsafe class SimpleBinaryOpTest__DecryptLastByte
+    public sealed unsafe class AesBinaryOpTest__DecryptLastByte
     {
         private struct TestStruct
         {
@@ -107,12 +137,27 @@ namespace JIT.HardwareIntrinsics.X86
                 return testStruct;
             }
 
-            public void RunStructFldScenario(SimpleBinaryOpTest__DecryptLastByte testClass)
+            public void RunStructFldScenario(AesBinaryOpTest__DecryptLastByte testClass)
             {
                 var result = Aes.DecryptLast(_fld1, _fld2);
 
                 Unsafe.Write(testClass._dataTable.outArrayPtr, result);
                 testClass.ValidateResult(testClass._dataTable.outArrayPtr);
+            }
+
+            public void RunStructFldScenario_Load(AesBinaryOpTest__DecryptLastByte testClass)
+            {
+                fixed (Vector128<Byte>* pFld1 = &_fld1)
+                fixed (Vector128<Byte>* pFld2 = &_fld2)
+                {
+                    var result = Aes.DecryptLast(
+                        Aes.LoadVector128((Byte*)(pFld1)),
+                        Aes.LoadVector128((Byte*)(pFld2))
+                    );
+
+                    Unsafe.Write(testClass._dataTable.outArrayPtr, result);
+                    testClass.ValidateResult(testClass._dataTable.outArrayPtr);
+                }
             }
         }
 
@@ -133,7 +178,7 @@ namespace JIT.HardwareIntrinsics.X86
 
         private SimpleBinaryOpTest__DataTable<Byte, Byte, Byte> _dataTable;
 
-        static SimpleBinaryOpTest__DecryptLastByte()
+        static AesBinaryOpTest__DecryptLastByte()
         {
 
             Unsafe.CopyBlockUnaligned(ref Unsafe.As<Vector128<Byte>, byte>(ref _clsVar1), ref Unsafe.As<Byte, byte>(ref _data1[0]), (uint)Unsafe.SizeOf<Vector128<Byte>>());
@@ -141,7 +186,7 @@ namespace JIT.HardwareIntrinsics.X86
             Unsafe.CopyBlockUnaligned(ref Unsafe.As<Vector128<Byte>, byte>(ref _clsVar2), ref Unsafe.As<Byte, byte>(ref _data2[0]), (uint)Unsafe.SizeOf<Vector128<Byte>>());
         }
 
-        public SimpleBinaryOpTest__DecryptLastByte()
+        public AesBinaryOpTest__DecryptLastByte()
         {
             Succeeded = true;
 
@@ -250,6 +295,23 @@ namespace JIT.HardwareIntrinsics.X86
             ValidateResult(_dataTable.outArrayPtr);
         }
 
+        public void RunClsVarScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunClsVarScenario_Load));
+
+            fixed (Vector128<Byte>* pClsVar1 = &_clsVar1)
+            fixed (Vector128<Byte>* pClsVar2 = &_clsVar2)
+            {
+                var result = Aes.DecryptLast(
+                    Aes.LoadVector128((Byte*)(pClsVar1)),
+                    Aes.LoadVector128((Byte*)(pClsVar2))
+                );
+
+                Unsafe.Write(_dataTable.outArrayPtr, result);
+                ValidateResult(_dataTable.outArrayPtr);
+            }
+        }
+
         public void RunLclVarScenario_UnsafeRead()
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunLclVarScenario_UnsafeRead));
@@ -290,11 +352,30 @@ namespace JIT.HardwareIntrinsics.X86
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunClassLclFldScenario));
 
-            var test = new SimpleBinaryOpTest__DecryptLastByte();
+            var test = new AesBinaryOpTest__DecryptLastByte();
             var result = Aes.DecryptLast(test._fld1, test._fld2);
 
             Unsafe.Write(_dataTable.outArrayPtr, result);
             ValidateResult(_dataTable.outArrayPtr);
+        }
+
+        public void RunClassLclFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunClassLclFldScenario_Load));
+
+            var test = new AesBinaryOpTest__DecryptLastByte();
+
+            fixed (Vector128<Byte>* pFld1 = &test._fld1)
+            fixed (Vector128<Byte>* pFld2 = &test._fld2)
+            {
+                var result = Aes.DecryptLast(
+                    Aes.LoadVector128((Byte*)(pFld1)),
+                    Aes.LoadVector128((Byte*)(pFld2))
+                );
+
+                Unsafe.Write(_dataTable.outArrayPtr, result);
+                ValidateResult(_dataTable.outArrayPtr);
+            }
         }
 
         public void RunClassFldScenario()
@@ -305,6 +386,23 @@ namespace JIT.HardwareIntrinsics.X86
 
             Unsafe.Write(_dataTable.outArrayPtr, result);
             ValidateResult(_dataTable.outArrayPtr);
+        }
+
+        public void RunClassFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunClassFldScenario_Load));
+
+            fixed (Vector128<Byte>* pFld1 = &_fld1)
+            fixed (Vector128<Byte>* pFld2 = &_fld2)
+            {
+                var result = Aes.DecryptLast(
+                    Aes.LoadVector128((Byte*)(pFld1)),
+                    Aes.LoadVector128((Byte*)(pFld2))
+                );
+
+                Unsafe.Write(_dataTable.outArrayPtr, result);
+                ValidateResult(_dataTable.outArrayPtr);
+            }
         }
 
         public void RunStructLclFldScenario()
@@ -318,12 +416,34 @@ namespace JIT.HardwareIntrinsics.X86
             ValidateResult(_dataTable.outArrayPtr);
         }
 
+        public void RunStructLclFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunStructLclFldScenario_Load));
+
+            var test = TestStruct.Create();
+            var result = Aes.DecryptLast(
+                Aes.LoadVector128((Byte*)(&test._fld1)),
+                Aes.LoadVector128((Byte*)(&test._fld2))
+            );
+
+            Unsafe.Write(_dataTable.outArrayPtr, result);
+            ValidateResult(_dataTable.outArrayPtr);
+        }
+
         public void RunStructFldScenario()
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunStructFldScenario));
 
             var test = TestStruct.Create();
             test.RunStructFldScenario(this);
+        }
+
+        public void RunStructFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunStructFldScenario_Load));
+
+            var test = TestStruct.Create();
+            test.RunStructFldScenario_Load(this);
         }
 
         public void RunUnsupportedScenario()

--- a/tests/src/JIT/HardwareIntrinsics/X86/Aes/Encrypt.Byte.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Aes/Encrypt.Byte.cs
@@ -21,7 +21,7 @@ namespace JIT.HardwareIntrinsics.X86
     {
         private static void EncryptByte()
         {
-            var test = new SimpleBinaryOpTest__EncryptByte();
+            var test = new AesBinaryOpTest__EncryptByte();
 
             if (test.IsSupported)
             {
@@ -52,6 +52,12 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates passing a static member works
                 test.RunClsVarScenario();
 
+                if (Aes.IsSupported)
+                {
+                    // Validates passing a static member works, using pinning and Load
+                    test.RunClsVarScenario_Load();
+                }
+
                 // Validates passing a local works, using Unsafe.Read
                 test.RunLclVarScenario_UnsafeRead();
 
@@ -67,14 +73,38 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates passing the field of a local class works
                 test.RunClassLclFldScenario();
 
+                if (Aes.IsSupported)
+                {
+                    // Validates passing the field of a local class works, using pinning and Load
+                    test.RunClassLclFldScenario_Load();
+                }
+
                 // Validates passing an instance member of a class works
                 test.RunClassFldScenario();
+
+                if (Aes.IsSupported)
+                {
+                    // Validates passing an instance member of a class works, using pinning and Load
+                    test.RunClassFldScenario_Load();
+                }
 
                 // Validates passing the field of a local struct works
                 test.RunStructLclFldScenario();
 
+                if (Aes.IsSupported)
+                {
+                    // Validates passing the field of a local struct works, using pinning and Load
+                    test.RunStructLclFldScenario_Load();
+                }
+
                 // Validates passing an instance member of a struct works
                 test.RunStructFldScenario();
+
+                if (Aes.IsSupported)
+                {
+                    // Validates passing an instance member of a struct works, using pinning and Load
+                    test.RunStructFldScenario_Load();
+                }
             }
             else
             {
@@ -89,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
         }
     }
 
-    public sealed unsafe class SimpleBinaryOpTest__EncryptByte
+    public sealed unsafe class AesBinaryOpTest__EncryptByte
     {
         private struct TestStruct
         {
@@ -107,12 +137,27 @@ namespace JIT.HardwareIntrinsics.X86
                 return testStruct;
             }
 
-            public void RunStructFldScenario(SimpleBinaryOpTest__EncryptByte testClass)
+            public void RunStructFldScenario(AesBinaryOpTest__EncryptByte testClass)
             {
                 var result = Aes.Encrypt(_fld1, _fld2);
 
                 Unsafe.Write(testClass._dataTable.outArrayPtr, result);
                 testClass.ValidateResult(testClass._dataTable.outArrayPtr);
+            }
+
+            public void RunStructFldScenario_Load(AesBinaryOpTest__EncryptByte testClass)
+            {
+                fixed (Vector128<Byte>* pFld1 = &_fld1)
+                fixed (Vector128<Byte>* pFld2 = &_fld2)
+                {
+                    var result = Aes.Encrypt(
+                        Aes.LoadVector128((Byte*)(pFld1)),
+                        Aes.LoadVector128((Byte*)(pFld2))
+                    );
+
+                    Unsafe.Write(testClass._dataTable.outArrayPtr, result);
+                    testClass.ValidateResult(testClass._dataTable.outArrayPtr);
+                }
             }
         }
 
@@ -133,7 +178,7 @@ namespace JIT.HardwareIntrinsics.X86
 
         private SimpleBinaryOpTest__DataTable<Byte, Byte, Byte> _dataTable;
 
-        static SimpleBinaryOpTest__EncryptByte()
+        static AesBinaryOpTest__EncryptByte()
         {
 
             Unsafe.CopyBlockUnaligned(ref Unsafe.As<Vector128<Byte>, byte>(ref _clsVar1), ref Unsafe.As<Byte, byte>(ref _data1[0]), (uint)Unsafe.SizeOf<Vector128<Byte>>());
@@ -141,7 +186,7 @@ namespace JIT.HardwareIntrinsics.X86
             Unsafe.CopyBlockUnaligned(ref Unsafe.As<Vector128<Byte>, byte>(ref _clsVar2), ref Unsafe.As<Byte, byte>(ref _data2[0]), (uint)Unsafe.SizeOf<Vector128<Byte>>());
         }
 
-        public SimpleBinaryOpTest__EncryptByte()
+        public AesBinaryOpTest__EncryptByte()
         {
             Succeeded = true;
 
@@ -250,6 +295,23 @@ namespace JIT.HardwareIntrinsics.X86
             ValidateResult(_dataTable.outArrayPtr);
         }
 
+        public void RunClsVarScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunClsVarScenario_Load));
+
+            fixed (Vector128<Byte>* pClsVar1 = &_clsVar1)
+            fixed (Vector128<Byte>* pClsVar2 = &_clsVar2)
+            {
+                var result = Aes.Encrypt(
+                    Aes.LoadVector128((Byte*)(pClsVar1)),
+                    Aes.LoadVector128((Byte*)(pClsVar2))
+                );
+
+                Unsafe.Write(_dataTable.outArrayPtr, result);
+                ValidateResult(_dataTable.outArrayPtr);
+            }
+        }
+
         public void RunLclVarScenario_UnsafeRead()
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunLclVarScenario_UnsafeRead));
@@ -290,11 +352,30 @@ namespace JIT.HardwareIntrinsics.X86
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunClassLclFldScenario));
 
-            var test = new SimpleBinaryOpTest__EncryptByte();
+            var test = new AesBinaryOpTest__EncryptByte();
             var result = Aes.Encrypt(test._fld1, test._fld2);
 
             Unsafe.Write(_dataTable.outArrayPtr, result);
             ValidateResult(_dataTable.outArrayPtr);
+        }
+
+        public void RunClassLclFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunClassLclFldScenario_Load));
+
+            var test = new AesBinaryOpTest__EncryptByte();
+
+            fixed (Vector128<Byte>* pFld1 = &test._fld1)
+            fixed (Vector128<Byte>* pFld2 = &test._fld2)
+            {
+                var result = Aes.Encrypt(
+                    Aes.LoadVector128((Byte*)(pFld1)),
+                    Aes.LoadVector128((Byte*)(pFld2))
+                );
+
+                Unsafe.Write(_dataTable.outArrayPtr, result);
+                ValidateResult(_dataTable.outArrayPtr);
+            }
         }
 
         public void RunClassFldScenario()
@@ -305,6 +386,23 @@ namespace JIT.HardwareIntrinsics.X86
 
             Unsafe.Write(_dataTable.outArrayPtr, result);
             ValidateResult(_dataTable.outArrayPtr);
+        }
+
+        public void RunClassFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunClassFldScenario_Load));
+
+            fixed (Vector128<Byte>* pFld1 = &_fld1)
+            fixed (Vector128<Byte>* pFld2 = &_fld2)
+            {
+                var result = Aes.Encrypt(
+                    Aes.LoadVector128((Byte*)(pFld1)),
+                    Aes.LoadVector128((Byte*)(pFld2))
+                );
+
+                Unsafe.Write(_dataTable.outArrayPtr, result);
+                ValidateResult(_dataTable.outArrayPtr);
+            }
         }
 
         public void RunStructLclFldScenario()
@@ -318,12 +416,34 @@ namespace JIT.HardwareIntrinsics.X86
             ValidateResult(_dataTable.outArrayPtr);
         }
 
+        public void RunStructLclFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunStructLclFldScenario_Load));
+
+            var test = TestStruct.Create();
+            var result = Aes.Encrypt(
+                Aes.LoadVector128((Byte*)(&test._fld1)),
+                Aes.LoadVector128((Byte*)(&test._fld2))
+            );
+
+            Unsafe.Write(_dataTable.outArrayPtr, result);
+            ValidateResult(_dataTable.outArrayPtr);
+        }
+
         public void RunStructFldScenario()
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunStructFldScenario));
 
             var test = TestStruct.Create();
             test.RunStructFldScenario(this);
+        }
+
+        public void RunStructFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunStructFldScenario_Load));
+
+            var test = TestStruct.Create();
+            test.RunStructFldScenario_Load(this);
         }
 
         public void RunUnsupportedScenario()

--- a/tests/src/JIT/HardwareIntrinsics/X86/Aes/EncryptLast.Byte.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Aes/EncryptLast.Byte.cs
@@ -21,7 +21,7 @@ namespace JIT.HardwareIntrinsics.X86
     {
         private static void EncryptLastByte()
         {
-            var test = new SimpleBinaryOpTest__EncryptLastByte();
+            var test = new AesBinaryOpTest__EncryptLastByte();
 
             if (test.IsSupported)
             {
@@ -52,6 +52,12 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates passing a static member works
                 test.RunClsVarScenario();
 
+                if (Aes.IsSupported)
+                {
+                    // Validates passing a static member works, using pinning and Load
+                    test.RunClsVarScenario_Load();
+                }
+
                 // Validates passing a local works, using Unsafe.Read
                 test.RunLclVarScenario_UnsafeRead();
 
@@ -67,14 +73,38 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates passing the field of a local class works
                 test.RunClassLclFldScenario();
 
+                if (Aes.IsSupported)
+                {
+                    // Validates passing the field of a local class works, using pinning and Load
+                    test.RunClassLclFldScenario_Load();
+                }
+
                 // Validates passing an instance member of a class works
                 test.RunClassFldScenario();
+
+                if (Aes.IsSupported)
+                {
+                    // Validates passing an instance member of a class works, using pinning and Load
+                    test.RunClassFldScenario_Load();
+                }
 
                 // Validates passing the field of a local struct works
                 test.RunStructLclFldScenario();
 
+                if (Aes.IsSupported)
+                {
+                    // Validates passing the field of a local struct works, using pinning and Load
+                    test.RunStructLclFldScenario_Load();
+                }
+
                 // Validates passing an instance member of a struct works
                 test.RunStructFldScenario();
+
+                if (Aes.IsSupported)
+                {
+                    // Validates passing an instance member of a struct works, using pinning and Load
+                    test.RunStructFldScenario_Load();
+                }
             }
             else
             {
@@ -89,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
         }
     }
 
-    public sealed unsafe class SimpleBinaryOpTest__EncryptLastByte
+    public sealed unsafe class AesBinaryOpTest__EncryptLastByte
     {
         private struct TestStruct
         {
@@ -107,12 +137,27 @@ namespace JIT.HardwareIntrinsics.X86
                 return testStruct;
             }
 
-            public void RunStructFldScenario(SimpleBinaryOpTest__EncryptLastByte testClass)
+            public void RunStructFldScenario(AesBinaryOpTest__EncryptLastByte testClass)
             {
                 var result = Aes.EncryptLast(_fld1, _fld2);
 
                 Unsafe.Write(testClass._dataTable.outArrayPtr, result);
                 testClass.ValidateResult(testClass._dataTable.outArrayPtr);
+            }
+
+            public void RunStructFldScenario_Load(AesBinaryOpTest__EncryptLastByte testClass)
+            {
+                fixed (Vector128<Byte>* pFld1 = &_fld1)
+                fixed (Vector128<Byte>* pFld2 = &_fld2)
+                {
+                    var result = Aes.EncryptLast(
+                        Aes.LoadVector128((Byte*)(pFld1)),
+                        Aes.LoadVector128((Byte*)(pFld2))
+                    );
+
+                    Unsafe.Write(testClass._dataTable.outArrayPtr, result);
+                    testClass.ValidateResult(testClass._dataTable.outArrayPtr);
+                }
             }
         }
 
@@ -133,7 +178,7 @@ namespace JIT.HardwareIntrinsics.X86
 
         private SimpleBinaryOpTest__DataTable<Byte, Byte, Byte> _dataTable;
 
-        static SimpleBinaryOpTest__EncryptLastByte()
+        static AesBinaryOpTest__EncryptLastByte()
         {
 
             Unsafe.CopyBlockUnaligned(ref Unsafe.As<Vector128<Byte>, byte>(ref _clsVar1), ref Unsafe.As<Byte, byte>(ref _data1[0]), (uint)Unsafe.SizeOf<Vector128<Byte>>());
@@ -141,7 +186,7 @@ namespace JIT.HardwareIntrinsics.X86
             Unsafe.CopyBlockUnaligned(ref Unsafe.As<Vector128<Byte>, byte>(ref _clsVar2), ref Unsafe.As<Byte, byte>(ref _data2[0]), (uint)Unsafe.SizeOf<Vector128<Byte>>());
         }
 
-        public SimpleBinaryOpTest__EncryptLastByte()
+        public AesBinaryOpTest__EncryptLastByte()
         {
             Succeeded = true;
 
@@ -250,6 +295,23 @@ namespace JIT.HardwareIntrinsics.X86
             ValidateResult(_dataTable.outArrayPtr);
         }
 
+        public void RunClsVarScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunClsVarScenario_Load));
+
+            fixed (Vector128<Byte>* pClsVar1 = &_clsVar1)
+            fixed (Vector128<Byte>* pClsVar2 = &_clsVar2)
+            {
+                var result = Aes.EncryptLast(
+                    Aes.LoadVector128((Byte*)(pClsVar1)),
+                    Aes.LoadVector128((Byte*)(pClsVar2))
+                );
+
+                Unsafe.Write(_dataTable.outArrayPtr, result);
+                ValidateResult(_dataTable.outArrayPtr);
+            }
+        }
+
         public void RunLclVarScenario_UnsafeRead()
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunLclVarScenario_UnsafeRead));
@@ -290,11 +352,30 @@ namespace JIT.HardwareIntrinsics.X86
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunClassLclFldScenario));
 
-            var test = new SimpleBinaryOpTest__EncryptLastByte();
+            var test = new AesBinaryOpTest__EncryptLastByte();
             var result = Aes.EncryptLast(test._fld1, test._fld2);
 
             Unsafe.Write(_dataTable.outArrayPtr, result);
             ValidateResult(_dataTable.outArrayPtr);
+        }
+
+        public void RunClassLclFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunClassLclFldScenario_Load));
+
+            var test = new AesBinaryOpTest__EncryptLastByte();
+
+            fixed (Vector128<Byte>* pFld1 = &test._fld1)
+            fixed (Vector128<Byte>* pFld2 = &test._fld2)
+            {
+                var result = Aes.EncryptLast(
+                    Aes.LoadVector128((Byte*)(pFld1)),
+                    Aes.LoadVector128((Byte*)(pFld2))
+                );
+
+                Unsafe.Write(_dataTable.outArrayPtr, result);
+                ValidateResult(_dataTable.outArrayPtr);
+            }
         }
 
         public void RunClassFldScenario()
@@ -305,6 +386,23 @@ namespace JIT.HardwareIntrinsics.X86
 
             Unsafe.Write(_dataTable.outArrayPtr, result);
             ValidateResult(_dataTable.outArrayPtr);
+        }
+
+        public void RunClassFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunClassFldScenario_Load));
+
+            fixed (Vector128<Byte>* pFld1 = &_fld1)
+            fixed (Vector128<Byte>* pFld2 = &_fld2)
+            {
+                var result = Aes.EncryptLast(
+                    Aes.LoadVector128((Byte*)(pFld1)),
+                    Aes.LoadVector128((Byte*)(pFld2))
+                );
+
+                Unsafe.Write(_dataTable.outArrayPtr, result);
+                ValidateResult(_dataTable.outArrayPtr);
+            }
         }
 
         public void RunStructLclFldScenario()
@@ -318,12 +416,34 @@ namespace JIT.HardwareIntrinsics.X86
             ValidateResult(_dataTable.outArrayPtr);
         }
 
+        public void RunStructLclFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunStructLclFldScenario_Load));
+
+            var test = TestStruct.Create();
+            var result = Aes.EncryptLast(
+                Aes.LoadVector128((Byte*)(&test._fld1)),
+                Aes.LoadVector128((Byte*)(&test._fld2))
+            );
+
+            Unsafe.Write(_dataTable.outArrayPtr, result);
+            ValidateResult(_dataTable.outArrayPtr);
+        }
+
         public void RunStructFldScenario()
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunStructFldScenario));
 
             var test = TestStruct.Create();
             test.RunStructFldScenario(this);
+        }
+
+        public void RunStructFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunStructFldScenario_Load));
+
+            var test = TestStruct.Create();
+            test.RunStructFldScenario_Load(this);
         }
 
         public void RunUnsupportedScenario()

--- a/tests/src/JIT/HardwareIntrinsics/X86/Aes/InverseMixColumns.Byte.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Aes/InverseMixColumns.Byte.cs
@@ -21,7 +21,7 @@ namespace JIT.HardwareIntrinsics.X86
     {
         private static void InverseMixColumnsByte()
         {
-            var test = new SimpleUnaryOpTest__InverseMixColumnsByte();
+            var test = new AesUnaryOpTest__InverseMixColumnsByte();
 
             if (test.IsSupported)
             {
@@ -52,6 +52,12 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates passing a static member works
                 test.RunClsVarScenario();
 
+                if (Aes.IsSupported)
+                {
+                    // Validates passing a static member works, using pinning and Load
+                    test.RunClsVarScenario_Load();
+                }
+
                 // Validates passing a local works, using Unsafe.Read
                 test.RunLclVarScenario_UnsafeRead();
 
@@ -67,14 +73,38 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates passing the field of a local class works
                 test.RunClassLclFldScenario();
 
+                if (Aes.IsSupported)
+                {
+                    // Validates passing the field of a local class works, using pinning and Load
+                    test.RunClassLclFldScenario_Load();
+                }
+
                 // Validates passing an instance member of a class works
                 test.RunClassFldScenario();
+
+                if (Aes.IsSupported)
+                {
+                    // Validates passing an instance member of a class works, using pinning and Load
+                    test.RunClassFldScenario_Load();
+                }
 
                 // Validates passing the field of a local struct works
                 test.RunStructLclFldScenario();
 
+                if (Aes.IsSupported)
+                {
+                    // Validates passing the field of a local struct works, using pinning and Load
+                    test.RunStructLclFldScenario_Load();
+                }
+
                 // Validates passing an instance member of a struct works
                 test.RunStructFldScenario();
+
+                if (Aes.IsSupported)
+                {
+                    // Validates passing an instance member of a struct works, using pinning and Load
+                    test.RunStructFldScenario_Load();
+                }
             }
             else
             {
@@ -89,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
         }
     }
 
-    public sealed unsafe class SimpleUnaryOpTest__InverseMixColumnsByte
+    public sealed unsafe class AesUnaryOpTest__InverseMixColumnsByte
     {
         private struct TestStruct
         {
@@ -104,12 +134,25 @@ namespace JIT.HardwareIntrinsics.X86
                 return testStruct;
             }
 
-            public void RunStructFldScenario(SimpleUnaryOpTest__InverseMixColumnsByte testClass)
+            public void RunStructFldScenario(AesUnaryOpTest__InverseMixColumnsByte testClass)
             {
                 var result = Aes.InverseMixColumns(_fld);
 
                 Unsafe.Write(testClass._dataTable.outArrayPtr, result);
                 testClass.ValidateResult(testClass._dataTable.outArrayPtr);
+            }
+
+            public void RunStructFldScenario_Load(AesUnaryOpTest__InverseMixColumnsByte testClass)
+            {
+                fixed (Vector128<Byte>* pFld = &_fld)
+                {
+                    var result = Aes.InverseMixColumns(
+                        Aes.LoadVector128((Byte*)(pFld))
+                    );
+
+                    Unsafe.Write(testClass._dataTable.outArrayPtr, result);
+                    testClass.ValidateResult(testClass._dataTable.outArrayPtr);
+                }
             }
         }
 
@@ -126,13 +169,13 @@ namespace JIT.HardwareIntrinsics.X86
 
         private SimpleUnaryOpTest__DataTable<Byte, Byte> _dataTable;
 
-        static SimpleUnaryOpTest__InverseMixColumnsByte()
+        static AesUnaryOpTest__InverseMixColumnsByte()
         {
 
             Unsafe.CopyBlockUnaligned(ref Unsafe.As<Vector128<Byte>, byte>(ref _clsVar), ref Unsafe.As<Byte, byte>(ref _data[0]), (uint)Unsafe.SizeOf<Vector128<Byte>>());
         }
 
-        public SimpleUnaryOpTest__InverseMixColumnsByte()
+        public AesUnaryOpTest__InverseMixColumnsByte()
         {
             Succeeded = true;
 
@@ -233,6 +276,21 @@ namespace JIT.HardwareIntrinsics.X86
             ValidateResult(_dataTable.outArrayPtr);
         }
 
+        public void RunClsVarScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunClsVarScenario_Load));
+
+            fixed (Vector128<Byte>* pClsVar = &_clsVar)
+            {
+                var result = Aes.InverseMixColumns(
+                    Aes.LoadVector128((Byte*)(pClsVar))
+                );
+
+                Unsafe.Write(_dataTable.outArrayPtr, result);
+                ValidateResult(_dataTable.outArrayPtr);
+            }
+        }
+
         public void RunLclVarScenario_UnsafeRead()
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunLclVarScenario_UnsafeRead));
@@ -270,11 +328,28 @@ namespace JIT.HardwareIntrinsics.X86
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunClassLclFldScenario));
 
-            var test = new SimpleUnaryOpTest__InverseMixColumnsByte();
+            var test = new AesUnaryOpTest__InverseMixColumnsByte();
             var result = Aes.InverseMixColumns(test._fld);
 
             Unsafe.Write(_dataTable.outArrayPtr, result);
             ValidateResult(_dataTable.outArrayPtr);
+        }
+
+        public void RunClassLclFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunClassLclFldScenario_Load));
+
+            var test = new SimpleBinaryOpTest__InverseMixColumnsByte();
+
+            fixed (Vector128<Byte>* pFld = &test._fld)
+            {
+                var result = Aes.InverseMixColumns(
+                    Aes.LoadVector128((Byte*)(pFld))
+                );
+
+                Unsafe.Write(_dataTable.outArrayPtr, result);
+                ValidateResult(_dataTable.outArrayPtr);
+            }
         }
 
         public void RunClassFldScenario()
@@ -285,6 +360,21 @@ namespace JIT.HardwareIntrinsics.X86
 
             Unsafe.Write(_dataTable.outArrayPtr, result);
             ValidateResult(_dataTable.outArrayPtr);
+        }
+
+        public void RunClassFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunClassFldScenario_Load));
+
+            fixed (Vector128<Byte>* pFld = &_fld)
+            {
+                var result = Aes.InverseMixColumns(
+                    Aes.LoadVector128((Byte*)(pFld))
+                );
+
+                Unsafe.Write(_dataTable.outArrayPtr, result);
+                ValidateResult(_dataTable.outArrayPtr);
+            }
         }
 
         public void RunStructLclFldScenario()
@@ -298,12 +388,33 @@ namespace JIT.HardwareIntrinsics.X86
             ValidateResult(_dataTable.outArrayPtr);
         }
 
+        public void RunStructLclFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunStructLclFldScenario_Load));
+
+            var test = TestStruct.Create();
+            var result = Aes.InverseMixColumns(
+                Aes.LoadVector128((Byte*)(&test._fld))
+            );
+
+            Unsafe.Write(_dataTable.outArrayPtr, result);
+            ValidateResult(_dataTable.outArrayPtr);
+        }
+
         public void RunStructFldScenario()
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunStructFldScenario));
 
             var test = TestStruct.Create();
             test.RunStructFldScenario(this);
+        }
+
+        public void RunStructFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunStructFldScenario_Load));
+
+            var test = TestStruct.Create();
+            test.RunStructFldScenario_Load(this);
         }
 
         public void RunUnsupportedScenario()

--- a/tests/src/JIT/HardwareIntrinsics/X86/Aes/InverseMixColumns.Byte.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Aes/InverseMixColumns.Byte.cs
@@ -339,7 +339,7 @@ namespace JIT.HardwareIntrinsics.X86
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunClassLclFldScenario_Load));
 
-            var test = new SimpleBinaryOpTest__InverseMixColumnsByte();
+            var test = new AesUnaryOpTest__InverseMixColumnsByte();
 
             fixed (Vector128<Byte>* pFld = &test._fld)
             {

--- a/tests/src/JIT/HardwareIntrinsics/X86/Aes/KeygenAssist.Byte.5.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Aes/KeygenAssist.Byte.5.cs
@@ -142,7 +142,7 @@ namespace JIT.HardwareIntrinsics.X86
                 testClass.ValidateResult(testClass._dataTable.outArrayPtr);
             }
 
-            public void RunStructFldScenario_Load(AesImmOpTest__KeygenAssistByte testClass)
+            public void RunStructFldScenario_Load(AesImmOpTest__KeygenAssistByte5 testClass)
             {
                 fixed (Vector128<Byte>* pFld = &_fld)
                 {
@@ -348,7 +348,7 @@ namespace JIT.HardwareIntrinsics.X86
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunClassLclFldScenario_Load));
 
-            var test = new SimpleBinaryOpTest__KeygenAssistByte();
+            var test = new AesImmOpTest__KeygenAssistByte5();
 
             fixed (Vector128<Byte>* pFld = &test._fld)
             {

--- a/tests/src/JIT/HardwareIntrinsics/X86/Aes/KeygenAssist.Byte.5.cs
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Aes/KeygenAssist.Byte.5.cs
@@ -21,7 +21,7 @@ namespace JIT.HardwareIntrinsics.X86
     {
         private static void KeygenAssistByte5()
         {
-            var test = new ImmUnaryOpTest__KeygenAssistByte5();
+            var test = new AesImmOpTest__KeygenAssistByte5();
 
             if (test.IsSupported)
             {
@@ -52,6 +52,12 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates passing a static member works
                 test.RunClsVarScenario();
 
+                if (Aes.IsSupported)
+                {
+                    // Validates passing a static member works, using pinning and Load
+                    test.RunClsVarScenario_Load();
+                }
+
                 // Validates passing a local works, using Unsafe.Read
                 test.RunLclVarScenario_UnsafeRead();
 
@@ -67,14 +73,38 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates passing the field of a local class works
                 test.RunClassLclFldScenario();
 
+                if (Aes.IsSupported)
+                {
+                    // Validates passing the field of a local class works, using pinning and Load
+                    test.RunClassLclFldScenario_Load();
+                }
+
                 // Validates passing an instance member of a class works
                 test.RunClassFldScenario();
+
+                if (Aes.IsSupported)
+                {
+                    // Validates passing an instance member of a class works, using pinning and Load
+                    test.RunClassFldScenario_Load();
+                }
 
                 // Validates passing the field of a local struct works
                 test.RunStructLclFldScenario();
 
+                if (Aes.IsSupported)
+                {
+                    // Validates passing the field of a local struct works, using pinning and Load
+                    test.RunStructLclFldScenario_Load();
+                }
+
                 // Validates passing an instance member of a struct works
                 test.RunStructFldScenario();
+
+                if (Aes.IsSupported)
+                {
+                    // Validates passing an instance member of a struct works, using pinning and Load
+                    test.RunStructFldScenario_Load();
+                }
             }
             else
             {
@@ -89,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
         }
     }
 
-    public sealed unsafe class ImmUnaryOpTest__KeygenAssistByte5
+    public sealed unsafe class AesImmOpTest__KeygenAssistByte5
     {
         private struct TestStruct
         {
@@ -104,12 +134,26 @@ namespace JIT.HardwareIntrinsics.X86
                 return testStruct;
             }
 
-            public void RunStructFldScenario(ImmUnaryOpTest__KeygenAssistByte5 testClass)
+            public void RunStructFldScenario(AesImmOpTest__KeygenAssistByte5 testClass)
             {
                 var result = Aes.KeygenAssist(_fld, 5);
 
                 Unsafe.Write(testClass._dataTable.outArrayPtr, result);
                 testClass.ValidateResult(testClass._dataTable.outArrayPtr);
+            }
+
+            public void RunStructFldScenario_Load(AesImmOpTest__KeygenAssistByte testClass)
+            {
+                fixed (Vector128<Byte>* pFld = &_fld)
+                {
+                    var result = Aes.KeygenAssist(
+                        Aes.LoadVector128((Byte*)(pFld)),
+                        5
+                    );
+
+                    Unsafe.Write(testClass._dataTable.outArrayPtr, result);
+                    testClass.ValidateResult(testClass._dataTable.outArrayPtr);
+                }
             }
         }
 
@@ -126,13 +170,13 @@ namespace JIT.HardwareIntrinsics.X86
 
         private SimpleUnaryOpTest__DataTable<Byte, Byte> _dataTable;
 
-        static ImmUnaryOpTest__KeygenAssistByte5()
+        static AesImmOpTest__KeygenAssistByte5()
         {
 
             Unsafe.CopyBlockUnaligned(ref Unsafe.As<Vector128<Byte>, byte>(ref _clsVar), ref Unsafe.As<Byte, byte>(ref _data[0]), (uint)Unsafe.SizeOf<Vector128<Byte>>());
         }
 
-        public ImmUnaryOpTest__KeygenAssistByte5()
+        public AesImmOpTest__KeygenAssistByte5()
         {
             Succeeded = true;
 
@@ -240,6 +284,22 @@ namespace JIT.HardwareIntrinsics.X86
             ValidateResult(_dataTable.outArrayPtr);
         }
 
+        public void RunClsVarScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunClsVarScenario_Load));
+
+            fixed (Vector128<Byte>* pClsVar = &_clsVar)
+            {
+                var result = Aes.KeygenAssist(
+                    Aes.LoadVector128((Byte*)(pClsVar)),
+                    5
+                );
+
+                Unsafe.Write(_dataTable.outArrayPtr, result);
+                ValidateResult(_dataTable.outArrayPtr);
+            }
+        }
+
         public void RunLclVarScenario_UnsafeRead()
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunLclVarScenario_UnsafeRead));
@@ -277,11 +337,29 @@ namespace JIT.HardwareIntrinsics.X86
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunClassLclFldScenario));
 
-            var test = new ImmUnaryOpTest__KeygenAssistByte5();
+            var test = new AesImmOpTest__KeygenAssistByte5();
             var result = Aes.KeygenAssist(test._fld, 5);
 
             Unsafe.Write(_dataTable.outArrayPtr, result);
             ValidateResult(_dataTable.outArrayPtr);
+        }
+
+        public void RunClassLclFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunClassLclFldScenario_Load));
+
+            var test = new SimpleBinaryOpTest__KeygenAssistByte();
+
+            fixed (Vector128<Byte>* pFld = &test._fld)
+            {
+                var result = Aes.KeygenAssist(
+                    Aes.LoadVector128((Byte*)(pFld)),
+                    5
+                );
+
+                Unsafe.Write(_dataTable.outArrayPtr, result);
+                ValidateResult(_dataTable.outArrayPtr);
+            }
         }
 
         public void RunClassFldScenario()
@@ -292,6 +370,22 @@ namespace JIT.HardwareIntrinsics.X86
 
             Unsafe.Write(_dataTable.outArrayPtr, result);
             ValidateResult(_dataTable.outArrayPtr);
+        }
+
+        public void RunClassFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunClassFldScenario_Load));
+
+            fixed (Vector128<Byte>* pFld = &_fld)
+            {
+                var result = Aes.KeygenAssist(
+                    Aes.LoadVector128((Byte*)(pFld)),
+                    5
+                );
+
+                Unsafe.Write(_dataTable.outArrayPtr, result);
+                ValidateResult(_dataTable.outArrayPtr);
+            }
         }
 
         public void RunStructLclFldScenario()
@@ -305,12 +399,34 @@ namespace JIT.HardwareIntrinsics.X86
             ValidateResult(_dataTable.outArrayPtr);
         }
 
+        public void RunStructLclFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunStructLclFldScenario_Load));
+
+            var test = TestStruct.Create();
+            var result = Aes.KeygenAssist(
+                Aes.LoadVector128((Byte*)(&test._fld)),
+                5
+            );
+
+            Unsafe.Write(_dataTable.outArrayPtr, result);
+            ValidateResult(_dataTable.outArrayPtr);
+        }
+
         public void RunStructFldScenario()
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunStructFldScenario));
 
             var test = TestStruct.Create();
             test.RunStructFldScenario(this);
+        }
+
+        public void RunStructFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunStructFldScenario_Load));
+
+            var test = TestStruct.Create();
+            test.RunStructFldScenario_Load(this);
         }
 
         public void RunUnsupportedScenario()

--- a/tests/src/JIT/HardwareIntrinsics/X86/Shared/AesBinOpTest.template
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Shared/AesBinOpTest.template
@@ -21,7 +21,7 @@ namespace JIT.HardwareIntrinsics.X86
     {
         private static void {Method}{RetBaseType}()
         {
-            var test = new SimpleBinaryOpTest__{Method}{RetBaseType}();
+            var test = new AesBinaryOpTest__{Method}{RetBaseType}();
 
             if (test.IsSupported)
             {
@@ -52,6 +52,12 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates passing a static member works
                 test.RunClsVarScenario();
 
+                if ({LoadIsa}.IsSupported)
+                {
+                    // Validates passing a static member works, using pinning and Load
+                    test.RunClsVarScenario_Load();
+                }
+
                 // Validates passing a local works, using Unsafe.Read
                 test.RunLclVarScenario_UnsafeRead();
 
@@ -67,14 +73,38 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates passing the field of a local class works
                 test.RunClassLclFldScenario();
 
+                if ({LoadIsa}.IsSupported)
+                {
+                    // Validates passing the field of a local class works, using pinning and Load
+                    test.RunClassLclFldScenario_Load();
+                }
+
                 // Validates passing an instance member of a class works
                 test.RunClassFldScenario();
+
+                if ({LoadIsa}.IsSupported)
+                {
+                    // Validates passing an instance member of a class works, using pinning and Load
+                    test.RunClassFldScenario_Load();
+                }
 
                 // Validates passing the field of a local struct works
                 test.RunStructLclFldScenario();
 
+                if ({LoadIsa}.IsSupported)
+                {
+                    // Validates passing the field of a local struct works, using pinning and Load
+                    test.RunStructLclFldScenario_Load();
+                }
+
                 // Validates passing an instance member of a struct works
                 test.RunStructFldScenario();
+
+                if ({LoadIsa}.IsSupported)
+                {
+                    // Validates passing an instance member of a struct works, using pinning and Load
+                    test.RunStructFldScenario_Load();
+                }
             }
             else
             {
@@ -89,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
         }
     }
 
-    public sealed unsafe class SimpleBinaryOpTest__{Method}{RetBaseType}
+    public sealed unsafe class AesBinaryOpTest__{Method}{RetBaseType}
     {
         private struct TestStruct
         {
@@ -107,12 +137,27 @@ namespace JIT.HardwareIntrinsics.X86
                 return testStruct;
             }
 
-            public void RunStructFldScenario(SimpleBinaryOpTest__{Method}{RetBaseType} testClass)
+            public void RunStructFldScenario(AesBinaryOpTest__{Method}{RetBaseType} testClass)
             {
                 var result = {Isa}.{Method}(_fld1, _fld2);
 
                 Unsafe.Write(testClass._dataTable.outArrayPtr, result);
                 testClass.ValidateResult(testClass._dataTable.outArrayPtr);
+            }
+
+            public void RunStructFldScenario_Load(AesBinaryOpTest__{Method}{RetBaseType} testClass)
+            {
+                fixed ({Op1VectorType}<{Op1BaseType}>* pFld1 = &_fld1)
+                fixed ({Op2VectorType}<{Op2BaseType}>* pFld2 = &_fld2)
+                {
+                    var result = {Isa}.{Method}(
+                        {LoadIsa}.Load{Op1VectorType}(({Op1BaseType}*)(pFld1)),
+                        {LoadIsa}.Load{Op2VectorType}(({Op2BaseType}*)(pFld2))
+                    );
+
+                    Unsafe.Write(testClass._dataTable.outArrayPtr, result);
+                    testClass.ValidateResult(testClass._dataTable.outArrayPtr);
+                }
             }
         }
 
@@ -133,7 +178,7 @@ namespace JIT.HardwareIntrinsics.X86
 
         private SimpleBinaryOpTest__DataTable<{RetBaseType}, {Op1BaseType}, {Op2BaseType}> _dataTable;
 
-        static SimpleBinaryOpTest__{Method}{RetBaseType}()
+        static AesBinaryOpTest__{Method}{RetBaseType}()
         {
 
             Unsafe.CopyBlockUnaligned(ref Unsafe.As<{Op1VectorType}<{Op1BaseType}>, byte>(ref _clsVar1), ref Unsafe.As<{Op1BaseType}, byte>(ref _data1[0]), (uint)Unsafe.SizeOf<{Op1VectorType}<{Op1BaseType}>>());
@@ -141,7 +186,7 @@ namespace JIT.HardwareIntrinsics.X86
             Unsafe.CopyBlockUnaligned(ref Unsafe.As<{Op2VectorType}<{Op2BaseType}>, byte>(ref _clsVar2), ref Unsafe.As<{Op2BaseType}, byte>(ref _data2[0]), (uint)Unsafe.SizeOf<{Op2VectorType}<{Op2BaseType}>>());
         }
 
-        public SimpleBinaryOpTest__{Method}{RetBaseType}()
+        public AesBinaryOpTest__{Method}{RetBaseType}()
         {
             Succeeded = true;
 
@@ -250,6 +295,23 @@ namespace JIT.HardwareIntrinsics.X86
             ValidateResult(_dataTable.outArrayPtr);
         }
 
+        public void RunClsVarScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunClsVarScenario_Load));
+
+            fixed ({Op1VectorType}<{Op1BaseType}>* pClsVar1 = &_clsVar1)
+            fixed ({Op2VectorType}<{Op2BaseType}>* pClsVar2 = &_clsVar2)
+            {
+                var result = {Isa}.{Method}(
+                    {LoadIsa}.Load{Op1VectorType}(({Op1BaseType}*)(pClsVar1)),
+                    {LoadIsa}.Load{Op2VectorType}(({Op2BaseType}*)(pClsVar2))
+                );
+
+                Unsafe.Write(_dataTable.outArrayPtr, result);
+                ValidateResult(_dataTable.outArrayPtr);
+            }
+        }
+
         public void RunLclVarScenario_UnsafeRead()
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunLclVarScenario_UnsafeRead));
@@ -290,11 +352,30 @@ namespace JIT.HardwareIntrinsics.X86
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunClassLclFldScenario));
 
-            var test = new SimpleBinaryOpTest__{Method}{RetBaseType}();
+            var test = new AesBinaryOpTest__{Method}{RetBaseType}();
             var result = {Isa}.{Method}(test._fld1, test._fld2);
 
             Unsafe.Write(_dataTable.outArrayPtr, result);
             ValidateResult(_dataTable.outArrayPtr);
+        }
+
+        public void RunClassLclFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunClassLclFldScenario_Load));
+
+            var test = new AesBinaryOpTest__{Method}{RetBaseType}();
+
+            fixed ({Op1VectorType}<{Op1BaseType}>* pFld1 = &test._fld1)
+            fixed ({Op2VectorType}<{Op2BaseType}>* pFld2 = &test._fld2)
+            {
+                var result = {Isa}.{Method}(
+                    {LoadIsa}.Load{Op1VectorType}(({Op1BaseType}*)(pFld1)),
+                    {LoadIsa}.Load{Op2VectorType}(({Op2BaseType}*)(pFld2))
+                );
+
+                Unsafe.Write(_dataTable.outArrayPtr, result);
+                ValidateResult(_dataTable.outArrayPtr);
+            }
         }
 
         public void RunClassFldScenario()
@@ -305,6 +386,23 @@ namespace JIT.HardwareIntrinsics.X86
 
             Unsafe.Write(_dataTable.outArrayPtr, result);
             ValidateResult(_dataTable.outArrayPtr);
+        }
+
+        public void RunClassFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunClassFldScenario_Load));
+
+            fixed ({Op1VectorType}<{Op1BaseType}>* pFld1 = &_fld1)
+            fixed ({Op2VectorType}<{Op2BaseType}>* pFld2 = &_fld2)
+            {
+                var result = {Isa}.{Method}(
+                    {LoadIsa}.Load{Op1VectorType}(({Op1BaseType}*)(pFld1)),
+                    {LoadIsa}.Load{Op2VectorType}(({Op2BaseType}*)(pFld2))
+                );
+
+                Unsafe.Write(_dataTable.outArrayPtr, result);
+                ValidateResult(_dataTable.outArrayPtr);
+            }
         }
 
         public void RunStructLclFldScenario()
@@ -318,12 +416,34 @@ namespace JIT.HardwareIntrinsics.X86
             ValidateResult(_dataTable.outArrayPtr);
         }
 
+        public void RunStructLclFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunStructLclFldScenario_Load));
+
+            var test = TestStruct.Create();
+            var result = {Isa}.{Method}(
+                {LoadIsa}.Load{Op1VectorType}(({Op1BaseType}*)(&test._fld1)),
+                {LoadIsa}.Load{Op2VectorType}(({Op2BaseType}*)(&test._fld2))
+            );
+
+            Unsafe.Write(_dataTable.outArrayPtr, result);
+            ValidateResult(_dataTable.outArrayPtr);
+        }
+
         public void RunStructFldScenario()
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunStructFldScenario));
 
             var test = TestStruct.Create();
             test.RunStructFldScenario(this);
+        }
+
+        public void RunStructFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunStructFldScenario_Load));
+
+            var test = TestStruct.Create();
+            test.RunStructFldScenario_Load(this);
         }
 
         public void RunUnsupportedScenario()

--- a/tests/src/JIT/HardwareIntrinsics/X86/Shared/AesImmOpTest.template
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Shared/AesImmOpTest.template
@@ -21,7 +21,7 @@ namespace JIT.HardwareIntrinsics.X86
     {
         private static void {Method}{RetBaseType}{Imm}()
         {
-            var test = new ImmUnaryOpTest__{Method}{RetBaseType}{Imm}();
+            var test = new AesImmOpTest__{Method}{RetBaseType}{Imm}();
 
             if (test.IsSupported)
             {
@@ -52,6 +52,12 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates passing a static member works
                 test.RunClsVarScenario();
 
+                if ({LoadIsa}.IsSupported)
+                {
+                    // Validates passing a static member works, using pinning and Load
+                    test.RunClsVarScenario_Load();
+                }
+
                 // Validates passing a local works, using Unsafe.Read
                 test.RunLclVarScenario_UnsafeRead();
 
@@ -67,14 +73,38 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates passing the field of a local class works
                 test.RunClassLclFldScenario();
 
+                if ({LoadIsa}.IsSupported)
+                {
+                    // Validates passing the field of a local class works, using pinning and Load
+                    test.RunClassLclFldScenario_Load();
+                }
+
                 // Validates passing an instance member of a class works
                 test.RunClassFldScenario();
+
+                if ({LoadIsa}.IsSupported)
+                {
+                    // Validates passing an instance member of a class works, using pinning and Load
+                    test.RunClassFldScenario_Load();
+                }
 
                 // Validates passing the field of a local struct works
                 test.RunStructLclFldScenario();
 
+                if ({LoadIsa}.IsSupported)
+                {
+                    // Validates passing the field of a local struct works, using pinning and Load
+                    test.RunStructLclFldScenario_Load();
+                }
+
                 // Validates passing an instance member of a struct works
                 test.RunStructFldScenario();
+
+                if ({LoadIsa}.IsSupported)
+                {
+                    // Validates passing an instance member of a struct works, using pinning and Load
+                    test.RunStructFldScenario_Load();
+                }
             }
             else
             {
@@ -89,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
         }
     }
 
-    public sealed unsafe class ImmUnaryOpTest__{Method}{RetBaseType}{Imm}
+    public sealed unsafe class AesImmOpTest__{Method}{RetBaseType}{Imm}
     {
         private struct TestStruct
         {
@@ -104,12 +134,26 @@ namespace JIT.HardwareIntrinsics.X86
                 return testStruct;
             }
 
-            public void RunStructFldScenario(ImmUnaryOpTest__{Method}{RetBaseType}{Imm} testClass)
+            public void RunStructFldScenario(AesImmOpTest__{Method}{RetBaseType}{Imm} testClass)
             {
                 var result = {Isa}.{Method}(_fld, {Imm});
 
                 Unsafe.Write(testClass._dataTable.outArrayPtr, result);
                 testClass.ValidateResult(testClass._dataTable.outArrayPtr);
+            }
+
+            public void RunStructFldScenario_Load(AesImmOpTest__{Method}{RetBaseType} testClass)
+            {
+                fixed ({Op1VectorType}<{Op1BaseType}>* pFld = &_fld)
+                {
+                    var result = {Isa}.{Method}(
+                        {LoadIsa}.Load{Op1VectorType}(({Op1BaseType}*)(pFld)),
+                        {Imm}
+                    );
+
+                    Unsafe.Write(testClass._dataTable.outArrayPtr, result);
+                    testClass.ValidateResult(testClass._dataTable.outArrayPtr);
+                }
             }
         }
 
@@ -126,13 +170,13 @@ namespace JIT.HardwareIntrinsics.X86
 
         private SimpleUnaryOpTest__DataTable<{RetBaseType}, {Op1BaseType}> _dataTable;
 
-        static ImmUnaryOpTest__{Method}{RetBaseType}{Imm}()
+        static AesImmOpTest__{Method}{RetBaseType}{Imm}()
         {
 
             Unsafe.CopyBlockUnaligned(ref Unsafe.As<{Op1VectorType}<{Op1BaseType}>, byte>(ref _clsVar), ref Unsafe.As<{Op1BaseType}, byte>(ref _data[0]), (uint)Unsafe.SizeOf<{Op1VectorType}<{Op1BaseType}>>());
         }
 
-        public ImmUnaryOpTest__{Method}{RetBaseType}{Imm}()
+        public AesImmOpTest__{Method}{RetBaseType}{Imm}()
         {
             Succeeded = true;
 
@@ -240,6 +284,22 @@ namespace JIT.HardwareIntrinsics.X86
             ValidateResult(_dataTable.outArrayPtr);
         }
 
+        public void RunClsVarScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunClsVarScenario_Load));
+
+            fixed ({Op1VectorType}<{Op1BaseType}>* pClsVar = &_clsVar)
+            {
+                var result = {Isa}.{Method}(
+                    {LoadIsa}.Load{Op1VectorType}(({Op1BaseType}*)(pClsVar)),
+                    {Imm}
+                );
+
+                Unsafe.Write(_dataTable.outArrayPtr, result);
+                ValidateResult(_dataTable.outArrayPtr);
+            }
+        }
+
         public void RunLclVarScenario_UnsafeRead()
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunLclVarScenario_UnsafeRead));
@@ -277,11 +337,29 @@ namespace JIT.HardwareIntrinsics.X86
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunClassLclFldScenario));
 
-            var test = new ImmUnaryOpTest__{Method}{RetBaseType}{Imm}();
+            var test = new AesImmOpTest__{Method}{RetBaseType}{Imm}();
             var result = {Isa}.{Method}(test._fld, {Imm});
 
             Unsafe.Write(_dataTable.outArrayPtr, result);
             ValidateResult(_dataTable.outArrayPtr);
+        }
+
+        public void RunClassLclFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunClassLclFldScenario_Load));
+
+            var test = new SimpleBinaryOpTest__{Method}{RetBaseType}();
+
+            fixed ({Op1VectorType}<{Op1BaseType}>* pFld = &test._fld)
+            {
+                var result = {Isa}.{Method}(
+                    {LoadIsa}.Load{Op1VectorType}(({Op1BaseType}*)(pFld)),
+                    {Imm}
+                );
+
+                Unsafe.Write(_dataTable.outArrayPtr, result);
+                ValidateResult(_dataTable.outArrayPtr);
+            }
         }
 
         public void RunClassFldScenario()
@@ -292,6 +370,22 @@ namespace JIT.HardwareIntrinsics.X86
 
             Unsafe.Write(_dataTable.outArrayPtr, result);
             ValidateResult(_dataTable.outArrayPtr);
+        }
+
+        public void RunClassFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunClassFldScenario_Load));
+
+            fixed ({Op1VectorType}<{Op1BaseType}>* pFld = &_fld)
+            {
+                var result = {Isa}.{Method}(
+                    {LoadIsa}.Load{Op1VectorType}(({Op1BaseType}*)(pFld)),
+                    {Imm}
+                );
+
+                Unsafe.Write(_dataTable.outArrayPtr, result);
+                ValidateResult(_dataTable.outArrayPtr);
+            }
         }
 
         public void RunStructLclFldScenario()
@@ -305,12 +399,34 @@ namespace JIT.HardwareIntrinsics.X86
             ValidateResult(_dataTable.outArrayPtr);
         }
 
+        public void RunStructLclFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunStructLclFldScenario_Load));
+
+            var test = TestStruct.Create();
+            var result = {Isa}.{Method}(
+                {LoadIsa}.Load{Op1VectorType}(({Op1BaseType}*)(&test._fld)),
+                {Imm}
+            );
+
+            Unsafe.Write(_dataTable.outArrayPtr, result);
+            ValidateResult(_dataTable.outArrayPtr);
+        }
+
         public void RunStructFldScenario()
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunStructFldScenario));
 
             var test = TestStruct.Create();
             test.RunStructFldScenario(this);
+        }
+
+        public void RunStructFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunStructFldScenario_Load));
+
+            var test = TestStruct.Create();
+            test.RunStructFldScenario_Load(this);
         }
 
         public void RunUnsupportedScenario()

--- a/tests/src/JIT/HardwareIntrinsics/X86/Shared/AesImmOpTest.template
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Shared/AesImmOpTest.template
@@ -142,7 +142,7 @@ namespace JIT.HardwareIntrinsics.X86
                 testClass.ValidateResult(testClass._dataTable.outArrayPtr);
             }
 
-            public void RunStructFldScenario_Load(AesImmOpTest__{Method}{RetBaseType} testClass)
+            public void RunStructFldScenario_Load(AesImmOpTest__{Method}{RetBaseType}{Imm} testClass)
             {
                 fixed ({Op1VectorType}<{Op1BaseType}>* pFld = &_fld)
                 {
@@ -348,7 +348,7 @@ namespace JIT.HardwareIntrinsics.X86
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunClassLclFldScenario_Load));
 
-            var test = new SimpleBinaryOpTest__{Method}{RetBaseType}();
+            var test = new AesImmOpTest__{Method}{RetBaseType}{Imm}();
 
             fixed ({Op1VectorType}<{Op1BaseType}>* pFld = &test._fld)
             {

--- a/tests/src/JIT/HardwareIntrinsics/X86/Shared/AesUnOpTest.template
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Shared/AesUnOpTest.template
@@ -21,7 +21,7 @@ namespace JIT.HardwareIntrinsics.X86
     {
         private static void {Method}{RetBaseType}()
         {
-            var test = new SimpleUnaryOpTest__{Method}{RetBaseType}();
+            var test = new AesUnaryOpTest__{Method}{RetBaseType}();
 
             if (test.IsSupported)
             {
@@ -52,6 +52,12 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates passing a static member works
                 test.RunClsVarScenario();
 
+                if ({LoadIsa}.IsSupported)
+                {
+                    // Validates passing a static member works, using pinning and Load
+                    test.RunClsVarScenario_Load();
+                }
+
                 // Validates passing a local works, using Unsafe.Read
                 test.RunLclVarScenario_UnsafeRead();
 
@@ -67,14 +73,38 @@ namespace JIT.HardwareIntrinsics.X86
                 // Validates passing the field of a local class works
                 test.RunClassLclFldScenario();
 
+                if ({LoadIsa}.IsSupported)
+                {
+                    // Validates passing the field of a local class works, using pinning and Load
+                    test.RunClassLclFldScenario_Load();
+                }
+
                 // Validates passing an instance member of a class works
                 test.RunClassFldScenario();
+
+                if ({LoadIsa}.IsSupported)
+                {
+                    // Validates passing an instance member of a class works, using pinning and Load
+                    test.RunClassFldScenario_Load();
+                }
 
                 // Validates passing the field of a local struct works
                 test.RunStructLclFldScenario();
 
+                if ({LoadIsa}.IsSupported)
+                {
+                    // Validates passing the field of a local struct works, using pinning and Load
+                    test.RunStructLclFldScenario_Load();
+                }
+
                 // Validates passing an instance member of a struct works
                 test.RunStructFldScenario();
+
+                if ({LoadIsa}.IsSupported)
+                {
+                    // Validates passing an instance member of a struct works, using pinning and Load
+                    test.RunStructFldScenario_Load();
+                }
             }
             else
             {
@@ -89,7 +119,7 @@ namespace JIT.HardwareIntrinsics.X86
         }
     }
 
-    public sealed unsafe class SimpleUnaryOpTest__{Method}{RetBaseType}
+    public sealed unsafe class AesUnaryOpTest__{Method}{RetBaseType}
     {
         private struct TestStruct
         {
@@ -104,12 +134,25 @@ namespace JIT.HardwareIntrinsics.X86
                 return testStruct;
             }
 
-            public void RunStructFldScenario(SimpleUnaryOpTest__{Method}{RetBaseType} testClass)
+            public void RunStructFldScenario(AesUnaryOpTest__{Method}{RetBaseType} testClass)
             {
                 var result = {Isa}.{Method}(_fld);
 
                 Unsafe.Write(testClass._dataTable.outArrayPtr, result);
                 testClass.ValidateResult(testClass._dataTable.outArrayPtr);
+            }
+
+            public void RunStructFldScenario_Load(AesUnaryOpTest__{Method}{RetBaseType} testClass)
+            {
+                fixed ({Op1VectorType}<{Op1BaseType}>* pFld = &_fld)
+                {
+                    var result = {Isa}.{Method}(
+                        {LoadIsa}.Load{Op1VectorType}(({Op1BaseType}*)(pFld))
+                    );
+
+                    Unsafe.Write(testClass._dataTable.outArrayPtr, result);
+                    testClass.ValidateResult(testClass._dataTable.outArrayPtr);
+                }
             }
         }
 
@@ -126,13 +169,13 @@ namespace JIT.HardwareIntrinsics.X86
 
         private SimpleUnaryOpTest__DataTable<{RetBaseType}, {Op1BaseType}> _dataTable;
 
-        static SimpleUnaryOpTest__{Method}{RetBaseType}()
+        static AesUnaryOpTest__{Method}{RetBaseType}()
         {
 
             Unsafe.CopyBlockUnaligned(ref Unsafe.As<{Op1VectorType}<{Op1BaseType}>, byte>(ref _clsVar), ref Unsafe.As<{Op1BaseType}, byte>(ref _data[0]), (uint)Unsafe.SizeOf<{Op1VectorType}<{Op1BaseType}>>());
         }
 
-        public SimpleUnaryOpTest__{Method}{RetBaseType}()
+        public AesUnaryOpTest__{Method}{RetBaseType}()
         {
             Succeeded = true;
 
@@ -233,6 +276,21 @@ namespace JIT.HardwareIntrinsics.X86
             ValidateResult(_dataTable.outArrayPtr);
         }
 
+        public void RunClsVarScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunClsVarScenario_Load));
+
+            fixed ({Op1VectorType}<{Op1BaseType}>* pClsVar = &_clsVar)
+            {
+                var result = {Isa}.{Method}(
+                    {LoadIsa}.Load{Op1VectorType}(({Op1BaseType}*)(pClsVar))
+                );
+
+                Unsafe.Write(_dataTable.outArrayPtr, result);
+                ValidateResult(_dataTable.outArrayPtr);
+            }
+        }
+
         public void RunLclVarScenario_UnsafeRead()
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunLclVarScenario_UnsafeRead));
@@ -270,11 +328,28 @@ namespace JIT.HardwareIntrinsics.X86
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunClassLclFldScenario));
 
-            var test = new SimpleUnaryOpTest__{Method}{RetBaseType}();
+            var test = new AesUnaryOpTest__{Method}{RetBaseType}();
             var result = {Isa}.{Method}(test._fld);
 
             Unsafe.Write(_dataTable.outArrayPtr, result);
             ValidateResult(_dataTable.outArrayPtr);
+        }
+
+        public void RunClassLclFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunClassLclFldScenario_Load));
+
+            var test = new SimpleBinaryOpTest__{Method}{RetBaseType}();
+
+            fixed ({Op1VectorType}<{Op1BaseType}>* pFld = &test._fld)
+            {
+                var result = {Isa}.{Method}(
+                    {LoadIsa}.Load{Op1VectorType}(({Op1BaseType}*)(pFld))
+                );
+
+                Unsafe.Write(_dataTable.outArrayPtr, result);
+                ValidateResult(_dataTable.outArrayPtr);
+            }
         }
 
         public void RunClassFldScenario()
@@ -285,6 +360,21 @@ namespace JIT.HardwareIntrinsics.X86
 
             Unsafe.Write(_dataTable.outArrayPtr, result);
             ValidateResult(_dataTable.outArrayPtr);
+        }
+
+        public void RunClassFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunClassFldScenario_Load));
+
+            fixed ({Op1VectorType}<{Op1BaseType}>* pFld = &_fld)
+            {
+                var result = {Isa}.{Method}(
+                    {LoadIsa}.Load{Op1VectorType}(({Op1BaseType}*)(pFld))
+                );
+
+                Unsafe.Write(_dataTable.outArrayPtr, result);
+                ValidateResult(_dataTable.outArrayPtr);
+            }
         }
 
         public void RunStructLclFldScenario()
@@ -298,12 +388,33 @@ namespace JIT.HardwareIntrinsics.X86
             ValidateResult(_dataTable.outArrayPtr);
         }
 
+        public void RunStructLclFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunStructLclFldScenario_Load));
+
+            var test = TestStruct.Create();
+            var result = {Isa}.{Method}(
+                {LoadIsa}.Load{Op1VectorType}(({Op1BaseType}*)(&test._fld))
+            );
+
+            Unsafe.Write(_dataTable.outArrayPtr, result);
+            ValidateResult(_dataTable.outArrayPtr);
+        }
+
         public void RunStructFldScenario()
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunStructFldScenario));
 
             var test = TestStruct.Create();
             test.RunStructFldScenario(this);
+        }
+
+        public void RunStructFldScenario_Load()
+        {
+            TestLibrary.TestFramework.BeginScenario(nameof(RunStructFldScenario_Load));
+
+            var test = TestStruct.Create();
+            test.RunStructFldScenario_Load(this);
         }
 
         public void RunUnsupportedScenario()

--- a/tests/src/JIT/HardwareIntrinsics/X86/Shared/AesUnOpTest.template
+++ b/tests/src/JIT/HardwareIntrinsics/X86/Shared/AesUnOpTest.template
@@ -339,7 +339,7 @@ namespace JIT.HardwareIntrinsics.X86
         {
             TestLibrary.TestFramework.BeginScenario(nameof(RunClassLclFldScenario_Load));
 
-            var test = new SimpleBinaryOpTest__{Method}{RetBaseType}();
+            var test = new AesUnaryOpTest__{Method}{RetBaseType}();
 
             fixed ({Op1VectorType}<{Op1BaseType}>* pFld = &test._fld)
             {


### PR DESCRIPTION
This is work towards: https://github.com/dotnet/coreclr/issues/19246. I am going through each ISA and validating that the templates cover all the same scenarios and that every method is covered by a template.

CC. @CarolEidt 