### PR TITLE
Fix: Diagnostics Server IPC thread causes 20-40ms shutdown delays on Windows

### DIFF
--- a/src/debug/debug-pal/unix/diagnosticsipc.cpp
+++ b/src/debug/debug-pal/unix/diagnosticsipc.cpp
@@ -15,7 +15,7 @@
 IpcStream::DiagnosticsIpc::DiagnosticsIpc(const int serverSocket, sockaddr_un *const pServerAddress) :
     _serverSocket(serverSocket),
     _pServerAddress(new sockaddr_un),
-    _isUnlinked(false)
+    _isClosed(false)
 {
     _ASSERTE(_pServerAddress != nullptr);
     _ASSERTE(_serverSocket != -1);
@@ -28,15 +28,8 @@ IpcStream::DiagnosticsIpc::DiagnosticsIpc(const int serverSocket, sockaddr_un *c
 
 IpcStream::DiagnosticsIpc::~DiagnosticsIpc()
 {
-    if (_serverSocket != -1)
-    {
-        const int fSuccessClose = ::close(_serverSocket);
-        _ASSERTE(fSuccessClose != -1); // TODO: Add error handling?
-
-        Unlink();
-
-        delete _pServerAddress;
-    }
+    Close();
+    delete _pServerAddress;
 }
 
 IpcStream::DiagnosticsIpc *IpcStream::DiagnosticsIpc::Create(const char *const pIpcName, ErrorCallback callback)
@@ -56,8 +49,10 @@ IpcStream::DiagnosticsIpc *IpcStream::DiagnosticsIpc::Create(const char *const p
         _ASSERTE(!"Failed to create diagnostics IPC socket.");
         return nullptr;
     }
+
     sockaddr_un serverAddress{};
     serverAddress.sun_family = AF_UNIX;
+
     const ProcessDescriptor pd = ProcessDescriptor::FromCurrentProcess();
     PAL_GetTransportName(
         sizeof(serverAddress.sun_path),
@@ -134,6 +129,25 @@ IpcStream *IpcStream::DiagnosticsIpc::Accept(ErrorCallback callback) const
     return new IpcStream(clientSocket);
 }
 
+void IpcStream::DiagnosticsIpc::Close(ErrorCallback callback)
+{
+    if (_isClosed)
+        return;
+    _isClosed = true;
+
+    if (_serverSocket != -1)
+    {
+        if (::close(_serverSocket) == -1)
+        {
+            if (callback != nullptr)
+                callback(strerror(errno), errno);
+            _ASSERTE(!"Failed to close unix domain socket."); // TODO: Add error handling?
+        }
+
+        Unlink(callback);
+    }
+}
+
 //! This helps remove the socket from the filesystem when the runtime exits.
 //! From: http://man7.org/linux/man-pages/man7/unix.7.html#NOTES
 //!   Binding to a socket with a filename creates a socket in the
@@ -143,16 +157,12 @@ IpcStream *IpcStream::DiagnosticsIpc::Accept(ErrorCallback callback) const
 //!   removed from the filesystem when the last reference to it is closed.
 void IpcStream::DiagnosticsIpc::Unlink(ErrorCallback callback)
 {
-    if (_isUnlinked)
-        return;
-    _isUnlinked = true;
-
     const int fSuccessUnlink = ::unlink(_pServerAddress->sun_path);
     if (fSuccessUnlink == -1)
     {
         if (callback != nullptr)
             callback(strerror(errno), errno);
-        _ASSERTE(fSuccessUnlink == 0);
+        _ASSERTE(!"Failed to unlink server address.");
     }
 }
 

--- a/src/debug/debug-pal/unix/diagnosticsipc.cpp
+++ b/src/debug/debug-pal/unix/diagnosticsipc.cpp
@@ -141,7 +141,7 @@ void IpcStream::DiagnosticsIpc::Close(ErrorCallback callback)
         {
             if (callback != nullptr)
                 callback(strerror(errno), errno);
-            _ASSERTE(!"Failed to close unix domain socket."); // TODO: Add error handling?
+            _ASSERTE(!"Failed to close unix domain socket.");
         }
 
         Unlink(callback);

--- a/src/debug/debug-pal/win/diagnosticsipc.cpp
+++ b/src/debug/debug-pal/win/diagnosticsipc.cpp
@@ -13,6 +13,7 @@ IpcStream::DiagnosticsIpc::DiagnosticsIpc(const char(&namedPipeName)[MaxNamedPip
 
 IpcStream::DiagnosticsIpc::~DiagnosticsIpc()
 {
+    Close();
 }
 
 IpcStream::DiagnosticsIpc *IpcStream::DiagnosticsIpc::Create(const char *const pIpcName, ErrorCallback callback)
@@ -73,7 +74,7 @@ IpcStream *IpcStream::DiagnosticsIpc::Accept(ErrorCallback callback) const
     return new IpcStream(hPipe);
 }
 
-void IpcStream::DiagnosticsIpc::Unlink(ErrorCallback)
+void IpcStream::DiagnosticsIpc::Close(ErrorCallback)
 {
 }
 

--- a/src/debug/inc/diagnosticsipc.h
+++ b/src/debug/inc/diagnosticsipc.h
@@ -34,18 +34,21 @@ public:
         //! Enables the underlaying IPC implementation to accept connection.
         IpcStream *Accept(ErrorCallback callback = nullptr) const;
 
-        //! Used to unlink the socket so it can be removed from the filesystem
-        //! when the last reference to it is closed.
-        void Unlink(ErrorCallback callback = nullptr);
+        //! Closes an open IPC.
+        void Close(ErrorCallback callback = nullptr);
 
     private:
 
 #ifdef FEATURE_PAL
         const int _serverSocket;
         sockaddr_un *const _pServerAddress;
-        bool _isUnlinked = false;
+        bool _isClosed = false;
 
         DiagnosticsIpc(const int serverSocket, sockaddr_un *const pServerAddress);
+
+        //! Used to unlink the socket so it can be removed from the filesystem
+        //! when the last reference to it is closed.
+        void Unlink(ErrorCallback callback = nullptr);
 #else
         static const uint32_t MaxNamedPipeNameLength = 256;
         char _pNamedPipeName[MaxNamedPipeNameLength]; // https://docs.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-createnamedpipea

--- a/src/debug/inc/diagnosticsipc.h
+++ b/src/debug/inc/diagnosticsipc.h
@@ -42,7 +42,7 @@ public:
 #ifdef FEATURE_PAL
         const int _serverSocket;
         sockaddr_un *const _pServerAddress;
-        bool _isClosed = false;
+        bool _isClosed;
 
         DiagnosticsIpc(const int serverSocket, sockaddr_un *const pServerAddress);
 

--- a/src/vm/diagnosticserver.cpp
+++ b/src/vm/diagnosticserver.cpp
@@ -166,7 +166,6 @@ bool DiagnosticServer::Initialize()
 #ifdef FEATURE_AUTO_TRACE
                 auto_trace_wait();
 #endif
-                // TODO: Add error handling?
                 fSuccess = true;
             }
         }
@@ -202,7 +201,7 @@ bool DiagnosticServer::Shutdown()
                 STRESS_LOG2(
                     LF_DIAGNOSTICS_PORT,                                  // facility
                     LL_ERROR,                                             // level
-                    "Failed to unlink diagnostic IPC: error (%d): %s.\n", // msg
+                    "Failed to close diagnostic IPC: error (%d): %s.\n",  // msg
                     code,                                                 // data1
                     szMessage);                                           // data2
             };

--- a/src/vm/diagnosticserver.cpp
+++ b/src/vm/diagnosticserver.cpp
@@ -214,14 +214,22 @@ bool DiagnosticServer::Shutdown()
                 {
                     _ASSERTE(!"Failed to mark pending synchronous I/O operations issued by Diagnostics Server Thread as canceled.");
                 }
-                ::WaitForSingleObject(s_hServerThread, INFINITE);
 #endif // FEATURE_PAL
 
+                // At this point, IO operations on the server thread through the
+                // IPC channel has been closed/cancelled.
+
+                // On non-Windows, this function is blocking on threads that already exit.
+                // ::WaitForSingleObject(s_hServerThread, INFINITE);
+
+                // Close the thread handle (dispose OS resource).
                 ::CloseHandle(s_hServerThread);
+                s_hServerThread = INVALID_HANDLE_VALUE;
             }
 
-            delete s_pIpc;
-            s_pIpc = nullptr;
+            // If we do not wait for thread to teardown, then we cannot delete this object.
+            // delete s_pIpc;
+            // s_pIpc = nullptr;
         }
         fSuccess = true;
     }

--- a/src/vm/diagnosticserver.cpp
+++ b/src/vm/diagnosticserver.cpp
@@ -212,7 +212,9 @@ bool DiagnosticServer::Shutdown()
             {
 #ifndef FEATURE_PAL
                 if (::CancelSynchronousIo(s_hServerThread) == 0)
+                {
                     _ASSERTE(!"Failed to mark pending synchronous I/O operations issued by Diagnostics Server Thread as canceled.");
+                }
 #endif // FEATURE_PAL
 
                 ::WaitForSingleObject(s_hServerThread, INFINITE);

--- a/src/vm/diagnosticserver.cpp
+++ b/src/vm/diagnosticserver.cpp
@@ -215,9 +215,9 @@ bool DiagnosticServer::Shutdown()
                 {
                     _ASSERTE(!"Failed to mark pending synchronous I/O operations issued by Diagnostics Server Thread as canceled.");
                 }
+                ::WaitForSingleObject(s_hServerThread, INFINITE);
 #endif // FEATURE_PAL
 
-                ::WaitForSingleObject(s_hServerThread, INFINITE);
                 ::CloseHandle(s_hServerThread);
             }
 

--- a/src/vm/diagnosticserver.h
+++ b/src/vm/diagnosticserver.h
@@ -42,8 +42,13 @@ public:
     //! Shutdown the event pipe.
     static bool Shutdown();
 
+    //! Diagnostics server thread.
+    static DWORD WINAPI DiagnosticsServerThread(LPVOID lpThreadParameter);
+
 private:
     static IpcStream::DiagnosticsIpc *s_pIpc;
+    static Volatile<bool> s_shuttingDown;
+    static HANDLE s_hServerThread;
 };
 
 #endif // FEATURE_PERFTRACING


### PR DESCRIPTION
Now, the diagnostics server attempts to do appropriate cleanup of its resources during shutdown.

```log
1. Closes the IPC channel
2. if Windows:
  - Cancel sync IO operations on the running server thread
  - Wait for the running server thread to exit
3. Closes the running server thread handle
4. Destroy IPC
```

This change alleviates the issue because it manually cancel the blocking `ConnectNamedPipe` sync call in order to allow the server thread exit gracefully (instead of waiting for the OS to tear it down).

Fixes: https://github.com/dotnet/coreclr/issues/25463