### PR TITLE
Reenable temporarily disabled Debug.Print corefx tests

### DIFF
--- a/tests/CoreFX/CoreFX.issues.rsp
+++ b/tests/CoreFX/CoreFX.issues.rsp
@@ -45,8 +45,6 @@
 -nomethod System.Security.Cryptography.Rsa.Tests.RSAXml.FromNonsenseXml
 
 # requires corefx test updates
--nomethod System.Diagnostics.Tests.DebugTestsNoListeners.Print
--nomethod System.Diagnostics.Tests.DebugTestsUsingListeners.Print
 -nomethod System.Tests.ArrayTests.Copy_SourceAndDestinationNeverConvertible_ThrowsArrayTypeMismatchException
 
 #


### PR DESCRIPTION
Concludes: https://github.com/dotnet/corefx/issues/38359

cc: @stephentoub @adamsitnik 

