### PR TITLE
Use pread() to read DOS/NT headers when mapping PE files

### DIFF
--- a/src/pal/src/map/map.cpp
+++ b/src/pal/src/map/map.cpp
@@ -2255,25 +2255,13 @@ void * MAPMapPEFile(HANDLE hFile)
     //Step 1: Read the PE headers and reserve enough space for the whole image somewhere.
     IMAGE_DOS_HEADER dosHeader;
     IMAGE_NT_HEADERS ntHeader;
-    errno = 0;
-    if (0 != lseek(fd, 0, SEEK_SET))
-    {
-        palError = FILEGetLastErrorFromErrno();
-        ERROR_(LOADER)( "lseek failed\n" );
-        goto done;
-    }
-    if (sizeof(dosHeader) != read(fd, &dosHeader, sizeof(dosHeader)))
+    if (sizeof(dosHeader) != pread(fd, &dosHeader, sizeof(dosHeader), 0))
     {
         palError = FILEGetLastErrorFromErrno();
         ERROR_(LOADER)( "reading dos header failed\n" );
         goto done;
     }
-    if (dosHeader.e_lfanew != lseek(fd, dosHeader.e_lfanew, SEEK_SET))
-    {
-        palError = FILEGetLastErrorFromErrno();
-        goto done;
-    }
-    if (sizeof(ntHeader) != read(fd, &ntHeader, sizeof(ntHeader)))
+    if (sizeof(ntHeader) != pread(fd, &ntHeader, sizeof(ntHeader), dosHeader.e_lfanew))
     {
         palError = FILEGetLastErrorFromErrno();
         goto done;


### PR DESCRIPTION
Shaves off two syscalls per managed assembly load.

(Other uses of the file descriptor in this function are only through memory mapping functions, and absolute offsets are used in those cases.  Not changing the file pointer isn't an issue in this case.)
