### PR TITLE
Enable coredumps on unix

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7040,10 +7040,6 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
 #endif // DEBUG
     };
 
-    // Test Core dumps.
-    int* junk = nullptr;
-    *junk = 1;
-
     // Note on vararg methods:
     // If the caller is vararg method, we don't know the number of arguments passed by caller's caller.
     // But we can be sure that in-coming arg area of vararg caller would be sufficient to hold its

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7040,6 +7040,10 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
 #endif // DEBUG
     };
 
+    // Test Core dumps.
+    int* junk = nullptr;
+    *junk = 1;
+
     // Note on vararg methods:
     // If the caller is vararg method, we don't know the number of arguments passed by caller's caller.
     // But we can be sure that in-coming arg area of vararg caller would be sufficient to hold its

--- a/tests/helixpublishwitharcade.proj
+++ b/tests/helixpublishwitharcade.proj
@@ -197,6 +197,10 @@
     <HelixPreCommand Include="export __TestEnv=$HELIX_WORKITEM_PAYLOAD/$(TestEnvFileName)" />
     <HelixPreCommand Include="export __TestTimeout=$(TimeoutPerTestInMilliseconds)" Condition=" '$(TimeoutPerTestInMilliseconds)' != '' " />
     <HelixPreCommand Include="cat $__TestEnv" />
+
+    <!-- Setup coredumps for linux. Core Dumps are currently not supported   -->
+    <!-- on OSX                                                              -->
+    <HelixPreCommand Include="sudo bash -c 'echo /home/helixbot/dotnetbuild/dumps/core.%u.%p > /proc/sys/kernel/core_pattern'" Condition=" '$(BuildOS)' != 'OSX' " />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Add workaround to enable coredumps on unix.