### PR TITLE
Fix module override for recursive generic signatures

### DIFF
--- a/src/vm/siginfo.hpp
+++ b/src/vm/siginfo.hpp
@@ -13,12 +13,12 @@
 #include "util.hpp"
 #include "vars.hpp"
 #include "clsload.hpp"
+#include "sigparser.h"
 #include "zapsig.h"
 #include "threads.h"
 
 #include "eecontract.h"
 #include "typectxt.h"
-#include "sigparser.h"
 
 //---------------------------------------------------------------------------------------
 // These macros define how arguments are mapped to the stack in the managed calling convention.

--- a/src/vm/zapsig.cpp
+++ b/src/vm/zapsig.cpp
@@ -1121,7 +1121,7 @@ void ZapSig::CopyTypeSignature(SigParser* pSigParser, SigBuilder* pSigBuilder, D
         CorElementType type = (CorElementType)byteType;
 
         // Some element types have sub-type that is what we are interested in
-        switch (type)
+        switch ((DWORD)type)
         {
             case ELEMENT_TYPE_BYREF:
             case ELEMENT_TYPE_PTR:

--- a/src/vm/zapsig.h
+++ b/src/vm/zapsig.h
@@ -23,6 +23,8 @@ typedef DWORD (*EncodeModuleCallback)(void* pModuleContext, Module *pReferencedM
 enum {
     // return value when EncodeModule fails
     ENCODE_MODULE_FAILED         = 0xffffffff,
+    // no module index override is needed 
+    MODULE_INDEX_NONE            = 0xfffffffe
 };
 
 typedef void(*DEFINETOKEN_CALLBACK)(LPVOID pModuleContext, CORINFO_MODULE_HANDLE moduleHandle, DWORD index, mdTypeRef* token);
@@ -127,6 +129,11 @@ private:
     //
     static CorElementType TryEncodeUsingShortcut(/* in  */ MethodTable * pMT);
 
+    // Copy single type signature, adding ELEMENT_TYPE_MODULE_ZAPSIG to types that are encoded using tokens.
+    // The source signature originates from the module with index specified by the parameter moduleIndex.
+    // Passing moduleIndex set to MODULE_INDEX_NONE results in pure copy of the signature.
+    //
+    static void CopyTypeSignature(SigParser* pSigParser, SigBuilder* pSigBuilder, DWORD moduleIndex);
 
 private:
 


### PR DESCRIPTION
When crossgen-ing with large version bubble enabled, generic signatures
that got copied from the source IL were missing module overrides at
deeper levels of the generic signature.
For example, in case of X<Y<A,B>,Z>, the override was applied only to Y
and Z, but not to A and B.

This change fixes that by inserting module override zapsig at all
levels.