### PR TITLE
Set the HasExplicitSize flag when a class size is specified in metadata.

### DIFF
--- a/src/vm/class.cpp
+++ b/src/vm/class.cpp
@@ -3767,6 +3767,10 @@ VOID EEClassLayoutInfo::CollectLayoutFieldMetadataThrowing(
     {
         classSizeInMetadata = 0;
     }
+    else
+    {
+        pEEClassLayoutInfoOut->SetHasExplicitSize(TRUE);
+    }
 
     BYTE parentAlignmentRequirement = 0;
     if (fParentHasLayout)

--- a/src/vm/class.cpp
+++ b/src/vm/class.cpp
@@ -3769,6 +3769,9 @@ VOID EEClassLayoutInfo::CollectLayoutFieldMetadataThrowing(
     }
     else
     {
+        // If we can get the class size from metadata, that means that the user
+        // explicitly provided a value to the StructLayoutAttribute.Size field
+        // or explicitly provided the size in IL.
         pEEClassLayoutInfoOut->SetHasExplicitSize(TRUE);
     }
 

--- a/tests/src/Loader/classloader/SequentialLayout/Regress/ExplicitSize/ExplicitSize.cs
+++ b/tests/src/Loader/classloader/SequentialLayout/Regress/ExplicitSize/ExplicitSize.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// The struct has an objref and is of odd size.
-// The GC requires that all valuetypes containing objrefs be sized to a multiple of sizeof(void*) )== 4).
-// Since the size of this struct was 17 we were throwing a TypeLoadException.
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -19,7 +16,7 @@ unsafe class Program
 
     static int Main()
     {
-        Guid initialGuid = Guid.NewGuid();
+        Guid initialGuid = Guid.Parse("E6218D43-3C16-48BF-9C3C-8076FF5AFCD0");
         GUID g = default;
         Test(initialGuid, &g);
         return Unsafe.As<GUID, Guid>(ref g) == initialGuid ? 100 : 101;

--- a/tests/src/Loader/classloader/SequentialLayout/Regress/ExplicitSize/ExplicitSize.cs
+++ b/tests/src/Loader/classloader/SequentialLayout/Regress/ExplicitSize/ExplicitSize.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// The struct has an objref and is of odd size.
+// The GC requires that all valuetypes containing objrefs be sized to a multiple of sizeof(void*) )== 4).
+// Since the size of this struct was 17 we were throwing a TypeLoadException.
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+unsafe class Program
+{
+    [StructLayout(LayoutKind.Sequential, Size = 16)]
+    struct GUID
+    {
+        private int align;
+    }
+
+    static int Main()
+    {
+        Guid initialGuid = Guid.NewGuid();
+        GUID g = default;
+        Test(initialGuid, &g);
+        return Unsafe.As<GUID, Guid>(ref g) == initialGuid ? 100 : 101;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static GUID GetGUID(ref Guid guid) => Unsafe.As<Guid, GUID>(ref guid);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static unsafe void Test(Guid initialGuid, GUID* result)
+    {
+        Guid g = initialGuid;
+        GUID guid = GetGUID(ref g);
+        Unsafe.CopyBlock(result, &guid, (uint)sizeof(GUID));
+    }
+}

--- a/tests/src/Loader/classloader/SequentialLayout/Regress/ExplicitSize/ExplicitSize.csproj
+++ b/tests/src/Loader/classloader/SequentialLayout/Regress/ExplicitSize/ExplicitSize.csproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>ExplicitSize</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ExplicitSize.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
Fixes #24705 
