### PR TITLE
Show nested exceptions more clearly

### DIFF
--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -668,7 +668,7 @@
     <value>Insufficient memory to continue the execution of the program.</value>
   </data>
   <data name="Arg_ParamName_Name" xml:space="preserve">
-    <value>Parameter name: {0}</value>
+    <value>(parameter '{0}')</value>
   </data>
   <data name="Arg_ParmArraySize" xml:space="preserve">
     <value>Must specify one or more parameters.</value>

--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -159,10 +159,6 @@
   <data name="AggregateException_DeserializationFailure" xml:space="preserve">
     <value>The serialization stream contains no inner exceptions.</value>
   </data>
-  <data name="AggregateException_InnerException" xml:space="preserve">
-    <value>(Inner Exception #{0}) </value>
-    <comment>This text is prepended to each inner exception description during aggregate exception formatting</comment>
-  </data>
   <data name="AppDomain_AppBaseNotSet" xml:space="preserve">
     <value>The ApplicationBase must be set before retrieving this property.</value>
   </data>
@@ -2223,9 +2219,6 @@
   </data>
   <data name="EventSource_VarArgsParameterMismatch" xml:space="preserve">
     <value>The parameters to the Event method do not match the parameters to the WriteEvent method. This may cause the event to be displayed incorrectly.</value>
-  </data>
-  <data name="Exception_EndOfInnerExceptionStack" xml:space="preserve">
-    <value>--- End of inner exception stack trace ---</value>
   </data>
   <data name="Exception_EndStackTraceFromPreviousThrow" xml:space="preserve">
     <value>--- End of stack trace from previous location where exception was thrown ---</value>

--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -2220,9 +2220,6 @@
   <data name="EventSource_VarArgsParameterMismatch" xml:space="preserve">
     <value>The parameters to the Event method do not match the parameters to the WriteEvent method. This may cause the event to be displayed incorrectly.</value>
   </data>
-  <data name="Exception_EndStackTraceFromPreviousThrow" xml:space="preserve">
-    <value>--- End of stack trace from previous location where exception was thrown ---</value>
-  </data>
   <data name="Exception_WasThrown" xml:space="preserve">
     <value>Exception of type '{0}' was thrown.</value>
   </data>

--- a/src/System.Private.CoreLib/shared/System/AggregateException.cs
+++ b/src/System.Private.CoreLib/shared/System/AggregateException.cs
@@ -440,26 +440,14 @@ namespace System
             }
         }
 
-        /// <summary>
-        /// Creates and returns a string representation of the current <see cref="AggregateException"/>.
-        /// </summary>
-        /// <returns>A string representation of the current exception.</returns>
-        public override string ToString()
+        protected internal override string InnerExceptionToString(Exception? inner = null)
         {
-            StringBuilder text = new StringBuilder();
-            text.Append(base.ToString());
-
-            for (int i = 0; i < m_innerExceptions.Count; i++)
+            var sb = new StringBuilder();
+            foreach(Exception ex in m_innerExceptions)
             {
-                text.AppendLine();
-                text.Append("---> ");
-                text.AppendFormat(CultureInfo.InvariantCulture, SR.AggregateException_InnerException, i);
-                text.Append(m_innerExceptions[i].ToString());
-                text.Append("<---");
-                text.AppendLine();
+                sb.Append(base.InnerExceptionToString(ex));
             }
-
-            return text.ToString();
+            return sb.ToString();
         }
 
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/ArgumentException.cs
+++ b/src/System.Private.CoreLib/shared/System/ArgumentException.cs
@@ -81,11 +81,10 @@ namespace System
                 string s = base.Message;
                 if (!string.IsNullOrEmpty(_paramName))
                 {
-                    string resourceString = SR.Format(SR.Arg_ParamName_Name, _paramName);
-                    return s + Environment.NewLine + resourceString;
+                    s += " " + SR.Format(SR.Arg_ParamName_Name, _paramName);
                 }
-                else
-                    return s;
+
+                return s;
             }
         }
 

--- a/src/System.Private.CoreLib/shared/System/BadImageFormatException.cs
+++ b/src/System.Private.CoreLib/shared/System/BadImageFormatException.cs
@@ -103,8 +103,7 @@ namespace System
             if (_fileName != null && _fileName.Length != 0)
                 s += Environment.NewLine + SR.Format(SR.IO_FileName_Name, _fileName);
 
-            if (InnerException != null)
-                s = s + " ---> " + InnerException.ToString();
+            s += InnerExceptionToString();
 
             if (StackTrace != null)
                 s += Environment.NewLine + StackTrace;

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/StackTrace.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/StackTrace.cs
@@ -319,13 +319,6 @@ namespace System.Diagnostics
                             sb.AppendFormat(CultureInfo.InvariantCulture, inFileLineNum, fileName, sf.GetFileLineNumber());
                         }
                     }
-
-                    // Skip EDI boundary for async
-                    if (sf.IsLastFrameFromForeignExceptionStackTrace && !isAsync)
-                    {
-                        sb.Append(Environment.NewLine);
-                        sb.Append(SR.Exception_EndStackTraceFromPreviousThrow);
-                    }
                 }
             }
 

--- a/src/System.Private.CoreLib/shared/System/Exception.cs
+++ b/src/System.Private.CoreLib/shared/System/Exception.cs
@@ -149,11 +149,7 @@ namespace System
                 s += ": " + message;
             }
 
-            if (_innerException != null)
-            {
-                s = s + " ---> " + _innerException.ToString() + Environment.NewLine +
-                "   " + SR.Exception_EndOfInnerExceptionStack;
-            }
+            s += InnerExceptionToString();
 
             string? stackTrace = StackTrace;
             if (stackTrace != null)
@@ -161,6 +157,17 @@ namespace System
                 s += Environment.NewLine + stackTrace;
             }
 
+            return s;
+        }
+
+        protected internal string InnerExceptionToString()
+        {
+            string s = String.Empty;
+            if (_innerException != null)
+            {
+                s += " ---> " + _innerException.ToString() + Environment.NewLine +
+                "   " + SR.Exception_EndOfInnerExceptionStack;
+            }
             return s;
         }
 

--- a/src/System.Private.CoreLib/shared/System/Exception.cs
+++ b/src/System.Private.CoreLib/shared/System/Exception.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.Text;
 using System.Runtime.Serialization;
 
 namespace System
@@ -162,13 +163,14 @@ namespace System
 
         protected internal string InnerExceptionToString()
         {
-            string s = String.Empty;
-            if (_innerException != null)
-            {
-                s += " ---> " + _innerException.ToString() + Environment.NewLine +
-                "   " + SR.Exception_EndOfInnerExceptionStack;
-            }
-            return s;
+            if (_innerException == null)
+                return "";
+
+            var sb = new StringBuilder(_innerException.ToString());
+            sb.Replace("\r\n", "\n");
+            sb.Replace("\n", Environment.NewLine + "      ");
+
+            return Environment.NewLine + " ---> " + sb.ToString();
         }
 
         protected event EventHandler<SafeSerializationEventArgs> SerializeObjectState

--- a/src/System.Private.CoreLib/shared/System/Exception.cs
+++ b/src/System.Private.CoreLib/shared/System/Exception.cs
@@ -3,8 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
-using System.Text;
 using System.Runtime.Serialization;
+using System.Text;
 
 namespace System
 {
@@ -161,12 +161,15 @@ namespace System
             return s;
         }
 
-        protected internal string InnerExceptionToString()
+        // Returns the indented inner exception's ToString() prefixed with a newline.
+        // If there is no inner exception, returns empty string.
+        protected internal virtual string InnerExceptionToString(Exception? inner = null)
         {
-            if (_innerException == null)
+            inner ??= _innerException;
+            if (inner == null)
                 return "";
 
-            var sb = new StringBuilder(_innerException.ToString());
+            var sb = new StringBuilder(inner.ToString());
             sb.Replace("\r\n", "\n");
             sb.Replace("\n", Environment.NewLine + "      ");
 

--- a/src/System.Private.CoreLib/shared/System/IO/FileLoadException.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileLoadException.cs
@@ -63,8 +63,7 @@ namespace System.IO
             if (FileName != null && FileName.Length != 0)
                 s += Environment.NewLine + SR.Format(SR.IO_FileName_Name, FileName);
 
-            if (InnerException != null)
-                s = s + " ---> " + InnerException.ToString();
+            s += InnerExceptionToString();
 
             if (StackTrace != null)
                 s += Environment.NewLine + StackTrace;

--- a/src/System.Private.CoreLib/shared/System/IO/FileNotFoundException.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileNotFoundException.cs
@@ -77,8 +77,7 @@ namespace System.IO
             if (FileName != null && FileName.Length != 0)
                 s += Environment.NewLine + SR.Format(SR.IO_FileName_Name, FileName);
 
-            if (InnerException != null)
-                s = s + " ---> " + InnerException.ToString();
+            s += InnerExceptionToString();
 
             if (StackTrace != null)
                 s += Environment.NewLine + StackTrace;

--- a/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/COMException.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/COMException.cs
@@ -58,11 +58,7 @@ namespace System.Runtime.InteropServices
                 s.Append(": ").Append(message);
             }
 
-            Exception? innerException = InnerException;
-            if (innerException != null)
-            {
-                s.Append(" ---> ").Append(innerException.ToString());
-            }
+            s.Append(InnerExceptionToString());
 
             string? stackTrace = StackTrace;
             if (stackTrace != null)

--- a/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/ExternalException.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/ExternalException.cs
@@ -72,11 +72,7 @@ namespace System.Runtime.InteropServices
                 s = s + ": " + message;
             }
 
-            Exception? innerException = InnerException;
-            if (innerException != null)
-            {
-                s = s + " ---> " + innerException.ToString();
-            }
+            s += InnerExceptionToString();
 
             if (StackTrace != null)
                 s += Environment.NewLine + StackTrace;


### PR DESCRIPTION
Possible fix for https://github.com/dotnet/corefx/issues/37816

### Changes made
1. Put messages from nested inner exceptions on their own line. This is to avoid the 600 char+ lines.
1. Format inner exceptions in a central place. This also fixes a bug in AggregateException where it would output one inner exception twice.
1. Indent output from inner exceptions. This is to make it clear which contain which.
1. Remove dividing markers for compactness. This is because indent makes them unnecessary.

### Did not change
1. Existing message content. This means that AggregateException's message still aggregates all interior messages to whatever length. (I did tweak ArgumentException message to be a single line though)
1. Existing ordering of outer->inner messages followed by inner->outer stacks. In the deepest part of the indentation the innermost exception message and stack are still together.

### Examples

Should change [this](https://github.com/dotnet/corefx/issues/37815#issue-446260820) from #37815 into more like [this](https://gist.github.com/danmosemsft/bd374185bec6db4ebaaa7092ed73f239) which removes duplication and draws the eye to the innermost exception, which in this case is the root cause.

Also [this](https://gist.github.com/danmosemsft/7f40cd33d91d55602403f2d383096e33) from #38293 to [this](https://gist.github.com/danmosemsft/536a74c5516328c9ecad2a5272182fbd). Again, half as long and it's easy to see which stack goes with which message.

Output of [this test program](https://gist.github.com/danmosemsft/03f6c6086f2d6937790bd8800cbee4f4) was [this](https://gist.github.com/danmosemsft/c24a671ce7d3623ad616e7fd94929042) is now [this](https://gist.github.com/danmosemsft/aeb8488430e9c30136ae3b799f545c80).

Thoughts?