### PR TITLE
Expose readonly heap segments to DAC

### DIFF
--- a/src/gc/gcinterface.dac.h
+++ b/src/gc/gcinterface.dac.h
@@ -11,6 +11,7 @@
 //      GC-internal type's fields, while still maintaining the same layout.
 // This interface is strictly versioned, see gcinterface.dacvars.def for more information.
 
+#define HEAP_SEGMENT_FLAGS_READONLY     1
 #define NUM_GC_DATA_POINTS              9
 #define MAX_COMPACT_REASONS_COUNT       11
 #define MAX_EXPAND_MECHANISMS_COUNT     6


### PR DESCRIPTION
This was in CoreRT's copy of gcinterface.dac.h, but got lost in dotnet/corert#7517.