### PR TITLE
Disable NativeVarargsTest on Windows Nano Server.

### DIFF
--- a/tests/src/Interop/IJW/NativeVarargs/NativeVarargsTest.cs
+++ b/tests/src/Interop/IJW/NativeVarargs/NativeVarargsTest.cs
@@ -17,7 +17,7 @@ namespace NativeVarargsTest
     {
         static int Main(string[] args)
         {
-            if(Environment.OSVersion.Platform != PlatformID.Win32NT || TestLibrary.Utilities.IsWindows7)
+            if(Environment.OSVersion.Platform != PlatformID.Win32NT || TestLibrary.Utilities.IsWindows7 || TestLibrary.Utilities.IsWindowsNanoServer)
             {
                 return 100;
             }


### PR DESCRIPTION
The MSVC++ redistributable isn't installed on the Windows 10 Nano Server docker images, so the NativeVarargs test fails to load. This PR disables the test on Nano Server.