### PR TITLE
Fix ReturnKind classification for byref like types returned in registers

### DIFF
--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -1282,7 +1282,7 @@ ReturnKind MethodDesc::ParseReturnKindFromSig(INDEBUG(bool supportStringConstruc
                         }
 #endif // UNIX_AMD64_ABI
 
-                        if (pReturnTypeMT->ContainsPointers())
+                        if (pReturnTypeMT->ContainsPointers() || pReturnTypeMT->IsByRefLike())
                         {
                             if (pReturnTypeMT->GetNumInstanceFields() == 1)
                             {


### PR DESCRIPTION
These types contain byrefs, and so when returned in registers we may need
to avoid GC stress at the return site.

Addresses part of #24263.