### PR TITLE
Improve fatal err msg

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.Unix.cs
@@ -27,19 +27,7 @@ namespace System.Diagnostics
                 // In Core, we do not show a dialog.
                 // Fail in order to avoid anyone catching an exception and masking
                 // an assert failure.
-                DebugAssertException ex;
-                if (message == string.Empty) 
-                {
-                    ex = new DebugAssertException(stackTrace);
-                }
-                else if (detailMessage == string.Empty) 
-                {
-                    ex = new DebugAssertException(message, stackTrace);
-                }
-                else
-                {
-                    ex = new DebugAssertException(message, detailMessage, stackTrace);
-                }
+                DebugAssertException ex = new DebugAssertException(message, detailMessage, stackTrace);
                 Environment.FailFast(ex.Message, ex, errorSource);
             }
         }

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.Windows.cs
@@ -23,19 +23,7 @@ namespace System.Diagnostics
                 // In Core, we do not show a dialog.
                 // Fail in order to avoid anyone catching an exception and masking
                 // an assert failure.
-                DebugAssertException ex;
-                if (message == string.Empty) 
-                {
-                    ex = new DebugAssertException(stackTrace);
-                }
-                else if (detailMessage == string.Empty) 
-                {
-                    ex = new DebugAssertException(message, stackTrace);
-                }
-                else
-                {
-                    ex = new DebugAssertException(message, detailMessage, stackTrace);
-                }
+                DebugAssertException ex = new DebugAssertException(message, detailMessage, stackTrace);
                 Environment.FailFast(ex.Message, ex, errorSource);
             }
         }

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
@@ -72,16 +72,6 @@ namespace System.Diagnostics
 
         private sealed class DebugAssertException : Exception
         {
-            internal DebugAssertException(string? stackTrace) :
-                base(stackTrace)
-            {
-            }
-
-            internal DebugAssertException(string? message, string? stackTrace) :
-                base(Terminate(message) + stackTrace)
-            {
-            }
-
             internal DebugAssertException(string? message, string? detailMessage, string? stackTrace) :
                 base(Terminate(message) + Terminate(detailMessage) + stackTrace)
             {

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
@@ -24,7 +24,7 @@ namespace System.Diagnostics
                 stackTrace = "";
             }
             WriteAssert(stackTrace, message, detailMessage);
-            FailCore(stackTrace, message, detailMessage, "Assertion Failed");
+            FailCore(stackTrace, message, detailMessage, "Assertion failed.");
         }
 
         internal void WriteAssert(string stackTrace, string? message, string? detailMessage)

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
@@ -73,18 +73,30 @@ namespace System.Diagnostics
         private sealed class DebugAssertException : Exception
         {
             internal DebugAssertException(string? stackTrace) :
-                base(Environment.NewLine + stackTrace)
+                base(stackTrace)
             {
             }
 
             internal DebugAssertException(string? message, string? stackTrace) :
-                base(message + Environment.NewLine + Environment.NewLine + stackTrace)
+                base(Terminate(message) + stackTrace)
             {
             }
 
             internal DebugAssertException(string? message, string? detailMessage, string? stackTrace) :
-                base(message + Environment.NewLine + detailMessage + Environment.NewLine + Environment.NewLine + stackTrace)
+                base(Terminate(message) + Terminate(detailMessage) + stackTrace)
             {
+            }
+
+            private string Terminate(string? s)
+            {
+                if (s == null)
+                    return s;
+
+                s = s.Trim();
+                if (s.Length > 0)
+                    s += Environment.NewLine;
+
+                return s;
             }
         }
 

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
@@ -87,7 +87,7 @@ namespace System.Diagnostics
             {
             }
 
-            private string Terminate(string? s)
+            private static string? Terminate(string? s)
             {
                 if (s == null)
                     return s;

--- a/src/System.Private.CoreLib/shared/System/Exception.cs
+++ b/src/System.Private.CoreLib/shared/System/Exception.cs
@@ -155,12 +155,10 @@ namespace System
                 "   " + SR.Exception_EndOfInnerExceptionStack;
             }
 
-            s += Environment.NewLine;
-
             string? stackTrace = StackTrace;
             if (stackTrace != null)
             {
-                s += stackTrace;
+                s += Environment.NewLine + stackTrace;
             }
 
             return s;

--- a/src/System.Private.CoreLib/shared/System/Exception.cs
+++ b/src/System.Private.CoreLib/shared/System/Exception.cs
@@ -152,13 +152,13 @@ namespace System
             if (_innerException != null)
             {
                 s = s + " ---> " + _innerException.ToString() + Environment.NewLine +
-                "   " + SR.Exception_EndOfInnerExceptionStack;
+                "   " + SR.Exception_EndOfInnerExceptionStack + Environment.NewLine;
             }
 
             string? stackTrace = StackTrace;
             if (stackTrace != null)
             {
-                s += Environment.NewLine + stackTrace;
+                s += stackTrace;
             }
 
             return s;

--- a/src/System.Private.CoreLib/shared/System/Exception.cs
+++ b/src/System.Private.CoreLib/shared/System/Exception.cs
@@ -152,8 +152,10 @@ namespace System
             if (_innerException != null)
             {
                 s = s + " ---> " + _innerException.ToString() + Environment.NewLine +
-                "   " + SR.Exception_EndOfInnerExceptionStack + Environment.NewLine;
+                "   " + SR.Exception_EndOfInnerExceptionStack;
             }
+
+            s += Environment.NewLine;
 
             string? stackTrace = StackTrace;
             if (stackTrace != null)

--- a/src/dlls/mscorrc/mscorrc.rc
+++ b/src/dlls/mscorrc/mscorrc.rc
@@ -837,7 +837,7 @@ BEGIN
     IDS_EE_STRUCTARRAYTOOLARGE              "Array size exceeds addressing limitations."
     IDS_EE_TOOMANYFIELDS                    "Internal limitation: too many fields."
 
-    IDS_EE_UNHANDLED_EXCEPTION              "Process is terminating due to an unhandled exception."
+    IDS_EE_UNHANDLED_EXCEPTION              "Unhandled exception."
     IDS_EE_EXCEPTION_TOSTRING_FAILED        "Cannot print exception string because Exception.ToString() failed."
 
     IDS_EE_THREAD_ABORT                     "Thread was being aborted."

--- a/src/dlls/mscorrc/mscorrc.rc
+++ b/src/dlls/mscorrc/mscorrc.rc
@@ -837,7 +837,7 @@ BEGIN
     IDS_EE_STRUCTARRAYTOOLARGE              "Array size exceeds addressing limitations."
     IDS_EE_TOOMANYFIELDS                    "Internal limitation: too many fields."
 
-    IDS_EE_UNHANDLED_EXCEPTION              "Unhandled Exception:"
+    IDS_EE_UNHANDLED_EXCEPTION              "Process is terminating due to an unhandled exception."
     IDS_EE_EXCEPTION_TOSTRING_FAILED        "Cannot print exception string because Exception.ToString() failed."
 
     IDS_EE_THREAD_ABORT                     "Thread was being aborted."

--- a/src/pal/src/include/pal/palinternal.h
+++ b/src/pal/src/include/pal/palinternal.h
@@ -760,7 +760,7 @@ inline T* InterlockedCompareExchangePointerT(
 
 #include "volatile.h"
 
-const char StackOverflowMessage[] = "Process is terminating due to StackOverflowException.\n";
+const char StackOverflowMessage[] = "Process is terminating due to a StackOverflowException.\n";
 
 #endif // __cplusplus
 

--- a/src/pal/src/include/pal/palinternal.h
+++ b/src/pal/src/include/pal/palinternal.h
@@ -760,7 +760,7 @@ inline T* InterlockedCompareExchangePointerT(
 
 #include "volatile.h"
 
-const char StackOverflowMessage[] = "Process is terminating due to a stack overflow.\n";
+const char StackOverflowMessage[] = "Stack overflow.\n";
 
 #endif // __cplusplus
 

--- a/src/pal/src/include/pal/palinternal.h
+++ b/src/pal/src/include/pal/palinternal.h
@@ -760,7 +760,7 @@ inline T* InterlockedCompareExchangePointerT(
 
 #include "volatile.h"
 
-const char StackOverflowMessage[] = "Process is terminating due to a StackOverflowException.\n";
+const char StackOverflowMessage[] = "Process is terminating due to a stack overflow.\n";
 
 #endif // __cplusplus
 

--- a/src/vm/comutilnative.cpp
+++ b/src/vm/comutilnative.cpp
@@ -43,8 +43,6 @@
 
 #include "arraynative.inl"
 
-#define STACK_OVERFLOW_MESSAGE   W("StackOverflowException")
-
 /*===================================IsDigit====================================
 **Returns a bool indicating whether the character passed in represents a   **
 **digit.
@@ -535,14 +533,6 @@ void ExceptionNative::GetExceptionData(OBJECTREF objException, ExceptionData *pE
     CONTRACTL_END;
 
     ZeroMemory(pED, sizeof(ExceptionData));
-
-    if (objException->GetMethodTable() == g_pStackOverflowExceptionClass) {
-        // In a low stack situation, most everything else in here will fail.
-        // <TODO>@TODO: We're not turning the guard page back on here, yet.</TODO>
-        pED->hr = COR_E_STACKOVERFLOW;
-        pED->bstrDescription = SysAllocString(STACK_OVERFLOW_MESSAGE);
-        return;
-    }
 
     GCPROTECT_BEGIN(objException);
     pED->hr = GetExceptionHResult(objException);

--- a/src/vm/eepolicy.cpp
+++ b/src/vm/eepolicy.cpp
@@ -817,7 +817,7 @@ void LogInfoForFatalError(UINT exitCode, LPCWSTR pszMessage, LPCWSTR errorSource
     Thread *pThread = GetThread();
     EX_TRY
     {
-        PrintToStdErrA("\nProcess is terminating due to a ");
+        PrintToStdErrA("Process is terminating due to a ");
         if (exitCode == (UINT)COR_E_FAILFAST)
         {
             PrintToStdErrA("FailFast.\n\n");

--- a/src/vm/eepolicy.cpp
+++ b/src/vm/eepolicy.cpp
@@ -804,8 +804,8 @@ inline void LogCallstackForLogWorker()
 // Arguments:
 //    exitCode - code of the fatal error
 //    pszMessage - error message (can be NULL)
-//    errorSource - details on the source of the error
-//    argExceptionString - exception details
+//    errorSource - details on the source of the error (can be NULL)
+//    argExceptionString - exception details (can be NULL)
 //
 // Return Value:
 //    None
@@ -817,9 +817,14 @@ void LogInfoForFatalError(UINT exitCode, LPCWSTR pszMessage, LPCWSTR errorSource
     Thread *pThread = GetThread();
     EX_TRY
     {
-        if ((exitCode == (UINT)COR_E_FAILFAST) && (errorSource == NULL))
+        PrintToStdErrA("Terminating process due to a ");
+        if (exitCode == (UINT)COR_E_FAILFAST)
         {
-            PrintToStdErrA("FailFast:\n");
+            PrintToStdErrA("FailFast.\n");
+        }
+        else
+        {
+            PrintToStdErrA("fatal error.\n");
         }
 
         if (errorSource != NULL)

--- a/src/vm/eepolicy.cpp
+++ b/src/vm/eepolicy.cpp
@@ -1049,7 +1049,7 @@ void DisplayStackOverflowException()
     LIMITED_METHOD_CONTRACT;
     PrintToStdErrA("\n");
 
-    PrintToStdErrA("Process is terminating due to StackOverflowException.\n");
+    PrintToStdErrA("Process is terminating due to a StackOverflowException.\n");
 }
 
 void DECLSPEC_NORETURN EEPolicy::HandleFatalStackOverflow(EXCEPTION_POINTERS *pExceptionInfo, BOOL fSkipDebugger)

--- a/src/vm/eepolicy.cpp
+++ b/src/vm/eepolicy.cpp
@@ -817,14 +817,14 @@ void LogInfoForFatalError(UINT exitCode, LPCWSTR pszMessage, LPCWSTR errorSource
     Thread *pThread = GetThread();
     EX_TRY
     {
-        PrintToStdErrA("Terminating process due to a ");
+        PrintToStdErrA("\nProcess is terminating due to a ");
         if (exitCode == (UINT)COR_E_FAILFAST)
         {
-            PrintToStdErrA("FailFast.\n");
+            PrintToStdErrA("FailFast.\n\n");
         }
         else
         {
-            PrintToStdErrA("fatal error.\n");
+            PrintToStdErrA("fatal error.\n\n");
         }
 
         if (errorSource != NULL)

--- a/src/vm/eepolicy.cpp
+++ b/src/vm/eepolicy.cpp
@@ -819,11 +819,11 @@ void LogInfoForFatalError(UINT exitCode, LPCWSTR pszMessage, LPCWSTR errorSource
     {
         if (exitCode == (UINT)COR_E_FAILFAST)
         {
-            PrintToStdErrA("\nProcess terminated. ");
+            PrintToStdErrA("Process terminated. ");
         }
         else
         {
-            PrintToStdErrA("\nFatal error. ");
+            PrintToStdErrA("Fatal error. ");
         }
 
         if (errorSource != NULL)
@@ -1042,7 +1042,6 @@ void EEPolicy::LogFatalError(UINT exitCode, UINT_PTR address, LPCWSTR pszMessage
 void DisplayStackOverflowException()
 {
     LIMITED_METHOD_CONTRACT;
-    PrintToStdErrA("\n");
 
     PrintToStdErrA("Stack overflow.\n");
 }

--- a/src/vm/eepolicy.cpp
+++ b/src/vm/eepolicy.cpp
@@ -830,7 +830,7 @@ void LogInfoForFatalError(UINT exitCode, LPCWSTR pszMessage, LPCWSTR errorSource
         if (errorSource != NULL)
         {
             PrintToStdErrW(errorSource);
-            PrintToStdErrA("\n");
+            PrintToStdErrA("\n\n");
         }
 
         if (pszMessage != NULL)
@@ -845,7 +845,7 @@ void LogInfoForFatalError(UINT exitCode, LPCWSTR pszMessage, LPCWSTR errorSource
             PrintToStdErrW((LPCWSTR)exitCodeMessage);
         }
 
-        PrintToStdErrA("\n");
+        PrintToStdErrA("\n\n");
 
         if (pThread && errorSource == NULL)
         {
@@ -854,7 +854,7 @@ void LogInfoForFatalError(UINT exitCode, LPCWSTR pszMessage, LPCWSTR errorSource
             if (argExceptionString != NULL) {
                 PrintToStdErrA("\n");
                 PrintToStdErrA("Exception details:");
-                PrintToStdErrA("\n");
+                PrintToStdErrA("\n\n");
                 PrintToStdErrW(argExceptionString);
                 PrintToStdErrA("\n");
             }
@@ -1049,7 +1049,7 @@ void DisplayStackOverflowException()
     LIMITED_METHOD_CONTRACT;
     PrintToStdErrA("\n");
 
-    PrintToStdErrA("Process is terminating due to a StackOverflowException.\n");
+    PrintToStdErrA("Process is terminating due to a stack overflow.\n");
 }
 
 void DECLSPEC_NORETURN EEPolicy::HandleFatalStackOverflow(EXCEPTION_POINTERS *pExceptionInfo, BOOL fSkipDebugger)

--- a/src/vm/eepolicy.cpp
+++ b/src/vm/eepolicy.cpp
@@ -819,7 +819,7 @@ void LogInfoForFatalError(UINT exitCode, LPCWSTR pszMessage, LPCWSTR errorSource
     {
         if (exitCode == (UINT)COR_E_FAILFAST)
         {
-            PrintToStdErrA("\nProcess stopped. ");
+            PrintToStdErrA("\nProcess terminated. ");
         }
         else
         {
@@ -829,7 +829,7 @@ void LogInfoForFatalError(UINT exitCode, LPCWSTR pszMessage, LPCWSTR errorSource
         if (errorSource != NULL)
         {
             PrintToStdErrW(errorSource);
-            PrintToStdErrA("\n\n");
+            PrintToStdErrA("\n");
         }
 
         if (pszMessage != NULL)
@@ -844,18 +844,14 @@ void LogInfoForFatalError(UINT exitCode, LPCWSTR pszMessage, LPCWSTR errorSource
             PrintToStdErrW((LPCWSTR)exitCodeMessage);
         }
 
-        PrintToStdErrA("\n\n");
+        PrintToStdErrA("\n");
 
         if (pThread && errorSource == NULL)
         {
             LogCallstackForLogWorker();
 
             if (argExceptionString != NULL) {
-                PrintToStdErrA("\n");
-                PrintToStdErrA("Exception details:");
-                PrintToStdErrA("\n\n");
                 PrintToStdErrW(argExceptionString);
-                PrintToStdErrA("\n");
             }
         }
     }

--- a/src/vm/eepolicy.cpp
+++ b/src/vm/eepolicy.cpp
@@ -817,14 +817,13 @@ void LogInfoForFatalError(UINT exitCode, LPCWSTR pszMessage, LPCWSTR errorSource
     Thread *pThread = GetThread();
     EX_TRY
     {
-        PrintToStdErrA("Process is terminating due to a ");
         if (exitCode == (UINT)COR_E_FAILFAST)
         {
-            PrintToStdErrA("FailFast.\n\n");
+            PrintToStdErrA("\nProcess stopped. ");
         }
         else
         {
-            PrintToStdErrA("fatal error.\n\n");
+            PrintToStdErrA("\nFatal error. ");
         }
 
         if (errorSource != NULL)
@@ -1049,7 +1048,7 @@ void DisplayStackOverflowException()
     LIMITED_METHOD_CONTRACT;
     PrintToStdErrA("\n");
 
-    PrintToStdErrA("Process is terminating due to a stack overflow.\n");
+    PrintToStdErrA("Stack overflow.\n");
 }
 
 void DECLSPEC_NORETURN EEPolicy::HandleFatalStackOverflow(EXCEPTION_POINTERS *pExceptionInfo, BOOL fSkipDebugger)

--- a/src/vm/eepolicy.h
+++ b/src/vm/eepolicy.h
@@ -181,7 +181,4 @@ inline EEPolicy* GetEEPolicy()
 // FailFast with specific error code and exception details
 #define EEPOLICY_HANDLE_FATAL_ERROR_USING_EXCEPTION_INFO(_exitcode, _pExceptionInfo) EEPolicy::HandleFatalError(_exitcode, GetCurrentIP(), NULL, _pExceptionInfo);
 
-// Failfast with specific error code, exception details, and debug info
-#define EEPOLICY_HANDLE_FATAL_ERROR_USING_EXCEPTION_AND_DEBUG_INFO(_exitcode, _pExceptionInfo, _isDebug) EEPolicy::HandleFatalError(_exitcode, GetCurrentIP(), NULL, _pExceptionInfo, _isDebug);
-
 #endif  // EEPOLICY_H_

--- a/src/vm/eventreporter.cpp
+++ b/src/vm/eventreporter.cpp
@@ -135,7 +135,7 @@ EventReporter::EventReporter(EventReporterType type)
 
     case ERT_ManagedFailFast:
         if(!ssMessage.LoadResource(CCompRC::Optional, IDS_ER_MANAGEDFAILFAST))
-            m_Description.Append(W("Description: The application requested process termination through System.Environment.FailFast(string message)."));
+            m_Description.Append(W("Description: The application requested process termination through Environment.FailFast."));
         else
         {
             m_Description.Append(ssMessage);
@@ -145,7 +145,7 @@ EventReporter::EventReporter(EventReporterType type)
 
     case ERT_UnmanagedFailFast:
         if(!ssMessage.LoadResource(CCompRC::Optional, IDS_ER_UNMANAGEDFAILFAST))
-            m_Description.Append(W("Description: The process was terminated due to an internal error in the .NET Runtime "));
+            m_Description.Append(W("Description: The process was terminated due to an internal error in the .NET Runtime."));
         else
         {
             m_Description.Append(ssMessage);
@@ -155,7 +155,7 @@ EventReporter::EventReporter(EventReporterType type)
     case ERT_StackOverflow:
         // Fetch the localized Stack Overflow Error text or fall back on a hardcoded variant if things get dire.
         if(!ssMessage.LoadResource(CCompRC::Optional, IDS_ER_STACK_OVERFLOW))
-            m_Description.Append(W("Description: The process was terminated due to stack overflow."));
+            m_Description.Append(W("Description: The process was terminated due to a stack overflow."));
         else
         {
             m_Description.Append(ssMessage);

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -105,7 +105,7 @@ BOOL IsExceptionFromManagedCode(const EXCEPTION_RECORD * pExceptionRecord)
 
 #ifndef DACCESS_COMPILE
 
-#define SZ_UNHANDLED_EXCEPTION W("Unhandled Exception:")
+#define SZ_UNHANDLED_EXCEPTION W("Process is terminating due to an unhandled exception.\n\n")
 #define SZ_UNHANDLED_EXCEPTION_CHARLEN ((sizeof(SZ_UNHANDLED_EXCEPTION) / sizeof(WCHAR)))
 
 
@@ -5251,7 +5251,7 @@ DefaultCatchHandlerExceptionMessageWorker(Thread* pThread,
         }
 
         PrintToStdErrW(buf);
-        PrintToStdErrA(" ");
+        PrintToStdErrA("\n\n");
 
         SString message = GetExceptionMessageWrapper(pThread, throwable);
 
@@ -5448,6 +5448,7 @@ DefaultCatchHandler(PEXCEPTION_POINTERS pExceptionPointers,
                     }
 
                     PrintToStdErrW(buf);
+                    PrintToStdErrA("\n\n");
 
                     if (IsOutOfMemory)
                     {

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -105,7 +105,7 @@ BOOL IsExceptionFromManagedCode(const EXCEPTION_RECORD * pExceptionRecord)
 
 #ifndef DACCESS_COMPILE
 
-#define SZ_UNHANDLED_EXCEPTION W("Process is terminating due to an unhandled exception.\n\n")
+#define SZ_UNHANDLED_EXCEPTION W("Unhandled exception.")
 #define SZ_UNHANDLED_EXCEPTION_CHARLEN ((sizeof(SZ_UNHANDLED_EXCEPTION) / sizeof(WCHAR)))
 
 
@@ -5251,7 +5251,7 @@ DefaultCatchHandlerExceptionMessageWorker(Thread* pThread,
         }
 
         PrintToStdErrW(buf);
-        PrintToStdErrA("\n\n");
+        PrintToStdErrA(" ");
 
         SString message = GetExceptionMessageWrapper(pThread, throwable);
 
@@ -5448,7 +5448,6 @@ DefaultCatchHandler(PEXCEPTION_POINTERS pExceptionPointers,
                     }
 
                     PrintToStdErrW(buf);
-                    PrintToStdErrA("\n\n");
 
                     if (IsOutOfMemory)
                     {

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -5243,8 +5243,6 @@ DefaultCatchHandlerExceptionMessageWorker(Thread* pThread,
     GCPROTECT_BEGIN(throwable);
     if (throwable != NULL)
     {
-        PrintToStdErrA("\n");
-
         if (FAILED(UtilLoadResourceString(CCompRC::Error, IDS_EE_UNHANDLED_EXCEPTION, buf, buf_size)))
         {
             wcsncpy_s(buf, buf_size, SZ_UNHANDLED_EXCEPTION, SZ_UNHANDLED_EXCEPTION_CHARLEN);
@@ -5440,22 +5438,14 @@ DefaultCatchHandler(PEXCEPTION_POINTERS pExceptionPointers,
                     // die. e.g. IsAsyncThreadException() and Exception.ToString both consume too much stack -- and can't
                     // be called here.
                     dump = FALSE;
-                    PrintToStdErrA("\n");
-
-                    if (FAILED(UtilLoadStringRC(IDS_EE_UNHANDLED_EXCEPTION, buf, buf_size)))
-                    {
-                        wcsncpy_s(buf, COUNTOF(buf), SZ_UNHANDLED_EXCEPTION, SZ_UNHANDLED_EXCEPTION_CHARLEN);
-                    }
-
-                    PrintToStdErrW(buf);
 
                     if (IsOutOfMemory)
                     {
-                        PrintToStdErrA(" OutOfMemoryException.\n");
+                        PrintToStdErrA("Out of memory.\n");
                     }
                     else
                     {
-                        PrintToStdErrA(" StackOverflowException.\n");
+                        PrintToStdErrA("Stack overflow.\n");
                     }
                 }
                 else if (SentEvent || IsAsyncThreadException(&throwable))

--- a/tests/CoreFX/CoreFX.issues.rsp
+++ b/tests/CoreFX/CoreFX.issues.rsp
@@ -51,3 +51,8 @@
 -nomethod System.Tests.AppDomainTests.MonitoringTotalAllocatedMemorySize
 -nomethod System.Tests.AppDomainTests.MonitoringTotalProcessorTime
 -nomethod System.Text.Tests.StringBuilderTests.AppendFormat
+
+# requires corefx test updates
+-nomethod System.Tests.EnvironmentTests.FailFast_ExceptionStackTrace_StackOverflowException
+-nomethod System.Tests.EnvironmentTests.FailFast_ExceptionStackTrace_InnerException
+-nomethod System.Tests.EnvironmentTests.FailFast_ExceptionStackTrace_ArgumentException


### PR DESCRIPTION
As suggested in [comment](https://github.com/dotnet/corefx/issues/37422#issuecomment-489284964)

Output of test program
<details><summary>test code</summary><p>

```c#
using System;
using System.Runtime.InteropServices;

namespace _1
{
    class Program
    {
        public static void Main(string[] args)
        {
            X(args[0]);
        }

        static unsafe void X(string arg)
        {
            switch(arg)
            {
                case "so":
                    while (true) X("so");
                case "ff":
                    Environment.FailFast("I am failing because reasons");
                    break;
                case "av":
                    ((byte*)0xFFFFFFFF)[0] = 1;
                       break;
               }
        }
    }
}
```
</p></details>

Before
```
C:\d\dotnet30\1>bin\Debug\netcoreapp3.0\win-x64\1.exe

Unhandled Exception: System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at _1.Program.Main(String[] args) in C:\d\dotnet30\1\Program.cs:line 9

C:\d\dotnet30\1>bin\Debug\netcoreapp3.0\win-x64\1.exe av
System.AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory is corrupt.
   at _1.Program.X(System.String)
   at _1.Program.Main(System.String[])

C:\d\dotnet30\1>bin\Debug\netcoreapp3.0\win-x64\1.exe so

Process is terminating due to StackOverflowException.

C:\d\dotnet30\1>bin\Debug\netcoreapp3.0\win-x64\1.exe ff
FailFast:
I am failing because reasons
   at System.Environment.FailFast(System.String)
   at _1.Program.X(System.String)
   at _1.Program.Main(System.String[])
```
After
```
C:\d\dotnet30\1>bin\Debug\netcoreapp3.0\win-x64\1.exe

Unhandled Exception: System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at _1.Program.Main(String[] args) in C:\d\dotnet30\1\Program.cs:line 9

C:\d\dotnet30\1>bin\Debug\netcoreapp3.0\win-x64\publish\1.exe av

Process is terminating due to a fatal error.

System.AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory is corrupt.
   at _1.Program.X(System.String)
   at _1.Program.Main(System.String[])

C:\d\dotnet30\1>bin\Debug\netcoreapp3.0\win-x64\publish\1.exe so

Process is terminating due to a StackOverflowException.

C:\d\dotnet30\1>bin\Debug\netcoreapp3.0\win-x64\publish\1.exe ff

Process is terminating due to a FailFast.

I am failing because reasons
   at System.Environment.FailFast(System.String)
   at _1.Program.X(System.String)
   at _1.Program.Main(System.String[])

```