### PR TITLE
Fixing the epilog size decoding

### DIFF
--- a/src/tools/r2rdump/Amd64/GcInfo.cs
+++ b/src/tools/r2rdump/Amd64/GcInfo.cs
@@ -119,7 +119,7 @@ namespace R2RDump.Amd64
             if (_hasGSCookie)
             {
                 uint normPrologSize = NativeReader.DecodeVarLengthUnsigned(image, _gcInfoTypes.NORM_PROLOG_SIZE_ENCBASE, ref bitOffset) + 1;
-                uint normEpilogSize = NativeReader.DecodeVarLengthUnsigned(image, _gcInfoTypes.NORM_PROLOG_SIZE_ENCBASE, ref bitOffset);
+                uint normEpilogSize = NativeReader.DecodeVarLengthUnsigned(image, _gcInfoTypes.NORM_EPILOG_SIZE_ENCBASE, ref bitOffset);
 
                 ValidRangeStart = normPrologSize;
                 ValidRangeEnd = (uint)CodeLength - normEpilogSize;

--- a/src/tools/r2rdump/GCInfoTypes.cs
+++ b/src/tools/r2rdump/GCInfoTypes.cs
@@ -79,6 +79,7 @@ namespace R2RDump
         internal int SIZE_OF_RETURN_KIND_FAT { get; } = 2;
         internal int CODE_LENGTH_ENCBASE { get; } = 8;
         internal int NORM_PROLOG_SIZE_ENCBASE { get; } = 5;
+        internal int NORM_EPILOG_SIZE_ENCBASE { get; } = 3;
         internal int SECURITY_OBJECT_STACK_SLOT_ENCBASE { get; } = 6;
         internal int GS_COOKIE_STACK_SLOT_ENCBASE { get; } = 6;
         internal int PSP_SYM_STACK_SLOT_ENCBASE { get; } = 6;

--- a/src/tools/r2rdump/R2RReader.cs
+++ b/src/tools/r2rdump/R2RReader.cs
@@ -553,19 +553,7 @@ namespace R2RDump
                         unwindInfo = new Amd64.UnwindInfo(Image, unwindOffset);
                         if (isEntryPoint[runtimeFunctionId])
                         {
-                            try
-                            {
-                                gcInfo = new Amd64.GcInfo(Image, unwindOffset + unwindInfo.Size, Machine, R2RHeader.MajorVersion);
-                            }
-                            catch (OverflowException)
-                            {
-                                Console.WriteLine($"Warning: Could not parse GC Info for method: {method.SignatureString}");
-                            }
-                            catch (IndexOutOfRangeException)
-                            {
-                                Console.WriteLine($"Warning: Could not parse GC Info for method: {method.SignatureString}");
-                            }
-                             
+                            gcInfo = new Amd64.GcInfo(Image, unwindOffset + unwindInfo.Size, Machine, R2RHeader.MajorVersion);
                         }
                     }
                     else if (Machine == Machine.I386)


### PR DESCRIPTION
I believe I have found a possible root cause of why R2RDump failed to parse the GCInfo.

In [`GcInfoEncoder::Build`](https://github.com/dotnet/coreclr/blob/bb75edbac9c40034b6683c17d86057ee9bf4192d/src/gcinfo/gcinfoencoder.cpp#L1067), we use a different base to encode the prolog length and the epilog length, but in the [`R2RDump.Amd64.GcInfo..ctor`](https://github.com/dotnet/coreclr/blob/bb75edbac9c40034b6683c17d86057ee9bf4192d/src/tools/r2rdump/Amd64/GcInfo.cs#L121), we used the same base to decode them, therefore the rest goes wrong.

I don't know if this fixes everything, but I know it won't throw any exception (and therefore I removed the catch clauses) when running on `System.Private.CoreLib.dll` on x64 debug build.

Unfortunately, it still crashes in x64 release build.