### PR TITLE
Make AppDomain.GetThreadPrincipal() internal

### DIFF
--- a/src/System.Private.CoreLib/shared/System/AppDomain.cs
+++ b/src/System.Private.CoreLib/shared/System/AppDomain.cs
@@ -390,7 +390,7 @@ namespace System
             return oh?.Unwrap();
         }
 
-        public IPrincipal? GetThreadPrincipal()
+        internal IPrincipal? GetThreadPrincipal()
         {
             IPrincipal? principal = _defaultPrincipal;
             if (principal == null)


### PR DESCRIPTION
While generating System.Runtime.Extensions reference assembly I noticed that this API is public but not exposed. It was made public because Thread uses it. However Thread was pushed down to Corelib already and there seem to be no other usages of this API in corefx/corert. 

I built corefx locally and it built fine.

cc: @jkotas @stephentoub 