### PR TITLE
Sign the DAC with MicrosoftSHA2 cert

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -6,6 +6,10 @@
     <ItemsToSign Include="$(BinDir)*.exe" />
   </ItemGroup>
 
+  <ItemGroup>
+    <FileSignInfo Include="mscordaccore.dll" CertificateName="MicrosoftSHA2" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(BuildArch)' == 'x86'">
     <!-- Sign api-ms-win-core-xstate-l2-1-0 binary as it is only catalog signed in the current SDK. -->
     <ItemsToSign Condition="'$(BuildType)'=='Release'" Include="$(BinDir)Redist\ucrt\DLLs\$(BuildArch)\api-ms-win-core-xstate-l2-1-0.dll" />


### PR DESCRIPTION
The current Microsoft certificate breaks minidumps/WER. The dbghelp
MiniDumpWriteDump code rejected the default cert. This started
failing when the obsolete SHA1 cert was removed from all of our
binaries.

Issue: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/919061