### PR TITLE
JitBench: Run PowerShell with an execution policy

### DIFF
--- a/tests/src/performance/Scenario/JitBench/Benchmarks/WebAppBenchmarks.cs
+++ b/tests/src/performance/Scenario/JitBench/Benchmarks/WebAppBenchmarks.cs
@@ -102,7 +102,7 @@ namespace JitBench
             string tfm = DotNetSetup.GetTargetFrameworkMonikerForFrameworkVersion(dotNetInstall.FrameworkVersion);
             string storeDirName = ".store";
             await (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
-                    new ProcessRunner("powershell.exe", $".\\AspNet-GenerateStore.ps1 -InstallDir {storeDirName} -Architecture {dotNetInstall.Architecture} -Runtime win7-{dotNetInstall.Architecture}") :
+                    new ProcessRunner("powershell.exe", $"-ExecutionPolicy Bypass .\\AspNet-GenerateStore.ps1 -InstallDir {storeDirName} -Architecture {dotNetInstall.Architecture} -Runtime win7-{dotNetInstall.Architecture}") :
                     new ProcessRunner("bash", $"./aspnet-generatestore.sh --install-dir {storeDirName} --architecture {dotNetInstall.Architecture} --runtime-id linux-{dotNetInstall.Architecture} -f {tfm} --fx-version {dotNetInstall.FrameworkVersion}"))
                 .WithWorkingDirectory(GetJitBenchRepoRootDir(outputDir))
                 .WithEnvironmentVariable("PATH", $"{dotNetInstall.DotNetDir}{Path.PathSeparator}{Environment.GetEnvironmentVariable("PATH")}")


### PR DESCRIPTION
PowerShell is useless without this argument in default Windows configurations.