### PR TITLE
Updating Dragon4 to ensure the number buffer always provides a significant digit if one exists.

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Decimal.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Decimal.cs
@@ -94,7 +94,7 @@ namespace System.Buffers.Text
 
                         Number.DecimalToNumber(ref value, ref number);
                         byte precision = (format.Precision == StandardFormat.NoPrecision) ? (byte)2 : format.Precision;
-                        Number.RoundNumber(ref number, number.Scale + precision);
+                        Number.RoundNumber(ref number, number.Scale + precision, isCorrectlyRounded: false);
                         Debug.Assert((number.Digits[0] != 0) || !number.IsNegative);   // For Decimals, -0 must print as normal 0. As it happens, Number.RoundNumber already ensures this invariant.
                         return TryFormatDecimalF(ref number, destination, out bytesWritten, precision);
                     }
@@ -107,7 +107,7 @@ namespace System.Buffers.Text
 
                         Number.DecimalToNumber(ref value, ref number);
                         byte precision = (format.Precision == StandardFormat.NoPrecision) ? (byte)6 : format.Precision;
-                        Number.RoundNumber(ref number, precision + 1);
+                        Number.RoundNumber(ref number, precision + 1, isCorrectlyRounded: false);
                         Debug.Assert((number.Digits[0] != 0) || !number.IsNegative);   // For Decimals, -0 must print as normal 0. As it happens, Number.RoundNumber already ensures this invariant.
                         return TryFormatDecimalE(ref number, destination, out bytesWritten, precision, exponentSymbol: (byte)format.Symbol);
                     }

--- a/src/System.Private.CoreLib/shared/System/Number.Dragon4.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Dragon4.cs
@@ -394,7 +394,7 @@ namespace System
 
                 // divide out the scale to extract the digit
                 outputDigit = BigInteger.HeuristicDivide(ref scaledValue, ref scale);
-                Debug.Assert(outputDigit < 10);
+                Debug.Assert((0 < outputDigit) && (outputDigit < 10));
 
                 if ((outputDigit > 5) || ((outputDigit == 5) && !scaledValue.IsZero()))
                 {

--- a/src/System.Private.CoreLib/shared/System/Number.Dragon4.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Dragon4.cs
@@ -384,13 +384,13 @@ namespace System
             }
             else
             {
-                // In the scenario where the first significand digit is after the cutoff, we want to treat that
-                // first significand digit as the rounding digit and increase the decimalExponent by one. This
-                // ensures we correctly handle the case where the first significand digit is exactly one after
+                // In the scenario where the first significant digit is after the cutoff, we want to treat that
+                // first significant digit as the rounding digit. If the first significant would cause the next
+                // digit to round, we will increase the decimalExponent by one and set the previous digit to one.
+                // This  ensures we correctly handle the case where the first significant digit is exactly one after
                 // the cutoff, it is a 4, and the subsequent digit would round that to 5 inducing a double rounding
-                // bug when NumberToString is does its own rounding checks.
-
-                decimalExponent++;
+                // bug when NumberToString does its own rounding checks. However, if the first significant digit
+                // would not cause the next one to round, we preserve that digit as is.
 
                 // divide out the scale to extract the digit
                 outputDigit = BigInteger.HeuristicDivide(ref scaledValue, ref scale);
@@ -398,9 +398,12 @@ namespace System
 
                 if ((outputDigit > 5) || ((outputDigit == 5) && !scaledValue.IsZero()))
                 {
-                    buffer[curDigit] = (byte)('1');
-                    curDigit += 1;
+                    decimalExponent++;
+                    outputDigit = 1;
                 }
+
+                buffer[curDigit] = (byte)('0' + outputDigit);
+                curDigit += 1;
 
                 // return the number of digits output
                 return (uint)(curDigit);

--- a/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
@@ -256,7 +256,7 @@ namespace System
         // In order to support more digits, we would need to update ParseFormatSpecifier to pre-parse
         // the format and determine exactly how many digits are being requested and whether they
         // represent "significant digits" or "digits after the decimal point".
-        private const int SinglePrecisionCustomFormat = 6;
+        private const int SinglePrecisionCustomFormat = 7;
         private const int DoublePrecisionCustomFormat = 15;
 
         private const int DefaultPrecisionExponentialFormat = 6;

--- a/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
@@ -2376,7 +2376,13 @@ namespace System
             while (i < pos && dig[i] != 0)
                 i++;
 
-            if (i == pos && dig[i] >= '5')
+            // We only want to round up if the digit is greater than or equal to 5 and we are
+            // not rounding a floating-point number. This is because the floating-point format
+            // algorithms already produce a correctly rounded result. They may, however, still
+            // produce trailing zeros that we don't currently display and so we still utilize
+            // the logic in the else block to trim those.
+
+            if ((i == pos) && (dig[i] >= 5) && (number.Kind != NumberBufferKind.FloatingPoint))
             {
                 while (i > 0 && dig[i - 1] == '9')
                     i--;
@@ -2397,6 +2403,7 @@ namespace System
                 while (i > 0 && dig[i - 1] == '0')
                     i--;
             }
+
             if (i == 0)
             {
                 if (number.Kind != NumberBufferKind.FloatingPoint)

--- a/tests/CoreFX/CoreFX.issues.rsp
+++ b/tests/CoreFX/CoreFX.issues.rsp
@@ -69,13 +69,6 @@
 -nomethod System.Linq.Expressions.Tests.ArrayBoundsTests.NewArrayBounds
 -nonamespace System.Linq.Expressions.Tests
 
-# Assertion in System.Number.FormatDouble
-# https://github.com/dotnet/coreclr/issues/25081
--nomethod System.Tests.RealFormatterTestsBase.TestFormatterSingle_F20
--noclass System.Tests.RealFormatterTestsBase
--noclass System.Tests.RealFormatterTests
--noclass System.Buffers.Text.Tests.RealFormatterTests
-
 # Timeout in System.Runtime.Serialization.Formatters.Tests.BinaryFormatterTests.SerializeHugeObjectGraphs: https://github.com/dotnet/coreclr/issues/20246
 -nomethod System.Runtime.Serialization.Formatters.Tests.BinaryFormatterTests.SerializeHugeObjectGraphs
 


### PR DESCRIPTION
This resolves https://github.com/dotnet/coreclr/issues/25081