### PR TITLE
ensure process-wide fence when updating GC write barrier on ARM64

### DIFF
--- a/src/gc/sample/GCSample.cpp
+++ b/src/gc/sample/GCSample.cpp
@@ -95,7 +95,7 @@ inline void ErectWriteBarrier(Object ** dst, Object * ref)
         return;
         
     // volatile is used here to prevent fetch of g_card_table from being reordered 
-    // with g_lowest/highest_address check above. See comment in code:gc_heap::grow_brick_card_tables.
+    // with g_lowest/highest_address check above. See comments in StompWriteBarrier
     uint8_t* pCardByte = (uint8_t *)*(volatile uint8_t **)(&g_gc_card_table) + card_byte((uint8_t *)dst);
     if(*pCardByte != 0xFF)
         *pCardByte = 0xFF;

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -844,11 +844,11 @@ void GCToEEInterface::StompWriteBarrier(WriteBarrierParameters* args)
         //     may put a stack/unmanaged write inside the new heap range. However the old card table would not cover it.
         //     Therefore we must ensure that the write barriers see the new table before seeing new bounds.
         //
-        //     On archtectures with strong ordering, we only need to prevent compiler reordering.
+        //     On architectures with strong ordering, we only need to prevent compiler reordering.
         //     Otherwise we put a process-wide fence here (so that we could use an ordinary read in the barrier)
 
 #if defined(_ARM64_) || defined(_ARM_)      
-        if(!is_runtime_suspended)
+        if (!is_runtime_suspended)
         {
             // If runtime is not suspended, force all threads to see the changed table before seeing updated heap boundaries.
             // See:Dev11 #346765
@@ -875,7 +875,7 @@ void GCToEEInterface::StompWriteBarrier(WriteBarrierParameters* args)
 
         // At this point either the old or the new set of globals (card_table, bounds etc) can be used. Card tables and card bundles allow such use. 
         // When card tables are de-published (at EE suspension) all the info will be merged, so the information will not be lost.
-        // Another point - we should not yet have any manaded objects/addresses outside of the former bounds, so either old or new bounds are fine.
+        // Another point - we should not yet have any managed objects/addresses outside of the former bounds, so either old or new bounds are fine.
         // That is - because bounds can only become wider and we are not yet done with widening.
         //
         // However!!
@@ -901,7 +901,7 @@ void GCToEEInterface::StompWriteBarrier(WriteBarrierParameters* args)
 
 #if defined(_ARM64_) || defined(_ARM_)      
         is_runtime_suspended = (stompWBCompleteActions & SWB_EE_RESTART) || is_runtime_suspended;
-        if(!is_runtime_suspended)
+        if (!is_runtime_suspended)
         {
             // If runtime is not suspended, force all threads to see the changed state before observing future allocations.
             FlushProcessWriteBuffers();

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -856,7 +856,7 @@ void GCToEEInterface::StompWriteBarrier(WriteBarrierParameters* args)
         }
 #endif
 
-        VolatileStoreWithoutBarrier(&g_lowest_address, args->lowest_address);
+        g_lowest_address = args->lowest_address;
         g_highest_address = args->highest_address;
 
 #if defined(_ARM64_) || defined(_ARM_)

--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -840,9 +840,9 @@ void GCToEEInterface::StompWriteBarrier(WriteBarrierParameters* args)
             ::FlushWriteBarrierInstructionCache();
         }
 
-        // NB: managed heap segments may surround unmanaged/stack segments. In such cases adding another managed heap segment
-        //     may put a stack/unmanaged write inside the new heap range. However the old card table would not cover it.
-        //     Therefore we must ensure that the write barriers see the new table before seeing new bounds.
+        // IMPORTANT: managed heap segments may surround unmanaged/stack segments. In such cases adding another managed 
+        //     heap segment may put a stack/unmanaged write inside the new heap range. However the old card table would 
+        //     not cover it. Therefore we must ensure that the write barriers see the new table before seeing the new bounds.
         //
         //     On architectures with strong ordering, we only need to prevent compiler reordering.
         //     Otherwise we put a process-wide fence here (so that we could use an ordinary read in the barrier)
@@ -851,7 +851,7 @@ void GCToEEInterface::StompWriteBarrier(WriteBarrierParameters* args)
         if (!is_runtime_suspended)
         {
             // If runtime is not suspended, force all threads to see the changed table before seeing updated heap boundaries.
-            // See:Dev11 #346765
+            // See: http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/346765
             FlushProcessWriteBuffers();
         }
 #endif
@@ -893,7 +893,7 @@ void GCToEEInterface::StompWriteBarrier(WriteBarrierParameters* args)
         //
         // We will do "b" because executing write barrier is by far more common than updating card table.
         //
-        // I.E. - for weak archeitectures we have to do a proccess-wide fence. 
+        // I.E. - for weak architectures we have to do a process-wide fence.  
         //
         // NOTE: suspending/resuming EE works the same as process-wide fence for our purposes here. 
         //       (we care only about managed threads and suspend/resume will do full fences - good enough for us).

--- a/src/vm/gchelpers.cpp
+++ b/src/vm/gchelpers.cpp
@@ -1257,7 +1257,7 @@ OBJECTREF AllocateObject(MethodTable *pMT
 
 static void SetCardBundleByte(BYTE* addr)
 {
-    BYTE* cbByte = (BYTE *)VolatileLoadWithoutBarrier(&g_card_bundle_table) + card_bundle_byte(addr);
+    BYTE* cbByte = (BYTE *)g_card_bundle_table + card_bundle_byte(addr);
     if (*cbByte != 0xFF)
     {
         *cbByte = 0xFF;
@@ -1406,9 +1406,7 @@ extern "C" HCIMPL2_RAW(VOID, JIT_CheckedWriteBarrier, Object **dst, Object *ref)
 #ifdef FEATURE_COUNT_GC_WRITE_BARRIERS
         CheckedAfterRefInEphemFilter++;
 #endif
-        // VolatileLoadWithoutBarrier() is used here to prevent fetch of g_card_table from being reordered 
-        // with g_lowest/highest_address check above. See comment in code:gc_heap::grow_brick_card_tables.
-        BYTE* pCardByte = (BYTE *)VolatileLoadWithoutBarrier(&g_card_table) + card_byte((BYTE *)dst);
+        BYTE* pCardByte = (BYTE *)g_card_table + card_byte((BYTE *)dst);
         if(*pCardByte != 0xFF)
         {
 #ifdef FEATURE_COUNT_GC_WRITE_BARRIERS
@@ -1467,7 +1465,7 @@ extern "C" HCIMPL2_RAW(VOID, JIT_WriteBarrier, Object **dst, Object *ref)
 #ifdef FEATURE_COUNT_GC_WRITE_BARRIERS
         UncheckedAfterRefInEphemFilter++;
 #endif
-        BYTE* pCardByte = (BYTE *)VolatileLoadWithoutBarrier(&g_card_table) + card_byte((BYTE *)dst);
+        BYTE* pCardByte = (BYTE *)g_card_table + card_byte((BYTE *)dst);
         if(*pCardByte != 0xFF)
         {
 #ifdef FEATURE_COUNT_GC_WRITE_BARRIERS
@@ -1530,9 +1528,7 @@ void ErectWriteBarrier(OBJECTREF *dst, OBJECTREF ref)
 
     if ((BYTE*) OBJECTREFToObject(ref) >= g_ephemeral_low && (BYTE*) OBJECTREFToObject(ref) < g_ephemeral_high)
     {
-        // VolatileLoadWithoutBarrier() is used here to prevent fetch of g_card_table from being reordered 
-        // with g_lowest/highest_address check above. See comment in code:gc_heap::grow_brick_card_tables.
-        BYTE* pCardByte = (BYTE *)VolatileLoadWithoutBarrier(&g_card_table) + card_byte((BYTE *)dst);
+        BYTE* pCardByte = (BYTE *)g_card_table + card_byte((BYTE *)dst);
         if (*pCardByte != 0xFF)
         {
             *pCardByte = 0xFF;
@@ -1572,7 +1568,7 @@ void ErectWriteBarrierForMT(MethodTable **dst, MethodTable *ref)
         if((BYTE*) refObject >= g_ephemeral_low && (BYTE*) refObject < g_ephemeral_high)
         {
             // See comment above
-            BYTE* pCardByte = (BYTE *)VolatileLoadWithoutBarrier(&g_card_table) + card_byte((BYTE *)dst);
+            BYTE* pCardByte = (BYTE *)g_card_table + card_byte((BYTE *)dst);
             if( !((*pCardByte) & card_bit((BYTE *)dst)) )
             {
                 *pCardByte = 0xFF;

--- a/src/vm/gchelpers.cpp
+++ b/src/vm/gchelpers.cpp
@@ -1257,7 +1257,7 @@ OBJECTREF AllocateObject(MethodTable *pMT
 
 static void SetCardBundleByte(BYTE* addr)
 {
-    BYTE* cbByte = (BYTE *)g_card_bundle_table + card_bundle_byte(addr);
+    BYTE* cbByte = (BYTE *)VolatileLoadWithoutBarrier(&g_card_bundle_table) + card_bundle_byte(addr);
     if (*cbByte != 0xFF)
     {
         *cbByte = 0xFF;

--- a/src/vm/gchelpers.inl
+++ b/src/vm/gchelpers.inl
@@ -90,7 +90,7 @@ FORCEINLINE void InlinedSetCardsAfterBulkCopyHelper(Object **start, size_t len)
     size_t endBundleByte = (endAddress + (1 << card_bundle_byte_shift) - 1) >> card_bundle_byte_shift;
     size_t bundleByteCount = endBundleByte - startBundleByte;
 
-    uint8_t* pBundleByte = (uint8_t*)g_card_bundle_table + startBundleByte;
+    uint8_t* pBundleByte = ((uint8_t*)VolatileLoadWithoutBarrier(&g_card_bundle_table)) + startBundleByte;
 
     do
     {

--- a/src/vm/gchelpers.inl
+++ b/src/vm/gchelpers.inl
@@ -66,9 +66,7 @@ FORCEINLINE void InlinedSetCardsAfterBulkCopyHelper(Object **start, size_t len)
 
     // calculate the number of clumps to mark (round_up(end) - start)
     size_t clumpCount = endingClump - startingClump;
-    // VolatileLoadWithoutBarrier() is used here to prevent fetch of g_card_table from being reordered
-    // with g_lowest/highest_address check at the beginning of this function.
-    uint8_t* card = ((uint8_t*)VolatileLoadWithoutBarrier(&g_card_table)) + startingClump;
+    uint8_t* card = (uint8_t*)g_card_table + startingClump;
 
     // Fill the cards. To avoid cache line thrashing we check whether the cards have already been set before
     // writing.
@@ -89,7 +87,7 @@ FORCEINLINE void InlinedSetCardsAfterBulkCopyHelper(Object **start, size_t len)
     size_t endBundleByte = (endAddress + (1 << card_bundle_byte_shift) - 1) >> card_bundle_byte_shift;
     size_t bundleByteCount = endBundleByte - startBundleByte;
 
-    uint8_t* pBundleByte = ((uint8_t*)VolatileLoadWithoutBarrier(&g_card_bundle_table)) + startBundleByte;
+    uint8_t* pBundleByte = (uint8_t*)g_card_bundle_table + startBundleByte;
 
     do
     {

--- a/src/vm/gchelpers.inl
+++ b/src/vm/gchelpers.inl
@@ -66,7 +66,10 @@ FORCEINLINE void InlinedSetCardsAfterBulkCopyHelper(Object **start, size_t len)
 
     // calculate the number of clumps to mark (round_up(end) - start)
     size_t clumpCount = endingClump - startingClump;
-    uint8_t* card = (uint8_t*)g_card_table + startingClump;
+
+    // VolatileLoadWithoutBarrier() is used here to prevent fetch of g_card_table from being reordered 
+    // with g_lowest/highest_address check above. See comment in StompWriteBarrier.
+    BYTE* card = (BYTE*)VolatileLoadWithoutBarrier(&g_card_table) + startingClump;
 
     // Fill the cards. To avoid cache line thrashing we check whether the cards have already been set before
     // writing.


### PR DESCRIPTION
This is related to https://github.com/dotnet/coreclr/issues/24028 , but may not be sufficient to be a complete fix.

The other problem is that process-wide fence is not 100% reliable on pre 4.14 kernels on ARM64. 
Lab has some machines like that and there is a chance they might still cause failures, as evidenced from 
https://github.com/dotnet/corefx/pull/38401  and
https://github.com/dotnet/coreclr/issues/20215