### PR TITLE
Specify TaskScheduler.Default in EventPipeEventDispatcher

### DIFF
--- a/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeEventDispatcher.cs
+++ b/src/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipeEventDispatcher.cs
@@ -138,7 +138,7 @@ namespace System.Diagnostics.Tracing
             if (m_dispatchTask == null)
             {
                 m_stopDispatchTask = false;
-                m_dispatchTask = Task.Factory.StartNew(DispatchEventsToEventListeners, TaskCreationOptions.LongRunning);
+                m_dispatchTask = Task.Factory.StartNew(DispatchEventsToEventListeners, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
             }
         }
 


### PR DESCRIPTION
Just in case there's a non-default TaskScheduler in play, explicitly specify TaskScheduler.Default so that we don't accidentally schedule this task to another scheduler, in which case it's up to that scheduler if and how to respect the LongRunning request.

cc: @jorive 