### PR TITLE
Fix contained LEA handling

### DIFF
--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -1356,6 +1356,10 @@ void CodeGen::genConsumeRegs(GenTree* tree)
         {
             genConsumeAddress(tree->AsIndir()->Addr());
         }
+        else if (tree->OperIs(GT_LEA))
+        {
+            genConsumeAddress(tree);
+        }
 #ifdef _TARGET_XARCH_
         else if (tree->OperIsLocalRead())
         {

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -11436,8 +11436,8 @@ void Compiler::gtDispLIRNode(GenTree* node, const char* prefixMsg /* = nullptr *
             printf("%*s", (int)prefixIndent, "");
         }
 
-        // 49 spaces for alignment
-        printf("%-49s", "");
+        // 50 spaces for alignment
+        printf("%-50s", "");
 #if FEATURE_SET_FLAGS
         // additional flag enlarges the flag field by one character
         printf(" ");

--- a/src/jit/lsrabuild.cpp
+++ b/src/jit/lsrabuild.cpp
@@ -2763,7 +2763,7 @@ int LinearScan::BuildOperandUses(GenTree* node, regMaskTP candidates)
     }
     if (node->OperIs(GT_LEA))
     {
-        BuildAddrUses(node, candidates);
+        return BuildAddrUses(node, candidates);
     }
 #ifdef FEATURE_HW_INTRINSICS
     if (node->OperIsHWIntrinsic())

--- a/src/jit/lsrabuild.cpp
+++ b/src/jit/lsrabuild.cpp
@@ -2761,6 +2761,10 @@ int LinearScan::BuildOperandUses(GenTree* node, regMaskTP candidates)
     {
         return BuildIndirUses(node->AsIndir(), candidates);
     }
+    if (node->OperIs(GT_LEA))
+    {
+        BuildAddrUses(node, candidates);
+    }
 #ifdef FEATURE_HW_INTRINSICS
     if (node->OperIsHWIntrinsic())
     {

--- a/tests/src/JIT/Regression/JitBlue/GitHub_25039/GitHub_25039.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_25039/GitHub_25039.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using static System.Runtime.Intrinsics.X86.Avx;
+using static System.Runtime.Intrinsics.X86.Avx2;
+
+class GitHub_25039
+{
+    static ReadOnlySpan<byte> PermTable => new byte[]
+    {
+        0, 1, 2, 3, 4, 5, 6, 7, /* 0*/
+        0, 1, 2, 3, 4, 5, 6, 7, /* 0*/
+        0, 1, 2, 3, 4, 5, 6, 7, /* 0*/
+        0, 1, 2, 3, 4, 5, 6, 7, /* 0*/
+        0, 1, 2, 3, 4, 5, 6, 7, /* 0*/
+        0, 1, 2, 3, 4, 5, 6, 7, /* 0*/
+        0, 1, 2, 3, 4, 5, 6, 7, /* 0*/
+        0, 1, 2, 3, 4, 5, 6, 7, /* 0*/
+    };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static unsafe Vector256<int> GetPermutation(byte* pBase, int pvbyte)
+    {
+        Debug.Assert(pvbyte >= 0);
+        Debug.Assert(pvbyte < 255);
+        Debug.Assert(pBase != null);
+        return ConvertToVector256Int32(pBase + pvbyte * 8);
+    }
+
+    static unsafe int Main(string[] args)
+    {
+        if (System.Runtime.Intrinsics.X86.Avx2.IsSupported)
+        {
+            try
+            {
+                var src = new int[1024];
+                fixed (int* pSrc = &src[0])
+                fixed (byte* pBase = &PermTable[0])
+                {
+
+                    for (var i = 0; i < 100; i++)
+                    {
+                        var srcv = LoadDquVector256(pSrc + i);
+                        var pe = i & 0x7;
+                        var permuted = PermuteVar8x32(srcv, GetPermutation(pBase, (int)pe));
+                        Store(pSrc + i, permuted);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Failed with exception " + e.Message);
+                return -1;
+            }
+        }
+        return 100;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_25039/GitHub_25039.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_25039/GitHub_25039.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
This adds an LEA case to both `LinearScan::BuildOperandUses` and `CodeGen::genConsumeRegs`.

Fix #25039