### PR TITLE
Remove all uses of CanRunManagedCode()

### DIFF
--- a/src/vm/clrex.h
+++ b/src/vm/clrex.h
@@ -971,47 +971,39 @@ LONG CLRNoCatchHandler(EXCEPTION_POINTERS* pExceptionInfo, PVOID pv);
 //   outside unmanaged code. If you want to connect internal pieces
 //   of CLR code, use EX_TRY instead.
 //===================================================================================
-#define BEGIN_EXTERNAL_ENTRYPOINT(phresult)                             \
-    {                                                                   \
-        HRESULT *__phr = (phresult);                                    \
-        *__phr = S_OK;                                                  \
-        _ASSERTE(GetThread() == NULL ||                                 \
-                    !GetThread()->PreemptiveGCDisabled());              \
-        if (!CanRunManagedCode())                                       \
-        {                                                               \
-            *__phr = E_PROCESS_SHUTDOWN_REENTRY;                        \
-        }                                                               \
-        else                                                            \
-        {                                                               \
-            MAKE_CURRENT_THREAD_AVAILABLE_EX(GetThreadNULLOk());        \
-            if (CURRENT_THREAD == NULL)                                 \
-            {                                                           \
-                CURRENT_THREAD = SetupThreadNoThrow(__phr);             \
-            }                                                           \
-            if (CURRENT_THREAD != NULL)                                 \
-            {                                                           \
-                EX_TRY_THREAD(CURRENT_THREAD);                          \
-                {                                                       \
+#define BEGIN_EXTERNAL_ENTRYPOINT(phresult)                         \
+    {                                                               \
+        HRESULT *__phr = (phresult);                                \
+        *__phr = S_OK;                                              \
+        _ASSERTE(GetThread() == NULL ||                             \
+                    !GetThread()->PreemptiveGCDisabled());          \
+        MAKE_CURRENT_THREAD_AVAILABLE_EX(GetThreadNULLOk());        \
+        if (CURRENT_THREAD == NULL)                                 \
+        {                                                           \
+            CURRENT_THREAD = SetupThreadNoThrow(__phr);             \
+        }                                                           \
+        if (CURRENT_THREAD != NULL)                                 \
+        {                                                           \
+            EX_TRY_THREAD(CURRENT_THREAD);                          \
+            {                                                       \
 
-#define END_EXTERNAL_ENTRYPOINT                                         \
-                }                                                       \
-                EX_CATCH_HRESULT(*__phr);                               \
-            }                                                           \
-        }                                                               \
-    }                                                                   \
+#define END_EXTERNAL_ENTRYPOINT                                     \
+            }                                                       \
+            EX_CATCH_HRESULT(*__phr);                               \
+        }                                                           \
+    }                                                               \
 
 // This macro should be used at the entry points (e.g. COM interop boundaries) 
 // where CE's are not expected to get swallowed.
 #define END_EXTERNAL_ENTRYPOINT_RETHROW_CORRUPTING_EXCEPTIONS_EX(fCond) \
-                }                                                       \
-                EX_CATCH                                                \
-                {                                                       \
-                    *__phr = GET_EXCEPTION()->GetHR();                  \
-                }                                                       \
-                EX_END_CATCH(RethrowCorruptingExceptionsEx(fCond));     \
-            }                                                           \
-        }                                                               \
-    }                                                                   \
+            }                                                       \
+            EX_CATCH                                                \
+            {                                                       \
+                *__phr = GET_EXCEPTION()->GetHR();                  \
+            }                                                       \
+            EX_END_CATCH(RethrowCorruptingExceptionsEx(fCond));     \
+        }                                                           \
+    }                                                               \
 
 // This macro should be used at the entry points (e.g. COM interop boundaries) 
 // where CE's are not expected to get swallowed.

--- a/src/vm/comcallablewrapper.h
+++ b/src/vm/comcallablewrapper.h
@@ -1717,7 +1717,7 @@ public:
         }
         CONTRACTL_END;
 
-        SetupForComCallHRNoHostNotifNoCheckCanRunManagedCode();
+        SetupForComCallHR();
 
         // we can safely assume that the CCW is still alive since this is an AddRef
         StackSString ssMessage;
@@ -1781,9 +1781,6 @@ private:
             MODE_ANY;
         }
         CONTRACTL_END;
-
-        if (!CanRunManagedCode())
-            return;
 
         m_pWrap->Cleanup();
     }

--- a/src/vm/comtoclrcall.cpp
+++ b/src/vm/comtoclrcall.cpp
@@ -136,30 +136,19 @@ extern "C" HRESULT STDCALL StubRareDisableHRWorker(Thread *pThread)
     // dangerous mode.  If we call managed code, we will potentially be active in
     // the GC heap, even as GC's are occuring!
 
-    // Check for ShutDown scenario.  This happens only when we have initiated shutdown 
-    // and someone is trying to call in after the CLR is suspended.  In that case, we
-    // must either raise an unmanaged exception or return an HRESULT, depending on the
-    // expectations of our caller.
-    if (!CanRunManagedCode())
+    // We must do the following in this order, because otherwise we would be constructing
+    // the exception for the abort without synchronizing with the GC.  Also, we have no
+    // CLR SEH set up, despite the fact that we may throw a ThreadAbortException.
+    pThread->RareDisablePreemptiveGC();
+    EX_TRY
     {
-        hr = E_PROCESS_SHUTDOWN_REENTRY;
+        pThread->HandleThreadAbort();
     }
-    else
+    EX_CATCH
     {
-        // We must do the following in this order, because otherwise we would be constructing
-        // the exception for the abort without synchronizing with the GC.  Also, we have no
-        // CLR SEH set up, despite the fact that we may throw a ThreadAbortException.
-        pThread->RareDisablePreemptiveGC();
-        EX_TRY
-        {
-            pThread->HandleThreadAbort();
-        }
-        EX_CATCH
-        {
-            hr = GET_EXCEPTION()->GetHR();
-        }
-        EX_END_CATCH(SwallowAllExceptions);
+        hr = GET_EXCEPTION()->GetHR();
     }
+    EX_END_CATCH(SwallowAllExceptions);
 
     // should always be in coop mode here
     _ASSERTE(pThread->PreemptiveGCDisabled());

--- a/src/vm/corhost.cpp
+++ b/src/vm/corhost.cpp
@@ -271,9 +271,7 @@ HRESULT CorHost2::GetCurrentAppDomainId(DWORD *pdwAppDomainId)
     CONTRACTL_END;
 
     // No point going further if the runtime is not running...
-    // We use CanRunManagedCode() instead of IsRuntimeActive() because this allows us
-    // to specify test using the form that does not trigger a GC.
-    if (!(g_fEEStarted && CanRunManagedCode(LoaderLockCheck::None)))
+    if (!IsRuntimeActive())
     {
         return HOST_E_CLRNOTAVAILABLE;
     }   

--- a/src/vm/dllimportcallback.cpp
+++ b/src/vm/dllimportcallback.cpp
@@ -852,8 +852,7 @@ extern "C" VOID STDCALL UMThunkStubRareDisableWorker(Thread *pThread, UMEntryThu
     STATIC_CONTRACT_THROWS;
     STATIC_CONTRACT_GC_TRIGGERS;
 
-    // Do not add a CONTRACT here.  We haven't set up SEH.  We rely
-    // on HandleThreadAbort and COMPlusThrowBoot dealing with this situation properly.
+    // Do not add a CONTRACT here.  We haven't set up SEH.
 
     // WARNING!!!!
     // when we start executing here, we are actually in cooperative mode.  But we

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -5469,11 +5469,6 @@ DefaultCatchHandler(PEXCEPTION_POINTERS pExceptionPointers,
                         PrintToStdErrA(" StackOverflowException.\n");
                     }
                 }
-                else if (!CanRunManagedCode(LoaderLockCheck::None))
-                {
-                    // Well, if we can't enter the runtime, we very well can't get the exception message.
-                    dump = FALSE;
-                }
                 else if (SentEvent || IsAsyncThreadException(&throwable))
                 {
                     // We don't print anything on async exceptions, like ThreadAbort.
@@ -5609,20 +5604,13 @@ BOOL NotifyAppDomainsOfUnhandledException(
 #endif
 
     GCPROTECT_BEGIN(throwable);
-    //BOOL IsStackOverflow = (throwable->GetMethodTable() == g_pStackOverflowExceptionClass);
 
     // Notify the AppDomain that we have taken an unhandled exception.  Can't notify of stack overflow -- guard
     // page is not yet reset.
 
     // Send up the unhandled exception appdomain event.
-    //
-    // If we can't run managed code, we can't deliver the event. Nor do we attempt to delieve the event in stack
-    // overflow or OOM conditions.
-    if (/*!IsStackOverflow &&*/
-        pThread->DetermineIfGuardPagePresent() &&
-        CanRunManagedCode(LoaderLockCheck::None))
+    if (pThread->DetermineIfGuardPagePresent())
     {
-
         // x86 only
 #if !defined(WIN64EXCEPTIONS)
         // If the Thread object's exception state's exception pointers

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -155,17 +155,6 @@ BOOL NotifyAppDomainsOfUnhandledException(
 VOID SetManagedUnhandledExceptionBit(
     BOOL        useLastThrownObject);
 
-
-void COMPlusThrowBoot(HRESULT hr)
-{
-    STATIC_CONTRACT_THROWS;
-
-    _ASSERTE(g_fEEShutDown >= ShutDown_Finalize2 || !"This should not be called unless we are in the last phase of shutdown!");
-    ULONG_PTR arg = hr;
-    RaiseException(BOOTUP_EXCEPTION_COMPLUS, EXCEPTION_NONCONTINUABLE, 1, &arg);
-}
-
-
 //-------------------------------------------------------------------------------
 // This simply tests to see if the exception object is a subclass of
 // the descriminating class specified in the exception clause.

--- a/src/vm/excep.h
+++ b/src/vm/excep.h
@@ -566,12 +566,8 @@ void VerifyValidTransitionFromManagedCode(Thread *pThread, CrawlFrame *pCF);
 // This is a workaround designed to allow the use of the StubLinker object at bootup
 // time where the EE isn't sufficient awake to create COM+ exception objects.
 // Instead, COMPlusThrow(rexcep) does a simple RaiseException using this code.
-// Or use COMPlusThrowBoot() to explicitly do so.
 //==========================================================================
 #define BOOTUP_EXCEPTION_COMPLUS  0xC0020001
-
-void COMPlusThrowBoot(HRESULT hr);
-
 
 //==========================================================================
 // Used by the classloader to record a managed exception object to explain

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -1051,8 +1051,7 @@ extern "C" VOID STDCALL StubRareDisableTHROWWorker(Thread *pThread)
     STATIC_CONTRACT_THROWS;
     STATIC_CONTRACT_GC_TRIGGERS;
 
-    // Do not add a CONTRACT here.  We haven't set up SEH.  We rely
-    // on HandleThreadAbort and COMPlusThrowBoot dealing with this situation properly.
+    // Do not add a CONTRACT here.  We haven't set up SEH.
 
     // WARNING!!!!
     // when we start executing here, we are actually in cooperative mode.  But we

--- a/src/vm/i386/cgenx86.cpp
+++ b/src/vm/i386/cgenx86.cpp
@@ -1060,19 +1060,6 @@ extern "C" VOID STDCALL StubRareDisableTHROWWorker(Thread *pThread)
     // dangerous mode.  If we call managed code, we will potentially be active in
     // the GC heap, even as GC's are occuring!
 
-    // Check for ShutDown scenario.  This happens only when we have initiated shutdown 
-    // and someone is trying to call in after the CLR is suspended.  In that case, we
-    // must either raise an unmanaged exception or return an HRESULT, depending on the
-    // expectations of our caller.
-    if (!CanRunManagedCode())
-    {
-        // DO NOT IMPROVE THIS EXCEPTION!  It cannot be a managed exception.  It
-        // cannot be a real exception object because we cannot execute any managed
-        // code here.
-        pThread->m_fPreemptiveGCDisabled = 0;
-        COMPlusThrowBoot(E_PROCESS_SHUTDOWN_REENTRY);
-    }
-
     // We must do the following in this order, because otherwise we would be constructing
     // the exception for the abort without synchronizing with the GC.  Also, we have no
     // CLR SEH set up, despite the fact that we may throw a ThreadAbortException.

--- a/src/vm/runtimeexceptionkind.h
+++ b/src/vm/runtimeexceptionkind.h
@@ -4,9 +4,6 @@
 // RuntimeExceptionKind.h
 //
 
-// 
-
-
 #ifndef __runtimeexceptionkind_h__
 #define __runtimeexceptionkind_h__
 
@@ -20,12 +17,5 @@ enum RuntimeExceptionKind {
 #include "rexcep.h"
 kLastException
 };
-
-
-// I would have preferred to define a unique HRESULT in our own facility, but we
-// weren't supposed to create new HRESULTs so close to ship.  And now it's set
-// in stone.
-#define E_PROCESS_SHUTDOWN_REENTRY    HRESULT_FROM_WIN32(ERROR_PROCESS_ABORTED)
-
 
 #endif  // __runtimeexceptionkind_h__

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -1025,14 +1025,6 @@ Thread* WINAPI CreateThreadBlockThrow()
     Thread* pThread = NULL;
     BEGIN_ENTRYPOINT_THROWS;
 
-    if (!CanRunManagedCode())
-    {
-        // CLR is shutting down - someone's DllMain detach event may be calling back into managed code.
-        // It is misleading to use our COM+ exception code, since this is not a managed exception.  
-        ULONG_PTR arg = E_PROCESS_SHUTDOWN_REENTRY;
-        RaiseException(EXCEPTION_EXX, 0, 1, &arg);
-    }
-
     HRESULT hr = S_OK;
     pThread = SetupThreadNoThrow(&hr);
     if (pThread == NULL)
@@ -3395,7 +3387,8 @@ DWORD Thread::DoAppropriateWaitWorker(int countHandles, HANDLE *handles, BOOL wa
     // since fundamental parts of the system (such as the GC) rely on non alertable
     // waits not running any managed code. Also if we are past the point in shutdown were we
     // are allowed to run managed code then we can't forward the call to the sync context.
-    if (!ignoreSyncCtx && alertable && CanRunManagedCode(LoaderLockCheck::None) 
+    if (!ignoreSyncCtx
+        && alertable
         && !HasThreadStateNC(Thread::TSNC_BlockedForShutdown))
     {
         GCX_COOP();

--- a/src/vm/util.cpp
+++ b/src/vm/util.cpp
@@ -2057,7 +2057,6 @@ HMODULE CLRGetModuleHandle(LPCWSTR lpModuleFileName)
 
 LPVOID EEHeapAllocInProcessHeap(DWORD dwFlags, SIZE_T dwBytes);
 BOOL EEHeapFreeInProcessHeap(DWORD dwFlags, LPVOID lpMem);
-void ShutdownRuntimeWithoutExiting(int exitCode);
 BOOL IsRuntimeStarted(DWORD *pdwStartupFlags);
 
 void *GetCLRFunction(LPCSTR FunctionName)
@@ -2075,10 +2074,6 @@ void *GetCLRFunction(LPCSTR FunctionName)
     else if (strcmp(FunctionName, "EEHeapFreeInProcessHeap") == 0)
     {
         func = (void*)EEHeapFreeInProcessHeap;
-    }
-    else if (strcmp(FunctionName, "ShutdownRuntimeWithoutExiting") == 0)
-    {
-        func = (void*)ShutdownRuntimeWithoutExiting;
     }
     else if (strcmp(FunctionName, "IsRuntimeStarted") == 0)
     {

--- a/src/vm/util.hpp
+++ b/src/vm/util.hpp
@@ -744,55 +744,8 @@ void GetProcessMemoryLoad(LPMEMORYSTATUSEX pMSEX);
             return OOMRetVal;                       \
     }                                               \
 
-
-#define InternalSetupForComCall(CannotEnterRetVal, OOMRetVal, SORetVal, CheckCanRunManagedCode) \
-SetupThreadForComCall(OOMRetVal);                       \
-if (CheckCanRunManagedCode && !CanRunManagedCode())     \
-    return CannotEnterRetVal;
-
-#define SetupForComCallHRNoHostNotif() InternalSetupForComCall(HOST_E_CLRNOTAVAILABLE, E_OUTOFMEMORY, COR_E_STACKOVERFLOW, true)
-#define SetupForComCallHRNoHostNotifNoCheckCanRunManagedCode() InternalSetupForComCall(HOST_E_CLRNOTAVAILABLE, E_OUTOFMEMORY, COR_E_STACKOVERFLOW, false)
-#define SetupForComCallDWORDNoHostNotif() InternalSetupForComCall(-1, -1, -1, true)
-
-#define SetupForComCallHR()                                                                \
-InternalSetupForComCall(HOST_E_CLRNOTAVAILABLE, E_OUTOFMEMORY, COR_E_STACKOVERFLOW, true)
-
-#define SetupForComCallHRNoCheckCanRunManagedCode()                                        \
-InternalSetupForComCall(HOST_E_CLRNOTAVAILABLE, E_OUTOFMEMORY, COR_E_STACKOVERFLOW, false)
-
-#ifdef FEATURE_CORRUPTING_EXCEPTIONS
-
-// Since Corrupting exceptions can escape COM interop boundaries,
-// these macros will be used to setup the initial SO-Intolerant transition.
-#define InternalSetupForComCallWithEscapingCorruptingExceptions(CannotEnterRetVal, OOMRetVal, SORetVal, CheckCanRunManagedCode) \
-if (CheckCanRunManagedCode && !CanRunManagedCode())                         \
-    return CannotEnterRetVal;                                               \
-SetupThreadForComCall(OOMRetVal);                                           \
-
-#define BeginSetupForComCallHRWithEscapingCorruptingExceptions()            \
-HRESULT __hr = S_OK;                                                        \
-InternalSetupForComCallWithEscapingCorruptingExceptions(HOST_E_CLRNOTAVAILABLE, E_OUTOFMEMORY, COR_E_STACKOVERFLOW, true)              \
-                                                                            \
-if (SUCCEEDED(__hr))                                                        \
-{                                                                           \
-
-#define EndSetupForComCallHRWithEscapingCorruptingExceptions()              \
-}                                                                           \
-                                                                            \
-if (FAILED(__hr))                                                           \
-{                                                                           \
-    return __hr;                                                            \
-}                                                                           \
-
-#endif // FEATURE_CORRUPTING_EXCEPTIONS
-
-#define SetupForComCallDWORD()                                              \
-InternalSetupForComCall(-1, -1, -1, true)
-
-// Special version of SetupForComCallDWORD that doesn't call
-// CanRunManagedCode() to avoid firing LoaderLock MDA
-#define SetupForComCallDWORDNoCheckCanRunManagedCode()                      \
-InternalSetupForComCall(-1, -1, -1, false)
+#define SetupForComCallHR() SetupThreadForComCall(E_OUTOFMEMORY)
+#define SetupForComCallDWORD() SetupThreadForComCall(ERROR_OUTOFMEMORY)
 
 // A holder for NATIVE_LIBRARY_HANDLE.
 FORCEINLINE void VoidFreeNativeLibrary(NATIVE_LIBRARY_HANDLE h)

--- a/src/vm/vars.hpp
+++ b/src/vm/vars.hpp
@@ -487,24 +487,6 @@ extern BOOL g_fEnableETW;
 BOOL IsRuntimeActive(); 
 
 //
-// Can we run managed code?
-//
-struct LoaderLockCheck
-{
-    enum kind
-    {
-        ForMDA,
-        ForCorrectness,
-        None,
-    };
-};
-BOOL CanRunManagedCode(LoaderLockCheck::kind checkKind, HINSTANCE hInst = 0);
-inline BOOL CanRunManagedCode(HINSTANCE hInst = 0)
-{
-    return CanRunManagedCode(LoaderLockCheck::ForMDA, hInst);
-}
-
-//
 // Global state variable indicating if the EE is in its init phase.
 //
 EXTERN bool g_fEEInit;


### PR DESCRIPTION
Handle race conditions between CLR shutdown and interop transitions.

Fixes https://github.com/dotnet/coreclr/issues/11404
Fixes https://github.com/dotnet/coreclr/issues/17394
Fixes https://github.com/dotnet/coreclr/issues/24727
Fixes https://github.com/dotnet/cli/issues/11403

Related https://github.com/dotnet/coreclr/issues/11432

cc @jkotas @davidwrighton @janvorli 
