### PR TITLE
Move resources.containers out of azure-pipelines to platform-matrix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,9 +4,6 @@ variables:
 
 resources:
   containers:
-  - container: ubuntu_1404_arm_cross_build_image
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-14.04-23cacb0-20190528233931
-
   - container: ubuntu_1604_arm64_cross_build_image
     image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-cfdd435-20190520220848
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,6 @@
 variables:
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+- name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
+  value: true
 
 resources:
   containers:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,14 +4,6 @@ variables:
 
 resources:
   containers:
-  - container: ubuntu_1604_arm64_cross_build_image
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-cfdd435-20190520220848
-
-  - container: musl_x64_build_image
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.6-WithNode-cfdd435-20190521001804
-
-  - container: musl_arm64_build_image
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-alpine-406629a-20190520220848
 
   - container: centos7_x64_build_image
     image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,15 +2,6 @@ variables:
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
 
-resources:
-  containers:
-
-  - container: centos7_x64_build_image
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343
-
-  - container: centos6_x64_build_image
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-6-3e800f1-20190501005338
-
 trigger:
 - master
 

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -3,7 +3,7 @@ parameters:
   archType: ''
   osGroup: ''
   osIdentifier: ''
-  containerName: ''
+  container: ''
   crossrootfsDir: ''
   timeoutInMinutes: ''
 
@@ -28,8 +28,8 @@ jobs:
       condition: false
 
     # Run all steps in the container.
-    # Note that the containers are resources defined in azure-pipelines.yml
-    containerName: ${{ parameters.containerName }}
+    # Note that the containers are defined in platform-matrix.yml
+    container: ${{ parameters.container }}
 
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
 

--- a/eng/format-job.yml
+++ b/eng/format-job.yml
@@ -3,7 +3,7 @@ parameters:
   archType: ''
   osGroup: ''
   osIdentifier: ''
-  containerName: ''
+  container: ''
   crossrootfsDir: ''
   timeoutInMinutes: ''
 
@@ -15,7 +15,7 @@ jobs:
     archType: ${{ parameters.archType }}
     osGroup: ${{ parameters.osGroup }}
     osIdentifier: ${{ parameters.osIdentifier }}
-    containerName: ${{ parameters.containerName }}
+    container: ${{ parameters.container }}
     crossrootfsDir: ${{ parameters.crossrootfsDir }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     name: ${{ format('format_{0}_{1}', parameters.osIdentifier, parameters.archType) }}

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -28,7 +28,7 @@ jobs:
       archType: arm
       osGroup: Linux
       osIdentifier: Linux
-      containerName: ubuntu_1404_arm_cross_build_image
+      container: ubuntu-16.04-cross-14.04-23cacb0-20190528233931
       helixQueues:
       # Ubuntu.1404.Arm32.Open is used only by CI while Ubuntu.1604.Arm32.Open serves PRs and scheduled builds.
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'ci')) }}:
@@ -51,7 +51,7 @@ jobs:
       archType: arm64
       osGroup: Linux
       osIdentifier: Linux
-      containerName: ubuntu_1604_arm64_cross_build_image
+      container: ubuntu-16.04-cross-arm64-cfdd435-20190520220848
       helixQueues:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
         - (Ubuntu.1804.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-0a0ebdd-20190312220351
@@ -72,7 +72,7 @@ jobs:
       archType: x64
       osGroup: Linux
       osIdentifier: Linux_musl
-      containerName: musl_x64_build_image
+      container: alpine-3.6-WithNode-cfdd435-20190521001804
       helixQueues:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
         - (Alpine.38.Amd64.Open)Ubuntu.1604.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-45b1fa2-20190327215821
@@ -90,7 +90,7 @@ jobs:
       archType: arm64
       osGroup: Linux
       osIdentifier: Linux_musl
-      containerName: musl_arm64_build_image
+      container: ubuntu-16.04-cross-arm64-alpine-406629a-20190520220848
       helixQueues:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
         - (Alpine.38.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-46e69dd-20190313223330

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -28,7 +28,9 @@ jobs:
       archType: arm
       osGroup: Linux
       osIdentifier: Linux
-      container: ubuntu-16.04-cross-14.04-23cacb0-20190528233931
+      container:
+        image: ubuntu-16.04-cross-14.04-23cacb0-20190528233931
+        registry: mcr
       helixQueues:
       # Ubuntu.1404.Arm32.Open is used only by CI while Ubuntu.1604.Arm32.Open serves PRs and scheduled builds.
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'ci')) }}:
@@ -51,7 +53,9 @@ jobs:
       archType: arm64
       osGroup: Linux
       osIdentifier: Linux
-      container: ubuntu-16.04-cross-arm64-cfdd435-20190520220848
+      container:
+        image: ubuntu-16.04-cross-arm64-cfdd435-20190520220848
+        registry: mcr
       helixQueues:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
         - (Ubuntu.1804.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-0a0ebdd-20190312220351
@@ -72,7 +76,9 @@ jobs:
       archType: x64
       osGroup: Linux
       osIdentifier: Linux_musl
-      container: alpine-3.6-WithNode-cfdd435-20190521001804
+      container:
+        image: alpine-3.6-WithNode-cfdd435-20190521001804
+        registry: mcr
       helixQueues:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
         - (Alpine.38.Amd64.Open)Ubuntu.1604.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-45b1fa2-20190327215821
@@ -90,7 +96,9 @@ jobs:
       archType: arm64
       osGroup: Linux
       osIdentifier: Linux_musl
-      container: ubuntu-16.04-cross-arm64-alpine-406629a-20190520220848
+      container:
+        image: ubuntu-16.04-cross-arm64-alpine-406629a-20190520220848
+        registry: mcr
       helixQueues:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
         - (Alpine.38.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-46e69dd-20190313223330
@@ -108,7 +116,9 @@ jobs:
       archType: x64
       osGroup: Linux
       osIdentifier: Linux_rhel6
-      container: centos-6-3e800f1-20190501005338
+      container:
+        image: centos-6-3e800f1-20190501005338
+        registry: mcr
       helixQueues:
       # TODO: enable RedHat.6.Amd64.Open once https://github.com/dotnet/coreclr/issues/23580 is resolved
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
@@ -124,7 +134,9 @@ jobs:
       archType: x64
       osGroup: Linux
       osIdentifier: Linux
-      container: centos-7-3e800f1-20190501005343
+      container:
+        image: centos-7-3e800f1-20190501005343
+        registry: mcr
       helixQueues:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'pr', 'ci')) }}:
         - Ubuntu.1804.Amd64.Open

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -28,7 +28,7 @@ jobs:
       archType: arm
       osGroup: Linux
       osIdentifier: Linux
-      containerName: ubuntu-16.04-cross-14.04-23cacb0-20190528233931
+      container: ubuntu-16.04-cross-14.04-23cacb0-20190528233931
       helixQueues:
       # Ubuntu.1404.Arm32.Open is used only by CI while Ubuntu.1604.Arm32.Open serves PRs and scheduled builds.
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'ci')) }}:
@@ -51,7 +51,7 @@ jobs:
       archType: arm64
       osGroup: Linux
       osIdentifier: Linux
-      containerName: ubuntu-16.04-cross-arm64-cfdd435-20190520220848
+      container: ubuntu-16.04-cross-arm64-cfdd435-20190520220848
       helixQueues:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
         - (Ubuntu.1804.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-0a0ebdd-20190312220351
@@ -72,7 +72,7 @@ jobs:
       archType: x64
       osGroup: Linux
       osIdentifier: Linux_musl
-      containerName: alpine-3.6-WithNode-cfdd435-20190521001804
+      container: alpine-3.6-WithNode-cfdd435-20190521001804
       helixQueues:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
         - (Alpine.38.Amd64.Open)Ubuntu.1604.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-45b1fa2-20190327215821
@@ -90,7 +90,7 @@ jobs:
       archType: arm64
       osGroup: Linux
       osIdentifier: Linux_musl
-      containerName: ubuntu-16.04-cross-arm64-alpine-406629a-20190520220848
+      container: ubuntu-16.04-cross-arm64-alpine-406629a-20190520220848
       helixQueues:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
         - (Alpine.38.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-46e69dd-20190313223330
@@ -108,7 +108,7 @@ jobs:
       archType: x64
       osGroup: Linux
       osIdentifier: Linux_rhel6
-      containerName: centos6_x64_build_image
+      container: centos-6-3e800f1-20190501005338
       helixQueues:
       # TODO: enable RedHat.6.Amd64.Open once https://github.com/dotnet/coreclr/issues/23580 is resolved
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
@@ -124,7 +124,7 @@ jobs:
       archType: x64
       osGroup: Linux
       osIdentifier: Linux
-      containerName: centos7_x64_build_image
+      container: centos-7-3e800f1-20190501005343
       helixQueues:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'pr', 'ci')) }}:
         - Ubuntu.1804.Amd64.Open

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -28,7 +28,7 @@ jobs:
       archType: arm
       osGroup: Linux
       osIdentifier: Linux
-      container: ubuntu-16.04-cross-14.04-23cacb0-20190528233931
+      containerName: ubuntu-16.04-cross-14.04-23cacb0-20190528233931
       helixQueues:
       # Ubuntu.1404.Arm32.Open is used only by CI while Ubuntu.1604.Arm32.Open serves PRs and scheduled builds.
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'ci')) }}:
@@ -51,7 +51,7 @@ jobs:
       archType: arm64
       osGroup: Linux
       osIdentifier: Linux
-      container: ubuntu-16.04-cross-arm64-cfdd435-20190520220848
+      containerName: ubuntu-16.04-cross-arm64-cfdd435-20190520220848
       helixQueues:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
         - (Ubuntu.1804.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-0a0ebdd-20190312220351
@@ -72,7 +72,7 @@ jobs:
       archType: x64
       osGroup: Linux
       osIdentifier: Linux_musl
-      container: alpine-3.6-WithNode-cfdd435-20190521001804
+      containerName: alpine-3.6-WithNode-cfdd435-20190521001804
       helixQueues:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
         - (Alpine.38.Amd64.Open)Ubuntu.1604.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-45b1fa2-20190327215821
@@ -90,7 +90,7 @@ jobs:
       archType: arm64
       osGroup: Linux
       osIdentifier: Linux_musl
-      container: ubuntu-16.04-cross-arm64-alpine-406629a-20190520220848
+      containerName: ubuntu-16.04-cross-arm64-alpine-406629a-20190520220848
       helixQueues:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
         - (Alpine.38.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-46e69dd-20190313223330

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -3,6 +3,7 @@ parameters:
   archType: ''
   osGroup: ''
   osIdentifier: ''
+  container: ''
   testGroup: ''
   readyToRun: false
   helixQueues: ''
@@ -94,8 +95,8 @@ jobs:
     dependsOn: ${{ format('build_{0}_{1}_{2}', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
 
     # Run all steps in the container.
-    # Note that the containers are resources defined in azure-pipelines.yml
-    containerName: ${{ parameters.containerName }}
+    # Note that the containers are defined in platform-matrix.yml
+    container: ${{ parameters.container }}
 
     # "Total" means building tests, waiting for a queue in Helix to become available, and running the tests.
     # In case test-job.yml gets split into two separate jobs (e.g. build-test-job.yml and run-test.yml)

--- a/eng/xplat-job.yml
+++ b/eng/xplat-job.yml
@@ -75,10 +75,7 @@ jobs:
       clean: all
 
     ${{ if ne(parameters.containerName, '') }}:
-      container: ${{ parameters.containerName }}
-
-    ${{ if ne(parameters.container, '') }}:
-      container: ${{ format('{0}:{1}', 'mcr.microsoft.com/dotnet-buildtools/prereqs', parameters.container) }}
+      container: ${{ format('{0}:{1}', 'mcr.microsoft.com/dotnet-buildtools/prereqs', parameters.containerName) }}
 
     ${{ if eq(parameters.osGroup, 'Linux') }}:
       agentOs: Ubuntu

--- a/eng/xplat-job.yml
+++ b/eng/xplat-job.yml
@@ -75,7 +75,7 @@ jobs:
 
     ${{ if contains(parameters.container, ':') }}:
       container: ${{ parameters.container }}
-    ${{ if and(ne(parameters.container, ''), not(contains(parameters.container, ':')) }}:
+    ${{ if and(ne(parameters.container, ''), not(contains(parameters.container, ':'))) }}:
       container: ${{ format('{0}:{1}', 'mcr.microsoft.com/dotnet-buildtools/prereqs', parameters.container) }}
 
     ${{ if eq(parameters.osGroup, 'Linux') }}:

--- a/eng/xplat-job.yml
+++ b/eng/xplat-job.yml
@@ -9,7 +9,6 @@ parameters:
   condition: ''
   dependsOn: ''
   container: ''
-  containerName: ''
   timeoutInMinutes: ''
   crossrootfsDir: ''
   enableMicrobuild: ''
@@ -74,8 +73,10 @@ jobs:
     workspace:
       clean: all
 
-    ${{ if ne(parameters.containerName, '') }}:
-      container: ${{ format('{0}:{1}', 'mcr.microsoft.com/dotnet-buildtools/prereqs', parameters.containerName) }}
+    ${{ if contains(parameters.container, ':') }}:
+      container: ${{ parameters.container }}
+    ${{ if and(ne(parameters.container, ''), not(contains(parameters.container, ':')) }}:
+      container: ${{ format('{0}:{1}', 'mcr.microsoft.com/dotnet-buildtools/prereqs', parameters.container) }}
 
     ${{ if eq(parameters.osGroup, 'Linux') }}:
       agentOs: Ubuntu

--- a/eng/xplat-job.yml
+++ b/eng/xplat-job.yml
@@ -76,6 +76,9 @@ jobs:
     ${{ if ne(parameters.containerName, '') }}:
       container: ${{ parameters.containerName }}
 
+    ${{ if ne(parameters.container, '') }}:
+      container: ${{ format('{0}:{1}', 'mcr.microsoft.com/dotnet-buildtools/prereqs', parameters.container) }}
+
     ${{ if eq(parameters.osGroup, 'Linux') }}:
       agentOs: Ubuntu
     ${{ if eq(parameters.osGroup, 'FreeBSD') }}:

--- a/eng/xplat-job.yml
+++ b/eng/xplat-job.yml
@@ -73,10 +73,11 @@ jobs:
     workspace:
       clean: all
 
-    ${{ if contains(parameters.container, ':') }}:
-      container: ${{ parameters.container }}
-    ${{ if and(ne(parameters.container, ''), not(contains(parameters.container, ':'))) }}:
-      container: ${{ format('{0}:{1}', 'mcr.microsoft.com/dotnet-buildtools/prereqs', parameters.container) }}
+    ${{ if ne(parameters.container, '') }}:
+      ${{ if eq(parameters.container.registry, 'mcr') }}:
+        container: ${{ format('{0}:{1}', 'mcr.microsoft.com/dotnet-buildtools/prereqs', parameters.container.image) }}
+      ${{ if ne(parameters.container.registry, 'mcr') }}:
+        container: ${{ format('{0}:{1}', parameters.container.registry, parameters.container.image) }}
 
     ${{ if eq(parameters.osGroup, 'Linux') }}:
       agentOs: Ubuntu

--- a/eng/xplat-job.yml
+++ b/eng/xplat-job.yml
@@ -8,6 +8,7 @@ parameters:
   helixType: '(unspecified)'
   condition: ''
   dependsOn: ''
+  container: ''
   containerName: ''
   timeoutInMinutes: ''
   crossrootfsDir: ''


### PR DESCRIPTION
Define containers in platform-matrix.yml - we don't need resources to be defined in azure-pipelines.yml (we use the corresponding aliases just once).

And if we want to have a separate file per build definition we must do something like this to avoid duplication.