### PR TITLE
sched_getaffinity: pass getpid() to get process affinity

### DIFF
--- a/src/gc/unix/gcenv.unix.cpp
+++ b/src/gc/unix/gcenv.unix.cpp
@@ -289,7 +289,7 @@ bool GCToOSInterface::Initialize()
     g_currentProcessCpuCount = 0;
 
     cpu_set_t cpuSet;
-    int st = sched_getaffinity(0, sizeof(cpu_set_t), &cpuSet);
+    int st = sched_getaffinity(getpid(), sizeof(cpu_set_t), &cpuSet);
 
     if (st == 0)
     {

--- a/src/pal/src/misc/sysinfo.cpp
+++ b/src/pal/src/misc/sysinfo.cpp
@@ -144,7 +144,7 @@ PAL_GetLogicalCpuCountFromOS()
 #if HAVE_SCHED_GETAFFINITY
 
     cpu_set_t cpuSet;
-    int st = sched_getaffinity(0, sizeof(cpu_set_t), &cpuSet);
+    int st = sched_getaffinity(getpid(), sizeof(cpu_set_t), &cpuSet);
     if (st != 0)
     {
         ASSERT("sched_getaffinity failed (%d)\n", errno);


### PR DESCRIPTION
sched_getaffinity is documented to return the process affinity
when called with pid zero. However, this is actually
returning the current thread affinity.

CC @janvorli 