### PR TITLE
Return the required padding size instead of the current position to avoid integer overflow.

### DIFF
--- a/src/vm/eventpipeblock.h
+++ b/src/vm/eventpipeblock.h
@@ -51,14 +51,13 @@ public:
         if (eventsSize == 0)
             return;
 
-        size_t currentPosition = pSerializer->GetCurrentPosition();
-        if (currentPosition % ALIGNMENT_SIZE != 0)
+        unsigned int requiredPadding = pSerializer->GetRequiredPadding();
+        if (requiredPadding != 0)
         {
             BYTE maxPadding[ALIGNMENT_SIZE - 1] = {}; // it's longest possible padding, we are going to use only part of it
-            unsigned int paddingLength = ALIGNMENT_SIZE - (currentPosition % ALIGNMENT_SIZE);
-            pSerializer->WriteBuffer(maxPadding, paddingLength); // we write zeros here, the reader is going to always read from the first aligned address of the serialized content
+            pSerializer->WriteBuffer(maxPadding, requiredPadding); // we write zeros here, the reader is going to always read from the first aligned address of the serialized content
 
-            _ASSERTE(pSerializer->HasWriteErrors() || (pSerializer->GetCurrentPosition() % ALIGNMENT_SIZE == 0));
+            _ASSERTE(pSerializer->HasWriteErrors() || (pSerializer->GetRequiredPadding() == 0));
         }
 
         pSerializer->WriteBuffer(m_pBlock, eventsSize);

--- a/src/vm/fastserializer.h
+++ b/src/vm/fastserializer.h
@@ -86,10 +86,10 @@ public:
     void WriteTag(FastSerializerTags tag, BYTE *payload = NULL, unsigned int payloadLength = 0);
     void WriteString(const char *strContents, unsigned int length);
 
-    size_t GetCurrentPosition() const
+    unsigned int GetRequiredPadding() const
     {
         LIMITED_METHOD_CONTRACT;
-        return m_currentPos;
+        return m_requiredPadding;
     }
 
     bool HasWriteErrors() const
@@ -104,7 +104,7 @@ private:
 
     StreamWriter *const m_pStreamWriter;
     bool m_writeErrorEncountered;
-    size_t m_currentPos;
+    unsigned int m_requiredPadding;
 };
 
 #endif // FEATURE_PERFTRACING


### PR DESCRIPTION
Fixes #24442 