### PR TITLE
Disqualify byref-like fields from ManagedSequential layout

### DIFF
--- a/src/vm/fieldmarshaler.cpp
+++ b/src/vm/fieldmarshaler.cpp
@@ -174,7 +174,8 @@ do                                                      \
             TypeHandle pNestedType = fsig.GetLastTypeHandleThrowing(ClassLoader::LoadTypes,
                                                                     CLASS_LOAD_APPROXPARENTS,
                                                                     TRUE);
-            if (pNestedType.GetMethodTable()->IsManagedSequential())
+            if (pNestedType.GetMethodTable()->IsManagedSequential() &&
+                !pNestedType.GetMethodTable()->IsByRefLike())
             {
                 pfwalk->m_managedPlacement.m_size = (pNestedType.GetMethodTable()->GetNumInstanceFieldBytes());
 

--- a/src/vm/fieldmarshaler.cpp
+++ b/src/vm/fieldmarshaler.cpp
@@ -1077,7 +1077,10 @@ BOOL IsStructMarshalable(TypeHandle th)
         if (th.IsArray())
             return FALSE;
         else
-            return TRUE;
+        {
+            // ByReference<T> shows up as blittable, but it actually isn't.
+            return !th.GetMethodTable()->HasSameTypeDefAs(g_pByReferenceClass);
+        }
     }
 
     // Check to see if the type has layout.
@@ -1086,6 +1089,9 @@ BOOL IsStructMarshalable(TypeHandle th)
 
     MethodTable *pMT= th.GetMethodTable();
     PREFIX_ASSUME(pMT != NULL);
+
+    // ByReference<T> should have taken the blittable path above
+    assert(!pMT->HasSameTypeDefAs(g_pByReferenceClass));
     
     if (pMT->IsStructMarshalable())
         return TRUE;

--- a/tests/src/Regressions/coreclr/20794/refstructpacking.il
+++ b/tests/src/Regressions/coreclr/20794/refstructpacking.il
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//
+// This test ensures that packing is ignored for byref-like types
+//
+
+.assembly extern System.Runtime { }
+
+.assembly refstructpacking { }
+
+// This will show up as a blittable type
+.class private sequential ansi sealed beforefieldinit NumberBuffer0
+       extends [System.Runtime]System.ValueType
+{
+  .pack 1
+  .size 0
+  .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = ( 01 00 00 00 ) 
+  .field public int8 Sign
+  .field public valuetype [System.Runtime]System.Span`1<char> Digits
+}
+
+// This will show up as a ManagedSequential type
+.class private sequential ansi sealed beforefieldinit NumberBuffer1
+       extends [System.Runtime]System.ValueType
+{
+  .pack 1
+  .size 0
+  .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = ( 01 00 00 00 ) 
+  .field public bool Sign
+  .field public valuetype [System.Runtime]System.Span`1<char> Digits
+}
+
+
+.method private hidebysig static int32 Main() cil managed
+{
+  .entrypoint
+  .locals init (valuetype NumberBuffer0 V_0,
+                valuetype NumberBuffer1 V_1)
+
+  ldloca.s V_0
+  ldflda valuetype [System.Runtime]System.Span`1<char> NumberBuffer0::Digits
+  ldloca.s V_0
+  sub
+  conv.i4
+  ldc.i4 100
+  mul
+  // Leaves PointerSize * 100 at the top of the stack
+
+  ldloca.s V_1
+  ldflda valuetype [System.Runtime]System.Span`1<char> NumberBuffer1::Digits
+  ldloca.s V_1
+  sub
+  conv.i4
+  // Leaves PointerSize at the top of the stack
+
+  add
+  // Should have PointerSize * 100 + PointerSize at the top of stack
+
+  sizeof native int
+  conv.i4
+  ldc.i4 100
+  mul
+  sizeof native int
+  conv.i4
+  add
+  // Should have PointerSize * 100 + PointerSize at the top of stack
+
+  sub
+  // Should have 0 at the top of stack
+
+  ldc.i4 100
+  add
+
+  ret
+}

--- a/tests/src/Regressions/coreclr/20794/refstructpacking.ilproj
+++ b/tests/src/Regressions/coreclr/20794/refstructpacking.ilproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{85DFC527-4DB1-595E-A7D7-E94EE1F8140D}</ProjectGuid>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="refstructpacking.il" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
Seems to do the trick to get packing ignored on ref structs.

Fixes #20794.