### PR TITLE
Unconditionally capture output of xUnit tests

### DIFF
--- a/tests/runtest.proj
+++ b/tests/runtest.proj
@@ -290,7 +290,7 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
                 {
                     Assert.True(false, "Test Infrastructure Failure: " + infraEx.Message)%3B
                 }
-                else if (ret != CoreclrTestWrapperLib.EXIT_SUCCESS_CODE)
+                else
                 {
                     List<string> allOutput = new List<string>()%3B
 
@@ -328,7 +328,7 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
                         output.WriteLine(line)%3B
                     }
 
-                    Assert.True(false, string.Join(Environment.NewLine, allOutput))%3B
+                    Assert.True(ret == CoreclrTestWrapperLib.EXIT_SUCCESS_CODE, string.Join(Environment.NewLine, allOutput))%3B
                 }
             }
         }


### PR DESCRIPTION
So we can check the output of passing tests in Azure DevOps Tests explorer.