### PR TITLE
Don't show AggressiveInlining items in exception stacks

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/StackTrace.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/StackTrace.cs
@@ -340,10 +340,31 @@ namespace System.Diagnostics
         {
             Debug.Assert(mb != null);
 
-            // Don't show AggressiveInlining or StackTraceHidden items
-            return !(((mb.MethodImplementationFlags & MethodImplAttributes.AggressiveInlining) != 0) ||
-                mb.IsDefined(typeof(StackTraceHiddenAttribute), inherit: false) ||
-                (mb.DeclaringType?.IsDefined(typeof(StackTraceHiddenAttribute), inherit: false) ?? false));
+            if (mb.MethodImplementationFlags.HasFlag(MethodImplAttributes.AggressiveInlining))
+            {
+                // Aggressive Inlines won't normally show in the StackTrace; however for Tier0 Jit and
+                // cross-assembly AoT/R2R these inlines will be blocked until Tier1 Jit re-Jits 
+                // them when they will inline. We don't show them in the StackTrace to bring consitency
+                // between this first-pass asm and fully optimized asm.
+                return false;
+            }
+
+            if (mb.IsDefined(typeof(StackTraceHiddenAttribute), inherit: false))
+            {
+                // Don't show where StackTraceHidden is applied to the method.
+                return false;
+            }
+
+            Type? declaringType = mb.DeclaringType;
+            // Methods don't always have containing types, for example dynamic RefEmit generated methods.
+            if (declaringType != null && 
+                declaringType.IsDefined(typeof(StackTraceHiddenAttribute), inherit: false))
+            {
+                // Don't show where StackTraceHidden is applied to the containing Type of the method.
+                return false;
+            }
+
+            return true;
         }
 
         private static bool TryResolveStateMachineMethod(ref MethodBase method, out Type declaringType)

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/StackTrace.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/StackTrace.cs
@@ -339,7 +339,11 @@ namespace System.Diagnostics
         private static bool ShowInStackTrace(MethodBase mb)
         {
             Debug.Assert(mb != null);
-            return !(mb.IsDefined(typeof(StackTraceHiddenAttribute)) || (mb.DeclaringType?.IsDefined(typeof(StackTraceHiddenAttribute)) ?? false));
+
+            // Don't show AggressiveInlining or StackTraceHidden items
+            return !(((mb.MethodImplementationFlags & MethodImplAttributes.AggressiveInlining) != 0) ||
+                mb.IsDefined(typeof(StackTraceHiddenAttribute), inherit: false) ||
+                (mb.DeclaringType?.IsDefined(typeof(StackTraceHiddenAttribute), inherit: false) ?? false));
         }
 
         private static bool TryResolveStateMachineMethod(ref MethodBase method, out Type declaringType)

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
@@ -51,7 +51,6 @@ namespace System.Runtime.CompilerServices
 
             /// <summary>Gets the result of the ValueTask.</summary>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [StackTraceHidden]
             public void GetResult() => _value.ThrowIfCompletedUnsuccessfully();
 
             /// <summary>Schedules the continuation action for the <see cref="ConfiguredValueTaskAwaitable"/>.</summary>
@@ -157,7 +156,6 @@ namespace System.Runtime.CompilerServices
 
             /// <summary>Gets the result of the ValueTask.</summary>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [StackTraceHidden]
             public TResult GetResult() => _value.Result;
 
             /// <summary>Schedules the continuation action for the <see cref="ConfiguredValueTaskAwaitable{TResult}"/>.</summary>

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
@@ -43,7 +43,6 @@ namespace System.Runtime.CompilerServices
         }
 
         /// <summary>Gets the result of the ValueTask.</summary>
-        [StackTraceHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void GetResult() => _value.ThrowIfCompletedUnsuccessfully();
 
@@ -126,7 +125,6 @@ namespace System.Runtime.CompilerServices
         }
 
         /// <summary>Gets the result of the ValueTask.</summary>
-        [StackTraceHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public TResult GetResult() => _value.Result;
 

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/ValueTask.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/ValueTask.cs
@@ -350,7 +350,6 @@ namespace System.Threading.Tasks
 
         /// <summary>Throws the exception that caused the <see cref="ValueTask"/> to fail.  If it completed successfully, nothing is thrown.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [StackTraceHidden]
         internal void ThrowIfCompletedUnsuccessfully()
         {
             object? obj = _obj;

--- a/src/System.Private.CoreLib/src/System/Utf8String.Manipulation.cs
+++ b/src/System.Private.CoreLib/src/System/Utf8String.Manipulation.cs
@@ -82,8 +82,6 @@ namespace System
         [ComponentModel.EditorBrowsable(ComponentModel.EditorBrowsableState.Never)]
         public Utf8String Slice(int startIndex, int length) => Substring(startIndex, length);
 
-
-        [StackTraceHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ValidateStartIndexAndLength(int startIndex, int length)
         {


### PR DESCRIPTION
`AggressiveInlining` stacks can show up in cross-assembly R2R and Tier0 compilation; which are then removed at Tier1 compilation.

This change discards `AggressiveInlining` stacks giving more consistency in with optimizations on vs. off.

/cc @jkotas @stephentoub 

Pre
```
>Exceptions.exe
System.Net.Http.HttpRequestException: No connection could be made because the target machine actively refused it.
 ---> System.Net.Sockets.SocketException (10061): No connection could be made because the target machine actively refused it.
   at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken)
   at System.Threading.Tasks.ValueTask`1.get_Result()
   at System.Net.Http.HttpConnectionPool.ConnectAsync(HttpRequestMessage request, Boolean allowHttp2, CancellationToken cancellationToken)
   at System.Threading.Tasks.ValueTask`1.get_Result()
   at System.Net.Http.HttpConnectionPool.CreateHttp11ConnectionAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Threading.Tasks.ValueTask`1.get_Result()
   at System.Net.Http.HttpConnectionPool.GetHttpConnectionAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Threading.Tasks.ValueTask`1.get_Result()
   at System.Net.Http.HttpConnectionPool.SendWithRetryAsync(HttpRequestMessage request, Boolean doRequestAuth, CancellationToken cancellationToken)
   at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.FinishSendAsyncUnbuffered(Task`1 sendTask, HttpRequestMessage request, CancellationTokenSource cts, Boolean disposeCts)
   at System.Net.Http.HttpClient.GetStringAsyncCore(Task`1 getTask)
   at Program.Main(String[] args) in C:\Work\NewForNetCore3Talk\Exceptions\Program.cs:line 15
```
Post
```
>Exceptions.exe
System.Net.Http.HttpRequestException: No connection could be made because the target machine actively refused it.
 ---> System.Net.Sockets.SocketException (10061): No connection could be made because the target machine actively refused it.
   at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.ConnectAsync(HttpRequestMessage request, Boolean allowHttp2, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.CreateHttp11ConnectionAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.GetHttpConnectionAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.SendWithRetryAsync(HttpRequestMessage request, Boolean doRequestAuth, CancellationToken cancellationToken)
   at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.FinishSendAsyncUnbuffered(Task`1 sendTask, HttpRequestMessage request, CancellationTokenSource cts, Boolean disposeCts)
   at System.Net.Http.HttpClient.GetStringAsyncCore(Task`1 getTask)
   at Program.Main(String[] args) in C:\Work\NewForNetCore3Talk\Exceptions\Program.cs:line 15
```