### PR TITLE
Add ZapDisable  and TailCallStress ADO testing.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -212,8 +212,8 @@ jobs:
           testGroup: innerloop
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop') }}:
           testGroup: outerloop
-        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitminopts-jitstress1-jitstress2') }}:
-          testGroup: outerloop-jitminopts-jitstress1-jitstress2
+        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress') }}:
+          testGroup: outerloop-jitstress
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs') }}:
           testGroup: outerloop-jitstressregs
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress2-jitstressregs') }}:

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -196,6 +196,8 @@ jobs:
           - jitstress1_tiered
           - jitstress2
           - jitstress2_tiered
+          - zapdisable
+          - tailcallstress
         ${{ if eq(parameters.testGroup, 'outerloop-jitstressregs') }}:
           scenarios:
           - jitstressregs1

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -94,7 +94,7 @@ jobs:
       timeoutInMinutes: 240
     ${{ if eq(parameters.testGroup, 'outerloop') }}:
       timeoutInMinutes: 360
-    ${{ if in(parameters.testGroup, 'outerloop-jitminopts-jitstress1-jitstress2', 'outerloop-jitstressregs', 'outerloop-jitstress2-jitstressregs', 'outerloop-gcstress0x3-gcstress0xc') }}:
+    ${{ if in(parameters.testGroup, 'outerloop-jitstress', 'outerloop-jitstressregs', 'outerloop-jitstress2-jitstressregs', 'outerloop-gcstress0x3-gcstress0xc') }}:
       timeoutInMinutes: 480
 
     steps:
@@ -165,7 +165,7 @@ jobs:
         ${{ if eq(parameters.testGroup, 'outerloop') }}:
           timeoutPerTestCollectionInMinutes: 60
           timeoutPerTestInMinutes: 10
-        ${{ if in(parameters.testGroup, 'outerloop-jitminopts-jitstress1-jitstress2', 'outerloop-jitstressregs', 'outerloop-jitstress2-jitstressregs') }}:
+        ${{ if in(parameters.testGroup, 'outerloop-jitstress', 'outerloop-jitstressregs', 'outerloop-jitstress2-jitstressregs') }}:
           timeoutPerTestCollectionInMinutes: 120
           timeoutPerTestInMinutes: 30
         ${{ if in(parameters.testGroup, 'outerloop-gcstress0x3-gcstress0xc') }}:
@@ -189,7 +189,7 @@ jobs:
           scenarios:
           - normal
           - no_tiered_compilation
-        ${{ if eq(parameters.testGroup, 'outerloop-jitminopts-jitstress1-jitstress2') }}:
+        ${{ if eq(parameters.testGroup, 'outerloop-jitstress') }}:
           scenarios:
           - jitminopts
           - jitstress1


### PR DESCRIPTION
4f3ad48f79: Rename ADO group outerloop-jitminopts-jitstress1-jitstress2 to outerloop-jitstress.

Allows us to add more scenarios there.

e1675ea520: Add zapdisable and tailcallstress testing.

Contributes to #24358.