### PR TITLE
Remove dependency which is now app-local in corefx

### DIFF
--- a/tests/src/Common/CoreFX/CoreFX.depproj
+++ b/tests/src/Common/CoreFX/CoreFX.depproj
@@ -13,7 +13,6 @@
       <SystemCompositionVersions>1.3.0-preview3-26501-04</SystemCompositionVersions>
       <MicrosoftDiagnosticsTracingTraceVentVersion>2.0.19</MicrosoftDiagnosticsTracingTraceVentVersion>
       <MicrosoftDotnetPlatformAbstractionsVersion>2.1.0</MicrosoftDotnetPlatformAbstractionsVersion>
-      <MicrosoftDiagnosticsRuntimePackageVersion>1.0.5</MicrosoftDiagnosticsRuntimePackageVersion>
   </PropertyGroup>
 
   <!-- Switch RuntimeIdentifier according to currently running OSGroup -->
@@ -163,12 +162,6 @@
   <ItemGroup Condition="'$(OSGroup)' != 'Windows_NT'">
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions">
       <Version>$(MicrosoftDotnetPlatformAbstractionsVersion)</Version>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Runtime">
-      <Version>$(MicrosoftDiagnosticsRuntimePackageVersion)</Version>
     </PackageReference>
   </ItemGroup>
   


### PR DESCRIPTION
https://github.com/dotnet/corefx/commit/c4c1985531cc1f25c805bbc4801b85c98e0dfee0 went into corefx/master yesterday which includes external references as app-local (test folder). This manual dependency isn't necessary anymore.