### PR TITLE
Fix armel tests build

### DIFF
--- a/build-test.sh
+++ b/build-test.sh
@@ -317,7 +317,10 @@ build_Tests()
     fi
 
     if [ $__SkipNative != 1 ]; then
+        export CROSSCOMPILEREAL=${CROSSCOMPILE}
+        export CROSSCOMPILE=0
         build_native_projects "$__BuildArch" "${__NativeTestIntermediatesDir}"
+        export CROSSCOMPILE=${CROSSCOMPILEREAL}
 
         if [ $? -ne 0 ]; then
             echo "${__MsgPrefix}Error: build failed. Refer to the build log files for details (above)"

--- a/build-test.sh
+++ b/build-test.sh
@@ -949,15 +949,6 @@ if [[ $__ClangMajorVersion == 0 && $__ClangMinorVersion == 0 ]]; then
     fi
 fi
 
-if [[ "$__BuildArch" == "armel" ]]; then
-    # Armel cross build is Tizen specific and does not support Portable RID build
-    __PortableBuild=0
-fi
-
-if [ $__PortableBuild == 0 ]; then
-    __CommonMSBuildArgs="$__CommonMSBuildArgs /p:PortableBuild=false"
-fi
-
 # Set dependent variables
 __LogsDir="$__RootBinDir/Logs"
 __MsbuildDebugLogsDir="$__LogsDir/MsbuildDebugLogs"
@@ -1002,6 +993,10 @@ fi
 
 # init the target distro name
 initTargetDistroRid
+
+if [ $__PortableBuild == 0 ]; then
+    __CommonMSBuildArgs="$__CommonMSBuildArgs /p:PortableBuild=false"
+fi
 
 # Restore Build Tools
 source $__ProjectRoot/init-tools.sh

--- a/build-test.sh
+++ b/build-test.sh
@@ -317,10 +317,7 @@ build_Tests()
     fi
 
     if [ $__SkipNative != 1 ]; then
-        export CROSSCOMPILEREAL=${CROSSCOMPILE}
-        export CROSSCOMPILE=0
         build_native_projects "$__BuildArch" "${__NativeTestIntermediatesDir}"
-        export CROSSCOMPILE=${CROSSCOMPILEREAL}
 
         if [ $? -ne 0 ]; then
             echo "${__MsgPrefix}Error: build failed. Refer to the build log files for details (above)"
@@ -950,6 +947,15 @@ if [[ $__ClangMajorVersion == 0 && $__ClangMinorVersion == 0 ]]; then
         __ClangMajorVersion=3
         __ClangMinorVersion=9
     fi
+fi
+
+if [[ "$__BuildArch" == "armel" ]]; then
+    # Armel cross build is Tizen specific and does not support Portable RID build
+    __PortableBuild=0
+fi
+
+if [ $__PortableBuild == 0 ]; then
+    __CommonMSBuildArgs="$__CommonMSBuildArgs /p:PortableBuild=false"
 fi
 
 # Set dependent variables

--- a/build.sh
+++ b/build.sh
@@ -1018,6 +1018,14 @@ if [ $__CrossBuild == 1 ]; then
 fi
 __CrossGenCoreLibLog="$__LogsDir/CrossgenCoreLib_$__BuildOS.$__BuildArch.$__BuildType.log"
 
+# Configure environment if we are doing a cross compile.
+if [ $__CrossBuild == 1 ]; then
+    export CROSSCOMPILE=1
+    if ! [[ -n "$ROOTFS_DIR" ]]; then
+        export ROOTFS_DIR="$__ProjectRoot/cross/rootfs/$__BuildArch"
+    fi
+fi
+
 # init the target distro name
 initTargetDistroRid
 
@@ -1037,14 +1045,6 @@ fi
 # Specify path to be set for CMAKE_INSTALL_PREFIX.
 # This is where all built CoreClr libraries will copied to.
 export __CMakeBinDir="$__BinDir"
-
-# Configure environment if we are doing a cross compile.
-if [ $__CrossBuild == 1 ]; then
-    export CROSSCOMPILE=1
-    if ! [[ -n "$ROOTFS_DIR" ]]; then
-        export ROOTFS_DIR="$__ProjectRoot/cross/rootfs/$__BuildArch"
-    fi
-fi
 
 # Make the directories necessary for build if they don't exist
 setup_dirs

--- a/build.sh
+++ b/build.sh
@@ -992,15 +992,6 @@ if [[ $__ClangMajorVersion == 0 && $__ClangMinorVersion == 0 ]]; then
     fi
 fi
 
-if [[ "$__BuildArch" == "armel" ]]; then
-    # Armel cross build is Tizen specific and does not support Portable RID build
-    __PortableBuild=0
-fi
-
-if [ $__PortableBuild == 0 ]; then
-    __CommonMSBuildArgs="$__CommonMSBuildArgs /p:PortableBuild=false"
-fi
-
 # Set dependent variables
 __LogsDir="$__RootBinDir/Logs"
 __MsbuildDebugLogsDir="$__LogsDir/MsbuildDebugLogs"
@@ -1028,6 +1019,10 @@ fi
 
 # init the target distro name
 initTargetDistroRid
+
+if [ $__PortableBuild == 0 ]; then
+    __CommonMSBuildArgs="$__CommonMSBuildArgs /p:PortableBuild=false"
+fi
 
 # Init if MSBuild for .NET Core is supported for this platform
 isMSBuildOnNETCoreSupported

--- a/build.sh
+++ b/build.sh
@@ -441,12 +441,18 @@ build_CoreLib()
         exit 1
     fi
 
+    local __CoreLibILDir=$__BinDir/IL
+
     if [ $__SkipCrossgen == 1 ]; then
         echo "Skipping generating native image"
+
+        if [ $__CrossBuild == 1 ]; then
+            # Crossgen not performed, so treat the IL version as the final version
+            cp $__CoreLibILDir/System.Private.CoreLib.dll $__BinDir/System.Private.CoreLib.dll
+        fi
+
         return
     fi
-
-    local __CoreLibILDir=$__BinDir/IL
 
     # The cross build generates a crossgen with the target architecture.
     if [ $__CrossBuild == 0 ]; then

--- a/init-distro-rid.sh
+++ b/init-distro-rid.sh
@@ -133,6 +133,12 @@ initDistroRidGlobal()
         fi
     fi
 
+    if [ "$buildArch" = "armel" ]; then
+        # Armel cross build is Tizen specific and does not support Portable RID build
+        export __PortableBuild=0
+        isPortable=0
+    fi
+
     initNonPortableDistroRid ${buildOs} ${buildArch} ${isPortable} ${rootfsDir}
 
     if [ -z "${__DistroRid}" ]; then

--- a/tests/src/JIT/Directed/PREFIX/unaligned/1/arglist.ilproj
+++ b/tests/src/JIT/Directed/PREFIX/unaligned/1/arglist.ilproj
@@ -30,6 +30,7 @@
     <Compile Condition="'$(BuildArch)' == 'x64'" Include="arglist64.il" />
     <Compile Condition="'$(BuildArch)' == 'arm'" Include="arglistARM.il" />
     <Compile Condition="'$(BuildArch)' == 'arm64'" Include="arglist64.il" />
+    <Compile Condition="'$(BuildArch)' == 'armel'" Include="arglistARM.il" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/JIT/Directed/PREFIX/unaligned/2/arglist.ilproj
+++ b/tests/src/JIT/Directed/PREFIX/unaligned/2/arglist.ilproj
@@ -30,6 +30,7 @@
     <Compile Condition="'$(BuildArch)' == 'x64'" Include="arglist64.il" />
     <Compile Condition="'$(BuildArch)' == 'arm'" Include="arglistARM.il" />
     <Compile Condition="'$(BuildArch)' == 'arm64'" Include="arglist64.il" />
+    <Compile Condition="'$(BuildArch)' == 'armel'" Include="arglistARM.il" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/JIT/Directed/PREFIX/unaligned/4/arglist.ilproj
+++ b/tests/src/JIT/Directed/PREFIX/unaligned/4/arglist.ilproj
@@ -30,6 +30,7 @@
     <Compile Condition="'$(BuildArch)' == 'x64'" Include="arglist64.il" />
     <Compile Condition="'$(BuildArch)' == 'arm'" Include="arglistARM.il" />
     <Compile Condition="'$(BuildArch)' == 'arm64'" Include="arglist64.il" />
+    <Compile Condition="'$(BuildArch)' == 'armel'" Include="arglistARM.il" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/JIT/Directed/PREFIX/volatile/1/arglist.ilproj
+++ b/tests/src/JIT/Directed/PREFIX/volatile/1/arglist.ilproj
@@ -30,6 +30,7 @@
     <Compile Condition="'$(BuildArch)' == 'x64'" Include="arglist64.il" />
     <Compile Condition="'$(BuildArch)' == 'arm'" Include="arglistARM.il" />
     <Compile Condition="'$(BuildArch)' == 'arm64'" Include="arglist64.il" />
+    <Compile Condition="'$(BuildArch)' == 'armel'" Include="arglistARM.il" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgi_array_merge.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgi_array_merge.ilproj
@@ -30,6 +30,7 @@
     <Compile Condition="'$(BuildArch)' == 'arm64'" Include="i_array_merge-ia64.il" />
     <Compile Condition="'$(BuildArch)' ==   'x86'" Include="i_array_merge-i386.il" />
     <Compile Condition="'$(BuildArch)' ==   'arm'" Include="i_array_merge-i386.il" />
+    <Compile Condition="'$(BuildArch)' ==   'armel'" Include="i_array_merge-i386.il" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgsizeof.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgsizeof.ilproj
@@ -28,6 +28,7 @@
     <Compile Condition="'$(BuildArch)' == 'arm64'" Include="sizeof-ia64.il" />
     <Compile Condition="'$(BuildArch)' ==   'x86'" Include="sizeof-i386.il" />
     <Compile Condition="'$(BuildArch)' ==   'arm'" Include="sizeof-i386.il" />
+    <Compile Condition="'$(BuildArch)' ==   'armel'" Include="sizeof-i386.il" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgu_array_merge.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgu_array_merge.ilproj
@@ -30,6 +30,7 @@
     <Compile Condition="'$(BuildArch)' == 'arm64'" Include="u_array_merge-ia64.il" />
     <Compile Condition="'$(BuildArch)' ==   'x86'" Include="u_array_merge-i386.il" />
     <Compile Condition="'$(BuildArch)' ==   'arm'" Include="u_array_merge-i386.il" />
+    <Compile Condition="'$(BuildArch)' ==   'armel'" Include="u_array_merge-i386.il" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_array_merge.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_array_merge.ilproj
@@ -30,6 +30,7 @@
     <Compile Condition="'$(BuildArch)' == 'arm64'" Include="i_array_merge-ia64.il" />
     <Compile Condition="'$(BuildArch)' ==   'x86'" Include="i_array_merge-i386.il" />
     <Compile Condition="'$(BuildArch)' ==   'arm'" Include="i_array_merge-i386.il" />
+    <Compile Condition="'$(BuildArch)' ==   'armel'" Include="i_array_merge-i386.il" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relsizeof.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relsizeof.ilproj
@@ -28,6 +28,7 @@
     <Compile Condition="'$(BuildArch)' == 'arm64'" Include="sizeof-ia64.il" />
     <Compile Condition="'$(BuildArch)' ==   'x86'" Include="sizeof-i386.il" />
     <Compile Condition="'$(BuildArch)' ==   'arm'" Include="sizeof-i386.il" />
+    <Compile Condition="'$(BuildArch)' ==   'armel'" Include="sizeof-i386.il" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_array_merge.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_array_merge.ilproj
@@ -30,6 +30,7 @@
     <Compile Condition="'$(BuildArch)' == 'arm64'" Include="u_array_merge-ia64.il" />
     <Compile Condition="'$(BuildArch)' ==   'x86'" Include="u_array_merge-i386.il" />
     <Compile Condition="'$(BuildArch)' ==   'arm'" Include="u_array_merge-i386.il" />
+    <Compile Condition="'$(BuildArch)' ==   'armel'" Include="u_array_merge-i386.il" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/dir.props
+++ b/tests/src/dir.props
@@ -34,6 +34,7 @@
     <PointerSize Condition="'$(Platform)'=='arm64'">64</PointerSize>
     <PointerSize Condition="'$(Platform)'=='x86'">32</PointerSize>
     <PointerSize Condition="'$(Platform)'=='arm'">32</PointerSize>
+    <PointerSize Condition="'$(Platform)'=='armel'">32</PointerSize>
   </PropertyGroup>
 
   <!-- Setup the default output and intermediate paths -->


### PR DESCRIPTION
After this PR System.Private.CoreLib.dll is copied to bin dir if `-skipcrossgen` is passed to build.sh, and build-test.sh successfully finishes for `armel` cross build. 

Also, cross build is fixed if `ROOTFS_DIR` is not passed explicitly.

cc @alpencolt @alexander-aksenov