### PR TITLE
Fix some small issues with stress logging.

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -11004,7 +11004,7 @@ BOOL gc_heap::grow_heap_segment (heap_segment* seg, uint8_t* high_address, bool*
 #endif //MARK_ARRAY
         heap_segment_committed (seg) += c_size;
 
-        STRESS_LOG1(LF_GC, LL_INFO10000, "New commit: %Ix",
+        STRESS_LOG1(LF_GC, LL_INFO10000, "New commit: %Ix\n",
                     (size_t)heap_segment_committed (seg));
 
         assert (heap_segment_committed (seg) <= heap_segment_reserved (seg));

--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -967,15 +967,18 @@ void GCFrame::GcScanRoots(promote_func *fn, ScanContext* sc)
 
     PTR_PTR_Object pRefs = dac_cast<PTR_PTR_Object>(m_pObjRefs);
 
-    for (UINT i = 0;i < m_numObjRefs; i++)  {
-
-        LOG((LF_GC, INFO3, "GC Protection Frame Promoting" FMT_ADDR "to",
-             DBG_ADDR(OBJECTREF_TO_UNCHECKED_OBJECTREF(m_pObjRefs[i])) ));
+    for (UINT i = 0;i < m_numObjRefs; i++)
+    {
+        OBJECTREF fromAddress = m_pObjRefs[i];
         if (m_MaybeInterior)
             PromoteCarefully(fn, pRefs + i, sc, GC_CALL_INTERIOR|CHECK_APP_DOMAIN);
         else
             (*fn)(pRefs + i, sc, 0);
-        LOG((LF_GC, INFO3, FMT_ADDR "\n", DBG_ADDR(OBJECTREF_TO_UNCHECKED_OBJECTREF(m_pObjRefs[i])) ));
+
+        OBJECTREF toAdress = m_pObjRefs[i];
+        LOG((LF_GC, INFO3, "GC Protection Frame Promoting" FMT_ADDR "to" FMT_ADDR "\n",
+            DBG_ADDR(OBJECTREF_TO_UNCHECKED_OBJECTREF(fromAddress)),
+            DBG_ADDR(OBJECTREF_TO_UNCHECKED_OBJECTREF(toAdress))));
     }
 }
 

--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -967,18 +967,21 @@ void GCFrame::GcScanRoots(promote_func *fn, ScanContext* sc)
 
     PTR_PTR_Object pRefs = dac_cast<PTR_PTR_Object>(m_pObjRefs);
 
-    for (UINT i = 0;i < m_numObjRefs; i++)
+    for (UINT i = 0; i < m_numObjRefs; i++)
     {
-        OBJECTREF fromAddress = m_pObjRefs[i];
+        auto fromAddress = OBJECTREF_TO_UNCHECKED_OBJECTREF(m_pObjRefs[i]);
         if (m_MaybeInterior)
-            PromoteCarefully(fn, pRefs + i, sc, GC_CALL_INTERIOR|CHECK_APP_DOMAIN);
+        {
+            PromoteCarefully(fn, pRefs + i, sc, GC_CALL_INTERIOR | CHECK_APP_DOMAIN);
+        }
         else
+        {
             (*fn)(pRefs + i, sc, 0);
+        }
 
-        OBJECTREF toAddress = m_pObjRefs[i];
+        auto toAddress = OBJECTREF_TO_UNCHECKED_OBJECTREF(m_pObjRefs[i]);
         LOG((LF_GC, INFO3, "GC Protection Frame promoted" FMT_ADDR "to" FMT_ADDR "\n",
-            DBG_ADDR(OBJECTREF_TO_UNCHECKED_OBJECTREF(fromAddress)),
-            DBG_ADDR(OBJECTREF_TO_UNCHECKED_OBJECTREF(toAddress))));
+            DBG_ADDR(fromAddress), DBG_ADDR(toAddress)));
     }
 }
 

--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -975,10 +975,10 @@ void GCFrame::GcScanRoots(promote_func *fn, ScanContext* sc)
         else
             (*fn)(pRefs + i, sc, 0);
 
-        OBJECTREF toAdress = m_pObjRefs[i];
-        LOG((LF_GC, INFO3, "GC Protection Frame Promoting" FMT_ADDR "to" FMT_ADDR "\n",
+        OBJECTREF toAddress = m_pObjRefs[i];
+        LOG((LF_GC, INFO3, "GC Protection Frame promoted" FMT_ADDR "to" FMT_ADDR "\n",
             DBG_ADDR(OBJECTREF_TO_UNCHECKED_OBJECTREF(fromAddress)),
-            DBG_ADDR(OBJECTREF_TO_UNCHECKED_OBJECTREF(toAdress))));
+            DBG_ADDR(OBJECTREF_TO_UNCHECKED_OBJECTREF(toAddress))));
     }
 }
 


### PR DESCRIPTION
`PromoteCarefully` can add its own logging to the output and we got string like
```
TID 5948: GC Protection Frame Promoting 00007fff`54010050 to    IGCHeap::Promote: Promote GC Root *00007FFFFFFFDC08 = 00007FFF54010050 MT = 00007FFF7DC97638T
TID 5948:  00007fff`54010050 
```
and without a newline:
`TID 5948: New commit: 7fff54031000Growing heap_segment: 7fff53ffe000 high address: 7fff5403e818`