### PR TITLE
WorkAround for #25050.

### DIFF
--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -884,6 +884,16 @@ protected:
         }
         void idCodeSize(unsigned sz)
         {
+            if (sz > 15)
+            {
+                // This is a temporary workaround for non-precise instr size
+                // estimator on XARCH. It often overestimates sizes and can
+                // return value more than 15 that doesn't fit in 4 bite _idCodeSize.
+                // If somehow we generate instruction that needs more than 15 bytes we
+                // will fail on another assert in emit.cpp: noway_assert(id->idCodeSize() >= csz).
+                // Issue 25050.
+                sz = 15;
+            }
             assert(sz <= 15); // Intel decoder limit.
             _idCodeSize = sz;
             assert(sz == _idCodeSize);

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -888,10 +888,10 @@ protected:
             {
                 // This is a temporary workaround for non-precise instr size
                 // estimator on XARCH. It often overestimates sizes and can
-                // return value more than 15 that doesn't fit in 4 bite _idCodeSize.
+                // return value more than 15 that doesn't fit in 4 bits _idCodeSize.
                 // If somehow we generate instruction that needs more than 15 bytes we
                 // will fail on another assert in emit.cpp: noway_assert(id->idCodeSize() >= csz).
-                // Issue 25050.
+                // Issue https://github.com/dotnet/coreclr/issues/25050.
                 sz = 15;
             }
             assert(sz <= 15); // Intel decoder limit.


### PR DESCRIPTION
A temporary workaround to push the milestone for #25050 to 3.next.

PTAL @dotnet/jit-contrib 