### PR TITLE
Remove JIT dependency on IEEMemoryManager

### DIFF
--- a/src/ToolBox/superpmi/superpmi-shim-counter/superpmi-shim-counter.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-counter/superpmi-shim-counter.cpp
@@ -70,10 +70,10 @@ void SetLogFilePath()
 
 extern "C"
 #ifdef FEATURE_PAL
-DLLEXPORT // For Win32 PAL LoadLibrary emulation
+    DLLEXPORT // For Win32 PAL LoadLibrary emulation
 #endif
-    BOOL
-    DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
+        BOOL
+        DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {
     switch (ul_reason_for_call)
     {
@@ -199,25 +199,23 @@ extern "C" DLLEXPORT void __stdcall sxsJitStartup(CoreClrCallbacks const& origin
 
     // get entry point
     pnsxsJitStartup = (PsxsJitStartup)::GetProcAddress(g_hRealJit, "sxsJitStartup");
-    if (pnsxsJitStartup == 0)
+
+    if (pnsxsJitStartup != nullptr)
     {
-        LogError("sxsJitStartup() - GetProcAddress 'sxsJitStartup' failed (0x%08x)", ::GetLastError());
-        return;
+        // Setup CoreClrCallbacks and call sxsJitStartup
+        original_CoreClrCallbacks                             = new CoreClrCallbacks();
+        original_CoreClrCallbacks->m_hmodCoreCLR              = original_cccallbacks.m_hmodCoreCLR;
+        original_CoreClrCallbacks->m_pfnIEE                   = original_cccallbacks.m_pfnIEE;
+        original_CoreClrCallbacks->m_pfnGetCORSystemDirectory = original_cccallbacks.m_pfnGetCORSystemDirectory;
+        original_CoreClrCallbacks->m_pfnGetCLRFunction        = original_cccallbacks.m_pfnGetCLRFunction;
+
+        CoreClrCallbacks* temp = new CoreClrCallbacks();
+
+        temp->m_hmodCoreCLR              = original_cccallbacks.m_hmodCoreCLR;
+        temp->m_pfnIEE                   = IEE_t;
+        temp->m_pfnGetCORSystemDirectory = original_cccallbacks.m_pfnGetCORSystemDirectory;
+        temp->m_pfnGetCLRFunction        = GetCLRFunction;
+
+        pnsxsJitStartup(*temp);
     }
-
-    // Setup CoreClrCallbacks and call sxsJitStartup
-    original_CoreClrCallbacks                             = new CoreClrCallbacks();
-    original_CoreClrCallbacks->m_hmodCoreCLR              = original_cccallbacks.m_hmodCoreCLR;
-    original_CoreClrCallbacks->m_pfnIEE                   = original_cccallbacks.m_pfnIEE;
-    original_CoreClrCallbacks->m_pfnGetCORSystemDirectory = original_cccallbacks.m_pfnGetCORSystemDirectory;
-    original_CoreClrCallbacks->m_pfnGetCLRFunction        = original_cccallbacks.m_pfnGetCLRFunction;
-
-    CoreClrCallbacks* temp = new CoreClrCallbacks();
-
-    temp->m_hmodCoreCLR              = original_cccallbacks.m_hmodCoreCLR;
-    temp->m_pfnIEE                   = IEE_t;
-    temp->m_pfnGetCORSystemDirectory = original_cccallbacks.m_pfnGetCORSystemDirectory;
-    temp->m_pfnGetCLRFunction        = GetCLRFunction;
-
-    pnsxsJitStartup(*temp);
 }

--- a/src/ToolBox/superpmi/superpmi-shim-simple/superpmi-shim-simple.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-simple/superpmi-shim-simple.cpp
@@ -60,10 +60,10 @@ void SetLogFilePath()
 
 extern "C"
 #ifdef FEATURE_PAL
-DLLEXPORT // For Win32 PAL LoadLibrary emulation
+    DLLEXPORT // For Win32 PAL LoadLibrary emulation
 #endif
-    BOOL
-    DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
+        BOOL
+        DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {
     switch (ul_reason_for_call)
     {
@@ -174,25 +174,23 @@ extern "C" DLLEXPORT void __stdcall sxsJitStartup(CoreClrCallbacks const& origin
 
     // get entry point
     pnsxsJitStartup = (PsxsJitStartup)::GetProcAddress(g_hRealJit, "sxsJitStartup");
-    if (pnsxsJitStartup == 0)
+
+    if (pnsxsJitStartup != nullptr)
     {
-        LogError("sxsJitStartup() - GetProcAddress 'sxsJitStartup' failed (0x%08x)", ::GetLastError());
-        return;
+        // Setup CoreClrCallbacks and call sxsJitStartup
+        original_CoreClrCallbacks                             = new CoreClrCallbacks();
+        original_CoreClrCallbacks->m_hmodCoreCLR              = original_cccallbacks.m_hmodCoreCLR;
+        original_CoreClrCallbacks->m_pfnIEE                   = original_cccallbacks.m_pfnIEE;
+        original_CoreClrCallbacks->m_pfnGetCORSystemDirectory = original_cccallbacks.m_pfnGetCORSystemDirectory;
+        original_CoreClrCallbacks->m_pfnGetCLRFunction        = original_cccallbacks.m_pfnGetCLRFunction;
+
+        CoreClrCallbacks* temp = new CoreClrCallbacks();
+
+        temp->m_hmodCoreCLR              = original_cccallbacks.m_hmodCoreCLR;
+        temp->m_pfnIEE                   = IEE_t;
+        temp->m_pfnGetCORSystemDirectory = original_cccallbacks.m_pfnGetCORSystemDirectory;
+        temp->m_pfnGetCLRFunction        = GetCLRFunction;
+
+        pnsxsJitStartup(*temp);
     }
-
-    // Setup CoreClrCallbacks and call sxsJitStartup
-    original_CoreClrCallbacks                             = new CoreClrCallbacks();
-    original_CoreClrCallbacks->m_hmodCoreCLR              = original_cccallbacks.m_hmodCoreCLR;
-    original_CoreClrCallbacks->m_pfnIEE                   = original_cccallbacks.m_pfnIEE;
-    original_CoreClrCallbacks->m_pfnGetCORSystemDirectory = original_cccallbacks.m_pfnGetCORSystemDirectory;
-    original_CoreClrCallbacks->m_pfnGetCLRFunction        = original_cccallbacks.m_pfnGetCLRFunction;
-
-    CoreClrCallbacks* temp = new CoreClrCallbacks();
-
-    temp->m_hmodCoreCLR              = original_cccallbacks.m_hmodCoreCLR;
-    temp->m_pfnIEE                   = IEE_t;
-    temp->m_pfnGetCORSystemDirectory = original_cccallbacks.m_pfnGetCORSystemDirectory;
-    temp->m_pfnGetCLRFunction        = GetCLRFunction;
-
-    pnsxsJitStartup(*temp);
 }

--- a/src/ToolBox/superpmi/superpmi/jitinstance.cpp
+++ b/src/ToolBox/superpmi/superpmi/jitinstance.cpp
@@ -12,10 +12,10 @@
 #include "errorhandling.h"
 #include "spmiutil.h"
 
-JitInstance* JitInstance::InitJit(char*          nameOfJit,
-                                  bool           breakOnAssert,
-                                  SimpleTimer*   st1,
-                                  MethodContext* firstContext,
+JitInstance* JitInstance::InitJit(char*                         nameOfJit,
+                                  bool                          breakOnAssert,
+                                  SimpleTimer*                  st1,
+                                  MethodContext*                firstContext,
                                   LightWeightMap<DWORD, DWORD>* forceOptions,
                                   LightWeightMap<DWORD, DWORD>* options)
 {
@@ -174,16 +174,14 @@ HRESULT JitInstance::StartUp(char* PathToJit, bool copyJit, bool breakOnDebugBre
         return -1;
     }
     pnsxsJitStartup = (PsxsJitStartup)::GetProcAddress(hLib, "sxsJitStartup");
-    if (pnsxsJitStartup == 0)
-    {
-        LogError("GetProcAddress 'sxsJitStartup' failed (0x%08x)", ::GetLastError());
-        return -1;
-    }
-    pnjitStartup = (PjitStartup)::GetProcAddress(hLib, "jitStartup");
+    pnjitStartup    = (PjitStartup)::GetProcAddress(hLib, "jitStartup");
 
-    // Setup CoreClrCallbacks and call sxsJitStartup
-    CoreClrCallbacks* cccallbacks = InitCoreClrCallbacks();
-    pnsxsJitStartup(*cccallbacks);
+    if (pnsxsJitStartup != nullptr)
+    {
+        // Setup CoreClrCallbacks and call sxsJitStartup
+        CoreClrCallbacks* cccallbacks = InitCoreClrCallbacks();
+        pnsxsJitStartup(*cccallbacks);
+    }
 
     // Setup ICorJitHost and call jitStartup if necessary
     if (pnjitStartup != nullptr)
@@ -244,16 +242,14 @@ bool JitInstance::reLoad(MethodContext* firstContext)
         return false;
     }
     pnsxsJitStartup = (PsxsJitStartup)::GetProcAddress(hLib, "sxsJitStartup");
-    if (pnsxsJitStartup == 0)
-    {
-        LogError("GetProcAddress 'sxsJitStartup' failed (0x%08x)", ::GetLastError());
-        return false;
-    }
-    pnjitStartup = (PjitStartup)::GetProcAddress(hLib, "jitStartup");
+    pnjitStartup    = (PjitStartup)::GetProcAddress(hLib, "jitStartup");
 
-    // Setup CoreClrCallbacks and call sxsJitStartup
-    CoreClrCallbacks* cccallbacks = InitCoreClrCallbacks();
-    pnsxsJitStartup(*cccallbacks);
+    if (pnsxsJitStartup != nullptr)
+    {
+        // Setup CoreClrCallbacks and call sxsJitStartup
+        CoreClrCallbacks* cccallbacks = InitCoreClrCallbacks();
+        pnsxsJitStartup(*cccallbacks);
+    }
 
     // Setup ICorJitHost and call jitStartup if necessary
     if (pnjitStartup != nullptr)

--- a/src/inc/corjit.h
+++ b/src/inc/corjit.h
@@ -292,7 +292,7 @@ public:
 class ICorJitInfo : public ICorDynamicInfo
 {
 public:
-    // return memory manager that the JIT can use to allocate a regular memory
+    // OBSOLETE: return memory manager that the JIT can use to allocate a regular memory
     virtual IEEMemoryManager* getMemoryManager() = 0;
 
     // get a block of memory for the code, readonly data, and read-write data

--- a/src/jit/ClrJit.PAL.exports
+++ b/src/jit/ClrJit.PAL.exports
@@ -1,6 +1,5 @@
 getJit
 jitStartup
-sxsJitStartup
 DllMain
 PAL_RegisterModule
 PAL_UnregisterModule

--- a/src/jit/ClrJit.exports
+++ b/src/jit/ClrJit.exports
@@ -5,4 +5,3 @@
 EXPORTS
     getJit
     jitStartup
-    sxsJitStartup

--- a/src/jit/armelnonjit/armelnonjit.def
+++ b/src/jit/armelnonjit/armelnonjit.def
@@ -4,4 +4,3 @@
 EXPORTS
     getJit
     jitStartup
-    sxsJitStartup

--- a/src/jit/dll/clrjit.def
+++ b/src/jit/dll/clrjit.def
@@ -4,4 +4,3 @@
 EXPORTS
     getJit
     jitStartup
-    sxsJitStartup

--- a/src/jit/ee_il_dll.cpp
+++ b/src/jit/ee_il_dll.cpp
@@ -176,12 +176,14 @@ HINSTANCE GetModuleInst()
     return (g_hInst);
 }
 
+#ifndef FEATURE_CORECLR
 extern "C" DLLEXPORT void __stdcall sxsJitStartup(CoreClrCallbacks const& cccallbacks)
 {
 #ifndef SELF_NO_HOST
     InitUtilcode(cccallbacks);
 #endif
 }
+#endif // FEATURE_CORECLR
 
 #endif // !FEATURE_MERGE_JIT_AND_ENGINE
 

--- a/src/jit/jittelemetry.cpp
+++ b/src/jit/jittelemetry.cpp
@@ -69,8 +69,6 @@
 //            This roughly translates to InitUtilcode() being called before jitDllOnProcessAttach.
 //
 //            For CLRJIT.dll, compStartup is called on jitOnDllProcessAttach().
-//            This can be called twice through sxsJitStartup -- so prevent double initialization.
-//            UtilCode is init-ed by this time. The same is true for CoreCLR.
 //
 //         2) For CLRJIT.dll and CoreCLR, compShutdown will be called during jitOnDllProcessDetach().
 //

--- a/src/jit/protojit/protojit.def
+++ b/src/jit/protojit/protojit.def
@@ -4,4 +4,3 @@
 EXPORTS
     getJit
     jitStartup
-    sxsJitStartup

--- a/src/jit/protononjit/protononjit.def
+++ b/src/jit/protononjit/protononjit.def
@@ -4,4 +4,3 @@
 EXPORTS
     getJit
     jitStartup
-    sxsJitStartup

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -10852,21 +10852,8 @@ bool CEEInfo::runWithErrorTrap(void (*function)(void*), void* param)
 /*********************************************************************/
 IEEMemoryManager* CEEInfo::getMemoryManager()
 {
-    CONTRACTL {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_PREEMPTIVE;
-    } CONTRACTL_END;
-
-    IEEMemoryManager* result = NULL;
-
-    JIT_TO_EE_TRANSITION_LEAF();
-
-    result = GetEEMemoryManager();
-
-    EE_TO_JIT_TRANSITION_LEAF();
-
-    return result;
+    UNREACHABLE(); // OBSOLETE
+    return NULL;
 }
 
 /*********************************************************************/

--- a/src/zap/zapper.cpp
+++ b/src/zap/zapper.cpp
@@ -510,19 +510,6 @@ void Zapper::LoadAndInitializeJITForNgen(LPCWSTR pwzJitName, OUT HINSTANCE* phJi
         ThrowLastError();
     }
 
-#if !defined(CROSSGEN_COMPILE)
-    typedef void (__stdcall* pSxsJitStartup) (CoreClrCallbacks const & cccallbacks);
-    pSxsJitStartup sxsJitStartupFn = (pSxsJitStartup) GetProcAddress(*phJit, "sxsJitStartup");
-    if (sxsJitStartupFn == NULL)
-    {
-        Error(W("Unable to load Jit startup function: %s\r\n"), pwzJitName);
-        ThrowLastError();
-    }
-
-    CoreClrCallbacks cccallbacks = GetClrCallbacks();
-    (*sxsJitStartupFn) (cccallbacks);
-#endif
-
     typedef void (__stdcall* pJitStartup)(ICorJitHost* host);
     pJitStartup jitStartupFn = (pJitStartup)GetProcAddress(*phJit, "jitStartup");
     if (jitStartupFn != nullptr)


### PR DESCRIPTION
This is next step in untangling the SQL hosting abstractions that are useless in .NET Core.