### PR TITLE
Reverting the ShouldRoundUp logic to not change for custom numeric format strings.

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
@@ -2436,26 +2436,13 @@ namespace System
                     return false;
                 }
 
-                if (digit > '5')
-                {
-                    // Values greater than 5 always round up
-                    return true;
-                }
+                // Values greater than or equal to 5 should round up, otherwise we round down. The IEEE
+                // 754 spec actually dictates that ties (exactly 5) should round to the nearest even number
+                // but that can have undesired behavior for custom numeric format strings. This probably
+                // needs further thought for .NET 5 so that we can be spec compliant and so that users
+                // can get the desired rounding behavior for their needs.
 
-                if (digit != '5')
-                {
-                    // Values less than 5 always round down
-                    return false;
-                }
-
-                if (numberKind != NumberBufferKind.FloatingPoint)
-                {
-                    // Non floating-point values always round up for 5
-                    return true;
-                }
-
-                // Floating-point values round up if there is a non-zero tail
-                return (dig[i + 1] != '\0');
+                return (digit >= '5');
             }
         }
 


### PR DESCRIPTION
Was pinged by @mjsabby from Bing that a change from https://github.com/dotnet/coreclr/commit/e3c9a4afbceb838d7bffab1f246190a3d72caf42 was impacting them.

This ensures that custom-numeric format strings have the same behavior as previous for .NET Core 3.0. Post 3.0, this likely needs further thought so that for format strings in general (both standard and custom) users can get spec compliant or the desired behavior. This would likely involve exposing some API that takes a `MidpointRoundingMode` enum so that it can be controlled as appropriate.