### PR TITLE
AutoTrace - stress testing for EventPipe

### DIFF
--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${ARCH_SOURCES_DIR})
 
+add_definitions(-DFEATURE_AUTO_TRACE)
 add_definitions(-DUNICODE)
 add_definitions(-D_UNICODE)
 
@@ -308,6 +309,7 @@ set(VM_SOURCES_WKS
     comwaithandle.cpp
     customattribute.cpp
     custommarshalerinfo.cpp
+    autotrace.cpp
     diagnosticserver.cpp
     dllimportcallback.cpp
     eeconfig.cpp
@@ -422,6 +424,7 @@ set(VM_HEADERS_WKS
     comwaithandle.h
     customattribute.h
     custommarshalerinfo.h
+    autotrace.h
     diagnosticserver.h
     diagnosticsprotocol.h
     dllimportcallback.h

--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -4,7 +4,8 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${ARCH_SOURCES_DIR})
 
-add_definitions(-DFEATURE_AUTO_TRACE)
+# EventPipe stress testing support
+# add_definitions(-DFEATURE_AUTO_TRACE)
 add_definitions(-DUNICODE)
 add_definitions(-D_UNICODE)
 

--- a/src/vm/autotrace.cpp
+++ b/src/vm/autotrace.cpp
@@ -1,0 +1,69 @@
+#include "common.h" // Required for pre-compiled header
+
+#ifdef FEATURE_AUTO_TRACE
+
+#include "pal.h"
+
+HANDLE auto_trace_event;
+
+void auto_trace_init()
+{
+    auto_trace_event = CreateEventW(
+        /* lpEventAttributes = */ NULL,
+        /* bManualReset      = */ FALSE,
+        /* bInitialState     = */ FALSE,
+        /* lpName            = */ nullptr
+    );
+}
+
+void auto_trace_launch()
+{
+    DWORD currentProcessId = GetCurrentProcessId();
+    STARTUPINFO si;
+    ZeroMemory(&si, sizeof(si));
+    si.cb = sizeof(STARTUPINFO);
+#ifndef FEATURE_PAL
+    si.dwFlags = STARTF_USESHOWWINDOW;
+    si.wShowWindow = SW_HIDE;
+#endif
+    
+    PROCESS_INFORMATION result;
+    #ifdef FEATURE_PAL
+    const char16_t* commandFormat = u"/Users/andrewau/git/diagnostics/src/Tools/dotnet-trace/run.sh collect --providers Microsoft-Windows-DotNETRuntime:FFFFFFFFFFFFFFBF -p %d";
+    #else
+    const char16_t* commandFormat = u"C:\\Windows\\System32\\cmd.exe /c run.cmd collect --providers Microsoft-Windows-DotNETRuntime:FFFFFFFFFFFFFFBF -p %d";
+    #endif
+    size_t len = wcslen(commandFormat) + 10 + 1;
+    char16_t* command = new char16_t[len];
+    _snwprintf_s(command, len, _TRUNCATE, commandFormat, currentProcessId);
+    const char16_t* currentDirectory = u"C:\\Dev\\diagnostics\\src\\Tools\\dotnet-trace";
+
+    BOOL code = CreateProcessW(
+        /* lpApplicationName    = */ nullptr,
+        /* lpCommandLine        = */ command,
+        /* lpCommandLine        = */ nullptr,
+        /* lpThreadAttributes   = */ nullptr,
+        /* bInheritHandles      = */ false,
+        /* dwCreationFlags      = */ CREATE_NEW_CONSOLE,
+        /* lpEnvironment        = */ nullptr,
+        /* lpCurrentDirectory   = */ currentDirectory,
+        /* lpStartupInfo        = */ &si,
+        /* lpProcessInformation = */ &result
+    );
+    delete[] command;
+}
+
+void auto_trace_wait()
+{
+    WaitForSingleObject(auto_trace_event, INFINITE);
+}
+
+void auto_trace_signal()
+{
+    #ifdef SetEvent
+    #undef SetEvent
+    #endif
+    SetEvent(auto_trace_event);    
+}
+
+#endif // FEATURE_AUTO_TRACE

--- a/src/vm/autotrace.cpp
+++ b/src/vm/autotrace.cpp
@@ -94,7 +94,6 @@ void auto_trace_signal()
     #undef SetEvent
     #endif
     static size_t nCalls = 0;
-    fprintf(stdout, "%d", nCalls);
     if (++nCalls == g_n_tracers)
         SetEvent(auto_trace_event);
 }

--- a/src/vm/autotrace.h
+++ b/src/vm/autotrace.h
@@ -4,6 +4,7 @@
 
 void auto_trace_init();
 void auto_trace_launch();
+void auto_trace_launch_internal();
 void auto_trace_wait();
 void auto_trace_signal();
 

--- a/src/vm/autotrace.h
+++ b/src/vm/autotrace.h
@@ -1,0 +1,11 @@
+#ifndef __AUTO_TRACE_H__
+#define __AUTO_TRACE_H__
+#ifdef FEATURE_AUTO_TRACE
+
+void auto_trace_init();
+void auto_trace_launch();
+void auto_trace_wait();
+void auto_trace_signal();
+
+#endif // FEATURE_AUTO_TRACE
+#endif // __AUTO_TRACE_H__

--- a/src/vm/diagnosticserver.cpp
+++ b/src/vm/diagnosticserver.cpp
@@ -13,6 +13,10 @@
 #include "pal.h"
 #endif // FEATURE_PAL
 
+#ifdef FEATURE_AUTO_TRACE
+#include "autotrace.h"
+#endif
+
 #ifdef FEATURE_PERFTRACING
 
 IpcStream::DiagnosticsIpc *DiagnosticServer::s_pIpc = nullptr;
@@ -45,9 +49,12 @@ static DWORD WINAPI DiagnosticsServerThread(LPVOID lpThreadParameter)
         {
             // FIXME: Ideally this would be something like a std::shared_ptr
             IpcStream *pStream = pIpc->Accept(LoggingCallback);
+            
             if (pStream == nullptr)
                 continue;
-
+#ifdef FEATURE_AUTO_TRACE
+            auto_trace_signal();
+#endif
             DiagnosticsIpc::IpcMessage message;
             if (!message.Initialize(pStream))
             {
@@ -128,6 +135,10 @@ bool DiagnosticServer::Initialize()
 
         if (s_pIpc != nullptr)
         {
+#ifdef FEATURE_AUTO_TRACE
+            auto_trace_init();
+            auto_trace_launch();
+#endif
             DWORD dwThreadId = 0;
             HANDLE hThread = ::CreateThread( // TODO: Is it correct to have this "lower" level call here?
                 nullptr,                     // no security attribute
@@ -148,6 +159,9 @@ bool DiagnosticServer::Initialize()
             }
             else
             {
+#ifdef FEATURE_AUTO_TRACE
+                auto_trace_wait();
+#endif
                 // FIXME: Maybe hold on to the thread to abort/cleanup at exit?
                 ::CloseHandle(hThread);
 


### PR DESCRIPTION
AutoTrace is a testability feature for the diagnostics server. Once the diagnostics server is ready to accept a connection, it will launch a configurable external process and wait until a certain number of connections is made to the server before letting the runtime to move on. This allows for deterministic stress testing of EventPipe. In the past, I have used the feature to launch `dotnet-trace` to trace through the whole process for some automated tests, and by doing so, find some bugs in EventPipe, and I believe it will find us more in the future when I expand my test bed to more variants (debuggee/profilee/others ...)

For now, the feature is completely turned off from compilation, it has zero impact to the runtime. To use it,  one must turn it on and recompile during stress testing. The choice to do so is just risk management. If the environment variable `AUTO_TRACE_CMD` is not set, nothing would happen (modulo reading a few environment variables access and a tiny number of checks). If we believe it is okay, I wish we can just turn it on (for CHECK only maybe).

Special thanks to @josalem for productizing the code.