### PR TITLE
Use auxiliary vector to obtain the executable path name

### DIFF
--- a/src/ToolBox/SOS/Strike/CMakeLists.txt
+++ b/src/ToolBox/SOS/Strike/CMakeLists.txt
@@ -132,7 +132,6 @@ else(WIN32)
     strike.cpp
     sos.cpp
     util.cpp
-    ../../../coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
   )
 
   set(SOS_LIBRARY
@@ -142,6 +141,7 @@ else(WIN32)
     # share the PAL in the dac module
     mscordaccore
     palrt
+    unixcoreruncommon
   )
 
   set(DEF_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/sos_unixexports.src)

--- a/src/coreclr/hosts/osxbundlerun/CMakeLists.txt
+++ b/src/coreclr/hosts/osxbundlerun/CMakeLists.txt
@@ -5,7 +5,6 @@ include_directories(../unixcoreruncommon)
 add_compile_options(-fPIE)
 
 set(CORERUN_SOURCES 
-    ../unixcoreruncommon/coreruncommon.cpp
     osxbundlerun.cpp 
 )
 
@@ -15,6 +14,7 @@ _add_executable(osxbundlerun
 
 target_link_libraries(osxbundlerun 
     dl
+    unixcoreruncommon
 )
 
 add_dependencies(osxbundlerun

--- a/src/coreclr/hosts/unixcoreruncommon/CMakeLists.txt
+++ b/src/coreclr/hosts/unixcoreruncommon/CMakeLists.txt
@@ -2,6 +2,10 @@ project(unixcoreruncommon)
 
 add_compile_options(-fPIC)
 
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+include(configure.cmake)
+
 _add_library(unixcoreruncommon
     STATIC
     coreruncommon.cpp

--- a/src/coreclr/hosts/unixcoreruncommon/config.h.in
+++ b/src/coreclr/hosts/unixcoreruncommon/config.h.in
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef __CONFIG_H__
+#define __CONFIG_H__
+
+#cmakedefine01 HAVE_GETAUXVAL
+
+#endif // __CONFIG_H__

--- a/src/coreclr/hosts/unixcoreruncommon/configure.cmake
+++ b/src/coreclr/hosts/unixcoreruncommon/configure.cmake
@@ -1,0 +1,5 @@
+check_symbol_exists(getauxval sys/auxv.h HAVE_GETAUXVAL)
+
+configure_file(
+	${CMAKE_CURRENT_SOURCE_DIR}/config.h.in
+	${CMAKE_CURRENT_BINARY_DIR}/config.h)

--- a/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
+++ b/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
@@ -6,6 +6,8 @@
 // Code that is used by both the Unix corerun and coreconsole.
 //
 
+#include "config.h"
+
 #include <cstdlib>
 #include <cstring>
 #include <assert.h>
@@ -19,6 +21,9 @@
 #if defined(__FreeBSD__)
 #include <sys/types.h>
 #include <sys/param.h>
+#endif
+#if HAVE_GETAUXVAL
+#include <sys/auxv.h>
 #endif
 #if defined(HAVE_SYS_SYSCTL_H) || defined(__FreeBSD__)
 #include <sys/sysctl.h>
@@ -105,6 +110,17 @@ bool GetEntrypointExecutableAbsolutePath(std::string& entrypointExecutable)
         result = false;
     }
 #else
+
+#if HAVE_GETAUXVAL && defined(AT_EXECFN)
+    const char *execfn = (const char *)getauxval(AT_EXECFN);
+
+    if (execfn)
+    {
+        entrypointExecutable.assign(execfn);
+        result = true;
+    }
+    else
+#endif
     // On other OSs, return the symlink that will be resolved by GetAbsolutePath
     // to fetch the entrypoint EXE absolute path, inclusive of filename.
     result = GetAbsolutePath(symlinkEntrypointExecutable, entrypointExecutable);


### PR DESCRIPTION
This vector is populated by the kernel while loading an ELF, and is available to user land without requiring any system calls.  This is specially interesting if programs are executed under a chroot where
/proc isn't available (and thus realpath("/proc/self/exe"), the current method of obtaining the full path name for the executable).