### PR TITLE
Fix field offset computation for large version bubble

### DIFF
--- a/src/utilcode/pedecoder.cpp
+++ b/src/utilcode/pedecoder.cpp
@@ -2839,7 +2839,7 @@ PTR_CVOID PEDecoder::GetNativeManifestMetadata(COUNT_T *pSize) const
     }
     CONTRACT_END;
     
-    IMAGE_DATA_DIRECTORY *pDir;
+    IMAGE_DATA_DIRECTORY *pDir = NULL;
 #ifdef FEATURE_PREJIT
     if (!HasReadyToRunHeader())
     {
@@ -2858,8 +2858,22 @@ PTR_CVOID PEDecoder::GetNativeManifestMetadata(COUNT_T *pSize) const
 
             READYTORUN_SECTION * pSection = pSections + i;
             if (pSection->Type == READYTORUN_SECTION_MANIFEST_METADATA)
+            {
                 // Set pDir to the address of the manifest metadata section
                 pDir = &pSection->Section;
+                break;
+            }
+        }
+
+        // ReadyToRun file without large version bubble support doesn't have the READYTORUN_SECTION_MANIFEST_METADATA
+        if (pDir == NULL)
+        {
+            if (pSize != NULL)
+            {
+                *pSize = 0;
+            }
+
+            RETURN NULL;
         }
     }
 

--- a/src/vm/ceeload.h
+++ b/src/vm/ceeload.h
@@ -1952,6 +1952,11 @@ protected:
 
     BOOL IsInCurrentVersionBubble();
 
+#if defined(FEATURE_READYTORUN) && !defined(FEATURE_READYTORUN_COMPILER)
+    BOOL IsInSameVersionBubble(Module *target);
+#endif // FEATURE_READYTORUN && !FEATURE_READYTORUN_COMPILER
+
+
     LPCWSTR GetPathForErrorMessages();
 
 


### PR DESCRIPTION
There was a discrepancy in field offset calculations at crossgen time
and at runtime in some rare cases due to the alignment of a derived
class offset.
The issue happened due to MethodTableBuilder::NeedsAlignedBaseOffset not
taking into account the fact that the module of the parent and child
class can both be in large version bubble.

We also had a bug in the PEDecoder::GetNativeManifestMetadata. When it
was called for regular crossgened image without large version bubble, it
left the pDir uninitialized due to the fact that there was no
READYTORUN_SECTION_MANIFEST_METADATA. And then it tried to dereference
that.