### PR TITLE
Revert "ILMarshaler Refactor"

### DIFF
--- a/src/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -1485,21 +1485,21 @@ namespace System.StubHelpers
         }
     }
 
-    // Keeps an object instance alive across the full Managed->Native call.
+    // Keeps a Delegate instance alive across the full Managed->Native call.
     // This ensures that users don't have to call GC.KeepAlive after passing a struct or class
     // that has a delegate field to native code.
-    internal sealed class KeepAliveCleanupWorkListElement : CleanupWorkListElement
+    internal sealed class DelegateCleanupWorkListElement : CleanupWorkListElement
     {
-        public KeepAliveCleanupWorkListElement(object obj)
+        public DelegateCleanupWorkListElement(Delegate del)
         {
-            m_obj = obj;
+            m_del = del;
         }
 
-        private object m_obj;
+        private Delegate m_del;
 
         protected override void DestroyCore()
         {
-            GC.KeepAlive(m_obj);
+            GC.KeepAlive(m_del);
         }
     }
 
@@ -1562,9 +1562,9 @@ namespace System.StubHelpers
             return element.AddRef();
         }
 
-        internal static void KeepAliveViaCleanupList(ref CleanupWorkListElement pCleanupWorkList, object obj)
+        internal static void AddToCleanupList(ref CleanupWorkListElement pCleanupWorkList, Delegate del)
         {
-            KeepAliveCleanupWorkListElement element = new KeepAliveCleanupWorkListElement(obj);
+            DelegateCleanupWorkListElement element = new DelegateCleanupWorkListElement(del);
             CleanupWorkListElement.AddToCleanupList(ref pCleanupWorkList, element);
         }
 

--- a/src/vm/fieldmarshaler.cpp
+++ b/src/vm/fieldmarshaler.cpp
@@ -3064,7 +3064,7 @@ VOID FieldMarshaler_Delegate::UpdateNativeImpl(OBJECTREF* pCLRValue, LPVOID pNat
     if (*pCLRValue != NULL && ppCleanupWorkListOnStack != NULL)
     {
         // Call StubHelpers.AddToCleanupList to ensure the delegate is kept alive across the full native call.
-        MethodDescCallSite AddToCleanupList(METHOD__STUBHELPERS__KEEP_ALIVE_VIA_CLEANUP_LIST);
+        MethodDescCallSite AddToCleanupList(METHOD__STUBHELPERS__ADD_TO_CLEANUP_LIST_DELEGATE);
 
         ARG_SLOT args[] =
         {

--- a/src/vm/ilmarshalers.cpp
+++ b/src/vm/ilmarshalers.cpp
@@ -78,17 +78,17 @@ void ILReflectionObjectMarshaler::EmitConvertContentsCLRToNative(ILCodeStream* p
 
     if (IsCLRToNative(m_dwMarshalFlags))
     {
-        EmitLoadCleanupWorkList(pslILEmit);
+        // keep the object alive across the call-out to native
         if (tokStruct__m_object != 0)
         {
-            EmitLoadManagedHomeAddr(pslILEmit);
-            pslILEmit->EmitLDFLD(tokStruct__m_object);
+            EmitLoadManagedHomeAddr(m_pcsUnmarshal);
+            m_pcsUnmarshal->EmitLDFLD(tokStruct__m_object);
         }
         else
         {
-            EmitLoadManagedValue(pslILEmit);
+            EmitLoadManagedValue(m_pcsUnmarshal);
         }
-        pslILEmit->EmitCALL(METHOD__STUBHELPERS__KEEP_ALIVE_VIA_CLEANUP_LIST, 2, 0);
+        m_pcsUnmarshal->EmitCALL(METHOD__GC__KEEP_ALIVE, 1, 0);
     }
 }
 
@@ -128,11 +128,18 @@ void ILDelegateMarshaler::EmitConvertContentsCLRToNative(ILCodeStream* pslILEmit
     EmitLoadManagedValue(pslILEmit);
     pslILEmit->EmitCALL(METHOD__MARSHAL__GET_FUNCTION_POINTER_FOR_DELEGATE, 1, 1);
     EmitStoreNativeValue(pslILEmit);
-    EmitLoadCleanupWorkList(pslILEmit);
-    EmitLoadManagedValue(pslILEmit);
-    pslILEmit->EmitCALL(METHOD__STUBHELPERS__KEEP_ALIVE_VIA_CLEANUP_LIST, 2, 0);
     
     pslILEmit->EmitLabel(pNullLabel);
+
+    //
+    // @TODO: is there a better way to do this?
+    //
+    if (IsCLRToNative(m_dwMarshalFlags))
+    {
+        // keep the delegate ref alive across the call-out to native
+        EmitLoadManagedValue(m_pcsUnmarshal);
+        m_pcsUnmarshal->EmitCALL(METHOD__GC__KEEP_ALIVE, 1, 0);
+    }
 }
 
 void ILDelegateMarshaler::EmitConvertContentsNativeToCLR(ILCodeStream* pslILEmit)
@@ -301,6 +308,41 @@ void ILWSTRMarshaler::EmitConvertContentsNativeToCLR(ILCodeStream* pslILEmit)
     pslILEmit->EmitLabel(pIsNullLabel);
 }    
 
+bool ILWSTRMarshaler::NeedsClearNative()
+{
+    LIMITED_METHOD_CONTRACT;
+
+    // will evaluate to true iff there is something CoTaskMemAlloc'ed that we need to free
+    bool needsClear = (IsByref(m_dwMarshalFlags) && IsOut(m_dwMarshalFlags)) || IsRetval(m_dwMarshalFlags);
+    
+    // m_fCoMemoryAllocated => needsClear
+    // (if we allocated the memory, we will free it; for byref [out] and retval we free memory allocated by the callee)
+    _ASSERTE(!m_fCoMemoryAllocated || needsClear);
+
+    return needsClear;
+}
+
+void ILWSTRMarshaler::EmitClearNative(ILCodeStream* pslILEmit)
+{
+    STANDARD_VM_CONTRACT;
+
+    EmitLoadNativeValue(pslILEmit);
+    // static void CoTaskMemFree(IntPtr ptr)
+    pslILEmit->EmitCALL(METHOD__MARSHAL__FREE_CO_TASK_MEM, 1, 0);
+}
+
+void ILWSTRMarshaler::EmitClearNativeTemp(ILCodeStream* pslILEmit)
+{
+    LIMITED_METHOD_CONTRACT;
+    UNREACHABLE_MSG("The string is either pinned or a copy is stack-allocated, NeedsClearNative should have returned false");
+}
+
+bool ILWSTRMarshaler::CanUsePinnedManagedString(DWORD dwMarshalFlags)
+{
+    LIMITED_METHOD_CONTRACT;
+    return IsCLRToNative(dwMarshalFlags) && !IsByref(dwMarshalFlags) && IsIn(dwMarshalFlags) && !IsOut(dwMarshalFlags);
+}
+
 //
 // input stack:  0: managed string
 // output stack: 0: (string_length+1) * sizeof(WCHAR)
@@ -320,6 +362,8 @@ void ILWSTRMarshaler::EmitCheckManagedStringLength(ILCodeStream* pslILEmit)
 void ILWSTRMarshaler::EmitConvertSpaceAndContentsCLRToNative(ILCodeStream* pslILEmit)
 {
     STANDARD_VM_CONTRACT;
+
+    INDEBUG(m_fCoMemoryAllocated = true);
 
     ILCodeLabel* pNullRefLabel = pslILEmit->NewCodeLabel();
     DWORD dwLengthLocalNum = pslILEmit->NewLocal(ELEMENT_TYPE_I4);
@@ -356,87 +400,73 @@ void ILWSTRMarshaler::EmitConvertSpaceAndContentsCLRToNative(ILCodeStream* pslIL
     pslILEmit->EmitLabel(pNullRefLabel);
 }
 
-void ILWSTRMarshaler::EmitMarshalViaPinning(ILCodeStream* pslILEmit)
-{
-    STANDARD_VM_CONTRACT;
-
-    LocalDesc locDesc = GetManagedType();
-    locDesc.MakePinned();
-    DWORD dwPinnedLocal = pslILEmit->NewLocal(locDesc);
-    int fieldDef = pslILEmit->GetToken(MscorlibBinder::GetField(FIELD__STRING__M_FIRST_CHAR));
-    ILCodeLabel* pNullRefLabel = pslILEmit->NewCodeLabel();
-    
-    pslILEmit->EmitLoadNullPtr();
-    EmitStoreNativeValue(pslILEmit);
-
-    EmitLoadManagedValue(pslILEmit);
-    pslILEmit->EmitBRFALSE(pNullRefLabel);
-
-    EmitLoadManagedValue(pslILEmit);
-    pslILEmit->EmitSTLOC(dwPinnedLocal);
-    pslILEmit->EmitLDLOC(dwPinnedLocal);
-    pslILEmit->EmitLDFLDA(fieldDef);
-    EmitStoreNativeValue(pslILEmit);
-
-    EmitLogNativeArgumentsIfNeeded(pslILEmit, dwPinnedLocal);
-
-    pslILEmit->EmitLabel(pNullRefLabel);
-}
-
 void ILWSTRMarshaler::EmitConvertSpaceAndContentsCLRToNativeTemp(ILCodeStream* pslILEmit)
 {
     STANDARD_VM_CONTRACT;
 
-    ILCodeLabel* pNullRefLabel = pslILEmit->NewCodeLabel();
-    DWORD dwLengthLocalNum = pslILEmit->NewLocal(ELEMENT_TYPE_I4);
-    
-    pslILEmit->EmitLoadNullPtr();
-    EmitStoreNativeValue(pslILEmit);
-    
-    EmitLoadManagedValue(pslILEmit);
-    pslILEmit->EmitBRFALSE(pNullRefLabel);
-    
-    EmitLoadManagedValue(pslILEmit);
-    EmitCheckManagedStringLength(pslILEmit);
+    if (CanUsePinnedManagedString(m_dwMarshalFlags))
+    {
+        LocalDesc locDesc = GetManagedType();
+        locDesc.MakePinned();
+        DWORD dwPinnedLocal = pslILEmit->NewLocal(locDesc);
+        int fieldDef = pslILEmit->GetToken(MscorlibBinder::GetField(FIELD__STRING__M_FIRST_CHAR));
+        ILCodeLabel* pNullRefLabel = pslILEmit->NewCodeLabel();
+        
+        pslILEmit->EmitLoadNullPtr();
+        EmitStoreNativeValue(pslILEmit);
 
-    pslILEmit->EmitSTLOC(dwLengthLocalNum);
+        EmitLoadManagedValue(pslILEmit);
+        pslILEmit->EmitBRFALSE(pNullRefLabel);
 
-    ILCodeLabel* pAllocRejoin = pslILEmit->NewCodeLabel();
-    ILCodeLabel* pNoOptimize = pslILEmit->NewCodeLabel();
-    m_dwLocalBuffer = pslILEmit->NewLocal(ELEMENT_TYPE_I);
+        EmitLoadManagedValue(pslILEmit);
+        pslILEmit->EmitSTLOC(dwPinnedLocal);
+        pslILEmit->EmitLDLOC(dwPinnedLocal);
+        pslILEmit->EmitLDFLDA(fieldDef);
+        EmitStoreNativeValue(pslILEmit);
 
-    // LocalBuffer = 0
-    pslILEmit->EmitLoadNullPtr();
-    pslILEmit->EmitSTLOC(m_dwLocalBuffer);
+        if (g_pConfig->InteropLogArguments())
+        {
+            m_pslNDirect->EmitLogNativeArgument(pslILEmit, dwPinnedLocal);
+        }
 
-    pslILEmit->EmitLDLOC(dwLengthLocalNum);
-    // if (alloc_size_in_bytes > MAX_LOCAL_BUFFER_LENGTH) goto NoOptimize
-    pslILEmit->EmitDUP();
-    pslILEmit->EmitLDC(MAX_LOCAL_BUFFER_LENGTH);
-    pslILEmit->EmitCGT_UN();
-    pslILEmit->EmitBRTRUE(pNoOptimize);
+        pslILEmit->EmitLabel(pNullRefLabel);
 
-    pslILEmit->EmitLOCALLOC();
-    pslILEmit->EmitDUP();
-    pslILEmit->EmitSTLOC(m_dwLocalBuffer);
-    pslILEmit->EmitBR(pAllocRejoin);
+    }
+    else
+    {
+        ILCodeLabel* pNullRefLabel = pslILEmit->NewCodeLabel();
+        DWORD dwLengthLocalNum = pslILEmit->NewLocal(ELEMENT_TYPE_I4);
+        
+        pslILEmit->EmitLoadNullPtr();
+        EmitStoreNativeValue(pslILEmit);
+        
+        EmitLoadManagedValue(pslILEmit);
+        pslILEmit->EmitBRFALSE(pNullRefLabel);
+        
+        EmitLoadManagedValue(pslILEmit);
+        EmitCheckManagedStringLength(pslILEmit);
 
-    pslILEmit->EmitLabel(pNoOptimize);
+        // cb
 
-    pslILEmit->EmitCALL(METHOD__MARSHAL__ALLOC_CO_TASK_MEM, 1, 1);
-    pslILEmit->EmitLabel(pAllocRejoin);
-    EmitStoreNativeValue(pslILEmit);
+        pslILEmit->EmitDUP();
+        pslILEmit->EmitSTLOC(dwLengthLocalNum);
 
-    EmitLoadManagedValue(pslILEmit);
-    EmitLoadNativeValue(pslILEmit);
+        // cb
 
-    // src, dst
+        pslILEmit->EmitLOCALLOC();              // @TODO: add a non-localloc path for large strings
+        EmitStoreNativeValue(pslILEmit);
 
-    pslILEmit->EmitLDLOC(dwLengthLocalNum); // length
-    
-    // static void System.String.InternalCopy(String src, IntPtr dest,int len)
-    pslILEmit->EmitCALL(METHOD__STRING__INTERNAL_COPY, 3, 0);
-    pslILEmit->EmitLabel(pNullRefLabel);
+        EmitLoadManagedValue(pslILEmit);
+        EmitLoadNativeValue(pslILEmit);
+
+        // src, dst
+
+        pslILEmit->EmitLDLOC(dwLengthLocalNum); // length
+        
+        // static void System.String.InternalCopy(String src, IntPtr dest,int len)
+        pslILEmit->EmitCALL(METHOD__STRING__INTERNAL_COPY, 3, 0);
+        pslILEmit->EmitLabel(pNullRefLabel);
+    }
 }
 
 //
@@ -1100,7 +1130,7 @@ void ILValueClassMarshaler::EmitConvertContentsCLRToNative(ILCodeStream* pslILEm
     pslILEmit->EmitLDTOKEN(managedVCToken); // pMT
     pslILEmit->EmitCALL(METHOD__RT_TYPE_HANDLE__GETVALUEINTERNAL, 1, 1); // Convert RTH to IntPtr
 
-    EmitLoadCleanupWorkList(pslILEmit);
+    m_pslNDirect->LoadCleanupWorkList(pslILEmit);
     pslILEmit->EmitCALL(METHOD__VALUECLASSMARSHALER__CONVERT_TO_NATIVE, 4, 0);        // void ConvertToNative(IntPtr dst, IntPtr src, IntPtr pMT, ref CleanupWorkListElement pCleanupWorkList)
 }
 
@@ -1368,9 +1398,8 @@ void ILInterfaceMarshaler::EmitConvertContentsCLRToNative(ILCodeStream* pslILEmi
         //
         // The fix is to extend the lifetime of the argument across the call to native by doing a GC.KeepAlive
         // keep the delegate ref alive across the call-out to native
-        EmitLoadCleanupWorkList(pslILEmit);
-        EmitLoadManagedValue(pslILEmit);
-        pslILEmit->EmitCALL(METHOD__STUBHELPERS__KEEP_ALIVE_VIA_CLEANUP_LIST, 2, 0);
+        EmitLoadManagedValue(m_pcsUnmarshal);
+        m_pcsUnmarshal->EmitCALL(METHOD__GC__KEEP_ALIVE, 1, 0);
     }
 }
 
@@ -1570,16 +1599,15 @@ bool ILVBByValStrWMarshaler::IsNativePassedByRef()
     return false;
 }
 
-void ILVBByValStrWMarshaler::EmitSetupArgumentForMarshalling(ILCodeStream* pslILEmit)
-{
-    m_dwLocalBuffer = pslILEmit->NewLocal(ELEMENT_TYPE_I);
-    pslILEmit->EmitLoadNullPtr();
-    pslILEmit->EmitSTLOC(m_dwLocalBuffer);
-}
-
 void ILVBByValStrWMarshaler::EmitConvertContentsCLRToNative(ILCodeStream* pslILEmit)
 {
     STANDARD_VM_CONTRACT;
+
+    ILCodeStream *pcsSetup = m_pslNDirect->GetSetupCodeStream();
+    m_dwLocalBuffer = pcsSetup->NewLocal(ELEMENT_TYPE_I);
+    pcsSetup->EmitLoadNullPtr();
+    pcsSetup->EmitSTLOC(m_dwLocalBuffer);
+
 
     ILCodeLabel* pNullRefLabel = pslILEmit->NewCodeLabel();
     m_dwCCHLocal = pslILEmit->NewLocal(ELEMENT_TYPE_I4);
@@ -1985,7 +2013,10 @@ void ILHSTRINGMarshaler::EmitConvertCLRToHSTRINGReference(ILCodeStream* pslILEmi
     pslILEmit->EmitLDLOCA(dwHStringHeaderLocal);
     pslILEmit->EmitCALL(METHOD__HSTRINGMARSHALER__CONVERT_TO_NATIVE_REFERENCE, 2, 1);
 
-    EmitLogNativeArgumentsIfNeeded(pslILEmit, dwPinnedStringLocal);
+    if (g_pConfig->InteropLogArguments())
+    {
+        m_pslNDirect->EmitLogNativeArgument(pslILEmit, dwPinnedStringLocal);
+    }
 
     EmitStoreNativeValue(pslILEmit);
 }
@@ -2376,7 +2407,7 @@ void ILLayoutClassPtrMarshaler::EmitConvertContentsCLRToNative(ILCodeStream* psl
     EmitLoadManagedValue(pslILEmit);
     EmitLoadNativeValue(pslILEmit);
 
-    EmitLoadCleanupWorkList(pslILEmit);
+    m_pslNDirect->LoadCleanupWorkList(pslILEmit);
 
     // static void FmtClassUpdateNativeInternal(object obj, byte* pNative, IntPtr pOptionalCleanupList);
 
@@ -2460,41 +2491,43 @@ void ILBlittablePtrMarshaler::EmitConvertContentsNativeToCLR(ILCodeStream* pslIL
     pslILEmit->EmitLabel(pNullRefLabel);
 }
 
-bool ILBlittablePtrMarshaler::CanUsePinnedLayoutClass()
+void ILBlittablePtrMarshaler::EmitMarshalArgumentCLRToNative()
 {
-    return IsCLRToNative(m_dwMarshalFlags) && !IsByref(m_dwMarshalFlags);
-}
-
-void ILBlittablePtrMarshaler::EmitConvertSpaceAndContentsCLRToNativeTemp(ILCodeStream* pslILEmit)
-{
-    STANDARD_VM_CONTRACT;
-
-    if (CanUsePinnedLayoutClass())
+    CONTRACTL
     {
-        ILCodeLabel* pSkipAddLabel = pslILEmit->NewCodeLabel();
-        LocalDesc managedTypePinned = GetManagedType();
-        managedTypePinned.MakePinned();
-        DWORD dwPinnedLocal = pslILEmit->NewLocal(managedTypePinned);
-
-        EmitLoadManagedValue(pslILEmit);
-
-        pslILEmit->EmitSTLOC(dwPinnedLocal);
-        pslILEmit->EmitLDLOC(dwPinnedLocal);
-        pslILEmit->EmitCONV_U();
-        pslILEmit->EmitDUP();
-        pslILEmit->EmitBRFALSE(pSkipAddLabel);
-        pslILEmit->EmitLDC(Object::GetOffsetOfFirstField());
-        pslILEmit->EmitADD();
-        pslILEmit->EmitLabel(pSkipAddLabel);
-
-        EmitLogNativeArgumentsIfNeeded(pslILEmit, dwPinnedLocal);
-
-        EmitStoreNativeValue(pslILEmit);
+        STANDARD_VM_CHECK;
+        PRECONDITION(IsCLRToNative(m_dwMarshalFlags) && !IsByref(m_dwMarshalFlags));
     }
-    else
+    CONTRACTL_END;
+
+    EmitSetupSigAndDefaultHomesCLRToNative();
+
+    //
+    // marshal
+    //
+
+    ILCodeLabel* pSkipAddLabel = m_pcsMarshal->NewCodeLabel();
+    LocalDesc managedTypePinned = GetManagedType();
+    managedTypePinned.MakePinned();
+    DWORD dwPinnedLocal = m_pcsMarshal->NewLocal(managedTypePinned);
+
+    EmitLoadManagedValue(m_pcsMarshal);
+    
+    m_pcsMarshal->EmitSTLOC(dwPinnedLocal);
+    m_pcsMarshal->EmitLDLOC(dwPinnedLocal);
+    m_pcsMarshal->EmitCONV_U();
+    m_pcsMarshal->EmitDUP();
+    m_pcsMarshal->EmitBRFALSE(pSkipAddLabel);
+    m_pcsMarshal->EmitLDC(Object::GetOffsetOfFirstField());
+    m_pcsMarshal->EmitADD();
+    m_pcsMarshal->EmitLabel(pSkipAddLabel);
+
+    if (g_pConfig->InteropLogArguments())
     {
-        ILLayoutClassPtrMarshalerBase::EmitConvertSpaceAndContentsCLRToNativeTemp(pslILEmit);
+        m_pslNDirect->EmitLogNativeArgument(m_pcsMarshal, dwPinnedLocal);
     }
+
+    EmitStoreNativeValue(m_pcsMarshal);
 }
 
 
@@ -2565,6 +2598,78 @@ MarshalerOverrideStatus ILHandleRefMarshaler::ReturnOverride(NDirectStubLinker* 
     return DISALLOWED;
 }
 
+LocalDesc ILSafeHandleMarshaler::GetManagedType()
+{
+    STANDARD_VM_CONTRACT;
+
+    return LocalDesc(MscorlibBinder::GetClass(CLASS__SAFE_HANDLE));
+}
+
+LocalDesc ILSafeHandleMarshaler::GetNativeType()
+{
+    LIMITED_METHOD_CONTRACT;
+
+    return LocalDesc(ELEMENT_TYPE_I);
+}
+
+bool ILSafeHandleMarshaler::NeedsClearNative()
+{
+    LIMITED_METHOD_CONTRACT;
+    return true;
+}
+
+void ILSafeHandleMarshaler::EmitClearNative(ILCodeStream* pslILEmit)
+{
+    STANDARD_VM_CONTRACT;
+
+    _ASSERTE(IsCLRToNative(m_dwMarshalFlags) && !IsByref(m_dwMarshalFlags));
+
+    // call StubHelpers::SafeHandleRelease
+    EmitLoadManagedValue(pslILEmit);
+    pslILEmit->EmitCALL(METHOD__STUBHELPERS__SAFE_HANDLE_RELEASE, 1, 0);
+}
+
+void ILSafeHandleMarshaler::EmitMarshalArgumentCLRToNative()
+{
+    CONTRACTL
+    {
+        STANDARD_VM_CHECK;
+        PRECONDITION(IsCLRToNative(m_dwMarshalFlags) && !IsByref(m_dwMarshalFlags));
+    }
+    CONTRACTL_END;
+
+    EmitSetupSigAndDefaultHomesCLRToNative();
+
+    // by-value CLR-to-native SafeHandle is always passed in-only regardless of [In], [Out]
+    // marshal and cleanup communicate via an extra local and are both emitted in this method
+
+    // bool <dwHandleAddRefedLocalNum> = false
+    ILCodeStream *pcsSetup = m_pslNDirect->GetSetupCodeStream();
+    DWORD dwHandleAddRefedLocalNum = pcsSetup->NewLocal(ELEMENT_TYPE_BOOLEAN);
+    
+    pcsSetup->EmitLDC(0);
+    pcsSetup->EmitSTLOC(dwHandleAddRefedLocalNum);
+
+    // <nativeHandle> = StubHelpers::SafeHandleAddRef(<managedSH>, ref <dwHandleAddRefedLocalNum>)
+    EmitLoadManagedValue(m_pcsMarshal);
+    m_pcsMarshal->EmitLDLOCA(dwHandleAddRefedLocalNum);
+    m_pcsMarshal->EmitCALL(METHOD__STUBHELPERS__SAFE_HANDLE_ADD_REF, 2, 1);
+    EmitStoreNativeValue(m_pcsMarshal);
+
+    // cleanup:
+    // if (<dwHandleAddRefedLocalNum>) StubHelpers.SafeHandleRelease(<managedSH>)
+    ILCodeStream *pcsCleanup = m_pslNDirect->GetCleanupCodeStream();
+    ILCodeLabel *pSkipClearNativeLabel = pcsCleanup->NewCodeLabel();
+
+    pcsCleanup->EmitLDLOC(dwHandleAddRefedLocalNum);
+    pcsCleanup->EmitBRFALSE(pSkipClearNativeLabel);
+
+    EmitClearNativeTemp(pcsCleanup);
+    m_pslNDirect->SetCleanupNeeded();
+
+    pcsCleanup->EmitLabel(pSkipClearNativeLabel);
+}
+
 MarshalerOverrideStatus ILSafeHandleMarshaler::ArgumentOverride(NDirectStubLinker* psl,
                                                 BOOL               byref,
                                                 BOOL               fin,
@@ -2588,9 +2693,10 @@ MarshalerOverrideStatus ILSafeHandleMarshaler::ArgumentOverride(NDirectStubLinke
 
     if (fManagedToNative)
     {
-        pslIL->SetStubTargetArgType(ELEMENT_TYPE_I);
         if (byref)
         {
+            pslIL->SetStubTargetArgType(ELEMENT_TYPE_I);
+
             // The specific SafeHandle subtype we're dealing with here.
             MethodTable *pHandleType = pargs->m_pMT;
 
@@ -2735,13 +2841,14 @@ MarshalerOverrideStatus ILSafeHandleMarshaler::ArgumentOverride(NDirectStubLinke
         }
         else
         {
-            DWORD dwNativeHandle = pslIL->NewLocal(ELEMENT_TYPE_I);
-            psl->LoadCleanupWorkList(pslIL);
-            pslIL->EmitLDARG(argidx);
-            pslIL->EmitCALL(METHOD__STUBHELPERS__ADD_TO_CLEANUP_LIST_SAFEHANDLE, 2, 1);
-            pslIL->EmitSTLOC(dwNativeHandle);
-
-            pslILDispatch->EmitLDLOC(dwNativeHandle);
+            // Avoid using the cleanup list in this common case for perf reasons (cleanup list is
+            // unmanaged and destroying it means excessive managed<->native transitions; in addition,
+            // as X86 IL stubs do not use interop frames, there's nothing protecting the cleanup list
+            // and the SafeHandle references must be GC handles which does not help perf either).
+            //
+            // This code path generates calls to StubHelpers.SafeHandleAddRef and SafeHandleRelease.
+            // NICE: Could SafeHandle.DangerousAddRef and DangerousRelease be implemented in managed?
+            return HANDLEASNORMAL;
         }
 
         return OVERRIDDEN;
@@ -3299,34 +3406,55 @@ bool ILArgIteratorMarshaler::SupportsArgumentMarshal(DWORD dwMarshalFlags, UINT*
     return true;
 }
 
-void ILArgIteratorMarshaler::EmitConvertSpaceAndContentsCLRToNative(ILCodeStream* pslILEmit)
+void ILArgIteratorMarshaler::EmitMarshalArgumentCLRToNative()
 {
-    STANDARD_VM_CONTRACT;
+    CONTRACTL
+    {
+        STANDARD_VM_CHECK;
+        PRECONDITION(IsCLRToNative(m_dwMarshalFlags) && !IsByref(m_dwMarshalFlags));
+    }
+    CONTRACTL_END;
+
+    EmitSetupSigAndDefaultHomesCLRToNative();
+    
+    //
+    // marshal
+    //
 
     // Allocate enough memory for va_list
-    DWORD dwVaListSizeLocal = pslILEmit->NewLocal(LocalDesc(ELEMENT_TYPE_U4));
-    EmitLoadManagedHomeAddr(pslILEmit);
-    pslILEmit->EmitCALL(METHOD__STUBHELPERS__CALC_VA_LIST_SIZE, 1, 1);
-    pslILEmit->EmitSTLOC(dwVaListSizeLocal);
-    pslILEmit->EmitLDLOC(dwVaListSizeLocal);
-    pslILEmit->EmitLOCALLOC();
-    EmitStoreNativeValue(pslILEmit);
-
-    // void MarshalToUnmanagedVaListInternal(va_list, uint vaListSize, VARARGS* data)
-    EmitLoadNativeValue(pslILEmit);
-    pslILEmit->EmitLDLOC(dwVaListSizeLocal);
-    EmitLoadManagedHomeAddr(pslILEmit);
-    pslILEmit->EmitCALL(METHOD__STUBHELPERS__MARSHAL_TO_UNMANAGED_VA_LIST_INTERNAL, 3, 0);
+    DWORD dwVaListSizeLocal = m_pcsMarshal->NewLocal(LocalDesc(ELEMENT_TYPE_U4));
+    EmitLoadManagedHomeAddr(m_pcsMarshal);
+    m_pcsMarshal->EmitCALL(METHOD__STUBHELPERS__CALC_VA_LIST_SIZE, 1, 1);
+    m_pcsMarshal->EmitSTLOC(dwVaListSizeLocal);    
+    m_pcsMarshal->EmitLDLOC(dwVaListSizeLocal);
+    m_pcsMarshal->EmitLOCALLOC();
+    EmitStoreNativeValue(m_pcsMarshal);
+    
+    // void MarshalToUnmanagedVaListInternal(cbVaListSize, va_list, VARARGS* data)
+    EmitLoadNativeValue(m_pcsMarshal);
+    m_pcsMarshal->EmitLDLOC(dwVaListSizeLocal);
+    EmitLoadManagedHomeAddr(m_pcsMarshal);
+    m_pcsMarshal->EmitCALL(METHOD__STUBHELPERS__MARSHAL_TO_UNMANAGED_VA_LIST_INTERNAL, 3, 0);
 }
 
-void ILArgIteratorMarshaler::EmitConvertContentsNativeToCLR(ILCodeStream* pslILEmit)
+void ILArgIteratorMarshaler::EmitMarshalArgumentNativeToCLR()
 {
-    EmitLoadNativeValue(pslILEmit);
-    EmitLoadManagedHomeAddr(pslILEmit);
+    CONTRACTL
+    {
+        STANDARD_VM_CHECK;
+        PRECONDITION(!IsCLRToNative(m_dwMarshalFlags) && !IsByref(m_dwMarshalFlags));
+    }
+    CONTRACTL_END;
+
+    EmitSetupSigAndDefaultHomesNativeToCLR();
+    
+    EmitLoadNativeValue(m_pcsMarshal);
+    EmitLoadManagedHomeAddr(m_pcsMarshal);
 
     // void MarshalToManagedVaList(va_list va, VARARGS *dataout)
-    pslILEmit->EmitCALL(METHOD__STUBHELPERS__MARSHAL_TO_MANAGED_VA_LIST_INTERNAL, 2, 0);
+    m_pcsMarshal->EmitCALL(METHOD__STUBHELPERS__MARSHAL_TO_MANAGED_VA_LIST_INTERNAL, 2, 0);    
 }
+
 
 LocalDesc ILArrayWithOffsetMarshaler::GetNativeType()
 {
@@ -3551,53 +3679,74 @@ bool ILAsAnyMarshalerBase::SupportsReturnMarshal(DWORD dwMarshalFlags, UINT* pEr
     return false;
 }
 
-void ILAsAnyMarshalerBase::EmitCreateMngdMarshaler(ILCodeStream* pslILEmit)
+void ILAsAnyMarshalerBase::EmitMarshalArgumentCLRToNative()
 {
     CONTRACTL
     {
-        THROWS;
-        GC_TRIGGERS;
-        MODE_ANY;
-        CONSISTENCY_CHECK(LOCAL_NUM_UNUSED == m_dwMngdMarshalerLocalNum);
+        STANDARD_VM_CHECK;
+        PRECONDITION(IsCLRToNative(m_dwMarshalFlags) && !IsByref(m_dwMarshalFlags));
+        CONSISTENCY_CHECK(LOCAL_NUM_UNUSED == m_dwMarshalerLocalNum);
     }
     CONTRACTL_END;
 
-    LocalDesc marshalerType(MscorlibBinder::GetClass(CLASS__ASANY_MARSHALER));
-    m_dwMngdMarshalerLocalNum = pslILEmit->NewLocal(marshalerType);
-    DWORD dwTmpLocalNum = pslILEmit->NewLocal(ELEMENT_TYPE_I);
+    EmitSetupSigAndDefaultHomesCLRToNative();
 
-    pslILEmit->EmitLDC(sizeof(MngdNativeArrayMarshaler));
-    pslILEmit->EmitLOCALLOC();
-    pslILEmit->EmitSTLOC(dwTmpLocalNum);
+    BYTE inout      = (IsIn(m_dwMarshalFlags) ? ML_IN : 0) | (IsOut(m_dwMarshalFlags) ? ML_OUT : 0);
+    BYTE fIsAnsi    = IsAnsi() ? 1 : 0;
+    BYTE fBestFit   = m_pargs->m_pMarshalInfo->GetBestFitMapping();
+    BYTE fThrow     = m_pargs->m_pMarshalInfo->GetThrowOnUnmappableChar();
+
+    DWORD dwFlags = 0;
+    
+    dwFlags |= inout    << 24;
+    dwFlags |= fIsAnsi  << 16;
+    dwFlags |= fThrow   <<  8;
+    dwFlags |= fBestFit <<  0;
+
+    //
+    // marshal
+    //
+
+    LocalDesc marshalerType(MscorlibBinder::GetClass(CLASS__ASANY_MARSHALER));
+    m_dwMarshalerLocalNum = m_pcsMarshal->NewLocal(marshalerType);
+    DWORD dwTmpLocalNum = m_pcsMarshal->NewLocal(ELEMENT_TYPE_I);
+
+    m_pcsMarshal->EmitLDC(sizeof(MngdNativeArrayMarshaler));
+    m_pcsMarshal->EmitLOCALLOC();
+    m_pcsMarshal->EmitSTLOC(dwTmpLocalNum);
 
     // marshaler = new AsAnyMarshaler(local_buffer)
-    pslILEmit->EmitLDLOCA(m_dwMngdMarshalerLocalNum);
-    pslILEmit->EmitINITOBJ(pslILEmit->GetToken(marshalerType.InternalToken));
+    m_pcsMarshal->EmitLDLOCA(m_dwMarshalerLocalNum);
+    m_pcsMarshal->EmitINITOBJ(m_pcsMarshal->GetToken(marshalerType.InternalToken));
 
-    pslILEmit->EmitLDLOCA(m_dwMngdMarshalerLocalNum);
-    pslILEmit->EmitLDLOC(dwTmpLocalNum);
-    pslILEmit->EmitCALL(METHOD__ASANY_MARSHALER__CTOR, 2, 0);
-}
+    m_pcsMarshal->EmitLDLOCA(m_dwMarshalerLocalNum);
+    m_pcsMarshal->EmitLDLOC(dwTmpLocalNum);
+    m_pcsMarshal->EmitCALL(METHOD__ASANY_MARSHALER__CTOR, 2, 0);
 
-void ILAsAnyMarshalerBase::EmitConvertContentsCLRToNative(ILCodeStream* pslILEmit)
-{
     // nativeValue = marshaler.ConvertToNative(managedValue, flags);
-    EmitLoadMngdMarshalerAddr(pslILEmit);
-    EmitLoadManagedValue(pslILEmit);
-    pslILEmit->EmitLDC(GetAsAnyFlags());
-    pslILEmit->EmitCALL(METHOD__ASANY_MARSHALER__CONVERT_TO_NATIVE, 3, 1);
-    EmitStoreNativeValue(pslILEmit);
-}
+    m_pcsMarshal->EmitLDLOCA(m_dwMarshalerLocalNum);
+    EmitLoadManagedValue(m_pcsMarshal);
+    m_pcsMarshal->EmitLDC(dwFlags);
+    m_pcsMarshal->EmitCALL(METHOD__ASANY_MARSHALER__CONVERT_TO_NATIVE, 3, 1);
+    EmitStoreNativeValue(m_pcsMarshal);
 
-void ILAsAnyMarshalerBase::EmitConvertContentsNativeToCLR(ILCodeStream* pslILEmit)
-{
-    // marshaler.ConvertToManaged(managedValue, nativeValue)
-    EmitLoadMngdMarshalerAddr(pslILEmit);
-    EmitLoadManagedValue(pslILEmit);
-    EmitLoadNativeValue(pslILEmit);
-    pslILEmit->EmitCALL(METHOD__ASANY_MARSHALER__CONVERT_TO_MANAGED, 3, 0);
-}
+    //
+    // unmarshal
+    //
+    if (IsOut(m_dwMarshalFlags))
+    {
+        // marshaler.ConvertToManaged(managedValue, nativeValue)
+        m_pcsUnmarshal->EmitLDLOCA(m_dwMarshalerLocalNum);
+        EmitLoadManagedValue(m_pcsUnmarshal);
+        EmitLoadNativeValue(m_pcsUnmarshal);
+        m_pcsUnmarshal->EmitCALL(METHOD__ASANY_MARSHALER__CONVERT_TO_MANAGED, 3, 0);
+    }
 
+    //
+    // cleanup
+    //
+    EmitCleanupCLRToNativeTemp();
+}
 
 bool ILAsAnyMarshalerBase::NeedsClearNative()
 {
@@ -3610,7 +3759,7 @@ void ILAsAnyMarshalerBase::EmitClearNativeTemp(ILCodeStream* pslILEmit)
     STANDARD_VM_CONTRACT;
 
     // marshaler.ClearNative(nativeHome)
-    EmitLoadMngdMarshalerAddr(pslILEmit);
+    pslILEmit->EmitLDLOCA(m_dwMarshalerLocalNum);
     EmitLoadNativeValue(pslILEmit);
     pslILEmit->EmitCALL(METHOD__ASANY_MARSHALER__CLEAR_NATIVE, 2, 0);
 }
@@ -3657,9 +3806,24 @@ void ILMngdMarshaler::EmitCallMngdMarshalerMethod(ILCodeStream* pslILEmit, Metho
     }
 }
 
+bool ILNativeArrayMarshaler::UsePinnedArraySpecialCase()
+{
+    if (IsCLRToNative(m_dwMarshalFlags) && !IsByref(m_dwMarshalFlags) && (NULL == OleVariant::GetMarshalerForVarType(m_pargs->na.m_vt, TRUE)))
+    {
+        return true;
+    }
+
+    return false;
+}
+
 void ILNativeArrayMarshaler::EmitCreateMngdMarshaler(ILCodeStream* pslILEmit)
 {
     STANDARD_VM_CONTRACT;
+
+    if (UsePinnedArraySpecialCase())
+    {
+        return;
+    }
             
     m_dwMngdMarshalerLocalNum = pslILEmit->NewLocal(ELEMENT_TYPE_I);
         
@@ -3691,12 +3855,8 @@ void ILNativeArrayMarshaler::EmitCreateMngdMarshaler(ILCodeStream* pslILEmit)
     pslILEmit->EmitCALL(METHOD__MNGD_NATIVE_ARRAY_MARSHALER__CREATE_MARSHALER, 3, 0);
 }
 
-bool ILNativeArrayMarshaler::CanMarshalViaPinning()
-{
-    return IsCLRToNative(m_dwMarshalFlags) && !IsByref(m_dwMarshalFlags) && (NULL == OleVariant::GetMarshalerForVarType(m_pargs->na.m_vt, TRUE));
-}
 
-void ILNativeArrayMarshaler::EmitMarshalViaPinning(ILCodeStream* pslILEmit)
+void ILNativeArrayMarshaler::EmitMarshalArgumentCLRToNative()
 {
     CONTRACTL
     {
@@ -3705,44 +3865,56 @@ void ILNativeArrayMarshaler::EmitMarshalViaPinning(ILCodeStream* pslILEmit)
     }
     CONTRACTL_END;
 
-    //
-    // Replicate ML_PINNEDISOMORPHICARRAY_C2N_EXPRESS behavior -- note that this
-    // gives in/out semantics "for free" even if the app doesn't specify one or
-    // the other.  Since there is no enforcement of this, apps blithely depend
-    // on it.  
-    //
+    if (UsePinnedArraySpecialCase())
+    {
+        //
+        // Replicate ML_PINNEDISOMORPHICARRAY_C2N_EXPRESS behavior -- note that this
+        // gives in/out semantics "for free" even if the app doesn't specify one or
+        // the other.  Since there is no enforcement of this, apps blithely depend
+        // on it.  
+        //
 
-    LocalDesc managedType = GetManagedType();
-    managedType.MakePinned();
+        EmitSetupSigAndDefaultHomesCLRToNative();
 
-    DWORD dwPinnedLocal = pslILEmit->NewLocal(managedType);
-    ILCodeLabel* pNullRefLabel = pslILEmit->NewCodeLabel();
+        LocalDesc managedType = GetManagedType();
+        managedType.MakePinned();
 
-    pslILEmit->EmitLoadNullPtr();
-    EmitStoreNativeValue(pslILEmit);
+        DWORD dwPinnedLocal = m_pcsMarshal->NewLocal(managedType);
+        ILCodeLabel* pNullRefLabel = m_pcsMarshal->NewCodeLabel();
 
-    EmitLoadManagedValue(pslILEmit);
-    pslILEmit->EmitBRFALSE(pNullRefLabel);        
+        m_pcsMarshal->EmitLoadNullPtr();
+        EmitStoreNativeValue(m_pcsMarshal);
 
-    // COMPAT: We cannot generate the same code that the C# compiler generates for
-    // a fixed() statement on an array since we need to provide a non-null value
-    // for a 0-length array. For compat reasons, we need to preserve old behavior.
-    // Additionally, we need to ensure that we do not pass non-null for a zero-length
-    // array when interacting with GDI/GDI+ since they fail on null arrays but succeed
-    // on 0-length arrays.
-    EmitLoadManagedValue(pslILEmit);
-    pslILEmit->EmitSTLOC(dwPinnedLocal);
-    pslILEmit->EmitLDLOC(dwPinnedLocal);
-    pslILEmit->EmitCONV_I();
-    // Optimize marshalling by emitting the data ptr offset directly into the IL stream
-    // instead of doing an FCall to recalulate it each time when possible.
-    pslILEmit->EmitLDC(ArrayBase::GetDataPtrOffset(m_pargs->m_pMarshalInfo->GetArrayElementTypeHandle().MakeSZArray().GetMethodTable()));
-    pslILEmit->EmitADD();
-    EmitStoreNativeValue(pslILEmit);
+        EmitLoadManagedValue(m_pcsMarshal);
+        m_pcsMarshal->EmitBRFALSE(pNullRefLabel);        
 
-    EmitLogNativeArgumentsIfNeeded(pslILEmit, dwPinnedLocal);
+        // COMPAT: We cannot generate the same code that the C# compiler generates for
+        // a fixed() statement on an array since we need to provide a non-null value
+        // for a 0-length array. For compat reasons, we need to preserve old behavior.
+        // Additionally, we need to ensure that we do not pass non-null for a zero-length
+        // array when interacting with GDI/GDI+ since they fail on null arrays but succeed
+        // on 0-length arrays.
+        EmitLoadManagedValue(m_pcsMarshal);
+        m_pcsMarshal->EmitSTLOC(dwPinnedLocal);
+        m_pcsMarshal->EmitLDLOC(dwPinnedLocal);
+        m_pcsMarshal->EmitCONV_I();
+        // Optimize marshalling by emitting the data ptr offset directly into the IL stream
+        // instead of doing an FCall to recalulate it each time when possible.
+        m_pcsMarshal->EmitLDC(ArrayBase::GetDataPtrOffset(m_pargs->m_pMarshalInfo->GetArrayElementTypeHandle().MakeSZArray().GetMethodTable()));
+        m_pcsMarshal->EmitADD();
+        EmitStoreNativeValue(m_pcsMarshal);
 
-    pslILEmit->EmitLabel(pNullRefLabel);
+        if (g_pConfig->InteropLogArguments())
+        {
+            m_pslNDirect->EmitLogNativeArgument(m_pcsMarshal, dwPinnedLocal);
+        }
+
+        m_pcsMarshal->EmitLabel(pNullRefLabel);
+    }
+    else
+    {
+        ILMngdMarshaler::EmitMarshalArgumentCLRToNative();
+    }
 }
 
 //
@@ -3857,7 +4029,7 @@ void ILNativeArrayMarshaler::EmitLoadElementCount(ILCodeStream* pslILEmit)
         unsigned countParamIdx = mops.countParamIdx;
         if (!IsCLRToNative(m_dwMarshalFlags))
         {
-            int lcidParamIdx = GetLCIDParamIndex();
+            int lcidParamIdx = m_pslNDirect->GetLCIDParamIdx();
     
             if (lcidParamIdx >= 0 && (unsigned)lcidParamIdx <= countParamIdx)
             {
@@ -4043,23 +4215,41 @@ void ILNativeArrayMarshaler::EmitClearNativeContents(ILCodeStream* pslILEmit)
     pslILEmit->EmitCALL(pslILEmit->GetToken(GetClearNativeContentsMethod()), 3, 0);
 }
 
-void ILNativeArrayMarshaler::EmitSetupArgumentForMarshalling(ILCodeStream* pslILEmit)
-{
-    if (IsByref(m_dwMarshalFlags))
-    {
-        EmitNewSavedSizeArgLocal(pslILEmit);
-    }
-}
-
-void ILNativeArrayMarshaler::EmitNewSavedSizeArgLocal(ILCodeStream* pslILEmit)
+void ILNativeArrayMarshaler::EmitNewSavedSizeArgLocal()
 {
     STANDARD_VM_CONTRACT;
 
     _ASSERTE(m_dwSavedSizeArg == LOCAL_NUM_UNUSED);
-    m_dwSavedSizeArg = pslILEmit->NewLocal(ELEMENT_TYPE_I4);
-    pslILEmit->EmitLDC(0);
-    pslILEmit->EmitSTLOC(m_dwSavedSizeArg);
+    ILCodeStream *pcsSetup = m_pslNDirect->GetSetupCodeStream();
+    m_dwSavedSizeArg = pcsSetup->NewLocal(ELEMENT_TYPE_I4);
+    pcsSetup->EmitLDC(0);
+    pcsSetup->EmitSTLOC(m_dwSavedSizeArg);
 }
+
+void ILNativeArrayMarshaler::EmitMarshalArgumentNativeToCLRByref()
+{
+    STANDARD_VM_CONTRACT;
+
+    if (IsByref(m_dwMarshalFlags))
+    {
+        EmitNewSavedSizeArgLocal();
+    }
+    
+    ILMngdMarshaler::EmitMarshalArgumentNativeToCLRByref();
+}
+
+void ILNativeArrayMarshaler::EmitMarshalArgumentCLRToNativeByref()
+{
+    STANDARD_VM_CONTRACT;
+
+    if (IsByref(m_dwMarshalFlags))
+    {
+        EmitNewSavedSizeArgLocal();
+    }
+    
+    ILMngdMarshaler::EmitMarshalArgumentCLRToNativeByref();
+}
+
 
 #ifndef CROSSGEN_COMPILE
 
@@ -4538,75 +4728,98 @@ void ILHiddenLengthArrayMarshaler::EmitCreateMngdMarshaler(ILCodeStream* pslILEm
 {
     STANDARD_VM_CONTRACT;
 
-    m_dwMngdMarshalerLocalNum = pslILEmit->NewLocal(ELEMENT_TYPE_I);
-    
-    pslILEmit->EmitLDC(sizeof(MngdHiddenLengthArrayMarshaler));
-    pslILEmit->EmitLOCALLOC();
-    pslILEmit->EmitSTLOC(m_dwMngdMarshalerLocalNum);
+    if (!CanUsePinnedArray())
+    {
+        m_dwMngdMarshalerLocalNum = pslILEmit->NewLocal(ELEMENT_TYPE_I);
+        
+        pslILEmit->EmitLDC(sizeof(MngdHiddenLengthArrayMarshaler));
+        pslILEmit->EmitLOCALLOC();
+        pslILEmit->EmitSTLOC(m_dwMngdMarshalerLocalNum);
 
-    MethodTable *pElementMT = m_pargs->m_pMarshalInfo->GetArrayElementTypeHandle().GetMethodTable();
-    pslILEmit->EmitLDLOC(m_dwMngdMarshalerLocalNum);
-    pslILEmit->EmitLDTOKEN(pslILEmit->GetToken(pElementMT));
-    pslILEmit->EmitCALL(METHOD__RT_TYPE_HANDLE__GETVALUEINTERNAL, 1, 1);
+        MethodTable *pElementMT = m_pargs->m_pMarshalInfo->GetArrayElementTypeHandle().GetMethodTable();
+        pslILEmit->EmitLDLOC(m_dwMngdMarshalerLocalNum);
+        pslILEmit->EmitLDTOKEN(pslILEmit->GetToken(pElementMT));
+        pslILEmit->EmitCALL(METHOD__RT_TYPE_HANDLE__GETVALUEINTERNAL, 1, 1);
 
-    pslILEmit->EmitLDC(m_pargs->na.m_cbElementSize);
-    pslILEmit->EmitLDC(m_pargs->na.m_vt);
+        pslILEmit->EmitLDC(m_pargs->na.m_cbElementSize);
+        pslILEmit->EmitLDC(m_pargs->na.m_vt);
 
-    pslILEmit->EmitCALL(METHOD__MNGD_HIDDEN_LENGTH_ARRAY_MARSHALER__CREATE_MARSHALER, 4, 0);
+        pslILEmit->EmitCALL(METHOD__MNGD_HIDDEN_LENGTH_ARRAY_MARSHALER__CREATE_MARSHALER, 4, 0);
+    }
 }
 
-void ILHiddenLengthArrayMarshaler::EmitMarshalViaPinning(ILCodeStream* pslILEmit)
+void ILHiddenLengthArrayMarshaler::EmitMarshalArgumentCLRToNative()
 {
-    LocalDesc managedType = GetManagedType();
-    managedType.MakePinned();
-    DWORD dwPinnedLocal = pslILEmit->NewLocal(managedType);
+    STANDARD_VM_CONTRACT;
 
-    ILCodeLabel* pMarshalDoneLabel = pslILEmit->NewCodeLabel();
+    // If we can pin the array, then do that rather than marshaling it in a more heavy weight way
+    // Otherwise, fall back to doing a full marshal
+    if (CanUsePinnedArray())
+    {
+        EmitSetupSigAndDefaultHomesCLRToNative();
 
-    // native = NULL
-    pslILEmit->EmitLoadNullPtr();
-    EmitStoreNativeValue(pslILEmit);
+        LocalDesc managedType = GetManagedType();
+        managedType.MakePinned();
+        DWORD dwPinnedLocal = m_pcsMarshal->NewLocal(managedType);
 
-    // if (managed == null) goto MarshalDone
-    EmitLoadManagedValue(pslILEmit);
-    pslILEmit->EmitBRFALSE(pMarshalDoneLabel);
+        ILCodeLabel* pMarshalDoneLabel = m_pcsMarshal->NewCodeLabel();
 
-    // pinnedLocal = managed;
-    EmitLoadManagedValue(pslILEmit);
-    pslILEmit->EmitSTLOC(dwPinnedLocal);
+        // native = NULL
+        m_pcsMarshal->EmitLoadNullPtr();
+        EmitStoreNativeValue(m_pcsMarshal);
 
-    // native = pinnedLocal + dataOffset
+        // if (managed == null) goto MarshalDone
+        EmitLoadManagedValue(m_pcsMarshal);
+        m_pcsMarshal->EmitBRFALSE(pMarshalDoneLabel);
 
-    // COMPAT: We cannot generate the same code that the C# compiler generates for
-    // a fixed() statement on an array since we need to provide a non-null value
-    // for a 0-length array. For compat reasons, we need to preserve old behavior.
-    EmitLoadManagedValue(pslILEmit);
-    pslILEmit->EmitSTLOC(dwPinnedLocal);
-    pslILEmit->EmitLDLOC(dwPinnedLocal);
-    pslILEmit->EmitCONV_I();
-    // Optimize marshalling by emitting the data ptr offset directly into the IL stream
-    // instead of doing an FCall to recalulate it each time.
-    pslILEmit->EmitLDC(ArrayBase::GetDataPtrOffset(m_pargs->m_pMarshalInfo->GetArrayElementTypeHandle().MakeSZArray().GetMethodTable()));
-    pslILEmit->EmitADD();
-    EmitStoreNativeValue(pslILEmit);
+        // pinnedLocal = managed;
+        EmitLoadManagedValue(m_pcsMarshal);
+        m_pcsMarshal->EmitSTLOC(dwPinnedLocal);
 
-    EmitLogNativeArgumentsIfNeeded(pslILEmit, dwPinnedLocal);
+        // native = pinnedLocal + dataOffset
 
-    // MarshalDone:
-    pslILEmit->EmitLabel(pMarshalDoneLabel);
+        // COMPAT: We cannot generate the same code that the C# compiler generates for
+        // a fixed() statement on an array since we need to provide a non-null value
+        // for a 0-length array. For compat reasons, we need to preserve old behavior.
+        EmitLoadManagedValue(m_pcsMarshal);
+        m_pcsMarshal->EmitSTLOC(dwPinnedLocal);
+        m_pcsMarshal->EmitLDLOC(dwPinnedLocal);
+        m_pcsMarshal->EmitCONV_I();
+        // Optimize marshalling by emitting the data ptr offset directly into the IL stream
+        // instead of doing an FCall to recalulate it each time.
+        m_pcsMarshal->EmitLDC(ArrayBase::GetDataPtrOffset(m_pargs->m_pMarshalInfo->GetArrayElementTypeHandle().MakeSZArray().GetMethodTable()));
+        m_pcsMarshal->EmitADD();
+        EmitStoreNativeValue(m_pcsMarshal);
+
+        if (g_pConfig->InteropLogArguments())
+        {
+            m_pslNDirect->EmitLogNativeArgument(m_pcsMarshal, dwPinnedLocal);
+        }
+
+        // MarshalDone:
+        m_pcsMarshal->EmitLabel(pMarshalDoneLabel);
+    }
+    else
+    {
+        ILMngdMarshaler::EmitMarshalArgumentCLRToNative();
+    }
+
 }
 
 void ILHiddenLengthArrayMarshaler::EmitConvertSpaceNativeToCLR(ILCodeStream* pslILEmit)
 {
     STANDARD_VM_CONTRACT;
 
-    EmitLoadMngdMarshaler(pslILEmit);
-    EmitLoadManagedHomeAddr(pslILEmit);
-    EmitLoadNativeHomeAddr(pslILEmit);
-    EmitLoadNativeArrayLength(pslILEmit);
-    
-    // MngdHiddenLengthArrayMarshaler::ConvertSpaceToManaged
-    pslILEmit->EmitCALL(pslILEmit->GetToken(GetConvertSpaceToManagedMethod()), 4, 0);
+    if (!CanUsePinnedArray())
+    {
+        EmitLoadMngdMarshaler(pslILEmit);
+        EmitLoadManagedHomeAddr(pslILEmit);
+        EmitLoadNativeHomeAddr(pslILEmit);
+        EmitLoadNativeArrayLength(pslILEmit);
+        
+        // MngdHiddenLengthArrayMarshaler::ConvertSpaceToManaged
+        pslILEmit->EmitCALL(pslILEmit->GetToken(GetConvertSpaceToManagedMethod()), 4, 0);
+    }
 }
 
 void ILHiddenLengthArrayMarshaler::EmitConvertSpaceCLRToNative(ILCodeStream* pslILEmit)
@@ -4618,7 +4831,7 @@ void ILHiddenLengthArrayMarshaler::EmitConvertSpaceCLRToNative(ILCodeStream* psl
     {
         if (IsByref(m_dwMarshalFlags) || IsRetval(m_dwMarshalFlags) || IsOut(m_dwMarshalFlags))
         {
-            ILCodeLabel *pSkipGetLengthLabel = pslILEmit->NewCodeLabel();
+            ILCodeLabel *pSkipGetLengthLabel = m_pcsMarshal->NewCodeLabel();
 
             // nativeLen = 0
             pslILEmit->EmitLDC(0);
@@ -4645,76 +4858,82 @@ void ILHiddenLengthArrayMarshaler::EmitConvertSpaceCLRToNative(ILCodeStream* psl
         }
     }
 
-    ILMngdMarshaler::EmitConvertSpaceCLRToNative(pslILEmit);
+    if (!CanUsePinnedArray())
+    {
+        ILMngdMarshaler::EmitConvertSpaceCLRToNative(pslILEmit);
+    }
 }
 
 void ILHiddenLengthArrayMarshaler::EmitConvertContentsCLRToNative(ILCodeStream* pslILEmit)
 {
     STANDARD_VM_CONTRACT;
 
-    if (m_pargs->na.m_vt == VTHACK_REDIRECTEDTYPE &&
-        (m_pargs->na.m_redirectedTypeIndex == WinMDAdapter::RedirectedTypeIndex_System_Uri ||
-            m_pargs->na.m_redirectedTypeIndex == WinMDAdapter::RedirectedTypeIndex_System_Collections_Specialized_NotifyCollectionChangedEventArgs ||
-            m_pargs->na.m_redirectedTypeIndex == WinMDAdapter::RedirectedTypeIndex_System_ComponentModel_PropertyChangedEventArgs))
+    if (!CanUsePinnedArray())
     {
-        // System.Uri/NotifyCollectionChangedEventArgs don't live in mscorlib so there's no marshaling helper to call - inline the loop
-        DWORD dwLoopCounterLocalNum = pslILEmit->NewLocal(ELEMENT_TYPE_I4);
-        DWORD dwNativePtrLocalNum = pslILEmit->NewLocal(ELEMENT_TYPE_I);
-        ILCodeLabel *pConditionLabel = pslILEmit->NewCodeLabel();
-        ILCodeLabel *pLoopBodyLabel = pslILEmit->NewCodeLabel();
-
-        // for (IntPtr ptr = pNative, int i = 0; ...
-        pslILEmit->EmitLDC(0);
-        pslILEmit->EmitSTLOC(dwLoopCounterLocalNum);
-        EmitLoadNativeValue(pslILEmit);
-        pslILEmit->EmitSTLOC(dwNativePtrLocalNum);
-        pslILEmit->EmitBR(pConditionLabel);
-
-        // *ptr = EmitConvertCLR*ToWinRT*(pManaged[i]);
-        pslILEmit->EmitLabel(pLoopBodyLabel);
-        pslILEmit->EmitLDLOC(dwNativePtrLocalNum);
-        EmitLoadManagedValue(pslILEmit);
-        pslILEmit->EmitLDLOC(dwLoopCounterLocalNum);
-        pslILEmit->EmitLDELEM_REF();
-
-        switch (m_pargs->na.m_redirectedTypeIndex)
+        if (m_pargs->na.m_vt == VTHACK_REDIRECTEDTYPE &&
+            (m_pargs->na.m_redirectedTypeIndex == WinMDAdapter::RedirectedTypeIndex_System_Uri ||
+             m_pargs->na.m_redirectedTypeIndex == WinMDAdapter::RedirectedTypeIndex_System_Collections_Specialized_NotifyCollectionChangedEventArgs ||
+             m_pargs->na.m_redirectedTypeIndex == WinMDAdapter::RedirectedTypeIndex_System_ComponentModel_PropertyChangedEventArgs))
         {
-            case WinMDAdapter::RedirectedTypeIndex_System_Uri:
-                ILUriMarshaler::EmitConvertCLRUriToWinRTUri(pslILEmit, m_pargs->m_pMarshalInfo->GetModule()->GetLoaderAllocator());
-                break;
+            // System.Uri/NotifyCollectionChangedEventArgs don't live in mscorlib so there's no marshaling helper to call - inline the loop
+            DWORD dwLoopCounterLocalNum = pslILEmit->NewLocal(ELEMENT_TYPE_I4);
+            DWORD dwNativePtrLocalNum = pslILEmit->NewLocal(ELEMENT_TYPE_I);
+            ILCodeLabel *pConditionLabel = pslILEmit->NewCodeLabel();
+            ILCodeLabel *pLoopBodyLabel = pslILEmit->NewCodeLabel();
 
-            case WinMDAdapter::RedirectedTypeIndex_System_Collections_Specialized_NotifyCollectionChangedEventArgs:
-                ILNCCEventArgsMarshaler::EmitConvertCLREventArgsToWinRTEventArgs(pslILEmit, m_pargs->m_pMarshalInfo->GetModule()->GetLoaderAllocator());
-                break;
+            // for (IntPtr ptr = pNative, int i = 0; ...
+            pslILEmit->EmitLDC(0);
+            pslILEmit->EmitSTLOC(dwLoopCounterLocalNum);
+            EmitLoadNativeValue(pslILEmit);
+            pslILEmit->EmitSTLOC(dwNativePtrLocalNum);
+            pslILEmit->EmitBR(pConditionLabel);
 
-            case WinMDAdapter::RedirectedTypeIndex_System_ComponentModel_PropertyChangedEventArgs:
-                ILPCEventArgsMarshaler::EmitConvertCLREventArgsToWinRTEventArgs(pslILEmit, m_pargs->m_pMarshalInfo->GetModule()->GetLoaderAllocator());
-                break;
+            // *ptr = EmitConvertCLR*ToWinRT*(pManaged[i]);
+            pslILEmit->EmitLabel(pLoopBodyLabel);
+            pslILEmit->EmitLDLOC(dwNativePtrLocalNum);
+            EmitLoadManagedValue(pslILEmit);
+            pslILEmit->EmitLDLOC(dwLoopCounterLocalNum);
+            pslILEmit->EmitLDELEM_REF();
 
-            default: UNREACHABLE();
+            switch (m_pargs->na.m_redirectedTypeIndex)
+            {
+                case WinMDAdapter::RedirectedTypeIndex_System_Uri:
+                    ILUriMarshaler::EmitConvertCLRUriToWinRTUri(pslILEmit, m_pargs->m_pMarshalInfo->GetModule()->GetLoaderAllocator());
+                    break;
+
+                case WinMDAdapter::RedirectedTypeIndex_System_Collections_Specialized_NotifyCollectionChangedEventArgs:
+                    ILNCCEventArgsMarshaler::EmitConvertCLREventArgsToWinRTEventArgs(pslILEmit, m_pargs->m_pMarshalInfo->GetModule()->GetLoaderAllocator());
+                    break;
+
+                case WinMDAdapter::RedirectedTypeIndex_System_ComponentModel_PropertyChangedEventArgs:
+                    ILPCEventArgsMarshaler::EmitConvertCLREventArgsToWinRTEventArgs(pslILEmit, m_pargs->m_pMarshalInfo->GetModule()->GetLoaderAllocator());
+                    break;
+
+                default: UNREACHABLE();
+            }
+
+            pslILEmit->EmitSTIND_I();
+
+            // ... i++, ptr += IntPtr.Size ...
+            pslILEmit->EmitLDLOC(dwLoopCounterLocalNum);
+            pslILEmit->EmitLDC(1);
+            pslILEmit->EmitADD();
+            pslILEmit->EmitSTLOC(dwLoopCounterLocalNum);
+            pslILEmit->EmitLDLOC(dwNativePtrLocalNum);
+            pslILEmit->EmitLDC(sizeof(LPVOID));
+            pslILEmit->EmitADD();
+            pslILEmit->EmitSTLOC(dwNativePtrLocalNum);
+
+            // ... i < pManaged.Length; ...
+            pslILEmit->EmitLabel(pConditionLabel);
+            pslILEmit->EmitLDLOC(dwLoopCounterLocalNum);
+            EmitLoadNativeArrayLength(pslILEmit);
+            pslILEmit->EmitBLT(pLoopBodyLabel);
+        }            
+        else
+        {
+            ILMngdMarshaler::EmitConvertContentsCLRToNative(pslILEmit);
         }
-
-        pslILEmit->EmitSTIND_I();
-
-        // ... i++, ptr += IntPtr.Size ...
-        pslILEmit->EmitLDLOC(dwLoopCounterLocalNum);
-        pslILEmit->EmitLDC(1);
-        pslILEmit->EmitADD();
-        pslILEmit->EmitSTLOC(dwLoopCounterLocalNum);
-        pslILEmit->EmitLDLOC(dwNativePtrLocalNum);
-        pslILEmit->EmitLDC(sizeof(LPVOID));
-        pslILEmit->EmitADD();
-        pslILEmit->EmitSTLOC(dwNativePtrLocalNum);
-
-        // ... i < pManaged.Length; ...
-        pslILEmit->EmitLabel(pConditionLabel);
-        pslILEmit->EmitLDLOC(dwLoopCounterLocalNum);
-        EmitLoadNativeArrayLength(pslILEmit);
-        pslILEmit->EmitBLT(pLoopBodyLabel);
-    }            
-    else
-    {
-        ILMngdMarshaler::EmitConvertContentsCLRToNative(pslILEmit);
     }
 }
 
@@ -4722,69 +4941,72 @@ void ILHiddenLengthArrayMarshaler::EmitConvertContentsNativeToCLR(ILCodeStream* 
 {
     STANDARD_VM_CONTRACT;
 
-    if (m_pargs->na.m_vt == VTHACK_REDIRECTEDTYPE &&
-        (m_pargs->na.m_redirectedTypeIndex == WinMDAdapter::RedirectedTypeIndex_System_Uri ||
-            m_pargs->na.m_redirectedTypeIndex == WinMDAdapter::RedirectedTypeIndex_System_Collections_Specialized_NotifyCollectionChangedEventArgs ||
-            m_pargs->na.m_redirectedTypeIndex == WinMDAdapter::RedirectedTypeIndex_System_ComponentModel_PropertyChangedEventArgs))
+    if (!CanUsePinnedArray())
     {
-        // System.Uri/NotifyCollectionChangedEventArgs don't live in mscorlib so there's no marshaling helper to call - inline the loop
-        DWORD dwLoopCounterLocalNum = pslILEmit->NewLocal(ELEMENT_TYPE_I4);
-        DWORD dwNativePtrLocalNum = pslILEmit->NewLocal(ELEMENT_TYPE_I);
-        ILCodeLabel *pConditionLabel = pslILEmit->NewCodeLabel();
-        ILCodeLabel *pLoopBodyLabel = pslILEmit->NewCodeLabel();
-
-        // for (IntPtr ptr = pNative, int i = 0; ...
-        pslILEmit->EmitLDC(0);
-        pslILEmit->EmitSTLOC(dwLoopCounterLocalNum);
-        EmitLoadNativeValue(pslILEmit);
-        pslILEmit->EmitSTLOC(dwNativePtrLocalNum);
-        pslILEmit->EmitBR(pConditionLabel);
-
-        // pManaged[i] = EmitConvertWinRT*ToCLR*(*ptr);
-        pslILEmit->EmitLabel(pLoopBodyLabel);
-        EmitLoadManagedValue(pslILEmit);
-        pslILEmit->EmitLDLOC(dwLoopCounterLocalNum);
-        pslILEmit->EmitLDLOC(dwNativePtrLocalNum);
-        pslILEmit->EmitLDIND_I();
-
-        switch (m_pargs->na.m_redirectedTypeIndex)
+        if (m_pargs->na.m_vt == VTHACK_REDIRECTEDTYPE &&
+            (m_pargs->na.m_redirectedTypeIndex == WinMDAdapter::RedirectedTypeIndex_System_Uri ||
+             m_pargs->na.m_redirectedTypeIndex == WinMDAdapter::RedirectedTypeIndex_System_Collections_Specialized_NotifyCollectionChangedEventArgs ||
+             m_pargs->na.m_redirectedTypeIndex == WinMDAdapter::RedirectedTypeIndex_System_ComponentModel_PropertyChangedEventArgs))
         {
-            case WinMDAdapter::RedirectedTypeIndex_System_Uri:
-                ILUriMarshaler::EmitConvertWinRTUriToCLRUri(pslILEmit, m_pargs->m_pMarshalInfo->GetModule()->GetLoaderAllocator());
-                break;
+            // System.Uri/NotifyCollectionChangedEventArgs don't live in mscorlib so there's no marshaling helper to call - inline the loop
+            DWORD dwLoopCounterLocalNum = pslILEmit->NewLocal(ELEMENT_TYPE_I4);
+            DWORD dwNativePtrLocalNum = pslILEmit->NewLocal(ELEMENT_TYPE_I);
+            ILCodeLabel *pConditionLabel = pslILEmit->NewCodeLabel();
+            ILCodeLabel *pLoopBodyLabel = pslILEmit->NewCodeLabel();
 
-            case WinMDAdapter::RedirectedTypeIndex_System_Collections_Specialized_NotifyCollectionChangedEventArgs:
-                ILNCCEventArgsMarshaler::EmitConvertWinRTEventArgsToCLREventArgs(pslILEmit, m_pargs->m_pMarshalInfo->GetModule()->GetLoaderAllocator());
-                break;
+            // for (IntPtr ptr = pNative, int i = 0; ...
+            pslILEmit->EmitLDC(0);
+            pslILEmit->EmitSTLOC(dwLoopCounterLocalNum);
+            EmitLoadNativeValue(pslILEmit);
+            pslILEmit->EmitSTLOC(dwNativePtrLocalNum);
+            pslILEmit->EmitBR(pConditionLabel);
 
-            case WinMDAdapter::RedirectedTypeIndex_System_ComponentModel_PropertyChangedEventArgs:
-                ILPCEventArgsMarshaler::EmitConvertWinRTEventArgsToCLREventArgs(pslILEmit, m_pargs->m_pMarshalInfo->GetModule()->GetLoaderAllocator());
-                break;
+            // pManaged[i] = EmitConvertWinRT*ToCLR*(*ptr);
+            pslILEmit->EmitLabel(pLoopBodyLabel);
+            EmitLoadManagedValue(pslILEmit);
+            pslILEmit->EmitLDLOC(dwLoopCounterLocalNum);
+            pslILEmit->EmitLDLOC(dwNativePtrLocalNum);
+            pslILEmit->EmitLDIND_I();
 
-            default: UNREACHABLE();
+            switch (m_pargs->na.m_redirectedTypeIndex)
+            {
+                case WinMDAdapter::RedirectedTypeIndex_System_Uri:
+                    ILUriMarshaler::EmitConvertWinRTUriToCLRUri(pslILEmit, m_pargs->m_pMarshalInfo->GetModule()->GetLoaderAllocator());
+                    break;
+
+                case WinMDAdapter::RedirectedTypeIndex_System_Collections_Specialized_NotifyCollectionChangedEventArgs:
+                    ILNCCEventArgsMarshaler::EmitConvertWinRTEventArgsToCLREventArgs(pslILEmit, m_pargs->m_pMarshalInfo->GetModule()->GetLoaderAllocator());
+                    break;
+
+                case WinMDAdapter::RedirectedTypeIndex_System_ComponentModel_PropertyChangedEventArgs:
+                    ILPCEventArgsMarshaler::EmitConvertWinRTEventArgsToCLREventArgs(pslILEmit, m_pargs->m_pMarshalInfo->GetModule()->GetLoaderAllocator());
+                    break;
+
+                default: UNREACHABLE();
+            }
+            
+            pslILEmit->EmitSTELEM_REF();
+
+            // ... i++, ptr += IntPtr.Size)
+            pslILEmit->EmitLDLOC(dwLoopCounterLocalNum);
+            pslILEmit->EmitLDC(1);
+            pslILEmit->EmitADD();
+            pslILEmit->EmitSTLOC(dwLoopCounterLocalNum);
+            pslILEmit->EmitLDLOC(dwNativePtrLocalNum);
+            pslILEmit->EmitLDC(sizeof(LPVOID));
+            pslILEmit->EmitADD();
+            pslILEmit->EmitSTLOC(dwNativePtrLocalNum);
+
+            // ... i < pManaged.Length; ...
+            pslILEmit->EmitLabel(pConditionLabel);
+            pslILEmit->EmitLDLOC(dwLoopCounterLocalNum);
+            EmitLoadNativeArrayLength(pslILEmit);
+            pslILEmit->EmitBLT(pLoopBodyLabel);
+        }            
+        else
+        {
+            ILMngdMarshaler::EmitConvertContentsNativeToCLR(pslILEmit);
         }
-        
-        pslILEmit->EmitSTELEM_REF();
-
-        // ... i++, ptr += IntPtr.Size)
-        pslILEmit->EmitLDLOC(dwLoopCounterLocalNum);
-        pslILEmit->EmitLDC(1);
-        pslILEmit->EmitADD();
-        pslILEmit->EmitSTLOC(dwLoopCounterLocalNum);
-        pslILEmit->EmitLDLOC(dwNativePtrLocalNum);
-        pslILEmit->EmitLDC(sizeof(LPVOID));
-        pslILEmit->EmitADD();
-        pslILEmit->EmitSTLOC(dwNativePtrLocalNum);
-
-        // ... i < pManaged.Length; ...
-        pslILEmit->EmitLabel(pConditionLabel);
-        pslILEmit->EmitLDLOC(dwLoopCounterLocalNum);
-        EmitLoadNativeArrayLength(pslILEmit);
-        pslILEmit->EmitBLT(pLoopBodyLabel);
-    }            
-    else
-    {
-        ILMngdMarshaler::EmitConvertContentsNativeToCLR(pslILEmit);
     }
 }
 
@@ -4794,37 +5016,43 @@ void ILHiddenLengthArrayMarshaler::EmitClearNative(ILCodeStream* pslILEmit)
 
     EmitClearNativeContents(pslILEmit);
 
-    EmitLoadNativeValue(pslILEmit);
-    pslILEmit->EmitCALL(pslILEmit->GetToken(GetClearNativeMethod()), 1, 0);
+    if (!CanUsePinnedArray())
+    {
+        EmitLoadNativeValue(pslILEmit);
+        pslILEmit->EmitCALL(pslILEmit->GetToken(GetClearNativeMethod()), 1, 0);
+    }
 }
 
 void ILHiddenLengthArrayMarshaler::EmitClearNativeContents(ILCodeStream* pslILEmit)
 {
     STANDARD_VM_CONTRACT;
 
-    MethodDesc *pMD = GetClearNativeContentsMethod();
-    if (pMD != NULL)
+    if (!CanUsePinnedArray())
     {
-        MetaSig sig(pMD);
-        UINT numArgs = sig.NumFixedArgs();
-
-        if (numArgs == 3)
+        MethodDesc *pMD = GetClearNativeContentsMethod();
+        if (pMD != NULL)
         {
-            EmitLoadMngdMarshaler(pslILEmit);
-        }
-        else
-        {
-            _ASSERTE(numArgs == 2);
-        }
+            MetaSig sig(pMD);
+            UINT numArgs = sig.NumFixedArgs();
 
-        EmitLoadNativeHomeAddr(pslILEmit);
-        EmitLoadNativeArrayLength(pslILEmit);
-        pslILEmit->EmitCALL(pslILEmit->GetToken(pMD), numArgs, 0);
+            if (numArgs == 3)
+            {
+                EmitLoadMngdMarshaler(pslILEmit);
+            }
+            else
+            {
+                _ASSERTE(numArgs == 2);
+            }
+
+            EmitLoadNativeHomeAddr(pslILEmit);
+            EmitLoadNativeArrayLength(pslILEmit);
+            pslILEmit->EmitCALL(pslILEmit->GetToken(pMD), numArgs, 0);
+        }
     }
 }
 
 // Determine if we can simply pin the managed array, rather than doing a full marshal
-bool ILHiddenLengthArrayMarshaler::CanMarshalViaPinning()
+bool ILHiddenLengthArrayMarshaler::CanUsePinnedArray()
 {
     STANDARD_VM_CONTRACT;
 

--- a/src/vm/metasig.h
+++ b/src/vm/metasig.h
@@ -587,7 +587,7 @@ DEFINE_METASIG(SM(RefObject_Object_Object_RetObject, r(j) j j, j))
 
 DEFINE_METASIG_T(SM(RefCleanupWorkListElement_RetVoid, r(C(CLEANUP_WORK_LIST_ELEMENT)), v))
 DEFINE_METASIG_T(SM(RefCleanupWorkListElement_SafeHandle_RetIntPtr, r(C(CLEANUP_WORK_LIST_ELEMENT)) C(SAFE_HANDLE), I))
-DEFINE_METASIG_T(SM(RefCleanupWorkListElement_Obj_RetVoid, r(C(CLEANUP_WORK_LIST_ELEMENT)) j, v))
+DEFINE_METASIG_T(SM(RefCleanupWorkListElement_Delegate_RetVoid, r(C(CLEANUP_WORK_LIST_ELEMENT)) C(DELEGATE), v))
 
 #ifdef FEATURE_ICASTABLE
 DEFINE_METASIG_T(SM(ICastable_RtType_RefException_RetBool, C(ICASTABLE) C(CLASS) r(C(EXCEPTION)), F))

--- a/src/vm/mlinfo.cpp
+++ b/src/vm/mlinfo.cpp
@@ -3269,7 +3269,7 @@ void MarshalInfo::GenerateArgumentIL(NDirectStubLinker* psl,
     pcsMarshal->EmitNOP("// } argument");
     pcsUnmarshal->EmitNOP("// } argument");
 
-    pMarshaler->EmitSetupArgumentForDispatch(pcsDispatch);
+    pMarshaler->EmitSetupArgument(pcsDispatch);
     if (m_paramidx == 0)
     {
         CorCallingConvention callConv = psl->GetStubTargetCallingConv();
@@ -4689,7 +4689,7 @@ void MarshalInfo::MarshalHiddenLengthArgument(NDirectStubLinker *psl, BOOL manag
     if (managedToNative)
     {
         ILCodeStream* pcsDispatch = psl->GetDispatchCodeStream();
-        pHiddenLengthMarshaler->EmitSetupArgumentForDispatch(pcsDispatch);
+        pHiddenLengthMarshaler->EmitSetupArgument(pcsDispatch);
     }
 }
 

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -973,7 +973,7 @@ DEFINE_METHOD(STUBHELPERS,          CLEAR_LAST_ERROR,       ClearLastError,     
 
 DEFINE_METHOD(STUBHELPERS,          THROW_INTEROP_PARAM_EXCEPTION, ThrowInteropParamException,   SM_Int_Int_RetVoid)
 DEFINE_METHOD(STUBHELPERS,          ADD_TO_CLEANUP_LIST_SAFEHANDLE,    AddToCleanupList,           SM_RefCleanupWorkListElement_SafeHandle_RetIntPtr)
-DEFINE_METHOD(STUBHELPERS,          KEEP_ALIVE_VIA_CLEANUP_LIST,    KeepAliveViaCleanupList,       SM_RefCleanupWorkListElement_Obj_RetVoid)
+DEFINE_METHOD(STUBHELPERS,          ADD_TO_CLEANUP_LIST_DELEGATE,    AddToCleanupList,             SM_RefCleanupWorkListElement_Delegate_RetVoid)
 DEFINE_METHOD(STUBHELPERS,          DESTROY_CLEANUP_LIST,   DestroyCleanupList,         SM_RefCleanupWorkListElement_RetVoid)
 DEFINE_METHOD(STUBHELPERS,          GET_HR_EXCEPTION_OBJECT, GetHRExceptionObject,      SM_Int_RetException)
 DEFINE_METHOD(STUBHELPERS,          CREATE_CUSTOM_MARSHALER_HELPER, CreateCustomMarshalerHelper, SM_IntPtr_Int_IntPtr_RetIntPtr)


### PR DESCRIPTION
Reverts dotnet/coreclr#21227

Backing out #21227 until after 3.0 because there are some managed object allocation/traffic issues that need to be fixed and we're very close to cutting for 3.0.
