### PR TITLE
String.Equals check first char for inequality

### DIFF
--- a/src/System.Private.CoreLib/shared/System/String.Comparison.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Comparison.cs
@@ -31,7 +31,9 @@ namespace System
             Debug.Assert(strB != null);
             Debug.Assert(strA.Length == strB.Length);
 
-            return SpanHelpers.SequenceEqual(
+            return (strA._firstChar != strB._firstChar) ? 
+                false :
+                SpanHelpers.SequenceEqual(
                     ref Unsafe.As<char, byte>(ref strA.GetRawStringData()),
                     ref Unsafe.As<char, byte>(ref strB.GetRawStringData()),
                     ((nuint)strA.Length) * 2);


### PR DESCRIPTION
prior to moving into vectorized check

Resolves https://github.com/dotnet/coreclr/issues/25635

/cc @jkotas @stephentoub 