### PR TITLE
Extend the assert for zero-offset fields

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -6655,7 +6655,7 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
 #endif
 
         // We expect 'addr' to be an address at this point.
-        assert(addr->TypeGet() == TYP_BYREF || addr->TypeGet() == TYP_I_IMPL);
+        assert(addr->TypeGet() == TYP_BYREF || addr->TypeGet() == TYP_I_IMPL || addr->TypeGet() == TYP_REF);
 
         // Since we don't make a constant zero to attach the field sequence to, associate it with the "addr" node.
         FieldSeqNode* fieldSeq =
@@ -18724,7 +18724,7 @@ private:
 void Compiler::fgAddFieldSeqForZeroOffset(GenTree* addr, FieldSeqNode* fieldSeqZero)
 {
     // We expect 'addr' to be an address at this point.
-    assert(addr->TypeGet() == TYP_BYREF || addr->TypeGet() == TYP_I_IMPL);
+    assert(addr->TypeGet() == TYP_BYREF || addr->TypeGet() == TYP_I_IMPL || addr->TypeGet() == TYP_REF);
 
     FieldSeqNode* fieldSeqUpdate   = fieldSeqZero;
     GenTree*      fieldSeqNode     = addr;


### PR DESCRIPTION
CoreRT has an [actual field](https://github.com/dotnet/corert/blob/ba3ba929c88bd80ec5d4dd9cf6917471ad8fa180/src/System.Private.CoreLib/src/System/Object.CoreRT.cs#L30) for the method table table pointer in `System.Object`. CoreCLR does shenanigans when laying out `System.Object` to leave a pointer-sized hole instead.

I think the zero-offset field is triggering these asserts.