### PR TITLE
Add missing TraceOperationCreation log event in GetStateMachineBox

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -516,6 +516,13 @@ namespace System.Runtime.CompilerServices
             m_task = box; // important: this must be done before storing stateMachine into box.StateMachine!
             box.StateMachine = stateMachine;
             box.Context = currentContext;
+
+            // Finally, log the creation of the state machine box object / task for this async method.
+            if (AsyncCausalityTracer.LoggingOn)
+            {
+                AsyncCausalityTracer.TraceOperationCreation(box, "Async: " + stateMachine.GetType().Name);
+            }
+
             return box;
         }
 


### PR DESCRIPTION
This was removed accidentally as part of overhauling the async infrastructure in 2.1. VS depends on it for some task tracking logic.

cc: @kouvel, @tarekgh, 