### PR TITLE
Use same Task for Task.CompletedTask and ATMB.Completed

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -308,9 +308,7 @@ namespace System.Runtime.CompilerServices
     {
 #if !PROJECTN
         /// <summary>A cached task for default(TResult).</summary>
-        internal readonly static Task<TResult> s_defaultResultTask = (null != (object)default(TResult)! && typeof(TResult) == typeof(VoidTaskResult)) ?
-            (Task<TResult>)(object)System.Threading.Tasks.Task.s_cachedCompleted : // Non-generic Task
-            AsyncTaskCache.CreateCacheableTask(default(TResult)!); // TODO-NULLABLE-GENERIC
+        internal readonly static Task<TResult> s_defaultResultTask = AsyncTaskCache.CreateCacheableTask(default(TResult)!); // TODO-NULLABLE-GENERIC
 #endif
 
         /// <summary>The lazily-initialized built task.</summary>

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/Task.cs
@@ -1497,9 +1497,10 @@ namespace System.Threading.Tasks
         /// </remarks>
         public static TaskFactory Factory { get; } = new TaskFactory();
 
+        // Is a Task{VoidTaskResult} so it can be shared with AsyncTaskMethodBuilder
         internal static readonly Task<VoidTaskResult> s_cachedCompleted = new Task<VoidTaskResult>(false, default, (TaskCreationOptions)InternalTaskOptions.DoNotDispose, default);
         /// <summary>Gets a task that's already been completed successfully.</summary>
-        public static Task CompletedTask { get; } = s_cachedCompleted;
+        public static Task CompletedTask => s_cachedCompleted;
 
         /// <summary>
         /// Provides an event that can be used to wait for completion.

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/Task.cs
@@ -1497,8 +1497,9 @@ namespace System.Threading.Tasks
         /// </remarks>
         public static TaskFactory Factory { get; } = new TaskFactory();
 
+        internal static readonly Task<VoidTaskResult> s_cachedCompleted = new Task<VoidTaskResult>(false, default, (TaskCreationOptions)InternalTaskOptions.DoNotDispose, default);
         /// <summary>Gets a task that's already been completed successfully.</summary>
-        public static Task CompletedTask { get; } = new Task(false, (TaskCreationOptions)InternalTaskOptions.DoNotDispose, default);
+        public static Task CompletedTask { get; } = s_cachedCompleted;
 
         /// <summary>
         /// Provides an event that can be used to wait for completion.


### PR DESCRIPTION
Keep it hotter in cache rather than alternating between the two for manually and compiler generated async methods

/cc @stephentoub 