### PR TITLE
Misc. changes in PAL_Random(): use getrandom(), fix O_CLOEXEC usage, etc.

### DIFF
--- a/src/pal/src/config.h.in
+++ b/src/pal/src/config.h.in
@@ -70,6 +70,7 @@
 #cmakedefine01 HAVE_XSW_USAGE
 #cmakedefine01 HAVE_PUBLIC_XSTATE_STRUCT
 #cmakedefine01 HAVE_PR_SET_PTRACER
+#cmakedefine01 HAVE_SYS_GETRANDOM
 
 #cmakedefine01 HAVE_STAT_TIMESPEC
 #cmakedefine01 HAVE_STAT_TIM

--- a/src/pal/src/configure.cmake
+++ b/src/pal/src/configure.cmake
@@ -131,6 +131,8 @@ check_function_exists(pthread_mutex_init HAS_PTHREAD_MUTEXES)
 check_function_exists(ttrace HAVE_TTRACE)
 check_function_exists(pipe2 HAVE_PIPE2)
 
+check_symbol_exists(SYS_getrandom sys/syscall.h HAVE_SYS_GETRANDOM)
+
 check_cxx_source_compiles("
 #include <pthread_np.h>
 int main(int argc, char **argv) {

--- a/src/pal/src/misc/miscpalapi.cpp
+++ b/src/pal/src/misc/miscpalapi.cpp
@@ -245,7 +245,7 @@ PAL_Random(
     {
         do
         {
-            rand_des = open("/dev/urandom", O_RDONLY, O_CLOEXEC);
+            rand_des = open(URANDOM_DEVICE_NAME, O_RDONLY, O_CLOEXEC);
         }
         while ((rand_des == -1) && (errno == EINTR));
 

--- a/src/pal/src/misc/miscpalapi.cpp
+++ b/src/pal/src/misc/miscpalapi.cpp
@@ -364,8 +364,6 @@ PAL_Random(
 
     if (needSrand)
     {
-        long num;
-
         if (!sInitializedMRand)
         {
             // FIXME: There's not enough entropy in time(NULL) to
@@ -375,14 +373,22 @@ PAL_Random(
             sInitializedMRand = TRUE;
         }
 
-        for (DWORD i = 0; i < dwLength; i++)
+        while (dwLength)
         {
-            if (i % sizeof(long) == 0) {
-                num = mrand48();
-            }
+            const auto num = mrand48();
 
-            *(((BYTE*)lpBuffer) + i) ^= num;
-            num >>= 8;
+            if (dwLength >= sizeof(num))
+            {
+                memcpy(lpBuffer, &num, sizeof(num));
+
+                lpBuffer = (char *)lpBuffer + sizeof(num);
+                dwLength -= sizeof(num);
+            }
+            else
+            {
+                memcpy(lpBuffer, &num, dwLength);
+                break;
+            }
         }
     }
 

--- a/src/pal/src/misc/miscpalapi.cpp
+++ b/src/pal/src/misc/miscpalapi.cpp
@@ -245,7 +245,7 @@ PAL_Random(
     {
         do
         {
-            rand_des = open(URANDOM_DEVICE_NAME, O_RDONLY, O_CLOEXEC);
+            rand_des = open(URANDOM_DEVICE_NAME, O_RDONLY | O_CLOEXEC);
         }
         while ((rand_des == -1) && (errno == EINTR));
 


### PR DESCRIPTION
There are two big changes here:

- Random data from /dev/urandom should not be messed around with, especially with a PRNG that has been initialized with little entropy (`time(NULL)`). Only use the userland PRNG if all other methods fail.
- `getrandom(2)`, introduced in Linux 3.17, is used if available. This makes it possible to gather data from the same pool `/dev/urandom` draws from, without requiring that device to exist (e.g. under a tight `chroot()`), and do not require opening a file.