### PR TITLE
PerfMap should output file offset instead of RVAs

### DIFF
--- a/src/vm/perfmap.h
+++ b/src/vm/perfmap.h
@@ -82,7 +82,7 @@ class NativeImagePerfMap : PerfMap
 {
 private:
     // Log a pre-compiled method to the map.
-    void LogPreCompiledMethod(MethodDesc * pMethod, PCODE pCode, SIZE_T baseAddr, const char *optimizationTier);
+    void LogPreCompiledMethod(MethodDesc * pMethod, PCODE pCode, PEImageLayout * pLoadedLayout, const char *optimizationTier);
 
 public:
     // Construct a new map for a native image.


### PR DESCRIPTION
Fixes #24966

There is a mismatch between `perf`, `crossgen` and `PerfView` causing this bug.

- I believe when `perf script` output a number of a stack frame, it outputs the file offset (*)
- `crossgen` outputs three tuple, `rva`, `size`, `name` of all methods. [Here](https://github.com/dotnet/coreclr/blob/ef2f9f41555c453451a5003f1be4bb9888ab078d/src/vm/perfmap.cpp#L391) is the code that computes the rva.
- PerfView takes the number generated by `perf script` and do a binary search in the `crossgen` output.

Essentially, PerfView is taking file offsets and comparing it against rva. That is why the lookup fails. Once I change `crossgen` to output file offset as is done in this PR, the lookup is successful.

The above is sufficient to understand the change, below is just a record on what I did to 'believe' perf output file offsets.

(*) Here is my experiment to 'prove' that perf outputs file offset. The prove is in quotes because it is really just a prove by observation.

The key problem is that `perf` is output random numbers, in order to diagnose what is going on, I need a way to make `perf` output something known, so I hacked CoreLib and added a method in it that does an infinite loop, and call it in my test, that way I know most of the number outputted in `perf` should correlate to my method.

I figured a tool `perf report -D` that can dump the raw `perf.data` outputted by the perf tool. There I found a raw IP. Cross-checking with the `perf.data.txt`. I subtracted them to figure out the base address assumed by `perf script` tool that generates the `perf.data.txt`. The base address is page aligned, making me believe it is a true base address.

The true base address was a mystery. If I look at the true IP and use the `memory region` command in `lldb`, it is slightly before the page that actually contains the executable code. The executable page base address together with its difference between the executable page is found in the same `perf report` output as an unnamed field on an event related to `mmap`, making me believe `perf` knew that offset and accounts for it.

Turning on the LOADER tracing in PAL using `export PAL_DBG_CHANNELS="+LOADER.all"`, I  discovered why. We used the `mmap` system call to map a file with an offset [here](https://github.com/dotnet/coreclr/blob/ef2f9f41555c453451a5003f1be4bb9888ab078d/src/pal/src/map/map.cpp#L2164). I believe the `perf` tool noted that and computes the file offset based on that information.

To prove it is indeed a file offset, I read the Linux binary as a byte array on a Windows machine, and I successfully disassembled the code at that address, it is indeed the instructions that correspond to my infinite loop method. That concludes my 'prove' that perf indeed output file offsets.