### PR TITLE
Arm64: Take more bounds checks into consideration when inlining immediates

### DIFF
--- a/src/jit/lowerarmarch.cpp
+++ b/src/jit/lowerarmarch.cpp
@@ -92,6 +92,7 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode)
             case GT_LE:
             case GT_GE:
             case GT_GT:
+            case GT_ARR_BOUNDS_CHECK:
                 return emitter::emitIns_valid_imm_for_cmp(immVal, size);
             case GT_AND:
             case GT_OR:

--- a/src/jit/lowerarmarch.cpp
+++ b/src/jit/lowerarmarch.cpp
@@ -93,6 +93,8 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode)
             case GT_GE:
             case GT_GT:
             case GT_ARR_BOUNDS_CHECK:
+            case GT_SIMD_CHK:
+            case GT_HW_INTRINSIC_CHK:
                 return emitter::emitIns_valid_imm_for_cmp(immVal, size);
             case GT_AND:
             case GT_OR:


### PR DESCRIPTION
This add `GT_ARR_BOUNDS_CHECK` to the list of operations that `IsContainableImmed` should consider in-lining the immediate for in the `cmp`.

changes

```
        52800041          mov     w1, #2
        B9800803          ldrsw   x3, [x0,#8]
        6B03003F          cmp     w1, w3
        54000082          bhs     G_M32566_IG04
        B9001802          str     w2, [x0,#24]
```

into 

```
        B9800803          ldrsw   x3, [x0,#8]
        6B03003F          cmp     w3, #2
        54000082          bls     G_M32566_IG04
        B9001802          str     w2, [x0,#24]
```

Fixes #24711 