### PR TITLE
Improve debugging stack walk performance

### DIFF
--- a/src/debug/di/shimremotedatatarget.cpp
+++ b/src/debug/di/shimremotedatatarget.cpp
@@ -20,7 +20,6 @@
 #include "dbgtransportsession.h"
 #include "dbgtransportmanager.h"
 
-
 class ShimRemoteDataTarget : public ShimDataTarget
 {
 public:
@@ -69,6 +68,7 @@ public:
 private:
     DbgTransportTarget  * m_pProxy;
     DbgTransportSession * m_pTransport;
+    int m_fd;                           // /proc/<pid>/mem handle
 };
 
 
@@ -103,6 +103,10 @@ ShimRemoteDataTarget::ShimRemoteDataTarget(DWORD processId,
 
     m_fpContinueStatusChanged = NULL;
     m_pContinueStatusChangedUserData = NULL;
+
+    char memPath[128];
+    _snprintf_s(memPath, sizeof(memPath), sizeof(memPath), "/proc/%lu/mem", m_processId);
+    m_fd = _open(memPath, 0); // O_RDONLY
 }
 
 //---------------------------------------------------------------------------------------
@@ -127,11 +131,15 @@ ShimRemoteDataTarget::~ShimRemoteDataTarget()
 
 void ShimRemoteDataTarget::Dispose()
 {
+    if (m_fd != -1)
+    {
+        _close(m_fd);
+        m_fd = -1;
+    }
     if (m_pTransport != NULL)
     {
         m_pProxy->ReleaseTransport(m_pTransport);
     }
-
     m_pTransport = NULL;
     m_hr = CORDBG_E_OBJECT_NEUTERED;
 }
@@ -244,7 +252,7 @@ ShimRemoteDataTarget::GetPlatform(
 
 // impl of interface method ICorDebugDataTarget::ReadVirtual
 HRESULT STDMETHODCALLTYPE
-ShimRemoteDataTarget::ReadVirtual( 
+ShimRemoteDataTarget::ReadVirtual(
     CORDB_ADDRESS address,
     PBYTE pBuffer,
     ULONG32 cbRequestSize,
@@ -252,13 +260,24 @@ ShimRemoteDataTarget::ReadVirtual(
 {
     ReturnFailureIfStateNotOk();
 
-    HRESULT hr = E_FAIL;
-    hr = m_pTransport->ReadMemory(reinterpret_cast<BYTE *>(CORDB_ADDRESS_TO_PTR(address)), 
-                                  pBuffer, 
-                                  cbRequestSize);
+    size_t read = cbRequestSize;
+    HRESULT hr = S_OK;
+
+    if (m_fd != -1)
+    {
+        read = _pread(m_fd, pBuffer, cbRequestSize, (ULONG64)address);
+        if (read == -1)
+        {
+            hr = E_FAIL;
+        }
+    }
+    else
+    {
+        hr = m_pTransport->ReadMemory(reinterpret_cast<BYTE *>(CORDB_ADDRESS_TO_PTR(address)), pBuffer, cbRequestSize);
+    }
     if (pcbRead != NULL)
     {
-        *pcbRead = (SUCCEEDED(hr) ? cbRequestSize : 0);
+        *pcbRead = (SUCCEEDED(hr) ? read : 0);
     }
     return hr;
 }

--- a/src/dlls/mscordac/mscordac_unixexports.src
+++ b/src/dlls/mscordac/mscordac_unixexports.src
@@ -65,6 +65,9 @@ nativeStringResourceTable_mscorrc_debug
 #PAL_wcscspn
 #PAL_wcscat
 #PAL_wcsstr
+#PAL__open
+#PAL__pread
+#PAL__close
 
 #_wcsicmp
 #_stricmp

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -4138,6 +4138,7 @@ PAL_GetCurrentThreadAffinitySet(SIZE_T size, UINT_PTR* data);
 #define _strdup       PAL__strdup
 #define _getcwd       PAL__getcwd
 #define _open         PAL__open
+#define _pread        PAL__pread
 #define _close        PAL__close
 #define _wcstoui64    PAL__wcstoui64
 #define _flushall     PAL__flushall
@@ -4507,7 +4508,9 @@ PALIMPORT char * __cdecl ctime(const time_t *);
 #endif // !PAL_STDCPP_COMPAT
 
 PALIMPORT int __cdecl _open_osfhandle(INT_PTR, int);
-PALIMPORT int __cdecl _close(int);
+PALIMPORT DLLEXPORT int __cdecl _open(const char *szPath, int nFlags, ...);
+PALIMPORT DLLEXPORT size_t __cdecl _pread(int fd, void *buf, size_t nbytes, ULONG64 offset);
+PALIMPORT DLLEXPORT int __cdecl _close(int);
 PALIMPORT DLLEXPORT int __cdecl _flushall();
 
 #ifdef PAL_STDCPP_COMPAT

--- a/src/pal/src/cruntime/file.cpp
+++ b/src/pal/src/cruntime/file.cpp
@@ -453,6 +453,18 @@ PAL_FILE * __cdecl PAL_get_stderr(int caller)
     return &PAL_Stderr;
 }
 
+/*++
+
+Function:
+
+    PAL_pread
+
+See msdn for more details.
+--*/
+size_t __cdecl PAL__pread(int fd, void *buf, size_t nbytes, ULONG64 offset)
+{
+    return pread(fd, buf, nbytes, offset);
+}
 
 /*++
 


### PR DESCRIPTION
Use /proc/<pid>/mem to read memory in remote DBI data target. It makes the test case run at least 4 to 5 times faster than before.

Fallback to old transport ReadMemory if /proc/<pid>/mem can't be opened. This happens on attach because of permissions/access, but works fine on the launch (the most important case).

Issue: https://github.com/dotnet/coreclr/issues/22315