### PR TITLE
Add new CoreFX exclusions.

### DIFF
--- a/tests/arm/corefx_test_exclusions.txt
+++ b/tests/arm/corefx_test_exclusions.txt
@@ -7,6 +7,7 @@ System.Drawing.Common.Tests          # https://github.com/dotnet/coreclr/issues/
 System.Globalization.Calendars.Tests # https://github.com/dotnet/coreclr/issues/22719
 System.IO.FileSystem.Tests           # https://github.com/dotnet/coreclr/issues/16001
 System.IO.Ports.Tests                # https://github.com/dotnet/coreclr/issues/16001
+System.Linq.Expressions.Tests        # https://github.com/dotnet/coreclr/issues/24413
 System.Management.Tests              # https://github.com/dotnet/coreclr/issues/16001
 System.Net.HttpListener.Tests        # https://github.com/dotnet/coreclr/issues/17584
 System.Net.Sockets.Tests             # flaky test

--- a/tests/arm64/corefx_linux_test_exclusions.txt
+++ b/tests/arm64/corefx_linux_test_exclusions.txt
@@ -8,5 +8,6 @@ System.Net.NameResolution.Pal.Tests           # https://github.com/dotnet/corefx
 System.Net.Sockets.Tests                      # https://github.com/dotnet/coreclr/issues/21576 -- continuing flakiness
 System.Runtime.Numerics.Tests                 # https://github.com/dotnet/coreclr/issues/23242 -- timeout
 System.Runtime.Serialization.Formatters.Tests # https://github.com/dotnet/coreclr/issues/20246 -- timeout
+System.Runtime.Tests                          # https://github.com/dotnet/coreclr/issues/24414
 System.Text.RegularExpressions.Tests          # https://github.com/dotnet/coreclr/issues/17754 -- timeout -- JitMinOpts + Tiered only
 System.Threading.Tests                        # https://github.com/dotnet/coreclr/issues/20215


### PR DESCRIPTION
Disable https://github.com/dotnet/coreclr/issues/24413 and https://github.com/dotnet/coreclr/issues/24414.