### PR TITLE
Improve corefx testhost construction

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,8 +118,13 @@ jobs:
         platformGroup: all
       ${{ if in(variables['Build.DefinitionName'], 'coreclr-corefx', 'coreclr-corefx-jitstress', 'coreclr-corefx-jitstressregs', 'coreclr-corefx-jitstress2-jitstressregs') }}:
         platforms:
+        # TODO: add Windows_NT_arm64, when we have hardware available, and .NET Core supports it. Note: platform-matrix.yml needs to enable a Helix queue for this.
+        - Linux_arm
+        - Linux_arm64
         - Linux_x64
+        # TODO: re-enable Windows_NT_arm when https://github.com/dotnet/corefx/issues/38863 is resolved
         - Windows_NT_x64
+        - Windows_NT_x86
 
 #
 # Release builds
@@ -222,10 +227,14 @@ jobs:
         - Windows_NT_x64
       ${{ if in(variables['Build.DefinitionName'], 'coreclr-corefx', 'coreclr-corefx-jitstress', 'coreclr-corefx-jitstressregs', 'coreclr-corefx-jitstress2-jitstressregs') }}:
         platforms:
+        # TODO: add Windows_NT_arm64, when we have hardware available, and .NET Core supports it. Note: platform-matrix.yml needs to enable a Helix queue for this.
+        - Linux_arm
+        - Linux_arm64
         - Linux_x64
+        # TODO: re-enable Windows_NT_arm when https://github.com/dotnet/corefx/issues/38863 is resolved
         - Windows_NT_x64
-      # We only want to run corefx testing on the minimum set of queues, no matter the build reason.
-      helixQueueGroup: pr
+        - Windows_NT_x86
+      helixQueueGroup: corefx
       jobParameters:
         ${{ if eq(variables['Build.DefinitionName'], 'coreclr-ci') }}:
           testGroup: innerloop

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -27,10 +27,6 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>60d8aa31a4c1ffa0e125bd7941aca171439a2f72</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0-preview7.19324.8">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>60d8aa31a4c1ffa0e125bd7941aca171439a2f72</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview7-27824-03">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>e1d780539e85f4d8de263957715f9d08db2ceef4</Sha>

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -11,6 +11,7 @@ parameters:
   # 'pr' - the queues used for a pull request for the platform. Typically a small set.
   # 'ci' - the queues used for a CI (post-merge) test run.
   # 'all' - the queues used for non-PR, non-CI test runs, e.g., Manual or Scheduled runs. Typically this is all available queues.
+  # 'corefx' - the queues used for a corefx test run.
   helixQueueGroup: 'pr'
   jobParameters: {}
 
@@ -59,7 +60,7 @@ jobs:
       helixQueues:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
         - (Ubuntu.1804.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-0a0ebdd-20190312220351
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(parameters.helixQueueGroup, 'pr', 'ci')) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(parameters.helixQueueGroup, 'pr', 'ci', 'corefx')) }}:
         - (Debian.9.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-0a0ebdd-20190312215438
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - (Debian.9.Arm64)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-0a0ebdd-20190312215438
@@ -138,9 +139,9 @@ jobs:
         image: centos-7-3e800f1-20190501005343
         registry: mcr
       helixQueues:
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'pr', 'ci')) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'pr', 'ci', 'corefx')) }}:
         - Ubuntu.1804.Amd64.Open
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(parameters.helixQueueGroup, 'pr', 'ci')) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(parameters.helixQueueGroup, 'pr', 'ci', 'corefx')) }}:
         - Debian.9.Amd64.Open
         - Ubuntu.1604.Amd64.Open
         - Ubuntu.1804.Amd64.Open
@@ -182,9 +183,9 @@ jobs:
       osGroup: OSX
       osIdentifier: OSX
       helixQueues:
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'pr', 'ci')) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'pr', 'ci', 'corefx')) }}:
         - OSX.1013.Amd64.Open
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(parameters.helixQueueGroup, 'pr', 'ci')) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(parameters.helixQueueGroup, 'pr', 'ci', 'corefx')) }}:
         - OSX.1012.Amd64.Open
         - OSX.1013.Amd64.Open
         - OSX.1014.Amd64.Open
@@ -204,9 +205,9 @@ jobs:
       osGroup: Windows_NT
       osIdentifier: Windows_NT
       helixQueues:
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'pr', 'ci')) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'pr', 'ci', 'corefx')) }}:
         - Windows.10.Amd64.Open
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(parameters.helixQueueGroup, 'pr', 'ci')) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(parameters.helixQueueGroup, 'pr', 'ci', 'corefx')) }}:
         # TODO: add Windows.10.Nano.Amd64.Open once https://github.com/dotnet/coreclr/issues/21693 has been resolved
         - Windows.7.Amd64.Open
         - Windows.81.Amd64.Open
@@ -229,9 +230,9 @@ jobs:
       osGroup: Windows_NT
       osIdentifier: Windows_NT
       helixQueues:
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'pr', 'ci')) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'pr', 'ci', 'corefx')) }}:
         - Windows.10.Amd64.Open
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(parameters.helixQueueGroup, 'pr', 'ci')) }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(parameters.helixQueueGroup, 'pr', 'ci', 'corefx')) }}:
         - Windows.7.Amd64.Open
         - Windows.81.Amd64.Open
         - Windows.10.Amd64.Open
@@ -252,8 +253,10 @@ jobs:
       osGroup: Windows_NT
       osIdentifier: Windows_NT
       helixQueues:
-      # TODO: Due to the limited capacity of the machines in Windows.10.Arm64.Open queue limit this to CI builds and only to Windows_NT/arm
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'ci')) }}:
+      # NOTE: there are no queues specified for Windows_NT_arm public with helixQueueGroup='pr'. This means that specifying
+      # Windows_NT_arm for a PR job causes a build, but no test run. If the test build and test runs were separate jobs,
+      # this could be more explicit (and less subtle).
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'ci', 'corefx')) }}:
         - Windows.10.Arm64.Open
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - Windows.10.Arm64

--- a/tests/dir.props
+++ b/tests/dir.props
@@ -54,6 +54,8 @@
     <BinDir>$(__BinDir)\</BinDir>
     <BinDir Condition="'$(__BinDir)'==''">$(RootBinDir)Product\$(BuildOS).$(BuildArch).$(BuildType)\</BinDir>
 
+    <TestWorkingDir Condition="'$(__TestWorkingDir)'==''">$(RootBinDir)tests\$(BuildOS).$(BuildArch).$(BuildType)\</TestWorkingDir>
+
     <AltJitArch>$(__AltJitArch)</AltJitArch>
   </PropertyGroup>
 
@@ -131,6 +133,14 @@
    -->
   <PropertyGroup>
     <CLRTestPriorityToBuild>0</CLRTestPriorityToBuild>
+  </PropertyGroup>
+
+  <!-- Where to put a "testhost" for running corefx tests -->
+  <PropertyGroup>
+    <TestHostVersion>$(ProductVersion)</TestHostVersion>
+    <TestHostRootPath>$([MSBuild]::NormalizeDirectory('$(TestWorkingDir)', 'testhost'))</TestHostRootPath>
+    <NETCoreAppTestHostFxrPath>$([MSBuild]::NormalizeDirectory('$(TestHostRootPath)', 'host', 'fxr', '$(TestHostVersion)'))</NETCoreAppTestHostFxrPath>
+    <NETCoreAppTestSharedFrameworkPath>$([MSBuild]::NormalizeDirectory('$(TestHostRootPath)', 'shared', 'Microsoft.NETCore.App', '$(TestHostVersion)'))</NETCoreAppTestSharedFrameworkPath>
   </PropertyGroup>
   
 </Project>

--- a/tests/runtest.proj
+++ b/tests/runtest.proj
@@ -8,14 +8,6 @@
     <MSBuildEnableAllPropertyFunctions>1</MSBuildEnableAllPropertyFunctions>
   </PropertyGroup>
 
-  <!-- TestHost destinations -->
-  <PropertyGroup>
-    <NETCoreAppTestSharedFxVersion>9.9.9</NETCoreAppTestSharedFxVersion>
-    <TestHostRootPath>$(BinDir)testhost\</TestHostRootPath>
-    <NETCoreAppTestHostFxrPath>$(TestHostRootPath)host\fxr\$(NETCoreAppTestSharedFxVersion)\</NETCoreAppTestHostFxrPath>
-    <NETCoreAppTestSharedFrameworkPath>$(TestHostRootPath)shared\Microsoft.NETCore.App\$(NETCoreAppTestSharedFxVersion)\</NETCoreAppTestSharedFrameworkPath>
-  </PropertyGroup>
-
   <ItemGroup>
     <DisabledTestDir Include="Common" />
     <_SkipTestDir Include="@(DisabledTestDir)" />
@@ -373,22 +365,23 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
              Properties="Language=C#;TargetRid=$(TargetRid)" />
   </Target>
 
-  <Target Name="ResolveTestHostDependencies">
+  <!--
+       Targets and properties for creating the testhost directory used to run corefx tests.
+   -->
+
+  <Target Name="CreateTestHost">
     <MSBuild Projects="$(MSBuildThisFileDirectory)src\Common\CoreFX\CoreFX.depproj"
-            Properties="OutputPath=$(NETCoreAppTestSharedFrameworkPath);" />
-  </Target>
-
-  <Target Name="CreateTestHost" DependsOnTargets="ResolveTestHostDependencies">
-    <MSBuild Projects="$(MSBuildProjectFile)"
-            Targets="SetupTestingHost"/>
+             Targets="Build;SetupTestingHost"
+             Properties="OutputPath=$(NETCoreAppTestSharedFrameworkPath)" />
 
     <MSBuild Projects="$(MSBuildProjectFile)"
-            Targets="GenerateTestSharedFrameworkDepsFile"/>
+             Targets="GenerateTestSharedFrameworkDepsFile"/>
   </Target>
 
   <UsingTask TaskName="GenerateDepsJson" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+
   <!-- After we copied all the framework libraries we need to generate a deps.json file for the shared test framework -->
-  <Target Name="GenerateTestSharedFrameworkDepsFile" AfterTargets="SetupTestingHost">
+  <Target Name="GenerateTestSharedFrameworkDepsFile">
     <ItemGroup>
       <!-- This is for HostPolicy, CoreCLR and Jit dependencies to continue to remain inside of the dep.json -->
       <ExceptionForDepsJson Include="microsoft.netcore.app" />
@@ -407,62 +400,6 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
                       RuntimeDirectory="$(NETCoreAppTestSharedFrameworkPath)"
                       DepsExceptions="@(ExceptionForDepsJson)"
                       OutputPath="$(_OutputTestSharedFrameworkDepsPath)"/>
-  </Target>
-
-  <Target Name="SetupTestingHost"  AfterTargets="CreateTestOverlay" Condition="'$(CreateTestHost)' != 'false'">
-
-    <PropertyGroup Condition="'$(OSGroup)'=='Windows_NT'">
-      <HostFxrFileName>hostfxr</HostFxrFileName>
-      <HostFxrFileExtension>dll</HostFxrFileExtension>
-      <DotnetExecutableName>dotnet.exe</DotnetExecutableName>
-      <HostPolicyFileName>hostpolicy</HostPolicyFileName>
-      <HostPolicyExtension>dll</HostPolicyExtension>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(OSGroup)'!='Windows_NT'">
-      <HostFxrFileName>libhostfxr</HostFxrFileName>
-      <HostFxrFileExtension Condition="'$(OSGroup)' == 'Linux' Or '$(OSGroup)' == 'FreeBSD'">so</HostFxrFileExtension>
-      <HostFxrFileExtension Condition="$(OSGroup) =='OSX'">dylib</HostFxrFileExtension>
-      <HostPolicyFileName>libhostpolicy</HostPolicyFileName>
-      <HostPolicyExtension>$(HostFxrFileExtension)</HostPolicyExtension>
-      <DotnetExecutableName>dotnet</DotnetExecutableName>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <!-- Workaround for packages on which Microsoft.NetCoreApp expresses a dependency
-      The <PackageToInclude> element doesn't allow a version to be specified and we end up with clashing assembly versions in Core_Root-->
-      <NetCoreAppPackagedAssemblies Include="System.Text.Encoding.CodePages.dll"/>
-      <!-- Use xunit dependencies defined in CoreFX.depproj instead of conflicting versions from test dependencies. -->
-      <TestDependenciesToExclude Include="$(CORE_ROOT)\**\xunit*"/>
-      <CoreCLRBinariesToExclude Include="@(NetCoreAppPackagedAssemblies);@(TestDependenciesToExclude -> '%(Identity)')" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <CoreCLRBinaries Include="$(CORE_ROOT)\**\*.*" Exclude="$(CORE_ROOT)\**\@(CoreCLRBinariesToExclude -> '%(Identity)' )" />
-      <HostFxFile Include="$(DotnetCliPath)\**\$(HostFxrFileName).$(HostFxrFileExtension)" />
-      <DotnetExe Include="$(DotnetCliPath)\$(DotnetExecutableName)" />
-      <HostPolicyFile Include="$(DotnetCliPath)\**\$(HostPolicyFileName).$(HostPolicyExtension)" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(HostFxFile)"
-          DestinationFolder="$(NETCoreAppTestHostFxrPath)"
-          SkipUnchangedFiles="true"
-          UseHardlinksIfPossible="true" />
-
-    <!-- Should this be referenced from a NuGet package? -->
-    <Copy SourceFiles="@(HostPolicyFile)"
-          DestinationFolder="$(NETCoreAppTestSharedFrameworkPath)"
-          SkipUnchangedFiles="true"
-          UseHardlinksIfPossible="true" />
-
-    <Copy SourceFiles="@(DotnetExe)"
-          DestinationFolder="$(TestHostRootPath)"
-          SkipUnchangedFiles="true"
-          UseHardlinksIfPossible="true"  />
-
-    <Copy SourceFiles="@(CoreCLRBinaries)"
-          DestinationFolder="$(NETCoreAppTestSharedFrameworkPath)"
-          SkipUnchangedFiles="true" />
   </Target>
 
   <Target Name="Build">

--- a/tests/src/Common/CoreFX/CoreFX.depproj
+++ b/tests/src/Common/CoreFX/CoreFX.depproj
@@ -9,173 +9,125 @@
       <ContainsPackageReferences>true</ContainsPackageReferences>
       <CLRTestKind>SharedLibrary</CLRTestKind>
       <IsTestProject>false</IsTestProject>
-      <!-- System.Composition and System.Composition.AttributedModel use different versioning conventions -->
-      <SystemCompositionVersions>1.3.0-preview3-26501-04</SystemCompositionVersions>
-      <MicrosoftDiagnosticsTracingTraceVentVersion>2.0.19</MicrosoftDiagnosticsTracingTraceVentVersion>
-      <MicrosoftDotnetPlatformAbstractionsVersion>2.1.0</MicrosoftDotnetPlatformAbstractionsVersion>
       <MicrosoftDiagnosticsRuntimePackageVersion>1.0.5</MicrosoftDiagnosticsRuntimePackageVersion>
   </PropertyGroup>
 
-  <!-- Switch RuntimeIdentifier according to currently running OSGroup -->
+  <!-- Switch RuntimeIdentifier according to currently targeted OSGroup -->
   <PropertyGroup>
-      <RuntimeIdentifier Condition="'$(OSGroup)' == 'Windows_NT'">win-x64</RuntimeIdentifier>
-      <RuntimeIdentifier Condition="'$(OSGroup)' == 'Linux'">linux-x64</RuntimeIdentifier>
-      <RuntimeIdentifier Condition="'$(OSGroup)' == 'OSX'">osx-x64</RuntimeIdentifier>
+      <RuntimeIdentifier Condition="'$(OSGroup)' == 'Windows_NT'">win-$(Platform)</RuntimeIdentifier>
+      <RuntimeIdentifier Condition="'$(OSGroup)' == 'Linux'">linux-$(Platform)</RuntimeIdentifier>
+      <RuntimeIdentifier Condition="'$(OSGroup)' == 'OSX'">osx-$(Platform)</RuntimeIdentifier>
       <NugetRuntimeIdentifier>$(RuntimeIdentifier)</NugetRuntimeIdentifier>
+
+      <!-- Set AdditionalRestoreArgs so the _DnuRestoreCommandFull in Tools\packageresolve.targets
+           passes these on to 'dotnet restore'. This is needed so all the various dirs.props files
+           set up the target architecture correctly, so $(Platform) above gets set correctly, among
+           other things. (Note that _DnuRestoreCommandFull doesn't properly set
+           TargetGroup/ConfigurationGroup/ArchGroup, and even if they are set, it isn't used by
+           the various dirs.props files.)
+      -->
+      <AdditionalRestoreArgs>/p:__BuildOS=$(__BuildOS) /p:__BuildType=$(__BuildType) /p:__BuildArch=$(__BuildArch)</AdditionalRestoreArgs>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CodeDom">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Configuration.ConfigurationManager">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Composition.Hosting">
-      <Version>$(SystemCompositionVersions)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Composition.AttributedModel">
-      <Version>$(SystemCompositionVersions)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Composition.Convention">
-      <Version>$(SystemCompositionVersions)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Composition.Runtime">
-      <Version>$(SystemCompositionVersions)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Composition.TypedParts">
-      <Version>$(SystemCompositionVersions)</Version>
-    </PackageReference>
-    <PackageReference Include="System.ComponentModel.Composition">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Data.Odbc">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="runtime.native.System.Data.SqlClient.sni">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Security.Principal.Windows">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Text.Encoding.CodePages">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Data.SqlClient">
-      <!-- The 4.6 packages of System.Data.SqlClient have a version of 4.5 in the dll so they fail to load -->
-      <Version>4.7.0-preview4.19164.7</Version>
-    </PackageReference>
-    <PackageReference Include="System.Diagnostics.PerformanceCounter">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.DirectoryServices">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.DirectoryServices.AccountManagement">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.DirectoryServices.Protocols">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Drawing.Common">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.IO.Packaging">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.IO.Pipelines">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.IO.Ports">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Management">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Net.Http.WinHttpHandler">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Net.WebSockets.WebSocketProtocol">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Reflection.MetadataLoadContext">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Runtime.Caching">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Reflection.Context">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.ProtectedData">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.Pkcs">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.Xml">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.ServiceModel.Syndication">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.ServiceProcess.ServiceController">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Text.Encoding.CodePages">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Text.Encodings.Web">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Threading.AccessControl">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Threading.Channels">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="System.Json">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
-      <Version>$(MicrosoftBclAsyncInterfacesVersion)</Version>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup Condition="'$(OSGroup)' == 'Windows_NT'">
-    <!-- Windows Dependencies -->
-    <PackageReference Include="Microsoft.Win32.Registry">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Win32.Registry.AccessControl">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Win32.SystemEvents">
-      <Version>$(MicrosoftPrivateCoreFxNETCoreAppVersion)</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent">
-      <Version>$(MicrosoftDiagnosticsTracingTraceVentVersion)</Version>
-    </PackageReference>
-  </ItemGroup>
-  
-  <ItemGroup Condition="'$(OSGroup)' != 'Windows_NT'">
-    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions">
-      <Version>$(MicrosoftDotnetPlatformAbstractionsVersion)</Version>
-    </PackageReference>
+
+    <!-- Microsoft.Private.CoreFx.OOB is a meta-package that contains references to most of what we need -->
+    <PackageReference Include="Microsoft.Private.CoreFx.OOB" Version="$(MicrosoftPrivateCoreFxNETCoreAppVersion)" />
+
+    <!-- dotnet.exe -->
+    <PackageReference Include="Microsoft.NETCore.DotNetHost" Version="$(MicrosoftNETCoreAppVersion)" />
+
+    <!-- hostfxr.dll -->
+    <PackageReference Include="Microsoft.NETCore.DotNetHostResolver" Version="$(MicrosoftNETCoreAppVersion)" />
+
+    <!-- hostpolicy.dll -->
+    <PackageReference Include="Microsoft.NETCore.DotNetHostPolicy" Version="$(MicrosoftNETCoreAppVersion)" />
+
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Runtime">
-      <Version>$(MicrosoftDiagnosticsRuntimePackageVersion)</Version>
-    </PackageReference>
-  </ItemGroup>
-  
-  <ItemGroup>
-    <PackageToInclude Include="@(PackageReference -> '%(Identity)' )"/>
-  </ItemGroup>
+  <!-- Target SetupTestingHost needs to run after "AfterResolveReferences" so @(ReferenceCopyLocalPaths) is
+       set up, and before "BeforeCompile" because @(ReferenceCopyLocalPaths) is cleared out during the
+       compile phase.
+  -->
+  <Target Name="SetupTestingHost" AfterTargets="AfterResolveReferences" BeforeTargets="BeforeCompile">
+
+    <Error Condition="'$(CORE_ROOT)' == ''"
+           Text="CORE_ROOT variable is not set." />
+
+    <PropertyGroup Condition="'$(OSGroup)'=='Windows_NT'">
+      <HostFxrFileName>hostfxr</HostFxrFileName>
+      <HostFxrFileExtension>dll</HostFxrFileExtension>
+      <DotnetExecutableName>dotnet.exe</DotnetExecutableName>
+      <HostPolicyFileName>hostpolicy</HostPolicyFileName>
+      <HostPolicyExtension>dll</HostPolicyExtension>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(OSGroup)'!='Windows_NT'">
+      <HostFxrFileName>libhostfxr</HostFxrFileName>
+      <HostFxrFileExtension Condition="'$(OSGroup)' == 'Linux' Or '$(OSGroup)' == 'FreeBSD'">so</HostFxrFileExtension>
+      <HostFxrFileExtension Condition="$(OSGroup) =='OSX'">dylib</HostFxrFileExtension>
+      <HostPolicyFileName>libhostpolicy</HostPolicyFileName>
+      <HostPolicyExtension>$(HostFxrFileExtension)</HostPolicyExtension>
+      <DotnetExecutableName>dotnet</DotnetExecutableName>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <!-- Workaround for packages on which Microsoft.NetCoreApp expresses a dependency
+           The <PackageToInclude> element doesn't allow a version to be specified and we end up with clashing assembly versions in Core_Root
+      -->
+      <!--
+      <NetCoreAppPackagedAssemblies Include="System.Text.Encoding.CodePages.dll"/>
+      -->
+
+      <!-- Use xunit dependencies defined in CoreFX.depproj instead of conflicting versions from test dependencies. -->
+      <TestDependenciesToExclude Include="$(CORE_ROOT)\**\xunit*"/>
+
+      <!-- Exclude subdirectories that contain cross-architecture (possibly cross-bitness) crossgen/JIT -->
+      <TestDependenciesToExclude Include="$(CORE_ROOT)\**\x64\*"/>
+
+      <!-- Don't include all the nuget files -->
+      <TestDependenciesToExclude Include="$(CORE_ROOT)\.nuget\**\*"/>
+
+      <CoreCLRBinariesToExclude Include="@(NetCoreAppPackagedAssemblies);@(TestDependenciesToExclude -> '%(Identity)')" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <!-- REVIEW: do we need to copy recursively (and flatten the structure into a single destination folder)? Can we just copy
+           the top level? Or, should we preserve the hierarchy?
+      -->
+      <CoreCLRBinaries Include="$(CORE_ROOT)\**\*.*" Exclude="$(CORE_ROOT)\**\@(CoreCLRBinariesToExclude -> '%(Identity)' )" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <HostFxFile Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == '$(HostFxrFileName)'" />
+      <DotnetExe Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'dotnet'" />
+      <HostPolicyFile Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == '$(HostPolicyFileName)'" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(HostFxFile)"
+          DestinationFolder="$(NETCoreAppTestHostFxrPath)"
+          SkipUnchangedFiles="true"
+          UseHardlinksIfPossible="true" />
+
+    <Copy SourceFiles="@(HostPolicyFile)"
+          DestinationFolder="$(NETCoreAppTestSharedFrameworkPath)"
+          SkipUnchangedFiles="true"
+          UseHardlinksIfPossible="true" />
+
+    <Copy SourceFiles="@(DotnetExe)"
+          DestinationFolder="$(TestHostRootPath)"
+          SkipUnchangedFiles="true"
+          UseHardlinksIfPossible="true"  />
+
+    <Copy SourceFiles="@(CoreCLRBinaries)"
+          DestinationFolder="$(NETCoreAppTestSharedFrameworkPath)"
+          SkipUnchangedFiles="true" />
+
+    <Exec Command="chmod +x $(TestHostRootPath)%(DotnetExe.Filename)%(DotnetExe.Extension)" Condition="'$(OSGroup)' != 'Windows_NT'"/>
+  </Target>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+
   <PropertyGroup>
     <ProjectAssetsFile>$(SourceDir)Common\CoreFX\obj\project.assets.json</ProjectAssetsFile>
   </PropertyGroup>


### PR DESCRIPTION
Expand corefx testing in coreclr repo

Currently, corefx testing is done on Windows/x64.
Expand testing to include:
1. Linux/x64, Linux/arm, Linux/arm64, Windows/x86 platforms.
   Windows/arm should be added after corefx official builds
   publish tests and test manifest. Windows/arm64 should be
   added after corefx tests are published, and we have
   sufficient hardware.
2. All JIT stress modes that are used in normal coreclr testing.

Testing is split into 4 Azure DevOps Pipelines: coreclr-corefx,
coreclr-corefx-jitstress, coreclr-corefx-jitstressregs, and
coreclr-corefx-jitstress2-jitstressregs.

In addition, we now use the corefx meta-package Microsoft.Private.CoreFx.OOB
instead of a list of individual assemblies when constructing
the testhost.