### PR TITLE
Use Microsoft.Build.Traversal instead of dir.traversal.targets for packaging .builds projects

### DIFF
--- a/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.builds
+++ b/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.builds
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.Build.Traversal">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <ItemGroup>
@@ -7,5 +7,5 @@
     <Project Include="$(MSBuildProjectName).pkgproj" />
   </ItemGroup>
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), builds.targets))\builds.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.builds
+++ b/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.builds
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.Build.Traversal">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <ItemGroup>
     <!-- identity project, runtime specific projects are included by props above -->
     <Project Include="$(MSBuildProjectName).pkgproj" />
   </ItemGroup>
-  
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), builds.targets))\builds.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Jit/Microsoft.NETCore.Jit.builds
+++ b/src/.nuget/Microsoft.NETCore.Jit/Microsoft.NETCore.Jit.builds
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.Build.Traversal">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <ItemGroup>
     <!-- identity project, runtime specific projects are included by props above -->
     <Project Include="$(MSBuildProjectName).pkgproj" />
   </ItemGroup>
-  
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), builds.targets))\builds.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Native/Microsoft.NETCore.Native.builds
+++ b/src/.nuget/Microsoft.NETCore.Native/Microsoft.NETCore.Native.builds
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.Build.Traversal">
   <Import Project="Microsoft.NETCore.Native.props" />
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
@@ -8,6 +8,6 @@
     <!-- identity project, runtime specific projects are included by props above -->
     <Project Include="$(MSBuildProjectName).pkgproj" />
   </ItemGroup>
-  
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), builds.targets))\builds.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.builds
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.builds
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.Build.Traversal">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <ItemGroup>
     <!-- identity project, runtime specific projects are included by props above -->
     <Project Include="$(MSBuildProjectName).pkgproj" />
   </ItemGroup>
-  
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), builds.targets))\builds.targets" />
 </Project>

--- a/src/.nuget/Microsoft.NETCore.TestHost/Microsoft.NETCore.TestHost.builds
+++ b/src/.nuget/Microsoft.NETCore.TestHost/Microsoft.NETCore.TestHost.builds
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.Build.Traversal">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <ItemGroup>
     <!-- identity project, runtime specific projects are included by props above -->
     <Project Include="$(MSBuildProjectName).pkgproj" />
   </ItemGroup>
-  
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), builds.targets))\builds.targets" />
 </Project>

--- a/src/.nuget/builds.targets
+++ b/src/.nuget/builds.targets
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <Import Project="$(MSBuildThisFileDirectory)..\..\dir.traversal.targets" />
-
+<Project>
   <PropertyGroup Condition="'$(BuildIdentityPackage)' == ''">
     <BuildIdentityPackage>true</BuildIdentityPackage>
 
@@ -28,8 +25,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Project Remove="@(Project)" />
-      <Project Include="@(_projectsToBuild)" />
+      <ProjectReference Include="@(_projectsToBuild)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/.nuget/dir.props
+++ b/src/.nuget/dir.props
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
+
+  <!-- Packaging projects (.pkgproj) are non-SDK-style, so they need to directly import Directory.Build.props -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))"
+          Condition="'$(MSBuildProjectExtension)' == '.pkgproj'" />
   <Import Project="packaging.props" />
 
   <PropertyGroup>

--- a/src/.nuget/dir.props
+++ b/src/.nuget/dir.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
 
   <!-- Packaging projects (.pkgproj) are non-SDK-style, so they need to directly import Directory.Build.props -->
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))"

--- a/src/.nuget/packages.builds
+++ b/src/.nuget/packages.builds
@@ -1,28 +1,27 @@
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
+<Project Sdk="Microsoft.Build.Traversal">
   <Import Project="packaging.props" />
 
   <ItemGroup Condition="'$(__SkipCoreLibBuild)'==''">
-    <Project Include="Microsoft.NETCore.Runtime.CoreCLR\Microsoft.NETCore.Runtime.CoreCLR.builds" />
+    <ProjectReference Include="Microsoft.NETCore.Runtime.CoreCLR\Microsoft.NETCore.Runtime.CoreCLR.builds" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetsWindows)'=='true'">
-    <Project Include="Microsoft.TargetingPack.Private.CoreCLR\Microsoft.TargetingPack.Private.CoreCLR.pkgproj" />
+    <ProjectReference Include="Microsoft.TargetingPack.Private.CoreCLR\Microsoft.TargetingPack.Private.CoreCLR.pkgproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetsWindows)'=='true' OR '$(DotNetBuildFromSource)'=='true'">
-    <Project Include="Microsoft.NET.Sdk.IL\Microsoft.NET.Sdk.IL.pkgproj" />
+    <ProjectReference Include="Microsoft.NET.Sdk.IL\Microsoft.NET.Sdk.IL.pkgproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(__SkipNativeBuild)'==''">
-    <Project Include="Microsoft.NETCore.Jit\Microsoft.NETCore.Jit.builds" />
-    <Project Include="Microsoft.NETCore.TestHost\Microsoft.NETCore.TestHost.builds" />
-    <Project Include="Microsoft.NETCore.Native\Microsoft.NETCore.Native.builds" />
+    <ProjectReference Include="Microsoft.NETCore.Jit\Microsoft.NETCore.Jit.builds" />
+    <ProjectReference Include="Microsoft.NETCore.TestHost\Microsoft.NETCore.TestHost.builds" />
+    <ProjectReference Include="Microsoft.NETCore.Native\Microsoft.NETCore.Native.builds" />
   </ItemGroup>
 
   <ItemGroup>
-    <Project Include="Microsoft.NETCore.ILAsm\Microsoft.NETCore.ILAsm.builds" />
-    <Project Include="Microsoft.NETCore.ILDAsm\Microsoft.NETCore.ILDAsm.builds" />
+    <ProjectReference Include="Microsoft.NETCore.ILAsm\Microsoft.NETCore.ILAsm.builds" />
+    <ProjectReference Include="Microsoft.NETCore.ILDAsm\Microsoft.NETCore.ILDAsm.builds" />
   </ItemGroup>
 
   <!-- Generate a version.txt file we include in our packages
@@ -50,6 +49,4 @@
           BeforeTargets="Build">
     <MSBuild Targets="Build" Projects="$(CoreclrDir)\src\createVersionFile.proj"/>
   </Target>
-
-  <Import Project="$(MSBuildThisFileDirectory)..\..\dir.traversal.targets" />
 </Project>

--- a/src/.nuget/packaging.props
+++ b/src/.nuget/packaging.props
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <PropertyGroup>
-    <!-- Packaging projects are non-SDK-style and directly import Directory.Build.props. They can also import Microsoft.Common.props.
-         Make sure Microsoft.Common.props does not import Directory.Build.props again -->
-    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
-  </PropertyGroup>
 
   <PropertyGroup>
     <PackageDescriptionFile>$(MSBuildThisFileDirectory)/descriptions.json</PackageDescriptionFile>


### PR DESCRIPTION
Sever the dependency of the `.builds` projects under `src/.nuget` on `src/dir.traversal.targets`. With this change, the only things still depending on `dir.traversal.targets` should be tests.