### PR TITLE
Fix initializing BuildTools when the Platform environment variable is set

### DIFF
--- a/build-test.cmd
+++ b/build-test.cmd
@@ -166,6 +166,9 @@ REM ===
 REM =========================================================================================
 
 call "%__ProjectDir%\init-tools.cmd"
+if NOT [%ERRORLEVEL%]==[0] (
+    exit /b %ERRORLEVEL%
+)
 @if defined _echo @echo on
 
 set "__ToolsDir=%__ProjectDir%\Tools"

--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -1,6 +1,10 @@
 @if not defined _echo @echo off
 setlocal
 
+:: Clear the 'Platform' environment variable for this session
+:: This avoids overriding the default value from BuildTools projects used for initialization
+set Platform=
+
 set INIT_TOOLS_LOG=%~dp0init-tools.log
 if [%PACKAGES_DIR%]==[] set PACKAGES_DIR=%~dp0.packages
 if [%TOOLRUNTIME_DIR%]==[] set TOOLRUNTIME_DIR=%~dp0Tools


### PR DESCRIPTION
- Clear `Platform` variable before initializing BuildTools
- Make `build-test.cmd` exit if `init-tools.cmd` fails

Some BuildTools initialization steps fail if `Platform` is set to a value with which they are not compatible. We were relying on `dotnet.cmd` to clear the `Platform` environment variable before `init-tools.cmd` was called. `build-test.cmd` was always calling `init-tools.cmd` in such a way that the `Platform` variable was not cleared, but generally the tools would previously have been initialized through `dotnet.cmd`, so they would not be initialized again. With #24841, we stopped initializing BuildTools in `dotnet.cmd`, so the call in `build-test.cmd` was actually doing the initialization (and failing depending on how `Platform is set).

Fixes #24943