### PR TITLE
Stop adding 7 before the build revision number

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,8 +1,3 @@
-
-# Temporarily set a build number format that includes a large revision
-# number that won't conflict with buildpipeline official builds.
-name: $(Date:yyyyMMdd)$(Rev:.7r)
-
 variables:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 


### PR DESCRIPTION
The artificially large revision number was a temporary workaround that should no longer be necessary.

The valid range for the revision number is [0, 99]. By having the 7 before it, official builds fail if there are more than 9 in one day.