### PR TITLE
Adding a jitstressregs_x86_noavx outerloop job group

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -151,7 +151,7 @@ jobs:
         - OSX_x64
         - Windows_NT_x64
         - Windows_NT_x86
-      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-regs-x86') }}:
+      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs-x86') }}:
         platforms:
         - Linux_x64
         - Windows_NT_x64
@@ -232,7 +232,7 @@ jobs:
         - OSX_x64
         - Windows_NT_x64
         - Windows_NT_x86
-      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-regs-x86') }}:
+      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs-x86') }}:
         platforms:
         - Linux_x64
         - Windows_NT_x64
@@ -248,8 +248,8 @@ jobs:
           testGroup: outerloop-jitstress-isas-arm
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-isas-x86') }}:
           testGroup: outerloop-jitstress-isas-x86
-        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-regs-x86') }}:
-          testGroup: outerloop-jitstress-regs-x86
+        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs-x86') }}:
+          testGroup: outerloop-jitstressregs-x86
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs') }}:
           testGroup: outerloop-jitstressregs
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress2-jitstressregs') }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -151,6 +151,11 @@ jobs:
         - OSX_x64
         - Windows_NT_x64
         - Windows_NT_x86
+      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-regs-x86') }}:
+        platforms:
+        - Linux_x64
+        - Windows_NT_x64
+        - Windows_NT_x86
 
 #
 # Release builds
@@ -227,6 +232,11 @@ jobs:
         - OSX_x64
         - Windows_NT_x64
         - Windows_NT_x86
+      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-regs-x86') }}:
+        platforms:
+        - Linux_x64
+        - Windows_NT_x64
+        - Windows_NT_x86
       jobParameters:
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-ci') }}:
           testGroup: innerloop
@@ -238,6 +248,8 @@ jobs:
           testGroup: outerloop-jitstress-isas-arm
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-isas-x86') }}:
           testGroup: outerloop-jitstress-isas-x86
+        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-regs-x86') }}:
+          testGroup: outerloop-jitstress-regs-x86
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs') }}:
           testGroup: outerloop-jitstressregs
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress2-jitstressregs') }}:

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -94,7 +94,7 @@ jobs:
       timeoutInMinutes: 240
     ${{ if eq(parameters.testGroup, 'outerloop') }}:
       timeoutInMinutes: 360
-    ${{ if in(parameters.testGroup, 'outerloop-jitstress', 'outerloop-jitstress-isas-arm', 'outerloop-jitstress-isas-x86', 'outerloop-jitstress-regs-x86', 'outerloop-jitstressregs', 'outerloop-jitstress2-jitstressregs', 'outerloop-gcstress0x3-gcstress0xc') }}:
+    ${{ if in(parameters.testGroup, 'outerloop-jitstress', 'outerloop-jitstress-isas-arm', 'outerloop-jitstress-isas-x86', 'outerloop-jitstressregs-x86', 'outerloop-jitstressregs', 'outerloop-jitstress2-jitstressregs', 'outerloop-gcstress0x3-gcstress0xc') }}:
       timeoutInMinutes: 480
     ${{ if in(parameters.testGroup, 'outerloop-gcstress-extra', 'outerloop-r2r-extra') }}:
       timeoutInMinutes: 600
@@ -167,7 +167,7 @@ jobs:
         ${{ if eq(parameters.testGroup, 'outerloop') }}:
           timeoutPerTestCollectionInMinutes: 60
           timeoutPerTestInMinutes: 10
-        ${{ if in(parameters.testGroup, 'outerloop-jitstress', 'outerloop-jitstress-isas-arm', 'outerloop-jitstress-isas-x86', 'outerloop-jitstress-regs-x86', 'outerloop-jitstressregs', 'outerloop-jitstress2-jitstressregs') }}:
+        ${{ if in(parameters.testGroup, 'outerloop-jitstress', 'outerloop-jitstress-isas-arm', 'outerloop-jitstress-isas-x86', 'outerloop-jitstressregs-x86', 'outerloop-jitstressregs', 'outerloop-jitstress2-jitstressregs') }}:
           timeoutPerTestCollectionInMinutes: 120
           timeoutPerTestInMinutes: 30
         ${{ if in(parameters.testGroup, 'outerloop-gcstress0x3-gcstress0xc') }}:
@@ -232,16 +232,16 @@ jobs:
           - jitstress_isas_x86_nosse41
           - jitstress_isas_x86_nosse42
           - jitstress_isas_x86_nossse3
-        ${{ if eq(parameters.testGroup, 'outerloop-jitstress-regs-x86') }}:
+        ${{ if eq(parameters.testGroup, 'outerloop-jitstressregs-x86') }}:
           scenarios:
-          - jitstress_regs1_x86_noavx
-          - jitstress_regs2_x86_noavx
-          - jitstress_regs3_x86_noavx
-          - jitstress_regs4_x86_noavx
-          - jitstress_regs8_x86_noavx
-          - jitstress_regs0x10_x86_noavx
-          - jitstress_regs0x80_x86_noavx
-          - jitstress_regs0x1000_x86_noavx
+          - jitstressregs1_x86_noavx
+          - jitstressregs2_x86_noavx
+          - jitstressregs3_x86_noavx
+          - jitstressregs4_x86_noavx
+          - jitstressregs8_x86_noavx
+          - jitstressregs0x10_x86_noavx
+          - jitstressregs0x80_x86_noavx
+          - jitstressregs0x1000_x86_noavx
         ${{ if eq(parameters.testGroup, 'outerloop-jitstressregs') }}:
           scenarios:
           - jitstressregs1

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -94,7 +94,7 @@ jobs:
       timeoutInMinutes: 240
     ${{ if eq(parameters.testGroup, 'outerloop') }}:
       timeoutInMinutes: 360
-    ${{ if in(parameters.testGroup, 'outerloop-jitstress', 'outerloop-jitstress-isas-arm', 'outerloop-jitstress-isas-x86', 'outerloop-jitstressregs', 'outerloop-jitstress2-jitstressregs', 'outerloop-gcstress0x3-gcstress0xc') }}:
+    ${{ if in(parameters.testGroup, 'outerloop-jitstress', 'outerloop-jitstress-isas-arm', 'outerloop-jitstress-isas-x86', 'outerloop-jitstress-regs-x86', 'outerloop-jitstressregs', 'outerloop-jitstress2-jitstressregs', 'outerloop-gcstress0x3-gcstress0xc') }}:
       timeoutInMinutes: 480
     ${{ if in(parameters.testGroup, 'outerloop-gcstress-extra', 'outerloop-r2r-extra') }}:
       timeoutInMinutes: 600
@@ -167,7 +167,7 @@ jobs:
         ${{ if eq(parameters.testGroup, 'outerloop') }}:
           timeoutPerTestCollectionInMinutes: 60
           timeoutPerTestInMinutes: 10
-        ${{ if in(parameters.testGroup, 'outerloop-jitstress', 'outerloop-jitstress-isas-arm', 'outerloop-jitstress-isas-x86', 'outerloop-jitstressregs', 'outerloop-jitstress2-jitstressregs') }}:
+        ${{ if in(parameters.testGroup, 'outerloop-jitstress', 'outerloop-jitstress-isas-arm', 'outerloop-jitstress-isas-x86', 'outerloop-jitstress-regs-x86', 'outerloop-jitstressregs', 'outerloop-jitstress2-jitstressregs') }}:
           timeoutPerTestCollectionInMinutes: 120
           timeoutPerTestInMinutes: 30
         ${{ if in(parameters.testGroup, 'outerloop-gcstress0x3-gcstress0xc') }}:
@@ -232,6 +232,16 @@ jobs:
           - jitstress_isas_x86_nosse41
           - jitstress_isas_x86_nosse42
           - jitstress_isas_x86_nossse3
+        ${{ if eq(parameters.testGroup, 'outerloop-jitstress-regs-x86') }}:
+          scenarios:
+          - jitstress_regs1_x86_noavx
+          - jitstress_regs2_x86_noavx
+          - jitstress_regs3_x86_noavx
+          - jitstress_regs4_x86_noavx
+          - jitstress_regs8_x86_noavx
+          - jitstress_regs0x10_x86_noavx
+          - jitstress_regs0x80_x86_noavx
+          - jitstress_regs0x1000_x86_noavx
         ${{ if eq(parameters.testGroup, 'outerloop-jitstressregs') }}:
           scenarios:
           - jitstressregs1

--- a/tests/testenvironment.proj
+++ b/tests/testenvironment.proj
@@ -84,14 +84,14 @@
     <TestEnvironment Include="jitstress_isas_x86_nosse41" EnableSSE41="0" /> <!-- Depends on SSSE3 and SSE3_4 -->
     <TestEnvironment Include="jitstress_isas_x86_nosse42" EnableSSE42="0" /> <!-- Depends on SSE41 -->
     <TestEnvironment Include="jitstress_isas_x86_nossse3" EnableSSSE3="0" /> <!-- Depends on SSE3 -->
-    <TestEnvironment Include="jitstress_regs1_x86_noavx" JitStressRegs="1" EnableAVX="0" />
-    <TestEnvironment Include="jitstress_regs2_x86_noavx" JitStressRegs="2" EnableAVX="0" />
-    <TestEnvironment Include="jitstress_regs3_x86_noavx" JitStressRegs="3" EnableAVX="0" />
-    <TestEnvironment Include="jitstress_regs4_x86_noavx" JitStressRegs="4" EnableAVX="0" />
-    <TestEnvironment Include="jitstress_regs8_x86_noavx" JitStressRegs="8" EnableAVX="0" />
-    <TestEnvironment Include="jitstress_regs0x10_x86_noavx" JitStressRegs="0x10" EnableAVX="0" />
-    <TestEnvironment Include="jitstress_regs0x80_x86_noavx" JitStressRegs="0x80" EnableAVX="0" />
-    <TestEnvironment Include="jitstress_regs0x1000_x86_noavx" JitStressRegs="0x1000" EnableAVX="0" />
+    <TestEnvironment Include="jitstressregs1_x86_noavx" JitStressRegs="1" EnableAVX="0" />
+    <TestEnvironment Include="jitstressregs2_x86_noavx" JitStressRegs="2" EnableAVX="0" />
+    <TestEnvironment Include="jitstressregs3_x86_noavx" JitStressRegs="3" EnableAVX="0" />
+    <TestEnvironment Include="jitstressregs4_x86_noavx" JitStressRegs="4" EnableAVX="0" />
+    <TestEnvironment Include="jitstressregs8_x86_noavx" JitStressRegs="8" EnableAVX="0" />
+    <TestEnvironment Include="jitstressregs0x10_x86_noavx" JitStressRegs="0x10" EnableAVX="0" />
+    <TestEnvironment Include="jitstressregs0x80_x86_noavx" JitStressRegs="0x80" EnableAVX="0" />
+    <TestEnvironment Include="jitstressregs0x1000_x86_noavx" JitStressRegs="0x1000" EnableAVX="0" />
     <TestEnvironment Include="jitstressregs1" JitStressRegs="1" />
     <TestEnvironment Include="jitstressregs2" JitStressRegs="2" />
     <TestEnvironment Include="jitstressregs3" JitStressRegs="3" />

--- a/tests/testenvironment.proj
+++ b/tests/testenvironment.proj
@@ -84,6 +84,14 @@
     <TestEnvironment Include="jitstress_isas_x86_nosse41" EnableSSE41="0" /> <!-- Depends on SSSE3 and SSE3_4 -->
     <TestEnvironment Include="jitstress_isas_x86_nosse42" EnableSSE42="0" /> <!-- Depends on SSE41 -->
     <TestEnvironment Include="jitstress_isas_x86_nossse3" EnableSSSE3="0" /> <!-- Depends on SSE3 -->
+    <TestEnvironment Include="jitstress_regs1_x86_noavx" JitStressRegs="1" EnableAVX="0" />
+    <TestEnvironment Include="jitstress_regs2_x86_noavx" JitStressRegs="2" EnableAVX="0" />
+    <TestEnvironment Include="jitstress_regs3_x86_noavx" JitStressRegs="3" EnableAVX="0" />
+    <TestEnvironment Include="jitstress_regs4_x86_noavx" JitStressRegs="4" EnableAVX="0" />
+    <TestEnvironment Include="jitstress_regs8_x86_noavx" JitStressRegs="8" EnableAVX="0" />
+    <TestEnvironment Include="jitstress_regs0x10_x86_noavx" JitStressRegs="0x10" EnableAVX="0" />
+    <TestEnvironment Include="jitstress_regs0x80_x86_noavx" JitStressRegs="0x80" EnableAVX="0" />
+    <TestEnvironment Include="jitstress_regs0x1000_x86_noavx" JitStressRegs="0x1000" EnableAVX="0" />
     <TestEnvironment Include="jitstressregs1" JitStressRegs="1" />
     <TestEnvironment Include="jitstressregs2" JitStressRegs="2" />
     <TestEnvironment Include="jitstressregs3" JitStressRegs="3" />


### PR DESCRIPTION
As per https://github.com/dotnet/coreclr/pull/24630#discussion_r285189916, this adds an outerloop build definition group that runs the register jitstress tests with AVX also disabled.

This, unlike many of the other configurations, is particularly interesting as AVX changes most SIMD instructions from `ins op1, src` (where `op1` is both a dst and src) to `ins dst, src, src`. This can end up impacting register allocation in interesting ways.