### PR TITLE
JIT: see if jmp offset will fit in 32 bit displacement

### DIFF
--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -2059,10 +2059,9 @@ void emitter::emitEndFnEpilog()
         // underestimation of the epilog size is harmless (since the EIP
         // can not be between instructions).
         assert(emitEpilogCnt == 1 ||
-               (emitExitSeqSize - newSize) <= 6 // delta between size of various forms of jmp (size is either 6 or 5,
-                                                // or a 5 byte mov plus 2 byte jmp)
+               (emitExitSeqSize - newSize) <= 5 // delta between size of various forms of jmp (size is either 6 or 5),
                                                 // and various forms of ret (size is either 1 or 3). The combination can
-                                                // be anything between 1 and 6.
+                                                // be anything between 1 and 5.
                );
         emitExitSeqSize = newSize;
     }

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -7057,7 +7057,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
 
     if (isJump)
     {
-        assert(callType == EC_FUNC_TOKEN || callType == EC_INDIR_ARD);
+        assert(callType == EC_FUNC_TOKEN || callType == EC_FUNC_TOKEN_INDIR || callType == EC_INDIR_ARD);
         if (callType == EC_FUNC_TOKEN)
         {
             ins = INS_l_jmp;


### PR DESCRIPTION
On x86 we can always reach any IAT_PVALUE entry via a 32 bit indirect
jump, and proper handling of jmp epilogs depends on this. So check if the
target address is reachable in 32 bits, and if so, use the jmp [addr] form
on x86, and the jmp [rip + disp] form for x64.

Fixes #25345
Fixes #25346
Undoes the assertion change from #25302
Fixes #25286