### PR TITLE
[No Merge] CopyBlk copyprop

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/ValueTask.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/ValueTask.cs
@@ -370,6 +370,7 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>Gets an awaiter for this <see cref="ValueTask"/>.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ValueTaskAwaiter GetAwaiter() => new ValueTaskAwaiter(in this);
 
         /// <summary>Configures an awaiter for this <see cref="ValueTask"/>.</summary>

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -6233,6 +6233,22 @@ public:
     void optCopyProp(BasicBlock* block, GenTreeStmt* stmt, GenTree* tree, LclNumToGenTreePtrStack* curSsaName);
     void optBlockCopyPropPopStacks(BasicBlock* block, LclNumToGenTreePtrStack* curSsaName);
     void optBlockCopyProp(BasicBlock* block, LclNumToGenTreePtrStack* curSsaName);
+    void optCopyPropFoldCopyBlks(BasicBlock* block);
+    void optCopyPropThroughCopyBlk(BasicBlock* block);
+    bool optTryGetCopyPropLclVars(GenTree* expr, GenTreeLclVarCommon*& srcLclVar, GenTreeLclVarCommon*& dstLclVar);
+    bool optTryGetCopyPropLclVar(GenTree* op, GenTreeLclVarCommon*& lclVar);
+    void optCopyPropUpdateTree(GenTreeStmt* currStmt, GenTreeStmt* updatedStmt, GenTree* newOpt);
+#ifndef DEBUG
+    bool optTryGetCopyPropNewOpt(GenTree* opt, GenTree*& newOpt);
+#else
+    bool optTryGetCopyPropNewOpt(GenTree*             opt,
+                                 GenTree*&            newOpt,
+                                 GenTree*             currExpr,
+                                 GenTree*             updatedExpr,
+                                 GenTreeLclVarCommon* currLclVar,
+                                 GenTreeLclVarCommon* updatedLclVar,
+                                 bool                 isReverse);
+#endif
     bool optIsSsaLocal(GenTree* tree);
     int optCopyProp_LclVarScore(LclVarDsc* lclVarDsc, LclVarDsc* copyVarDsc, bool preferOp2);
     void optVnCopyProp();


### PR DESCRIPTION
Propagate through struct copies backwards, picking up:
```
x1 (def) = x0 (last use)
x2 (def) = x1 (last use)
```
Converting to
```
x2 (def) = x0 (last use)
```
Next, propagate forwards through struct copies for usage, picking up:
```
x2 (def) = x0 (last use)
use x2 (last use)
```
Converting to
```
use x0 (last use)
```

Example change to `<ReadBlockAsyncInternal>d__20:MoveNext():this`

![image](https://user-images.githubusercontent.com/1142958/58768002-f2aec880-858b-11e9-904c-9a44b87fdbad.png)

While it resolves almost all the copies in `awaiti`ng ValueTasks (and all the copies in the sample in https://github.com/dotnet/coreclr/issues/18542#issuecomment-497850725) in async/await one remains (as above) 😢 

 And 

Sample change from Pipelines `<ReadAsyncInternal>d__23:MoveNext():this`

![image](https://user-images.githubusercontent.com/1142958/58962165-8659e200-87a2-11e9-9f04-8db495339cda.png)

Resolves: https://github.com/dotnet/coreclr/issues/18542

Is a bit messy, but seeking feedback (assuming tests pass) /cc @CarolEidt @AndyAyersMS @mikedn @stephentoub 