### PR TITLE
Was too aggressive with changes to PackageOutputPath property.

### DIFF
--- a/dir.common.props
+++ b/dir.common.props
@@ -7,9 +7,6 @@
   <PropertyGroup>
     <CoreclrDir>$(MSBuildThisFileDirectory)</CoreclrDir>
     <PackagesDir>$(CoreclrDir)/.packages/</PackagesDir>
-
-    <!-- [ARCADE_REMOVE] This property can be removed after build-tools is removed. -->
-    <PackageOutputPath>$(PackagesDir)</PackageOutputPath>
   </PropertyGroup>
 
   <!-- Define NuGet properties for scenarios where they aren't set. From the command line.

--- a/dir.props
+++ b/dir.props
@@ -152,8 +152,9 @@
     <CrossTargetComponentFolder Condition="'$(PackagePlatform)' == 'arm' and '$(TargetsWindows)' == 'true'">x86</CrossTargetComponentFolder>
     <CrossTargetComponentFolder Condition="'$(PackagePlatform)' == 'arm' and '$(TargetsLinux)' == 'true'">x64</CrossTargetComponentFolder>
 
-    <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(PackagesBinDir)/pkg/</PackageOutputPath>
-    <SymbolPackageOutputPath Condition="'$(SymbolPackageOutputPath)' == ''">$(PackagesBinDir)/symbolpkg/</SymbolPackageOutputPath>
+    <!-- Created package output locations must be kept in sync with eng/build-job.yml -->
+    <PackageOutputPath>$(PackagesBinDir)/pkg/</PackageOutputPath>
+    <SymbolPackageOutputPath>$(PackagesBinDir)/symbolpkg/</SymbolPackageOutputPath>
     <PackageIndexFile>$(MSBuildThisFileDirectory)/src/.nuget/packageIndex.json</PackageIndexFile>
 
     <!-- coreclr doesn't currently use the index so don't force it to be in sync -->


### PR DESCRIPTION
  - This represents this repo's generated packages rather than
    packages it consumes.

cc @RussKeldorph @sbomer 