### PR TITLE
Remove unused TRACE_LEVEL_NONE (#23711)

### DIFF
--- a/src/inc/eventtracebase.h
+++ b/src/inc/eventtracebase.h
@@ -163,7 +163,6 @@ class Object;
 /* Tracing levels supported by CLR ETW */
 /***************************************/
 #define ETWMAX_TRACE_LEVEL 6        // Maximum Number of Trace Levels supported
-#define TRACE_LEVEL_NONE        0   // Tracing is not on
 #define TRACE_LEVEL_FATAL       1   // Abnormal exit or termination
 #define TRACE_LEVEL_ERROR       2   // Severe errors that need logging
 #define TRACE_LEVEL_WARNING     3   // Warnings such as allocation failure

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -4206,7 +4206,6 @@ VOID EtwCallbackCommon(
 
     bool bIsPublicTraceHandle = ProviderIndex == DotNETRuntime;
 #if !defined(FEATURE_PAL)
-    static_assert(GCEventLevel_None == TRACE_LEVEL_NONE, "GCEventLevel_None value mismatch");
     static_assert(GCEventLevel_Fatal == TRACE_LEVEL_FATAL, "GCEventLevel_Fatal value mismatch");
     static_assert(GCEventLevel_Error == TRACE_LEVEL_ERROR, "GCEventLevel_Error value mismatch");
     static_assert(GCEventLevel_Warning == TRACE_LEVEL_WARNING, "GCEventLevel_Warning mismatch");


### PR DESCRIPTION
Removed define TRACE_LEVEL_NONE from eventtracebase.h.
Removed static_assert(GCEventLevel_None == TRACE_LEVEL_NONE, "GCEventLevel_None value mismatch"); from eventtrace.cpp

Enhancement #23711