### PR TITLE
Fix memory corruption in GetResultFileName in SuperPMI

### DIFF
--- a/src/ToolBox/superpmi/superpmi-shared/spmiutil.h
+++ b/src/ToolBox/superpmi/superpmi-shared/spmiutil.h
@@ -25,6 +25,6 @@ LPSTR GetCommandLineA();
 
 bool LoadRealJitLib(HMODULE& realJit, WCHAR* realJitPath);
 
-WCHAR* getResultFileName(const WCHAR* folderPath, WCHAR* executableName, const WCHAR* extension);
+WCHAR* GetResultFileName(const WCHAR* folderPath, const WCHAR* fileName, const WCHAR* extension);
 
 #endif // !_SPMIUtil

--- a/src/ToolBox/superpmi/superpmi-shim-collector/superpmi-shim-collector.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-collector/superpmi-shim-collector.cpp
@@ -65,15 +65,11 @@ void SetLogPath()
 void SetLogPathName()
 {
     // NOTE: under PAL, we don't get the command line, so we depend on the random number generator to give us a unique
-    // filename.
-    const WCHAR* originalExecutableName = GetCommandLineW();
-    size_t       executableNameLength   = wcslen(originalExecutableName);
-    WCHAR*       executableName         = new WCHAR[executableNameLength + 1];
-    wcscpy_s(executableName, executableNameLength + 1, originalExecutableName);
-    executableName[executableNameLength] = W('\0');
+    // filename
+    const WCHAR* fileName  = GetCommandLineW();
+    const WCHAR* extension = W(".mc");
 
-    const WCHAR* DataFileExtension = W(".mc");
-    g_dataFileName                 = getResultFileName(g_logPath, executableName, DataFileExtension);
+    g_dataFileName = GetResultFileName(g_logPath, fileName, extension);
 }
 
 // TODO: this only works for ANSI file paths...

--- a/src/ToolBox/superpmi/superpmi-shim-counter/methodcallsummarizer.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-counter/methodcallsummarizer.cpp
@@ -14,10 +14,10 @@ MethodCallSummarizer::MethodCallSummarizer(WCHAR* logPath)
     names    = nullptr;
     counts   = nullptr;
 
-    WCHAR*       executableName    = GetCommandLineW();
-    const WCHAR* dataFileExtension = W(".csv");
+    const WCHAR* fileName  = GetCommandLineW();
+    const WCHAR* extension = W(".csv");
 
-    dataFileName = getResultFileName(logPath, executableName, dataFileExtension);
+    dataFileName = GetResultFileName(logPath, fileName, extension);
 }
 
 // lots of ways will be faster.. this happens to be decently simple and good enough for the task at hand and nicely


### PR DESCRIPTION
Fixes #24527:

The issue was due to heap memory corruption introduced in #21252 (https://github.com/dotnet/coreclr/pull/21252/files#diff-09cd8c002b00a272bb8b222c1c2717c6) that increased the expected size of the buffer (`executableNameLength += randStringLength;`) without increasing the actual size of the buffer