### PR TITLE
Re-enable accidentally disabled tests.

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -93,9 +93,6 @@
 
     <!-- All Unix targets -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TargetsWindows)' != 'true'">
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutExp/*">
-            <Issue>Issue building native components for the test.</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/arglist/vararg/*">
             <Issue>Native varargs not supported on unix</Issue>
         </ExcludeList>


### PR DESCRIPTION
Apparently the Explicit struct marshalling tests have been disabled on CI for a while via issues.targets. We should re-enable them on CI.