### PR TITLE
Refresh GC reliability scripts/tests.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,18 +80,6 @@ jobs:
       ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
         platforms:
         - Windows_NT_x64
-        - Windows_NT_x86
-      ${{ if and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
-        platforms:
-        - Linux_arm
-        - Linux_arm64
-        - Linux_musl_arm64
-        - Linux_musl_x64
-        - Linux_rhel6_x64
-        - Linux_x64
-        - OSX_x64
-        - Windows_NT_arm
-        - Windows_NT_arm64
 
 #
 # Checked builds
@@ -103,52 +91,7 @@ jobs:
       buildConfig: checked
       ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
         platforms:
-        - Linux_arm
-        - Linux_arm64
-        - Linux_musl_x64
-        - Linux_x64
-        - OSX_x64
-        - Windows_NT_arm
-        - Windows_NT_arm64
         - Windows_NT_x64
-        - Windows_NT_x86
-      ${{ if and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
-        platformGroup: all
-      ${{ if in(variables['Build.DefinitionName'], 'coreclr-outerloop', 'coreclr-outerloop-jitstress', 'coreclr-outerloop-jitstressregs', 'coreclr-outerloop-jitstress2-jitstressregs') }}:
-        platformGroup: all
-      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-isas-arm') }}:
-        platforms:
-        - Linux_arm64
-        - Windows_NT_arm64
-      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-isas-x86') }}:
-        platforms:
-        - Linux_x64
-        - OSX_x64
-        - Windows_NT_x64
-        - Windows_NT_x86
-      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs-x86') }}:
-        platforms:
-        - Linux_x64
-        - Windows_NT_x64
-        - Windows_NT_x86
-      ${{ if in(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress0x3-gcstress0xc', 'coreclr-outerloop-gcstress-extra', 'coreclr-outerloop-r2r-extra') }}:
-        platformGroup: gcstress
-      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r') }}:
-        platforms:
-        - Linux_arm
-        - Linux_arm64
-        - Linux_x64
-        - Windows_NT_x64
-        - Windows_NT_x86
-      ${{ if in(variables['Build.DefinitionName'], 'coreclr-corefx', 'coreclr-corefx-jitstress', 'coreclr-corefx-jitstressregs', 'coreclr-corefx-jitstress2-jitstressregs') }}:
-        platforms:
-        - Linux_x64
-        - Windows_NT_x64
-      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-runincontext') }}:
-        platforms:
-        - Linux_x64
-        - Windows_NT_x64
-        - Windows_NT_x86
 
 #
 # Release builds
@@ -160,19 +103,7 @@ jobs:
       buildConfig: release
       ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
         platforms:
-        - Linux_arm64
-        - Linux_musl_x64
-        - Linux_rhel6_x64
-        - Windows_NT_arm
-        - Windows_NT_arm64
         - Windows_NT_x64
-      ${{ if and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
-        platforms:
-        - Linux_arm
-        - Linux_musl_arm64
-        - Linux_x64
-        - OSX_x64
-        - Windows_NT_x86
 
 - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng/platform-matrix.yml
@@ -197,71 +128,11 @@ jobs:
       buildConfig: checked
       ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
         platforms:
-        - Linux_arm
-        - Linux_arm64
-        - Linux_musl_x64
-        - Linux_x64
-        - OSX_x64
-        - Windows_NT_arm
-        - Windows_NT_arm64
         - Windows_NT_x64
-        - Windows_NT_x86
         helixQueueGroup: pr
-      ${{ if in(variables['Build.DefinitionName'], 'coreclr-outerloop', 'coreclr-outerloop-jitstress', 'coreclr-outerloop-jitstressregs', 'coreclr-outerloop-jitstress2-jitstressregs') }}:
-        platformGroup: all
-        helixQueueGroup: all
-      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-isas-arm') }}:
-        platforms:
-        - Linux_arm64
-        - Windows_NT_arm64
-        helixQueueGroup: all
-      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-isas-x86') }}:
-        platforms:
-        - Linux_x64
-        - OSX_x64
-        - Windows_NT_x64
-        - Windows_NT_x86
-        helixQueueGroup: all
-      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs-x86') }}:
-        platforms:
-        - Linux_x64
-        - Windows_NT_x64
-        - Windows_NT_x86
-        helixQueueGroup: all
-      ${{ if in(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress0x3-gcstress0xc', 'coreclr-outerloop-gcstress-extra') }}:
-        platformGroup: gcstress
-        helixQueueGroup: all
-      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-runincontext') }}:
-        platforms:
-        - Linux_x64
-        - Windows_NT_x64
-        - Windows_NT_x86
-        helixQueueGroup: all
       jobParameters:
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-ci') }}:
           testGroup: innerloop
-        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop') }}:
-          testGroup: outerloop
-        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress') }}:
-          testGroup: jitstress
-        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-isas-arm') }}:
-          testGroup: jitstress-isas-arm
-        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-isas-x86') }}:
-          testGroup: jitstress-isas-x86
-        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs-x86') }}:
-          testGroup: jitstressregs-x86
-        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs') }}:
-          testGroup: jitstressregs
-        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress2-jitstressregs') }}:
-          testGroup: jitstress2-jitstressregs
-        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress0x3-gcstress0xc') }}:
-          testGroup: gcstress0x3-gcstress0xc
-        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress-extra') }}:
-          testGroup: gcstress-extra
-        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-runincontext') }}:
-          testGroup: outerloop
-          runInUnloadableContext: true
-          displayNameArgs: RunInContext
 
 # ReadyToRun test jobs that are triggered by default from a PR.
 
@@ -272,31 +143,8 @@ jobs:
       buildConfig: checked
       ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
         platforms:
-        - Linux_x64
-        - OSX_x64
         - Windows_NT_x64
-        - Windows_NT_x86
         helixQueueGroup: pr
-      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r') }}:
-        platforms:
-        - Linux_arm
-        - Linux_arm64
-        - Linux_x64
-        - Windows_NT_x64
-        - Windows_NT_x86
-        helixQueueGroup: all
-      ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r-extra') }}:
-        platformGroup: gcstress # r2r-extra testGroup runs gcstress15 scenario
-        helixQueueGroup: all
-      jobParameters:
-        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-ci') }}:
-          testGroup: innerloop
-        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r') }}:
-          testGroup: outerloop
-        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r-extra') }}:
-          testGroup: r2r-extra
-        readyToRun: true
-        displayNameArgs: R2R
 
 #
 # CoreFX test runs against CoreCLR
@@ -309,25 +157,12 @@ jobs:
       buildConfig: checked
       ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
         platforms:
-        - Linux_x64
         - Windows_NT_x64
-      ${{ if in(variables['Build.DefinitionName'], 'coreclr-corefx', 'coreclr-corefx-jitstress', 'coreclr-corefx-jitstressregs', 'coreclr-corefx-jitstress2-jitstressregs') }}:
-        platforms:
-        - Linux_x64
-        - Windows_NT_x64
-      # We only want to run corefx testing on the minimum set of queues, no matter the build reason.
+       # We only want to run corefx testing on the minimum set of queues, no matter the build reason.
       helixQueueGroup: pr
       jobParameters:
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-ci') }}:
           testGroup: innerloop
-        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx') }}:
-          testGroup: outerloop
-        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstress') }}:
-          testGroup: jitstress
-        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstressregs') }}:
-          testGroup: jitstressregs
-        ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstress2-jitstressregs') }}:
-          testGroup: jitstress2-jitstressregs
         corefxTests: true
         displayNameArgs: CoreFX
 
@@ -375,7 +210,7 @@ jobs:
       jobTemplate: test-job.yml
       buildConfig: release
       platforms:
-      - Linux_musl_x64
+        - Windows_NT_x64
       helixQueueGroup: pr
       jobParameters:
         testGroup: innerloop
@@ -408,7 +243,6 @@ jobs:
     parameters:
       jobTemplate: format-job.yml
       platforms:
-      - Linux_x64
       - Windows_NT_x64
 
 # Publish build information to Build Assets Registry

--- a/tests/scripts/run-gc-reliability-framework.sh
+++ b/tests/scripts/run-gc-reliability-framework.sh
@@ -1,7 +1,31 @@
 #!/bin/bash
 
-export CORE_ROOT=`pwd`/bin/tests/Windows_NT.$1.$2/Tests/coreoverlay
-FRAMEWORK_DIR=`pwd`/bin/tests/Windows_NT.$1.$2/GC/Stress/Framework/ReliabilityFramework
+OSName=$(uname -s)
+case $OSName in
+    Darwin)
+        OS=OSX
+        ;;
+
+    FreeBSD)
+        OS=FreeBSD
+        ;;
+
+    Linux)
+        OS=Linux
+        ;;
+
+    NetBSD)
+        OS=NetBSD
+        ;;
+
+    *)
+        echo "Unsupported OS $OSName detected, configuring as if for Linux"
+        OS=Linux
+        ;;
+esac
+
+export CORE_ROOT=`pwd`/bin/tests/$OSName.$1.$2/Tests/Core_Root
+FRAMEWORK_DIR=`pwd`/bin/tests/$OSName.$1.$2/GC/Stress/Framework/ReliabilityFramework
 $CORE_ROOT/corerun $FRAMEWORK_DIR/ReliabilityFramework.exe $FRAMEWORK_DIR/testmix_gc.config
 EXIT_CODE=$?
 if [ $EXIT_CODE -eq 100 ]

--- a/tests/src/GC/Stress/Framework/ReliabilityFramework.cs
+++ b/tests/src/GC/Stress/Framework/ReliabilityFramework.cs
@@ -167,7 +167,7 @@ public class ReliabilityFramework
         foreach (string arg in args)
         {
             rf._logger.WriteToInstrumentationLog(null, LoggingLevels.StartupShutdown, String.Format("Argument: {0}", arg));
-            if (arg[0] == '/' || arg[0] == '-')
+            if (arg[0] == '-')
             {
                 if (String.Compare(arg.Substring(1), "replay", true) == 0)
                 {
@@ -207,14 +207,14 @@ public class ReliabilityFramework
         }
         if (!okToContinue)
         {
-            Console.WriteLine("\r\nWhidbey Host Interface Reliability Harness\r\n");
+            Console.WriteLine("\r\nHost Interface Reliability Harness\r\n");
             Console.WriteLine("Usage: ReliabiltityFramework [options] <test config file>");
             Console.WriteLine("");
             Console.WriteLine("Available options: ");
             Console.WriteLine("");
-            Console.WriteLine(" /replay     -   Replay from log file");
-            Console.WriteLine(" /{0}:<tests>	-	Comma delimited list of tests to run (no spaces)", sTests);
-            Console.WriteLine(" /{0}:<seed>	-	Random Number seed for replays", sSeed);
+            Console.WriteLine(" -replay     -   Replay from log file");
+            Console.WriteLine(" -{0}:<tests>	-	Comma delimited list of tests to run (no spaces)", sTests);
+            Console.WriteLine(" -{0}:<seed>	-	Random Number seed for replays", sSeed);
             rf._logger.WriteToInstrumentationLog(null, LoggingLevels.StartupShutdown, "Not ok to continue.");
 
 #if PROJECTK_BUILD

--- a/tests/src/GC/Stress/Framework/ReliabilityFramework.csproj
+++ b/tests/src/GC/Stress/Framework/ReliabilityFramework.csproj
@@ -12,7 +12,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <CLRTestKind>BuildOnly</CLRTestKind>
     <GenerateRunScript>false</GenerateRunScript>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>0</CLRTestPriority>
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/GC/Stress/stress_run_readme.txt
+++ b/tests/src/GC/Stress/stress_run_readme.txt
@@ -18,7 +18,11 @@ The stress framework is built from <REPO_ROOT>\tests\src\GC\Stress\Framework
 
 The tests are built from <REPO_ROOT>\tests\src\GC\Stress\Tests
 
-The config is at <REPO_ROOT>NDP\clr\tests\src\GC\Stress\testmix_gc.config, this will be copied to the output folder of Framework
+The config is at <REPO_ROOT>\tests\src\GC\Stress\testmix_gc.config, this will be copied to the output folder of Framework
+
+The easiest way to build the Framework+Tests is by building all tests - "<REPO_ROOT>\build_test[.bat|.sh]"
+
+It is possible to build tests by going directly into the Framework directory and building manually- Ex: "dotnet build -c:debug".
 
 3. Running stress
 
@@ -30,7 +34,7 @@ To run stress:
 
 (or if you copied testmix_gc.config somewhere else you need to tell it so, eg, c:\TestConfigs\testmix_gc.config)
 
-We recommand to run it for 48 hours (see the comments below on maximumExecutionTime in test config for more detail).
+We recommend to run it for 48 hours (see the comments below on maximumExecutionTime in test config for more detail).
 
 4. Test config
 


### PR DESCRIPTION
* GC reliability tests can build on Linux
* GC reliability tests can run on Linux
* GC reliability tests are buildable together with other Pri-0 tests. 
( BuildOnly though, we do not want to run them with other tests )

Verified running locally on  Windows, Linux, x64, arm64 

next step (possibly in a separate PR) - adding trigger commands to run in the lab.