### PR TITLE
Add COMPlus_Lttng environment variable

### DIFF
--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -249,6 +249,10 @@ CONFIG_DWORD_INFO(INTERNAL_SuppressLockViolationsOnReentryFromOS, W("SuppressLoc
 #endif // WIN64EXCEPTIONS
 CONFIG_STRING_INFO(INTERNAL_TestHooks, W("TestHooks"), "Used by tests to get test an insight on various CLR workings")
 
+///
+/// Diagnostics (unsuported general-purpose)
+///
+RETAIL_CONFIG_DWORD_INFO(UNSUPORTED_DisableLttngLibraryLoad, W("DisableLttngLibraryLoad"), 0, "Disables the dynamic load of the LTtng library")
 
 ///
 /// Exception Handling

--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -252,7 +252,7 @@ CONFIG_STRING_INFO(INTERNAL_TestHooks, W("TestHooks"), "Used by tests to get tes
 ///
 /// Diagnostics (unsuported general-purpose)
 ///
-RETAIL_CONFIG_DWORD_INFO(UNSUPORTED_DisableLttngLibraryLoad, W("LTTng"), 1, "If COMPlus_LTTng is set to 0, this will prevent the LTTng library from being loaded at runtime")
+RETAIL_CONFIG_DWORD_INFO(UNSUPORTED_LTTng, W("LTTng"), 1, "If COMPlus_LTTng is set to 0, this will prevent the LTTng library from being loaded at runtime")
 
 ///
 /// Exception Handling

--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -252,7 +252,7 @@ CONFIG_STRING_INFO(INTERNAL_TestHooks, W("TestHooks"), "Used by tests to get tes
 ///
 /// Diagnostics (unsuported general-purpose)
 ///
-RETAIL_CONFIG_DWORD_INFO(UNSUPORTED_DisableLttngLibraryLoad, W("Lttng"), 1, "If COMPlus_Lttng is set to 0, this will prevent the LTTng library from being loaded at runtime")
+RETAIL_CONFIG_DWORD_INFO(UNSUPORTED_DisableLttngLibraryLoad, W("LTTng"), 1, "If COMPlus_LTTng is set to 0, this will prevent the LTTng library from being loaded at runtime")
 
 ///
 /// Exception Handling

--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -252,7 +252,7 @@ CONFIG_STRING_INFO(INTERNAL_TestHooks, W("TestHooks"), "Used by tests to get tes
 ///
 /// Diagnostics (unsuported general-purpose)
 ///
-RETAIL_CONFIG_DWORD_INFO(UNSUPORTED_DisableLttngLibraryLoad, W("DisableLttngLibraryLoad"), 0, "Disables the dynamic load of the LTtng library")
+RETAIL_CONFIG_DWORD_INFO(UNSUPORTED_DisableLttngLibraryLoad, W("Lttng"), 1, "If COMPlus_Lttng is set to 0, this will prevent the LTTng library from being loaded at runtime")
 
 ///
 /// Exception Handling

--- a/src/pal/src/misc/tracepointprovider.cpp
+++ b/src/pal/src/misc/tracepointprovider.cpp
@@ -59,6 +59,14 @@ __attribute__((constructor (200)))
 static void
 PAL_InitializeTracing(void)
 {
+    int shouldDisableLoad = 0;
+    // Check if loading the LTTng providers should be disabled.
+    char *disableValue = getenv("COMPlus_DisableLttngLibraryLoad");
+    if (disableValue != NULL)
+    {
+        shouldDisableLoad = strtol(disableValue, NULL, 10);
+    }
+
     // Get the path to the currently executing shared object (libcoreclr.so).
     Dl_info info;
     int succeeded = dladdr((void *)PAL_InitializeTracing, &info);
@@ -99,7 +107,8 @@ PAL_InitializeTracing(void)
         return;
     }
     
-    if (CLRConfig::GetConfigValue(CLRConfig::UNSUPORTED_DisableLttngLibraryLoad) == 0)
+    
+    if (!shouldDisableLoad)
     {
         // Load the tracepoint provider.
         // It's OK if this fails - that just means that tracing dependencies aren't available.

--- a/src/pal/src/misc/tracepointprovider.cpp
+++ b/src/pal/src/misc/tracepointprovider.cpp
@@ -61,7 +61,9 @@ PAL_InitializeTracing(void)
 {
     int fShouldLoad = 1;
     // Check if loading the LTTng providers should be disabled.
-    char *disableValue = getenv("COMPlus_Lttng");
+    // Note: this env var is formally declared in clrconfigvalues.h, but
+    // this code is excuted too early to use the mechanics that come with that definition.
+    char *disableValue = getenv("COMPlus_LTTng");
     if (disableValue != NULL)
     {
         fShouldLoad = strtol(disableValue, NULL, 10);

--- a/src/pal/src/misc/tracepointprovider.cpp
+++ b/src/pal/src/misc/tracepointprovider.cpp
@@ -99,11 +99,12 @@ PAL_InitializeTracing(void)
         return;
     }
     
-
-
-    // Load the tracepoint provider.
-    // It's OK if this fails - that just means that tracing dependencies aren't available.
-    dlopen(tpProvPath, RTLD_NOW | RTLD_GLOBAL);
+    if (CLRConfig::GetConfigValue(CLRConfig::UNSUPORTED_DisableLttngLibraryLoad) == 0)
+    {
+        // Load the tracepoint provider.
+        // It's OK if this fails - that just means that tracing dependencies aren't available.
+        dlopen(tpProvPath, RTLD_NOW | RTLD_GLOBAL);
+    }
 }
 
 #endif

--- a/src/pal/src/misc/tracepointprovider.cpp
+++ b/src/pal/src/misc/tracepointprovider.cpp
@@ -62,7 +62,7 @@ PAL_InitializeTracing(void)
     int fShouldLoad = 1;
     // Check if loading the LTTng providers should be disabled.
     // Note: this env var is formally declared in clrconfigvalues.h, but
-    // this code is excuted too early to use the mechanics that come with that definition.
+    // this code is executed too early to use the mechanics that come with that definition.
     char *disableValue = getenv("COMPlus_LTTng");
     if (disableValue != NULL)
     {

--- a/src/pal/src/misc/tracepointprovider.cpp
+++ b/src/pal/src/misc/tracepointprovider.cpp
@@ -110,7 +110,6 @@ PAL_InitializeTracing(void)
     
     if (fShouldLoad)
     {
-        fprintf(stdout, "LOADED\n");
         // Load the tracepoint provider.
         // It's OK if this fails - that just means that tracing dependencies aren't available.
         dlopen(tpProvPath, RTLD_NOW | RTLD_GLOBAL);

--- a/src/pal/src/misc/tracepointprovider.cpp
+++ b/src/pal/src/misc/tracepointprovider.cpp
@@ -59,12 +59,12 @@ __attribute__((constructor (200)))
 static void
 PAL_InitializeTracing(void)
 {
-    int shouldDisableLoad = 0;
+    int fShouldLoad = 1;
     // Check if loading the LTTng providers should be disabled.
-    char *disableValue = getenv("COMPlus_DisableLttngLibraryLoad");
+    char *disableValue = getenv("COMPlus_Lttng");
     if (disableValue != NULL)
     {
-        shouldDisableLoad = strtol(disableValue, NULL, 10);
+        fShouldLoad = strtol(disableValue, NULL, 10);
     }
 
     // Get the path to the currently executing shared object (libcoreclr.so).
@@ -108,8 +108,9 @@ PAL_InitializeTracing(void)
     }
     
     
-    if (!shouldDisableLoad)
+    if (fShouldLoad)
     {
+        fprintf(stdout, "LOADED\n");
         // Load the tracepoint provider.
         // It's OK if this fails - that just means that tracing dependencies aren't available.
         dlopen(tpProvPath, RTLD_NOW | RTLD_GLOBAL);


### PR DESCRIPTION
Adds a `COMPlus_DisableLttngLibraryLoad` environment variable for preventing LTTng from being loaded.  This doesn't change any default behavior and this library load can safely be skipped.

Should hopefully unblock people stuck on #15693.

CC - @tommcdon 