### PR TITLE
Allow the write when the buffer can fit the event exactly

### DIFF
--- a/src/vm/eventpipebuffer.cpp
+++ b/src/vm/eventpipebuffer.cpp
@@ -74,7 +74,7 @@ bool EventPipeBuffer::WriteEvent(Thread *pThread, EventPipeSession &session, Eve
     unsigned int eventSize = sizeof(EventPipeEventInstance) + payload.GetSize();
     
     // Make sure we have enough space to write the event.
-    if(m_pCurrent + eventSize >= m_pLimit)
+    if(m_pCurrent + eventSize > m_pLimit)
     {
         return false;
     }

--- a/src/vm/eventpipebuffer.h
+++ b/src/vm/eventpipebuffer.h
@@ -118,7 +118,7 @@ private:
     FORCEINLINE BYTE* GetNextAlignedAddress(BYTE *pAddress)
     {
         LIMITED_METHOD_CONTRACT;
-        _ASSERTE(m_pBuffer <= pAddress && m_pLimit > pAddress);
+        _ASSERTE(m_pBuffer <= pAddress && pAddress <= m_pLimit);
 
         pAddress = (BYTE*)ALIGN_UP(pAddress, AlignmentSize);
 


### PR DESCRIPTION
Fixes #24470