### PR TITLE
Add generate crash dump command to diagnostics server

### DIFF
--- a/Documentation/botr/xplat-minidump-generation.md
+++ b/Documentation/botr/xplat-minidump-generation.md
@@ -46,6 +46,8 @@ Gathering the crash information on OS X will be quite a bit different than Linux
 
 # Configuration/Policy #
 
+NOTE: Core dump generation in docker containers require the ptrace capability (--cap-add=SYS_PTRACE or --privileged run/exec options).
+
 Any configuration or policy is set with environment variables which are passed as options to the _createdump_ utility.
 
 Environment variables supported:

--- a/src/debug/createdump/crashinfo.cpp
+++ b/src/debug/createdump/crashinfo.cpp
@@ -191,16 +191,16 @@ CrashInfo::GatherCrashInfo(MINIDUMP_TYPE minidumpType)
         }
         for (const MemoryRegion& region : m_otherMappings)
         {
-            InsertMemoryBackedRegion(region);
+            // Don't add uncommitted pages to the full dump
+            if ((region.Permissions() & (PF_R | PF_W | PF_X)) != 0)
+            {
+                InsertMemoryBackedRegion(region);
+            }
         }
     }
     // Add all the heap (read/write) memory regions (m_otherMappings contains the heaps)
     else if (minidumpType & MiniDumpWithPrivateReadWriteMemory)
     {
-        for (const MemoryRegion& region : m_moduleMappings)
-        {
-            InsertMemoryBackedRegion(region);
-        }
         for (const MemoryRegion& region : m_otherMappings)
         {
             if (region.Permissions() == (PF_R | PF_W))

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -450,6 +450,14 @@ PALAPI
 PAL_SetShutdownCallback(
     IN PSHUTDOWN_CALLBACK callback);
 
+PALIMPORT
+BOOL
+PALAPI
+PAL_GenerateCoreDump(
+    IN LPCSTR dumpName,
+    IN INT dumpType,
+    IN BOOL diag);
+
 typedef VOID (*PPAL_STARTUP_CALLBACK)(
     char *modulePath,
     HMODULE hModule,

--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -58,6 +58,7 @@ set(VM_SOURCES_DAC_AND_WKS_COMMON
     debughelp.cpp
     debuginfostore.cpp
     decodemd.cpp
+    diagnosticprotocolhelper.cpp
     disassembler.cpp
     dllimport.cpp
     domainfile.cpp

--- a/src/vm/diagnosticprotocolhelper.cpp
+++ b/src/vm/diagnosticprotocolhelper.cpp
@@ -1,0 +1,83 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "common.h"
+#include "fastserializer.h"
+#include "diagnosticprotocolhelper.h"
+#include "diagnosticsipc.h"
+#include "diagnosticsprotocol.h"
+
+#ifdef FEATURE_PERFTRACING
+#ifdef FEATURE_PAL
+
+static void WriteStatus(uint64_t result, IpcStream* pStream)
+{
+    uint32_t nBytesWritten = 0;
+    bool fSuccess = pStream->Write(&result, sizeof(result), nBytesWritten);
+    if (fSuccess)
+    {
+        fSuccess = pStream->Flush();
+    }
+}
+
+void DiagnosticProtocolHelper::GenerateCoreDump(IpcStream* pStream)
+{
+    CONTRACTL
+    {
+        THROWS;
+        GC_TRIGGERS;
+        MODE_PREEMPTIVE;
+        PRECONDITION(pStream != nullptr);
+    }
+    CONTRACTL_END;
+
+    if (pStream == nullptr)
+        return;
+
+    HRESULT hr = S_OK;
+
+    // TODO: Read within a loop.
+    uint8_t buffer[IpcStreamReadBufferSize] { };
+    uint32_t nNumberOfBytesRead = 0;
+    bool fSuccess = pStream->Read(buffer, sizeof(buffer), nNumberOfBytesRead);
+    if (fSuccess)
+    {
+        // The protocol buffer is defined as:
+        //   string - dumpName (array<char> where the last char must = 0) or (length = 0)
+        //   int - dumpType
+        //   int - diagnostics
+        // returns
+        //   ulong - status
+        LPCSTR dumpName;
+        INT dumpType;
+        INT diagnostics;
+
+        uint8_t *pBufferCursor = buffer;
+        uint32_t bufferLen = nNumberOfBytesRead;
+
+        if (TryParseString(pBufferCursor, bufferLen, dumpName) &&
+            TryParse(pBufferCursor, bufferLen, dumpType) &&
+            TryParse(pBufferCursor, bufferLen, diagnostics))
+        {
+            if (!PAL_GenerateCoreDump(dumpName, dumpType, diagnostics))
+            {
+                hr = E_FAIL;
+            }
+        }
+        else
+        {
+            hr = E_INVALIDARG;
+        }
+    }
+    else 
+    {
+        hr = E_UNEXPECTED;
+    }
+
+    WriteStatus(hr, pStream);
+    delete pStream;
+}
+
+#endif // FEATURE_PAL
+#endif // FEATURE_PERFTRACING

--- a/src/vm/diagnosticprotocolhelper.h
+++ b/src/vm/diagnosticprotocolhelper.h
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef __DIAGNOSTIC_PROTOCOL_HELPER_H__
+#define __DIAGNOSTIC_PROTOCOL_HELPER_H__
+
+#ifdef FEATURE_PERFTRACING
+
+#include "common.h"
+
+class IpcStream;
+
+class DiagnosticProtocolHelper
+{
+public:
+    // IPC event handlers.
+#ifdef FEATURE_PAL
+    static void GenerateCoreDump(IpcStream *pStream); // `dotnet-dump collect`
+#endif
+
+private:
+    const static uint32_t IpcStreamReadBufferSize = 8192;
+};
+
+#endif // FEATURE_PERFTRACING
+
+#endif // __DIAGNOSTIC_PROTOCOL_HELPER_H__

--- a/src/vm/diagnosticserver.cpp
+++ b/src/vm/diagnosticserver.cpp
@@ -5,6 +5,7 @@
 #include "common.h"
 #include "diagnosticserver.h"
 #include "eventpipeprotocolhelper.h"
+#include "diagnosticprotocolhelper.h"
 
 #ifdef FEATURE_PAL
 #include "pal.h"
@@ -64,6 +65,12 @@ static DWORD WINAPI DiagnosticsServerThread(LPVOID lpThreadParameter)
             case DiagnosticMessageType::CollectEventPipeTracing:
                 EventPipeProtocolHelper::CollectTracing(pStream);
                 break;
+
+#ifdef FEATURE_PAL
+            case DiagnosticMessageType::GenerateCoreDump:
+                DiagnosticProtocolHelper::GenerateCoreDump(pStream);
+                break;
+#endif
 
             default:
                 STRESS_LOG1(LF_DIAGNOSTICS_PORT, LL_WARNING, "Received unknown request type (%d)\n", header.RequestType);

--- a/src/vm/diagnosticserver.h
+++ b/src/vm/diagnosticserver.h
@@ -15,12 +15,13 @@ enum class DiagnosticMessageType : uint32_t
 {
     ///////////////////////////////////////////////////////////////////////////
     // Debug = 0
+    GenerateCoreDump = 1,           // Initiates core dump generation
 
     ///////////////////////////////////////////////////////////////////////////
-    // EventPipe
-    StartEventPipeTracing = 1024, // To file
+    // EventPipe = 1024
+    StartEventPipeTracing = 1024,   // To file
     StopEventPipeTracing,
-    CollectEventPipeTracing, // To IPC
+    CollectEventPipeTracing,        // To IPC
 
     ///////////////////////////////////////////////////////////////////////////
     // Profiler = 2048


### PR DESCRIPTION
Add the DiagnosticProtocolHelper class to deserialize and dispatch
the new GenerateCoreDump command.

Refactor the PAL createdump launch on unhandled exception code to
used by a new PAL_GenerateCoreDump method that doesn't depend on
the complus dump environment variables.