### PR TITLE
Relax the assertion for FieldDesc::GetBase

### DIFF
--- a/src/vm/field.h
+++ b/src/vm/field.h
@@ -455,9 +455,8 @@ public:
     {
         CONTRACTL
         {
-          THROWS;
-          GC_TRIGGERS;
-          INJECT_FAULT(COMPlusThrowOM());
+          NOTHROW;
+          GC_NOTRIGGER;
         }
         CONTRACTL_END
 


### PR DESCRIPTION
In [`proftoeeinterfaceimpl.cpp`](https://github.com/dotnet/coreclr/blob/96e8c58d77762497a8333e675db2fd396887decb/src/vm/proftoeeinterfaceimpl.cpp#L3303), we are calling [`FieldDesc.GetBase()`](https://github.com/dotnet/coreclr/blob/96e8c58d77762497a8333e675db2fd396887decb/src/vm/field.h#L454) under the [assumption](https://github.com/dotnet/coreclr/blob/96e8c58d77762497a8333e675db2fd396887decb/src/vm/proftoeeinterfaceimpl.cpp#L3203) that it will not throw or trigger GC, but the [contract](https://github.com/dotnet/coreclr/blob/96e8c58d77762497a8333e675db2fd396887decb/src/vm/field.h#L458) on `FieldDesc.GetBase()` seems to imply otherwise. 

After careful reading through the code, it appears that the contract of `FieldDesc.GetBase()` is wrong, the implementation of it won't throw or trigger GC, therefore I updated the contract to reflect what it is.