### PR TITLE
Make Debug.Print(string) behavior consistent with .NET Framework

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Debug.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Debug.cs
@@ -77,13 +77,13 @@ namespace System.Diagnostics
         [System.Diagnostics.Conditional("DEBUG")]
         public static void Print(string? message)
         {
-            Write(message);
+            WriteLine(message);
         }
 
         [System.Diagnostics.Conditional("DEBUG")]
         public static void Print(string format, params object?[] args)
         {
-            Write(string.Format(null, format, args));
+            WriteLine(string.Format(null, format, args));
         }
 
         [System.Diagnostics.Conditional("DEBUG")]

--- a/tests/CoreFX/CoreFX.issues.rsp
+++ b/tests/CoreFX/CoreFX.issues.rsp
@@ -51,6 +51,7 @@
 -nomethod System.Tests.AppDomainTests.MonitoringTotalAllocatedMemorySize
 -nomethod System.Tests.AppDomainTests.MonitoringTotalProcessorTime
 -nomethod System.Text.Tests.StringBuilderTests.AppendFormat
+-nomethod System.Diagnostics.Tests.DebugTestsNoListeners.Print
 
 # requires corefx test updates
 -nomethod System.Tests.EnvironmentTests.FailFast_ExceptionStackTrace_StackOverflowException

--- a/tests/CoreFX/CoreFX.issues.rsp
+++ b/tests/CoreFX/CoreFX.issues.rsp
@@ -52,6 +52,7 @@
 -nomethod System.Tests.AppDomainTests.MonitoringTotalProcessorTime
 -nomethod System.Text.Tests.StringBuilderTests.AppendFormat
 -nomethod System.Diagnostics.Tests.DebugTestsNoListeners.Print
+-nomethod System.Diagnostics.Tests.DebugTestsUsingListeners.Print
 
 # requires corefx test updates
 -nomethod System.Tests.EnvironmentTests.FailFast_ExceptionStackTrace_StackOverflowException


### PR DESCRIPTION
Debug.Print(string) should call WriteLine not Write.

- [ ] Add tests in corefx

More info:
https://github.com/dotnet/corefx/issues/38359

