### PR TITLE
Avoid doing dangerous cleanup in case of process detach

### DIFF
--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -196,6 +196,20 @@ void EventPipe::Shutdown()
     }
     CONTRACTL_END;
 
+    if (g_fProcessDetach)
+    {
+        // If g_fProcessDetach is true, all threads except this got ripped because someone called ExitProcess(). 
+        // This check is an attempt recognize that case and skip all unsafe cleanup work. 
+
+        // Since event reading/writing could happen while that ExitProcess happened, the stream is probably 
+        // screwed anyway. Therefore we do NOT attempt to flush buffer, do rundown. Cleaning up memory at this
+        // point is rather meaningless too since the process is going to terminate soon. Therefore we simply 
+        // quickly exit here
+        
+        // TODO: Consider releasing the resources that could last longer than the process (e.g. the files)
+        return;
+    }
+
     // Mark tracing as no longer initialized.
     s_tracingInitialized = false;
 

--- a/src/vm/sampleprofiler.cpp
+++ b/src/vm/sampleprofiler.cpp
@@ -113,23 +113,18 @@ void SampleProfiler::Disable()
         return;
     }
 
-    // If g_fProcessDetach is true, the sampling profiler thread probably got
-    // ripped because someone called ExitProcess(). This check is an attempt 
-    // to recognize that case and avoid waiting for the (already dead) sampling
-    // profiler thread to tell us it is terminated.
-    if (!g_fProcessDetach)
-    {
-        // Reset the event before shutdown.
-        s_threadShutdownEvent.Reset();
+    _ASSERTE(!g_fProcessDetach);
+    
+    // Reset the event before shutdown.
+    s_threadShutdownEvent.Reset();
 
-        // The sampling thread will watch this value and exit
-        // when profiling is disabled.
-        s_profilingEnabled = false;
+    // The sampling thread will watch this value and exit
+    // when profiling is disabled.
+    s_profilingEnabled = false;
 
-        // Wait for the sampling thread to clean itself up.
-        s_threadShutdownEvent.Wait(INFINITE, FALSE /* bAlertable */);
-        s_threadShutdownEvent.CloseEvent();
-    }
+    // Wait for the sampling thread to clean itself up.
+    s_threadShutdownEvent.Wait(INFINITE, FALSE /* bAlertable */);
+    s_threadShutdownEvent.CloseEvent();
 
     if(s_timePeriodIsSet)
     {


### PR DESCRIPTION
Fixes #24472

When s_fProcessDetach occurs, all threads (except the one running EEShutdown) are terminated by the operating system at the moment the request to terminate the process happens (e.g. Ctrl+C or ExitProcess). Therefore, if a thread obtained a lock and got terminated, that thread will never be able to release the lock, or signal an event, so any operation pending on lock is dangerous in the shutdown.

We fixed this once in PR #24466 for issue #24459, however the fix is not sufficient. Here I simply skipped the whole process, in an attempt for a full fix.