### PR TITLE
Fix Handling time patterns with quotes

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Globalization/CultureData.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CultureData.Unix.cs
@@ -264,6 +264,19 @@ namespace System.Globalization
             {
                 switch (icuFormatString[i])
                 {
+                    case '\'':
+                        result[resultPos++] = icuFormatString[i++];
+                        while (i < icuFormatString.Length)
+                        {
+                            char current = icuFormatString[i++];
+                            result[resultPos++] = current;
+                            if (current == '\'')
+                            {
+                                break;
+                            }
+                        }
+                        break;
+
                     case ':':
                     case '.':
                     case 'H':


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/37557
We encountered some cultures have a time patterns with single quotes which we should handle keeping the parts between quotes as fixed text inside the pattern and not treat it as any of the time specifiers