### PR TITLE
Enable createdump on arm and arm64 

### DIFF
--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_PlatformDoesNotSupportCreatedump Condition="'$(Platform)' == 'arm'">true</_PlatformDoesNotSupportCreatedump>
-    <_PlatformDoesNotSupportCreatedump Condition="'$(Platform)' == 'armel'">true</_PlatformDoesNotSupportCreatedump>
     <_PlatformDoesNotSupportCreatedump Condition="'$(Platform)' == 'x86'">true</_PlatformDoesNotSupportCreatedump>
-    <_PlatformDoesNotSupportCreatedump Condition="'$(Platform)' == 'arm64'">true</_PlatformDoesNotSupportCreatedump>
     <_PlatformDoesNotSupportCreatedump Condition="'$(_runtimeOSFamily)' == 'tizen'">true</_PlatformDoesNotSupportCreatedump>
     <_PlatformDoesNotSupportEventTrace Condition="'$(_runtimeOSFamily)' == 'tizen'">true</_PlatformDoesNotSupportEventTrace>
     <_PlatformDoesNotSupportEventTrace Condition="'$(Platform)' == 'x86'">true</_PlatformDoesNotSupportEventTrace>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -6,7 +6,6 @@
     <_PlatformDoesNotSupportEventTrace Condition="'$(_runtimeOSFamily)' == 'tizen'">true</_PlatformDoesNotSupportEventTrace>
     <_PlatformDoesNotSupportEventTrace Condition="'$(Platform)' == 'x86'">true</_PlatformDoesNotSupportEventTrace>
     <_PlatformDoesNotSupportSosPlugin Condition="'$(_runtimeOSFamily)' == 'android'">true</_PlatformDoesNotSupportSosPlugin>
-    <_PlatformDoesNotSupportSosPlugin Condition="'$(Platform)' == 'arm64'">true</_PlatformDoesNotSupportSosPlugin>
   </PropertyGroup>
   <ItemGroup>
     <NativeBinary Include="$(BinDir)libcoreclr.so" />

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,10 +16,8 @@ endif(WIN32 AND FEATURE_EVENT_TRACE)
 
 
 if(CLR_CMAKE_PLATFORM_UNIX)
-  if(CLR_CMAKE_PLATFORM_LINUX)
-    if(CLR_CMAKE_PLATFORM_UNIX_AMD64 OR CLR_CMAKE_PLATFORM_UNIX_ARM)
-      add_subdirectory(debug/createdump)
-    endif()
+  if(CLR_CMAKE_PLATFORM_LINUX AND NOT CLR_CMAKE_PLATFORM_UNIX_X86)
+    add_subdirectory(debug/createdump)
   endif(CLR_CMAKE_PLATFORM_LINUX)
 
   add_subdirectory(ToolBox/SOS/Strike)

--- a/src/ToolBox/SOS/Strike/CMakeLists.txt
+++ b/src/ToolBox/SOS/Strike/CMakeLists.txt
@@ -149,14 +149,15 @@ else(WIN32)
   generate_exports_file(${DEF_SOURCES} ${EXPORTS_FILE})
 endif(WIN32)
 
+if(CLR_CMAKE_PLATFORM_LINUX)
+  list(APPEND 
+    SOS_LIBRARY 
+    createdump_lib
+  )
+  add_definitions(-DCREATE_DUMP_SUPPORTED)
+endif(CLR_CMAKE_PLATFORM_LINUX)
+
 if(CLR_CMAKE_PLATFORM_ARCH_AMD64)
-  if(CLR_CMAKE_PLATFORM_LINUX)
-    list(APPEND 
-      SOS_LIBRARY 
-      createdump_lib
-    )
-    add_definitions(-DCREATE_DUMP_SUPPORTED)
-  endif(CLR_CMAKE_PLATFORM_LINUX)
   set(SOS_SOURCES_ARCH
     disasmX86.cpp
   )

--- a/src/debug/createdump/dumpwriter.cpp
+++ b/src/debug/createdump/dumpwriter.cpp
@@ -447,7 +447,6 @@ DumpWriter::WriteThread(const ThreadInfo& thread, int fatal_signal)
         return false;
     }
 
-#if defined(__i386__) || defined(__x86_64__) || defined(__arm__)
     nhdr.n_descsz = sizeof(user_fpregs_struct);
     nhdr.n_type = NT_FPREGSET;
     if (!WriteData(&nhdr, sizeof(nhdr)) ||
@@ -455,7 +454,6 @@ DumpWriter::WriteThread(const ThreadInfo& thread, int fatal_signal)
         !WriteData(thread.FPRegisters(), sizeof(user_fpregs_struct))) {
         return false;
     }
-#endif
 
     nhdr.n_namesz = 6;
 

--- a/src/debug/createdump/dumpwriter.h
+++ b/src/debug/createdump/dumpwriter.h
@@ -18,6 +18,8 @@
 #define ELF_ARCH  EM_X86_64
 #elif defined(__i386__)
 #define ELF_ARCH  EM_386
+#elif defined(__aarch64__)
+#define ELF_ARCH  EM_AARCH64
 #elif defined(__arm__)
 #define ELF_ARCH  EM_ARM
 #endif
@@ -60,9 +62,7 @@ private:
     size_t GetThreadInfoSize() const
     {
         return m_crashInfo.Threads().size() * ((sizeof(Nhdr) + 8 + sizeof(prstatus_t))
-#if defined(__i386__) || defined(__x86_64__) || defined(__arm__)
             + sizeof(Nhdr) + 8 + sizeof(user_fpregs_struct)
-#endif
 #if defined(__i386__)
             + sizeof(Nhdr) + 8 + sizeof(user_fpxregs_struct)
 #endif

--- a/src/debug/createdump/memoryregion.h
+++ b/src/debug/createdump/memoryregion.h
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if defined(__arm__)
+#if defined(__arm__) || defined(__aarch64__)
 #define PAGE_SIZE sysconf(_SC_PAGESIZE)
 #define PAGE_MASK (~(PAGE_SIZE-1))
 #endif

--- a/src/debug/createdump/threadinfo.cpp
+++ b/src/debug/createdump/threadinfo.cpp
@@ -50,10 +50,14 @@ ThreadInfo::Initialize(ICLRDataTarget* pDataTarget)
         }
     }
 
-#if defined(__arm__)
+#if defined(__aarch64__)
+    TRACE("Thread %04x PC %016llx SP %016llx\n", m_tid, (unsigned long long)m_gpRegisters.pc, (unsigned long long)m_gpRegisters.sp);
+#elif defined(__arm__)
     TRACE("Thread %04x PC %08lx SP %08lx\n", m_tid, (unsigned long)m_gpRegisters.ARM_pc, (unsigned long)m_gpRegisters.ARM_sp);
-#else
+#elif defined(__x86_64__)
     TRACE("Thread %04x RIP %016llx RSP %016llx\n", m_tid, (unsigned long long)m_gpRegisters.rip, (unsigned long long)m_gpRegisters.rsp);
+#else
+#error "Unsupported architecture"
 #endif
     return true;
 }
@@ -78,6 +82,9 @@ GetFrameLocation(CONTEXT* pContext, uint64_t* ip, uint64_t* sp)
 #elif defined(__i386__)
     *ip = pContext->Eip;
     *sp = pContext->Esp;
+#elif defined(__aarch64__)
+    *ip = pContext->Pc;
+    *sp = pContext->Sp;
 #elif defined(__arm__)
     *ip = pContext->Pc & ~THUMB_CODE;
     *sp = pContext->Sp;
@@ -176,6 +183,23 @@ ThreadInfo::UnwindThread(CrashInfo& crashInfo, IXCLRDataProcess* pClrDataProcess
 bool 
 ThreadInfo::GetRegistersWithPTrace()
 {
+#if defined(__aarch64__)
+    struct iovec gpRegsVec = { &m_gpRegisters, sizeof(m_gpRegisters) };
+    if (ptrace((__ptrace_request)PTRACE_GETREGSET, m_tid, NT_PRSTATUS, &gpRegsVec) == -1)
+    {
+        fprintf(stderr, "ptrace(PTRACE_GETREGSET, %d, NT_PRSTATUS) FAILED %d (%s)\n", m_tid, errno, strerror(errno));
+        return false;
+    }
+    assert(sizeof(m_gpRegisters) == gpRegsVec.iov_len);
+
+    struct iovec fpRegsVec = { &m_fpRegisters, sizeof(m_fpRegisters) };
+    if (ptrace((__ptrace_request)PTRACE_GETREGSET, m_tid, NT_FPREGSET, &fpRegsVec) == -1)
+    {
+        fprintf(stderr, "ptrace(PTRACE_GETREGSET, %d, NT_FPREGSET) FAILED %d (%s)\n", m_tid, errno, strerror(errno));
+        return false;
+    }
+    assert(sizeof(m_fpRegisters) == fpRegsVec.iov_len);
+#else
     if (ptrace((__ptrace_request)PTRACE_GETREGS, m_tid, nullptr, &m_gpRegisters) == -1)
     {
         fprintf(stderr, "ptrace(GETREGS, %d) FAILED %d (%s)\n", m_tid, errno, strerror(errno));
@@ -203,6 +227,7 @@ ThreadInfo::GetRegistersWithPTrace()
         fprintf(stderr, "ptrace(PTRACE_GETVFPREGS, %d) FAILED %d (%s)\n", m_tid, errno, strerror(errno));
         return false;
     }
+#endif
 #endif
     return true;
 }
@@ -265,6 +290,20 @@ ThreadInfo::GetRegistersWithDataTarget(ICLRDataTarget* pDataTarget)
 
     assert(sizeof(context.FltSave.XmmRegisters) == sizeof(m_fpRegisters.xmm_space));
     memcpy(m_fpRegisters.xmm_space, context.FltSave.XmmRegisters, sizeof(m_fpRegisters.xmm_space));
+#elif defined(__aarch64__)
+    // See MCREG maps in PAL's context.h
+    assert(sizeof(m_gpRegisters.regs) == (sizeof(context.X) + sizeof(context.Fp) + sizeof(context.Lr)));
+    memcpy(m_gpRegisters.regs, context.X, sizeof(context.X));
+    m_gpRegisters.regs[29] = context.Fp;
+    m_gpRegisters.regs[30] = context.Lr;
+    m_gpRegisters.sp = context.Sp;
+    m_gpRegisters.pc = context.Pc;
+    m_gpRegisters.pstate = context.Cpsr;
+
+    assert(sizeof(m_fpRegisters.vregs) == sizeof(context.V));
+    memcpy(m_fpRegisters.vregs, context.V, sizeof(context.V));
+    m_fpRegisters.fpcr = context.Fpcr;
+    m_fpRegisters.fpsr = context.Fpsr;
 #elif defined(__arm__)
     m_gpRegisters.ARM_sp = context.Sp;
     m_gpRegisters.ARM_lr = context.Lr;
@@ -304,7 +343,9 @@ ThreadInfo::GetThreadStack(CrashInfo& crashInfo)
     uint64_t startAddress;
     size_t size;
 
-#if defined(__arm__)
+#if defined(__aarch64__)
+    startAddress = m_gpRegisters.sp & PAGE_MASK;
+#elif defined(__arm__)
     startAddress = m_gpRegisters.ARM_sp & PAGE_MASK;
 #else
     startAddress = m_gpRegisters.rsp & PAGE_MASK;
@@ -387,6 +428,27 @@ ThreadInfo::GetThreadContext(uint32_t flags, CONTEXT* context) const
         memcpy(context->FltSave.XmmRegisters, m_fpRegisters.xmm_space, sizeof(context->FltSave.XmmRegisters));
     }
     // TODO: debug registers?
+#elif defined(__aarch64__)
+    if ((flags & CONTEXT_CONTROL) == CONTEXT_CONTROL)
+    {
+        context->Fp = m_gpRegisters.regs[29];
+        context->Lr = m_gpRegisters.regs[30];
+        context->Sp = m_gpRegisters.sp;
+        context->Pc = m_gpRegisters.pc;
+        context->Cpsr = m_gpRegisters.pstate;
+    }
+    if ((flags & CONTEXT_INTEGER) == CONTEXT_INTEGER)
+    {
+        assert(sizeof(m_gpRegisters.regs) == (sizeof(context->X) + sizeof(context->Fp) + sizeof(context->Lr)));
+        memcpy(context->X, m_gpRegisters.regs, sizeof(context->X));
+    }
+    if ((flags & CONTEXT_FLOATING_POINT) == CONTEXT_FLOATING_POINT)
+    {
+        assert(sizeof(m_fpRegisters.vregs) == sizeof(context->V));
+        memcpy(context->V, m_fpRegisters.vregs, sizeof(context->V));
+        context->Fpcr = m_fpRegisters.fpcr;
+        context->Fpsr = m_fpRegisters.fpsr;
+    }
 #elif defined(__arm__)
     if ((flags & CONTEXT_CONTROL) == CONTEXT_CONTROL)
     {
@@ -394,7 +456,6 @@ ThreadInfo::GetThreadContext(uint32_t flags, CONTEXT* context) const
         context->Lr = m_gpRegisters.ARM_lr;
         context->Pc = m_gpRegisters.ARM_pc;
         context->Cpsr = m_gpRegisters.ARM_cpsr;
-
     }
     if ((flags & CONTEXT_INTEGER) == CONTEXT_INTEGER)
     {

--- a/src/debug/createdump/threadinfo.h
+++ b/src/debug/createdump/threadinfo.h
@@ -7,15 +7,18 @@ class CrashInfo;
 #if defined(__arm__)
 #define user_regs_struct user_regs
 #define user_fpregs_struct user_fpregs
+#endif
 
-#if defined(__VFP_FP__) && !defined(__SOFTFP__)
+#if defined(__aarch64__)
+#define user_fpregs_struct user_fpsimd_struct
+#endif
+
+#if defined(__arm__) && defined(__VFP_FP__) && !defined(__SOFTFP__)
 struct user_vfpregs_struct
 {
   unsigned long long  fpregs[32];
   unsigned long       fpscr;
 } __attribute__((__packed__));
-#endif
-
 #endif
 
 class ThreadInfo 


### PR DESCRIPTION
Fixes #18893

- Enable build of ARM64 createdump build
  - Adds definitions of necessary constructs and aligments for Elf formats in aarch64.
  - Work around changes in ptrace for aarch64.
- Package createdump for arm and arm64 Linux in runtime transport nupkg.