### PR TITLE
Fix dotnet-dump/createdump launch failure

### DIFF
--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -3337,8 +3337,9 @@ PROCCreateCrashDump(char** argv)
         // Gives the child process permission to use /proc/<pid>/mem and ptrace
         if (prctl(PR_SET_PTRACER, childpid, 0, 0, 0) == -1)
         {
+            // Ignore any error because on some CentOS and OpenSUSE distros, it isn't
+            // supported but createdump works just fine.
             ERROR("PPROCCreateCrashDump: prctl() FAILED %d (%s)\n", errno, strerror(errno));
-            return false;
         }
         // Parent waits until the child process is done
         int wstatus = 0;


### PR DESCRIPTION
On CentOS or OpenSUSE dotnet-dump collect fails but a
valid coredump is generated. The "prctl()" call is failing
that gives the child createdump process permission to ptrace
to the runtime process. On CentOS/OpenSUSE the PR_SET_PTRACER
option isn't supported and not needed.

Issue: https://github.com/dotnet/diagnostics/issues/334