### PR TITLE
Remove stale Task async extension methods from TaskExtensions

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskExtensions.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskExtensions.cs
@@ -47,35 +47,5 @@ namespace System.Threading.Tasks
                 task.Result ??
                 Task.FromCanceled<TResult>(new CancellationToken(true));
         }
-
-        // TODO: Remove the below three methods once corefx has consumed a build with them in their new TaskAsyncEnumerableExtensions location.
-
-        /// <summary>Configures how awaits on the tasks returned from an async disposable will be performed.</summary>
-        /// <param name="source">The source async disposable.</param>
-        /// <param name="continueOnCapturedContext">Whether to capture and marshal back to the current context.</param>
-        /// <returns>The configured async disposable.</returns>
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        public static ConfiguredAsyncDisposable ConfigureAwait(this IAsyncDisposable source, bool continueOnCapturedContext) =>
-            new ConfiguredAsyncDisposable(source, continueOnCapturedContext);
-
-        /// <summary>Configures how awaits on the tasks returned from an async iteration will be performed.</summary>
-        /// <typeparam name="T">The type of the objects being iterated.</typeparam>
-        /// <param name="source">The source enumerable being iterated.</param>
-        /// <param name="continueOnCapturedContext">Whether to capture and marshal back to the current context.</param>
-        /// <returns>The configured enumerable.</returns>
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        public static ConfiguredCancelableAsyncEnumerable<T> ConfigureAwait<T>(
-            this IAsyncEnumerable<T> source, bool continueOnCapturedContext) =>
-            new ConfiguredCancelableAsyncEnumerable<T>(source, continueOnCapturedContext, cancellationToken: default);
-
-        /// <summary>Sets the <see cref="CancellationToken"/> to be passed to <see cref="IAsyncEnumerable{T}.GetAsyncEnumerator(CancellationToken)"/> when iterating.</summary>
-        /// <typeparam name="T">The type of the objects being iterated.</typeparam>
-        /// <param name="source">The source enumerable being iterated.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use.</param>
-        /// <returns>The configured enumerable.</returns>
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        public static ConfiguredCancelableAsyncEnumerable<T> WithCancellation<T>(
-            this IAsyncEnumerable<T> source, CancellationToken cancellationToken) =>
-            new ConfiguredCancelableAsyncEnumerable<T>(source, continueOnCapturedContext: true, cancellationToken);
     }
 }


### PR DESCRIPTION
While re-generating System.Threading.Tasks reference source against implementation I noticed these APIs were showing on both TaskExtensions and TaskAsyncEnumerableExtensions, then found the TODO comment.

cc: @stephentoub @jkotas 