### PR TITLE
emit rundown event for generic methods in R2R images

### DIFF
--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -6852,8 +6852,6 @@ VOID ETW::MethodLog::SendEventsForNgenMethods(Module *pModule, DWORD dwEventOpti
             MethodDesc *hotDesc = (MethodDesc *)gmi.GetMethodDesc_NoRestore();
             if (hotDesc != NULL)
             {
-                // TODO: remove
-                // DebugBreak();
                 ETW::MethodLog::SendMethodEvent(hotDesc, dwEventOptions, FALSE);
             }
         }

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -6845,6 +6845,19 @@ VOID ETW::MethodLog::SendEventsForNgenMethods(Module *pModule, DWORD dwEventOpti
             }
         }
 
+        ReadyToRunInfo::GenericMethodIterator gmi(pModule->GetReadyToRunInfo());
+        while (gmi.Next())
+        {
+            // Call GetMethodDesc_NoRestore instead of GetMethodDesc to avoid restoring methods at shutdown.
+            MethodDesc *hotDesc = (MethodDesc *)gmi.GetMethodDesc_NoRestore();
+            if (hotDesc != NULL)
+            {
+                // TODO: remove
+                // DebugBreak();
+                ETW::MethodLog::SendMethodEvent(hotDesc, dwEventOptions, FALSE);
+            }
+        }
+
         return;
     }
 #endif // FEATURE_READYTORUN

--- a/src/vm/nativeformatreader.h
+++ b/src/vm/nativeformatreader.h
@@ -495,7 +495,7 @@ namespace NativeFormat
 
         public:
             AllEntriesEnumerator() :
-                _table(dac_cast<PTR_NativeHashtable>(NULL)),
+                _table(dac_cast<PTR_NativeHashtable>(nullptr)),
                 _parser(),
                 _currentBucket(0),
                 _endOffset(0)

--- a/src/vm/nativeformatreader.h
+++ b/src/vm/nativeformatreader.h
@@ -42,7 +42,9 @@
 namespace NativeFormat
 {
     class NativeReader;
-    typedef DPTR(NativeReader) PTR_NativeReader;
+    class NativeHashtable;
+    typedef DPTR(NativeReader)      PTR_NativeReader;
+    typedef DPTR(NativeHashtable)   PTR_NativeHashtable;
 
     class NativeReader
     {
@@ -275,6 +277,8 @@ namespace NativeFormat
             _offset = offset;
         }
 
+        bool IsNull() { return _pReader == NULL; }
+
         NativeReader * GetNativeReader() { return _pReader; }
 
         uint GetOffset() { return _offset; }
@@ -481,6 +485,60 @@ namespace NativeFormat
         }
 
         bool IsNull() { return _pReader == NULL; }
+
+        class AllEntriesEnumerator
+        {
+            PTR_NativeHashtable _table;
+            NativeParser        _parser;
+            uint                _currentBucket;
+            uint                _endOffset;
+
+        public:
+            AllEntriesEnumerator() :
+                _table(dac_cast<PTR_NativeHashtable>(NULL)),
+                _parser(),
+                _currentBucket(0),
+                _endOffset(0)
+            {
+
+            }
+
+            AllEntriesEnumerator(PTR_NativeHashtable table)
+            {
+                _table = table;
+                _currentBucket = 0;
+                if (_table != NULL)
+                {
+                    _parser = _table->GetParserForBucket(_currentBucket, &_endOffset);
+                }
+            }
+
+            NativeParser GetNext()
+            {
+                if (_table == NULL)
+                {
+                    return NativeParser();
+                }
+
+                for (; ; )
+                {
+                    if (_parser.GetOffset() < _endOffset)
+                    {
+                        // Skip hashcode to get to the offset
+                        _parser.GetUInt8();
+                        return _parser.GetParserFromRelativeOffset();
+                    }
+
+                    if (_currentBucket >= _table->_bucketMask)
+                    {
+                        return NativeParser();
+                    }
+
+                    _currentBucket++;
+                    _parser = _table->GetParserForBucket(_currentBucket, &_endOffset);
+                }
+            }
+        };
 
         //
         // The enumerator does not conform to the regular C# enumerator pattern to avoid paying 

--- a/src/vm/readytoruninfo.cpp
+++ b/src/vm/readytoruninfo.cpp
@@ -903,6 +903,10 @@ MethodDesc *ReadyToRunInfo::GenericMethodIterator::GetMethodDesc_NoRestore()
     PCCOR_SIGNATURE pBlob = (PCCOR_SIGNATURE)m_current.GetBlob();
     SigPointer sig(pBlob);
     DWORD methodFlags = 0;
+    uint id = 0;
+    DWORD i = 0;
+    uint offset = 0;
+    uint val;
     RID rid = 0;
     DWORD numGenericArgs = 0;
     PCCOR_SIGNATURE pSigNew = NULL;
@@ -928,7 +932,7 @@ MethodDesc *ReadyToRunInfo::GenericMethodIterator::GetMethodDesc_NoRestore()
     {
         IfFailGoto(sig.GetData(&numGenericArgs), Done);
     
-        for (DWORD i = 0; i < numGenericArgs; i++)
+        for (i = 0; i < numGenericArgs; i++)
         {
             IfFailGoto(sig.SkipExactlyOne(), Done);
         }
@@ -936,16 +940,14 @@ MethodDesc *ReadyToRunInfo::GenericMethodIterator::GetMethodDesc_NoRestore()
 
     // Now that we have the size of the signature we can grab the offset and decode it
     sig.GetSignature(&pSigNew, &cbSigNew);
-    uint offset = m_current.GetOffset() + (uint)(pSigNew - pBlob);
+    offset = m_current.GetOffset() + (uint)(pSigNew - pBlob);
 
-    uint id;
     offset = m_pInfo->m_nativeReader.DecodeUnsigned(offset, &id);
 
     if (id & 1)
     {
         if (id & 2)
         {
-            uint val;
             m_pInfo->m_nativeReader.DecodeUnsigned(offset, &val);
             offset -= val;
         }

--- a/src/vm/readytoruninfo.h
+++ b/src/vm/readytoruninfo.h
@@ -118,8 +118,9 @@ public:
         int m_methodDefIndex;
 
     public:
-        MethodIterator(ReadyToRunInfo * pInfo)
-            : m_pInfo(pInfo), m_methodDefIndex(-1)
+        MethodIterator(ReadyToRunInfo * pInfo) : 
+            m_pInfo(pInfo), 
+            m_methodDefIndex(-1)
         {
         }
 
@@ -128,6 +129,31 @@ public:
         MethodDesc * GetMethodDesc();
         MethodDesc * GetMethodDesc_NoRestore();
         PCODE GetMethodStartAddress();
+    };
+
+    class GenericMethodIterator
+    {
+        ReadyToRunInfo *m_pInfo;
+        NativeFormat::NativeHashtable::AllEntriesEnumerator m_enum;
+        NativeFormat::NativeParser m_current;
+
+    public:
+        GenericMethodIterator(ReadyToRunInfo *pInfo) :
+            m_pInfo(pInfo), 
+            m_enum(),
+            m_current()
+        {
+            NativeFormat::PTR_NativeHashtable pHash = NULL;
+            if (!pInfo->m_instMethodEntryPoints.IsNull())
+            {
+                pHash = NativeFormat::PTR_NativeHashtable(&pInfo->m_instMethodEntryPoints);
+            }
+
+            m_enum = NativeFormat::NativeHashtable::AllEntriesEnumerator(pHash);
+        }
+
+        BOOL Next();
+        MethodDesc * GetMethodDesc_NoRestore();
     };
 
     static DWORD GetFieldBaseOffset(MethodTable * pMT);


### PR DESCRIPTION
After Jan's first fix for #25014 we were still seeing missing events. Doing some analysis on the trace all of the missing events were from generic instantiations of methods from R2R assemblies. This change is to emit rundown events for these methods.

It's probably worth mentioning that I don't actually know what caused this regression. This fixes the broken frames in perfview, but I was never able to find what change broke them in the first place. My suspicion is that something was causing the runtime to never use the R2R generic instantiations and instead always jit them previously, but I can't find any changes that would have obviously impacted that.

CC @nattress @fadimounir since this touches R2R.