### PR TITLE
Add missing pin to two tests and re-enable for GC stress

### DIFF
--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgu_fld.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgu_fld.ilproj
@@ -10,9 +10,6 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-
-    <!-- Test currently fails under GCStress. https://github.com/dotnet/coreclr/issues/24173 -->
-    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_fld.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_fld.ilproj
@@ -10,8 +10,6 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <!-- https://github.com/dotnet/coreclr/issues/24464 -->
-    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/u_fld.il
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/u_fld.il
@@ -25,9 +25,14 @@
     {
 		.entrypoint
 		.maxstack  8
-		.locals (class Test.AA pinned, native unsigned int[0...], native unsigned int, int32)
+		.locals (class Test.AA pinned, native unsigned int[0...], native unsigned int, int32, native unsigned int[0...] pinned)
 		newobj instance void Test.AA::.ctor()
 		stloc.0
+
+		// test bug fix: make sure to pin Test.AA::m_ai
+		ldloc.0
+		ldfld native unsigned int[0...] Test.AA::m_ai
+		stloc 4
 
 		ldc.i4 18
 		stloc.2


### PR DESCRIPTION
Test was evidently assuming that because an object that referred to an array
was pinned, so was the array. Failure was intermittent, GC is not guaranteed
to move objects or to render their former contents inaccessible.

Fixes #24173.
Fixes #24464.