### PR TITLE
abort build-tests if failed to restore stress dependencies

### DIFF
--- a/build-test.cmd
+++ b/build-test.cmd
@@ -180,6 +180,10 @@ REM ===
 REM =========================================================================================
 
 call "%__TestDir%\setup-stress-dependencies.cmd" /arch %__BuildArch% /outputdir %__BinDir%
+if errorlevel 1 (
+    echo %__MsgPrefix%Error: setup-stress-dependencies failed.
+    goto     :Exit_Failure
+)
 @if defined _echo @echo on
 
 REM =========================================================================================

--- a/build-test.sh
+++ b/build-test.sh
@@ -159,6 +159,10 @@ generate_layout()
         nextCommand="\"$__TestDir/setup-stress-dependencies.sh\" --outputDir=$CORE_ROOT"
         echo "Resolve runtime dependences via $nextCommand"
         eval $nextCommand
+        if [ $? != 0 ]; then
+            echo "${__MsgPrefix}Error: setup-stress-dependencies failed."
+            exit 1
+        fi
     fi
 
     # Precompile framework assemblies with crossgen if required

--- a/build-test.sh
+++ b/build-test.sh
@@ -156,7 +156,7 @@ generate_layout()
     cp -r $__BinDir/* $CORE_ROOT/ > /dev/null
 
     if [ "$__BuildOS" != "OSX" ]; then
-        nextCommand="\"$__TestDir/setup-stress-dependencies.sh\" --outputDir=$CORE_ROOT"
+        nextCommand="\"$__TestDir/setup-stress-dependencies.sh\" --arch=$__BuildArch --outputDir=$CORE_ROOT"
         echo "Resolve runtime dependences via $nextCommand"
         eval $nextCommand
         if [ $? != 0 ]; then

--- a/tests/bringup_runtest.sh
+++ b/tests/bringup_runtest.sh
@@ -1451,14 +1451,8 @@ else
     load_failing_tests
 fi
 
-# Other architectures are not supported yet.
-if [ "$ARCH" == "x64" ]
-then
-    scriptPath=$(dirname $0)
-    ${scriptPath}/setup-stress-dependencies.sh --outputDir=$coreOverlayDir
-elif [ "$ARCH" != "arm64" ] && [ "$ARCH" != "arm" ]; then
-    echo "Skip preparing for GC stress test. Dependent package is not supported on this architecture."
-fi
+scriptPath=$(dirname $0)
+${scriptPath}/setup-stress-dependencies.sh --arch=$ARCH --outputDir=$coreOverlayDir
 
 export __TestEnv=$testEnv
 

--- a/tests/setup-stress-dependencies.cmd
+++ b/tests/setup-stress-dependencies.cmd
@@ -41,6 +41,11 @@ if /i "%__Arch%" == "arm" (
     exit /b 0
 )
 
+if /i "%__Arch%" == "arm64" (
+    echo No runtime dependencies for Arm64.
+    exit /b 0
+)
+
 REM =========================================================================================
 REM ===
 REM === Check if dotnet CLI and necessary directories exist

--- a/tests/setup-stress-dependencies.cmd
+++ b/tests/setup-stress-dependencies.cmd
@@ -36,10 +36,10 @@ if not defined __OutputDir goto Usage
 if not defined __Arch goto Usage 
 
 REM Check if the platform is supported
-if /i %__Arch% == "arm" (
+if /i "%__Arch%" == "arm" (
     echo No runtime dependencies for Arm32.
     exit /b 0
-    )
+)
 
 REM =========================================================================================
 REM ===

--- a/tests/setup-stress-dependencies.sh
+++ b/tests/setup-stress-dependencies.sh
@@ -16,9 +16,10 @@ function print_usage {
     echo ''
     echo 'Command line:'
     echo ''
-    echo './setup-gcstress.sh --outputDir=<coredistools_lib_install_path>'
+    echo './setup-gcstress.sh --arch=<TargetArch> --outputDir=<coredistools_lib_install_path>'
     echo ''
     echo 'Required arguments:'
+    echo '  --arch=<TargetArch>        : Target arch for the build'
     echo '  --outputDir=<path>         : Directory to install libcoredistools.so'
     echo ''
 }
@@ -55,6 +56,9 @@ do
         -v|--verbose)
             verbose=1
             ;;
+        --arch=*)
+            __BuildArch=${i#*=}
+            ;;
         --outputDir=*)
             libInstallDir=${i#*=}
             ;;
@@ -66,10 +70,21 @@ do
     esac
 done
 
-if [ -z "$libInstallDir" ]; then
-    echo "--libInstallDir is required."
+if [ -z "$__BuildArch" ]; then
+    echo "--arch is required."
     print_usage
     exit_with_error 1
+fi
+
+if [ -z "$libInstallDir" ]; then
+    echo "--outputDir is required."
+    print_usage
+    exit_with_error 1
+fi
+
+if [ "$__BuildArch" == "arm64" ] || [ "$__BuildArch" == "arm" ]; then
+    echo "No runtime dependencies for arm32/arm64"
+    exit $EXIT_CODE_SUCCESS
 fi
 
 # This script must be located in coreclr/tests.


### PR DESCRIPTION
Allows us to catch failures like #25131 earlier.