### PR TITLE
Add Arm64 to ImageFileMachine and ProcessorArchitecture

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Reflection/AssemblyName.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/AssemblyName.cs
@@ -89,14 +89,14 @@ namespace System.Reflection
             get
             {
                 int x = (((int)_flags) & 0x70) >> 4;
-                if (x > 5)
+                if (x > 6)
                     x = 0;
                 return (ProcessorArchitecture)x;
             }
             set
             {
                 int x = ((int)value) & 0x07;
-                if (x <= 5)
+                if (x <= 6)
                 {
                     _flags = (AssemblyNameFlags)((int)_flags & 0xFFFFFF0F);
                     _flags |= (AssemblyNameFlags)(x << 4);

--- a/src/System.Private.CoreLib/shared/System/Reflection/ImageFileMachine.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/ImageFileMachine.cs
@@ -10,6 +10,7 @@ namespace System.Reflection
         IA64 = 0x0200,
         AMD64 = 0x8664,
         ARM = 0x01c4,
+        ARM64 = 0xaa64,
     }
 }
 

--- a/src/System.Private.CoreLib/shared/System/Reflection/ProcessorArchitecture.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/ProcessorArchitecture.cs
@@ -11,6 +11,7 @@ namespace System.Reflection
         X86 = 0x0002,
         IA64 = 0x0003,
         Amd64 = 0x0004,
-        Arm = 0x0005
+        Arm = 0x0005,
+        Arm64 = 0x0006,
     }
 }

--- a/src/System.Private.CoreLib/src/System/Reflection/AssemblyName.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/AssemblyName.CoreCLR.cs
@@ -82,6 +82,8 @@ namespace System.Reflection
                         return ProcessorArchitecture.IA64;
                     case ImageFileMachine.AMD64:
                         return ProcessorArchitecture.Amd64;
+                    case ImageFileMachine.ARM64:
+                        return ProcessorArchitecture.Arm64;
                     case ImageFileMachine.I386:
                         if ((pek & PortableExecutableKinds.ILOnly) == PortableExecutableKinds.ILOnly)
                             return ProcessorArchitecture.MSIL;

--- a/src/vm/baseassemblyspec.cpp
+++ b/src/vm/baseassemblyspec.cpp
@@ -685,7 +685,7 @@ HRESULT BaseAssemblySpec::CreateFusionName(
         {
             DWORD dwPEkind = (DWORD)PAIndex(m_dwFlags);
             // Note: Value 0x07 = code:afPA_NoPlatform falls through
-            if ((dwPEkind >= peMSIL) && (dwPEkind <= peARM))
+            if ((dwPEkind >= peMSIL) && (dwPEkind <= peARM64))
             {
                 PEKIND peKind = (PEKIND)dwPEkind;
                 IfFailGo(pFusionAssemblyName->SetProperty(ASM_NAME_ARCHITECTURE, 

--- a/src/vm/coreassemblyspec.cpp
+++ b/src/vm/coreassemblyspec.cpp
@@ -433,6 +433,9 @@ HRESULT BaseAssemblySpec::ParseName()
             case peARM:
                 m_dwFlags |= afPA_ARM;
                 break;
+            case peARM64:
+                m_dwFlags |= afPA_ARM64;
+                break;
             case peMSIL:
                 m_dwFlags |= afPA_MSIL;
                 break;
@@ -576,6 +579,8 @@ VOID BaseAssemblySpec::GetFileOrDisplayName(DWORD flags, SString &result) const
             assemblyIdentity.m_kProcessorArchitecture = peAMD64;
         else if (m_dwFlags & afPA_ARM)
             assemblyIdentity.m_kProcessorArchitecture = peARM;
+        else if (m_dwFlags & afPA_ARM64)
+            assemblyIdentity.m_kProcessorArchitecture = peARM64;
     }
 
     if ((flags & ASM_DISPLAYF_RETARGET) && (m_dwFlags & afRetargetable))

--- a/src/vm/pefile.inl
+++ b/src/vm/pefile.inl
@@ -1370,6 +1370,8 @@ inline BOOL PEFile::HasNativeImageMetadata()
                 result.Append(W("AMD64"));
             else if (dwFlags & afPA_ARM)
                 result.Append(W("ARM"));
+            else if (dwFlags & afPA_ARM64)
+                result.Append(W("ARM64"));
         }
     }
 }


### PR DESCRIPTION
This all started when a C++ Unity application referencing an ARM64 winmd failed to build using MSBuild.

MSBuild currently has a dependency on `System.Reflection.ProcessorArchitecture`, and needs to support arm64 binaries. Here's a proposed PR:

https://github.com/microsoft/msbuild/pull/4389

The current proposed fix is to use a direct integer constant value as ProcessorArchitecture, but ideally we'd like to avoid the enum values to diverge if somebody adds another enum entry for another architecture.

Any comment on the approach or interest in this?