### PR TITLE
Move EventPipeEventSource deletion to a better place

### DIFF
--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -259,6 +259,11 @@ void EventPipe::Shutdown()
     EX_CATCH {}
     EX_END_CATCH(SwallowAllExceptions);
 
+    // Remove EventPipeEventSource first since it tries to use the data structures that we remove below.
+    // We need to do this after Disabling sessions since those try to write to EventPipeEventSource.
+    delete s_pEventSource;
+    s_pEventSource = nullptr;
+
     EventPipeConfiguration *pConfig = s_pConfig;
     EventPipeSessions *pSessions = s_pSessions;
 
@@ -271,8 +276,6 @@ void EventPipe::Shutdown()
     // Free resources.
     delete pConfig;
     delete pSessions;
-    delete s_pEventSource;
-    s_pEventSource = nullptr;
 }
 
 EventPipeSessionID EventPipe::Enable(

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -260,7 +260,7 @@ void EventPipe::Shutdown()
     EX_END_CATCH(SwallowAllExceptions);
 
     // Remove EventPipeEventSource first since it tries to use the data structures that we remove below.
-    // We need to do this after Disabling sessions since those try to write to EventPipeEventSource.
+    // We need to do this after disabling sessions since those try to write to EventPipeEventSource.
     delete s_pEventSource;
     s_pEventSource = nullptr;
 


### PR DESCRIPTION
Inside the destructor of `EventPipeEventSource` we call EventPipe::DeleteProvider(). This always failed because we already removed the s_pConfig and s_pSessions by the time we call this destructor. Moving it to a better spot so that we can successfully call DeleteProvider(). 