### PR TITLE
Make s_numberOfSessions Volatile

### DIFF
--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -36,7 +36,7 @@ VolatilePtr<EventPipeSession> EventPipe::s_pSessions[MaxNumberOfSessions];
 #ifndef FEATURE_PAL
 unsigned int * EventPipe::s_pProcGroupOffsets = nullptr;
 #endif
-uint32_t EventPipe::s_numberOfSessions = 0;
+Volatile<uint32_t> EventPipe::s_numberOfSessions(0);
 
 // This function is auto-generated from /src/scripts/genEventPipe.py
 #ifdef FEATURE_PAL
@@ -238,7 +238,7 @@ bool EventPipe::EnableInternal(
         return false;
     }
 
-    if (s_numberOfSessions > MaxNumberOfSessions)
+    if (s_numberOfSessions >= MaxNumberOfSessions)
     {
         _ASSERTE(!"Max number of sessions reached.");
         return false;

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -63,7 +63,7 @@ public:
     static bool Enabled()
     {
         LIMITED_METHOD_CONTRACT;
-        return s_tracingInitialized && (s_numberOfSessions > 0);
+        return s_tracingInitialized && (s_numberOfSessions.LoadWithoutBarrier() > 0);
     }
 
     // Create a provider.
@@ -206,7 +206,7 @@ private:
 #ifndef FEATURE_PAL
     static unsigned int * s_pProcGroupOffsets;
 #endif
-    static uint32_t s_numberOfSessions;
+    static Volatile<uint32_t> s_numberOfSessions;
 };
 
 static_assert(EventPipe::MaxNumberOfSessions == 64, "Maximum number of EventPipe sessions is not 64.");


### PR DESCRIPTION
Make s_numberOfSessions Volatile as advertisement to other devs that the data is being used across multiple threads and a portion of that usage is lock-free.
See comment: https://github.com/dotnet/coreclr/pull/25308#discussion_r296946291