### PR TITLE
Use Helix Client docker feature for Nano runs

### DIFF
--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -196,6 +196,7 @@ jobs:
         helixQueues:
         - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
           - Windows.10.Amd64.Open
+          - "`(Windows.Nano.1803.Amd64.Open`)windows.10.amd64.serverrs4.open@mcr.microsoft.com/dotnet-buildtools/prereqs:nanoserver-1803-helix-amd64-05227e1-20190509225944"
         - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
           - Windows.7.Amd64.Open
           - Windows.81.Amd64.Open

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -197,10 +197,10 @@ jobs:
         - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
           - Windows.10.Amd64.Open
         - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-          # TODO: add Windows.10.Nano.Amd64.Open once https://github.com/dotnet/coreclr/issues/21693 has been resolved (see below queue id)
           - Windows.7.Amd64.Open
           - Windows.81.Amd64.Open
           - Windows.10.Amd64.Open
+          - "`(Windows.Nano.1803.Amd64.Open`)windows.10.amd64.serverrs4.open@mcr.microsoft.com/dotnet-buildtools/prereqs:nanoserver-1803-helix-amd64-05227e1-20190509225944"
         - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           - Windows.7.Amd64
           - Windows.81.Amd64

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -197,7 +197,7 @@ jobs:
         - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
           - Windows.10.Amd64.Open
         - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-          # TODO: add Windows.10.Nano.Amd64.Open once https://github.com/dotnet/coreclr/issues/21693 has been resolved
+          # TODO: add Windows.10.Nano.Amd64.Open once https://github.com/dotnet/coreclr/issues/21693 has been resolved (see below queue id)
           - Windows.7.Amd64.Open
           - Windows.81.Amd64.Open
           - Windows.10.Amd64.Open
@@ -206,7 +206,7 @@ jobs:
           - Windows.81.Amd64
           - Windows.10.Amd64
           - Windows.10.Amd64.Core
-          - Windows.10.Nano.Amd64
+          - "`(Windows.Nano.1803.Amd64`)windows.10.amd64.serverrs4@mcr.microsoft.com/dotnet-buildtools/prereqs:nanoserver-1803-helix-amd64-05227e1-20190509225944"
         ${{ insert }}: ${{ parameters.jobParameters }}
 
   # Windows x86


### PR DESCRIPTION
The old Nano queue is unreliable, stuck at version 1709, and will be deprecated; this change moves to running on a Server RS4 host with an 1803 version, and an 1809 version should be available soonish.

@jkoritzinsky  - it seems like  https://github.com/dotnet/coreclr/issues/21693 is closed, should this also be on the open runs?

(Weird "" and ` syntax is to work around the funkiness of Yaml / PS1)