### PR TITLE
Fix field signature generation

### DIFF
--- a/src/vm/zapsig.cpp
+++ b/src/vm/zapsig.cpp
@@ -1462,7 +1462,7 @@ void ZapSig::EncodeField(
     DWORD fieldFlags = ENCODE_FIELD_SIG_OwnerType;
 
 #ifdef FEATURE_READYTORUN_COMPILER
-    if (IsReadyToRunCompilation())
+    if (IsReadyToRunCompilation() && (!IsLargeVersionBubbleEnabled() || !pField->GetModule()->IsInCurrentVersionBubble()))
     {
         if (pResolvedToken == NULL)
         {


### PR DESCRIPTION
The ZapSig::EncodeField was missing similar treatment that was made to
the encodeMethod in the past for enabling large version bubble. We
should encode all fields as field defs and the module override at the
beginning of the fixup signature is computed with that assumption.
The issue was that we were storing memberrefs in some cases and the
module override made them invalid.
It fixes a corefx test that was failing due to this when crossgen-ed
with large version bubble enabled.