### PR TITLE
Prevent loading byref-like types with invalid layout

### DIFF
--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -8397,6 +8397,16 @@ MethodTableBuilder::HandleExplicitLayout(
             if (pFD->IsByValue())
             {
                 MethodTable *pByValueMT = pByValueClassCache[valueClassCacheIndex];
+                if (pByValueMT->IsByRefLike())
+                {
+                    if ((pFD->GetOffset_NoLogging() & ((ULONG)TARGET_POINTER_SIZE - 1)) != 0)
+                    {
+                        // If we got here, then a byref-like valuetype was misaligned.
+                        badOffset = pFD->GetOffset_NoLogging();
+                        fieldTrust.SetTrust(ExplicitFieldTrust::kNone);
+                        break;
+                    }
+                }
                 if (pByValueMT->ContainsPointers())
                 {
                     if ((pFD->GetOffset_NoLogging() & ((ULONG)TARGET_POINTER_SIZE - 1)) == 0)

--- a/tests/src/Regressions/coreclr/25057/byref.cs
+++ b/tests/src/Regressions/coreclr/25057/byref.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[StructLayout(LayoutKind.Explicit)]
+ref struct InvalidRefStruct
+{
+    [FieldOffset(2)]
+    public Span<int> Y;
+}
+
+class Program
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Type LoadInvalidRefStruct()
+    {
+        return typeof(InvalidRefStruct);
+    }
+
+    static int Main()
+    {
+        try
+        {
+            LoadInvalidRefStruct();
+            return -1;
+        }
+        catch (TypeLoadException)
+        {
+            return 100;
+        }
+    }
+}

--- a/tests/src/Regressions/coreclr/25057/byref.csproj
+++ b/tests/src/Regressions/coreclr/25057/byref.csproj
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{CBD0D777-3583-49CC-8538-DD84447F6522}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+    <DebugType>None</DebugType>
+    <Optimize>False</Optimize>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="byref.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
First approximation of a fix for #25057.

This has two problems:
* We're checking for any byref-like typed fields. Types that don't actually contain interior pointers but were marked as `ref struct` will fail to load when not aligned properly.
* We're not doing the deep validation that we do for reference types to make sure the `ByReference<T>` field doesn't overlap with another non-byreference field.

Question is whether we're okay with those limitations, or whether we need a better fix. Better fix would likely entail inefficiently walking over the fields à la `FindByRefPointerOffsetsInByRefLikeObject` (doing the more efficient thing that we do for object references below would require a GCDesc representation of byrefness).

Contributes to #25057.