### PR TITLE
Improved perf of MemoryExtensions.Contains()

### DIFF
--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
@@ -111,7 +111,7 @@ namespace System
             IntPtr offset = (IntPtr)0; // Use IntPtr for arithmetic to avoid unnecessary 64->32->64 truncations
             IntPtr lengthToExamine = (IntPtr)length;
 
-            if (Avx2.IsSupported || Sse2.IsSupported)
+            if (Sse2.IsSupported)
             {
                 // Avx2 branch also operates on Sse2 sizes, so check is combined.
                 if (length >= Vector128<byte>.Count * 2)

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
@@ -172,7 +172,7 @@ namespace System
                 offset += 1;
             }
 
-            // We get past SequentialScan only if IsHardwareAccelerated or intrinsic .IsSupported is true; and remain length is greater than Vector length.
+            // We get past SequentialScan only if IsHardwareAccelerated or intrinsic .IsSupported is true; and remaining length is greater than Vector length.
             // However, we still have the redundant check to allow the JIT to see that the code is unreachable and eliminate it when the platform does not
             // have hardware accelerated. After processing Vector lengths we return to SequentialScan to finish any remaining.
             if (Avx2.IsSupported)

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Byte.cs
@@ -179,28 +179,6 @@ namespace System
             {
                 if ((int)(byte*)offset < length)
                 {
-                    if ((((nuint)Unsafe.AsPointer(ref searchSpace) + (nuint)offset) & (nuint)(Vector256<byte>.Count - 1)) != 0)
-                    {
-                        // Not currently aligned to Vector256 (is aligned to Vector128); this can cause a problem for searches
-                        // with no upper bound e.g. String.strlen.
-                        // Start with a check on Vector128 to align to Vector256, before moving to processing Vector256.
-                        // This ensures we do not fault across memory pages while searching for an end of string.
-                        Vector128<byte> values = Vector128.Create(value);
-                        Vector128<byte> search = LoadVector128(ref searchSpace, offset);
-
-                        // Same method as below
-                        int matches = Sse2.MoveMask(Sse2.CompareEqual(values, search));
-                        if (matches == 0)
-                        {
-                            // Zero flags set so no matches
-                            offset += Vector128<byte>.Count;
-                        }
-                        else
-                        {
-                            return true;
-                        }
-                    }
-
                     lengthToExamine = GetByteVector256SpanLength(offset, length);
                     if ((byte*)lengthToExamine > (byte*)offset)
                     {

--- a/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
+++ b/src/System.Private.CoreLib/shared/System/SpanHelpers.Char.cs
@@ -189,8 +189,7 @@ namespace System
                     {
                         // Using Unsafe.Read instead of ReadUnaligned since the search space is pinned and pCh is always vector aligned
                         Debug.Assert(((int)pCh & (Unsafe.SizeOf<Vector<ushort>>() - 1)) == 0);
-                        Vector<ushort> vMatches = Vector.Equals(vComparison, Unsafe.Read<Vector<ushort>>(pCh));
-                        if (Vector<ushort>.Zero.Equals(vMatches))
+                        if (!Vector.EqualsAny(vComparison, Unsafe.Read<Vector<ushort>>(pCh)))
                         {
                             pCh += Vector<ushort>.Count;
                             length -= Vector<ushort>.Count;


### PR DESCRIPTION
Improved performance of `MemoryExtensions.Contains()` for `byte`s and
`char`s.

``` ini

BenchmarkDotNet=v0.11.5, OS=Windows 10.0.17134.706 (1803/April2018Update/Redstone4)
Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
Frequency=3609378 Hz, Resolution=277.0560 ns, Timer=TSC
.NET Core SDK=3.0.100-preview5-011281
  [Host]     : .NET Core 3.0.0-preview5-27613-06 (CoreCLR 4.6.27613.71, CoreFX 4.700.19.21214), 64bit RyuJIT
  Job-BAAJAC : .NET Core ? (CoreCLR 4.6.27704.0, CoreFX 4.700.19.21911), 64bit RyuJIT
  Job-CTXWTG : .NET Core ? (CoreCLR 4.6.27704.0, CoreFX 4.700.19.21911), 64bit RyuJIT


```
|                  Type |        Method | Toolchain |      Mean |     Error |    StdDev |    Median |       Min |       Max | Ratio |
|---------------------- |-------------- |---------- |----------:|----------:|----------:|----------:|----------:|----------:|------:|
| ContainsByteBenchmark |  ContainsTrue |    Master |  2.240 us | 0.0068 us | 0.0060 us |  2.240 us |  2.227 us |  2.249 us |  1.00 |
| ContainsByteBenchmark |  ContainsTrue |      Test |  1.286 us | 0.0091 us | 0.0085 us |  1.284 us |  1.270 us |  1.302 us |  0.57 |
|                       |               |           |           |           |           |           |           |           |       |
| ContainsCharBenchmark |  ContainsTrue |    Master |  6.953 us | 0.0315 us | 0.0295 us |  6.941 us |  6.917 us |  7.011 us |  1.00 |
| ContainsCharBenchmark |  ContainsTrue |      Test |  6.527 us | 0.0108 us | 0.0095 us |  6.526 us |  6.513 us |  6.546 us |  0.94 |
|                       |               |           |           |           |           |           |           |           |       |
| ContainsByteBenchmark | ContainsFalse |    Master |  3.189 us | 0.0069 us | 0.0058 us |  3.188 us |  3.183 us |  3.203 us |  1.00 |
| ContainsByteBenchmark | ContainsFalse |      Test |  2.936 us | 0.0075 us | 0.0067 us |  2.935 us |  2.929 us |  2.951 us |  0.92 |
|                       |               |           |           |           |           |           |           |           |       |
| ContainsCharBenchmark | ContainsFalse |    Master | 11.950 us | 0.0178 us | 0.0158 us | 11.953 us | 11.929 us | 11.983 us |  1.00 |
| ContainsCharBenchmark | ContainsFalse |      Test |  9.406 us | 0.0569 us | 0.0475 us |  9.391 us |  9.347 us |  9.487 us |  0.79 |
