### PR TITLE
Fix `EventPipe::Disable` threading issues.

### DIFF
--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -489,22 +489,25 @@ void EventPipe::DisableInternal(EventPipeSessionID id, EventPipeProviderCallback
 EventPipeSession *EventPipe::GetSession(EventPipeSessionID id)
 {
     LIMITED_METHOD_CONTRACT;
-	_ASSERTE(s_tracingInitialized);
-    CrstHolder _crst(GetLock()); // TODO: Is this correct?
+    _ASSERTE(s_tracingInitialized);
 
     if (!s_tracingInitialized)
         return nullptr;
 
-    // Attempt to get the specified session ID.
-    const uint64_t index = GetArrayIndex(id);
-    if (index >= 64)
     {
-        _ASSERTE(!"Computed index was out of range.");
-        return nullptr;
-    }
+        CrstHolder _crst(GetLock());
 
-    return s_pSessions[index].LoadWithoutBarrier() != nullptr ?
-        s_pSessions[index].Load() : nullptr;
+        // Attempt to get the specified session ID.
+        const uint64_t index = GetArrayIndex(id);
+        if (index >= 64)
+        {
+            _ASSERTE(!"Computed index was out of range.");
+            return nullptr;
+        }
+
+        return s_pSessions[index].LoadWithoutBarrier() != nullptr ?
+            s_pSessions[index].Load() : nullptr;
+    }
 }
 
 bool EventPipe::Enabled()

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -632,7 +632,6 @@ void EventPipe::WriteEventInternal(EventPipeEvent &event, EventPipeEventPayload 
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        PRECONDITION(s_tracingInitialized);
     }
     CONTRACTL_END;
 

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -245,11 +245,11 @@ void EventPipe::Shutdown()
     // We are shutting down, so if disabling EventPipe throws, we need to move along anyway.
     EX_TRY
     {
-        for (auto session : s_pSessions)
+        for (uint32_t i = 0; i < MaxNumberOfSessions; ++i)
         {
-            EventPipeSession *pSession = session.Load();
+            EventPipeSession *pSession = s_pSessions[i].Load();
             if (pSession)
-                Disable(pSession->GetId());
+                Disable(static_cast<EventPipeSessionID>(1 << i));
         }
     }
     EX_CATCH {}

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -258,6 +258,8 @@ void EventPipe::Shutdown()
     // We need to do this after disabling sessions since those try to write to EventPipeEventSource.
     delete s_pEventSource;
     s_pEventSource = nullptr;
+
+    s_config.Shutdown();
 }
 
 EventPipeSessionID EventPipe::Enable(

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -435,10 +435,8 @@ void EventPipe::DisableInternal(EventPipeSessionID id, EventPipeProviderCallback
         return;
     }
 
-    EventPipeSession *const pSession = s_pSessions[index].LoadWithoutBarrier() != nullptr ?
-        s_pSessions[index].Load() : nullptr;
-
     // If the session was not found, then there is nothing else to do.
+    EventPipeSession *const pSession = s_pSessions[index];
     if (pSession == nullptr)
         return;
 
@@ -507,8 +505,7 @@ EventPipeSession *EventPipe::GetSession(EventPipeSessionID id)
             return nullptr;
         }
 
-        return s_pSessions[index].LoadWithoutBarrier() != nullptr ?
-            s_pSessions[index].Load() : nullptr;
+        return s_pSessions[index];
     }
 }
 

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -249,7 +249,7 @@ void EventPipe::Shutdown()
         {
             EventPipeSession *pSession = s_pSessions[i].Load();
             if (pSession)
-                Disable(static_cast<EventPipeSessionID>(1 << i));
+                Disable(static_cast<EventPipeSessionID>(1ULL << i));
         }
     }
     EX_CATCH {}

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -371,6 +371,7 @@ private:
     static void ForEachSession(EventPipeSessionHandlerCallback callback)
     {
         LIMITED_METHOD_CONTRACT;
+        _ASSERTE(IsLockOwnedByCurrentThread());
 
         for (Volatile<EventPipeSession *> &session : s_pSessions)
         {

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -373,7 +373,7 @@ private:
         LIMITED_METHOD_CONTRACT;
         _ASSERTE(IsLockOwnedByCurrentThread());
 
-        for (Volatile<EventPipeSession *> &session : s_pSessions)
+        for (VolatilePtr<EventPipeSession> &session : s_pSessions)
         {
             // Entering EventPipe lock gave us a barrier, we don't need
             // more of them
@@ -394,8 +394,7 @@ private:
     static Volatile<bool> s_tracingInitialized;
     static EventPipeConfiguration s_config;
     static const uint32_t MaxNumberOfSessions = 64;
-    static Volatile<EventPipeSession *> s_pSessions[MaxNumberOfSessions];
-    static Volatile<EventPipeSession *> s_pRundownSession;
+    static VolatilePtr<EventPipeSession> s_pSessions[MaxNumberOfSessions];
     static EventPipeEventSource *s_pEventSource;
     static HANDLE s_fileSwitchTimerHandle;
     static ULONGLONG s_lastFlushTime;

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -383,14 +383,6 @@ private:
         }
     }
 
-    // Get the configuration object.
-    // This is called directly by the EventPipeProvider constructor to register the new provider.
-    static EventPipeConfiguration *GetConfiguration()
-    {
-        LIMITED_METHOD_CONTRACT;
-        return s_pConfig;
-    }
-
     // Get the event pipe configuration lock.
     static CrstStatic *GetLock()
     {
@@ -399,8 +391,8 @@ private:
     }
 
     static CrstStatic s_configCrst;
-    static bool s_tracingInitialized;
-    static EventPipeConfiguration *s_pConfig; // Volatile?
+    static Volatile<bool> s_tracingInitialized;
+    static EventPipeConfiguration s_config;
     static const uint32_t MaxNumberOfSessions = 64;
     static Volatile<EventPipeSession *> s_pSessions[MaxNumberOfSessions];
     static Volatile<EventPipeSession *> s_pRundownSession;

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -355,7 +355,20 @@ public:
 
 private:
     // The counterpart to WriteEvent which after the payload is constructed
-    static void WriteEventInternal(EventPipeEvent &event, EventPipeEventPayload &payload, LPCGUID pActivityId = NULL, LPCGUID pRelatedActivityId = NULL);
+    static void WriteEventInternal(
+        EventPipeEvent &event,
+        EventPipeEventPayload &payload,
+        LPCGUID pActivityId = nullptr,
+        LPCGUID pRelatedActivityId = nullptr);
+
+    static void WriteEventInternal(
+        Thread *pThread,
+        EventPipeEvent &event,
+        EventPipeEventPayload &payload,
+        LPCGUID pActivityId,
+        LPCGUID pRelatedActivityId,
+        Thread *pEventThread = nullptr,
+        StackContents *pStack = nullptr);
 
     static void DisableInternal(EventPipeSessionID id, EventPipeProviderCallbackDataQueue* pEventPipeProviderCallbackDataQueue);
 

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -371,7 +371,6 @@ private:
     static void ForEachSession(EventPipeSessionHandlerCallback callback)
     {
         LIMITED_METHOD_CONTRACT;
-        _ASSERTE(IsLockOwnedByCurrentThread());
 
         for (Volatile<EventPipeSession *> &session : s_pSessions)
         {

--- a/src/vm/eventpipebuffermanager.cpp
+++ b/src/vm/eventpipebuffermanager.cpp
@@ -414,16 +414,6 @@ bool EventPipeBufferManager::WriteEvent(Thread *pThread, EventPipeSession &sessi
         return false;
     }
 
-    // TODO: Checking twice? Why not more times?
-    // Check one more time to make sure that the event is still enabled.
-    // We do this because we might be trying to disable tracing and free buffers, so we
-    // must make sure that the event is enabled after we mark that we're writing to avoid
-    // races with the destructing thread.
-    if (!event.IsEnabled())
-    {
-        return false;
-    }
-
     StackContents stackContents;
     if (pStack == NULL && event.NeedStack() && !session.RundownEnabled())
     {
@@ -508,7 +498,6 @@ bool EventPipeBufferManager::WriteEvent(Thread *pThread, EventPipeSession &sessi
     }
 
 #ifdef _DEBUG
-    // TODO: These stats might need to be protected.
     if (!allocNewBuffer)
     {
         InterlockedIncrement(&m_numEventsStored);
@@ -779,8 +768,6 @@ void EventPipeBufferManager::SuspendWriteEvent(EventPipeSessionID sessionId)
                     // setting s_pSessions[this_session_id] = NULL above guaranteed that can't happen indefinately.
                     // Sooner or later the thread is going to see the NULL value and once it does it won't store
                     // this_session_id into the flag again.
-                    // As above I'm pretty sure this read barrier isn't necessary for correctness, but this isn't the hot
-                    // path so I am not being stingy
                 }
             }
 

--- a/src/vm/eventpipebuffermanager.h
+++ b/src/vm/eventpipebuffermanager.h
@@ -51,6 +51,9 @@ class EventPipeThread
     // it is protected by EventPipeBufferManager::m_lock
     EventPipeBufferLists *m_pBufferLists = nullptr;
 
+    //
+    bool m_isWritingEvent = false;
+
     // This lock is designed to have low contention. Normally it is only taken by this thread,
     // but occasionally it may also be taken by another thread which is trying to collect and drain
     // buffers from all threads.
@@ -82,6 +85,18 @@ public:
     EventPipeBufferList *GetBufferList(EventPipeBufferManager *pBufferManager);
     void SetBufferList(EventPipeBufferManager *pBufferManager, EventPipeBufferList *pBufferList);
     void Remove(EventPipeBufferManager *pBufferManager);
+
+    void SetWritingEvent(bool isWritingEvent)
+    {
+        LIMITED_METHOD_CONTRACT;
+        m_isWritingEvent = isWritingEvent;
+    }
+
+    bool IsWritingEvent() const
+    {
+        LIMITED_METHOD_CONTRACT;
+        return m_isWritingEvent;
+    }
 };
 
 class EventPipeBufferManager
@@ -105,7 +120,6 @@ private:
 
     // Lock to protect access to the per-thread buffer list and total allocation size.
     SpinLock m_lock;
-    Volatile<BOOL> m_writeEventSuspending;
 
 #ifdef _DEBUG
     // For debugging purposes.
@@ -146,7 +160,7 @@ public:
     // Ends the suspension period created by SuspendWriteEvent(). After this call returns WriteEvent()
     // can again be called succesfully, new BufferLists and Buffers may be allocated.
     // The caller is required to synchronize all calls to SuspendWriteEvent() and ResumeWriteEvent()
-    void ResumeWriteEvent();
+    void ResumeWriteEvent(); // TODO: Remove this. Not used anymore.
 
     // From the time this function returns until ResumeWriteEvent() is called a suspended state will
     // be in effect that blocks all WriteEvent activity. All existing buffers will be in the

--- a/src/vm/eventpipebuffermanager.h
+++ b/src/vm/eventpipebuffermanager.h
@@ -8,13 +8,13 @@
 #ifdef FEATURE_PERFTRACING
 
 #include "eventpipe.h"
-#include "eventpipefile.h"
-#include "eventpipebuffer.h"
-#include "eventpipesession.h"
 #include "spinlock.h"
 
+class EventPipeBuffer;
 class EventPipeBufferList;
 class EventPipeBufferManager;
+class EventPipeFile;
+class EventPipeSession;
 class EventPipeThread;
 
 void ReleaseEventPipeThreadRef(EventPipeThread* pThread);
@@ -24,14 +24,15 @@ typedef Wrapper<EventPipeThread*, AcquireEventPipeThreadRef, ReleaseEventPipeThr
 typedef MapSHashWithRemove<EventPipeBufferManager *, EventPipeBuffer *> EventPipeWriteBuffers;
 typedef MapSHashWithRemove<EventPipeBufferManager *, EventPipeBufferList *> EventPipeBufferLists;
 
+#ifndef __GNUC__
+  #define EVENTPIPE_THREAD_LOCAL __declspec(thread)
+#else  // !__GNUC__
+  #define EVENTPIPE_THREAD_LOCAL thread_local
+#endif // !__GNUC__
+
 class EventPipeThread
 {
-#ifndef __GNUC__
-    __declspec(thread) static
-#else  // !__GNUC__
-    thread_local static
-#endif // !__GNUC__
-        EventPipeThreadHolder gCurrentEventPipeThreadHolder;
+    static EVENTPIPE_THREAD_LOCAL EventPipeThreadHolder gCurrentEventPipeThreadHolder;
 
     ~EventPipeThread();
 
@@ -51,13 +52,13 @@ class EventPipeThread
     // it is protected by EventPipeBufferManager::m_lock
     EventPipeBufferLists *m_pBufferLists = nullptr;
 
-    //
-    bool m_isWritingEvent = false;
-
     // This lock is designed to have low contention. Normally it is only taken by this thread,
     // but occasionally it may also be taken by another thread which is trying to collect and drain
     // buffers from all threads.
     SpinLock m_lock;
+
+    //
+    EventPipeSession *m_pRundownSession = nullptr;
 
 #ifdef DEBUG
     template <typename T>
@@ -73,12 +74,32 @@ class EventPipeThread
 
 public:
     static EventPipeThread *Get();
+    static EventPipeThread *GetOrCreate();
     static void Set(EventPipeThread *pThread);
+
+    bool IsRundownThread() const
+    {
+        LIMITED_METHOD_CONTRACT;
+        return (m_pRundownSession != nullptr);
+    }
+
+    void SetAsRundownThread(EventPipeSession *pSession)
+    {
+        LIMITED_METHOD_CONTRACT;
+        m_pRundownSession = pSession;
+    }
+
+    EventPipeSession *GetRundownSession() const
+    {
+        LIMITED_METHOD_CONTRACT;
+        return m_pRundownSession;
+    }
 
     EventPipeThread();
     void AddRef();
     void Release();
     SpinLock *GetLock();
+    Volatile<EventPipeSessionID> m_writingEventInProgress;
 
     EventPipeBuffer *GetWriteBuffer(EventPipeBufferManager *pBufferManager);
     void SetWriteBuffer(EventPipeBufferManager *pBufferManager, EventPipeBuffer *pNewBuffer);
@@ -86,16 +107,16 @@ public:
     void SetBufferList(EventPipeBufferManager *pBufferManager, EventPipeBufferList *pBufferList);
     void Remove(EventPipeBufferManager *pBufferManager);
 
-    void SetWritingEvent(bool isWritingEvent)
+    void SetSessionWriteInProgress(uint64_t index)
     {
         LIMITED_METHOD_CONTRACT;
-        m_isWritingEvent = isWritingEvent;
+        m_writingEventInProgress.Store((index < 64) ? (1ULL << index) : UINT64_MAX);
     }
 
-    bool IsWritingEvent() const
+    EventPipeSessionID GetSessionWriteInProgress() const
     {
         LIMITED_METHOD_CONTRACT;
-        return m_isWritingEvent;
+        return m_writingEventInProgress.Load();
     }
 };
 
@@ -120,6 +141,7 @@ private:
 
     // Lock to protect access to the per-thread buffer list and total allocation size.
     SpinLock m_lock;
+    Volatile<BOOL> m_writeEventSuspending;
 
 #ifdef _DEBUG
     // For debugging purposes.
@@ -157,13 +179,7 @@ public:
     // Otherwise, if a stack trace is needed, one will be automatically collected.
     bool WriteEvent(Thread *pThread, EventPipeSession &session, EventPipeEvent &event, EventPipeEventPayload &payload, LPCGUID pActivityId, LPCGUID pRelatedActivityId, Thread *pEventThread = NULL, StackContents *pStack = NULL);
 
-    // Ends the suspension period created by SuspendWriteEvent(). After this call returns WriteEvent()
-    // can again be called succesfully, new BufferLists and Buffers may be allocated.
-    // The caller is required to synchronize all calls to SuspendWriteEvent() and ResumeWriteEvent()
-    void ResumeWriteEvent(); // TODO: Remove this. Not used anymore.
-
-    // From the time this function returns until ResumeWriteEvent() is called a suspended state will
-    // be in effect that blocks all WriteEvent activity. All existing buffers will be in the
+    // Suspends all WriteEvent activity. All existing buffers will be in the
     // READ_ONLY state and no new EventPipeBuffers or EventPipeBufferLists can be created. Calls to
     // WriteEvent that start during the suspension period or were in progress but hadn't yet recorded
     // their event into a buffer before the start of the suspension period will return false and the
@@ -172,8 +188,7 @@ public:
     // EXPECTED USAGE: First the caller will disable all events via configuration, then call
     // SuspendWriteEvent() to force any WriteEvent calls that may still be in progress to either
     // finish or cancel. After that all BufferLists and Buffers can be safely drained and/or deleted.
-    // The caller is required to synchronize all calls to SuspendWriteEvent() and ResumeWriteEvent()
-    void SuspendWriteEvent();
+    void SuspendWriteEvent(EventPipeSessionID sessionId);
 
     // Write the contents of the managed buffers to the specified file.
     // The stopTimeStamp is used to determine when tracing was stopped to ensure that we

--- a/src/vm/eventpipeconfiguration.cpp
+++ b/src/vm/eventpipeconfiguration.cpp
@@ -14,13 +14,6 @@
 
 const WCHAR *EventPipeConfiguration::s_configurationProviderName = W("Microsoft-DotNETCore-EventPipeConfiguration");
 
-EventPipeConfiguration::EventPipeConfiguration() : m_pProviderList(new SList<SListElem<EventPipeProvider *>>()),
-                                                   m_pConfigProvider(nullptr),
-                                                   m_activeSessions(0)
-{
-    STANDARD_VM_CONTRACT;
-}
-
 void EventPipeConfiguration::Initialize()
 {
     CONTRACTL
@@ -30,6 +23,8 @@ void EventPipeConfiguration::Initialize()
         MODE_PREEMPTIVE;
     }
     CONTRACTL_END;
+
+    m_pProviderList = new SList<SListElem<EventPipeProvider *>>();
 
     EventPipe::RunWithCallbackPostponed([&](EventPipeProviderCallbackDataQueue *pEventPipeProviderCallbackDataQueue) {
         // Create the configuration provider.

--- a/src/vm/eventpipeconfiguration.cpp
+++ b/src/vm/eventpipeconfiguration.cpp
@@ -21,6 +21,10 @@ void EventPipeConfiguration::Initialize()
         THROWS;
         GC_TRIGGERS;
         MODE_PREEMPTIVE;
+        PRECONDITION(m_pProviderList == nullptr);
+        PRECONDITION(m_pConfigProvider == nullptr);
+        PRECONDITION(m_pMetadataEvent == nullptr);
+        PRECONDITION(m_activeSessions == 0);
     }
     CONTRACTL_END;
 

--- a/src/vm/eventpipeconfiguration.h
+++ b/src/vm/eventpipeconfiguration.h
@@ -18,9 +18,6 @@ class EventPipeSession;
 class EventPipeConfiguration
 {
 public:
-    EventPipeConfiguration() = default;
-    ~EventPipeConfiguration() = default;
-
     // Perform initialization that cannot be performed in the constructor.
     void Initialize();
 

--- a/src/vm/eventpipeconfiguration.h
+++ b/src/vm/eventpipeconfiguration.h
@@ -76,7 +76,7 @@ public:
     void DeleteSession(EventPipeSession *pSession);
 
     // Check that a single bit is set.
-    bool IsValidId(EventPipeSessionID id)
+    static bool IsValidId(EventPipeSessionID id)
     {
         return (id > 0) && ((id & (id - 1)) == 0);
     }

--- a/src/vm/eventpipeconfiguration.h
+++ b/src/vm/eventpipeconfiguration.h
@@ -19,10 +19,13 @@ class EventPipeConfiguration
 {
 public:
     EventPipeConfiguration();
-    ~EventPipeConfiguration();
+    ~EventPipeConfiguration() = default;
 
     // Perform initialization that cannot be performed in the constructor.
     void Initialize();
+
+    // Perform cleanup that cannot be performed in the destructor.
+    void Shutdown();
 
     // Create a new provider.
     EventPipeProvider *CreateProvider(const SString &providerName, EventPipeCallback pCallbackFunction, void *pCallbackData, EventPipeProviderCallbackDataQueue *pEventPipeProviderCallbackDataQueue);
@@ -107,7 +110,7 @@ private:
     EventPipeSessionProvider *GetSessionProvider(EventPipeSession &session, EventPipeProvider *pProvider);
 
     // The list of event pipe providers.
-    SList<SListElem<EventPipeProvider *>> *const m_pProviderList;
+    SList<SListElem<EventPipeProvider *>> *m_pProviderList;
 
     // The provider used to write configuration events to the event stream.
     EventPipeProvider *m_pConfigProvider;

--- a/src/vm/eventpipeconfiguration.h
+++ b/src/vm/eventpipeconfiguration.h
@@ -18,7 +18,7 @@ class EventPipeSession;
 class EventPipeConfiguration
 {
 public:
-    EventPipeConfiguration();
+    EventPipeConfiguration() = default;
     ~EventPipeConfiguration() = default;
 
     // Perform initialization that cannot be performed in the constructor.
@@ -110,19 +110,20 @@ private:
     EventPipeSessionProvider *GetSessionProvider(EventPipeSession &session, EventPipeProvider *pProvider);
 
     // The list of event pipe providers.
-    SList<SListElem<EventPipeProvider *>> *m_pProviderList;
+    SList<SListElem<EventPipeProvider *>> *m_pProviderList = nullptr;
 
     // The provider used to write configuration events to the event stream.
-    EventPipeProvider *m_pConfigProvider;
+    EventPipeProvider *m_pConfigProvider = nullptr;
 
     // The event used to write event information to the event stream.
-    EventPipeEvent *m_pMetadataEvent;
+    EventPipeEvent *m_pMetadataEvent = nullptr;
 
     // The provider name for the configuration event pipe provider.
     // This provider is used to emit configuration events.
     const static WCHAR *s_configurationProviderName;
 
-    uint64_t m_activeSessions;
+    // Bitmask tracking EventPipe active sessions.
+    uint64_t m_activeSessions = 0;
 };
 
 #endif // FEATURE_PERFTRACING

--- a/src/vm/eventpipeconfiguration.h
+++ b/src/vm/eventpipeconfiguration.h
@@ -18,7 +18,7 @@ class EventPipeSession;
 class EventPipeConfiguration
 {
 public:
-    EventPipeConfiguration(EventPipeSessions *pSessions);
+    EventPipeConfiguration();
     ~EventPipeConfiguration();
 
     // Perform initialization that cannot be performed in the constructor.
@@ -106,11 +106,8 @@ private:
     // Get the enabled provider.
     EventPipeSessionProvider *GetSessionProvider(EventPipeSession &session, EventPipeProvider *pProvider);
 
-    // The list of EventPipe sessions.
-    EventPipeSessions *const m_pSessions;
-
     // The list of event pipe providers.
-    SList<SListElem<EventPipeProvider *>> *m_pProviderList;
+    SList<SListElem<EventPipeProvider *>> *const m_pProviderList;
 
     // The provider used to write configuration events to the event stream.
     EventPipeProvider *m_pConfigProvider;

--- a/src/vm/eventpipesession.cpp
+++ b/src/vm/eventpipesession.cpp
@@ -432,9 +432,6 @@ void EventPipeSession::Disable()
     }
     CONTRACTL_END;
 
-    if (m_pFile == nullptr)
-        return;
-
     DisableIpcStreamingThread();
 
     // Force all in-progress writes to either finish or cancel

--- a/src/vm/eventpipesession.cpp
+++ b/src/vm/eventpipesession.cpp
@@ -25,8 +25,7 @@ EventPipeSession::EventPipeSession(
                            m_CircularBufferSizeInBytes(static_cast<size_t>(circularBufferSizeInMB) << 20),
                            m_pBufferManager(new EventPipeBufferManager()),
                            m_rundownEnabled(rundownEnabled),
-                           m_SessionType(sessionType),
-                           m_writeEventSuspending(false)
+                           m_SessionType(sessionType)
 {
     CONTRACTL
     {
@@ -184,14 +183,17 @@ DWORD WINAPI EventPipeSession::ThreadProc(void *args)
 
             if (!fSuccess)
             {
-                EventPipe::RunWithCallbackPostponed([pEventPipeSession](EventPipeProviderCallbackDataQueue *pEventPipeProviderCallbackDataQueue){pEventPipeSession->Disable();});
+                // TODO: Notify `EventPipe::Disable` instead, this would disable the session, and remove it from the active list.
+                EventPipe::RunWithCallbackPostponed([pEventPipeSession](EventPipeProviderCallbackDataQueue *pEventPipeProviderCallbackDataQueue) {
+                    pEventPipeSession->Disable();
+                });
             }
         }
         EX_CATCH
         {
             pEventPipeSession->SetThreadShutdownEvent();
             // TODO: STRESS_LOG ?
-            // TODO: Should we notify EventPipe itself to remove this session from the list.
+            // TODO: Notify `EventPipe` itself to remove this session from the list.
         }
         EX_END_CATCH(SwallowAllExceptions);
     }
@@ -236,7 +238,7 @@ bool EventPipeSession::IsValid()
     }
     CONTRACTL_END;
 
-    return (m_pProviderList != nullptr) && (!m_pProviderList->IsEmpty());
+    return !m_pProviderList->IsEmpty();
 }
 
 void EventPipeSession::AddSessionProvider(EventPipeSessionProvider *pProvider)
@@ -393,7 +395,6 @@ void EventPipeSession::EnableRundown()
             Config.GetFilterData()));
     }
 
-    m_pRundownThread = GetThread();
     m_rundownEnabled = true;
 }
 
@@ -438,8 +439,7 @@ void EventPipeSession::Disable()
 
     // Force all in-progress writes to either finish or cancel
     // This is required to ensure we can safely flush and delete the buffers
-    m_writeEventSuspending.Store(true);
-    m_pBufferManager->SuspendWriteEvent();
+    m_pBufferManager->SuspendWriteEvent(GetId());
     WriteAllBuffersToFile();
     m_pProviderList->Clear();
 }

--- a/src/vm/eventpipesession.h
+++ b/src/vm/eventpipesession.h
@@ -68,6 +68,9 @@ private:
     //
     Thread *m_pRundownThread = nullptr;
 
+    //
+    Volatile<bool> m_writeEventSuspending;
+
     void CreateIpcStreamingThread();
 
     static DWORD WINAPI ThreadProc(void *args);
@@ -141,6 +144,13 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
         return m_ipcStreamingEnabled;
+    }
+
+    // Determine if rundown is enabled.
+    bool IsWriteEventSuspending() const
+    {
+        LIMITED_METHOD_CONTRACT;
+        return m_writeEventSuspending;
     }
 
     // Add a new provider to the session.

--- a/src/vm/eventpipesession.h
+++ b/src/vm/eventpipesession.h
@@ -32,7 +32,7 @@ private:
     const EventPipeSessionID m_Id;
 
     // The set of configurations for each provider in the session.
-    EventPipeSessionProviderList *m_pProviderList;
+    EventPipeSessionProviderList *const m_pProviderList;
 
     // The configured size of the circular buffer.
     const size_t m_CircularBufferSizeInBytes;
@@ -64,12 +64,6 @@ private:
 
     //
     CLREvent m_threadShutdownEvent;
-
-    //
-    Thread *m_pRundownThread = nullptr;
-
-    //
-    Volatile<bool> m_writeEventSuspending;
 
     void CreateIpcStreamingThread();
 
@@ -127,12 +121,6 @@ public:
         return m_sessionStartTime;
     }
 
-    bool IsRundownThread() const
-    {
-        LIMITED_METHOD_CONTRACT;
-        return (m_pRundownThread == GetThread());
-    }
-
     // Get the session start timestamp.
     LARGE_INTEGER GetStartTimeStamp() const
     {
@@ -144,13 +132,6 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
         return m_ipcStreamingEnabled;
-    }
-
-    // Determine if rundown is enabled.
-    bool IsWriteEventSuspending() const
-    {
-        LIMITED_METHOD_CONTRACT;
-        return m_writeEventSuspending;
     }
 
     // Add a new provider to the session.


### PR DESCRIPTION
`EventPipe::WriteEvent*` does not use the `EventPipe::Crst` which created race conditions with other methods such as EventPipe::Disable.