### PR TITLE
Enable byref primitive types to be considered for pinvoke inlining

### DIFF
--- a/src/vm/dllimport.cpp
+++ b/src/vm/dllimport.cpp
@@ -3217,7 +3217,6 @@ HRESULT NDirect::HasNAT_LAttribute(IMDInternalImport *pInternalImport, mdToken t
     return S_FALSE;
 }
 
-
 // Either MD or signature & module must be given.
 /*static*/
 BOOL NDirect::MarshalingRequired(MethodDesc *pMD, PCCOR_SIGNATURE pSig /*= NULL*/, Module *pModule /*= NULL*/)
@@ -3315,6 +3314,20 @@ BOOL NDirect::MarshalingRequired(MethodDesc *pMD, PCCOR_SIGNATURE pSig /*= NULL*
                     }
                 }
                 if (i > 0) dwStackSize += sizeof(SLOT);
+                break;
+            }
+
+            case ELEMENT_TYPE_BYREF:
+            {
+                IfFailThrow(arg.GetElemType(NULL)); // skip ELEMENT_TYPE_BYREF
+                IfFailThrow(arg.PeekElemType(&type));
+
+                if (!CorTypeInfo::IsPrimitiveType(type))
+                    return TRUE;
+
+                if (i > 0) 
+                    dwStackSize += StackElemSize(CorTypeInfo::Size(type));
+
                 break;
             }
 


### PR DESCRIPTION
I was investigating #23873 and found this interesting issue where we fail to pre-compile some pinvokes because they have "out" parameters. These can really be treated as pointer types.

Enabled byrefs for primitive types only to minimize risk. This might actually work for valuetypes without the need for marshalling, and we can just make it the same behavior that we have for the ELEMENT_TYPE_PTR case. Not sure about it though...