### PR TITLE
Fix crash/corruption in VSD hash tables when backpatching entry point slots is enabled

### DIFF
--- a/src/vm/virtualcallstub.h
+++ b/src/vm/virtualcallstub.h
@@ -495,7 +495,8 @@ private:
     DispatchHolder *GenerateDispatchStub(PCODE addrOfCode,
                                          PCODE addrOfFail,
                                          void *pMTExpected,
-                                         size_t dispatchToken);
+                                         size_t dispatchToken,
+                                         bool *pMayHaveReenteredCooperativeGCMode);
 
 #ifdef _TARGET_AMD64_
     // Used to allocate a long jump dispatch stub. See comment around
@@ -503,7 +504,8 @@ private:
     DispatchHolder *GenerateDispatchStubLong(PCODE addrOfCode,
                                              PCODE addrOfFail,
                                              void *pMTExpected,
-                                             size_t dispatchToken);
+                                             size_t dispatchToken,
+                                             bool *pMayHaveReenteredCooperativeGCMode);
 #endif
 
     ResolveHolder *GenerateResolveStub(PCODE addrOfResolver,
@@ -529,7 +531,8 @@ private:
     // The resolve cache is static across all AppDomains
     ResolveCacheElem *GenerateResolveCacheElem(void *addrOfCode,
                                                void *pMTExpected,
-                                               size_t token);
+                                               size_t token,
+                                               bool *pMayHaveReenteredCooperativeGCMode);
 
     ResolveCacheElem *GetResolveCacheElem(void *pMT,
                                           size_t token,


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/25080
Fixes https://github.com/dotnet/coreclr/issues/22964
- The prober used to look for an item (`DispatchStub` or `ResolveCacheElem`) stores information specific to the table
- Cooperative GC mode guarantees that the information stored in the prober remains valid when the prober is reused to add a new item when one is not found
- The lock taken to record/backpatch an item's slot exits and reenters cooperative GC mode, which can cause the table to be reclaimed and replaced with a new table, and the prober still refers to the old table
- Upon adding the new item it may crash or corrupt some other memory
- Fixed by resetting the prober if a path is taken that may reenter cooperative GC mode