### PR TITLE
Add Series/CounterType to CounterPayload and IncrementingCounterPayload

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterGroup.cs
@@ -182,7 +182,7 @@ namespace System.Diagnostics.Tracing
 
                     foreach (var counter in _counters)
                     {
-                        counter.WritePayload((float)elapsed.TotalSeconds);
+                        counter.WritePayload((float)elapsed.TotalSeconds, _pollingIntervalInMilliseconds);
                     }
                     _timeStampSinceCollectionStarted = now;
                 }

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterPayload.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterPayload.cs
@@ -37,6 +37,10 @@ namespace System.Diagnostics.Tracing
 
         public float IntervalSec { get; internal set; }
 
+        public string? Series { get; set; }
+
+        public string? CounterType { get; set; }
+
         public string? Metadata { get; set; }
 
         #region Implementation of the IEnumerable interface
@@ -86,6 +90,10 @@ namespace System.Diagnostics.Tracing
         public float IntervalSec { get; internal set; }
 
         public string? Metadata { get; set; }
+
+        public string? Series { get; set; }
+
+        public string? CounterType { get; set; }
 
         #region Implementation of the IEnumerable interface
 

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/DiagnosticCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/DiagnosticCounter.cs
@@ -87,7 +87,7 @@ namespace System.Diagnostics.Tracing
         private CounterGroup _group;
         private Dictionary<string, string>? _metadata;
 
-        internal abstract void WritePayload(float intervalSec);
+        internal abstract void WritePayload(float intervalSec, int pollingIntervalMillisec);
 
         // arbitrarily we use name as the lock object.  
         internal object MyLock { get { return Name; } }

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventCounter.cs
@@ -84,7 +84,7 @@ namespace System.Diagnostics.Tracing
             _count++;
         }
 
-        internal override void WritePayload(float intervalSec)
+        internal override void WritePayload(float intervalSec, int pollingIntervalMillisec)
         {
             lock (MyLock)
             {
@@ -104,7 +104,8 @@ namespace System.Diagnostics.Tracing
                 }
                 payload.Min = _min;
                 payload.Max = _max;
-                
+                payload.Series = $"Interval={pollingIntervalMillisec}"; // TODO: This may need to change when we support multi-session
+                payload.CounterType = "Mean";
                 payload.Metadata = GetMetadataString();
                 payload.DisplayName = DisplayName;
                 payload.Name = Name;

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/IncrementingEventCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/IncrementingEventCounter.cs
@@ -56,7 +56,7 @@ namespace System.Diagnostics.Tracing
 
         public override string ToString() => $"IncrementingEventCounter '{Name}' Increment {_increment}";
 
-        internal override void WritePayload(float intervalSec)
+        internal override void WritePayload(float intervalSec, int pollingIntervalMillisec)
         {
             lock (MyLock)     // Lock the counter
             {
@@ -65,6 +65,8 @@ namespace System.Diagnostics.Tracing
                 payload.IntervalSec = intervalSec;
                 payload.DisplayName = DisplayName ?? "";
                 payload.DisplayRateTimeScale = (DisplayRateTimeScale == TimeSpan.Zero) ? "" : DisplayRateTimeScale.ToString("c");
+                payload.Series = $"Interval={pollingIntervalMillisec}"; // TODO: This may need to change when we support multi-session
+                payload.CounterType = "Sum";
                 payload.Metadata = GetMetadataString();
                 payload.Increment = _increment - _prevIncrement;
                 _prevIncrement = _increment;

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/IncrementingPollingCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/IncrementingPollingCounter.cs
@@ -68,7 +68,7 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-        internal override void WritePayload(float intervalSec)
+        internal override void WritePayload(float intervalSec, int pollingIntervalMillisec)
         {
             UpdateMetric();
             lock (MyLock)     // Lock the counter
@@ -78,6 +78,8 @@ namespace System.Diagnostics.Tracing
                 payload.DisplayName = DisplayName ?? "";
                 payload.DisplayRateTimeScale = (DisplayRateTimeScale == TimeSpan.Zero) ? "" : DisplayRateTimeScale.ToString("c");
                 payload.IntervalSec = intervalSec;
+                payload.Series = $"Interval={pollingIntervalMillisec}"; // TODO: This may need to change when we support multi-session
+                payload.CounterType = "Sum";
                 payload.Metadata = GetMetadataString();
                 payload.Increment = _increment - _prevIncrement;
                 _prevIncrement = _increment;

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/PollingCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/PollingCounter.cs
@@ -46,7 +46,7 @@ namespace System.Diagnostics.Tracing
         private Func<double> _metricProvider;
         private double _lastVal;
 
-        internal override void WritePayload(float intervalSec)
+        internal override void WritePayload(float intervalSec, int pollingIntervalMillisec)
         {
             lock (MyLock)
             {
@@ -65,6 +65,8 @@ namespace System.Diagnostics.Tracing
                 payload.DisplayName = DisplayName ?? "";
                 payload.Count = 1; // NOTE: These dumb-looking statistics is intentional
                 payload.IntervalSec = intervalSec;
+                payload.Series = $"Interval={pollingIntervalMillisec}";  // TODO: This may need to change when we support multi-session
+                payload.CounterType = "Mean";
                 payload.Mean = value;
                 payload.Max = value;
                 payload.Min = value;


### PR DESCRIPTION
This fixes #24346. 

For now, `Series` field contains the current polling interval in milliseconds. This may need to change once we start supporting multi-session for EventPipe.