### PR TITLE
Change how build.sh/build.cmd parse the PGO and IBC versions

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -395,7 +395,7 @@ set IbcDataPackageVersionOutputFile="%__IntermediatesDir%\ibcoptdataversion.txt"
 REM Parse the optdata package versions out of msbuild so that we can pass them on to CMake
 call "%__ProjectDir%\dotnet.cmd" msbuild "%OptDataProjectFilePath%" /t:DumpPgoDataPackageVersion /nologo %__CommonMSBuildArgs% /p:PgoDataPackageVersionOutputFile=%PgoDataPackageVersionOutputFile%
 
- if not not !errorlevel! == 0 (
+ if not !errorlevel! == 0 (
     echo "Failed to get PGO data package version."
     exit /b 1
 )
@@ -408,7 +408,7 @@ set /p __PgoOptDataVersion=<"%PgoDataPackageVersionOutputFile%"
 
 call "%__ProjectDir%\dotnet.cmd" msbuild "%OptDataProjectFilePath%" /t:DumpIbcDataPackageVersion /nologo %__CommonMSBuildArgs% /p:IbcDataPackageVersionOutputFile=%IbcDataPackageVersionOutputFile%
 
- if not not !errorlevel! == 0 (
+ if not !errorlevel! == 0 (
     echo "Failed to get IBC data package version."
     exit /b 1
 )
@@ -660,7 +660,7 @@ if %__BuildCoreLib% EQU 1 (
         set IbcMergePackageVersionOutputFile="%__IntermediatesDir%\ibcmergeversion.txt"
         call "%__ProjectDir%\dotnet.cmd" msbuild "!IbcMergeProjectFilePath!" /t:DumpIbcMergePackageVersion /nologo %__CommonMSBuildArgs% /p:IbcMergePackageVersionOutputFile=%IbcMergePackageVersionOutputFile%
 
-        if not not !errorlevel! == 0 (
+        if not !errorlevel! == 0 (
             echo "Failed to determine IBC Merge version."
             exit /b 1
         )

--- a/build.cmd
+++ b/build.cmd
@@ -397,11 +397,11 @@ call "%__ProjectDir%\dotnet.cmd" msbuild "%OptDataProjectFilePath%" /t:DumpPgoDa
 
  if not !errorlevel! == 0 (
     echo "Failed to get PGO data package version."
-    exit /b 1
+    exit /b !errorlevel!
 )
 if not exist "%PgoDataPackageVersionOutputFile%" (
     echo "Failed to get PGO data package version."
-    exit /b !errorlevel!
+    exit /b 1
 )
 
 set /p __PgoOptDataVersion=<"%PgoDataPackageVersionOutputFile%"
@@ -410,12 +410,12 @@ call "%__ProjectDir%\dotnet.cmd" msbuild "%OptDataProjectFilePath%" /t:DumpIbcDa
 
  if not !errorlevel! == 0 (
     echo "Failed to get IBC data package version."
-    exit /b 1
+    exit /b !errorlevel!
 )
 
 if not exist "%IbcDataPackageVersionOutputFile%" (
     echo "Failed to get IBC data package version."
-    exit /b !errorlevel!
+    exit /b 1
 )
 
 set /p __IbcOptDataVersion=<"%IbcDataPackageVersionOutputFile%"
@@ -662,7 +662,7 @@ if %__BuildCoreLib% EQU 1 (
 
         if not !errorlevel! == 0 (
             echo "Failed to determine IBC Merge version."
-            exit /b 1
+            exit /b !errorlevel!
         )
         if not exist "%IbcMergePackageVersionOutputFile%" (
             echo "Failed to determine IBC Merge version."

--- a/build.cmd
+++ b/build.cmd
@@ -390,7 +390,7 @@ if %__RestoreOptData% EQU 1 (
 )
 
 REM Parse the optdata package versions out of msbuild so that we can pass them on to CMake
-call "%__ProjectDir%\dotnet.cmd" msbuild "%OptDataProjectFilePath%" /t:DumpPgoDataPackageVersion /nologo
+call "%__ProjectDir%\dotnet.cmd" msbuild "%OptDataProjectFilePath%" /t:DumpPgoDataPackageVersion /nologo %__CommonMSBuildArgs%
 
 if not exist "%__IntermediatesDir%\optdataversion.txt" (
     echo "Failed to get PGO data package version."
@@ -399,7 +399,7 @@ if not exist "%__IntermediatesDir%\optdataversion.txt" (
 
 set /p __PgoOptDataVersion<"%__IntermediatesDir%\optdataversion.txt"
 
-call "%__ProjectDir%\dotnet.cmd" msbuild "%OptDataProjectFilePath%" /t:DumpIbcDataPackageVersion /nologo
+call "%__ProjectDir%\dotnet.cmd" msbuild "%OptDataProjectFilePath%" /t:DumpIbcDataPackageVersion /nologo %__CommonMSBuildArgs%
 
 if not exist "%__IntermediatesDir%\ibcoptdataversion.txt" (
     echo "Failed to get PGO data package version."

--- a/build.cmd
+++ b/build.cmd
@@ -645,9 +645,14 @@ if %__BuildCoreLib% EQU 1 (
     if %__IbcOptimize% EQU 1 (
         echo %__MsgPrefix%Commencing IBCMerge of System.Private.CoreLib for %__BuildOS%.%__BuildArch%.%__BuildType%
         set IbcMergeProjectFilePath=%__ProjectDir%\src\.nuget\optdata\ibcmerge.csproj
-        for /f "tokens=*" %%s in ('call "%__ProjectDir%\dotnet.cmd" msbuild "!IbcMergeProjectFilePath!" /t:DumpIbcMergePackageVersion /nologo') do @(
-            set __IbcMergeVersion=%%s
+        call "%__ProjectDir%\dotnet.cmd" msbuild "!IbcMergeProjectFilePath!" /t:DumpIbcMergePackageVersion /nologo %__CommonMSBuildArgs%
+
+        if not exist "%__IntermediatesDir%\ibcmergeversion.txt" (
+            echo "Failed to determine IBC Merge version."
+            exit /b 1
         )
+        
+        set /p __IbcMergeVersion<"%__IntermediatesDir%\ibcmergeversion.txt"
 
         set IbcMergePath=%__PackagesDir%\microsoft.dotnet.ibcmerge\!__IbcMergeVersion!\tools\netcoreapp2.0\ibcmerge.dll
         if exist !IbcMergePath! (

--- a/build.cmd
+++ b/build.cmd
@@ -397,7 +397,7 @@ if not exist "%__IntermediatesDir%\optdataversion.txt" (
     exit /b !errorlevel!
 )
 
-set /p __PgoOptDataVersion<"%__IntermediatesDir%\optdataversion.txt"
+set /p __PgoOptDataVersion=<"%__IntermediatesDir%\optdataversion.txt"
 
 call "%__ProjectDir%\dotnet.cmd" msbuild "%OptDataProjectFilePath%" /t:DumpIbcDataPackageVersion /nologo %__CommonMSBuildArgs%
 
@@ -652,7 +652,7 @@ if %__BuildCoreLib% EQU 1 (
             exit /b 1
         )
         
-        set /p __IbcMergeVersion<"%__IntermediatesDir%\ibcmergeversion.txt"
+        set /p __IbcMergeVersion=<"%__IntermediatesDir%\ibcmergeversion.txt"
 
         set IbcMergePath=%__PackagesDir%\microsoft.dotnet.ibcmerge\!__IbcMergeVersion!\tools\netcoreapp2.0\ibcmerge.dll
         if exist !IbcMergePath! (

--- a/build.cmd
+++ b/build.cmd
@@ -390,12 +390,23 @@ if %__RestoreOptData% EQU 1 (
 )
 
 REM Parse the optdata package versions out of msbuild so that we can pass them on to CMake
-for /f "tokens=*" %%s in ('call "%__ProjectDir%\dotnet.cmd" msbuild "%OptDataProjectFilePath%" /t:DumpPgoDataPackageVersion /nologo') do (
-    set __PgoOptDataVersion=%%s
+call "%__ProjectDir%\dotnet.cmd" msbuild "%OptDataProjectFilePath%" /t:DumpPgoDataPackageVersion /nologo
+
+if not exist "%__IntermediatesDir%\optdataversion.txt" (
+    echo "Failed to get PGO data package version."
+    exit /b !errorlevel!
 )
-for /f "tokens=*" %%s in ('call "%__ProjectDir%\dotnet.cmd" msbuild "%OptDataProjectFilePath%" /t:DumpIbcDataPackageVersion /nologo') do (
-    set __IbcOptDataVersion=%%s
+
+set /p __PgoOptDataVersion<"%__IntermediatesDir%\optdataversion.txt"
+
+call "%__ProjectDir%\dotnet.cmd" msbuild "%OptDataProjectFilePath%" /t:DumpIbcDataPackageVersion /nologo
+
+if not exist "%__IntermediatesDir%\ibcoptdataversion.txt" (
+    echo "Failed to get PGO data package version."
+    exit /b !errorlevel!
 )
+
+set /p __IbcOptDataVersion=<"%__IntermediatesDir%\ibcoptdataversion.txt"
 
 REM =========================================================================================
 REM ===

--- a/build.sh
+++ b/build.sh
@@ -151,23 +151,26 @@ restore_optdata()
     if [ $__isMSBuildOnNETCoreSupported == 1 ]; then
         # Parse the optdata package versions out of msbuild so that we can pass them on to CMake
 
-        # Writes into ${__IntermediatesDir}/optdataversion.txt
-        ${__ProjectDir}/dotnet.sh msbuild $OptDataProjectFilePath /t:DumpPgoDataPackageVersion ${__CommonMSBuildArgs} /nologo 2>&1 >/dev/null
-        if [ ! -f "${__IntermediatesDir}/optdataversion.txt" ]; then
+        local PgoDataPackageVersionOutputFile="${__IntermediatesDir}/optdataversion.txt"
+        local IbcDataPackageVersionOutputFile="${__IntermediatesDir}/ibcoptdataversion.txt"
+
+        # Writes into ${PgoDataPackageVersionOutputFile}
+        ${__ProjectDir}/dotnet.sh msbuild $OptDataProjectFilePath /t:DumpPgoDataPackageVersion ${__CommonMSBuildArgs} /p:PgoDataPackageVersionOutputFile=${PgoDataPackageVersionOutputFile} /nologo 2>&1 > /dev/null
+        if [ $? != 0 ] || [ ! -f "${PgoDataPackageVersionOutputFile}" ]; then
             echo "Failed to get PGO data package version."
             exit $?
         fi
 
-        __PgoOptDataVersion=$(<"${__IntermediatesDir}/optdataversion.txt")
+        __PgoOptDataVersion=$(<"${PgoDataPackageVersionOutputFile}")
 
-        # Writes into ${__IntermediatesDir}/ibcoptdataversion.txt
-        ${__ProjectDir}/dotnet.sh msbuild $OptDataProjectFilePath /t:DumpIbcDataPackageVersion ${__CommonMSBuildArgs} /nologo 2>&1 >/dev/null
-        if [ ! -f "${__IntermediatesDir}/ibcoptdataversion.txt" ]; then
+        # Writes into ${IbcDataPackageVersionOutputFile}
+        ${__ProjectDir}/dotnet.sh msbuild $OptDataProjectFilePath /t:DumpIbcDataPackageVersion ${__CommonMSBuildArgs} /p:IbcDataPackageVersionOutputFile=${IbcDataPackageVersionOutputFile} /nologo 2>&1 > /dev/null
+        if [ $? != 0 ] || [ ! -f "${IbcDataPackageVersionOutputFile}" ]; then
             echo "Failed to get IBC data package version."
             exit $?
         fi
 
-        __IbcOptDataVersion=$(<"${__IntermediatesDir}/ibcoptdataversion.txt")
+        __IbcOptDataVersion=$(<"${IbcDataPackageVersionOutputFile}")
     fi
 }
 

--- a/build.sh
+++ b/build.sh
@@ -152,7 +152,7 @@ restore_optdata()
         # Parse the optdata package versions out of msbuild so that we can pass them on to CMake
 
         # Writes into ${__IntermediatesDir}/optdataversion.txt
-        ${__ProjectDir}/dotnet.sh msbuild $OptDataProjectFilePath /t:DumpPgoDataPackageVersion /nologo 2>&1 >/dev/null
+        ${__ProjectDir}/dotnet.sh msbuild $OptDataProjectFilePath /t:DumpPgoDataPackageVersion ${__CommonMSBuildArgs} /nologo 2>&1 >/dev/null
         if [ ! -f "${__IntermediatesDir}/optdataversion.txt" ]; then
             echo "Failed to get PGO data package version."
             exit $?
@@ -161,7 +161,7 @@ restore_optdata()
         __PgoOptDataVersion=$(<"${__IntermediatesDir}/optdataversion.txt")
 
         # Writes into ${__IntermediatesDir}/ibcoptdataversion.txt
-        ${__ProjectDir}/dotnet.sh msbuild $OptDataProjectFilePath /t:DumpIbcDataPackageVersion /nologo 2>&1 >/dev/null
+        ${__ProjectDir}/dotnet.sh msbuild $OptDataProjectFilePath /t:DumpIbcDataPackageVersion ${__CommonMSBuildArgs} /nologo 2>&1 >/dev/null
         if [ ! -f "${__IntermediatesDir}/ibcoptdataversion.txt" ]; then
             echo "Failed to get IBC data package version."
             exit $?

--- a/build.sh
+++ b/build.sh
@@ -151,22 +151,23 @@ restore_optdata()
     if [ $__isMSBuildOnNETCoreSupported == 1 ]; then
         # Parse the optdata package versions out of msbuild so that we can pass them on to CMake
 
-        # Init dotnet
-        source "${__ProjectRoot}/init-dotnet.sh"
-        local DotNetCli=${_InitializeDotNetCli}/dotnet
-
-        __PgoOptDataVersion=$(DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 $DotNetCli msbuild $OptDataProjectFilePath /t:DumpPgoDataPackageVersion /nologo)
-        if [ $? != 0 ]; then
+        # Writes into ${__IntermediatesDir}/optdataversion.txt
+        ${__ProjectDir}/dotnet.sh msbuild $OptDataProjectFilePath /t:DumpPgoDataPackageVersion /nologo 2>&1 >/dev/null
+        if [ ! -f "${__IntermediatesDir}/optdataversion.txt" ]; then
             echo "Failed to get PGO data package version."
             exit $?
         fi
-        __PgoOptDataVersion=$(echo $__PgoOptDataVersion | sed 's/^\s*//')
-        __IbcOptDataVersion=$(DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 $DotNetCli msbuild $OptDataProjectFilePath /t:DumpIbcDataPackageVersion /nologo)
-        if [ $? != 0 ]; then
+
+        __PgoOptDataVersion=$(<"${__IntermediatesDir}/optdataversion.txt")
+
+        # Writes into ${__IntermediatesDir}/ibcoptdataversion.txt
+        ${__ProjectDir}/dotnet.sh msbuild $OptDataProjectFilePath /t:DumpIbcDataPackageVersion /nologo 2>&1 >/dev/null
+        if [ ! -f "${__IntermediatesDir}/ibcoptdataversion.txt" ]; then
             echo "Failed to get IBC data package version."
             exit $?
         fi
-        __IbcOptDataVersion=$(echo $__IbcOptDataVersion | sed 's/^[[:blank:]]*//')
+
+        __IbcOptDataVersion=$(<"${__IntermediatesDir}/ibcoptdataversion.txt")
     fi
 }
 

--- a/dir.common.props
+++ b/dir.common.props
@@ -56,6 +56,8 @@
     <BinDir>$(__BinDir)\</BinDir>
     <BinDir Condition="'$(__BinDir)'==''">$(RootBinDir)Product\$(PlatformConfigPathPart)\</BinDir>
 
+    <OptDataIntermediateOutputPath Condition="'$(OptDataIntermediateOutputPath)' == ''">$(RootBinDir)obj/$(BuildOS).$(BuildArch).$(BuildType)/</OptDataIntermediateOutputPath>
+
     <!-- We don't append back slash because this path is used by nuget.exe as output directory and it
          fails to write packages to it if the path contains the forward slash.
     -->

--- a/dir.common.props
+++ b/dir.common.props
@@ -56,10 +56,12 @@
     <BinDir>$(__BinDir)\</BinDir>
     <BinDir Condition="'$(__BinDir)'==''">$(RootBinDir)Product\$(PlatformConfigPathPart)\</BinDir>
 
-    <!-- Use the global __IntermediatesDir to find the location of the obj   -->
+    <!-- Use the envvar __IntermediatesDir to find the location of the obj   -->
     <!-- dir                                                                 -->
     <!-- Note that if nmake is used, the obj/ folder is nmakeobj/ therefore  -->
-    <!-- env variable is the only source of truth.                           -->
+    <!-- env variable is the only source of truth. This is only done for the -->
+    <!-- windows formatting jobs which use nmake and clang-format to build   -->
+    <!-- the product.                                                        -->
     <__IntermediatesDir Condition="'$(__IntermediatesDir)' == ''">$(RootBinDir)obj/$(BuildOS).$(BuildArch).$(BuildType)/</__IntermediatesDir>
 
     <!-- We don't append back slash because this path is used by nuget.exe as output directory and it

--- a/dir.common.props
+++ b/dir.common.props
@@ -56,7 +56,11 @@
     <BinDir>$(__BinDir)\</BinDir>
     <BinDir Condition="'$(__BinDir)'==''">$(RootBinDir)Product\$(PlatformConfigPathPart)\</BinDir>
 
-    <OptDataIntermediateOutputPath Condition="'$(OptDataIntermediateOutputPath)' == ''">$(RootBinDir)obj/$(BuildOS).$(BuildArch).$(BuildType)/</OptDataIntermediateOutputPath>
+    <!-- Use the global __IntermediatesDir to find the location of the obj   -->
+    <!-- dir                                                                 -->
+    <!-- Note that if nmake is used, the obj/ folder is nmakeobj/ therefore  -->
+    <!-- env variable is the only source of truth.                           -->
+    <__IntermediatesDir Condition="'$(__IntermediatesDir)' == ''">$(RootBinDir)obj/$(BuildOS).$(BuildArch).$(BuildType)/</__IntermediatesDir>
 
     <!-- We don't append back slash because this path is used by nuget.exe as output directory and it
          fails to write packages to it if the path contains the forward slash.

--- a/dir.common.props
+++ b/dir.common.props
@@ -56,14 +56,6 @@
     <BinDir>$(__BinDir)\</BinDir>
     <BinDir Condition="'$(__BinDir)'==''">$(RootBinDir)Product\$(PlatformConfigPathPart)\</BinDir>
 
-    <!-- Use the envvar __IntermediatesDir to find the location of the obj   -->
-    <!-- dir                                                                 -->
-    <!-- Note that if nmake is used, the obj/ folder is nmakeobj/ therefore  -->
-    <!-- env variable is the only source of truth. This is only done for the -->
-    <!-- windows formatting jobs which use nmake and clang-format to build   -->
-    <!-- the product.                                                        -->
-    <__IntermediatesDir Condition="'$(__IntermediatesDir)' == ''">$(RootBinDir)obj/$(BuildOS).$(BuildArch).$(BuildType)/</__IntermediatesDir>
-
     <!-- We don't append back slash because this path is used by nuget.exe as output directory and it
          fails to write packages to it if the path contains the forward slash.
     -->

--- a/init-dotnet.sh
+++ b/init-dotnet.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-__scriptpath=$(cd "$(dirname "$0")"; pwd -P)
+__scriptpath="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 echo "Installing dotnet using Arcade..."
 
-source $__scriptpath/eng/configure-toolset.sh
-source $__scriptpath/eng/common/tools.sh
+source ${__scriptpath}/eng/configure-toolset.sh
+source ${__scriptpath}/eng/common/tools.sh
 
 InitializeBuildTool
 

--- a/src/.nuget/optdata/ibcmerge.csproj
+++ b/src/.nuget/optdata/ibcmerge.csproj
@@ -17,12 +17,16 @@
   <!-- DumpIbcMergePackageVersion is used by build.sh and build.cmd to pass  -->
   <!-- the version information to cmake. The task will write a file to the   -->
   <!-- intermediates directory to be read back by build.cmd/sh. The path for -->
-  <!-- the file is $(__IntermediatesDir)\ibcmergeversion.txt      -->
+  <!-- the file is IbcMergePackageVersionOutputFile                          -->
   <!--                                                                       -->
   <Target Name="DumpIbcMergePackageVersion">
-    <!-- Output the package version to stdout for backcompat -->
-    <Message Importance="high" Text="$(IbcMergePackageVersion)" />
-    <WriteLinesToFile File="$(__IntermediatesDir)\ibcmergeversion.txt" Lines="$(IbcMergePackageVersion)" Overwrite="true"/>
+    <!-- Error if PgoDataPackageVersionOutputFile is not set. -->
+    <Error Condition="'$(IbcMergePackageVersionOutputFile)'==''" />
+
+    <!-- Cleanup old version file -->
+    <Delete Files="$(IbcMergePackageVersionOutputFile)" Condition="Exists('$(IbcMergePackageVersionOutputFile)')" />
+    <Message Text="IbcMergePackageVersion: $(IbcMergePackageVersion) written to: $(IbcMergePackageVersionOutputFile)" Importance="High" />
+    <WriteLinesToFile File="$(IbcMergePackageVersionOutputFile)" Lines="$(optimizationIBCCoreCLRVersion)" Overwrite="true"/>
   </Target>
 
   <PropertyGroup>

--- a/src/.nuget/optdata/ibcmerge.csproj
+++ b/src/.nuget/optdata/ibcmerge.csproj
@@ -17,12 +17,12 @@
   <!-- DumpIbcMergePackageVersion is used by build.sh and build.cmd to pass  -->
   <!-- the version information to cmake. The task will write a file to the   -->
   <!-- intermediates directory to be read back by build.cmd/sh. The path for -->
-  <!-- the file is $(OptDataIntermediateOutputPath)\ibcmergeversion.txt      -->
+  <!-- the file is $(__IntermediatesDir)\ibcmergeversion.txt      -->
   <!--                                                                       -->
   <Target Name="DumpIbcMergePackageVersion">
     <!-- Output the package version to stdout for backcompat -->
     <Message Importance="high" Text="$(IbcMergePackageVersion)" />
-    <WriteLinesToFile File="$(OptDataIntermediateOutputPath)\ibcmergeversion.txt" Lines="$(IbcMergePackageVersion)" Overwrite="true"/>
+    <WriteLinesToFile File="$(__IntermediatesDir)\ibcmergeversion.txt" Lines="$(IbcMergePackageVersion)" Overwrite="true"/>
   </Target>
 
   <PropertyGroup>

--- a/src/.nuget/optdata/ibcmerge.csproj
+++ b/src/.nuget/optdata/ibcmerge.csproj
@@ -9,8 +9,20 @@
     <PackageReference Include="microsoft.dotnet.ibcmerge" Version="[$(IbcMergePackageVersion)]" Condition="'$(IbcMergePackageVersion)'!=''" />
   </ItemGroup>
 
+  <!--                                                                       -->
+  <!-- Task: DumpIbcMergePackageVersion                                       -->
+  <!--                                                                       -->
+  <!-- Notes:                                                                -->
+  <!--                                                                       -->
+  <!-- DumpIbcMergePackageVersion is used by build.sh and build.cmd to pass  -->
+  <!-- the version information to cmake. The task will write a file to the   -->
+  <!-- intermediates directory to be read back by build.cmd/sh. The path for -->
+  <!-- the file is $(OptDataIntermediateOutputPath)\ibcmergeversion.txt      -->
+  <!--                                                                       -->
   <Target Name="DumpIbcMergePackageVersion">
+    <!-- Output the package version to stdout for backcompat -->
     <Message Importance="high" Text="$(IbcMergePackageVersion)" />
+    <WriteLinesToFile File="$(OptDataIntermediateOutputPath)\ibcmergeversion.txt" Lines="$(IbcMergePackageVersion)" Overwrite="true"/>
   </Target>
 
   <PropertyGroup>

--- a/src/.nuget/optdata/ibcmerge.csproj
+++ b/src/.nuget/optdata/ibcmerge.csproj
@@ -15,9 +15,9 @@
   <!-- Notes:                                                                -->
   <!--                                                                       -->
   <!-- DumpIbcMergePackageVersion is used by build.sh and build.cmd to pass  -->
-  <!-- the version information to cmake. The task will write a file to the   -->
-  <!-- intermediates directory to be read back by build.cmd/sh. The path for -->
-  <!-- the file is IbcMergePackageVersionOutputFile                          -->
+  <!-- the version information to cmake. The task will write a file to be    -->
+  <!-- read back by build.cmd/sh. The path for the file is:                  --> 
+  <!-- $(IbcMergePackageVersionOutputFile)                                    -->
   <!--                                                                       -->
   <Target Name="DumpIbcMergePackageVersion">
     <!-- Error if PgoDataPackageVersionOutputFile is not set. -->

--- a/src/.nuget/optdata/ibcmerge.csproj
+++ b/src/.nuget/optdata/ibcmerge.csproj
@@ -21,12 +21,12 @@
   <!--                                                                       -->
   <Target Name="DumpIbcMergePackageVersion">
     <!-- Error if PgoDataPackageVersionOutputFile is not set. -->
-    <Error Condition="'$(IbcMergePackageVersionOutputFile)'==''" />
+    <Error Condition="'$(IbcMergePackageVersionOutputFile)'==''" Text="IbcMergePackageVersionOutputFile must be passed as a property." />
 
     <!-- Cleanup old version file -->
     <Delete Files="$(IbcMergePackageVersionOutputFile)" Condition="Exists('$(IbcMergePackageVersionOutputFile)')" />
-    <Message Text="IbcMergePackageVersion: $(IbcMergePackageVersion) written to: $(IbcMergePackageVersionOutputFile)" Importance="High" />
     <WriteLinesToFile File="$(IbcMergePackageVersionOutputFile)" Lines="$(optimizationIBCCoreCLRVersion)" Overwrite="true"/>
+    <Message Text="IbcMergePackageVersion: $(IbcMergePackageVersion) written to: $(IbcMergePackageVersionOutputFile)" Importance="High" />
   </Target>
 
   <PropertyGroup>

--- a/src/.nuget/optdata/optdata.csproj
+++ b/src/.nuget/optdata/optdata.csproj
@@ -26,7 +26,7 @@
   <!-- DumpPgoDataPackageVersion is used by build.sh and build.cmd to pass   -->
   <!-- the version information to cmake. The task will write a file to the   -->
   <!-- intermediates directory to be read back by build.cmd/sh. The path for -->
-  <!-- the file is $(OptDataIntermediateOutputPath)\optdataversion.txt          -->
+  <!-- the file is $(OptDataIntermediateOutputPath)\optdataversion.txt       -->
   <!--                                                                       -->
 
   <Target Name="DumpPgoDataPackageVersion">
@@ -43,7 +43,7 @@
   <!-- DumpIbcDataPackageVersion is used by build.sh and build.cmd to pass   -->
   <!-- the version information to cmake. The task will write a file to the   -->
   <!-- intermediates directory to be read back by build.cmd/sh. The path for -->
-  <!-- the file is $(OptDataIntermediateOutputPath)\ibcoptdataversion.txt       -->
+  <!-- the file is $(OptDataIntermediateOutputPath)\ibcoptdataversion.txt    -->
   <!--                                                                       -->
   <Target Name="DumpIbcDataPackageVersion">
     <!-- Keep the old message for backcompat. -->

--- a/src/.nuget/optdata/optdata.csproj
+++ b/src/.nuget/optdata/optdata.csproj
@@ -18,12 +18,37 @@
     </RestoreSources>
   </PropertyGroup>
 
+  <!--                                                                       -->
+  <!-- Task: DumpPgoDataPackageVersion                                       -->
+  <!--                                                                       -->
+  <!-- Notes:                                                                -->
+  <!--                                                                       -->
+  <!-- DumpPgoDataPackageVersion is used by build.sh and build.cmd to pass   -->
+  <!-- the version information to cmake. The task will write a file to the   -->
+  <!-- intermediates directory to be read back by build.cmd/sh. The path for -->
+  <!-- the file is $(OptDataIntermediateOutputPath)\optdataversion.txt          -->
+  <!--                                                                       -->
+
   <Target Name="DumpPgoDataPackageVersion">
-    <Message Importance="high" Text="$(optimizationPGOCoreCLRVersion)" />
+    <!-- Keep the old message for backcompat. -->
+    <Message Text="$(optimizationIBCCoreCLRVersion)" Importance="High" />
+    <WriteLinesToFile File="$(OptDataIntermediateOutputPath)\optdataversion.txt" Lines="$(optimizationIBCCoreCLRVersion)" Overwrite="true"/>
   </Target>
 
+  <!--                                                                       -->
+  <!-- Task: DumpIbcDataPackageVersion                                       -->
+  <!--                                                                       -->
+  <!-- Notes:                                                                -->
+  <!--                                                                       -->
+  <!-- DumpIbcDataPackageVersion is used by build.sh and build.cmd to pass   -->
+  <!-- the version information to cmake. The task will write a file to the   -->
+  <!-- intermediates directory to be read back by build.cmd/sh. The path for -->
+  <!-- the file is $(OptDataIntermediateOutputPath)\ibcoptdataversion.txt       -->
+  <!--                                                                       -->
   <Target Name="DumpIbcDataPackageVersion">
+    <!-- Keep the old message for backcompat. -->
     <Message Importance="high" Text="$(optimizationIBCCoreCLRVersion)" />
+    <WriteLinesToFile File="$(OptDataIntermediateOutputPath)\ibcoptdataversion.txt" Lines="$(optimizationIBCCoreCLRVersion)" Overwrite="true"/>
   </Target>
 
 </Project>

--- a/src/.nuget/optdata/optdata.csproj
+++ b/src/.nuget/optdata/optdata.csproj
@@ -26,13 +26,17 @@
   <!-- DumpPgoDataPackageVersion is used by build.sh and build.cmd to pass   -->
   <!-- the version information to cmake. The task will write a file to the   -->
   <!-- intermediates directory to be read back by build.cmd/sh. The path for -->
-  <!-- the file is $(__IntermediatesDir)\optdataversion.txt       -->
+  <!-- the file is passed as proprty: PgoDataPackageVersionOutputFile        -->
   <!--                                                                       -->
 
   <Target Name="DumpPgoDataPackageVersion">
-    <!-- Keep the old message for backcompat. -->
-    <Message Text="$(optimizationIBCCoreCLRVersion)" Importance="High" />
-    <WriteLinesToFile File="$(__IntermediatesDir)\optdataversion.txt" Lines="$(optimizationIBCCoreCLRVersion)" Overwrite="true"/>
+    <!-- Error if PgoDataPackageVersionOutputFile is not set. -->
+    <Error Condition="'$(PgoDataPackageVersionOutputFile)'==''" />
+
+    <!-- Cleanup old version file -->
+    <Delete Files="$(PgoDataPackageVersionOutputFile)" Condition="Exists('$(PgoDataPackageVersionOutputFile)')" />
+    <Message Text="optimizationPGOCoreCLRVersion: $(optimizationPGOCoreCLRVersion) written to: $(PgoDataPackageVersionOutputFile)" Importance="High" />
+    <WriteLinesToFile File="$(PgoDataPackageVersionOutputFile)" Lines="$(optimizationPGOCoreCLRVersion)" Overwrite="true"/>
   </Target>
 
   <!--                                                                       -->
@@ -43,12 +47,16 @@
   <!-- DumpIbcDataPackageVersion is used by build.sh and build.cmd to pass   -->
   <!-- the version information to cmake. The task will write a file to the   -->
   <!-- intermediates directory to be read back by build.cmd/sh. The path for -->
-  <!-- the file is $(__IntermediatesDir)\ibcoptdataversion.txt    -->
+  <!-- the file is IbcDataPackageVersionOutputFile                           -->
   <!--                                                                       -->
   <Target Name="DumpIbcDataPackageVersion">
-    <!-- Keep the old message for backcompat. -->
-    <Message Importance="high" Text="$(optimizationIBCCoreCLRVersion)" />
-    <WriteLinesToFile File="$(__IntermediatesDir)\ibcoptdataversion.txt" Lines="$(optimizationIBCCoreCLRVersion)" Overwrite="true"/>
+    <!-- Error if PgoDataPackageVersionOutputFile is not set. -->
+    <Error Condition="'$(IbcDataPackageVersionOutputFile)'==''" />
+
+    <!-- Cleanup old version file -->
+    <Delete Files="$(IbcDataPackageVersionOutputFile)" Condition="Exists('$(IbcDataPackageVersionOutputFile)')" />
+    <Message Text="optimizationIBCCoreCLRVersion: $(optimizationIBCCoreCLRVersion) written to: $(IbcDataPackageVersionOutputFile)" Importance="High" />
+    <WriteLinesToFile File="$(IbcDataPackageVersionOutputFile)" Lines="$(optimizationIBCCoreCLRVersion)" Overwrite="true"/>
   </Target>
 
 </Project>

--- a/src/.nuget/optdata/optdata.csproj
+++ b/src/.nuget/optdata/optdata.csproj
@@ -24,9 +24,9 @@
   <!-- Notes:                                                                -->
   <!--                                                                       -->
   <!-- DumpPgoDataPackageVersion is used by build.sh and build.cmd to pass   -->
-  <!-- the version information to cmake. The task will write a file to the   -->
-  <!-- intermediates directory to be read back by build.cmd/sh. The path for -->
-  <!-- the file is passed as proprty: PgoDataPackageVersionOutputFile        -->
+  <!-- the version information to cmake. The task will write a file to be    -->
+  <!-- read back by build.cmd/sh. The path for the file is:                  --> 
+  <!-- $(PgoDataPackageVersionOutputFile)                                    -->
   <!--                                                                       -->
 
   <Target Name="DumpPgoDataPackageVersion">
@@ -45,9 +45,9 @@
   <!-- Notes:                                                                -->
   <!--                                                                       -->
   <!-- DumpIbcDataPackageVersion is used by build.sh and build.cmd to pass   -->
-  <!-- the version information to cmake. The task will write a file to the   -->
-  <!-- intermediates directory to be read back by build.cmd/sh. The path for -->
-  <!-- the file is IbcDataPackageVersionOutputFile                           -->
+  <!-- the version information to cmake. The task will write a file to be    -->
+  <!-- read back by build.cmd/sh. The path for the file is:                  --> 
+  <!-- $(IbcDataPackageVersionOutputFile)                                    -->
   <!--                                                                       -->
   <Target Name="DumpIbcDataPackageVersion">
     <!-- Error if PgoDataPackageVersionOutputFile is not set. -->

--- a/src/.nuget/optdata/optdata.csproj
+++ b/src/.nuget/optdata/optdata.csproj
@@ -26,13 +26,13 @@
   <!-- DumpPgoDataPackageVersion is used by build.sh and build.cmd to pass   -->
   <!-- the version information to cmake. The task will write a file to the   -->
   <!-- intermediates directory to be read back by build.cmd/sh. The path for -->
-  <!-- the file is $(OptDataIntermediateOutputPath)\optdataversion.txt       -->
+  <!-- the file is $(__IntermediatesDir)\optdataversion.txt       -->
   <!--                                                                       -->
 
   <Target Name="DumpPgoDataPackageVersion">
     <!-- Keep the old message for backcompat. -->
     <Message Text="$(optimizationIBCCoreCLRVersion)" Importance="High" />
-    <WriteLinesToFile File="$(OptDataIntermediateOutputPath)\optdataversion.txt" Lines="$(optimizationIBCCoreCLRVersion)" Overwrite="true"/>
+    <WriteLinesToFile File="$(__IntermediatesDir)\optdataversion.txt" Lines="$(optimizationIBCCoreCLRVersion)" Overwrite="true"/>
   </Target>
 
   <!--                                                                       -->
@@ -43,12 +43,12 @@
   <!-- DumpIbcDataPackageVersion is used by build.sh and build.cmd to pass   -->
   <!-- the version information to cmake. The task will write a file to the   -->
   <!-- intermediates directory to be read back by build.cmd/sh. The path for -->
-  <!-- the file is $(OptDataIntermediateOutputPath)\ibcoptdataversion.txt    -->
+  <!-- the file is $(__IntermediatesDir)\ibcoptdataversion.txt    -->
   <!--                                                                       -->
   <Target Name="DumpIbcDataPackageVersion">
     <!-- Keep the old message for backcompat. -->
     <Message Importance="high" Text="$(optimizationIBCCoreCLRVersion)" />
-    <WriteLinesToFile File="$(OptDataIntermediateOutputPath)\ibcoptdataversion.txt" Lines="$(optimizationIBCCoreCLRVersion)" Overwrite="true"/>
+    <WriteLinesToFile File="$(__IntermediatesDir)\ibcoptdataversion.txt" Lines="$(optimizationIBCCoreCLRVersion)" Overwrite="true"/>
   </Target>
 
 </Project>

--- a/src/.nuget/optdata/optdata.csproj
+++ b/src/.nuget/optdata/optdata.csproj
@@ -31,12 +31,12 @@
 
   <Target Name="DumpPgoDataPackageVersion">
     <!-- Error if PgoDataPackageVersionOutputFile is not set. -->
-    <Error Condition="'$(PgoDataPackageVersionOutputFile)'==''" />
+    <Error Condition="'$(PgoDataPackageVersionOutputFile)'==''" Text="PgoDataPackageVersionOutputFile must be passed as a property." />
 
     <!-- Cleanup old version file -->
     <Delete Files="$(PgoDataPackageVersionOutputFile)" Condition="Exists('$(PgoDataPackageVersionOutputFile)')" />
-    <Message Text="optimizationPGOCoreCLRVersion: $(optimizationPGOCoreCLRVersion) written to: $(PgoDataPackageVersionOutputFile)" Importance="High" />
     <WriteLinesToFile File="$(PgoDataPackageVersionOutputFile)" Lines="$(optimizationPGOCoreCLRVersion)" Overwrite="true"/>
+    <Message Text="optimizationPGOCoreCLRVersion: $(optimizationPGOCoreCLRVersion) written to: $(PgoDataPackageVersionOutputFile)" Importance="High" />
   </Target>
 
   <!--                                                                       -->
@@ -51,12 +51,12 @@
   <!--                                                                       -->
   <Target Name="DumpIbcDataPackageVersion">
     <!-- Error if PgoDataPackageVersionOutputFile is not set. -->
-    <Error Condition="'$(IbcDataPackageVersionOutputFile)'==''" />
+    <Error Condition="'$(IbcDataPackageVersionOutputFile)'==''" Text="IbcDataPackageVersionOutputFile must be passed as a property." />
 
     <!-- Cleanup old version file -->
     <Delete Files="$(IbcDataPackageVersionOutputFile)" Condition="Exists('$(IbcDataPackageVersionOutputFile)')" />
-    <Message Text="optimizationIBCCoreCLRVersion: $(optimizationIBCCoreCLRVersion) written to: $(IbcDataPackageVersionOutputFile)" Importance="High" />
     <WriteLinesToFile File="$(IbcDataPackageVersionOutputFile)" Lines="$(optimizationIBCCoreCLRVersion)" Overwrite="true"/>
+    <Message Text="optimizationIBCCoreCLRVersion: $(optimizationIBCCoreCLRVersion) written to: $(IbcDataPackageVersionOutputFile)" Importance="High" />
   </Target>
 
 </Project>


### PR DESCRIPTION
This will reduce fragility in our build pipeline, by explicitely controlling the output of dotnet msbuild. It also unblocks the source-build effort, as source-build will write extra console output breaking our old parsing.

/cc @RussKeldorph 