### PR TITLE
Emit a message when skipping a method in crossgen

### DIFF
--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -427,7 +427,11 @@ void ZapInfo::CompileMethod()
 
     // If we are doing partial ngen, only compile methods with profile data
     if (!CurrentMethodHasProfileData() && m_zapper->m_pOpt->m_fPartialNGen)
+    {
+        if (m_zapper->m_pOpt->m_verbose)
+            m_zapper->Info(W("Skipped because of no profile data\n"));
         return;
+    }
 
     // During ngen we look for a hint attribute on the method that indicates
     // the method should be preprocessed for early
@@ -444,6 +448,8 @@ void ZapInfo::CompileMethod()
         // Skip methods marked with MethodImplOptions.AggressiveOptimization, they will be jitted instead. In the future,
         // consider letting the JIT determine whether aggressively optimized code can/should be pregenerated for the method
         // instead of this check.
+        if (m_zapper->m_pOpt->m_verbose)
+            m_zapper->Info(W("Skipped because of aggressive optimization flag\n"));
         return;
     }
 


### PR DESCRIPTION
Since crossgen normally prints a message when the compilation didn't happen (because e.g. something is not supported), we should print something here too. Otherwise the `/verbose` log makes it look like pregeneration succeeded and sends someone down a wrong path investigating why it's not picked up at runtime...