### PR TITLE
GC Moved Objects Profiler API fix

### DIFF
--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -676,7 +676,7 @@ void ETW::GCLog::MovedReference(
     // ProfAPI
     if (fAllowProfApiNotification)
     {
-        BEGIN_PIN_PROFILER(CORProfilerTrackGC());
+        BEGIN_PIN_PROFILER(CORProfilerTrackGC() || CORProfilerTrackGCMovedObjects());
         g_profControlBlock.pProfInterface->MovedReference(pbMemBlockStart,
                                                           pbMemBlockEnd,
                                                           cbRelocDistance,
@@ -802,7 +802,7 @@ VOID ETW::GCLog::EndMovedReferences(size_t profilingContext, BOOL fAllowProfApiN
     // ProfAPI
     if (fAllowProfApiNotification)
     {
-        BEGIN_PIN_PROFILER(CORProfilerTrackGC());
+        BEGIN_PIN_PROFILER(CORProfilerTrackGC() || CORProfilerTrackGCMovedObjects());
         g_profControlBlock.pProfInterface->EndMovedReferences(&(pCtxForEtwAndProfapi->pctxProfAPI));
         END_PIN_PROFILER();
     }


### PR DESCRIPTION
This should have been a part of https://github.com/dotnet/coreclr/pull/24156

When I initially checked in the code for this I tested it using the old profiler test which had GC tracking turned on, so this got missed.

Found while working on tests.