### PR TITLE
Change Diagnostic Server transport name to align with spec

### DIFF
--- a/src/vm/diagnosticserver.cpp
+++ b/src/vm/diagnosticserver.cpp
@@ -131,7 +131,7 @@ bool DiagnosticServer::Initialize()
 
         // TODO: Should we handle/assert that (s_pIpc == nullptr)?
         s_pIpc = IpcStream::DiagnosticsIpc::Create(
-            "dotnetcore-diagnostic", ErrorCallback);
+            "dotnet-diagnostic", ErrorCallback);
 
         if (s_pIpc != nullptr)
         {


### PR DESCRIPTION
resolves #24859

Requires corresponding change in diagnostic tooling (dotnet/diagnostics#315)