### PR TITLE
Fix French Decimal number parsing

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Parsing.cs
@@ -1886,6 +1886,8 @@ namespace System
             return true;
         }
 
+        private static bool IsSpaceReplacingChar(char c) => c == '\u00a0' || c == '\u202f';
+
         private static unsafe char* MatchChars(char* p, char* pEnd, string value)
         {
             Debug.Assert(p != null && pEnd != null && p <= pEnd && value != null);
@@ -1895,12 +1897,12 @@ namespace System
                 if (*str != '\0')
                 {
                     // We only hurt the failure case
-                    // This fix is for French or Kazakh cultures. Since a user cannot type 0xA0 as a
+                    // This fix is for French or Kazakh cultures. Since a user cannot type 0xA0 or 0x202F as a
                     // space character we use 0x20 space character instead to mean the same.
                     while (true)
                     {
                         char cp = p < pEnd ? *p : '\0';
-                        if (cp != *str && !(*str == '\u00a0' && cp == '\u0020'))
+                        if (cp != *str && !(IsSpaceReplacingChar(*str) && cp == '\u0020'))
                         {
                             break;
                         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/38455

ICU used to use 0xA0 character as a number group separator for French cultures but in newer versions (63 and up), this has changed to use a different character 0x202F. We have a special handling for parsing decimal number with such culture to treat the space (0x20) as a separator and we were handling 0xA0. Now, we need to add 0x202F too.