### PR TITLE
EventPipe events should only be sent to sessions that are listening to the event

### DIFF
--- a/src/vm/eventpipeconfiguration.h
+++ b/src/vm/eventpipeconfiguration.h
@@ -54,7 +54,9 @@ public:
 
     // Delete deferred providers.
     void DeleteDeferredProviders();
-
+    
+    // Compute the enabled bit mask, the ith bit is 1 iff an event with the given (provider, keywords, eventLevel) is enabled for the ith session.
+    INT64 ComputeEventEnabledMask(const EventPipeProvider& provider, INT64 keywords, EventPipeEventLevel eventLevel) const;
 private:
     // Get the provider without taking the lock.
     EventPipeProvider *GetProviderNoLock(const SString &providerID);

--- a/src/vm/eventpipeevent.h
+++ b/src/vm/eventpipeevent.h
@@ -34,8 +34,8 @@ private:
     // True if a call stack should be captured when writing the event.
     const bool m_needStack;
 
-    // True if the event is current enabled.
-    Volatile<bool> m_enabled;
+    // The ith bit is 1 iff the event is enabled for the ith session
+    Volatile<INT64> m_enabledMask;
 
     // Metadata
     BYTE *m_pMetadata;

--- a/src/vm/eventpipeprovider.cpp
+++ b/src/vm/eventpipeprovider.cpp
@@ -84,26 +84,18 @@ const SString &EventPipeProvider::GetProviderName() const
     return m_providerName;
 }
 
-bool EventPipeProvider::EventEnabled(INT64 keywords) const
+INT64 EventPipeProvider::ComputeEventEnabledMask(INT64 keywords, EventPipeEventLevel eventLevel) const
 {
-    LIMITED_METHOD_CONTRACT;
+    CONTRACTL
+    {
+        THROWS;
+        GC_TRIGGERS;
+        MODE_PREEMPTIVE;
+        PRECONDITION(EventPipe::IsLockOwnedByCurrentThread());
+    }
+    CONTRACTL_END;
 
-    // The event is enabled if:
-    //  - The provider is enabled.
-    //  - The event keywords are unspecified in the manifest (== 0) or when masked with the enabled config are != 0.
-    return (Enabled() && ((keywords == 0) || ((m_keywords & keywords) != 0)));
-}
-
-bool EventPipeProvider::EventEnabled(INT64 keywords, EventPipeEventLevel eventLevel) const
-{
-    LIMITED_METHOD_CONTRACT;
-
-    // The event is enabled if:
-    //  - The provider is enabled.
-    //  - The event keywords are unspecified in the manifest (== 0) or when masked with the enabled config are != 0.
-    //  - The event level is LogAlways or the provider's verbosity level is set to greater than the event's verbosity level in the manifest.
-    return (EventEnabled(keywords) &&
-            ((eventLevel == EventPipeEventLevel::LogAlways) || (m_providerLevel >= eventLevel)));
+    return m_pConfig->ComputeEventEnabledMask((*this), keywords, eventLevel);
 }
 
 EventPipeProviderCallbackData EventPipeProvider::SetConfiguration(
@@ -130,7 +122,7 @@ EventPipeProviderCallbackData EventPipeProvider::SetConfiguration(
     m_providerLevel = providerLevelForAllSessions;
 
     RefreshAllEvents();
-    return PrepareCallbackData(keywords, providerLevel, pFilterData);
+    return PrepareCallbackData(m_keywords, m_providerLevel, pFilterData);
 }
 
 EventPipeProviderCallbackData EventPipeProvider::UnsetConfiguration(
@@ -158,7 +150,7 @@ EventPipeProviderCallbackData EventPipeProvider::UnsetConfiguration(
     m_providerLevel = providerLevelForAllSessions;
 
     RefreshAllEvents();
-    return PrepareCallbackData(keywords, providerLevel, pFilterData);
+    return PrepareCallbackData(m_keywords, m_providerLevel, pFilterData);
 }
 
 EventPipeEvent *EventPipeProvider::AddEvent(unsigned int eventID, INT64 keywords, unsigned int eventVersion, EventPipeEventLevel level, bool needStack, BYTE *pMetadata, unsigned int metadataLength)
@@ -166,7 +158,7 @@ EventPipeEvent *EventPipeProvider::AddEvent(unsigned int eventID, INT64 keywords
     CONTRACTL
     {
         THROWS;
-        GC_NOTRIGGER;
+        GC_TRIGGERS;
         MODE_ANY;
     }
     CONTRACTL_END;
@@ -192,7 +184,7 @@ void EventPipeProvider::AddEvent(EventPipeEvent &event)
     CONTRACTL
     {
         THROWS;
-        GC_NOTRIGGER;
+        GC_TRIGGERS;
         MODE_ANY;
     }
     CONTRACTL_END;
@@ -304,7 +296,7 @@ void EventPipeProvider::RefreshAllEvents()
     CONTRACTL
     {
         THROWS;
-        GC_NOTRIGGER;
+        GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(EventPipe::IsLockOwnedByCurrentThread());
     }

--- a/src/vm/eventpipeprovider.h
+++ b/src/vm/eventpipeprovider.h
@@ -72,11 +72,8 @@ public:
         return ((m_sessions & sessionMask) != 0);
     }
 
-    // Determine if the specified keywords are enabled.
-    bool EventEnabled(INT64 keywords) const;
-
-    // Determine if the specified keywords and level match the configuration.
-    bool EventEnabled(INT64 keywords, EventPipeEventLevel eventLevel) const;
+    // Compute the enabled bit mask, the ith bit is 1 iff an event with the given (provider, keywords, eventLevel) is enabled for the ith session.
+    INT64 ComputeEventEnabledMask(INT64 keywords, EventPipeEventLevel eventLevel) const;
 
     // Create a new event.
     EventPipeEvent* AddEvent(unsigned int eventID, INT64 keywords, unsigned int eventVersion, EventPipeEventLevel level, bool needStack, BYTE *pMetadata = NULL, unsigned int metadataLength = 0);


### PR DESCRIPTION
Fixes #25232 

**(1 st commit)**

1. Changed `EventPipeEvent::m_enabled` from a single boolean value to a bitmask. It used to represent if the event is enabled for any session, now it represents if the event is enabled by a particular session.
2. Changed `EventPipeProvider::EventEnabled(keyword,level)` to `EventPipeProvider::ComputeEventEnabledMask(keyword,level)` so that it computes the bitmask we needed.
3. `EventPipeProvider::ComputeEventEnabledMask` simply delegates to `EventPipeConfiguration::ComputeEventEnabledMask` because it needs the sessions. The helper method on `EventPipeProvider` is removed and inlined into `EventPipeConfiguration::ComputeEventEnabledMask`.
4. Use the pre-computed `m_enableMask` to determine whether the event is enabled for a particular session (That's the whole point of this change).
5. Independent of the above. I changed the code to use the combined keyword to invoke the callbacks in `EventPipeProvider::PrepareCallbackData`. This is done to ensure `EventPipeHelper::IsEnabled` get the combined keyword for the early check.
6. A couple of contract changes to please asserts - there is no reason to forbid GC while adding or refreshing events.