### PR TITLE
Disable WinRT NETClientBindings test on ARM/ARM64

### DIFF
--- a/tests/src/Interop/WinRT/NETClients/Bindings/NETClientBindings.csproj
+++ b/tests/src/Interop/WinRT/NETClients/Bindings/NETClientBindings.csproj
@@ -12,6 +12,7 @@
     <!-- Test unsupported outside of windows -->
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>
+    <DisableProjectBuild Condition="'$(Platform)' == 'arm' or '$(Platform)' == 'arm64'">true</DisableProjectBuild>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">


### PR DESCRIPTION
Fixes WinRT test failures on the official build.