### PR TITLE
Fix publishing in official build

### DIFF
--- a/src/publishwitharcade.proj
+++ b/src/publishwitharcade.proj
@@ -1,11 +1,11 @@
 <Project DefaultTargets="PublishPackages">
 
-  <!-- TODO: move properties imported from here into a common props file -->
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <!-- Publishing should always use Arcade -->
+  <PropertyGroup>
+    <ArcadeBuild>true</ArcadeBuild>
+  </PropertyGroup>
 
-  <!-- Use an explicit SDK import so that arcade uses the build
-       configuration computed in dir.common.props. -->
-  <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+  <Import Project="Directory.Build.props" />
 
   <Import Project="$(NuGetPackageRoot)microsoft.dotnet.build.tasks.feed\$(MicrosoftDotNetBuildTasksFeedVersion)\build\Microsoft.DotNet.Build.Tasks.Feed.targets" />
 


### PR DESCRIPTION
The error was due to a a file being imported twice (Version.props). Switched publishwitharcade.proj to stop importing dir.props (should not be needed for things onboarded to Arcade).

Eventually (when we actually use `artifacts` as the output path for everything), we should probably just use the projects / scripts provided by the Arcade system for publishing as well.