### PR TITLE
Exclude superpmicollect with JitStress on arm.

### DIFF
--- a/tests/src/JIT/superpmi/superpmicollect.csproj
+++ b/tests/src/JIT/superpmi/superpmicollect.csproj
@@ -14,6 +14,8 @@
     <CrossGenTest>false</CrossGenTest>
     <!-- This test takes a long time to complete -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <!-- https://github.com/dotnet/coreclr/issues/24633 --> 
+    <JitOptimizationSensitive Condition="'$(Platform)' == 'arm'">true</JitOptimizationSensitive>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
Revert this when https://github.com/dotnet/coreclr/issues/24633 get fixed.

Stress jobs are failing because of that https://dev.azure.com/dnceng/public/_build/results?buildId=193952&view=ms.vss-test-web.build-test-results-tab.