### PR TITLE
Mark local struct as having overlapping fields after struct reinterpretation

### DIFF
--- a/tests/scripts/run-corefx-tests-exclusions.txt
+++ b/tests/scripts/run-corefx-tests-exclusions.txt
@@ -20,10 +20,6 @@
 #
 # Please list a GitHub issue for every exclusion.
 
-# https://github.com/dotnet/coreclr/issues/24159
--nomethod "System.Buffers.Tests.ArrayBufferWriterTests_Byte.Advance"
--nomethod "System.Buffers.Tests.ArrayBufferWriterTests_Char.Advance"
-
 # https://github.com/dotnet/coreclr/issues/22442
 -nomethod "Microsoft.Win32.SystemEventsTests.CreateTimerTests.ConcurrentTimers"
 -nomethod "Microsoft.Win32.SystemEventsTests.SessionSwitchTests.SignalsSessionSwitch"

--- a/tests/src/JIT/Regression/JitBlue/GitHub_24159/GitHub_24159.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_24159/GitHub_24159.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace GitHub_24159
+{
+
+    public struct Str1
+    {
+        public int i1;
+        public int i2;
+        public int i3;
+        public int i4;
+        public int i5;
+    }
+
+    public struct Str2
+    {
+        public int j1;
+        public int j2;
+        public int j3;
+        public int j4;
+        public int j5;
+    }
+
+    class Test
+    {
+        static int i;
+
+        public static int Main()
+        {
+            i = 0;
+
+            Str1 str1 = new Str1();
+
+            if (i != 0)
+            {
+                str1 = new Str1();
+            }
+            else
+            {
+                str1.i2 = 7;
+            }
+
+            // This call reinterprets the struct.
+            Str2 str2 = Unsafe.As<Str1, Str2>(ref str1);
+
+            // The bug was that value numbering couldn't recognize
+            // that this field has been updated on str1.
+            int k = str2.j2;
+
+            Console.WriteLine(k);
+
+            return k + 93;
+
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_24159/GitHub_24159.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_24159/GitHub_24159.csproj
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
Methods like System.Runtime.CompilerServices.Unsafe.As<TFrom, TTo> may
have struct reinterpretation when function signature specifies Struct1&
and the method returns Struct2& where Struct1 and Struct2 are different
structs. This may confuse jit optimizations (in particular, value
numbering) because fields of a struct of type Struct1 may be accessed
using handles of Struct2. This fix marks the source local involved in
such struct reinterpretation as having overlapping fields. That prevents
SSA builder from inserting the local into SSA.

Fixes #24159.

No diffs in framework assemblies and coreclr benchmarks.