### PR TITLE
Disable unloading incompatible test for runincontext

### DIFF
--- a/src/tools/runincontext/runincontext.cs
+++ b/src/tools/runincontext/runincontext.cs
@@ -483,6 +483,7 @@ public class TestRunner
         {
             GC.Collect();
             GC.WaitForPendingFinalizers();
+            Thread.Sleep(10);
         }
 
         if (_input.BreakAfterRun)
@@ -562,6 +563,7 @@ public class RunInContext
 
     private static void OnUnhandledException(object sender, UnhandledExceptionEventArgs e)
     {
+        Console.WriteLine($"RunInContext FAIL! Exiting due to unhandled exception in the test: {e.ExceptionObject}");
         Environment.Exit(FailureExitCode);
     }
 

--- a/tests/scripts/runincontext.sh
+++ b/tests/scripts/runincontext.sh
@@ -14,4 +14,4 @@
 # 3. - n. Additional arguments that were passed to the test .sh
 
 export CORE_LIBRARIES=$1
-$_DebuggerFullPath "$CORE_ROOT/corerun" "$CORE_ROOT/runincontext.dll" $RunInContextExtraArgs /referencespath:$CORE_ROOT/ $1$2 $3 $4 $5 $6 $7 $8 $9
+$_DebuggerFullPath "$CORE_ROOT/corerun" "$CORE_ROOT/runincontext.dll" $RunInContextExtraArgs /referencespath:$CORE_ROOT/ $1$2 "${@:3}"

--- a/tests/src/GC/Features/KeepAlive/keepaliveother/keepalivefinalize.csproj
+++ b/tests/src/GC/Features/KeepAlive/keepaliveother/keepalivefinalize.csproj
@@ -11,6 +11,8 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <GCStressIncompatible>true</GCStressIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- This test tries to print to console from a finalizer after the static with stdout SafeHandle is finalized -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>

--- a/tests/src/Interop/COM/Activator/Activator.csproj
+++ b/tests/src/Interop/COM/Activator/Activator.csproj
@@ -12,6 +12,8 @@
     <!-- Test unsupported outside of windows -->
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsWindows)' != 'true'">true</DisableProjectBuild>
+    <!-- The test fails casting from ClassFromA from the default ALC to type IGetTypeFromC from a custom ALC -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Interop.settings.targets))\Interop.settings.targets" />
 

--- a/tests/src/Interop/WinRT/NETClients/Bindings/NETClientBindings.csproj
+++ b/tests/src/Interop/WinRT/NETClients/Bindings/NETClientBindings.csproj
@@ -13,6 +13,8 @@
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>
     <DisableProjectBuild Condition="'$(Platform)' == 'arm' or '$(Platform)' == 'arm64'">true</DisableProjectBuild>
+    <!-- WinRT interop is not compatible with unloadability -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">

--- a/tests/src/Interop/WinRT/NETClients/Primitives/NETClientPrimitives.csproj
+++ b/tests/src/Interop/WinRT/NETClients/Primitives/NETClientPrimitives.csproj
@@ -12,7 +12,9 @@
     <!-- Test unsupported outside of windows -->
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
     <DisableProjectBuild Condition="'$(TargetsUnix)' == 'true'">true</DisableProjectBuild>
-  </PropertyGroup>
+    <!-- WinRT interop is not compatible with unloadability -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+</PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
   </PropertyGroup>

--- a/tests/src/Loader/AssemblyLoadContext30Extensions/AssemblyLoadContext30Extensions.csproj
+++ b/tests/src/Loader/AssemblyLoadContext30Extensions/AssemblyLoadContext30Extensions.csproj
@@ -10,6 +10,8 @@
     <OutputType>Exe</OutputType>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <!-- The test uses non-unloadable AssemblyLoadContext  -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">

--- a/tests/src/Loader/ContextualReflection/ContextualReflection.csproj
+++ b/tests/src/Loader/ContextualReflection/ContextualReflection.csproj
@@ -8,6 +8,10 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <ProjectGuid>{78030DC5-F1A6-4B98-A130-A66F5047FF29}</ProjectGuid>
+    <!-- The test uses AssemblyLoadContext (directly) to load the test assembly and its dependency that's part of the test again.
+    When the test is loaded into an unloadable context in the runincontext tool, the dependency assembly cannot be found
+    since it is in a different folder than the runincontext tool.  -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ContextualReflection.cs" />

--- a/tests/src/baseservices/exceptions/regressions/V1/SEH/VJ/HandlerException.csproj
+++ b/tests/src/baseservices/exceptions/regressions/V1/SEH/VJ/HandlerException.csproj
@@ -12,6 +12,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- The test can have threads running at exit -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/exceptions/regressions/V1/SEH/VJ/NestedException.csproj
+++ b/tests/src/baseservices/exceptions/regressions/V1/SEH/VJ/NestedException.csproj
@@ -12,7 +12,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
+      <!-- This test leaves secondary threads running at exit -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+</PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>


### PR DESCRIPTION
These tests do various things that make them incompatible with running
in an unloadable assembly load context using the runincontext tool.
I've attached comments to the UnloadabilityIncompatible element
describing the specific problems of each test.

I've also found a problem in the parameter passing in the
runincontext.sh where it was always passing 7 parameters to each test
and tests that were checking the number of parameters were failing due
to that. This change fixes it by passing just the parameters that were
passed to the runincontext.sh.