### PR TITLE
Introduce a "PerfScore" rating in the JIT disassembly for each method

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2255,8 +2255,9 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
 #ifdef DEBUG
     if (compiler->opts.disAsm)
     {
-        printf("; Total bytes of code %d, prolog size %d, perf score %I64d for method %s, (MethodHash=%08x)\n", 
-               codeSize, prologSize, compiler->info.compPerfScore, compiler->info.compFullName, compiler->info.compMethodHash());
+        printf("; Total bytes of code %d, prolog size %d, perf score %I64d for method %s, (MethodHash=%08x)\n",
+               codeSize, prologSize, compiler->info.compPerfScore, compiler->info.compFullName,
+               compiler->info.compMethodHash());
         printf("; ============================================================\n");
         printf(""); // in our logic this causes a flush
     }

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -334,7 +334,7 @@ void CodeGen::genCodeForBBlist()
 
 #if defined(DEBUG) || defined(LATE_DISASM)
         // We also want to start a new Instruction group by calling emitAddLabel below,
-        // when we need accurate bbWeights for thsi block in the emitter.  We force this 
+        // when we need accurate bbWeights for thsi block in the emitter.  We force this
         // whenever our previous block was a BBJ_COND and it has a different weight than us.
         //
         // Note: We need to have set compCurBB before calling emitAddLabel

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -3542,7 +3542,7 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
 
         if (jitFlags->IsSet(JitFlags::JIT_FLAG_BBOPT) && fgHaveProfileData())
         {
-            printf("OPTIONS: using real profile data\n");
+            printf("OPTIONS: optimized using profile data\n");
         }
 
         if (fgProfileData_ILSizeMismatch)
@@ -5244,7 +5244,8 @@ int Compiler::compCompile(CORINFO_METHOD_HANDLE methodHnd,
     info.compClassName  = getAllocator(CMK_DebugOnly).allocate<char>(len);
     strcpy_s((char*)info.compClassName, len, classNamePtr);
 
-    info.compFullName = eeGetMethodFullName(methodHnd);
+    info.compFullName  = eeGetMethodFullName(methodHnd);
+    info.compPerfScore = 0;
 #endif // defined(DEBUG) || defined(LATE_DISASM)
 
 #ifdef DEBUG

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -8638,6 +8638,7 @@ public:
         const char* compMethodName;
         const char* compClassName;
         const char* compFullName;
+        INT64       compPerfScore;
 #endif // defined(DEBUG) || defined(LATE_DISASM)
 
 #if defined(DEBUG) || defined(INLINE_DATA)

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -1226,6 +1226,54 @@ int emitter::instrDesc::idAddrUnion::iiaGetJitDataOffset() const
     return Compiler::eeGetJitDataOffs(iiaFieldHnd);
 }
 
+#ifndef _TARGET_XARCH_
+//----------------------------------------------------------------------------------------
+// getInsThroughput: Return an estimate of the instruction execution throughput
+//
+// Arguments:
+//    id  - THe current intstruction descriptor to be evaluated
+//
+// Return Value:
+//    The estimated instruction execution cost
+//
+// Notes:
+//    This is the default implementation that can be used when we don't
+//    have a target specific implementation available
+//
+int emitter::getInsThroughput(instrDesc* id)
+{
+    return PERFSCORE_INS_THROUGHPUT_DEFAULT;
+}
+#endif // ! _TARGET_XARCH_
+
+//----------------------------------------------------------------------------------------
+// getCurrentBlockWeight: Return the block weight for the currently active block
+//
+// Arguments:
+//    None
+//
+// Return Value:
+//    The block weight for the current block
+//
+// Notes:
+//    The current block is recorded in emitComp->compCurBB by
+//    CodeGen::genCodeForBBlist() as it walks the blocks.
+//    When we are in the prolog/epilog this value is nullptr.
+//
+BasicBlock::weight_t emitter::getCurrentBlockWeight()
+{
+    // If we have a non-null compCurBB, then use it to get the current block weight
+    if (emitComp->compCurBB != nullptr)
+    {
+        return emitComp->compCurBB->getBBWeight(emitComp);
+    }
+    else // we have a null compCurBB
+    {
+        // prolog or epilog case, so just use the standard weight
+        return BB_UNITY_WEIGHT;
+    }
+}
+
 void emitter::dispIns(instrDesc* id)
 {
 #ifdef DEBUG
@@ -3353,7 +3401,7 @@ void emitter::emitDispIG(insGroup* ig, insGroup* igPrev, bool verbose)
     }
     else
     {
-        printf("offs=%06XH, size=%04XH", ig->igOffs, ig->igSize);
+        printf("offs=%06XH, size=%04XH, bbWeight=%s", ig->igOffs, ig->igSize, refCntWtd2str(ig->igWeight));
 
         if (ig->igFlags & IGF_GC_VARS)
         {
@@ -4911,7 +4959,14 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
             }
             else
             {
-                printf("\nG_M%03u_IG%02u:\n", Compiler::s_compMethodsCount, ig->igNum);
+                printf("\nG_M%03u_IG%02u:", Compiler::s_compMethodsCount, ig->igNum);
+
+                // Display the block weight, but only when it isn't the standard BB_UNITY_WEIGHT
+                if (ig->igWeight != BB_UNITY_WEIGHT)
+                {
+                    printf("\t\t;; bbWeight=%s", refCntWtd2str(ig->igWeight));
+                }
+                printf("\n");
             }
         }
 
@@ -6898,6 +6953,10 @@ insGroup* emitter::emitAllocIG()
 
 #ifdef DEBUG
     ig->igSelf = ig;
+#endif
+
+#if defined(DEBUG) || defined(LATE_DISASM)
+    ig->igWeight = getCurrentBlockWeight();
 #endif
 
 #if EMITTER_STATS

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -262,6 +262,9 @@ struct insGroup
 #ifdef DEBUG
     insGroup* igSelf; // for consistency checking
 #endif
+#if defined(DEBUG) || defined(LATE_DISASM)
+    BasicBlock::weight_t igWeight; // the block weight used for this insGroup
+#endif
 
     UNATIVE_OFFSET igNum;     // for ordering (and display) purposes
     UNATIVE_OFFSET igOffs;    // offset of this group within method
@@ -1225,6 +1228,31 @@ protected:
             return &this->_idAddrUnion;
         }
     }; // End of  struct instrDesc
+
+#ifdef _TARGET_XARCH_
+    insFormat emitter::getMemoryOperation(insFormat insFmt);
+#endif
+
+#define PERFSCORE_INS_THROUGHPUT_DEFAULT   12
+#define PERFSCORE_INS_THROUGHPUT_2X         6    // Faster - Dual issue
+#define PERFSCORE_INS_THROUGHPUT_3X         4    // Faster - Three issue
+#define PERFSCORE_INS_THROUGHPUT_4X         3    // Faster - Quad issue
+
+#define PERFSCORE_INS_BRANCH_DIRECT        12    // cost of an unconditional branch
+#define PERFSCORE_INS_BRANCH_COND          24    // includes cost of a possible misprediction
+#define PERFSCORE_INS_BRANCH_INDIRECT      24    // includes cosr of a possible misprediction
+
+
+#define PERFSCORE_COST_MEM_READ_STACK      12    // a read from stack location, possible def to use latency from L0 cache
+#define PERFSCORE_COST_MEM_READ_GENERAL    24    // a read from memory location, possible def to use latency from L0 or L1 cache
+
+#define PERFSCORE_COST_CODESIZE_HOT        10
+#define PERFSCORE_COST_CODESIZE_COLD        1
+
+
+    int getInsThroughput(instrDesc* id);
+
+    BasicBlock::weight_t getCurrentBlockWeight();
 
     void dispIns(instrDesc* id);
 

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -1233,22 +1233,21 @@ protected:
     insFormat emitter::getMemoryOperation(insFormat insFmt);
 #endif
 
-#define PERFSCORE_INS_THROUGHPUT_DEFAULT   12
-#define PERFSCORE_INS_THROUGHPUT_2X         6    // Faster - Dual issue
-#define PERFSCORE_INS_THROUGHPUT_3X         4    // Faster - Three issue
-#define PERFSCORE_INS_THROUGHPUT_4X         3    // Faster - Quad issue
+#define PERFSCORE_INS_THROUGHPUT_DEFAULT 12
+#define PERFSCORE_INS_THROUGHPUT_2X 6 // Faster - Dual issue
+#define PERFSCORE_INS_THROUGHPUT_3X 4 // Faster - Three issue
+#define PERFSCORE_INS_THROUGHPUT_4X 3 // Faster - Quad issue
 
-#define PERFSCORE_INS_BRANCH_DIRECT        12    // cost of an unconditional branch
-#define PERFSCORE_INS_BRANCH_COND          24    // includes cost of a possible misprediction
-#define PERFSCORE_INS_BRANCH_INDIRECT      24    // includes cosr of a possible misprediction
+#define PERFSCORE_INS_BRANCH_DIRECT 12   // cost of an unconditional branch
+#define PERFSCORE_INS_BRANCH_COND 24     // includes cost of a possible misprediction
+#define PERFSCORE_INS_BRANCH_INDIRECT 24 // includes cosr of a possible misprediction
 
+#define PERFSCORE_COST_MEM_READ_STACK 12 // a read from stack location, possible def to use latency from L0 cache
+#define PERFSCORE_COST_MEM_READ_GENERAL                                                                                \
+    24 // a read from memory location, possible def to use latency from L0 or L1 cache
 
-#define PERFSCORE_COST_MEM_READ_STACK      12    // a read from stack location, possible def to use latency from L0 cache
-#define PERFSCORE_COST_MEM_READ_GENERAL    24    // a read from memory location, possible def to use latency from L0 or L1 cache
-
-#define PERFSCORE_COST_CODESIZE_HOT        10
-#define PERFSCORE_COST_CODESIZE_COLD        1
-
+#define PERFSCORE_COST_CODESIZE_HOT 10
+#define PERFSCORE_COST_CODESIZE_COLD 1
 
     int getInsThroughput(instrDesc* id);
 

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -1242,11 +1242,11 @@ protected:
 #define PERFSCORE_INS_BRANCH_COND 24     // includes cost of a possible misprediction
 #define PERFSCORE_INS_BRANCH_INDIRECT 24 // includes cosr of a possible misprediction
 
-    // a read from stack location, possible def to use latency from L0 cache
+// a read from stack location, possible def to use latency from L0 cache
 #define PERFSCORE_COST_MEM_READ_STACK 12
-    // a read from constant location, possible def to use latency from L0 cache
+// a read from constant location, possible def to use latency from L0 cache
 #define PERFSCORE_COST_MEM_READ_CONST 12
-    // a read from memory location, possible def to use latency from L0 or L1 cache
+// a read from memory location, possible def to use latency from L0 or L1 cache
 #define PERFSCORE_COST_MEM_READ_GENERAL 24
 
 #define PERFSCORE_COST_CODESIZE_HOT 10

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -1242,9 +1242,12 @@ protected:
 #define PERFSCORE_INS_BRANCH_COND 24     // includes cost of a possible misprediction
 #define PERFSCORE_INS_BRANCH_INDIRECT 24 // includes cosr of a possible misprediction
 
-#define PERFSCORE_COST_MEM_READ_STACK 12 // a read from stack location, possible def to use latency from L0 cache
-#define PERFSCORE_COST_MEM_READ_GENERAL                                                                                \
-    24 // a read from memory location, possible def to use latency from L0 or L1 cache
+    // a read from stack location, possible def to use latency from L0 cache
+#define PERFSCORE_COST_MEM_READ_STACK 12
+    // a read from constant location, possible def to use latency from L0 cache
+#define PERFSCORE_COST_MEM_READ_CONST 12
+    // a read from memory location, possible def to use latency from L0 or L1 cache
+#define PERFSCORE_COST_MEM_READ_GENERAL 24
 
 #define PERFSCORE_COST_CODESIZE_HOT 10
 #define PERFSCORE_COST_CODESIZE_COLD 1

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -14082,12 +14082,23 @@ int emitter::getInsThroughput(instrDesc* id)
     {
         // Model a read from stack location, possible def to use latency from L0 cache
         case IF_SRD:
+        case IF_SRW:
             result = max(result, PERFSCORE_COST_MEM_READ_STACK);
+            break;
+
+            // Model a read from a constant location, possible def to use latency from L0 cache
+        case IF_MRD:
+        case IF_MRW:
+            result = max(result, PERFSCORE_COST_MEM_READ_CONST);
             break;
 
         // Model a read from memory location, possible def to use latency from L0 or L1 cache
         case IF_ARD:
+        case IF_ARW:
             result = max(result, PERFSCORE_COST_MEM_READ_GENERAL);
+            break;
+
+        default:
             break;
     }
 

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -13882,8 +13882,6 @@ int emitter::getInsThroughput(instrDesc* id)
                     break;
 
                 default:
-                    printf("INFO:  IF_RWR_ARD is %d\n", IF_RWR_ARD);
-                    printf("ERROR: insFmt is %d\n", insFmt);
                     assert(!"Unhandled insFmt for INS_lea");
                     result = PERFSCORE_INS_THROUGHPUT_DEFAULT;
                     break;
@@ -14022,8 +14020,6 @@ int emitter::getInsThroughput(instrDesc* id)
                     break;
 
                 default:
-                    printf("INFO:  IF_METHOD is %d\n", IF_METHOD);
-                    printf("ERROR: insFmt is %d\n", insFmt);
                     assert(!"Unhandled insFmt for INS_call");
                     result = PERFSCORE_INS_THROUGHPUT_DEFAULT;
                     break;

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -14082,7 +14082,7 @@ int emitter::getInsThroughput(instrDesc* id)
             result = max(result, PERFSCORE_COST_MEM_READ_STACK);
             break;
 
-            // Model a read from a constant location, possible def to use latency from L0 cache
+        // Model a read from a constant location, possible def to use latency from L0 cache
         case IF_MRD:
         case IF_MRW:
             result = max(result, PERFSCORE_COST_MEM_READ_CONST);

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -13781,7 +13781,7 @@ emitter::insFormat emitter::getMemoryOperation(insFormat insFmt)
             result = IF_SWR;
             break;
 
-    default:
+        default:
             result = IF_NONE;
             break;
     }
@@ -13855,13 +13855,13 @@ int emitter::getInsThroughput(instrDesc* id)
         case INS_lea:
             // an INS_lea instruction doesn't actually read memory
             memFmt = IF_NONE;
-                
+
             switch (insFmt)
             {
                 case IF_RWR_LABEL:
-                    // lea   reg,[pc-rel]
+                // lea   reg,[pc-rel]
                 case IF_RWR_SRD:
-                    // lea   reg,[stack]
+                // lea   reg,[stack]
                 case IF_RWR_MRD:
                     // lea   reg,[cns]
                     result = PERFSCORE_INS_THROUGHPUT_2X;
@@ -13869,7 +13869,8 @@ int emitter::getInsThroughput(instrDesc* id)
 
                 case IF_RWR_ARD:
                     // lea   reg,[mem]  ; with 1 or 2 compoents in address
-                    if ((id->idAddr()->iiaAddrMode.amIndxReg == REG_NA) || (id->idAddr()->iiaAddrMode.amBaseReg == REG_NA))
+                    if ((id->idAddr()->iiaAddrMode.amIndxReg == REG_NA) ||
+                        (id->idAddr()->iiaAddrMode.amBaseReg == REG_NA))
                     {
                         result = PERFSCORE_INS_THROUGHPUT_2X;
                     }
@@ -13886,7 +13887,6 @@ int emitter::getInsThroughput(instrDesc* id)
                     assert(!"Unhandled insFmt for INS_lea");
                     result = PERFSCORE_INS_THROUGHPUT_DEFAULT;
                     break;
-
             }
             break;
 
@@ -13897,7 +13897,7 @@ int emitter::getInsThroughput(instrDesc* id)
             {
                 result = 32 * PERFSCORE_INS_THROUGHPUT_DEFAULT;
             }
-            else  
+            else
             {
                 assert(id->idOpSize() == EA_4BYTE);
                 result = 6 * PERFSCORE_INS_THROUGHPUT_DEFAULT;
@@ -14027,7 +14027,6 @@ int emitter::getInsThroughput(instrDesc* id)
                     assert(!"Unhandled insFmt for INS_call");
                     result = PERFSCORE_INS_THROUGHPUT_DEFAULT;
                     break;
-
             }
             break;
 


### PR DESCRIPTION
This rating that estimated the execution costs of each instruction and also takes into
accounts for the BasicBlock weights and yields a single score that can be used to judge the
overall execution throughput and code quality of the generated code.

The inlining of methods will cause a score to increase, so this can't be used to directly compare
optimized vs. non-optimized code quality.  We are not modeling instruction scheduling or the
exact latency of memory reads feeding into their next use.  Instead we just model a simplistic
fixed read latency, with a small benefit for reads from the stack.

Estimates for the x64 instruction throughput are based upon data for the Intel Skylake architecture.