### PR TITLE
Avoid boxing in TextWriter.Write(StringBuilder)

### DIFF
--- a/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
@@ -305,7 +305,7 @@ namespace System.IO
             if (value != null)
             {
                 foreach (ReadOnlyMemory<char> chunk in value.GetChunks())
-                    Write(chunk);
+                    Write(chunk.Span);
             }
         }
 


### PR DESCRIPTION
Fixes #24663 by calling `Write(ReadOnlySpan<char>)` instead of `Write(object)` with a boxed `Memory<char>`.