### PR TITLE
MemoryExtensions ToUpper / ToLower throws for overlapping buffer

### DIFF
--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -2956,7 +2956,7 @@
   <data name="NotSupported_GlobalMethodSerialization" xml:space="preserve">
     <value>Serialization of global methods (including implicit serialization via the use of asynchronous delegates) is not supported.</value>
   </data>
-    <data name="NotSupported_SpanOverlappedOperation" xml:space="preserve">
+    <data name="InvalidOperation_SpanOverlappedOperation" xml:space="preserve">
     <value>This operation is invalid on overlapping buffers.</value>
   </data>
   <data name="NotSupported_IDispInvokeDefaultMemberWithNamedArgs" xml:space="preserve">

--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -2956,6 +2956,9 @@
   <data name="NotSupported_GlobalMethodSerialization" xml:space="preserve">
     <value>Serialization of global methods (including implicit serialization via the use of asynchronous delegates) is not supported.</value>
   </data>
+    <data name="NotSupported_SpanOverlappedOperation" xml:space="preserve">
+    <value>This operation is invalid on overlapping buffers.</value>
+  </data>
   <data name="NotSupported_IDispInvokeDefaultMemberWithNamedArgs" xml:space="preserve">
     <value>Invoking default method with named arguments is not supported.</value>
   </data>

--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
@@ -225,7 +225,7 @@ namespace System
         public static int ToLower(this ReadOnlySpan<char> source, Span<char> destination, CultureInfo? culture)
         {
             if (source.Overlaps(destination))
-               ThrowHelper.ThrowInvalidOperationException(ExceptionResource.NotSupported_SpanOverlappedOperation);
+                throw new InvalidOperationException(SR.NotSupported_SpanOverlappedOperation);
 
             if (culture == null)
                 culture = CultureInfo.CurrentCulture;
@@ -252,7 +252,7 @@ namespace System
         public static int ToLowerInvariant(this ReadOnlySpan<char> source, Span<char> destination)
         {
             if (source.Overlaps(destination))
-                ThrowHelper.ThrowInvalidOperationException(ExceptionResource.NotSupported_SpanOverlappedOperation);
+                throw new InvalidOperationException(SR.NotSupported_SpanOverlappedOperation);
 
             // Assuming that changing case does not affect length
             if (destination.Length < source.Length)
@@ -278,7 +278,7 @@ namespace System
         public static int ToUpper(this ReadOnlySpan<char> source, Span<char> destination, CultureInfo? culture)
         {
             if (source.Overlaps(destination))
-                ThrowHelper.ThrowInvalidOperationException(ExceptionResource.NotSupported_SpanOverlappedOperation);
+                throw new InvalidOperationException(SR.NotSupported_SpanOverlappedOperation);
 
             if (culture == null)
                 culture = CultureInfo.CurrentCulture;
@@ -305,7 +305,7 @@ namespace System
         public static int ToUpperInvariant(this ReadOnlySpan<char> source, Span<char> destination)
         {
             if (source.Overlaps(destination))
-                ThrowHelper.ThrowInvalidOperationException(ExceptionResource.NotSupported_SpanOverlappedOperation);
+                throw new InvalidOperationException(SR.NotSupported_SpanOverlappedOperation);
 
             // Assuming that changing case does not affect length
             if (destination.Length < source.Length)

--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
@@ -219,13 +219,13 @@ namespace System
         /// <param name="source">The source span.</param>
         /// <param name="destination">The destination span which contains the transformed characters.</param>
         /// <param name="culture">An object that supplies culture-specific casing rules.</param>
-        /// <remarks>If the source and destinations overlap, this method throws InvalidOperationException. 
-        /// If <paramref name="culture"/> is null, <see cref="System.Globalization.CultureInfo.CurrentCulture"/> will be used.</remarks>
+        /// <remarks>If <paramref name="culture"/> is null, <see cref="System.Globalization.CultureInfo.CurrentCulture"/> will be used.</remarks>
         /// <returns>The number of characters written into the destination span. If the destination is too small, returns -1.</returns>
+        /// <exception cref="InvalidOperationException">The source and destination buffers overlap.</exception>
         public static int ToLower(this ReadOnlySpan<char> source, Span<char> destination, CultureInfo? culture)
         {
             if (source.Overlaps(destination))
-                throw new InvalidOperationException(SR.NotSupported_SpanOverlappedOperation);
+                throw new InvalidOperationException(SR.InvalidOperation_SpanOverlappedOperation);
 
             if (culture == null)
                 culture = CultureInfo.CurrentCulture;
@@ -247,12 +247,12 @@ namespace System
         /// </summary>
         /// <param name="source">The source span.</param>
         /// <param name="destination">The destination span which contains the transformed characters.</param>
-        /// <remarks>If the source and destinations overlap, this method throws InvalidOperationException</remarks>
         /// <returns>The number of characters written into the destination span. If the destination is too small, returns -1.</returns>
+        /// <exception cref="InvalidOperationException">The source and destination buffers overlap.</exception>
         public static int ToLowerInvariant(this ReadOnlySpan<char> source, Span<char> destination)
         {
             if (source.Overlaps(destination))
-                throw new InvalidOperationException(SR.NotSupported_SpanOverlappedOperation);
+                throw new InvalidOperationException(SR.InvalidOperation_SpanOverlappedOperation);
 
             // Assuming that changing case does not affect length
             if (destination.Length < source.Length)
@@ -272,13 +272,13 @@ namespace System
         /// <param name="source">The source span.</param>
         /// <param name="destination">The destination span which contains the transformed characters.</param>
         /// <param name="culture">An object that supplies culture-specific casing rules.</param>
-        /// <remarks>If the source and destinations overlap, this method throws InvalidOperationException. 
-        /// If <paramref name="culture"/> is null, <see cref="System.Globalization.CultureInfo.CurrentCulture"/> will be used.</remarks>
+        /// <remarks>If <paramref name="culture"/> is null, <see cref="System.Globalization.CultureInfo.CurrentCulture"/> will be used.</remarks>
         /// <returns>The number of characters written into the destination span. If the destination is too small, returns -1.</returns>
+        /// <exception cref="InvalidOperationException">The source and destination buffers overlap.</exception>
         public static int ToUpper(this ReadOnlySpan<char> source, Span<char> destination, CultureInfo? culture)
         {
             if (source.Overlaps(destination))
-                throw new InvalidOperationException(SR.NotSupported_SpanOverlappedOperation);
+                throw new InvalidOperationException(SR.InvalidOperation_SpanOverlappedOperation);
 
             if (culture == null)
                 culture = CultureInfo.CurrentCulture;
@@ -300,12 +300,12 @@ namespace System
         /// </summary>
         /// <param name="source">The source span.</param>
         /// <param name="destination">The destination span which contains the transformed characters.</param>
-        /// <remarks>If the source and destinations overlap, this method throws InvalidOperationException</remarks>
         /// <returns>The number of characters written into the destination span. If the destination is too small, returns -1.</returns>
+        /// <exception cref="InvalidOperationException">The source and destination buffers overlap.</exception>
         public static int ToUpperInvariant(this ReadOnlySpan<char> source, Span<char> destination)
         {
             if (source.Overlaps(destination))
-                throw new InvalidOperationException(SR.NotSupported_SpanOverlappedOperation);
+                throw new InvalidOperationException(SR.InvalidOperation_SpanOverlappedOperation);
 
             // Assuming that changing case does not affect length
             if (destination.Length < source.Length)

--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
@@ -219,11 +219,14 @@ namespace System
         /// <param name="source">The source span.</param>
         /// <param name="destination">The destination span which contains the transformed characters.</param>
         /// <param name="culture">An object that supplies culture-specific casing rules.</param>
-        /// <remarks>If the source and destinations overlap, this method behaves as if the original values are in
-        /// a temporary location before the destination is overwritten. If <paramref name="culture"/> is null, <see cref="System.Globalization.CultureInfo.CurrentCulture"/> will be used.</remarks>
+        /// <remarks>If the source and destinations overlap, this method throws InvalidOperationException. 
+        /// If <paramref name="culture"/> is null, <see cref="System.Globalization.CultureInfo.CurrentCulture"/> will be used.</remarks>
         /// <returns>The number of characters written into the destination span. If the destination is too small, returns -1.</returns>
         public static int ToLower(this ReadOnlySpan<char> source, Span<char> destination, CultureInfo? culture)
         {
+            if (source.Overlaps(destination))
+               ThrowHelper.ThrowInvalidOperationException(ExceptionResource.NotSupported_SpanOverlappedOperation);
+
             if (culture == null)
                 culture = CultureInfo.CurrentCulture;
 
@@ -244,11 +247,13 @@ namespace System
         /// </summary>
         /// <param name="source">The source span.</param>
         /// <param name="destination">The destination span which contains the transformed characters.</param>
-        /// <remarks>If the source and destinations overlap, this method behaves as if the original values are in
-        /// a temporary location before the destination is overwritten.</remarks>
+        /// <remarks>If the source and destinations overlap, this method throws InvalidOperationException</remarks>
         /// <returns>The number of characters written into the destination span. If the destination is too small, returns -1.</returns>
         public static int ToLowerInvariant(this ReadOnlySpan<char> source, Span<char> destination)
         {
+            if (source.Overlaps(destination))
+                ThrowHelper.ThrowInvalidOperationException(ExceptionResource.NotSupported_SpanOverlappedOperation);
+
             // Assuming that changing case does not affect length
             if (destination.Length < source.Length)
                 return -1;
@@ -267,11 +272,14 @@ namespace System
         /// <param name="source">The source span.</param>
         /// <param name="destination">The destination span which contains the transformed characters.</param>
         /// <param name="culture">An object that supplies culture-specific casing rules.</param>
-        /// <remarks>If the source and destinations overlap, this method behaves as if the original values are in
-        /// a temporary location before the destination is overwritten. If <paramref name="culture"/> is null, <see cref="System.Globalization.CultureInfo.CurrentCulture"/> will be used.</remarks>
+        /// <remarks>If the source and destinations overlap, this method throws InvalidOperationException. 
+        /// If <paramref name="culture"/> is null, <see cref="System.Globalization.CultureInfo.CurrentCulture"/> will be used.</remarks>
         /// <returns>The number of characters written into the destination span. If the destination is too small, returns -1.</returns>
         public static int ToUpper(this ReadOnlySpan<char> source, Span<char> destination, CultureInfo? culture)
         {
+            if (source.Overlaps(destination))
+                ThrowHelper.ThrowInvalidOperationException(ExceptionResource.NotSupported_SpanOverlappedOperation);
+
             if (culture == null)
                 culture = CultureInfo.CurrentCulture;
 
@@ -292,11 +300,13 @@ namespace System
         /// </summary>
         /// <param name="source">The source span.</param>
         /// <param name="destination">The destination span which contains the transformed characters.</param>
-        /// <remarks>If the source and destinations overlap, this method behaves as if the original values are in
-        /// a temporary location before the destination is overwritten.</remarks>
+        /// <remarks>If the source and destinations overlap, this method throws InvalidOperationException</remarks>
         /// <returns>The number of characters written into the destination span. If the destination is too small, returns -1.</returns>
         public static int ToUpperInvariant(this ReadOnlySpan<char> source, Span<char> destination)
         {
+            if (source.Overlaps(destination))
+                ThrowHelper.ThrowInvalidOperationException(ExceptionResource.NotSupported_SpanOverlappedOperation);
+
             // Assuming that changing case does not affect length
             if (destination.Length < source.Length)
                 return -1;

--- a/src/System.Private.CoreLib/shared/System/ThrowHelper.cs
+++ b/src/System.Private.CoreLib/shared/System/ThrowHelper.cs
@@ -969,7 +969,6 @@ namespace System
         Arg_RanksAndBounds,
         InvalidOperation_IComparerFailed,
         NotSupported_FixedSizeCollection,
-        NotSupported_SpanOverlappedOperation,
         Rank_MultiDimNotSupported,
         Arg_TypeNotSupported,
     }

--- a/src/System.Private.CoreLib/shared/System/ThrowHelper.cs
+++ b/src/System.Private.CoreLib/shared/System/ThrowHelper.cs
@@ -969,6 +969,7 @@ namespace System
         Arg_RanksAndBounds,
         InvalidOperation_IComparerFailed,
         NotSupported_FixedSizeCollection,
+        NotSupported_SpanOverlappedOperation,
         Rank_MultiDimNotSupported,
         Arg_TypeNotSupported,
     }

--- a/tests/CoreFX/CoreFX.issues.rsp
+++ b/tests/CoreFX/CoreFX.issues.rsp
@@ -132,3 +132,9 @@
 -nomethod System.Diagnostics.Tests.StackTraceTests.Ctor_Exception_LargeSkipFrames_FNeedFileInfo
 -nomethod System.Diagnostics.Tests.StackTraceTests.Ctor_LargeSkipFrames_GetFramesReturnsNull
 -nomethod System.Diagnostics.Tests.StackTraceTests.Ctor_LargeSkipFramesFNeedFileInfo_GetFramesReturnsNull
+
+# requires corefx test updates
+-nomethod System.Tests.StringTests.SameSpanToLower
+-nomethod System.Tests.StringTests.ToLowerOverlapping
+-nomethod System.Tests.StringTests.SameSpanToUpper
+-nomethod System.Tests.StringTests.ToUpperOverlapping


### PR DESCRIPTION
contributes to https://github.com/dotnet/corefx/issues/34799

I kept the same style of other code in this file no open/close brackets.

/cc @ahsonkhan @GrabYourPitchforks 