### PR TITLE
Add PlatformGroup parameter

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,7 +99,7 @@ jobs:
         platforms:
         - Windows_NT_x64
         - Windows_NT_x86
-      ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI') }}:
+      ${{ if and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
         platforms:
         - Linux_arm
         - Linux_arm64
@@ -130,7 +130,7 @@ jobs:
         - Windows_NT_arm64
         - Windows_NT_x64
         - Windows_NT_x86
-      ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI') }}:
+      ${{ if and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
         platformGroup: all
       ${{ if in(variables['Build.DefinitionName'], 'coreclr-outerloop', 'coreclr-outerloop-jitstress', 'coreclr-outerloop-jitstressregs', 'coreclr-outerloop-jitstress2-jitstressregs') }}:
         platformGroup: all
@@ -184,7 +184,7 @@ jobs:
         - Windows_NT_arm
         - Windows_NT_arm64
         - Windows_NT_x64
-      ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI') }}:
+      ${{ if and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
         platforms:
         - Linux_arm
         - Linux_musl_arm64
@@ -295,7 +295,7 @@ jobs:
         - Windows_NT_x64
         - Windows_NT_x86
       ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r-extra') }}:
-        platformGroup: gcstress
+        platformGroup: gcstress # r2r-extra testGroup runs gcstress15 scenario
       jobParameters:
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-ci') }}:
           testGroup: innerloop
@@ -339,7 +339,7 @@ jobs:
 
 # CI (merge) jobs
 
-- ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
+- ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: test-job.yml
@@ -373,14 +373,13 @@ jobs:
 #
 
 # Pull-Request test
-- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+- ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: test-job.yml
       buildConfig: release
-      ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
-        platforms:
-        - Linux_musl_x64
+      platforms:
+      - Linux_musl_x64
       jobParameters:
         testGroup: innerloop
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,12 +90,12 @@ jobs:
 #
 # Debug builds
 #
-- ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: build-job.yml
       buildConfig: debug
-      ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
         platforms:
         - Windows_NT_x64
         - Windows_NT_x86
@@ -112,7 +112,7 @@ jobs:
         - Windows_NT_arm64
 
 #
-# Checked build
+# Checked builds
 #
 - ${{ if eq(variables['System.TeamProject'], 'public') }}:
   - template: eng/platform-matrix.yml
@@ -130,13 +130,10 @@ jobs:
         - Windows_NT_arm64
         - Windows_NT_x64
         - Windows_NT_x86
-      ${{ if in(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress0x3-gcstress0xc', 'coreclr-outerloop-gcstress-extra', 'coreclr-outerloop-r2r', 'coreclr-outerloop-r2r-extra') }}:
-        platforms:
-        - Linux_arm
-        - Linux_arm64
-        - Linux_x64
-        - Windows_NT_x64
-        - Windows_NT_x86
+      ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI') }}:
+        platformGroup: all
+      ${{ if in(variables['Build.DefinitionName'], 'coreclr-outerloop', 'coreclr-outerloop-jitstress', 'coreclr-outerloop-jitstressregs', 'coreclr-outerloop-jitstress2-jitstressregs') }}:
+        platformGroup: all
       ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-isas-arm') }}:
         platforms:
         - Linux_arm64
@@ -149,6 +146,15 @@ jobs:
         - Windows_NT_x86
       ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs-x86') }}:
         platforms:
+        - Linux_x64
+        - Windows_NT_x64
+        - Windows_NT_x86
+      ${{ if in(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress0x3-gcstress0xc', 'coreclr-outerloop-gcstress-extra', 'coreclr-outerloop-r2r-extra') }}:
+        platformGroup: gcstress
+      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r') }}:
+        platforms:
+        - Linux_arm
+        - Linux_arm64
         - Linux_x64
         - Windows_NT_x64
         - Windows_NT_x86
@@ -165,12 +171,12 @@ jobs:
 #
 # Release builds
 #
-- ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: build-job.yml
       buildConfig: release
-      ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
         platforms:
         - Linux_arm64
         - Linux_musl_x64
@@ -186,15 +192,13 @@ jobs:
         - OSX_x64
         - Windows_NT_x86
 
-#
-# Release builds (Official build) - non-PullRequest
-#
 - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: build-job.yml
       buildConfig: release
       jobParameters:
+        platformGroup: all
         # Publishing packages to blob feeds sometimes takes a long time
         # due to waiting for an exclusive lock on the feed.
         # See https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/AsyncPublishing.md
@@ -204,8 +208,7 @@ jobs:
 # Checked test builds
 #
 # The test jobs that can be triggered by a PR, manually from ADO and that are scheduled
-# TODO: This long 'in' condition needs to be make data driven, perhaps by adding another layer of template.
-- ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'Manual', 'Schedule'), in(variables['Build.DefinitionName'], 'coreclr-ci', 'coreclr-outerloop', 'coreclr-outerloop-jitstress', 'coreclr-outerloop-jitstress-isas-arm', 'coreclr-outerloop-jitstress-isas-x86', 'coreclr-outerloop-jitstressregs-x86', 'coreclr-outerloop-jitstressregs', 'coreclr-outerloop-jitstress2-jitstressregs', 'coreclr-outerloop-gcstress0x3-gcstress0xc', 'coreclr-outerloop-gcstress-extra', 'coreclr-outerloop-r2r', 'coreclr-outerloop-r2r-extra', 'coreclr-runincontext')) }}:
+- ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'Manual', 'Schedule')) }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: test-job.yml
@@ -221,13 +224,8 @@ jobs:
         - Windows_NT_arm64
         - Windows_NT_x64
         - Windows_NT_x86
-      ${{ if in(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress0x3-gcstress0xc', 'coreclr-outerloop-gcstress-extra', 'coreclr-outerloop-r2r', 'coreclr-outerloop-r2r-extra') }}:
-        platforms:
-        - Linux_arm
-        - Linux_arm64
-        - Linux_x64
-        - Windows_NT_x64
-        - Windows_NT_x86
+      ${{ if in(variables['Build.DefinitionName'], 'coreclr-outerloop', 'coreclr-outerloop-jitstress', 'coreclr-outerloop-jitstressregs', 'coreclr-outerloop-jitstress2-jitstressregs') }}:
+        platformGroup: all
       ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-isas-arm') }}:
         platforms:
         - Linux_arm64
@@ -243,6 +241,8 @@ jobs:
         - Linux_x64
         - Windows_NT_x64
         - Windows_NT_x86
+      ${{ if in(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress0x3-gcstress0xc', 'coreclr-outerloop-gcstress-extra') }}:
+        platformGroup: gcstress
       ${{ if eq(variables['Build.DefinitionName'], 'coreclr-runincontext') }}:
         platforms:
         - Linux_x64
@@ -269,14 +269,6 @@ jobs:
           testGroup: gcstress0x3-gcstress0xc
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress-extra') }}:
           testGroup: gcstress-extra
-        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r') }}:
-          testGroup: outerloop
-          readyToRun: true
-          displayNameArgs: R2R
-        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r-extra') }}:
-          testGroup: r2r-extra
-          readyToRun: true
-          displayNameArgs: R2R
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-runincontext') }}:
           testGroup: outerloop
           runInUnloadableContext: true
@@ -284,29 +276,41 @@ jobs:
 
 # ReadyToRun test jobs that are triggered by default from a PR.
 
-- ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: test-job.yml
       buildConfig: checked
-      platforms:
-      - Linux_x64
-      - OSX_x64
-      - Windows_NT_x64
-      - Windows_NT_x86
+      ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
+        platforms:
+        - Linux_x64
+        - OSX_x64
+        - Windows_NT_x64
+        - Windows_NT_x86
+      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r') }}:
+        platforms:
+        - Linux_arm
+        - Linux_arm64
+        - Linux_x64
+        - Windows_NT_x64
+        - Windows_NT_x86
+      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r-extra') }}:
+        platformGroup: gcstress
       jobParameters:
+        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-ci') }}:
+          testGroup: innerloop
+        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r') }}:
+          testGroup: outerloop
+        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r-extra') }}:
+          testGroup: r2r-extra
         readyToRun: true
-        testGroup: innerloop
         displayNameArgs: R2R
 
 #
 # CoreFX test runs against CoreCLR
 #
 
-# PR innerloop checked build
-
-# TODO: This long 'in' condition needs to be make data driven, perhaps by adding another layer of template.
-- ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'Manual', 'Schedule'), in(variables['Build.DefinitionName'], 'coreclr-ci', 'coreclr-corefx', 'coreclr-corefx-jitstress', 'coreclr-corefx-jitstressregs', 'coreclr-corefx-jitstress2-jitstressregs')) }}:
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: test-job.yml
@@ -340,6 +344,7 @@ jobs:
     parameters:
       jobTemplate: test-job.yml
       buildConfig: checked
+      platformGroup: all
       jobParameters:
         testGroup: outerloop
 
@@ -368,13 +373,14 @@ jobs:
 #
 
 # Pull-Request test
-- ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
   - template: eng/platform-matrix.yml
     parameters:
       jobTemplate: test-job.yml
       buildConfig: release
-      platforms:
-      - Linux_musl_x64
+      ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
+        platforms:
+        - Linux_musl_x64
       jobParameters:
         testGroup: innerloop
 
@@ -384,6 +390,7 @@ jobs:
     parameters:
       jobTemplate: test-job.yml
       buildConfig: release
+      platformGroup: all
       jobParameters:
         testGroup: outerloop
 
@@ -391,6 +398,7 @@ jobs:
     parameters:
       jobTemplate: test-job.yml
       buildConfig: release
+      platformGroup: all
       jobParameters:
         testGroup: outerloop
         readyToRun: true

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -2,6 +2,9 @@ parameters:
   jobTemplate: ''
   buildConfig: ''
   platforms: []
+  # platformGroup is a named collection of platforms. Allowed values:
+  # 'all' - all platforms
+  # 'gcstress' - platforms that support running under GCStress0x3 and GCStress0xC scenarios
   platformGroup: ''
   jobParameters: {}
 

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -1,18 +1,8 @@
 parameters:
   jobTemplate: ''
   buildConfig: ''
-  platforms:
-  - Linux_arm
-  - Linux_arm64
-  - Linux_musl_x64
-  - Linux_musl_arm64
-  - Linux_rhel6_x64
-  - Linux_x64
-  - OSX_x64
-  - Windows_NT_x64
-  - Windows_NT_x86
-  - Windows_NT_arm
-  - Windows_NT_arm64
+  platforms: []
+  platformGroup: ''
   jobParameters: {}
 
 jobs:
@@ -20,130 +10,129 @@ jobs:
 # TODO: simplify osIdentifier by adding osGroup and osSubGroup. See
 # https://github.com/Microsoft/azure-pipelines-yaml/pull/46 for more information
 
-- ${{ each platform in parameters.platforms }}:
-  # Linux arm
+# Linux arm
 
-  - ${{ if eq(platform, 'Linux_arm') }}:
-    - template: ${{ parameters.jobTemplate }}
-      parameters:
-        buildConfig: ${{ parameters.buildConfig }}
-        archType: arm
-        osGroup: Linux
-        osIdentifier: Linux
-        containerName: ubuntu_1404_arm_cross_build_image
-        helixQueues:
-        # Ubuntu.1404.Arm32.Open is used only by CI while Ubuntu.1604.Arm32.Open serves PRs and scheduled builds.
-        - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
-          - Ubuntu.1404.Arm32.Open
-        - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
-          - (Ubuntu.1804.Arm32.Open)Ubuntu.1604.Arm32.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-0a0ebdd-20190312215532
-        - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          - (Debian.9.Arm32)Ubuntu.1604.Arm32@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm32v7-0a0ebdd-20190312215452
-          - (Ubuntu.1604.Arm32)Ubuntu.1604.Arm32@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-helix-arm32v7-0a0ebdd-20190312215551
-          - (Ubuntu.1804.Arm32)Ubuntu.1604.Arm32@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-0a0ebdd-20190312215532
-        crossrootfsDir: '/crossrootfs/arm'
-        ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if or(containsValue(parameters.platforms, 'Linux_arm'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+  - template: ${{ parameters.jobTemplate }}
+    parameters:
+      buildConfig: ${{ parameters.buildConfig }}
+      archType: arm
+      osGroup: Linux
+      osIdentifier: Linux
+      containerName: ubuntu_1404_arm_cross_build_image
+      helixQueues:
+      # Ubuntu.1404.Arm32.Open is used only by CI while Ubuntu.1604.Arm32.Open serves PRs and scheduled builds.
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
+        - Ubuntu.1404.Arm32.Open
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
+        - (Ubuntu.1804.Arm32.Open)Ubuntu.1604.Arm32.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-0a0ebdd-20190312215532
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - (Debian.9.Arm32)Ubuntu.1604.Arm32@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm32v7-0a0ebdd-20190312215452
+        - (Ubuntu.1604.Arm32)Ubuntu.1604.Arm32@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-helix-arm32v7-0a0ebdd-20190312215551
+        - (Ubuntu.1804.Arm32)Ubuntu.1604.Arm32@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-0a0ebdd-20190312215532
+      crossrootfsDir: '/crossrootfs/arm'
+      ${{ insert }}: ${{ parameters.jobParameters }}
 
-  # Linux arm64
+# Linux arm64
 
-  - ${{ if eq(platform, 'Linux_arm64') }}:
-    - template: ${{ parameters.jobTemplate }}
-      parameters:
-        buildConfig: ${{ parameters.buildConfig }}
-        archType: arm64
-        osGroup: Linux
-        osIdentifier: Linux
-        containerName: ubuntu_1604_arm64_cross_build_image
-        helixQueues:
-        - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          - (Ubuntu.1804.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-0a0ebdd-20190312220351
-        - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-          - (Debian.9.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-0a0ebdd-20190312215438
-        - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          - (Debian.9.Arm64)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-0a0ebdd-20190312215438
-          - (Ubuntu.1804.Arm64)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-0a0ebdd-20190312220351
-        crossrootfsDir: '/crossrootfs/arm64'
-        ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if or(containsValue(parameters.platforms, 'Linux_arm64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+  - template: ${{ parameters.jobTemplate }}
+    parameters:
+      buildConfig: ${{ parameters.buildConfig }}
+      archType: arm64
+      osGroup: Linux
+      osIdentifier: Linux
+      containerName: ubuntu_1604_arm64_cross_build_image
+      helixQueues:
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - (Ubuntu.1804.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-0a0ebdd-20190312220351
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+        - (Debian.9.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-0a0ebdd-20190312215438
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - (Debian.9.Arm64)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-0a0ebdd-20190312215438
+        - (Ubuntu.1804.Arm64)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-0a0ebdd-20190312220351
+      crossrootfsDir: '/crossrootfs/arm64'
+      ${{ insert }}: ${{ parameters.jobParameters }}
 
-  # Linux musl x64
+# Linux musl x64
 
-  - ${{ if eq(platform, 'Linux_musl_x64') }}:
-    - template: ${{ parameters.jobTemplate }}
-      parameters:
-        buildConfig: ${{ parameters.buildConfig }}
-        archType: x64
-        osGroup: Linux
-        osIdentifier: Linux_musl
-        containerName: musl_x64_build_image
-        helixQueues:
-        - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          - (Alpine.38.Amd64.Open)Ubuntu.1604.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-45b1fa2-20190327215821
-        - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          - (Alpine.38.Amd64)ubuntu.1604.amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-09ca40b-20190508143246
-          - (Alpine.39.Amd64)ubuntu.1604.amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.9-helix-09ca40b-20190508143246
-        ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if or(containsValue(parameters.platforms, 'Linux_musl_x64'), eq(parameters.platformGroup, 'all')) }}:
+  - template: ${{ parameters.jobTemplate }}
+    parameters:
+      buildConfig: ${{ parameters.buildConfig }}
+      archType: x64
+      osGroup: Linux
+      osIdentifier: Linux_musl
+      containerName: musl_x64_build_image
+      helixQueues:
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - (Alpine.38.Amd64.Open)Ubuntu.1604.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-45b1fa2-20190327215821
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - (Alpine.38.Amd64)ubuntu.1604.amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-09ca40b-20190508143246
+        - (Alpine.39.Amd64)ubuntu.1604.amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.9-helix-09ca40b-20190508143246
+      ${{ insert }}: ${{ parameters.jobParameters }}
 
-  # Linux musl arm64
+# Linux musl arm64
 
-  - ${{ if eq(platform, 'Linux_musl_arm64') }}:
-    - template: ${{ parameters.jobTemplate }}
-      parameters:
-        buildConfig: ${{ parameters.buildConfig }}
-        archType: arm64
-        osGroup: Linux
-        osIdentifier: Linux_musl
-        containerName: musl_arm64_build_image
-        helixQueues:
-        - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          - (Alpine.38.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-46e69dd-20190313223330
-        - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          - (Alpine.38.Arm64)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-46e69dd-20190313223330
-        crossrootfsDir: '/crossrootfs/arm64'
-        ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if or(containsValue(parameters.platforms, 'Linux_musl_arm64'), eq(parameters.platformGroup, 'all')) }}:
+  - template: ${{ parameters.jobTemplate }}
+    parameters:
+      buildConfig: ${{ parameters.buildConfig }}
+      archType: arm64
+      osGroup: Linux
+      osIdentifier: Linux_musl
+      containerName: musl_arm64_build_image
+      helixQueues:
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - (Alpine.38.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-46e69dd-20190313223330
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - (Alpine.38.Arm64)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-46e69dd-20190313223330
+      crossrootfsDir: '/crossrootfs/arm64'
+      ${{ insert }}: ${{ parameters.jobParameters }}
 
-  # Linux rhel6 x64
+# Linux rhel6 x64
 
-  - ${{ if eq(platform, 'Linux_rhel6_x64') }}:
-    - template: ${{ parameters.jobTemplate }}
-      parameters:
-        buildConfig: ${{ parameters.buildConfig }}
-        archType: x64
-        osGroup: Linux
-        osIdentifier: Linux_rhel6
-        containerName: centos6_x64_build_image
-        helixQueues:
-        # TODO: enable RedHat.6.Amd64.Open once https://github.com/dotnet/coreclr/issues/23580 is resolved
-        - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          - RedHat.6.Amd64
-        ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if or(containsValue(parameters.platforms, 'Linux_rhel6_x64'), eq(parameters.platformGroup, 'all')) }}:
+  - template: ${{ parameters.jobTemplate }}
+    parameters:
+      buildConfig: ${{ parameters.buildConfig }}
+      archType: x64
+      osGroup: Linux
+      osIdentifier: Linux_rhel6
+      containerName: centos6_x64_build_image
+      helixQueues:
+      # TODO: enable RedHat.6.Amd64.Open once https://github.com/dotnet/coreclr/issues/23580 is resolved
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - RedHat.6.Amd64
+      ${{ insert }}: ${{ parameters.jobParameters }}
 
-  # Linux x64
+# Linux x64
 
-  - ${{ if eq(platform, 'Linux_x64') }}:
-    - template: ${{ parameters.jobTemplate }}
-      parameters:
-        buildConfig: ${{ parameters.buildConfig }}
-        archType: x64
-        osGroup: Linux
-        osIdentifier: Linux
-        containerName: centos7_x64_build_image
-        helixQueues:
-        - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-          - Ubuntu.1804.Amd64.Open
-        - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-          - Debian.9.Amd64.Open
-          - Ubuntu.1604.Amd64.Open
-          - Ubuntu.1804.Amd64.Open
-          - Centos.7.Amd64.Open
-          - RedHat.7.Amd64.Open
-        - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          - Debian.9.Amd64
-          - Ubuntu.1604.Amd64
-          - Ubuntu.1804.Amd64
-          - Centos.7.Amd64
-          - (Fedora.28.Amd64)Ubuntu.1604.amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-28-helix-45b1fa2-20190327215722
-          - RedHat.7.Amd64
-        ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if or(containsValue(parameters.platforms, 'Linux_x64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+  - template: ${{ parameters.jobTemplate }}
+    parameters:
+      buildConfig: ${{ parameters.buildConfig }}
+      archType: x64
+      osGroup: Linux
+      osIdentifier: Linux
+      containerName: centos7_x64_build_image
+      helixQueues:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+        - Ubuntu.1804.Amd64.Open
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+        - Debian.9.Amd64.Open
+        - Ubuntu.1604.Amd64.Open
+        - Ubuntu.1804.Amd64.Open
+        - Centos.7.Amd64.Open
+        - RedHat.7.Amd64.Open
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - Debian.9.Amd64
+        - Ubuntu.1604.Amd64
+        - Ubuntu.1804.Amd64
+        - Centos.7.Amd64
+        - (Fedora.28.Amd64)Ubuntu.1604.amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-28-helix-45b1fa2-20190327215722
+        - RedHat.7.Amd64
+      ${{ insert }}: ${{ parameters.jobParameters }}
 
 # FreeBSD
 
@@ -162,104 +151,104 @@ jobs:
 #       asArray: []
 #     ${{ insert }}: ${{ parameters.jobParameters }}
 
-  # macOS x64
+# macOS x64
 
-  - ${{ if eq(platform, 'OSX_x64') }}:
-    - template: ${{ parameters.jobTemplate }}
-      parameters:
-        buildConfig: ${{ parameters.buildConfig }}
-        archType: x64
-        osGroup: OSX
-        osIdentifier: OSX
-        helixQueues:
-        - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-          - OSX.1013.Amd64.Open
-        - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-          - OSX.1012.Amd64.Open
-          - OSX.1013.Amd64.Open
-          - OSX.1014.Amd64.Open
-        - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          - OSX.1012.Amd64
-          - OSX.1013.Amd64
-          - OSX.1014.Amd64
-        ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if or(containsValue(parameters.platforms, 'OSX_x64'), eq(parameters.platformGroup, 'all')) }}:
+  - template: ${{ parameters.jobTemplate }}
+    parameters:
+      buildConfig: ${{ parameters.buildConfig }}
+      archType: x64
+      osGroup: OSX
+      osIdentifier: OSX
+      helixQueues:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+        - OSX.1013.Amd64.Open
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+        - OSX.1012.Amd64.Open
+        - OSX.1013.Amd64.Open
+        - OSX.1014.Amd64.Open
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - OSX.1012.Amd64
+        - OSX.1013.Amd64
+        - OSX.1014.Amd64
+      ${{ insert }}: ${{ parameters.jobParameters }}
 
-  # Windows x64
+# Windows x64
 
-  - ${{ if eq(platform, 'Windows_NT_x64') }}:
-    - template: ${{ parameters.jobTemplate }}
-      parameters:
-        buildConfig: ${{ parameters.buildConfig }}
-        archType: x64
-        osGroup: Windows_NT
-        osIdentifier: Windows_NT
-        helixQueues:
-        - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-          - Windows.10.Amd64.Open
-        - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-          # TODO: add Windows.10.Nano.Amd64.Open once https://github.com/dotnet/coreclr/issues/21693 has been resolved
-          - Windows.7.Amd64.Open
-          - Windows.81.Amd64.Open
-          - Windows.10.Amd64.Open
-        - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          - Windows.7.Amd64
-          - Windows.81.Amd64
-          - Windows.10.Amd64
-          - Windows.10.Amd64.Core
-          - (Windows.Nano.1803.Amd64)windows.10.amd64.serverrs4@mcr.microsoft.com/dotnet-buildtools/prereqs:nanoserver-1803-helix-amd64-05227e1-20190509225944
-        ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if or(containsValue(parameters.platforms, 'Windows_NT_x64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+  - template: ${{ parameters.jobTemplate }}
+    parameters:
+      buildConfig: ${{ parameters.buildConfig }}
+      archType: x64
+      osGroup: Windows_NT
+      osIdentifier: Windows_NT
+      helixQueues:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+        - Windows.10.Amd64.Open
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+        # TODO: add Windows.10.Nano.Amd64.Open once https://github.com/dotnet/coreclr/issues/21693 has been resolved
+        - Windows.7.Amd64.Open
+        - Windows.81.Amd64.Open
+        - Windows.10.Amd64.Open
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - Windows.7.Amd64
+        - Windows.81.Amd64
+        - Windows.10.Amd64
+        - Windows.10.Amd64.Core
+        - (Windows.Nano.1803.Amd64)windows.10.amd64.serverrs4@mcr.microsoft.com/dotnet-buildtools/prereqs:nanoserver-1803-helix-amd64-05227e1-20190509225944
+      ${{ insert }}: ${{ parameters.jobParameters }}
 
-  # Windows x86
+# Windows x86
 
-  - ${{ if eq(platform, 'Windows_NT_x86') }}:
-    - template: ${{ parameters.jobTemplate }}
-      parameters:
-        buildConfig: ${{ parameters.buildConfig }}
-        archType: x86
-        osGroup: Windows_NT
-        osIdentifier: Windows_NT
-        helixQueues:
-        - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-          - Windows.10.Amd64.Open
-        - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
-          - Windows.7.Amd64.Open
-          - Windows.81.Amd64.Open
-          - Windows.10.Amd64.Open
-        - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          - Windows.7.Amd64
-          - Windows.81.Amd64
-          - Windows.10.Amd64
-          - Windows.10.Amd64.Core
-        ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if or(containsValue(parameters.platforms, 'Windows_NT_x86'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+  - template: ${{ parameters.jobTemplate }}
+    parameters:
+      buildConfig: ${{ parameters.buildConfig }}
+      archType: x86
+      osGroup: Windows_NT
+      osIdentifier: Windows_NT
+      helixQueues:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+        - Windows.10.Amd64.Open
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+        - Windows.7.Amd64.Open
+        - Windows.81.Amd64.Open
+        - Windows.10.Amd64.Open
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - Windows.7.Amd64
+        - Windows.81.Amd64
+        - Windows.10.Amd64
+        - Windows.10.Amd64.Core
+      ${{ insert }}: ${{ parameters.jobParameters }}
 
-  # Windows arm
+# Windows arm
 
-  - ${{ if eq(platform, 'Windows_NT_arm') }}:
-    - template: ${{ parameters.jobTemplate }}
-      parameters:
-        buildConfig: ${{ parameters.buildConfig }}
-        archType: arm
-        osGroup: Windows_NT
-        osIdentifier: Windows_NT
-        helixQueues:
-        # TODO: Due to the limited capacity of the machines in Windows.10.Arm64.Open queue limit this to CI builds and only to Windows_NT/arm
-        - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
-          - Windows.10.Arm64.Open
-        - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          - Windows.10.Arm64
-        ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if or(containsValue(parameters.platforms, 'Windows_NT_arm'), eq(parameters.platformGroup, 'all')) }}:
+  - template: ${{ parameters.jobTemplate }}
+    parameters:
+      buildConfig: ${{ parameters.buildConfig }}
+      archType: arm
+      osGroup: Windows_NT
+      osIdentifier: Windows_NT
+      helixQueues:
+      # TODO: Due to the limited capacity of the machines in Windows.10.Arm64.Open queue limit this to CI builds and only to Windows_NT/arm
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
+        - Windows.10.Arm64.Open
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - Windows.10.Arm64
+      ${{ insert }}: ${{ parameters.jobParameters }}
 
-  # Windows arm64
+# Windows arm64
 
-  - ${{ if eq(platform, 'Windows_NT_arm64') }}:
-    - template: ${{ parameters.jobTemplate }}
-      parameters:
-        buildConfig: ${{ parameters.buildConfig }}
-        archType: arm64
-        osGroup: Windows_NT
-        osIdentifier: Windows_NT
-        helixQueues:
-        # TODO: Consider adding Windows.10.Arm64.Open here if capacity is enough for handling both Windows_NT/arm and Windows_NT/arm64 testing
-        - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          - Windows.10.Arm64
-        ${{ insert }}: ${{ parameters.jobParameters }}
+- ${{ if or(containsValue(parameters.platforms, 'Windows_NT_arm64'), eq(parameters.platformGroup, 'all')) }}:
+  - template: ${{ parameters.jobTemplate }}
+    parameters:
+      buildConfig: ${{ parameters.buildConfig }}
+      archType: arm64
+      osGroup: Windows_NT
+      osIdentifier: Windows_NT
+      helixQueues:
+      # TODO: Consider adding Windows.10.Arm64.Open here if capacity is enough for handling both Windows_NT/arm and Windows_NT/arm64 testing
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - Windows.10.Arm64
+      ${{ insert }}: ${{ parameters.jobParameters }}


### PR DESCRIPTION
This adds `platformGroup` parameter to platform-matrix.yml and makes the default value of `platforms` parameter to be empty. This allows to not specify the superset of all conditions in azure-pipelines.yml, e.g.

```
- ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'Manual', 'Schedule'), in(variables['Build.DefinitionName'], 'coreclr-ci', 'coreclr-outerloop', 'coreclr-outerloop-jitstress', 'coreclr-outerloop-jitstress-isas-arm', 'coreclr-outerloop-jitstress-isas-x86', 'coreclr-outerloop-jitstressregs-x86', 'coreclr-outerloop-jitstressregs', 'coreclr-outerloop-jitstress2-jitstressregs', 'coreclr-outerloop-gcstress0x3-gcstress0xc', 'coreclr-outerloop-gcstress-extra', 'coreclr-outerloop-r2r', 'coreclr-outerloop-r2r-extra')) }}:
```

I also used recently added containsValue function and removed the for-each loop in platform-matrix.yml. 

These changes is better viewed with hidden whitespace changes.