### PR TITLE
Add some perf events/data for tiered compilation

### DIFF
--- a/src/ToolBox/SOS/Strike/util.cpp
+++ b/src/ToolBox/SOS/Strike/util.cpp
@@ -3252,21 +3252,27 @@ void DumpTieredNativeCodeAddressInfo(struct DacpTieredVersionData * pTieredVersi
     for(int i = cTieredVersionData - 1; i >= 0; --i)
     {
         const char *descriptor = NULL;
-        switch(pTieredVersionData[i].TieredInfo)
+        switch(pTieredVersionData[i].OptimizationTier)
         {
-        case DacpTieredVersionData::TIERED_UNKNOWN:
+        case DacpTieredVersionData::OptimizationTier_Unknown:
         default:
             _ASSERTE(!"Update SOS to understand the new tier");
             descriptor = "Unknown Tier";
             break;
-        case DacpTieredVersionData::NON_TIERED:
-            descriptor = "Non-Tiered";
+        case DacpTieredVersionData::OptimizationTier_MinOptJitted:
+            descriptor = "MinOptJitted";
             break;
-        case DacpTieredVersionData::TIERED_0:
-            descriptor = "Tier 0";
+        case DacpTieredVersionData::OptimizationTier_Optimized:
+            descriptor = "Optimized";
             break;
-        case DacpTieredVersionData::TIERED_1:
-            descriptor = "Tier 1";
+        case DacpTieredVersionData::OptimizationTier_QuickJitted:
+            descriptor = "QuickJitted";
+            break;
+        case DacpTieredVersionData::OptimizationTier_OptimizedTier1:
+            descriptor = "OptimizedTier1";
+            break;
+        case DacpTieredVersionData::OptimizationTier_ReadyToRun:
+            descriptor = "ReadyToRun";
             break;
         }
 

--- a/src/inc/corinfo.h
+++ b/src/inc/corinfo.h
@@ -864,7 +864,8 @@ enum CorInfoMethodRuntimeFlags
     CORINFO_FLG_BAD_INLINEE         = 0x00000001, // The method is not suitable for inlining
     CORINFO_FLG_VERIFIABLE          = 0x00000002, // The method has verifiable code
     CORINFO_FLG_UNVERIFIABLE        = 0x00000004, // The method has unverifiable code
-    CORINFO_FLG_SWITCHED_TO_TIER1   = 0x00000008, // The JIT decided to switch to tier 1 for this method, when a different tier was requested
+    CORINFO_FLG_SWITCHED_TO_MIN_OPT = 0x00000008, // The JIT decided to switch to MinOpt for this method, when it was not requested
+    CORINFO_FLG_SWITCHED_TO_OPTIMIZED = 0x00000010, // The JIT decided to switch to tier 1 for this method, when a different tier was requested
 };
 
 

--- a/src/inc/dacprivate.h
+++ b/src/inc/dacprivate.h
@@ -587,16 +587,18 @@ struct MSLAYOUT DacpMethodDescTransparencyData : ZeroInit<DacpMethodDescTranspar
 
 struct MSLAYOUT DacpTieredVersionData
 {
-    enum TieredState 
+    enum OptimizationTier
     {
-        NON_TIERED,
-        TIERED_0,
-        TIERED_1,
-        TIERED_UNKNOWN
+        OptimizationTier_Unknown,
+        OptimizationTier_MinOptJitted,
+        OptimizationTier_Optimized,
+        OptimizationTier_QuickJitted,
+        OptimizationTier_OptimizedTier1,
+        OptimizationTier_ReadyToRun,
     };
     
     CLRDATA_ADDRESS NativeCodeAddr;
-    TieredState     TieredInfo;
+    OptimizationTier OptimizationTier;
     CLRDATA_ADDRESS NativeCodeVersionNodePtr;
 };
 

--- a/src/inc/eventtracebase.h
+++ b/src/inc/eventtracebase.h
@@ -596,7 +596,7 @@ namespace ETW
                 JitHelperMethod=0x10,
                 ProfilerRejectedPrecompiledCode=0x20,
                 ReadyToRunRejectedPrecompiledCode=0x40,
-                // 0x80 to 0x100 are used for the tier
+                // 0x80 to 0x200 are used for the optimization tier
             }MethodFlags;
 
             typedef enum _MethodExtent
@@ -611,8 +611,9 @@ namespace ETW
         {
             Unknown, // to identify older runtimes that would send this value
             MinOptJitted,
-            QuickJitted,
             Optimized,
+            QuickJitted,
+            OptimizedTier1,
 
             Count
         };

--- a/src/inc/eventtracebase.h
+++ b/src/inc/eventtracebase.h
@@ -31,7 +31,7 @@
 struct EventStructTypeData;
 void InitializeEventTracing();
 
-typedef DWORD NativeCodeVersionId; // keep in sync with codeversion.h
+class PrepareCodeConfig;
 
 // !!!!!!! NOTE !!!!!!!!
 // The flags must match those in the ETW manifest exactly
@@ -582,7 +582,7 @@ namespace ETW
         static VOID SendEventsForNgenMethods(Module *pModule, DWORD dwEventOptions);
         static VOID SendMethodJitStartEvent(MethodDesc *pMethodDesc, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL);
         static VOID SendMethodILToNativeMapEvent(MethodDesc * pMethodDesc, DWORD dwEventOptions, PCODE pNativeCodeStartAddress, ReJITID ilCodeId);
-        static VOID SendMethodEvent(MethodDesc *pMethodDesc, DWORD dwEventOptions, BOOL bIsJit, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL, PCODE pNativeCodeStartAddress = 0, NativeCodeVersionId nativeCodeId = 0, BOOL bProfilerRejectedPrecompiledCode = FALSE, BOOL bReadyToRunRejectedPrecompiledCode = FALSE);
+        static VOID SendMethodEvent(MethodDesc *pMethodDesc, DWORD dwEventOptions, BOOL bIsJit, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL, PCODE pNativeCodeStartAddress = 0, PrepareCodeConfig *pConfig = NULL);
         static VOID SendHelperEvent(ULONGLONG ullHelperStartAddress, ULONG ulHelperSize, LPCWSTR pHelperName);
     public:
         typedef union _MethodStructs
@@ -596,6 +596,7 @@ namespace ETW
                 JitHelperMethod=0x10,
                 ProfilerRejectedPrecompiledCode=0x20,
                 ReadyToRunRejectedPrecompiledCode=0x40,
+                // 0x80 to 0x100 are used for the tier
             }MethodFlags;
 
             typedef enum _MethodExtent
@@ -606,9 +607,22 @@ namespace ETW
 
         }MethodStructs;
 
+        enum class JitOptimizationTier
+        {
+            Unknown, // to identify older runtimes that would send this value
+            MinOptJitted,
+            QuickJitted,
+            Optimized,
+
+            Count
+        };
+
+        static const UINT8 MethodFlagsJitOptimizationTierShift = 7;
+        static const unsigned int MethodFlagsJitOptimizationTierLowMask = 0x7;
+
         static VOID GetR2RGetEntryPoint(MethodDesc *pMethodDesc, PCODE pEntryPoint);
-        static VOID MethodJitting(MethodDesc *pMethodDesc, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL);
-        static VOID MethodJitted(MethodDesc *pMethodDesc, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL, PCODE pNativeCodeStartAddress = 0, ReJITID ilCodeId = 0, NativeCodeVersionId nativeCodeId = 0, BOOL bProfilerRejectedPrecompiledCode = FALSE, BOOL bReadyToRunRejectedPrecompiledCode = FALSE);
+        static VOID MethodJitting(MethodDesc *pMethodDesc, SString *namespaceOrClassName, SString *methodName, SString *methodSignature);
+        static VOID MethodJitted(MethodDesc *pMethodDesc, SString *namespaceOrClassName, SString *methodName, SString *methodSignature, PCODE pNativeCodeStartAddress, PrepareCodeConfig *pConfig);
         static VOID StubInitialized(ULONGLONG ullHelperStartAddress, LPCWSTR pHelperName);
         static VOID StubsInitialized(PVOID *pHelperStartAddresss, PVOID *pHelperNames, LONG ulNoOfHelpers);
         static VOID MethodRestored(MethodDesc * pMethodDesc);
@@ -617,8 +631,8 @@ namespace ETW
 #else // FEATURE_EVENT_TRACE
     public:
         static VOID GetR2RGetEntryPoint(MethodDesc *pMethodDesc, PCODE pEntryPoint) {};
-        static VOID MethodJitting(MethodDesc *pMethodDesc, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL) {};
-        static VOID MethodJitted(MethodDesc *pMethodDesc, SString *namespaceOrClassName=NULL, SString *methodName=NULL, SString *methodSignature=NULL, PCODE pNativeCodeStartAddress = 0, ReJITID ilCodeId = 0, NativeCodeVersionId nativeCodeId = 0, BOOL bProfilerRejectedPrecompiledCode = FALSE, BOOL bReadyToRunRejectedPrecompiledCode = FALSE) {};
+        static VOID MethodJitting(MethodDesc *pMethodDesc, SString *namespaceOrClassName, SString *methodName, SString *methodSignature);
+        static VOID MethodJitted(MethodDesc *pMethodDesc, SString *namespaceOrClassName, SString *methodName, SString *methodSignature, PCODE pNativeCodeStartAddress, PrepareCodeConfig *pConfig);
         static VOID StubInitialized(ULONGLONG ullHelperStartAddress, LPCWSTR pHelperName) {};
         static VOID StubsInitialized(PVOID *pHelperStartAddresss, PVOID *pHelperNames, LONG ulNoOfHelpers) {};
         static VOID MethodRestored(MethodDesc * pMethodDesc) {};
@@ -873,6 +887,56 @@ namespace ETW
             DWORD countSymbolBytes, DWORD* pCountSymbolBytesRead) {    return S_OK; }
 #endif // FEATURE_EVENT_TRACE
     };
+
+#define DISABLE_CONSTRUCT_COPY(T) \
+    T() = delete; \
+    T(const T &) = delete; \
+    T &operator =(const T &) = delete
+
+    // Class to wrap all TieredCompilation logic for ETW
+    class TieredCompilationLog
+    {
+    private:
+        static void ValidateSend();
+        static void GetSettings(UINT32 *flagsRef);
+
+    public:
+        class Runtime
+        {
+        public:
+#ifdef FEATURE_EVENT_TRACE
+            static bool IsEnabled();
+            static void SendSettings();
+            static void SendPause();
+            static void SendResume(UINT32 newMethodCount);
+            static void SendBackgroundJitStart(UINT32 pendingMethodCount);
+            static void SendBackgroundJitStop(UINT32 pendingMethodCount, UINT32 jittedMethodCount);
+#else
+            static bool IsEnabled() { return false; }
+            static void SendSettings() {}
+#endif
+
+            DISABLE_CONSTRUCT_COPY(Runtime);
+        };
+
+        class Rundown
+        {
+        public:
+#ifdef FEATURE_EVENT_TRACE
+            static bool IsEnabled();
+            static void SendSettings();
+#else
+            static bool IsEnabled() { return false; }
+            static void SendSettings() {}
+#endif
+
+            DISABLE_CONSTRUCT_COPY(Rundown);
+        };
+
+        DISABLE_CONSTRUCT_COPY(TieredCompilationLog);
+    };
+
+#undef DISABLE_CONSTRUCT_COPY
 };
 
 

--- a/src/inc/eventtracebase.h
+++ b/src/inc/eventtracebase.h
@@ -897,7 +897,6 @@ namespace ETW
     class TieredCompilationLog
     {
     private:
-        static void ValidateSend();
         static void GetSettings(UINT32 *flagsRef);
 
     public:

--- a/src/inc/eventtracebase.h
+++ b/src/inc/eventtracebase.h
@@ -894,26 +894,17 @@ namespace ETW
     T(const T &) = delete; \
     T &operator =(const T &) = delete
 
-    // Class to wrap all TieredCompilation logic for ETW
-    class TieredCompilationLog
+    // Class to wrap all Compilation logic for ETW
+    class CompilationLog
     {
-    private:
-        static void GetSettings(UINT32 *flagsRef);
-
     public:
         class Runtime
         {
         public:
 #ifdef FEATURE_EVENT_TRACE
             static bool IsEnabled();
-            static void SendSettings();
-            static void SendPause();
-            static void SendResume(UINT32 newMethodCount);
-            static void SendBackgroundJitStart(UINT32 pendingMethodCount);
-            static void SendBackgroundJitStop(UINT32 pendingMethodCount, UINT32 jittedMethodCount);
 #else
             static bool IsEnabled() { return false; }
-            static void SendSettings() {}
 #endif
 
             DISABLE_CONSTRUCT_COPY(Runtime);
@@ -924,16 +915,56 @@ namespace ETW
         public:
 #ifdef FEATURE_EVENT_TRACE
             static bool IsEnabled();
-            static void SendSettings();
 #else
             static bool IsEnabled() { return false; }
-            static void SendSettings() {}
 #endif
 
             DISABLE_CONSTRUCT_COPY(Rundown);
         };
 
-        DISABLE_CONSTRUCT_COPY(TieredCompilationLog);
+        // Class to wrap all TieredCompilation logic for ETW
+        class TieredCompilation
+        {
+        private:
+            static void GetSettings(UINT32 *flagsRef);
+
+        public:
+            class Runtime
+            {
+            public:
+#ifdef FEATURE_EVENT_TRACE
+                static bool IsEnabled();
+                static void SendSettings();
+                static void SendPause();
+                static void SendResume(UINT32 newMethodCount);
+                static void SendBackgroundJitStart(UINT32 pendingMethodCount);
+                static void SendBackgroundJitStop(UINT32 pendingMethodCount, UINT32 jittedMethodCount);
+#else
+                static bool IsEnabled() { return false; }
+                static void SendSettings() {}
+#endif
+
+                DISABLE_CONSTRUCT_COPY(Runtime);
+            };
+
+            class Rundown
+            {
+            public:
+#ifdef FEATURE_EVENT_TRACE
+                static bool IsEnabled();
+                static void SendSettings();
+#else
+                static bool IsEnabled() { return false; }
+                static void SendSettings() {}
+#endif
+
+                DISABLE_CONSTRUCT_COPY(Rundown);
+            };
+
+            DISABLE_CONSTRUCT_COPY(TieredCompilation);
+        };
+
+        DISABLE_CONSTRUCT_COPY(CompilationLog);
     };
 
 #undef DISABLE_CONSTRUCT_COPY

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4050,6 +4050,13 @@ _SetMinOpts:
     // Set the MinOpts value
     opts.SetMinOpts(theMinOptsValue);
 
+    // Notify the VM if MinOpts is being used when not requested
+    if (theMinOptsValue && !compIsForInlining() && !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER0) &&
+        !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_MIN_OPT) && !opts.compDbgCode)
+    {
+        info.compCompHnd->setMethodAttribs(info.compMethodHnd, CORINFO_FLG_SWITCHED_TO_MIN_OPT);
+    }
+
 #ifdef DEBUG
     if (verbose && !compIsForInlining())
     {
@@ -5949,14 +5956,14 @@ int Compiler::compCompileHelper(CORINFO_MODULE_HANDLE            classPtr,
     }
 
 #ifdef FEATURE_CORECLR
-    if (fgHasBackwardJump && (info.compFlags & CORINFO_FLG_DISABLE_TIER0_FOR_LOOPS) != 0 && fgCanSwitchToTier1())
+    if (fgHasBackwardJump && (info.compFlags & CORINFO_FLG_DISABLE_TIER0_FOR_LOOPS) != 0 && fgCanSwitchToOptimized())
 #else // !FEATURE_CORECLR
     // We may want to use JitConfig value here to support DISABLE_TIER0_FOR_LOOPS
     if (fgHasBackwardJump && fgCanSwitchToTier1())
 #endif
     {
         // Method likely has a loop, switch to the OptimizedTier to avoid spending too much time running slower code
-        fgSwitchToTier1();
+        fgSwitchToOptimized();
     }
 
     compSetOptimizationLevel();

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5105,8 +5105,8 @@ protected:
 
     bool fgHasBackwardJump;
 
-    bool fgCanSwitchToTier1();
-    void fgSwitchToTier1();
+    bool fgCanSwitchToOptimized();
+    void fgSwitchToOptimized();
 
     bool fgMayExplicitTailCall();
 

--- a/src/vm/ClrEtwAll.man
+++ b/src/vm/ClrEtwAll.man
@@ -382,8 +382,6 @@
                             <opcode name="Settings" message="$(string.RuntimePublisher.TieredCompilationSettingsOpcodeMessage)" symbol="CLR_TIERED_COMPILATION_SETTINGS_OPCODE" value="11"/>
                             <opcode name="Pause" message="$(string.RuntimePublisher.TieredCompilationPauseOpcodeMessage)" symbol="CLR_TIERED_COMPILATION_PAUSE_OPCODE" value="12"/>
                             <opcode name="Resume" message="$(string.RuntimePublisher.TieredCompilationResumeOpcodeMessage)" symbol="CLR_TIERED_COMPILATION_RESUME_OPCODE" value="13"/>
-                            <opcode name="BackgroundJitStart" message="$(string.RuntimePublisher.TieredCompilationBackgroundJitStartOpcodeMessage)" symbol="CLR_TIERED_COMPILATION_BACKGROUND_JIT_START_OPCODE" value="14"/>
-                            <opcode name="BackgroundJitStop" message="$(string.RuntimePublisher.TieredCompilationBackgroundJitStopOpcodeMessage)" symbol="CLR_TIERED_COMPILATION_BACKGROUND_JIT_STOP_OPCODE" value="15"/>
                         </opcodes>
                     </task>
                 <!--Next available ID is 32-->
@@ -3398,10 +3396,10 @@
                            keywords="TieredCompilationKeyword" task="TieredCompilation" opcode="Resume"
                            symbol="TieredCompilationResume" message="$(string.RuntimePublisher.TieredCompilationResumeEventMessage)"/>
                     <event value="283" version="0" level="win:Informational" template="TieredCompilationBackgroundJitStart"
-                           keywords="TieredCompilationKeyword" task="TieredCompilation" opcode="BackgroundJitStart"
+                           keywords="TieredCompilationKeyword" task="TieredCompilation" opcode="win:Start"
                            symbol="TieredCompilationBackgroundJitStart" message="$(string.RuntimePublisher.TieredCompilationBackgroundJitStartEventMessage)"/>
                     <event value="284" version="0" level="win:Informational" template="TieredCompilationBackgroundJitStop"
-                           keywords="TieredCompilationKeyword" task="TieredCompilation" opcode="BackgroundJitStop"
+                           keywords="TieredCompilationKeyword" task="TieredCompilation" opcode="win:Stop"
                            symbol="TieredCompilationBackgroundJitStop" message="$(string.RuntimePublisher.TieredCompilationBackgroundJitStopEventMessage)"/>
                 </events>
             </provider>
@@ -7214,8 +7212,6 @@
                 <string id="RuntimePublisher.TieredCompilationSettingsOpcodeMessage" value="Settings" />
                 <string id="RuntimePublisher.TieredCompilationPauseOpcodeMessage" value="Pause" />
                 <string id="RuntimePublisher.TieredCompilationResumeOpcodeMessage" value="Resume" />
-                <string id="RuntimePublisher.TieredCompilationBackgroundJitStartOpcodeMessage" value="BackgroundJitStart" />
-                <string id="RuntimePublisher.TieredCompilationBackgroundJitStopOpcodeMessage" value="BackgroundJitStop" />
 
                 <string id="RundownPublisher.MethodDCStartOpcodeMessage" value="DCStart" />
                 <string id="RundownPublisher.MethodDCEndOpcodeMessage" value="DCStop" />

--- a/src/vm/ClrEtwAll.man
+++ b/src/vm/ClrEtwAll.man
@@ -77,6 +77,8 @@
                              message="$(string.RuntimePublisher.CodeSymbolsKeywordMessage)" symbol="CLR_CODESYMBOLS_KEYWORD" />
                     <keyword name="EventSourceKeyword" mask="0x800000000"
                              message="$(string.RuntimePublisher.EventSourceKeywordMessage)" symbol="CLR_EVENTSOURCE_KEYWORD" />
+                    <keyword name="TieredCompilationKeyword" mask="0x1000000000"
+                             message="$(string.RuntimePublisher.TieredCompilationKeywordMessage)" symbol="CLR_TIERED_COMPILATION_KEYWORD" />
                 </keywords>
                 <!--Tasks-->
                 <tasks>
@@ -364,16 +366,27 @@
                     <task name="DebugExceptionProcessing" symbol="CLR_EXCEPTION_PROCESSING_TASK"
                           value="26" eventGUID="{C4412198-EF03-47F1-9BD1-11C6637A2062}"
                           message="$(string.RuntimePublisher.DebugExceptionProcessingTaskMessage)">
-                    <opcodes>
-                    </opcodes>
-                  </task>
+                        <opcodes>
+                        </opcodes>
+                    </task>
                     <task name="CodeSymbols" symbol="CLR_CODE_SYMBOLS_TASK"
                           value="30" eventGUID="{53aedf69-2049-4f7d-9345-d3018b5c4d80}"
                           message="$(string.RuntimePublisher.CodeSymbolsTaskMessage)">
-                    <opcodes>
-                    </opcodes>
-                  </task>
-                <!--Next available ID is 31-->
+                        <opcodes>
+                        </opcodes>
+                    </task>
+                    <task name="TieredCompilation" symbol="CLR_TIERED_COMPILATION_TASK"
+                          value="31" eventGUID="{A77F474D-9D0D-4311-B98E-CFBCF84B9E0F}"
+                          message="$(string.RuntimePublisher.TieredCompilationTaskMessage)">
+                        <opcodes>
+                            <opcode name="Settings" message="$(string.RuntimePublisher.TieredCompilationSettingsOpcodeMessage)" symbol="CLR_TIERED_COMPILATION_SETTINGS_OPCODE" value="11"/>
+                            <opcode name="Pause" message="$(string.RuntimePublisher.TieredCompilationPauseOpcodeMessage)" symbol="CLR_TIERED_COMPILATION_PAUSE_OPCODE" value="12"/>
+                            <opcode name="Resume" message="$(string.RuntimePublisher.TieredCompilationResumeOpcodeMessage)" symbol="CLR_TIERED_COMPILATION_RESUME_OPCODE" value="13"/>
+                            <opcode name="BackgroundJitStart" message="$(string.RuntimePublisher.TieredCompilationBackgroundJitStartOpcodeMessage)" symbol="CLR_TIERED_COMPILATION_BACKGROUND_JIT_START_OPCODE" value="14"/>
+                            <opcode name="BackgroundJitStop" message="$(string.RuntimePublisher.TieredCompilationBackgroundJitStopOpcodeMessage)" symbol="CLR_TIERED_COMPILATION_BACKGROUND_JIT_STOP_OPCODE" value="15"/>
+                        </opcodes>
+                    </task>
+                <!--Next available ID is 32-->
                 </tasks>
                 <!--Maps-->
                 <maps>
@@ -483,6 +496,10 @@
                         <map value="0x2" message="$(string.RuntimePublisher.Method.GenericMapMessage)"/>
                         <map value="0x4" message="$(string.RuntimePublisher.Method.HasSharedGenericCodeMapMessage)"/>
                         <map value="0x8" message="$(string.RuntimePublisher.Method.JittedMapMessage)"/>
+                        <map value="0x10" message="$(string.RuntimePublisher.Method.JitHelperMapMessage)"/>
+                        <map value="0x20" message="$(string.RuntimePublisher.Method.ProfilerRejectedPrecompiledCodeMapMessage)"/>
+                        <map value="0x40" message="$(string.RuntimePublisher.Method.ReadyToRunRejectedPrecompiledCodeMapMessage)"/>
+                        <!-- 0x80 to 0x200 are used for the optimization tier -->
                     </bitMap>
                     <bitMap name="StartupModeMap">
                         <map value="0x1" message="$(string.RuntimePublisher.StartupMode.ManagedExeMapMessage)"/>
@@ -550,6 +567,11 @@
                       <map value="0x1" message="$(string.RuntimePublisher.ThreadFlags.GCSpecial)"/>
                       <map value="0x2" message="$(string.RuntimePublisher.ThreadFlags.Finalizer)"/>
                       <map value="0x4" message="$(string.RuntimePublisher.ThreadFlags.ThreadPoolWorker)"/>
+                    </bitMap>
+                    <bitMap name="TieredCompilationSettingsFlagsMap">
+                      <map value="0x0" message="$(string.RuntimePublisher.TieredCompilationSettingsFlags.NoneMapMessage)"/>
+                      <map value="0x1" message="$(string.RuntimePublisher.TieredCompilationSettingsFlags.QuickJitMapMessage)"/>
+                      <map value="0x2" message="$(string.RuntimePublisher.TieredCompilationSettingsFlags.QuickJitForLoopsMapMessage)"/>
                     </bitMap>
                 </maps>
 
@@ -1415,12 +1437,12 @@
                     <template tid="ContentionStop_V1">
                         <data name="ContentionFlags" inType="win:UInt8" map="ContentionFlagsMap" />
                         <data name="ClrInstanceID" inType="win:UInt16" />
-                        <data name="Duration" inType="win:Double" />
+                        <data name="DurationNs" inType="win:Double" />
                         <UserData>
                             <Contention xmlns="myNs">
                                 <ContentionFlags> %1 </ContentionFlags>
                                 <ClrInstanceID> %2 </ClrInstanceID>
-                                <Duration> %3 </Duration>
+                                <DurationNs> %3 </DurationNs>
                             </Contention>
                         </UserData>
                     </template>
@@ -2400,6 +2422,60 @@
                       </UserData>
                     </template>
 
+                    <template tid="TieredCompilationEmpty">
+                      <data name="ClrInstanceID" inType="win:UInt16"/>
+                      <UserData>
+                        <Settings xmlns="myNs">
+                          <ClrInstanceID> %1 </ClrInstanceID>
+                        </Settings>
+                      </UserData>
+                    </template>
+
+                    <template tid="TieredCompilationSettings">
+                      <data name="ClrInstanceID" inType="win:UInt16"/>
+                      <data name="Flags" inType="win:UInt32" outType="win:HexInt32" map="TieredCompilationSettingsFlagsMap"/>
+                      <UserData>
+                        <Settings xmlns="myNs">
+                          <ClrInstanceID> %1 </ClrInstanceID>
+                          <Flags> %2 </Flags>
+                        </Settings>
+                      </UserData>
+                    </template>
+
+                    <template tid="TieredCompilationResume">
+                      <data name="ClrInstanceID" inType="win:UInt16"/>
+                      <data name="NewMethodCount" inType="win:UInt32"/>
+                      <UserData>
+                        <Settings xmlns="myNs">
+                          <ClrInstanceID> %1 </ClrInstanceID>
+                          <NewMethodCount> %2 </NewMethodCount>
+                        </Settings>
+                      </UserData>
+                    </template>
+
+                    <template tid="TieredCompilationBackgroundJitStart">
+                      <data name="ClrInstanceID" inType="win:UInt16"/>
+                      <data name="PendingMethodCount" inType="win:UInt32"/>
+                      <UserData>
+                        <Settings xmlns="myNs">
+                          <ClrInstanceID> %1 </ClrInstanceID>
+                          <PendingMethodCount> %2 </PendingMethodCount>
+                        </Settings>
+                      </UserData>
+                    </template>
+
+                    <template tid="TieredCompilationBackgroundJitStop">
+                      <data name="ClrInstanceID" inType="win:UInt16"/>
+                      <data name="PendingMethodCount" inType="win:UInt32"/>
+                      <data name="JittedMethodCount" inType="win:UInt32"/>
+                      <UserData>
+                        <Settings xmlns="myNs">
+                          <ClrInstanceID> %1 </ClrInstanceID>
+                          <PendingMethodCount> %2 </PendingMethodCount>
+                          <JittedMethodCount> %2 </JittedMethodCount>
+                        </Settings>
+                      </UserData>
+                    </template>
                 </templates>
 
                 <events>
@@ -3307,9 +3383,26 @@
                            task="CodeSymbols"
                            symbol="CodeSymbols" message="$(string.RuntimePublisher.CodeSymbolsEventMessage)"/>
 
-                   <event value="270" version="0" level="win:Informational"  template="EventSource"
+                    <event value="270" version="0" level="win:Informational"  template="EventSource"
                            keywords="EventSourceKeyword"
                            symbol="EventSource" />
+
+                    <!-- Tiered compilation events 280-289 -->
+                    <event value="280" version="0" level="win:Informational" template="TieredCompilationSettings"
+                           keywords="TieredCompilationKeyword" task="TieredCompilation" opcode="Settings"
+                           symbol="TieredCompilationSettings" message="$(string.RuntimePublisher.TieredCompilationSettingsEventMessage)"/>
+                    <event value="281" version="0" level="win:Informational" template="TieredCompilationEmpty"
+                           keywords="TieredCompilationKeyword" task="TieredCompilation" opcode="Pause"
+                           symbol="TieredCompilationPause" message="$(string.RuntimePublisher.TieredCompilationPauseEventMessage)"/>
+                    <event value="282" version="0" level="win:Informational" template="TieredCompilationResume"
+                           keywords="TieredCompilationKeyword" task="TieredCompilation" opcode="Resume"
+                           symbol="TieredCompilationResume" message="$(string.RuntimePublisher.TieredCompilationResumeEventMessage)"/>
+                    <event value="283" version="0" level="win:Informational" template="TieredCompilationBackgroundJitStart"
+                           keywords="TieredCompilationKeyword" task="TieredCompilation" opcode="BackgroundJitStart"
+                           symbol="TieredCompilationBackgroundJitStart" message="$(string.RuntimePublisher.TieredCompilationBackgroundJitStartEventMessage)"/>
+                    <event value="284" version="0" level="win:Informational" template="TieredCompilationBackgroundJitStop"
+                           keywords="TieredCompilationKeyword" task="TieredCompilation" opcode="BackgroundJitStop"
+                           symbol="TieredCompilationBackgroundJitStop" message="$(string.RuntimePublisher.TieredCompilationBackgroundJitStopEventMessage)"/>
                 </events>
             </provider>
 
@@ -3346,6 +3439,8 @@
                              message="$(string.RundownPublisher.PerfTrackRundownKeywordMessage)" symbol="CLR_RUNDOWNPERFTRACK_KEYWORD"/>
                     <keyword name="StackKeyword" mask="0x40000000"
                              message="$(string.RundownPublisher.StackKeywordMessage)" symbol="CLR_RUNDOWNSTACK_KEYWORD"/>
+                    <keyword name="TieredCompilationKeyword" mask="0x1000000000"
+                             message="$(string.RundownPublisher.TieredCompilationKeywordMessage)" symbol="CLR_TIERED_COMPILATION_RUNDOWN_KEYWORD" />
                 </keywords>
 
                 <!--Tasks-->
@@ -3406,6 +3501,14 @@
                             <opcode name="ModuleRangeDCEnd" message="$(string.RundownPublisher.ModuleRangeDCEndOpcodeMessage)" symbol="CLR_PERFTRACKRUNDOWN_MODULERANGEDCEND_OPCODE" value="11"> </opcode>
                         </opcodes>
                     </task>
+
+                    <task name="TieredCompilationRundown" symbol="CLR_TIERED_COMPILATION_RUNDOWN_TASK"
+                          value="31" eventGUID="{A1673472-0564-48EA-A95D-B49D4173F105}"
+                          message="$(string.RundownPublisher.TieredCompilationTaskMessage)">
+                        <opcodes>
+                            <opcode name="SettingsDCStart" message="$(string.RundownPublisher.TieredCompilationSettingsDCStartOpcodeMessage)" symbol="CLR_TIERED_COMPILATION_SETTINGS_DCSTART_OPCODE" value="11"/>
+                        </opcodes>
+                    </task>
                 </tasks>
 
                 <maps>
@@ -3439,6 +3542,10 @@
                         <map value="0x2" message="$(string.RundownPublisher.Method.GenericMapMessage)"/>
                         <map value="0x4" message="$(string.RundownPublisher.Method.HasSharedGenericCodeMapMessage)"/>
                         <map value="0x8" message="$(string.RundownPublisher.Method.JittedMapMessage)"/>
+                        <map value="0x10" message="$(string.RuntimePublisher.Method.JitHelperMapMessage)"/>
+                        <map value="0x20" message="$(string.RuntimePublisher.Method.ProfilerRejectedPrecompiledCodeMapMessage)"/>
+                        <map value="0x40" message="$(string.RuntimePublisher.Method.ReadyToRunRejectedPrecompiledCodeMapMessage)"/>
+                      <!-- 0x80 to 0x200 are used for the optimization tier -->
                     </bitMap>
                     <bitMap name="StartupModeMap">
                         <map value="0x1" message="$(string.RundownPublisher.StartupMode.ManagedExeMapMessage)"/>
@@ -3472,6 +3579,11 @@
                       <map value="0x1" message="$(string.RundownPublisher.ThreadFlags.GCSpecial)"/>
                       <map value="0x2" message="$(string.RundownPublisher.ThreadFlags.Finalizer)"/>
                       <map value="0x4" message="$(string.RundownPublisher.ThreadFlags.ThreadPoolWorker)"/>
+                    </bitMap>
+                    <bitMap name="TieredCompilationSettingsFlagsMap">
+                      <map value="0x0" message="$(string.RundownPublisher.TieredCompilationSettingsFlags.NoneMapMessage)"/>
+                      <map value="0x1" message="$(string.RundownPublisher.TieredCompilationSettingsFlags.QuickJitMapMessage)"/>
+                      <map value="0x2" message="$(string.RundownPublisher.TieredCompilationSettingsFlags.QuickJitForLoopsMapMessage)"/>
                     </bitMap>
                 </maps>
 
@@ -3920,6 +4032,17 @@
                             </ModuleRangeRundown>
                         </UserData>
                     </template>
+
+                    <template tid="TieredCompilationSettings">
+                      <data name="ClrInstanceID" inType="win:UInt16"/>
+                      <data name="Flags" inType="win:UInt32" outType="win:HexInt32" map="TieredCompilationSettingsFlagsMap"/>
+                      <UserData>
+                        <Settings xmlns="myNs">
+                          <ClrInstanceID> %1 </ClrInstanceID>
+                          <Flags> %2 </Flags>
+                        </Settings>
+                      </UserData>
+                    </template>
                 </templates>
 
                 <events>
@@ -4153,6 +4276,11 @@
                            opcode="win:Start"
                            task="CLRRuntimeInformationRundown"
                            symbol="RuntimeInformationDCStart" message="$(string.RundownPublisher.RuntimeInformationEventMessage)"/>
+
+                    <!-- Tiered compilation events 280-289 -->
+                    <event value="280" version="0" level="win:Informational" template="TieredCompilationSettings"
+                           keywords="TieredCompilationKeyword" task="TieredCompilationRundown" opcode="SettingsDCStart"
+                           symbol="TieredCompilationSettingsDCStart" message="$(string.RundownPublisher.TieredCompilationSettingsDCStartEventMessage)"/>
                 </events>
             </provider>
 
@@ -6426,7 +6554,7 @@
                 <string id="RuntimePublisher.ContentionStartEventMessage" value="NONE" />
                 <string id="RuntimePublisher.ContentionStart_V1EventMessage" value="ContentionFlags=%1;%nClrInstanceID=%2"/>
                 <string id="RuntimePublisher.ContentionStopEventMessage" value="ContentionFlags=%1;%nClrInstanceID=%2"/>
-                <string id="RuntimePublisher.ContentionStop_V1EventMessage" value="ContentionFlags=%1;%nClrInstanceID=%2;Duration=%3"/>
+                <string id="RuntimePublisher.ContentionStop_V1EventMessage" value="ContentionFlags=%1;%nClrInstanceID=%2;DurationNs=%3"/>
                 <string id="RuntimePublisher.DCStartCompleteEventMessage" value="NONE" />
                 <string id="RuntimePublisher.DCEndCompleteEventMessage" value="NONE" />
                 <string id="RuntimePublisher.MethodDCStartEventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6" />
@@ -6494,6 +6622,12 @@
                 <string id="RuntimePublisher.SetGCHandleEventMessage" value="HandleID=%1;%nObjectID=%2;%nKind=%3;%nGeneration=%4;%nAppDomainID=%5;%nClrInstanceID=%6" />
                 <string id="RuntimePublisher.DestroyGCHandleEventMessage" value="HandleID=%1;%nClrInstanceID=%2" />
                 <string id="RuntimePublisher.CodeSymbolsEventMessage" value="%nClrInstanceId=%1;%nModuleId=%2;%nTotalChunks=%3;%nChunkNumber=%4;%nChunkLength=%5;%nChunk=%6" />
+                <string id="RuntimePublisher.TieredCompilationSettingsEventMessage" value="ClrInstanceID=%1;%nFlags=%2" />
+                <string id="RuntimePublisher.TieredCompilationPauseEventMessage" value="ClrInstanceID=%1" />
+                <string id="RuntimePublisher.TieredCompilationResumeEventMessage" value="ClrInstanceID=%1;%nNewMethodCount=%2" />
+                <string id="RuntimePublisher.TieredCompilationBackgroundJitStartEventMessage" value="ClrInstanceID=%1;%nPendingMethodCount=%2" />
+                <string id="RuntimePublisher.TieredCompilationBackgroundJitStopEventMessage" value="ClrInstanceID=%1;%nPendingMethodCount=%2;%nJittedMethodCount=%3" />
+              
                 <string id="RundownPublisher.MethodDCStartEventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6" />
                 <string id="RundownPublisher.MethodDCStart_V1EventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6;%nClrInstanceID=%7" />
                 <string id="RundownPublisher.MethodDCStart_V2EventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6;%nClrInstanceID=%7;%nReJITID=%8" />
@@ -6536,9 +6670,12 @@
                 <string id="RundownPublisher.StackEventMessage" value="ClrInstanceID=%1;%nReserved1=%2;%nReserved2=%3;%nFrameCount=%4;%nStack=%5" />
                 <string id="RundownPublisher.ModuleRangeDCStartEventMessage" value="ClrInstanceID=%1;%ModuleID=%2;%nRangeBegin=%3;%nRangeSize=%4;%nRangeType=%5" />
                 <string id="RundownPublisher.ModuleRangeDCEndEventMessage" value= "ClrInstanceID=%1;%ModuleID=%2;%nRangeBegin=%3;%nRangeSize=%4;%nRangeType=%5" />
+                <string id="RundownPublisher.TieredCompilationSettingsDCStartEventMessage" value="ClrInstanceID=%1;%nFlags=%2" />
+              
                 <string id="StressPublisher.StressLogEventMessage" value="Facility=%1;%nLevel=%2;%nMessage=%3" />
                 <string id="StressPublisher.StressLog_V1EventMessage" value="Facility=%1;%nLevel=%2;%nMessage=%3;%nClrInstanceID=%4" />
                 <string id="StressPublisher.StackEventMessage" value="ClrInstanceID=%1;%nReserved1=%2;%nReserved2=%3;%nFrameCount=%4;%nStack=%5" />
+              
                 <string id="PrivatePublisher.FailFastEventMessage" value="FailFastUserMessage=%1;%nFailedEIP=%2;%nOSExitCode=%3;%nClrExitCode=%4;%nClrInstanceID=%5" />
                 <string id="PrivatePublisher.FinalizeObjectEventMessage" value="TypeName=%1;%nTypeID=%2;%nObjectID=%3;%nClrInstanceID=%4" />
                 <string id="PrivatePublisher.SetGCHandleEventMessage" value="HandleID=%1;%nObjectID=%2;%n;%nClrInstanceID=%3" />
@@ -6650,11 +6787,15 @@
                 <string id="RuntimePublisher.DebugIPCEventTaskMessage" value="DebugIPCEvent" />
                 <string id="RuntimePublisher.DebugExceptionProcessingTaskMessage" value="DebugExceptionProcessing" />
                 <string id="RuntimePublisher.CodeSymbolsTaskMessage" value="CodeSymbols" />
+                <string id="RuntimePublisher.TieredCompilationTaskMessage" value="TieredCompilation" />
+              
                 <string id="RundownPublisher.EEStartupTaskMessage" value="Runtime" />
                 <string id="RundownPublisher.MethodTaskMessage" value="Method" />
                 <string id="RundownPublisher.LoaderTaskMessage" value="Loader" />
                 <string id="RundownPublisher.StackTaskMessage" value="ClrStack" />
                 <string id="RundownPublisher.PerfTrackTaskMessage" value="ClrPerfTrack" />
+                <string id="RundownPublisher.TieredCompilationTaskMessage" value="TieredCompilation" />
+              
                 <string id="PrivatePublisher.GarbageCollectionTaskMessage" value="GC" />
                 <string id="PrivatePublisher.StartupTaskMessage" value="Startup"/>
                 <string id="PrivatePublisher.StackTaskMessage" value="ClrStack" />
@@ -6691,6 +6832,9 @@
                 <string id="RuntimePublisher.Method.GenericMapMessage" value="Generic" />
                 <string id="RuntimePublisher.Method.HasSharedGenericCodeMapMessage" value="HasSharedGenericCode" />
                 <string id="RuntimePublisher.Method.JittedMapMessage" value="Jitted" />
+                <string id="RuntimePublisher.Method.JitHelperMapMessage" value="JitHelper" />
+                <string id="RuntimePublisher.Method.ProfilerRejectedPrecompiledCodeMapMessage" value="ProfilerRejectedPrecompiledCode" />
+                <string id="RuntimePublisher.Method.ReadyToRunRejectedPrecompiledCodeMapMessage" value="ReadyToRunRejectedPrecompiledCode" />
                 <string id="RuntimePublisher.GCSegment.SmallObjectHeapMapMessage" value="SmallObjectHeap" />
                 <string id="RuntimePublisher.GCSegment.LargeObjectHeapMapMessage" value="LargeObjectHeap" />
                 <string id="RuntimePublisher.GCSegment.ReadOnlyHeapMapMessage" value="ReadOnlyHeap" />
@@ -6794,6 +6938,10 @@
                 <string id="RuntimePublisher.GCHandleKind.DependentMessage" value="Dependent" />
                 <string id="RuntimePublisher.GCHandleKind.AsyncPinnedMessage" value="AsyncPinned" />
                 <string id="RuntimePublisher.GCHandleKind.SizedRefMessage" value="SizedRef" />
+                <string id="RuntimePublisher.TieredCompilationSettingsFlags.NoneMapMessage" value="None" />
+                <string id="RuntimePublisher.TieredCompilationSettingsFlags.QuickJitMapMessage" value="QuickJit" />
+                <string id="RuntimePublisher.TieredCompilationSettingsFlags.QuickJitForLoopsMapMessage" value="QuickJitForLoops" />
+              
                 <string id="RundownPublisher.AppDomain.ExecutableMapMessage" value="Executable" />
                 <string id="RundownPublisher.AppDomain.SharedMapMessage" value="Shared" />
                 <string id="RundownPublisher.Assembly.DomainNeutralMapMessage" value="DomainNeutral" />
@@ -6811,6 +6959,9 @@
                 <string id="RundownPublisher.Method.GenericMapMessage" value="Generic" />
                 <string id="RundownPublisher.Method.HasSharedGenericCodeMapMessage" value="HasSharedGenericCode" />
                 <string id="RundownPublisher.Method.JittedMapMessage" value="Jitted" />
+                <string id="RundownPublisher.Method.JitHelperMapMessage" value="JitHelper" />
+                <string id="RundownPublisher.Method.ProfilerRejectedPrecompiledCodeMapMessage" value="ProfilerRejectedPrecompiledCode" />
+                <string id="RundownPublisher.Method.ReadyToRunRejectedPrecompiledCodeMapMessage" value="ReadyToRunRejectedPrecompiledCode" />
                 <string id="RundownPublisher.StartupMode.ManagedExeMapMessage" value="ManagedExe" />
                 <string id="RundownPublisher.StartupMode.HostedCLRMapMessage" value="HostedClr" />
                 <string id="RundownPublisher.StartupMode.IjwDllMapMessage" value="IjwDll" />
@@ -6837,6 +6988,10 @@
                 <string id="RundownPublisher.ThreadFlags.GCSpecial" value="GCSpecial"/>
                 <string id="RundownPublisher.ThreadFlags.Finalizer" value="Finalizer"/>
                 <string id="RundownPublisher.ThreadFlags.ThreadPoolWorker" value="ThreadPoolWorker"/>
+                <string id="RundownPublisher.TieredCompilationSettingsFlags.NoneMapMessage" value="None" />
+                <string id="RundownPublisher.TieredCompilationSettingsFlags.QuickJitMapMessage" value="QuickJit" />
+                <string id="RundownPublisher.TieredCompilationSettingsFlags.QuickJitForLoopsMapMessage" value="QuickJitForLoops" />
+              
                 <string id="PrivatePublisher.ModuleRangeSectionTypeMap.ModuleSection" value="ModuleSection"/>
                 <string id="PrivatePublisher.ModuleRangeSectionTypeMap.EETableSection" value="EETableSection"/>
                 <string id="PrivatePublisher.ModuleRangeSectionTypeMap.WriteDataSection" value="WriteDataSection"/>
@@ -6931,6 +7086,8 @@
                 <string id="RuntimePublisher.MonitoringKeywordMessage" value="Monitoring" />
                 <string id="RuntimePublisher.CodeSymbolsKeywordMessage" value="CodeSymbols" />
                 <string id="RuntimePublisher.EventSourceKeywordMessage" value="EventSource" />
+                <string id="RuntimePublisher.TieredCompilationKeywordMessage" value="TieredCompilation" />
+              
                 <string id="RundownPublisher.LoaderKeywordMessage" value="Loader" />
                 <string id="RundownPublisher.JitKeywordMessage" value="Jit" />
                 <string id="RundownPublisher.JittedMethodILToNativeMapRundownKeywordMessage" value="JittedMethodILToNativeMapRundown" />
@@ -6942,6 +7099,8 @@
                 <string id="RundownPublisher.OverrideAndSuppressNGenEventsRundownKeywordMessage" value="OverrideAndSuppressNGenEvents" />
                 <string id="RundownPublisher.PerfTrackRundownKeywordMessage" value="PerfTrack" />
                 <string id="RundownPublisher.StackKeywordMessage" value="Stack" />
+                <string id="RundownPublisher.TieredCompilationKeywordMessage" value="TieredCompilation" />
+              
                 <string id="PrivatePublisher.GCPrivateKeywordMessage" value="GC" />
                 <string id="PrivatePublisher.StartupKeywordMessage" value="Startup" />
                 <string id="PrivatePublisher.StackKeywordMessage" value="Stack" />
@@ -7051,6 +7210,12 @@
                 <string id="RuntimePublisher.DebugIPCEventEndOpcodeMessage" value="IPCEventEnd" />
                 <string id="RuntimePublisher.DebugExceptionProcessingStartOpcodeMessage" value="ExceptionProcessingStart" />
                 <string id="RuntimePublisher.DebugExceptionProcessingEndOpcodeMessage" value="ExceptionProcessingEnd" />
+              
+                <string id="RuntimePublisher.TieredCompilationSettingsOpcodeMessage" value="Settings" />
+                <string id="RuntimePublisher.TieredCompilationPauseOpcodeMessage" value="Pause" />
+                <string id="RuntimePublisher.TieredCompilationResumeOpcodeMessage" value="Resume" />
+                <string id="RuntimePublisher.TieredCompilationBackgroundJitStartOpcodeMessage" value="BackgroundJitStart" />
+                <string id="RuntimePublisher.TieredCompilationBackgroundJitStopOpcodeMessage" value="BackgroundJitStop" />
 
                 <string id="RundownPublisher.MethodDCStartOpcodeMessage" value="DCStart" />
                 <string id="RundownPublisher.MethodDCEndOpcodeMessage" value="DCStop" />
@@ -7074,8 +7239,9 @@
                 <string id="RundownPublisher.CLRStackWalkOpcodeMessage" value="Walk" />
                 <string id="RundownPublisher.ModuleRangeDCStartOpcodeMessage" value="ModuleRangeDCStart" />
                 <string id="RundownPublisher.ModuleRangeDCEndOpcodeMessage" value="ModuleRangeDCEnd" />
+                <string id="RundownPublisher.TieredCompilationSettingsDCStartOpcodeMessage" value="SettingsDCStart" />
+              
                 <string id="PrivatePublisher.FailFastOpcodeMessage" value="FailFast" />
-
 
                 <string id="PrivatePublisher.GCDecisionOpcodeMessage" value="Decision" />
                 <string id="PrivatePublisher.GCSettingsOpcodeMessage" value="Settings" />

--- a/src/vm/ClrEtwAll.man
+++ b/src/vm/ClrEtwAll.man
@@ -77,8 +77,8 @@
                              message="$(string.RuntimePublisher.CodeSymbolsKeywordMessage)" symbol="CLR_CODESYMBOLS_KEYWORD" />
                     <keyword name="EventSourceKeyword" mask="0x800000000"
                              message="$(string.RuntimePublisher.EventSourceKeywordMessage)" symbol="CLR_EVENTSOURCE_KEYWORD" />
-                    <keyword name="TieredCompilationKeyword" mask="0x1000000000"
-                             message="$(string.RuntimePublisher.TieredCompilationKeywordMessage)" symbol="CLR_TIERED_COMPILATION_KEYWORD" />
+                    <keyword name="CompilationKeyword" mask="0x1000000000"
+                             message="$(string.RuntimePublisher.CompilationKeywordMessage)" symbol="CLR_COMPILATION_KEYWORD" />
                 </keywords>
                 <!--Tasks-->
                 <tasks>
@@ -3387,19 +3387,19 @@
 
                     <!-- Tiered compilation events 280-289 -->
                     <event value="280" version="0" level="win:Informational" template="TieredCompilationSettings"
-                           keywords="TieredCompilationKeyword" task="TieredCompilation" opcode="Settings"
+                           keywords="CompilationKeyword" task="TieredCompilation" opcode="Settings"
                            symbol="TieredCompilationSettings" message="$(string.RuntimePublisher.TieredCompilationSettingsEventMessage)"/>
                     <event value="281" version="0" level="win:Informational" template="TieredCompilationEmpty"
-                           keywords="TieredCompilationKeyword" task="TieredCompilation" opcode="Pause"
+                           keywords="CompilationKeyword" task="TieredCompilation" opcode="Pause"
                            symbol="TieredCompilationPause" message="$(string.RuntimePublisher.TieredCompilationPauseEventMessage)"/>
                     <event value="282" version="0" level="win:Informational" template="TieredCompilationResume"
-                           keywords="TieredCompilationKeyword" task="TieredCompilation" opcode="Resume"
+                           keywords="CompilationKeyword" task="TieredCompilation" opcode="Resume"
                            symbol="TieredCompilationResume" message="$(string.RuntimePublisher.TieredCompilationResumeEventMessage)"/>
                     <event value="283" version="0" level="win:Informational" template="TieredCompilationBackgroundJitStart"
-                           keywords="TieredCompilationKeyword" task="TieredCompilation" opcode="win:Start"
+                           keywords="CompilationKeyword" task="TieredCompilation" opcode="win:Start"
                            symbol="TieredCompilationBackgroundJitStart" message="$(string.RuntimePublisher.TieredCompilationBackgroundJitStartEventMessage)"/>
                     <event value="284" version="0" level="win:Informational" template="TieredCompilationBackgroundJitStop"
-                           keywords="TieredCompilationKeyword" task="TieredCompilation" opcode="win:Stop"
+                           keywords="CompilationKeyword" task="TieredCompilation" opcode="win:Stop"
                            symbol="TieredCompilationBackgroundJitStop" message="$(string.RuntimePublisher.TieredCompilationBackgroundJitStopEventMessage)"/>
                 </events>
             </provider>
@@ -3437,8 +3437,8 @@
                              message="$(string.RundownPublisher.PerfTrackRundownKeywordMessage)" symbol="CLR_RUNDOWNPERFTRACK_KEYWORD"/>
                     <keyword name="StackKeyword" mask="0x40000000"
                              message="$(string.RundownPublisher.StackKeywordMessage)" symbol="CLR_RUNDOWNSTACK_KEYWORD"/>
-                    <keyword name="TieredCompilationKeyword" mask="0x1000000000"
-                             message="$(string.RundownPublisher.TieredCompilationKeywordMessage)" symbol="CLR_TIERED_COMPILATION_RUNDOWN_KEYWORD" />
+                    <keyword name="CompilationKeyword" mask="0x1000000000"
+                             message="$(string.RundownPublisher.CompilationKeywordMessage)" symbol="CLR_COMPILATION_RUNDOWN_KEYWORD" />
                 </keywords>
 
                 <!--Tasks-->
@@ -4277,7 +4277,7 @@
 
                     <!-- Tiered compilation events 280-289 -->
                     <event value="280" version="0" level="win:Informational" template="TieredCompilationSettings"
-                           keywords="TieredCompilationKeyword" task="TieredCompilationRundown" opcode="SettingsDCStart"
+                           keywords="CompilationKeyword" task="TieredCompilationRundown" opcode="SettingsDCStart"
                            symbol="TieredCompilationSettingsDCStart" message="$(string.RundownPublisher.TieredCompilationSettingsDCStartEventMessage)"/>
                 </events>
             </provider>
@@ -7084,7 +7084,7 @@
                 <string id="RuntimePublisher.MonitoringKeywordMessage" value="Monitoring" />
                 <string id="RuntimePublisher.CodeSymbolsKeywordMessage" value="CodeSymbols" />
                 <string id="RuntimePublisher.EventSourceKeywordMessage" value="EventSource" />
-                <string id="RuntimePublisher.TieredCompilationKeywordMessage" value="TieredCompilation" />
+                <string id="RuntimePublisher.CompilationKeywordMessage" value="Compilation" />
               
                 <string id="RundownPublisher.LoaderKeywordMessage" value="Loader" />
                 <string id="RundownPublisher.JitKeywordMessage" value="Jit" />
@@ -7097,7 +7097,7 @@
                 <string id="RundownPublisher.OverrideAndSuppressNGenEventsRundownKeywordMessage" value="OverrideAndSuppressNGenEvents" />
                 <string id="RundownPublisher.PerfTrackRundownKeywordMessage" value="PerfTrack" />
                 <string id="RundownPublisher.StackKeywordMessage" value="Stack" />
-                <string id="RundownPublisher.TieredCompilationKeywordMessage" value="TieredCompilation" />
+                <string id="RundownPublisher.CompilationKeywordMessage" value="Compilation" />
               
                 <string id="PrivatePublisher.GCPrivateKeywordMessage" value="GC" />
                 <string id="PrivatePublisher.StartupKeywordMessage" value="Startup" />

--- a/src/vm/ClrEtwAllMeta.lst
+++ b/src/vm/ClrEtwAllMeta.lst
@@ -297,6 +297,20 @@ nomac:CLRAuthenticodeVerification:::AuthenticodeVerificationStop_V1
 ####################
 nostack:CLRRuntimeInformation:::RuntimeInformationStart
 
+###########################
+# Tiered compilation events
+###########################
+nomac:TieredCompilation:::TieredCompilationSettings
+nostack:TieredCompilation:::TieredCompilationSettings
+nomac:TieredCompilation:::TieredCompilationPause
+nostack:TieredCompilation:::TieredCompilationPause
+nomac:TieredCompilation:::TieredCompilationResume
+nostack:TieredCompilation:::TieredCompilationResume
+nomac:TieredCompilation:::TieredCompilationBackgroundJitStart
+nostack:TieredCompilation:::TieredCompilationBackgroundJitStart
+nomac:TieredCompilation:::TieredCompilationBackgroundJitStop
+nostack:TieredCompilation:::TieredCompilationBackgroundJitStop
+
 ##################################
 # Events from the rundown provider
 ##################################
@@ -374,6 +388,12 @@ nostack:CLRPerfTrack:::ModuleRangeDCEnd
 # RuntimeInfo events
 ####################
 nomac:CLRRuntimeInformationRundown:::RuntimeInformationDCStart
+
+###########################
+# Tiered compilation events
+###########################
+nomac:TieredCompilationRundown:::TieredCompilationSettingsDCStart
+nostack:TieredCompilationRundown:::TieredCompilationSettingsDCStart
 
 ##################################
 # Events from the private provider

--- a/src/vm/callcounter.cpp
+++ b/src/vm/callcounter.cpp
@@ -91,6 +91,18 @@ void CallCounter::DisableCallCounting(MethodDesc* pMethodDesc)
     m_methodToCallCount.Add(CallCounterEntry::CreateWithCallCountingDisabled(pMethodDesc));
 }
 
+bool CallCounter::WasCalledAtMostOnce(MethodDesc* pMethodDesc)
+{
+    WRAPPER_NO_CONTRACT;
+
+    SpinLockHolder holder(&m_lock);
+
+    const CallCounterEntry *existingEntry = m_methodToCallCount.LookupPtr(pMethodDesc);
+    return
+        existingEntry == nullptr ||
+        existingEntry->callCountLimit >= (int)g_pConfig->TieredCompilation_CallCountThreshold() - 1;
+}
+
 // This is called by the prestub each time the method is invoked in a particular
 // AppDomain (the AppDomain for which AppDomain.GetCallCounter() == this). These
 // calls continue until we backpatch the prestub to avoid future calls. This allows

--- a/src/vm/callcounter.h
+++ b/src/vm/callcounter.h
@@ -94,6 +94,7 @@ public:
     bool IsCallCountingEnabled(PTR_MethodDesc pMethodDesc);
 #ifndef DACCESS_COMPILE
     void DisableCallCounting(MethodDesc* pMethodDesc);
+    bool WasCalledAtMostOnce(MethodDesc* pMethodDesc);
 #endif
 
     void OnMethodCalled(MethodDesc* pMethodDesc, TieredCompilationManager *pTieredCompilationManager, BOOL* shouldStopCountingCallsRef, BOOL* wasPromotedToNextTierRef);

--- a/src/vm/codeversion.h
+++ b/src/vm/codeversion.h
@@ -67,7 +67,8 @@ public:
     enum OptimizationTier
     {
         OptimizationTier0,
-        OptimizationTier1
+        OptimizationTier1,
+        OptimizationTierOptimized, // may do less optimizations than tier 1
     };
 #ifdef FEATURE_TIERED_COMPILATION
     OptimizationTier GetOptimizationTier() const;

--- a/src/vm/common.h
+++ b/src/vm/common.h
@@ -470,6 +470,7 @@ extern DummyGlobalContract ___contract;
 #include "WinRTRedirector.h"
 #include "winrtredirector.inl"
 #endif // FEATURE_COMINTEROP
+#include "eventtrace.inl"
 
 #if defined(COMMON_TURNED_FPO_ON)
 #pragma optimize("", on)        // Go back to command line default optimizations

--- a/src/vm/eeconfig.cpp
+++ b/src/vm/eeconfig.cpp
@@ -1203,46 +1203,55 @@ HRESULT EEConfig::sync()
 
 #if defined(FEATURE_TIERED_COMPILATION)
     fTieredCompilation = Configuration::GetKnobBooleanValue(W("System.Runtime.TieredCompilation"), CLRConfig::EXTERNAL_TieredCompilation);
-
-    fTieredCompilation_QuickJit =
-        Configuration::GetKnobBooleanValue(
-            W("System.Runtime.TieredCompilation.QuickJit"),
-            CLRConfig::EXTERNAL_TC_QuickJit);
-    fTieredCompilation_QuickJitForLoops =
-        Configuration::GetKnobBooleanValue(
-            W("System.Runtime.TieredCompilation.QuickJitForLoops"),
-            CLRConfig::UNSUPPORTED_TC_QuickJitForLoops);
-
-    fTieredCompilation_CallCounting = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_TC_CallCounting) != 0;
-
-    tieredCompilation_CallCountThreshold = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_TC_CallCountThreshold);
-    if (tieredCompilation_CallCountThreshold < 1)
+    if (fTieredCompilation)
     {
-        tieredCompilation_CallCountThreshold = 1;
-    }
-    else if (tieredCompilation_CallCountThreshold > INT_MAX) // CallCounter uses 'int'
-    {
-        tieredCompilation_CallCountThreshold = INT_MAX;
-    }
+        fTieredCompilation_QuickJit =
+            Configuration::GetKnobBooleanValue(
+                W("System.Runtime.TieredCompilation.QuickJit"),
+                CLRConfig::EXTERNAL_TC_QuickJit);
+        if (fTieredCompilation_QuickJit)
+        {
+            fTieredCompilation_QuickJitForLoops =
+                Configuration::GetKnobBooleanValue(
+                    W("System.Runtime.TieredCompilation.QuickJitForLoops"),
+                    CLRConfig::UNSUPPORTED_TC_QuickJitForLoops);
+        }
 
-    tieredCompilation_CallCountingDelayMs = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_TC_CallCountingDelayMs);
+        fTieredCompilation_CallCounting = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_TC_CallCounting) != 0;
+
+        tieredCompilation_CallCountThreshold = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_TC_CallCountThreshold);
+        if (tieredCompilation_CallCountThreshold < 1)
+        {
+            tieredCompilation_CallCountThreshold = 1;
+        }
+        else if (tieredCompilation_CallCountThreshold > INT_MAX) // CallCounter uses 'int'
+        {
+            tieredCompilation_CallCountThreshold = INT_MAX;
+        }
+
+        tieredCompilation_CallCountingDelayMs = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_TC_CallCountingDelayMs);
 
 #ifndef FEATURE_PAL
-    bool hadSingleProcessorAtStartup = CPUGroupInfo::HadSingleProcessorAtStartup();
+        bool hadSingleProcessorAtStartup = CPUGroupInfo::HadSingleProcessorAtStartup();
 #else // !FEATURE_PAL
-    bool hadSingleProcessorAtStartup = g_SystemInfo.dwNumberOfProcessors == 1;
+        bool hadSingleProcessorAtStartup = g_SystemInfo.dwNumberOfProcessors == 1;
 #endif // !FEATURE_PAL
-
-    if (hadSingleProcessorAtStartup)
-    {
-        DWORD delayMultiplier = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_TC_DelaySingleProcMultiplier);
-        if (delayMultiplier > 1)
+        if (hadSingleProcessorAtStartup)
         {
-            DWORD newDelay = tieredCompilation_CallCountingDelayMs * delayMultiplier;
-            if (newDelay / delayMultiplier == tieredCompilation_CallCountingDelayMs)
+            DWORD delayMultiplier = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_TC_DelaySingleProcMultiplier);
+            if (delayMultiplier > 1)
             {
-                tieredCompilation_CallCountingDelayMs = newDelay;
+                DWORD newDelay = tieredCompilation_CallCountingDelayMs * delayMultiplier;
+                if (newDelay / delayMultiplier == tieredCompilation_CallCountingDelayMs)
+                {
+                    tieredCompilation_CallCountingDelayMs = newDelay;
+                }
             }
+        }
+
+        if (ETW::TieredCompilationLog::Runtime::IsEnabled())
+        {
+            ETW::TieredCompilationLog::Runtime::SendSettings();
         }
     }
 #endif

--- a/src/vm/eeconfig.cpp
+++ b/src/vm/eeconfig.cpp
@@ -1249,9 +1249,9 @@ HRESULT EEConfig::sync()
             }
         }
 
-        if (ETW::TieredCompilationLog::Runtime::IsEnabled())
+        if (ETW::CompilationLog::TieredCompilation::Runtime::IsEnabled())
         {
-            ETW::TieredCompilationLog::Runtime::SendSettings();
+            ETW::CompilationLog::TieredCompilation::Runtime::SendSettings();
         }
     }
 #endif

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -4464,6 +4464,11 @@ extern "C"
                 // Fire the runtime information event
                 ETW::InfoLog::RuntimeInformation(ETW::InfoLog::InfoStructs::Callback);
 
+                if (ETW::TieredCompilationLog::Rundown::IsEnabled() && g_pConfig->TieredCompilation())
+                {
+                    ETW::TieredCompilationLog::Rundown::SendSettings();
+                }
+
                 // Start and End Method/Module Rundowns
                 // Used to fire events that we missed since we started the controller after the process started
                 // flags for immediate start rundown
@@ -5212,7 +5217,7 @@ VOID ETW::MethodLog::GetR2RGetEntryPoint(MethodDesc *pMethodDesc, PCODE pEntryPo
 /*******************************************************/
 /* This is called by the runtime when a method is jitted completely */
 /*******************************************************/
-VOID ETW::MethodLog::MethodJitted(MethodDesc *pMethodDesc, SString *namespaceOrClassName, SString *methodName, SString *methodSignature, PCODE pNativeCodeStartAddress, ReJITID ilCodeId, NativeCodeVersionId nativeCodeId, BOOL bProfilerRejectedPrecompiledCode, BOOL bReadyToRunRejectedPrecompiledCode)
+VOID ETW::MethodLog::MethodJitted(MethodDesc *pMethodDesc, SString *namespaceOrClassName, SString *methodName, SString *methodSignature, PCODE pNativeCodeStartAddress, PrepareCodeConfig *pConfig)
 {
     CONTRACTL {
         NOTHROW;
@@ -5225,7 +5230,7 @@ VOID ETW::MethodLog::MethodJitted(MethodDesc *pMethodDesc, SString *namespaceOrC
                                         TRACE_LEVEL_INFORMATION, 
                                         CLR_JIT_KEYWORD))
         {
-            ETW::MethodLog::SendMethodEvent(pMethodDesc, ETW::EnumerationLog::EnumerationStructs::JitMethodLoad, TRUE, namespaceOrClassName, methodName, methodSignature, pNativeCodeStartAddress, nativeCodeId, bProfilerRejectedPrecompiledCode, bReadyToRunRejectedPrecompiledCode);
+            ETW::MethodLog::SendMethodEvent(pMethodDesc, ETW::EnumerationLog::EnumerationStructs::JitMethodLoad, TRUE, namespaceOrClassName, methodName, methodSignature, pNativeCodeStartAddress, pConfig);
         }
 
         if(ETW_TRACING_CATEGORY_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_Context, 
@@ -5240,7 +5245,7 @@ VOID ETW::MethodLog::MethodJitted(MethodDesc *pMethodDesc, SString *namespaceOrC
             _ASSERTE(g_pDebugInterface != NULL);
             g_pDebugInterface->InitializeLazyDataIfNecessary();
             
-            ETW::MethodLog::SendMethodILToNativeMapEvent(pMethodDesc, ETW::EnumerationLog::EnumerationStructs::JitMethodILToNativeMap, pNativeCodeStartAddress, ilCodeId);
+            ETW::MethodLog::SendMethodILToNativeMapEvent(pMethodDesc, ETW::EnumerationLog::EnumerationStructs::JitMethodILToNativeMap, pNativeCodeStartAddress, pConfig->GetCodeVersion().GetILCodeVersionId());
         }
 
     } EX_CATCH { } EX_END_CATCH(SwallowAllExceptions);
@@ -6248,7 +6253,7 @@ VOID ETW::MethodLog::SendMethodJitStartEvent(MethodDesc *pMethodDesc, SString *n
 /****************************************************************************/
 /* This routine is used to send a method load/unload or rundown event                              */
 /****************************************************************************/
-VOID ETW::MethodLog::SendMethodEvent(MethodDesc *pMethodDesc, DWORD dwEventOptions, BOOL bIsJit, SString *namespaceOrClassName, SString *methodName, SString *methodSignature, PCODE pNativeCodeStartAddress, NativeCodeVersionId nativeCodeId, BOOL bProfilerRejectedPrecompiledCode, BOOL bReadyToRunRejectedPrecompiledCode)
+VOID ETW::MethodLog::SendMethodEvent(MethodDesc *pMethodDesc, DWORD dwEventOptions, BOOL bIsJit, SString *namespaceOrClassName, SString *methodName, SString *methodSignature, PCODE pNativeCodeStartAddress, PrepareCodeConfig *pConfig)
 {
     CONTRACTL {
         THROWS;
@@ -6317,13 +6322,63 @@ VOID ETW::MethodLog::SendMethodEvent(MethodDesc *pMethodDesc, DWORD dwEventOptio
     if(pMethodDesc->GetMethodTable_NoLogging())
         bIsGenericMethod = pMethodDesc->HasClassOrMethodInstantiation_NoLogging();
 
-    ulMethodFlags = ((ulMethodFlags |
+    int jitOptimizationTier = -1;
+    NativeCodeVersionId nativeCodeId = 0;
+    ulMethodFlags = ulMethodFlags |
         (bHasSharedGenericCode ? ETW::MethodLog::MethodStructs::SharedGenericCode : 0) |
         (bIsGenericMethod ? ETW::MethodLog::MethodStructs::GenericMethod : 0) |
         (bIsDynamicMethod ? ETW::MethodLog::MethodStructs::DynamicMethod : 0) |
-        (bIsJit ? ETW::MethodLog::MethodStructs::JittedMethod : 0) |
-        (bProfilerRejectedPrecompiledCode ? ETW::MethodLog::MethodStructs::ProfilerRejectedPrecompiledCode : 0) |
-        (bReadyToRunRejectedPrecompiledCode ? ETW::MethodLog::MethodStructs::ReadyToRunRejectedPrecompiledCode : 0)));
+        (bIsJit ? ETW::MethodLog::MethodStructs::JittedMethod : 0);
+    if (pConfig != nullptr)
+    {
+        if (pConfig->ProfilerRejectedPrecompiledCode())
+        {
+            ulMethodFlags |= ETW::MethodLog::MethodStructs::ProfilerRejectedPrecompiledCode;
+        }
+        if (pConfig->ReadyToRunRejectedPrecompiledCode())
+        {
+            ulMethodFlags |= ETW::MethodLog::MethodStructs::ReadyToRunRejectedPrecompiledCode;
+        }
+
+        _ASSERTE(((ulMethodFlags >> MethodFlagsJitOptimizationTierShift) & MethodFlagsJitOptimizationTierLowMask) == 0);
+#ifdef FEATURE_TIERED_COMPILATION
+        if (pMethodDesc->IsEligibleForTieredCompilation())
+        {
+            switch (pConfig->GetCodeVersion().GetOptimizationTier())
+            {
+                case NativeCodeVersion::OptimizationTier0:
+                    jitOptimizationTier = (int)JitOptimizationTier::QuickJitted;
+                    break;
+
+                case NativeCodeVersion::OptimizationTier1:
+                    jitOptimizationTier = (int)JitOptimizationTier::Optimized;
+                    break;
+
+                default:
+                    UNREACHABLE();
+            }
+        }
+#endif
+
+#ifdef FEATURE_CODE_VERSIONING
+        nativeCodeId = pConfig->GetCodeVersion().GetVersionId();
+#endif
+    }
+
+    if (jitOptimizationTier < 0)
+    {
+        if (pMethodDesc->IsJitOptimizationDisabled())
+        {
+            jitOptimizationTier = (int)JitOptimizationTier::MinOptJitted;
+        }
+        else
+        {
+            jitOptimizationTier = (int)JitOptimizationTier::Optimized;
+        }
+    }
+    static_assert_no_msg((unsigned int)JitOptimizationTier::Count - 1 <= MethodFlagsJitOptimizationTierLowMask);
+    _ASSERTE((unsigned int)jitOptimizationTier <= MethodFlagsJitOptimizationTierLowMask);
+    ulMethodFlags |= (unsigned int)jitOptimizationTier << MethodFlagsJitOptimizationTierShift;
 
     // Intentionally set the extent flags (cold vs. hot) only after all the other common
     // flags (above) have been set.
@@ -6813,18 +6868,18 @@ VOID ETW::MethodLog::SendEventsForJitMethodsHelper(LoaderAllocator *pLoaderAlloc
 
         PCODE codeStart = PINSTRToPCODE(heapIterator.GetMethodCode());
 
-        // Get the IL and native code IDs. In some cases, such as collectible loader
+        // Get info relevant to the native code version. In some cases, such as collectible loader
         // allocators, we don't support code versioning so we need to short circuit the call.
         // This also allows our caller to avoid having to pre-enter the relevant locks.
         // see code:#TableLockHolder
         ReJITID ilCodeId = 0;
-        NativeCodeVersionId nativeCodeId = 0;
+        NativeCodeVersion nativeCodeVersion;
 #ifdef FEATURE_CODE_VERSIONING
         if (fGetCodeIds)
         {
             CodeVersionManager *pCodeVersionManager = pMD->GetCodeVersionManager();
             _ASSERTE(pCodeVersionManager->LockOwnedByCurrentThread());
-            NativeCodeVersion nativeCodeVersion = pCodeVersionManager->GetNativeCodeVersion(pMD, codeStart);
+            nativeCodeVersion = pCodeVersionManager->GetNativeCodeVersion(pMD, codeStart);
             if (nativeCodeVersion.IsNull())
             {
                 // The code version manager hasn't been updated with the jitted code
@@ -6835,7 +6890,6 @@ VOID ETW::MethodLog::SendEventsForJitMethodsHelper(LoaderAllocator *pLoaderAlloc
             }
             else
             {
-                nativeCodeId = nativeCodeVersion.GetVersionId();
                 ilCodeId = nativeCodeVersion.GetILCodeVersionId();
             }
         }
@@ -6845,6 +6899,8 @@ VOID ETW::MethodLog::SendEventsForJitMethodsHelper(LoaderAllocator *pLoaderAlloc
         {
             continue;
         }
+
+        PrepareCodeConfig config(!nativeCodeVersion.IsNull() ? nativeCodeVersion : NativeCodeVersion(pMD), FALSE, FALSE);
 
         // When we're called to announce loads, then the methodload event itself must
         // precede any supplemental events, so that the method load or method jitting
@@ -6862,7 +6918,7 @@ VOID ETW::MethodLog::SendEventsForJitMethodsHelper(LoaderAllocator *pLoaderAlloc
                     NULL,           // methodName
                     NULL,           // methodSignature
                     codeStart,
-                    nativeCodeId);
+                    &config);
             }
         }
 
@@ -6885,7 +6941,7 @@ VOID ETW::MethodLog::SendEventsForJitMethodsHelper(LoaderAllocator *pLoaderAlloc
                     NULL,           // methodName
                     NULL,           // methodSignature
                     codeStart,
-                    nativeCodeId);
+                    &config);
             }
         }
     }
@@ -7330,6 +7386,144 @@ VOID ETW::EnumerationLog::EnumerationHelper(Module *moduleFilter, BaseDomain *do
             }
         }
     }
+}
+
+void ETW::TieredCompilationLog::ValidateSend()
+{
+    CONTRACTL {
+        NOTHROW;
+        GC_NOTRIGGER;
+    } CONTRACTL_END;
+    _ASSERTE(IsEnabled());
+    _ASSERTE(g_pConfig->TieredCompilation());
+}
+
+bool ETW::TieredCompilationLog::Runtime::IsEnabled()
+{
+    CONTRACTL {
+        NOTHROW;
+        GC_NOTRIGGER;
+    } CONTRACTL_END;
+
+    return
+        ETW_TRACING_CATEGORY_ENABLED(
+            MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_Context,
+            TRACE_LEVEL_INFORMATION,
+            CLR_TIERED_COMPILATION_KEYWORD);
+}
+
+bool ETW::TieredCompilationLog::Rundown::IsEnabled()
+{
+    CONTRACTL {
+        NOTHROW;
+        GC_NOTRIGGER;
+    } CONTRACTL_END;
+
+    return
+        ETW_TRACING_CATEGORY_ENABLED(
+            MICROSOFT_WINDOWS_DOTNETRUNTIME_RUNDOWN_PROVIDER_Context,
+            TRACE_LEVEL_INFORMATION,
+            CLR_TIERED_COMPILATION_RUNDOWN_KEYWORD);
+}
+
+void ETW::TieredCompilationLog::GetSettings(UINT32 *flagsRef)
+{
+    CONTRACTL {
+        NOTHROW;
+        GC_NOTRIGGER;
+    } CONTRACTL_END;
+    ValidateSend();
+    _ASSERTE(flagsRef != nullptr);
+
+    enum class Flags : UINT32
+    {
+        None = 0x0,
+        QuickJit = 0x1,
+        QuickJitForLoops = 0x2,
+    };
+
+    UINT32 flags = (UINT32)Flags::None;
+    if (g_pConfig->TieredCompilation_QuickJit())
+    {
+        flags |= (UINT32)Flags::QuickJit;
+        if (g_pConfig->TieredCompilation_QuickJitForLoops())
+        {
+            flags |= (UINT32)Flags::QuickJitForLoops;
+        }
+    }
+    *flagsRef = flags;
+}
+
+void ETW::TieredCompilationLog::Runtime::SendSettings()
+{
+    CONTRACTL {
+        NOTHROW;
+        GC_NOTRIGGER;
+    } CONTRACTL_END;
+    ValidateSend();
+
+    UINT32 flags;
+    GetSettings(&flags);
+
+    FireEtwTieredCompilationSettings(GetClrInstanceId(), flags);
+}
+
+void ETW::TieredCompilationLog::Rundown::SendSettings()
+{
+    CONTRACTL {
+        NOTHROW;
+        GC_NOTRIGGER;
+    } CONTRACTL_END;
+    ValidateSend();
+
+    UINT32 flags;
+    GetSettings(&flags);
+
+    FireEtwTieredCompilationSettingsDCStart(GetClrInstanceId(), flags);
+}
+
+void ETW::TieredCompilationLog::Runtime::SendPause()
+{
+    CONTRACTL {
+        NOTHROW;
+        GC_NOTRIGGER;
+    } CONTRACTL_END;
+    ValidateSend();
+
+    FireEtwTieredCompilationPause(GetClrInstanceId());
+}
+
+void ETW::TieredCompilationLog::Runtime::SendResume(UINT32 newMethodCount)
+{
+    CONTRACTL {
+        NOTHROW;
+        GC_NOTRIGGER;
+    } CONTRACTL_END;
+    ValidateSend();
+
+    FireEtwTieredCompilationResume(GetClrInstanceId(), newMethodCount);
+}
+
+void ETW::TieredCompilationLog::Runtime::SendBackgroundJitStart(UINT32 pendingMethodCount)
+{
+    CONTRACTL {
+        NOTHROW;
+        GC_NOTRIGGER;
+    } CONTRACTL_END;
+    ValidateSend();
+
+    FireEtwTieredCompilationBackgroundJitStart(GetClrInstanceId(), pendingMethodCount);
+}
+
+void ETW::TieredCompilationLog::Runtime::SendBackgroundJitStop(UINT32 pendingMethodCount, UINT32 jittedMethodCount)
+{
+    CONTRACTL {
+        NOTHROW;
+        GC_NOTRIGGER;
+    } CONTRACTL_END;
+    ValidateSend();
+
+    FireEtwTieredCompilationBackgroundJitStop(GetClrInstanceId(), pendingMethodCount, jittedMethodCount);
 }
 
 #endif // !FEATURE_REDHAWK

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -7388,16 +7388,6 @@ VOID ETW::EnumerationLog::EnumerationHelper(Module *moduleFilter, BaseDomain *do
     }
 }
 
-void ETW::TieredCompilationLog::ValidateSend()
-{
-    CONTRACTL {
-        NOTHROW;
-        GC_NOTRIGGER;
-    } CONTRACTL_END;
-    _ASSERTE(IsEnabled());
-    _ASSERTE(g_pConfig->TieredCompilation());
-}
-
 bool ETW::TieredCompilationLog::Runtime::IsEnabled()
 {
     CONTRACTL {
@@ -7432,7 +7422,7 @@ void ETW::TieredCompilationLog::GetSettings(UINT32 *flagsRef)
         NOTHROW;
         GC_NOTRIGGER;
     } CONTRACTL_END;
-    ValidateSend();
+    _ASSERTE(g_pConfig->TieredCompilation());
     _ASSERTE(flagsRef != nullptr);
 
     enum class Flags : UINT32
@@ -7460,7 +7450,8 @@ void ETW::TieredCompilationLog::Runtime::SendSettings()
         NOTHROW;
         GC_NOTRIGGER;
     } CONTRACTL_END;
-    ValidateSend();
+    _ASSERTE(IsEnabled());
+    _ASSERTE(g_pConfig->TieredCompilation());
 
     UINT32 flags;
     GetSettings(&flags);
@@ -7474,7 +7465,8 @@ void ETW::TieredCompilationLog::Rundown::SendSettings()
         NOTHROW;
         GC_NOTRIGGER;
     } CONTRACTL_END;
-    ValidateSend();
+    _ASSERTE(IsEnabled());
+    _ASSERTE(g_pConfig->TieredCompilation());
 
     UINT32 flags;
     GetSettings(&flags);
@@ -7488,7 +7480,8 @@ void ETW::TieredCompilationLog::Runtime::SendPause()
         NOTHROW;
         GC_NOTRIGGER;
     } CONTRACTL_END;
-    ValidateSend();
+    _ASSERTE(IsEnabled());
+    _ASSERTE(g_pConfig->TieredCompilation());
 
     FireEtwTieredCompilationPause(GetClrInstanceId());
 }
@@ -7499,7 +7492,8 @@ void ETW::TieredCompilationLog::Runtime::SendResume(UINT32 newMethodCount)
         NOTHROW;
         GC_NOTRIGGER;
     } CONTRACTL_END;
-    ValidateSend();
+    _ASSERTE(IsEnabled());
+    _ASSERTE(g_pConfig->TieredCompilation());
 
     FireEtwTieredCompilationResume(GetClrInstanceId(), newMethodCount);
 }
@@ -7510,7 +7504,8 @@ void ETW::TieredCompilationLog::Runtime::SendBackgroundJitStart(UINT32 pendingMe
         NOTHROW;
         GC_NOTRIGGER;
     } CONTRACTL_END;
-    ValidateSend();
+    _ASSERTE(IsEnabled());
+    _ASSERTE(g_pConfig->TieredCompilation());
 
     FireEtwTieredCompilationBackgroundJitStart(GetClrInstanceId(), pendingMethodCount);
 }
@@ -7521,7 +7516,8 @@ void ETW::TieredCompilationLog::Runtime::SendBackgroundJitStop(UINT32 pendingMet
         NOTHROW;
         GC_NOTRIGGER;
     } CONTRACTL_END;
-    ValidateSend();
+    _ASSERTE(IsEnabled());
+    _ASSERTE(g_pConfig->TieredCompilation());
 
     FireEtwTieredCompilationBackgroundJitStop(GetClrInstanceId(), pendingMethodCount, jittedMethodCount);
 }

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -4464,9 +4464,9 @@ extern "C"
                 // Fire the runtime information event
                 ETW::InfoLog::RuntimeInformation(ETW::InfoLog::InfoStructs::Callback);
 
-                if (ETW::TieredCompilationLog::Rundown::IsEnabled() && g_pConfig->TieredCompilation())
+                if (ETW::CompilationLog::TieredCompilation::Rundown::IsEnabled() && g_pConfig->TieredCompilation())
                 {
-                    ETW::TieredCompilationLog::Rundown::SendSettings();
+                    ETW::CompilationLog::TieredCompilation::Rundown::SendSettings();
                 }
 
                 // Start and End Method/Module Rundowns
@@ -7402,7 +7402,7 @@ VOID ETW::EnumerationLog::EnumerationHelper(Module *moduleFilter, BaseDomain *do
     }
 }
 
-void ETW::TieredCompilationLog::GetSettings(UINT32 *flagsRef)
+void ETW::CompilationLog::TieredCompilation::GetSettings(UINT32 *flagsRef)
 {
     CONTRACTL {
         NOTHROW;
@@ -7430,7 +7430,7 @@ void ETW::TieredCompilationLog::GetSettings(UINT32 *flagsRef)
     *flagsRef = flags;
 }
 
-void ETW::TieredCompilationLog::Runtime::SendSettings()
+void ETW::CompilationLog::TieredCompilation::Runtime::SendSettings()
 {
     CONTRACTL {
         NOTHROW;
@@ -7445,7 +7445,7 @@ void ETW::TieredCompilationLog::Runtime::SendSettings()
     FireEtwTieredCompilationSettings(GetClrInstanceId(), flags);
 }
 
-void ETW::TieredCompilationLog::Rundown::SendSettings()
+void ETW::CompilationLog::TieredCompilation::Rundown::SendSettings()
 {
     CONTRACTL {
         NOTHROW;
@@ -7460,7 +7460,7 @@ void ETW::TieredCompilationLog::Rundown::SendSettings()
     FireEtwTieredCompilationSettingsDCStart(GetClrInstanceId(), flags);
 }
 
-void ETW::TieredCompilationLog::Runtime::SendPause()
+void ETW::CompilationLog::TieredCompilation::Runtime::SendPause()
 {
     CONTRACTL {
         NOTHROW;
@@ -7472,7 +7472,7 @@ void ETW::TieredCompilationLog::Runtime::SendPause()
     FireEtwTieredCompilationPause(GetClrInstanceId());
 }
 
-void ETW::TieredCompilationLog::Runtime::SendResume(UINT32 newMethodCount)
+void ETW::CompilationLog::TieredCompilation::Runtime::SendResume(UINT32 newMethodCount)
 {
     CONTRACTL {
         NOTHROW;
@@ -7484,7 +7484,7 @@ void ETW::TieredCompilationLog::Runtime::SendResume(UINT32 newMethodCount)
     FireEtwTieredCompilationResume(GetClrInstanceId(), newMethodCount);
 }
 
-void ETW::TieredCompilationLog::Runtime::SendBackgroundJitStart(UINT32 pendingMethodCount)
+void ETW::CompilationLog::TieredCompilation::Runtime::SendBackgroundJitStart(UINT32 pendingMethodCount)
 {
     CONTRACTL {
         NOTHROW;
@@ -7496,7 +7496,7 @@ void ETW::TieredCompilationLog::Runtime::SendBackgroundJitStart(UINT32 pendingMe
     FireEtwTieredCompilationBackgroundJitStart(GetClrInstanceId(), pendingMethodCount);
 }
 
-void ETW::TieredCompilationLog::Runtime::SendBackgroundJitStop(UINT32 pendingMethodCount, UINT32 jittedMethodCount)
+void ETW::CompilationLog::TieredCompilation::Runtime::SendBackgroundJitStop(UINT32 pendingMethodCount, UINT32 jittedMethodCount)
 {
     CONTRACTL {
         NOTHROW;

--- a/src/vm/eventtrace.inl
+++ b/src/vm/eventtrace.inl
@@ -10,7 +10,7 @@ FORCEINLINE bool ETW::TieredCompilationLog::Runtime::IsEnabled()
 {
     CONTRACTL{
         NOTHROW;
-    GC_NOTRIGGER;
+        GC_NOTRIGGER;
     } CONTRACTL_END;
 
     return
@@ -24,7 +24,7 @@ FORCEINLINE bool ETW::TieredCompilationLog::Rundown::IsEnabled()
 {
     CONTRACTL{
         NOTHROW;
-    GC_NOTRIGGER;
+        GC_NOTRIGGER;
     } CONTRACTL_END;
 
     return

--- a/src/vm/eventtrace.inl
+++ b/src/vm/eventtrace.inl
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#ifdef FEATURE_EVENT_TRACE
+
+FORCEINLINE bool ETW::TieredCompilationLog::Runtime::IsEnabled()
+{
+    CONTRACTL{
+        NOTHROW;
+    GC_NOTRIGGER;
+    } CONTRACTL_END;
+
+    return
+        ETW_TRACING_CATEGORY_ENABLED(
+            MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_Context,
+            TRACE_LEVEL_INFORMATION,
+            CLR_TIERED_COMPILATION_KEYWORD);
+}
+
+FORCEINLINE bool ETW::TieredCompilationLog::Rundown::IsEnabled()
+{
+    CONTRACTL{
+        NOTHROW;
+    GC_NOTRIGGER;
+    } CONTRACTL_END;
+
+    return
+        ETW_TRACING_CATEGORY_ENABLED(
+            MICROSOFT_WINDOWS_DOTNETRUNTIME_RUNDOWN_PROVIDER_Context,
+            TRACE_LEVEL_INFORMATION,
+            CLR_TIERED_COMPILATION_RUNDOWN_KEYWORD);
+}
+
+#endif // FEATURE_EVENT_TRACE

--- a/src/vm/eventtrace.inl
+++ b/src/vm/eventtrace.inl
@@ -6,9 +6,9 @@
 
 #ifdef FEATURE_EVENT_TRACE
 
-FORCEINLINE bool ETW::TieredCompilationLog::Runtime::IsEnabled()
+FORCEINLINE bool ETW::CompilationLog::Runtime::IsEnabled()
 {
-    CONTRACTL{
+    CONTRACTL {
         NOTHROW;
         GC_NOTRIGGER;
     } CONTRACTL_END;
@@ -17,12 +17,12 @@ FORCEINLINE bool ETW::TieredCompilationLog::Runtime::IsEnabled()
         ETW_TRACING_CATEGORY_ENABLED(
             MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_Context,
             TRACE_LEVEL_INFORMATION,
-            CLR_TIERED_COMPILATION_KEYWORD);
+            CLR_COMPILATION_KEYWORD);
 }
 
-FORCEINLINE bool ETW::TieredCompilationLog::Rundown::IsEnabled()
+FORCEINLINE bool ETW::CompilationLog::Rundown::IsEnabled()
 {
-    CONTRACTL{
+    CONTRACTL {
         NOTHROW;
         GC_NOTRIGGER;
     } CONTRACTL_END;
@@ -31,7 +31,19 @@ FORCEINLINE bool ETW::TieredCompilationLog::Rundown::IsEnabled()
         ETW_TRACING_CATEGORY_ENABLED(
             MICROSOFT_WINDOWS_DOTNETRUNTIME_RUNDOWN_PROVIDER_Context,
             TRACE_LEVEL_INFORMATION,
-            CLR_TIERED_COMPILATION_RUNDOWN_KEYWORD);
+            CLR_COMPILATION_RUNDOWN_KEYWORD);
+}
+
+FORCEINLINE bool ETW::CompilationLog::TieredCompilation::Runtime::IsEnabled()
+{
+    WRAPPER_NO_CONTRACT;
+    return CompilationLog::Runtime::IsEnabled();
+}
+
+FORCEINLINE bool ETW::CompilationLog::TieredCompilation::Rundown::IsEnabled()
+{
+    WRAPPER_NO_CONTRACT;
+    return CompilationLog::Rundown::IsEnabled();
 }
 
 #endif // FEATURE_EVENT_TRACE

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -4803,9 +4803,9 @@ bool MethodDesc::DetermineAndSetIsEligibleForTieredCompilation()
         // Functional requirement
         CodeVersionManager::IsMethodSupported(this) &&
 
-        // Policy - If quick JIT is disabled for the startup tier and the module is not ReadyToRun, the method would effectively
-        // not be tiered currently, so make the method ineligible for tiering to avoid some unnecessary overhead
-        (g_pConfig->TieredCompilation_QuickJit() || GetModule()->IsReadyToRun()) &&
+        // Policy - If QuickJit is disabled and the module does not have any pregenerated code, the method would effectively not
+        // be tiered currently, so make the method ineligible for tiering to avoid some unnecessary overhead
+        (g_pConfig->TieredCompilation_QuickJit() || GetModule()->HasNativeOrReadyToRunImage()) &&
 
         // Policy - Generating optimized code is not disabled
         !IsJitOptimizationDisabled() &&
@@ -4822,8 +4822,9 @@ bool MethodDesc::DetermineAndSetIsEligibleForTieredCompilation()
     return false;
 }
 
-#ifndef CROSSGEN_COMPILE
+#endif // !DACCESS_COMPILE
 
+#ifndef CROSSGEN_COMPILE
 bool MethodDesc::IsJitOptimizationDisabled()
 {
     WRAPPER_NO_CONTRACT;
@@ -4836,6 +4837,10 @@ bool MethodDesc::IsJitOptimizationDisabled()
         CORDisableJITOptimizations(GetModule()->GetDebuggerInfoBits()) ||
         (!IsNoMetadata() && IsMiNoOptimization(GetImplAttrs()));
 }
+#endif
+
+#ifndef DACCESS_COMPILE
+#ifndef CROSSGEN_COMPILE
 
 void MethodDesc::RecordAndBackpatchEntryPointSlot(
     LoaderAllocator *slotLoaderAllocator, // the loader allocator from which the slot's memory is allocated

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -1243,6 +1243,8 @@ public:
     // can optimize its performance? Eligibility is invariant for the lifetime of a method.
     bool DetermineAndSetIsEligibleForTieredCompilation();
 
+    bool IsJitOptimizationDisabled();
+
 private:
     // This function is not intended to be called in most places, and is named as such to discourage calling it accidentally
     bool Helper_IsEligibleForVersioningWithVtableSlotBackpatch()

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -2092,6 +2092,20 @@ public:
         }
     }
 #endif
+
+    PrepareCodeConfig *GetNextInSameThread() const
+    {
+        LIMITED_METHOD_CONTRACT;
+        return m_nextInSameThread;
+    }
+
+    void SetNextInSameThread(PrepareCodeConfig *config)
+    {
+        LIMITED_METHOD_CONTRACT;
+        _ASSERTE(config == nullptr || m_nextInSameThread == nullptr);
+
+        m_nextInSameThread = config;
+    }
 #endif // !CROSSGEN_COMPILE
     
 protected:
@@ -2108,6 +2122,7 @@ private:
 #ifdef FEATURE_TIERED_COMPILATION
     bool m_jitSwitchedToOptimized; // when a different tier was requested
 #endif
+    PrepareCodeConfig *m_nextInSameThread;
 #endif // !CROSSGEN_COMPILE
 };
 

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -2057,6 +2057,42 @@ public:
     BOOL ReadyToRunRejectedPrecompiledCode();
     void SetProfilerRejectedPrecompiledCode();
     void SetReadyToRunRejectedPrecompiledCode();
+
+#ifndef CROSSGEN_COMPILE
+    bool JitSwitchedToMinOpt() const
+    {
+        LIMITED_METHOD_CONTRACT;
+        return m_jitSwitchedToMinOpt;
+    }
+
+    void SetJitSwitchedToMinOpt()
+    {
+        LIMITED_METHOD_CONTRACT;
+
+#ifdef FEATURE_TIERED_COMPILATION
+        m_jitSwitchedToOptimized = false;
+#endif
+        m_jitSwitchedToMinOpt = true;
+    }
+
+#ifdef FEATURE_TIERED_COMPILATION
+    bool JitSwitchedToOptimized() const
+    {
+        LIMITED_METHOD_CONTRACT;
+        return m_jitSwitchedToOptimized;
+    }
+
+    void SetJitSwitchedToOptimized()
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        if (!m_jitSwitchedToMinOpt)
+        {
+            m_jitSwitchedToOptimized = true;
+        }
+    }
+#endif
+#endif // !CROSSGEN_COMPILE
     
 protected:
     MethodDesc* m_pMethodDesc;
@@ -2065,6 +2101,14 @@ protected:
     BOOL m_mayUsePrecompiledCode;
     BOOL m_ProfilerRejectedPrecompiledCode;
     BOOL m_ReadyToRunRejectedPrecompiledCode;
+
+#ifndef CROSSGEN_COMPILE
+private:
+    bool m_jitSwitchedToMinOpt; // when it wasn't requested
+#ifdef FEATURE_TIERED_COMPILATION
+    bool m_jitSwitchedToOptimized; // when a different tier was requested
+#endif
+#endif // !CROSSGEN_COMPILE
 };
 
 #ifdef FEATURE_CODE_VERSIONING

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -6959,9 +6959,9 @@ MethodTableBuilder::NeedsNativeCodeSlot(bmtMDMethod * pMDMethod)
     // Keep in-sync with MethodDesc::DetermineAndSetIsEligibleForTieredCompilation()
     if (g_pConfig->TieredCompilation() &&
 
-        // Policy - If QuickJit is disabled and the module is not ReadyToRun, the method would be ineligible for tiering
-        // currently to avoid some unnecessary overhead
-        (g_pConfig->TieredCompilation_QuickJit() || GetModule()->IsReadyToRun()) &&
+        // Policy - If QuickJit is disabled and the module does not have any pregenerated code, the method would be ineligible
+        // for tiering currently to avoid some unnecessary overhead
+        (g_pConfig->TieredCompilation_QuickJit() || GetModule()->HasNativeOrReadyToRunImage()) &&
 
         (pMDMethod->GetMethodType() == METHOD_TYPE_NORMAL || pMDMethod->GetMethodType() == METHOD_TYPE_INSTANTIATED))
     {

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -377,7 +377,7 @@ PCODE MethodDesc::PrepareILBasedCode(PrepareCodeConfig* pConfig)
             CallCounter::IsEligibleForCallCounting(this))
         {
             GetCallCounter()->DisableCallCounting(this);
-            pConfig->GetCodeVersion().SetOptimizationTier(NativeCodeVersion::OptimizationTier1);
+            pConfig->GetCodeVersion().SetOptimizationTier(NativeCodeVersion::OptimizationTierOptimized);
         }
 #endif
 
@@ -912,6 +912,10 @@ PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEn
     PCODE pOtherCode = NULL;
     EX_TRY
     {
+#ifndef CROSSGEN_COMPILE
+        Thread::CurrentPrepareCodeConfigHolder threadPrepareCodeConfigHolder(GetThread(), pConfig);
+#endif
+
         pCode = UnsafeJitFunction(pConfig->GetCodeVersion(), pilHeader, *pFlags, pSizeOfCode);
     }
     EX_CATCH
@@ -937,15 +941,15 @@ PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEn
     }
     EX_END_CATCH(RethrowTerminalExceptions)
 
-        if (pOtherCode != NULL)
-        {
-            // Somebody finished jitting recursively while we were jitting the method.
-            // Just use their method & leak the one we finished. (Normally we hope
-            // not to finish our JIT in this case, as we will abort early if we notice
-            // a reentrant jit has occurred.  But we may not catch every place so we
-            // do a definitive final check here.
-            return pOtherCode;
-        }
+    if (pOtherCode != NULL)
+    {
+        // Somebody finished jitting recursively while we were jitting the method.
+        // Just use their method & leak the one we finished. (Normally we hope
+        // not to finish our JIT in this case, as we will abort early if we notice
+        // a reentrant jit has occurred.  But we may not catch every place so we
+        // do a definitive final check here.
+        return pOtherCode;
+    }
 
     _ASSERTE(pCode != NULL);
 
@@ -989,17 +993,17 @@ PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEn
     }
 
 #ifdef FEATURE_TIERED_COMPILATION
-    if (pFlags->IsSet(CORJIT_FLAGS::CORJIT_FLAG_TIER0))
+    if (pConfig->JitSwitchedToOptimized())
     {
+        _ASSERTE(pFlags->IsSet(CORJIT_FLAGS::CORJIT_FLAG_TIER0));
+
         MethodDesc *methodDesc = pConfig->GetMethodDesc();
         _ASSERTE(methodDesc->IsEligibleForTieredCompilation());
 
-        // Update the tier in the code version. The JIT may have decided to switch from tier 0 to tier 1, in which case call
-        // counting would have been disabled for the method.
-        if (!methodDesc->GetCallCounter()->IsCallCountingEnabled(methodDesc))
-        {
-            pConfig->GetCodeVersion().SetOptimizationTier(NativeCodeVersion::OptimizationTier1);
-        }
+        // Update the tier in the code version. The JIT may have decided to switch from tier 0 to optimized, in which case call
+        // counting would have to be disabled for the method.
+        methodDesc->GetCallCounter()->DisableCallCounting(methodDesc);
+        pConfig->GetCodeVersion().SetOptimizationTier(NativeCodeVersion::OptimizationTierOptimized);
     }
 #endif
 
@@ -1023,7 +1027,11 @@ PrepareCodeConfig::PrepareCodeConfig(NativeCodeVersion codeVersion, BOOL needsMu
     m_needsMulticoreJitNotification(needsMulticoreJitNotification),
     m_mayUsePrecompiledCode(mayUsePrecompiledCode),
     m_ProfilerRejectedPrecompiledCode(FALSE),
-    m_ReadyToRunRejectedPrecompiledCode(FALSE)
+    m_ReadyToRunRejectedPrecompiledCode(FALSE),
+    m_jitSwitchedToMinOpt(false)
+#ifdef FEATURE_TIERED_COMPILATION
+    , m_jitSwitchedToOptimized(false)
+#endif
 {}
 
 MethodDesc* PrepareCodeConfig::GetMethodDesc()

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -1028,10 +1028,11 @@ PrepareCodeConfig::PrepareCodeConfig(NativeCodeVersion codeVersion, BOOL needsMu
     m_mayUsePrecompiledCode(mayUsePrecompiledCode),
     m_ProfilerRejectedPrecompiledCode(FALSE),
     m_ReadyToRunRejectedPrecompiledCode(FALSE),
-    m_jitSwitchedToMinOpt(false)
+    m_jitSwitchedToMinOpt(false),
 #ifdef FEATURE_TIERED_COMPILATION
-    , m_jitSwitchedToOptimized(false)
+    m_jitSwitchedToOptimized(false),
 #endif
+    m_nextInSameThread(nullptr)
 {}
 
 MethodDesc* PrepareCodeConfig::GetMethodDesc()

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -811,10 +811,7 @@ PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, J
                 &methodName,
                 &methodSignature,
                 pCode,
-                pConfig->GetCodeVersion().GetILCodeVersionId(),
-                pConfig->GetCodeVersion().GetVersionId(),
-                pConfig->ProfilerRejectedPrecompiledCode(),
-                pConfig->ReadyToRunRejectedPrecompiledCode());
+                pConfig);
         }
 
     }

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -1551,6 +1551,8 @@ Thread::Thread()
 #endif // FEATURE_PERFTRACING
     m_HijackReturnKind = RT_Illegal;
     m_DeserializationTracker = NULL;
+
+    m_currentPrepareCodeConfig = nullptr;
 }
 
 //--------------------------------------------------------------------

--- a/src/vm/threads.h
+++ b/src/vm/threads.h
@@ -167,6 +167,7 @@ enum      BinderMethodID : int;
 class     CRWLock;
 struct    LockEntry;
 class     PendingTypeLoadHolder;
+class     PrepareCodeConfig;
 
 struct    ThreadLocalBlock;
 typedef DPTR(struct ThreadLocalBlock) PTR_ThreadLocalBlock;
@@ -5002,6 +5003,32 @@ private:
 
 public:
     static uint64_t dead_threads_non_alloc_bytes;
+
+#ifndef DACCESS_COMPILE
+public:
+    class CurrentPrepareCodeConfigHolder
+    {
+    private:
+        Thread *const m_thread;
+#ifdef _DEBUG
+        PrepareCodeConfig *const m_config;
+#endif
+
+    public:
+        CurrentPrepareCodeConfigHolder(Thread *thread, PrepareCodeConfig *config);
+        ~CurrentPrepareCodeConfigHolder();
+    };
+
+public:
+    PrepareCodeConfig *GetCurrentPrepareCodeConfig() const
+    {
+        LIMITED_METHOD_CONTRACT;
+        return m_currentPrepareCodeConfig;
+    }
+#endif // !DACCESS_COMPILE
+
+private:
+    PrepareCodeConfig *m_currentPrepareCodeConfig;
 };
 
 // End of class Thread

--- a/src/vm/threads.inl
+++ b/src/vm/threads.inl
@@ -195,17 +195,23 @@ inline Thread::CurrentPrepareCodeConfigHolder::CurrentPrepareCodeConfigHolder(Th
     _ASSERTE(thread != nullptr);
     _ASSERTE(thread == GetThread());
     _ASSERTE(config != nullptr);
-    _ASSERTE(thread->m_currentPrepareCodeConfig == nullptr);
 
+    PrepareCodeConfig *previousConfig = thread->m_currentPrepareCodeConfig;
+    if (previousConfig != nullptr)
+    {
+        config->SetNextInSameThread(previousConfig);
+    }
     thread->m_currentPrepareCodeConfig = config;
 }
 
 inline Thread::CurrentPrepareCodeConfigHolder::~CurrentPrepareCodeConfigHolder()
 {
     LIMITED_METHOD_CONTRACT;
-    _ASSERTE(m_thread->m_currentPrepareCodeConfig == m_config);
 
-    m_thread->m_currentPrepareCodeConfig = nullptr;
+    PrepareCodeConfig *config = m_thread->m_currentPrepareCodeConfig;
+    _ASSERTE(config == m_config);
+    m_thread->m_currentPrepareCodeConfig = config->GetNextInSameThread();
+    config->SetNextInSameThread(nullptr);
 }
 
 #endif // !DACCESS_COMPILE && !CROSSGEN_COMPILE

--- a/src/vm/threads.inl
+++ b/src/vm/threads.inl
@@ -183,4 +183,31 @@ inline void Thread::SetGCSpecial(bool fGCSpecial)
     m_fGCSpecial = fGCSpecial;
 }
 
+#if !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
+
+inline Thread::CurrentPrepareCodeConfigHolder::CurrentPrepareCodeConfigHolder(Thread *thread, PrepareCodeConfig *config)
+    : m_thread(thread)
+#ifdef _DEBUG
+    , m_config(config)
+#endif
+{
+    LIMITED_METHOD_CONTRACT;
+    _ASSERTE(thread != nullptr);
+    _ASSERTE(thread == GetThread());
+    _ASSERTE(config != nullptr);
+    _ASSERTE(thread->m_currentPrepareCodeConfig == nullptr);
+
+    thread->m_currentPrepareCodeConfig = config;
+}
+
+inline Thread::CurrentPrepareCodeConfigHolder::~CurrentPrepareCodeConfigHolder()
+{
+    LIMITED_METHOD_CONTRACT;
+    _ASSERTE(m_thread->m_currentPrepareCodeConfig == m_config);
+
+    m_thread->m_currentPrepareCodeConfig = nullptr;
+}
+
+#endif // !DACCESS_COMPILE && !CROSSGEN_COMPILE
+
 #endif

--- a/src/vm/tieredcompilation.cpp
+++ b/src/vm/tieredcompilation.cpp
@@ -386,9 +386,9 @@ bool TieredCompilationManager::TryInitiateTieringDelay()
     }
 
     timerContextHolder.SuppressRelease(); // the timer context is automatically deleted by the timer infrastructure
-    if (ETW::TieredCompilationLog::Runtime::IsEnabled())
+    if (ETW::CompilationLog::TieredCompilation::Runtime::IsEnabled())
     {
-        ETW::TieredCompilationLog::Runtime::SendPause();
+        ETW::CompilationLog::TieredCompilation::Runtime::SendPause();
     }
     return true;
 }
@@ -488,7 +488,7 @@ void TieredCompilationManager::TieringDelayTimerCallbackWorker()
     MethodDesc** methods = methodsPendingCountingForTier1->GetElements();
     COUNT_T methodCount = methodsPendingCountingForTier1->GetCount();
 
-    if (ETW::TieredCompilationLog::Runtime::IsEnabled())
+    if (ETW::CompilationLog::TieredCompilation::Runtime::IsEnabled())
     {
         // TODO: Avoid scanning the list in the future
         UINT32 newMethodCount = 0;
@@ -500,7 +500,7 @@ void TieredCompilationManager::TieringDelayTimerCallbackWorker()
                 ++newMethodCount;
             }
         }
-        ETW::TieredCompilationLog::Runtime::SendResume(newMethodCount);
+        ETW::CompilationLog::TieredCompilation::Runtime::SendResume(newMethodCount);
     }
 
     // Install call counters
@@ -624,9 +624,9 @@ void TieredCompilationManager::OptimizeMethods()
     // work item to the thread pool and return this thread back to the pool.
     const DWORD OptimizationQuantumMs = 50;
 
-    if (ETW::TieredCompilationLog::Runtime::IsEnabled())
+    if (ETW::CompilationLog::TieredCompilation::Runtime::IsEnabled())
     {
-        ETW::TieredCompilationLog::Runtime::SendBackgroundJitStart(m_countOfMethodsToOptimize);
+        ETW::CompilationLog::TieredCompilation::Runtime::SendBackgroundJitStart(m_countOfMethodsToOptimize);
     }
 
     UINT32 jittedMethodCount = 0;
@@ -684,9 +684,9 @@ void TieredCompilationManager::OptimizeMethods()
     }
     EX_END_CATCH(RethrowTerminalExceptions);
 
-    if (ETW::TieredCompilationLog::Runtime::IsEnabled())
+    if (ETW::CompilationLog::TieredCompilation::Runtime::IsEnabled())
     {
-        ETW::TieredCompilationLog::Runtime::SendBackgroundJitStop(m_countOfMethodsToOptimize, jittedMethodCount);
+        ETW::CompilationLog::TieredCompilation::Runtime::SendBackgroundJitStop(m_countOfMethodsToOptimize, jittedMethodCount);
     }
 }
 

--- a/src/vm/tieredcompilation.h
+++ b/src/vm/tieredcompilation.h
@@ -65,9 +65,9 @@ private:
 
     Crst m_lock;
     SList<SListElem<NativeCodeVersion>> m_methodsToOptimize;
+    UINT32 m_countOfMethodsToOptimize;
     BOOL m_isAppDomainShuttingDown;
     DWORD m_countOptimizationThreadsRunning;
-    DWORD m_optimizationQuantumMs;
     SArray<MethodDesc*>* m_methodsPendingCountingForTier1;
     HANDLE m_tieringDelayTimerHandle;
     bool m_tier1CallCountingCandidateMethodRecentlyRecorded;


### PR DESCRIPTION
New events:
- `Settings` - Sent when TC is enabled
  - `Flags` - Currently indicates whether QuickJit and QuickJitForLoops are enabled
- `Pause` - Sent when TC is paused (due to a new method being called for the first time)
- `Resume` - Sent when TC resumes
  - `NewMethodCount` - Number of methods called for the first time while tiering was paused
- `BackgroundJitStart` - Sent when starting to JIT methods in the background
  - `PendingMethodCount` - Number of methods currently scheduled for background JIT
- `BackgroundJitStop` - Sent when background jitting stops
  - `PendingMethodCount` - Same as above. When 0, background jitting has completed.
  - `JittedMethodCount` - Number of methods jitted in the background since the previous `BackgroundJitStart` event on the same thread

Miscellaneous:
- Updated method JIT events to include the optimization tier
- Added a couple more cases where tiered compilation is disabled for methods that have JIT optimization disabled for some reason
- Renamed `Duration` field of the new version of the `ContentionEnd` to `DurationNs` to indicate the units of time

PerfView PR: https://github.com/microsoft/perfview/pull/939
PerfCollect PR: https://github.com/dotnet/corefx-tools/pull/103
Fixes https://github.com/dotnet/coreclr/issues/23221