### PR TITLE
Check for JitDisasmIncludeAssembliesList being non-empty before calling getClassModule

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -3182,7 +3182,7 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
             }
 
             // If we have an assembly name list for disassembly, also check this method's assembly.
-            if (s_pJitDisasmIncludeAssembliesList != nullptr)
+            if (s_pJitDisasmIncludeAssembliesList != nullptr && !s_pJitDisasmIncludeAssembliesList->IsEmpty())
             {
                 const char* assemblyName = info.compCompHnd->getAssemblyName(
                     info.compCompHnd->getModuleAssembly(info.compCompHnd->getClassModule(info.compClassHnd)));


### PR DESCRIPTION
If we run SuperPMI collection with COMPlus_JitDisasmAssemblies being set to some non-empty string value then SuperPMI replay is going to fail in https://github.com/dotnet/coreclr/blob/master/src/ToolBox/superpmi/superpmi/icorjitinfo.cpp#L525.

To avoid this we can try to run superpmi with `-jitoption force JitDisasmAssemblies=` but it's not going to help since s_pJitDisasmIncludeAssembliesList will be still initialized (but empty). 

To fix this we can also check whether it's non-empty before calling getClassModule.

@dotnet/jit-contrib 