### PR TITLE
Make counters use dedicated thread instead of timer

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterGroup.cs
@@ -139,7 +139,6 @@ namespace System.Diagnostics.Tracing
             {
                 Debug.WriteLine("Polling interval changed at " + DateTime.UtcNow.ToString("mm.ss.ffffff"));
                 _pollingIntervalInMilliseconds = (int)(pollingIntervalInSeconds * 1000);
-                DisposeTimer();
                 _timeStampSinceCollectionStarted = DateTime.UtcNow;
                 // Don't capture the current ExecutionContext and its AsyncLocals onto the timer causing them to live forever
                 bool restoreFlow = false;


### PR DESCRIPTION
This fixes #25071. When there is a threadpool starvation, counter timer doesn't get fired because of threadpool starvation. Since counters are used to diagnose such an issue, we should make sure counter itself doesn't just aggravate the problem & become useless in such a scenario. 

This fix creates a dedicated thread used for polling counter values at the interval requested and removes the existing code using timers. 