### PR TITLE
Propagate module override recursively in generic signatures

### DIFF
--- a/src/vm/siginfo.cpp
+++ b/src/vm/siginfo.cpp
@@ -1403,7 +1403,7 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
 
                 if (typeHnd.IsNull())
                 {
-                    typeHnd = psig.GetTypeHandleThrowing(pOrigModule, 
+                    typeHnd = psig.GetTypeHandleThrowing(pModule,
                                                          pTypeContext, 
                                                          fLoadTypes, 
                                                          argLevel,

--- a/src/vm/zapsig.cpp
+++ b/src/vm/zapsig.cpp
@@ -262,6 +262,10 @@ BOOL ZapSig::GetSignatureForTypeHandle(TypeHandle      handle,
 
     if (fNeedsInstantiation)
     {
+        // Save the current pInfoModule and change it to the module of the type handle 
+        Module *pOrigModule = this->context.pInfoModule;
+        this->context.pInfoModule = pTypeHandleModule;
+
         pSigBuilder->AppendData(pMT->GetNumGenericArgs());
         Instantiation inst = pMT->GetInstantiation();
         for (DWORD i = 0; i < inst.GetNumArgs(); i++)
@@ -271,6 +275,9 @@ BOOL ZapSig::GetSignatureForTypeHandle(TypeHandle      handle,
             if (!this->GetSignatureForTypeHandle(t, pSigBuilder))
                 return FALSE;
         }
+
+        // Restore the saved pInfoModule
+        this->context.pInfoModule = pOrigModule;
     }
     return TRUE;
 }


### PR DESCRIPTION
Signatures of generic types that contain multiple levels of generics
currently apply module override only on the level where it was defined.
This complicates cases when we copy a signature as-is from one module
and want to apply module override to it since we store it in another
module. We would need to parse the whole signature and insert overrides
at all levels.
This change modifies runtime so that the module override is propagated
recursively through a generic signature hierarchy. A related change
was necessary on the crossgen side.

It fixes failure in IEnumerable_Generic_Enumerator_Reset_ModifiedDuringEnumeration_ThrowsInvalidOperationException corefx test when crossgen-ed with large version bubble enabled.