### PR TITLE
Add a note about ReadyToRun to ManagedNativeHeader

### DIFF
--- a/src/inc/corhdr.h
+++ b/src/inc/corhdr.h
@@ -239,7 +239,8 @@ typedef struct IMAGE_COR20_HEADER
     IMAGE_DATA_DIRECTORY    VTableFixups;
     IMAGE_DATA_DIRECTORY    ExportAddressTableJumps;
 
-	// null for ordinary IL images.  NGEN images it points at a code:CORCOMPILE_HEADER structure
+	// null for ordinary IL images. In NGEN images it points at a code:CORCOMPILE_HEADER structure.
+	// In Ready2Run images it points to a READYTORUN_HEADER.
     IMAGE_DATA_DIRECTORY    ManagedNativeHeader;
     
 } IMAGE_COR20_HEADER, *PIMAGE_COR20_HEADER;


### PR DESCRIPTION
I was trying to parse PE files manually and this one really confused me for a while.