### PR TITLE
Allow events with keyword 0 to be fired under EventPipe

### DIFF
--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -7531,7 +7531,7 @@ bool EventPipeHelper::IsEnabled(DOTNET_TRACE_CONTEXT Context, UCHAR Level, ULONG
 
     if (Level <= Context.EventPipeProvider.Level || Context.EventPipeProvider.Level == 0)
     {
-        return (Keyword & Context.EventPipeProvider.EnabledKeywordsBitmask) != 0;
+        return (Keyword == (ULONGLONG)0) || (Keyword & Context.EventPipeProvider.EnabledKeywordsBitmask) != 0;
     }
 
     return false;


### PR DESCRIPTION
#25221 makes EventPipe to filter against keywords instead of always returning `TRUE`. But some events have keyword of 0 so they were not getting fired. 