### PR TITLE
Fix tmp dir in configure.cmake

### DIFF
--- a/src/pal/src/configure.cmake
+++ b/src/pal/src/configure.cmake
@@ -539,9 +539,10 @@ check_cxx_source_runs("
 #include <string.h>
 #include <sys/types.h>
 #include <sys/mman.h>
+#include <algorithm>
 
 #define MEM_SIZE 1024
-
+#define TEMP_FILE_TEMPLATE \"${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/multiplemaptestXXXXXX\"
 int main(void)
 {
   char * fname;
@@ -549,10 +550,10 @@ int main(void)
   int ret;
   void * pAddr0, * pAddr1;
 
-  fname = (char *)malloc(MEM_SIZE);
+  fname = (char *)malloc(std::max((size_t)MEM_SIZE, sizeof(TEMP_FILE_TEMPLATE)));
   if (!fname)
     exit(1);
-  strcpy(fname, \"/tmp/name/multiplemaptestXXXXXX\");
+  strcpy(fname, TEMP_FILE_TEMPLATE);
 
   fd = mkstemp(fname);
   if (fd < 0)


### PR DESCRIPTION
The ONE_SHARED_MAPPING_PER_FILEREGION_PER_PROCESS check was using a temp
path that had some non-existent components. While this works fine on Linux,
it fails to create the temp file on OSX.
The fix is to use temp dir in the CMake's output dir.

Close #25000