### PR TITLE
Fix restoring internal tools

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -394,10 +394,10 @@ if %__RestoreOptData% EQU 1 (
 
 REM Parse the optdata package versions out of msbuild so that we can pass them on to CMake
 set OptDataProjectFilePath=%__ProjectDir%\src\.nuget\optdata\optdata.csproj
-for /f "tokens=*" %%s in ('call "%__ProjectDir%\dotnet.cmd" msbuild "%OptDataProjectFilePath%" /t:DumpPgoDataPackageVersion /p:ArcadeBuild^=true /nologo') do (
+for /f "tokens=*" %%s in ('call "%__ProjectDir%\dotnet.cmd" msbuild "%OptDataProjectFilePath%" /t:DumpPgoDataPackageVersion /nologo') do (
     set __PgoOptDataVersion=%%s
 )
-for /f "tokens=*" %%s in ('call "%__ProjectDir%\dotnet.cmd" msbuild "%OptDataProjectFilePath%" /t:DumpIbcDataPackageVersion /p:ArcadeBuild^=true /nologo') do (
+for /f "tokens=*" %%s in ('call "%__ProjectDir%\dotnet.cmd" msbuild "%OptDataProjectFilePath%" /t:DumpIbcDataPackageVersion /nologo') do (
     set __IbcOptDataVersion=%%s
 )
 
@@ -646,7 +646,7 @@ if %__BuildCoreLib% EQU 1 (
     if %__IbcOptimize% EQU 1 (
         echo %__MsgPrefix%Commencing IBCMerge of System.Private.CoreLib for %__BuildOS%.%__BuildArch%.%__BuildType%
         set IbcMergeProjectFilePath=%__ProjectDir%\src\.nuget\optdata\ibcmerge.csproj
-        for /f "tokens=*" %%s in ('call "%__ProjectDir%\dotnet.cmd" msbuild "!IbcMergeProjectFilePath!" /t:DumpIbcMergePackageVersion /p:ArcadeBuild^=true /nologo') do @(
+        for /f "tokens=*" %%s in ('call "%__ProjectDir%\dotnet.cmd" msbuild "!IbcMergeProjectFilePath!" /t:DumpIbcMergePackageVersion /nologo') do @(
             set __IbcMergeVersion=%%s
         )
 

--- a/build.proj
+++ b/build.proj
@@ -7,7 +7,7 @@
   <Import Project="dir.traversal.targets" />
 
   <Target Name="RestoreOptData" Condition="'$(RestoreDuringBuild)'=='true' and '$(BuildType)'=='Release'">
-    <Exec Command="$(DotnetRestoreCommand) $(SourceDir).nuget/optdata/optdata.csproj /p:ArcadeBuild=true" StandardOutputImportance="Low" />
+    <Exec Command="$(DotnetRestoreCommand) $(SourceDir).nuget/optdata/optdata.csproj" StandardOutputImportance="Low" />
   </Target>
 
   <Import Project="$(ToolsDir)clean.targets" />

--- a/build.sh
+++ b/build.sh
@@ -160,13 +160,13 @@ restore_optdata()
             fi
         fi
         local OptDataProjectFilePath="$__ProjectRoot/src/.nuget/optdata/optdata.csproj"
-        __PgoOptDataVersion=$(DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 $DotNetCli msbuild $OptDataProjectFilePath /t:DumpPgoDataPackageVersion /p:ArcadeBuild=true /nologo)
+        __PgoOptDataVersion=$(DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 $DotNetCli msbuild $OptDataProjectFilePath /t:DumpPgoDataPackageVersion /nologo)
         if [ $? != 0 ]; then
             echo "Failed to get PGO data package version."
             exit $?
         fi
         __PgoOptDataVersion=$(echo $__PgoOptDataVersion | sed 's/^\s*//')
-        __IbcOptDataVersion=$(DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 $DotNetCli msbuild $OptDataProjectFilePath /t:DumpIbcDataPackageVersion /p:ArcadeBuild=true /nologo)
+        __IbcOptDataVersion=$(DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 $DotNetCli msbuild $OptDataProjectFilePath /t:DumpIbcDataPackageVersion /nologo)
         if [ $? != 0 ]; then
             echo "Failed to get IBC data package version."
             exit $?

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -114,7 +114,6 @@ jobs:
           displayName: Restore internal tools
           inputs:
             command: restore
-            arguments: /p:ArcadeBuild=true
             feedsToUse: config
             projects: 'src/.nuget/optdata/ibcmerge.csproj'
             nugetConfigPath: 'eng/internal/NuGet.config'

--- a/src/.nuget/optdata/Directory.Build.props
+++ b/src/.nuget/optdata/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  <!-- Projects for optdata should all use Arcade  -->
+  <PropertyGroup>
+    <ArcadeBuild>true</ArcadeBuild>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/.nuget/optdata/ibcmerge.csproj
+++ b/src/.nuget/optdata/ibcmerge.csproj
@@ -15,6 +15,7 @@
 
   <PropertyGroup>
     <RestoreSources>
+      $(RestoreSources);
       https://devdiv.pkgs.visualstudio.com/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json;
     </RestoreSources>
   </PropertyGroup>


### PR DESCRIPTION
When restoring internal tools through the DotNetCroeCLI task, there isn't a simple way to specify additional arguments while also relying on a config and external feed credentials. The projects under optdata should now always build with Arcade, so add a Directory.Build.props in that folder such that `ArcadeBuild` is always set to true for those projects instead of having to pass it as an argument.

As we onboard more to Arcade, the way we do IBC merge should really be changed so that we rely on the system provided by Arcade: set `UsingToolIbcOptimization` and restore using the Tools project in eng/, set `IbcOptimizationDataDir` (other required properties) and rely on the `ApplyOptimizations` target provided by Arcade, remove ibcmerge.csproj