### PR TITLE
Disable a tail call test when using minopts

### DIFF
--- a/tests/src/JIT/Directed/IL/Tailcall/ExplicitTailCallNoSO.ilproj
+++ b/tests/src/JIT/Directed/IL/Tailcall/ExplicitTailCallNoSO.ilproj
@@ -29,11 +29,20 @@
   <PropertyGroup>
     <CLRTestBatchPreCommands><![CDATA[
 $(CLRTestBatchPreCommands)
+if "%COMPlus_JITMinOpts%" equ "1" (
+  echo Skipping test because COMPlus_JITMinOpts=1
+  exit /b 0
+)
 set COMPlus_TC_QuickJit=1
 set COMPlus_TC_QuickJitForLoops=1
 ]]></CLRTestBatchPreCommands>
     <BashCLRTestPreCommands><![CDATA[
 $(BashCLRTestPreCommands)
+if [[ "$COMPlus_JITMinOpts" == "1" ]]
+then
+  echo "Skipping test because COMPlus_JITMinOpts=1"
+  exit $(GCBashScriptExitCode)
+fi
 export COMPlus_TC_QuickJit=1
 export COMPlus_TC_QuickJitForLoops=1
 ]]></BashCLRTestPreCommands>

--- a/tests/src/JIT/Directed/IL/Tailcall/ExplicitTailCallNoSO.ilproj
+++ b/tests/src/JIT/Directed/IL/Tailcall/ExplicitTailCallNoSO.ilproj
@@ -17,6 +17,7 @@
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
@@ -29,20 +30,11 @@
   <PropertyGroup>
     <CLRTestBatchPreCommands><![CDATA[
 $(CLRTestBatchPreCommands)
-if "%COMPlus_JITMinOpts%" equ "1" (
-  echo Skipping test because COMPlus_JITMinOpts=1
-  exit /b 0
-)
 set COMPlus_TC_QuickJit=1
 set COMPlus_TC_QuickJitForLoops=1
 ]]></CLRTestBatchPreCommands>
     <BashCLRTestPreCommands><![CDATA[
 $(BashCLRTestPreCommands)
-if [[ "$COMPlus_JITMinOpts" == "1" ]]
-then
-  echo "Skipping test because COMPlus_JITMinOpts=1"
-  exit $(GCBashScriptExitCode)
-fi
 export COMPlus_TC_QuickJit=1
 export COMPlus_TC_QuickJitForLoops=1
 ]]></BashCLRTestPreCommands>


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/24424