### PR TITLE
Fix generation of RID on distros that do not set VERSION_ID

### DIFF
--- a/init-distro-rid.sh
+++ b/init-distro-rid.sh
@@ -56,7 +56,13 @@ initNonPortableDistroRid()
                     VERSION_ID=${VERSION_ID%.*}
                 fi
 
-                nonPortableBuildID="${ID}.${VERSION_ID}-${buildArch}"
+                if [ -z ${VERSION_ID+x} ]; then
+                        # Rolling release distros do not set VERSION_ID, so omit
+                        # it here to be consistent with everything else.
+                        nonPortableBuildID="${ID}-${buildArch}"
+                else
+                        nonPortableBuildID="${ID}.${VERSION_ID}-${buildArch}"
+                fi
             fi
             
         elif [ -e "${rootfsDir}/etc/redhat-release" ]; then


### PR DESCRIPTION
Not all distros (such as Arch Linux and Gentoo) set VERSION_ID in /etc/os-release.  This leads to ini-distro-rid.sh generating RIDs with an invalid sequence of characters, leading to errors such as `The package ID 'runtime.gentoo.-x64.Microsoft.(...)' contains invalid characters` during build.

This field is optional, so use "1" as fallback.

Fixes #19769.