### PR TITLE
Make Idn.GetAscii compatible with Windows

### DIFF
--- a/src/corefx/System.Globalization.Native/pal_idna.c
+++ b/src/corefx/System.Globalization.Native/pal_idna.c
@@ -50,6 +50,9 @@ int32_t GlobalizationNative_ToAscii(
 
     int32_t asciiStrLen = uidna_nameToASCII(pIdna, lpSrc, cwSrcLength, lpDst, cwDstLength, &info, &err);
 
+    // To have a consistent behavior with Windows, we mask out the error when having 2 hyphens in the third and fourth place.
+    info.errors &= ~UIDNA_ERROR_HYPHEN_3_4;
+
     uidna_close(pIdna);
 
     return ((U_SUCCESS(err) || (err == U_BUFFER_OVERFLOW_ERROR)) && (info.errors == 0)) ? asciiStrLen : 0;


### PR DESCRIPTION
GetAscii on Windows ignore if the uri has hyphens in the third and fourth places. We relaxing this on Linux too for the sake of the consistent behavior. This issue was causing some problems with the http stack.

Fixes https://github.com/dotnet/corefx/issues/29703