### PR TITLE
Use -falign-new flag for gcc 7+

### DIFF
--- a/configure.cmake
+++ b/configure.cmake
@@ -1,4 +1,5 @@
 include(CheckCXXSourceCompiles)
+include(CheckCXXCompilerFlag)
 
 # VC++ guarantees support for LTCG (LTO's equivalent)
 if(NOT WIN32)
@@ -9,4 +10,6 @@ if(NOT WIN32)
     check_cxx_source_compiles("int main() { return 0; }" HAVE_LTO)
   endfunction(check_have_lto)
   check_have_lto()
+
+  check_cxx_compiler_flag(-faligned-new COMPILER_SUPPORTS_F_ALIGNED_NEW)
 endif(NOT WIN32)

--- a/configurecompiler.cmake
+++ b/configurecompiler.cmake
@@ -485,6 +485,9 @@ if (CLR_CMAKE_PLATFORM_UNIX)
     add_compile_options(-Wno-unused-but-set-variable)
     add_compile_options(-fms-extensions)
     add_compile_options(-Wno-unknown-pragmas)
+    if (COMPILER_SUPPORTS_F_ALIGNED_NEW)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -faligned-new")
+    endif()
   endif()
 
   # Some architectures (e.g., ARM) assume char type is unsigned while CoreCLR assumes char is signed


### PR DESCRIPTION
Versions of gcc lower than 7 do not have C++17's "over-aligned new"
support. With gcc 7 and 8, following error is thrown:

```
/datadrive/projects/coreclr/src/vm/threadpoolrequest.cpp: In static member function static TPIndex PerAppDomainTPCountList::AddNewTPIndex():
/datadrive/projects/coreclr/src/vm/threadpoolrequest.cpp:79:81: error: new of type ManagedPerAppDomainTPCount with extended alignment 64 [-Werror=aligned-new=]
     ManagedPerAppDomainTPCount * pAdCount = new ManagedPerAppDomainTPCount(index);
                                                                                 ^
/datadrive/projects/coreclr/src/vm/threadpoolrequest.cpp:79:81: note: uses void* operator new(size_t), which does not have an alignment parameter
/datadrive/projects/coreclr/src/vm/threadpoolrequest.cpp:79:81: note: use -faligned-new to enable C++17 over-aligned new support
```

The fix is to enable `-faligned-new` (without fully activating C++17
features), that does auto-alignment like gcc 6x and below and clang.