### PR TITLE
Disable debugger evaluation of ValueTask<T>.Result

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/ValueTask.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/ValueTask.cs
@@ -740,6 +740,7 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>Gets the result.</summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)] // prevent debugger evaluation from invalidating an underling IValueTaskSource<T>
         public TResult Result
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -780,6 +781,8 @@ namespace System.Threading.Tasks
         {
             if (IsCompletedSuccessfully)
             {
+                Debugger.NotifyOfCrossThreadDependency(); // prevent debugger evaluation from invalidating an underling IValueTaskSource<T> unless forced
+
                 TResult result = Result;
                 if (result != null)
                 {


### PR DESCRIPTION
If the debugger evaluates a `ValueTask<T>`'s `Result`, that counts as the "you should only consume a `ValueTask<T>` once", and ends up breaking / hanging / throwing exceptions and other bad stuff while stepping through code in the debugger.

This commit addresses that in two ways:
1. Adds `[DebuggerBrowsable(Never)]` to `Result` to prevent it from showing up in debugger views.  This is the same as what `Task<T>.Result` does.
2. Adds a NotifyOfCrossThreadDependency call to its ToString.  This prevents the debugger from using ToString to show an implicit representation of the instance, and it forces the developer explicitly trying to access ToString (e.g. in the watch window) to click a button acknowleding the impact.

(Post 3.0, we should consider removing the `ValueTask<T>.ToString()` override altogether.  I don't remember why we added that, but the purpose is better served with a DebuggerDisplay attribute.)

Fixes https://github.com/dotnet/corefx/issues/39536
cc: @jkotas, @kouvel, @tarekgh, @AArnott, @davidfowl, @noahfalk 