### PR TITLE
Handle more configs in GCToEEInterface

### DIFF
--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -1053,6 +1053,12 @@ bool GCToEEInterface::GetBooleanConfigValue(const char* key, bool* value)
         *value = !!g_pConfig->GetGCconcurrent();
         return true;
     }
+    
+    if (strcmp(key, "GCNoAffinitize") == 0)
+    {
+        *value = g_pConfig->GetGCNoAffinitize();
+        return true;
+    }
 
     if (strcmp(key, "GCRetainVM") == 0)
     {
@@ -1094,6 +1100,18 @@ bool GCToEEInterface::GetIntConfigValue(const char* key, int64_t* value)
     if (strcmp(key, "GCgen0size") == 0)
     {
         *value = g_pConfig->GetGCgen0size();
+        return true;
+    }
+
+    if (strcmp(key, "GCHeapAffinitizeMask") == 0)
+    {
+        *value = g_pConfig->GetGCAffinityMask();
+        return true;
+    }
+
+    if (strcmp(key, "GCHeapCount") == 0)
+    {
+        *value = g_pConfig->GetGCHeapCount();
         return true;
     }
 


### PR DESCRIPTION
Adds handling for the following configs:
* "GCNoAffinitize" (from "System.GC.NoAffinitize")
* "GCHeapAffinitizeMask" (from "System.GC.HeapAffinitizeMask")
* "GCHeapCount" (from "System.GC.HeapCount")

These configs were already handled correctly in EEConfig::sync, so that
does not need to be changed. Just the access from GC needs to be fixed.

Previously the configs were correctly read,
but GC did not see those values.

Verified this change by debugging into
GCToEEInterface::GetBooleanConfigValue and
GCToEEInterface::GetIntConfigValue as well as their uses in
SVR::GCHeap::Initialize.