### PR TITLE
Bump reference to "dotnet" in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "2.1.504"
+    "dotnet": "2.1.604"
   },
   "native-tools": {
     "cmake": "3.11.1",


### PR DESCRIPTION
While trying to build on Arch Linux, which ships with OpenSSL 1.1.1 by default, `dotnet` was unable to find a suitable libssl version to use. It expects one with the 1.0 API.

Took me some time with strace to figure out why this wasn't working the way it's supposed to work.

Make this clearer in the documentation so others don't have to guess.