### PR TITLE
Set VSDevCmd winsdk version explicitly.

### DIFF
--- a/build-test.cmd
+++ b/build-test.cmd
@@ -22,6 +22,8 @@ if defined VS160COMNTOOLS (
     set __VSVersion=vs2017
 )
 
+set __WinSDKVersion=10.0.17763.0
+
 :: Set the default arguments for build
 set __BuildArch=x64
 set __BuildType=Debug
@@ -202,8 +204,8 @@ if /i "%__BuildArch%" == "x86" ( set __VCBuildArch=x86 )
 if /i "%__BuildArch%" == "arm" ( set __VCBuildArch=x86_arm )
 if /i "%__BuildArch%" == "arm64" ( set __VCBuildArch=x86_arm64 )
 
-echo %__MsgPrefix%Using environment: "%__VCToolsRoot%\vcvarsall.bat" %__VCBuildArch%
-call                                 "%__VCToolsRoot%\vcvarsall.bat" %__VCBuildArch%
+echo %__MsgPrefix%Using environment: "%__VCToolsRoot%\vcvarsall.bat" %__VCBuildArch% %__WinSDKVersion%
+call                                 "%__VCToolsRoot%\vcvarsall.bat" %__VCBuildArch% %__WinSDKVersion%
 @if defined _echo @echo on
 
 if not defined VSINSTALLDIR (

--- a/build.cmd
+++ b/build.cmd
@@ -23,6 +23,8 @@ if defined VS160COMNTOOLS (
     set __VSVersion=vs2017
 )
 
+set __WinSDKVersion=10.0.17763.0
+
 :: Work around Jenkins CI + msbuild problem: Jenkins sometimes creates very large environment
 :: variables, and msbuild can't handle environment blocks with such large variables. So clear
 :: out the variables that might be too large.
@@ -461,8 +463,8 @@ if %__BuildCrossArchNative% EQU 1 (
     set __VCBuildArch=x86_amd64
     if /i "%__CrossArch%" == "x86" ( set __VCBuildArch=x86 )
 
-    echo %__MsgPrefix%Using environment: "%__VCToolsRoot%\vcvarsall.bat" !__VCBuildArch!
-    call                                 "%__VCToolsRoot%\vcvarsall.bat" !__VCBuildArch!
+    echo %__MsgPrefix%Using environment: "%__VCToolsRoot%\vcvarsall.bat" !__VCBuildArch! %__WinSDKVersion%
+    call                                 "%__VCToolsRoot%\vcvarsall.bat" !__VCBuildArch! %__WinSDKVersion%
     @if defined _echo @echo on
 
     if not exist "%__CrossCompIntermediatesDir%" md "%__CrossCompIntermediatesDir%"
@@ -540,8 +542,8 @@ if %__BuildNative% EQU 1 (
         set ___CrossBuildDefine="-DCLR_CMAKE_CROSS_ARCH=1" "-DCLR_CMAKE_CROSS_HOST_ARCH=%__CrossArch%"
     )
 
-    echo %__MsgPrefix%Using environment: "%__VCToolsRoot%\vcvarsall.bat" !__VCBuildArch!
-    call                                 "%__VCToolsRoot%\vcvarsall.bat" !__VCBuildArch!
+    echo %__MsgPrefix%Using environment: "%__VCToolsRoot%\vcvarsall.bat" !__VCBuildArch! %__WinSDKVersion%
+    call                                 "%__VCToolsRoot%\vcvarsall.bat" !__VCBuildArch! %__WinSDKVersion%
     @if defined _echo @echo on
 
     if not defined VSINSTALLDIR (
@@ -775,8 +777,8 @@ if %__BuildNativeCoreLib% EQU 1 (
     if %__PgoInstrument% EQU 1 (
         set __VCExecArch=%__BuildArch%
         if /i [%__BuildArch%] == [x64] set __VCExecArch=amd64
-        echo %__MsgPrefix%Using environment: "%__VCToolsRoot%\vcvarsall.bat" !__VCExecArch!
-        call                                 "%__VCToolsRoot%\vcvarsall.bat" !__VCExecArch!
+        echo %__MsgPrefix%Using environment: "%__VCToolsRoot%\vcvarsall.bat" !__VCExecArch! %__WinSDKVersion%
+        call                                 "%__VCToolsRoot%\vcvarsall.bat" !__VCExecArch! %__WinSDKVersion%
         @if defined _echo @echo on
         if NOT !errorlevel! == 0 (
             echo %__MsgPrefix%Error: Failed to load native tools environment for !__VCExecArch!

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -127,3 +127,4 @@ jobs:
     jobTemplate: format-job.yml
     platforms:
     - Linux_x64
+    - Windows_NT_x64

--- a/setup_vs_tools.cmd
+++ b/setup_vs_tools.cmd
@@ -34,8 +34,8 @@ if not exist "%_VSCOMNTOOLS%" (
     echo        Please see https://github.com/dotnet/coreclr/blob/master/Documentation/building/windows-instructions.md for build instructions.
     exit /b 1
 )
-echo %__MsgPrefix%"%_VSCOMNTOOLS%\VsDevCmd.bat"
-call "%_VSCOMNTOOLS%\VsDevCmd.bat"
+echo %__MsgPrefix%"%_VSCOMNTOOLS%\VsDevCmd.bat -winsdk=10.0.17763.0"
+call "%_VSCOMNTOOLS%\VsDevCmd.bat" -winsdk=10.0.17763.0
 
 :skip_setup
 

--- a/tests/src/Interop/Interop.settings.targets
+++ b/tests/src/Interop/Interop.settings.targets
@@ -25,12 +25,7 @@
 
     <None Include="$(VCToolsRedistDir)onecore/debug_nonredist/$(Platform)/Microsoft.VC*.DebugCRT/vcruntime*d.dll" CopyToOutputDirectory="Always" />
     <None Include="$(VCToolsRedistDir)onecore/debug_nonredist/$(Platform)/Microsoft.VC*.DebugCRT/msvcp*d.dll" CopyToOutputDirectory="Always" />
-    <None Include="$(ExtensionSdkDir)/Microsoft.UniversalCRT.Debug/$(UCRTVersion)/Redist/Debug/$(Platform)/ucrtbased.dll" CopyToOutputDirectory="Always"
-        Condition="Exists('$(ExtensionSdkDir)/Microsoft.UniversalCRT.Debug/$(UCRTVersion)/Redist/Debug/$(Platform)/ucrtbased.dll')" />
-    
-    <!-- There's a bug in VS that causes UCRTVersion env var to get set to a version that isn't actually installed on the machine. -->
-    <!-- Until that gets resolved, we need this workaround to grab the last "known" good version of ucrtbased.dll -->
-    <None Include="$(ExtensionSdkDir)/Microsoft.UniversalCRT.Debug/10.0.17763.0/Redist/Debug/$(Platform)/ucrtbased.dll" CopyToOutputDirectory="Always"
-        Condition="!Exists('$(ExtensionSdkDir)/Microsoft.UniversalCRT.Debug/$(UCRTVersion)/Redist/Debug/$(Platform)/ucrtbased.dll')" />
+    <None Include="$(ExtensionSdkDir)/Microsoft.UniversalCRT.Debug/$(UCRTVersion)/Redist/Debug/$(Platform)/ucrtbased.dll" CopyToOutputDirectory="Always" />
+
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Auto-detection of winsdk version proved to be fragile so
this change sets it explicitly.
Undo the workaround for UCRTVersion (#25444).
Re-enable Windows formatting job (#25507).

Fixes #25447, #25499.