### PR TITLE
[RyuJit] Always go to non-tail call route for Linux/x86

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8295,6 +8295,11 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
                 }
             }
         }
+#elif defined(_TARGET_UNIX_)
+        if (!canFastTailCall && szFailReason == nullptr)
+        {
+            szFailReason = "Morphing Vararg call that needed for tail call on non Windows targets is not yet implemented.";
+        }
 #endif // !_TARGET_X86_
 
         if (szFailReason != nullptr)


### PR DESCRIPTION
Linux/x86 doesn't support fast tail call so fgMorphTailCall is used, it changes call type to vararg and we get NYI in fgInitArgInfo. Fixes https://github.com/dotnet/coreclr/issues/25020