### PR TITLE
Use -c when trying to find Python

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -411,7 +411,9 @@ set __IntermediatesIncDir=%__IntermediatesDir%\src\inc
 set __IntermediatesEventingDir=%__IntermediatesDir%\Eventing
 
 REM Find python and set it to the variable PYTHON
-echo import sys; sys.stdout.write(sys.executable) | (py -3 || py -2 || python3 || python2 || python) > %TEMP%\pythonlocation.txt 2> NUL
+set _C=-c "import sys; sys.stdout.write(sys.executable)"
+(py -3 %_C% || py -2 %_C% || python3 %_C% || python2 %_C% || python %_C%) > %TEMP%\pythonlocation.txt 2> NUL
+set _C=
 set /p PYTHON=<%TEMP%\pythonlocation.txt
 
 if NOT DEFINED PYTHON (


### PR DESCRIPTION
Piping code into Python is indistinguishable from interactive execution, but since we never want interactive execution here it's better to use `-c <CODE>`.

See https://twitter.com/MStrehovsky/status/1131216623086460933?s=20 for the original problem report.