### PR TITLE
Adjust several `where T : class?` constraints

### DIFF
--- a/src/System.Private.CoreLib/shared/Internal/Runtime/CompilerServices/Unsafe.cs
+++ b/src/System.Private.CoreLib/shared/Internal/Runtime/CompilerServices/Unsafe.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 
@@ -71,6 +72,7 @@ namespace Internal.Runtime.CompilerServices
         [Intrinsic]
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NotNullIfNotNull("value")]
         public static T As<T>(object? value) where T : class?
         {
             throw new PlatformNotSupportedException();

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/ConditionalWeakTable.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/ConditionalWeakTable.cs
@@ -12,7 +12,7 @@ using Internal.Runtime.CompilerServices;
 namespace System.Runtime.CompilerServices
 {
     public sealed class ConditionalWeakTable<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue>>
-        where TKey : class?
+        where TKey : class
         where TValue : class?
     {
         // Lifetimes of keys and values:
@@ -59,7 +59,7 @@ namespace System.Runtime.CompilerServices
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
             }
 
-            return _container.TryGetValueWorker(key, out value);
+            return _container.TryGetValueWorker(key!, out value); // TODO-NULLABLE: Remove ! when nullable attributes are respected
         }
 
         /// <summary>Adds a key to the table.</summary>
@@ -80,13 +80,13 @@ namespace System.Runtime.CompilerServices
 
             lock (_lock)
             {
-                int entryIndex = _container.FindEntry(key, out _);
+                int entryIndex = _container.FindEntry(key!, out _); // TODO-NULLABLE: Remove ! when nullable attributes are respected
                 if (entryIndex != -1)
                 {
                     ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_AddingDuplicate);
                 }
 
-                CreateEntry(key, value);
+                CreateEntry(key!, value); // TODO-NULLABLE: Remove ! when nullable attributes are respected
             }
         }
 
@@ -102,7 +102,7 @@ namespace System.Runtime.CompilerServices
 
             lock (_lock)
             {
-                int entryIndex = _container.FindEntry(key, out _);
+                int entryIndex = _container.FindEntry(key!, out _); // TODO-NULLABLE: Remove ! when nullable attributes are respected
 
                 // if we found a key we should just update, if no we should create a new entry.
                 if (entryIndex != -1)
@@ -111,7 +111,7 @@ namespace System.Runtime.CompilerServices
                 }
                 else
                 {
-                    CreateEntry(key, value);
+                    CreateEntry(key!, value); // TODO-NULLABLE: Remove ! when nullable attributes are respected
                 }
             }
         }
@@ -133,7 +133,7 @@ namespace System.Runtime.CompilerServices
 
             lock (_lock)
             {
-                return _container.Remove(key);
+                return _container.Remove(key!); // TODO-NULLABLE: Remove ! when nullable attributes are respected
             }
         }
 
@@ -537,7 +537,7 @@ namespace System.Runtime.CompilerServices
             }
 
             /// <summary>Gets the entry at the specified entry index.</summary>
-            internal bool TryGetEntry(int index, [MaybeNullWhen(false)] out TKey key, [MaybeNullWhen(false)] out TValue value)
+            internal bool TryGetEntry(int index, [MaybeNull, NotNullWhen(true)] out TKey key, [MaybeNullWhen(false)] out TValue value)
             {
                 if (index < _entries.Length)
                 {

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/ConditionalWeakTable.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/ConditionalWeakTable.cs
@@ -59,7 +59,7 @@ namespace System.Runtime.CompilerServices
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
             }
 
-            return _container.TryGetValueWorker(key!, out value); // TODO-NULLABLE: Remove ! when nullable attributes are respected
+            return _container.TryGetValueWorker(key!, out value); // TODO-NULLABLE: Remove ! when [DoesNotReturn] respected
         }
 
         /// <summary>Adds a key to the table.</summary>
@@ -80,13 +80,13 @@ namespace System.Runtime.CompilerServices
 
             lock (_lock)
             {
-                int entryIndex = _container.FindEntry(key!, out _); // TODO-NULLABLE: Remove ! when nullable attributes are respected
+                int entryIndex = _container.FindEntry(key!, out _); // TODO-NULLABLE: Remove ! when [DoesNotReturn] respected
                 if (entryIndex != -1)
                 {
                     ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_AddingDuplicate);
                 }
 
-                CreateEntry(key!, value); // TODO-NULLABLE: Remove ! when nullable attributes are respected
+                CreateEntry(key!, value); // TODO-NULLABLE: Remove ! when [DoesNotReturn] respected
             }
         }
 
@@ -102,7 +102,7 @@ namespace System.Runtime.CompilerServices
 
             lock (_lock)
             {
-                int entryIndex = _container.FindEntry(key!, out _); // TODO-NULLABLE: Remove ! when nullable attributes are respected
+                int entryIndex = _container.FindEntry(key!, out _); // TODO-NULLABLE: Remove ! when [DoesNotReturn] respected
 
                 // if we found a key we should just update, if no we should create a new entry.
                 if (entryIndex != -1)
@@ -111,7 +111,7 @@ namespace System.Runtime.CompilerServices
                 }
                 else
                 {
-                    CreateEntry(key!, value); // TODO-NULLABLE: Remove ! when nullable attributes are respected
+                    CreateEntry(key!, value); // TODO-NULLABLE: Remove ! when [DoesNotReturn] respected
                 }
             }
         }
@@ -133,7 +133,7 @@ namespace System.Runtime.CompilerServices
 
             lock (_lock)
             {
-                return _container.Remove(key!); // TODO-NULLABLE: Remove ! when nullable attributes are respected
+                return _container.Remove(key!); // TODO-NULLABLE: Remove ! when [DoesNotReturn] respected
             }
         }
 
@@ -337,9 +337,9 @@ namespace System.Runtime.CompilerServices
                             while (_currentIndex < _maxIndexInclusive)
                             {
                                 _currentIndex++;
-                                if (c.TryGetEntry(_currentIndex, out TKey key, out TValue value))
+                                if (c.TryGetEntry(_currentIndex, out TKey? key, out TValue value))
                                 {
-                                    _current = new KeyValuePair<TKey, TValue>(key, value);
+                                    _current = new KeyValuePair<TKey, TValue>(key!, value); // TODO-NULLABLE: Remove ! when nullable attributes are respected
                                     return true;
                                 }
                             }
@@ -537,7 +537,7 @@ namespace System.Runtime.CompilerServices
             }
 
             /// <summary>Gets the entry at the specified entry index.</summary>
-            internal bool TryGetEntry(int index, [MaybeNull, NotNullWhen(true)] out TKey key, [MaybeNullWhen(false)] out TValue value)
+            internal bool TryGetEntry(int index, [NotNullWhen(true)] out TKey? key, [MaybeNullWhen(false)] out TValue value)
             {
                 if (index < _entries.Length)
                 {
@@ -552,7 +552,7 @@ namespace System.Runtime.CompilerServices
                     }
                 }
 
-                key = default!;
+                key = default;
                 value = default!;
                 return false;
             }

--- a/src/System.Private.CoreLib/shared/System/WeakReference.T.cs
+++ b/src/System.Private.CoreLib/shared/System/WeakReference.T.cs
@@ -52,7 +52,7 @@ namespace System
         //          DoSomething(ref.Target)
         //
         [MethodImplAttribute(MethodImplOptions.AggressiveInlining)]
-        public bool TryGetTarget([NotNullWhen(true)] out T target)
+        public bool TryGetTarget([MaybeNull, NotNullWhen(true)] out T target)
         {
             // Call the worker method that has more performant but less user friendly signature.
             T o = this.Target;

--- a/src/System.Private.CoreLib/src/System/WeakReference.T.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/WeakReference.T.CoreCLR.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using System.Runtime.CompilerServices;
 
@@ -19,6 +20,7 @@ namespace System
         }
 
         // This is property for better debugging experience (VS debugger shows values of properties when you hover over the variables)
+        [MaybeNull]
         private extern T Target
         {
             [MethodImplAttribute(MethodImplOptions.InternalCall)]


### PR DESCRIPTION
Fixing a few constraints and attributes.

For `ConditionalWeakTable`, keys aren't allowed to be null, so I changed the `class?` to `class`.

For `WeakReference<T>`, we need to make the TryGetTarget have both `[NotNullWhen(true)]` and `[MaybeNull]`, as the former won't imply the latter.  I went back and forth on whether to add `[AllowNull]` to the `ctor` and `SetTarget` arguments, but for now decided not to add them; I could probably be convinced either way.

cc: @dotnet/nullablefc 