### PR TITLE
Fix first value of counter payload being skewed

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterGroup.cs
@@ -145,7 +145,7 @@ namespace System.Diagnostics.Tracing
                 Debug.WriteLine("Polling interval changed at " + DateTime.UtcNow.ToString("mm.ss.ffffff"));
                 _pollingIntervalInMilliseconds = (int)(pollingIntervalInSeconds * 1000);
                 DisposeTimer();
-                Update(); // Reset statistics for counters before we start the thread.
+                ResetCounters(); // Reset statistics for counters before we start the thread.
                 _timeStampSinceCollectionStarted = DateTime.UtcNow;
                 // Don't capture the current ExecutionContext and its AsyncLocals onto the timer causing them to live forever
                 bool restoreFlow = false;
@@ -168,7 +168,7 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-        private void Update()
+        private void ResetCounters()
         {
             lock (this) // Lock the CounterGroup
             {

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/CounterGroup.cs
@@ -172,31 +172,20 @@ namespace System.Diagnostics.Tracing
         {
             lock (this) // Lock the CounterGroup
             {
-                if (_eventSource.IsEnabled())
+                foreach (var counter in _counters)
                 {
-                    DateTime now = DateTime.UtcNow;
-                    TimeSpan elapsed = now - _timeStampSinceCollectionStarted;
-
-                    foreach (var counter in _counters)
+                    if (counter is IncrementingEventCounter ieCounter)
                     {
-                        if (counter is IncrementingEventCounter ieCounter)
-                        {
-                            ieCounter.UpdateMetric();    
-                        }
-                        else if (counter is IncrementingPollingCounter ipCounter)
-                        {
-                            ipCounter.UpdateMetric();    
-                        }
-                        else if (counter is EventCounter eCounter)
-                        {
-                            eCounter.ResetStatistics();
-                        }
+                        ieCounter.UpdateMetric();
                     }
-                    _timeStampSinceCollectionStarted = now;
-                }
-                else
-                {
-                    DisposeTimer();
+                    else if (counter is IncrementingPollingCounter ipCounter)
+                    {
+                        ipCounter.UpdateMetric();
+                    }
+                    else if (counter is EventCounter eCounter)
+                    {
+                        eCounter.ResetStatistics();
+                    }
                 }
             }
         }

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventCounter.cs
@@ -114,7 +114,7 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-        private void ResetStatistics()
+        internal void ResetStatistics()
         {
             Debug.Assert(Monitor.IsEntered(this));
             _count = 0;

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/IncrementingEventCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/IncrementingEventCounter.cs
@@ -73,6 +73,15 @@ namespace System.Diagnostics.Tracing
                 EventSource.Write("EventCounters", new EventSourceOptions() { Level = EventLevel.LogAlways }, new IncrementingEventCounterPayloadType(payload));
             }
         }
+
+        // Updates the value.
+        internal void UpdateMetric()
+        {
+            lock (this)
+            {
+                _prevIncrement = _increment;
+            }
+        }
     }
 
 

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/IncrementingPollingCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/IncrementingPollingCounter.cs
@@ -52,13 +52,15 @@ namespace System.Diagnostics.Tracing
         /// <summary>
         /// Calls "_totalValueProvider" to enqueue the counter value to the queue. 
         /// </summary>
-        private void UpdateMetric()
+        internal void UpdateMetric()
         {
             try
             {
                 lock (this)
                 {
+                    double temp = _increment;
                     _increment = _totalValueProvider();
+                    _prevIncrement = temp;
                 }
             }
             catch (Exception ex)
@@ -82,7 +84,6 @@ namespace System.Diagnostics.Tracing
                 payload.Metadata = GetMetadataString();
                 payload.Increment = _increment - _prevIncrement;
                 payload.DisplayUnits = DisplayUnits ?? "";
-                _prevIncrement = _increment;
                 EventSource.Write("EventCounters", new EventSourceOptions() { Level = EventLevel.LogAlways }, new IncrementingPollingCounterPayloadType(payload));
             }
         }

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/IncrementingPollingCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/IncrementingPollingCounter.cs
@@ -58,9 +58,8 @@ namespace System.Diagnostics.Tracing
             {
                 lock (this)
                 {
-                    double temp = _increment;
+                    _prevIncrement = _increment;
                     _increment = _totalValueProvider();
-                    _prevIncrement = temp;
                 }
             }
             catch (Exception ex)

--- a/tests/src/tracing/eventcounter/regression-25709.cs
+++ b/tests/src/tracing/eventcounter/regression-25709.cs
@@ -1,0 +1,112 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
+using System.Diagnostics.Tracing;
+#endif
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+
+namespace BasicEventSourceTests
+{
+
+    public class SimpleEventListener : EventListener
+    {        
+        private readonly EventLevel _level = EventLevel.Verbose;
+
+        public int MaxIncrement { get; private set; } = 0;
+
+        public SimpleEventListener()
+        {
+        }
+
+
+        protected override void OnEventSourceCreated(EventSource source)
+        {
+            if (source.Name.Equals("System.Runtime"))
+            {
+                Dictionary<string, string> refreshInterval = new Dictionary<string, string>();
+                refreshInterval.Add("EventCounterIntervalSec", "1");
+                EnableEvents(source, _level, (EventKeywords)(-1), refreshInterval);
+            }
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            int increment = 0;
+            bool isExceptionCounter = false;
+
+            for (int i = 0; i < eventData.Payload.Count; i++)
+            {
+                IDictionary<string, object> eventPayload = eventData.Payload[i] as IDictionary<string, object>;
+                if (eventPayload != null)
+                {
+                    foreach (KeyValuePair<string, object> payload in eventPayload)
+                    {
+                        if (payload.Key.Equals("Name") && payload.Value.ToString().Equals("exception-count"))
+                            isExceptionCounter = true;
+                        if (payload.Key.Equals("Increment"))
+                        {
+                            increment = Int32.Parse(payload.Value.ToString());
+                        }
+                    }
+                    if (isExceptionCounter)
+                    {
+                        if (MaxIncrement < increment)
+                        {
+                            MaxIncrement = increment;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public partial class TestEventCounter
+    {
+
+        public static void ThrowExceptionTask()
+        {
+            // This will throw an exception every 1000 ms
+            while (true)
+            {
+                Thread.Sleep(1000);
+                try
+                {
+                    throw new Exception("an exception");
+                }
+                catch
+                {}
+            }
+        }
+
+        public static int Main(string[] args)
+        {
+            Task exceptionTask = Task.Run(ThrowExceptionTask);
+            Thread.Sleep(5000);
+
+            // Create an EventListener.
+            using (SimpleEventListener myListener = new SimpleEventListener())
+            {
+                Thread.Sleep(5000);
+
+                if (myListener.MaxIncrement > 1)
+                {
+                    Console.WriteLine($"Test Failed - Saw more than 5 exceptions / sec {myListener.MaxIncrement}");
+                    return 1;
+                }
+                else
+                {
+                    Console.WriteLine("Test passed");
+                    return 100;
+                }
+            }
+        }
+    }
+}

--- a/tests/src/tracing/eventcounter/regression-25709.cs
+++ b/tests/src/tracing/eventcounter/regression-25709.cs
@@ -11,7 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-
+using System.Diagnostics;
 
 namespace EventCounterRegressionTests
 {
@@ -79,6 +79,7 @@ namespace EventCounterRegressionTests
                 Thread.Sleep(1000);
                 try
                 {
+                    Debug.WriteLine("Exception thrown at " + DateTime.UtcNow.ToString("mm.ss.ffffff"));
                     throw new Exception("an exception");
                 }
                 catch
@@ -96,9 +97,13 @@ namespace EventCounterRegressionTests
             {
                 Thread.Sleep(5000);
 
-                if (myListener.MaxIncrement > 5)
+                // The number below is supposed to be 2 at maximum, but in debug builds, the calls to 
+                // EventSource.Write() takes a lot longer than we thought, and the reflection in 
+                // workingset counter also adds a huge amount of time, which makes the test fail in 
+                // debug CIs. Setting the check to 3 to compensate for these.
+                if (myListener.MaxIncrement > 3)
                 {
-                    Console.WriteLine($"Test Failed - Saw more than 5 exceptions / sec {myListener.MaxIncrement}");
+                    Console.WriteLine($"Test Failed - Saw more than 3 exceptions / sec {myListener.MaxIncrement}");
                     return 1;
                 }
                 else

--- a/tests/src/tracing/eventcounter/regression-25709.cs
+++ b/tests/src/tracing/eventcounter/regression-25709.cs
@@ -13,7 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 
-namespace BasicEventSourceTests
+namespace EventCounterRegressionTests
 {
 
     public class SimpleEventListener : EventListener
@@ -96,7 +96,7 @@ namespace BasicEventSourceTests
             {
                 Thread.Sleep(5000);
 
-                if (myListener.MaxIncrement > 1)
+                if (myListener.MaxIncrement > 5)
                 {
                     Console.WriteLine($"Test Failed - Saw more than 5 exceptions / sec {myListener.MaxIncrement}");
                     return 1;

--- a/tests/src/tracing/eventcounter/regression-25709.csproj
+++ b/tests/src/tracing/eventcounter/regression-25709.csproj
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{8E3244CB-407F-4142-BAAB-E7A55901A5FA}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestPriority>0</CLRTestPriority>
+    <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- This test has a secondary thread with an infinite loop -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="regression-25709.cs" />
+    <ProjectReference Include="../common/common.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
Fixes #25709. 

EventCounter, IncrementingPollingCounter, and IncrementingEventCounter may report a non-meaningful value when counter is enabled for the first time (or a long time after disable). This fixes it by reseting the statistics when counter is enabled, and not firing immediately when the EventSource is enabled.