### PR TITLE
Disable Interop/WinRT/NETClients/Primitives test on Nano Server.

### DIFF
--- a/tests/src/Common/CoreCLRTestLibrary/Utilities.cs
+++ b/tests/src/Common/CoreCLRTestLibrary/Utilities.cs
@@ -67,7 +67,7 @@ namespace TestLibrary
         public static bool IsLinux => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
         public static bool IsMacOSX => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
         public static bool IsWindows7 => IsWindows && Environment.OSVersion.Version.Major == 6 && Environment.OSVersion.Version.Minor == 1;
-        public static bool IsWinRTSupported => IsWindows && !IsWindows7;
+        public static bool IsWinRTSupported => IsWindows && !IsWindows7 && !IsWindowsNanoServer;
         public static bool IsWindowsNanoServer => (!IsWindowsIoTCore && GetInstallationType().Equals("Nano Server", StringComparison.OrdinalIgnoreCase));
         
         // Windows 10 October 2018 Update

--- a/tests/src/Interop/WinRT/NETClients/Bindings/Program.cs
+++ b/tests/src/Interop/WinRT/NETClients/Bindings/Program.cs
@@ -10,7 +10,7 @@ namespace NetClient
     {
         static int Main(string[] args)
         {
-            if (!TestLibrary.Utilities.IsWinRTSupported || TestLibrary.Utilities.IsWindowsNanoServer || !TestLibrary.Utilities.IsWindows10Version1809OrGreater)
+            if (!TestLibrary.Utilities.IsWinRTSupported || !TestLibrary.Utilities.IsWindows10Version1809OrGreater)
             {
                 Console.WriteLine("XAML Islands are unsupported on this platform.");
                 return 100;

--- a/tests/src/Interop/WinRT/NETClients/Primitives/Program.cs
+++ b/tests/src/Interop/WinRT/NETClients/Primitives/Program.cs
@@ -10,7 +10,7 @@ namespace NetClient
     {
         static int Main(string[] args)
         {
-            if (!TestLibrary.Utilities.IsWinRTSupported || TestLibrary.Utilities.IsWindowsNanoServer)
+            if (!TestLibrary.Utilities.IsWinRTSupported)
             {
                 return 100;
             }

--- a/tests/src/Interop/WinRT/NETClients/Primitives/Program.cs
+++ b/tests/src/Interop/WinRT/NETClients/Primitives/Program.cs
@@ -10,7 +10,7 @@ namespace NetClient
     {
         static int Main(string[] args)
         {
-            if (!TestLibrary.Utilities.IsWinRTSupported)
+            if (!TestLibrary.Utilities.IsWinRTSupported || TestLibrary.Utilities.IsWindowsNanoServer)
             {
                 return 100;
             }


### PR DESCRIPTION
Fixes #24661 