### PR TITLE
Tweak a few nullable annotations

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/CodeAnalysis/SuppressMessageAttribute.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/CodeAnalysis/SuppressMessageAttribute.cs
@@ -24,14 +24,14 @@ namespace System.Diagnostics.CodeAnalysis
     [Conditional("CODE_ANALYSIS")]
     public sealed class SuppressMessageAttribute : Attribute
     {
-        public SuppressMessageAttribute(string? category, string? checkId)
+        public SuppressMessageAttribute(string category, string checkId)
         {
             Category = category;
             CheckId = checkId;
         }
 
-        public string? Category { get; }
-        public string? CheckId { get; }
+        public string Category { get; }
+        public string CheckId { get; }
         public string? Scope { get; set; }
         public string? Target { get; set; }
         public string? MessageId { get; set; }

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebuggerTypeProxyAttribute.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebuggerTypeProxyAttribute.cs
@@ -18,15 +18,15 @@ namespace System.Diagnostics
                 throw new ArgumentNullException(nameof(type));
             }
 
-            ProxyTypeName = type.AssemblyQualifiedName;
+            ProxyTypeName = type.AssemblyQualifiedName!;
         }
 
-        public DebuggerTypeProxyAttribute(string? typeName)
+        public DebuggerTypeProxyAttribute(string typeName)
         {
             ProxyTypeName = typeName;
         }
 
-        public string? ProxyTypeName { get; }
+        public string ProxyTypeName { get; }
 
         public Type? Target
         {

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebuggerVisualizerAttribute.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebuggerVisualizerAttribute.cs
@@ -15,18 +15,18 @@ namespace System.Diagnostics
     {
         private Type? _target;
 
-        public DebuggerVisualizerAttribute(string? visualizerTypeName)
+        public DebuggerVisualizerAttribute(string visualizerTypeName)
         {
             VisualizerTypeName = visualizerTypeName;
         }
 
-        public DebuggerVisualizerAttribute(string? visualizerTypeName, string? visualizerObjectSourceTypeName)
+        public DebuggerVisualizerAttribute(string visualizerTypeName, string? visualizerObjectSourceTypeName)
         {
             VisualizerTypeName = visualizerTypeName;
             VisualizerObjectSourceTypeName = visualizerObjectSourceTypeName;
         }
 
-        public DebuggerVisualizerAttribute(string? visualizerTypeName, Type visualizerObjectSource)
+        public DebuggerVisualizerAttribute(string visualizerTypeName, Type visualizerObjectSource)
         {
             if (visualizerObjectSource == null)
             {
@@ -44,7 +44,7 @@ namespace System.Diagnostics
                 throw new ArgumentNullException(nameof(visualizer));
             }
 
-            VisualizerTypeName = visualizer.AssemblyQualifiedName;
+            VisualizerTypeName = visualizer.AssemblyQualifiedName!;
         }
 
         public DebuggerVisualizerAttribute(Type visualizer, Type visualizerObjectSource)
@@ -58,7 +58,7 @@ namespace System.Diagnostics
                 throw new ArgumentNullException(nameof(visualizerObjectSource));
             }
 
-            VisualizerTypeName = visualizer.AssemblyQualifiedName;
+            VisualizerTypeName = visualizer.AssemblyQualifiedName!;
             VisualizerObjectSourceTypeName = visualizerObjectSource.AssemblyQualifiedName;
         }
 
@@ -69,13 +69,13 @@ namespace System.Diagnostics
                 throw new ArgumentNullException(nameof(visualizer));
             }
 
-            VisualizerTypeName = visualizer.AssemblyQualifiedName;
+            VisualizerTypeName = visualizer.AssemblyQualifiedName!;
             VisualizerObjectSourceTypeName = visualizerObjectSourceTypeName;
         }
 
         public string? VisualizerObjectSourceTypeName { get; }
 
-        public string? VisualizerTypeName { get; }
+        public string VisualizerTypeName { get; }
 
         public string? Description { get; set; }
         

--- a/src/System.Private.CoreLib/shared/System/Reflection/Assembly.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Assembly.cs
@@ -141,13 +141,9 @@ namespace System.Reflection
 
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context) { throw NotImplemented.ByDesign; }
 
-        public override string? ToString()
+        public override string ToString()
         {
-            string? displayName = FullName;
-            if (displayName == null)
-                return base.ToString();
-            else
-                return displayName;
+            return FullName ?? base.ToString()!;
         }
 
         /*


### PR DESCRIPTION
- Assembly.ToString() won't return null
- Several attributes have the intent that their arguments are non-nullable, even though they don't check and throw; the annotations should match the intent in such cases.

cc: @dotnet/nullablefc 