### PR TITLE
Minor tweaks for gcc

### DIFF
--- a/src/corefx/System.Globalization.Native/pal_collation.c
+++ b/src/corefx/System.Globalization.Native/pal_collation.c
@@ -17,13 +17,13 @@ c_static_assert_msg(UCOL_LESS < 0, "managed side requires less than zero for a <
 c_static_assert_msg(UCOL_GREATER > 0, "managed side requires greater than zero for a > b");
 c_static_assert_msg(USEARCH_DONE == -1, "managed side requires -1 for not found");
 
-const int32_t CompareOptionsIgnoreCase = 0x1;
-const int32_t CompareOptionsIgnoreNonSpace = 0x2;
-const int32_t CompareOptionsIgnoreSymbols = 0x4;
-const int32_t CompareOptionsIgnoreKanaType = 0x8;
-const int32_t CompareOptionsIgnoreWidth = 0x10;
-const int32_t CompareOptionsMask = 0x1f;
-// const int32_t CompareOptionsStringSort = 0x20000000;
+#define CompareOptionsIgnoreCase 0x1
+#define CompareOptionsIgnoreNonSpace 0x2
+#define CompareOptionsIgnoreSymbols 0x4
+#define CompareOptionsIgnoreKanaType 0x8
+#define CompareOptionsIgnoreWidth 0x10
+#define CompareOptionsMask 0x1f
+// #define CompareOptionsStringSort 0x20000000
 // ICU's default is to use "StringSort", i.e. nonalphanumeric symbols come before alphanumeric.
 // When StringSort is not specified (.NET's default), the sort order will be different between
 // Windows and Unix platforms. The nonalphanumeric symbols will come after alphanumeric

--- a/src/ilasm/CMakeLists.txt
+++ b/src/ilasm/CMakeLists.txt
@@ -51,8 +51,7 @@ if(CLR_CMAKE_PLATFORM_UNIX)
   # Need generate a right form of asmparse.cpp to avoid the following options.
   # Clang also produces a bad-codegen on this prebuilt file with optimization.
   # https://github.com/dotnet/coreclr/issues/2305
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-delete-non-virtual-dtor")
-  add_compile_options(-Wno-register)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-delete-non-virtual-dtor -Wno-register")
   add_compile_options(-Wno-array-bounds)
   add_compile_options(-Wno-unused-label)
   set_source_files_properties( prebuilt/asmparse.cpp PROPERTIES COMPILE_FLAGS "-O0" )

--- a/src/md/compiler/mdutil.cpp
+++ b/src/md/compiler/mdutil.cpp
@@ -24,7 +24,7 @@
 
 LOADEDMODULES * LOADEDMODULES::s_pLoadedModules = NULL;
 UTSemReadWrite * LOADEDMODULES::m_pSemReadWrite = NULL;
-RegMeta * (LOADEDMODULES::m_HashedModules[LOADEDMODULES_HASH_SIZE]) = { NULL };
+RegMeta * LOADEDMODULES::m_HashedModules[LOADEDMODULES_HASH_SIZE] = { NULL };
 
 //*****************************************************************************
 // Hash a file name.

--- a/src/md/compiler/mdutil.h
+++ b/src/md/compiler/mdutil.h
@@ -90,7 +90,7 @@ public:
     
     // Named for locking macros - see code:LOCKREAD
     static UTSemReadWrite * m_pSemReadWrite;
-    static RegMeta *(m_HashedModules[LOADEDMODULES_HASH_SIZE]);
+    static RegMeta *m_HashedModules[LOADEDMODULES_HASH_SIZE];
     
     static ULONG HashFileName(LPCWSTR szName);
 

--- a/src/utilcode/pedecoder.cpp
+++ b/src/utilcode/pedecoder.cpp
@@ -2081,7 +2081,7 @@ bool EnumerateLangIDs(const PEDecoder *pDecoder, DWORD rvaOfResourceSection, boo
 
     BYTE *pData = (BYTE*)pDecoder->GetRvaData(resourceDataRva);
 
-    return state->langIDcallback(state->nameName, state->nameType, (DWORD)name, pData, cbData, state->context);
+    return state->langIDcallback(state->nameName, state->nameType, (DWORD)(uintptr_t)name, pData, cbData, state->context);
 }
 
 

--- a/src/vm/stubgen.cpp
+++ b/src/vm/stubgen.cpp
@@ -977,7 +977,7 @@ bool ILCodeStream::IsSupportedInstruction(ILInstrEnum instr)
     LIMITED_METHOD_CONTRACT;
     
     CONSISTENCY_CHECK_MSG(instr != CEE_SWITCH, "CEE_SWITCH is not supported currently due to InlineSwitch in s_rgbOpcodeSizes");
-    CONSISTENCY_CHECK_MSG(((instr >= CEE_BR_S) && (instr <= CEE_BLT_UN_S)) || (CEE_LEAVE), "we only use long-form branch opcodes");
+    CONSISTENCY_CHECK_MSG(((instr >= CEE_BR_S) && (instr <= CEE_BLT_UN_S)) || instr == CEE_LEAVE, "we only use long-form branch opcodes");
     return true;
 }
 #endif // _DEBUG


### PR DESCRIPTION
* Fix a consistency check condition (debug configuration)
    > error: enum constant in boolean context [-Werror=int-in-bool-context]
* Apply -Wno-register only to CXX flags
  ```
  [ 96%] Building C object src/ilasm/CMakeFiles/ilasm.dir/__/__/version.c.o
  cc1: error: command line option -Wno-register is valid for C++/ObjC++ but not for C [-Werror]
  cc1: all warnings being treated as errors
  src/ilasm/CMakeFiles/ilasm.dir/build.make:254: recipe for target 'src/ilasm/CMakeFiles/ilasm.dir/__/__/version.c.o' failed
  make[2]: *** [src/ilasm/CMakeFiles/ilasm.dir/__/__/version.c.o] Error 1
  CMakeFiles/Makefile2:5710: recipe for target 'src/ilasm/CMakeFiles/ilasm.dir/all' failed
  make[1]: *** [src/ilasm/CMakeFiles/ilasm.dir/all] Error 2
  ```

* Remove extra parantheses from variable declaration … 
  > error: unnecessary parentheses in declaration of m_HashedModules [-Werror=parentheses]

* Use macro instead of const in C
  > error: variably modified collatorsPerOption at file scope
       UCollator* collatorsPerOption[CompareOptionsMask + 1];

  Besides, in CoreFX, and other places in Globalization, `#define` is being used instead of `const`

* Cast to uintptr_t before (32-bit) DWORD
    Usually DWORD is `unsigned long`, but here it is typedef'd as `unsigned int`, so direct narrowing was failing:
  > error: cast from LPCWSTR {aka const char16_t*} to DWORD {aka unsigned int} loses precision [-fpermissive]

cc @jkotas, @janvorli