### PR TITLE
Shrink AsyncValueTaskMethodBuilder

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncIteratorMethodBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncIteratorMethodBuilder.cs
@@ -4,6 +4,7 @@
 
 using System.Runtime.InteropServices;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Runtime.CompilerServices
 {
@@ -12,29 +13,29 @@ namespace System.Runtime.CompilerServices
     public struct AsyncIteratorMethodBuilder
     {
         // AsyncIteratorMethodBuilder is used by the language compiler as part of generating
-        // async iterators. For now, the implementation just wraps AsyncTaskMethodBuilder, as
-        // most of the logic is shared.  However, in the future this could be changed and
+        // async iterators. For now, the implementation just forwards to AsyncMethodBuilderCore, 
+        // as most of the logic is shared.  However, in the future this could be changed and
         // optimized.  For example, we do need to allocate an object (once) to flow state like
-        // ExecutionContext, which AsyncTaskMethodBuilder handles, but it handles it by
+        // ExecutionContext, which AsyncMethodBuilderCore handles, but it handles it by
         // allocating a Task-derived object.  We could optimize this further by removing
         // the Task from the hierarchy, but in doing so we'd also lose a variety of optimizations
         // related to it, so we'd need to replicate all of those optimizations (e.g. storing
         // that box object directly into a Task's continuation field).
 
-        private AsyncTaskMethodBuilder _methodBuilder; // mutable struct; do not make it readonly
+        /// <summary>The lazily-initialized built task.</summary>
+        private Task<VoidTaskResult> m_task; // Debugger depends on the exact name of this field.
 
         /// <summary>Creates an instance of the <see cref="AsyncIteratorMethodBuilder"/> struct.</summary>
         /// <returns>The initialized instance.</returns>
-        public static AsyncIteratorMethodBuilder Create() =>
+        public static AsyncIteratorMethodBuilder Create()
+        {
 #if PROJECTN
-            // ProjectN's AsyncTaskMethodBuilder.Create() currently does additional debugger-related
-            // work, so we need to delegate to it.
-            new AsyncIteratorMethodBuilder() { _methodBuilder = AsyncTaskMethodBuilder.Create() };
+            var result = new AsyncIteratorMethodBuilder();
+            return AsyncMethodBuilderCore.InitalizeTaskIfDebugging(ref result, ref result.m_task!); // TODO-NULLABLE: Remove ! when nullable attributes are respected
 #else
-            // _methodBuilder should be initialized to AsyncTaskMethodBuilder.Create(), but on coreclr
-            // that Create() is a nop, so we can just return the default here.
-            default; 
+            return default;
 #endif
+        }
 
         /// <summary>Invokes <see cref="IAsyncStateMachine.MoveNext"/> on the state machine while guarding the <see cref="ExecutionContext"/>.</summary>
         /// <typeparam name="TStateMachine">The type of the state machine.</typeparam>
@@ -50,8 +51,8 @@ namespace System.Runtime.CompilerServices
         /// <param name="stateMachine">The state machine.</param>
         public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
             where TAwaiter : INotifyCompletion
-            where TStateMachine : IAsyncStateMachine =>
-            _methodBuilder.AwaitOnCompleted(ref awaiter, ref stateMachine);
+            where TStateMachine : IAsyncStateMachine
+            => AsyncMethodBuilderCore.AwaitOnCompleted(ref awaiter, ref stateMachine, ref m_task);
 
         /// <summary>Schedules the state machine to proceed to the next action when the specified awaiter completes.</summary>
         /// <typeparam name="TAwaiter">The type of the awaiter.</typeparam>
@@ -60,13 +61,13 @@ namespace System.Runtime.CompilerServices
         /// <param name="stateMachine">The state machine.</param>
         public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
             where TAwaiter : ICriticalNotifyCompletion
-            where TStateMachine : IAsyncStateMachine =>
-            _methodBuilder.AwaitUnsafeOnCompleted(ref awaiter, ref stateMachine);
+            where TStateMachine : IAsyncStateMachine
+            => AsyncMethodBuilderCore.AwaitUnsafeOnCompleted(ref awaiter, ref stateMachine, ref m_task);
 
         /// <summary>Marks iteration as being completed, whether successfully or otherwise.</summary>
-        public void Complete() => _methodBuilder.SetResult();
+        public void Complete() => AsyncMethodBuilderCore.SetResult(ref m_task, Task.s_cachedCompleted);
 
         /// <summary>Gets an object that may be used to uniquely identify this builder to the debugger.</summary>
-        internal object ObjectIdForDebugger => _methodBuilder.ObjectIdForDebugger;
+        internal object ObjectIdForDebugger => AsyncMethodBuilderCore.ObjectIdForDebugger(ref m_task);
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/Task.cs
@@ -1483,8 +1483,11 @@ namespace System.Threading.Tasks
         /// </remarks>
         public static TaskFactory Factory { get; } = new TaskFactory();
 
+        // Is a Task{VoidTaskResult} so it can be shared with AsyncTaskMethodBuilder
+        internal static readonly Task<VoidTaskResult> s_cachedCompleted = new Task<VoidTaskResult>(false, default, (TaskCreationOptions)InternalTaskOptions.DoNotDispose, default);
+ 
         /// <summary>Gets a task that's already been completed successfully.</summary>
-        public static Task CompletedTask { get; } = new Task(false, (TaskCreationOptions)InternalTaskOptions.DoNotDispose, default);
+        public static Task CompletedTask => s_cachedCompleted;
 
         /// <summary>
         /// Provides an event that can be used to wait for completion.

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/ValueTask.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/ValueTask.cs
@@ -527,7 +527,7 @@ namespace System.Threading.Tasks
 
             if (obj == null)
             {
-                return AsyncTaskMethodBuilder<TResult>.GetTaskForResult(_result);
+                return AsyncTaskCache<TResult>.GetTaskForResult(_result);
             }
 
             if (obj is Task<TResult> t)
@@ -555,7 +555,7 @@ namespace System.Threading.Tasks
                 {
                     // Get the result of the operation and return a task for it.
                     // If any exception occurred, propagate it
-                    return AsyncTaskMethodBuilder<TResult>.GetTaskForResult(t.GetResult(_token));
+                    return AsyncTaskCache<TResult>.GetTaskForResult(t.GetResult(_token));
 
                     // If status is Faulted or Canceled, GetResult should throw.  But
                     // we can't guarantee every implementation will do the "right thing".


### PR DESCRIPTION
Remove the struct wrappings over Task in the AsyncMethodBuilders by moving the implementations to static helper members on AsyncMethodBuilderCore.

Shrink `AsyncValueTaskMethodBuilder` to a single pointer size.

Remove `bool _useBuilder` field from `AsyncValueTaskMethodBuilder<TResult>` as we can check if `m_task` is set instead.

/cc @stephentoub 