### PR TITLE
Resolve Windows 10 Kits dir via the environment variable.

### DIFF
--- a/tests/src/Interop/WinRT/NativeComponent/CMakeLists.txt
+++ b/tests/src/Interop/WinRT/NativeComponent/CMakeLists.txt
@@ -28,11 +28,8 @@ else()
   message("Using Windows SDK version ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION} for WinRT interop tests.")
 endif()
 
-set (PROGRAM_FILES_X86 "ProgramFiles(x86)")
-set (WINDOWS_KITS_DIR "$ENV{${PROGRAM_FILES_X86}}/Windows Kits/10")
-if (NOT EXISTS ${WINDOWS_KITS_DIR})
-  set (WINDOWS_KITS_DIR "$ENV{ProgramFiles}/Windows Kits/10")
-endif()
+get_filename_component(WINDOWS_KITS_DIR "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots;KitsRoot10]" ABSOLUTE CACHE)
+
 set (METADATA_DIR "${WINDOWS_KITS_DIR}/References/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/windows.foundation.foundationcontract/*" )
 set (REFERENCE_WINMDS
   "${WINDOWS_KITS_DIR}/References/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/Windows.Foundation.FoundationContract/*/Windows.Foundation.FoundationContract.winmd"

--- a/tests/src/Interop/WinRT/NativeComponent/CMakeLists.txt
+++ b/tests/src/Interop/WinRT/NativeComponent/CMakeLists.txt
@@ -28,7 +28,7 @@ else()
   message("Using Windows SDK version ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION} for WinRT interop tests.")
 endif()
 
-get_filename_component(WINDOWS_KITS_DIR "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots;KitsRoot10]" ABSOLUTE CACHE)
+file(TO_CMAKE_PATH "$ENV{WindowsSdkDir}" WINDOWS_KITS_DIR)
 
 set (METADATA_DIR "${WINDOWS_KITS_DIR}/References/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/windows.foundation.foundationcontract/*" )
 set (REFERENCE_WINMDS


### PR DESCRIPTION
Resolve the Windows 10 SDK location via the registry to support contributors who don't install the Windows 10 SDK in the default location.

Fixes #24828 