### PR TITLE
Allow CORINFO_BOX_THIS for primitives and enums

### DIFF
--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -2147,6 +2147,15 @@ void ZapInfo::getCallInfo(CORINFO_RESOLVED_TOKEN * pResolvedToken,
     if (flags & CORINFO_CALLINFO_KINDONLY)
         return;
 
+    if (IsReadyToRunCompilation())
+    {
+        if (pResult->thisTransform == CORINFO_BOX_THIS)
+        {
+            // READYTORUN: FUTURE: Optionally create boxing stub at runtime
+            ThrowHR(E_NOTIMPL);
+        }
+    }
+
     // OK, if the EE said we're not doing a stub dispatch then just return the kind to
     // the caller.  No other kinds of virtual calls have extra information attached.
     switch (pResult->kind)

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -2147,15 +2147,6 @@ void ZapInfo::getCallInfo(CORINFO_RESOLVED_TOKEN * pResolvedToken,
     if (flags & CORINFO_CALLINFO_KINDONLY)
         return;
 
-    if (IsReadyToRunCompilation())
-    {
-        if (pResult->thisTransform == CORINFO_BOX_THIS)
-        {
-            // READYTORUN: FUTURE: Optionally create boxing stub at runtime
-            ThrowHR(E_NOTIMPL);
-        }
-    }
-
     // OK, if the EE said we're not doing a stub dispatch then just return the kind to
     // the caller.  No other kinds of virtual calls have extra information attached.
     switch (pResult->kind)

--- a/tests/src/readytorun/tests/main.cs
+++ b/tests/src/readytorun/tests/main.cs
@@ -59,6 +59,15 @@ class Program
          var iface = (IMyInterface)o;
          Assert.AreEqual(iface.InterfaceMethod(" "), "Interface result");
          Assert.AreEqual(MyClass.TestInterfaceMethod(iface, "+"), "Interface+result");
+
+        // V2 adds override of ToString
+        if (typeof(MyStructWithVirtuals).GetMethod("ToString").DeclaringType == typeof(MyStructWithVirtuals))
+        {
+            // Make sure the constrained call to ToString doesn't box
+            var mystruct = new MyStructWithVirtuals();
+            mystruct.ToString();
+            Assert.AreEqual(mystruct.X, "Overriden");
+        }
     }
 
     static void TestMovedVirtualMethods()

--- a/tests/src/readytorun/tests/test.cs
+++ b/tests/src/readytorun/tests/test.cs
@@ -389,6 +389,19 @@ public struct MyChangingHFAStruct
     }
 }
 
+public struct MyStructWithVirtuals
+{
+    public string X;
+
+#if V2
+    public override string ToString()
+    {
+        X = "Overriden";
+        return base.ToString();
+    }
+#endif
+}
+
 public class ByteBaseClass : List<byte>
 {
     public byte BaseByte;


### PR DESCRIPTION
We abort R2R compiling methods with `thisTransform == CORINFO_BOX_THIS`. This means we don't R2R compile some methods that do virtual calls on valuetypes (e.g. calling `ToString` on a struct that doesn't itself provide a `ToString` method).

We can't allow this in general, but enums and primitives should be fine.