### PR TITLE
Re-enable EventSourceTrace test

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -193,9 +193,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/eh/FinallyExec/nonlocalexitinhandler/*">
             <Issue>times out</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventsource/eventsourcetrace/eventsourcetrace/*">
-            <Issue>needs triage</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/tracevalidation/inducedgc/inducedgc/*">
             <Issue>times out</Issue>
         </ExcludeList>


### PR DESCRIPTION
This test was disabled because of an issue with EventPipeCrst lock ordering. That was addressed in https://github.com/dotnet/coreclr/pull/24101, so I'm going to re-enable this test. 