### PR TITLE
Change DllImportPath policy to create unicode-named test library immediately before use

### DIFF
--- a/tests/src/Interop/PInvoke/DllImportPath/CMakeLists.txt
+++ b/tests/src/Interop/PInvoke/DllImportPath/CMakeLists.txt
@@ -5,27 +5,18 @@ set(SOURCES
     DllImportPathNative.cpp 
 ) 
 
-# Set CMP0037 to OLD for this directory, so that
-# CMake doesn't complain about the libraries with Unicode characters.
-if(NOT (CMAKE_MAJOR_VERSION LESS 3)) 
-    cmake_policy(SET CMP0037 OLD)
-endif()
-  
 # Additional files to reference: 
 # add the executable 
 add_library (DllImportPath_Local SHARED ${SOURCES})
 add_library (DllImportPath.Local SHARED ${SOURCES})
 add_library (DllImportPath_PathEnv SHARED ${SOURCES})
 add_library (DllImportPath_Relative SHARED ${SOURCES})
-add_library (DllImportPath_U�n�i�c�o�d�e SHARED ${SOURCES}) 
 target_link_libraries(DllImportPath_Local ${LINK_LIBRARIES_ADDITIONAL}) 
 target_link_libraries(DllImportPath.Local ${LINK_LIBRARIES_ADDITIONAL}) 
 target_link_libraries(DllImportPath_PathEnv ${LINK_LIBRARIES_ADDITIONAL}) 
-target_link_libraries(DllImportPath_Relative ${LINK_LIBRARIES_ADDITIONAL}) 
-target_link_libraries(DllImportPath_U�n�i�c�o�d�e ${LINK_LIBRARIES_ADDITIONAL}) 
+target_link_libraries(DllImportPath_Relative ${LINK_LIBRARIES_ADDITIONAL})  
 # add the install targets 
 install (TARGETS DllImportPath_Local DESTINATION bin) 
 install (TARGETS DllImportPath.Local DESTINATION bin) 
 install (TARGETS DllImportPath_PathEnv DESTINATION bin) 
 install (TARGETS DllImportPath_Relative DESTINATION bin) 
-install (TARGETS DllImportPath_U�n�i�c�o�d�e DESTINATION bin) 

--- a/tests/src/Interop/PInvoke/DllImportPath/DllImportPathTest.cs
+++ b/tests/src/Interop/PInvoke/DllImportPath/DllImportPathTest.cs
@@ -240,7 +240,11 @@ class Test
         var currentDirectory = Directory.GetCurrentDirectory();
         var info = new DirectoryInfo(currentDirectory);
 
-        var file = info.EnumerateFiles("*DllImportPath_Local*", SearchOption.TopDirectoryOnly).FirstOrDefault();
+        var file = info.EnumerateFiles("*DllImportPath_Local*", SearchOption.TopDirectoryOnly)
+                        .FirstOrDefault(localFile =>
+                            localFile.Extension == ".dll"
+                            || localFile.Extension == ".so"
+                            || localFile.Extension == ".dylib");
         
         var unicodeFileLocation = file.FullName.Replace("DllImportPath_Local", UnicodeFileName);
 

--- a/tests/src/Interop/PInvoke/DllImportPath/DllImportPathTest.cs
+++ b/tests/src/Interop/PInvoke/DllImportPath/DllImportPathTest.cs
@@ -21,6 +21,8 @@ class Test
     private const string RelativePath3 = @"../DllImportPathTest/libDllImportPath_Relative";
 #endif
 
+    private const string UnicodeFileName = "DllImportPath_Unicode✔";
+
     [DllImport(@"DllImportPath_Local", CharSet = CharSet.Unicode, EntryPoint = "MarshalStringPointer_InOut")]
     private static extern bool MarshalStringPointer_InOut_Local1([In, Out]ref string strManaged);
 
@@ -45,7 +47,7 @@ class Test
     [DllImport(@".\..\DllImportPathTest\DllImportPath_Relative.dll", CharSet = CharSet.Unicode, EntryPoint = "MarshalStringPointer_InOut")]
     private static extern bool MarshalStringPointer_InOut_Relative4([In, Out]ref string strManaged);
 
-    [DllImport(@"DllImportPath_Unicode✔", CharSet = CharSet.Unicode, EntryPoint = "MarshalStringPointer_InOut")]
+    [DllImport(UnicodeFileName, CharSet = CharSet.Unicode, EntryPoint = "MarshalStringPointer_InOut")]
     private static extern bool MarshalStringPointer_InOut_Unicode([In, Out]ref string strManaged);
     
     [DllImport(PathEnvFileName, CharSet = CharSet.Unicode, EntryPoint = "MarshalStringPointer_InOut")]
@@ -233,8 +235,22 @@ class Test
         return true;
     }
 
+    private static void SetupUnicodeTest()
+    {
+        var currentDirectory = Directory.GetCurrentDirectory();
+        var info = new DirectoryInfo(currentDirectory);
+
+        var file = info.EnumerateFiles("*DllImportPath_Local*", SearchOption.TopDirectoryOnly).FirstOrDefault();
+        
+        var unicodeFileLocation = file.FullName.Replace("DllImportPath_Local", UnicodeFileName);
+
+        file.CopyTo(unicodeFileLocation, true);
+    }
+
     static bool DllExistsUnicode()
     {
+        SetupUnicodeTest();
+
         string managed = "Managed";
         string native = " Native";
         

--- a/tests/src/Interop/PInvoke/DllImportPath/DllImportPathTest.cs
+++ b/tests/src/Interop/PInvoke/DllImportPath/DllImportPathTest.cs
@@ -45,7 +45,7 @@ class Test
     [DllImport(@".\..\DllImportPathTest\DllImportPath_Relative.dll", CharSet = CharSet.Unicode, EntryPoint = "MarshalStringPointer_InOut")]
     private static extern bool MarshalStringPointer_InOut_Relative4([In, Out]ref string strManaged);
 
-    [DllImport(@"DllImportPath_U�n�i�c�o�d�e", CharSet = CharSet.Unicode, EntryPoint = "MarshalStringPointer_InOut")]
+    [DllImport(@"DllImportPath_Unicode✔", CharSet = CharSet.Unicode, EntryPoint = "MarshalStringPointer_InOut")]
     private static extern bool MarshalStringPointer_InOut_Unicode([In, Out]ref string strManaged);
     
     [DllImport(PathEnvFileName, CharSet = CharSet.Unicode, EntryPoint = "MarshalStringPointer_InOut")]

--- a/tests/src/Interop/PInvoke/DllImportPath/DllImportPathTest.csproj
+++ b/tests/src/Interop/PInvoke/DllImportPath/DllImportPathTest.csproj
@@ -39,5 +39,22 @@
   <ItemGroup>
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
+  <Target Name="CreateUnicodeNamedNativeLibrary" AfterTargets="CopyNativeProjectBinaries">
+    <Copy
+      Condition="$([MSBuild]::IsOSPlatform(Windows))"
+      SourceFiles="$(OutDir)/DllImportPath_Local.dll"
+      DestinationFiles="$(OutDir)/DllImportPath_Unicode✔.dll"
+    /> 
+    <Copy
+      Condition="$([MSBuild]::IsOSPlatform(Linux))"
+      SourceFiles="$(OutDir)/libDllImportPath_Local.so"
+      DestinationFiles="$(OutDir)/libDllImportPath_Unicode✔.so"
+    />
+    <Copy
+      Condition="$([MSBuild]::IsOSPlatform(OSX))"
+      SourceFiles="$(OutDir)/libDllImportPath_Local.dylib"
+      DestinationFiles="$(OutDir)/libDllImportPath_Unicode✔.dylib"
+    />
+  </Target>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/tests/src/Interop/PInvoke/DllImportPath/DllImportPathTest.csproj
+++ b/tests/src/Interop/PInvoke/DllImportPath/DllImportPathTest.csproj
@@ -39,22 +39,5 @@
   <ItemGroup>
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
-  <Target Name="CreateUnicodeNamedNativeLibrary" AfterTargets="CopyNativeProjectBinaries">
-    <Copy
-      Condition="$([MSBuild]::IsOSPlatform(Windows))"
-      SourceFiles="$(OutDir)/DllImportPath_Local.dll"
-      DestinationFiles="$(OutDir)/DllImportPath_Unicode✔.dll"
-    /> 
-    <Copy
-      Condition="$([MSBuild]::IsOSPlatform(Linux))"
-      SourceFiles="$(OutDir)/libDllImportPath_Local.so"
-      DestinationFiles="$(OutDir)/libDllImportPath_Unicode✔.so"
-    />
-    <Copy
-      Condition="$([MSBuild]::IsOSPlatform(OSX))"
-      SourceFiles="$(OutDir)/libDllImportPath_Local.dylib"
-      DestinationFiles="$(OutDir)/libDllImportPath_Unicode✔.dylib"
-    />
-  </Target>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
Fixes #24791 