### PR TITLE
Fix some nullable annotations from API Review

### DIFF
--- a/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -200,6 +200,7 @@
     <Compile Include="$(BclSourcesRoot)\System\Reflection\Emit\CustomAttributeBuilder.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Reflection\Emit\DynamicILGenerator.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Reflection\Emit\DynamicMethod.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Reflection\Emit\EmptyCAHolder.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Reflection\Emit\EnumBuilder.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Reflection\Emit\EventBuilder.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Reflection\Emit\FieldBuilder.cs" />

--- a/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -54,8 +54,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <!-- Remove CS8609 once https://github.com/dotnet/roslyn/issues/23268 is resolved -->
-    <NoWarn>$(NoWarn);649,1573,1591,0419,3021,CS8609</NoWarn>
+    <NoWarn>$(NoWarn);649,1573,1591,0419,3021</NoWarn>
     <Nullable>enable</Nullable>
 
     <!-- Ignore all previous constants since SPCL is sensitive to what is defined and the Sdk adds some by default -->

--- a/src/System.Private.CoreLib/shared/System/Activator.RuntimeType.cs
+++ b/src/System.Private.CoreLib/shared/System/Activator.RuntimeType.cs
@@ -116,7 +116,7 @@ namespace System
                 if (assemblyName.ContentType == AssemblyContentType.WindowsRuntime)
                 {
                     // WinRT type - we have to use Type.GetType
-                    type = Type.GetType(typeName + ", " + assemblyString, true /*throwOnError*/, ignoreCase);
+                    type = Type.GetType(typeName + ", " + assemblyString, throwOnError: true, ignoreCase);
                 }
                 else
                 {
@@ -131,7 +131,7 @@ namespace System
                 type = assembly!.GetType(typeName, throwOnError: true, ignoreCase);
             }
 
-            object? o = CreateInstance(type, bindingAttr, binder, args, culture, activationAttributes);
+            object? o = CreateInstance(type!, bindingAttr, binder, args, culture, activationAttributes);
 
             return o != null ? new ObjectHandle(o) : null;          
         }

--- a/src/System.Private.CoreLib/shared/System/Activator.cs
+++ b/src/System.Private.CoreLib/shared/System/Activator.cs
@@ -45,7 +45,7 @@ namespace System
         public static ObjectHandle? CreateInstanceFrom(string assemblyFile, string typeName, bool ignoreCase, BindingFlags bindingAttr, Binder? binder, object?[]? args, CultureInfo? culture, object?[]? activationAttributes)
         {
             Assembly assembly = Assembly.LoadFrom(assemblyFile);
-            Type t = assembly.GetType(typeName, true, ignoreCase);
+            Type t = assembly.GetType(typeName, throwOnError: true, ignoreCase)!;
 
             object? o = CreateInstance(t, bindingAttr, binder, args, culture, activationAttributes);
 

--- a/src/System.Private.CoreLib/shared/System/AppContext.cs
+++ b/src/System.Private.CoreLib/shared/System/AppContext.cs
@@ -17,14 +17,14 @@ namespace System
         private static Dictionary<string, bool>? s_switches;
         private static string? s_defaultBaseDirectory;
 
-        public static string? BaseDirectory
+        public static string BaseDirectory
         {
             get
             {
                 // The value of APP_CONTEXT_BASE_DIRECTORY key has to be a string and it is not allowed to be any other type. 
                 // Otherwise the caller will get invalid cast exception
                 return (string?)GetData("APP_CONTEXT_BASE_DIRECTORY") ??
-                    (s_defaultBaseDirectory ?? (s_defaultBaseDirectory = GetBaseDirectoryCore()));
+                    (s_defaultBaseDirectory ?? (s_defaultBaseDirectory = GetBaseDirectoryCore())) ?? string.Empty;
             }
         }
 

--- a/src/System.Private.CoreLib/shared/System/AppContext.cs
+++ b/src/System.Private.CoreLib/shared/System/AppContext.cs
@@ -24,7 +24,7 @@ namespace System
                 // The value of APP_CONTEXT_BASE_DIRECTORY key has to be a string and it is not allowed to be any other type. 
                 // Otherwise the caller will get invalid cast exception
                 return (string?)GetData("APP_CONTEXT_BASE_DIRECTORY") ??
-                    (s_defaultBaseDirectory ?? (s_defaultBaseDirectory = GetBaseDirectoryCore())) ?? string.Empty;
+                    s_defaultBaseDirectory ?? (s_defaultBaseDirectory = GetBaseDirectoryCore());
             }
         }
 

--- a/src/System.Private.CoreLib/shared/System/ComponentModel/DefaultValueAttribute.cs
+++ b/src/System.Private.CoreLib/shared/System/ComponentModel/DefaultValueAttribute.cs
@@ -30,7 +30,7 @@ namespace System.ComponentModel
         /// class, converting the specified value to the specified type, and using the U.S. English
         /// culture as the translation context.
         /// </summary>
-        public DefaultValueAttribute(Type? type, string? value)
+        public DefaultValueAttribute(Type type, string? value)
         {
             // The null check and try/catch here are because attributes should never throw exceptions.
             // We would fail to load an otherwise normal class.

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -3521,19 +3521,19 @@ namespace System.Diagnostics.Tracing
             if (!reflectionOnly && (staticFieldType == typeof(EventOpcode)) || AttributeTypeNamesMatch(staticFieldType, typeof(EventOpcode)))
             {
                 if (providerEnumKind != "Opcodes") goto Error;
-                int value = (int)staticField.GetRawConstantValue();
+                int value = (int)staticField.GetRawConstantValue()!;
                 manifest.AddOpcode(staticField.Name, value);
             }
             else if (!reflectionOnly && (staticFieldType == typeof(EventTask)) || AttributeTypeNamesMatch(staticFieldType, typeof(EventTask)))
             {
                 if (providerEnumKind != "Tasks") goto Error;
-                int value = (int)staticField.GetRawConstantValue();
+                int value = (int)staticField.GetRawConstantValue()!;
                 manifest.AddTask(staticField.Name, value);
             }
             else if (!reflectionOnly && (staticFieldType == typeof(EventKeywords)) || AttributeTypeNamesMatch(staticFieldType, typeof(EventKeywords)))
             {
                 if (providerEnumKind != "Keywords") goto Error;
-                ulong value = unchecked((ulong)(long)staticField.GetRawConstantValue());
+                ulong value = unchecked((ulong)(long)staticField.GetRawConstantValue()!);
                 manifest.AddKeyword(staticField.Name, value);
             }
 #if FEATURE_MANAGED_ETW_CHANNELS && FEATURE_ADVANCED_MANAGED_ETW_CHANNELS
@@ -3730,7 +3730,7 @@ namespace System.Diagnostics.Tracing
 #if ES_BUILD_STANDALONE
             (new ReflectionPermission(ReflectionPermissionFlag.MemberAccess)).Assert();
 #endif
-            byte[] instrs = method.GetMethodBody().GetILAsByteArray()!;
+            byte[] instrs = method.GetMethodBody()!.GetILAsByteArray()!;
             int retVal = -1;
             for (int idx = 0; idx < instrs.Length;)
             {
@@ -5828,7 +5828,7 @@ namespace System.Diagnostics.Tracing
                     bool anyValuesWritten = false;
                     foreach (FieldInfo staticField in staticFields)
                     {
-                        object constantValObj = staticField.GetRawConstantValue();
+                        object? constantValObj = staticField.GetRawConstantValue();
 
                         if (constantValObj != null)
                         {

--- a/src/System.Private.CoreLib/shared/System/Globalization/TimeSpanParse.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/TimeSpanParse.cs
@@ -655,7 +655,7 @@ namespace System.Globalization
             return false;
         }
 
-        internal static TimeSpan ParseExactMultiple(ReadOnlySpan<char> input, string?[] formats, IFormatProvider? formatProvider, TimeSpanStyles styles)
+        internal static TimeSpan ParseExactMultiple(ReadOnlySpan<char> input, string[] formats, IFormatProvider? formatProvider, TimeSpanStyles styles)
         {
             var parseResult = new TimeSpanResult(throwOnFailure: true, originalTimeSpanString: input);
             bool success = TryParseExactMultipleTimeSpan(input, formats, formatProvider, styles, ref parseResult);
@@ -663,7 +663,7 @@ namespace System.Globalization
             return parseResult.parsedTimeSpan;
         }
 
-        internal static bool TryParseExactMultiple(ReadOnlySpan<char> input, string?[]? formats, IFormatProvider? formatProvider, TimeSpanStyles styles, out TimeSpan result)
+        internal static bool TryParseExactMultiple(ReadOnlySpan<char> input, string[] formats, IFormatProvider? formatProvider, TimeSpanStyles styles, out TimeSpan result)
         {
             var parseResult = new TimeSpanResult(throwOnFailure: false, originalTimeSpanString: input);
 
@@ -1669,7 +1669,7 @@ namespace System.Globalization
         }
 
         /// <summary>Common private ParseExactMultiple method called by both ParseExactMultiple and TryParseExactMultiple.</summary>
-        private static bool TryParseExactMultipleTimeSpan(ReadOnlySpan<char> input, string?[]? formats, IFormatProvider? formatProvider, TimeSpanStyles styles, ref TimeSpanResult result)
+        private static bool TryParseExactMultipleTimeSpan(ReadOnlySpan<char> input, string[] formats, IFormatProvider? formatProvider, TimeSpanStyles styles, ref TimeSpanResult result)
         {
             if (formats == null)
             {
@@ -1690,8 +1690,7 @@ namespace System.Globalization
             // one of the formats.
             for (int i = 0; i < formats.Length; i++)
             {
-                // TODO-NULLABLE: Indexer nullability tracked (https://github.com/dotnet/roslyn/issues/34644)
-                if (formats[i] == null || formats[i]!.Length == 0)
+                if (formats[i] == null || formats[i].Length == 0)
                 {
                     return result.SetBadFormatSpecifierFailure();
                 }

--- a/src/System.Private.CoreLib/shared/System/Nullable.cs
+++ b/src/System.Private.CoreLib/shared/System/Nullable.cs
@@ -71,12 +71,10 @@ namespace System
             return hasValue ? value.GetHashCode() : 0;
         }
 
-#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         public override string? ToString()
         {
             return hasValue ? value.ToString() : "";
         }
-#pragma warning restore CS8609
 
         [NonVersionable]
         public static implicit operator Nullable<T>(T value)

--- a/src/System.Private.CoreLib/shared/System/Nullable.cs
+++ b/src/System.Private.CoreLib/shared/System/Nullable.cs
@@ -71,10 +71,12 @@ namespace System
             return hasValue ? value.GetHashCode() : 0;
         }
 
+#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         public override string? ToString()
         {
             return hasValue ? value.ToString() : "";
         }
+#pragma warning restore CS8609
 
         [NonVersionable]
         public static implicit operator Nullable<T>(T value)

--- a/src/System.Private.CoreLib/shared/System/Reflection/Assembly.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Assembly.cs
@@ -92,9 +92,9 @@ namespace System.Reflection
         public virtual AssemblyName GetName() => GetName(copiedName: false);
         public virtual AssemblyName GetName(bool copiedName) { throw NotImplemented.ByDesign; }
 
-        public virtual Type GetType(string name) => GetType(name, throwOnError: false, ignoreCase: false);
-        public virtual Type GetType(string name, bool throwOnError) => GetType(name, throwOnError: throwOnError, ignoreCase: false);
-        public virtual Type GetType(string name, bool throwOnError, bool ignoreCase) { throw NotImplemented.ByDesign; }
+        public virtual Type? GetType(string name) => GetType(name, throwOnError: false, ignoreCase: false);
+        public virtual Type? GetType(string name, bool throwOnError) => GetType(name, throwOnError: throwOnError, ignoreCase: false);
+        public virtual Type? GetType(string name, bool throwOnError, bool ignoreCase) { throw NotImplemented.ByDesign; }
 
         public virtual bool IsDefined(Type attributeType, bool inherit) { throw NotImplemented.ByDesign; }
 
@@ -110,7 +110,7 @@ namespace System.Reflection
         public object? CreateInstance(string typeName, bool ignoreCase) => CreateInstance(typeName, ignoreCase, BindingFlags.Public | BindingFlags.Instance, binder: null, args: null, culture: null, activationAttributes: null);
         public virtual object? CreateInstance(string typeName, bool ignoreCase, BindingFlags bindingAttr, Binder? binder, object[]? args, CultureInfo? culture, object[]? activationAttributes)
         {
-            Type t = GetType(typeName, throwOnError: false, ignoreCase: ignoreCase);
+            Type? t = GetType(typeName, throwOnError: false, ignoreCase: ignoreCase);
             if (t == null)
                 return null;
 
@@ -120,7 +120,7 @@ namespace System.Reflection
         public virtual event ModuleResolveEventHandler ModuleResolve { add { throw NotImplemented.ByDesign; } remove { throw NotImplemented.ByDesign; } }
 
         public virtual Module? ManifestModule { get { throw NotImplemented.ByDesign; } }
-        public virtual Module GetModule(string name) { throw NotImplemented.ByDesign; }
+        public virtual Module? GetModule(string name) { throw NotImplemented.ByDesign; }
 
         public Module[] GetModules() => GetModules(getResourceModules: false);
         public virtual Module[] GetModules(bool getResourceModules) { throw NotImplemented.ByDesign; }
@@ -324,19 +324,19 @@ namespace System.Reflection
             return AssemblyLoadContext.Default.LoadFromAssemblyPath(fullPath);
         }
 
-        public static Assembly LoadFrom(string? assemblyFile, byte[]? hashValue, AssemblyHashAlgorithm hashAlgorithm)
+        public static Assembly LoadFrom(string assemblyFile, byte[]? hashValue, AssemblyHashAlgorithm hashAlgorithm)
         {
             throw new NotSupportedException(SR.NotSupported_AssemblyLoadFromHash);
         }
 
         public static Assembly UnsafeLoadFrom(string assemblyFile) => LoadFrom(assemblyFile);
 
-        public Module LoadModule(string? moduleName, byte[]? rawModule) => LoadModule(moduleName, rawModule, null);
-        public virtual Module LoadModule(string? moduleName, byte[]? rawModule, byte[]? rawSymbolStore) { throw NotImplemented.ByDesign; }
+        public Module LoadModule(string moduleName, byte[]? rawModule) => LoadModule(moduleName, rawModule, null);
+        public virtual Module LoadModule(string moduleName, byte[]? rawModule, byte[]? rawSymbolStore) { throw NotImplemented.ByDesign; }
 
-        public static Assembly ReflectionOnlyLoad(byte[]? rawAssembly) { throw new PlatformNotSupportedException(SR.PlatformNotSupported_ReflectionOnly); }
-        public static Assembly ReflectionOnlyLoad(string? assemblyString) { throw new PlatformNotSupportedException(SR.PlatformNotSupported_ReflectionOnly); }
-        public static Assembly ReflectionOnlyLoadFrom(string? assemblyFile) { throw new PlatformNotSupportedException(SR.PlatformNotSupported_ReflectionOnly); }
+        public static Assembly ReflectionOnlyLoad(byte[] rawAssembly) { throw new PlatformNotSupportedException(SR.PlatformNotSupported_ReflectionOnly); }
+        public static Assembly ReflectionOnlyLoad(string assemblyString) { throw new PlatformNotSupportedException(SR.PlatformNotSupported_ReflectionOnly); }
+        public static Assembly ReflectionOnlyLoadFrom(string assemblyFile) { throw new PlatformNotSupportedException(SR.PlatformNotSupported_ReflectionOnly); }
 
         public virtual SecurityRuleSet SecurityRuleSet => SecurityRuleSet.None;
     }

--- a/src/System.Private.CoreLib/shared/System/Reflection/Assembly.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Assembly.cs
@@ -119,7 +119,7 @@ namespace System.Reflection
 
         public virtual event ModuleResolveEventHandler ModuleResolve { add { throw NotImplemented.ByDesign; } remove { throw NotImplemented.ByDesign; } }
 
-        public virtual Module? ManifestModule { get { throw NotImplemented.ByDesign; } }
+        public virtual Module ManifestModule { get { throw NotImplemented.ByDesign; } }
         public virtual Module? GetModule(string name) { throw NotImplemented.ByDesign; }
 
         public Module[] GetModules() => GetModules(getResourceModules: false);

--- a/src/System.Private.CoreLib/shared/System/Reflection/AssemblyName.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/AssemblyName.cs
@@ -226,7 +226,7 @@ namespace System.Reflection
                 if (this.Name == null)
                     return string.Empty;
                 // Do not call GetPublicKeyToken() here - that latches the result into AssemblyName which isn't a side effect we want.
-                byte[] pkt = _publicKeyToken ?? ComputePublicKeyToken();
+                byte[]? pkt = _publicKeyToken ?? ComputePublicKeyToken();
                 return AssemblyNameFormatter.ComputeDisplayName(Name, Version, CultureName, pkt, Flags, ContentType);
             }
         }

--- a/src/System.Private.CoreLib/shared/System/Reflection/AssemblyName.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/AssemblyName.cs
@@ -172,7 +172,7 @@ namespace System.Reflection
 
         // The compressed version of the public key formed from a truncated hash.
         // Will throw a SecurityException if _publicKey is invalid
-        public byte[] GetPublicKeyToken()
+        public byte[]? GetPublicKeyToken()
         {
             if (_publicKeyToken == null)
                 _publicKeyToken = ComputePublicKeyToken();

--- a/src/System.Private.CoreLib/shared/System/Reflection/CustomAttributeNamedArgument.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/CustomAttributeNamedArgument.cs
@@ -47,7 +47,7 @@ namespace System.Reflection
         public override string ToString()
         {
             if (m_memberInfo == null)
-                return base.ToString();
+                return base.ToString()!;
 
             return string.Format("{0} = {1}", MemberInfo.Name, TypedValue.ToString(ArgumentType != typeof(object)));
         }

--- a/src/System.Private.CoreLib/shared/System/Reflection/CustomAttributeTypedArgument.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/CustomAttributeTypedArgument.cs
@@ -41,7 +41,7 @@ namespace System.Reflection
         internal string ToString(bool typed)
         {
             if (m_argumentType == null)
-                return base.ToString();
+                return base.ToString()!;
 
             if (ArgumentType.IsEnum)
                 return string.Format(typed ? "{0}" : "({1}){0}", Value, ArgumentType.FullName);

--- a/src/System.Private.CoreLib/shared/System/Reflection/Emit/Opcode.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Emit/Opcode.cs
@@ -183,9 +183,11 @@ namespace System.Reflection.Emit
             return Value;
         }
 
+#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         public override string? ToString()
         {
             return Name;
         }
+#pragma warning restore CS8609
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Reflection/Emit/Opcode.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Emit/Opcode.cs
@@ -183,11 +183,9 @@ namespace System.Reflection.Emit
             return Value;
         }
 
-#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         public override string? ToString()
         {
             return Name;
         }
-#pragma warning restore CS8609
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Reflection/FieldInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/FieldInfo.cs
@@ -72,9 +72,9 @@ namespace System.Reflection
         [CLSCompliant(false)]
         public virtual void SetValueDirect(TypedReference obj, object value) { throw new NotSupportedException(SR.NotSupported_AbstractNonCLS); }
         [CLSCompliant(false)]
-        public virtual object GetValueDirect(TypedReference obj) { throw new NotSupportedException(SR.NotSupported_AbstractNonCLS); }
+        public virtual object? GetValueDirect(TypedReference obj) { throw new NotSupportedException(SR.NotSupported_AbstractNonCLS); }
 
-        public virtual object GetRawConstantValue() { throw new NotSupportedException(SR.NotSupported_AbstractNonCLS); }
+        public virtual object? GetRawConstantValue() { throw new NotSupportedException(SR.NotSupported_AbstractNonCLS); }
 
         public virtual Type[] GetOptionalCustomModifiers() { throw NotImplemented.ByDesign; }
         public virtual Type[] GetRequiredCustomModifiers() { throw NotImplemented.ByDesign; }

--- a/src/System.Private.CoreLib/shared/System/Reflection/FieldInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/FieldInfo.cs
@@ -66,7 +66,7 @@ namespace System.Reflection
 
         [DebuggerHidden]
         [DebuggerStepThrough]
-        public void SetValue(object? obj, object value) => SetValue(obj, value, BindingFlags.Default, Type.DefaultBinder, null);
+        public void SetValue(object? obj, object? value) => SetValue(obj, value, BindingFlags.Default, Type.DefaultBinder, null);
         public abstract void SetValue(object? obj, object? value, BindingFlags invokeAttr, Binder? binder, CultureInfo? culture);
 
         [CLSCompliant(false)]

--- a/src/System.Private.CoreLib/shared/System/Reflection/IReflect.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/IReflect.cs
@@ -67,7 +67,7 @@ namespace System.Reflection
         // For the default binder, the most specific method will be selected.
         // 
         // This will invoke a specific member...
-        object? InvokeMember(string name, BindingFlags invokeAttr, Binder? binder, object? target, object[]? args, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParameters);
+        object? InvokeMember(string name, BindingFlags invokeAttr, Binder? binder, object? target, object?[]? args, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParameters);
 
         // Return the underlying Type that represents the IReflect Object.  For expando object,
         // this is the (Object) IReflectInstance.GetType().  For Type object it is this.

--- a/src/System.Private.CoreLib/shared/System/Reflection/MemberFilter.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/MemberFilter.cs
@@ -4,5 +4,5 @@
 
 namespace System.Reflection
 {
-    public delegate bool MemberFilter(MemberInfo m, object filterCriteria);
+    public delegate bool MemberFilter(MemberInfo m, object? filterCriteria);
 }

--- a/src/System.Private.CoreLib/shared/System/Reflection/MethodBase.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/MethodBase.cs
@@ -16,7 +16,7 @@ namespace System.Reflection
         public abstract MethodAttributes Attributes { get; }
         public virtual MethodImplAttributes MethodImplementationFlags => GetMethodImplementationFlags();
         public abstract MethodImplAttributes GetMethodImplementationFlags();
-        public virtual MethodBody GetMethodBody() { throw new InvalidOperationException(); }
+        public virtual MethodBody? GetMethodBody() { throw new InvalidOperationException(); }
         public virtual CallingConventions CallingConvention => CallingConventions.Standard;
 
         public bool IsAbstract => (Attributes & MethodAttributes.Abstract) != 0;

--- a/src/System.Private.CoreLib/shared/System/Reflection/MethodInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/MethodInfo.cs
@@ -12,7 +12,7 @@ namespace System.Reflection
 
         public override MemberTypes MemberType => MemberTypes.Method;
 
-        public virtual ParameterInfo? ReturnParameter { get { throw NotImplemented.ByDesign; } }
+        public virtual ParameterInfo ReturnParameter { get { throw NotImplemented.ByDesign; } }
         public virtual Type ReturnType { get { throw NotImplemented.ByDesign; } }
 
         public override Type[] GetGenericArguments() { throw new NotSupportedException(SR.NotSupported_SubclassOverride); }

--- a/src/System.Private.CoreLib/shared/System/Reflection/MethodInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/MethodInfo.cs
@@ -13,15 +13,15 @@ namespace System.Reflection
         public override MemberTypes MemberType => MemberTypes.Method;
 
         public virtual ParameterInfo? ReturnParameter { get { throw NotImplemented.ByDesign; } }
-        public virtual Type? ReturnType { get { throw NotImplemented.ByDesign; } }
+        public virtual Type ReturnType { get { throw NotImplemented.ByDesign; } }
 
         public override Type[] GetGenericArguments() { throw new NotSupportedException(SR.NotSupported_SubclassOverride); }
-        public virtual MethodInfo? GetGenericMethodDefinition() { throw new NotSupportedException(SR.NotSupported_SubclassOverride); }
-        public virtual MethodInfo? MakeGenericMethod(params Type[] typeArguments) { throw new NotSupportedException(SR.NotSupported_SubclassOverride); }
+        public virtual MethodInfo GetGenericMethodDefinition() { throw new NotSupportedException(SR.NotSupported_SubclassOverride); }
+        public virtual MethodInfo MakeGenericMethod(params Type[] typeArguments) { throw new NotSupportedException(SR.NotSupported_SubclassOverride); }
 
-        public abstract MethodInfo? GetBaseDefinition();
+        public abstract MethodInfo GetBaseDefinition();
 
-        public abstract ICustomAttributeProvider? ReturnTypeCustomAttributes { get; }
+        public abstract ICustomAttributeProvider ReturnTypeCustomAttributes { get; }
 
         public virtual Delegate CreateDelegate(Type delegateType) { throw new NotSupportedException(SR.NotSupported_SubclassOverride); }
         public virtual Delegate CreateDelegate(Type delegateType, object? target) { throw new NotSupportedException(SR.NotSupported_SubclassOverride); }

--- a/src/System.Private.CoreLib/shared/System/Reflection/Module.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Module.cs
@@ -70,7 +70,7 @@ namespace System.Reflection
         public virtual Type? GetType(string className, bool ignoreCase) => GetType(className, throwOnError: false, ignoreCase: ignoreCase);
         public virtual Type? GetType(string className, bool throwOnError, bool ignoreCase) { throw NotImplemented.ByDesign; }
 
-        public virtual Type[] FindTypes(TypeFilter? filter, object filterCriteria)
+        public virtual Type[] FindTypes(TypeFilter? filter, object? filterCriteria)
         {
             Type[] c = GetTypes();
             int cnt = 0;
@@ -140,8 +140,8 @@ namespace System.Reflection
 
         public override string ToString() => ScopeName;
 
-        public static readonly TypeFilter FilterTypeName = (m, c) => FilterTypeNameImpl(m, c, StringComparison.Ordinal);
-        public static readonly TypeFilter FilterTypeNameIgnoreCase = (m, c) => FilterTypeNameImpl(m, c, StringComparison.OrdinalIgnoreCase);
+        public static readonly TypeFilter FilterTypeName = (m, c) => FilterTypeNameImpl(m, c!, StringComparison.Ordinal);
+        public static readonly TypeFilter FilterTypeNameIgnoreCase = (m, c) => FilterTypeNameImpl(m, c!, StringComparison.OrdinalIgnoreCase);
 
         private const BindingFlags DefaultLookup = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public;
 

--- a/src/System.Private.CoreLib/shared/System/Reflection/ParameterInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/ParameterInfo.cs
@@ -69,7 +69,7 @@ namespace System.Reflection
                     if (PositionImpl == -1)
                     {
                         if (MemberImpl.MemberType == MemberTypes.Method)
-                            return ((MethodInfo)MemberImpl).ReturnParameter!;
+                            return ((MethodInfo)MemberImpl).ReturnParameter;
                         else
                             throw new SerializationException(SR.Serialization_BadParameterInfo);
                     }

--- a/src/System.Private.CoreLib/shared/System/Reflection/PropertyInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/PropertyInfo.cs
@@ -45,16 +45,16 @@ namespace System.Reflection
         public virtual object? GetValue(object? obj, object?[]? index) => GetValue(obj, BindingFlags.Default, binder: null, index: index, culture: null);
         public abstract object? GetValue(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? index, CultureInfo? culture);
 
-        public virtual object GetConstantValue() { throw NotImplemented.ByDesign; }
-        public virtual object GetRawConstantValue() { throw NotImplemented.ByDesign; }
+        public virtual object? GetConstantValue() { throw NotImplemented.ByDesign; }
+        public virtual object? GetRawConstantValue() { throw NotImplemented.ByDesign; }
 
         [DebuggerHidden]
         [DebuggerStepThrough]
         public void SetValue(object? obj, object? value) => SetValue(obj, value, index: null);
         [DebuggerHidden]
         [DebuggerStepThrough]
-        public virtual void SetValue(object? obj, object? value, object[]? index) => SetValue(obj, value, BindingFlags.Default, binder: null, index: index, culture: null);
-        public abstract void SetValue(object? obj, object? value, BindingFlags invokeAttr, Binder? binder, object[]? index, CultureInfo? culture);
+        public virtual void SetValue(object? obj, object? value, object?[]? index) => SetValue(obj, value, BindingFlags.Default, binder: null, index: index, culture: null);
+        public abstract void SetValue(object? obj, object? value, BindingFlags invokeAttr, Binder? binder, object?[]? index, CultureInfo? culture);
 
         public override bool Equals(object? obj) => base.Equals(obj);
         public override int GetHashCode() => base.GetHashCode();

--- a/src/System.Private.CoreLib/shared/System/Reflection/SignatureType.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/SignatureType.cs
@@ -111,11 +111,11 @@ namespace System.Reflection
         public sealed override Type GetNestedType(string name, BindingFlags bindingAttr) => throw new NotSupportedException(SR.NotSupported_SignatureType);
         public sealed override Type[] GetNestedTypes(BindingFlags bindingAttr) => throw new NotSupportedException(SR.NotSupported_SignatureType);
         public sealed override PropertyInfo[] GetProperties(BindingFlags bindingAttr) => throw new NotSupportedException(SR.NotSupported_SignatureType);
-        public sealed override object InvokeMember(string name, BindingFlags invokeAttr, Binder? binder, object? target, object[]? args, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParameters) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override object InvokeMember(string name, BindingFlags invokeAttr, Binder? binder, object? target, object?[]? args, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParameters) => throw new NotSupportedException(SR.NotSupported_SignatureType);
         protected sealed override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder? binder, CallingConventions callConvention, Type[]? types, ParameterModifier[]? modifiers) => throw new NotSupportedException(SR.NotSupported_SignatureType);
         protected sealed override MethodInfo GetMethodImpl(string name, int genericParameterCount, BindingFlags bindingAttr, Binder? binder, CallingConventions callConvention, Type[]? types, ParameterModifier[]? modifiers) => throw new NotSupportedException(SR.NotSupported_SignatureType);
         protected sealed override PropertyInfo GetPropertyImpl(string name, BindingFlags bindingAttr, Binder? binder, Type? returnType, Type[]? types, ParameterModifier[]? modifiers) => throw new NotSupportedException(SR.NotSupported_SignatureType);
-        public sealed override MemberInfo[] FindMembers(MemberTypes memberType, BindingFlags bindingAttr, MemberFilter? filter, object filterCriteria) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override MemberInfo[] FindMembers(MemberTypes memberType, BindingFlags bindingAttr, MemberFilter? filter, object? filterCriteria) => throw new NotSupportedException(SR.NotSupported_SignatureType);
         public sealed override MemberInfo[] GetMember(string name, BindingFlags bindingAttr) => throw new NotSupportedException(SR.NotSupported_SignatureType);
         public sealed override MemberInfo[] GetMember(string name, MemberTypes type, BindingFlags bindingAttr) => throw new NotSupportedException(SR.NotSupported_SignatureType);
         public sealed override MemberInfo[] GetDefaultMembers() => throw new NotSupportedException(SR.NotSupported_SignatureType);
@@ -129,7 +129,7 @@ namespace System.Reflection
         protected sealed override bool IsCOMObjectImpl() => throw new NotSupportedException(SR.NotSupported_SignatureType);
         protected sealed override bool IsPrimitiveImpl() => throw new NotSupportedException(SR.NotSupported_SignatureType);
         public sealed override IEnumerable<CustomAttributeData> CustomAttributes => throw new NotSupportedException(SR.NotSupported_SignatureType);
-        public sealed override Type[] FindInterfaces(TypeFilter filter, object filterCriteria) => throw new NotSupportedException(SR.NotSupported_SignatureType);
+        public sealed override Type[] FindInterfaces(TypeFilter filter, object? filterCriteria) => throw new NotSupportedException(SR.NotSupported_SignatureType);
         public sealed override InterfaceMapping GetInterfaceMap(Type interfaceType) => throw new NotSupportedException(SR.NotSupported_SignatureType);
         protected sealed override bool IsContextfulImpl() => throw new NotSupportedException(SR.NotSupported_SignatureType);
         public sealed override bool IsEnum => throw new NotSupportedException(SR.NotSupported_SignatureType);

--- a/src/System.Private.CoreLib/shared/System/Reflection/TypeDelegator.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/TypeDelegator.cs
@@ -35,7 +35,7 @@ namespace System.Reflection
         public override int MetadataToken => typeImpl.MetadataToken;
 
         public override object? InvokeMember(string name, BindingFlags invokeAttr, Binder? binder, object? target,
-            object[]? args, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParameters)
+            object?[]? args, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParameters)
         {
             return typeImpl.InvokeMember(name, invokeAttr, binder, target, args, modifiers, culture, namedParameters);
         }

--- a/src/System.Private.CoreLib/shared/System/Reflection/TypeFilter.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/TypeFilter.cs
@@ -4,5 +4,5 @@
 
 namespace System.Reflection
 {
-    public delegate bool TypeFilter(Type m, object filterCriteria);
+    public delegate bool TypeFilter(Type m, object? filterCriteria);
 }

--- a/src/System.Private.CoreLib/shared/System/Resources/ManifestBasedResourceGroveler.cs
+++ b/src/System.Private.CoreLib/shared/System/Resources/ManifestBasedResourceGroveler.cs
@@ -444,15 +444,17 @@ namespace System.Resources
                 satAssemName += ", Version=" + _mediator.SatelliteContractVersion.ToString();
             }
 
-            byte[] token = _mediator.MainAssembly.GetName().GetPublicKeyToken()!;
-
-            int iLen = token.Length;
-            StringBuilder publicKeyTok = new StringBuilder(iLen * 2);
-            for (int i = 0; i < iLen; i++)
+            byte[]? token = _mediator.MainAssembly.GetName().GetPublicKeyToken();
+            if (token != null)
             {
-                publicKeyTok.Append(token[i].ToString("x", CultureInfo.InvariantCulture));
+                int iLen = token.Length;
+                StringBuilder publicKeyTok = new StringBuilder(iLen * 2);
+                for (int i = 0; i < iLen; i++)
+                {
+                    publicKeyTok.Append(token[i].ToString("x", CultureInfo.InvariantCulture));
+                }
+                satAssemName += ", PublicKeyToken=" + publicKeyTok;
             }
-            satAssemName += ", PublicKeyToken=" + publicKeyTok;
 
             Debug.Assert(_mediator.NeutralResourcesCulture != null);
             string missingCultureName = _mediator.NeutralResourcesCulture.Name;

--- a/src/System.Private.CoreLib/shared/System/Resources/ManifestBasedResourceGroveler.cs
+++ b/src/System.Private.CoreLib/shared/System/Resources/ManifestBasedResourceGroveler.cs
@@ -444,7 +444,7 @@ namespace System.Resources
                 satAssemName += ", Version=" + _mediator.SatelliteContractVersion.ToString();
             }
 
-            byte[] token = _mediator.MainAssembly.GetName().GetPublicKeyToken();
+            byte[] token = _mediator.MainAssembly.GetName().GetPublicKeyToken()!;
 
             int iLen = token.Length;
             StringBuilder publicKeyTok = new StringBuilder(iLen * 2);

--- a/src/System.Private.CoreLib/shared/System/Resources/ResourceReader.Core.cs
+++ b/src/System.Private.CoreLib/shared/System/Resources/ResourceReader.Core.cs
@@ -79,7 +79,7 @@ namespace System.Resources
                 // create an unbound delegate that can accept a BinaryFormatter instance as object
                 return (Func<object?, Stream, object>)typeof(ResourceReader)
                         .GetMethod(nameof(CreateUntypedDelegate), BindingFlags.NonPublic | BindingFlags.Static)!
-                        .MakeGenericMethod(s_binaryFormatterType)!
+                        .MakeGenericMethod(s_binaryFormatterType)
                         .Invoke(null, new object[] { binaryFormatterDeserialize })!;
             });
 #pragma warning restore CS8634

--- a/src/System.Private.CoreLib/shared/System/Resources/ResourceSet.cs
+++ b/src/System.Private.CoreLib/shared/System/Resources/ResourceSet.cs
@@ -120,7 +120,7 @@ namespace System.Resources
         public virtual Type GetDefaultWriter()
         {
             Assembly resourceWriterAssembly = Assembly.Load("System.Resources.Writer, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
-            return resourceWriterAssembly.GetType("System.Resources.ResourceWriter", true);
+            return resourceWriterAssembly.GetType("System.Resources.ResourceWriter", throwOnError: true)!;
         }
 
         public virtual IDictionaryEnumerator GetEnumerator()

--- a/src/System.Private.CoreLib/shared/System/String.Comparison.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Comparison.cs
@@ -251,14 +251,10 @@ namespace System
         // to determine whether it is lexicographically less, equal, or greater, and then a
         // negative integer, 0, or a positive integer is returned; respectively.
         //
-        public static int Compare(string? strA, string? strB, CultureInfo culture, CompareOptions options)
+        public static int Compare(string? strA, string? strB, CultureInfo? culture, CompareOptions options)
         {
-            if (culture == null)
-            {
-                throw new ArgumentNullException(nameof(culture));
-            }
-
-            return culture.CompareInfo.Compare(strA, strB, options);
+            CultureInfo compareCulture = culture ?? CultureInfo.CurrentCulture;
+            return compareCulture.CompareInfo.Compare(strA, strB, options);
         }
 
 
@@ -269,7 +265,7 @@ namespace System
         // The case-sensitive option is set by ignoreCase, and the culture is set
         // by culture
         //
-        public static int Compare(string? strA, string? strB, bool ignoreCase, CultureInfo culture)
+        public static int Compare(string? strA, string? strB, bool ignoreCase, CultureInfo? culture)
         {
             var options = ignoreCase ? CompareOptions.IgnoreCase : CompareOptions.None;
             return Compare(strA, strB, culture, options);
@@ -328,7 +324,7 @@ namespace System
         // beginning at indexB of the same length.  Case sensitivity is determined by the ignoreCase boolean,
         // and the culture is set by culture.
         //
-        public static int Compare(string? strA, int indexA, string? strB, int indexB, int length, bool ignoreCase, CultureInfo culture)
+        public static int Compare(string? strA, int indexA, string? strB, int indexB, int length, bool ignoreCase, CultureInfo? culture)
         {
             var options = ignoreCase ? CompareOptions.IgnoreCase : CompareOptions.None;
             return Compare(strA, indexA, strB, indexB, length, culture, options);
@@ -339,13 +335,9 @@ namespace System
         // at indexA of length length is compared with the substring of strB
         // beginning at indexB of the same length.
         //
-        public static int Compare(string? strA, int indexA, string? strB, int indexB, int length, CultureInfo culture, CompareOptions options)
+        public static int Compare(string? strA, int indexA, string? strB, int indexB, int length, CultureInfo? culture, CompareOptions options)
         {
-            if (culture == null)
-            {
-                throw new ArgumentNullException(nameof(culture));
-            }
-
+            CultureInfo compareCulture = culture ?? CultureInfo.CurrentCulture;
             int lengthA = length;
             int lengthB = length;
 
@@ -359,7 +351,7 @@ namespace System
                 lengthB = Math.Min(lengthB, strB.Length - indexB);
             }
 
-            return culture.CompareInfo.Compare(strA, indexA, lengthA, strB, indexB, lengthB, options);
+            return compareCulture.CompareInfo.Compare(strA, indexA, lengthA, strB, indexB, lengthB, options);
         }
 
         public static int Compare(string? strA, int indexA, string? strB, int indexB, int length, StringComparison comparisonType)

--- a/src/System.Private.CoreLib/shared/System/String.Manipulation.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Manipulation.cs
@@ -1702,13 +1702,10 @@ namespace System
         }
 
         // Creates a copy of this string in lower case.  The culture is set by culture.
-        public string ToLower(CultureInfo culture)
+        public string ToLower(CultureInfo? culture)
         {
-            if (culture == null)
-            {
-                throw new ArgumentNullException(nameof(culture));
-            }
-            return culture.TextInfo.ToLower(this);
+            CultureInfo cult = culture ?? CultureInfo.CurrentCulture;
+            return cult.TextInfo.ToLower(this);
         }
 
         // Creates a copy of this string in lower case based on invariant culture.
@@ -1723,13 +1720,10 @@ namespace System
         }
 
         // Creates a copy of this string in upper case.  The culture is set by culture.
-        public string ToUpper(CultureInfo culture)
+        public string ToUpper(CultureInfo? culture)
         {
-            if (culture == null)
-            {
-                throw new ArgumentNullException(nameof(culture));
-            }
-            return culture.TextInfo.ToUpper(this);
+            CultureInfo cult = culture ?? CultureInfo.CurrentCulture;
+            return cult.TextInfo.ToUpper(this);
         }
 
         //Creates a copy of this string in upper case based on invariant culture.

--- a/src/System.Private.CoreLib/shared/System/String.Manipulation.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Manipulation.cs
@@ -1696,10 +1696,7 @@ namespace System
         }
 
         // Creates a copy of this string in lower case.  The culture is set by culture.
-        public string ToLower()
-        {
-            return CultureInfo.CurrentCulture.TextInfo.ToLower(this);
-        }
+        public string ToLower() => ToLower(null);
 
         // Creates a copy of this string in lower case.  The culture is set by culture.
         public string ToLower(CultureInfo? culture)
@@ -1714,10 +1711,7 @@ namespace System
             return CultureInfo.InvariantCulture.TextInfo.ToLower(this);
         }
 
-        public string ToUpper()
-        {
-            return CultureInfo.CurrentCulture.TextInfo.ToUpper(this);
-        }
+        public string ToUpper() => ToUpper(null);
 
         // Creates a copy of this string in upper case.  The culture is set by culture.
         public string ToUpper(CultureInfo? culture)

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskContinuation.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskContinuation.cs
@@ -341,6 +341,7 @@ namespace System.Threading.Tasks
             else continuationTask.InternalCancel(false);
         }
 
+#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         internal override Delegate[]? GetDelegateContinuationsForDebugger()
         {
             if (m_task.m_action == null)
@@ -350,6 +351,8 @@ namespace System.Threading.Tasks
 
             return new Delegate[] { m_task.m_action };
         }
+#pragma warning restore CS8609
+
     }
 
     /// <summary>Task continuation for awaiting with a current synchronization context.</summary>

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskContinuation.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskContinuation.cs
@@ -256,7 +256,7 @@ namespace System.Threading.Tasks
 #if PROJECTN
         [DependencyReductionRoot]
 #endif
-        internal abstract Delegate[] GetDelegateContinuationsForDebugger();
+        internal abstract Delegate[]? GetDelegateContinuationsForDebugger();
     }
 
     /// <summary>Provides the standard implementation of a task continuation.</summary>
@@ -341,7 +341,6 @@ namespace System.Threading.Tasks
             else continuationTask.InternalCancel(false);
         }
 
-#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         internal override Delegate[]? GetDelegateContinuationsForDebugger()
         {
             if (m_task.m_action == null)
@@ -351,7 +350,6 @@ namespace System.Threading.Tasks
 
             return new Delegate[] { m_task.m_action };
         }
-#pragma warning restore CS8609
 
     }
 

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/ValueTask.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/ValueTask.cs
@@ -776,6 +776,7 @@ namespace System.Threading.Tasks
         public ConfiguredValueTaskAwaitable<TResult> ConfigureAwait(bool continueOnCapturedContext) =>
             new ConfiguredValueTaskAwaitable<TResult>(new ValueTask<TResult>(_obj, _result, _token, continueOnCapturedContext));
 
+#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         /// <summary>Gets a string-representation of this <see cref="ValueTask{TResult}"/>.</summary>
         public override string? ToString()
         {
@@ -790,5 +791,6 @@ namespace System.Threading.Tasks
 
             return string.Empty;
         }
+#pragma warning restore CS8609
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/ValueTask.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/ValueTask.cs
@@ -776,7 +776,6 @@ namespace System.Threading.Tasks
         public ConfiguredValueTaskAwaitable<TResult> ConfigureAwait(bool continueOnCapturedContext) =>
             new ConfiguredValueTaskAwaitable<TResult>(new ValueTask<TResult>(_obj, _result, _token, continueOnCapturedContext));
 
-#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         /// <summary>Gets a string-representation of this <see cref="ValueTask{TResult}"/>.</summary>
         public override string? ToString()
         {
@@ -791,6 +790,5 @@ namespace System.Threading.Tasks
 
             return string.Empty;
         }
-#pragma warning restore CS8609
     }
 }

--- a/src/System.Private.CoreLib/shared/System/TimeSpan.cs
+++ b/src/System.Private.CoreLib/shared/System/TimeSpan.cs
@@ -382,7 +382,7 @@ namespace System
         {
             return TimeSpanParse.TryParse(input, formatProvider, out result);
         }
-        public static bool TryParseExact(string? input, string? format, IFormatProvider? formatProvider, out TimeSpan result)
+        public static bool TryParseExact(string? input, string format, IFormatProvider? formatProvider, out TimeSpan result)
         {
             if (input == null || format == null)
             {
@@ -396,7 +396,7 @@ namespace System
         {
             return TimeSpanParse.TryParseExact(input, format, formatProvider, TimeSpanStyles.None, out result);
         }
-        public static bool TryParseExact(string? input, string?[]? formats, IFormatProvider? formatProvider, out TimeSpan result)
+        public static bool TryParseExact(string? input, string[] formats, IFormatProvider? formatProvider, out TimeSpan result)
         {
             if (input == null)
             {
@@ -405,12 +405,12 @@ namespace System
             }
             return TimeSpanParse.TryParseExactMultiple(input, formats, formatProvider, TimeSpanStyles.None, out result);
         }
-        public static bool TryParseExact(ReadOnlySpan<char> input, string?[]? formats, IFormatProvider? formatProvider, out TimeSpan result)
+        public static bool TryParseExact(ReadOnlySpan<char> input, string[] formats, IFormatProvider? formatProvider, out TimeSpan result)
         {
             return TimeSpanParse.TryParseExactMultiple(input, formats, formatProvider, TimeSpanStyles.None, out result);
         }
 
-        public static bool TryParseExact(string? input, string? format, IFormatProvider? formatProvider, TimeSpanStyles styles, out TimeSpan result)
+        public static bool TryParseExact(string? input, string format, IFormatProvider? formatProvider, TimeSpanStyles styles, out TimeSpan result)
         {
             ValidateStyles(styles, nameof(styles));
             if (input == null || format == null)
@@ -427,7 +427,7 @@ namespace System
             ValidateStyles(styles, nameof(styles));
             return TimeSpanParse.TryParseExact(input, format, formatProvider, styles, out result);
         }
-        public static bool TryParseExact(string? input, string?[]? formats, IFormatProvider? formatProvider, TimeSpanStyles styles, out TimeSpan result)
+        public static bool TryParseExact(string? input, string[] formats, IFormatProvider? formatProvider, TimeSpanStyles styles, out TimeSpan result)
         {
             ValidateStyles(styles, nameof(styles));
             if (input == null)
@@ -438,7 +438,7 @@ namespace System
             return TimeSpanParse.TryParseExactMultiple(input, formats, formatProvider, styles, out result);
         }
 
-        public static bool TryParseExact(ReadOnlySpan<char> input, string?[]? formats, IFormatProvider? formatProvider, TimeSpanStyles styles, out TimeSpan result)
+        public static bool TryParseExact(ReadOnlySpan<char> input, string[] formats, IFormatProvider? formatProvider, TimeSpanStyles styles, out TimeSpan result)
         {
             ValidateStyles(styles, nameof(styles));
             return TimeSpanParse.TryParseExactMultiple(input, formats, formatProvider, styles, out result);

--- a/src/System.Private.CoreLib/shared/System/Type.Enum.cs
+++ b/src/System.Private.CoreLib/shared/System/Type.Enum.cs
@@ -121,7 +121,7 @@ namespace System
             for (int i = 0; i < flds.Length; i++)
             {
                 names[i] = flds[i].Name;
-                values[i] = flds[i].GetRawConstantValue();
+                values[i] = flds[i].GetRawConstantValue()!;
             }
 
             // Insertion Sort these values in ascending order.

--- a/src/System.Private.CoreLib/shared/System/Type.Helpers.cs
+++ b/src/System.Private.CoreLib/shared/System/Type.Helpers.cs
@@ -113,7 +113,7 @@ namespace System
             }
         }
 
-        public virtual Type[] FindInterfaces(TypeFilter filter, object filterCriteria)
+        public virtual Type[] FindInterfaces(TypeFilter filter, object? filterCriteria)
         {
             if (filter == null)
                 throw new ArgumentNullException(nameof(filter));
@@ -140,7 +140,7 @@ namespace System
             return ret;
         }
 
-        public virtual MemberInfo[] FindMembers(MemberTypes memberType, BindingFlags bindingAttr, MemberFilter? filter, object filterCriteria)
+        public virtual MemberInfo[] FindMembers(MemberTypes memberType, BindingFlags bindingAttr, MemberFilter? filter, object? filterCriteria)
         {
             // Define the work arrays
             MethodInfo?[]? m = null;

--- a/src/System.Private.CoreLib/shared/System/Type.cs
+++ b/src/System.Private.CoreLib/shared/System/Type.cs
@@ -221,12 +221,10 @@ namespace System
             return GetPropertyImpl(name, bindingAttr, null, null, null, null);
         }
 
-        public PropertyInfo? GetProperty(string name, Type returnType)
+        public PropertyInfo? GetProperty(string name, Type? returnType)
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
-            if (returnType == null)
-                throw new ArgumentNullException(nameof(returnType));
             return GetPropertyImpl(name, Type.DefaultLookup, null, returnType, null, null);
         }
 
@@ -290,24 +288,24 @@ namespace System
 
         public abstract Guid GUID { get; }
 
-        public static Type GetTypeFromCLSID(Guid clsid) => GetTypeFromCLSID(clsid, null, throwOnError: false);
-        public static Type GetTypeFromCLSID(Guid clsid, bool throwOnError) => GetTypeFromCLSID(clsid, null, throwOnError: throwOnError);
-        public static Type GetTypeFromCLSID(Guid clsid, string? server) => GetTypeFromCLSID(clsid, server, throwOnError: false);
+        public static Type? GetTypeFromCLSID(Guid clsid) => GetTypeFromCLSID(clsid, null, throwOnError: false);
+        public static Type? GetTypeFromCLSID(Guid clsid, bool throwOnError) => GetTypeFromCLSID(clsid, null, throwOnError: throwOnError);
+        public static Type? GetTypeFromCLSID(Guid clsid, string? server) => GetTypeFromCLSID(clsid, server, throwOnError: false);
 
-        public static Type GetTypeFromProgID(string progID) => GetTypeFromProgID(progID, null, throwOnError: false);
-        public static Type GetTypeFromProgID(string progID, bool throwOnError) => GetTypeFromProgID(progID, null, throwOnError: throwOnError);
-        public static Type GetTypeFromProgID(string progID, string? server) => GetTypeFromProgID(progID, server, throwOnError: false);
+        public static Type? GetTypeFromProgID(string progID) => GetTypeFromProgID(progID, null, throwOnError: false);
+        public static Type? GetTypeFromProgID(string progID, bool throwOnError) => GetTypeFromProgID(progID, null, throwOnError: throwOnError);
+        public static Type? GetTypeFromProgID(string progID, string? server) => GetTypeFromProgID(progID, server, throwOnError: false);
 
         public abstract Type? BaseType { get; }
 
         [DebuggerHidden]
         [DebuggerStepThrough]
-        public object? InvokeMember(string name, BindingFlags invokeAttr, Binder? binder, object? target, object[]? args) => InvokeMember(name, invokeAttr, binder, target, args, null, null, null);
+        public object? InvokeMember(string name, BindingFlags invokeAttr, Binder? binder, object? target, object?[]? args) => InvokeMember(name, invokeAttr, binder, target, args, null, null, null);
 
         [DebuggerHidden]
         [DebuggerStepThrough]
-        public object? InvokeMember(string name, BindingFlags invokeAttr, Binder? binder, object? target, object[]? args, CultureInfo? culture) => InvokeMember(name, invokeAttr, binder, target, args, null, culture, null);
-        public abstract object? InvokeMember(string name, BindingFlags invokeAttr, Binder? binder, object? target, object[]? args, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParameters);
+        public object? InvokeMember(string name, BindingFlags invokeAttr, Binder? binder, object? target, object?[]? args, CultureInfo? culture) => InvokeMember(name, invokeAttr, binder, target, args, null, culture, null);
+        public abstract object? InvokeMember(string name, BindingFlags invokeAttr, Binder? binder, object? target, object?[]? args, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParameters);
 
         public Type? GetInterface(string name) => GetInterface(name, ignoreCase: false);
         public abstract Type? GetInterface(string name, bool ignoreCase);
@@ -366,7 +364,7 @@ namespace System
         }
         public virtual bool Equals(Type? o) => o == null ? false : object.ReferenceEquals(this.UnderlyingSystemType, o.UnderlyingSystemType);
 
-        public static Type ReflectionOnlyGetType(string typeName, bool throwIfNotFound, bool ignoreCase) { throw new PlatformNotSupportedException(SR.PlatformNotSupported_ReflectionOnly); }
+        public static Type? ReflectionOnlyGetType(string typeName, bool throwIfNotFound, bool ignoreCase) { throw new PlatformNotSupportedException(SR.PlatformNotSupported_ReflectionOnly); }
 
         public static Binder DefaultBinder
         {
@@ -387,9 +385,9 @@ namespace System
         public static readonly Type[] EmptyTypes = Array.Empty<Type>();
         public static readonly object Missing = System.Reflection.Missing.Value;
 
-        public static readonly MemberFilter FilterAttribute = FilterAttributeImpl;
-        public static readonly MemberFilter FilterName = (m, c) => FilterNameImpl(m, c, StringComparison.Ordinal);
-        public static readonly MemberFilter FilterNameIgnoreCase = (m, c) => FilterNameImpl(m, c, StringComparison.OrdinalIgnoreCase);
+        public static readonly MemberFilter FilterAttribute = FilterAttributeImpl!;
+        public static readonly MemberFilter FilterName = (m, c) => FilterNameImpl(m, c!, StringComparison.Ordinal);
+        public static readonly MemberFilter FilterNameIgnoreCase = (m, c) => FilterNameImpl(m, c!, StringComparison.OrdinalIgnoreCase);
 
         private const BindingFlags DefaultLookup = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public;
     }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivator.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivator.cs
@@ -350,7 +350,7 @@ $@"{nameof(UnregisterClassForTypeInternal)} arguments:
                 AssemblyLoadContext alc = GetALC(assemblyPath);
                 var assemblyNameLocal = new AssemblyName(assemblyName);
                 Assembly assem = alc.LoadFromAssemblyName(assemblyNameLocal);
-                Type t = assem.GetType(typeName);
+                Type? t = assem.GetType(typeName);
                 if (t != null)
                 {
                     return t;

--- a/src/System.Private.CoreLib/src/System/AppContext.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/AppContext.CoreCLR.cs
@@ -17,13 +17,13 @@ namespace System
             }
         }
 
-        private static string? GetBaseDirectoryCore()
+        private static string GetBaseDirectoryCore()
         {
             // Fallback path for hosts that do not set APP_CONTEXT_BASE_DIRECTORY explicitly
             string? directory = Path.GetDirectoryName(Assembly.GetEntryAssembly()?.Location);
             if (directory != null && !Path.EndsInDirectorySeparator(directory))
                 directory += Path.DirectorySeparatorChar;
-            return directory;
+            return directory ?? string.Empty;
         }
     }
 }

--- a/src/System.Private.CoreLib/src/System/Reflection/AssemblyName.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/AssemblyName.CoreCLR.cs
@@ -62,7 +62,7 @@ namespace System.Reflection
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private extern byte[] ComputePublicKeyToken();
+        private extern byte[]? ComputePublicKeyToken();
 
         internal void SetProcArchIndex(PortableExecutableKinds pek, ImageFileMachine ifm)
         {

--- a/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -112,7 +112,7 @@ namespace System.Reflection
 
             // No pseudo attributes for RuntimeAssembly
 
-            return GetCustomAttributes((RuntimeModule)target.ManifestModule!, RuntimeAssembly.GetToken(target.GetNativeHandle()));
+            return GetCustomAttributes((RuntimeModule)target.ManifestModule, RuntimeAssembly.GetToken(target.GetNativeHandle()));
         }
 
         internal static IList<CustomAttributeData> GetCustomAttributesInternal(RuntimeParameterInfo target)

--- a/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -440,7 +440,7 @@ namespace System.Reflection
         #endregion
 
         #region Public Members
-        public virtual Type? AttributeType { get { return Constructor.DeclaringType; } }
+        public virtual Type AttributeType { get { return Constructor.DeclaringType!; } }
 
         public virtual ConstructorInfo Constructor { get { return m_ctor; } }
 

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
@@ -497,7 +497,7 @@ namespace System.Reflection.Emit
             return InternalAssembly.GetType(name, throwOnError, ignoreCase);
         }
 
-        public override Module? ManifestModule => _manifestModuleBuilder.InternalModule;
+        public override Module ManifestModule => _manifestModuleBuilder.InternalModule;
 
         public override bool ReflectionOnly => InternalAssembly.ReflectionOnly;
 

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/ConstructorBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/ConstructorBuilder.cs
@@ -190,11 +190,13 @@ namespace System.Reflection.Emit
             return m_methodBuilder.GetModule();
         }
 
+#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         // This always returns null. Is that what we want?
         internal override Type? GetReturnType()
         {
             return m_methodBuilder.ReturnType;
         }
+#pragma warning restore CS8609
 
         public string Signature
         {

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/ConstructorBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/ConstructorBuilder.cs
@@ -190,13 +190,10 @@ namespace System.Reflection.Emit
             return m_methodBuilder.GetModule();
         }
 
-#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
-        // This always returns null. Is that what we want?
-        internal override Type? GetReturnType()
+        internal override Type GetReturnType()
         {
             return m_methodBuilder.ReturnType;
         }
-#pragma warning restore CS8609
 
         public string Signature
         {

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
@@ -738,10 +738,12 @@ namespace System.Reflection.Emit
             return m_localSignature;
         }
 
+#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         internal override byte[]? GetRawEHInfo()
         {
             return m_exceptionHeader;
         }
+#pragma warning restore CS8609
 
         internal override unsafe void GetEHInfo(int excNumber, void* exc)
         {
@@ -768,7 +770,9 @@ namespace System.Reflection.Emit
             }
         }
 
+#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         internal override string? GetStringLiteral(int token) { return m_scope.GetString(token); }
+#pragma warning restore CS8609
 
 
         internal override void ResolveToken(int token, out IntPtr typeHandle, out IntPtr methodHandle, out IntPtr fieldHandle)
@@ -835,10 +839,12 @@ namespace System.Reflection.Emit
             }
         }
 
+#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         internal override byte[]? ResolveSignature(int token, int fromMethod)
         {
             return m_scope.ResolveSignature(token, fromMethod);
         }
+#pragma warning restore CS8609
 
         internal override MethodInfo GetDynamicMethod()
         {

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
@@ -738,12 +738,10 @@ namespace System.Reflection.Emit
             return m_localSignature;
         }
 
-#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         internal override byte[]? GetRawEHInfo()
         {
             return m_exceptionHeader;
         }
-#pragma warning restore CS8609
 
         internal override unsafe void GetEHInfo(int excNumber, void* exc)
         {
@@ -770,10 +768,7 @@ namespace System.Reflection.Emit
             }
         }
 
-#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         internal override string? GetStringLiteral(int token) { return m_scope.GetString(token); }
-#pragma warning restore CS8609
-
 
         internal override void ResolveToken(int token, out IntPtr typeHandle, out IntPtr methodHandle, out IntPtr fieldHandle)
         {
@@ -839,12 +834,10 @@ namespace System.Reflection.Emit
             }
         }
 
-#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         internal override byte[]? ResolveSignature(int token, int fromMethod)
         {
             return m_scope.ResolveSignature(token, fromMethod);
         }
-#pragma warning restore CS8609
 
         internal override MethodInfo GetDynamicMethod()
         {

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
@@ -490,11 +490,11 @@ namespace System.Reflection.Emit
 
         public override bool IsDefined(Type attributeType, bool inherit) { return m_dynMethod.IsDefined(attributeType, inherit); }
 
-        public override Type? ReturnType { get { return m_dynMethod.ReturnType; } }
+        public override Type ReturnType { get { return m_dynMethod.ReturnType; } }
 
         public override ParameterInfo? ReturnParameter { get { return m_dynMethod.ReturnParameter; } }
 
-        public override ICustomAttributeProvider? ReturnTypeCustomAttributes { get { return m_dynMethod.ReturnTypeCustomAttributes; } }
+        public override ICustomAttributeProvider ReturnTypeCustomAttributes { get { return m_dynMethod.ReturnTypeCustomAttributes; } }
 
         //
         // DynamicMethod specific methods
@@ -706,7 +706,6 @@ namespace System.Reflection.Emit
                 get { return m_owner.IsSecurityTransparent; }
             }
 
-#pragma warning disable CS8608 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
             public override Type ReturnType
             {
                 get
@@ -714,19 +713,16 @@ namespace System.Reflection.Emit
                     return m_owner.m_returnType;
                 }
             }
-#pragma warning restore CS8608
 
             public override ParameterInfo? ReturnParameter
             {
                 get { return null; }
             }
 
-#pragma warning disable CS8608 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
             public override ICustomAttributeProvider ReturnTypeCustomAttributes
             {
                 get { return GetEmptyCAHolder(); }
             }
-#pragma warning restore CS8608
 
             //
             // private implementation

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
@@ -719,14 +719,7 @@ namespace System.Reflection.Emit
                 get { return new RuntimeParameterInfo(this, null, m_owner.m_returnType, -1); }
             }
 
-            public override ICustomAttributeProvider ReturnTypeCustomAttributes
-            {
-                get { return GetEmptyCAHolder(); }
-            }
-
-            //
-            // private implementation
-            //
+            public override ICustomAttributeProvider ReturnTypeCustomAttributes => new EmptyCAHolder();
 
             internal RuntimeParameterInfo[] LoadParameters()
             {
@@ -741,34 +734,6 @@ namespace System.Reflection.Emit
                         m_parameters = parameters;
                 }
                 return m_parameters;
-            }
-
-            // private implementation of CA for the return type
-            private ICustomAttributeProvider GetEmptyCAHolder()
-            {
-                return new EmptyCAHolder();
-            }
-
-            ///////////////////////////////////////////////////
-            // EmptyCAHolder
-            private class EmptyCAHolder : ICustomAttributeProvider
-            {
-                internal EmptyCAHolder() { }
-
-                object[] ICustomAttributeProvider.GetCustomAttributes(Type attributeType, bool inherit)
-                {
-                    return Array.Empty<object>();
-                }
-
-                object[] ICustomAttributeProvider.GetCustomAttributes(bool inherit)
-                {
-                    return Array.Empty<object>();
-                }
-
-                bool ICustomAttributeProvider.IsDefined(Type attributeType, bool inherit)
-                {
-                    return false;
-                }
             }
         }
     }

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
@@ -492,7 +492,7 @@ namespace System.Reflection.Emit
 
         public override Type ReturnType { get { return m_dynMethod.ReturnType; } }
 
-        public override ParameterInfo? ReturnParameter { get { return m_dynMethod.ReturnParameter; } }
+        public override ParameterInfo ReturnParameter { get { return m_dynMethod.ReturnParameter; } }
 
         public override ICustomAttributeProvider ReturnTypeCustomAttributes { get { return m_dynMethod.ReturnTypeCustomAttributes; } }
 
@@ -714,9 +714,9 @@ namespace System.Reflection.Emit
                 }
             }
 
-            public override ParameterInfo? ReturnParameter
+            public override ParameterInfo ReturnParameter
             {
-                get { return null; }
+                get { return new RuntimeParameterInfo(this, null, m_owner.m_returnType, -1); }
             }
 
             public override ICustomAttributeProvider ReturnTypeCustomAttributes

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/EmptyCAHolder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/EmptyCAHolder.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Reflection.Emit
+{
+    internal class EmptyCAHolder : ICustomAttributeProvider
+    {
+        internal EmptyCAHolder() { }
+
+        object[] ICustomAttributeProvider.GetCustomAttributes(Type attributeType, bool inherit) => Array.Empty<object>();
+
+        object[] ICustomAttributeProvider.GetCustomAttributes(bool inherit) => Array.Empty<object>();
+
+        bool ICustomAttributeProvider.IsDefined(Type attributeType, bool inherit) => false;
+    }
+}

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/EnumBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/EnumBuilder.cs
@@ -83,7 +83,7 @@ namespace System.Reflection.Emit
             BindingFlags invokeAttr,
             Binder? binder,
             object? target,
-            object[]? args,
+            object?[]? args,
             ParameterModifier[]? modifiers,
             CultureInfo? culture,
             string[]? namedParameters)

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/GenericTypeParameterBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/GenericTypeParameterBuilder.cs
@@ -94,7 +94,7 @@ namespace System.Reflection.Emit
 
         public override Guid GUID { get { throw new NotSupportedException(); } }
 
-        public override object InvokeMember(string name, BindingFlags invokeAttr, Binder? binder, object? target, object[]? args, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParameters) { throw new NotSupportedException(); }
+        public override object InvokeMember(string name, BindingFlags invokeAttr, Binder? binder, object? target, object?[]? args, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParameters) { throw new NotSupportedException(); }
 
         public override Assembly Assembly { get { return m_type.Assembly; } }
 

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/ILGenerator.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/ILGenerator.cs
@@ -1121,7 +1121,7 @@ namespace System.Reflection.Emit
                 throw new ArgumentException(SR.NotSupported_OutputStreamUsingTypeBuilder);
             }
             parameterTypes[0] = (Type)cls;
-            MethodInfo? mi = prop.ReturnType!.GetMethod("WriteLine", parameterTypes);
+            MethodInfo? mi = prop.ReturnType.GetMethod("WriteLine", parameterTypes);
             if (mi == null)
             {
                 throw new ArgumentException(SR.Argument_EmitWriteLineType, nameof(localBuilder));
@@ -1161,7 +1161,7 @@ namespace System.Reflection.Emit
                 throw new NotSupportedException(SR.NotSupported_OutputStreamUsingTypeBuilder);
             }
             parameterTypes[0] = (Type)cls;
-            MethodInfo? mi = prop.ReturnType!.GetMethod("WriteLine", parameterTypes);
+            MethodInfo? mi = prop.ReturnType.GetMethod("WriteLine", parameterTypes);
             if (mi == null)
             {
                 throw new ArgumentException(SR.Argument_EmitWriteLineType, nameof(fld));

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.cs
@@ -86,16 +86,7 @@ namespace System.Reflection.Emit
             m_strName = name;
             m_module = mod;
             m_containingType = type;
-
-
-            if (returnType == null)
-            {
-                m_returnType = typeof(void);
-            }
-            else
-            {
-                m_returnType = returnType;
-            }
+            m_returnType = returnType ?? typeof(void);
 
             if ((attributes & MethodAttributes.Static) == 0)
             {
@@ -649,9 +640,7 @@ namespace System.Reflection.Emit
 
         public override bool IsGenericMethod { get { return m_inst != null; } }
 
-#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
-        public override Type[]? GetGenericArguments() { return m_inst; }
-#pragma warning restore CS8609
+        public override Type[] GetGenericArguments() => m_inst ?? Array.Empty<Type>();
 
         public override MethodInfo MakeGenericMethod(params Type[] typeArguments)
         {

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.cs
@@ -44,7 +44,7 @@ namespace System.Reflection.Emit
         // Parameters
         private SignatureHelper? m_signature;
         internal Type[]? m_parameterTypes;
-        private Type? m_returnType;
+        private Type m_returnType;
         private Type[]? m_returnTypeRequiredCustomModifiers;
         private Type[]? m_returnTypeOptionalCustomModifiers;
         private Type[][]? m_parameterTypeRequiredCustomModifiers;
@@ -87,12 +87,12 @@ namespace System.Reflection.Emit
             m_module = mod;
             m_containingType = type;
 
-            // 
-            //if (returnType == null)
-            //{
-            //    m_returnType = typeof(void);
-            //}
-            //else
+
+            if (returnType == null)
+            {
+                m_returnType = typeof(void);
+            }
+            else
             {
                 m_returnType = returnType;
             }
@@ -362,7 +362,7 @@ namespace System.Reflection.Emit
                 m_parameterTypes = Array.Empty<Type>();
 
             m_signature = SignatureHelper.GetMethodSigHelper(m_module, m_callingConvention, m_inst != null ? m_inst.Length : 0,
-                m_returnType == null ? typeof(void) : m_returnType, m_returnTypeRequiredCustomModifiers, m_returnTypeOptionalCustomModifiers,
+                m_returnType, m_returnTypeRequiredCustomModifiers, m_returnTypeOptionalCustomModifiers,
                 m_parameterTypes, m_parameterTypeRequiredCustomModifiers, m_parameterTypeOptionalCustomModifiers);
 
             return m_signature;
@@ -522,6 +522,7 @@ namespace System.Reflection.Emit
             }
         }
 
+#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         public override ICustomAttributeProvider? ReturnTypeCustomAttributes
         {
             get
@@ -529,6 +530,7 @@ namespace System.Reflection.Emit
                 return null;
             }
         }
+#pragma warning restore CS8609
 
         public override Type? ReflectedType
         {
@@ -588,7 +590,7 @@ namespace System.Reflection.Emit
             return this;
         }
 
-        public override Type? ReturnType
+        public override Type ReturnType
         {
             get
             {
@@ -647,7 +649,9 @@ namespace System.Reflection.Emit
 
         public override bool IsGenericMethod { get { return m_inst != null; } }
 
+#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         public override Type[]? GetGenericArguments() { return m_inst; }
+#pragma warning restore CS8609
 
         public override MethodInfo MakeGenericMethod(params Type[] typeArguments)
         {

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.cs
@@ -513,15 +513,7 @@ namespace System.Reflection.Emit
             }
         }
 
-#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
-        public override ICustomAttributeProvider? ReturnTypeCustomAttributes
-        {
-            get
-            {
-                return null;
-            }
-        }
-#pragma warning restore CS8609
+        public override ICustomAttributeProvider ReturnTypeCustomAttributes => new EmptyCAHolder();
 
         public override Type? ReflectedType
         {

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.cs
@@ -599,7 +599,7 @@ namespace System.Reflection.Emit
             return rmi.GetParameters();
         }
 
-        public override ParameterInfo? ReturnParameter
+        public override ParameterInfo ReturnParameter
         {
             get
             {

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilderInstantiation.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilderInstantiation.cs
@@ -96,7 +96,7 @@ namespace System.Reflection.Emit
             }
         }
 
-        public override ParameterInfo ReturnParameter { get { throw new NotSupportedException(); } }
+        public override ParameterInfo? ReturnParameter { get { throw new NotSupportedException(); } }
         public override ICustomAttributeProvider ReturnTypeCustomAttributes { get { throw new NotSupportedException(); } }
         public override MethodInfo GetBaseDefinition() { throw new NotSupportedException(); }
         #endregion

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilderInstantiation.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilderInstantiation.cs
@@ -96,7 +96,7 @@ namespace System.Reflection.Emit
             }
         }
 
-        public override ParameterInfo? ReturnParameter { get { throw new NotSupportedException(); } }
+        public override ParameterInfo ReturnParameter { get { throw new NotSupportedException(); } }
         public override ICustomAttributeProvider ReturnTypeCustomAttributes { get { throw new NotSupportedException(); } }
         public override MethodInfo GetBaseDefinition() { throw new NotSupportedException(); }
         #endregion

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilderInstantiation.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilderInstantiation.cs
@@ -88,7 +88,7 @@ namespace System.Reflection.Emit
         #endregion
 
         #region Public Abstract\Virtual Members
-        public override Type? ReturnType
+        public override Type ReturnType
         {
             get
             {
@@ -96,8 +96,8 @@ namespace System.Reflection.Emit
             }
         }
 
-        public override ParameterInfo? ReturnParameter { get { throw new NotSupportedException(); } }
-        public override ICustomAttributeProvider? ReturnTypeCustomAttributes { get { throw new NotSupportedException(); } }
+        public override ParameterInfo ReturnParameter { get { throw new NotSupportedException(); } }
+        public override ICustomAttributeProvider ReturnTypeCustomAttributes { get { throw new NotSupportedException(); } }
         public override MethodInfo GetBaseDefinition() { throw new NotSupportedException(); }
         #endregion
     }

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.cs
@@ -1232,7 +1232,7 @@ namespace System.Reflection.Emit
                     {
                         sigHelp = SignatureHelper.GetMethodSigHelper(
                         this, method.CallingConvention, method.ReturnType,
-                        method.ReturnParameter!.GetRequiredCustomModifiers(), method.ReturnParameter.GetOptionalCustomModifiers(),
+                        method.ReturnParameter.GetRequiredCustomModifiers(), method.ReturnParameter.GetOptionalCustomModifiers(),
                         parameterTypes, requiredCustomModifiers, optionalCustomModifiers);
                     }
                     catch (NotImplementedException)

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/ParameterBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/ParameterBuilder.cs
@@ -14,7 +14,7 @@ namespace System.Reflection.Emit
             TypeBuilder.SetConstantValue(
                 _methodBuilder.GetModuleBuilder(),
                 _token.Token,
-                _position == 0 ? _methodBuilder.ReturnType! : _methodBuilder.m_parameterTypes![_position - 1],
+                _position == 0 ? _methodBuilder.ReturnType : _methodBuilder.m_parameterTypes![_position - 1],
                 defaultValue);
         }
 

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/PropertyBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/PropertyBuilder.cs
@@ -155,12 +155,12 @@ namespace System.Reflection.Emit
             throw new NotSupportedException(SR.NotSupported_DynamicModule);
         }
 
-        public override void SetValue(object? obj, object? value, object[]? index)
+        public override void SetValue(object? obj, object? value, object?[]? index)
         {
             throw new NotSupportedException(SR.NotSupported_DynamicModule);
         }
 
-        public override void SetValue(object? obj, object? value, BindingFlags invokeAttr, Binder? binder, object[]? index, CultureInfo? culture)
+        public override void SetValue(object? obj, object? value, BindingFlags invokeAttr, Binder? binder, object?[]? index, CultureInfo? culture)
         {
             throw new NotSupportedException(SR.NotSupported_DynamicModule);
         }

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/SymbolMethod.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/SymbolMethod.cs
@@ -13,7 +13,7 @@ namespace System.Reflection.Emit
         private Type m_containingType;
         private string m_name;
         private CallingConventions m_callingConvention;
-        private Type? m_returnType;
+        private Type m_returnType;
         private MethodToken m_mdMethod;
         private Type[] m_parameterTypes;
         private SignatureHelper m_signature;
@@ -33,7 +33,7 @@ namespace System.Reflection.Emit
             m_mdMethod = token;
 
             // The ParameterTypes are also a bit interesting in that they may be unbaked TypeBuilders.
-            m_returnType = returnType;
+            m_returnType = returnType ?? typeof(void);
             if (parameterTypes != null)
             {
                 m_parameterTypes = new Type[parameterTypes.Length];
@@ -118,8 +118,7 @@ namespace System.Reflection.Emit
         #endregion
 
         #region MethodInfo Overrides
-#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
-        public override Type? ReturnType
+        public override Type ReturnType
         {
             get
             {
@@ -127,6 +126,7 @@ namespace System.Reflection.Emit
             }
         }
 
+#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         public override ICustomAttributeProvider? ReturnTypeCustomAttributes
         {
             get { return null; }

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/SymbolMethod.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/SymbolMethod.cs
@@ -126,12 +126,7 @@ namespace System.Reflection.Emit
             }
         }
 
-#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
-        public override ICustomAttributeProvider? ReturnTypeCustomAttributes
-        {
-            get { return null; }
-        }
-#pragma warning restore CS8608
+        public override ICustomAttributeProvider ReturnTypeCustomAttributes => new EmptyCAHolder();
 
         public override object Invoke(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
         {

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/SymbolMethod.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/SymbolMethod.cs
@@ -118,6 +118,7 @@ namespace System.Reflection.Emit
         #endregion
 
         #region MethodInfo Overrides
+#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         public override Type? ReturnType
         {
             get
@@ -130,6 +131,7 @@ namespace System.Reflection.Emit
         {
             get { return null; }
         }
+#pragma warning restore CS8608
 
         public override object Invoke(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
         {

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/SymbolType.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/SymbolType.cs
@@ -318,7 +318,7 @@ namespace System.Reflection.Emit
         }
 
         public override object InvokeMember(string name, BindingFlags invokeAttr, Binder? binder, object? target,
-            object[]? args, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParameters)
+            object?[]? args, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParameters)
         {
             throw new NotSupportedException(SR.NotSupported_NonReflectedType);
         }

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
@@ -771,7 +771,7 @@ namespace System.Reflection.Emit
         }
 
         public override object? InvokeMember(string name, BindingFlags invokeAttr, Binder? binder, object? target,
-            object[]? args, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParameters)
+            object?[]? args, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParameters)
         {
             if (!IsCreated())
                 throw new NotSupportedException(SR.NotSupported_TypeNotYetCreated);
@@ -1250,7 +1250,10 @@ namespace System.Reflection.Emit
             return TypeBuilderInstantiation.MakeGenericType(this, typeArguments);
         }
 
+#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         public override Type[]? GetGenericArguments() { return m_inst; }
+#pragma warning restore CS8609
+
         // If a TypeBuilder is generic, it must be a generic type definition
         // All instantiated generic types are TypeBuilderInstantiation.
         public override bool IsGenericTypeDefinition { get { return IsGenericType; } }

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
@@ -1250,9 +1250,7 @@ namespace System.Reflection.Emit
             return TypeBuilderInstantiation.MakeGenericType(this, typeArguments);
         }
 
-#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
-        public override Type[]? GetGenericArguments() { return m_inst; }
-#pragma warning restore CS8609
+        public override Type[] GetGenericArguments() => m_inst ?? Array.Empty<Type>();
 
         // If a TypeBuilder is generic, it must be a generic type definition
         // All instantiated generic types are TypeBuilderInstantiation.

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilderInstantiation.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilderInstantiation.cs
@@ -98,7 +98,7 @@ namespace System.Reflection.Emit
             return SymbolType.FormCompoundType(s, this, 0)!;
         }
         public override Guid GUID { get { throw new NotSupportedException(); } }
-        public override object InvokeMember(string name, BindingFlags invokeAttr, Binder? binder, object? target, object[]? args, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParameters) { throw new NotSupportedException(); }
+        public override object InvokeMember(string name, BindingFlags invokeAttr, Binder? binder, object? target, object?[]? args, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParameters) { throw new NotSupportedException(); }
         public override Assembly Assembly { get { return m_type.Assembly; } }
         public override RuntimeTypeHandle TypeHandle { get { throw new NotSupportedException(); } }
         public override string? FullName

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/XXXOnTypeBuilderInstantiation.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/XXXOnTypeBuilderInstantiation.cs
@@ -75,7 +75,7 @@ namespace System.Reflection.Emit
 
         #region Public Abstract\Virtual Members
         public override Type ReturnType { get { return m_method.ReturnType; } }
-        public override ParameterInfo ReturnParameter { get { throw new NotSupportedException(); } }
+        public override ParameterInfo? ReturnParameter { get { throw new NotSupportedException(); } }
         public override ICustomAttributeProvider ReturnTypeCustomAttributes { get { throw new NotSupportedException(); } }
         public override MethodInfo GetBaseDefinition() { throw new NotSupportedException(); }
         #endregion    
@@ -110,12 +110,10 @@ namespace System.Reflection.Emit
             return m_ctor.GetParameterTypes();
         }
 
-#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
-        internal override Type? GetReturnType()
+        internal override Type GetReturnType()
         {
-            return DeclaringType;
+            return m_type;
         }
-#pragma warning restore CS8609
 
         #region MemberInfo Overrides
         public override MemberTypes MemberType { get { return m_ctor.MemberType; } }

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/XXXOnTypeBuilderInstantiation.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/XXXOnTypeBuilderInstantiation.cs
@@ -74,9 +74,9 @@ namespace System.Reflection.Emit
         #endregion
 
         #region Public Abstract\Virtual Members
-        public override Type? ReturnType { get { return m_method.ReturnType; } }
-        public override ParameterInfo? ReturnParameter { get { throw new NotSupportedException(); } }
-        public override ICustomAttributeProvider? ReturnTypeCustomAttributes { get { throw new NotSupportedException(); } }
+        public override Type ReturnType { get { return m_method.ReturnType; } }
+        public override ParameterInfo ReturnParameter { get { throw new NotSupportedException(); } }
+        public override ICustomAttributeProvider ReturnTypeCustomAttributes { get { throw new NotSupportedException(); } }
         public override MethodInfo GetBaseDefinition() { throw new NotSupportedException(); }
         #endregion    
     }
@@ -110,10 +110,12 @@ namespace System.Reflection.Emit
             return m_ctor.GetParameterTypes();
         }
 
+#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         internal override Type? GetReturnType()
         {
             return DeclaringType;
         }
+#pragma warning restore CS8609
 
         #region MemberInfo Overrides
         public override MemberTypes MemberType { get { return m_ctor.MemberType; } }

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/XXXOnTypeBuilderInstantiation.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/XXXOnTypeBuilderInstantiation.cs
@@ -75,7 +75,7 @@ namespace System.Reflection.Emit
 
         #region Public Abstract\Virtual Members
         public override Type ReturnType { get { return m_method.ReturnType; } }
-        public override ParameterInfo? ReturnParameter { get { throw new NotSupportedException(); } }
+        public override ParameterInfo ReturnParameter { get { throw new NotSupportedException(); } }
         public override ICustomAttributeProvider ReturnTypeCustomAttributes { get { throw new NotSupportedException(); } }
         public override MethodInfo GetBaseDefinition() { throw new NotSupportedException(); }
         #endregion    

--- a/src/System.Private.CoreLib/src/System/Reflection/MdFieldInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/MdFieldInfo.cs
@@ -66,12 +66,14 @@ namespace System.Reflection
         public override bool IsSecuritySafeCritical { get { return DeclaringType!.IsSecuritySafeCritical; } }
         public override bool IsSecurityTransparent { get { return DeclaringType!.IsSecurityTransparent; } }
 
+#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         [DebuggerStepThroughAttribute]
         [Diagnostics.DebuggerHidden]
         public override object? GetValueDirect(TypedReference obj)
         {
             return GetValue(null);
         }
+#pragma warning restore CS8609
 
         [DebuggerStepThroughAttribute]
         [Diagnostics.DebuggerHidden]
@@ -87,7 +89,9 @@ namespace System.Reflection
             return GetValue(false);
         }
 
+#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         public override object? GetRawConstantValue() { return GetValue(true); }
+#pragma warning restore CS8609
 
         private object? GetValue(bool raw)
         {

--- a/src/System.Private.CoreLib/src/System/Reflection/MdFieldInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/MdFieldInfo.cs
@@ -66,14 +66,12 @@ namespace System.Reflection
         public override bool IsSecuritySafeCritical { get { return DeclaringType!.IsSecuritySafeCritical; } }
         public override bool IsSecurityTransparent { get { return DeclaringType!.IsSecurityTransparent; } }
 
-#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         [DebuggerStepThroughAttribute]
         [Diagnostics.DebuggerHidden]
         public override object? GetValueDirect(TypedReference obj)
         {
             return GetValue(null);
         }
-#pragma warning restore CS8609
 
         [DebuggerStepThroughAttribute]
         [Diagnostics.DebuggerHidden]
@@ -89,9 +87,7 @@ namespace System.Reflection
             return GetValue(false);
         }
 
-#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         public override object? GetRawConstantValue() { return GetValue(true); }
-#pragma warning restore CS8609
 
         private object? GetValue(bool raw)
         {

--- a/src/System.Private.CoreLib/src/System/Reflection/RtFieldInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RtFieldInfo.cs
@@ -188,6 +188,7 @@ namespace System.Reflection
 
         public override object GetRawConstantValue() { throw new InvalidOperationException(); }
 
+#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         [DebuggerStepThroughAttribute]
         [Diagnostics.DebuggerHidden]
         public override object? GetValueDirect(TypedReference obj)
@@ -201,6 +202,7 @@ namespace System.Reflection
                 return RuntimeFieldHandle.GetValueDirect(this, (RuntimeType)FieldType, &obj, (RuntimeType?)DeclaringType);
             }
         }
+#pragma warning restore CS8609
 
         [DebuggerStepThroughAttribute]
         [Diagnostics.DebuggerHidden]

--- a/src/System.Private.CoreLib/src/System/Reflection/RtFieldInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RtFieldInfo.cs
@@ -188,7 +188,6 @@ namespace System.Reflection
 
         public override object GetRawConstantValue() { throw new InvalidOperationException(); }
 
-#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         [DebuggerStepThroughAttribute]
         [Diagnostics.DebuggerHidden]
         public override object? GetValueDirect(TypedReference obj)
@@ -202,7 +201,6 @@ namespace System.Reflection
                 return RuntimeFieldHandle.GetValueDirect(this, (RuntimeType)FieldType, &obj, (RuntimeType?)DeclaringType);
             }
         }
-#pragma warning restore CS8609
 
         [DebuggerStepThroughAttribute]
         [Diagnostics.DebuggerHidden]

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -104,13 +104,10 @@ namespace System.Reflection
                     null); // strong name key pair
 
             Module manifestModule = ManifestModule;
-            if (manifestModule != null)
+            if (manifestModule.MDStreamVersion > 0x10000)
             {
-                if (manifestModule.MDStreamVersion > 0x10000)
-                {
-                    manifestModule.GetPEKind(out PortableExecutableKinds pek, out ImageFileMachine ifm);
-                    an.SetProcArchIndex(pek, ifm);
-                }
+                manifestModule.GetPEKind(out PortableExecutableKinds pek, out ImageFileMachine ifm);
+                an.SetProcArchIndex(pek, ifm);
             }
             return an;
         }

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -103,7 +103,7 @@ namespace System.Reflection
                     GetFlags() | AssemblyNameFlags.PublicKey,
                     null); // strong name key pair
 
-            Module? manifestModule = ManifestModule;
+            Module manifestModule = ManifestModule;
             if (manifestModule != null)
             {
                 if (manifestModule.MDStreamVersion > 0x10000)
@@ -271,7 +271,7 @@ namespace System.Reflection
             throw new PlatformNotSupportedException();
         }
 
-        public override Module? ManifestModule
+        public override Module ManifestModule
         {
             get
             {

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
@@ -376,6 +376,7 @@ namespace System.Reflection
             return RuntimeMethodHandle.InvokeMethod(obj, null, sig, false, wrapExceptions);
         }
 
+#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         public override MethodBody? GetMethodBody()
         {
             RuntimeMethodBody? mb = RuntimeMethodHandle.GetMethodBody(this, ReflectedTypeInternal);
@@ -383,6 +384,7 @@ namespace System.Reflection
                 mb._methodBase = this;
             return mb;
         }
+#pragma warning restore CS8609
 
         public override bool IsSecurityCritical
         {

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
@@ -376,7 +376,6 @@ namespace System.Reflection
             return RuntimeMethodHandle.InvokeMethod(obj, null, sig, false, wrapExceptions);
         }
 
-#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         public override MethodBody? GetMethodBody()
         {
             RuntimeMethodBody? mb = RuntimeMethodHandle.GetMethodBody(this, ReflectedTypeInternal);
@@ -384,7 +383,6 @@ namespace System.Reflection
                 mb._methodBase = this;
             return mb;
         }
-#pragma warning restore CS8609
 
         public override bool IsSecurityCritical
         {

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
@@ -394,6 +394,7 @@ namespace System.Reflection
             }
         }
 
+#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         public override MethodBody? GetMethodBody()
         {
             RuntimeMethodBody? mb = RuntimeMethodHandle.GetMethodBody(this, ReflectedTypeInternal);
@@ -401,6 +402,8 @@ namespace System.Reflection
                 mb._methodBase = this;
             return mb;
         }
+#pragma warning restore CS8609
+
         #endregion
 
         #region Invocation Logic(On MemberBase)
@@ -509,7 +512,6 @@ namespace System.Reflection
 
         #region MethodInfo Overrides
 
-#pragma warning disable CS8608 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         public override Type ReturnType
         {
             get { return Signature.ReturnType; }
@@ -520,6 +522,7 @@ namespace System.Reflection
             get { return ReturnParameter; }
         }
 
+#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         public override ParameterInfo ReturnParameter
         {
             get
@@ -528,11 +531,11 @@ namespace System.Reflection
                 return (m_returnParameter as ParameterInfo)!;
             }
         }
-#pragma warning restore CS8608
+#pragma warning restore CS8609
 
         public override bool IsCollectible => (RuntimeMethodHandle.GetIsCollectible(new RuntimeMethodHandleInternal(m_handle)) != Interop.BOOL.FALSE);
 
-        public override MethodInfo? GetBaseDefinition()
+        public override MethodInfo GetBaseDefinition()
         {
             if (!IsVirtual || IsStatic || m_declaringType == null || m_declaringType.IsInterface)
                 return this;
@@ -555,7 +558,7 @@ namespace System.Reflection
                 declaringType = (RuntimeType)declaringType.BaseType!;
             } while (declaringType != null);
 
-            return (MethodInfo?)RuntimeType.GetMethodBase(baseDeclaringType, baseMethodHandle);
+            return (MethodInfo)RuntimeType.GetMethodBase(baseDeclaringType, baseMethodHandle)!;
         }
 
         public override Delegate CreateDelegate(Type delegateType)
@@ -612,7 +615,7 @@ namespace System.Reflection
         #endregion
 
         #region Generics
-        public override MethodInfo? MakeGenericMethod(params Type[] methodInstantiation)
+        public override MethodInfo MakeGenericMethod(params Type[] methodInstantiation)
         {
             if (methodInstantiation == null)
                 throw new ArgumentNullException(nameof(methodInstantiation));
@@ -661,7 +664,7 @@ namespace System.Reflection
                 throw;
             }
 
-            return ret;
+            return ret!;
         }
 
         internal RuntimeType[] GetGenericArgumentsInternal()
@@ -680,12 +683,12 @@ namespace System.Reflection
             return types;
         }
 
-        public override MethodInfo? GetGenericMethodDefinition()
+        public override MethodInfo GetGenericMethodDefinition()
         {
             if (!IsGenericMethod)
                 throw new InvalidOperationException();
 
-            return RuntimeType.GetMethodBase(m_declaringType, RuntimeMethodHandle.StripMethodInstantiation(this)) as MethodInfo;
+            return (RuntimeType.GetMethodBase(m_declaringType, RuntimeMethodHandle.StripMethodInstantiation(this)) as MethodInfo)!;
         }
 
         public override bool IsGenericMethod

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
@@ -394,7 +394,6 @@ namespace System.Reflection
             }
         }
 
-#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         public override MethodBody? GetMethodBody()
         {
             RuntimeMethodBody? mb = RuntimeMethodHandle.GetMethodBody(this, ReflectedTypeInternal);
@@ -402,7 +401,6 @@ namespace System.Reflection
                 mb._methodBase = this;
             return mb;
         }
-#pragma warning restore CS8609
 
         #endregion
 
@@ -522,16 +520,9 @@ namespace System.Reflection
             get { return ReturnParameter; }
         }
 
-#pragma warning disable CS8609 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
-        public override ParameterInfo ReturnParameter
-        {
-            get
-            {
-                FetchReturnParameter();
-                return (m_returnParameter as ParameterInfo)!;
-            }
-        }
-#pragma warning restore CS8609
+#pragma warning disable CS6809 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
+        public override ParameterInfo ReturnParameter => FetchReturnParameter();
+#pragma warning restore CS6809
 
         public override bool IsCollectible => (RuntimeMethodHandle.GetIsCollectible(new RuntimeMethodHandleInternal(m_handle)) != Interop.BOOL.FALSE);
 

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
@@ -520,9 +520,7 @@ namespace System.Reflection
             get { return ReturnParameter; }
         }
 
-#pragma warning disable CS6809 // TODO-NULLABLE: Covariant return types (https://github.com/dotnet/roslyn/issues/23268)
         public override ParameterInfo ReturnParameter => FetchReturnParameter();
-#pragma warning restore CS6809
 
         public override bool IsCollectible => (RuntimeMethodHandle.GetIsCollectible(new RuntimeMethodHandleInternal(m_handle)) != Interop.BOOL.FALSE);
 

--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
@@ -248,9 +248,9 @@ namespace System.Reflection
             return defaultValue!;
         }
 
-        public override object GetConstantValue() { return GetConstantValue(false); }
+        public override object? GetConstantValue() { return GetConstantValue(false); }
 
-        public override object GetRawConstantValue() { return GetConstantValue(true); }
+        public override object? GetRawConstantValue() { return GetConstantValue(true); }
 
         public override MethodInfo[] GetAccessors(bool nonPublic)
         {
@@ -400,7 +400,7 @@ namespace System.Reflection
 
         [DebuggerStepThroughAttribute]
         [Diagnostics.DebuggerHidden]
-        public override void SetValue(object? obj, object? value, object[]? index)
+        public override void SetValue(object? obj, object? value, object?[]? index)
         {
             SetValue(obj,
                     value,
@@ -412,7 +412,7 @@ namespace System.Reflection
 
         [DebuggerStepThroughAttribute]
         [Diagnostics.DebuggerHidden]
-        public override void SetValue(object? obj, object? value, BindingFlags invokeAttr, Binder? binder, object[]? index, CultureInfo? culture)
+        public override void SetValue(object? obj, object? value, BindingFlags invokeAttr, Binder? binder, object?[]? index, CultureInfo? culture)
         {
             MethodInfo? m = GetSetMethod(true);
 

--- a/src/System.Private.CoreLib/src/System/RtType.cs
+++ b/src/System.Private.CoreLib/src/System/RtType.cs
@@ -3841,7 +3841,7 @@ namespace System
         [DebuggerHidden]
         public override object? InvokeMember(
             string name, BindingFlags bindingFlags, Binder? binder, object? target,
-            object[]? providedArgs, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParams)
+            object?[]? providedArgs, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParams)
         {
             if (IsGenericParameter)
                 throw new InvalidOperationException(SR.Arg_GenericParameter);
@@ -3986,7 +3986,7 @@ namespace System
                 }
                 else if (flds.Length > 0)
                 {
-                    selFld = binder.BindToField(bindingFlags, flds, IsGetField ? Empty.Value : providedArgs![0], culture);
+                    selFld = binder.BindToField(bindingFlags, flds, IsGetField ? Empty.Value : providedArgs![0]!, culture);
                 }
 
                 if (selFld != null)
@@ -4013,7 +4013,7 @@ namespace System
                             {
                                 try
                                 {
-                                    idx[i] = ((IConvertible)providedArgs![i]).ToInt32(null);
+                                    idx[i] = ((IConvertible)providedArgs![i]!).ToInt32(null);
                                 }
                                 catch (InvalidCastException)
                                 {
@@ -4614,7 +4614,7 @@ namespace System
 #if FEATURE_COMINTEROP       
         [MethodImpl(MethodImplOptions.InternalCall)]
         private extern object InvokeDispMethod(
-            string name, BindingFlags invokeAttr, object target, object[]? args,
+            string name, BindingFlags invokeAttr, object target, object?[]? args,
             bool[]? byrefModifiers, int culture, string[]? namedParameters);
 #endif // FEATURE_COMINTEROP        
 

--- a/src/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -1545,15 +1545,15 @@ namespace System
         }
 
         // ILHeader info
-        internal abstract RuntimeType GetJitContext(out int securityControlFlags);
+        internal abstract RuntimeType? GetJitContext(out int securityControlFlags);
         internal abstract byte[] GetCodeInfo(out int stackSize, out int initLocals, out int EHCount);
         internal abstract byte[] GetLocalsSignature();
         internal abstract unsafe void GetEHInfo(int EHNumber, void* exception);
-        internal abstract byte[] GetRawEHInfo();
+        internal abstract byte[]? GetRawEHInfo();
         // token resolution
-        internal abstract string GetStringLiteral(int token);
+        internal abstract string? GetStringLiteral(int token);
         internal abstract void ResolveToken(int token, out IntPtr typeHandle, out IntPtr methodHandle, out IntPtr fieldHandle);
-        internal abstract byte[] ResolveSignature(int token, int fromMethod);
+        internal abstract byte[]? ResolveSignature(int token, int fromMethod);
         //
         internal abstract MethodInfo GetDynamicMethod();
     }

--- a/src/System.Private.CoreLib/src/System/StartupHookProvider.cs
+++ b/src/System.Private.CoreLib/src/System/StartupHookProvider.cs
@@ -126,7 +126,7 @@ namespace System
             }
 
             Debug.Assert(assembly != null);
-            Type type = assembly.GetType(StartupHookTypeName, throwOnError: true);
+            Type type = assembly.GetType(StartupHookTypeName, throwOnError: true)!;
 
             // Look for a static method without any parameters
             MethodInfo? initializeMethod = type.GetMethod(InitializeMethodName,

--- a/src/System.Private.CoreLib/src/System/ValueType.cs
+++ b/src/System.Private.CoreLib/src/System/ValueType.cs
@@ -88,7 +88,7 @@ namespace System
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern int GetHashCodeOfPtr(IntPtr ptr);
 
-        public override string ToString()
+        public override string? ToString()
         {
             return this.GetType().ToString();
         }

--- a/src/vm/runtimehandles.cpp
+++ b/src/vm/runtimehandles.cpp
@@ -2754,9 +2754,6 @@ FCIMPL1(ReflectModuleBaseObject*, AssemblyHandle::GetManifestModule, AssemblyBas
     DomainAssembly *pAssembly = refAssembly->GetDomainAssembly();
     Assembly* currentAssembly = pAssembly->GetCurrentAssembly();
 
-    if (currentAssembly == NULL)
-        return NULL;
-
     Module *pModule = currentAssembly->GetManifestModule();
     DomainFile * pDomainFile = pModule->GetDomainFile();
 

--- a/tests/CoreFX/CoreFX.issues.rsp
+++ b/tests/CoreFX/CoreFX.issues.rsp
@@ -56,3 +56,16 @@
 -nomethod System.Tests.EnvironmentTests.FailFast_ExceptionStackTrace_StackOverflowException
 -nomethod System.Tests.EnvironmentTests.FailFast_ExceptionStackTrace_InnerException
 -nomethod System.Tests.EnvironmentTests.FailFast_ExceptionStackTrace_ArgumentException
+
+# requires corefx test updates: https://github.com/dotnet/corefx/pull/38269
+-nomethod System.Reflection.Emit.Tests.DynamicMethodctor1.String_Type_TypeArray_Module
+-nomethod System.Reflection.Emit.Tests.DynamicMethodctor1.String_Type_TypeArray_Type
+-nomethod System.Reflection.Emit.Tests.MethodBuilderGetGenericArguments.GetGenericArguments_NonGenericMethod_ReturnsNull
+-nomethod System.Reflection.Emit.Tests.MethodBuilderSetReturnType.SetReturnType_NullReturnType_ReturnsVoid
+-nomethod System.Reflection.Emit.Tests.MethodBuilderSetSignature.SetSignature_AllParametersNull
+-nomethod System.Reflection.Emit.Tests.MethodBuilderSetSignature.SetSignature_NullReturnType_CustomModifiersSetToWrongTypes
+-nomethod System.Reflection.Emit.Tests.TypeBuilderDefineMethodTests.DefineMethod
+-nomethod System.Tests.StringTests.CasingNegativeTest
+-nomethod System.Tests.StringTests.CompareNegativeTest
+-nomethod System.Tests.StringTests.ToLowerNullCulture
+-nomethod System.Tests.StringTests.ToUpperNullCulture


### PR DESCRIPTION
I fixed the annotations that we found out were wrong during API Reviews and also enabled CS8609 (covariant overriden return type) globally and disabled in places where we intentionally are overriding with a different return type.

Also, fixed some annotations in MethodInfo based on an offline conversation with @jkotas 

Here are the notes from the review: https://github.com/dotnet/apireviews/blob/b2a7fcaf18d92267cf41258205e55ad0dd1b2a41/2019/System.Runtime-Nullable/README.md