### PR TITLE
Start cleaning emitxarch::GetSize estimates.

### DIFF
--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -3772,7 +3772,7 @@ AGAIN:
 
         /* Get hold of the current jump size */
 
-        jsz = emitSizeOfJump(jmp);
+        jsz = jmp->idCodeSize();
 
         /* Get the group the jump is in */
 
@@ -3860,7 +3860,7 @@ AGAIN:
 
             if (jmp->idjShort)
             {
-                assert(emitSizeOfJump(jmp) == ssz);
+                assert(jmp->idCodeSize() == ssz);
 
                 // We should not be jumping/branching across funclets/functions
                 emitCheckFuncletBranch(jmp, jmpIG);
@@ -4229,7 +4229,7 @@ AGAIN:
 
         /* Make sure the size of the jump is marked correctly */
 
-        assert((0 == (jsz | jmpDist)) || (jsz == emitSizeOfJump(jmp)));
+        assert((0 == (jsz | jmpDist)) || (jsz == jmp->idCodeSize()));
 
 #ifdef DEBUG
         if (EMITVERBOSE)

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -3404,7 +3404,7 @@ void emitter::emitDispIG(insGroup* ig, insGroup* igPrev, bool verbose)
                     emitDispIns(id, false, true, false, ofs, nullptr, 0, ig);
 
                     ins += emitSizeOfInsDsc(id);
-                    ofs += emitInstCodeSz(id);
+                    ofs += id->idCodeSize();
                 } while (--cnt);
 
                 printf("\n");
@@ -3497,12 +3497,12 @@ size_t emitter::emitIssue1Instr(insGroup* ig, instrDesc* id, BYTE** dp)
     if (csz != id->idCodeSize())
     {
         /* It is fatal to under-estimate the instruction size */
-        noway_assert(emitInstCodeSz(id) >= csz);
+        noway_assert(id->idCodeSize() >= csz);
 
 #if DEBUG_EMIT
         if (EMITVERBOSE)
         {
-            printf("Instruction predicted size = %u, actual = %u\n", emitInstCodeSz(id), csz);
+            printf("Instruction predicted size = %u, actual = %u\n", id->idCodeSize(), csz);
         }
 #endif // DEBUG_EMIT
 
@@ -5297,7 +5297,7 @@ UNATIVE_OFFSET emitter::emitFindOffset(insGroup* ig, unsigned insNum)
 
     while (insNum > 0)
     {
-        of += emitInstCodeSz(id);
+        of += id->idCodeSize();
 
         castto(id, BYTE*) += emitSizeOfInsDsc(id);
 

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -638,7 +638,7 @@ protected:
 
     private:
 #if defined(_TARGET_XARCH_)
-        unsigned _idCodeSize : 4; // size of instruction in bytes, max is 15 bytes, because of the Intel decoder limit.
+        unsigned _idCodeSize : 4; // size of instruction in bytes. Max size of an Intel instruction is 15 bytes.
         opSize   _idOpSize : 3;   // operand size: 0=1 , 1=2 , 2=4 , 3=8, 4=16, 5=32
                                   // At this point we have fully consumed first DWORD so that next field
                                   // doesn't cross a byte boundary.
@@ -886,6 +886,7 @@ protected:
         {
             assert(sz <= 15); // Intel decoder limit.
             _idCodeSize = sz;
+            assert(sz == _idCodeSize);
         }
 
 #elif defined(_TARGET_ARM64_)

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -638,7 +638,7 @@ protected:
 
     private:
 #if defined(_TARGET_XARCH_)
-        unsigned _idCodeSize : 4; // size of instruction in bytes
+        unsigned _idCodeSize : 4; // size of instruction in bytes, max is 15 bytes, because of the Intel decoder limit.
         opSize   _idOpSize : 3;   // operand size: 0=1 , 1=2 , 2=4 , 3=8, 4=16, 5=32
                                   // At this point we have fully consumed first DWORD so that next field
                                   // doesn't cross a byte boundary.
@@ -884,8 +884,8 @@ protected:
         }
         void idCodeSize(unsigned sz)
         {
+            assert(sz <= 15); // Intel decoder limit.
             _idCodeSize = sz;
-            assert(sz == _idCodeSize);
         }
 
 #elif defined(_TARGET_ARM64_)

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -1584,7 +1584,6 @@ private:
 
     void emitSetShortJump(instrDescJmp* id);
     void emitSetMediumJump(instrDescJmp* id);
-    UNATIVE_OFFSET emitInstCodeSz(instrDesc* id);
 
 public:
     CORINFO_FIELD_HANDLE emitAnyConst(const void* cnsAddr, unsigned cnsSize, emitDataAlignment alignment);

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -1584,7 +1584,6 @@ private:
 
     void emitSetShortJump(instrDescJmp* id);
     void emitSetMediumJump(instrDescJmp* id);
-    UNATIVE_OFFSET emitSizeOfJump(instrDescJmp* jmp);
     UNATIVE_OFFSET emitInstCodeSz(instrDesc* id);
 
 public:

--- a/src/jit/emitinl.h
+++ b/src/jit/emitinl.h
@@ -17,11 +17,6 @@ inline UNATIVE_OFFSET emitter::emitInstCodeSz(instrDesc* id)
     return id->idCodeSize();
 }
 
-inline UNATIVE_OFFSET emitter::emitSizeOfJump(instrDescJmp* jmp)
-{
-    return jmp->idCodeSize();
-}
-
 #ifdef _TARGET_XARCH_
 
 /* static */

--- a/src/jit/emitinl.h
+++ b/src/jit/emitinl.h
@@ -5,17 +5,6 @@
 
 #ifndef _EMITINL_H_
 #define _EMITINL_H_
-/*****************************************************************************/
-/*****************************************************************************
- *
- *  Return the number of bytes of machine code the given instruction will
- *  produce.
- */
-
-inline UNATIVE_OFFSET emitter::emitInstCodeSz(instrDesc* id)
-{
-    return id->idCodeSize();
-}
 
 #ifdef _TARGET_XARCH_
 

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -8250,7 +8250,7 @@ void emitter::emitDispIns(
 
     /* By now the size better be set to something */
 
-    assert(emitInstCodeSz(id) || emitInstHasNoCode(ins));
+    assert(id->idCodeSize() || emitInstHasNoCode(ins));
 
     /* Figure out the operand size */
 
@@ -12307,9 +12307,9 @@ BYTE* emitter::emitOutputLJ(BYTE* dst, instrDesc* i)
 
         assert(jmp);
 
-        if (emitInstCodeSz(id) != JMP_SIZE_SMALL)
+        if (id->idCodeSize() != JMP_SIZE_SMALL)
         {
-            emitOffsAdj += emitInstCodeSz(id) - JMP_SIZE_SMALL;
+            emitOffsAdj += id->idCodeSize() - JMP_SIZE_SMALL;
 
 #ifdef DEBUG
             if (emitComp->verbose)


### PR DESCRIPTION
The PR deletes two functions:
```
    UNATIVE_OFFSET emitSizeOfJump(instrDescJmp* jmp);	
    UNATIVE_OFFSET emitInstCodeSz(instrDesc* id);
```
that did not add any value and made readability worse (because they were used along with direct calls to `idCodeSize()`).

Also adds a comment about the Intel decoder limit and change the assert that fires in #25050  :
it was not obvious why 
```
_idCodeSize = sz;
assert(sz == _idCodeSize);
```
could fail until you saw that `_idCodeSize` size was 4 bites.
