### PR TITLE
Call derived ToString on inner exceptions

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Exception.cs
+++ b/src/System.Private.CoreLib/shared/System/Exception.cs
@@ -141,26 +141,20 @@ namespace System
 
         public override string ToString()
         {
-            return ToString(true, true);
-        }
-
-        private string ToString(bool needFileLineInfo, bool needMessage)
-        {
             string s = GetClassName();
 
-            string? message = (needMessage ? Message : null);
-            if (!string.IsNullOrEmpty(message))
+            if (!string.IsNullOrEmpty(Message))
             {
-                s += ": " + message;
+                s += ": " + Message;
             }
 
             if (_innerException != null)
             {
-                s = s + " ---> " + _innerException.ToString(needFileLineInfo, needMessage) + Environment.NewLine +
+                s = s + " ---> " + _innerException.ToString() + Environment.NewLine +
                 "   " + SR.Exception_EndOfInnerExceptionStack;
             }
 
-            string? stackTrace = GetStackTrace(needFileLineInfo);
+            string? stackTrace = GetStackTrace(needFileInfo: true);
             if (stackTrace != null)
             {
                 s += Environment.NewLine + stackTrace;

--- a/src/System.Private.CoreLib/shared/System/Exception.cs
+++ b/src/System.Private.CoreLib/shared/System/Exception.cs
@@ -143,9 +143,10 @@ namespace System
         {
             string s = GetClassName();
 
-            if (!string.IsNullOrEmpty(Message))
+            string? message = Message;
+            if (!string.IsNullOrEmpty(message))
             {
-                s += ": " + Message;
+                s += ": " + message;
             }
 
             if (_innerException != null)

--- a/src/System.Private.CoreLib/src/System/Exception.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Exception.CoreCLR.cs
@@ -410,7 +410,7 @@ namespace System
         internal string InternalToString()
         {
             // Get the current stack trace string. 
-            return ToString(true, true);
+            return ToString();
         }
 
         internal bool IsTransient

--- a/src/System.Private.CoreLib/src/System/Exception.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Exception.CoreCLR.cs
@@ -406,13 +406,6 @@ namespace System
         // See src\inc\corexcep.h's EXCEPTION_COMPLUS definition:
         private const int _COMPlusExceptionCode = unchecked((int)0xe0434352);   // Win32 exception code for COM+ exceptions
 
-        // InternalToString is called by the runtime to get the exception text.
-        internal string InternalToString()
-        {
-            // Get the current stack trace string. 
-            return ToString();
-        }
-
         internal bool IsTransient
         {
             get

--- a/src/vm/debughelp.cpp
+++ b/src/vm/debughelp.cpp
@@ -779,13 +779,13 @@ void PrintException(OBJECTREF pObjectRef)
     }
     else
     {
-        MethodDescCallSite internalToString(METHOD__EXCEPTION__INTERNAL_TO_STRING, &pObjectRef);
+        MethodDescCallSite toString(METHOD__EXCEPTION__TO_STRING, &pObjectRef);
 
         ARG_SLOT arg[1] = {
             ObjToArgSlot(pObjectRef)
         };
 
-        STRINGREF str = internalToString.Call_RetSTRINGREF(arg);
+        STRINGREF str = toString.Call_RetSTRINGREF(arg);
 
         if(str->GetBuffer() != NULL)
         {

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -243,7 +243,7 @@ ULONG GetExceptionMessage(OBJECTREF throwable,
 
 //-----------------------------------------------------------------------------
 // Given an object, get the "message" from it.  If the object is an Exception
-//  call Exception.InternalToString, otherwise, call Object.ToString
+//  call Exception.ToString, otherwise, call Object.ToString
 //-----------------------------------------------------------------------------
 void GetExceptionMessage(OBJECTREF throwable, SString &result)
 {
@@ -339,8 +339,8 @@ STRINGREF GetExceptionMessage(OBJECTREF throwable)
     if (throwable == NULL)
         return NULL;
 
-    // Assume we're calling Exception.InternalToString() ...
-    BinderMethodID sigID = METHOD__EXCEPTION__INTERNAL_TO_STRING;
+    // Assume we're calling Exception.ToString() ...
+    BinderMethodID sigID = METHOD__EXCEPTION__TO_STRING;
 
     // ... but if it isn't an exception, call Object.ToString().
     _ASSERTE(IsException(throwable->GetMethodTable()));        // what is the pathway here?

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -357,7 +357,7 @@ DEFINE_METHOD(EXCEPTION,            GET_CLASS_NAME,         GetClassName,       
 DEFINE_PROPERTY(EXCEPTION,          MESSAGE,                Message,                    Str)
 DEFINE_PROPERTY(EXCEPTION,          SOURCE,                 Source,                     Str)
 DEFINE_PROPERTY(EXCEPTION,          HELP_LINK,              HelpLink,                   Str)
-DEFINE_METHOD(EXCEPTION,            INTERNAL_TO_STRING,     InternalToString,           IM_RetStr)
+DEFINE_METHOD(EXCEPTION,            TO_STRING,              ToString,                   IM_RetStr)
 DEFINE_METHOD(EXCEPTION,            INTERNAL_PRESERVE_STACK_TRACE, InternalPreserveStackTrace, IM_RetVoid)
 #ifdef FEATURE_COMINTEROP
 DEFINE_METHOD(EXCEPTION,            ADD_EXCEPTION_DATA_FOR_RESTRICTED_ERROR_INFO, AddExceptionDataForRestrictedErrorInfo, IM_Str_Str_Str_Obj_Bool_RetVoid)

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -358,7 +358,6 @@ DEFINE_PROPERTY(EXCEPTION,          MESSAGE,                Message,            
 DEFINE_PROPERTY(EXCEPTION,          SOURCE,                 Source,                     Str)
 DEFINE_PROPERTY(EXCEPTION,          HELP_LINK,              HelpLink,                   Str)
 DEFINE_METHOD(EXCEPTION,            INTERNAL_TO_STRING,     InternalToString,           IM_RetStr)
-DEFINE_METHOD(EXCEPTION,            TO_STRING,              ToString,                   IM_Bool_Bool_RetStr)
 DEFINE_METHOD(EXCEPTION,            INTERNAL_PRESERVE_STACK_TRACE, InternalPreserveStackTrace, IM_RetVoid)
 #ifdef FEATURE_COMINTEROP
 DEFINE_METHOD(EXCEPTION,            ADD_EXCEPTION_DATA_FOR_RESTRICTED_ERROR_INFO, AddExceptionDataForRestrictedErrorInfo, IM_Str_Str_Str_Obj_Bool_RetVoid)


### PR DESCRIPTION
For https://github.com/dotnet/corefx/issues/35647
Not https://github.com/dotnet/coreclr/issues/8694

Remove `Exception.InternalToString` and `Exception.ToString(bool,bool)`

I'll add a test.