### PR TITLE
Add ICorDebugChain::GetStackRange error check

### DIFF
--- a/src/debug/di/shimstackwalk.cpp
+++ b/src/debug/di/shimstackwalk.cpp
@@ -1663,6 +1663,11 @@ HRESULT ShimChain::GetStackRange(CORDB_ADDRESS * pStart, CORDB_ADDRESS * pEnd)
         {
             *pEnd = PTR_TO_CORDB_ADDRESS(m_fpRoot.GetSPValue());
         }
+
+        if (m_fpRoot.GetSPValue() < CORDbgGetSP(&m_context))
+        {
+            hr = E_FAIL;
+        }
     }
     EX_CATCH_HRESULT(hr);
     return hr;


### PR DESCRIPTION
Add an error check to ShimChain::GetStackRange to handle a rare case where the debugger stops inside of a IL_STUB_PInvoke frame being called from another IL_STUB_PInvoke frame. In the case I was able to repro the issue the leaf frame was in System.StubHelpers.InterfaceMarshaler.ClearNative, being called by Windows.Data.Xml.Dom.XmlElement.AppendChild in an UWP application.  The stackrange check is a small fix which addresses a bug where calling ICorDebugChain::GetChain on the leaf frame, then GetCaller, GetActiveFrame returns the leaf node frame the previous chain.  The stack range check causes GetChain to fail, which is handled gracefully by the debugger.