### PR TITLE
Change StreamReader.ReadBufferAsync to return ValueTask<int>

### DIFF
--- a/src/System.Private.CoreLib/shared/System/IO/StreamReader.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/StreamReader.cs
@@ -1238,7 +1238,7 @@ namespace System.IO
             return new ValueTask<int>(t);
         }
 
-        private async Task<int> ReadBufferAsync()
+        private async ValueTask<int> ReadBufferAsync()
         {
             _charLen = 0;
             _charPos = 0;


### PR DESCRIPTION
It's a private helper that's always directly awaited.  No need to allocate a task each time it's called and data is synchronously available.

cc: @JeremyKuhne 