### PR TITLE
Stop using BuildTools for signing

### DIFF
--- a/dir.common.props
+++ b/dir.common.props
@@ -99,6 +99,10 @@
     <!-- We are only tracking Linux Distributions for Nuget RID mapping -->
     <DistroRid Condition="'$(TargetsLinux)' == 'true'">$(__DistroRid)</DistroRid>
 
+    <!-- Folder for cross target components -->
+    <CrossTargetComponentFolder Condition="'$(BuildArch)' == 'arm64'">x64</CrossTargetComponentFolder>
+    <CrossTargetComponentFolder Condition="'$(BuildArch)' == 'arm' and '$(TargetsWindows)' == 'true'">x86</CrossTargetComponentFolder>
+    <CrossTargetComponentFolder Condition="'$(BuildArch)' == 'arm' and '$(TargetsLinux)' == 'true'">x64</CrossTargetComponentFolder>
   </PropertyGroup>
 
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,56 +1,24 @@
 <Project>
-  <Import Project="..\dir.props"/>
-  <Import Project="..\dir.targets" />
-
-  <PropertyGroup>
-    <!-- The SignFiles target needs OutDir to be defined -->
-    <OutDir>$(BinDir)</OutDir>
-  </PropertyGroup>
-
-  <UsingTask AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" TaskName="ReadSigningRequired" />
-
+  <Import Project="..\dir.common.props"/>
+  
   <ItemGroup>
-    <WindowsNativeLocation Include="$(BinDir)*.dll" />
-    <WindowsNativeLocation Include="$(BinDir)*.exe" />
+    <ItemsToSign Include="$(BinDir)*.dll" />
+    <ItemsToSign Include="$(BinDir)*.exe" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildArch)' == 'x86'">
     <!-- Sign api-ms-win-core-xstate-l2-1-0 binary as it is only catalog signed in the current SDK. -->
-    <WindowsNativeLocation Condition="'$(BuildType)'=='Release'" Include="$(BinDir)Redist\ucrt\DLLs\$(BuildArch)\api-ms-win-core-xstate-l2-1-0.dll" />
+    <ItemsToSign Condition="'$(BuildType)'=='Release'" Include="$(BinDir)Redist\ucrt\DLLs\$(BuildArch)\api-ms-win-core-xstate-l2-1-0.dll" />
   </ItemGroup>
 
   <!-- sign the cross targeted files as well -->
   <ItemGroup Condition="'$(CrossTargetComponentFolder)' != ''">
-    <WindowsNativeLocation Include="$(BinDir)$(CrossTargetComponentFolder)/*.dll" />
-    <WindowsNativeLocation Include="$(BinDir)$(CrossTargetComponentFolder)/*.exe" />
+    <ItemsToSign Include="$(BinDir)$(CrossTargetComponentFolder)/*.dll" />
+    <ItemsToSign Include="$(BinDir)$(CrossTargetComponentFolder)/*.exe" />
   </ItemGroup>
-
-  <Target Name="GenerateSignForWindowsNative">
-    <!--
-      Managed assemblies should already have a requires_signing file dropped so only generate
-      a requires_signing file for ones that don't exist which should leave just native assembies
-    -->
-    <WriteSigningRequired AuthenticodeSig="$(AuthenticodeSig)"
-                          MarkerFile="%(WindowsNativeLocation.Identity).requires_signing"
-                          Condition="!Exists('%(WindowsNativeLocation.Identity).requires_signing')" />
-  </Target>
-
-  <!-- populates item group ItemsToSign with the list of files to sign -->
-  <Target Name="GetFilesToSignItems"
-          DependsOnTargets="GenerateSignForWindowsNative"
-          BeforeTargets="ValidateSignFileListIsNotEmpty">
-    <!-- read all of the marker files and populate the ItemsToSign item group -->
-    <ItemGroup>
-      <SignMarkerFile Include="$(OutDir)**\*.requires_signing" />
-    </ItemGroup>
-    <ReadSigningRequired MarkerFiles="@(SignMarkerFile)">
-      <Output TaskParameter="SigningMetadata" ItemName="ItemsToSign" />
-    </ReadSigningRequired>
-
-    <Message Importance="High" Text="Attempting to sign %(ItemsToSign.Identity) with authenticode='%(ItemsToSign.Authenticode)' and strongname='%(ItemsToSign.StrongName)'" />
-  </Target>
 
   <Target Name="ValidateSignFileListIsNotEmpty" BeforeTargets="Sign">
     <Error Condition="'@(ItemsToSign)' == ''" Text="List of files to sign is empty" />
+    <Message Importance="High" Text="Attempting to sign %(ItemsToSign.Identity)" />
   </Target>
 </Project>

--- a/src/.nuget/packaging.props
+++ b/src/.nuget/packaging.props
@@ -21,9 +21,6 @@
     <!-- Define packaging attributes for cross target components -->
     <HasCrossTargetComponents Condition="'$(TargetsWindows)' == 'true' and ('$(PackagePlatform)' =='arm64' or '$(PackagePlatform)' =='arm')">true</HasCrossTargetComponents>
     <HasCrossTargetComponents Condition="'$(TargetsLinux)' == 'true' and ('$(PackagePlatform)' =='arm64' or '$(PackagePlatform)' =='arm') and '$(__DoCrossArchBuild)' == '1'">true</HasCrossTargetComponents>
-    <CrossTargetComponentFolder Condition="'$(PackagePlatform)' == 'arm64'">x64</CrossTargetComponentFolder>
-    <CrossTargetComponentFolder Condition="'$(PackagePlatform)' == 'arm' and '$(TargetsWindows)' == 'true'">x86</CrossTargetComponentFolder>
-    <CrossTargetComponentFolder Condition="'$(PackagePlatform)' == 'arm' and '$(TargetsLinux)' == 'true'">x64</CrossTargetComponentFolder>
 
     <!-- Created package output locations must be kept in sync with eng/build-job.yml -->
     <PackageOutputPath>$(PackagesBinDir)/pkg/</PackageOutputPath>


### PR DESCRIPTION
We were just using the BuildTools tasks to create then read a JSON file for metadata about how to sign each file, but with the build and signing both already using Arcade, that is not actually necessary. (The signing task in Arcade doesn't use that metadata - we were already relying on the default configuration provided by Arcade).

Verified with a manually queued real-signed build.

cc @RussKeldorph 