### PR TITLE
Reduce corefx testing load

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -162,6 +162,8 @@ jobs:
         platforms:
         - Linux_x64
         - Windows_NT_x64
+        # We only want to run on a single, latest queue. We don't need to run on all the platforms.
+        helixQueueGroup: latest
       ${{ if eq(variables['Build.DefinitionName'], 'coreclr-runincontext') }}:
         platforms:
         - Linux_x64
@@ -323,6 +325,8 @@ jobs:
         platforms:
         - Linux_x64
         - Windows_NT_x64
+      # We only want to run on a single, latest queue. We don't need to run on all the platforms.
+      helixQueueGroup: latest
       jobParameters:
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-ci') }}:
           testGroup: innerloop

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,6 +83,7 @@ jobs:
 ## azure-pipelines.yml -> platform-matrix.yml -------> build-job.yml -------> xplat-job.yml -> base.yml
 ##                                            |  (passed-in jobTemplate)  |                    (arcade)
 ##                                            \------> test-job.yml ------/
+##                                            \------> format-job.yml ----/
 
 # TODO: simplify logic surrounding official build/ci. See
 # https://github.com/Microsoft/azure-pipelines-yaml/pull/46 for more information
@@ -99,7 +100,6 @@ jobs:
         platforms:
         - Windows_NT_x64
         - Windows_NT_x86
-        helixQueueGroup: pr
       ${{ if and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
         platforms:
         - Linux_arm
@@ -111,7 +111,6 @@ jobs:
         - OSX_x64
         - Windows_NT_arm
         - Windows_NT_arm64
-        helixQueueGroup: ci
 
 #
 # Checked builds
@@ -132,34 +131,27 @@ jobs:
         - Windows_NT_arm64
         - Windows_NT_x64
         - Windows_NT_x86
-        helixQueueGroup: pr
       ${{ if and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
         platformGroup: all
-        helixQueueGroup: ci
       ${{ if in(variables['Build.DefinitionName'], 'coreclr-outerloop', 'coreclr-outerloop-jitstress', 'coreclr-outerloop-jitstressregs', 'coreclr-outerloop-jitstress2-jitstressregs') }}:
         platformGroup: all
-        helixQueueGroup: all
       ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-isas-arm') }}:
         platforms:
         - Linux_arm64
         - Windows_NT_arm64
-        helixQueueGroup: all
       ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-isas-x86') }}:
         platforms:
         - Linux_x64
         - OSX_x64
         - Windows_NT_x64
         - Windows_NT_x86
-        helixQueueGroup: all
       ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs-x86') }}:
         platforms:
         - Linux_x64
         - Windows_NT_x64
         - Windows_NT_x86
-        helixQueueGroup: all
       ${{ if in(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress0x3-gcstress0xc', 'coreclr-outerloop-gcstress-extra', 'coreclr-outerloop-r2r-extra') }}:
         platformGroup: gcstress
-        helixQueueGroup: all
       ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r') }}:
         platforms:
         - Linux_arm
@@ -167,19 +159,15 @@ jobs:
         - Linux_x64
         - Windows_NT_x64
         - Windows_NT_x86
-        helixQueueGroup: all
       ${{ if in(variables['Build.DefinitionName'], 'coreclr-corefx', 'coreclr-corefx-jitstress', 'coreclr-corefx-jitstressregs', 'coreclr-corefx-jitstress2-jitstressregs') }}:
         platforms:
         - Linux_x64
         - Windows_NT_x64
-        # We only want to run corefx testing on the minimum set of queues, no matter the build reason.
-        helixQueueGroup: pr
       ${{ if eq(variables['Build.DefinitionName'], 'coreclr-runincontext') }}:
         platforms:
         - Linux_x64
         - Windows_NT_x64
         - Windows_NT_x86
-        helixQueueGroup: all
 
 #
 # Release builds
@@ -197,7 +185,6 @@ jobs:
         - Windows_NT_arm
         - Windows_NT_arm64
         - Windows_NT_x64
-        helixQueueGroup: pr
       ${{ if and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
         platforms:
         - Linux_arm
@@ -205,7 +192,6 @@ jobs:
         - Linux_x64
         - OSX_x64
         - Windows_NT_x86
-        helixQueueGroup: ci
 
 - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng/platform-matrix.yml
@@ -213,7 +199,6 @@ jobs:
       jobTemplate: build-job.yml
       buildConfig: release
       platformGroup: all
-      helixQueueGroup: all
       jobParameters:
         # Publishing packages to blob feeds sometimes takes a long time
         # due to waiting for an exclusive lock on the feed.
@@ -444,8 +429,6 @@ jobs:
       platforms:
       - Linux_x64
       - Windows_NT_x64
-      # The format job only needs to run on one queue per platform.
-      helixQueueGroup: pr
 
 # Publish build information to Build Assets Registry
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,6 +99,7 @@ jobs:
         platforms:
         - Windows_NT_x64
         - Windows_NT_x86
+        helixQueueGroup: pr
       ${{ if and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
         platforms:
         - Linux_arm
@@ -110,6 +111,7 @@ jobs:
         - OSX_x64
         - Windows_NT_arm
         - Windows_NT_arm64
+        helixQueueGroup: ci
 
 #
 # Checked builds
@@ -130,27 +132,34 @@ jobs:
         - Windows_NT_arm64
         - Windows_NT_x64
         - Windows_NT_x86
+        helixQueueGroup: pr
       ${{ if and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
         platformGroup: all
+        helixQueueGroup: ci
       ${{ if in(variables['Build.DefinitionName'], 'coreclr-outerloop', 'coreclr-outerloop-jitstress', 'coreclr-outerloop-jitstressregs', 'coreclr-outerloop-jitstress2-jitstressregs') }}:
         platformGroup: all
+        helixQueueGroup: all
       ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-isas-arm') }}:
         platforms:
         - Linux_arm64
         - Windows_NT_arm64
+        helixQueueGroup: all
       ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-isas-x86') }}:
         platforms:
         - Linux_x64
         - OSX_x64
         - Windows_NT_x64
         - Windows_NT_x86
+        helixQueueGroup: all
       ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs-x86') }}:
         platforms:
         - Linux_x64
         - Windows_NT_x64
         - Windows_NT_x86
+        helixQueueGroup: all
       ${{ if in(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress0x3-gcstress0xc', 'coreclr-outerloop-gcstress-extra', 'coreclr-outerloop-r2r-extra') }}:
         platformGroup: gcstress
+        helixQueueGroup: all
       ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r') }}:
         platforms:
         - Linux_arm
@@ -158,17 +167,19 @@ jobs:
         - Linux_x64
         - Windows_NT_x64
         - Windows_NT_x86
+        helixQueueGroup: all
       ${{ if in(variables['Build.DefinitionName'], 'coreclr-corefx', 'coreclr-corefx-jitstress', 'coreclr-corefx-jitstressregs', 'coreclr-corefx-jitstress2-jitstressregs') }}:
         platforms:
         - Linux_x64
         - Windows_NT_x64
-        # We only want to run on a single, latest queue. We don't need to run on all the platforms.
-        helixQueueGroup: latest
+        # We only want to run corefx testing on the minimum set of queues, no matter the build reason.
+        helixQueueGroup: pr
       ${{ if eq(variables['Build.DefinitionName'], 'coreclr-runincontext') }}:
         platforms:
         - Linux_x64
         - Windows_NT_x64
         - Windows_NT_x86
+        helixQueueGroup: all
 
 #
 # Release builds
@@ -186,6 +197,7 @@ jobs:
         - Windows_NT_arm
         - Windows_NT_arm64
         - Windows_NT_x64
+        helixQueueGroup: pr
       ${{ if and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), eq(variables['Build.DefinitionName'], 'coreclr-ci')) }}:
         platforms:
         - Linux_arm
@@ -193,6 +205,7 @@ jobs:
         - Linux_x64
         - OSX_x64
         - Windows_NT_x86
+        helixQueueGroup: ci
 
 - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng/platform-matrix.yml
@@ -200,6 +213,7 @@ jobs:
       jobTemplate: build-job.yml
       buildConfig: release
       platformGroup: all
+      helixQueueGroup: all
       jobParameters:
         # Publishing packages to blob feeds sometimes takes a long time
         # due to waiting for an exclusive lock on the feed.
@@ -226,30 +240,37 @@ jobs:
         - Windows_NT_arm64
         - Windows_NT_x64
         - Windows_NT_x86
+        helixQueueGroup: pr
       ${{ if in(variables['Build.DefinitionName'], 'coreclr-outerloop', 'coreclr-outerloop-jitstress', 'coreclr-outerloop-jitstressregs', 'coreclr-outerloop-jitstress2-jitstressregs') }}:
         platformGroup: all
+        helixQueueGroup: all
       ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-isas-arm') }}:
         platforms:
         - Linux_arm64
         - Windows_NT_arm64
+        helixQueueGroup: all
       ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress-isas-x86') }}:
         platforms:
         - Linux_x64
         - OSX_x64
         - Windows_NT_x64
         - Windows_NT_x86
+        helixQueueGroup: all
       ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs-x86') }}:
         platforms:
         - Linux_x64
         - Windows_NT_x64
         - Windows_NT_x86
+        helixQueueGroup: all
       ${{ if in(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress0x3-gcstress0xc', 'coreclr-outerloop-gcstress-extra') }}:
         platformGroup: gcstress
+        helixQueueGroup: all
       ${{ if eq(variables['Build.DefinitionName'], 'coreclr-runincontext') }}:
         platforms:
         - Linux_x64
         - Windows_NT_x64
         - Windows_NT_x86
+        helixQueueGroup: all
       jobParameters:
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-ci') }}:
           testGroup: innerloop
@@ -289,6 +310,7 @@ jobs:
         - OSX_x64
         - Windows_NT_x64
         - Windows_NT_x86
+        helixQueueGroup: pr
       ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r') }}:
         platforms:
         - Linux_arm
@@ -296,8 +318,10 @@ jobs:
         - Linux_x64
         - Windows_NT_x64
         - Windows_NT_x86
+        helixQueueGroup: all
       ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r-extra') }}:
         platformGroup: gcstress # r2r-extra testGroup runs gcstress15 scenario
+        helixQueueGroup: all
       jobParameters:
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-ci') }}:
           testGroup: innerloop
@@ -325,8 +349,8 @@ jobs:
         platforms:
         - Linux_x64
         - Windows_NT_x64
-      # We only want to run on a single, latest queue. We don't need to run on all the platforms.
-      helixQueueGroup: latest
+      # We only want to run corefx testing on the minimum set of queues, no matter the build reason.
+      helixQueueGroup: pr
       jobParameters:
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-ci') }}:
           testGroup: innerloop
@@ -349,6 +373,7 @@ jobs:
       jobTemplate: test-job.yml
       buildConfig: checked
       platformGroup: all
+      helixQueueGroup: ci
       jobParameters:
         testGroup: outerloop
 
@@ -367,6 +392,7 @@ jobs:
       - Windows_NT_x86
       - Windows_NT_arm
       - Windows_NT_arm64
+      helixQueueGroup: ci
       jobParameters:
         testGroup: outerloop
         readyToRun: true
@@ -384,6 +410,7 @@ jobs:
       buildConfig: release
       platforms:
       - Linux_musl_x64
+      helixQueueGroup: pr
       jobParameters:
         testGroup: innerloop
 
@@ -394,6 +421,7 @@ jobs:
       jobTemplate: test-job.yml
       buildConfig: release
       platformGroup: all
+      helixQueueGroup: all
       jobParameters:
         testGroup: outerloop
 
@@ -402,6 +430,7 @@ jobs:
       jobTemplate: test-job.yml
       buildConfig: release
       platformGroup: all
+      helixQueueGroup: all
       jobParameters:
         testGroup: outerloop
         readyToRun: true
@@ -415,6 +444,8 @@ jobs:
       platforms:
       - Linux_x64
       - Windows_NT_x64
+      # The format job only needs to run on one queue per platform.
+      helixQueueGroup: pr
 
 # Publish build information to Build Assets Registry
 

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -8,10 +8,10 @@ parameters:
   platformGroup: ''
   # helixQueueGroup is a named collection of Helix Queues. If specified, it determines which Helix queues are
   # used, instead of the usual criteria. Allowed values:
-  # 'latest' - a single, recent queue for the platform
-  # 'comprehensive' - large set of queues for more comprehensive platform testing
-  # 'all' - all queues for the platform
-  helixQueueGroup: ''
+  # 'pr' - the queues used for a pull request for the platform. Typically a small set.
+  # 'ci' - the queues used for a CI (post-merge) test run.
+  # 'all' - the queues used for non-PR, non-CI test runs, e.g., Manual or Scheduled runs. Typically this is all available queues.
+  helixQueueGroup: 'pr'
   jobParameters: {}
 
 jobs:
@@ -31,9 +31,9 @@ jobs:
       containerName: ubuntu_1404_arm_cross_build_image
       helixQueues:
       # Ubuntu.1404.Arm32.Open is used only by CI while Ubuntu.1604.Arm32.Open serves PRs and scheduled builds.
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'ci')) }}:
         - Ubuntu.1404.Arm32.Open
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(parameters.helixQueueGroup, 'ci')) }}:
         - (Ubuntu.1804.Arm32.Open)Ubuntu.1604.Arm32.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-0a0ebdd-20190312215532
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - (Debian.9.Arm32)Ubuntu.1604.Arm32@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm32v7-0a0ebdd-20190312215452
@@ -55,7 +55,7 @@ jobs:
       helixQueues:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
         - (Ubuntu.1804.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-0a0ebdd-20190312220351
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(parameters.helixQueueGroup, 'pr', 'ci')) }}:
         - (Debian.9.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-0a0ebdd-20190312215438
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - (Debian.9.Arm64)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-0a0ebdd-20190312215438
@@ -126,15 +126,15 @@ jobs:
       osIdentifier: Linux
       containerName: centos7_x64_build_image
       helixQueues:
-      - ${{ if or(eq(parameters.helixQueueGroup, 'latest'), and(ne(parameters.helixQueueGroup, ''), eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI'))) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'pr', 'ci')) }}:
         - Ubuntu.1804.Amd64.Open
-      - ${{ if or(eq(parameters.helixQueueGroup, 'comprehensive'), and(ne(parameters.helixQueueGroup, ''), eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI'))) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(parameters.helixQueueGroup, 'pr', 'ci')) }}:
         - Debian.9.Amd64.Open
         - Ubuntu.1604.Amd64.Open
         - Ubuntu.1804.Amd64.Open
         - Centos.7.Amd64.Open
         - RedHat.7.Amd64.Open
-      - ${{ if or(eq(parameters.helixQueueGroup, 'all'), and(ne(parameters.helixQueueGroup, ''), eq(variables['System.TeamProject'], 'internal'))) }}:
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - Debian.9.Amd64
         - Ubuntu.1604.Amd64
         - Ubuntu.1804.Amd64
@@ -170,13 +170,13 @@ jobs:
       osGroup: OSX
       osIdentifier: OSX
       helixQueues:
-      - ${{ if or(eq(parameters.helixQueueGroup, 'latest'), and(ne(parameters.helixQueueGroup, ''), eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI'))) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'pr', 'ci')) }}:
         - OSX.1013.Amd64.Open
-      - ${{ if or(eq(parameters.helixQueueGroup, 'comprehensive'), and(ne(parameters.helixQueueGroup, ''), eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI'))) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(parameters.helixQueueGroup, 'pr', 'ci')) }}:
         - OSX.1012.Amd64.Open
         - OSX.1013.Amd64.Open
         - OSX.1014.Amd64.Open
-      - ${{ if or(eq(parameters.helixQueueGroup, 'all'), and(ne(parameters.helixQueueGroup, ''), eq(variables['System.TeamProject'], 'internal'))) }}:
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - OSX.1012.Amd64
         - OSX.1013.Amd64
         - OSX.1014.Amd64
@@ -192,9 +192,9 @@ jobs:
       osGroup: Windows_NT
       osIdentifier: Windows_NT
       helixQueues:
-      - ${{ if or(eq(parameters.helixQueueGroup, 'latest'), and(ne(parameters.helixQueueGroup, ''), eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI'))) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'pr', 'ci')) }}:
         - Windows.10.Amd64.Open
-      - ${{ if or(eq(parameters.helixQueueGroup, 'comprehensive'), and(ne(parameters.helixQueueGroup, ''), eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI'))) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(parameters.helixQueueGroup, 'pr', 'ci')) }}:
         # TODO: add Windows.10.Nano.Amd64.Open once https://github.com/dotnet/coreclr/issues/21693 has been resolved
         - Windows.7.Amd64.Open
         - Windows.81.Amd64.Open
@@ -217,9 +217,9 @@ jobs:
       osGroup: Windows_NT
       osIdentifier: Windows_NT
       helixQueues:
-      - ${{ if or(eq(parameters.helixQueueGroup, 'latest'), and(ne(parameters.helixQueueGroup, ''), eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI'))) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'pr', 'ci')) }}:
         - Windows.10.Amd64.Open
-      - ${{ if or(eq(parameters.helixQueueGroup, 'comprehensive'), and(ne(parameters.helixQueueGroup, ''), eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI'))) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(parameters.helixQueueGroup, 'pr', 'ci')) }}:
         - Windows.7.Amd64.Open
         - Windows.81.Amd64.Open
         - Windows.10.Amd64.Open
@@ -241,7 +241,7 @@ jobs:
       osIdentifier: Windows_NT
       helixQueues:
       # TODO: Due to the limited capacity of the machines in Windows.10.Arm64.Open queue limit this to CI builds and only to Windows_NT/arm
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'ci')) }}:
         - Windows.10.Arm64.Open
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - Windows.10.Arm64

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -199,7 +199,7 @@ jobs:
         - Windows.7.Amd64.Open
         - Windows.81.Amd64.Open
         - Windows.10.Amd64.Open
-      - ${{ if or(eq(parameters.helixQueueGroup, 'all'), and(ne(parameters.helixQueueGroup, ''), eq(variables['System.TeamProject'], 'internal'))) }}:
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - Windows.7.Amd64
         - Windows.81.Amd64
         - Windows.10.Amd64
@@ -223,7 +223,7 @@ jobs:
         - Windows.7.Amd64.Open
         - Windows.81.Amd64.Open
         - Windows.10.Amd64.Open
-      - ${{ if or(eq(parameters.helixQueueGroup, 'all'), and(ne(parameters.helixQueueGroup, ''), eq(variables['System.TeamProject'], 'internal'))) }}:
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - Windows.7.Amd64
         - Windows.81.Amd64
         - Windows.10.Amd64

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -6,6 +6,12 @@ parameters:
   # 'all' - all platforms
   # 'gcstress' - platforms that support running under GCStress0x3 and GCStress0xC scenarios
   platformGroup: ''
+  # helixQueueGroup is a named collection of Helix Queues. If specified, it determines which Helix queues are
+  # used, instead of the usual criteria. Allowed values:
+  # 'latest' - a single, recent queue for the platform
+  # 'comprehensive' - large set of queues for more comprehensive platform testing
+  # 'all' - all queues for the platform
+  helixQueueGroup: ''
   jobParameters: {}
 
 jobs:
@@ -120,15 +126,15 @@ jobs:
       osIdentifier: Linux
       containerName: centos7_x64_build_image
       helixQueues:
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+      - ${{ if or(eq(parameters.helixQueueGroup, 'latest'), and(ne(parameters.helixQueueGroup, ''), eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI'))) }}:
         - Ubuntu.1804.Amd64.Open
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+      - ${{ if or(eq(parameters.helixQueueGroup, 'comprehensive'), and(ne(parameters.helixQueueGroup, ''), eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI'))) }}:
         - Debian.9.Amd64.Open
         - Ubuntu.1604.Amd64.Open
         - Ubuntu.1804.Amd64.Open
         - Centos.7.Amd64.Open
         - RedHat.7.Amd64.Open
-      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      - ${{ if or(eq(parameters.helixQueueGroup, 'all'), and(ne(parameters.helixQueueGroup, ''), eq(variables['System.TeamProject'], 'internal'))) }}:
         - Debian.9.Amd64
         - Ubuntu.1604.Amd64
         - Ubuntu.1804.Amd64
@@ -164,13 +170,13 @@ jobs:
       osGroup: OSX
       osIdentifier: OSX
       helixQueues:
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+      - ${{ if or(eq(parameters.helixQueueGroup, 'latest'), and(ne(parameters.helixQueueGroup, ''), eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI'))) }}:
         - OSX.1013.Amd64.Open
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+      - ${{ if or(eq(parameters.helixQueueGroup, 'comprehensive'), and(ne(parameters.helixQueueGroup, ''), eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI'))) }}:
         - OSX.1012.Amd64.Open
         - OSX.1013.Amd64.Open
         - OSX.1014.Amd64.Open
-      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      - ${{ if or(eq(parameters.helixQueueGroup, 'all'), and(ne(parameters.helixQueueGroup, ''), eq(variables['System.TeamProject'], 'internal'))) }}:
         - OSX.1012.Amd64
         - OSX.1013.Amd64
         - OSX.1014.Amd64
@@ -186,14 +192,14 @@ jobs:
       osGroup: Windows_NT
       osIdentifier: Windows_NT
       helixQueues:
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+      - ${{ if or(eq(parameters.helixQueueGroup, 'latest'), and(ne(parameters.helixQueueGroup, ''), eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI'))) }}:
         - Windows.10.Amd64.Open
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+      - ${{ if or(eq(parameters.helixQueueGroup, 'comprehensive'), and(ne(parameters.helixQueueGroup, ''), eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI'))) }}:
         # TODO: add Windows.10.Nano.Amd64.Open once https://github.com/dotnet/coreclr/issues/21693 has been resolved
         - Windows.7.Amd64.Open
         - Windows.81.Amd64.Open
         - Windows.10.Amd64.Open
-      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      - ${{ if or(eq(parameters.helixQueueGroup, 'all'), and(ne(parameters.helixQueueGroup, ''), eq(variables['System.TeamProject'], 'internal'))) }}:
         - Windows.7.Amd64
         - Windows.81.Amd64
         - Windows.10.Amd64
@@ -211,13 +217,13 @@ jobs:
       osGroup: Windows_NT
       osIdentifier: Windows_NT
       helixQueues:
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+      - ${{ if or(eq(parameters.helixQueueGroup, 'latest'), and(ne(parameters.helixQueueGroup, ''), eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI'))) }}:
         - Windows.10.Amd64.Open
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI')) }}:
+      - ${{ if or(eq(parameters.helixQueueGroup, 'comprehensive'), and(ne(parameters.helixQueueGroup, ''), eq(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI'))) }}:
         - Windows.7.Amd64.Open
         - Windows.81.Amd64.Open
         - Windows.10.Amd64.Open
-      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      - ${{ if or(eq(parameters.helixQueueGroup, 'all'), and(ne(parameters.helixQueueGroup, ''), eq(variables['System.TeamProject'], 'internal'))) }}:
         - Windows.7.Amd64
         - Windows.81.Amd64
         - Windows.10.Amd64


### PR DESCRIPTION
Have azure-pipelines.yml specify the Helix queue group to use instead of platform-matrix.yml determining it by consulting the Build.Reason variable. This allows the corefx testing to force using a smaller queue group (just one queue per platform), to reduce corefx test load in the system. We don't believe running corefx-on-coreclr testing across multiple queues (e.g., different versions of Windows, or different flavors of Linux) provides valuable additional coverage above single queue coverage, and it has a high cost.