### PR TITLE
Update Microsoft.Build.Traversal SDK to v2.

### DIFF
--- a/global.json
+++ b/global.json
@@ -10,6 +10,6 @@
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19229.8",
     "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19229.8",
     "Microsoft.Build.NoTargets": "1.0.53",
-    "Microsoft.Build.Traversal": "1.0.52"
+    "Microsoft.Build.Traversal": "2.0.2"
   }
 }


### PR DESCRIPTION
Version 2.0 of the Microsoft.Build.Traversal has some breaking changes from V1.X. We currently aren't using any of the features that were changed/removed. I think we should upgrade before we accidentally start relying on any removed features and block ourselves from being able to upgrade.