### PR TITLE
Stack size override

### DIFF
--- a/Documentation/project-docs/clr-configuration-knobs.md
+++ b/Documentation/project-docs/clr-configuration-knobs.md
@@ -759,6 +759,7 @@ Name | Description | Type | Class | Default Value | Flags
 
 Name | Description | Type | Class | Default Value | Flags
 -----|-------------|------|-------|---------------|-------
+`DefaultStackSize` | Stack size to use for new VM threads when thread is created with default stack size (dwStackSize == 0). | `DWORD` | `INTERNAL` | `0` |
 `Thread_DeadThreadCountThresholdForGCTrigger` | In the heuristics to clean up dead threads, this threshold must be reached before triggering a GC will be considered. Set to 0 to disable triggering a GC based on dead threads. | `DWORD` | `INTERNAL` | `75` |
 `Thread_DeadThreadGCTriggerPeriodMilliseconds` | In the heuristics to clean up dead threads, this much time must have elapsed since the previous max-generation GC before triggering another GC will be considered | `DWORD` | `INTERNAL` | `1000 * 60 * 30` |
 

--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -606,6 +606,7 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_ThreadSuspendInjection, W("INTERNAL_ThreadSusp
 ///
 /// Thread (miscellaneous)
 ///
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_DefaultStackSize, W("DefaultStackSize"), 0, "Stack size to use for new VM threads when thread is created with default stack size (dwStackSize == 0).")
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_Thread_DeadThreadCountThresholdForGCTrigger, W("Thread_DeadThreadCountThresholdForGCTrigger"), 75, "In the heuristics to clean up dead threads, this threshold must be reached before triggering a GC will be considered. Set to 0 to disable triggering a GC based on dead threads.")
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_Thread_DeadThreadGCTriggerPeriodMilliseconds, W("Thread_DeadThreadGCTriggerPeriodMilliseconds"), 1000 * 60 * 30, "In the heuristics to clean up dead threads, this much time must have elapsed since the previous max-generation GC before triggering another GC will be considered")
 

--- a/src/vm/corhost.cpp
+++ b/src/vm/corhost.cpp
@@ -742,7 +742,7 @@ HRESULT CorHost2::_CreateAppDomain(
             pwzAppNiPaths = pPropertyValues[i];
         }
         else
-        if (wcscmp(pPropertyNames[i], W("OVERRIDE_DEFAULT_STACK_SIZE_4KPAGES")) == 0)
+        if (wcscmp(pPropertyNames[i], W("OVERRIDE_DEFAULT_STACK_SIZE")) == 0)
         {
             extern void OverrideDefaultStackSize(LPCWSTR value);
             OverrideDefaultStackSize(pPropertyValues[i]);

--- a/src/vm/corhost.cpp
+++ b/src/vm/corhost.cpp
@@ -742,6 +742,12 @@ HRESULT CorHost2::_CreateAppDomain(
             pwzAppNiPaths = pPropertyValues[i];
         }
         else
+        if (wcscmp(pPropertyNames[i], W("OVERRIDE_DEFAULT_STACK_SIZE_4KPAGES")) == 0)
+        {
+            extern void OverrideDefaultStackSize(LPCWSTR value);
+            OverrideDefaultStackSize(pPropertyValues[i]);
+        }
+        else
         if (wcscmp(pPropertyNames[i], W("USE_ENTRYPOINT_FILTER")) == 0)
         {
             extern void ParseUseEntryPointFilter(LPCWSTR value);

--- a/src/vm/corhost.cpp
+++ b/src/vm/corhost.cpp
@@ -742,10 +742,10 @@ HRESULT CorHost2::_CreateAppDomain(
             pwzAppNiPaths = pPropertyValues[i];
         }
         else
-        if (wcscmp(pPropertyNames[i], W("OVERRIDE_DEFAULT_STACK_SIZE")) == 0)
+        if (wcscmp(pPropertyNames[i], W("DEFAULT_STACK_SIZE")) == 0)
         {
-            extern void ParseOverrideDefaultStackSize(LPCWSTR value);
-            ParseOverrideDefaultStackSize(pPropertyValues[i]);
+            extern void ParseDefaultStackSize(LPCWSTR value);
+            ParseDefaultStackSize(pPropertyValues[i]);
         }
         else
         if (wcscmp(pPropertyNames[i], W("USE_ENTRYPOINT_FILTER")) == 0)

--- a/src/vm/corhost.cpp
+++ b/src/vm/corhost.cpp
@@ -744,8 +744,8 @@ HRESULT CorHost2::_CreateAppDomain(
         else
         if (wcscmp(pPropertyNames[i], W("OVERRIDE_DEFAULT_STACK_SIZE")) == 0)
         {
-            extern void OverrideDefaultStackSize(LPCWSTR value);
-            OverrideDefaultStackSize(pPropertyValues[i]);
+            extern void ParseOverrideDefaultStackSize(LPCWSTR value);
+            ParseOverrideDefaultStackSize(pPropertyValues[i]);
         }
         else
         if (wcscmp(pPropertyNames[i], W("USE_ENTRYPOINT_FILTER")) == 0)

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -2144,10 +2144,10 @@ HANDLE Thread::CreateUtilityThread(Thread::StackSizeBucket stackSizeBucket, LPTH
 }
 
 
-// Represent the value of OVERRIDE_DEFAULT_STACK_SIZE as passed in the property bag to the host during construction
-static unsigned long s_overrideDefaultStackSizeProperty = 0;
+// Represent the value of DEFAULT_STACK_SIZE as passed in the property bag to the host during construction
+static unsigned long s_defaultStackSizeProperty = 0;
 
-void ParseOverrideDefaultStackSize(LPCWSTR valueStr)
+void ParseDefaultStackSize(LPCWSTR valueStr)
 {
     if (valueStr)
     {
@@ -2164,16 +2164,16 @@ void ParseOverrideDefaultStackSize(LPCWSTR valueStr)
         }
         else
         {
-            s_overrideDefaultStackSizeProperty = value;
+            s_defaultStackSizeProperty = value;
         }
     }
 }
 
-SIZE_T GetOverrideDefaultStackSize()
+SIZE_T GetDefaultStackSizeSetting()
 {
-    static DWORD s_overrideDefaultStackSizeEnv = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_DefaultStackSize);
+    static DWORD s_defaultStackSizeEnv = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_DefaultStackSize);
 
-    uint64_t value = s_overrideDefaultStackSizeEnv ? s_overrideDefaultStackSizeEnv : s_overrideDefaultStackSizeProperty;
+    uint64_t value = s_defaultStackSizeEnv ? s_defaultStackSizeEnv : s_defaultStackSizeProperty;
 
     SIZE_T minStack = 0x10000;     // 64K - Somewhat arbitrary minimum thread stack size
     SIZE_T maxStack = 0x80000000;  //  2G - Somewhat arbitrary maximum thread stack size
@@ -2205,12 +2205,12 @@ BOOL Thread::GetProcessDefaultStackSize(SIZE_T* reserveSize, SIZE_T* commitSize)
 
     if (!fSizesGot)
     {
-        SIZE_T overrideDefaultStackSize = GetOverrideDefaultStackSize();
+        SIZE_T defaultStackSizeSetting = GetDefaultStackSizeSetting();
 
-        if (overrideDefaultStackSize != 0)
+        if (defaultStackSizeSetting != 0)
         {
-            ExeSizeOfStackReserve = overrideDefaultStackSize;
-            ExeSizeOfStackCommit = overrideDefaultStackSize;
+            ExeSizeOfStackReserve = defaultStackSizeSetting;
+            ExeSizeOfStackCommit = defaultStackSizeSetting;
             fSizesGot = TRUE;
         }
     }
@@ -2262,7 +2262,7 @@ BOOL Thread::CreateNewOSThread(SIZE_T sizeToCommitOrReserve, LPTHREAD_START_ROUT
 
     if (sizeToCommitOrReserve == 0)
     {
-        sizeToCommitOrReserve = GetOverrideDefaultStackSize();
+        sizeToCommitOrReserve = GetDefaultStackSizeSetting();
     }
 
 #ifndef FEATURE_PAL // the PAL does its own adjustments as necessary

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -2145,7 +2145,7 @@ HANDLE Thread::CreateUtilityThread(Thread::StackSizeBucket stackSizeBucket, LPTH
 
 
 // Represent the value of OVERRIDE_DEFAULT_STACK_SIZE_4KPAGES as passed in the property bag to the host during construction
-static uint32_t s_overrideDefaultStackSize = 0;
+static SIZE_T s_overrideDefaultStackSize = 0;
 
 void OverrideDefaultStackSize(LPCWSTR valueStr)
 {
@@ -2163,7 +2163,7 @@ void OverrideDefaultStackSize(LPCWSTR valueStr)
         }
         else
         {
-            FastInterlockExchange((int32_t*)&s_overrideDefaultStackSize, (uint32_t) value * 4096);
+            s_overrideDefaultStackSize = (SIZE_T) value * 4096;
         }
     }
 }


### PR DESCRIPTION
Add code to override process default stack size for VM from the property bag

Fixes #21450

/cc @jkotalik 

