### PR TITLE
Add back AssemblyDescription attribute

### DIFF
--- a/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -106,6 +106,7 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <ExcludeAssemblyInfoPartialFile>true</ExcludeAssemblyInfoPartialFile>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    <Description>$(AssemblyName)</Description>
   </PropertyGroup>
 
   <!-- Signing -->


### PR DESCRIPTION
This was present in System.Private.CoreLib previously, but removed in recent versions (I compared 3.0.0-preview5-27610-03 and 3.0.0-preview6-27715-05 on macos). It's unclear to me what used to be adding the attribute  - https://github.com/dotnet/coreclr/commit/099177b0899156a4e8a352083a273805240c0ccd touched the SPC logic, but even in that change I see no mention of it. Maybe it used to be autogenerated by the old project files. In any case, I believe it should be added back.
Its value used to be "System.Private.CoreLib":
```diff
-  .custom instance void System.Reflection.AssemblyDescriptionAttribute::.ctor(string) = ( 01 00 16 53 79 73 74 65 6D 2E 50 72 69 76 61 74   // ...System.Privat
-                                                                                          65 2E 43 6F 72 65 4C 69 62 00 00 )                // e.CoreLib..
```