### PR TITLE
follow the ICU User Guide recommendation to optimize the perf of InvariantCultureIgnoreCase on Linux

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
@@ -876,13 +876,14 @@ namespace System.Globalization
         private unsafe bool TryGetSortKey(ReadOnlySpan<char> source, CompareOptions options, int requestedSortKeyLength, out int actualSortKeyLength, out int hash)
         {
             Debug.Assert(requestedSortKeyLength > 0);
+            Debug.Assert(source.Length > 0);
 
             byte[]? borrowedArr = null;
             Span<byte> span = requestedSortKeyLength <= 512 ?
                 stackalloc byte[requestedSortKeyLength] :
                 (borrowedArr = ArrayPool<byte>.Shared.Rent(requestedSortKeyLength));
 
-            fixed (char* pSource = source)
+            fixed (char* pSource = &MemoryMarshal.GetReference(source))
             fixed (byte* pSortKey = &MemoryMarshal.GetReference(span))
             {
                 actualSortKeyLength = Interop.Globalization.GetSortKey(_sortHandle, pSource, source.Length, pSortKey, requestedSortKeyLength, options);

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
@@ -855,9 +855,7 @@ namespace System.Globalization
             // according to ICU User Guide the performance of ucol_getSortKey is worse when it is called with null output buffer
             // the solution is to try to fill the sort key in a temporary buffer of size equal 4 x string length
 
-            int guessedSize = source.Length > 1024 * 1024 / 4 
-                ? source.Length * 4 
-                : 1024 * 1024; // the biggest array that can be rented from ArrayPool.Shared without memory allocation
+            int guessedSize = (int)Math.Min((long)source.Length * 4, 1024 * 1024); // 1MB is the biggest array that can be rented from ArrayPool.Shared without memory allocation
 
             if (TryGetSortKey(source, options, guessedSize, out int actualSortKeyLength, out int hash))
             {

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
@@ -855,7 +855,7 @@ namespace System.Globalization
             // according to ICU User Guide: 
             // "The overall performance is poorer than if the function is called with a zero output buffer"
             // "A recommended size for the temporary buffer is four times the length of the longest string processed"
-            int recommendedSize = source.Length * 4; 
+            int recommendedSize = int.MaxValue / 4 > source.Length ? source.Length * 4 : source.Length;
 
             // "Call ucol_getSortKey() to find out how big the sort key buffer should be, and fill in the temporary buffer at the same time"
             if (TryGetSortKey(source, options, recommendedSize, out int actualSortKeyLength, out int hash))

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Windows.cs
@@ -131,7 +131,7 @@ namespace System.Globalization
                                                   pSource, source.Length /* in chars */,
                                                   null, 0,
                                                   null, null, _sortHandle);
-                if (sortKeyLength == 0)
+                if (sortKeyLength <= 0)
                 {
                     throw new ArgumentException(SR.Arg_ExternalException);
                 }

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Windows.cs
@@ -131,7 +131,7 @@ namespace System.Globalization
                                                   pSource, source.Length /* in chars */,
                                                   null, 0,
                                                   null, null, _sortHandle);
-                if (sortKeyLength <= 0)
+                if (sortKeyLength == 0)
                 {
                     throw new ArgumentException(SR.Arg_ExternalException);
                 }
@@ -143,7 +143,7 @@ namespace System.Globalization
 
                 byte[]? borrowedArr = null;
                 Span<byte> span = sortKeyLength <= 512 ?
-                    stackalloc byte[sortKeyLength] :
+                    stackalloc byte[512] :
                     (borrowedArr = ArrayPool<byte>.Shared.Rent(sortKeyLength));
 
                 fixed (byte* pSortKey = &MemoryMarshal.GetReference(span))

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Windows.cs
@@ -143,7 +143,7 @@ namespace System.Globalization
 
                 byte[]? borrowedArr = null;
                 Span<byte> span = sortKeyLength <= 512 ?
-                    stackalloc byte[512] :
+                    stackalloc byte[sortKeyLength] :
                     (borrowedArr = ArrayPool<byte>.Shared.Rent(sortKeyLength));
 
                 fixed (byte* pSortKey = &MemoryMarshal.GetReference(span))


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/37691

I have profiled the benchmarks attached in https://github.com/dotnet/corefx/issues/37691 and figured out that `ucol_getSortKey()` slows `InvariantCultureIgnoreCase` string comparison on Linux.

http://icu-project.org/apiref/icu4c/ucol_8h.html#a1f83f9c96a0950e2c22bd5c5c31ff6bf says:

> Note that sort keys are often less efficient than simply doing comparison. For more details, see the ICU User Guide.

While [ICU User Guide](ftp://ftp.software.ibm.com/software/globalization/icu/3.2/icu-3.2-userguide.pdf):

> ucol_getSortKey() can operate in 'preflighting' mode, which returns the amount ofmemory needed to store the resulting sort key. This mode is automatically activated if theoutput buffer size passed is set to zero. Should the sort key become longer than the bufferprovided, function again slips into preflighting mode. The overall performance is poorerthan if the function is called with a zero output buffer . If the size of the sort key returnedis greater than the size of the buffer provided, the content of the result buffer is undefined.In that case, the result buffer could be reallocated to its proper size and the sort keygenerator function can be used again. 
The best way to generate a series of sort keys is to do the following:
1.Create a big temporary buffer on the stack. Typically, this buffer is allocated onlyonce, and reused with every sort key generated. There is no need to keep it as small aspossible. A recommended size for the temporary buffer is four times the length of thelongest string processed.
2.Start the loop. Call ucol_getSortKey()to find out how big the sort key buffer shouldbe, and fill in the temporary buffer at the same time.
3.If the temporary buffer is too small, allocate or reallocate more space for in anoverflow buffer to handle the overflow situations. Fill in the sort key values in theoverflow buffer.
4.Allocate the sort key buffer with the size returned by ucol_getSortKey() and callmemcpy to copy the sort key content from the temp buffer to the sort key buffer. 
5.Loop back to step 1 until you are done.
6.Delete the overflow buffer if you created one.

So I just applied it to the code.

@tarekgh @GrabYourPitchforks PTAL

I have to leave home now, I am going to provide the updated perf numbers tomorrow. Please don't merge until then. 
