### PR TITLE
Fix overlooked moduleIndex initial value

### DIFF
--- a/src/vm/zapsig.cpp
+++ b/src/vm/zapsig.cpp
@@ -1530,7 +1530,7 @@ BOOL ZapSig::EncodeMethod(
         {
             _ASSERTE(pConstrainedResolvedToken->cbTypeSpec > 0);
 
-            DWORD moduleIndex = (DWORD)-1;
+            DWORD moduleIndex = MODULE_INDEX_NONE;
             if (IsReadyToRunCompilation() && pMethod->GetModule()->IsInCurrentVersionBubble() && pInfoModule != (Module *) pConstrainedResolvedToken->tokenScope)
             {
                 moduleIndex = (*((EncodeModuleCallback)pfnEncodeModule))(pEncodeModuleContext, (Module *) pConstrainedResolvedToken->tokenScope);


### PR DESCRIPTION
When adding the signature copying some time ago, I have overlooked one
place where the moduleIndex was set to -1 instead of MODULE_INDEX_NONE.
I was using the -1 during the development and replaced it by creating
MODULE_INDEX_NONE during final cleanup at all but one places.

This caused issues during crossgen even without large version bubble
enabled. Methods requiring generic constraint were not crossgen-ed due
to this.

Close #24877