### PR TITLE
Use Array.MaxArrayLength in ArrayList

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Collections/ArrayList.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ArrayList.cs
@@ -39,9 +39,6 @@ namespace System.Collections
 
         private const int _defaultCapacity = 4;
 
-        // Copy of Array.MaxArrayLength
-        internal const int MaxArrayLength = 0X7FEFFFFF;
-
         // Note: this constructor is a bogus constructor that does nothing
         // and is for use only with SyncArrayList.
         internal ArrayList(bool trash)
@@ -347,7 +344,7 @@ namespace System.Collections
                 int newCapacity = _items.Length == 0 ? _defaultCapacity : _items.Length * 2;
                 // Allow the list to grow to maximum possible capacity (~2G elements) before encountering overflow.
                 // Note that this check works even when _items.Length overflowed thanks to the (uint) cast
-                if ((uint)newCapacity > MaxArrayLength) newCapacity = MaxArrayLength;
+                if ((uint)newCapacity > Array.MaxArrayLength) newCapacity = Array.MaxArrayLength;
                 if (newCapacity < min) newCapacity = min;
                 Capacity = newCapacity;
             }


### PR DESCRIPTION
Now that `ArrayList` is in CoreLib, we don't need the copy.