### PR TITLE
Fix EventPipe initialization order

### DIFF
--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -663,8 +663,8 @@ void EEStartupHelper(COINITIEE fFlags)
 
 #ifdef FEATURE_PERFTRACING
         // Initialize the event pipe.
-        DiagnosticServer::Initialize();
         EventPipe::Initialize();
+        DiagnosticServer::Initialize();
 #endif // FEATURE_PERFTRACING
 
 #ifdef FEATURE_GDBJIT


### PR DESCRIPTION
Once `DiagnosticServer::Initialize()` is called, a connection might cause `EventPipe::Enable()` to be called on the `DiagnosticServerThread`, but if `EventPipe::Initialize()` is not called yet, then `EventPipe::GetLock()` is not initialized yet, which will cause the `EventPipe::Enable()` call on the `DiagnosticServerThread` to fail.

The fix is simply swapping the initialization order.