### PR TITLE
Fix duplicate imports in managed product build

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -11,7 +11,8 @@
     </RestoreSources>
   </PropertyGroup>
 
-  <Import Project="eng/Versions.props" />
+  <!-- [ARCADE REMOVE] Versions.props is imported by Arcade SDK targets when building with Arcade -->
+  <Import Project="eng/Versions.props" Condition="'$(ArcadeBuild)' != 'true'" />
 
   <!-- Source of truth for dependency tooling: the commit hash of the dotnet/versions master branch as of the last auto-upgrade. -->
   <PropertyGroup>

--- a/dir.props
+++ b/dir.props
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <Import Project="dir.common.props" />
+  <!-- dir.common.props is imported by Directory.Build.props when building with Arcade -->
+  <Import Project="dir.common.props" Condition="'$(ArcadeBuild)' != 'true'" />
 
   <!-- [ARCADE REMOVE] This entire file can be removed. Properties set by this file should be moved into
        dir.common.props and Directory.Build.props as appropriate and projects should stop importing this. -->


### PR DESCRIPTION
Avoid duplicate imports in managed product build.

Since we still have other BuildTools dependencies, a cleaner fix would require a bunch more finagling to split things up / move them about. Once we remove other BuildTools dependencies and are fully on Arcade, the nice fix should 'naturally' happen.

Fixes #24448