### PR TITLE
Add information in docs for required Windows SDK version for test build.

### DIFF
--- a/Documentation/building/windows-instructions.md
+++ b/Documentation/building/windows-instructions.md
@@ -42,6 +42,7 @@ For Visual Studio 2017:
     * Windows 10 SDK or Windows 8.1 SDK
 * To build for Arm32, Make sure that you have the Windows 10 SDK installed (or selected to be installed as part of VS installation). To explicitly install Windows SDK, download it from here: [Windows SDK for Windows 10](https://developer.microsoft.com/en-us/windows/downloads).
   * In addition, ensure you install the ARM tools. In the "Individual components" window, in the "Compilers, build tools, and runtimes" section, check the box for "Visual C++ compilers and libraries for ARM".
+* To build the tests, make sure you have a Windows 10 SDK for at least version 10.0.17763 or newer.
 * **Important:** You must have the `msdia120.dll` COM Library registered in order to build the repository.
   * This binary is registered by default when installing the "VC++ Tools" with Visual Studio 2015
   * You can also manually register the binary by launching the "Developer Command Prompt for VS2017" with Administrative privileges and running `regsvr32.exe "%VSINSTALLDIR%\Common7\IDE\msdia120.dll"`


### PR DESCRIPTION
After adding the WinRT tests in #23529, the minimum version of the Windows 10 SDK needed for our test build became 10.0.17763. This PR updates our documentation to clarify that this version is the minimum required for the test build on Windows.

Fixes #24660.
