### PR TITLE
Fix cross-compilation with CMake 3.14

### DIFF
--- a/cross/tryrun.cmake
+++ b/cross/tryrun.cmake
@@ -3,6 +3,7 @@ set(TARGET_ARCH_NAME $ENV{TARGET_BUILD_ARCH})
 
 macro(set_cache_value)
   set(${ARGV0} ${ARGV1} CACHE STRING "Result from TRY_RUN" FORCE)
+  set(${ARGV0}__TRYRUN_OUTPUT "dummy output" CACHE STRING "Output from TRY_RUN" FORCE)
 endmacro()
 
 if(EXISTS ${CROSS_ROOTFS}/usr/lib/gcc/armv6-alpine-linux-musleabihf OR


### PR DESCRIPTION
I've been trying to compile the dotnet-source-build 2.2.3 tag after updating my Yocto distribution from "thud" (2.6) to "warrior" (2.7). That resulted in a cmake error complaining that both both `*_EXITCODE` **and** `*_EXITCODE__TRYRUN_OUTPUT` have to be set when using TRY_RUN in a cross-compilation environment. Doing that fixes the error.

The only notable difference in the new Yocto release is the update from CMake v3.12.2 to v3.14.1.
