### PR TITLE
Comment the include files that have SOS dependencies

### DIFF
--- a/src/inc/gcdecoder.cpp
+++ b/src/inc/gcdecoder.cpp
@@ -13,6 +13,11 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 */
 
+// ******************************************************************************
+// WARNING!!!: This code is also used by SOS in the diagnostics repo. Should be
+// updated in a backwards and forwards compatible way.
+// See: https://github.com/dotnet/diagnostics/blob/master/src/inc/gcdecoder.cpp
+// ******************************************************************************
 
 #ifdef _TARGET_X86_
 

--- a/src/inc/gcinfo.h
+++ b/src/inc/gcinfo.h
@@ -2,6 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// ******************************************************************************
+// WARNING!!!: These values are used by SOS in the diagnostics repo. Values should 
+// added or removed in a backwards and forwards compatible way.
+// See: https://github.com/dotnet/diagnostics/blob/master/src/inc/gcinfo.h
+// ******************************************************************************
 
 /*****************************************************************************/
 #ifndef _GCINFO_H_

--- a/src/inc/gcinfodecoder.h
+++ b/src/inc/gcinfodecoder.h
@@ -8,6 +8,12 @@
  *
  *****************************************************************/
 
+// ******************************************************************************
+// WARNING!!!: These values are used by SOS in the diagnostics repo. Values should 
+// added or removed in a backwards and forwards compatible way.
+// See: https://github.com/dotnet/diagnostics/blob/master/src/inc/gcinfodecoder.h
+// ******************************************************************************
+
 #ifndef _GC_INFO_DECODER_
 #define _GC_INFO_DECODER_
 

--- a/src/inc/gcinfodumper.h
+++ b/src/inc/gcinfodumper.h
@@ -8,6 +8,11 @@
 #include "gcinfotypes.h"
 #include "gcinfodecoder.h"
 
+// *****************************************************************************
+// WARNING!!!: These values and code are also used by SOS in the diagnostics
+// repo. Should updated in a backwards and forwards compatible way.
+// See: https://github.com/dotnet/diagnostics/blob/master/src/inc/gcinfodumper.h
+// *****************************************************************************
 
 //
 // This class dumps the contents of the gc encodings, providing outputs

--- a/src/inc/gcinfotypes.h
+++ b/src/inc/gcinfotypes.h
@@ -10,6 +10,11 @@
 #include "gcinfo.h"
 #endif
 
+// *****************************************************************************
+// WARNING!!!: These values and code are also used by SOS in the diagnostics
+// repo. Should updated in a backwards and forwards compatible way.
+// See: https://github.com/dotnet/diagnostics/blob/master/src/inc/gcinfotypes.h
+// *****************************************************************************
 
 #define PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED
 

--- a/src/inc/stresslog.h
+++ b/src/inc/stresslog.h
@@ -17,7 +17,12 @@
 /* The log has a very simple structure, and it meant to be dumped from a NTSD 
    extention (eg. strike). There is no memory allocation system calls etc to purtub things */
 
-/* see the tools/strike/stressdump.cpp for the dumper utility that parses this log */
+// ******************************************************************************
+// WARNING!!!: These classes are used by SOS in the diagnostics repo. Values should 
+// added or removed in a backwards and forwards compatible way.
+// See: https://github.com/dotnet/diagnostics/blob/master/src/inc/stresslog.h
+// Parser: https://github.com/dotnet/diagnostics/blob/master/src/SOS/Strike/stressLogDump.cpp
+// ******************************************************************************
 
 /*************************************************************************************/
 


### PR DESCRIPTION
Added back the TlsIdx_StackProbe slot (as TlsIdx_Unused) because it
broke the "clrthreads -special" command in the diagnostics repo.

Add warning headers

Issue https://github.com/dotnet/diagnostics/issues/38