### PR TITLE
Replace E_FAIL with E_NOTIMPL for an unsupported R2R encoding (Futurework)

### DIFF
--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -5239,7 +5239,9 @@ mdTypeRef Module::LookupTypeRefByMethodTable(MethodTable *pMT)
 
         // FUTURE: Encoding of new cross-module references for ReadyToRun
         // This warning is hit for recursive cross-module inlining. It is commented out to avoid noise.
-        // GetSvcLogger()->Log(W("ReadyToRun: Type reference outside of current version bubble cannot be encoded\n"));
+        // if (g_CorCompileVerboseLevel >= CORCOMPILE_VERBOSE)
+        //     GetSvcLogger()->Log(W("ReadyToRun: Type reference outside of current version bubble cannot be encoded\n"));
+        ThrowHR(E_NOTIMPL);
     }
     else
 #endif // FEATURE_READYTORUN_COMPILER


### PR DESCRIPTION
/cc @sergiy-k @VSadov 

This fixes the "Unspecified error (0x80004005 (E_FAIL))" errors you saw when compiling Microsoft.CodeAnalysis.dll. It's really not a failure... it's some encoding we don't support yet in R2R. Should be addressed as part of the version bubble work.

Nit: keeping the warning message commented out, but just under an also commented-out verbosity check.