### PR TITLE
Exception format cleanup subset

### DIFF
--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -668,7 +668,7 @@
     <value>Insufficient memory to continue the execution of the program.</value>
   </data>
   <data name="Arg_ParamName_Name" xml:space="preserve">
-    <value>Parameter name: {0}</value>
+    <value>(parameter '{0}')</value>
   </data>
   <data name="Arg_ParmArraySize" xml:space="preserve">
     <value>Must specify one or more parameters.</value>

--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -668,7 +668,7 @@
     <value>Insufficient memory to continue the execution of the program.</value>
   </data>
   <data name="Arg_ParamName_Name" xml:space="preserve">
-    <value>(parameter '{0}')</value>
+    <value>(Parameter '{0}')</value>
   </data>
   <data name="Arg_ParmArraySize" xml:space="preserve">
     <value>Must specify one or more parameters.</value>

--- a/src/System.Private.CoreLib/shared/System/AggregateException.cs
+++ b/src/System.Private.CoreLib/shared/System/AggregateException.cs
@@ -454,7 +454,7 @@ namespace System
                 if (m_innerExceptions[i] == InnerException)
                     continue; // Already logged in base.ToString()
 
-                text.Append(InnerExceptionPrefix);
+                text.Append(Environment.NewLine).Append(InnerExceptionPrefix);
                 text.AppendFormat(CultureInfo.InvariantCulture, SR.AggregateException_InnerException, i);
                 text.Append(m_innerExceptions[i].ToString());
                 text.Append("<---");

--- a/src/System.Private.CoreLib/shared/System/AggregateException.cs
+++ b/src/System.Private.CoreLib/shared/System/AggregateException.cs
@@ -451,6 +451,9 @@ namespace System
 
             for (int i = 0; i < m_innerExceptions.Count; i++)
             {
+                if (m_innerExceptions[i] == InnerException)
+                    continue; // Already logged in base.ToString()
+
                 text.AppendLine();
                 text.Append("---> ");
                 text.AppendFormat(CultureInfo.InvariantCulture, SR.AggregateException_InnerException, i);

--- a/src/System.Private.CoreLib/shared/System/AggregateException.cs
+++ b/src/System.Private.CoreLib/shared/System/AggregateException.cs
@@ -454,8 +454,7 @@ namespace System
                 if (m_innerExceptions[i] == InnerException)
                     continue; // Already logged in base.ToString()
 
-                text.AppendLine();
-                text.Append("---> ");
+                text.Append(InnerExceptionPrefix);
                 text.AppendFormat(CultureInfo.InvariantCulture, SR.AggregateException_InnerException, i);
                 text.Append(m_innerExceptions[i].ToString());
                 text.Append("<---");

--- a/src/System.Private.CoreLib/shared/System/ArgumentException.cs
+++ b/src/System.Private.CoreLib/shared/System/ArgumentException.cs
@@ -81,11 +81,10 @@ namespace System
                 string s = base.Message;
                 if (!string.IsNullOrEmpty(_paramName))
                 {
-                    string resourceString = SR.Format(SR.Arg_ParamName_Name, _paramName);
-                    return s + Environment.NewLine + resourceString;
+                    s += " " + SR.Format(SR.Arg_ParamName_Name, _paramName);
                 }
-                else
-                    return s;
+
+                return s;
             }
         }
 

--- a/src/System.Private.CoreLib/shared/System/BadImageFormatException.cs
+++ b/src/System.Private.CoreLib/shared/System/BadImageFormatException.cs
@@ -104,7 +104,7 @@ namespace System
                 s += Environment.NewLine + SR.Format(SR.IO_FileName_Name, _fileName);
 
             if (InnerException != null)
-                s = s + " ---> " + InnerException.ToString();
+                s = s + InnerExceptionPrefix + InnerException.ToString();
 
             if (StackTrace != null)
                 s += Environment.NewLine + StackTrace;

--- a/src/System.Private.CoreLib/shared/System/Exception.cs
+++ b/src/System.Private.CoreLib/shared/System/Exception.cs
@@ -11,7 +11,7 @@ namespace System
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public partial class Exception : ISerializable
     {
-        internal protected const InnerExceptionPrefix = Environment.NewLine + " ---> ";
+        internal protected const string InnerExceptionPrefix = " ---> ";
 
         public Exception()
         {
@@ -153,7 +153,7 @@ namespace System
 
             if (_innerException != null)
             {
-                s = s + InnerExceptionPrefix + _innerException.ToString() + Environment.NewLine +
+                s = s + Environment.NewLine + InnerExceptionPrefix + _innerException.ToString() + Environment.NewLine +
                 "   " + SR.Exception_EndOfInnerExceptionStack;
             }
 

--- a/src/System.Private.CoreLib/shared/System/Exception.cs
+++ b/src/System.Private.CoreLib/shared/System/Exception.cs
@@ -11,6 +11,8 @@ namespace System
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public partial class Exception : ISerializable
     {
+        internal protected const InnerExceptionPrefix = Environment.NewLine + " ---> ";
+
         public Exception()
         {
             _HResult = HResults.COR_E_EXCEPTION;
@@ -151,7 +153,7 @@ namespace System
 
             if (_innerException != null)
             {
-                s = s + " ---> " + _innerException.ToString() + Environment.NewLine +
+                s = s + InnerExceptionPrefix + _innerException.ToString() + Environment.NewLine +
                 "   " + SR.Exception_EndOfInnerExceptionStack;
             }
 

--- a/src/System.Private.CoreLib/shared/System/IO/FileLoadException.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileLoadException.cs
@@ -64,7 +64,7 @@ namespace System.IO
                 s += Environment.NewLine + SR.Format(SR.IO_FileName_Name, FileName);
 
             if (InnerException != null)
-                s = s + InnerExceptionPrefix + InnerException.ToString();
+                s = s + Environment.NewLine + InnerExceptionPrefix + InnerException.ToString();
 
             if (StackTrace != null)
                 s += Environment.NewLine + StackTrace;

--- a/src/System.Private.CoreLib/shared/System/IO/FileLoadException.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileLoadException.cs
@@ -64,7 +64,7 @@ namespace System.IO
                 s += Environment.NewLine + SR.Format(SR.IO_FileName_Name, FileName);
 
             if (InnerException != null)
-                s = s + " ---> " + InnerException.ToString();
+                s = s + InnerExceptionPrefix + InnerException.ToString();
 
             if (StackTrace != null)
                 s += Environment.NewLine + StackTrace;

--- a/src/System.Private.CoreLib/shared/System/IO/FileNotFoundException.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileNotFoundException.cs
@@ -78,7 +78,7 @@ namespace System.IO
                 s += Environment.NewLine + SR.Format(SR.IO_FileName_Name, FileName);
 
             if (InnerException != null)
-                s = s + InnerExceptionPrefix + InnerException.ToString();
+                s = s + Environment.NewLine + InnerExceptionPrefix + InnerException.ToString();
 
             if (StackTrace != null)
                 s += Environment.NewLine + StackTrace;

--- a/src/System.Private.CoreLib/shared/System/IO/FileNotFoundException.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileNotFoundException.cs
@@ -78,7 +78,7 @@ namespace System.IO
                 s += Environment.NewLine + SR.Format(SR.IO_FileName_Name, FileName);
 
             if (InnerException != null)
-                s = s + " ---> " + InnerException.ToString();
+                s = s + InnerExceptionPrefix + InnerException.ToString();
 
             if (StackTrace != null)
                 s += Environment.NewLine + StackTrace;

--- a/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/COMException.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/COMException.cs
@@ -61,7 +61,7 @@ namespace System.Runtime.InteropServices
             Exception? innerException = InnerException;
             if (innerException != null)
             {
-                s.Append(" ---> ").Append(innerException.ToString());
+                s.Append(InnerExceptionPrefix).Append(innerException.ToString());
             }
 
             string? stackTrace = StackTrace;

--- a/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/COMException.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/COMException.cs
@@ -48,7 +48,7 @@ namespace System.Runtime.InteropServices
         public override string ToString()
         {
             StringBuilder s = new StringBuilder();
-            
+
             string className = GetType().ToString();
             s.Append(className).Append(" (0x").Append(HResult.ToString("X8", CultureInfo.InvariantCulture)).Append(')');
 
@@ -61,7 +61,7 @@ namespace System.Runtime.InteropServices
             Exception? innerException = InnerException;
             if (innerException != null)
             {
-                s.Append(InnerExceptionPrefix).Append(innerException.ToString());
+                s.Append(Environment.NewLine).Append(InnerExceptionPrefix).Append(innerException.ToString());
             }
 
             string? stackTrace = StackTrace;

--- a/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/ExternalException.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/ExternalException.cs
@@ -75,7 +75,7 @@ namespace System.Runtime.InteropServices
             Exception? innerException = InnerException;
             if (innerException != null)
             {
-                s = s + InnerExceptionPrefix + innerException.ToString();
+                s = s + Environment.NewLine + InnerExceptionPrefix + innerException.ToString();
             }
 
             if (StackTrace != null)

--- a/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/ExternalException.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/ExternalException.cs
@@ -75,7 +75,7 @@ namespace System.Runtime.InteropServices
             Exception? innerException = InnerException;
             if (innerException != null)
             {
-                s = s + " ---> " + innerException.ToString();
+                s = s + InnerExceptionPrefix + innerException.ToString();
             }
 
             if (StackTrace != null)

--- a/tests/CoreFX/CoreFX.issues.rsp
+++ b/tests/CoreFX/CoreFX.issues.rsp
@@ -92,6 +92,10 @@
 # Assert: https://github.com/dotnet/coreclr/issues/25050
 -nonamespace System.Data.Common.Tests
 
+# requires corefx test updates
+-nomethod System.Data.Tests.Common.DbConnectionStringBuilderTest.Add_Keyword_Invalid
+-nomethod System.Data.Tests.Common.DbConnectionStringBuilderTest.Indexer_Keyword_Invalid
+
 # requires corefx test updates https://github.com/dotnet/corefx/pull/38452
 -nomethod System.SpanTests.ReadOnlySpanTests.ZeroLengthIndexOfAny_ManyInteger
 -nomethod System.SpanTests.ReadOnlySpanTests.ZeroLengthIndexOfAny_ManyString


### PR DESCRIPTION
Subset of #25045 that seems reasonable to put into 3.0 as it's less likely to break output-parsing.

1. Remove newline within AE message.
2. Put newlines before each inner exception (this puts `---> somemessage` on their own lines)
3. Stop duplicating one of the inner exceptoins in the AgE.ToString().

Deferred:
1. Indenting
2. Removing `<---` and the various horizontal markers.

Test program [original output ](https://gist.github.com/danmosemsft/ef14298ab1ee85a41b79684f7a2a94a6) and [new output](https://gist.github.com/danmosemsft/a501f2cec1348049a268629a320b86d9) (file/line numbers aren't resolving for some reason to do with Debug runtime build)