### PR TITLE
Update build docker images to enable NUMA  support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,22 +9,22 @@ variables:
 resources:
   containers:
   - container: ubuntu_1404_arm_cross_build_image
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-14.04-cross-e435274-20180426002420
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-14.04-cross-cfdd435-20190501010458
 
   - container: ubuntu_1604_arm64_cross_build_image
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-a3ae44b-20180315221921
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-cfdd435-20190503204407
 
   - container: musl_x64_build_image
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.6-WithNode-f4d3fe3-20181220200247
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.6-WithNode-cfdd435-20190502142303
 
   - container: musl_arm64_build_image
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-alpine-406629a-20190403203438
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-alpine-406629a-20190503204407
 
   - container: centos7_x64_build_image
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-d485f41-20173404063424
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343
 
   - container: centos6_x64_build_image
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-6-376e1a3-20174311014331
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-6-3e800f1-20190501005338
 
 trigger:
 - master

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,16 +9,16 @@ variables:
 resources:
   containers:
   - container: ubuntu_1404_arm_cross_build_image
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-14.04-cross-cfdd435-20190501010458
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-14.04-cross-1735d26-20190521133857
 
   - container: ubuntu_1604_arm64_cross_build_image
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-cfdd435-20190503204407
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-cfdd435-20190520220848
 
   - container: musl_x64_build_image
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.6-WithNode-cfdd435-20190502142303
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.6-WithNode-cfdd435-20190521001804
 
   - container: musl_arm64_build_image
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-alpine-406629a-20190503204407
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-alpine-406629a-20190520220848
 
   - container: centos7_x64_build_image
     image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -57,7 +57,7 @@ jobs:
     - ${{ if eq(parameters.osGroup, 'FreeBSD') }}:
       - name: clangArg
         value: '-clang6.0'
-    - ${{ if and(eq(parameters.osIdentifier, 'Linux_musl'), eq(parameters.archType, 'arm64')) }}:
+    - ${{ if eq(parameters.archType, 'arm64') }}:
       - name: clangArg
         value: '-clang5.0'
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -62,7 +62,7 @@ jobs:
     - ${{ if eq(parameters.osGroup, 'FreeBSD') }}:
       - name: clangArg
         value: '-clang6.0'
-    - ${{ if and(eq(parameters.osIdentifier, 'Linux_musl'), eq(parameters.archType, 'arm64')) }}:
+    - ${{ if eq(parameters.archType, 'arm64') }}:
       - name: clangArg
         value: '-clang5.0'
 


### PR DESCRIPTION
So far, the NUMA support for Linux was disabled due to the fact that the
build docker images didn't have libnuma development package installed.
This change updates the images to ones that have the libnuma added that
were created recently.