### PR TITLE
Fix GCStress coverage for multi reg returns.

### DIFF
--- a/src/inc/gcinfotypes.h
+++ b/src/inc/gcinfotypes.h
@@ -251,6 +251,12 @@ inline bool IsValidFieldReturnKind(ReturnKind returnKind)
     return (returnKind == RT_Scalar || returnKind == RT_Object || returnKind == RT_ByRef);
 }
 
+inline bool IsPointerFieldReturnKind(ReturnKind returnKind)
+{
+    _ASSERTE(IsValidFieldReturnKind(returnKind));
+    return (returnKind == RT_Object || returnKind == RT_ByRef);
+}
+
 inline bool IsValidReturnRegister(size_t regNo)
 {
     return (regNo == 0)

--- a/src/vm/gccover.cpp
+++ b/src/vm/gccover.cpp
@@ -105,7 +105,7 @@ bool IsGcCoverageInterruptInstruction(SLOT instrPtr)
     else
     {
         _ASSERTE(instrLen == 4);
-        UINT16 instrVal = *reinterpret_cast<UINT16*>(instrPtr);
+        UINT32 instrVal = *reinterpret_cast<UINT32*>(instrPtr);
         switch (instrVal)
         {
         case INTERRUPT_INSTR_32:
@@ -380,18 +380,22 @@ void ReplaceInstrAfterCall(SLOT instrToReplace, MethodDesc* callMD)
     {
         bool protectRegister[2] = { false, false };
 
-        int regNo = 0;
         bool moreRegisters = false;
-        do
+
+        ReturnKind fieldKind1 = ExtractRegReturnKind(returnKind, 0, moreRegisters);
+        if (IsPointerFieldReturnKind(fieldKind1))
         {
-            ReturnKind fieldKind = ExtractRegReturnKind(returnKind, regNo, moreRegisters);
-            if (IsPointerFieldReturnKind(fieldKind))
+            protectRegister[0] = true;
+        }
+        if (moreRegisters)
+        {
+            ReturnKind fieldKind2 = ExtractRegReturnKind(returnKind, 1, moreRegisters);
+            if (IsPointerFieldReturnKind(fieldKind2))
             {
-                protectRegister[regNo] = true;
+                protectRegister[1] = true;
             }
-            regNo++;
-            _ASSERTE(regNo <= 2);
-        } while (moreRegisters);
+        }
+        _ASSERTE(!moreRegisters);
 
         if (protectRegister[0] && !protectRegister[1])
         {

--- a/src/vm/gccover.cpp
+++ b/src/vm/gccover.cpp
@@ -511,9 +511,9 @@ public:
 
 #endif // _TARGET_AMD64_
 
-// When Sprinking break points, we must make sure that certain calls to 
-// Thread-suspension routines inlined into the managed method are not 
-// converted to GC-Stress points. Otherwise, this will lead to race 
+// When sprinkling break points, we must make sure that certain calls to
+// Thread-suspension routines inlined into the managed method are not
+// converted to GC-Stress points. Otherwise, this will lead to race
 // conditions with the GC.
 //
 // For example, for an inlined PInvoke stub, the JIT generates the following code
@@ -567,9 +567,9 @@ public:
 extern "C" FCDECL0(VOID, JIT_RareDisableHelper);
 
 /****************************************************************************/
-/* sprinkle interupt instructions that will stop on every GCSafe location
+/* sprinkle interrupt instructions that will stop on every GCSafe location
    regionOffsetAdj - Represents the offset of the current region 
-                   from the beginning of the method (is 0 for hot region)
+                     from the beginning of the method (is 0 for hot region)
 */
 
 void GCCoverageInfo::SprinkleBreakpoints(
@@ -647,7 +647,7 @@ void GCCoverageInfo::SprinkleBreakpoints(
         // for code.  It uses some for switch tables.  Because the first few offsets
         // may be decodable as instructions, we can't reason about where we should
         // encounter invalid instructions.  However, we do not want to silently skip
-        // large chunks of methods just becuase the JIT started emitting a new
+        // large chunks of methods just because the JIT started emitting a new
         // instruction, so only assume it is a switch table if we've seen the switch
         // code (an indirect unconditional jump)
         if ((len == 0) && fSawPossibleSwitch)
@@ -754,7 +754,7 @@ void GCCoverageInfo::SprinkleBreakpoints(
 
     // If we are not able to place an interrupt at the first instruction, this means that
     // we are partially interruptible with no prolog.  Just don't bother to do the
-    // the epilog checks, since the epilog will be trival (a single return instr)
+    // the epilog checks, since the epilog will be trivial (a single return instr)
     assert(codeSize > 0);
     if ((regionOffsetAdj==0) && (*codeStart != INTERRUPT_INSTR))
         doingEpilogChecks = false;
@@ -888,7 +888,7 @@ void replaceSafePointInstructionWithGcStressInstr(UINT32 safePointOffset, LPVOID
     if(instructionIsACallThroughRegister)
     {
         // If it is call by register then cannot know MethodDesc so replace the call instruction with illegal instruction
-        // safe point will be replaced with appropiate illegal instruction at execution time when reg value is known
+        // safe point will be replaced with appropriate illegal instruction at execution time when reg value is known
 #if defined(_TARGET_ARM_)
         *((WORD*)instrPtr - 1) = INTERRUPT_INSTR_CALL;
 #elif defined(_TARGET_ARM64_)
@@ -955,7 +955,7 @@ bool replaceInterruptibleRangesWithGcStressInstr (UINT32 startOffset, UINT32 sto
     SLOT rangeStart = NULL;
     SLOT rangeStop = NULL;
 
-    //Interruptible range can span accross hot & cold region
+    //Interruptible range can span across hot & cold region
     int acrossHotRegion = 1; // 1 means range is not across end of hot region & 2 is when it is across end of hot region
 
     //Find the code addresses from offsets
@@ -1103,7 +1103,7 @@ static SLOT getTargetOfCall(SLOT instrPtr, PCONTEXT regs, SLOT*nextInstr) {
     // When decoding the instructions of a method which is sprinkled with 
     // TRAP instructions for GCStress, we decode the bytes from a copy 
     // of the instructions stored before the traps-for-gc were inserted.
-    // Hoiwever, the PC-relative addressing/displacement of the CALL-target
+    // However, the PC-relative addressing/displacement of the CALL-target
     // will still be with respect to the currently executing PC.
     // So, if a register context is available, we pick the PC from it 
     // (for address calculation purposes only). 
@@ -1566,7 +1566,7 @@ void DoGcStress (PCONTEXT regs, MethodDesc *pMD)
         } 
 
         // If some other thread removes interrupt points, we abandon epilog testing
-        // for this routine since the barrier at the begining of the routine may not
+        // for this routine since the barrier at the beginning of the routine may not
         // be up anymore, and thus the caller context is now not guaranteed to be correct.  
         // This should happen only very rarely so is not a big deal.
         if (gcCover->callerThread != pThread)
@@ -1654,7 +1654,7 @@ void DoGcStress (PCONTEXT regs, MethodDesc *pMD)
 #if defined(_TARGET_X86_) || defined(_TARGET_AMD64_) || defined(_TARGET_ARM_) || defined(_TARGET_ARM64_)
 
     /* In non-fully interrruptable code, if the EIP is just after a call instr
-       means something different because it expects that that we are IN the 
+       means something different because it expects that we are IN the
        called method, not actually at the instruction just after the call. This
        is important, because until the called method returns, IT is responsible
        for protecting the return value.  Thus just after a call instruction
@@ -1694,7 +1694,7 @@ void DoGcStress (PCONTEXT regs, MethodDesc *pMD)
         {
             if (!pThread->PreemptiveGCDisabled())
             {
-                // We are in preemtive mode in JITTed code. This implies that we are into IL stub 
+                // We are in preemptive mode in JITTed code. This implies that we are into IL stub 
                 // close to PINVOKE method. This call will never return objectrefs.
 #ifdef _TARGET_ARM_
                     size_t instrLen = GetARMInstructionLength(nextInstr);
@@ -1728,7 +1728,7 @@ void DoGcStress (PCONTEXT regs, MethodDesc *pMD)
         FlushInstructionCache(GetCurrentProcess(), (LPCVOID)instrPtr, 10);
 
         // It's not GC safe point, the GC Stress instruction is 
-        // already commited and interrupt is already put at next instruction so we just return.
+        // already committed and interrupt is already put at next instruction so we just return.
         return;
     }
 #else 

--- a/src/vm/gccover.cpp
+++ b/src/vm/gccover.cpp
@@ -254,9 +254,12 @@ void SetupGcCoverageForNativeImage(Module* module)
 void ReplaceInstrAfterCall(SLOT instrToReplace, MethodDesc* callMD)
 {
     ReturnKind returnKind = callMD->GetReturnKind(true);
-    bool protectReturn = IsPointerReturnKind(returnKind);
+    _ASSERTE(IsValidReturnKind(returnKind));
+
+    bool pointerKind = IsPointerReturnKind(returnKind);
 #ifdef _TARGET_ARM_
-    size_t instrLen = GetARMInstructionLength(nextInstr);
+    size_t instrLen = GetARMInstructionLength(instrToReplace);
+    bool protectReturn = pointerKind;
     if (protectReturn)
         if (instrLen == 2)
             *(WORD*)instrToReplace = INTERRUPT_INSTR_PROTECT_RET;
@@ -268,15 +271,48 @@ void ReplaceInstrAfterCall(SLOT instrToReplace, MethodDesc* callMD)
         else
             *(DWORD*)instrToReplace = INTERRUPT_INSTR_32;
 #elif defined(_TARGET_ARM64_)
+    bool protectReturn = pointerKind;
     if (protectReturn)
         *(DWORD*)instrToReplace = INTERRUPT_INSTR_PROTECT_RET;
     else
         *(DWORD*)instrToReplace = INTERRUPT_INSTR;
-#else
-    if (protectReturn)
-        * instrToReplace = INTERRUPT_INSTR_PROTECT_RET;
+#elif defined(_TARGET_AMD64_) || defined(_TARGET_X86_)
+
+
+    if (pointerKind)
+    {
+        bool protectRegister[2] = { false };
+
+        int regNo = 0;
+        bool moreRegisters = false;
+        do
+        {
+            ReturnKind fieldKind = ExtractRegReturnKind(returnKind, regNo, moreRegisters);
+            if (IsPointerFieldReturnKind(fieldKind))
+            {
+                protectRegister[regNo] = true;
+            }
+            regNo++;
+        } while (moreRegisters);
+
+        if (protectRegister[0] && !protectRegister[1])
+        {
+            *instrToReplace = INTERRUPT_INSTR_PROTECT_FIRST_RET;
+        }
+        else
+        {
+#if !defined(_TARGET_AMD64_) || !defined(PLATFORM_UNIX)
+            _ASSERTE(!"Not expected multi reg return with pointers.");
+#endif // !_TARGET_AMD64_ || !PLATFORM_UNIX
+            // Skip gc stress coverage for now, do not do replacement.
+        }
+    }
     else
+    {
         *instrToReplace = INTERRUPT_INSTR;
+    }
+#else
+    _ASSERTE(!"not implemented for platform");
 #endif
 }
 
@@ -1249,7 +1285,11 @@ bool IsGcCoverageInterrupt(LPVOID ip)
     {
         case INTERRUPT_INSTR:
         case INTERRUPT_INSTR_CALL:
+#if defined(_TARGET_ARM_) || defined(_TARGET_ARM64_)
         case INTERRUPT_INSTR_PROTECT_RET:
+#else
+        case INTERRUPT_INSTR_PROTECT_FIRST_RET:
+#endif
             return true;
 
         default:
@@ -1378,13 +1418,13 @@ void DoGcStress (PCONTEXT regs, MethodDesc *pMD)
     
     if (instrVal != INTERRUPT_INSTR && 
         instrVal != INTERRUPT_INSTR_CALL && 
-        instrVal != INTERRUPT_INSTR_PROTECT_RET) {
+        instrVal != INTERRUPT_INSTR_PROTECT_FIRST_RET) {
         _ASSERTE(instrVal == gcCover->savedCode[offset]);  // someone beat us to it.
         return;       // Someone beat us to it, just go on running
     }
 
     bool atCall = (instrVal == INTERRUPT_INSTR_CALL);
-    bool afterCallProtect = (instrVal == INTERRUPT_INSTR_PROTECT_RET);
+    bool afterCallProtect = (instrVal == INTERRUPT_INSTR_PROTECT_FIRST_RET);
 
 #elif defined(_TARGET_ARM_)
 

--- a/src/vm/gccover.cpp
+++ b/src/vm/gccover.cpp
@@ -1487,7 +1487,11 @@ void DoGcStress (PCONTEXT regs, MethodDesc *pMD)
 
     if (!IsGcCoverageInterruptInstruction(instrPtr))
     {
-        _ASSERTE(IsOriginalInstruction(instrPtr, gcCover, offset));
+        // This assert can fail if another thread changed original instruction to 
+        // GCCoverage Interrupt instruction between these two commands. Uncomment it
+        // when threading issue gets resolved.
+        // _ASSERTE(IsOriginalInstruction(instrPtr, gcCover, offset));
+
         // Someone beat us to it, just go on running.
         return;
     }

--- a/src/vm/gccover.cpp
+++ b/src/vm/gccover.cpp
@@ -342,6 +342,15 @@ void SetupGcCoverageForNativeImage(Module* module)
 void ReplaceInstrAfterCall(SLOT instrToReplace, MethodDesc* callMD)
 {
     ReturnKind returnKind = callMD->GetReturnKind(true);
+    if (!IsValidReturnKind(returnKind))
+    {
+#if !defined(_TARGET_AMD64_) || !defined(PLATFORM_UNIX)
+        // SKip GC coverage after the call.
+        return;
+#else // _TARGET_AMD64_ && PLATFORM_UNIX
+        _ASSERTE("Unexpected return kind for x64 Unix.");
+#endif // _TARGET_AMD64_ && PLATFORM_UNIX
+    }
     _ASSERTE(IsValidReturnKind(returnKind));
 
     bool pointerKind = IsPointerReturnKind(returnKind);

--- a/src/vm/gccover.cpp
+++ b/src/vm/gccover.cpp
@@ -123,6 +123,8 @@ bool IsGcCoveregeInterruptInstruction(SLOT instrPtr)
     case INTERRUPT_INSTR:
     case INTERRUPT_INSTR_CALL:
     case INTERRUPT_INSTR_PROTECT_FIRST_RET:
+    case INTERRUPT_INSTR_PROTECT_SECOND_RET:
+    case INTERRUPT_INSTR_PROTECT_BOTH_RET:
         return true;
     default:
         return false;
@@ -390,7 +392,15 @@ void ReplaceInstrAfterCall(SLOT instrToReplace, MethodDesc* callMD)
 #if !defined(_TARGET_AMD64_) || !defined(PLATFORM_UNIX)
             _ASSERTE(!"Not expected multi reg return with pointers.");
 #endif // !_TARGET_AMD64_ || !PLATFORM_UNIX
-            // Skip gc stress coverage for now, do not do replacement.
+            if (!protectRegister[0] && protectRegister[1])
+            {
+                *instrToReplace = INTERRUPT_INSTR_PROTECT_SECOND_RET;
+            }
+            else
+            {
+                _ASSERTE(protectRegister[0] && protectRegister[1]);
+                *instrToReplace = INTERRUPT_INSTR_PROTECT_BOTH_RET;
+            }
         }
     }
     else
@@ -1468,27 +1478,45 @@ void DoGcStress (PCONTEXT regs, MethodDesc *pMD)
         return;
     }
 
+    bool atCall;
+    bool afterCallProtect[2] = { 0 };
+
 #if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
 
     BYTE instrVal = *instrPtr;
     forceStack[6] = &instrVal;            // This is so I can see it fastchecked
 
-    bool atCall = (instrVal == INTERRUPT_INSTR_CALL);
-    bool afterCallProtect = (instrVal == INTERRUPT_INSTR_PROTECT_FIRST_RET);
+    atCall = (instrVal == INTERRUPT_INSTR_CALL);
+
+    if (instrVal == INTERRUPT_INSTR_PROTECT_BOTH_RET)
+    {
+        afterCallProtect[0] = afterCallProtect[1] = true;
+    }
+    else if (instrVal == INTERRUPT_INSTR_PROTECT_FIRST_RET)
+    {
+        afterCallProtect[0] = true;
+        afterCallProtect[1] = false;
+    }
+    else if (instrVal == INTERRUPT_INSTR_PROTECT_SECOND_RET)
+    {
+        afterCallProtect[0] = false;
+        afterCallProtect[1] = true;
+    }
+    else
+    {
+        afterCallProtect[0] = afterCallProtect[1] = false;
+    }
 
 #elif defined(_TARGET_ARM_)
     forceStack[6] = (WORD*)instrPtr;            // This is so I can see it fastchecked
 
     size_t instrLen = GetARMInstructionLength(instrPtr);
 
-    bool atCall;
-    bool afterCallProtect;
-
     if (instrLen == 2)
     {
         WORD instrVal = *(WORD*)instrPtr;
         atCall           = (instrVal == INTERRUPT_INSTR_CALL);
-        afterCallProtect = (instrVal == INTERRUPT_INSTR_PROTECT_RET);
+        afterCallProtect[0] = (instrVal == INTERRUPT_INSTR_PROTECT_RET);
     }
     else
     {
@@ -1497,14 +1525,14 @@ void DoGcStress (PCONTEXT regs, MethodDesc *pMD)
         DWORD instrVal32 = *(DWORD*)instrPtr;
 
         atCall           = (instrVal32 == INTERRUPT_INSTR_CALL_32);
-        afterCallProtect = (instrVal32 == INTERRUPT_INSTR_PROTECT_RET_32);
+        afterCallProtect[0] = (instrVal32 == INTERRUPT_INSTR_PROTECT_RET_32);
     }
 #elif defined(_TARGET_ARM64_)
     DWORD instrVal = *(DWORD *)instrPtr; 
     forceStack[6] = &instrVal;            // This is so I can see it fastchecked
 
-    bool atCall = (instrVal == INTERRUPT_INSTR_CALL);
-    bool afterCallProtect = (instrVal == INTERRUPT_INSTR_PROTECT_RET);
+    atCall = (instrVal == INTERRUPT_INSTR_CALL);
+    afterCallProtect[0] = (instrVal == INTERRUPT_INSTR_PROTECT_RET);
 
 #endif // _TARGET_*
 
@@ -1735,26 +1763,38 @@ void DoGcStress (PCONTEXT regs, MethodDesc *pMD)
     frame.Push(pThread);
 #endif // USE_REDIRECT_FOR_GCSTRESS
 
-#if defined(_TARGET_X86_) || defined(_TARGET_AMD64_) || defined(_TARGET_ARM_) || defined(_TARGET_ARM64_)
-    FrameWithCookie<GCFrame> gcFrame;
-    DWORD_PTR retVal = 0;
 
-    if (afterCallProtect)   // Do I need to protect return value?
-    {         
-#ifdef _TARGET_AMD64_
-        retVal = regs->Rax;
+    DWORD_PTR retValRegs[2] = { 0 };
+    UINT  numberOfRegs = 0;
+
+    if (afterCallProtect[0])
+    {
+#if defined(_TARGET_AMD64_)
+        retValRegs[numberOfRegs++] = regs->Rax;
 #elif defined(_TARGET_X86_)
-        retVal = regs->Eax;
-#elif defined(_TARGET_ARM_)
-        retVal = regs->R0;
+        retValRegs[numberOfRegs++] = regs->Eax;
+#elif  defined(_TARGET_ARM_)
+        retValRegs[numberOfRegs++] = regs->R0;
 #elif defined(_TARGET_ARM64_)
-        retVal = regs->X0;
-#else
-        PORTABILITY_ASSERT("DoGCStress - return register");
-#endif
-        gcFrame.Init(pThread, (OBJECTREF*) &retVal, 1, TRUE);
+        retValRegs[numberOfRegs++] = regs->X0;
+#endif // _TARGET_ARM64_
     }
-#endif // _TARGET_*
+
+    if (afterCallProtect[1])
+    {
+#if defined(_TARGET_AMD64_) && defined(PLATFORM_UNIX)
+        retValRegs[numberOfRegs++] = regs->Rdx;
+#else // !_TARGET_AMD64_ || !PLATFORM_UNIX
+        _ASSERTE(!"Not expected multi reg return with pointers.");
+#endif // !_TARGET_AMD64_ || !PLATFORM_UNIX
+    }
+
+    FrameWithCookie<GCFrame> gcFrame;
+    if (numberOfRegs != 0)
+    {
+        _ASSERTE(sizeof(OBJECTREF) == sizeof(DWORD_PTR));
+        gcFrame.Init(pThread, (OBJECTREF*)retValRegs, numberOfRegs, TRUE);
+    }
 
     if (gcCover->lastMD != pMD) 
     {
@@ -1788,23 +1828,34 @@ void DoGcStress (PCONTEXT regs, MethodDesc *pMD)
 
     CONSISTENCY_CHECK(!pThread->HasPendingGCStressInstructionUpdate());
 
-#if defined(_TARGET_X86_) || defined(_TARGET_AMD64_) || defined(_TARGET_ARM_) || defined(_TARGET_ARM64_)
-    if (afterCallProtect) 
+    if (numberOfRegs != 0)
     {
-#ifdef _TARGET_AMD64_
-        regs->Rax = retVal;
+        if (afterCallProtect[0])
+        {
+#if defined(_TARGET_AMD64_)
+            regs->Rax = retValRegs[0]; // I should cut my own hands for writing this.
 #elif defined(_TARGET_X86_)
-        regs->Eax = retVal;
+            regs->Eax = retValRegs[0];
 #elif defined(_TARGET_ARM_)
-        regs->R0 = retVal;
+            regs->R0 = retValRegs[0];
 #elif defined(_TARGET_ARM64_)
-        regs->X[0] = retVal;
+            regs->X[0] = retValRegs[0];
 #else
-        PORTABILITY_ASSERT("DoGCStress - return register");
-#endif
+            PORTABILITY_ASSERT("DoGCStress - return register");
+#endif            
+        }
+
+        if (afterCallProtect[1])
+        {
+#if defined(_TARGET_AMD64_) && defined(PLATFORM_UNIX)
+            regs->Rdx = retValRegs[numberOfRegs - 1];
+#else // !_TARGET_AMD64_ || !PLATFORM_UNIX
+            _ASSERTE(!"Not expected multi reg return with pointers.");
+#endif // !_TARGET_AMD64_ || !PLATFORM_UNIX   
+        }
+
         gcFrame.Pop();
     }
-#endif // _TARGET_*
 
 #if !defined(USE_REDIRECT_FOR_GCSTRESS)
     frame.Pop(pThread);

--- a/src/vm/gccover.h
+++ b/src/vm/gccover.h
@@ -72,7 +72,7 @@ public:
 #define INTERRUPT_INSTR_CALL                   0xFA    // X86 CLI instruction 
 #define INTERRUPT_INSTR_PROTECT_FIRST_RET      0xFB    // X86 STI instruction, protect the first return register
 #define INTERRUPT_INSTR_PROTECT_SECOND_RET     0xEC    // X86 IN instruction, protect the second return register
-#define INTERRUPT_INSTR_PROTECT_BOTH_RET       0xED    // X86 IN instruction, protect the both return registers
+#define INTERRUPT_INSTR_PROTECT_BOTH_RET       0xED    // X86 IN instruction, protect both return registers
 
 #elif defined(_TARGET_ARM_)
 

--- a/src/vm/gccover.h
+++ b/src/vm/gccover.h
@@ -68,9 +68,9 @@ public:
 
 #if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
 
-#define INTERRUPT_INSTR                 0xF4    // X86 HLT instruction (any 1 byte illegal instruction will do)
-#define INTERRUPT_INSTR_CALL            0xFA    // X86 CLI instruction 
-#define INTERRUPT_INSTR_PROTECT_RET     0xFB    // X86 STI instruction 
+#define INTERRUPT_INSTR                       0xF4    // X86 HLT instruction (any 1 byte illegal instruction will do)
+#define INTERRUPT_INSTR_CALL                  0xFA    // X86 CLI instruction 
+#define INTERRUPT_INSTR_PROTECT_FIRST_RET     0xFB    // X86 STI instruction, protect the first return register
 
 #elif defined(_TARGET_ARM_)
 

--- a/src/vm/gccover.h
+++ b/src/vm/gccover.h
@@ -68,9 +68,11 @@ public:
 
 #if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
 
-#define INTERRUPT_INSTR                       0xF4    // X86 HLT instruction (any 1 byte illegal instruction will do)
-#define INTERRUPT_INSTR_CALL                  0xFA    // X86 CLI instruction 
-#define INTERRUPT_INSTR_PROTECT_FIRST_RET     0xFB    // X86 STI instruction, protect the first return register
+#define INTERRUPT_INSTR                        0xF4    // X86 HLT instruction (any 1 byte illegal instruction will do)
+#define INTERRUPT_INSTR_CALL                   0xFA    // X86 CLI instruction 
+#define INTERRUPT_INSTR_PROTECT_FIRST_RET      0xFB    // X86 STI instruction, protect the first return register
+#define INTERRUPT_INSTR_PROTECT_SECOND_RET     0xEC    // X86 IN instruction, protect the second return register
+#define INTERRUPT_INSTR_PROTECT_BOTH_RET       0xED    // X86 IN instruction, protect the both return registers
 
 #elif defined(_TARGET_ARM_)
 

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -1284,8 +1284,17 @@ ReturnKind MethodDesc::ParseReturnKindFromSig(INDEBUG(bool supportStringConstruc
 
                         if (pReturnTypeMT->ContainsPointers())
                         {
-                            _ASSERTE(pReturnTypeMT->GetNumInstanceFieldBytes() == sizeof(void*));
-                            return RT_Object;
+                            if (pReturnTypeMT->GetNumInstanceFields() == 1)
+                            {
+                                _ASSERTE(pReturnTypeMT->GetNumInstanceFieldBytes() == sizeof(void*));
+                                // Note: we can't distinguish RT_Object from RT_ByRef, the caller has to tolerate that. 
+                                return RT_Object;
+                            }
+                            else
+                            {
+                                // Multi reg return case with pointers, can't restore the actual kind.
+                                return RT_Illegal;
+                            }
                         }
                     }
                 }

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -1666,6 +1666,12 @@ private:
     ReturnKind ParseReturnKindFromSig(INDEBUG(bool supportStringConstructors = false));
 
 public:
+    // This method is used to restore ReturnKind using the class handle, it is fully supported only on x64 Ubuntu,
+    // other platforms do not support multi-reg return case with pointers. 
+    // Use this method only when you can't hit this case
+    // (like ComPlusMethodFrame::GcScanRoots) or when you can tolerate RT_Illegal return.
+    // Also, on the other platforms for a single field struct return case
+    // the function can't distinguish RT_Object and RT_ByRef.
     ReturnKind GetReturnKind(INDEBUG(bool supportStringConstructors = false));
 
 public:

--- a/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+// The test revealed some problems of GCStress infrastructure on platforms with multi reg returns (arm64, amd64 Unix).
+// It required GCStress=0xc and GcStressOnDirectCalls=1 to hit issues. The issues were with saving GC pointers in the return registers.
+// The GC infra has to correctly mark registers with pointers as alive and must not report registers without pointers.
+
+namespace GitHub_23199
+{
+    public class Program
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static Object TestCrossgenedReturnWith2PointersStruct()
+        {
+            ProcessStartInfo pi = new ProcessStartInfo();
+            // pi.Environment calls crossgened HashtableEnumerator::get_Entry returning struct that we need.
+            Console.WriteLine(pi.Environment.Count);
+            return pi;
+        }
+
+        struct TwoPointers
+        {
+            public Object a;
+            public Object b;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static TwoPointers GetTwoPointersStruct()
+        {
+            var a = new TwoPointers();
+            a.a = new String("TestTwoPointers");
+            a.b = new string("Passed");
+            return a;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static Object TestTwoPointers()
+        {
+            var a = GetTwoPointersStruct(); // Report both.
+            Console.WriteLine(a.a + " " + a.b);
+            return a;
+        }
+
+        struct OnePointer
+        {
+            public Object a;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static TwoPointers GetOnePointer()
+        {
+            var a = new TwoPointers();
+            a.a = new String("TestOnePointer Passed");
+            return a;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static Object TestOnePointer()
+        {
+            var a = GetOnePointer();  // Report one.
+            Console.WriteLine(a.a);
+            return a;
+        }
+
+        struct FirstPointer
+        {
+            public Object a;
+            public int b;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static FirstPointer GetFirstPointer()
+        {
+            var a = new FirstPointer();
+            a.a = new String("TestFirstPointer Passed");
+            a.b = 100;
+            return a;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static Object TestFirstPointer()
+        {
+            var a = GetFirstPointer();  // Report the first field, do not report the second.
+            Console.WriteLine(a.a);
+            return a;
+        }
+
+        struct SecondPointer
+        {
+            public int a;
+            public Object b;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static SecondPointer GetSecondPointer()
+        {
+            var a = new SecondPointer();
+            a.a = 100;
+            a.b = new String("TestSecondPointer Passed");
+            return a;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static Object TestSecondPointer()
+        {
+            var a = GetSecondPointer(); // Report the second field, do not report the first.
+            Console.WriteLine(a.b);
+            return a;
+        }
+
+        struct NoPointer1
+        {
+            public int a;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static NoPointer1 GetNoPointer1()
+        {
+            var a = new NoPointer1();
+            a.a = 100;
+            return a;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static Object TestNoPointer1()
+        {
+            var a = GetNoPointer1(); // Do not report anything.
+            Console.WriteLine("TestNoPointer1 Passed");
+            return a;
+        }
+
+        struct NoPointer2
+        {
+            public int a;
+            public int b;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static NoPointer2 GetNoPointer2()
+        {
+            var a = new NoPointer2();
+            a.a = 100;
+            a.b = 100;
+            return a;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static Object TestNoPointer2()
+        {
+            NoPointer2 a = GetNoPointer2();  // Do not report anything.
+            Console.WriteLine("TestNoPointer2 Passed");
+            return a;
+        }
+        
+        struct ThirdPointer
+        {
+            public int a;
+            public int b;
+            public Object c;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static ThirdPointer GetThirdPointer()
+        {
+            var a = new ThirdPointer();
+            a.a = 100;
+            a.b = 100;
+            a.c = new String("TestThirdPointer Passed");
+            return a;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static Object TestThirdPointer()
+        {
+            ThirdPointer a = GetThirdPointer();  // Do not return in registers.
+            Console.WriteLine(a.c);
+            return a;
+        }
+
+
+        static int Main(string[] args)
+        {
+            TestCrossgenedReturnWith2PointersStruct();
+            TestTwoPointers();
+            TestOnePointer();
+            TestFirstPointer();
+            TestSecondPointer();
+            TestNoPointer1();
+            TestNoPointer2();
+            TestThirdPointer();
+            return 100;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.cs
@@ -6,6 +6,12 @@ using System.Runtime.CompilerServices;
 // It required GCStress=0xc and GcStressOnDirectCalls=1 to hit issues. The issues were with saving GC pointers in the return registers.
 // The GC infra has to correctly mark registers with pointers as alive and must not report registers without pointers.
 
+#if BIT32
+using nint = System.Int32;
+#else
+using nint = System.Int64;
+#endif
+
 namespace GitHub_23199
 {
     public class Program
@@ -66,7 +72,7 @@ namespace GitHub_23199
         struct FirstPointer
         {
             public Object a;
-            public int b;
+            public nint b;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -88,7 +94,7 @@ namespace GitHub_23199
 
         struct SecondPointer
         {
-            public int a;
+            public nint a;
             public Object b;
         }
 
@@ -111,7 +117,7 @@ namespace GitHub_23199
 
         struct NoPointer1
         {
-            public int a;
+            public nint a;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -132,8 +138,8 @@ namespace GitHub_23199
 
         struct NoPointer2
         {
-            public int a;
-            public int b;
+            public nint a;
+            public nint b;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -155,8 +161,8 @@ namespace GitHub_23199
         
         struct ThirdPointer
         {
-            public int a;
-            public int b;
+            public nint a;
+            public nint b;
             public Object c;
         }
 

--- a/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.csproj
@@ -9,6 +9,7 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.csproj
@@ -11,6 +11,9 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(PointerSize)' == '32' ">
+    <DefineConstants>BIT32;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />

--- a/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.csproj
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_GcStressOnDirectCalls=1
+set COMPlus_GcStress=0xc
+]]></CLRTestBatchPreCommands>
+  <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_GcStressOnDirectCalls=1
+export COMPlus_GcStress=0xc
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>

--- a/tests/src/ilasm/System/Runtime/CompilerServices/MethodImplOptionsTests.csproj
+++ b/tests/src/ilasm/System/Runtime/CompilerServices/MethodImplOptionsTests.csproj
@@ -6,8 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{1AFDD005-7AB9-48E0-B6D4-4DE0560C936D}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <!-- https://github.com/dotnet/coreclr/issues/23199 -->
-    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">


### PR DESCRIPTION
The PR fixes #23199 and a few issues that were found along the way.
The preparation for these changes was done in #24600.

Summary: determinate the exact return kind when we can (Linux x64 ABI) and do not insert GCStress instruction when we can't. 
On Linux x64 I added new 1-byte illegal user instructions to mark which registers we need to protect. I used [IN ](https://c9x.me/x86/html/file_module_x86_id_139.html) for this case and have not found any other suitable 1-byte instructions.

Commits:
f7bd7ffc80: Extract ReplaceInstrAfterCall.

e34235a619: Avoid GCStress when return multireg with pointers.

Determinate when we need to protect the second register and do not cause GCStress in such cases.

2e3232b0df: Add a repro test.

07ddcf4c85: Reenable MethodImplOptionsTests.

249dc7f6cf: Extract IsGcCoveregeInterruptInstruction.

That changes how we do checks for arm32 in `IsGcCoverageInterrupt`.

99e3c22e8c: Tolerate direct call to JIT_RareDisableHelper.

x86 ILStubClass:IL_STUB_PInvoke(byref,ref,int,byref):int generates it like:
Generating: N119 (  4,  7) [000118] ------------              *  RETURNTRAP int    REG NA
IN0021:        cmp      dword ptr [0F9BF9F8H], 0
New Basic Block BB10 [0009] created.
IN0022:        je       L_M6496_BB10
                                                        Call: GCvars=00000001 {V01}, gcrefRegs=00000000 {}, byrefRegs=00000000 {}
IN0023:        call     CORINFO_HELP_STOP_FOR_GC

fdc0f152df: Support GC stress protect return 1/2/both Unix x64.

036fb05965: Fix arm64.

Do not insert GC Stress instrucitons when we can't determinate the exact return kind.