### PR TITLE
Decorate SuperPMI DllMain jitStartup getJit with DLLEXPORT

### DIFF
--- a/src/ToolBox/superpmi/superpmi-shim-collector/superpmi-shim-collector.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-collector/superpmi-shim-collector.cpp
@@ -86,10 +86,10 @@ void SetLogFilePath()
     }
 }
 
-extern "C" BOOL
-#ifndef FEATURE_PAL
-    APIENTRY
-#endif // !FEATURE_PAL
+#ifdef FEATURE_PAL
+DLLEXPORT // For Win32 PAL LoadLibrary emulation
+#endif
+    extern "C" BOOL
     DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {
     switch (ul_reason_for_call)

--- a/src/ToolBox/superpmi/superpmi-shim-collector/superpmi-shim-collector.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-collector/superpmi-shim-collector.cpp
@@ -123,8 +123,7 @@ DLLEXPORT // For Win32 PAL LoadLibrary emulation
     return TRUE;
 }
 
-// Exported via def file
-extern "C" void __stdcall jitStartup(ICorJitHost* host)
+extern "C" DLLEXPORT void __stdcall jitStartup(ICorJitHost* host)
 {
     SetDefaultPaths();
     SetLibName();
@@ -147,8 +146,7 @@ extern "C" void __stdcall jitStartup(ICorJitHost* host)
     pnjitStartup(g_ourJitHost);
 }
 
-// Exported via def file
-extern "C" ICorJitCompiler* __stdcall getJit()
+extern "C" DLLEXPORT ICorJitCompiler* __stdcall getJit()
 {
     DWORD             dwRetVal = 0;
     PgetJit           pngetJit;
@@ -194,8 +192,7 @@ extern "C" ICorJitCompiler* __stdcall getJit()
     return pJitInstance;
 }
 
-// Exported via def file
-extern "C" void __stdcall sxsJitStartup(CoreClrCallbacks const& original_cccallbacks)
+extern "C" DLLEXPORT void __stdcall sxsJitStartup(CoreClrCallbacks const& original_cccallbacks)
 {
     PsxsJitStartup pnsxsJitStartup;
 

--- a/src/ToolBox/superpmi/superpmi-shim-counter/superpmi-shim-counter.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-counter/superpmi-shim-counter.cpp
@@ -68,10 +68,10 @@ void SetLogFilePath()
     }
 }
 
-extern "C" BOOL
-#ifndef FEATURE_PAL
-    APIENTRY
-#endif // !FEATURE_PAL
+#ifdef FEATURE_PAL
+DLLEXPORT // For Win32 PAL LoadLibrary emulation
+#endif
+    extern "C" BOOL
     DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {
     switch (ul_reason_for_call)

--- a/src/ToolBox/superpmi/superpmi-shim-counter/superpmi-shim-counter.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-counter/superpmi-shim-counter.cpp
@@ -110,8 +110,7 @@ DLLEXPORT // For Win32 PAL LoadLibrary emulation
     return TRUE;
 }
 
-// Exported via def file
-extern "C" void __stdcall jitStartup(ICorJitHost* host)
+extern "C" DLLEXPORT void __stdcall jitStartup(ICorJitHost* host)
 {
     SetDefaultPaths();
     SetLibName();
@@ -143,8 +142,7 @@ extern "C" void __stdcall jitStartup(ICorJitHost* host)
     pnjitStartup(g_ourJitHost);
 }
 
-// Exported via def file
-extern "C" ICorJitCompiler* __stdcall getJit()
+extern "C" DLLEXPORT ICorJitCompiler* __stdcall getJit()
 {
     DWORD             dwRetVal = 0;
     PgetJit           pngetJit;
@@ -186,8 +184,7 @@ extern "C" ICorJitCompiler* __stdcall getJit()
     return pJitInstance;
 }
 
-// Exported via def file
-extern "C" void __stdcall sxsJitStartup(CoreClrCallbacks const& original_cccallbacks)
+extern "C" DLLEXPORT void __stdcall sxsJitStartup(CoreClrCallbacks const& original_cccallbacks)
 {
     PsxsJitStartup pnsxsJitStartup;
 

--- a/src/ToolBox/superpmi/superpmi-shim-simple/superpmi-shim-simple.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-simple/superpmi-shim-simple.cpp
@@ -58,10 +58,10 @@ void SetLogFilePath()
     }
 }
 
-extern "C" BOOL
-#ifndef FEATURE_PAL
-    APIENTRY
-#endif // !FEATURE_PAL
+#ifdef FEATURE_PAL
+DLLEXPORT // For Win32 PAL LoadLibrary emulation
+#endif
+    extern "C" BOOL
     DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {
     switch (ul_reason_for_call)

--- a/src/ToolBox/superpmi/superpmi-shim-simple/superpmi-shim-simple.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-simple/superpmi-shim-simple.cpp
@@ -95,8 +95,7 @@ DLLEXPORT // For Win32 PAL LoadLibrary emulation
     return TRUE;
 }
 
-// Exported via def file
-extern "C" void __stdcall jitStartup(ICorJitHost* host)
+extern "C" DLLEXPORT void __stdcall jitStartup(ICorJitHost* host)
 {
     SetDefaultPaths();
     SetLibName();
@@ -119,8 +118,7 @@ extern "C" void __stdcall jitStartup(ICorJitHost* host)
     pnjitStartup(g_ourJitHost);
 }
 
-// Exported via def file
-extern "C" ICorJitCompiler* __stdcall getJit()
+extern "C" DLLEXPORT ICorJitCompiler* __stdcall getJit()
 {
     DWORD             dwRetVal = 0;
     PgetJit           pngetJit;
@@ -155,8 +153,7 @@ extern "C" ICorJitCompiler* __stdcall getJit()
     return pJitInstance;
 }
 
-// Exported via def file
-extern "C" void __stdcall sxsJitStartup(CoreClrCallbacks const& original_cccallbacks)
+extern "C" DLLEXPORT void __stdcall sxsJitStartup(CoreClrCallbacks const& original_cccallbacks)
 {
     PsxsJitStartup pnsxsJitStartup;
 


### PR DESCRIPTION
SuperPMI collector doesn't work on Linux. DllMain, getJit and jitStartup symbol are hidden so EEJitManager won't be called to initialize AltJITCompiler in EEJitManager::LoadJIT. 

This PR makes the methods to have the same visibility as the corresponding methods in libclrjit.so have (i.e. the same as in jit/ee_il_dll.cpp)
