### PR TITLE
Improve corefx testing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -258,7 +258,8 @@ jobs:
           readyToRun: true
           displayNameArgs: R2R
 
-# The ReadyToRun test jobs that are triggered by default from a PR.
+# ReadyToRun test jobs that are triggered by default from a PR.
+
 - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
   - template: eng/platform-matrix.yml
     parameters:
@@ -273,19 +274,36 @@ jobs:
         readyToRun: true
         testGroup: innerloop
         displayNameArgs: R2R
-  # The CoreFX runs against CoreCLR
+
+#
+# CoreFX test runs against CoreCLR
+#
+
+# PR innerloop checked build
+
+- ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: test-job.yml
-      buildConfig: release
+      buildConfig: checked
       platforms:
+      - Linux_arm64
+      - Linux_musl_x64
+      - Linux_musl_arm64
+      - Linux_rhel6_x64
+      - Linux_x64
+      - OSX_x64
       - Windows_NT_x64
+      - Windows_NT_x86
+      - Windows_NT_arm
+      - Windows_NT_arm64
       jobParameters:
-        corefxTests: true
         testGroup: innerloop
+        corefxTests: true
         displayNameArgs: CoreFX
 
-# CI
+# CI (merge) jobs
+
 - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
   - template: eng/platform-matrix.yml
     parameters:
@@ -310,9 +328,18 @@ jobs:
       - Windows_NT_arm
       - Windows_NT_arm64
       jobParameters:
-        readyToRun: true
         testGroup: outerloop
+        readyToRun: true
         displayNameArgs: R2R
+
+  - template: eng/platform-matrix.yml
+    parameters:
+      jobTemplate: test-job.yml
+      buildConfig: checked
+      jobParameters:
+        testGroup: outerloop
+        corefxTests: true
+        displayNameArgs: CoreFX
 
 #
 # Release test builds
@@ -346,6 +373,15 @@ jobs:
         testGroup: outerloop
         readyToRun: true
         displayNameArgs: R2R
+
+  - template: eng/platform-matrix.yml
+    parameters:
+      jobTemplate: test-job.yml
+      buildConfig: release
+      jobParameters:
+        testGroup: outerloop
+        corefxTests: true
+        displayNameArgs: CoreFX
 
 # Format
 - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -242,23 +242,23 @@ jobs:
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop') }}:
           testGroup: outerloop
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress') }}:
-          testGroup: outerloop-jitstress
+          testGroup: jitstress
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-isas-arm') }}:
-          testGroup: outerloop-jitstress-isas-arm
+          testGroup: jitstress-isas-arm
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-isas-x86') }}:
-          testGroup: outerloop-jitstress-isas-x86
+          testGroup: jitstress-isas-x86
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs-x86') }}:
-          testGroup: outerloop-jitstressregs-x86
+          testGroup: jitstressregs-x86
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs') }}:
-          testGroup: outerloop-jitstressregs
+          testGroup: jitstressregs
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress2-jitstressregs') }}:
-          testGroup: outerloop-jitstress2-jitstressregs
+          testGroup: jitstress2-jitstressregs
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress0x3-gcstress0xc') }}:
-          testGroup: outerloop-gcstress0x3-gcstress0xc
+          testGroup: gcstress0x3-gcstress0xc
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress-extra') }}:
-          testGroup: outerloop-gcstress-extra
+          testGroup: gcstress-extra
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r-extra') }}:
-          testGroup: outerloop-r2r-extra
+          testGroup: r2r-extra
           readyToRun: true
           displayNameArgs: R2R
 
@@ -302,13 +302,13 @@ jobs:
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-ci') }}:
           testGroup: innerloop
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx') }}:
-          testGroup: corefx
+          testGroup: outerloop
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstress') }}:
-          testGroup: corefx-jitstress
+          testGroup: jitstress
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstressregs') }}:
-          testGroup: corefx-jitstressregs
+          testGroup: jitstressregs
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstress2-jitstressregs') }}:
-          testGroup: corefx-jitstress2-jitstressregs
+          testGroup: jitstress2-jitstressregs
         corefxTests: true
         displayNameArgs: CoreFX
 
@@ -350,7 +350,7 @@ jobs:
       # Temporary: only one known good platform for outerloop CoreFX jobs
       - Windows_NT_x64
       jobParameters:
-        testGroup: corefx
+        testGroup: outerloop
         corefxTests: true
         displayNameArgs: CoreFX
 
@@ -395,7 +395,7 @@ jobs:
       # Temporary: only one known good platform for outerloop CoreFX jobs
       - Windows_NT_x64
       jobParameters:
-        testGroup: corefx
+        testGroup: outerloop
         corefxTests: true
         displayNameArgs: CoreFX
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -287,16 +287,15 @@ jobs:
       jobTemplate: test-job.yml
       buildConfig: checked
       platforms:
+      - Linux_arm
       - Linux_arm64
       - Linux_musl_x64
-      - Linux_musl_arm64
-      - Linux_rhel6_x64
       - Linux_x64
       - OSX_x64
-      - Windows_NT_x64
-      - Windows_NT_x86
       - Windows_NT_arm
       - Windows_NT_arm64
+      - Windows_NT_x64
+      - Windows_NT_x86
       jobParameters:
         testGroup: innerloop
         corefxTests: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -281,24 +281,34 @@ jobs:
 
 # PR innerloop checked build
 
-- ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
+- ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest, 'Manual', 'Schedule')) }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: test-job.yml
       buildConfig: checked
-      platforms:
-      - Linux_arm
-      - Linux_arm64
-      - Linux_musl_x64
-      - Linux_x64
-      - OSX_x64
+      ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
+        platforms:
+        - Linux_arm
+        - Linux_arm64
+        - Linux_musl_x64
+        - Linux_x64
+        - OSX_x64
         # No Windows arm/arm64 helix queues defined for processing PRs currently.
         #- Windows_NT_arm
         #- Windows_NT_arm64
-      - Windows_NT_x64
-      - Windows_NT_x86
+        - Windows_NT_x64
+        - Windows_NT_x86
       jobParameters:
-        testGroup: innerloop
+        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-ci') }}:
+          testGroup: innerloop
+        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx') }}:
+          testGroup: corefx
+        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstress') }}:
+          testGroup: corefx-jitstress
+        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstressregs') }}:
+          testGroup: corefx-jitstressregs
+        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstress2-jitstressregs') }}:
+          testGroup: corefx-jitstress2-jitstressregs
         corefxTests: true
         displayNameArgs: CoreFX
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -281,7 +281,7 @@ jobs:
 
 # PR innerloop checked build
 
-- ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest, 'Manual', 'Schedule')) }}:
+- ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest, 'Manual', 'Schedule')) }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: test-job.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -198,22 +198,7 @@ jobs:
 # Checked test builds
 #
 # The test jobs that can be triggered by a PR, manually from ADO and that are scheduled
-- ${{ if and(
-        eq(variables['System.TeamProject'], 'public'),
-        in(variables['Build.Reason'], 'PullRequest', 'Manual', 'Schedule'),
-        in(variables['Build.DefinitionName'],
-            'coreclr-ci',
-            'coreclr-outerloop',
-            'coreclr-outerloop-jitstress',
-            'coreclr-outerloop-jitstress-isas-arm',
-            'coreclr-outerloop-jitstress-isas-x86',
-            'coreclr-outerloop-jitstressregs-x86',
-            'coreclr-outerloop-jitstressregs',
-            'coreclr-outerloop-jitstress2-jitstressregs',
-            'coreclr-outerloop-gcstress0x3-gcstress0xc',
-            'coreclr-outerloop-gcstress-extra',
-            'coreclr-outerloop-r2r-extra')
-        ) }}:
+- ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'Manual', 'Schedule'), in(variables['Build.DefinitionName'], 'coreclr-ci', 'coreclr-outerloop', 'coreclr-outerloop-jitstress', 'coreclr-outerloop-jitstress-isas-arm', 'coreclr-outerloop-jitstress-isas-x86', 'coreclr-outerloop-jitstressregs-x86', 'coreclr-outerloop-jitstressregs', 'coreclr-outerloop-jitstress2-jitstressregs', 'coreclr-outerloop-gcstress0x3-gcstress0xc', 'coreclr-outerloop-gcstress-extra', 'coreclr-outerloop-r2r-extra')) }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: test-job.yml
@@ -279,11 +264,7 @@ jobs:
 
 # ReadyToRun test jobs that are triggered by default from a PR.
 
-- ${{ if and(
-        eq(variables['System.TeamProject'], 'public'),
-        eq(variables['Build.Reason'], 'PullRequest'),
-        eq(variables['Build.DefinitionName'], 'coreclr-ci')
-        ) }}:
+- ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: test-job.yml
@@ -304,17 +285,7 @@ jobs:
 
 # PR innerloop checked build
 
-- ${{ if and(
-        eq(variables['System.TeamProject'], 'public'),
-        in(variables['Build.Reason'], 'PullRequest', 'Manual', 'Schedule'),
-        in(variables['Build.DefinitionName'],
-            'coreclr-ci',
-            'coreclr-corefx',
-            'coreclr-corefx-jitstress',
-            'coreclr-corefx-jitstressregs',
-            'coreclr-corefx-jitstress2-jitstressregs'
-            )
-        ) }}:
+- ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'Manual', 'Schedule'), in(variables['Build.DefinitionName'], 'coreclr-ci', 'coreclr-corefx', 'coreclr-corefx-jitstress', 'coreclr-corefx-jitstressregs', 'coreclr-corefx-jitstress2-jitstressregs')) }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: test-job.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,7 +118,7 @@ jobs:
     parameters:
       jobTemplate: build-job.yml
       buildConfig: checked
-      ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
+      ${{ if and(in(variables['Build.Reason'], 'PullRequest'), in(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
         platforms:
         - Linux_arm
         - Linux_arm64
@@ -136,21 +136,25 @@ jobs:
         - Linux_x64
         - Windows_NT_x64
         - Windows_NT_x86
-      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-isas-arm') }}:
+      ${{ if in(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-isas-arm') }}:
         platforms:
         - Linux_arm64
         - Windows_NT_arm64
-      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-isas-x86') }}:
+      ${{ if in(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-isas-x86') }}:
         platforms:
         - Linux_x64
         - OSX_x64
         - Windows_NT_x64
         - Windows_NT_x86
-      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs-x86') }}:
+      ${{ if in(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs-x86') }}:
         platforms:
         - Linux_x64
         - Windows_NT_x64
         - Windows_NT_x86
+      ${{ if in(variables['Build.DefinitionName'], 'coreclr-corefx', 'coreclr-corefx-jitstress', 'coreclr-corefx-jitstressregs', 'coreclr-corefx-jitstress2-jitstressregs') }}:
+        platforms:
+        - Linux_x64
+        - Windows_NT_x64
 
 #
 # Release builds
@@ -194,7 +198,22 @@ jobs:
 # Checked test builds
 #
 # The test jobs that can be triggered by a PR, manually from ADO and that are scheduled
-- ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'Manual', 'Schedule')) }}:
+- ${{ if and(
+        eq(variables['System.TeamProject'], 'public'),
+        in(variables['Build.Reason'], 'PullRequest', 'Manual', 'Schedule'),
+        in(variables['Build.DefinitionName'],
+            'coreclr-ci',
+            'coreclr-outerloop',
+            'coreclr-outerloop-jitstress',
+            'coreclr-outerloop-jitstress-isas-arm',
+            'coreclr-outerloop-jitstress-isas-x86',
+            'coreclr-outerloop-jitstressregs-x86',
+            'coreclr-outerloop-jitstressregs',
+            'coreclr-outerloop-jitstress2-jitstressregs',
+            'coreclr-outerloop-gcstress0x3-gcstress0xc',
+            'coreclr-outerloop-gcstress-extra',
+            'coreclr-outerloop-r2r-extra')
+        ) }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: test-job.yml
@@ -260,7 +279,11 @@ jobs:
 
 # ReadyToRun test jobs that are triggered by default from a PR.
 
-- ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
+- ${{ if and(
+        eq(variables['System.TeamProject'], 'public'),
+        eq(variables['Build.Reason'], 'PullRequest'),
+        eq(variables['Build.DefinitionName'], 'coreclr-ci')
+        ) }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: test-job.yml
@@ -281,24 +304,25 @@ jobs:
 
 # PR innerloop checked build
 
-- ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'Manual', 'Schedule')) }}:
+- ${{ if and(
+        eq(variables['System.TeamProject'], 'public'),
+        in(variables['Build.Reason'], 'PullRequest', 'Manual', 'Schedule'),
+        in(variables['Build.DefinitionName'],
+            'coreclr-ci',
+            'coreclr-corefx',
+            'coreclr-corefx-jitstress',
+            'coreclr-corefx-jitstressregs',
+            'coreclr-corefx-jitstress2-jitstressregs'
+            )
+        ) }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: test-job.yml
       buildConfig: checked
       ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
         platforms:
-        - Linux_arm
-        - Linux_arm64
-        - Linux_musl_x64
         - Linux_x64
-        - OSX_x64
-        # No Windows arm/arm64 helix queues defined for processing PRs currently.
-        #- Windows_NT_arm
-        #- Windows_NT_arm64
         - Windows_NT_x64
-        - Windows_NT_x86
-      # Limit corefx jobs platforms until all platforms work
       ${{ if in(variables['Build.DefinitionName'], 'coreclr-corefx', 'coreclr-corefx-jitstress', 'coreclr-corefx-jitstressregs', 'coreclr-corefx-jitstress2-jitstressregs') }}:
         platforms:
         - Linux_x64
@@ -351,8 +375,11 @@ jobs:
     parameters:
       jobTemplate: test-job.yml
       buildConfig: checked
+      platforms:
+      # Temporary: only one known good platform for outerloop CoreFX jobs
+      - Windows_NT_x64
       jobParameters:
-        testGroup: outerloop
+        testGroup: corefx
         corefxTests: true
         displayNameArgs: CoreFX
 
@@ -393,8 +420,11 @@ jobs:
     parameters:
       jobTemplate: test-job.yml
       buildConfig: release
+      platforms:
+      # Temporary: only one known good platform for outerloop CoreFX jobs
+      - Windows_NT_x64
       jobParameters:
-        testGroup: outerloop
+        testGroup: corefx
         corefxTests: true
         displayNameArgs: CoreFX
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -281,7 +281,7 @@ jobs:
 
 # PR innerloop checked build
 
-- ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest, 'Manual', 'Schedule')) }}:
+- ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'Manual', 'Schedule')) }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: test-job.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -292,8 +292,9 @@ jobs:
       - Linux_musl_x64
       - Linux_x64
       - OSX_x64
-      - Windows_NT_arm
-      - Windows_NT_arm64
+        # No Windows arm/arm64 helix queues defined for processing PRs currently.
+        #- Windows_NT_arm
+        #- Windows_NT_arm64
       - Windows_NT_x64
       - Windows_NT_x86
       jobParameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -298,6 +298,11 @@ jobs:
         #- Windows_NT_arm64
         - Windows_NT_x64
         - Windows_NT_x86
+      # Limit corefx jobs platforms until all platforms work
+      ${{ if in(variables['Build.DefinitionName'], 'coreclr-corefx', 'coreclr-corefx-jitstress', 'coreclr-corefx-jitstressregs', 'coreclr-corefx-jitstress2-jitstressregs') }}:
+        platforms:
+        - Linux_x64
+        - Windows_NT_x64
       jobParameters:
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-ci') }}:
           testGroup: innerloop

--- a/eng/helixcorefxtests.proj
+++ b/eng/helixcorefxtests.proj
@@ -95,7 +95,7 @@
          any particular job. However, this mechanism is super simple; we don't need to manage fine-
          grained exclusions; and there really shouldn't be any (or many) exclusions anyway.
     -->
-    <CoreFXTestExclusionFile>$(ProjectDir)\tests\CoreFX\CoreFX.issues.rsp</CoreFXTestExclusionFile>
+    <CoreFXTestExclusionFile>$(ProjectDir)tests\CoreFX\CoreFX.issues.rsp</CoreFXTestExclusionFile>
 
     <TestHostRootPath>$(TestWorkingDir)testhost\</TestHostRootPath>
     <TestArchiveRuntimeRoot>$(TestWorkingDir)helix\</TestArchiveRuntimeRoot>

--- a/eng/helixcorefxtests.proj
+++ b/eng/helixcorefxtests.proj
@@ -85,6 +85,12 @@
   <Target Name="GetTestAssetManifest" 
           Returns="@(TestAssetBlobInfos)">
 
+    <!--
+       Parse the test asset manifest at, e.g.,
+           https://dotnetfeed.blob.core.windows.net/dotnet-core/corefx-tests/4.6.0-preview6.19264.9/Linux.arm64/netcoreapp/corefx-test-assets.xml
+       to figure out the tests to run.
+     -->
+
     <PropertyGroup>
       <_TargetGroup>netcoreapp</_TargetGroup>
       <_AssetManifestPath>$(TestAssetBlobFeedUrl)/corefx-tests/$(MicrosoftPrivateCoreFxNETCoreAppVersion)/$(__BuildOS).$(__BuildArch)/$(_TargetGroup)/corefx-test-assets.xml</_AssetManifestPath>

--- a/eng/helixcorefxtests.proj
+++ b/eng/helixcorefxtests.proj
@@ -133,26 +133,6 @@
     <Message Importance="High" Text="Copied $(CoreFXTestExclusionFile) into $(TestHostRootPath)" />
   </Target>
 
-  <!--
-    Compress the testhost directory into a ZIP file to pass it as the Helix correlation directory.
-    Note: this might be unnecessary; I've been told you can just pass the directory to Helix without
-    compressing it to a single file, and it will do the compression/uncompression itself.
-  -->
-  <Target Name="CompressRuntimeDirectory"
-          Inputs="@(TestArchiveRuntimeInputs)"
-          Outputs="$(TestArchiveRuntimeFile)"
-          DependsOnTargets="CopyRSPFile" >
-
-    <MakeDir Directories="$(TestArchiveRuntimeRoot)" />
-
-    <ZipDirectory
-        SourceDirectory="$(TestHostRootPath)"
-        DestinationFile="$(TestArchiveRuntimeFile)"
-        Overwrite="true" />
-
-    <Message Importance="High" Text="Zipped correlation payload into $(TestArchiveRuntimeFile)" />
-  </Target>
-
   <PropertyGroup>
     <!-- Set the name of the scenario file. Note that this is only used in invocations where $(Scenario) is set. -->
     <TestEnvFileName Condition=" '$(TargetsWindows)' == 'true' ">SetStressModes_$(Scenario).cmd</TestEnvFileName>
@@ -163,7 +143,7 @@
     <!-- This target creates one __TestEnv file for the single $(Scenario). -->
 
     <PropertyGroup>
-      <TestEnvFilePath>$(TestHostRootPath)\$(TestEnvFileName)</TestEnvFilePath>
+      <TestEnvFilePath>$(TestHostRootPath)$(TestEnvFileName)</TestEnvFilePath>
     </PropertyGroup>
 
     <ItemGroup>
@@ -192,11 +172,31 @@
   </Target>
 
   <!--
+    Compress the testhost directory into a ZIP file to pass it as the Helix correlation directory.
+    Note: this might be unnecessary; I've been told you can just pass the directory to Helix without
+    compressing it to a single file, and it will do the compression/uncompression itself.
+  -->
+  <Target Name="CompressRuntimeDirectory"
+          Inputs="@(TestArchiveRuntimeInputs)"
+          Outputs="$(TestArchiveRuntimeFile)"
+          DependsOnTargets="CopyRSPFile;CreateAllScenarioTestEnvFiles" >
+
+    <MakeDir Directories="$(TestArchiveRuntimeRoot)" />
+
+    <ZipDirectory
+        SourceDirectory="$(TestHostRootPath)"
+        DestinationFile="$(TestArchiveRuntimeFile)"
+        Overwrite="true" />
+
+    <Message Importance="High" Text="Zipped correlation payload into $(TestArchiveRuntimeFile)" />
+  </Target>
+
+  <!--
     Collect all the tasks needed to be run once, to prepare the Helix correlation payload directory.
     This just causes its dependent targets to be run.
   -->
   <Target Name="PrepareCorrelationPayloadDirectory"
-          DependsOnTargets="CompressRuntimeDirectory;CreateAllScenarioTestEnvFiles">
+          DependsOnTargets="CompressRuntimeDirectory">
   </Target>
 
   <!--

--- a/eng/helixcorefxtests.proj
+++ b/eng/helixcorefxtests.proj
@@ -33,8 +33,7 @@
       </_PropertiesToPass>
     </PropertyGroup>
 
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="PrepareCorrelationPayloadDirectory" />
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="CreateAllTestEnvFiles" Properties="Scenarios=$(_Scenarios)" StopOnFirstFailure="true" />
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="PrepareCorrelationPayloadDirectory" Properties="Scenarios=$(_Scenarios)" />
 
     <ItemGroup>
       <_Scenarios Include="$(_Scenarios.Split(','))" />
@@ -50,14 +49,17 @@
       <_BuildInParallel Condition=" '@(_ProjectsToBuild->Count())' &gt; '1' ">true</_BuildInParallel>
     </PropertyGroup>
 
+    <!-- Invoke MSBuild on this project file once for each Scenario (because of the "batching" defined in "_ProjectsToBuild").
+         Set "UsesHelixSdk=true" to indicate we want to invoke Helix on this invocation: create the Helix work items and start
+         the jobs. This is done by invoking the "Test" Helix target.
+    -->
     <MSBuild Projects="@(_ProjectsToBuild)" Targets="Test" BuildInParallel="$(_BuildInParallel)" StopOnFirstFailure="false" Properties="UsesHelixSdk=true" />
-    <!-- <MSBuild Projects="@(_ProjectsToBuild)" Targets="FakeTest" BuildInParallel="false" StopOnFirstFailure="false" Properties="UsesHelixSdk=true" /> -->
   </Target>
 
-  <PropertyGroup>
-    <!-- Set the TargetFramework just to make the SDK happy -->
-    <!-- NEEDED? <TargetFramework>netstandard2.0</TargetFramework> -->
-  </PropertyGroup>
+  <!-- Define a set of properties that are input to the Project, and that must be passed down to child processes.
+      (See "_PropertiesToPass" in target "RunInParallelForEachScenario".) If something can be computed, such as
+      properties needed by Helix, they should probably be set in target "BuildHelixWorkItems" instead.
+  -->
 
   <PropertyGroup>
     <Creator>$(_Creator)</Creator>
@@ -66,8 +68,6 @@
     <HelixSource>$(_HelixSource)</HelixSource>
     <HelixTargetQueues>$(_HelixTargetQueues)</HelixTargetQueues>
     <HelixType>$(_HelixType)</HelixType>
-    <HelixArchitecture>$(__BuildArch)</HelixArchitecture>
-    <HelixConfiguration>$(__BuildType)</HelixConfiguration>
 
     <!--
       TODO: ProjectDir, RootBinDir, TestWorkingDir, and TargetsWindows are global properties set in dir.props, remove the property assignment here when we port to arcade.
@@ -81,16 +81,7 @@
     <TestArchiveRuntimeRoot>$(TestWorkingDir)helix\</TestArchiveRuntimeRoot>
     <TestArchiveRuntimeFile>$(TestArchiveRuntimeRoot)testhost-runtime.zip</TestArchiveRuntimeFile>
 
-    <EnableAzurePipelinesReporter>$(_PublishTestResults)</EnableAzurePipelinesReporter>
-    <EnableAzurePipelinesReporter Condition=" '$(EnableAzurePipelinesReporter)' == '' ">false</EnableAzurePipelinesReporter>
-    <EnableXUnitReporter>true</EnableXUnitReporter>
-    <FailOnMissionControlTestFailure>true</FailOnMissionControlTestFailure>
-    <FailOnWorkItemFailure>true</FailOnWorkItemFailure>
-
-    <TimeoutInSeconds Condition="'$(TimeoutInSeconds)' == ''">600</TimeoutInSeconds>
-    <CommandTimeoutSpan>$([System.TimeSpan]::FromSeconds($(TimeoutInSeconds)))</CommandTimeoutSpan>
-    <MaxRetryCount Condition="'$(MaxRetryCount)' == ''">4</MaxRetryCount>
-    <WaitForWorkItemCompletion>true</WaitForWorkItemCompletion>
+    <TestAssetBlobFeedUrl>https://dotnetfeed.blob.core.windows.net/dotnet-core</TestAssetBlobFeedUrl>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -109,42 +100,22 @@
     <TestArchiveRuntimeInputs Include="$(TestHostRootPath)**/*" />
   </ItemGroup>
 
+  <!--
+    Copy the CoreFX test exclusion response file (which is passed to the xunit console runner) to someplace we can
+    access it during the test run. We currently just copy it to the root of the generated .NET Core testhost
+    directory, which we use as the root of the correlation directory.
+  -->
   <Target Name="CopyRSPFile">
     <Copy
       SourceFiles="$(ProjectDir)\tests\CoreFX\CoreFX.issues.rsp"
       DestinationFolder="$(TestHostRootPath)" />
   </Target>
 
-  <PropertyGroup>
-    <TestEnvFileName Condition=" '$(TargetsWindows)' == 'true' ">SetStressModes_$(Scenario).cmd</TestEnvFileName>
-    <TestEnvFileName Condition=" '$(TargetsWindows)' != 'true' ">SetStressModes_$(Scenario).sh</TestEnvFileName>
-  </PropertyGroup>
-
-  <Target Name="CreateTestEnvFiles">
-    <!-- This target creates one __TestEnv file for the $(Scenario). -->
-
-    <ItemGroup>
-      <_ProjectsToBuild Include="..\tests\testenvironment.proj">
-        <Properties>Scenario=$(Scenario);TestEnvFileName=$(TestHostRootPath)\$(TestEnvFileName);TargetsWindows=$(TargetsWindows)</Properties>
-      </_ProjectsToBuild>
-    </ItemGroup>
-
-    <MSBuild Projects="@(_ProjectsToBuild)" Targets="CreateTestEnvFile" StopOnFirstFailure="true" />
-  </Target>
-
-  <Target Name="CreateAllTestEnvFiles">
-    <!-- This target creates one __TestEnv file for each of the $(Scenarios). -->
-
-    <ItemGroup>
-      <_Scenario Include="$(Scenarios.Split(','))" />
-      <_ProjectsToBuild Include="$(MSBuildProjectFile)">
-        <AdditionalProperties>Scenario=%(_Scenario.Identity)</AdditionalProperties>
-      </_ProjectsToBuild>
-    </ItemGroup>
-
-    <MSBuild Projects="@(_ProjectsToBuild)" Targets="CreateTestEnvFiles" StopOnFirstFailure="true" />
-  </Target>
-
+  <!--
+    Compress the testhost directory into a ZIP file to pass it as the Helix correlation directory.
+    Note: this might be unnecessary; I've been told you can just pass the directory to Helix without
+    compressing it to a single file, and it will do the compression/uncompression itself.
+  -->
   <Target Name="CompressRuntimeDirectory"
           Inputs="@(TestArchiveRuntimeInputs)"
           Outputs="$(TestArchiveRuntimeFile)"
@@ -161,39 +132,56 @@
   </Target>
 
   <PropertyGroup>
-    <TestAssetBlobFeedUrl>https://dotnetfeed.blob.core.windows.net/dotnet-core</TestAssetBlobFeedUrl>
+    <!-- Set the name of the scenario file. Note that this is only used in invocations where $(Scenario) is set. -->
+    <TestEnvFileName Condition=" '$(TargetsWindows)' == 'true' ">SetStressModes_$(Scenario).cmd</TestEnvFileName>
+    <TestEnvFileName Condition=" '$(TargetsWindows)' != 'true' ">SetStressModes_$(Scenario).sh</TestEnvFileName>
   </PropertyGroup>
 
-  <!-- WARNING: HelixPreCommand ItemGroup is intentionally minimal and should be kept that way. -->
+  <Target Name="CreateTestEnvFile">
+    <!-- This target creates one __TestEnv file for the single $(Scenario). -->
 
-  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
-    <HelixPreCommand Include="set __TestEnv=%HELIX_CORRELATION_PAYLOAD%\$(TestEnvFileName)" />
-    <HelixPreCommand Include="type %__TestEnv%" />
-    <HelixPreCommand Include="call %__TestEnv%" />
-  </ItemGroup>
+    <ItemGroup>
+      <_ProjectsToBuild Include="..\tests\testenvironment.proj">
+        <Properties>Scenario=$(Scenario);TestEnvFileName=$(TestHostRootPath)\$(TestEnvFileName);TargetsWindows=$(TargetsWindows)</Properties>
+      </_ProjectsToBuild>
+    </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetsWindows)' != 'true' ">
-    <HelixPreCommand Include="export __TestEnv=$HELIX_CORRELATION_PAYLOAD/$(TestEnvFileName)" />
-    <HelixPreCommand Include="cat $__TestEnv" />
-    <HelixPreCommand Include="source $__TestEnv" />
-  </ItemGroup>
-
-  <PropertyGroup>
-    <HelixPreCommands>@(HelixPreCommand)</HelixPreCommands>
-  </PropertyGroup>
-
-  <Target Name="PrepareCorrelationPayloadDirectory"
-          DependsOnTargets="CompressRuntimeDirectory">
+    <MSBuild Projects="@(_ProjectsToBuild)" Targets="CreateTestEnvFile" StopOnFirstFailure="true" />
   </Target>
 
+  <Target Name="CreateAllScenarioTestEnvFiles">
+    <!-- This target creates one __TestEnv file for each of the scenarios in the $(Scenarios) comma-separated list. -->
+
+    <ItemGroup>
+      <_Scenario Include="$(Scenarios.Split(','))" />
+      <_ProjectsToBuild Include="$(MSBuildProjectFile)">
+        <AdditionalProperties>Scenario=%(_Scenario.Identity)</AdditionalProperties>
+      </_ProjectsToBuild>
+    </ItemGroup>
+
+    <MSBuild Projects="@(_ProjectsToBuild)" Targets="CreateTestEnvFile" StopOnFirstFailure="true" />
+  </Target>
+
+  <!--
+    Collect all the tasks needed to be run once, to prepare the Helix correlation payload directory.
+    This just causes its dependent targets to be run.
+  -->
+  <Target Name="PrepareCorrelationPayloadDirectory"
+          DependsOnTargets="CompressRuntimeDirectory;CreateAllScenarioTestEnvFiles">
+  </Target>
+
+  <!--
+    Parse the test asset manifest at, e.g.,
+        https://dotnetfeed.blob.core.windows.net/dotnet-core/corefx-tests/4.6.0-preview6.19264.9/Linux.arm64/netcoreapp/corefx-test-assets.xml
+    to figure out the tests to run. This manifest is created by the corefx official build, for use in the coreclr repo.
+    
+    This creates a "TestAssetBlobInfos" item group, which is used to create the Helix work items.
+
+    NOTE: we are running this once for each Scenario, meaning we are reading and parsing it once per scenario. Ideally, we would
+    do this once and pass it down to the "BuildHelixWorkItems" task later. That's a little difficult given all the re-invocations
+    of this Project we do. It doesn't seem too expensive anyway.
+  -->
   <Target Name="GetTestAssetManifest" Condition=" '$(UsesHelixSdk)' == 'true' " >
-
-    <!--
-       Parse the test asset manifest at, e.g.,
-           https://dotnetfeed.blob.core.windows.net/dotnet-core/corefx-tests/4.6.0-preview6.19264.9/Linux.arm64/netcoreapp/corefx-test-assets.xml
-       to figure out the tests to run. This manifest is created by the corefx official build, for use in the coreclr repo.
-     -->
-
     <PropertyGroup>
       <_TargetGroup>netcoreapp</_TargetGroup>
       <_AssetManifestPath>$(TestAssetBlobFeedUrl)/corefx-tests/$(MicrosoftPrivateCoreFxNETCoreAppVersion)/$(__BuildOS).$(__BuildArch)/$(_TargetGroup)/corefx-test-assets.xml</_AssetManifestPath>
@@ -202,12 +190,64 @@
     <ParseBuildManifest AssetManifestPath="$(_AssetManifestPath)">
       <Output TaskParameter="BlobInfos" ItemName="TestAssetBlobInfos" />
     </ParseBuildManifest>
-
-    <!-- <Message Importance="High" Text="%(TestAssetBlobInfos.Identity): %(FileName)" /> -->
-
   </Target>
 
+  <!--
+    Create all the Helix data to start a set of jobs. This is invoked once for each Scenario (see
+    target "RunInParallelForEachScenario"). Create a set of work items, one for each CoreFX test assembly.
+    All will have the same Scenario specific command line.  Note that this target is listed in the
+    InitialTargets for this Project. This causes it to be invoked (and the Helix data created,
+    such as the HelixWorkItem item group) before Helix "Test" target is invoked (as a normal target).
+    We conditionalize this (and its dependent targets) with "UsesHelixSdk=true" so they aren't invoked
+    during the other invocations of this Project, such as when "RunInParallelForEachScenario" is run.
+  -->
   <Target Name="BuildHelixWorkItems" DependsOnTargets="GetTestAssetManifest" Condition=" '$(UsesHelixSdk)' == 'true' " >
+
+    <!-- HelixPreCommands is a set of commands run before the work item command. We use it here to inject
+         setting up the per-scenario environment.
+    -->
+
+    <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
+      <HelixPreCommand Include="set __TestEnv=%HELIX_CORRELATION_PAYLOAD%\$(TestEnvFileName)" />
+      <HelixPreCommand Include="type %__TestEnv%" />
+      <HelixPreCommand Include="call %__TestEnv%" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetsWindows)' != 'true' ">
+      <HelixPreCommand Include="export __TestEnv=$HELIX_CORRELATION_PAYLOAD/$(TestEnvFileName)" />
+      <HelixPreCommand Include="cat $__TestEnv" />
+      <HelixPreCommand Include="source $__TestEnv" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <HelixPreCommands>@(HelixPreCommand)</HelixPreCommands>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <HelixArchitecture>$(__BuildArch)</HelixArchitecture>
+
+      <HelixConfiguration Condition=" '$(Scenario)' == 'normal' ">$(BuildType)</HelixConfiguration>
+      <HelixConfiguration Condition=" '$(Scenario)' != 'normal' ">$(BuildType)-$(Scenario)</HelixConfiguration>
+
+      <TestRunNamePrefix Condition=" '$(Scenario)' == 'normal' ">$(TestRunNamePrefix)$(BuildOS) $(BuildArch) $(BuildType) @ </TestRunNamePrefix>
+      <TestRunNamePrefix Condition=" '$(Scenario)' != 'normal' ">$(TestRunNamePrefix)$(BuildOS) $(BuildArch) $(BuildType) $(Scenario) @ </TestRunNamePrefix>
+
+      <!-- REVIEW: it seems like this should be referencing "PublishTestResults" instead (without the underscore) -->
+      <EnableAzurePipelinesReporter>$(_PublishTestResults)</EnableAzurePipelinesReporter>
+      <EnableAzurePipelinesReporter Condition=" '$(EnableAzurePipelinesReporter)' == '' ">false</EnableAzurePipelinesReporter>
+
+      <EnableXUnitReporter>true</EnableXUnitReporter>
+      <FailOnMissionControlTestFailure>true</FailOnMissionControlTestFailure>
+      <FailOnWorkItemFailure>true</FailOnWorkItemFailure>
+      <WaitForWorkItemCompletion>true</WaitForWorkItemCompletion>
+
+      <!-- REVIEW: should we be using "TimeoutPerTestInMinutes" or "TimeoutPerTestCollectionInMinutes"? -->
+      <TimeoutInSeconds Condition="'$(TimeoutInSeconds)' == ''">600</TimeoutInSeconds>
+      <CommandTimeoutSpan>$([System.TimeSpan]::FromSeconds($(TimeoutInSeconds)))</CommandTimeoutSpan>
+
+      <!-- Specify the retry policy for Helix jobs: -->
+      <MaxRetryCount Condition="'$(MaxRetryCount)' == ''">4</MaxRetryCount>
+    </PropertyGroup>
 
     <ItemGroup Condition=" '$(UsesHelixSdk)' == 'true' ">
       <HelixCorrelationPayload 
@@ -220,19 +260,6 @@
       </HelixWorkItem>
     </ItemGroup>
 
-  </Target>
-
-  <!-- for testing! -->
-  <Target Name="FakeTest" Condition=" '$(UsesHelixSdk)' == 'true' " >
-    <Message Importance="High" Text="Starting FakeTest" />  
-    <Message Importance="High" Text="Scenario = $(Scenario)" />  
-    <Message Importance="High" Text="TestHostRootPath = $(TestHostRootPath)" />  
-    <Message Importance="High" Text="TestArchiveRuntimeFile = $(TestArchiveRuntimeFile)" />  
-    <Message Importance="High" Text="BuildInParallel = $(BuildInParallel)" />  
-    <Message Importance="High" Text="UsesHelixSdk = $(UsesHelixSdk)" />  
-    <Message Importance="High" Text="%(HelixWorkItem.Identity): %(Command)" />  
-    <Message Importance="High" Text="Pre commands: $(HelixPreCommands)" />  
-    <Message Importance="High" Text="Ending FakeTest" />  
   </Target>
 
   <Import Sdk="Microsoft.DotNet.Helix.Sdk" Project="Sdk.targets" Condition=" '$(UsesHelixSdk)' == 'true' " />

--- a/eng/helixcorefxtests.proj
+++ b/eng/helixcorefxtests.proj
@@ -181,6 +181,8 @@
           Outputs="$(TestArchiveRuntimeFile)"
           DependsOnTargets="CopyRSPFile;CreateAllScenarioTestEnvFiles" >
 
+    <!-- TEMPORARY: don't actually ZIP the testhost directory. See if executable permissions get preserved on Linux.
+
     <MakeDir Directories="$(TestArchiveRuntimeRoot)" />
 
     <ZipDirectory
@@ -189,6 +191,8 @@
         Overwrite="true" />
 
     <Message Importance="High" Text="Zipped correlation payload into $(TestArchiveRuntimeFile)" />
+
+    END TEMPORARY -->
   </Target>
 
   <!--
@@ -243,7 +247,7 @@
   <ItemGroup Condition=" '$(TargetsWindows)' != 'true' ">
     <HelixPreCommand Include="export __TestEnv=$HELIX_CORRELATION_PAYLOAD/$(TestEnvFileName)" />
     <HelixPreCommand Include="cat $__TestEnv" />
-    <HelixPreCommand Include="source $__TestEnv" />
+    <HelixPreCommand Include=". $__TestEnv" /> <!-- Use "." not "source"; some clients appear to run scripts with "sh" not "bash" -->
   </ItemGroup>
 
   <PropertyGroup>
@@ -272,7 +276,7 @@
     <TimeoutInSeconds Condition="'$(TimeoutInSeconds)' == ''">600</TimeoutInSeconds>
     <CommandTimeoutSpan>$([System.TimeSpan]::FromSeconds($(TimeoutInSeconds)))</CommandTimeoutSpan>
 
-    <!-- Specify the retry policy for Helix jobs: -->
+    <!-- Specify the retry policy for Helix jobs -->
     <MaxRetryCount Condition="'$(MaxRetryCount)' == ''">4</MaxRetryCount>
   </PropertyGroup>
 
@@ -287,8 +291,10 @@
   -->
   <Target Name="BuildHelixWorkItems" DependsOnTargets="GetTestAssetManifest" Condition=" '$(UsesHelixSdk)' == 'true' " >
     <ItemGroup Condition=" '$(UsesHelixSdk)' == 'true' ">
-      <HelixCorrelationPayload 
-        Include="$(TestArchiveRuntimeFile)" />
+      <!-- TEMPORARY: try passing directory, not ZIP file.
+      <HelixCorrelationPayload Include="$(TestArchiveRuntimeFile)" />
+      -->
+      <HelixCorrelationPayload Include="$(TestHostRootPath)" />
 
       <HelixWorkItem Include="@(TestAssetBlobInfos -> '%(FileName)')">
         <PayloadUri>$(TestAssetBlobFeedUrl)/%(Identity)</PayloadUri>

--- a/eng/helixcorefxtests.proj
+++ b/eng/helixcorefxtests.proj
@@ -1,9 +1,62 @@
-<Project InitialTargets="BuildHelixWorkItems" Sdk="Microsoft.DotNet.Helix.Sdk">
-  <Import Project="$(NuGetPackageRoot)microsoft.dotnet.build.tasks.feed\$(MicrosoftDotNetBuildTasksFeedVersion)\build\Microsoft.DotNet.Build.Tasks.Feed.targets" />
+<Project InitialTargets="BuildHelixWorkItems" DefaultTargets="RunInParallelForEachScenario">
+
+  <!-- This project uses the helix SDK, documented at
+       https://github.com/dotnet/arcade/tree/master/src/Microsoft.DotNet.Helix/Sdk,
+       to send test jobs to helix. -->
+
+  <Import Sdk="Microsoft.DotNet.Helix.Sdk" Project="Sdk.props" Condition=" '$(UsesHelixSdk)' == 'true' " />
+
+  <!-- Import Microsoft.DotNet.Build.Tasks.Feed.targets for `ParseBuildManifest` -->
+  <Import Project="..\dir.props" Condition=" '$(NuGetPackageRoot)'=='' "/>
+  <Import Project="$(NuGetPackageRoot)microsoft.dotnet.build.tasks.feed\$(MicrosoftDotNetBuildTasksFeedVersion)\build\Microsoft.DotNet.Build.Tasks.Feed.targets" />  
+
+  <!-- This project is copies much logic from helixpublishwitharcade.proj, used to send coreclr tests to Helix. -->
+
+  <Target Name="RunInParallelForEachScenario">
+    <PropertyGroup>
+      <!-- This specifies what properties are needed to be passed down as global properties to a child project. -->
+
+      <_PropertiesToPass>
+        __BuildArch=$(__BuildArch);
+        __BuildOS=$(__BuildOS);
+        __BuildType=$(__BuildType);
+        Creator=$(_Creator);
+        HelixAccessToken=$(_HelixAccessToken);
+        HelixBuild=$(_HelixBuild);
+        HelixSource=$(_HelixSource);
+        HelixTargetQueues=$(_HelixTargetQueues);
+        HelixType=$(_HelixType);
+        PublishTestResults=$(_PublishTestResults);
+        RunCrossGen=$(_RunCrossGen);
+        TimeoutPerTestCollectionInMinutes=$(_TimeoutPerTestCollectionInMinutes);
+        TimeoutPerTestInMinutes=$(_TimeoutPerTestInMinutes)
+      </_PropertiesToPass>
+    </PropertyGroup>
+
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="PrepareCorrelationPayloadDirectory" />
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="CreateAllTestEnvFiles" Properties="Scenarios=$(_Scenarios)" StopOnFirstFailure="true" />
+
+    <ItemGroup>
+      <_Scenarios Include="$(_Scenarios.Split(','))" />
+
+      <!-- MSBuild creates a new instance of the project for each %(_Scenarios.Identity) and can build them in parallel. -->
+      <_ProjectsToBuild Include="$(MSBuildProjectFile)">
+        <AdditionalProperties>$(_PropertiesToPass);Scenario=%(_Scenarios.Identity)</AdditionalProperties>
+      </_ProjectsToBuild>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_BuildInParallel>false</_BuildInParallel>
+      <_BuildInParallel Condition=" '@(_ProjectsToBuild->Count())' &gt; '1' ">true</_BuildInParallel>
+    </PropertyGroup>
+
+    <MSBuild Projects="@(_ProjectsToBuild)" Targets="Test" BuildInParallel="$(_BuildInParallel)" StopOnFirstFailure="false" Properties="UsesHelixSdk=true" />
+    <!-- <MSBuild Projects="@(_ProjectsToBuild)" Targets="FakeTest" BuildInParallel="false" StopOnFirstFailure="false" Properties="UsesHelixSdk=true" /> -->
+  </Target>
 
   <PropertyGroup>
     <!-- Set the TargetFramework just to make the SDK happy -->
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <!-- NEEDED? <TargetFramework>netstandard2.0</TargetFramework> -->
   </PropertyGroup>
 
   <PropertyGroup>
@@ -27,7 +80,6 @@
     <TestHostRootPath>$(TestWorkingDir)testhost\</TestHostRootPath>
     <TestArchiveRuntimeRoot>$(TestWorkingDir)helix\</TestArchiveRuntimeRoot>
     <TestArchiveRuntimeFile>$(TestArchiveRuntimeRoot)testhost-runtime.zip</TestArchiveRuntimeFile>
-    <HelixCorrelationPayload></HelixCorrelationPayload>
 
     <EnableAzurePipelinesReporter>$(_PublishTestResults)</EnableAzurePipelinesReporter>
     <EnableAzurePipelinesReporter Condition=" '$(EnableAzurePipelinesReporter)' == '' ">false</EnableAzurePipelinesReporter>
@@ -43,9 +95,9 @@
 
   <PropertyGroup>
     <!--
-      For windows we need to use call, since the command is going to be called from a bat script created by Helix
-      and we exit /b at the end of RunTests.cmd, Helix runs some other commands after ours within the bat script,
-      if we don't use call, then we cause the parent script to exit, and anything after will not be executed.
+      For Windows we need to use "call", since the command is going to be called from a batch script created by Helix.
+      We "exit /b" at the end of RunTests.cmd. Helix runs some other commands after ours within the batch script,
+      so if we don't use call, then we cause the parent script to exit, and anything after will not be executed.
       The arguments passed in to the run script in order are the runtime directory, the dotnet root directory (for
       helix submissions same as the runtime directory) and the global tools directory.
     -->
@@ -61,6 +113,36 @@
     <Copy
       SourceFiles="$(ProjectDir)\tests\CoreFX\CoreFX.issues.rsp"
       DestinationFolder="$(TestHostRootPath)" />
+  </Target>
+
+  <PropertyGroup>
+    <TestEnvFileName Condition=" '$(TargetsWindows)' == 'true' ">SetStressModes_$(Scenario).cmd</TestEnvFileName>
+    <TestEnvFileName Condition=" '$(TargetsWindows)' != 'true' ">SetStressModes_$(Scenario).sh</TestEnvFileName>
+  </PropertyGroup>
+
+  <Target Name="CreateTestEnvFiles">
+    <!-- This target creates one __TestEnv file for the $(Scenario). -->
+
+    <ItemGroup>
+      <_ProjectsToBuild Include="..\tests\testenvironment.proj">
+        <Properties>Scenario=$(Scenario);TestEnvFileName=$(TestHostRootPath)\$(TestEnvFileName);TargetsWindows=$(TargetsWindows)</Properties>
+      </_ProjectsToBuild>
+    </ItemGroup>
+
+    <MSBuild Projects="@(_ProjectsToBuild)" Targets="CreateTestEnvFile" StopOnFirstFailure="true" />
+  </Target>
+
+  <Target Name="CreateAllTestEnvFiles">
+    <!-- This target creates one __TestEnv file for each of the $(Scenarios). -->
+
+    <ItemGroup>
+      <_Scenario Include="$(Scenarios.Split(','))" />
+      <_ProjectsToBuild Include="$(MSBuildProjectFile)">
+        <AdditionalProperties>Scenario=%(_Scenario.Identity)</AdditionalProperties>
+      </_ProjectsToBuild>
+    </ItemGroup>
+
+    <MSBuild Projects="@(_ProjectsToBuild)" Targets="CreateTestEnvFiles" StopOnFirstFailure="true" />
   </Target>
 
   <Target Name="CompressRuntimeDirectory"
@@ -82,13 +164,34 @@
     <TestAssetBlobFeedUrl>https://dotnetfeed.blob.core.windows.net/dotnet-core</TestAssetBlobFeedUrl>
   </PropertyGroup>
 
-  <Target Name="GetTestAssetManifest" 
-          Returns="@(TestAssetBlobInfos)">
+  <!-- WARNING: HelixPreCommand ItemGroup is intentionally minimal and should be kept that way. -->
+
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
+    <HelixPreCommand Include="set __TestEnv=%HELIX_CORRELATION_PAYLOAD%\$(TestEnvFileName)" />
+    <HelixPreCommand Include="type %__TestEnv%" />
+    <HelixPreCommand Include="call %__TestEnv%" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetsWindows)' != 'true' ">
+    <HelixPreCommand Include="export __TestEnv=$HELIX_CORRELATION_PAYLOAD/$(TestEnvFileName)" />
+    <HelixPreCommand Include="cat $__TestEnv" />
+    <HelixPreCommand Include="source $__TestEnv" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <HelixPreCommands>@(HelixPreCommand)</HelixPreCommands>
+  </PropertyGroup>
+
+  <Target Name="PrepareCorrelationPayloadDirectory"
+          DependsOnTargets="CompressRuntimeDirectory">
+  </Target>
+
+  <Target Name="GetTestAssetManifest" Condition=" '$(UsesHelixSdk)' == 'true' " >
 
     <!--
        Parse the test asset manifest at, e.g.,
            https://dotnetfeed.blob.core.windows.net/dotnet-core/corefx-tests/4.6.0-preview6.19264.9/Linux.arm64/netcoreapp/corefx-test-assets.xml
-       to figure out the tests to run.
+       to figure out the tests to run. This manifest is created by the corefx official build, for use in the coreclr repo.
      -->
 
     <PropertyGroup>
@@ -99,14 +202,14 @@
     <ParseBuildManifest AssetManifestPath="$(_AssetManifestPath)">
       <Output TaskParameter="BlobInfos" ItemName="TestAssetBlobInfos" />
     </ParseBuildManifest>
+
+    <!-- <Message Importance="High" Text="%(TestAssetBlobInfos.Identity): %(FileName)" /> -->
+
   </Target>
 
-  <Target Name="BuildHelixWorkItems"
-          Inputs="$(TestArchiveRuntimeFile);@(TestAssetBlobInfos)"
-          Outputs="@(HelixCorrelationPayload);@(HelixWorkItem)"
-          DependsOnTargets="CompressRuntimeDirectory;GetTestAssetManifest">
+  <Target Name="BuildHelixWorkItems" DependsOnTargets="GetTestAssetManifest" Condition=" '$(UsesHelixSdk)' == 'true' " >
 
-    <ItemGroup>
+    <ItemGroup Condition=" '$(UsesHelixSdk)' == 'true' ">
       <HelixCorrelationPayload 
         Include="$(TestArchiveRuntimeFile)" />
 
@@ -117,6 +220,21 @@
       </HelixWorkItem>
     </ItemGroup>
 
-    <Message Importance="High" Text="@(HelixWorkItem -> '%(PayloadUri)')" />
   </Target>
+
+  <!-- for testing! -->
+  <Target Name="FakeTest" Condition=" '$(UsesHelixSdk)' == 'true' " >
+    <Message Importance="High" Text="Starting FakeTest" />  
+    <Message Importance="High" Text="Scenario = $(Scenario)" />  
+    <Message Importance="High" Text="TestHostRootPath = $(TestHostRootPath)" />  
+    <Message Importance="High" Text="TestArchiveRuntimeFile = $(TestArchiveRuntimeFile)" />  
+    <Message Importance="High" Text="BuildInParallel = $(BuildInParallel)" />  
+    <Message Importance="High" Text="UsesHelixSdk = $(UsesHelixSdk)" />  
+    <Message Importance="High" Text="%(HelixWorkItem.Identity): %(Command)" />  
+    <Message Importance="High" Text="Pre commands: $(HelixPreCommands)" />  
+    <Message Importance="High" Text="Ending FakeTest" />  
+  </Target>
+
+  <Import Sdk="Microsoft.DotNet.Helix.Sdk" Project="Sdk.targets" Condition=" '$(UsesHelixSdk)' == 'true' " />
+
 </Project>

--- a/eng/helixcorefxtests.proj
+++ b/eng/helixcorefxtests.proj
@@ -8,7 +8,7 @@
 
   <!-- Import Microsoft.DotNet.Build.Tasks.Feed.targets for `ParseBuildManifest` -->
   <Import Project="..\dir.props" Condition=" '$(NuGetPackageRoot)'=='' "/>
-  <Import Project="$(NuGetPackageRoot)microsoft.dotnet.build.tasks.feed\$(MicrosoftDotNetBuildTasksFeedVersion)\build\Microsoft.DotNet.Build.Tasks.Feed.targets" />  
+  <Import Project="$(NuGetPackageRoot)microsoft.dotnet.build.tasks.feed\$(MicrosoftDotNetBuildTasksFeedVersion)\build\Microsoft.DotNet.Build.Tasks.Feed.targets" />
 
   <!-- This project is copies much logic from helixpublishwitharcade.proj, used to send coreclr tests to Helix. -->
 
@@ -222,6 +222,61 @@
   </Target>
 
   <!--
+    The following item and property groups are setting things needed by Helix, to describe the jobs
+    we are creating. Ideally, we would put them inside the "BuildHelixWorkItems" task, which is what
+    we run to create the Helix correlation payload and work item groups. However, the Helix SDK
+    references some of these in "InitialTargets", and we don't have control over the order of
+    InitialTargets running, so we need to make these "global". All the "global" item and property
+    groups will be evaluated before the Helix InitialTargets are run.
+  -->
+
+  <!-- HelixPreCommands is a set of commands run before the work item command. We use it here to inject
+       setting up the per-scenario environment.
+  -->
+
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
+    <HelixPreCommand Include="set __TestEnv=%HELIX_CORRELATION_PAYLOAD%\$(TestEnvFileName)" />
+    <HelixPreCommand Include="type %__TestEnv%" />
+    <HelixPreCommand Include="call %__TestEnv%" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetsWindows)' != 'true' ">
+    <HelixPreCommand Include="export __TestEnv=$HELIX_CORRELATION_PAYLOAD/$(TestEnvFileName)" />
+    <HelixPreCommand Include="cat $__TestEnv" />
+    <HelixPreCommand Include="source $__TestEnv" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <HelixPreCommands>@(HelixPreCommand)</HelixPreCommands>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <HelixArchitecture>$(__BuildArch)</HelixArchitecture>
+
+    <HelixConfiguration Condition=" '$(Scenario)' == 'normal' ">$(BuildType)</HelixConfiguration>
+    <HelixConfiguration Condition=" '$(Scenario)' != 'normal' ">$(BuildType)-$(Scenario)</HelixConfiguration>
+
+    <TestRunNamePrefix Condition=" '$(Scenario)' == 'normal' ">$(TestRunNamePrefix)$(BuildOS) $(BuildArch) $(BuildType) @ </TestRunNamePrefix>
+    <TestRunNamePrefix Condition=" '$(Scenario)' != 'normal' ">$(TestRunNamePrefix)$(BuildOS) $(BuildArch) $(BuildType) $(Scenario) @ </TestRunNamePrefix>
+
+    <!-- REVIEW: it seems like this should be referencing "PublishTestResults" instead (without the underscore) -->
+    <EnableAzurePipelinesReporter>$(_PublishTestResults)</EnableAzurePipelinesReporter>
+    <EnableAzurePipelinesReporter Condition=" '$(EnableAzurePipelinesReporter)' == '' ">false</EnableAzurePipelinesReporter>
+
+    <EnableXUnitReporter>true</EnableXUnitReporter>
+    <FailOnMissionControlTestFailure>true</FailOnMissionControlTestFailure>
+    <FailOnWorkItemFailure>true</FailOnWorkItemFailure>
+    <WaitForWorkItemCompletion>true</WaitForWorkItemCompletion>
+
+    <!-- REVIEW: should we be using "TimeoutPerTestInMinutes" or "TimeoutPerTestCollectionInMinutes"? -->
+    <TimeoutInSeconds Condition="'$(TimeoutInSeconds)' == ''">600</TimeoutInSeconds>
+    <CommandTimeoutSpan>$([System.TimeSpan]::FromSeconds($(TimeoutInSeconds)))</CommandTimeoutSpan>
+
+    <!-- Specify the retry policy for Helix jobs: -->
+    <MaxRetryCount Condition="'$(MaxRetryCount)' == ''">4</MaxRetryCount>
+  </PropertyGroup>
+
+  <!--
     Create all the Helix data to start a set of jobs. This is invoked once for each Scenario (see
     target "RunInParallelForEachScenario"). Create a set of work items, one for each CoreFX test assembly.
     All will have the same Scenario specific command line.  Note that this target is listed in the
@@ -231,53 +286,6 @@
     during the other invocations of this Project, such as when "RunInParallelForEachScenario" is run.
   -->
   <Target Name="BuildHelixWorkItems" DependsOnTargets="GetTestAssetManifest" Condition=" '$(UsesHelixSdk)' == 'true' " >
-
-    <!-- HelixPreCommands is a set of commands run before the work item command. We use it here to inject
-         setting up the per-scenario environment.
-    -->
-
-    <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
-      <HelixPreCommand Include="set __TestEnv=%HELIX_CORRELATION_PAYLOAD%\$(TestEnvFileName)" />
-      <HelixPreCommand Include="type %__TestEnv%" />
-      <HelixPreCommand Include="call %__TestEnv%" />
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetsWindows)' != 'true' ">
-      <HelixPreCommand Include="export __TestEnv=$HELIX_CORRELATION_PAYLOAD/$(TestEnvFileName)" />
-      <HelixPreCommand Include="cat $__TestEnv" />
-      <HelixPreCommand Include="source $__TestEnv" />
-    </ItemGroup>
-
-    <PropertyGroup>
-      <HelixPreCommands>@(HelixPreCommand)</HelixPreCommands>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <HelixArchitecture>$(__BuildArch)</HelixArchitecture>
-
-      <HelixConfiguration Condition=" '$(Scenario)' == 'normal' ">$(BuildType)</HelixConfiguration>
-      <HelixConfiguration Condition=" '$(Scenario)' != 'normal' ">$(BuildType)-$(Scenario)</HelixConfiguration>
-
-      <TestRunNamePrefix Condition=" '$(Scenario)' == 'normal' ">$(TestRunNamePrefix)$(BuildOS) $(BuildArch) $(BuildType) @ </TestRunNamePrefix>
-      <TestRunNamePrefix Condition=" '$(Scenario)' != 'normal' ">$(TestRunNamePrefix)$(BuildOS) $(BuildArch) $(BuildType) $(Scenario) @ </TestRunNamePrefix>
-
-      <!-- REVIEW: it seems like this should be referencing "PublishTestResults" instead (without the underscore) -->
-      <EnableAzurePipelinesReporter>$(_PublishTestResults)</EnableAzurePipelinesReporter>
-      <EnableAzurePipelinesReporter Condition=" '$(EnableAzurePipelinesReporter)' == '' ">false</EnableAzurePipelinesReporter>
-
-      <EnableXUnitReporter>true</EnableXUnitReporter>
-      <FailOnMissionControlTestFailure>true</FailOnMissionControlTestFailure>
-      <FailOnWorkItemFailure>true</FailOnWorkItemFailure>
-      <WaitForWorkItemCompletion>true</WaitForWorkItemCompletion>
-
-      <!-- REVIEW: should we be using "TimeoutPerTestInMinutes" or "TimeoutPerTestCollectionInMinutes"? -->
-      <TimeoutInSeconds Condition="'$(TimeoutInSeconds)' == ''">600</TimeoutInSeconds>
-      <CommandTimeoutSpan>$([System.TimeSpan]::FromSeconds($(TimeoutInSeconds)))</CommandTimeoutSpan>
-
-      <!-- Specify the retry policy for Helix jobs: -->
-      <MaxRetryCount Condition="'$(MaxRetryCount)' == ''">4</MaxRetryCount>
-    </PropertyGroup>
-
     <ItemGroup Condition=" '$(UsesHelixSdk)' == 'true' ">
       <HelixCorrelationPayload 
         Include="$(TestArchiveRuntimeFile)" />
@@ -288,7 +296,6 @@
         <Timeout>$(CommandTimeoutSpan)</Timeout>
       </HelixWorkItem>
     </ItemGroup>
-
   </Target>
 
   <Import Sdk="Microsoft.DotNet.Helix.Sdk" Project="Sdk.targets" Condition=" '$(UsesHelixSdk)' == 'true' " />

--- a/eng/helixcorefxtests.proj
+++ b/eng/helixcorefxtests.proj
@@ -12,6 +12,17 @@
 
   <!-- This project is copies much logic from helixpublishwitharcade.proj, used to send coreclr tests to Helix. -->
 
+  <!--
+    "RunInParallelForEachScenario" is the "root" target for this Project. It invokes other targets to set up the
+    information needed to submit a job to Helix. It does so by "recursively" invoking this project file with
+    different properties and targets to run, as well as invoking MSBuild on other project files. In particular,
+    it first creates the "correlation payload directory", which is the directory of files used by all Helix
+    submissions. Then, it recursively invokes this Project once per scenario (e.g., normal Pri-1 run, JitStress=2
+    run, JitStressRegs=8 run, etc.), creating a new set of Helix work items for each scenario. For the CoreFX
+    tests, we create one Helix work item for each CoreFX test assembly; there is currently no concept of
+    grouping multiple assemblies into a single Helix work item to, for instance, consolidate multiple short-running
+    assemblies together. (Note that this grouping is done for the CoreCLR tests in helixpublishwitharcade.proj.)
+  -->
   <Target Name="RunInParallelForEachScenario">
     <PropertyGroup>
       <!-- This specifies what properties are needed to be passed down as global properties to a child project. -->
@@ -77,6 +88,15 @@
     <TestWorkingDir Condition="'$(__TestWorkingDir)'==''">$(RootBinDir)tests\$(__BuildOS).$(__BuildArch).$(__BuildType)\</TestWorkingDir>
     <TargetsWindows Condition="'$(__BuildOS)' == 'Windows_NT'">true</TargetsWindows>
 
+    <!-- We have a single, universal exclusion file for all CoreFX test exclusions, for CoreFX tests run
+         in the CoreCLR repo. Note in particular that we don't have a unique exclusion file for each test
+         assembly, or for each processor architecture, or for each operating system, or for each stress
+         scenario type. This means that we generally exclude more tests than is strictly necessary for
+         any particular job. However, this mechanism is super simple; we don't need to manage fine-
+         grained exclusions; and there really shouldn't be any (or many) exclusions anyway.
+    -->
+    <CoreFXTestExclusionFile>$(ProjectDir)\tests\CoreFX\CoreFX.issues.rsp</CoreFXTestExclusionFile>
+
     <TestHostRootPath>$(TestWorkingDir)testhost\</TestHostRootPath>
     <TestArchiveRuntimeRoot>$(TestWorkingDir)helix\</TestArchiveRuntimeRoot>
     <TestArchiveRuntimeFile>$(TestArchiveRuntimeRoot)testhost-runtime.zip</TestArchiveRuntimeFile>
@@ -86,11 +106,11 @@
 
   <PropertyGroup>
     <!--
-      For Windows we need to use "call", since the command is going to be called from a batch script created by Helix.
+      For Windows, we need to use "call", since the command is going to be called from a batch script created by Helix.
       We "exit /b" at the end of RunTests.cmd. Helix runs some other commands after ours within the batch script,
       so if we don't use call, then we cause the parent script to exit, and anything after will not be executed.
-      The arguments passed in to the run script in order are the runtime directory, the dotnet root directory (for
-      helix submissions same as the runtime directory) and the global tools directory.
+      The arguments passed in to the run script in are the runtime directory (-r), the dotnet root directory (-d) (for
+      Helix submissions this is the same as the runtime directory) and the global tools directory (-g).
     -->
     <HelixCommand Condition="'$(TargetsWindows)' == 'true'">call RunTests.cmd -r %HELIX_CORRELATION_PAYLOAD% -d %HELIX_CORRELATION_PAYLOAD% -g %HELIX_CORRELATION_PAYLOAD%\tools --rsp-file %HELIX_CORRELATION_PAYLOAD%\CoreFX.issues.rsp </HelixCommand>
     <HelixCommand Condition="'$(TargetsWindows)' != 'true'">./RunTests.sh -r $HELIX_CORRELATION_PAYLOAD -d $HELIX_CORRELATION_PAYLOAD -g $HELIX_CORRELATION_PAYLOAD/tools --rsp-file $HELIX_CORRELATION_PAYLOAD/CoreFX.issues.rsp </HelixCommand>
@@ -107,8 +127,10 @@
   -->
   <Target Name="CopyRSPFile">
     <Copy
-      SourceFiles="$(ProjectDir)\tests\CoreFX\CoreFX.issues.rsp"
+      SourceFiles="$(CoreFXTestExclusionFile)"
       DestinationFolder="$(TestHostRootPath)" />
+
+    <Message Importance="High" Text="Copied $(CoreFXTestExclusionFile) into $(TestHostRootPath)" />
   </Target>
 
   <!--
@@ -140,13 +162,20 @@
   <Target Name="CreateTestEnvFile">
     <!-- This target creates one __TestEnv file for the single $(Scenario). -->
 
+    <PropertyGroup>
+      <TestEnvFilePath>$(TestHostRootPath)\$(TestEnvFileName)</TestEnvFilePath>
+    </PropertyGroup>
+
     <ItemGroup>
       <_ProjectsToBuild Include="..\tests\testenvironment.proj">
-        <Properties>Scenario=$(Scenario);TestEnvFileName=$(TestHostRootPath)\$(TestEnvFileName);TargetsWindows=$(TargetsWindows)</Properties>
+        <Properties>Scenario=$(Scenario);TestEnvFileName=$(TestEnvFilePath);TargetsWindows=$(TargetsWindows)</Properties>
       </_ProjectsToBuild>
     </ItemGroup>
 
     <MSBuild Projects="@(_ProjectsToBuild)" Targets="CreateTestEnvFile" StopOnFirstFailure="true" />
+
+    <Message Importance="High" Text="Created $(TestEnvFilePath) for scenario $(Scenario)" />
+    <Error Condition="!Exists('$(TestEnvFilePath)')" Text="File $(TestEnvFilePath) not found!" />
   </Target>
 
   <Target Name="CreateAllScenarioTestEnvFiles">

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -318,6 +318,7 @@ jobs:
     - task: PublishBuildArtifacts@1
       displayName: Publish Logs
       inputs:
+        pathtoPublish: $(Build.SourcesDirectory)/bin/Logs
         ${{ if and(eq(parameters.corefxTests, true), eq(parameters.readyToRun, true)) }}:
           artifactName: ${{ format('test{0}_{1}_{2}_{3}_{4}_Logs', '_r2r_corefx', parameters.osIdentifier, parameters.archType, parameters.buildConfig, parameters.testGroup) }}
         ${{ if and(eq(parameters.corefxTests, true), ne(parameters.readyToRun, true)) }}:
@@ -326,6 +327,5 @@ jobs:
           artifactName: ${{ format('test{0}_{1}_{2}_{3}_{4}_Logs', '_r2r',        parameters.osIdentifier, parameters.archType, parameters.buildConfig, parameters.testGroup) }}
         ${{ if and(ne(parameters.corefxTests, true), ne(parameters.readyToRun, true)) }}:
           artifactName: ${{ format('test{0}_{1}_{2}_{3}_{4}_Logs', '',            parameters.osIdentifier, parameters.archType, parameters.buildConfig, parameters.testGroup) }}
-        targetPath: $(Build.SourcesDirectory)/bin/Logs
       continueOnError: true
       condition: always()

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -101,9 +101,9 @@ jobs:
     # this number should be adjusted accordingly.
     ${{ if eq(parameters.testGroup, 'innerloop') }}:
       timeoutInMinutes: 240
-    ${{ if eq(parameters.testGroup, 'outerloop') }}:
+    ${{ if in(parameters.testGroup, 'outerloop', 'corefx') }}:
       timeoutInMinutes: 360
-    ${{ if in(parameters.testGroup, 'outerloop-jitstress', 'outerloop-jitstress-isas-arm', 'outerloop-jitstressregs-x86', 'outerloop-jitstressregs', 'outerloop-jitstress2-jitstressregs', 'outerloop-gcstress0x3-gcstress0xc') }}:
+    ${{ if in(parameters.testGroup, 'outerloop-jitstress', 'outerloop-jitstress-isas-arm', 'outerloop-jitstressregs-x86', 'outerloop-jitstressregs', 'outerloop-jitstress2-jitstressregs', 'outerloop-gcstress0x3-gcstress0xc', 'corefx-jitstress', 'corefx-jitstressregs', 'corefx-jitstress2-jitstressregs') }}:
       timeoutInMinutes: 480
     ${{ if in(parameters.testGroup, 'outerloop-jitstress-isas-x86', 'outerloop-gcstress-extra', 'outerloop-r2r-extra') }}:
       timeoutInMinutes: 600
@@ -183,10 +183,10 @@ jobs:
           timeoutPerTestCollectionInMinutes: 30
           # "PerTest" corresponds to individual test running time (i.e. __TestTimeout).
           timeoutPerTestInMinutes: 10
-        ${{ if eq(parameters.testGroup, 'outerloop') }}:
+        ${{ if in(parameters.testGroup, 'outerloop', 'corefx') }}:
           timeoutPerTestCollectionInMinutes: 120
           timeoutPerTestInMinutes: 10
-        ${{ if in(parameters.testGroup, 'outerloop-jitstress', 'outerloop-jitstress-isas-arm', 'outerloop-jitstress-isas-x86', 'outerloop-jitstressregs-x86', 'outerloop-jitstressregs', 'outerloop-jitstress2-jitstressregs') }}:
+        ${{ if in(parameters.testGroup, 'outerloop-jitstress', 'outerloop-jitstress-isas-arm', 'outerloop-jitstress-isas-x86', 'outerloop-jitstressregs-x86', 'outerloop-jitstressregs', 'outerloop-jitstress2-jitstressregs', 'corefx-jitstress', 'corefx-jitstressregs', 'corefx-jitstress2-jitstressregs') }}:
           timeoutPerTestCollectionInMinutes: 120
           timeoutPerTestInMinutes: 30
         ${{ if in(parameters.testGroup, 'outerloop-gcstress0x3-gcstress0xc') }}:
@@ -209,11 +209,11 @@ jobs:
         ${{ if eq(parameters.corefxTests, false) }}:
           helixProjectArguments: 'tests/helixpublishwitharcade.proj'
 
-        ${{ if in(parameters.testGroup, 'innerloop', 'outerloop') }}:
+        ${{ if in(parameters.testGroup, 'innerloop', 'outerloop', 'corefx') }}:
           scenarios:
           - normal
           - no_tiered_compilation
-        ${{ if eq(parameters.testGroup, 'outerloop-jitstress') }}:
+        ${{ if in(parameters.testGroup, 'outerloop-jitstress', 'corefx-jitstress') }}:
           scenarios:
           - jitminopts
           - jitstress1
@@ -261,7 +261,7 @@ jobs:
           - jitstressregs0x10_x86_noavx
           - jitstressregs0x80_x86_noavx
           - jitstressregs0x1000_x86_noavx
-        ${{ if eq(parameters.testGroup, 'outerloop-jitstressregs') }}:
+        ${{ if in(parameters.testGroup, 'outerloop-jitstressregs', 'corefx-jitstressregs') }}:
           scenarios:
           - jitstressregs1
           - jitstressregs2
@@ -271,7 +271,7 @@ jobs:
           - jitstressregs0x10
           - jitstressregs0x80
           - jitstressregs0x1000
-        ${{ if eq(parameters.testGroup, 'outerloop-jitstress2-jitstressregs') }}:
+        ${{ if in(parameters.testGroup, 'outerloop-jitstress2-jitstressregs', 'corefx-jitstress2-jitstressregs') }}:
           scenarios:
           - jitstress2_jitstressregs1
           - jitstress2_jitstressregs2

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -11,43 +11,6 @@ parameters:
   corefxTests: false
   displayNameArgs: ''
 
-variables:
-# Create some useful global variables
-
-# Display name for "innerloop" and "outerloop"
-- name: testGroupDisplayArg
-  value: ''
-- ${{ if eq(parameters.testGroup, 'innerloop') }}:
-  - name: testGroupDisplayArg
-    value: 'Pri0'
-- ${{ if ne(parameters.testGroup, 'innerloop') }}:
-  - name: testGroupDisplayArg
-    value: 'Pri1'
-
-# Filename for "innerloop" and "outerloop". Use a short name, for easier typing, and because AzDO UI sometimes
-# crops filename.
-- name: testGroupFilenameArg
-  value: ''
-- ${{ if eq(parameters.testGroup, 'innerloop') }}:
-  - name: testGroupFilenameArg
-    value: 'p0'
-- ${{ if ne(parameters.testGroup, 'innerloop') }}:
-  - name: testGroupFilenameArg
-    value: 'p1'
-
-# Filename component to indicate R2R or CoreFX job.
-- name: testTypeFilenameArg
-  value: ''
-  ${{ if and(eq(parameters.corefxTests, true), eq(parameters.readyToRun, true)) }}:
-  - name: testTypeFilenameArg
-    value: '_r2r_corefx'
-  ${{ if and(eq(parameters.corefxTests, true), ne(parameters.readyToRun, true)) }}:
-  - name: testTypeFilenameArg
-    value: '_corefx'
-  ${{ if and(ne(parameters.corefxTests, true), eq(parameters.readyToRun, true)) }}:
-  - name: testTypeFilenameArg
-    value: '_r2r'
-
 ### Test job
 
 ### Each test job depends on a corresponding build job with the same
@@ -63,8 +26,13 @@ jobs:
     helixType: 'build/tests/'
 
     # Compute job name from template parameters
-    name: ${{ format('test_{0}_{1}_{2}_{3}_{4}', $(testGroupFilenameArg), parameters.displayNameArgs, parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
-    displayName: ${{ format('Test {0} {1} {2} {3} {4}', $(testGroupDisplayArg), parameters.displayNameArgs, parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+    ${{ if eq(parameters.testGroup, 'innerloop') }}:
+      name: ${{ format('test_{0}_{1}_{2}_{3}_{4}', 'p0', parameters.displayNameArgs, parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+      displayName: ${{ format('Test {0} {1} {2} {3} {4}', 'Pri0', parameters.displayNameArgs, parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+
+    ${{ if ne(parameters.testGroup, 'innerloop') }}:
+      name: ${{ format('test_{0}_{1}_{2}_{3}_{4}', 'p1', parameters.displayNameArgs, parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+      displayName: ${{ format('Test {0} {1} {2} {3} {4}', 'Pri1', parameters.displayNameArgs, parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
 
     crossrootfsDir: ${{ parameters.crossrootfsDir }}
 
@@ -182,12 +150,16 @@ jobs:
         helixBuild: $(Build.BuildNumber)
         helixSource: $(_HelixSource)
 
-        ${{ if and(ne(parameters.corefxTests, true), eq(parameters.readyToRun, false)) }}:
-          helixType: 'test/functional/cli/'
+        # REVIEW: not sure why "cli" is part of the names here. Leave it for the ones that already had it,
+        # but don't add it to new ones.
+        ${{ if and(eq(parameters.corefxTests, true), eq(parameters.readyToRun, true)) }}:
+          helixType: 'test/functional/r2r_corefx/'
+        ${{ if and(eq(parameters.corefxTests, true), ne(parameters.readyToRun, true)) }}:
+          helixType: 'test/functional/corefx/'
         ${{ if and(ne(parameters.corefxTests, true), eq(parameters.readyToRun, true)) }}:
           helixType: 'test/functional/r2r/cli/'
-        ${{ if eq(parameters.corefxTests, true) }}:
-          helixType: 'test/functional/corefx/'
+        ${{ if and(ne(parameters.corefxTests, true), ne(parameters.readyToRun, true)) }}:
+          helixType: 'test/functional/cli/'
 
         helixQueues: ${{ parameters.helixQueues }}
 
@@ -338,7 +310,14 @@ jobs:
     - task: PublishBuildArtifacts@1
       displayName: Publish Logs
       inputs:
-        artifactName: ${{ format('test_{0}_{1}_{2}_{3}{4}_Logs', parameters.osIdentifier, parameters.archType, parameters.buildConfig, parameters.testGroup, $(testTypeFilenameArg)) }}
+        ${{ if and(eq(parameters.corefxTests, true), eq(parameters.readyToRun, true)) }}:
+          artifactName: ${{ format('test_{0}_{1}_{2}_{3}{4}_Logs', parameters.osIdentifier, parameters.archType, parameters.buildConfig, parameters.testGroup, '_r2r_corefx') }}
+        ${{ if and(eq(parameters.corefxTests, true), ne(parameters.readyToRun, true)) }}:
+          artifactName: ${{ format('test_{0}_{1}_{2}_{3}{4}_Logs', parameters.osIdentifier, parameters.archType, parameters.buildConfig, parameters.testGroup, '_corefx') }}
+        ${{ if and(ne(parameters.corefxTests, true), eq(parameters.readyToRun, true)) }}:
+          artifactName: ${{ format('test_{0}_{1}_{2}_{3}{4}_Logs', parameters.osIdentifier, parameters.archType, parameters.buildConfig, parameters.testGroup, '_r2r') }}
+        ${{ if and(ne(parameters.corefxTests, true), ne(parameters.readyToRun, true)) }}:
+          artifactName: ${{ format('test_{0}_{1}_{2}_{3}{4}_Logs', parameters.osIdentifier, parameters.archType, parameters.buildConfig, parameters.testGroup, '') }}
         targetPath: $(Build.SourcesDirectory)/bin/Logs
       continueOnError: true
       condition: always()

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -319,13 +319,13 @@ jobs:
       displayName: Publish Logs
       inputs:
         ${{ if and(eq(parameters.corefxTests, true), eq(parameters.readyToRun, true)) }}:
-          artifactName: ${{ format('test_{0}_{1}_{2}_{3}{4}_Logs', parameters.osIdentifier, parameters.archType, parameters.buildConfig, parameters.testGroup, '_r2r_corefx') }}
+          artifactName: ${{ format('test{0}_{1}_{2}_{3}_{4}_Logs', '_r2r_corefx', parameters.osIdentifier, parameters.archType, parameters.buildConfig, parameters.testGroup) }}
         ${{ if and(eq(parameters.corefxTests, true), ne(parameters.readyToRun, true)) }}:
-          artifactName: ${{ format('test_{0}_{1}_{2}_{3}{4}_Logs', parameters.osIdentifier, parameters.archType, parameters.buildConfig, parameters.testGroup, '_corefx') }}
+          artifactName: ${{ format('test{0}_{1}_{2}_{3}_{4}_Logs', '_corefx',     parameters.osIdentifier, parameters.archType, parameters.buildConfig, parameters.testGroup) }}
         ${{ if and(ne(parameters.corefxTests, true), eq(parameters.readyToRun, true)) }}:
-          artifactName: ${{ format('test_{0}_{1}_{2}_{3}{4}_Logs', parameters.osIdentifier, parameters.archType, parameters.buildConfig, parameters.testGroup, '_r2r') }}
+          artifactName: ${{ format('test{0}_{1}_{2}_{3}_{4}_Logs', '_r2r',        parameters.osIdentifier, parameters.archType, parameters.buildConfig, parameters.testGroup) }}
         ${{ if and(ne(parameters.corefxTests, true), ne(parameters.readyToRun, true)) }}:
-          artifactName: ${{ format('test_{0}_{1}_{2}_{3}{4}_Logs', parameters.osIdentifier, parameters.archType, parameters.buildConfig, parameters.testGroup, '') }}
+          artifactName: ${{ format('test{0}_{1}_{2}_{3}_{4}_Logs', '',            parameters.osIdentifier, parameters.archType, parameters.buildConfig, parameters.testGroup) }}
         targetPath: $(Build.SourcesDirectory)/bin/Logs
       continueOnError: true
       condition: always()

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -195,9 +195,9 @@ jobs:
           # DotNet-HelixApi-Access variable group
           helixAccessToken: $(HelixApiAccessToken)
 
-        # Sets up the template to run the corefx tests
+        # Choose which tests to send to Helix: CoreFX or CoreCLR.
         ${{ if eq(parameters.corefxTests, true) }}:
-          helixProjectArguments: 'eng/helixcorefxtests.proj /t:Test /p:ArcadeBuild=True'
+          helixProjectArguments: 'eng/helixcorefxtests.proj'
         ${{ if eq(parameters.corefxTests, false) }}:
           helixProjectArguments: 'tests/helixpublishwitharcade.proj'
 

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -11,6 +11,43 @@ parameters:
   corefxTests: false
   displayNameArgs: ''
 
+variables:
+# Create some useful global variables
+
+# Display name for "innerloop" and "outerloop"
+- name: testGroupDisplayArg
+  value: ''
+- ${{ if eq(parameters.testGroup, 'innerloop') }}:
+  - name: testGroupDisplayArg
+    value: 'Pri0'
+- ${{ if ne(parameters.testGroup, 'innerloop') }}:
+  - name: testGroupDisplayArg
+    value: 'Pri1'
+
+# Filename for "innerloop" and "outerloop". Use a short name, for easier typing, and because AzDO UI sometimes
+# crops filename.
+- name: testGroupFilenameArg
+  value: ''
+- ${{ if eq(parameters.testGroup, 'innerloop') }}:
+  - name: testGroupFilenameArg
+    value: 'p0'
+- ${{ if ne(parameters.testGroup, 'innerloop') }}:
+  - name: testGroupFilenameArg
+    value: 'p1'
+
+# Filename component to indicate R2R or CoreFX job.
+- name: testTypeFilenameArg
+  value: ''
+  ${{ if and(eq(parameters.corefxTests, true), eq(parameters.readyToRun, true)) }}:
+  - name: testTypeFilenameArg
+    value: '_r2r_corefx'
+  ${{ if and(eq(parameters.corefxTests, true), ne(parameters.readyToRun, true)) }}:
+  - name: testTypeFilenameArg
+    value: '_corefx'
+  ${{ if and(ne(parameters.corefxTests, true), eq(parameters.readyToRun, true)) }}:
+  - name: testTypeFilenameArg
+    value: '_r2r'
+
 ### Test job
 
 ### Each test job depends on a corresponding build job with the same
@@ -26,13 +63,8 @@ jobs:
     helixType: 'build/tests/'
 
     # Compute job name from template parameters
-    ${{ if eq(parameters.testGroup, 'innerloop') }}:
-      name: ${{ format('testbuild_pri0_{0}_{1}_{2}_{3}', parameters.displayNameArgs, parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
-      displayName: ${{ format('Test Pri0 {0} {1} {2}_{3}', parameters.displayNameArgs, parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
-
-    ${{ if ne(parameters.testGroup, 'innerloop') }}:
-      name: ${{ format('testbuild_pri1_{0}_{1}_{2}_{3}', parameters.displayNameArgs, parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
-      displayName: ${{ format('Test Pri1 {0} {1} {2} {3}', parameters.displayNameArgs, parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+    name: ${{ format('test_{0}_{1}_{2}_{3}_{4}', $(testGroupFilenameArg), parameters.displayNameArgs, parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+    displayName: ${{ format('Test {0} {1} {2} {3} {4}', $(testGroupDisplayArg), parameters.displayNameArgs, parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
 
     crossrootfsDir: ${{ parameters.crossrootfsDir }}
 
@@ -306,10 +338,7 @@ jobs:
     - task: PublishBuildArtifacts@1
       displayName: Publish Logs
       inputs:
-        pathtoPublish: $(Build.SourcesDirectory)/bin/Logs
-        ${{ if eq(parameters.readyToRun, false) }}:
-          artifactName: ${{ format('testbuild_{0}_{1}_{2}_{3}_Logs', parameters.osIdentifier, parameters.archType, parameters.buildConfig, parameters.testGroup) }}
-        ${{ if eq(parameters.readyToRun, true) }}:
-          artifactName: ${{ format('testbuild_{0}_{1}_{2}_{3}_r2r_Logs', parameters.osIdentifier, parameters.archType, parameters.buildConfig, parameters.testGroup) }}
+        artifactName: ${{ format('test_{0}_{1}_{2}_{3}{4}_Logs', parameters.osIdentifier, parameters.archType, parameters.buildConfig, parameters.testGroup, $(testTypeFilenameArg)) }}
+        targetPath: $(Build.SourcesDirectory)/bin/Logs
       continueOnError: true
       condition: always()

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -39,6 +39,7 @@ jobs:
     variables:
     - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       - group: DotNet-HelixApi-Access
+
     # Map template parameters to command line arguments
     - name: priorityArg
       value: ''
@@ -149,10 +150,12 @@ jobs:
         helixBuild: $(Build.BuildNumber)
         helixSource: $(_HelixSource)
 
-        ${{ if eq(parameters.readyToRun, false) }}:
+        ${{ if and(ne(parameters.corefxTests, true), eq(parameters.readyToRun, false)) }}:
           helixType: 'test/functional/cli/'
-        ${{ if eq(parameters.readyToRun, true) }}:
+        ${{ if and(ne(parameters.corefxTests, true), eq(parameters.readyToRun, true)) }}:
           helixType: 'test/functional/r2r/cli/'
+        ${{ if eq(parameters.corefxTests, true) }}:
+          helixType: 'test/functional/corefx/'
 
         helixQueues: ${{ parameters.helixQueues }}
 
@@ -306,7 +309,7 @@ jobs:
         pathtoPublish: $(Build.SourcesDirectory)/bin/Logs
         ${{ if eq(parameters.readyToRun, false) }}:
           artifactName: ${{ format('testbuild_{0}_{1}_{2}_{3}_Logs', parameters.osIdentifier, parameters.archType, parameters.buildConfig, parameters.testGroup) }}
-        ${{ if  eq(parameters.readyToRun, true) }}:
+        ${{ if eq(parameters.readyToRun, true) }}:
           artifactName: ${{ format('testbuild_{0}_{1}_{2}_{3}_r2r_Logs', parameters.osIdentifier, parameters.archType, parameters.buildConfig, parameters.testGroup) }}
       continueOnError: true
       condition: always()

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -26,11 +26,19 @@ jobs:
     helixType: 'build/tests/'
 
     # Compute job name from template parameters
-    ${{ if eq(parameters.testGroup, 'innerloop') }}:
+    ${{ if and(eq(parameters.testGroup, 'innerloop'), eq(parameters.displayNameArgs, '')) }}:
+      name: ${{ format('test_{0}_{1}_{2}_{3}', 'p0', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+      displayName: ${{ format('Test {0} {1} {2} {3}', 'Pri0', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+
+    ${{ if and(ne(parameters.testGroup, 'innerloop'), eq(parameters.displayNameArgs, '')) }}:
+      name: ${{ format('test_{0}_{1}_{2}_{3}', 'p1', parameters.displayNameArgs, parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+      displayName: ${{ format('Test {0} {1} {2} {3}', 'Pri1', parameters.displayNameArgs, parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+
+    ${{ if and(eq(parameters.testGroup, 'innerloop'), ne(parameters.displayNameArgs, '')) }}:
       name: ${{ format('test_{0}_{1}_{2}_{3}_{4}', 'p0', parameters.displayNameArgs, parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
       displayName: ${{ format('Test {0} {1} {2} {3} {4}', 'Pri0', parameters.displayNameArgs, parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
 
-    ${{ if ne(parameters.testGroup, 'innerloop') }}:
+    ${{ if and(ne(parameters.testGroup, 'innerloop'), ne(parameters.displayNameArgs, '')) }}:
       name: ${{ format('test_{0}_{1}_{2}_{3}_{4}', 'p1', parameters.displayNameArgs, parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
       displayName: ${{ format('Test {0} {1} {2} {3} {4}', 'Pri1', parameters.displayNameArgs, parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
 

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -3,7 +3,7 @@ parameters:
   archType: ''
   osGroup: ''
   osIdentifier: ''
-  testGroup: ''
+  testGroup: 'UNDEFINED'
   readyToRun: false
   helixQueues: ''
   crossrootfsDir: ''
@@ -101,11 +101,11 @@ jobs:
     # this number should be adjusted accordingly.
     ${{ if eq(parameters.testGroup, 'innerloop') }}:
       timeoutInMinutes: 240
-    ${{ if in(parameters.testGroup, 'outerloop', 'corefx') }}:
+    ${{ if in(parameters.testGroup, 'outerloop') }}:
       timeoutInMinutes: 360
-    ${{ if in(parameters.testGroup, 'outerloop-jitstress', 'outerloop-jitstress-isas-arm', 'outerloop-jitstressregs-x86', 'outerloop-jitstressregs', 'outerloop-jitstress2-jitstressregs', 'outerloop-gcstress0x3-gcstress0xc', 'corefx-jitstress', 'corefx-jitstressregs', 'corefx-jitstress2-jitstressregs') }}:
+    ${{ if in(parameters.testGroup, 'jitstress', 'jitstress-isas-arm', 'jitstressregs-x86', 'jitstressregs', 'jitstress2-jitstressregs', 'gcstress0x3-gcstress0xc') }}:
       timeoutInMinutes: 480
-    ${{ if in(parameters.testGroup, 'outerloop-jitstress-isas-x86', 'outerloop-gcstress-extra', 'outerloop-r2r-extra') }}:
+    ${{ if in(parameters.testGroup, 'jitstress-isas-x86', 'gcstress-extra', 'r2r-extra') }}:
       timeoutInMinutes: 600
 
     steps:
@@ -183,16 +183,16 @@ jobs:
           timeoutPerTestCollectionInMinutes: 30
           # "PerTest" corresponds to individual test running time (i.e. __TestTimeout).
           timeoutPerTestInMinutes: 10
-        ${{ if in(parameters.testGroup, 'outerloop', 'corefx') }}:
+        ${{ if in(parameters.testGroup, 'outerloop') }}:
           timeoutPerTestCollectionInMinutes: 120
           timeoutPerTestInMinutes: 10
-        ${{ if in(parameters.testGroup, 'outerloop-jitstress', 'outerloop-jitstress-isas-arm', 'outerloop-jitstress-isas-x86', 'outerloop-jitstressregs-x86', 'outerloop-jitstressregs', 'outerloop-jitstress2-jitstressregs', 'corefx-jitstress', 'corefx-jitstressregs', 'corefx-jitstress2-jitstressregs') }}:
+        ${{ if in(parameters.testGroup, 'jitstress', 'jitstress-isas-arm', 'jitstress-isas-x86', 'jitstressregs-x86', 'jitstressregs', 'jitstress2-jitstressregs' ) }}:
           timeoutPerTestCollectionInMinutes: 120
           timeoutPerTestInMinutes: 30
-        ${{ if in(parameters.testGroup, 'outerloop-gcstress0x3-gcstress0xc') }}:
+        ${{ if in(parameters.testGroup, 'gcstress0x3-gcstress0xc') }}:
           timeoutPerTestCollectionInMinutes: 240
           timeoutPerTestInMinutes: 60
-        ${{ if in(parameters.testGroup, 'outerloop-gcstress-extra', 'outerloop-r2r-extra') }}:
+        ${{ if in(parameters.testGroup, 'gcstress-extra', 'r2r-extra') }}:
           timeoutPerTestCollectionInMinutes: 300
           timeoutPerTestInMinutes: 90
 
@@ -209,11 +209,15 @@ jobs:
         ${{ if eq(parameters.corefxTests, false) }}:
           helixProjectArguments: 'tests/helixpublishwitharcade.proj'
 
-        ${{ if in(parameters.testGroup, 'innerloop', 'outerloop', 'corefx') }}:
+        # Error checking
+        ${{ if in(parameters.testGroup, 'UNDEFINED') }}:
+          scenarios:
+          - UNDEFINED
+        ${{ if in(parameters.testGroup, 'innerloop', 'outerloop') }}:
           scenarios:
           - normal
           - no_tiered_compilation
-        ${{ if in(parameters.testGroup, 'outerloop-jitstress', 'corefx-jitstress') }}:
+        ${{ if in(parameters.testGroup, 'jitstress') }}:
           scenarios:
           - jitminopts
           - jitstress1
@@ -222,13 +226,13 @@ jobs:
           - jitstress2_tiered
           - zapdisable
           - tailcallstress
-        ${{ if eq(parameters.testGroup, 'outerloop-jitstress-isas-arm') }}:
+        ${{ if in(parameters.testGroup, 'jitstress-isas-arm') }}:
           scenarios:
           - jitstress_isas_incompletehwintrinsic
           - jitstress_isas_nohwintrinsic
           - jitstress_isas_nohwintrinsic_nosimd
           - jitstress_isas_nosimd
-        ${{ if eq(parameters.testGroup, 'outerloop-jitstress-isas-x86') }}:
+        ${{ if in(parameters.testGroup, 'jitstress-isas-x86') }}:
           scenarios:
           - jitstress_isas_incompletehwintrinsic
           - jitstress_isas_nohwintrinsic
@@ -251,7 +255,7 @@ jobs:
           - jitstress_isas_x86_nosse41
           - jitstress_isas_x86_nosse42
           - jitstress_isas_x86_nossse3
-        ${{ if eq(parameters.testGroup, 'outerloop-jitstressregs-x86') }}:
+        ${{ if in(parameters.testGroup, 'jitstressregs-x86') }}:
           scenarios:
           - jitstressregs1_x86_noavx
           - jitstressregs2_x86_noavx
@@ -261,7 +265,7 @@ jobs:
           - jitstressregs0x10_x86_noavx
           - jitstressregs0x80_x86_noavx
           - jitstressregs0x1000_x86_noavx
-        ${{ if in(parameters.testGroup, 'outerloop-jitstressregs', 'corefx-jitstressregs') }}:
+        ${{ if in(parameters.testGroup, 'jitstressregs' ) }}:
           scenarios:
           - jitstressregs1
           - jitstressregs2
@@ -271,7 +275,7 @@ jobs:
           - jitstressregs0x10
           - jitstressregs0x80
           - jitstressregs0x1000
-        ${{ if in(parameters.testGroup, 'outerloop-jitstress2-jitstressregs', 'corefx-jitstress2-jitstressregs') }}:
+        ${{ if in(parameters.testGroup, 'jitstress2-jitstressregs') }}:
           scenarios:
           - jitstress2_jitstressregs1
           - jitstress2_jitstressregs2
@@ -281,11 +285,11 @@ jobs:
           - jitstress2_jitstressregs0x10
           - jitstress2_jitstressregs0x80
           - jitstress2_jitstressregs0x1000
-        ${{ if eq(parameters.testGroup, 'outerloop-gcstress0x3-gcstress0xc') }}:
+        ${{ if in(parameters.testGroup, 'gcstress0x3-gcstress0xc') }}:
           scenarios:
           - gcstress0x3
           - gcstress0xc
-        ${{ if eq(parameters.testGroup, 'outerloop-gcstress-extra') }}:
+        ${{ if in(parameters.testGroup, 'gcstress-extra') }}:
           scenarios:
           - heapverify1
           - gcstress0xc_zapdisable
@@ -294,7 +298,7 @@ jobs:
           - gcstress0xc_jitstress1
           - gcstress0xc_jitstress2
           - gcstress0xc_jitminopts_heapverify1
-        ${{ if eq(parameters.testGroup, 'outerloop-r2r-extra') }}:
+        ${{ if in(parameters.testGroup, 'r2r-extra') }}:
           scenarios:
           - jitstress1
           - jitstress2


### PR DESCRIPTION
1. Add many more platforms.
2. Test using checked in `public`.
3. Test using release in official build.
4. Move corefx results to a separate Mission Control grid
(not just appended to coreclr tests)