### PR TITLE
Fix loading libcoreclrtraceptprovider.so

### DIFF
--- a/src/dlls/mscoree/coreclr/CMakeLists.txt
+++ b/src/dlls/mscoree/coreclr/CMakeLists.txt
@@ -131,7 +131,9 @@ endif(WIN32)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     list(APPEND CORECLR_LIBRARIES
+        ${START_WHOLE_ARCHIVE}
         tracepointprovider
+        ${END_WHOLE_ARCHIVE}
     )
 endif(CMAKE_SYSTEM_NAME STREQUAL Linux)
 


### PR DESCRIPTION
This commit [#5bb7eb68](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fdotnet%2Fcoreclr%2Fcommit%2F5bb7eb68035e98e356aba68115e28ed22d3d34aa&data=02%7C01%7Cmikem%40microsoft.com%7Cd2ed3cc0c912442ee56308d6de3f3a93%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C636940760475991923&sdata=A%2Ful4WNpa2WacPoHXDLUNvybsX8%2BF6cY4YHMSPw32T8%3D&reserved=0) in coreclr broken loading the tracepointer provider.  The change in [src/dlls/mscoree/coreclr/CMakeLists.txt](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fdotnet%2Fcoreclr%2Fcommit%2F5bb7eb68035e98e356aba68115e28ed22d3d34aa%23diff-32d08c372954bc5f13d3635781753df6R129&data=02%7C01%7Cmikem%40microsoft.com%7Cd2ed3cc0c912442ee56308d6de3f3a93%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C636940760476001911&sdata=66y1qlxNFII0WhAtcPlaLMIwx4JUiNbwE8YwpgkJSrQ%3D&reserved=0).  