### PR TITLE
Fix SIGSEGV in GC when dealing with large double[] on ARM32

### DIFF
--- a/src/vm/gchelpers.cpp
+++ b/src/vm/gchelpers.cpp
@@ -503,7 +503,7 @@ OBJECTREF AllocateSzArray(MethodTable* pArrayMT, INT32 cElements, GC_ALLOC_FLAGS
         else
 #else
         if ((DATA_ALIGNMENT < sizeof(double)) && (elemType == ELEMENT_TYPE_R8) &&
-            (totalSize < g_pConfig->GetGCLOHThreshold() + MIN_OBJECT_SIZE))
+            (totalSize < g_pConfig->GetGCLOHThreshold() - MIN_OBJECT_SIZE))
         {
             // Creation of an array of doubles, not in the large object heap.
             // We want to align the doubles to 8 byte boundaries, but the GC gives us pointers aligned

--- a/src/vm/gchelpers.cpp
+++ b/src/vm/gchelpers.cpp
@@ -256,6 +256,7 @@ inline Object* Alloc(size_t size, GC_ALLOC_FLAGS flags)
     return retVal;
 }
 
+#ifdef FEATURE_64BIT_ALIGNMENT
 // Helper for allocating 8-byte aligned objects (on platforms where this doesn't happen naturally, e.g. 32-bit
 // platforms).
 inline Object* AllocAlign8(size_t size, GC_ALLOC_FLAGS flags)
@@ -293,6 +294,7 @@ inline Object* AllocAlign8(size_t size, GC_ALLOC_FLAGS flags)
 
     return retVal;
 }
+#endif // FEATURE_64BIT_ALIGNMENT
 
 // This is one of three ways of allocating an object (see code:Alloc for more). This variation is used in the
 // rare circumstance when you want to allocate an object on the large object heap but the object is not big

--- a/tests/src/GC/Regressions/v3.0/25252/25252.cs
+++ b/tests/src/GC/Regressions/v3.0/25252/25252.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+class Program
+{
+    static void Main()
+    {
+        var matrix = new double[128 * 128];
+
+        Console.WriteLine("SIGSEGV upcoming");
+        GC.Collect(GC.MaxGeneration);
+
+        GC.KeepAlive(matrix);
+    }
+}
+

--- a/tests/src/GC/Regressions/v3.0/25252/25252.cs
+++ b/tests/src/GC/Regressions/v3.0/25252/25252.cs
@@ -6,7 +6,7 @@ using System;
 
 class Program
 {
-    static void Main()
+    static int Main()
     {
         var matrix = new double[128 * 128];
 
@@ -14,6 +14,7 @@ class Program
         GC.Collect(GC.MaxGeneration);
 
         GC.KeepAlive(matrix);
+        return 100;
     }
 }
 

--- a/tests/src/GC/Regressions/v3.0/25252/25252.csproj
+++ b/tests/src/GC/Regressions/v3.0/25252/25252.csproj
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="25252.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' "></PropertyGroup>
+</Project>


### PR DESCRIPTION
It is an interesting issue. It was introduced in the UninitializedArray change. I did some clean-up of GC interfaces to reduce VM/JIT helpers that worked the same. 
There was some confusion about when an array is known to be LOH allocated and in the combined code we ended up with a possible case of trying to 8-align a LOH-allocated `double[]` in the GC helpers. GC helpers do it via introducing intentionally mis-aligned pad objects. Those objects were causing trouble because everything in LOH is already 8-aligned and mis-aligned objects are both unnecessary and unexpected.

Fix:
-	Assign bAllocateInLargeHeap to TRUE as soon as we see that the array goes into LOH. Otherwise the purpose of the flag is confusing.
-	GC has general support for 8-aligned allocations when on ARM32, and it does the right thing regardless SOH or LOH. We should just call that on ARM32. 
The support for alignment in GC helpers should only be used on x86.

Fixes:#25252
