### PR TITLE
Make DisplayUnits string.Empty by default instead of null

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/DiagnosticCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/DiagnosticCounter.cs
@@ -45,6 +45,7 @@ namespace System.Diagnostics.Tracing
             _group = CounterGroup.GetCounterGroup(eventSource);
             _group.Add(this);
             Name = name;
+            DisplayUnits = string.Empty;
             EventSource = eventSource;
         }
 
@@ -77,7 +78,7 @@ namespace System.Diagnostics.Tracing
 
         public string? DisplayName { get; set; }
 
-        public string? DisplayUnits { get; set; }
+        public string DisplayUnits { get; set; }
 
         public string Name { get; }
 

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/DiagnosticCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/DiagnosticCounter.cs
@@ -76,9 +76,29 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-        public string? DisplayName { get; set; }
+        private string _displayName = "";
+        public string DisplayName
+        {
+            set
+            {
+                if (value == null)
+                    throw new ArgumentException("Cannot set null as DisplayName");
+                _displayName = value;
+            }
+            get { return _displayName; }
+        }
 
-        public string DisplayUnits { get; set; }
+        private string _displayUnits = "";
+        public string DisplayUnits
+        {
+            set
+            {
+                if (value == null)
+                    throw new ArgumentException("Cannot set null as DisplayUnits");
+                _displayUnits = value;
+            }
+            get { return _displayUnits; }
+        }
 
         public string Name { get; }
 


### PR DESCRIPTION
Making change based on the API review meeting today.