### PR TITLE
Add a documentation link to the missing resources exception messages

### DIFF
--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -2840,19 +2840,19 @@
     <value>Field '{0}' not found.</value>
   </data>
   <data name="MissingManifestResource_MultipleBlobs" xml:space="preserve">
-    <value>A case-insensitive lookup for resource file "{0}" in assembly "{1}" found multiple entries. Remove the duplicates or specify the exact case.</value>
+    <value>A case-insensitive lookup for resource file "{0}" in assembly "{1}" found multiple entries. Remove the duplicates or specify the exact case. For more information, consult the document https://aka.ms/MissingManagedResource.</value>
   </data>
   <data name="MissingManifestResource_NoNeutralAsm" xml:space="preserve">
-    <value>Could not find any resources appropriate for the specified culture or the neutral culture.  Make sure "{0}" was correctly embedded or linked into assembly "{1}" at compile time, or that all the satellite assemblies required are loadable and fully signed.</value>
+    <value>Could not find any resources appropriate for the specified culture or the neutral culture.  Make sure "{0}" was correctly embedded or linked into assembly "{1}" at compile time, or that all the satellite assemblies required are loadable and fully signed. For more information, consult the document https://aka.ms/MissingManagedResource.</value>
   </data>
   <data name="MissingManifestResource_NoNeutralDisk" xml:space="preserve">
-    <value>Could not find any resources appropriate for the specified culture (or the neutral culture) on disk.</value>
+    <value>Could not find any resources appropriate for the specified culture (or the neutral culture) on disk. For more information, consult the document https://aka.ms/MissingManagedResource.</value>
   </data>
   <data name="MissingManifestResource_NoPRIresources" xml:space="preserve">
-    <value>Unable to open Package Resource Index.</value>
+    <value>Unable to open Package Resource Index. For more information, consult the document https://aka.ms/MissingManagedResource.</value>
   </data>
   <data name="MissingManifestResource_ResWFileNotLoaded" xml:space="preserve">
-    <value>Unable to load resources for resource file "{0}" in package "{1}".</value>
+    <value>Unable to load resources for resource file "{0}" in package "{1}". For more information, consult the document https://aka.ms/MissingManagedResource.</value>
   </data>
   <data name="MissingMember" xml:space="preserve">
     <value>Member not found.</value>


### PR DESCRIPTION
Add a documentation link to the missing resources exception messages

The link would include more information regarding what can cause this exception to help developers diagnose and fix it. Note, the link is pointing at the exception documentation and we have a tracking doc issue https://github.com/dotnet/docs/issues/10031 to capture the needed information there.