### PR TITLE
Add /eng/pipelines/*.yml

### DIFF
--- a/eng/pipelines/corefx-jitstress.yml
+++ b/eng/pipelines/corefx-jitstress.yml
@@ -1,0 +1,33 @@
+trigger: none
+
+pr: none
+
+schedules:
+- cron: "0 7 * * *"
+  displayName: Mon through Sun at 11:00 PM (UTC-8:00)
+  branches:
+    include:
+    - master
+  always: true
+
+jobs:
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: build-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_x64
+    - Windows_NT_x64
+
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: test-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_x64
+    - Windows_NT_x64
+    helixQueueGroup: ci
+    jobParameters:
+      testGroup: jitstress
+      corefxTests: true
+      displayNameArgs: CoreFX

--- a/eng/pipelines/corefx-jitstress.yml
+++ b/eng/pipelines/corefx-jitstress.yml
@@ -26,7 +26,7 @@ jobs:
     platforms:
     - Linux_x64
     - Windows_NT_x64
-    helixQueueGroup: ci
+    helixQueueGroup: pr
     jobParameters:
       testGroup: jitstress
       corefxTests: true

--- a/eng/pipelines/corefx-jitstress2-jitstressregs.yml
+++ b/eng/pipelines/corefx-jitstress2-jitstressregs.yml
@@ -1,0 +1,33 @@
+trigger: none
+
+pr: none
+
+schedules:
+- cron: "0 9 * * *"
+  displayName: Mon through Sun at 1:00 AM (UTC-8:00)
+  branches:
+    include:
+    - master
+  always: true
+
+jobs:
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: build-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_x64
+    - Windows_NT_x64
+
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: test-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_x64
+    - Windows_NT_x64
+    helixQueueGroup: ci
+    jobParameters:
+      testGroup: jitstress2-jitstressregs
+      corefxTests: true
+      displayNameArgs: CoreFX

--- a/eng/pipelines/corefx-jitstress2-jitstressregs.yml
+++ b/eng/pipelines/corefx-jitstress2-jitstressregs.yml
@@ -26,7 +26,7 @@ jobs:
     platforms:
     - Linux_x64
     - Windows_NT_x64
-    helixQueueGroup: ci
+    helixQueueGroup: pr
     jobParameters:
       testGroup: jitstress2-jitstressregs
       corefxTests: true

--- a/eng/pipelines/corefx-jitstressregs.yml
+++ b/eng/pipelines/corefx-jitstressregs.yml
@@ -1,0 +1,33 @@
+trigger: none
+
+pr: none
+
+schedules:
+- cron: "0 12 * * *"
+  displayName: Mon through Sun at 4:00 AM (UTC-8:00)
+  branches:
+    include:
+    - master
+  always: true
+
+jobs:
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: build-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_x64
+    - Windows_NT_x64
+
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: test-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_x64
+    - Windows_NT_x64
+    helixQueueGroup: ci
+    jobParameters:
+      testGroup: jitstressregs
+      corefxTests: true
+      displayNameArgs: CoreFX

--- a/eng/pipelines/corefx-jitstressregs.yml
+++ b/eng/pipelines/corefx-jitstressregs.yml
@@ -26,7 +26,7 @@ jobs:
     platforms:
     - Linux_x64
     - Windows_NT_x64
-    helixQueueGroup: ci
+    helixQueueGroup: pr
     jobParameters:
       testGroup: jitstressregs
       corefxTests: true

--- a/eng/pipelines/corefx.yml
+++ b/eng/pipelines/corefx.yml
@@ -1,0 +1,33 @@
+trigger: none
+
+pr: none
+
+schedules:
+- cron: "0 11 * * *"
+  displayName: Mon through Sun at 3:00 AM (UTC-8:00)
+  branches:
+    include:
+    - master
+  always: true
+
+jobs:
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: build-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_x64
+    - Windows_NT_x64
+
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: test-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_x64
+    - Windows_NT_x64
+    helixQueueGroup: ci
+    jobParameters:
+      testGroup: outerloop
+      corefxTests: true
+      displayNameArgs: CoreFX

--- a/eng/pipelines/corefx.yml
+++ b/eng/pipelines/corefx.yml
@@ -26,7 +26,7 @@ jobs:
     platforms:
     - Linux_x64
     - Windows_NT_x64
-    helixQueueGroup: ci
+    helixQueueGroup: pr
     jobParameters:
       testGroup: outerloop
       corefxTests: true

--- a/eng/pipelines/gcstress-extra.yml
+++ b/eng/pipelines/gcstress-extra.yml
@@ -1,0 +1,27 @@
+trigger: none
+
+pr: none
+
+schedules:
+- cron: "0 21 * * 6,0"
+  displayName: Sat and Sun at 1:00 PM (UTC-8:00)
+  branches:
+    include:
+    - master
+  always: true
+
+jobs:
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: build-job.yml
+    buildConfig: checked
+    platformGroup: gcstress
+
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: test-job.yml
+    buildConfig: checked
+    platformGroup: gcstress
+    helixQueueGroup: ci
+    jobParameters:
+      testGroup: gcstress-extra

--- a/eng/pipelines/gcstress0x3-gcstress0xc.yml
+++ b/eng/pipelines/gcstress0x3-gcstress0xc.yml
@@ -1,0 +1,27 @@
+trigger: none
+
+pr: none
+
+schedules:
+- cron: "0 13 * * 6,0"
+  displayName: Sat and Sun at 5:00 AM (UTC-8:00)
+  branches:
+    include:
+    - master
+  always: true
+
+jobs:
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: build-job.yml
+    buildConfig: checked
+    platformGroup: gcstress
+
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: test-job.yml
+    buildConfig: checked
+    platformGroup: gcstress
+    helixQueueGroup: ci
+    jobParameters:
+      testGroup: gcstress0x3-gcstress0xc

--- a/eng/pipelines/jitstress-isas-arm.yml
+++ b/eng/pipelines/jitstress-isas-arm.yml
@@ -1,0 +1,23 @@
+trigger: none
+
+pr: none
+
+jobs:
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: build-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_arm64
+    - Windows_NT_arm64
+
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: test-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_arm64
+    - Windows_NT_arm64
+    helixQueueGroup: ci
+    jobParameters:
+      testGroup: jitstress-isas-arm

--- a/eng/pipelines/jitstress-isas-x86.yml
+++ b/eng/pipelines/jitstress-isas-x86.yml
@@ -1,0 +1,27 @@
+trigger: none
+
+pr: none
+
+jobs:
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: build-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_x64
+    - OSX_x64
+    - Windows_NT_x64
+    - Windows_NT_x86
+
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: test-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_x64
+    - OSX_x64
+    - Windows_NT_x64
+    - Windows_NT_x86
+    helixQueueGroup: ci
+    jobParameters:
+      testGroup: jitstress-isas-x86

--- a/eng/pipelines/jitstress.yml
+++ b/eng/pipelines/jitstress.yml
@@ -1,0 +1,27 @@
+trigger: none
+
+pr: none
+
+schedules:
+- cron: "0 4 * * *"
+  displayName: Mon through Sun at 8:00 PM (UTC-8:00)
+  branches:
+    include:
+    - master
+  always: true
+
+jobs:
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: build-job.yml
+    buildConfig: checked
+    platformGroup: all
+
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: test-job.yml
+    buildConfig: checked
+    platformGroup: all
+    helixQueueGroup: ci
+    jobParameters:
+      testGroup: jitstress

--- a/eng/pipelines/jitstress2-jitstressregs.yml
+++ b/eng/pipelines/jitstress2-jitstressregs.yml
@@ -1,0 +1,27 @@
+trigger: none
+
+pr: none
+
+schedules:
+- cron: "0 17 * * 6,0"
+  displayName: Sat and Sun at 9:00 AM (UTC-8:00)
+  branches:
+    include:
+    - master
+  always: true
+
+jobs:
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: build-job.yml
+    buildConfig: checked
+    platformGroup: all
+
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: test-job.yml
+    buildConfig: checked
+    platformGroup: all
+    helixQueueGroup: ci
+    jobParameters:
+      testGroup: jitstress2-jitstressregs

--- a/eng/pipelines/jitstressregs-x86.yml
+++ b/eng/pipelines/jitstressregs-x86.yml
@@ -1,0 +1,25 @@
+trigger: none
+
+pr: none
+
+jobs:
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: build-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_x64
+    - Windows_NT_x64
+    - Windows_NT_x86
+
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: test-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_x64
+    - Windows_NT_x64
+    - Windows_NT_x86
+    helixQueueGroup: ci
+    jobParameters:
+      testGroup: jitstressregs-x86

--- a/eng/pipelines/jitstressregs.yml
+++ b/eng/pipelines/jitstressregs.yml
@@ -1,0 +1,27 @@
+trigger: none
+
+pr: none
+
+schedules:
+- cron: "0 10 * * 6,0"
+  displayName: Sat and Sun at 2:00 AM (UTC-8:00)
+  branches:
+    include:
+    - master
+  always: true
+
+jobs:
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: build-job.yml
+    buildConfig: checked
+    platformGroup: all
+
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: test-job.yml
+    buildConfig: checked
+    platformGroup: all
+    helixQueueGroup: ci
+    jobParameters:
+      testGroup: jitstressregs

--- a/eng/pipelines/r2r-extra.yml
+++ b/eng/pipelines/r2r-extra.yml
@@ -1,0 +1,29 @@
+trigger: none
+
+pr: none
+
+schedules:
+- cron: "0 2 * * 0,1"
+  displayName: Sat and Sun at 6:00 PM (UTC-8:00)
+  branches:
+    include:
+    - master
+  always: true
+
+jobs:
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: build-job.yml
+    buildConfig: checked
+    platformGroup: gcstress
+
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: test-job.yml
+    buildConfig: checked
+    platformGroup: gcstress # r2r-extra testGroup runs gcstress15 scenario
+    helixQueueGroup: ci
+    jobParameters:
+      testGroup: r2r-extra
+      readyToRun: true
+      displayNameArgs: R2R

--- a/eng/pipelines/r2r.yml
+++ b/eng/pipelines/r2r.yml
@@ -1,0 +1,31 @@
+trigger: none
+
+pr: none
+
+jobs:
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: build-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - Windows_NT_x64
+    - Windows_NT_x86
+
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: test-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - Windows_NT_x64
+    - Windows_NT_x86
+    helixQueueGroup: ci
+    jobParameters:
+      testGroup: outerloop
+      readyToRun: true
+      displayNameArgs: R2R

--- a/eng/pipelines/runincontext.yml
+++ b/eng/pipelines/runincontext.yml
@@ -1,0 +1,35 @@
+trigger: none
+
+pr: none
+
+schedules:
+- cron: "0 13 * * 6,0"
+  displayName: Sat and Sun at 5:00 AM (UTC-8:00)
+  branches:
+    include:
+    - master
+  always: true
+
+jobs:
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: build-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_x64
+    - Windows_NT_x64
+    - Windows_NT_x86
+
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: test-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_x64
+    - Windows_NT_x64
+    - Windows_NT_x86
+    helixQueueGroup: ci
+    jobParameters:
+      testGroup: outerloop
+      runInUnloadableContext: true
+      displayNameArgs: RunInContext


### PR DESCRIPTION
The plan is to commit these files first and then starting changing the build definitions one-by-one (i.e. changing their root files from azure-pipelines.yml to /eng/pipelines/x.yml.

The last step should be cleaning up azure-pipelines.yml from the logic for all the build definitions except main ones - official build and coreclr-ci.