### PR TITLE
Added an overflow check for the S_SIZE_T value

### DIFF
--- a/src/gcinfo/arraylist.cpp
+++ b/src/gcinfo/arraylist.cpp
@@ -44,9 +44,8 @@ void GcInfoArrayListBase::AppendNewChunk(size_t firstChunkCapacity, size_t eleme
     size_t chunkCapacity = (m_firstChunk == nullptr) ? firstChunkCapacity : (m_lastChunkCapacity * GrowthFactor);
 
     S_SIZE_T chunkSize = S_SIZE_T(roundUp(sizeof(ChunkBase), chunkAlignment)) + (S_SIZE_T(elementSize) * S_SIZE_T(chunkCapacity));
-    assert(!chunkSize.IsOverflow());
 
-    if(chunkSize.IsOverflow())
+    if (chunkSize.IsOverflow())
     {
         ThrowHR(COR_E_OVERFLOW);
     }

--- a/src/gcinfo/arraylist.cpp
+++ b/src/gcinfo/arraylist.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include <windows.h>
+#include <ex.h>
 #include "debugmacros.h"
 #include "iallocator.h"
 #include "gcinfoarraylist.h"
@@ -44,6 +45,11 @@ void GcInfoArrayListBase::AppendNewChunk(size_t firstChunkCapacity, size_t eleme
 
     S_SIZE_T chunkSize = S_SIZE_T(roundUp(sizeof(ChunkBase), chunkAlignment)) + (S_SIZE_T(elementSize) * S_SIZE_T(chunkCapacity));
     assert(!chunkSize.IsOverflow());
+
+    if(chunkSize.IsOverflow())
+    {
+        ThrowHR(COR_E_OVERFLOW);
+    }
 
     ChunkBase* chunk = reinterpret_cast<ChunkBase*>(m_allocator->Alloc(chunkSize.Value()));
     chunk->m_next = nullptr;


### PR DESCRIPTION
I added an overflow check for the S_SIZE_T value using S_SIZE_T.IsOverflow().

At the old code, the overflow check is being done by 'assert' which works only in debug mode. 

I found other 46 occurrence of S_SIZE_T values checks overflow using S_SIZE_T.IsOverflow() before accessing S_SIZE_T.value().

For example, the following code snippet in "src/zap/zapcode.cpp' shows such case: 

1069:    S_SIZE_T cbAllocSize = S_SIZE_T(sizeof(ZapGCInfo)) + S_SIZE_T(cbGCInfo) + S_SIZE_T(cbUnwindInfo);
1070:    if(cbAllocSize.IsOverflow())
1071:        ThrowHR(COR_E_OVERFLOW);
1072:
1073:    void * pMemory = new (pWriter->GetHeap()) BYTE[cbAllocSize.Value()];