### PR TITLE
Ensure that SIMD fields are correctly typed

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -4672,6 +4672,8 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
             return;
         }
 
+        // TODO-CQ: It would be better to simply contain the zero, rather than
+        // generating zero into a register.
         if (varTypeIsSIMD(targetType) && (targetReg != REG_NA) && op1->IsCnsIntOrI())
         {
             // This is only possible for a zero-init.

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -1178,6 +1178,12 @@ inline GenTree* Compiler::gtNewFieldRef(var_types typ, CORINFO_FIELD_HANDLE fldH
     /* 'GT_FIELD' nodes may later get transformed into 'GT_IND' */
     assert(GenTree::s_gtNodeSizes[GT_IND] <= GenTree::s_gtNodeSizes[GT_FIELD]);
 
+    if (typ == TYP_STRUCT)
+    {
+        CORINFO_CLASS_HANDLE fieldClass;
+        (void)info.compCompHnd->getFieldType(fldHnd, &fieldClass);
+        typ = impNormStructType(fieldClass);
+    }
     GenTree* tree = new (this, GT_FIELD) GenTreeField(typ, obj, fldHnd, offset);
 
     // If "obj" is the address of a local, note that a field of that struct local has been accessed.

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -50,6 +50,13 @@ void Compiler::fgMarkUseDef(GenTreeLclVarCommon* tree)
         // loads aliasing it across a store to it.
         assert(!varDsc->lvAddrExposed);
 
+        if (compRationalIRForm && (varDsc->lvType != TYP_STRUCT) && !varTypeIsMultiReg(varDsc))
+        {
+            // If this is an enregisterable variable that is not marked doNotEnregister,
+            // we should only see direct references (not ADDRs).
+            assert(varDsc->lvDoNotEnregister || tree->OperIs(GT_LCL_VAR, GT_STORE_LCL_VAR));
+        }
+
         if (isUse && !VarSetOps::IsMember(this, fgCurDefSet, varDsc->lvVarIndex))
         {
             // This is an exposed use; add it to the set of uses.

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -755,8 +755,8 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, Compiler::Ge
             break;
 
         case GT_BLK:
-            // We should only see GT_BLK for TYP_STRUCT.
-            assert(node->TypeGet() == TYP_STRUCT);
+            // We should only see GT_BLK for TYP_STRUCT or for InitBlocks.
+            assert((node->TypeGet() == TYP_STRUCT) || use.User()->OperIsInitBlkOp());
             break;
 
         case GT_OBJ:


### PR DESCRIPTION
When a struct field is imported, its type needs to be normalized.
Also, the LHS of a struct init, even if a SIMD type, should not be transformed to a non-block node.
Also, add an assert to catch this kind of bug in liveness.

Fix #24336