### PR TITLE
Fix an assertion failure in the thread pool's QueueUserWorkItemCallbackBase

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/ThreadPool.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ThreadPool.cs
@@ -770,11 +770,12 @@ namespace System.Threading
     internal abstract class QueueUserWorkItemCallbackBase : IThreadPoolWorkItem
     {
 #if DEBUG
-        private volatile int executed;
+        private int executed;
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1821:RemoveEmptyFinalizers")]
         ~QueueUserWorkItemCallbackBase()
         {
+            Interlocked.MemoryBarrier(); // ensure that an old cached value is not read below
             Debug.Assert(
                 executed != 0, "A QueueUserWorkItemCallback was never called!");
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/25242
- The issue could be that there is no memory barrier (or in the wrong place) on the thread reading the value, and an old value could be cached and read