### PR TITLE
Build error fix on FEATURE_PREJIT=true

### DIFF
--- a/src/vm/dllimport.cpp
+++ b/src/vm/dllimport.cpp
@@ -5569,7 +5569,7 @@ MethodDesc* RestoreNGENedStub(MethodDesc* pStubMD)
 
 #if defined(HAVE_GCCOVER)
         if (GCStress<cfg_instr_ngen>::IsEnabled())
-            SetupGcCoverage(pStubMD, (BYTE*) pCode);
+            SetupGcCoverage(NativeCodeVersion(pStubMD), (BYTE*)pCode);
 #endif // HAVE_GCCOVER
 
     }

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -538,7 +538,7 @@ PCODE MethodDesc::GetPrecompiledNgenCode(PrepareCodeConfig* pConfig)
 
 #ifdef HAVE_GCCOVER
         if (GCStress<cfg_instr_ngen>::IsEnabled())
-            SetupGcCoverage(this, (BYTE*)pCode);
+            SetupGcCoverage(pConfig->GetCodeVersion(), (BYTE*)pCode);
 #endif // HAVE_GCCOVER
 
 #ifdef PROFILING_SUPPORTED 


### PR DESCRIPTION
This fix is to update usages of SetupGcCoverage() under FEATURE_PREJIT aligned to the signature change in #25261.

cc @kouvel @alpencolt