### PR TITLE
Exclude eventsourcetrace from jitstress runs.

### DIFF
--- a/tests/src/tracing/eventsource/eventsourcetrace/eventsourcetrace.csproj
+++ b/tests/src/tracing/eventsource/eventsourcetrace/eventsourcetrace.csproj
@@ -14,6 +14,8 @@
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
+    <!-- https://github.com/dotnet/coreclr/issues/24423 -->
+    <JitOptimizationSensitive>True</JitOptimizationSensitive>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'"></PropertyGroup>


### PR DESCRIPTION
It blocks clean[ JitStress runs](https://dev.azure.com/dnceng/public/_build?definitionId=348).

Revert this when #24423 is fixed.