### PR TITLE
Remove the Crossgen-specific VSD flag from R2RDump

### DIFF
--- a/src/tools/r2rdump/R2RConstants.cs
+++ b/src/tools/r2rdump/R2RConstants.cs
@@ -270,9 +270,6 @@ namespace R2RDump
 
         // JIT32 x86-specific exception handling
         READYTORUN_HELPER_EndCatch = 0x110,
-
-        // A flag to indicate that a helper call uses VSD
-        READYTORUN_HELPER_FLAG_VSD = 0x10000000,
     }
 
     public enum CorElementType : byte

--- a/src/tools/r2rdump/R2RSignature.cs
+++ b/src/tools/r2rdump/R2RSignature.cs
@@ -1230,12 +1230,8 @@ namespace R2RDump
         private void ParseHelper(StringBuilder builder)
         {
             uint helperType = ReadUIntAndEmitInlineSignatureBinary(builder);
-            if ((helperType & (uint)ReadyToRunHelper.READYTORUN_HELPER_FLAG_VSD) != 0)
-            {
-                builder.Append("VSD_");
-            }
 
-            switch ((ReadyToRunHelper)(helperType & ~(uint)ReadyToRunHelper.READYTORUN_HELPER_FLAG_VSD))
+            switch ((ReadyToRunHelper)helperType)
             {
                 case ReadyToRunHelper.READYTORUN_HELPER_Invalid:
                     builder.Append("INVALID");


### PR DESCRIPTION
Based on JanK's advice I have removed the VSD flag from R2RDump.
The flag should get never observed by the dump tool as it's just
an intermediate contract internal to the Crossgen ZAP logic.

Thanks

Tomas