### PR TITLE
Change timeouts for outerloop job and move one test to longRunningGc.

### DIFF
--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -165,7 +165,7 @@ jobs:
           # "PerTest" corresponds to individual test running time (i.e. __TestTimeout).
           timeoutPerTestInMinutes: 10
         ${{ if eq(parameters.testGroup, 'outerloop') }}:
-          timeoutPerTestCollectionInMinutes: 60
+          timeoutPerTestCollectionInMinutes: 120
           timeoutPerTestInMinutes: 10
         ${{ if in(parameters.testGroup, 'outerloop-jitstress', 'outerloop-jitstress-isas-arm', 'outerloop-jitstress-isas-x86', 'outerloop-jitstressregs', 'outerloop-jitstress2-jitstressregs') }}:
           timeoutPerTestCollectionInMinutes: 120

--- a/tests/src/JIT/Methodical/tailcall/Desktop/_il_relthread-race.csproj
+++ b/tests/src/JIT/Methodical/tailcall/Desktop/_il_relthread-race.csproj
@@ -14,6 +14,9 @@
     <!-- NOTE: this test simply takes too long to complete under heap verify or GCStress. It is not fundamentally incompatible. -->
     <HeapVerifyIncompatible>true</HeapVerifyIncompatible>
     <GCStressIncompatible>true</GCStressIncompatible>
+    
+    <IsLongRunningGCTest>true</IsLongRunningGCTest>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
6d46cf4711: Change outerloop timeout per collection.

We have different test collections timeouts on Alpine.38.Amd64, examples:
https://mc.dot.net/#/user/coreclr-ci/ci~2Fdotnet~2Fcoreclr~2Frefs~2Fheads~2Fmaster/test~2Ffunctional~2Fcli~2F/20190521.780/workItem/JIT.jit64.hfa/wilogs
https://mc.dot.net/#/user/coreclr-ci/ci~2Fdotnet~2Fcoreclr~2Frefs~2Fheads~2Fmaster/test~2Ffunctional~2Fcli~2F/20190521.779/workItem/PayloadGroup0/wilogs
https://mc.dot.net/#/user/coreclr-ci/ci~2Fdotnet~2Fcoreclr~2Frefs~2Fheads~2Fmaster/test~2Ffunctional~2Fr2r~2Fcli~2F/20190521.783/workItem/Loader.classloader.TypeGeneratorTests.TypeGeneratorTest0-299/wilogs

3f0922e778: Move _il_relthread-race to pri1 and mark as long running GC test.
The test is using 4 threads and calls GC.Collect while waiting for them.

Link https://github.com/dotnet/coreclr/issues/23624.