### PR TITLE
Fix a mutex abandon case with WaitHandle.WaitAll in the PAL

### DIFF
--- a/src/pal/src/synchmgr/wait.cpp
+++ b/src/pal/src/synchmgr/wait.cpp
@@ -531,14 +531,18 @@ DWORD CorUnix::InternalWaitForMultipleObjectsEx(
     iSignaledObjIndex = -1;
     for (i=0;i<(int)nCount;i++)
     {
-        bool fValue;
-        palErr = ppISyncWaitCtrlrs[i]->CanThreadWaitWithoutBlocking(&fValue, &fAbandoned);
+        bool fValue, fWaitObjectAbandoned = false;
+        palErr = ppISyncWaitCtrlrs[i]->CanThreadWaitWithoutBlocking(&fValue, &fWaitObjectAbandoned);
         if (NO_ERROR != palErr)
         {
             ERROR("ISynchWaitController::CanThreadWaitWithoutBlocking() failed for "
                   "%d-th object [handle=%p error=%u]\n", i, lpHandles[i], palErr);
             pThread->SetLastError(ERROR_INTERNAL_ERROR);
             goto WFMOExIntReleaseControllers;            
+        }
+        if (fWaitObjectAbandoned)
+        {
+            fAbandoned = true;
         }
         if (fValue)
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/25108
- Upon a `WaitAll` when all waits are already satisfied, the abandoned flag is overwritten with the abandoned state of the last wait object in the array
- So if the first wait object is an abandoned mutex and the second wait object is a signaled event, the `WaitAll` succeeds and does not report that anything was abandoned
- Fixed to accumulate into the flag instead of overwriting it