### PR TITLE
Implement AppDomain.Monitoring*MemorySize

### DIFF
--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -3220,9 +3220,6 @@
   <data name="PlatformNotSupported_CAS" xml:space="preserve">
     <value>Code Access Security is not supported on this platform.</value>
   </data>
-  <data name="PlatformNotSupported_AppDomain_ResMon" xml:space="preserve">
-    <value>AppDomain resource monitoring is not supported on this platform.</value>
-  </data>
   <data name="PlatformNotSupported_Principal" xml:space="preserve">
     <value>Windows Principal functionality is not supported on this platform.</value>
   </data>

--- a/src/System.Private.CoreLib/shared/Interop/Unix/System.Native/Interop.GetCpuUtilization.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Unix/System.Native/Interop.GetCpuUtilization.cs
@@ -13,9 +13,9 @@ internal static partial class Interop
         [StructLayout(LayoutKind.Sequential)]
         internal struct ProcessCpuInformation
         {
-            ulong lastRecordedCurrentTime;
-            ulong lastRecordedKernelTime;
-            ulong lastRecordedUserTime;
+            internal ulong lastRecordedCurrentTime;
+            internal ulong lastRecordedKernelTime;
+            internal ulong lastRecordedUserTime;
         }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetCpuUtilization")]

--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -1091,6 +1091,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Internal\IO\File.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeFileHandle.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeFindHandle.Windows.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\AppDomain.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffer.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\DateTime.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Environment.Windows.cs" />
@@ -1253,6 +1254,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Unix\System.Native\Interop.Write.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Internal\IO\File.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeFileHandle.Unix.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\AppDomain.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffer.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\DateTime.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\DebugProvider.Unix.cs" />

--- a/src/System.Private.CoreLib/shared/System/AppDomain.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/AppDomain.Unix.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System
+{
+    public sealed partial class AppDomain
+    {
+        public TimeSpan MonitoringTotalProcessorTime
+        {
+            get
+            {
+                Interop.Sys.ProcessCpuInformation cpuInfo = default;
+                Interop.Sys.GetCpuUtilization(ref cpuInfo);
+
+                ulong userTime100Nanoseconds = cpuInfo.lastRecordedUserTime / 100; // nanoseconds to 100-nanoseconds
+                if (userTime100Nanoseconds > long.MaxValue)
+                {
+                    userTime100Nanoseconds = long.MaxValue;
+                }
+
+                return new TimeSpan((long)userTime100Nanoseconds);
+            }
+        }
+    }
+}

--- a/src/System.Private.CoreLib/shared/System/AppDomain.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/AppDomain.Windows.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System
+{
+    public sealed partial class AppDomain
+    {
+        public TimeSpan MonitoringTotalProcessorTime =>
+            Interop.Kernel32.GetProcessTimes(Interop.Kernel32.GetCurrentProcess(), out _, out _, out _, out long userTime100Nanoseconds) ?
+                new TimeSpan(userTime100Nanoseconds) :
+                TimeSpan.Zero;
+    }
+}

--- a/src/System.Private.CoreLib/shared/System/AppDomain.cs
+++ b/src/System.Private.CoreLib/shared/System/AppDomain.cs
@@ -205,7 +205,7 @@ namespace System
             }
         }
 
-        public long MonitoringTotalAllocatedMemorySize => GC.GetTotalAllocatedBytes(precise: true);
+        public long MonitoringTotalAllocatedMemorySize => GC.GetTotalAllocatedBytes(precise: false);
 
         [ObsoleteAttribute("AppDomain.GetCurrentThreadId has been deprecated because it does not provide a stable Id when managed threads are running on fibers (aka lightweight threads). To get a stable identifier for a managed thread, use the ManagedThreadId property on Thread.  https://go.microsoft.com/fwlink/?linkid=14202", false)]
         public static int GetCurrentThreadId() => Environment.CurrentManagedThreadId;

--- a/src/System.Private.CoreLib/shared/System/AppDomain.cs
+++ b/src/System.Private.CoreLib/shared/System/AppDomain.cs
@@ -184,26 +184,28 @@ namespace System
 
         public static bool MonitoringIsEnabled
         {
-            get { return false; }
+            get { return true; }
             set
             {
                 if (!value)
                 {
                     throw new ArgumentException(SR.Arg_MustBeTrue);
                 }
-                throw new PlatformNotSupportedException(SR.PlatformNotSupported_AppDomain_ResMon);
             }
         }
 
-        public long MonitoringSurvivedMemorySize { get { throw CreateResMonNotAvailException(); } }
+        public long MonitoringSurvivedMemorySize => MonitoringSurvivedProcessMemorySize;
 
-        public static long MonitoringSurvivedProcessMemorySize { get { throw CreateResMonNotAvailException(); } }
+        public static long MonitoringSurvivedProcessMemorySize
+        {
+            get
+            {
+                GCMemoryInfo mi = GC.GetGCMemoryInfo();
+                return mi.HeapSizeBytes - mi.FragmentedBytes;
+            }
+        }
 
-        public long MonitoringTotalAllocatedMemorySize { get { throw CreateResMonNotAvailException(); } }
-
-        public TimeSpan MonitoringTotalProcessorTime { get { throw CreateResMonNotAvailException(); } }
-
-        private static Exception CreateResMonNotAvailException() => new InvalidOperationException(SR.PlatformNotSupported_AppDomain_ResMon);
+        public long MonitoringTotalAllocatedMemorySize => GC.GetTotalAllocatedBytes(precise: true);
 
         [ObsoleteAttribute("AppDomain.GetCurrentThreadId has been deprecated because it does not provide a stable Id when managed threads are running on fibers (aka lightweight threads). To get a stable identifier for a managed thread, use the ManagedThreadId property on Thread.  https://go.microsoft.com/fwlink/?linkid=14202", false)]
         public static int GetCurrentThreadId() => Environment.CurrentManagedThreadId;

--- a/tests/CoreFX/CoreFX.issues.rsp
+++ b/tests/CoreFX/CoreFX.issues.rsp
@@ -324,6 +324,11 @@
 -nomethod System.CodeDom.Compiler.Tests.VBCodeGenerationTests.MetadataAttributes
 -nomethod System.CodeDom.Compiler.Tests.VBCodeGenerationTests.ProviderSupports
 -nomethod System.Runtime.InteropServices.RuntimeInformationTests.DescriptionNameTests.VerifyRuntimeDebugNameOnNetCoreApp
+-nomethod System.Tests.AppDomainTests.MonitoringIsEnabled
+-nomethod System.Tests.AppDomainTests.MonitoringSurvivedMemorySize
+-nomethod System.Tests.AppDomainTests.MonitoringSurvivedProcessMemorySize
+-nomethod System.Tests.AppDomainTests.MonitoringTotalAllocatedMemorySize
+-nomethod System.Tests.AppDomainTests.MonitoringTotalProcessorTime
 
 # Disable Tests from SqlClient entirely
 -nonamespace System.Data.SqlClient.Tests


### PR DESCRIPTION
Tools like Benchmark.NET use this API to get total allocated memory.  Any reason not to make it work by just calling GC.GetTotalAllocatedBytes?

cc: @jkotas, @Maoni0, @VSadov, @luhenry 