### PR TITLE
Fixed link to .NET Core SDK

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -11,7 +11,7 @@ Intro to .NET Core
 Getting Started
 ===============
 
-- [Installing the .NET Core SDK](https://www.microsoft.com/net/core)
+- [Installing the .NET Core SDK](https://dotnet.microsoft.com/download)
 - [Official .NET Core Docs](https://docs.microsoft.com/dotnet/core/)
 
 Project Docs


### PR DESCRIPTION
Changed a link to .NET Core download page. Previously it led to a sample application.