### PR TITLE
Adding echo command makes batch execution correct (OS bug maybe?)

### DIFF
--- a/tests/src/CLRTest.Execute.Batch.targets
+++ b/tests/src/CLRTest.Execute.Batch.targets
@@ -293,6 +293,8 @@ $(BatchCopyCoreShimLocalCmds)
 $(BatchLinkerTestLaunchCmds)
 $(BatchCLRTestLaunchCmds)
 
+ECHO Executing Test
+
 if defined RunCrossGen (
   call :TakeLock
 )


### PR DESCRIPTION
Adding the echo command made the R2R CI legs in PR #24333 work correctly.

After being able to repro the CI failures locally using the environment from the lab, I added a bunch of echo commands in the test's .cmd file to debug this. I saw some inconsistent output, suggesting the script execution wasn't flowing correctly, and seemed to jump from one place to the other. After adding more echo commands, suddenly it started to work correctly again, and the scripts stdout started to make sense.
Literally, quite impressive.

I was able to narrow this down to just one extra echo command that for some mysterious reason made the cmd execution correct again