### PR TITLE
Remove obsolete DomainLocalModule::m_pADThunkTable

### DIFF
--- a/src/vm/amd64/asmconstants.h
+++ b/src/vm/amd64/asmconstants.h
@@ -254,18 +254,16 @@ ASMCONSTANTS_C_ASSERT(OFFSETOF__InterfaceInfo_t__m_pMethodTable
 ASMCONSTANTS_C_ASSERT(SIZEOF__InterfaceInfo_t
                     == sizeof(InterfaceInfo_t));
 
-#define               OFFSETOF__DomainLocalModule__m_pDataBlob   0x030
+#define               OFFSETOF__DomainLocalModule__m_pDataBlob   0x028
 ASMCONSTANTS_C_ASSERT(OFFSETOF__DomainLocalModule__m_pDataBlob  
                     == offsetof(DomainLocalModule, m_pDataBlob));
-
-// If this changes then we can't just test one bit in the assembly code.
 ASMCONSTANTS_C_ASSERT(ClassInitFlags::INITIALIZED_FLAG == 1);
 
 // End for JIT_GetSharedNonGCStaticBaseWorker
 
 // For JIT_GetSharedGCStaticBaseWorker
 
-#define               OFFSETOF__DomainLocalModule__m_pGCStatics 0x020 
+#define               OFFSETOF__DomainLocalModule__m_pGCStatics 0x018
 ASMCONSTANTS_C_ASSERT(OFFSETOF__DomainLocalModule__m_pGCStatics
                     == offsetof(DomainLocalModule, m_pGCStatics));
 

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -191,18 +191,6 @@ struct DomainLocalModule
         Volatile<DWORD>             m_dwFlags;
     };
     typedef DPTR(DynamicClassInfo) PTR_DynamicClassInfo;
-    
-    inline UMEntryThunk * GetADThunkTable()
-    {
-        LIMITED_METHOD_CONTRACT
-        return m_pADThunkTable;
-    }
-
-    inline void SetADThunkTable(UMEntryThunk* pADThunkTable)
-    {
-        LIMITED_METHOD_CONTRACT
-        InterlockedCompareExchangeT(m_pADThunkTable.GetPointer(), pADThunkTable, NULL);
-    }
 
     // Note the difference between:
     // 
@@ -444,7 +432,6 @@ private:
     PTR_DomainFile           m_pDomainFile;
     VolatilePtr<DynamicClassInfo, PTR_DynamicClassInfo> m_pDynamicClassTable;   // used for generics and reflection.emit in memory
     Volatile<SIZE_T>         m_aDynamicEntries;      // number of entries in dynamic table
-    VolatilePtr<UMEntryThunk> m_pADThunkTable;
     PTR_OBJECTREF            m_pGCStatics;           // Handle to GC statics of the module
 
     // In addition to storing the ModuleIndex in the Module class, we also

--- a/src/vm/arm/asmconstants.h
+++ b/src/vm/arm/asmconstants.h
@@ -176,10 +176,10 @@ ASMCONSTANTS_C_ASSERT(Thread__m_pFrame == offsetof(Thread, m_pFrame));
 #define Thread_m_pFrame Thread__m_pFrame
 
 #ifndef CROSSGEN_COMPILE
-#define               DomainLocalModule__m_pDataBlob                 0x18
+#define               DomainLocalModule__m_pDataBlob                 0x14
 ASMCONSTANTS_C_ASSERT(DomainLocalModule__m_pDataBlob == offsetof(DomainLocalModule, m_pDataBlob));
 
-#define               DomainLocalModule__m_pGCStatics                 0x10
+#define               DomainLocalModule__m_pGCStatics                 0x0c
 ASMCONSTANTS_C_ASSERT(DomainLocalModule__m_pGCStatics == offsetof(DomainLocalModule, m_pGCStatics));
 
 #endif

--- a/src/vm/arm64/asmconstants.h
+++ b/src/vm/arm64/asmconstants.h
@@ -193,8 +193,8 @@ ASMCONSTANTS_C_ASSERT(ResolveCacheElem__target == offsetof(ResolveCacheElem, tar
 ASMCONSTANTS_C_ASSERT(ResolveCacheElem__pNext == offsetof(ResolveCacheElem, pNext));
 #endif // CROSSGEN_COMPILE
 
-#define DomainLocalModule__m_pDataBlob 0x30
-#define DomainLocalModule__m_pGCStatics 0x20
+#define DomainLocalModule__m_pDataBlob 0x28
+#define DomainLocalModule__m_pGCStatics 0x18
 ASMCONSTANTS_C_ASSERT(DomainLocalModule__m_pDataBlob == offsetof(DomainLocalModule, m_pDataBlob));
 ASMCONSTANTS_C_ASSERT(DomainLocalModule__m_pGCStatics == offsetof(DomainLocalModule, m_pGCStatics));
 


### PR DESCRIPTION
The m_pADThunkTable is not used anywhere.
This change removes the member, its getter and setter and also updates
offsets used by assembler helpers.