### PR TITLE
Add RundownRequested switch to EventPipe IPC protocol

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/StackTrace.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/StackTrace.cs
@@ -340,11 +340,11 @@ namespace System.Diagnostics
         {
             Debug.Assert(mb != null);
 
-            if (mb.MethodImplementationFlags.HasFlag(MethodImplAttributes.AggressiveInlining))
+            if ((mb.MethodImplementationFlags & MethodImplAttributes.AggressiveInlining) != 0)
             {
                 // Aggressive Inlines won't normally show in the StackTrace; however for Tier0 Jit and
                 // cross-assembly AoT/R2R these inlines will be blocked until Tier1 Jit re-Jits 
-                // them when they will inline. We don't show them in the StackTrace to bring consitency
+                // them when they will inline. We don't show them in the StackTrace to bring consistency
                 // between this first-pass asm and fully optimized asm.
                 return false;
             }

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -168,7 +168,7 @@ EventPipeSessionID EventPipe::Enable(
     uint32_t numProviders,
     EventPipeSessionType sessionType,
     EventPipeSerializationFormat format,
-    EventPipeRundownSwitch rundownSwitch,
+    const bool rundownRequested,
     IpcStream *const pStream)
 {
     CONTRACTL
@@ -177,7 +177,6 @@ EventPipeSessionID EventPipe::Enable(
         GC_TRIGGERS;
         MODE_PREEMPTIVE;
         PRECONDITION(format < EventPipeSerializationFormat::Count);
-        PRECONDITION(rundownSwitch < EventPipeRundownSwitch::Count);
         PRECONDITION(circularBufferSizeInMB > 0);
         PRECONDITION(numProviders > 0 && pProviders != nullptr);
     }
@@ -204,7 +203,7 @@ EventPipeSessionID EventPipe::Enable(
             pStream,
             sessionType,
             format,
-            rundownSwitch,
+            rundownRequested,
             circularBufferSizeInMB,
             pProviders,
             numProviders);
@@ -348,7 +347,7 @@ void EventPipe::DisableInternal(EventPipeSessionID id, EventPipeProviderCallback
     pSession->Disable(); // Suspend EventPipeBufferManager, and remove providers.
 
     // Do rundown before fully stopping the session unless rundown wasn't requested
-    if (pSession->RundownRequested() == EventPipeRundownSwitch::Enable)
+    if (pSession->RundownRequested())
     {
         pSession->EnableRundown(); // Set Rundown provider.
 

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -22,6 +22,7 @@ class EventPipeSession;
 class IpcStream;
 enum class EventPipeSessionType;
 enum class EventPipeSerializationFormat;
+enum class EventPipeRundownSwitch;
 class EventPipeEventPayload;
 struct EventData;
 
@@ -51,6 +52,7 @@ public:
         uint32_t numProviders,
         EventPipeSessionType sessionType,
         EventPipeSerializationFormat format,
+        EventPipeRundownSwitch rundownSwitch,
         IpcStream *const pStream);
 
     // Disable tracing via the event pipe.

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -52,7 +52,7 @@ public:
         uint32_t numProviders,
         EventPipeSessionType sessionType,
         EventPipeSerializationFormat format,
-        EventPipeRundownSwitch rundownSwitch,
+        bool rundownSwitch,
         IpcStream *const pStream);
 
     // Disable tracing via the event pipe.

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -51,7 +51,7 @@ public:
         uint32_t numProviders,
         EventPipeSessionType sessionType,
         EventPipeSerializationFormat format,
-        bool rundownRequested,
+        const bool rundownRequested,
         IpcStream *const pStream);
 
     // Disable tracing via the event pipe.

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -22,7 +22,6 @@ class EventPipeSession;
 class IpcStream;
 enum class EventPipeSessionType;
 enum class EventPipeSerializationFormat;
-enum class EventPipeRundownSwitch;
 class EventPipeEventPayload;
 struct EventData;
 
@@ -52,7 +51,7 @@ public:
         uint32_t numProviders,
         EventPipeSessionType sessionType,
         EventPipeSerializationFormat format,
-        bool rundownSwitch,
+        bool rundownRequested,
         IpcStream *const pStream);
 
     // Disable tracing via the event pipe.

--- a/src/vm/eventpipeinternal.cpp
+++ b/src/vm/eventpipeinternal.cpp
@@ -46,6 +46,7 @@ UINT64 QCALLTYPE EventPipeInternal::Enable(
             numProviders,
             outputFile != NULL ? EventPipeSessionType::File : EventPipeSessionType::Listener,
             format,
+            EventPipeRundownSwitch::Enable,
             nullptr);
     }
     END_QCALL;

--- a/src/vm/eventpipeinternal.cpp
+++ b/src/vm/eventpipeinternal.cpp
@@ -46,7 +46,7 @@ UINT64 QCALLTYPE EventPipeInternal::Enable(
             numProviders,
             outputFile != NULL ? EventPipeSessionType::File : EventPipeSessionType::Listener,
             format,
-            EventPipeRundownSwitch::Enable,
+            true,
             nullptr);
     }
     END_QCALL;

--- a/src/vm/eventpipeprotocolhelper.cpp
+++ b/src/vm/eventpipeprotocolhelper.cpp
@@ -38,10 +38,9 @@ static bool TryParseSerializationFormat(uint8_t*& bufferCursor, uint32_t& buffer
     return CanParse && (0 <= (int)serializationFormat) && ((int)serializationFormat < (int)EventPipeSerializationFormat::Count);
 }
 
-static bool TryParseRundownEnabled(uint8_t*& bufferCursor, uint32_t& bufferLen, EventPipeRundownSwitch& rundownSwitch)
+static bool TryParseRundownRequested(uint8_t*& bufferCursor, uint32_t& bufferLen, bool& rundownRequested)
 {
-    const bool CanParse = TryParse(bufferCursor, bufferLen, (uint32_t&)rundownSwitch);
-    return CanParse && (0 <= (int)rundownSwitch) && ((int)rundownSwitch < (int)EventPipeRundownSwitch::Count);
+    return TryParse(bufferCursor, bufferLen, rundownRequested);
 }
 
 const EventPipeCollectTracingCommandPayload* EventPipeCollectTracingCommandPayload::TryParse(BYTE* lpBuffer, uint16_t& BufferSize)
@@ -67,7 +66,7 @@ const EventPipeCollectTracingCommandPayload* EventPipeCollectTracingCommandPaylo
     uint32_t bufferLen = BufferSize;
     if (!TryParseCircularBufferSize(pBufferCursor, bufferLen, payload->circularBufferSizeInMB) ||
         !TryParseSerializationFormat(pBufferCursor, bufferLen, payload->serializationFormat) ||
-        !TryParseRundownEnabled(pBufferCursor, bufferLen, payload->rundownSwitch) ||
+        !TryParseRundownRequested(pBufferCursor, bufferLen, payload->rundownRequested) ||
         !EventPipeProtocolHelper::TryParseProviderConfiguration(pBufferCursor, bufferLen, payload->providerConfigs))
     {
         delete payload;
@@ -207,7 +206,7 @@ void EventPipeProtocolHelper::CollectTracing(DiagnosticsIpc::IpcMessage& message
         static_cast<uint32_t>(payload->providerConfigs.Size()),  // numConfigs
         EventPipeSessionType::IpcStream,                // EventPipeSessionType
         payload->serializationFormat,                   // EventPipeSerializationFormat
-        payload->rundownSwitch,                         // EventPipeRundownSwitch
+        payload->rundownRequested,                      // rundownRequested
         pStream);                                       // IpcStream
 
     if (sessionId == 0)

--- a/src/vm/eventpipeprotocolhelper.cpp
+++ b/src/vm/eventpipeprotocolhelper.cpp
@@ -38,6 +38,12 @@ static bool TryParseSerializationFormat(uint8_t*& bufferCursor, uint32_t& buffer
     return CanParse && (0 <= (int)serializationFormat) && ((int)serializationFormat < (int)EventPipeSerializationFormat::Count);
 }
 
+static bool TryParseRundownEnabled(uint8_t*& bufferCursor, uint32_t& bufferLen, EventPipeRundownSwitch& rundownSwitch)
+{
+    const bool CanParse = TryParse(bufferCursor, bufferLen, (uint32_t&)rundownSwitch);
+    return CanParse && (0 <= (int)rundownSwitch) && ((int)rundownSwitch < (int)EventPipeRundownSwitch::Count);
+}
+
 const EventPipeCollectTracingCommandPayload* EventPipeCollectTracingCommandPayload::TryParse(BYTE* lpBuffer, uint16_t& BufferSize)
 {
     CONTRACTL
@@ -61,6 +67,7 @@ const EventPipeCollectTracingCommandPayload* EventPipeCollectTracingCommandPaylo
     uint32_t bufferLen = BufferSize;
     if (!TryParseCircularBufferSize(pBufferCursor, bufferLen, payload->circularBufferSizeInMB) ||
         !TryParseSerializationFormat(pBufferCursor, bufferLen, payload->serializationFormat) ||
+        !TryParseRundownEnabled(pBufferCursor, bufferLen, payload->rundownSwitch) ||
         !EventPipeProtocolHelper::TryParseProviderConfiguration(pBufferCursor, bufferLen, payload->providerConfigs))
     {
         delete payload;
@@ -200,6 +207,7 @@ void EventPipeProtocolHelper::CollectTracing(DiagnosticsIpc::IpcMessage& message
         static_cast<uint32_t>(payload->providerConfigs.Size()),  // numConfigs
         EventPipeSessionType::IpcStream,                // EventPipeSessionType
         payload->serializationFormat,                   // EventPipeSerializationFormat
+        payload->rundownSwitch,                         // EventPipeRundownSwitch
         pStream);                                       // IpcStream
 
     if (sessionId == 0)

--- a/src/vm/eventpipeprotocolhelper.h
+++ b/src/vm/eventpipeprotocolhelper.h
@@ -38,6 +38,7 @@ struct EventPipeCollectTracingCommandPayload
     // provider_config = ulong keywords, uint logLevel, string provider_name, string filter_data
     uint32_t circularBufferSizeInMB;
     EventPipeSerializationFormat serializationFormat;
+    EventPipeRundownSwitch rundownSwitch;
     CQuickArray<EventPipeProviderConfiguration> providerConfigs;
     static const EventPipeCollectTracingCommandPayload* TryParse(BYTE* lpBuffer, uint16_t& BufferSize);
 };
@@ -58,7 +59,6 @@ public:
     static bool TryParseProviderConfiguration(uint8_t *&bufferCursor, uint32_t &bufferLen, CQuickArray<EventPipeProviderConfiguration> &result);
 
 private:
-    const static uint32_t DefaultCircularBufferMB = 1024; // 1 GB
     const static uint32_t IpcStreamReadBufferSize = 8192;
 };
 

--- a/src/vm/eventpipeprotocolhelper.h
+++ b/src/vm/eventpipeprotocolhelper.h
@@ -38,7 +38,7 @@ struct EventPipeCollectTracingCommandPayload
     // provider_config = ulong keywords, uint logLevel, string provider_name, string filter_data
     uint32_t circularBufferSizeInMB;
     EventPipeSerializationFormat serializationFormat;
-    EventPipeRundownSwitch rundownSwitch;
+    bool rundownRequested;
     CQuickArray<EventPipeProviderConfiguration> providerConfigs;
     static const EventPipeCollectTracingCommandPayload* TryParse(BYTE* lpBuffer, uint16_t& BufferSize);
 };

--- a/src/vm/eventpipeprotocolhelper.h
+++ b/src/vm/eventpipeprotocolhelper.h
@@ -20,8 +20,31 @@ enum class EventPipeCommandId : uint8_t
 {
     StopTracing    = 0x01,
     CollectTracing = 0x02,
+    CollectTracing2 = 0x03,
     // future
 };
+
+
+// Command = 0x0203
+struct EventPipeCollectTracing2CommandPayload
+{
+    NewArrayHolder<BYTE> incomingBuffer;
+
+    // The protocol buffer is defined as:
+    // X, Y, Z means encode bytes for X followed by bytes for Y followed by bytes for Z
+    // message = uint circularBufferMB, uint format, array<provider_config> providers
+    // uint = 4 little endian bytes
+    // wchar = 2 little endian bytes, UTF16 encoding
+    // array<T> = uint length, length # of Ts
+    // string = (array<char> where the last char must = 0) or (length = 0)
+    // provider_config = ulong keywords, uint logLevel, string provider_name, string filter_data
+    uint32_t circularBufferSizeInMB;
+    EventPipeSerializationFormat serializationFormat;
+    bool rundownRequested;
+    CQuickArray<EventPipeProviderConfiguration> providerConfigs;
+    static const EventPipeCollectTracing2CommandPayload* TryParse(BYTE* lpBuffer, uint16_t& BufferSize);
+};
+
 
 // Command = 0x0202
 struct EventPipeCollectTracingCommandPayload
@@ -38,7 +61,6 @@ struct EventPipeCollectTracingCommandPayload
     // provider_config = ulong keywords, uint logLevel, string provider_name, string filter_data
     uint32_t circularBufferSizeInMB;
     EventPipeSerializationFormat serializationFormat;
-    bool rundownRequested;
     CQuickArray<EventPipeProviderConfiguration> providerConfigs;
     static const EventPipeCollectTracingCommandPayload* TryParse(BYTE* lpBuffer, uint16_t& BufferSize);
 };
@@ -56,6 +78,7 @@ public:
     static void HandleIpcMessage(DiagnosticsIpc::IpcMessage& message, IpcStream *pStream);
     static void StopTracing(DiagnosticsIpc::IpcMessage& message, IpcStream *pStream);
     static void CollectTracing(DiagnosticsIpc::IpcMessage& message, IpcStream *pStream); // `dotnet-trace collect`
+    static void CollectTracing2(DiagnosticsIpc::IpcMessage& message, IpcStream *pStream);
     static bool TryParseProviderConfiguration(uint8_t *&bufferCursor, uint32_t &bufferLen, CQuickArray<EventPipeProviderConfiguration> &result);
 
 private:

--- a/src/vm/eventpipesession.cpp
+++ b/src/vm/eventpipesession.cpp
@@ -18,12 +18,14 @@ EventPipeSession::EventPipeSession(
     IpcStream *const pStream,
     EventPipeSessionType sessionType,
     EventPipeSerializationFormat format,
+    EventPipeRundownSwitch rundownSwitch,
     uint32_t circularBufferSizeInMB,
     const EventPipeProviderConfiguration *pProviders,
     uint32_t numProviders,
     bool rundownEnabled) : m_index(index),
                            m_pProviderList(new EventPipeSessionProviderList(pProviders, numProviders)),
                            m_rundownEnabled(rundownEnabled),
+                           m_rundownRequested(rundownSwitch),
                            m_SessionType(sessionType),
                            m_format(format)
 {

--- a/src/vm/eventpipesession.cpp
+++ b/src/vm/eventpipesession.cpp
@@ -18,7 +18,7 @@ EventPipeSession::EventPipeSession(
     IpcStream *const pStream,
     EventPipeSessionType sessionType,
     EventPipeSerializationFormat format,
-    EventPipeRundownSwitch rundownSwitch,
+    bool rundownSwitch,
     uint32_t circularBufferSizeInMB,
     const EventPipeProviderConfiguration *pProviders,
     uint32_t numProviders,

--- a/src/vm/eventpipesession.h
+++ b/src/vm/eventpipesession.h
@@ -43,6 +43,16 @@ enum class EventPipeSerializationFormat
     Count
 };
 
+enum class EventPipeRundownSwitch
+{
+    // Flag that indicates whether rundown events should be emitted
+    // for this session.
+    Disable,
+    Enable,
+
+    Count
+};
+
 //! Encapsulates an EventPipe session information and memory management.
 class EventPipeSession
 {
@@ -65,6 +75,9 @@ private:
     // For file/IPC sessions this controls the format emitted. For in-proc EventListener it is
     // irrelevant.
     EventPipeSerializationFormat m_format;
+
+    // For determininig if a particular session needs rundown events
+    EventPipeRundownSwitch m_rundownRequested;
 
     // Start date and time in UTC.
     FILETIME m_sessionStartTime;
@@ -99,6 +112,7 @@ public:
         IpcStream *const pStream,
         EventPipeSessionType sessionType,
         EventPipeSerializationFormat format,
+        EventPipeRundownSwitch rundownSwitch,
         uint32_t circularBufferSizeInMB,
         const EventPipeProviderConfiguration *pProviders,
         uint32_t numProviders,
@@ -129,6 +143,13 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
         return m_format;
+    }
+
+    // Get whether rundown was requested by the client.
+    EventPipeRundownSwitch RundownRequested() const
+    {
+        LIMITED_METHOD_CONTRACT;
+        return m_rundownRequested;
     }
 
     // Determine if rundown is enabled.

--- a/src/vm/eventpipesession.h
+++ b/src/vm/eventpipesession.h
@@ -43,16 +43,6 @@ enum class EventPipeSerializationFormat
     Count
 };
 
-enum class EventPipeRundownSwitch
-{
-    // Flag that indicates whether rundown events should be emitted
-    // for this session.
-    Disable,
-    Enable,
-
-    Count
-};
-
 //! Encapsulates an EventPipe session information and memory management.
 class EventPipeSession
 {
@@ -77,7 +67,7 @@ private:
     EventPipeSerializationFormat m_format;
 
     // For determininig if a particular session needs rundown events
-    EventPipeRundownSwitch m_rundownRequested;
+    const bool m_rundownRequested;
 
     // Start date and time in UTC.
     FILETIME m_sessionStartTime;
@@ -112,7 +102,7 @@ public:
         IpcStream *const pStream,
         EventPipeSessionType sessionType,
         EventPipeSerializationFormat format,
-        EventPipeRundownSwitch rundownSwitch,
+        bool rundownRequested,
         uint32_t circularBufferSizeInMB,
         const EventPipeProviderConfiguration *pProviders,
         uint32_t numProviders,
@@ -146,7 +136,7 @@ public:
     }
 
     // Get whether rundown was requested by the client.
-    EventPipeRundownSwitch RundownRequested() const
+    bool RundownRequested() const
     {
         LIMITED_METHOD_CONTRACT;
         return m_rundownRequested;


### PR DESCRIPTION
This is for https://github.com/dotnet/coreclr/issues/25268. It lets users to specify rundown to not be emitted. 

Corresponding diagnostics tool change is https://github.com/dotnet/diagnostics/pull/375