### PR TITLE
Re-enable Microsoft.VisualBasic tests

### DIFF
--- a/tests/CoreFX/CoreFX.issues.rsp
+++ b/tests/CoreFX/CoreFX.issues.rsp
@@ -74,8 +74,5 @@
 # https://github.com/dotnet/coreclr/issues/18912
 -nomethod System.Text.RegularExpressions.Tests.RegexMatchTests.Match_ExcessPrefix
 
-# Assert with JITMinOpts=1: https://github.com/dotnet/coreclr/issues/25070
--nonamespace Microsoft.VisualBasic.Tests
-
 # Assert: https://github.com/dotnet/coreclr/issues/25050
 -nonamespace System.Data.Common.Tests


### PR DESCRIPTION
After many attempts, we still cannot reproduce issue https://github.com/dotnet/coreclr/issues/25070 locally. I’m re-enabling the test so we can see if it will reproduce in the lab.
