### PR TITLE
Fix build.cmd passing of args to runtest.cmd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -904,7 +904,7 @@ if %__BuildTests% EQU 1 (
 ) else if %__GenerateLayout% EQU 1 (
     echo %__MsgPrefix%Generating layout for %__BuildOS%.%__BuildArch%.%__BuildType%
 
-    set NEXTCMD=call %__ProjectDir%\tests\runtest.cmd %__BuildArch% %__BuildType% GenerateLayoutOnly %__UnprocessedBuildArgs%
+    set NEXTCMD=call %__ProjectDir%\tests\runtest.cmd %__BuildArch% %__BuildType% GenerateLayoutOnly msbuildargs %__UnprocessedBuildArgs%
     echo %__MsgPrefix%!NEXTCMD!
     !NEXTCMD!
 


### PR DESCRIPTION
If you use the `generatelayout` argument to build.cmd, it passes
all "unprocessed" arguments directly on to msbuild. To accomplish
the same this with runtest.cmd, you must use the "msbuildargs"
argument, or else the arg will be treated as a `CORE_ROOT` argument.
(This seems like a bad design, but that's a separate issue.)

E.g., I always pass `/consoleloggerparameters:ForceNoAlign`, and want
that passed on to runtest.cmd. (This should also be the default, but
once again, that's a separate issue.)