### PR TITLE
Fix GCToOSInterface::SetCurrentThreadIdealAffinity on Unix

### DIFF
--- a/src/gc/unix/gcenv.unix.cpp
+++ b/src/gc/unix/gcenv.unix.cpp
@@ -379,7 +379,8 @@ uint32_t GCToOSInterface::GetCurrentProcessId()
 //  true if it has succeeded, false if it has failed
 bool GCToOSInterface::SetCurrentThreadIdealAffinity(uint16_t srcProcNo, uint16_t dstProcNo)
 {
-    return GCToOSInterface::SetThreadAffinity(dstProcNo);
+    // There is no way to set a thread ideal processor on Unix, so do nothing.
+    return true;
 }
 
 // Get the number of the current processor

--- a/src/vm/gcenv.os.cpp
+++ b/src/vm/gcenv.os.cpp
@@ -228,7 +228,9 @@ bool GCToOSInterface::SetCurrentThreadIdealAffinity(uint16_t srcProcNo, uint16_t
     return success;
 
 #else // !FEATURE_PAL
-    return GCToOSInterface::SetThreadAffinity(dstProcNo);
+
+    // There is no way to set a thread ideal processor on Unix, so do nothing.
+    return true;
 
 #endif // !FEATURE_PAL
 }


### PR DESCRIPTION
The code was using GCToOSInterface::SetThreadAffinity, which
effectively pinned the current thread to a specific processor. On
Windows, it calls SetThreadIdealProcessor which is basically just a
scheduler hint, but the thread can stil run on other threads.

Since there is no way to set ideal affinity on Unix, the fix is to do
nothing in the GCToOSInterface::SetCurrentThreadIdealAffinity.