### PR TITLE
Add  StackTraceHidden to awaited ValueTask<T> results

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
@@ -158,7 +158,7 @@ namespace System.Runtime.CompilerServices
             /// <summary>Gets the result of the ValueTask.</summary>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             [StackTraceHidden]
-            public TResult GetResult() => _value.Result;
+            public TResult GetResult() => _value.GetResult();
 
             /// <summary>Schedules the continuation action for the <see cref="ConfiguredValueTaskAwaitable{TResult}"/>.</summary>
             public void OnCompleted(Action continuation)

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
@@ -128,7 +128,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>Gets the result of the ValueTask.</summary>
         [StackTraceHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public TResult GetResult() => _value.Result;
+        public TResult GetResult() => _value.GetResult();
 
         /// <summary>Schedules the continuation action for this ValueTask.</summary>
         public void OnCompleted(Action continuation)

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/ValueTask.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/ValueTask.cs
@@ -743,26 +743,29 @@ namespace System.Threading.Tasks
         /// <summary>Gets the result.</summary>
         public TResult Result
         {
-            [StackTraceHidden]
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
+            get => GetResult();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [StackTraceHidden]
+        internal TResult GetResult()
+        {
+            object? obj = _obj;
+            Debug.Assert(obj == null || obj is Task<TResult> || obj is IValueTaskSource<TResult>);
+
+            if (obj == null)
             {
-                object? obj = _obj;
-                Debug.Assert(obj == null || obj is Task<TResult> || obj is IValueTaskSource<TResult>);
-
-                if (obj == null)
-                {
-                    return _result;
-                }
-
-                if (obj is Task<TResult> t)
-                {
-                    TaskAwaiter.ValidateEnd(t);
-                    return t.ResultOnSuccess;
-                }
-
-                return Unsafe.As<IValueTaskSource<TResult>>(obj).GetResult(_token);
+                return _result;
             }
+
+            if (obj is Task<TResult> t)
+            {
+                TaskAwaiter.ValidateEnd(t);
+                return t.ResultOnSuccess;
+            }
+
+            return Unsafe.As<IValueTaskSource<TResult>>(obj).GetResult(_token);
         }
 
         /// <summary>Gets an awaiter for this <see cref="ValueTask{TResult}"/>.</summary>

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/ValueTask.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/ValueTask.cs
@@ -743,6 +743,7 @@ namespace System.Threading.Tasks
         /// <summary>Gets the result.</summary>
         public TResult Result
         {
+            [StackTraceHidden]
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {


### PR DESCRIPTION
Remove it from exception the stack trace as it doesn't add value.

```csharp
static async Task Main(string[] args)
{
    var httpClient = new HttpClient();
    var str = await httpClient.GetStringAsync("https://127.0.0.1/");
}
```
Outputs
```csharp
Unhandled exception. System.Net.Http.HttpRequestException: No connection could be made because the target machine actively refused it.
 ---> System.Net.Sockets.SocketException (10061): No connection could be made because the target machine actively refused it.
   at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken)
   at System.Threading.Tasks.ValueTask`1.get_Result()
   at System.Net.Http.HttpConnectionPool.ConnectAsync(HttpRequestMessage request, Boolean allowHttp2, CancellationToken cancellationToken)
   at System.Threading.Tasks.ValueTask`1.get_Result()
   at System.Net.Http.HttpConnectionPool.CreateHttp11ConnectionAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Threading.Tasks.ValueTask`1.get_Result()
   at System.Net.Http.HttpConnectionPool.GetHttpConnectionAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Threading.Tasks.ValueTask`1.get_Result()
   at System.Net.Http.HttpConnectionPool.SendWithRetryAsync(HttpRequestMessage request, Boolean doRequestAuth, CancellationToken cancellationToken)
   at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.FinishSendAsyncUnbuffered(Task`1 sendTask, HttpRequestMessage request, CancellationTokenSource cts, Boolean disposeCts)
   at System.Net.Http.HttpClient.GetStringAsyncCore(Task`1 getTask)
   at Program.Main(String[] args) in C:\Work\NewForNetCore3Talk\Exceptions\Program.cs:line 10
   at Program.<Main>(String[] args)
```
With this change it skips the x4 `System.Threading.Tasks.ValueTask`1.get_Result()` and outputs
```csharp
Unhandled exception. System.Net.Http.HttpRequestException: No connection could be made because the target machine actively refused it.
 ---> System.Net.Sockets.SocketException (10061): No connection could be made because the target machine actively refused it.
   at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.ConnectAsync(HttpRequestMessage request, Boolean allowHttp2, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.CreateHttp11ConnectionAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.GetHttpConnectionAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.SendWithRetryAsync(HttpRequestMessage request, Boolean doRequestAuth, CancellationToken cancellationToken)
   at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.FinishSendAsyncUnbuffered(Task`1 sendTask, HttpRequestMessage request, CancellationTokenSource cts, Boolean disposeCts)
   at System.Net.Http.HttpClient.GetStringAsyncCore(Task`1 getTask)
   at Program.Main(String[] args) in C:\Work\NewForNetCore3Talk\Exceptions\Program.cs:line 10
   at Program.<Main>(String[] args)
```

/cc @stephentoub 