### PR TITLE
Do not force GcStress=0xc for GitHub_23199 on OSX.

### DIFF
--- a/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.csproj
@@ -34,12 +34,10 @@
     <CLRTestBatchPreCommands><![CDATA[
 $(CLRTestBatchPreCommands)
 set COMPlus_GcStressOnDirectCalls=1
-set COMPlus_GCStress=0xc
 ]]></CLRTestBatchPreCommands>
   <BashCLRTestPreCommands><![CDATA[
 $(BashCLRTestPreCommands)
 export COMPlus_GcStressOnDirectCalls=1
-export COMPlus_GCStress=0xc
 ]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.csproj
@@ -29,8 +29,7 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <!-- OSX doesn't support GCStress=0xc. -->
-  <PropertyGroup Condition="'$(__BuildOS)' != 'OSX'">
+  <PropertyGroup>
     <CLRTestBatchPreCommands><![CDATA[
 $(CLRTestBatchPreCommands)
 set COMPlus_GcStressOnDirectCalls=1

--- a/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_23199/GitHub_23199.csproj
@@ -29,16 +29,17 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <PropertyGroup>
+  <!-- OSX doesn't support GCStress=0xc. -->
+  <PropertyGroup Condition="'$(__BuildOS)' != 'OSX'">
     <CLRTestBatchPreCommands><![CDATA[
 $(CLRTestBatchPreCommands)
 set COMPlus_GcStressOnDirectCalls=1
-set COMPlus_GcStress=0xc
+set COMPlus_GCStress=0xc
 ]]></CLRTestBatchPreCommands>
   <BashCLRTestPreCommands><![CDATA[
 $(BashCLRTestPreCommands)
 export COMPlus_GcStressOnDirectCalls=1
-export COMPlus_GcStress=0xc
+export COMPlus_GCStress=0xc
 ]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
There was a typo for Unix (it is COMPlus_GCStress, not COMPlus_GcStress, but COMPlus_GcStressOnDirectCalls was correct). That was why the test passed on OSX.