### PR TITLE
Switch to zero-length array in otherwise empty class

### DIFF
--- a/src/vm/virtualcallstub.h
+++ b/src/vm/virtualcallstub.h
@@ -1591,7 +1591,7 @@ private:
     //we store the used count in bucket[CALL_STUB_COUNT_INDEX==1],
     //we have an unused cell to use as a temp at bucket[CALL_STUB_DEAD_LINK==2],
     //and the table starts at bucket[CALL_STUB_FIRST_INDEX==3],
-    size_t contents[];
+    size_t contents[0];
 };
 #ifdef _MSC_VER 
 #pragma warning(pop)


### PR DESCRIPTION
Flexible array is a feature of ISO C99, that ISO C++ has not ([yet](https://thephd.github.io/vendor/future_cxx/papers/d1039.html))
included. Therefore clang and gcc with `-fpedantic` and msvc with
`/Wall` warn about it, and are equally unhappy when flexible array is
used in C++ code.

The exception in CoreCLR is `FastTable` class, where there is only one
member which is a flexible array. The length of array is written at a
specific offset of contents array.

gcc 6+ does not like this particular case, and gives a fatal error that
cannot be suppressed by regular means (`-Wno-XXX`):

```
error: flexible array member FastTable::contents in an otherwise empty class FastTable
    size_t contents[];
                    ^
```

Fix is to either not wrap this single field in concrete data structure
or use a zero-length array instead, which produces same assembly code
as the flexible array; tested with clang, gcc and msvc.

Read about this fix here: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69550