### PR TITLE
Delete RETURNTYPE and change how we get ReturnKind for gccover.

### DIFF
--- a/src/inc/gcinfotypes.h
+++ b/src/inc/gcinfotypes.h
@@ -273,7 +273,7 @@ inline bool IsScalarReturnKind(ReturnKind returnKind)
 
 inline bool IsPointerReturnKind(ReturnKind returnKind)
 {
-    return !IsScalarReturnKind(returnKind);
+    return IsValidReturnKind(returnKind) && !IsScalarReturnKind(returnKind);
 }
 
 // Helpers for combining/extracting individual ReturnKinds from/to Struct ReturnKinds.

--- a/src/inc/gcinfotypes.h
+++ b/src/inc/gcinfotypes.h
@@ -262,6 +262,16 @@ inline bool IsStructReturnKind(ReturnKind returnKind)
     return returnKind > 3;
 }
 
+inline bool IsPointerReturnKind(ReturnKind returnKind)
+{
+    bool isScalarReturnType = (returnKind == RT_Scalar)
+#ifdef _TARGET_X86_
+        || (returnKind == RT_Float)
+#endif // _TARGET_X86_
+        ;
+    return !isScalarReturnType;
+}
+
 // Helpers for combining/extracting individual ReturnKinds from/to Struct ReturnKinds.
 // Encoding is two bits per register
 

--- a/src/inc/gcinfotypes.h
+++ b/src/inc/gcinfotypes.h
@@ -262,14 +262,18 @@ inline bool IsStructReturnKind(ReturnKind returnKind)
     return returnKind > 3;
 }
 
-inline bool IsPointerReturnKind(ReturnKind returnKind)
+inline bool IsScalarReturnKind(ReturnKind returnKind)
 {
-    bool isScalarReturnType = (returnKind == RT_Scalar)
+    return (returnKind == RT_Scalar)
 #ifdef _TARGET_X86_
         || (returnKind == RT_Float)
 #endif // _TARGET_X86_
         ;
-    return !isScalarReturnType;
+}
+
+inline bool IsPointerReturnKind(ReturnKind returnKind)
+{
+    return !IsScalarReturnKind(returnKind);
 }
 
 // Helpers for combining/extracting individual ReturnKinds from/to Struct ReturnKinds.

--- a/src/vm/callhelpers.h
+++ b/src/vm/callhelpers.h
@@ -362,10 +362,6 @@ public:
 #define MDCALLDEF_ARGSLOT(wrappedmethod, ext)                                       \
         FORCEINLINE void wrappedmethod##ext (const ARG_SLOT* pArguments, ARG_SLOT *pReturnValue, int cbReturnValue) \
         {                                                                           \
-            WRAPPER_NO_CONTRACT;                                                    \
-            {                                                                       \
-                GCX_FORBID();  /* arg array is not protected */                     \
-            }                                                                       \
             CallTargetWorker(pArguments, pReturnValue, cbReturnValue);              \
             /* Bigendian layout not support */                                      \
         }
@@ -373,11 +369,6 @@ public:
 #define MDCALLDEF_REFTYPE(wrappedmethod,  permitvaluetypes, ext, ptrtype, reftype)              \
         FORCEINLINE reftype wrappedmethod##ext (const ARG_SLOT* pArguments)                     \
         {                                                                                       \
-            WRAPPER_NO_CONTRACT;                                                                \
-            {                                                                                   \
-                GCX_FORBID();  /* arg array is not protected */                                 \
-                CONSISTENCY_CHECK(MetaSig::RETOBJ == m_pMD->ReturnsObject(true));               \
-            }                                                                                   \
             ARG_SLOT retval;                                                                    \
             CallTargetWorker(pArguments, &retval, sizeof(retval));                              \
             return ObjectTo##reftype(*(ptrtype *)                                               \

--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -1356,30 +1356,6 @@ BOOL CanDeduplicateCode(CORINFO_METHOD_HANDLE method, CORINFO_METHOD_HANDLE dupl
     DynamicMethodDesc * pDuplicateMethod = GetMethod(duplicateMethod)->AsDynamicMethodDesc();
 
     //
-    // Make sure that the return types match (for code:Thread::HijackThread)
-    //
-
-#ifdef _TARGET_X86_
-    MetaSig msig1(pMethod);
-    MetaSig msig2(pDuplicateMethod);
-    if (!msig1.HasFPReturn() != !msig2.HasFPReturn())
-        return FALSE;
-#endif // _TARGET_X86_
-
-    MetaSig::RETURNTYPE returnType = pMethod->ReturnsObject();
-    MetaSig::RETURNTYPE returnTypeDuplicate = pDuplicateMethod->ReturnsObject();
-
-    if (returnType != returnTypeDuplicate)
-        return FALSE;
-
-    //
-    // Do not enable deduplication of structs returned in registers
-    //
-
-    if (returnType == MetaSig::RETVALUETYPE)
-        return FALSE;
-
-    //
     // Make sure that the IL stub flags match
     //
 

--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -1434,9 +1434,8 @@ void ComPlusMethodFrame::GcScanRoots(promote_func* fn, ScanContext* sc)
 
 
     // Promote the returned object
-    Thread* pThread = GetThread();
     MethodDesc* methodDesc = GetFunction();
-    ReturnKind returnKind = methodDesc->GetReturnKindFromMethodTable(pThread);
+    ReturnKind returnKind = methodDesc->GetReturnKind();
     if (returnKind == RT_Object)
     {
         (*fn)(GetReturnObjectPtr(), sc, CHECK_APP_DOMAIN);

--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -1445,6 +1445,11 @@ void ComPlusMethodFrame::GcScanRoots(promote_func* fn, ScanContext* sc)
     {
         PromoteCarefully(fn, GetReturnObjectPtr(), sc, GC_CALL_INTERIOR | CHECK_APP_DOMAIN);
     }
+    else
+    {
+        _ASSERTE_MSG(!IsStructReturnKind(returnKind), "NYI: We can't promote multiregs struct returns");
+        _ASSERTE_MSG(IsScalarReturnKind(returnKind), "Non-scalar types must be promoted.");
+    }
 }
 #endif // FEATURE_COMINTEROP
 

--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -1422,7 +1422,7 @@ ComPlusMethodFrame::ComPlusMethodFrame(TransitionBlock * pTransitionBlock, Metho
 #endif // #ifndef DACCESS_COMPILE
 
 //virtual
-void ComPlusMethodFrame::GcScanRoots(promote_func *fn, ScanContext* sc)
+void ComPlusMethodFrame::GcScanRoots(promote_func* fn, ScanContext* sc)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1432,13 +1432,19 @@ void ComPlusMethodFrame::GcScanRoots(promote_func *fn, ScanContext* sc)
     FramedMethodFrame::GcScanRoots(fn, sc);
     PromoteCallerStack(fn, sc);
 
-    MetaSig::RETURNTYPE returnType = GetFunction()->ReturnsObject();
 
     // Promote the returned object
-    if(returnType == MetaSig::RETOBJ)
+    Thread* pThread = GetThread();
+    MethodDesc* methodDesc = GetFunction();
+    ReturnKind returnKind = methodDesc->GetReturnKindFromMethodTable(pThread);
+    if (returnKind == RT_Object)
+    {
         (*fn)(GetReturnObjectPtr(), sc, CHECK_APP_DOMAIN);
-    else if (returnType == MetaSig::RETBYREF)
-        PromoteCarefully(fn, GetReturnObjectPtr(), sc, GC_CALL_INTERIOR|CHECK_APP_DOMAIN);
+    }
+    else if (returnKind == RT_ByRef)
+    {
+        PromoteCarefully(fn, GetReturnObjectPtr(), sc, GC_CALL_INTERIOR | CHECK_APP_DOMAIN);
+    }
 }
 #endif // FEATURE_COMINTEROP
 

--- a/src/vm/gccover.cpp
+++ b/src/vm/gccover.cpp
@@ -532,7 +532,6 @@ void GCCoverageInfo::SprinkleBreakpoints(
 
         if (prevDirectCallTargetMD != 0)
         {
-            Thread* pThread = GetThread();
             ReturnKind returnKind = prevDirectCallTargetMD->GetReturnKind(true);
             if (IsPointerReturnKind(returnKind))
                 *cur = INTERRUPT_INSTR_PROTECT_RET;  

--- a/src/vm/gccover.cpp
+++ b/src/vm/gccover.cpp
@@ -532,7 +532,9 @@ void GCCoverageInfo::SprinkleBreakpoints(
 
         if (prevDirectCallTargetMD != 0)
         {
-            if (prevDirectCallTargetMD->ReturnsObject(true) != MetaSig::RETNONOBJ)
+            Thread* pThread = GetThread();
+            ReturnKind returnKind = prevDirectCallTargetMD->GetReturnKindFromMethodTable(pThread, true);
+            if (IsPointerReturnKind(returnKind))
                 *cur = INTERRUPT_INSTR_PROTECT_RET;  
             else
                 *cur = INTERRUPT_INSTR;
@@ -759,16 +761,16 @@ void replaceSafePointInstructionWithGcStressInstr(UINT32 safePointOffset, LPVOID
                 // never requires restore, however it is possible that it is initially in an invalid state
                 // and remains invalid until one or more eager fixups are applied.
                 //
-                // MethodDesc::ReturnsObject() consults the method signature, meaning it consults the
+                // GetReturnKindFromMethodTable consults the method signature, meaning it consults the
                 // metadata in the owning module.  For generic instantiations stored in non-preferred
                 // modules, reaching the owning module requires following the module override pointer for
                 // the enclosing MethodTable.  In this case, the module override pointer is generally
                 // invalid until an associated eager fixup is applied.
                 //
-                // In situations like this, MethodDesc::ReturnsObject() will try to dereference an
+                // In situations like this, GetReturnKindFromMethodTable will try to dereference an
                 // unresolved fixup and will AV.
                 //
-                // Given all of this, skip the MethodDesc::ReturnsObject() call by default to avoid
+                // Given all of this, skip the GetReturnKindFromMethodTable call by default to avoid
                 // unexpected AVs.  This implies leaving out the GC coverage breakpoints for direct calls
                 // unless COMPlus_GcStressOnDirectCalls=1 is explicitly set in the environment.
                 //
@@ -777,8 +779,11 @@ void replaceSafePointInstructionWithGcStressInstr(UINT32 safePointOffset, LPVOID
 
                 if (fGcStressOnDirectCalls.val(CLRConfig::INTERNAL_GcStressOnDirectCalls))
                 {
+                    Thread* pThread = GetThread();
+                    ReturnKind returnKind = targetMD->GetReturnKindFromMethodTable(pThread, true);
+
                     // If the method returns an object then should protect the return object
-                    if (targetMD->ReturnsObject(true) != MetaSig::RETNONOBJ)
+                    if (IsPointerReturnKind(returnKind))
                     {
                         // replace with corresponding 2 or 4 byte illegal instruction (which roots the return value)
 #if defined(_TARGET_ARM_)
@@ -1607,17 +1612,16 @@ void DoGcStress (PCONTEXT regs, MethodDesc *pMD)
 
                 if (targetMD != 0)
                 {
-                    // Mark that we are performing a stackwalker like operation on the current thread.
-                    // This is necessary to allow the ReturnsObject function to work without triggering any loads
-                    ClrFlsValueSwitch _threadStackWalking(TlsIdx_StackWalkerWalkingThread, pThread);
-
                     // @Todo: possible race here, might need to be fixed  if it become a problem.
                     // It could become a problem if 64bit does partially interrupt work.
                     // OK, we have the MD, mark the instruction after the CALL
                     // appropriately
+
+                    ReturnKind returnKind = targetMD->GetReturnKindFromMethodTable(pThread, true);
+                    bool protectReturn = IsPointerReturnKind(returnKind);
 #ifdef _TARGET_ARM_
                     size_t instrLen = GetARMInstructionLength(nextInstr);
-                    if (targetMD->ReturnsObject(true) != MetaSig::RETNONOBJ)
+                    if (protectReturn)
                         if (instrLen == 2)
                             *(WORD*)nextInstr  = INTERRUPT_INSTR_PROTECT_RET;
                         else
@@ -1628,12 +1632,12 @@ void DoGcStress (PCONTEXT regs, MethodDesc *pMD)
                         else
                             *(DWORD*)nextInstr = INTERRUPT_INSTR_32;
 #elif defined(_TARGET_ARM64_)
-                    if (targetMD->ReturnsObject(true) != MetaSig::RETNONOBJ)
+                    if (protectReturn)
                         *(DWORD *)nextInstr = INTERRUPT_INSTR_PROTECT_RET;  
                     else
                         *(DWORD *)nextInstr = INTERRUPT_INSTR;
 #else
-                    if (targetMD->ReturnsObject(true) != MetaSig::RETNONOBJ)
+                    if (protectReturn)
                         *nextInstr = INTERRUPT_INSTR_PROTECT_RET;  
                     else
                         *nextInstr = INTERRUPT_INSTR;

--- a/src/vm/gccover.cpp
+++ b/src/vm/gccover.cpp
@@ -533,7 +533,7 @@ void GCCoverageInfo::SprinkleBreakpoints(
         if (prevDirectCallTargetMD != 0)
         {
             Thread* pThread = GetThread();
-            ReturnKind returnKind = prevDirectCallTargetMD->GetReturnKindFromMethodTable(pThread, true);
+            ReturnKind returnKind = prevDirectCallTargetMD->GetReturnKind(true);
             if (IsPointerReturnKind(returnKind))
                 *cur = INTERRUPT_INSTR_PROTECT_RET;  
             else
@@ -761,16 +761,16 @@ void replaceSafePointInstructionWithGcStressInstr(UINT32 safePointOffset, LPVOID
                 // never requires restore, however it is possible that it is initially in an invalid state
                 // and remains invalid until one or more eager fixups are applied.
                 //
-                // GetReturnKindFromMethodTable consults the method signature, meaning it consults the
+                // GetReturnKind consults the method signature, meaning it consults the
                 // metadata in the owning module.  For generic instantiations stored in non-preferred
                 // modules, reaching the owning module requires following the module override pointer for
                 // the enclosing MethodTable.  In this case, the module override pointer is generally
                 // invalid until an associated eager fixup is applied.
                 //
-                // In situations like this, GetReturnKindFromMethodTable will try to dereference an
+                // In situations like this, GetReturnKind will try to dereference an
                 // unresolved fixup and will AV.
                 //
-                // Given all of this, skip the GetReturnKindFromMethodTable call by default to avoid
+                // Given all of this, skip the GetReturnKind call by default to avoid
                 // unexpected AVs.  This implies leaving out the GC coverage breakpoints for direct calls
                 // unless COMPlus_GcStressOnDirectCalls=1 is explicitly set in the environment.
                 //
@@ -779,8 +779,7 @@ void replaceSafePointInstructionWithGcStressInstr(UINT32 safePointOffset, LPVOID
 
                 if (fGcStressOnDirectCalls.val(CLRConfig::INTERNAL_GcStressOnDirectCalls))
                 {
-                    Thread* pThread = GetThread();
-                    ReturnKind returnKind = targetMD->GetReturnKindFromMethodTable(pThread, true);
+                    ReturnKind returnKind = targetMD->GetReturnKind(true);
 
                     // If the method returns an object then should protect the return object
                     if (IsPointerReturnKind(returnKind))
@@ -1617,7 +1616,7 @@ void DoGcStress (PCONTEXT regs, MethodDesc *pMD)
                     // OK, we have the MD, mark the instruction after the CALL
                     // appropriately
 
-                    ReturnKind returnKind = targetMD->GetReturnKindFromMethodTable(pThread, true);
+                    ReturnKind returnKind = targetMD->GetReturnKind(true);
                     bool protectReturn = IsPointerReturnKind(returnKind);
 #ifdef _TARGET_ARM_
                     size_t instrLen = GetARMInstructionLength(nextInstr);

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -1305,7 +1305,11 @@ MetaSig::RETURNTYPE MethodDesc::ReturnsObject(
     return(MetaSig::RETNONOBJ);
 }
 
-ReturnKind MethodDesc::GetReturnKindFromMethodTable(Thread* pThread)
+ReturnKind MethodDesc::GetReturnKindFromMethodTable(Thread* pThread
+#ifdef _DEBUG
+    , bool supportStringConstructors
+#endif
+)
 {
 #ifdef _WIN64
     // For simplicity, we don't hijack in funclets, but if you ever change that, 
@@ -1331,7 +1335,7 @@ ReturnKind MethodDesc::GetReturnKindFromMethodTable(Thread* pThread)
 #endif // _TARGET_X86_
 
     MethodTable* pMT = NULL;
-    MetaSig::RETURNTYPE type = ReturnsObject(INDEBUG_COMMA(false) & pMT);
+    MetaSig::RETURNTYPE type = ReturnsObject(INDEBUG_COMMA(supportStringConstructors) & pMT);
     if (type == MetaSig::RETOBJ)
     {
         return RT_Object;

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -1305,6 +1305,75 @@ MetaSig::RETURNTYPE MethodDesc::ReturnsObject(
     return(MetaSig::RETNONOBJ);
 }
 
+ReturnKind MethodDesc::GetReturnKindFromMethodTable(Thread* pThread)
+{
+#ifdef _WIN64
+    // For simplicity, we don't hijack in funclets, but if you ever change that, 
+    // be sure to choose the OnHijack... callback type to match that of the FUNCLET
+    // not the main method (it would probably be Scalar).
+#endif // _WIN64
+
+    ENABLE_FORBID_GC_LOADER_USE_IN_THIS_SCOPE();
+    // Mark that we are performing a stackwalker like operation on the current thread.
+    // This is necessary to allow the signature parsing functions to work without triggering any loads
+    ClrFlsValueSwitch threadStackWalking(TlsIdx_StackWalkerWalkingThread, pThread);
+
+#ifdef _TARGET_X86_
+    MetaSig msig(this);
+    if (msig.HasFPReturn())
+    {
+        // Figuring out whether the function returns FP or not is hard to do
+        // on-the-fly, so we use a different callback helper on x86 where this
+        // piece of information is needed in order to perform the right save &
+        // restore of the return value around the call to OnHijackScalarWorker.
+        return RT_Float;
+    }
+#endif // _TARGET_X86_
+
+    MethodTable* pMT = NULL;
+    MetaSig::RETURNTYPE type = ReturnsObject(INDEBUG_COMMA(false) & pMT);
+    if (type == MetaSig::RETOBJ)
+    {
+        return RT_Object;
+    }
+
+    if (type == MetaSig::RETBYREF)
+    {
+        return RT_ByRef;
+    }
+
+#ifdef UNIX_AMD64_ABI
+    // The Multi-reg return case using the classhandle is only implemented for AMD64 SystemV ABI.
+    // On other platforms, multi-reg return is not supported with GcInfo v1.
+    // So, the relevant information must be obtained from the GcInfo tables (which requires version2).
+    if (type == MetaSig::RETVALUETYPE)
+    {
+        EEClass* eeClass = pMT->GetClass();
+        ReturnKind regKinds[2] = { RT_Unset, RT_Unset };
+        int orefCount = 0;
+        for (int i = 0; i < 2; i++)
+        {
+            if (eeClass->GetEightByteClassification(i) == SystemVClassificationTypeIntegerReference)
+            {
+                regKinds[i] = RT_Object;
+            }
+            else if (eeClass->GetEightByteClassification(i) == SystemVClassificationTypeIntegerByRef)
+            {
+                regKinds[i] = RT_ByRef;
+            }
+            else
+            {
+                regKinds[i] = RT_Scalar;
+            }
+        }
+        ReturnKind structReturnKind = GetStructReturnKind(regKinds[0], regKinds[1]);
+        return structReturnKind;
+    }
+#endif // UNIX_AMD64_ABI
+
+    return RT_Scalar;
+}
+
 #ifdef FEATURE_COMINTEROP
 
 #ifndef DACCESS_COMPILE

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -1213,14 +1213,11 @@ COR_ILMETHOD* MethodDesc::GetILHeader(BOOL fAllowOverrides /*=FALSE*/)
 }
 
 //*******************************************************************************
-ReturnKind MethodDesc::ReturnsObject(INDEBUG(bool supportStringConstructors))
+ReturnKind MethodDesc::ParseReturnKindFromSig(INDEBUG(bool supportStringConstructors))
 {
     CONTRACTL
     {
-        if (FORBIDGC_LOADER_USE_ENABLED()) 
-            NOTHROW; 
-        else 
-            THROWS;
+        if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
         GC_NOTRIGGER;
         FORBID_FAULT;
     }
@@ -1320,11 +1317,7 @@ ReturnKind MethodDesc::ReturnsObject(INDEBUG(bool supportStringConstructors))
     return RT_Scalar;
 }
 
-ReturnKind MethodDesc::GetReturnKindFromMethodTable(Thread* pThread
-#ifdef _DEBUG
-    , bool supportStringConstructors
-#endif
-)
+ReturnKind MethodDesc::GetReturnKind(INDEBUG(bool supportStringConstructors))
 {
 #ifdef _WIN64
     // For simplicity, we don't hijack in funclets, but if you ever change that, 
@@ -1335,7 +1328,7 @@ ReturnKind MethodDesc::GetReturnKindFromMethodTable(Thread* pThread
     ENABLE_FORBID_GC_LOADER_USE_IN_THIS_SCOPE();
     // Mark that we are performing a stackwalker like operation on the current thread.
     // This is necessary to allow the signature parsing functions to work without triggering any loads
-    ClrFlsValueSwitch threadStackWalking(TlsIdx_StackWalkerWalkingThread, pThread);
+    ClrFlsValueSwitch threadStackWalking(TlsIdx_StackWalkerWalkingThread, GetThread());
 
 #ifdef _TARGET_X86_
     MetaSig msig(this);
@@ -1349,7 +1342,7 @@ ReturnKind MethodDesc::GetReturnKindFromMethodTable(Thread* pThread
     }
 #endif // _TARGET_X86_
     
-    return ReturnsObject(INDEBUG(supportStringConstructors));
+    return ParseReturnKindFromSig(INDEBUG(supportStringConstructors));
 }
 
 #ifdef FEATURE_COMINTEROP

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -1653,20 +1653,13 @@ public:
 public:
 
     // does this function return an object reference?
-    MetaSig::RETURNTYPE ReturnsObject(
-#ifdef _DEBUG 
-        bool supportStringConstructors = false,
-#endif
-        MethodTable** pMT = NULL
-        );
+    ReturnKind ReturnsObject(INDEBUG(bool supportStringConstructors = false));
 
     ReturnKind GetReturnKindFromMethodTable(Thread* pThread
 #ifdef _DEBUG
         , bool supportStringConstructors = false
 #endif
     );
-
-    void Destruct();
 
 public:
     // In general you don't want to call GetCallTarget - you want to

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -1660,6 +1660,7 @@ public:
         MethodTable** pMT = NULL
         );
 
+    ReturnKind GetReturnKindFromMethodTable(Thread* pThread);
 
     void Destruct();
 

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -1650,16 +1650,11 @@ public:
     MethodDesc *ResolveGenericVirtualMethod(OBJECTREF *orThis);
 
 
+private:
+    ReturnKind ParseReturnKindFromSig(INDEBUG(bool supportStringConstructors = false));
+
 public:
-
-    // does this function return an object reference?
-    ReturnKind ReturnsObject(INDEBUG(bool supportStringConstructors = false));
-
-    ReturnKind GetReturnKindFromMethodTable(Thread* pThread
-#ifdef _DEBUG
-        , bool supportStringConstructors = false
-#endif
-    );
+    ReturnKind GetReturnKind(INDEBUG(bool supportStringConstructors = false));
 
 public:
     // In general you don't want to call GetCallTarget - you want to

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -1660,7 +1660,11 @@ public:
         MethodTable** pMT = NULL
         );
 
-    ReturnKind GetReturnKindFromMethodTable(Thread* pThread);
+    ReturnKind GetReturnKindFromMethodTable(Thread* pThread
+#ifdef _DEBUG
+        , bool supportStringConstructors = false
+#endif
+    );
 
     void Destruct();
 

--- a/src/vm/siginfo.hpp
+++ b/src/vm/siginfo.hpp
@@ -887,9 +887,6 @@ class MetaSig
 
         BOOL IsReturnTypeVoid() const;
 
-
-        enum RETURNTYPE {RETOBJ, RETBYREF, RETNONOBJ, RETVALUETYPE};
-
         CorElementType GetReturnTypeNormalized(TypeHandle * pthValueType = NULL) const;
 
         //------------------------------------------------------------------

--- a/src/vm/threadsuspend.cpp
+++ b/src/vm/threadsuspend.cpp
@@ -5727,20 +5727,6 @@ ReturnKind GetReturnKind(Thread *pThread, EECodeInfo *codeInfo)
 {
     GCInfoToken gcInfoToken = codeInfo->GetGCInfoToken();
     ReturnKind returnKind = codeInfo->GetCodeManager()->GetReturnKind(gcInfoToken);
-
-    MethodDesc* methodDesc = codeInfo->GetMethodDesc();
-    if (!IsValidReturnKind(returnKind))
-    {
-        returnKind = methodDesc->GetReturnKindFromMethodTable(pThread);
-    }
-    else
-    {
-#if !defined(FEATURE_MULTIREG_RETURN) || defined(UNIX_AMD64_ABI)
-         // For ARM64 struct-return, GetReturnKindFromMethodTable() is not supported
-        _ASSERTE(returnKind == methodDesc->GetReturnKindFromMethodTable(pThread));
-#endif // !FEATURE_MULTIREG_RETURN || UNIX_AMD64_ABI
-    }
-
     _ASSERTE(IsValidReturnKind(returnKind));
     return returnKind;
 }

--- a/src/vm/threadsuspend.cpp
+++ b/src/vm/threadsuspend.cpp
@@ -5723,92 +5723,21 @@ void STDCALL OnHijackWorker(HijackArgs * pArgs)
 #endif // HIJACK_NONINTERRUPTIBLE_THREADS
 }
 
-ReturnKind GetReturnKindFromMethodTable(Thread *pThread, EECodeInfo *codeInfo)
-{
-#ifdef _WIN64
-    // For simplicity, we don't hijack in funclets, but if you ever change that, 
-    // be sure to choose the OnHijack... callback type to match that of the FUNCLET
-    // not the main method (it would probably be Scalar).
-#endif // _WIN64
-
-    ENABLE_FORBID_GC_LOADER_USE_IN_THIS_SCOPE();
-    // Mark that we are performing a stackwalker like operation on the current thread.
-    // This is necessary to allow the signature parsing functions to work without triggering any loads
-    ClrFlsValueSwitch threadStackWalking(TlsIdx_StackWalkerWalkingThread, pThread);
-
-    MethodDesc *methodDesc = codeInfo->GetMethodDesc();
-    _ASSERTE(methodDesc != nullptr);
-
-#ifdef _TARGET_X86_
-    MetaSig msig(methodDesc);
-    if (msig.HasFPReturn())
-    {
-        // Figuring out whether the function returns FP or not is hard to do
-        // on-the-fly, so we use a different callback helper on x86 where this
-        // piece of information is needed in order to perform the right save &
-        // restore of the return value around the call to OnHijackScalarWorker.
-        return RT_Float;
-    }
-#endif // _TARGET_X86_
-
-    MethodTable* pMT = NULL;
-    MetaSig::RETURNTYPE type = methodDesc->ReturnsObject(INDEBUG_COMMA(false) &pMT);
-    if (type == MetaSig::RETOBJ)
-    {
-        return RT_Object;
-    }
-
-    if (type == MetaSig::RETBYREF)
-    {
-        return RT_ByRef;
-    }
-
-#ifdef UNIX_AMD64_ABI
-    // The Multi-reg return case using the classhandle is only implemented for AMD64 SystemV ABI.
-    // On other platforms, multi-reg return is not supported with GcInfo v1.
-    // So, the relevant information must be obtained from the GcInfo tables (which requires version2).
-    if (type == MetaSig::RETVALUETYPE)
-    {
-        EEClass *eeClass = pMT->GetClass();
-        ReturnKind regKinds[2] = { RT_Unset, RT_Unset };
-        int orefCount = 0;
-        for (int i = 0; i < 2; i++)
-        {
-            if (eeClass->GetEightByteClassification(i) == SystemVClassificationTypeIntegerReference)
-            {
-                regKinds[i] = RT_Object;
-            }
-            else if (eeClass->GetEightByteClassification(i) == SystemVClassificationTypeIntegerByRef)
-            {
-                regKinds[i] = RT_ByRef;
-            }
-            else
-            {
-                regKinds[i] = RT_Scalar;
-            }
-        }
-        ReturnKind structReturnKind = GetStructReturnKind(regKinds[0], regKinds[1]);
-        return structReturnKind;
-    }
-#endif // UNIX_AMD64_ABI
-
-    return RT_Scalar;
-}
-
 ReturnKind GetReturnKind(Thread *pThread, EECodeInfo *codeInfo)
 {
     GCInfoToken gcInfoToken = codeInfo->GetGCInfoToken();
     ReturnKind returnKind = codeInfo->GetCodeManager()->GetReturnKind(gcInfoToken);
 
+    MethodDesc* methodDesc = codeInfo->GetMethodDesc();
     if (!IsValidReturnKind(returnKind))
     {
-        returnKind = GetReturnKindFromMethodTable(pThread, codeInfo);
+        returnKind = methodDesc->GetReturnKindFromMethodTable(pThread);
     }
     else
     {
 #if !defined(FEATURE_MULTIREG_RETURN) || defined(UNIX_AMD64_ABI)
          // For ARM64 struct-return, GetReturnKindFromMethodTable() is not supported
-        _ASSERTE(returnKind == GetReturnKindFromMethodTable(pThread, codeInfo));
+        _ASSERTE(returnKind == methodDesc->GetReturnKindFromMethodTable(pThread));
 #endif // !FEATURE_MULTIREG_RETURN || UNIX_AMD64_ABI
     }
 


### PR DESCRIPTION
There are several places where we need to know the return type for a call:
1. `HijackFrame::GcScanRoots`, it uses `vm\threadsuspend.cpp::GetReturnKind` that gets correct kind it from `EECodeInfo` that points to a compiled method (it can't be a prestub), so code in `HijackFrame::GcScanRoots` is our role model: https://github.com/dotnet/coreclr/blob/bdb995987178231ba541f22143cb3cab56309daa/src/vm/frames.cpp#L1080

**question**: can hijacking happen when we are in a compile stub and EECodeInfo is invalid?

2. `GcCover.cpp` needs to know when to protect call return values when imitating Hijacking, but it doesn't have `EECodeInfo` (because most `MethodDescriptor` point to uncompiled code and `PCODEs` point to compile stubs, so we can't get `EECodeInfo->gcInfoToken`), so we have to restore `ReturnKind` from method descriptor. This PR changes `MethodDesc::ReturnsObject` to return precise information using code that was in `ReturnKind GetReturnKindFromMethodTable(Thread *pThread, EECodeInfo *codeInfo)` as example.
Using this `ReturnKind` we can correctly understand when we need to protect first/second/both return registers on x64 Unix/arm64 and, for example, do not use `INTERRUPT_INSTR_PROTECT_RET` in tricky cases.

However,   `ReturnKind GetReturnKindFromMethodTable` supports only x64 Unix and doesn't support arm64. So if we call it on arm64 with a method that return 16 bytes struct it fails with assert:
https://github.com/dotnet/coreclr/blob/221dc73878027e95b515d0c46cad0266331e538d/src/vm/method.cpp#L1266-L1278

and there is comment: 
https://github.com/dotnet/coreclr/blob/883a27180106affebd45814f5b6fc236c9d7eab2/src/vm/threadsuspend.cpp#L5767-L5769
that says that it is not a simple restriction.

**question**: how can we get the necessary information for arm64?

3. `ComPlusMethodFrame::GcScanRoots` needs to know which registers to protect but has the same issues as `GCCoder`, but  this method is not stress testing specific, so I assume it can cause gc holes in a real app that uses COM methods that return struct on arm64 Windows (we can't have COM on Unix).

**question**: What should we do in this case?


This PR is preparation for https://github.com/dotnet/coreclr/issues/23199. With that change, I have correct kind in `GCCover` and can use different instruction to mark which registers I need to restore.

Changes by commits:
0af5c9698a: Move GetReturnKindFromMethodTable to method.hpp.

We would need this in other places in the next commits.

2b0b08d41e: Delete unnecessary checks from callhelpers.

56e4ad897e: Do not check return types in CanDeduplicateCode.

GC info v.2 has this information and it is checked in another place.

f96c1a0083: Change ComPlusMethodFrame to use the new function.

92708d4b34: Change gccover.cpp to use GetReturnKindFromMethodTable.

69307803a5: Delete RETURNTYPE.

fcb3ee4573: Add check to ComPlusMethodFrame.

2e6011d683: Delete check from threadsuspend.

codeInfo->GetCodeManager()->GetReturnKind(gcInfoToken) must always return a valid kind nowdays (it could return an invalid lind only when GC Info v2 was not available).