### PR TITLE
Store ARM volatile registers when populating RegDisplay

### DIFF
--- a/src/inc/regdisp.h
+++ b/src/inc/regdisp.h
@@ -406,6 +406,13 @@ inline void FillRegDisplay(const PREGDISPLAY pRD, PT_CONTEXT pctx, PT_CONTEXT pC
     FillContextPointers(&pRD->ctxPtrsOne, pctx);
 
 #if defined(_TARGET_ARM_)
+    // Fill volatile context pointers. They can be used by GC in the case of the leaf frame
+    pRD->volatileCurrContextPointers.R0 = &pctx->R0;
+    pRD->volatileCurrContextPointers.R1 = &pctx->R1;
+    pRD->volatileCurrContextPointers.R2 = &pctx->R2;
+    pRD->volatileCurrContextPointers.R3 = &pctx->R3;
+    pRD->volatileCurrContextPointers.R12 = &pctx->R12;
+
     pRD->ctxPtrsOne.Lr = &pctx->Lr;
     pRD->pPC = &pRD->pCurrentContext->Pc;
 #endif // _TARGET_ARM_


### PR DESCRIPTION
Porting ARM stepping fix from uwp6.2 to uwp6.1 branch.  
cherry-pick fab34e2b5cc6a9f07bdefcf18b6bc83fc4738f4f