### PR TITLE
Fix EventCounter disable logic

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterGroup.cs
@@ -70,6 +70,13 @@ namespace System.Diagnostics.Tracing
                     }
                 }
             }
+            else if (e.Command == EventCommand.Disable)
+            {
+                lock (this)
+                {
+                    _pollingIntervalInMilliseconds = 0;
+                }
+            }
         }
 
         #endregion // EventSource Command Processing


### PR DESCRIPTION
This fixes #24517. 

#24517 happens because of this:

When we disable EventCounter, we call `CounterGroup.DisposeTimer()` in the Timer callback by checking whether the `EventSource` is enabled, and in `DisposeTimer`, we remove the timer object. 

When we enable it again, `EnableTimer` is called which checks for two conditions:
1. If _`pollingIntervalnSecond` (user-provided argument) that it was called with is negative, don't enable timer.
2. If the current pollingInterval is zero, (which it is at initial state), or `_pollingIntervalInSecond` is less than the current one (which suggests we should poll more often), dispose the current timer and make a new one with the new interval. 

Neither of this scenario is the case if we simply disposed the timer and never reset the current polling interval to zero. 

The fix is simple - when we disable, set the current polling interval to zero. 