### PR TITLE
Try to allocate method tables in 32-bit address range

### DIFF
--- a/src/inc/loaderheap.h
+++ b/src/inc/loaderheap.h
@@ -288,7 +288,8 @@ protected:
                        SIZE_T dwReservedRegionSize,
                        size_t *pPrivatePerfCounter_LoaderBytes = NULL,
                        RangeList *pRangeList = NULL,
-                       BOOL fMakeExecutable = FALSE);
+                       BOOL fMakeExecutable = FALSE,
+                       BOOL fTry32Bit = FALSE);
 
     ~UnlockedLoaderHeap();
 #endif
@@ -399,6 +400,7 @@ public:
     }
 
     BOOL IsExecutable();
+    BOOL Tries32Bit();
 
 public:
 #ifdef _DEBUG
@@ -443,14 +445,16 @@ public:
                DWORD dwCommitBlockSize,
                size_t *pPrivatePerfCounter_LoaderBytes = NULL,
                RangeList *pRangeList = NULL,
-               BOOL fMakeExecutable = FALSE
+               BOOL fMakeExecutable = FALSE,
+               BOOL fTry32Bit = FALSE
                )
       : UnlockedLoaderHeap(dwReserveBlockSize,
                            dwCommitBlockSize,
                            NULL, 0,
                            pPrivatePerfCounter_LoaderBytes,
                            pRangeList,
-                           fMakeExecutable)
+                           fMakeExecutable,
+                           fTry32Bit)
     {
         WRAPPER_NO_CONTRACT;
         m_CriticalSection = NULL;
@@ -465,7 +469,8 @@ public:
                SIZE_T dwReservedRegionSize,
                size_t *pPrivatePerfCounter_LoaderBytes = NULL,
                RangeList *pRangeList = NULL,
-               BOOL fMakeExecutable = FALSE
+               BOOL fMakeExecutable = FALSE,
+               BOOL fTry32Bit = FALSE
                )
       : UnlockedLoaderHeap(dwReserveBlockSize,
                            dwCommitBlockSize,
@@ -473,7 +478,8 @@ public:
                            dwReservedRegionSize,
                            pPrivatePerfCounter_LoaderBytes,
                            pRangeList,
-                           fMakeExecutable)
+                           fMakeExecutable,
+                           fTry32Bit)
     {
         WRAPPER_NO_CONTRACT;
         m_CriticalSection = NULL;

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -709,6 +709,9 @@ private:
 #define HIGH_FREQUENCY_HEAP_RESERVE_SIZE       (10 * GetOsPageSize())
 #define HIGH_FREQUENCY_HEAP_COMMIT_SIZE        (1 * GetOsPageSize())
 
+#define METHOD_TABLE_HEAP_RESERVE_SIZE         (3 * GetOsPageSize())
+#define METHOD_TABLE_HEAP_COMMIT_SIZE          (1 * GetOsPageSize())
+
 #define STUB_HEAP_RESERVE_SIZE                 (3 * GetOsPageSize())
 #define STUB_HEAP_COMMIT_SIZE                  (1 * GetOsPageSize())
 

--- a/src/vm/loaderallocator.hpp
+++ b/src/vm/loaderallocator.hpp
@@ -154,10 +154,12 @@ protected:
     BYTE *              m_InitialReservedMemForLoaderHeaps;
     BYTE                m_LowFreqHeapInstance[sizeof(LoaderHeap)];
     BYTE                m_HighFreqHeapInstance[sizeof(LoaderHeap)];
+    BYTE                m_MethodTableHeapInstance[sizeof(LoaderHeap)];
     BYTE                m_StubHeapInstance[sizeof(LoaderHeap)];
     BYTE                m_PrecodeHeapInstance[sizeof(CodeFragmentHeap)];
     PTR_LoaderHeap      m_pLowFrequencyHeap;
     PTR_LoaderHeap      m_pHighFrequencyHeap;
+    PTR_LoaderHeap      m_pMethodTableHeap;
     PTR_LoaderHeap      m_pStubHeap; // stubs for PInvoke, remoting, etc
     PTR_CodeFragmentHeap m_pPrecodeHeap;
     PTR_LoaderHeap      m_pExecutableHeap;
@@ -418,6 +420,12 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
         return m_pHighFrequencyHeap;
+    }
+
+    PTR_LoaderHeap GetMethodTableHeap()
+    {
+        LIMITED_METHOD_CONTRACT;
+        return m_pMethodTableHeap;
     }
 
     PTR_LoaderHeap GetStubHeap()

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -9954,7 +9954,7 @@ MethodTable * MethodTableBuilder::AllocateNewMT(Module *pLoaderModule,
         cbTotalSize += S_SIZE_T(dwNonVirtualSlots) * S_SIZE_T(sizeof(PCODE));
     }
 
-    BYTE *pData = (BYTE *)pamTracker->Track(pAllocator->GetHighFrequencyHeap()->AllocMem(cbTotalSize));
+    BYTE *pData = (BYTE *)pamTracker->Track(pAllocator->GetMethodTableHeap()->AllocMem(cbTotalSize));
 
     _ASSERTE(IS_ALIGNED(pData, TARGET_POINTER_SIZE));
     


### PR DESCRIPTION
In type check heavy code 64-bit method table pointers waste I$.
This patch adds a separate LoaderHeap just for method tables that tries to allocate them in 32-bit address range.

On Linux.x64 type checks for a sealed class with 32-bit immediates are:
* 6 bytes smaller (40%)
* 1 instruction shorter
* use one register instead of two

Before:
```asm
48B8187395C59D7F0000 mov      rax, 0x7F9DC5957318
483902               cmp      qword ptr [rdx], rax
7402                 je       SHORT G_M15815_IG03
```

After:
```asm
48813AD83E0240       cmp      qword ptr [rdx], 0x40023ED8
7402                 je       SHORT G_M15815_IG03
```

This is a rough draft, not thoroughly tested.

Potential issues:
* compatibility with crossgen, R2R, collectible assemblies
* this should probably be controllable by a runtime switch
* ClrVirtualAllocWithinRange scans the range linearly on each VM reserve
