### PR TITLE
Use SIZE_T for SectionSize in RegisterFrozenSegment

### DIFF
--- a/src/System.Private.CoreLib/src/System/GC.cs
+++ b/src/System.Private.CoreLib/src/System/GC.cs
@@ -345,7 +345,7 @@ namespace System
         }
 
         [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
-        private static extern IntPtr _RegisterFrozenSegment(IntPtr sectionAddress, int sectionSize);
+        private static extern IntPtr _RegisterFrozenSegment(IntPtr sectionAddress, IntPtr sectionSize);
 
         [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
         private static extern IntPtr _UnregisterFrozenSegment(IntPtr segmentHandle);

--- a/src/vm/comutilnative.cpp
+++ b/src/vm/comutilnative.cpp
@@ -1342,7 +1342,7 @@ FCIMPLEND;
 **Arguments: args-> pointer to section, size of section
 **Exceptions: None
 ==============================================================================*/
-void* QCALLTYPE GCInterface::RegisterFrozenSegment(void* pSection, INT32 sizeSection)
+void* QCALLTYPE GCInterface::RegisterFrozenSegment(void* pSection, SIZE_T sizeSection)
 {
     QCALL_CONTRACT;
 

--- a/src/vm/comutilnative.h
+++ b/src/vm/comutilnative.h
@@ -146,7 +146,7 @@ public:
 
 #ifdef FEATURE_BASICFREEZE
     static
-    void* QCALLTYPE RegisterFrozenSegment(void *pSection, INT32 sizeSection);
+    void* QCALLTYPE RegisterFrozenSegment(void *pSection, SIZE_T sizeSection);
 
     static
     void QCALLTYPE UnregisterFrozenSegment(void *segmentHandle);


### PR DESCRIPTION
I accidentally put SectionSize as INT32. Noticed it when our frozen segment size went over 4GB.