### PR TITLE
DateTimeOffset optimizations to prevent unnecessary checks and conversions

### DIFF
--- a/src/System.Private.CoreLib/shared/System/DateTimeOffset.cs
+++ b/src/System.Private.CoreLib/shared/System/DateTimeOffset.cs
@@ -176,7 +176,8 @@ namespace System
         {
             get
             {
-                return new DateTimeOffset(DateTime.Now);
+                DateTime utcNow = DateTime.UtcNow;
+                return new DateTimeOffset(utcNow.Ticks, TimeZoneInfo.GetLocalUtcOffset(utcNow, TimeZoneInfoOptions.NoThrowOnInvalidTime));
             }
         }
 
@@ -559,7 +560,8 @@ namespace System
         //
         public static DateTimeOffset FromFileTime(long fileTime)
         {
-            return new DateTimeOffset(DateTime.FromFileTime(fileTime));
+            DateTime utcDateTime = DateTime.FromFileTimeUtc(fileTime);
+            return new DateTimeOffset(utcDateTime.Ticks, TimeZoneInfo.GetLocalUtcOffset(utcDateTime, TimeZoneInfoOptions.NoThrowOnInvalidTime));
         }
 
         public static DateTimeOffset FromUnixTimeSeconds(long seconds)
@@ -792,7 +794,21 @@ namespace System
 
         internal DateTimeOffset ToLocalTime(bool throwOnOverflow)
         {
-            return new DateTimeOffset(UtcDateTime.ToLocalTime(throwOnOverflow));
+            DateTime utcDateTime = UtcDateTime;
+            TimeSpan offset = TimeZoneInfo.GetLocalUtcOffset(utcDateTime, TimeZoneInfoOptions.NoThrowOnInvalidTime);
+            long utcTicks = utcDateTime.Ticks;
+            long localTicks = utcTicks + offset.Ticks;
+            if (localTicks < DateTime.MinTicks)
+                localTicks = DateTime.MinTicks;
+            else if (localTicks > DateTime.MaxTicks)
+                localTicks = DateTime.MaxTicks;
+            else
+                return new DateTimeOffset(utcTicks, offset);
+
+            if (throwOnOverflow)
+                throw new ArgumentException(SR.Arg_ArgumentOutOfRangeException);
+
+            return new DateTimeOffset(localTicks, TimeSpan.Zero);
         }
 
         public override string ToString()

--- a/src/System.Private.CoreLib/shared/System/DefaultBinder.cs
+++ b/src/System.Private.CoreLib/shared/System/DefaultBinder.cs
@@ -42,7 +42,7 @@ namespace System
 
             state = null;
 
-#region Map named parameters to candidate parameter positions
+            #region Map named parameters to candidate parameter positions
             // We are creating an paramOrder array to act as a mapping
             //  between the order of the args and the actual order of the
             //  parameters in the method.  This order may differ because
@@ -71,13 +71,13 @@ namespace System
                         candidates[i] = null;
                 }
             }
-#endregion
+            #endregion
 
             Type[] paramArrayTypes = new Type[candidates.Length];
 
             Type[] argTypes = new Type[args.Length];
 
-#region Cache the type of the provided arguments
+            #region Cache the type of the provided arguments
             // object that contain a null are treated as if they were typeless (but match either object 
             // references or value classes).  We mark this condition by placing a null in the argTypes array.
             for (i = 0; i < args.Length; i++)
@@ -87,7 +87,7 @@ namespace System
                     argTypes[i] = args[i]!.GetType();
                 }
             }
-#endregion
+            #endregion
 
 
             // Find the method that matches...
@@ -96,7 +96,7 @@ namespace System
 
             Type? paramArrayType;
 
-#region Filter methods by parameter count and type
+            #region Filter methods by parameter count and type
             for (i = 0; i < candidates.Length; i++)
             {
                 paramArrayType = null;
@@ -108,10 +108,10 @@ namespace System
                 // Validate the parameters.
                 ParameterInfo[] par = candidates[i]!.GetParametersNoCopy(); // TODO-NULLABLE: Indexer nullability tracked (https://github.com/dotnet/roslyn/issues/34644)
 
-#region Match method by parameter count
+                #region Match method by parameter count
                 if (par.Length == 0)
                 {
-#region No formal parameters
+                    #region No formal parameters
                     if (args.Length != 0)
                     {
                         if ((candidates[i]!.CallingConvention & CallingConventions.VarArgs) == 0) // TODO-NULLABLE: Indexer nullability tracked (https://github.com/dotnet/roslyn/issues/34644)
@@ -123,11 +123,11 @@ namespace System
                     candidates[CurIdx++] = candidates[i];
 
                     continue;
-#endregion
+                    #endregion
                 }
                 else if (par.Length > args.Length)
                 {
-#region Shortage of provided parameters
+                    #region Shortage of provided parameters
                     // If the number of parameters is greater than the number of args then 
                     // we are in the situation were we may be using default values.
                     for (j = args.Length; j < par.Length - 1; j++)
@@ -149,11 +149,11 @@ namespace System
 
                         paramArrayType = par[j].ParameterType.GetElementType();
                     }
-#endregion
+                    #endregion
                 }
                 else if (par.Length < args.Length)
                 {
-#region Excess provided parameters
+                    #region Excess provided parameters
                     // test for the ParamArray case
                     int lastArgPos = par.Length - 1;
 
@@ -167,11 +167,11 @@ namespace System
                         continue;
 
                     paramArrayType = par[lastArgPos].ParameterType.GetElementType();
-#endregion
+                    #endregion
                 }
                 else
                 {
-#region Test for paramArray, save paramArray type
+                    #region Test for paramArray, save paramArray type
                     int lastArgPos = par.Length - 1;
 
                     if (par[lastArgPos].ParameterType.IsArray
@@ -181,17 +181,17 @@ namespace System
                         if (!par[lastArgPos].ParameterType.IsAssignableFrom(argTypes[lastArgPos]))
                             paramArrayType = par[lastArgPos].ParameterType.GetElementType();
                     }
-#endregion
+                    #endregion
                 }
-#endregion
+                #endregion
 
                 Type pCls;
                 int argsToCheck = (paramArrayType != null) ? par.Length - 1 : args.Length;
 
-#region Match method by parameter type
+                #region Match method by parameter type
                 for (j = 0; j < argsToCheck; j++)
                 {
-#region Classic argument coersion checks
+                    #region Classic argument coersion checks
                     // get the formal type
                     pCls = par[j].ParameterType;
 
@@ -237,12 +237,12 @@ namespace System
                             break;
                         }
                     }
-#endregion
+                    #endregion
                 }
 
                 if (paramArrayType != null && j == par.Length - 1)
                 {
-#region Check that excess arguments can be placed in the param array
+                    #region Check that excess arguments can be placed in the param array
                     for (; j < args.Length; j++)
                     {
                         if (paramArrayType.IsPrimitive)
@@ -267,20 +267,20 @@ namespace System
                             }
                         }
                     }
-#endregion
+                    #endregion
                 }
-#endregion
+                #endregion
 
                 if (j == args.Length)
                 {
-#region This is a valid routine so we move it up the candidates list
+                    #region This is a valid routine so we move it up the candidates list
                     paramOrder[CurIdx] = paramOrder[i];
                     paramArrayTypes[CurIdx] = paramArrayType!;
                     candidates[CurIdx++] = candidates[i];
-#endregion
+                    #endregion
                 }
             }
-#endregion
+            #endregion
 
             // If we didn't find a method 
             if (CurIdx == 0)
@@ -288,7 +288,7 @@ namespace System
 
             if (CurIdx == 1)
             {
-#region Found only one method
+                #region Found only one method
                 if (names != null)
                 {
                     state = new BinderState((int[])paramOrder[0].Clone(), args.Length, paramArrayTypes[0] != null);
@@ -341,7 +341,7 @@ namespace System
                         args = objs;
                     }
                 }
-#endregion
+                #endregion
 
                 return candidates[0]!;
             }
@@ -350,7 +350,7 @@ namespace System
             bool ambig = false;
             for (i = 1; i < CurIdx; i++)
             {
-#region Walk all of the methods looking the most specific method to invoke
+                #region Walk all of the methods looking the most specific method to invoke
                 int newMin = FindMostSpecificMethod(candidates[currentMin]!, paramOrder[currentMin], paramArrayTypes[currentMin],
                                                     candidates[i]!, paramOrder[i], paramArrayTypes[i], argTypes, args);
 
@@ -363,7 +363,7 @@ namespace System
                     currentMin = i;
                     ambig = false;
                 }
-#endregion
+                #endregion
             }
 
             if (ambig)

--- a/src/System.Private.CoreLib/shared/System/Globalization/Calendar.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/Calendar.cs
@@ -532,7 +532,8 @@ namespace System.Globalization
                     throw new ArgumentOutOfRangeException(
                         nameof(rule),
                         rule,
-                        SR.Format(SR.ArgumentOutOfRange_Range, CalendarWeekRule.FirstDay, CalendarWeekRule.FirstFourDayWeek));            }
+                        SR.Format(SR.ArgumentOutOfRange_Range, CalendarWeekRule.FirstDay, CalendarWeekRule.FirstFourDayWeek));
+            }
         }
 
         /// <summary>
@@ -588,17 +589,18 @@ namespace System.Globalization
         /// </summary>
         public virtual int GetLeapMonth(int year, int era)
         {
-            if (!IsLeapYear(year, era))
+            if (IsLeapYear(year, era))
             {
-                return 0;
-            }
 
-            int monthsCount = GetMonthsInYear(year, era);
-            for (int month = 1; month <= monthsCount; month++)
-            {
-                if (IsLeapMonth(year, month, era))
+
+
+                int monthsCount = GetMonthsInYear(year, era);
+                for (int month = 1; month <= monthsCount; month++)
                 {
-                    return month;
+                    if (IsLeapMonth(year, month, era))
+                    {
+                        return month;
+                    }
                 }
             }
 

--- a/src/System.Private.CoreLib/shared/System/Globalization/Calendar.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/Calendar.cs
@@ -592,8 +592,6 @@ namespace System.Globalization
             if (IsLeapYear(year, era))
             {
 
-
-
                 int monthsCount = GetMonthsInYear(year, era);
                 for (int month = 1; month <= monthsCount; month++)
                 {

--- a/src/System.Private.CoreLib/shared/System/Globalization/CultureInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CultureInfo.cs
@@ -143,12 +143,12 @@ namespace System.Globalization
 
         // LOCALE constants of interest to us internally and privately for LCID functions
         // (ie: avoid using these and use names if possible)
-        internal const int LOCALE_NEUTRAL        = 0x0000;
-        private  const int LOCALE_USER_DEFAULT   = 0x0400;
-        private  const int LOCALE_SYSTEM_DEFAULT = 0x0800;
+        internal const int LOCALE_NEUTRAL = 0x0000;
+        private const int LOCALE_USER_DEFAULT = 0x0400;
+        private const int LOCALE_SYSTEM_DEFAULT = 0x0800;
         internal const int LOCALE_CUSTOM_UNSPECIFIED = 0x1000;
-        internal const int LOCALE_CUSTOM_DEFAULT  = 0x0c00;
-        internal const int LOCALE_INVARIANT       = 0x007F;
+        internal const int LOCALE_CUSTOM_DEFAULT = 0x0c00;
+        internal const int LOCALE_INVARIANT = 0x007F;
 
         private static CultureInfo InitializeUserDefaultCulture()
         {
@@ -371,7 +371,7 @@ namespace System.Globalization
             // name and we know that all names are valid in files.
             if (culture._isInherited)
             {
-                VerifyCultureName(culture.Name, throwException);
+                return VerifyCultureName(culture.Name, throwException);
             }
 
             return true;

--- a/src/System.Private.CoreLib/shared/System/Globalization/CultureInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CultureInfo.cs
@@ -369,12 +369,12 @@ namespace System.Globalization
         {
             // If we have an instance of one of our CultureInfos, the user can't have changed the
             // name and we know that all names are valid in files.
-            if (!culture._isInherited)
+            if (culture._isInherited)
             {
-                return true;
+                VerifyCultureName(culture.Name, throwException);
             }
 
-            return VerifyCultureName(culture.Name, throwException);
+            return true;
         }
 
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/DateTimeFormatInfo.cs
@@ -2449,14 +2449,15 @@ namespace System.Globalization
                 string str = GetMonthName(i);
                 if (str.Length > 0)
                 {
-                    if (!monthPostfix.IsEmpty)
+                    if (monthPostfix.IsEmpty)
                     {
-                        // Insert the month name with the postfix first, so it can be matched first.
-                        InsertHash(temp, string.Concat(str, monthPostfix), TokenType.MonthToken, i);
+                        InsertHash(temp, str, TokenType.MonthToken, i);
                     }
                     else
                     {
-                        InsertHash(temp, str, TokenType.MonthToken, i);
+                        // Insert the month name with the postfix first, so it can be matched first.
+                        InsertHash(temp, string.Concat(str, monthPostfix), TokenType.MonthToken, i);
+                        
                     }
                 }
                 str = GetAbbreviatedMonthName(i);

--- a/src/System.Private.CoreLib/shared/System/Globalization/JapaneseCalendar.Win32.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/JapaneseCalendar.Win32.cs
@@ -160,9 +160,9 @@ namespace System.Globalization
             int day;
 
             ReadOnlySpan<char> valueSpan = value.AsSpan();
-            if (!int.TryParse(valueSpan.Slice(0, 4), NumberStyles.None, NumberFormatInfo.InvariantInfo, out year) ||
-                !int.TryParse(valueSpan.Slice(5, 2), NumberStyles.None, NumberFormatInfo.InvariantInfo, out month) ||
-                !int.TryParse(valueSpan.Slice(8, 2), NumberStyles.None, NumberFormatInfo.InvariantInfo, out day))
+            if (!(int.TryParse(valueSpan.Slice(0, 4), NumberStyles.None, NumberFormatInfo.InvariantInfo, out year) &&
+                int.TryParse(valueSpan.Slice(5, 2), NumberStyles.None, NumberFormatInfo.InvariantInfo, out month) &&
+                int.TryParse(valueSpan.Slice(8, 2), NumberStyles.None, NumberFormatInfo.InvariantInfo, out day)))
             {
                 // Couldn't convert integer, fail
                 return null;

--- a/src/System.Private.CoreLib/shared/System/IO/FileStream.Win32.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileStream.Win32.cs
@@ -71,13 +71,13 @@ namespace System.IO
                     // We were successful
                     break;
                 case Interop.NtDll.STATUS_INVALID_HANDLE:
-                    if (!ignoreInvalid)
+                    if (ignoreInvalid)
                     {
-                        throw Win32Marshal.GetExceptionForWin32Error(Interop.Errors.ERROR_INVALID_HANDLE);
+                        return null;
                     }
                     else
                     {
-                        return null;
+                        throw Win32Marshal.GetExceptionForWin32Error(Interop.Errors.ERROR_INVALID_HANDLE);
                     }
                 default:
                     // Something else is preventing access
@@ -95,12 +95,14 @@ namespace System.IO
             // any particular file handle type.
 
             // If the handle was passed in without an explicit async setting, we already looked it up in GetDefaultIsAsync
-            if (!handle.IsAsync.HasValue)
-                return;
+            if (handle.IsAsync.HasValue)
+            {
 
-            // If we can't check the handle, just assume it is ok.
-            if (!(IsHandleSynchronous(handle, ignoreInvalid: false) ?? true))
-                throw new ArgumentException(SR.Arg_HandleNotSync, nameof(handle));
+
+                // If we can't check the handle, just assume it is ok.
+                if (!(IsHandleSynchronous(handle, ignoreInvalid: false) ?? true))
+                    throw new ArgumentException(SR.Arg_HandleNotSync, nameof(handle));
+            }
         }
     }
 }

--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.Fast.cs
@@ -615,7 +615,7 @@ namespace System
                 Index startIndex = range.Start;
                 Index endIndex = range.End;
 
-                if (!startIndex.Equals(Index.Start) || !endIndex.Equals(Index.Start))
+                if (!(startIndex.Equals(Index.Start) && endIndex.Equals(Index.Start)))
                     ThrowHelper.ThrowArgumentNullException(ExceptionArgument.text);
 
                 return default;

--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.Trim.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.Trim.cs
@@ -779,10 +779,9 @@ namespace System
                 }
 
                 return span.Slice(start);
-
             }
-            return span.Slice(start);
 
+            return span.Slice(start);
 
         }
 
@@ -808,16 +807,11 @@ namespace System
                 if (span[end] == trimChars[i])
                 {
                     i = 0;
-
+                    continue;
                 }
-                else
-                {
-                    i++;
-                }
+                i++;
 
             }
-
-
 
             return span.Slice(0, end + 1);
         }

--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.Trim.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.Trim.cs
@@ -172,22 +172,20 @@ namespace System
 
             if (trimElement != null)
             {
-                for (; start < span.Length; start++)
+                while (start < span.Length && trimElement.Equals(span[start]))
                 {
-                    if (!trimElement.Equals(span[start]))
-                    {
-                        break;
-                    }
+                    start++;
                 }
             }
             else
             {
-                for (; start < span.Length; start++)
+                while (start < span.Length)
                 {
                     if (span[start] != null)
                     {
                         break;
                     }
+                    start++;
                 }
             }
 
@@ -212,22 +210,20 @@ namespace System
 
             if (trimElement != null)
             {
-                for (; end >= start; end--)
+                while (end >= start && trimElement.Equals(span[end]))
                 {
-                    if (!trimElement.Equals(span[end]))
-                    {
-                        break;
-                    }
+                    end--;
                 }
             }
             else
             {
-                for (; end >= start; end--)
+                while (end >= start)
                 {
                     if (span[end] != null)
                     {
                         break;
                     }
+                    end--;
                 }
             }
 
@@ -557,12 +553,9 @@ namespace System
 #nullable restore
         {
             int start = 0;
-            for (; start < span.Length; start++)
+            while (start < span.Length && trimElements.Contains(span[start]))
             {
-                if (!trimElements.Contains(span[start]))
-                {
-                    break;
-                }
+                start++;
             }
 
             return start;
@@ -584,12 +577,9 @@ namespace System
             Debug.Assert((uint)start <= span.Length);
 
             int end = span.Length - 1;
-            for (; end >= start; end--)
+            while (end >= start && trimElements.Contains(span[end]))
             {
-                if (!trimElements.Contains(span[end]))
-                {
-                    break;
-                }
+                end--;
             }
 
             return end - start + 1;
@@ -654,21 +644,15 @@ namespace System
         public static ReadOnlySpan<char> Trim(this ReadOnlySpan<char> span)
         {
             int start = 0;
-            for (; start < span.Length; start++)
+            while (start < span.Length && char.IsWhiteSpace(span[start]))
             {
-                if (!char.IsWhiteSpace(span[start]))
-                {
-                    break;
-                }
+                start++;
             }
 
             int end = span.Length - 1;
-            for (; end > start; end--)
+            while (end > start && char.IsWhiteSpace(span[end]))
             {
-                if (!char.IsWhiteSpace(span[end]))
-                {
-                    break;
-                }
+                end--;
             }
 
             return span.Slice(start, end - start + 1);
@@ -681,12 +665,9 @@ namespace System
         public static ReadOnlySpan<char> TrimStart(this ReadOnlySpan<char> span)
         {
             int start = 0;
-            for (; start < span.Length; start++)
+            while (start < span.Length && char.IsWhiteSpace(span[start]))
             {
-                if (!char.IsWhiteSpace(span[start]))
-                {
-                    break;
-                }
+                start++;
             }
 
             return span.Slice(start);
@@ -699,12 +680,9 @@ namespace System
         public static ReadOnlySpan<char> TrimEnd(this ReadOnlySpan<char> span)
         {
             int end = span.Length - 1;
-            for (; end >= 0; end--)
+            while (end >= 0 && char.IsWhiteSpace(span[end]))
             {
-                if (!char.IsWhiteSpace(span[end]))
-                {
-                    break;
-                }
+                end--;
             }
 
             return span.Slice(0, end + 1);
@@ -718,21 +696,15 @@ namespace System
         public static ReadOnlySpan<char> Trim(this ReadOnlySpan<char> span, char trimChar)
         {
             int start = 0;
-            for (; start < span.Length; start++)
+            while (start < span.Length && span[start] == trimChar)
             {
-                if (span[start] != trimChar)
-                {
-                    break;
-                }
+                start++;
             }
 
             int end = span.Length - 1;
-            for (; end > start; end--)
+            while (end > start && span[end] == trimChar)
             {
-                if (span[end] != trimChar)
-                {
-                    break;
-                }
+                end--;
             }
 
             return span.Slice(start, end - start + 1);
@@ -746,12 +718,9 @@ namespace System
         public static ReadOnlySpan<char> TrimStart(this ReadOnlySpan<char> span, char trimChar)
         {
             int start = 0;
-            for (; start < span.Length; start++)
+            while (start < span.Length && span[start] == trimChar)
             {
-                if (span[start] != trimChar)
-                {
-                    break;
-                }
+                start++;
             }
 
             return span.Slice(start);
@@ -765,12 +734,9 @@ namespace System
         public static ReadOnlySpan<char> TrimEnd(this ReadOnlySpan<char> span, char trimChar)
         {
             int end = span.Length - 1;
-            for (; end >= 0; end--)
+            while (end >= 0 && span[end] == trimChar)
             {
-                if (span[end] != trimChar)
-                {
-                    break;
-                }
+                end--;
             }
 
             return span.Slice(0, end + 1);
@@ -800,23 +766,22 @@ namespace System
                 return span.TrimStart();
             }
 
-            int start = 0;
-            for (; start < span.Length; start++)
+
+            for (int start = 0; start < span.Length; start++)
             {
                 for (int i = 0; i < trimChars.Length; i++)
                 {
                     if (span[start] == trimChars[i])
                     {
-                        goto Next;
+                        continue;
                     }
                 }
 
-                break;
-            Next:
-                ;
+                return span.Slice(start);
+
             }
 
-            return span.Slice(start);
+
         }
 
         /// <summary>
@@ -834,20 +799,23 @@ namespace System
             }
 
             int end = span.Length - 1;
-            for (; end >= 0; end--)
+
+
+            for (int i = 0; end >= 0 && i < trimChars.Length; end--)
             {
-                for (int i = 0; i < trimChars.Length; i++)
+                if (span[end] == trimChars[i])
                 {
-                    if (span[end] == trimChars[i])
-                    {
-                        goto Next;
-                    }
+                    i = 0;
+
+                }
+                else
+                {
+                    i++;
                 }
 
-                break;
-            Next:
-                ;
             }
+
+
 
             return span.Slice(0, end + 1);
         }
@@ -885,12 +853,9 @@ namespace System
         {
             int start = 0;
 
-            for (; start < span.Length; start++)
+            while (start < span.Length && char.IsWhiteSpace(span[start]))
             {
-                if (!char.IsWhiteSpace(span[start]))
-                {
-                    break;
-                }
+                start++;
             }
 
             return start;
@@ -908,12 +873,9 @@ namespace System
 
             int end = span.Length - 1;
 
-            for (; end >= start; end--)
+            while (end >= start && char.IsWhiteSpace(span[end]))
             {
-                if (!char.IsWhiteSpace(span[end]))
-                {
-                    break;
-                }
+                end--;
             }
 
             return end - start + 1;

--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.Trim.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.Trim.cs
@@ -766,13 +766,14 @@ namespace System
                 return span.TrimStart();
             }
 
-
-            for (int start = 0; start < span.Length; start++)
+            int start = 0;
+            while (start < span.Length)
             {
                 for (int i = 0; i < trimChars.Length; i++)
                 {
                     if (span[start] == trimChars[i])
                     {
+                        start++;
                         continue;
                     }
                 }
@@ -780,6 +781,7 @@ namespace System
                 return span.Slice(start);
 
             }
+            return span.Slice(start);
 
 
         }

--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.Trim.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.Trim.cs
@@ -774,7 +774,7 @@ namespace System
                     if (span[start] == trimChars[i])
                     {
                         start++;
-                        continue;
+                        i = 0;
                     }
                 }
 
@@ -801,7 +801,6 @@ namespace System
 
             int end = span.Length - 1;
 
-
             for (int i = 0; end >= 0 && i < trimChars.Length; end--)
             {
                 if (span[end] == trimChars[i])
@@ -809,9 +808,8 @@ namespace System
                     i = 0;
                     continue;
                 }
-            
-                i++;
 
+                i++;
             }
 
             return span.Slice(0, end + 1);

--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.Trim.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.Trim.cs
@@ -767,18 +767,18 @@ namespace System
             }
 
             int start = 0;
-            while (start < span.Length)
-            {
-                for (int i = 0; i < trimChars.Length; i++)
-                {
-                    if (span[start] == trimChars[i])
-                    {
-                        start++;
-                        i = 0;
-                    }
-                }
 
-                return span.Slice(start);
+            for (int i = 0; i < trimChars.Length; i++)
+            {
+                if (span[start] == trimChars[i])
+                {
+                    start++;
+                    if (start < span.Length)
+                    {
+                        return span.Slice(start);
+                    }
+                    i = -1;
+                }
             }
 
             return span.Slice(start);

--- a/src/System.Private.CoreLib/shared/System/MemoryExtensions.Trim.cs
+++ b/src/System.Private.CoreLib/shared/System/MemoryExtensions.Trim.cs
@@ -809,6 +809,7 @@ namespace System
                     i = 0;
                     continue;
                 }
+            
                 i++;
 
             }

--- a/src/System.Private.CoreLib/shared/System/Runtime/MemoryFailPoint.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/MemoryFailPoint.cs
@@ -218,7 +218,7 @@ namespace System.Runtime
                     $"Space reserved via process's MemoryFailPoints: {reserved} MB");
 #endif
 
-                if (!needPageFile && !needAddressSpace && !needContiguousVASpace)
+                if (!(needPageFile || needAddressSpace || needContiguousVASpace))
                     break;
 
                 switch (stage)

--- a/src/debug/createdump/threadinfo.cpp
+++ b/src/debug/createdump/threadinfo.cpp
@@ -106,7 +106,7 @@ ReadMemoryAdapter(PVOID address, PVOID buffer, SIZE_T size)
 void ThreadInfo::UnwindNativeFrames(CrashInfo &crashInfo, CONTEXT *pContext)
 {
     // For each native frame
-    for(;;)
+    for (;;)
     {
         uint64_t ip = 0, sp = 0;
         GetFrameLocation(pContext, &ip, &sp);

--- a/src/ilasm/method.hpp
+++ b/src/ilasm/method.hpp
@@ -11,49 +11,52 @@ class Assembler;
 class PermissionDecl;
 class PermissionSetDecl;
 
-#define MAX_EXCEPTIONS 16   // init.number; increased by 16 when needed
+#define MAX_EXCEPTIONS 16 // init.number; increased by 16 when needed
 
 extern unsigned int g_uCodePage;
-extern WCHAR    wzUniBuf[];
+extern WCHAR wzUniBuf[];
 
 /**************************************************************************/
 struct LinePC
 {
-    ULONG   Line;
-    ULONG   Column;
-    ULONG   LineEnd;
-    ULONG   ColumnEnd;
-    ULONG   PC;
-    ISymUnmanagedDocumentWriter* pWriter;
+    ULONG Line;
+    ULONG Column;
+    ULONG LineEnd;
+    ULONG ColumnEnd;
+    ULONG PC;
+    ISymUnmanagedDocumentWriter *pWriter;
 };
 typedef FIFO<LinePC> LinePCList;
-
 
 struct PInvokeDescriptor
 {
     mdModuleRef mrDll;
-    char*   szAlias;
-    DWORD   dwAttrs;
+    char *szAlias;
+    DWORD dwAttrs;
 };
 
 struct TokenRelocDescr // for OBJ generation only!
 {
-    DWORD   offset;
+    DWORD offset;
     mdToken token;
-    TokenRelocDescr(DWORD off, mdToken tk) { offset = off; token = tk; };
+    TokenRelocDescr(DWORD off, mdToken tk)
+    {
+        offset = off;
+        token = tk;
+    };
 };
 typedef FIFO<TokenRelocDescr> TRDList;
 /* structure - element of [local] signature name list */
 
-struct  ARG_NAME_LIST
+struct ARG_NAME_LIST
 {
     LPCUTF8 szName; //szName[1024];
     DWORD dwName;
-    BinStr*   pSig; // argument's signature  ptr
-    BinStr*   pMarshal;
-    BinStr*   pValue;
-    int  nNum;
-    DWORD     dwAttr;
+    BinStr *pSig; // argument's signature  ptr
+    BinStr *pMarshal;
+    BinStr *pValue;
+    int nNum;
+    DWORD dwAttr;
     CustomDescrList CustDList;
     ARG_NAME_LIST *pNext;
     __forceinline ARG_NAME_LIST(int i, LPCUTF8 sz, BinStr *pbSig, BinStr *pbMarsh, DWORD attr)
@@ -64,17 +67,21 @@ struct  ARG_NAME_LIST
         szName = sz;
         dwName = (sz == NULL) ? 0 : (DWORD)strlen(sz);
         pNext = NULL;
-        pSig=pbSig;
+        pSig = pbSig;
         pMarshal = pbMarsh;
         dwAttr = attr;
-        pValue=NULL;
+        pValue = NULL;
     };
     inline ~ARG_NAME_LIST()
     {
-        if(pSig) delete pSig;
-        if(pMarshal) delete pMarshal;
-        if(pValue) delete pValue;
-        if(szName) delete [] szName;
+        if (pSig)
+            delete pSig;
+        if (pMarshal)
+            delete pMarshal;
+        if (pValue)
+            delete pValue;
+        if (szName)
+            delete[] szName;
     }
 };
 
@@ -83,43 +90,58 @@ typedef FIFO<Scope> ScopeList;
 class Scope
 {
 public:
-    DWORD   dwStart;
-    DWORD   dwEnd;
-    ARG_NAME_LIST*  pLocals;
-    ScopeList       SubScope;
-    Scope*          pSuperScope;
-    Scope() { dwStart = dwEnd = 0; pLocals = NULL; pSuperScope = NULL; };
+    DWORD dwStart;
+    DWORD dwEnd;
+    ARG_NAME_LIST *pLocals;
+    ScopeList SubScope;
+    Scope *pSuperScope;
+    Scope()
+    {
+        dwStart = dwEnd = 0;
+        pLocals = NULL;
+        pSuperScope = NULL;
+    };
     ~Scope() { Reset(); };
     void Reset()
     {
-        ARG_NAME_LIST* pNext;
-        while(pLocals) { pNext = pLocals->pNext; delete pLocals; pLocals = pNext; }
-        Scope* pS;
-        while((pS = SubScope.POP()) != NULL) delete pS;
+        ARG_NAME_LIST *pNext;
+        while (pLocals)
+        {
+            pNext = pLocals->pNext;
+            delete pLocals;
+            pLocals = pNext;
+        }
+        Scope *pS;
+        while ((pS = SubScope.POP()) != NULL)
+            delete pS;
         pSuperScope = NULL;
         dwStart = dwEnd = 0;
     };
 };
 struct VarDescr
 {
-    DWORD   dwSlot;
-    BinStr* pbsSig;
-    BOOL    bInScope;
-    VarDescr() { dwSlot = (DWORD) -1; pbsSig = NULL; bInScope = FALSE; };
+    DWORD dwSlot;
+    BinStr *pbsSig;
+    BOOL bInScope;
+    VarDescr()
+    {
+        dwSlot = (DWORD)-1;
+        pbsSig = NULL;
+        bInScope = FALSE;
+    };
 };
 typedef FIFO<VarDescr> VarDescrList;
 
-
 struct Label
 {
-//public:
-    LPCUTF8  m_szName;
-    DWORD   m_PC;
+    //public:
+    LPCUTF8 m_szName;
+    DWORD m_PC;
 
-    Label() :m_szName(NULL),m_PC(0){};
-    Label(LPCUTF8 pszName, DWORD PC):m_szName(pszName),m_PC(PC){};
-    ~Label(){ delete [] m_szName; };
-    int ComparedTo(Label* L) { return strcmp(m_szName,L->m_szName); };
+    Label() : m_szName(NULL), m_PC(0){};
+    Label(LPCUTF8 pszName, DWORD PC) : m_szName(pszName), m_PC(PC){};
+    ~Label() { delete[] m_szName; };
+    int ComparedTo(Label *L) { return strcmp(m_szName, L->m_szName); };
     //int Compare(char* L) { return strcmp(L,m_szName); };
     LPCUTF8 NameOf() { return m_szName; };
 };
@@ -129,52 +151,56 @@ typedef FIFO_INDEXED<Label> LabelList;
 class GlobalFixup
 {
 public:
-    LPCUTF8  m_szLabel;
-    BYTE *  m_pReference;               // The place to fix up
+    LPCUTF8 m_szLabel;
+    BYTE *m_pReference; // The place to fix up
 
-    GlobalFixup(LPCUTF8 pszName, BYTE* pReference)
+    GlobalFixup(LPCUTF8 pszName, BYTE *pReference)
     {
-        m_pReference   = pReference;
+        m_pReference = pReference;
         m_szLabel = pszName;
     }
-    ~GlobalFixup(){ delete [] m_szLabel; }
+    ~GlobalFixup() { delete[] m_szLabel; }
 };
 typedef FIFO<GlobalFixup> GlobalFixupList;
-
 
 class Fixup
 {
 public:
-    LPCUTF8  m_szLabel;
-    BYTE *  m_pBytes; // where to make the fixup
-    DWORD   m_RelativeToPC;
-    BYTE    m_FixupSize;
+    LPCUTF8 m_szLabel;
+    BYTE *m_pBytes; // where to make the fixup
+    DWORD m_RelativeToPC;
+    BYTE m_FixupSize;
 
     Fixup(LPCUTF8 pszName, BYTE *pBytes, DWORD RelativeToPC, BYTE FixupSize)
     {
-        m_pBytes        = pBytes;
-        m_RelativeToPC  = RelativeToPC;
-        m_FixupSize     = FixupSize;
+        m_pBytes = pBytes;
+        m_RelativeToPC = RelativeToPC;
+        m_FixupSize = FixupSize;
         m_szLabel = pszName;
     }
-    ~Fixup(){ delete [] m_szLabel; }
+    ~Fixup() { delete[] m_szLabel; }
 };
 typedef FIFO<Fixup> FixupList;
 
-typedef enum { ilRVA, ilToken, ilGlobal} ILFixupType;
+typedef enum
+{
+    ilRVA,
+    ilToken,
+    ilGlobal
+} ILFixupType;
 
 class ILFixup
 {
 public:
-    ILFixupType   m_Kind;
-    DWORD         m_OffsetInMethod;
-    GlobalFixup * m_Fixup;
+    ILFixupType m_Kind;
+    DWORD m_OffsetInMethod;
+    GlobalFixup *m_Fixup;
 
     ILFixup(DWORD Offset, ILFixupType Kind, GlobalFixup *Fix)
     {
-      m_Kind           = Kind;
-      m_OffsetInMethod = Offset;
-      m_Fixup          = Fix;
+        m_Kind = Kind;
+        m_OffsetInMethod = Offset;
+        m_Fixup = Fix;
     }
 };
 typedef FIFO<ILFixup> ILFixupList;
@@ -182,75 +208,81 @@ typedef FIFO<ILFixup> ILFixupList;
 class Method
 {
 public:
-    Class  *m_pClass;
+    Class *m_pClass;
     //BinStr **m_TyParBounds;
     //LPCWSTR *m_TyParNames;
-    TyParDescr* m_TyPars;
-    DWORD   m_NumTyPars;
-    DWORD   m_SigInfoCount;
-    USHORT  m_MaxStack;
-    mdSignature  m_LocalsSig;
-    DWORD   m_Flags;
-    char*   m_szName;
-    DWORD   m_dwName;
-    char*   m_szExportAlias;
-    DWORD   m_dwExportOrdinal;
+    TyParDescr *m_TyPars;
+    DWORD m_NumTyPars;
+    DWORD m_SigInfoCount;
+    USHORT m_MaxStack;
+    mdSignature m_LocalsSig;
+    DWORD m_Flags;
+    char *m_szName;
+    DWORD m_dwName;
+    char *m_szExportAlias;
+    DWORD m_dwExportOrdinal;
     COR_ILMETHOD_SECT_EH_CLAUSE_FAT *m_ExceptionList;
-    DWORD   m_dwNumExceptions;
-    DWORD   m_dwMaxNumExceptions;
-    DWORD*  m_EndfilterOffsetList;
-    DWORD   m_dwNumEndfilters;
-    DWORD   m_dwMaxNumEndfilters;
-    DWORD   m_Attr;
-    BOOL    m_fEntryPoint;
-    BOOL    m_fGlobalMethod;
-    BOOL    m_fNewBody;
-    BOOL    m_fNew;
-    DWORD   m_methodOffset;
-    DWORD   m_headerOffset;
-    BYTE *  m_pCode;
-    DWORD   m_CodeSize;
-    WORD    m_wImplAttr;
-    ULONG   m_ulLines[2];
-    ULONG   m_ulColumns[2];
+    DWORD m_dwNumExceptions;
+    DWORD m_dwMaxNumExceptions;
+    DWORD *m_EndfilterOffsetList;
+    DWORD m_dwNumEndfilters;
+    DWORD m_dwMaxNumEndfilters;
+    DWORD m_Attr;
+    BOOL m_fEntryPoint;
+    BOOL m_fGlobalMethod;
+    BOOL m_fNewBody;
+    BOOL m_fNew;
+    DWORD m_methodOffset;
+    DWORD m_headerOffset;
+    BYTE *m_pCode;
+    DWORD m_CodeSize;
+    WORD m_wImplAttr;
+    ULONG m_ulLines[2];
+    ULONG m_ulColumns[2];
     // PInvoke attributes
-    PInvokeDescriptor* m_pPInvoke;
+    PInvokeDescriptor *m_pPInvoke;
     // Security attributes
-    PermissionDecl* m_pPermissions;
-    PermissionSetDecl* m_pPermissionSets;
+    PermissionDecl *m_pPermissions;
+    PermissionSetDecl *m_pPermissionSets;
     // VTable attributes
-    WORD            m_wVTEntry;
-    WORD            m_wVTSlot;
+    WORD m_wVTEntry;
+    WORD m_wVTSlot;
     // Return marshaling
-    BinStr* m_pRetMarshal;
-    BinStr* m_pRetValue;
-    DWORD   m_dwRetAttr;
+    BinStr *m_pRetMarshal;
+    BinStr *m_pRetValue;
+    DWORD m_dwRetAttr;
     CustomDescrList m_RetCustDList;
-    ILFixupList     m_lstILFixup;
-    FixupList       m_lstFixup;
-//    LabelList       m_lstLabel;
+    ILFixupList m_lstILFixup;
+    FixupList m_lstFixup;
+    //    LabelList       m_lstLabel;
     // Member ref fixups
-    LocalMemberRefFixupList  m_LocalMemberRefFixupList;
+    LocalMemberRefFixupList m_LocalMemberRefFixupList;
     // Method body (header+code+EH)
-    BinStr* m_pbsBody;
+    BinStr *m_pbsBody;
     mdToken m_Tok;
-    Method(Assembler *pAssembler, Class *pClass, __in __nullterminated char *pszName, BinStr* pbsSig, DWORD Attr);
+    Method(Assembler *pAssembler, Class *pClass, __in __nullterminated char *pszName, BinStr *pbsSig, DWORD Attr);
     ~Method()
     {
         m_lstFixup.RESET(true);
         //m_lstLabel.RESET(true);
-        delete [] m_szName;
-        if(m_szExportAlias) delete [] m_szExportAlias;
+        delete[] m_szName;
+        if (m_szExportAlias)
+            delete[] m_szExportAlias;
         delArgNameList(m_firstArgName);
         delArgNameList(m_firstVarName);
         delete m_pbsMethodSig;
-        delete [] m_ExceptionList;
-        delete [] m_EndfilterOffsetList;
-        if(m_pRetMarshal) delete m_pRetMarshal;
-        if(m_pRetValue) delete m_pRetValue;
-        while(m_MethodImplDList.POP()); // ptrs in m_MethodImplDList are dups of those in Assembler
-        if(m_pbsBody) delete m_pbsBody;
-        if(m_TyPars) delete [] m_TyPars;
+        delete[] m_ExceptionList;
+        delete[] m_EndfilterOffsetList;
+        if (m_pRetMarshal)
+            delete m_pRetMarshal;
+        if (m_pRetValue)
+            delete m_pRetValue;
+        while (m_MethodImplDList.POP())
+            ; // ptrs in m_MethodImplDList are dups of those in Assembler
+        if (m_pbsBody)
+            delete m_pbsBody;
+        if (m_TyPars)
+            delete[] m_TyPars;
     };
 
     BOOL IsGlobalMethod()
@@ -265,39 +297,45 @@ public:
 
     void delArgNameList(ARG_NAME_LIST *pFirst)
     {
-        ARG_NAME_LIST *pArgList=pFirst, *pArgListNext;
-        for(; pArgList; pArgListNext=pArgList->pNext,
-                        delete pArgList,
-                        pArgList=pArgListNext);
+        ARG_NAME_LIST *pArgList = pFirst, *pArgListNext;
+        for (; pArgList; pArgListNext = pArgList->pNext,
+                         delete pArgList,
+                         pArgList = pArgListNext)
+            ;
     };
 
     ARG_NAME_LIST *catArgNameList(ARG_NAME_LIST *pBase, ARG_NAME_LIST *pAdd)
     {
-        if(pAdd) //even if nothing to concatenate, result == head
+        if (pAdd) //even if nothing to concatenate, result == head
         {
             ARG_NAME_LIST *pAN = pBase;
-            if(pBase)
+            if (pBase)
             {
                 int i;
-                for(; pAN->pNext; pAN = pAN->pNext) ;
+                while (pAN->pNext)
+                {
+                    pAN = pAN->pNext;
+                }
                 pAN->pNext = pAdd;
                 i = pAN->nNum;
-                for(pAN = pAdd; pAN; pAN->nNum = ++i, pAN = pAN->pNext);
+                for (pAN = pAdd; pAN; pAN->nNum = ++i, pAN = pAN->pNext)
+                    ;
             }
-            else pBase = pAdd; //nothing to concatenate to, result == tail
+            else
+                pBase = pAdd; //nothing to concatenate to, result == tail
         }
         return pBase;
     };
 
     int findArgNum(ARG_NAME_LIST *pFirst, LPCUTF8 szArgName, DWORD dwArgName)
     {
-        int ret=-1;
-        if(dwArgName)
+        int ret = -1;
+        if (dwArgName)
         {
             ARG_NAME_LIST *pAN;
-            for(pAN=pFirst; pAN; pAN = pAN->pNext)
+            for (pAN = pFirst; pAN; pAN = pAN->pNext)
             {
-                if((pAN->dwName == dwArgName)&& ((dwArgName==0)||(!strcmp(pAN->szName,szArgName))))
+                if ((pAN->dwName == dwArgName) && ((dwArgName == 0) || (!strcmp(pAN->szName, szArgName))))
                 {
                     ret = pAN->nNum;
                     break;
@@ -309,13 +347,13 @@ public:
 
     int findLocSlot(ARG_NAME_LIST *pFirst, LPCUTF8 szArgName, DWORD dwArgName)
     {
-        int ret=-1;
-        if(dwArgName)
+        int ret = -1;
+        if (dwArgName)
         {
             ARG_NAME_LIST *pAN;
-            for(pAN=pFirst; pAN; pAN = pAN->pNext)
+            for (pAN = pFirst; pAN; pAN = pAN->pNext)
             {
-                if((pAN->dwName == dwArgName)&& ((dwArgName==0)||(!strcmp(pAN->szName,szArgName))))
+                if ((pAN->dwName == dwArgName) && ((dwArgName == 0) || (!strcmp(pAN->szName, szArgName))))
                 {
                     ret = (int)(pAN->dwAttr);
                     break;
@@ -325,13 +363,13 @@ public:
         return ret;
     };
 
-    BinStr  *m_pbsMethodSig;
-    COR_SIGNATURE*  m_pMethodSig;
-    DWORD   m_dwMethodCSig;
+    BinStr *m_pbsMethodSig;
+    COR_SIGNATURE *m_pMethodSig;
+    DWORD m_dwMethodCSig;
     ARG_NAME_LIST *m_firstArgName;
     ARG_NAME_LIST *m_firstVarName;
     // to call error() from Method:
-    const char* m_FileName;
+    const char *m_FileName;
     unsigned m_LineNum;
     // debug info
     LinePCList m_LinePCList;
@@ -342,39 +380,39 @@ public:
     // method's own list of method impls
     MethodImplDList m_MethodImplDList;
     // lexical scope handling
-    Assembler*      m_pAssembler;
-    Scope           m_MainScope;
-    Scope*          m_pCurrScope;
-    VarDescrList    m_Locals;
+    Assembler *m_pAssembler;
+    Scope m_MainScope;
+    Scope *m_pCurrScope;
+    VarDescrList m_Locals;
     void OpenScope();
     void CloseScope();
 
     Label *FindLabel(LPCUTF8 pszName);
     Label *FindLabel(DWORD PC);
 
-    int FindTyPar(__in __nullterminated WCHAR* wz)
+    int FindTyPar(__in __nullterminated WCHAR *wz)
     {
-        int i,retval=-1;
-        for(i=0; i < (int)m_NumTyPars; i++)
+        int retval = -1;
+        for (int i = 0; i < (int)m_NumTyPars; i++)
         {
-            if(!wcscmp(wz,m_TyPars[i].Name()))
+            if (!wcscmp(wz, m_TyPars[i].Name()))
             {
                 retval = i;
             }
         }
         return retval;
     };
-    int FindTyPar(__in __nullterminated char* sz)
+    int FindTyPar(__in __nullterminated char *sz)
     {
-        if(sz)
+        if (sz)
         {
             wzUniBuf[0] = 0;
-            WszMultiByteToWideChar(g_uCodePage,0,sz,-1,wzUniBuf,dwUniBuf);
+            WszMultiByteToWideChar(g_uCodePage, 0, sz, -1, wzUniBuf, dwUniBuf);
             return FindTyPar(wzUniBuf);
         }
-        else return -1;
+        else
+            return -1;
     };
 };
 
 #endif /* _METHOD_HPP */
-

--- a/tests/src/tracing/eventcounter/pollingcounter.cs
+++ b/tests/src/tracing/eventcounter/pollingcounter.cs
@@ -33,7 +33,7 @@ namespace BasicEventSourceTests
             private readonly string _targetSourceName;
             private readonly EventLevel _level;
             private Dictionary<string, string> args;
-            
+
             public int FailureEventCount { get; private set; } = 0;
             public int SuccessEventCount { get; private set; } = 0;
             public bool Failed = false;
@@ -46,7 +46,7 @@ namespace BasicEventSourceTests
                 args = new Dictionary<string, string>();
                 args.Add("EventCounterIntervalSec", "1");
             }
-            
+
             protected override void OnEventSourceCreated(EventSource source)
             {
                 if (source.Name.Equals(_targetSourceName))
@@ -103,7 +103,7 @@ namespace BasicEventSourceTests
                         // Check if the mean is what we expect it to be
                         if (name.Equals("failureCount"))
                         {
-                            if (Int32.Parse(mean) != successCountCalled)  
+                            if (Int32.Parse(mean) != successCountCalled)
                             {
                                 Console.WriteLine($"Mean is not what we expected: {mean} vs {successCountCalled}");
                                 Failed = true;
@@ -118,7 +118,7 @@ namespace BasicEventSourceTests
                         }
 
                         // In PollingCounter, min/max/mean should have the same value since we aggregate value only once per counter
-                        if (!min.Equals(mean) || !min.Equals(max))
+                        if (!(min.Equals(mean) && min.Equals(max)))
                         {
                             Console.WriteLine("mean/min/max are not equal");
                             Failed = true;
@@ -164,7 +164,7 @@ namespace BasicEventSourceTests
                 if (myListener.FailureEventCount > 0 && myListener.SuccessEventCount > 0 && !myListener.Failed && (mockedCountCalled > 0 && successCountCalled > 0))
                 {
                     Console.WriteLine("Test Passed");
-                    return 100;    
+                    return 100;
                 }
                 else
                 {


### PR DESCRIPTION
Running DateTimeOffset caused an unnecessary number of DateTime conversions as well as unnecessary boolean checks during those conversions. This not only optimizes the program but simplifies the control flow for better performance and future maintenance. 

I used the Format Document tool to ensure the files were properly formatted, which is why the diffs show multiple changes in the same files I edited.

I hope this proves useful!