### PR TITLE
Add header check for atomic_ops.h

### DIFF
--- a/src/pal/src/libunwind/src/config.h.in
+++ b/src/pal/src/libunwind/src/config.h.in
@@ -13,4 +13,6 @@
 #cmakedefine HAVE__BUILTIN_UNREACHABLE
 #cmakedefine HAVE_SYNC_ATOMICS
 
+#cmakedefine HAVE_ATOMIC_OPS_H
+
 #endif

--- a/src/pal/src/libunwind/src/configure.cmake
+++ b/src/pal/src/libunwind/src/configure.cmake
@@ -10,6 +10,8 @@ check_include_files(sys/endian.h HAVE_SYS_ENDIAN_H)
 check_include_files(link.h HAVE_LINK_H)
 check_include_files(sys/link.h HAVE_SYS_LINK_H)
 
+check_include_files(atomic_ops.h HAVE_ATOMIC_OPS_H)
+
 check_cxx_source_compiles("
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
gcc reported the following (warning_as)error on a system, which this PR fixes:

```sh
/datadrive/projects/coreclr/src/pal/src/libunwind/src/mi/flush_cache.c:56:3: error: #warning unw_flush_cache(): need a way to atomically increment an integer. [-Werror=cpp]
 # warning unw_flush_cache(): need a way to atomically increment an integer.
   ^~~~~~~
```

cc @janvorli 