### PR TITLE
R2RDump: Add support for partially interruptible regions

### DIFF
--- a/src/tools/r2rdump/Amd64/GcSlotTable.cs
+++ b/src/tools/r2rdump/Amd64/GcSlotTable.cs
@@ -96,11 +96,11 @@ namespace R2RDump.Amd64
             {
                 DecodeRegisters(image, gcInfoTypes, ref bitOffset);
             }
-            if ((NumStackSlots > 0) && (GcSlots.Count < gcInfoTypes.MAX_PREDECODED_SLOTS))
+            if (NumStackSlots > 0)
             {
                 DecodeStackSlots(image, machine, gcInfoTypes, NumStackSlots, false, ref bitOffset);
             }
-            if ((NumUntracked > 0) && (GcSlots.Count < gcInfoTypes.MAX_PREDECODED_SLOTS))
+            if (NumUntracked > 0)
             {
                 DecodeStackSlots(image, machine, gcInfoTypes, NumUntracked, true, ref bitOffset);
             }

--- a/src/tools/r2rdump/Amd64/GcSlotTable.cs
+++ b/src/tools/r2rdump/Amd64/GcSlotTable.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Reflection.PortableExecutable;
 using System.Text;
 using System.Xml.Serialization;
@@ -12,7 +13,7 @@ namespace R2RDump.Amd64
 {
     public class GcSlotTable
     {
-        public class GcSlot
+        public class GcSlot : BaseGcSlot
         {
             [XmlAttribute("Index")]
             public int Index { get; set; }
@@ -60,6 +61,16 @@ namespace R2RDump.Amd64
         public uint NumStackSlots { get; set; }
         public uint NumUntracked { get; set; }
         public uint NumSlots { get; set; }
+
+        public uint NumTracked
+        {
+            get
+            {
+                Debug.Assert(NumSlots == GcSlots.Count);
+                return NumSlots - NumUntracked;
+            }
+        }
+
         public List<GcSlot> GcSlots { get; set; }
 
         public GcSlotTable() { }

--- a/src/tools/r2rdump/GCInfoTypes.cs
+++ b/src/tools/r2rdump/GCInfoTypes.cs
@@ -93,7 +93,6 @@ namespace R2RDump
         internal int INTERRUPTIBLE_RANGE_DELTA1_ENCBASE { get; } = 6;
         internal int INTERRUPTIBLE_RANGE_DELTA2_ENCBASE { get; } = 6;
 
-        internal int MAX_PREDECODED_SLOTS { get; } = 64;
         internal int NUM_REGISTERS_ENCBASE { get; } = 2;
         internal int NUM_STACK_SLOTS_ENCBASE { get; } = 2;
         internal int NUM_UNTRACKED_SLOTS_ENCBASE { get; } = 1;

--- a/src/tools/r2rdump/R2RMethod.cs
+++ b/src/tools/r2rdump/R2RMethod.cs
@@ -32,6 +32,10 @@ namespace R2RDump
         }
     }
 
+    public abstract class BaseGcSlot
+    {
+    }
+
     public abstract class BaseGcInfo
     {
         public int Size { get; set; }
@@ -39,6 +43,7 @@ namespace R2RDump
         public int CodeLength { get; set; }
         [XmlIgnore]
         public Dictionary<int, List<BaseGcTransition>> Transitions { get; set; }
+        public List<List<BaseGcSlot>> LiveSlotsAtSafepoints { get; set; }
     }
 
     /// <summary>
@@ -221,6 +226,8 @@ namespace R2RDump
                 foreach (Amd64.GcInfo.SafePointOffset safePoint in gcInfo.SafePointOffsets)
                 {
                     writer.WriteLine($@"        Index: {safePoint.Index,2}; Value: 0x{safePoint.Value:X4}");
+                    if (gcInfo.LiveSlotsAtSafepoints != null)
+                        writer.WriteLine($@"        Live slots: {String.Join(", ", gcInfo.LiveSlotsAtSafepoints[safePoint.Index])}");
                 }
 
                 writer.WriteLine($@"    InterruptibleRanges: {gcInfo.InterruptibleRanges.Count}");

--- a/src/tools/r2rdump/TextDumper.cs
+++ b/src/tools/r2rdump/TextDumper.cs
@@ -203,7 +203,7 @@ namespace R2RDump
                     }
                 }
 
-                if (rtf.Method.GcInfo != null && rtf.Method.GcInfo.Transitions.ContainsKey(codeOffset))
+                if (rtf.Method.GcInfo?.Transitions != null && rtf.Method.GcInfo.Transitions.ContainsKey(codeOffset))
                 {
                     foreach (BaseGcTransition transition in rtf.Method.GcInfo.Transitions[codeOffset])
                     {


### PR DESCRIPTION
We were basically missing this block:

https://github.com/dotnet/coreclr/blob/030a3ea9b8dbeae89c90d34441d4d9a1cf4a7de6/src/vm/gcinfodecoder.cpp#L726-L810