### PR TITLE
Add pipeline schedules to YAML file

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,6 +27,87 @@ trigger:
 pr:
 - master
 
+schedules:
+  - ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress') }}:
+    - cron: '0 20 * * *'
+      displayName: 'coreclr-outerloop-jitstress 8pm daily build'
+      branches:
+        include:
+        - master
+      always: true
+
+  - ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs') }}:
+    - cron: '0 2 * * 0,6'
+      displayName: 'coreclr-outerloop-jitstressregs 2am Sat/Sun build'
+      branches:
+        include:
+        - master
+      always: true
+
+  - ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress2-jitstressregs') }}:
+    - cron: '0 9 * * 0,6'
+      displayName: 'coreclr-outerloop-jitstress2-jitstressregs 9am Sat/Sun build'
+      branches:
+        include:
+        - master
+      always: true
+
+  - ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress0x3-gcstress0xc') }}:
+    - cron: '0 5 * * 0,6'
+      displayName: 'coreclr-outerloop-gcstress0x3-gcstress0xc 5pm Sat/Sun build'
+      branches:
+        include:
+        - master
+      always: true
+
+  - ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress-extra') }}:
+    - cron: '0 13 * * 0,6'
+      displayName: 'coreclr-outerloop-gcstress-extra 1pm Sat/Sun build'
+      branches:
+        include:
+        - master
+      always: true
+
+  - ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r-extra') }}:
+    - cron: '0 18 * * 0,6'
+      displayName: 'coreclr-outerloop-r2r-extra 6pm Sat/Sun build'
+      branches:
+        include:
+        - master
+      always: true
+
+  - ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx') }}:
+    - cron: '0 3 * * *'
+      displayName: 'coreclr-corefx 3am nightly build'
+      branches:
+        include:
+        - master
+      always: true
+
+  - ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstress') }}:
+    - cron: '30 0 * * *'
+      displayName: 'coreclr-corefx-jitstress 12:30am nightly build'
+      branches:
+        include:
+        - master
+      always: true
+
+  - ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstressregs') }}:
+    - cron: '0 4 * * *'
+      displayName: 'coreclr-corefx-jitstressregs 4am nightly build'
+      branches:
+        include:
+        - master
+      always: true
+
+  - ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstress2-jitstressregs') }}:
+    - cron: '30 1 * * *'
+      displayName: 'coreclr-corefx-jitstress2-jitstressregs 1:30am nightly build'
+      branches:
+        include:
+        - master
+      always: true
+
 jobs:
 
 ##   The following is the matrix of test runs that we have. This is

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ pr:
 - master
 
 schedules:
-  - ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress') }}:
+  ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress') }}:
     - cron: '0 20 * * *'
       displayName: 'coreclr-outerloop-jitstress 8pm daily build'
       branches:
@@ -36,7 +36,7 @@ schedules:
         - master
       always: true
 
-  - ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs') }}:
+  ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs') }}:
     - cron: '0 2 * * 0,6'
       displayName: 'coreclr-outerloop-jitstressregs 2am Sat/Sun build'
       branches:
@@ -44,7 +44,7 @@ schedules:
         - master
       always: true
 
-  - ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress2-jitstressregs') }}:
+  ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress2-jitstressregs') }}:
     - cron: '0 9 * * 0,6'
       displayName: 'coreclr-outerloop-jitstress2-jitstressregs 9am Sat/Sun build'
       branches:
@@ -52,7 +52,7 @@ schedules:
         - master
       always: true
 
-  - ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress0x3-gcstress0xc') }}:
+  ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress0x3-gcstress0xc') }}:
     - cron: '0 5 * * 0,6'
       displayName: 'coreclr-outerloop-gcstress0x3-gcstress0xc 5pm Sat/Sun build'
       branches:
@@ -60,7 +60,7 @@ schedules:
         - master
       always: true
 
-  - ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress-extra') }}:
+  ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress-extra') }}:
     - cron: '0 13 * * 0,6'
       displayName: 'coreclr-outerloop-gcstress-extra 1pm Sat/Sun build'
       branches:
@@ -68,7 +68,7 @@ schedules:
         - master
       always: true
 
-  - ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r-extra') }}:
+  ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r-extra') }}:
     - cron: '0 18 * * 0,6'
       displayName: 'coreclr-outerloop-r2r-extra 6pm Sat/Sun build'
       branches:
@@ -76,7 +76,7 @@ schedules:
         - master
       always: true
 
-  - ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx') }}:
+  ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx') }}:
     - cron: '0 3 * * *'
       displayName: 'coreclr-corefx 3am nightly build'
       branches:
@@ -84,7 +84,7 @@ schedules:
         - master
       always: true
 
-  - ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstress') }}:
+  ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstress') }}:
     - cron: '30 0 * * *'
       displayName: 'coreclr-corefx-jitstress 12:30am nightly build'
       branches:
@@ -92,7 +92,7 @@ schedules:
         - master
       always: true
 
-  - ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstressregs') }}:
+  ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstressregs') }}:
     - cron: '0 4 * * *'
       displayName: 'coreclr-corefx-jitstressregs 4am nightly build'
       branches:
@@ -100,7 +100,7 @@ schedules:
         - master
       always: true
 
-  - ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstress2-jitstressregs') }}:
+  ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstress2-jitstressregs') }}:
     - cron: '30 1 * * *'
       displayName: 'coreclr-corefx-jitstress2-jitstressregs 1:30am nightly build'
       branches:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,86 +27,95 @@ trigger:
 pr:
 - master
 
-schedules:
-  ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress') }}:
-    - cron: '0 20 * * *'
-      displayName: 'coreclr-outerloop-jitstress 8pm daily build'
-      branches:
-        include:
-        - master
-      always: true
+${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress') }}:
+  schedules:
+  - cron: '0 20 * * *'
+    displayName: 'coreclr-outerloop-jitstress 8pm daily build'
+    branches:
+      include:
+      - master
+    always: true
 
-  ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs') }}:
-    - cron: '0 2 * * 0,6'
-      displayName: 'coreclr-outerloop-jitstressregs 2am Sat/Sun build'
-      branches:
-        include:
-        - master
-      always: true
+${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs') }}:
+  schedules:
+  - cron: '0 2 * * 0,6'
+    displayName: 'coreclr-outerloop-jitstressregs 2am Sat/Sun build'
+    branches:
+      include:
+      - master
+    always: true
 
-  ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress2-jitstressregs') }}:
-    - cron: '0 9 * * 0,6'
-      displayName: 'coreclr-outerloop-jitstress2-jitstressregs 9am Sat/Sun build'
-      branches:
-        include:
-        - master
-      always: true
+${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress2-jitstressregs') }}:
+  schedules:
+  - cron: '0 9 * * 0,6'
+    displayName: 'coreclr-outerloop-jitstress2-jitstressregs 9am Sat/Sun build'
+    branches:
+      include:
+      - master
+    always: true
 
-  ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress0x3-gcstress0xc') }}:
-    - cron: '0 5 * * 0,6'
-      displayName: 'coreclr-outerloop-gcstress0x3-gcstress0xc 5pm Sat/Sun build'
-      branches:
-        include:
-        - master
-      always: true
+${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress0x3-gcstress0xc') }}:
+  schedules:
+  - cron: '0 5 * * 0,6'
+    displayName: 'coreclr-outerloop-gcstress0x3-gcstress0xc 5pm Sat/Sun build'
+    branches:
+      include:
+      - master
+    always: true
 
-  ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress-extra') }}:
-    - cron: '0 13 * * 0,6'
-      displayName: 'coreclr-outerloop-gcstress-extra 1pm Sat/Sun build'
-      branches:
-        include:
-        - master
-      always: true
+${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress-extra') }}:
+  schedules:
+  - cron: '0 13 * * 0,6'
+    displayName: 'coreclr-outerloop-gcstress-extra 1pm Sat/Sun build'
+    branches:
+      include:
+      - master
+    always: true
 
-  ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r-extra') }}:
-    - cron: '0 18 * * 0,6'
-      displayName: 'coreclr-outerloop-r2r-extra 6pm Sat/Sun build'
-      branches:
-        include:
-        - master
-      always: true
+${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r-extra') }}:
+  schedules:
+  - cron: '0 18 * * 0,6'
+    displayName: 'coreclr-outerloop-r2r-extra 6pm Sat/Sun build'
+    branches:
+      include:
+      - master
+    always: true
 
-  ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx') }}:
-    - cron: '0 3 * * *'
-      displayName: 'coreclr-corefx 3am nightly build'
-      branches:
-        include:
-        - master
-      always: true
+${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx') }}:
+  schedules:
+  - cron: '0 3 * * *'
+    displayName: 'coreclr-corefx 3am nightly build'
+    branches:
+      include:
+      - master
+    always: true
 
-  ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstress') }}:
-    - cron: '30 0 * * *'
-      displayName: 'coreclr-corefx-jitstress 12:30am nightly build'
-      branches:
-        include:
-        - master
-      always: true
+${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstress') }}:
+  schedules:
+  - cron: '30 0 * * *'
+    displayName: 'coreclr-corefx-jitstress 12:30am nightly build'
+    branches:
+      include:
+      - master
+    always: true
 
-  ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstressregs') }}:
-    - cron: '0 4 * * *'
-      displayName: 'coreclr-corefx-jitstressregs 4am nightly build'
-      branches:
-        include:
-        - master
-      always: true
+${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstressregs') }}:
+  schedules:
+  - cron: '0 4 * * *'
+    displayName: 'coreclr-corefx-jitstressregs 4am nightly build'
+    branches:
+      include:
+      - master
+    always: true
 
-  ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstress2-jitstressregs') }}:
-    - cron: '30 1 * * *'
-      displayName: 'coreclr-corefx-jitstress2-jitstressregs 1:30am nightly build'
-      branches:
-        include:
-        - master
-      always: true
+${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstress2-jitstressregs') }}:
+  schedules:
+  - cron: '30 1 * * *'
+    displayName: 'coreclr-corefx-jitstress2-jitstressregs 1:30am nightly build'
+    branches:
+      include:
+      - master
+    always: true
 
 jobs:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,8 +27,8 @@ trigger:
 pr:
 - master
 
-${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress') }}:
-  schedules:
+schedules:
+- ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress') }}:
   - cron: '0 20 * * *'
     displayName: 'coreclr-outerloop-jitstress 8pm daily build'
     branches:
@@ -36,8 +36,7 @@ ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress') }}:
       - master
     always: true
 
-${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs') }}:
-  schedules:
+- ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs') }}:
   - cron: '0 2 * * 0,6'
     displayName: 'coreclr-outerloop-jitstressregs 2am Sat/Sun build'
     branches:
@@ -45,8 +44,7 @@ ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstressregs') 
       - master
     always: true
 
-${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress2-jitstressregs') }}:
-  schedules:
+- ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress2-jitstressregs') }}:
   - cron: '0 9 * * 0,6'
     displayName: 'coreclr-outerloop-jitstress2-jitstressregs 9am Sat/Sun build'
     branches:
@@ -54,8 +52,7 @@ ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-jitstress2-jitst
       - master
     always: true
 
-${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress0x3-gcstress0xc') }}:
-  schedules:
+- ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress0x3-gcstress0xc') }}:
   - cron: '0 5 * * 0,6'
     displayName: 'coreclr-outerloop-gcstress0x3-gcstress0xc 5pm Sat/Sun build'
     branches:
@@ -63,8 +60,7 @@ ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress0x3-gcst
       - master
     always: true
 
-${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress-extra') }}:
-  schedules:
+- ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress-extra') }}:
   - cron: '0 13 * * 0,6'
     displayName: 'coreclr-outerloop-gcstress-extra 1pm Sat/Sun build'
     branches:
@@ -72,8 +68,7 @@ ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-gcstress-extra')
       - master
     always: true
 
-${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r-extra') }}:
-  schedules:
+- ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r-extra') }}:
   - cron: '0 18 * * 0,6'
     displayName: 'coreclr-outerloop-r2r-extra 6pm Sat/Sun build'
     branches:
@@ -81,8 +76,7 @@ ${{ if eq(variables['Build.DefinitionName'], 'coreclr-outerloop-r2r-extra') }}:
       - master
     always: true
 
-${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx') }}:
-  schedules:
+- ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx') }}:
   - cron: '0 3 * * *'
     displayName: 'coreclr-corefx 3am nightly build'
     branches:
@@ -90,8 +84,7 @@ ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx') }}:
       - master
     always: true
 
-${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstress') }}:
-  schedules:
+- ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstress') }}:
   - cron: '30 0 * * *'
     displayName: 'coreclr-corefx-jitstress 12:30am nightly build'
     branches:
@@ -99,8 +92,7 @@ ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstress') }}:
       - master
     always: true
 
-${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstressregs') }}:
-  schedules:
+- ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstressregs') }}:
   - cron: '0 4 * * *'
     displayName: 'coreclr-corefx-jitstressregs 4am nightly build'
     branches:
@@ -108,8 +100,7 @@ ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstressregs') }}:
       - master
     always: true
 
-${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstress2-jitstressregs') }}:
-  schedules:
+- ${{ if eq(variables['Build.DefinitionName'], 'coreclr-corefx-jitstress2-jitstressregs') }}:
   - cron: '30 1 * * *'
     displayName: 'coreclr-corefx-jitstress2-jitstressregs 1:30am nightly build'
     branches:


### PR DESCRIPTION
Schedules can no longer be specified in the UI; they must be
specified in the YAML file.

Extremely minimal documentation is here: https://docs.microsoft.com/en-us/azure/devops/release-notes/2019/sprint-153-update#use-cron-syntax-to-specify-schedules-in-a-yaml-file