### PR TITLE
Add a new CompilationVerbose ETW Keyword

### DIFF
--- a/src/vm/ClrEtwAll.man
+++ b/src/vm/ClrEtwAll.man
@@ -3081,7 +3081,7 @@
                            symbol="MethodLoad_V2" message="$(string.RuntimePublisher.MethodLoad_V2EventMessage)"/>
 
                     <event value="159" version="0" level="win:Verbose" template="R2RGetEntryPoint"
-                           keywords ="NGenKeyword" opcode="MethodLoad"
+                           keywords ="CompilationKeyword" opcode="MethodLoad"
                            task="CLRMethod"
                            symbol="R2RGetEntryPoint" message="$(string.RuntimePublisher.R2RGetEntryPointEventMessage)"/>
 

--- a/src/vm/ClrEtwAll.man
+++ b/src/vm/ClrEtwAll.man
@@ -3083,7 +3083,7 @@
                            symbol="MethodLoad_V2" message="$(string.RuntimePublisher.MethodLoad_V2EventMessage)"/>
 
                     <event value="159" version="0" level="win:Verbose" template="R2RGetEntryPoint"
-                           keywords ="CompilationVerboseKeyword" opcode="MethodLoad"
+                           keywords ="CompilationDiagnosticKeyword" opcode="MethodLoad"
                            task="CLRMethod"
                            symbol="R2RGetEntryPoint" message="$(string.RuntimePublisher.R2RGetEntryPointEventMessage)"/>
 
@@ -7087,7 +7087,7 @@
                 <string id="RuntimePublisher.CodeSymbolsKeywordMessage" value="CodeSymbols" />
                 <string id="RuntimePublisher.EventSourceKeywordMessage" value="EventSource" />
                 <string id="RuntimePublisher.CompilationKeywordMessage" value="Compilation" />
-                <string id="RuntimePublisher.CompilationVerboseKeywordMessage" value="CompilationVerbose" />
+                <string id="RuntimePublisher.CompilationDiagnosticKeywordMessage" value="CompilationDiagnostic" />
               
                 <string id="RundownPublisher.LoaderKeywordMessage" value="Loader" />
                 <string id="RundownPublisher.JitKeywordMessage" value="Jit" />

--- a/src/vm/ClrEtwAll.man
+++ b/src/vm/ClrEtwAll.man
@@ -79,8 +79,8 @@
                              message="$(string.RuntimePublisher.EventSourceKeywordMessage)" symbol="CLR_EVENTSOURCE_KEYWORD" />
                     <keyword name="CompilationKeyword" mask="0x1000000000"
                              message="$(string.RuntimePublisher.CompilationKeywordMessage)" symbol="CLR_COMPILATION_KEYWORD" />
-                    <keyword name="CompilationVerboseKeyword" mask="0x2000000000"
-                             message="$(string.RuntimePublisher.CompilationVerboseKeywordMessage)" symbol="CLR_COMPILATIONVERBOSE_KEYWORD" />
+                    <keyword name="CompilationDiagnosticKeyword" mask="0x2000000000"
+                             message="$(string.RuntimePublisher.CompilationDiagnosticKeywordMessage)" symbol="CLR_COMPILATIONDIAGNOSTIC_KEYWORD" />
                 </keywords>
                 <!--Tasks-->
                 <tasks>

--- a/src/vm/ClrEtwAll.man
+++ b/src/vm/ClrEtwAll.man
@@ -79,6 +79,8 @@
                              message="$(string.RuntimePublisher.EventSourceKeywordMessage)" symbol="CLR_EVENTSOURCE_KEYWORD" />
                     <keyword name="CompilationKeyword" mask="0x1000000000"
                              message="$(string.RuntimePublisher.CompilationKeywordMessage)" symbol="CLR_COMPILATION_KEYWORD" />
+                    <keyword name="CompilationVerboseKeyword" mask="0x2000000000"
+                             message="$(string.RuntimePublisher.CompilationVerboseKeywordMessage)" symbol="CLR_COMPILATIONVERBOSE_KEYWORD" />
                 </keywords>
                 <!--Tasks-->
                 <tasks>
@@ -3081,7 +3083,7 @@
                            symbol="MethodLoad_V2" message="$(string.RuntimePublisher.MethodLoad_V2EventMessage)"/>
 
                     <event value="159" version="0" level="win:Verbose" template="R2RGetEntryPoint"
-                           keywords ="CompilationKeyword" opcode="MethodLoad"
+                           keywords ="CompilationVerboseKeyword" opcode="MethodLoad"
                            task="CLRMethod"
                            symbol="R2RGetEntryPoint" message="$(string.RuntimePublisher.R2RGetEntryPointEventMessage)"/>
 
@@ -7085,6 +7087,7 @@
                 <string id="RuntimePublisher.CodeSymbolsKeywordMessage" value="CodeSymbols" />
                 <string id="RuntimePublisher.EventSourceKeywordMessage" value="EventSource" />
                 <string id="RuntimePublisher.CompilationKeywordMessage" value="Compilation" />
+                <string id="RuntimePublisher.CompilationVerboseKeywordMessage" value="CompilationVerbose" />
               
                 <string id="RundownPublisher.LoaderKeywordMessage" value="Loader" />
                 <string id="RundownPublisher.JitKeywordMessage" value="Jit" />


### PR DESCRIPTION
Add a new CompilationVerbose ETW keyword and move the R2RGetEntryPoint event under this keyword.  This allows us to continue enabling Verbose events on the .NET runtime provider (which we've done for a long time) without significantly perturbing the results with this very verbose event.

The R2RGetEntryPoint event as well as other verbose compilation events, such as a tiered compilation counter hit event, can be added to this keyword in the future.

Fixes #25492 