### PR TITLE
Move to non-docker versions of these queues until Python 3 rollout 

### DIFF
--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -77,7 +77,7 @@ jobs:
         containerName: musl_x64_build_image
         helixQueues:
         - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          - Alpine.38.Amd64
+
         - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           - Alpine.36.Amd64
           - Alpine.38.Amd64

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -77,7 +77,7 @@ jobs:
         containerName: musl_x64_build_image
         helixQueues:
         - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          - (Alpine.38.Amd64.Open)Ubuntu.1604.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-45b1fa2-20190327215821
+          - Alpine.38.Amd64
         - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           - Alpine.36.Amd64
           - Alpine.38.Amd64
@@ -141,7 +141,7 @@ jobs:
           - Ubuntu.1604.Amd64
           - Ubuntu.1804.Amd64
           - Centos.7.Amd64
-          - (Fedora.28.Amd64)Ubuntu.1604.amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-28-helix-45b1fa2-20190327215722
+          - Fedora.28.Amd64
           - RedHat.7.Amd64
         ${{ insert }}: ${{ parameters.jobParameters }}
 


### PR DESCRIPTION
@RussKeldorph  - it looks like you're using far fewer of these than I thought!  Will check rel/3.0 tomorrow. 