### PR TITLE
Make CoreRun probe for `*.ni.exe` files

### DIFF
--- a/src/coreclr/hosts/corerun/corerun.cpp
+++ b/src/coreclr/hosts/corerun/corerun.cpp
@@ -264,8 +264,10 @@ public:
             wcscpy_s(appAssemblyWithoutExtension, MAX_PATH_FNAME, appAssembly);
 
             RemoveExtensionAndNi(appAssemblyWithoutExtension);
+            StackSString appAssemblyPathPrefix(appPath);
+            appAssemblyPathPrefix.Append(appAssemblyWithoutExtension);
 
-            AddFilesFromDirectoryToTPAList(appAssemblyWithoutExtension, rgTPAExtensions, _countof(rgTPAExtensions));
+            AddFilesFromDirectoryToTPAList(appAssemblyPathPrefix.GetUnicode(), rgTPAExtensions, _countof(rgTPAExtensions));
 
             // Add files from %CORE_LIBRARIES% if specified
             StackSString coreLibraries;


### PR DESCRIPTION
#10525 regressed loading ni.exe files - after that change, the runtime no longer looks for the .ni.exe variants of .exe files because the .exe is considered trusted.

This regression was worked around in #11272 for crossgen testing, but we still have tests (such as tests\src\readytorun\tests) that are now not testing anything because we're silently falling back to JIT.

This makes corerun add both .exe and .ni.exe into the trusted assembly list.