### PR TITLE
Two changes to !dumpasync

### DIFF
--- a/src/ToolBox/SOS/Strike/util.h
+++ b/src/ToolBox/SOS/Strike/util.h
@@ -1862,7 +1862,7 @@ BOOL TryGetMethodDescriptorForDelegate(CLRDATA_ADDRESS delegateAddr, CLRDATA_ADD
  *      ArrayHolder class.
  */
 DWORD_PTR *ModuleFromName(__in_opt LPSTR name, int *numModules);
-void GetInfoFromName(DWORD_PTR ModuleAddr, const char* name);
+void GetInfoFromName(DWORD_PTR ModuleAddr, const char* name, mdTypeDef* retMdTypeDef=NULL);
 void GetInfoFromModule (DWORD_PTR ModuleAddr, ULONG token, DWORD_PTR *ret=NULL);
 
     


### PR DESCRIPTION
1. Improve performance.  A significant portion of the time running dumpasync was spent in getting a type name for each object on the heap in order to compare that to “AsyncStateMachineBox”.  It’s much faster to compare module and md type defs.  For an ~1GB dump on my machine, this improved the time to run !dumpasync from 43 seconds to 11 seconds.
2. Tweak behavior of -stacks -fields.  Prior to this change, -fields would output the field information for the top-level state machine only.  Now if -fields is used in conjunction with -stacks, it’ll output the fields for each state machine in the continuation chain as well.

cc: @noahfalk, @mikem8361, @patrickcarnahan