### PR TITLE
Fix CPUSET_T definition for FreeBSD

### DIFF
--- a/src/gc/unix/config.h.in
+++ b/src/gc/unix/config.h.in
@@ -18,5 +18,7 @@
 #cmakedefine01 HAVE_MACH_ABSOLUTE_TIME
 #cmakedefine01 HAVE_SCHED_GETAFFINITY
 #cmakedefine01 HAVE_PTHREAD_GETAFFINITY_NP
+#cmakedefine01 HAVE_PTHREAD_NP_H
+#cmakedefine01 HAVE_CPUSET_T
 
 #endif // __CONFIG_H__

--- a/src/gc/unix/configure.cmake
+++ b/src/gc/unix/configure.cmake
@@ -1,7 +1,10 @@
 check_include_files(sys/time.h HAVE_SYS_TIME_H)
 check_include_files(sys/mman.h HAVE_SYS_MMAN_H)
 check_include_files(numa.h HAVE_NUMA_H)
+check_include_files(pthread_np.h HAVE_PTHREAD_NP_H)
+
 check_function_exists(vm_allocate HAVE_VM_ALLOCATE)
+
 check_cxx_source_compiles("
     #include <pthread.h>
     #include <stdint.h>
@@ -41,6 +44,14 @@ check_cxx_source_compiles("
         return MAP_HUGETLB;
     }
     " HAVE_MAP_HUGETLB)
+
+check_cxx_source_compiles("
+#include <pthread_np.h>
+int main(int argc, char **argv) {
+  cpuset_t cpuSet;
+
+  return 0;
+}" HAVE_CPUSET_T)
 
 check_cxx_source_runs("
     #include <sched.h>

--- a/src/gc/unix/gcenv.unix.cpp
+++ b/src/gc/unix/gcenv.unix.cpp
@@ -48,6 +48,14 @@
 # endif
 #endif
 
+#if HAVE_PTHREAD_NP_H
+#include <pthread_np.h>
+#endif
+
+#if HAVE_CPUSET_T
+typedef cpuset_t cpu_set_t;
+#endif
+
 #include <time.h> // nanosleep
 #include <sched.h> // sched_yield
 #include <errno.h>
@@ -135,10 +143,6 @@ static size_t g_RestrictedPhysicalMemoryLimit = 0;
 uint32_t g_pageSizeUnixInl = 0;
 
 AffinitySet g_processAffinitySet;
-
-#if HAVE_CPUSET_T
-typedef cpuset_t cpu_set_t;
-#endif
 
 // The highest NUMA node available
 int g_highestNumaNode = 0;

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -37,6 +37,7 @@ Abstract:
 #define __PAL_H__
 
 #ifdef PAL_STDCPP_COMPAT
+#include <limits.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -256,19 +257,6 @@ typedef char * va_list;
 
 #endif // __GNUC__
 
-#endif // !PAL_STDCPP_COMPAT
-
-/******************* PAL-Specific Entrypoints *****************************/
-
-#define IsDebuggerPresent PAL_IsDebuggerPresent
-
-PALIMPORT
-BOOL
-PALAPI
-PAL_IsDebuggerPresent(VOID);
-
-#define MAXIMUM_SUSPEND_COUNT  MAXCHAR
-
 #define CHAR_BIT      8
 
 #define SCHAR_MIN   (-128)
@@ -286,6 +274,17 @@ PAL_IsDebuggerPresent(VOID);
 #define LONG_MIN    (-2147483647L - 1)
 #define LONG_MAX      2147483647L
 #define ULONG_MAX     0xffffffffUL
+
+#endif // !PAL_STDCPP_COMPAT
+
+/******************* PAL-Specific Entrypoints *****************************/
+
+#define IsDebuggerPresent PAL_IsDebuggerPresent
+
+PALIMPORT
+BOOL
+PALAPI
+PAL_IsDebuggerPresent(VOID);
 
 #define FLT_MAX 3.402823466e+38F
 #define DBL_MAX 1.7976931348623157e+308

--- a/src/pal/src/eventprovider/lttngprovider/eventproviderhelpers.cpp
+++ b/src/pal/src/eventprovider/lttngprovider/eventproviderhelpers.cpp
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 #include "palrt.h"
 #include "pal.h"
 #include "stdlib.h"


### PR DESCRIPTION
Build command used: `./build.sh -skipmanaged`
(skipped managed artifacts because the required version of cli package is not available for FreeBSD)
