### PR TITLE
Fix GCStress for multireg returns. 

### DIFF
--- a/src/vm/gccover.cpp
+++ b/src/vm/gccover.cpp
@@ -1696,7 +1696,7 @@ void DoGcStress (PCONTEXT regs, MethodDesc *pMD)
     OBJECTREF* retPointer = 0;
     UINT numObjRefs = 1;
 #if defined(UNIX_AMD64_ABI) || defined(_TARGET_ARM64_)
-    // Multireg return.
+    // These targets support multireg returns.
     DWORD_PTR retValArray[2];
     retPointer = (OBJECTREF*)retValArray;
 #else // ARM32, x86, AMD64 Windows.

--- a/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+// The test returns 2*pointer size struct where the second pointer is a managed object
+// and need a gc reference. On amd64 Unix and arm64 such structs are returned via registers.
+// The was a problem in GCStress infrastracture where it did not mark this pointer alive.
+
+namespace GitHub_23199
+{
+    public class Program
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void Test1()
+        {
+            ProcessStartInfo pi = new ProcessStartInfo();
+            // pi.Environment calls crossgened HashtableEnumerator::get_Entry returning struct that we need.
+            Console.WriteLine(pi.Environment.Count);
+        }
+
+        struct A
+        {
+            public String a;
+            public String b;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static A GetA()
+        {
+            A a = new A();
+            a.a = new String("Hello");
+            a.b = new string("World!");
+            return a;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void Test2()
+        {
+            A a = GetA();
+            Console.WriteLine(a.a + " " + a.b);
+        }
+
+        static int Main(string[] args)
+        {
+            Test1();
+            Test2();
+            return 100;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.csproj
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Fixes #23199, thanks @BruceForstall for finding the bug.

0c16be11a2: Add a repro test.

353637b8cd: Fix DoGcStress for multireg return with GC pointers.

Note: we are overprotecting registers here, for example, we always protect 2 registers even if only one is returned. GCStress infrastructure should be able to tolerate extra registers. We have had such examples before (for example when returned a struct without pointers we protected the first reg anyway).