### PR TITLE
Fixes AV when accessing LoaderModule for some objects

### DIFF
--- a/src/vm/object.cpp
+++ b/src/vm/object.cpp
@@ -173,6 +173,11 @@ TypeHandle Object::GetGCSafeTypeHandleIfPossible() const
     MethodTable * pMT = GetGCSafeMethodTable();
     _ASSERTE(pMT != NULL);
 
+    if (pMT == g_pFreeObjectMethodTable)
+    {
+        return NULL;
+    }
+
     // Don't look at types that belong to an unloading AppDomain, or else
     // pObj->GetGCSafeTypeHandle() can AV. For example, we encountered this AV when pObj
     // was an array like this:
@@ -222,8 +227,6 @@ TypeHandle Object::GetGCSafeTypeHandleIfPossible() const
     }
 
     Module * pLoaderModule = pMTToCheck->GetLoaderModule();
-
-    BaseDomain * pBaseDomain = pLoaderModule->GetDomain();
 
     // Don't look up types that are unloading due to Collectible Assemblies. Haven't been
     // able to find a case where we actually encounter objects like this that can cause


### PR DESCRIPTION
`GetGCSafeTypeHandleIfPossible` is called by the Profiler API (and some ETW event code) when the profiler calls `GetClassFromObject`.

For whatever reason, some `ObjectID`s (discovered by calling `GetGenerationBounds`) fail in `GetClassFromObject` and an AV occurs when doing `ReadPointer(this, &MethodTable::m_pLoaderModule)`.

I'm adding a new function that returns NULL instead of AVing. This function is only called from `GetGCSafeTypeHandleIfPossible` which in turn is only called by ProfAPI and ETW code and they both are allowed to return null to their callers.