### PR TITLE
Hardcode LKG version of ucrtbased.dll

### DIFF
--- a/tests/src/Interop/Interop.settings.targets
+++ b/tests/src/Interop/Interop.settings.targets
@@ -2,6 +2,10 @@
   <!-- Properties for all Interop managed test assets -->
   <PropertyGroup>
     <InteropCommonDir>$(MSBuildThisFileDirectory)common/</InteropCommonDir>
+
+    <!-- There's a bug in VS that causes this to get set to a version that isn't actually installed on the machine. -->
+    <!-- Until that gets resolved, we need this workaround to grab the last "known" good version of ucrtbased.dll -->
+    <UCRTVersion>10.0.17763.0</UCRTVersion>
   </PropertyGroup>
 
   <!-- Add the CoreCLRTestLibrary dependency -->

--- a/tests/src/Interop/Interop.settings.targets
+++ b/tests/src/Interop/Interop.settings.targets
@@ -26,11 +26,11 @@
     <None Include="$(VCToolsRedistDir)onecore/debug_nonredist/$(Platform)/Microsoft.VC*.DebugCRT/vcruntime*d.dll" CopyToOutputDirectory="Always" />
     <None Include="$(VCToolsRedistDir)onecore/debug_nonredist/$(Platform)/Microsoft.VC*.DebugCRT/msvcp*d.dll" CopyToOutputDirectory="Always" />
     <None Include="$(ExtensionSdkDir)/Microsoft.UniversalCRT.Debug/$(UCRTVersion)/Redist/Debug/$(Platform)/ucrtbased.dll" CopyToOutputDirectory="Always"
-        Condition="Exists($(ExtensionSdkDir)/Microsoft.UniversalCRT.Debug/$(UCRTVersion)/Redist/Debug/$(Platform)/ucrtbased.dll)" />
+        Condition="Exists('$(ExtensionSdkDir)/Microsoft.UniversalCRT.Debug/$(UCRTVersion)/Redist/Debug/$(Platform)/ucrtbased.dll')" />
     
     <!-- There's a bug in VS that causes UCRTVersion env var to get set to a version that isn't actually installed on the machine. -->
     <!-- Until that gets resolved, we need this workaround to grab the last "known" good version of ucrtbased.dll -->
     <None Include="$(ExtensionSdkDir)/Microsoft.UniversalCRT.Debug/10.0.17763.0/Redist/Debug/$(Platform)/ucrtbased.dll" CopyToOutputDirectory="Always"
-        Condition="!Exists($(ExtensionSdkDir)/Microsoft.UniversalCRT.Debug/$(UCRTVersion)/Redist/Debug/$(Platform)/ucrtbased.dll)" />
+        Condition="!Exists('$(ExtensionSdkDir)/Microsoft.UniversalCRT.Debug/$(UCRTVersion)/Redist/Debug/$(Platform)/ucrtbased.dll')" />
   </ItemGroup>
 </Project>

--- a/tests/src/Interop/Interop.settings.targets
+++ b/tests/src/Interop/Interop.settings.targets
@@ -2,10 +2,6 @@
   <!-- Properties for all Interop managed test assets -->
   <PropertyGroup>
     <InteropCommonDir>$(MSBuildThisFileDirectory)common/</InteropCommonDir>
-
-    <!-- There's a bug in VS that causes this to get set to a version that isn't actually installed on the machine. -->
-    <!-- Until that gets resolved, we need this workaround to grab the last "known" good version of ucrtbased.dll -->
-    <UCRTVersion>10.0.17763.0</UCRTVersion>
   </PropertyGroup>
 
   <!-- Add the CoreCLRTestLibrary dependency -->
@@ -29,6 +25,12 @@
 
     <None Include="$(VCToolsRedistDir)onecore/debug_nonredist/$(Platform)/Microsoft.VC*.DebugCRT/vcruntime*d.dll" CopyToOutputDirectory="Always" />
     <None Include="$(VCToolsRedistDir)onecore/debug_nonredist/$(Platform)/Microsoft.VC*.DebugCRT/msvcp*d.dll" CopyToOutputDirectory="Always" />
-    <None Include="$(ExtensionSdkDir)/Microsoft.UniversalCRT.Debug/$(UCRTVersion)/Redist/Debug/$(Platform)/ucrtbased.dll" CopyToOutputDirectory="Always" />
+    <None Include="$(ExtensionSdkDir)/Microsoft.UniversalCRT.Debug/$(UCRTVersion)/Redist/Debug/$(Platform)/ucrtbased.dll" CopyToOutputDirectory="Always"
+        Condition="Exists($(ExtensionSdkDir)/Microsoft.UniversalCRT.Debug/$(UCRTVersion)/Redist/Debug/$(Platform)/ucrtbased.dll)" />
+    
+    <!-- There's a bug in VS that causes UCRTVersion env var to get set to a version that isn't actually installed on the machine. -->
+    <!-- Until that gets resolved, we need this workaround to grab the last "known" good version of ucrtbased.dll -->
+    <None Include="$(ExtensionSdkDir)/Microsoft.UniversalCRT.Debug/10.0.17763.0/Redist/Debug/$(Platform)/ucrtbased.dll" CopyToOutputDirectory="Always"
+        Condition="!Exists($(ExtensionSdkDir)/Microsoft.UniversalCRT.Debug/$(UCRTVersion)/Redist/Debug/$(Platform)/ucrtbased.dll)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Should unblock CI errors that look like:

> F:\workspace_work\1\s.dotnet\sdk\3.0.100-preview6-012264\Microsoft.Common.CurrentVersion.targets(4583,5): error MSB3030: Could not copy the file "C:\Program Files (x86)\Microsoft SDKs\Windows Kits\10\ExtensionSDKs\Microsoft.UniversalCRT.Debug\10.0.18362.0\Redist\Debug\x64\ucrtbased.dll" because it was not found. 

@MattGal and I investigated this, it appears to be a bug with the new version of VS that incorrectly sets `UCRTVersion` to a version that isn't installed on the machine. This workaround hard-codes the LKG version until the bug gets resolved (or permanently, if we decide that we don't want to risk getting broken like this again).

@MattGal @hoyosjs @BruceForstall @jkoritzinsky @AaronRobinsonMSFT PTAL