### PR TITLE
Specify restore sources in optdata.csproj

### DIFF
--- a/src/.nuget/optdata/optdata.csproj
+++ b/src/.nuget/optdata/optdata.csproj
@@ -11,6 +11,13 @@
     <PackageReference Include="optimization.IBC.CoreCLR" Version="$(optimizationIBCCoreCLRVersion)" Condition="'$(optimizationIBCCoreCLRVersion)'!=''" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <RestoreSources>
+      https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
+      $(RestoreSources);
+    </RestoreSources>
+  </PropertyGroup>
+
   <Target Name="DumpPgoDataPackageVersion">
     <Message Importance="high" Text="$(optimizationPGOCoreCLRVersion)" />
   </Target>


### PR DESCRIPTION
This broke with #24619 (stopped pulling in dir.props). This was still 'working' in the coreclr build because the scripts restore opt data through build.proj which explicitly adds sources to the restore command it executes. This is the first step (unless `skiprestoreoptdata` is specified), so anything referencing the project afterwards detected it was already restored.

Fixes #24820 