### PR TITLE
SuperPMI: Fix `getFieldType`

### DIFF
--- a/src/ToolBox/superpmi/superpmi-shared/lightweightmap.h
+++ b/src/ToolBox/superpmi/superpmi-shared/lightweightmap.h
@@ -299,7 +299,7 @@ public:
         return size;
     }
 
-    // its worth noting that the actual order of insert here doesnt meet what you migth expect.  Its using memcmp, so
+    // It's worth noting that the actual order of insertion here doesnt meet what you might expect.  It's using memcmp, so
     // since we are on a little endian machine we'd use the lowest 8 bits as the first part of the key.  This is
     // a side effect of using the same code for large structs and DWORDS etc...
     bool Add(_Key key, _Item item)
@@ -364,6 +364,11 @@ public:
         pItems[insert] = item;
         numItems++;
         return true;
+    }
+
+    void Update(int index, _Item item)
+    {
+        pItems[index] = item;
     }
 
     int GetIndex(_Key key)

--- a/src/ToolBox/superpmi/superpmi-shared/lightweightmap.h
+++ b/src/ToolBox/superpmi/superpmi-shared/lightweightmap.h
@@ -299,7 +299,7 @@ public:
         return size;
     }
 
-    // its worth noting that the acutal order of insert here doesnt meet what you migth expect.  Its using memcmp, so
+    // its worth noting that the actual order of insert here doesnt meet what you migth expect.  Its using memcmp, so
     // since we are on a little endian machine we'd use the lowest 8 bits as the first part of the key.  This is
     // a side effect of using the same code for large structs and DWORDS etc...
     bool Add(_Key key, _Item item)

--- a/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/ToolBox/superpmi/superpmi-shared/methodcontext.cpp
@@ -4353,6 +4353,7 @@ void MethodContext::recGetFieldType(CORINFO_FIELD_HANDLE  field,
     key.A = (DWORDLONG)field;
     key.B = (DWORDLONG)memberParent;
 
+    value.B = (DWORD)result;
     if (structType == nullptr)
     {
         value.A = 0;
@@ -4360,9 +4361,18 @@ void MethodContext::recGetFieldType(CORINFO_FIELD_HANDLE  field,
     else
     {
         value.A = (DWORDLONG)*structType;
-    }
-    value.B = (DWORD)result;
 
+        // If we had a previous call with null 'structType', we will not have captured the
+        // class handle (we use only 'field' and 'memberParent' as keys).
+        // Update the value in that case.
+        unsigned index = GetFieldType->GetIndex(key);
+        if ((index != -1) && (GetFieldType->GetItem(index).A == 0))
+        {
+            GetFieldType->Update(index, value);
+            DEBUG_REC(dmpGetFieldType(key, value));
+            return;
+        }
+    }
     GetFieldType->Add(key, value);
     DEBUG_REC(dmpGetFieldType(key, value));
 }

--- a/src/ToolBox/superpmi/superpmi-shim-collector/icorjitinfo.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-collector/icorjitinfo.cpp
@@ -1118,6 +1118,13 @@ CorInfoType interceptor_ICJI::getFieldType(CORINFO_FIELD_HANDLE  field,
                                            )
 {
     mc->cr->AddCall("getFieldType");
+    // 'structType' may be null, but since we use only 'field' and 'memberParent' as keys,
+    // we don't want to pass null, in case we have a subsequent call with non-null 'structType'.
+    CORINFO_CLASS_HANDLE dummyStructType;
+    if (structType == nullptr)
+    {
+        structType = &dummyStructType;
+    }
     CorInfoType temp = original_ICorJitInfo->getFieldType(field, structType, memberParent);
     mc->recGetFieldType(field, structType, memberParent, temp);
     return temp;

--- a/src/ToolBox/superpmi/superpmi-shim-collector/icorjitinfo.cpp
+++ b/src/ToolBox/superpmi/superpmi-shim-collector/icorjitinfo.cpp
@@ -1118,13 +1118,6 @@ CorInfoType interceptor_ICJI::getFieldType(CORINFO_FIELD_HANDLE  field,
                                            )
 {
     mc->cr->AddCall("getFieldType");
-    // 'structType' may be null, but since we use only 'field' and 'memberParent' as keys,
-    // we don't want to pass null, in case we have a subsequent call with non-null 'structType'.
-    CORINFO_CLASS_HANDLE dummyStructType;
-    if (structType == nullptr)
-    {
-        structType = &dummyStructType;
-    }
     CorInfoType temp = original_ICorJitInfo->getFieldType(field, structType, memberParent);
     mc->recGetFieldType(field, structType, memberParent, temp);
     return temp;

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -2055,7 +2055,7 @@ bool Compiler::StructPromotionHelper::TryPromoteStructField(lvaStructFieldInfo& 
     if (fieldSize == 0 || fieldSize > TARGET_POINTER_SIZE || varTypeIsFloating(fieldVarType))
     {
         JITDUMP("Promotion blocked: struct contains struct field with one field,"
-                " but that field has invalid size or type");
+                " but that field has invalid size or type.\n");
         return false;
     }
 
@@ -2066,7 +2066,7 @@ bool Compiler::StructPromotionHelper::TryPromoteStructField(lvaStructFieldInfo& 
         if ((outerFieldOffset % fieldSize) != 0)
         {
             JITDUMP("Promotion blocked: struct contains struct field with one field,"
-                    " but the outer struct offset %u is not a multiple of the inner field size %u",
+                    " but the outer struct offset %u is not a multiple of the inner field size %u.\n",
                     outerFieldOffset, fieldSize);
             return false;
         }
@@ -2078,7 +2078,7 @@ bool Compiler::StructPromotionHelper::TryPromoteStructField(lvaStructFieldInfo& 
     if (fieldSize != innerStructSize)
     {
         JITDUMP("Promotion blocked: struct contains struct field with one field,"
-                " but that field is not the same size as its parent.");
+                " but that field is not the same size as its parent.\n");
         return false;
     }
 


### PR DESCRIPTION
The `structType` out parameter is optional (i.e. it may be null), but it's not used as a key, so we need to capture it in case other calls with the same keys (`field` and `memberParent`) require it.