### PR TITLE
Multiple EventPipe related bugs/issues

### DIFF
--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -1290,9 +1290,11 @@ void STDMETHODCALLTYPE EEShutDownHelper(BOOL fIsDllUnloading)
     }
 
 #ifdef FEATURE_PERFTRACING
-    // Shutdown the event pipe.
-    EventPipe::Shutdown();
-    DiagnosticServer::Shutdown();
+    if (!fIsDllUnloading)
+    {
+        EventPipe::Shutdown();
+        DiagnosticServer::Shutdown();
+    }
 #endif // FEATURE_PERFTRACING
 
 #if defined(FEATURE_COMINTEROP)

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -31,7 +31,6 @@ CrstStatic EventPipe::s_configCrst;
 Volatile<bool> EventPipe::s_tracingInitialized = false;
 EventPipeConfiguration EventPipe::s_config;
 EventPipeEventSource *EventPipe::s_pEventSource = NULL;
-HANDLE EventPipe::s_fileSwitchTimerHandle = NULL;
 VolatilePtr<EventPipeSession> EventPipe::s_pSessions[MaxNumberOfSessions];
 ULONGLONG EventPipe::s_lastFlushTime = 0;
 

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -650,6 +650,10 @@ void EventPipe::WriteEventInternal(EventPipeEvent &event, EventPipeEventPayload 
     }
     CONTRACTL_END;
 
+    // We can't proceed if tracing is not initialized.
+    if (!s_tracingInitialized)
+        return;
+
     // Exit early if the event is not enabled.
     if (!event.IsEnabled())
         return;

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -32,7 +32,6 @@ Volatile<bool> EventPipe::s_tracingInitialized = false;
 EventPipeConfiguration EventPipe::s_config;
 EventPipeEventSource *EventPipe::s_pEventSource = nullptr;
 VolatilePtr<EventPipeSession> EventPipe::s_pSessions[MaxNumberOfSessions];
-ULONGLONG EventPipe::s_lastFlushTime = 0;
 
 #ifdef FEATURE_PAL
 // This function is auto-generated from /src/scripts/genEventPipe.py

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -687,6 +687,10 @@ void EventPipe::WriteEventInternal(
     }
     CONTRACTL_END;
 
+    // We can't proceed if tracing is not initialized.
+    if (!s_tracingInitialized)
+        return;
+
     EventPipeThread *const pEventPipeThread = EventPipeThread::GetOrCreate();
     if (pEventPipeThread == nullptr)
     {

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -412,7 +412,6 @@ private:
     static EventPipeConfiguration s_config;
     static VolatilePtr<EventPipeSession> s_pSessions[MaxNumberOfSessions];
     static EventPipeEventSource *s_pEventSource;
-    static HANDLE s_fileSwitchTimerHandle;
     static ULONGLONG s_lastFlushTime;
 };
 

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -412,7 +412,6 @@ private:
     static EventPipeConfiguration s_config;
     static VolatilePtr<EventPipeSession> s_pSessions[MaxNumberOfSessions];
     static EventPipeEventSource *s_pEventSource;
-    static ULONGLONG s_lastFlushTime;
 };
 
 struct EventPipeProviderConfiguration

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -352,12 +352,12 @@ public:
             InvokeCallback(eventPipeProviderCallbackData);
     }
 
+private:
     static void InvokeCallback(EventPipeProviderCallbackData eventPipeProviderCallbackData);
 
     // Get the event used to write metadata to the event stream.
     static EventPipeEventInstance *BuildEventMetadataEvent(EventPipeEventInstance &instance, unsigned int metadataId);
 
-private:
     // The counterpart to WriteEvent which after the payload is constructed
     static void WriteEventInternal(
         EventPipeEvent &event,

--- a/src/vm/eventpipeconfiguration.cpp
+++ b/src/vm/eventpipeconfiguration.cpp
@@ -51,6 +51,7 @@ void EventPipeConfiguration::Shutdown()
         NOTHROW;
         GC_TRIGGERS;
         MODE_ANY;
+        PRECONDITION(m_activeSessions == 0);
     }
     CONTRACTL_END;
 


### PR DESCRIPTION
- Addressing https://github.com/dotnet/coreclr/pull/24896#discussion_r291790885
- EventPipe::Shutdown can be called concurrently from multiple threads, then EventPipe::s_pSessions could change from not-null to null, which could trigger an AV.
- Addressing the following assertion:
```log
CoreRun.exe ".\bin\tests\Windows_NT.x64.Debug\tracing\runtimeeventsource\runtimeeventsource\runtimeeventsource.exe"
-------------------------------------------------------------------------------


Assert failure(PID 25672 [0x00006448], Thread: 29384 [0x72c8]): CONTRACT VIOLATION by EventPipeBufferManager::MoveNextEventAnyThread at ".\src\vm\eventpipebuffermanager.cpp" @ 755

THROWS called in a NOTHROW region.

                        CONTRACT in EventPipeBufferManager::MoveNextEventAnyThread at ".\src\vm\eventpipebuffermanager.cpp" @ 755
VIOLATED-->  CONTRACT in EventPipeBufferManager::GetNextEvent at ".\src\vm\eventpipebuffermanager.cpp" @ 705
                        CONTRACT in EventPipeSession::GetNextEvent at ".\src\vm\eventpipesession.cpp" @ 385
                        CONTRACT in EventPipe::GetNextEvent at ".\src\vm\eventpipe.cpp" @ 889
                        CONTRACT in EventPipeInternal::GetNextEvent at ".\src\vm\eventpipeinternal.cpp" @ 264
                        OVERRIDE_TYPE_LOAD_LEVEL_LIMIT in MethodDescCallSite::CallTargetWorker at ".\src\vm\callhelpers.cpp" @ 354
                        CONTRACT in MethodDescCallSite::CallTargetWorker at ".\src\vm\callhelpers.cpp" @ 344
                        CONTRACT in ThreadNative::KickOffThread_Worker at ".\src\vm\comsynchronizable.cpp" @ 193
                        CONTRACT in ManagedThreadBase_DispatchInner at ".\src\vm\threads.cpp" @ 7407
                        CONTRACT in ManagedThreadBase_FullTransition at ".\src\vm\threads.cpp" @ 7663
                        CONTRACT in ThreadNative::KickOffThread at ".\src\vm\comsynchronizable.cpp" @ 289



CORECLR! CONTRACT_ASSERT + 0x426 (0x00007ffc`d2473e16)
CORECLR! BaseContract::DoChecks + 0x233 (0x00007ffc`d24766c7)
CORECLR! EEContract::DoChecks + 0xD3 (0x00007ffc`d253de57)
CORECLR! EventPipeBufferManager::MoveNextEventAnyThread + 0x2CA (0x00007ffc`d2cd8316)
CORECLR! EventPipeBufferManager::GetNextEvent + 0xC5 (0x00007ffc`d2cd5aa5)
CORECLR! EventPipeSession::GetNextEvent + 0xB8 (0x00007ffc`d2b9d044)
CORECLR! EventPipe::GetNextEvent + 0xC4 (0x00007ffc`d282b50c)
CORECLR! EventPipeInternal::GetNextEvent + 0x162 (0x00007ffc`d2c3d952)
<no module>! <no symbol> + 0x0 (0x00007ffc`73305484)
<no module>! <no symbol> + 0x0 (0x00000216`57e4bb00)
    File: .\src\vm\eventpipebuffermanager.cpp Line: 755
    Image: .\bin\tests\Windows_NT.x64.Checked\Tests\Core_Root\CoreRun.exe
```
- Removed unused `EventPipe::s_fileSwitchTimerHandle` static member.