### PR TITLE
ArgumentException: use system-supplied message if message is null

### DIFF
--- a/src/System.Private.CoreLib/shared/System/ArgumentException.cs
+++ b/src/System.Private.CoreLib/shared/System/ArgumentException.cs
@@ -93,7 +93,8 @@ namespace System
 
         private void SetMessageField()
         {
-            if (_message == null && HResult == System.HResults.COR_E_ARGUMENT)
+            if (_message == null && HResult == System.HResults.COR_E_ARGUMENT) 
+            {
                     _message = SR.Arg_ArgumentException;
             }
         }

--- a/src/System.Private.CoreLib/shared/System/ArgumentException.cs
+++ b/src/System.Private.CoreLib/shared/System/ArgumentException.cs
@@ -95,7 +95,7 @@ namespace System
         {
             if (_message == null && HResult == System.HResults.COR_E_ARGUMENT) 
             {
-                    _message = SR.Arg_ArgumentException;
+                _message = SR.Arg_ArgumentException;
             }
         }
         

--- a/src/System.Private.CoreLib/shared/System/ArgumentException.cs
+++ b/src/System.Private.CoreLib/shared/System/ArgumentException.cs
@@ -78,6 +78,8 @@ namespace System
         {
             get
             {
+                SetMessageField();
+                
                 string s = base.Message;
                 if (!string.IsNullOrEmpty(_paramName))
                 {
@@ -89,6 +91,13 @@ namespace System
             }
         }
 
+        private void SetMessageField()
+        {
+            if (_message == null && HResult == System.HResults.COR_E_ARGUMENT)
+                    _message = SR.Arg_ArgumentException;
+            }
+        }
+        
         public virtual string? ParamName
         {
             get { return _paramName; }


### PR DESCRIPTION
Enable using a system-supplied message while also providing an argument/parameter name by passing in a null message. While providing a specific error message would be best, providing a parameter name is better than nothing.

Made my changes to match the behavior of FileNotFoundException. I think this change is relatively safe since it checks the HResult value, so subclasses that set the HResult will not be affected. Also the basic Exception class already provides a default string if the message is null, so `Message == null` checks should not exist.