### PR TITLE
Add native asset lists for IL linker

### DIFF
--- a/src/.nuget/Microsoft.NETCore.Jit/runtime.FreeBSD.Microsoft.NETCore.Jit.props
+++ b/src/.nuget/Microsoft.NETCore.Jit/runtime.FreeBSD.Microsoft.NETCore.Jit.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <NativeBinary Include="$(BinDir)libclrjit.so" />
+    <NativeBinary Include="$(BinDir)libclrjit.so" LinkerUsage="runtime" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/runtime.Linux.Microsoft.NETCore.Jit.props
+++ b/src/.nuget/Microsoft.NETCore.Jit/runtime.Linux.Microsoft.NETCore.Jit.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <NativeBinary Include="$(BinDir)libclrjit.so" />
+    <NativeBinary Include="$(BinDir)libclrjit.so" LinkerUsage="runtime" />
     <CrossArchitectureSpecificNativeFileAndSymbol Condition="'$(HasCrossTargetComponents)' == 'true'" Include="$(BinDir)$(CrossTargetComponentFolder)\libclrjit.so" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/runtime.OSX.Microsoft.NETCore.Jit.props
+++ b/src/.nuget/Microsoft.NETCore.Jit/runtime.OSX.Microsoft.NETCore.Jit.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <NativeBinary Include="$(BinDir)libclrjit.dylib" />
+    <NativeBinary Include="$(BinDir)libclrjit.dylib" LinkerUsage="runtime" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/runtime.Windows_NT.Microsoft.NETCore.Jit.props
+++ b/src/.nuget/Microsoft.NETCore.Jit/runtime.Windows_NT.Microsoft.NETCore.Jit.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <NativeBinary Include="$(BinDir)clrjit.dll" />
+    <NativeBinary Include="$(BinDir)clrjit.dll" LinkerUsage="runtime" />
     <CrossArchitectureSpecificNativeFileAndSymbol Include="$(BinDir)$(CrossTargetComponentFolder)\clrjit.dll" />
 
     <!-- prevent accidental inclusion in AOT projects. -->

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.FreeBSD.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.FreeBSD.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <NativeBinary Include="$(BinDir)libcoreclr.so" />
+    <NativeBinary Include="$(BinDir)libcoreclr.so" LinkerUsage="runtime" />
     <NativeBinary Condition="'$(_PlatformDoesNotSupportEventTrace)' != 'true'" Include="$(BinDir)libcoreclrtraceptprovider.so" />
     <NativeBinary Include="$(BinDir)libdbgshim.so" />
-    <NativeBinary Include="$(BinDir)libmscordaccore.so" />
-    <NativeBinary Include="$(BinDir)libmscordbi.so" />
+    <NativeBinary Include="$(BinDir)libmscordaccore.so" LinkerUsage="diagnostic" />
+    <NativeBinary Include="$(BinDir)libmscordbi.so" LinkerUsage="diagnostic" />
     <NativeBinary Include="$(BinDir)libsos.so" />
     <NativeBinary Condition="'$(_PlatformDoesNotSupportSosPlugin)' != 'true'" Include="$(BinDir)libsosplugin.so" />
     <NativeBinary Include="$(BinDir)System.Globalization.Native.so" />

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -12,11 +12,11 @@
     <_PlatformDoesNotSupportSosPlugin Condition="'$(Platform)' == 'arm64'">true</_PlatformDoesNotSupportSosPlugin>
   </PropertyGroup>
   <ItemGroup>
-    <NativeBinary Include="$(BinDir)libcoreclr.so" />
+    <NativeBinary Include="$(BinDir)libcoreclr.so" LinkerUsage="runtime" />
     <NativeBinary Condition="'$(_PlatformDoesNotSupportEventTrace)' != 'true'" Include="$(BinDir)libcoreclrtraceptprovider.so" />
     <NativeBinary Include="$(BinDir)libdbgshim.so" />
-    <NativeBinary Include="$(BinDir)libmscordaccore.so" />
-    <NativeBinary Include="$(BinDir)libmscordbi.so" />
+    <NativeBinary Include="$(BinDir)libmscordaccore.so" LinkerUsage="diagnostic" />
+    <NativeBinary Include="$(BinDir)libmscordbi.so" LinkerUsage="diagnostic" />
     <NativeBinary Include="$(BinDir)libsos.so" />
     <NativeBinary Condition="'$(_PlatformDoesNotSupportSosPlugin)' != 'true'" Include="$(BinDir)libsosplugin.so" />
     <NativeBinary Include="$(BinDir)System.Globalization.Native.so" />

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.OSX.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.OSX.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <NativeBinary Include="$(BinDir)libcoreclr.dylib" />
+    <NativeBinary Include="$(BinDir)libcoreclr.dylib" LinkerUsage="runtime" />
     <NativeBinary Include="$(BinDir)libdbgshim.dylib" />
-    <NativeBinary Include="$(BinDir)libmscordaccore.dylib" />
-    <NativeBinary Include="$(BinDir)libmscordbi.dylib" />
+    <NativeBinary Include="$(BinDir)libmscordaccore.dylib" LinkerUsage="diagnostic" />
+    <NativeBinary Include="$(BinDir)libmscordbi.dylib" LinkerUsage="diagnostic" />
     <NativeBinary Include="$(BinDir)libsos.dylib" />
     <NativeBinary Include="$(BinDir)System.Globalization.Native.dylib" />
     <NativeBinary Include="$(BinDir)sosdocsunix.txt" />

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Windows_NT.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Windows_NT.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -11,13 +11,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <NativeBinary Include="$(BinDir)clretwrc.dll" />
-    <NativeBinary Include="$(BinDir)coreclr.dll" />
+    <NativeBinary Include="$(BinDir)clretwrc.dll" LinkerUsage="diagnostic" />
+    <NativeBinary Include="$(BinDir)coreclr.dll" LinkerUsage="runtime" />
     <NativeBinary Include="$(BinDir)dbgshim.dll" />
-    <NativeBinary Include="$(BinDir)mscordaccore.dll" />
-    <NativeBinary Include="$(BinDir)mscordbi.dll" />
-    <NativeBinary Include="$(BinDir)mscorrc.debug.dll" />
-    <NativeBinary Include="$(BinDir)mscorrc.dll" />
+    <NativeBinary Include="$(BinDir)mscordaccore.dll" LinkerUsage="diagnostic" />
+    <NativeBinary Include="$(BinDir)mscordbi.dll" LinkerUsage="diagnostic" />
+    <NativeBinary Include="$(BinDir)mscorrc.debug.dll" LinkerUsage="diagnostic" />
+    <NativeBinary Include="$(BinDir)mscorrc.dll" LinkerUsage="diagnostic" />
     <NativeBinary Include="$(BinDir)sos.dll" />
     <NativeBinary Include="$(BinDir)Redist\ucrt\DLLs\$(BuildArch)\*.dll" Condition="'$(BuildType)'=='Release' AND '$(BuildArch)' != 'arm64'" />
     <CrossGenBinary Include="$(BinDir)System.Private.CoreLib.dll" />

--- a/src/.nuget/dir.targets
+++ b/src/.nuget/dir.targets
@@ -96,22 +96,20 @@
   <!--
     Creates listings of native files that the IL Linker should keep, and injects them
     into the package build.
-    Do so before GetPackageAssets (instead of GetPackageFiles), to avoid the .txt file getting
-    created for each RID-specific package during the recursive GetPackageFiles call.
-    Oh. GetPackageAssets only runs AFTER the package is created, too late.
+    Happens after GetPackageDependencies. This is essentially just before GetPackageFiles, but
+    avoids creating these text files for ProjectReferences which have GetPackageFiles called
+    recursively.
   -->
   <Target Name="GetLinkerNativeIncludes" AfterTargets="GetPackageDependencies">
     <ItemGroup>
       <LinkerRuntimeFiles Include="@(NativeBinary)" Condition=" '%(NativeBinary.LinkerUsage)' == 'runtime' " />
       <LinkerDiagnosticFiles Include="@(NativeBinary)" Condition=" '%(NativeBinary.LinkerUsage)' == 'diagnostic' " />
     </ItemGroup>
-    <!-- when called for lineup package, the package Id is set to each RID -->
-    <!-- however NativeBinary is still always the osx version. -->
+
     <PropertyGroup>
       <HasLinkerRuntimeFiles Condition=" '@(LinkerRuntimeFiles->Count())' != '0' ">true</HasLinkerRuntimeFiles>
       <HasLinkerDiagnosticFiles Condition=" '@(LinkerDiagnosticFiles->Count())' != '0' ">true</HasLinkerDiagnosticFiles>
       <LinkerFileListOutputPath>$(NuspecOutputPath)$(Id)/</LinkerFileListOutputPath>
-      <!--<LinkerFileListOutputPath>$(PackageOutputPath)$(Id)/</LinkerFileListOutputPath>-->
       <LinkerRuntimeList>$(LinkerFileListOutputPath)linkerruntimefiles.txt</LinkerRuntimeList>
       <LinkerDiagnosticList>$(LinkerFileListOutputPath)linkerdiagnosticfiles.txt</LinkerDiagnosticList>
     </PropertyGroup>
@@ -126,8 +124,7 @@
                       Condition=" '$(HasLinkerDiagnosticFiles)' == 'true' "
                       Overwrite="true" />
 
-<!-->    <ItemGroup Condition=" '$(PackageTargetRuntime)' != '' ">-->
-    <ItemGroup>
+    <ItemGroup Condition=" '$(PackageTargetRuntime)' != '' ">
       <File Include="$(LinkerRuntimeList)"
             Condition=" '$(HasLinkerRuntimeFiles)' == 'true' ">
         <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
@@ -137,8 +134,6 @@
         <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
       </File>
     </ItemGroup>
-
-    <Message Importance="High" Text="file for $(MSBuildProjectName): @(File)" />
   </Target>
 
   <!-- OverrideLicenseUrl is temporary till we update the buildtools to v2 -->  

--- a/src/.nuget/dir.targets
+++ b/src/.nuget/dir.targets
@@ -93,6 +93,37 @@
     </ItemGroup>
   </Target>
 
+  <!--
+    Creates listings of native files that the IL Linker should keep, and injects them
+    into the package build.
+  -->
+  <Target Name="GetLinkerNativeIncludes" BeforeTargets="GetPackageFiles">
+    <ItemGroup>
+      <LinkerRuntimeFiles Include="@(NativeBinary)" Condition=" '%(NativeBinary.LinkerUsage)' == 'runtime' " />
+      <LinkerDiagnosticFiles Include="@(NativeBinary)" Condition=" '%(NativeBinary.LinkerUsage)' == 'diagnostic' " />
+    </ItemGroup>
+    <PropertyGroup>
+      <LinkerRuntimeList>$(BinDir)linkerruntimefiles.txt</LinkerRuntimeList>
+      <LinkerDiagnosticList>$(BinDir)linkerdiagnosticfiles.txt</LinkerDiagnosticList>
+    </PropertyGroup>
+
+    <WriteLinesToFile File="$(LinkerRuntimeList)" Lines="@(LinkerRuntimeFiles->'%(Filename)%(Extension)')"
+                      Condition=" '@(LinkerRuntimeFiles->Count())' != '0' "
+                      Overwrite="true" />
+    <WriteLinesToFile File="$(LinkerDiagnosticList)" Lines="@(LinkerDiagnosticFiles->'%(Filename)%(Extension)')"
+                      Condition=" '@(LinkerDiagnosticFiles->Count())' != '0' "
+                      Overwrite="true" />
+
+    <ItemGroup>
+      <File Include="$(LinkerRuntimeList);$(LinkerDiagnosticList)"
+            Condition=" Exists('%(Identity)') And '$(PackageTargetRuntime)' != '' ">
+        <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+      </File>
+    </ItemGroup>
+
+    <Message Importance="High" Text="file for $(MSBuildProjectName): @(File)" />
+  </Target>
+
   <!-- OverrideLicenseUrl is temporary till we update the buildtools to v2 -->  
   <Target Name="OverrideLicenseUrl" BeforeTargets="GenerateNuSpec">
     <PropertyGroup>

--- a/src/.nuget/dir.targets
+++ b/src/.nuget/dir.targets
@@ -96,32 +96,51 @@
   <!--
     Creates listings of native files that the IL Linker should keep, and injects them
     into the package build.
+    Do so before GetPackageAssets (instead of GetPackageFiles), to avoid the .txt file getting
+    created for each RID-specific package during the recursive GetPackageFiles call.
   -->
-  <Target Name="GetLinkerNativeIncludes" BeforeTargets="GetPackageFiles">
+  <Target Name="GetLinkerNativeIncludes" BeforeTargets="GetPackageAssets">
     <ItemGroup>
       <LinkerRuntimeFiles Include="@(NativeBinary)" Condition=" '%(NativeBinary.LinkerUsage)' == 'runtime' " />
       <LinkerDiagnosticFiles Include="@(NativeBinary)" Condition=" '%(NativeBinary.LinkerUsage)' == 'diagnostic' " />
     </ItemGroup>
+    <!-- when called for lineup package, the package Id is set to each RID -->
+    <!-- however NativeBinary is still always the osx version. -->
     <PropertyGroup>
-      <LinkerRuntimeList>$(BinDir)linkerruntimefiles.txt</LinkerRuntimeList>
-      <LinkerDiagnosticList>$(BinDir)linkerdiagnosticfiles.txt</LinkerDiagnosticList>
+      <HasLinkerRuntimeFiles Condition=" '@(LinkerRuntimeFiles->Count())' != '0' ">true</HasLinkerRuntimeFiles>
+      <HasLinkerDiagnosticFiles Condition=" '@(LinkerDiagnosticFiles->Count())' != '0' ">true</HasLinkerDiagnosticFiles>
+      <LinkerFileListOutputPath>$(NuspecOutputPath)$(Id)/</LinkerFileListOutputPath>
+      <!--<LinkerFileListOutputPath>$(PackageOutputPath)$(Id)/</LinkerFileListOutputPath>-->
+      <LinkerRuntimeList>$(LinkerFileListOutputPath)linkerruntimefiles.txt</LinkerRuntimeList>
+      <LinkerDiagnosticList>$(LinkerFileListOutputPath)linkerdiagnosticfiles.txt</LinkerDiagnosticList>
     </PropertyGroup>
 
+    <MakeDir Directories="$(LinkerFileListOutputPath)" />
+
     <WriteLinesToFile File="$(LinkerRuntimeList)" Lines="@(LinkerRuntimeFiles->'%(Filename)%(Extension)')"
-                      Condition=" '@(LinkerRuntimeFiles->Count())' != '0' "
+                      Condition=" '$(HasLinkerRuntimeFiles)' == 'true' "
                       Overwrite="true" />
     <WriteLinesToFile File="$(LinkerDiagnosticList)" Lines="@(LinkerDiagnosticFiles->'%(Filename)%(Extension)')"
-                      Condition=" '@(LinkerDiagnosticFiles->Count())' != '0' "
+                      Condition=" '$(HasLinkerDiagnosticFiles)' == 'true' "
                       Overwrite="true" />
 
+<!-->    <ItemGroup Condition=" '$(PackageTargetRuntime)' != '' ">-->
     <ItemGroup>
-      <File Include="$(LinkerRuntimeList);$(LinkerDiagnosticList)"
-            Condition=" Exists('%(Identity)') And '$(PackageTargetRuntime)' != '' ">
+      <PackageFile Include="$(LinkerRuntimeList)"
+            Condition=" '$(HasLinkerRuntimeFiles)' == 'true' ">
         <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-      </File>
+        <PackageId>$(Id)</PackageId>
+        <PackageVersion>$(PackageVersion)</PackageVersion>
+      </PackageFile>
+      <PackageFile Include="$(LinkerDiagnosticList)"
+            Condition=" '$(HasLinkerDiagnosticFiles)' == 'true' ">
+        <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+        <PackageId>$(Id)</PackageId>
+        <PackageVersion>$(PackageVersion)</PackageVersion>
+      </PackageFile>
     </ItemGroup>
 
-    <Message Importance="High" Text="file for $(MSBuildProjectName): @(File)" />
+    <Message Importance="High" Text="file for $(MSBuildProjectName): @(PackageFile)" />
   </Target>
 
   <!-- OverrideLicenseUrl is temporary till we update the buildtools to v2 -->  

--- a/src/.nuget/dir.targets
+++ b/src/.nuget/dir.targets
@@ -98,8 +98,9 @@
     into the package build.
     Do so before GetPackageAssets (instead of GetPackageFiles), to avoid the .txt file getting
     created for each RID-specific package during the recursive GetPackageFiles call.
+    Oh. GetPackageAssets only runs AFTER the package is created, too late.
   -->
-  <Target Name="GetLinkerNativeIncludes" BeforeTargets="GetPackageAssets">
+  <Target Name="GetLinkerNativeIncludes" AfterTargets="GetPackageDependencies">
     <ItemGroup>
       <LinkerRuntimeFiles Include="@(NativeBinary)" Condition=" '%(NativeBinary.LinkerUsage)' == 'runtime' " />
       <LinkerDiagnosticFiles Include="@(NativeBinary)" Condition=" '%(NativeBinary.LinkerUsage)' == 'diagnostic' " />
@@ -126,21 +127,17 @@
 
 <!-->    <ItemGroup Condition=" '$(PackageTargetRuntime)' != '' ">-->
     <ItemGroup>
-      <PackageFile Include="$(LinkerRuntimeList)"
+      <File Include="$(LinkerRuntimeList)"
             Condition=" '$(HasLinkerRuntimeFiles)' == 'true' ">
         <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-        <PackageId>$(Id)</PackageId>
-        <PackageVersion>$(PackageVersion)</PackageVersion>
-      </PackageFile>
-      <PackageFile Include="$(LinkerDiagnosticList)"
+      </File>
+      <File Include="$(LinkerDiagnosticList)"
             Condition=" '$(HasLinkerDiagnosticFiles)' == 'true' ">
         <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
-        <PackageId>$(Id)</PackageId>
-        <PackageVersion>$(PackageVersion)</PackageVersion>
-      </PackageFile>
+      </File>
     </ItemGroup>
 
-    <Message Importance="High" Text="file for $(MSBuildProjectName): @(PackageFile)" />
+    <Message Importance="High" Text="file for $(MSBuildProjectName): @(File)" />
   </Target>
 
   <!-- OverrideLicenseUrl is temporary till we update the buildtools to v2 -->  

--- a/src/.nuget/dir.targets
+++ b/src/.nuget/dir.targets
@@ -116,7 +116,8 @@
       <LinkerDiagnosticList>$(LinkerFileListOutputPath)linkerdiagnosticfiles.txt</LinkerDiagnosticList>
     </PropertyGroup>
 
-    <MakeDir Directories="$(LinkerFileListOutputPath)" />
+    <MakeDir Directories="$(LinkerFileListOutputPath)"
+             Condition=" '$(HasLinkerRuntimeFiles)' == 'true' Or '$(HasLinkerDiagnosticFiles)' == 'true' " />
 
     <WriteLinesToFile File="$(LinkerRuntimeList)" Lines="@(LinkerRuntimeFiles->'%(Filename)%(Extension)')"
                       Condition=" '$(HasLinkerRuntimeFiles)' == 'true' "


### PR DESCRIPTION
This is part of the work suggested in https://github.com/dotnet/sdk/pull/3157. The IL linker will be able to remove unused native dependencies, but we need a whitelist mechanism. This change adds text files to the runtime and jit packages that list the files that are required either at runtime or for using the debugger. These packages flow to core-setup, where I'll make a follow-up change to ensure that these lists also flow to runtime packs.

@nguerrera @fadimounir @swaroop-sridhar