### PR TITLE
Add DefaultBinder.CanChangePrimitive overload

### DIFF
--- a/src/System.Private.CoreLib/shared/System/DefaultBinder.cs
+++ b/src/System.Private.CoreLib/shared/System/DefaultBinder.cs
@@ -1214,8 +1214,13 @@ namespace System
                 (source == typeof(UIntPtr) && target == typeof(UIntPtr)))
                 return true;
 
-            Primitives widerCodes = s_primitiveConversions[(int)(Type.GetTypeCode(source))];
-            Primitives targetCode = (Primitives)(1 << (int)(Type.GetTypeCode(target)));
+            return CanChangePrimitive(Type.GetTypeCode(source), Type.GetTypeCode(target));
+        }
+
+        internal static bool CanChangePrimitive(TypeCode source, TypeCode target)
+        {
+            Primitives widerCodes = s_primitiveConversions[(int)source];
+            Primitives targetCode = (Primitives)(1 << (int)target);
 
             return (widerCodes & targetCode) != 0;
         }

--- a/src/System.Private.CoreLib/shared/System/DefaultBinder.cs
+++ b/src/System.Private.CoreLib/shared/System/DefaultBinder.cs
@@ -4,6 +4,7 @@
 
 using System.Reflection;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using CultureInfo = System.Globalization.CultureInfo;
 
 namespace System
@@ -1217,6 +1218,7 @@ namespace System
             return CanChangePrimitive(Type.GetTypeCode(source), Type.GetTypeCode(target));
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool CanChangePrimitive(TypeCode source, TypeCode target)
         {
             Primitives widerCodes = s_primitiveConversions[(int)source];


### PR DESCRIPTION
We'd like to re-use this type conversion check in Mono's managed version of `Array.Copy` and in order to be able to normalize (like @jkotas did [here](https://github.com/dotnet/coreclr/pull/25209/files#diff-b378ad87d76d7a53ad8576a457eee387R1406)) types we need an overload accepting TypeCodes instead of Types. Probably makes sense to move this logic to a separate class? 

/cc @jkotas @filipnavara 