### PR TITLE
Change [:space:] to [[:space:]] in awk scripts

### DIFF
--- a/generateexportedsymbols.awk
+++ b/generateexportedsymbols.awk
@@ -4,7 +4,7 @@
     gsub(/\r/,"", $0);
 
     # Skip empty lines and comment lines starting with semicolon
-    if (NF && !match($0, /^[:space:]*;/))
+    if (NF && !match($0, /^[[:space:]]*;/))
     {
         gsub(/^#/,"", $0);
         print "_"  $0;

--- a/generateredefinesfile.awk
+++ b/generateredefinesfile.awk
@@ -7,7 +7,7 @@
     gsub(/\r/,"", $0);
     
     # Skip empty lines and comment lines starting with semicolon
-    if (NF && !match($0, /^[:space:]*;/))
+    if (NF && !match($0, /^[[:space:]]*;/))
     {
         # Only process the entries that begin with "#"
         if (match($0, /^#.*/))


### PR DESCRIPTION
During coreclr build on RHEL 7, awk prints out some warnings:

    awk: /builddir/build/BUILD/dotnet-v2.2.6/src/coreclr/generateredefinesfile.awk:10:
    warning: regexp component `[:space:]' should probably be `[[:space:]]'

The awk man page says:

    A character class is only valid in a regular expression inside the
    brackets of a character list.

So fix the '[:space:]' notation by replacing with the valid
'[[:space:]]'.

Fixing this warning doesn't actually result in a change in the generated
files (dbgshim.exports, mscordbi.exports, libredefines.inc,
palredefines.inc, clrjit.exports, mscordac.exports, coreclr.exports,
dlltest1.exports and dlltest2.exports) on my system.