### PR TITLE
Fix 23317

### DIFF
--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -5447,21 +5447,33 @@ void CEEInfo::getCallInfo(
         //    (c) constraint calls that require runtime context lookup are never resolved 
         //        to underlying shared generic code
 
+        bool unresolvedLdVirtFtn = (flags & CORINFO_CALLINFO_LDFTN) && (flags & CORINFO_CALLINFO_CALLVIRT) && !resolvedCallVirt;
+
         if (((pResult->exactContextNeedsRuntimeLookup && pTargetMD->IsInstantiatingStub() && (!allowInstParam || fResolvedConstraint)) || fForceUseRuntimeLookup)
                 // Handle invalid IL - see comment in code:CEEInfo::ComputeRuntimeLookupForSharedGenericToken
                 && ContextIsShared(pResolvedToken->tokenContext))
         {
             _ASSERTE(!m_pMethodBeingCompiled->IsDynamicMethod());
-            pResult->kind = CORINFO_CALL_CODE_POINTER;
 
-            // For reference types, the constrained type does not affect method resolution
-            DictionaryEntryKind entryKind = (!constrainedType.IsNull() && constrainedType.IsValueType()) ? ConstrainedMethodEntrySlot : MethodEntrySlot;
+            if (IsReadyToRunCompilation() && unresolvedLdVirtFtn)
+            {
+                // Compensate for always treating delegates as direct calls above.
+                // Dictionary lookup is computed in embedGenericHandle as part of the LDVIRTFTN code sequence
+                pResult->kind = CORINFO_VIRTUALCALL_LDVIRTFTN;
+            }
+            else
+            {
+                pResult->kind = CORINFO_CALL_CODE_POINTER;
 
-            ComputeRuntimeLookupForSharedGenericToken(entryKind,
-                                                      pResolvedToken,
-                                                      pConstrainedResolvedToken,
-                                                      pMD,
-                                                      &pResult->codePointerLookup);
+                // For reference types, the constrained type does not affect method resolution
+                DictionaryEntryKind entryKind = (!constrainedType.IsNull() && constrainedType.IsValueType()) ? ConstrainedMethodEntrySlot : MethodEntrySlot;
+
+                ComputeRuntimeLookupForSharedGenericToken(entryKind,
+                                                            pResolvedToken,
+                                                            pConstrainedResolvedToken,
+                                                            pMD,
+                                                            &pResult->codePointerLookup);
+            }
         }
         else
         {
@@ -5472,13 +5484,10 @@ void CEEInfo::getCallInfo(
 
             pResult->kind = CORINFO_CALL;
 
-            if (IsReadyToRunCompilation())
+            if (IsReadyToRunCompilation() && unresolvedLdVirtFtn)
             {
                 // Compensate for always treating delegates as direct calls above
-                if ((flags & CORINFO_CALLINFO_LDFTN) && (flags & CORINFO_CALLINFO_CALLVIRT) && !resolvedCallVirt)
-                {
-                   pResult->kind = CORINFO_VIRTUALCALL_LDVIRTFTN;
-                }
+                pResult->kind = CORINFO_VIRTUALCALL_LDVIRTFTN;
             }
         }
         pResult->nullInstanceCheck = resolvedCallVirt;

--- a/tests/src/Loader/classloader/regressions/GitHub_23317/LdVirtFtnOnAbstractMethod.cs
+++ b/tests/src/Loader/classloader/regressions/GitHub_23317/LdVirtFtnOnAbstractMethod.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+
+delegate int Del(object p);
+
+abstract class Base
+{
+    public abstract int Target<U>(object p);
+}
+
+class Middle : Base
+{
+    public override int Target<U>(object p) => 123;
+}
+
+class Top : Middle
+{
+    public override int Target<U>(object p) => 456;
+
+    public Del TestA<U>()
+    {
+        return new Del(base.Target<U>);
+    }
+
+    public Del TestB<U>()
+    {
+        return new Del(Target<U>);
+    }
+}
+
+class Test
+{
+    public static int Main() 
+    {
+        var del1 = new Top().TestA<object>();
+        var del2 = new Top().TestB<object>();
+        
+        var x = del1(null);
+        var y = del2(null);
+        Console.WriteLine(x);
+        Console.WriteLine(y);
+
+        if (x == 123 && y == 456)
+        {
+            Console.WriteLine("Pass");
+            return 100;
+        }
+        Console.WriteLine("FAIL");
+        return -1;
+    }
+}

--- a/tests/src/Loader/classloader/regressions/GitHub_23317/LdVirtFtnOnAbstractMethod.csproj
+++ b/tests/src/Loader/classloader/regressions/GitHub_23317/LdVirtFtnOnAbstractMethod.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>LdVirtFtnOnAbstractMethod</AssemblyName>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="LdVirtFtnOnAbstractMethod.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
The issue is that a LDVIRTFTN operation becomes a dictionary lookup to a direct call to an abstract function with no code. We AV later when executing the PreStub of that direct call. Fixed by making this a dictionary lookup to a MethodDescSlot lookup, followed by the call to the JIT_VirtualFunctionPointer helper to resolve the target code (Same logic executing in jitted IL mode)