### PR TITLE
Change the default FMA codegen to be of 231 form instead of 213 form

### DIFF
--- a/src/jit/hwintrinsiccodegenxarch.cpp
+++ b/src/jit/hwintrinsiccodegenxarch.cpp
@@ -2316,23 +2316,14 @@ void CodeGen::genFMAIntrinsic(GenTreeHWIntrinsic* node)
         op2Reg = op3->gtRegNum;
         op3    = op2;
     }
-    else if (op1->isContained() || op1->isUsedFromSpillTemp())
+    else
     {
-        // 231 form: op3 = (op2 * op3) + [op1]
+        // 231 form: o1 = (op2 * op3) + [op1]
 
         ins    = (instruction)(ins + 1);
         op1Reg = op3->gtRegNum;
         op2Reg = op2->gtRegNum;
         op3    = op1;
-    }
-    else
-    {
-        // 213 form: op1 = (op2 * op1) + op3
-
-        op1Reg = op1->gtRegNum;
-        op2Reg = op2->gtRegNum;
-
-        isCommutative = !copiesUpperBits;
     }
 
     if (isCommutative && (op1Reg != targetReg) && (op2Reg == targetReg))

--- a/src/jit/lsraxarch.cpp
+++ b/src/jit/lsraxarch.cpp
@@ -2606,37 +2606,15 @@ int LinearScan::BuildHWIntrinsic(GenTreeHWIntrinsic* intrinsicTree)
                     srcCount += BuildOperandUses(op2);
                     srcCount += BuildDelayFreeUses(op3);
                 }
-                else if (op1->isContained())
+                else
                 {
-                    // 231 form: op3 = (op2 * op3) + [op1]
+                    // 231 form: op1 = (op2 * op3) + [op1]
 
                     tgtPrefUse = BuildUse(op3);
 
                     srcCount += BuildOperandUses(op1);
                     srcCount += BuildDelayFreeUses(op2);
                     srcCount += 1;
-                }
-                else
-                {
-                    // 213 form: op1 = (op2 * op1) + op3
-
-                    if (copiesUpperBits)
-                    {
-                        tgtPrefUse = BuildUse(op1);
-
-                        srcCount += 1;
-                        srcCount += BuildDelayFreeUses(op2);
-                    }
-                    else
-                    {
-                        // op1 and op2 are commutative, so don't
-                        // set either to be tgtPref or delayFree
-
-                        srcCount += BuildOperandUses(op1);
-                        srcCount += BuildOperandUses(op2);
-                    }
-
-                    srcCount += BuildDelayFreeUses(op3);
                 }
 
                 buildUses = false;


### PR DESCRIPTION
as it is likely to be most prevalent. E.g., `x = Fma.MultiplyAdd(a, b, x)`, and it removes the need for the redundant register to register move.

Current codegen for the following code:
```
static unsafe float fmaTest2(float *b, float *c, int d)
{
    Vector256<float> tmp = Vector256<float>.Zero;
    for (int k = 0; k + 8 <= d; k += 8)
    {
        Vector256<float> v1 = Avx.LoadVector256(b + k);
        Vector256<float> v2 = Avx.LoadVector256(c + k);
        tmp = Fma.MultiplyAdd(Avx.Multiply(v2, v2), Avx.Multiply(v1, v1), tmp);
    }

    return tmp.ToScalar();
}
```
is
```
G_M8770_IG03:
       4C63C8               movsxd   r9, eax
       C4A17C100C89         vmovups  ymm1, ymmword ptr[rcx+4*r9]
       C4A17C10148A         vmovups  ymm2, ymmword ptr[rdx+4*r9]
       C5EC59D2             vmulps   ymm2, ymm2, ymm2
       C5F459C9             vmulps   ymm1, ymm1, ymm1
       C4E26DA8C8           vfmadd213ps ymm1, ymm2, ymm0
       C5FC28C1             vmovaps  ymm0, ymm1
       83C008               add      eax, 8
       448D4808             lea      r9d, [rax+8]
       453BC8               cmp      r9d, r8d
       7ED4                 jle      SHORT G_M8770_IG03
```

With this PR:

```
G_M8770_IG03:
       4C63C8               movsxd   r9, eax
       C4A17C100C89         vmovups  ymm1, ymmword ptr[rcx+4*r9]
       C4A17C10148A         vmovups  ymm2, ymmword ptr[rdx+4*r9]
       C5EC59D2             vmulps   ymm2, ymm2, ymm2
       C5F459C9             vmulps   ymm1, ymm1, ymm1
       C4E275B8C2           vfmadd231ps ymm0, ymm1, ymm2
       83C008               add      eax, 8
       448D4808             lea      r9d, [rax+8]
       453BC8               cmp      r9d, r8d
       7ED8                 jle      SHORT G_M8770_IG03
```