### PR TITLE
make DiagnosticCounter and its children lock 'this' instead of String

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/DiagnosticCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/DiagnosticCounter.cs
@@ -68,7 +68,7 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         public void AddMetadata(string key, string value)
         {
-            lock (MyLock)
+            lock (this)
             {
                 _metadata = _metadata ?? new Dictionary<string, string>();
                 _metadata.Add(key, value);
@@ -90,9 +90,6 @@ namespace System.Diagnostics.Tracing
 
         internal abstract void WritePayload(float intervalSec, int pollingIntervalMillisec);
 
-        // arbitrarily we use name as the lock object.  
-        internal object MyLock { get { return Name; } }
-
         internal void ReportOutOfBandMessage(string message)
         {
             EventSource.ReportOutOfBandMessage(message, true);
@@ -100,6 +97,8 @@ namespace System.Diagnostics.Tracing
 
         internal string GetMetadataString()
         {
+            Debug.Assert(Monitor.IsEntered(this));
+
             if (_metadata == null)
             {
                 return "";

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventCounter.cs
@@ -71,7 +71,7 @@ namespace System.Diagnostics.Tracing
 
         internal void OnMetricWritten(double value)
         {
-            Debug.Assert(Monitor.IsEntered(MyLock));
+            Debug.Assert(Monitor.IsEntered(this));
             _sum += value;
             _sumSquared += value * value;
             if (value > _max)
@@ -85,7 +85,7 @@ namespace System.Diagnostics.Tracing
 
         internal override void WritePayload(float intervalSec, int pollingIntervalMillisec)
         {
-            lock (MyLock)
+            lock (this)
             {
                 Flush();
                 CounterPayload payload = new CounterPayload();
@@ -116,7 +116,7 @@ namespace System.Diagnostics.Tracing
 
         private void ResetStatistics()
         {
-            Debug.Assert(Monitor.IsEntered(MyLock));
+            Debug.Assert(Monitor.IsEntered(this));
             _count = 0;
             _sum = 0;
             _sumSquared = 0;
@@ -154,7 +154,7 @@ namespace System.Diagnostics.Tracing
                 {
                     // It is possible that two threads both think the buffer is full, but only one get to actually flush it, the other
                     // will eventually enter this code path and potentially calling Flushing on a buffer that is not full, and that's okay too.
-                    lock (MyLock) // Lock the counter
+                    lock (this) // Lock the counter
                         Flush();
                     i = 0;
                 }
@@ -170,7 +170,7 @@ namespace System.Diagnostics.Tracing
 
         protected void Flush()
         {
-            Debug.Assert(Monitor.IsEntered(MyLock));
+            Debug.Assert(Monitor.IsEntered(this));
             for (int i = 0; i < _bufferedValues.Length; i++)
             {
                 var value = Interlocked.Exchange(ref _bufferedValues[i], UnusedBufferSlotValue);

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/IncrementingEventCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/IncrementingEventCounter.cs
@@ -43,7 +43,7 @@ namespace System.Diagnostics.Tracing
         /// <param name="increment">The value to increment by.</param>
         public void Increment(double increment = 1)
         {
-            lock (MyLock)
+            lock (this)
             {
                 _increment += increment;
             }
@@ -57,7 +57,7 @@ namespace System.Diagnostics.Tracing
 
         internal override void WritePayload(float intervalSec, int pollingIntervalMillisec)
         {
-            lock (MyLock)     // Lock the counter
+            lock (this)     // Lock the counter
             {
                 IncrementingCounterPayload payload = new IncrementingCounterPayload();
                 payload.Name = Name;

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/IncrementingPollingCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/IncrementingPollingCounter.cs
@@ -56,7 +56,7 @@ namespace System.Diagnostics.Tracing
         {
             try
             {
-                lock (MyLock)
+                lock (this)
                 {
                     _increment = _totalValueProvider();
                 }
@@ -70,7 +70,7 @@ namespace System.Diagnostics.Tracing
         internal override void WritePayload(float intervalSec, int pollingIntervalMillisec)
         {
             UpdateMetric();
-            lock (MyLock)     // Lock the counter
+            lock (this)     // Lock the counter
             {
                 IncrementingCounterPayload payload = new IncrementingCounterPayload();
                 payload.Name = Name;

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/PollingCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/PollingCounter.cs
@@ -47,7 +47,7 @@ namespace System.Diagnostics.Tracing
 
         internal override void WritePayload(float intervalSec, int pollingIntervalMillisec)
         {
-            lock (MyLock)
+            lock (this)
             {
                 double value = 0;
                 try 


### PR DESCRIPTION
Fix #25157 