### PR TITLE
Fix an overflow issue with EventPipe buffer size

### DIFF
--- a/src/vm/eventpipesession.cpp
+++ b/src/vm/eventpipesession.cpp
@@ -27,7 +27,7 @@ EventPipeSession::EventPipeSession(
     CONTRACTL_END;
 
     m_sessionType = sessionType;
-    m_circularBufferSizeInBytes = circularBufferSizeInMB * 1024 * 1024; // 1MB;
+    m_circularBufferSizeInBytes = (size_t)circularBufferSizeInMB << 20; // 1MB;
     m_rundownEnabled = false;
     m_pProviderList = new EventPipeSessionProviderList(pProviders, numProviders);
     GetSystemTimeAsFileTime(&m_sessionStartTime);


### PR DESCRIPTION
This should address #24491. 

If we set CircularBufferSizeInMB to something massive, then m_circularBufferSizeInBytes becomes 0. 

The root cause is because `circularBufferSizeInMB` is a 32 bit integer, and so are 1024s that we are multiplying to it. So even though we're trying to save it to a 64 bit integer, we get an overflow on the RHS and end up saving something that already overflowed.

