### PR TITLE
Launch DiagnosticServer after EEStartup

### DIFF
--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -664,7 +664,6 @@ void EEStartupHelper(COINITIEE fFlags)
 #ifdef FEATURE_PERFTRACING
         // Initialize the event pipe.
         EventPipe::Initialize();
-        DiagnosticServer::Initialize();
 #endif // FEATURE_PERFTRACING
 
 #ifdef FEATURE_GDBJIT
@@ -999,6 +998,11 @@ void EEStartupHelper(COINITIEE fFlags)
 #endif // CROSSGEN_COMPILE
 
         g_fEEStarted = TRUE;
+#ifndef CROSSGEN_COMPILE
+#ifdef FEATURE_PERFTRACING
+        DiagnosticServer::Initialize();
+#endif
+#endif
         g_EEStartupStatus = S_OK;
         hr = S_OK;
         STRESS_LOG0(LF_STARTUP, LL_ALWAYS, "===================EEStartup Completed===================");


### PR DESCRIPTION
Fixed #24385 

Not just the ThreadPool is not ready. The sampling profiler also chokes when it attempts to suspend the uninitialized runtime. We better not allow connection until the runtime is ready.