### PR TITLE
Make sure EventPipeProvider::m_keywords is accurate after EventPipeConfiguration::Disable

### DIFF
--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -342,13 +342,6 @@ void EventPipe::DisableInternal(EventPipeSessionID id, EventPipeProviderCallback
     // Disable pSession tracing.
     s_config.Disable(*pSession, pEventPipeProviderCallbackDataQueue);
 
-    // At this point, we should not be writing events to this session anymore
-    // This is a good time to remove the session from the array.
-    _ASSERTE(s_pSessions[pSession->GetIndex()] == pSession);
-
-    // Remove the session from the array, and mask.
-    s_pSessions[pSession->GetIndex()].Store(nullptr);
-
     pSession->Disable(); // Suspend EventPipeBufferManager, and remove providers.
 
     // Do rundown before fully stopping the session.
@@ -374,6 +367,13 @@ void EventPipe::DisableInternal(EventPipeSessionID id, EventPipeProviderCallback
     }
 
     --s_numberOfSessions;
+
+    // At this point, we should not be writing events to this session anymore
+    // This is a good time to remove the session from the array.
+    _ASSERTE(s_pSessions[pSession->GetIndex()] == pSession);
+
+    // Remove the session from the array, and mask.
+    s_pSessions[pSession->GetIndex()].Store(nullptr);
 
     // Write a final sequence point to the file now that all events have
     // been emitted.

--- a/src/vm/eventpipeconfiguration.cpp
+++ b/src/vm/eventpipeconfiguration.cpp
@@ -328,14 +328,14 @@ void EventPipeConfiguration::Enable(EventPipeSession &session, EventPipeProvider
         {
             EventPipeProvider *pProvider = pElem->GetValue();
 
-            INT64 keywordForAllSessions;
-            EventPipeEventLevel levelForAllSessions;
-            ComputeKeywordAndLevel(*pProvider, /* out */ keywordForAllSessions, /* out */ levelForAllSessions);
-
             // Enable the provider if it has been configured.
             EventPipeSessionProvider *pSessionProvider = GetSessionProvider(session, pProvider);
             if (pSessionProvider != NULL)
             {
+                INT64 keywordForAllSessions;
+                EventPipeEventLevel levelForAllSessions;
+                ComputeKeywordAndLevel(*pProvider, /* out */ keywordForAllSessions, /* out */ levelForAllSessions);
+
                 EventPipeProviderCallbackData eventPipeProviderCallbackData =
                     pProvider->SetConfiguration(
                         keywordForAllSessions,
@@ -370,16 +370,15 @@ void EventPipeConfiguration::Disable(const EventPipeSession &session, EventPipeP
         while (pElem != NULL)
         {
             EventPipeProvider *pProvider = pElem->GetValue();
-
-            INT64 keywordForAllSessions;
-            EventPipeEventLevel levelForAllSessions;
-            ComputeKeywordAndLevel(*pProvider, /* out */ keywordForAllSessions, /* out */ levelForAllSessions);
-
             if (pProvider->IsEnabled(session.GetMask()))
             {
                 EventPipeSessionProvider *pSessionProvider = GetSessionProvider(session, pProvider);
                 if (pSessionProvider != nullptr)
                 {
+                    INT64 keywordForAllSessions;
+                    EventPipeEventLevel levelForAllSessions;
+                    ComputeKeywordAndLevel(*pProvider, /* out */ keywordForAllSessions, /* out */ levelForAllSessions);
+
                     EventPipeProviderCallbackData eventPipeProviderCallbackData = pProvider->UnsetConfiguration(
                         keywordForAllSessions,
                         levelForAllSessions,

--- a/src/vm/eventpipeconfiguration.cpp
+++ b/src/vm/eventpipeconfiguration.cpp
@@ -271,7 +271,7 @@ EventPipeProvider *EventPipeConfiguration::GetProviderNoLock(const SString &prov
     return NULL;
 }
 
-EventPipeSessionProvider *EventPipeConfiguration::GetSessionProvider(const EventPipeSession &session, EventPipeProvider *pProvider)
+EventPipeSessionProvider *EventPipeConfiguration::GetSessionProvider(const EventPipeSession &session, const EventPipeProvider *pProvider) const
 {
     CONTRACTL
     {
@@ -285,7 +285,7 @@ EventPipeSessionProvider *EventPipeConfiguration::GetSessionProvider(const Event
     return session.GetSessionProvider(pProvider);
 }
 
-void EventPipeConfiguration::ComputeKeywordAndLevel(EventPipeProvider& provider, INT64& keywordForAllSessions, EventPipeEventLevel& levelForAllSessions)
+void EventPipeConfiguration::ComputeKeywordAndLevel(const EventPipeProvider& provider, INT64& keywordForAllSessions, EventPipeEventLevel& levelForAllSessions) const
 {
     CONTRACTL
     {

--- a/src/vm/eventpipeconfiguration.h
+++ b/src/vm/eventpipeconfiguration.h
@@ -62,6 +62,9 @@ private:
     // Get the enabled provider.
     EventPipeSessionProvider *GetSessionProvider(const EventPipeSession &session, EventPipeProvider *pProvider);
 
+    // Compute the keyword union and maximum level for a provider across all sessions
+    void ComputeKeywordAndLevel(/* const */EventPipeProvider& provider, INT64& keywordsForAllSessions, EventPipeEventLevel& levelForAllSessions); /* const */
+
     // The list of event pipe providers.
     SList<SListElem<EventPipeProvider *>> *m_pProviderList = nullptr;
 

--- a/src/vm/eventpipeconfiguration.h
+++ b/src/vm/eventpipeconfiguration.h
@@ -60,10 +60,10 @@ private:
     EventPipeProvider *GetProviderNoLock(const SString &providerID);
 
     // Get the enabled provider.
-    EventPipeSessionProvider *GetSessionProvider(const EventPipeSession &session, EventPipeProvider *pProvider);
+    EventPipeSessionProvider *GetSessionProvider(const EventPipeSession &session, const EventPipeProvider *pProvider) const;
 
     // Compute the keyword union and maximum level for a provider across all sessions
-    void ComputeKeywordAndLevel(/* const */EventPipeProvider& provider, INT64& keywordsForAllSessions, EventPipeEventLevel& levelForAllSessions); /* const */
+    void ComputeKeywordAndLevel(const EventPipeProvider& provider, INT64& keywordsForAllSessions, EventPipeEventLevel& levelForAllSessions) const;
 
     // The list of event pipe providers.
     SList<SListElem<EventPipeProvider *>> *m_pProviderList = nullptr;

--- a/src/vm/eventpipeprovider.cpp
+++ b/src/vm/eventpipeprovider.cpp
@@ -129,7 +129,7 @@ EventPipeProviderCallbackData EventPipeProvider::SetConfiguration(
     m_keywords = keywordsForAllSessions;
     m_providerLevel = providerLevelForAllSessions;
 
-    RefreshAllEvents(m_keywords, m_providerLevel);
+    RefreshAllEvents();
     return PrepareCallbackData(keywords, providerLevel, pFilterData);
 }
 
@@ -157,7 +157,7 @@ EventPipeProviderCallbackData EventPipeProvider::UnsetConfiguration(
     m_keywords = keywordsForAllSessions;
     m_providerLevel = providerLevelForAllSessions;
 
-    RefreshAllEvents(m_keywords, m_providerLevel);
+    RefreshAllEvents();
     return PrepareCallbackData(keywords, providerLevel, pFilterData);
 }
 
@@ -299,9 +299,7 @@ void EventPipeProvider::SetDeleteDeferred()
     m_deleteDeferred = true;
 }
 
-void EventPipeProvider::RefreshAllEvents(
-    INT64 keywords,
-    EventPipeEventLevel providerLevel)
+void EventPipeProvider::RefreshAllEvents()
 {
     CONTRACTL
     {

--- a/src/vm/eventpipeprovider.h
+++ b/src/vm/eventpipeprovider.h
@@ -107,9 +107,7 @@ private:
         LPCWSTR pFilterData);
 
     // Refresh the runtime state of all events.
-    void RefreshAllEvents(
-        INT64 keywords,
-        EventPipeEventLevel providerLevel);
+    void RefreshAllEvents();
 
     // Prepare the data required for invoking callback
     EventPipeProviderCallbackData PrepareCallbackData(

--- a/src/vm/eventpipeprovider.h
+++ b/src/vm/eventpipeprovider.h
@@ -89,6 +89,8 @@ private:
     // Set the provider configuration (enable sets of events).
     // This is called by EventPipeConfiguration.
     EventPipeProviderCallbackData SetConfiguration(
+        INT64 keywordsForAllSessions,
+        EventPipeEventLevel providerLevelForAllSessions,
         uint64_t sessionMask,
         INT64 keywords,
         EventPipeEventLevel providerLevel,
@@ -97,6 +99,8 @@ private:
     // Unset the provider configuration for the specified session (disable sets of events).
     // This is called by EventPipeConfiguration.
     EventPipeProviderCallbackData UnsetConfiguration(
+        INT64 keywordsForAllSessions,
+        EventPipeEventLevel providerLevelForAllSessions,
         uint64_t sessionMask,
         INT64 keywords,
         EventPipeEventLevel providerLevel,
@@ -104,7 +108,6 @@ private:
 
     // Refresh the runtime state of all events.
     void RefreshAllEvents(
-        uint64_t sessionMask,
         INT64 keywords,
         EventPipeEventLevel providerLevel);
 

--- a/src/vm/eventpipesession.cpp
+++ b/src/vm/eventpipesession.cpp
@@ -259,7 +259,7 @@ void EventPipeSession::AddSessionProvider(EventPipeSessionProvider *pProvider)
     m_pProviderList->AddSessionProvider(pProvider);
 }
 
-EventPipeSessionProvider *EventPipeSession::GetSessionProvider(EventPipeProvider *pProvider) const
+EventPipeSessionProvider *EventPipeSession::GetSessionProvider(const EventPipeProvider *pProvider) const
 {
     CONTRACTL
     {

--- a/src/vm/eventpipesession.h
+++ b/src/vm/eventpipesession.h
@@ -176,7 +176,7 @@ public:
     void AddSessionProvider(EventPipeSessionProvider *pProvider);
 
     // Get the session provider for the specified provider if present.
-    EventPipeSessionProvider* GetSessionProvider(EventPipeProvider *pProvider) const;
+    EventPipeSessionProvider* GetSessionProvider(const EventPipeProvider *pProvider) const;
 
     bool WriteAllBuffersToFile();
 

--- a/src/vm/eventpipesessionprovider.cpp
+++ b/src/vm/eventpipesessionprovider.cpp
@@ -137,7 +137,7 @@ void EventPipeSessionProviderList::AddSessionProvider(EventPipeSessionProvider *
         m_pProviders->InsertTail(new SListElem<EventPipeSessionProvider *>(pProvider));
 }
 
-EventPipeSessionProvider *EventPipeSessionProviderList::GetSessionProvider(EventPipeProvider *pProvider) const
+EventPipeSessionProvider *EventPipeSessionProviderList::GetSessionProvider(const EventPipeProvider *pProvider) const
 {
     CONTRACTL
     {

--- a/src/vm/eventpipesessionprovider.h
+++ b/src/vm/eventpipesessionprovider.h
@@ -57,7 +57,7 @@ public:
 
     // Get the session provider for the specified provider.
     // Return NULL if one doesn't exist.
-    EventPipeSessionProvider* GetSessionProvider(EventPipeProvider *pProvider) const;
+    EventPipeSessionProvider* GetSessionProvider(const EventPipeProvider *pProvider) const;
 
     // Returns true if the list is empty.
     bool IsEmpty() const;


### PR DESCRIPTION
Fixes #25298 

**(1st commit)**

1. Added a method `EventPipeConfiguration::ComputeKeywordAndLevel` to compute the bitwise or of all the keywords and the maximum level across all sessions.
2. Call `EventPipeConfiguration::ComputeKeywordAndLevel` everywhere `EventPipeProvider::SetConfiguration` or `EventPipeProvider::UnsetConfiguration` is called, pass the combined value into it instead of having it to compute itself.
3. Removed the logic to compute union and maximum inside `EventPipeProvider::SetConfiguration`, the computation is now done in `EventPipeConfiguration::ComputeKeywordAndLevel`.
4. Passing the combined keyword and level to `RefreshAllEvents` instead of the per session keyword and level there, I believe that was a bug.
5. Remove the unnecessary `sessionId` parameter to `RefreshAllEvents`
6. Call `RefreshAllEvents` on `EventPipeProvider::UnsetConfiguration` since the combined keyword and level could change at that point.

**(2nd commit)**
1. Adding const everywhere I needed to allow the wanted const constraint on `EventPipeConfiguration::ComputeKeywordAndLevel`

**(3rd commit)**
1. CI discovered a bug in my previous change, if the session is removed from `EventPipe::s_pSessions` before it is re-enabled for rundown, `ComputeKeywordAndLevel` would be wrong because the rundown provider would think there is no session listening to it while that's not true.

**(4th commit)**
1. Removed all other unused parameters to `RefreshAllEvents` (Thanks Sung for the comment)
2. Moved the computation of keyword and level so that we save the computation time when it is unused. (Thanks Noah for the comment)