### PR TITLE
Reduce allocations in GetLocale()

### DIFF
--- a/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -545,7 +545,7 @@ namespace System.Reflection
             if (locale == null)
                 return CultureInfo.InvariantCulture;
 
-            return new CultureInfo(locale);
+            return CultureInfo.GetCultureInfo(locale);
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]


### PR DESCRIPTION
Fix #25474

Before the fix every time we call Assembly.GetName().Name we allocate CultureInfo in GetLocale().