### PR TITLE
Renamed pInitRegZeroed to pInitRegModified, per #24985

### DIFF
--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -308,12 +308,12 @@ protected:
     void genSaveCalleeSavedRegistersHelp(regMaskTP regsToSaveMask, int lowestCalleeSavedOffset, int spDelta);
     void genRestoreCalleeSavedRegistersHelp(regMaskTP regsToRestoreMask, int lowestCalleeSavedOffset, int spDelta);
 
-    void genPushCalleeSavedRegisters(regNumber initReg, bool* pInitRegZeroed);
+    void genPushCalleeSavedRegisters(regNumber initReg, bool* pInitRegModified);
 #else
     void genPushCalleeSavedRegisters();
 #endif
 
-    void genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pInitRegZeroed, regMaskTP maskArgRegsLiveIn);
+    void genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pInitRegModified, regMaskTP maskArgRegsLiveIn);
 
 #if defined(_TARGET_ARM_)
 
@@ -402,18 +402,18 @@ protected:
 
     void genZeroInitFltRegs(const regMaskTP& initFltRegs, const regMaskTP& initDblRegs, const regNumber& initReg);
 
-    regNumber genGetZeroReg(regNumber initReg, bool* pInitRegZeroed);
+    regNumber genGetZeroReg(regNumber initReg, bool* pInitRegModified);
 
-    void genZeroInitFrame(int untrLclHi, int untrLclLo, regNumber initReg, bool* pInitRegZeroed);
+    void genZeroInitFrame(int untrLclHi, int untrLclLo, regNumber initReg, bool* pInitRegModified);
 
-    void genReportGenericContextArg(regNumber initReg, bool* pInitRegZeroed);
+    void genReportGenericContextArg(regNumber initReg, bool* pInitRegModified);
 
-    void genSetGSSecurityCookie(regNumber initReg, bool* pInitRegZeroed);
+    void genSetGSSecurityCookie(regNumber initReg, bool* pInitRegModified);
 
     void genFinalizeFrame();
 
 #ifdef PROFILING_SUPPORTED
-    void genProfilingEnterCallback(regNumber initReg, bool* pInitRegZeroed);
+    void genProfilingEnterCallback(regNumber initReg, bool* pInitRegModified);
     void genProfilingLeaveCallback(unsigned helper = CORINFO_HELP_PROF_FCN_LEAVE);
 #endif // PROFILING_SUPPORTED
 
@@ -479,7 +479,7 @@ protected:
     void genFuncletEpilog();
     void genCaptureFuncletPrologEpilogInfo();
 
-    void genSetPSPSym(regNumber initReg, bool* pInitRegZeroed);
+    void genSetPSPSym(regNumber initReg, bool* pInitRegModified);
 
     void genUpdateCurrentFunclet(BasicBlock* block);
 #if defined(_TARGET_ARM_)

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -572,13 +572,13 @@ void CodeGen::genSetRegToIcon(regNumber reg, ssize_t val, var_types type, insFla
 //
 // Arguments:
 //     initReg        - register to use as a scratch register
-//     pInitRegZeroed - OUT parameter. *pInitRegZeroed is set to 'false' if and only if
+//     pInitRegModified - OUT parameter. *pInitRegModified set to 'true' if and only if
 //                      this call sets 'initReg' to a non-zero value.
 //
 // Return Value:
 //     None
 //
-void CodeGen::genSetGSSecurityCookie(regNumber initReg, bool* pInitRegZeroed)
+void CodeGen::genSetGSSecurityCookie(regNumber initReg, bool* pInitRegModified)
 {
     assert(compiler->compGeneratingProlog);
 
@@ -602,7 +602,7 @@ void CodeGen::genSetGSSecurityCookie(regNumber initReg, bool* pInitRegZeroed)
         getEmitter()->emitIns_S_R(INS_str, EA_PTRSIZE, initReg, compiler->lvaGSSecurityCookie, 0);
     }
 
-    *pInitRegZeroed = false;
+    *pInitRegModified = true;
 }
 
 //---------------------------------------------------------------------
@@ -3859,7 +3859,7 @@ void CodeGen::genStructReturn(GenTree* treeNode)
 //      happen immediately before calling this function, so the SP at the current location has already
 //      been touched.
 //
-void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pInitRegZeroed, regMaskTP maskArgRegsLiveIn)
+void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pInitRegModified, regMaskTP maskArgRegsLiveIn)
 {
     assert(compiler->compGeneratingProlog);
 
@@ -3909,7 +3909,7 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
             instGen_Set_Reg_To_Imm(EA_PTRSIZE, initReg, -(ssize_t)probeOffset);
             getEmitter()->emitIns_R_R_R(INS_ldr, EA_4BYTE, rTemp, REG_SPBASE, initReg);
             regSet.verifyRegUsed(initReg);
-            *pInitRegZeroed = false; // The initReg does not contain zero
+            *pInitRegModified = true; // The initReg does not contain zero
 
 #ifdef _TARGET_ARM64_
             lastTouchDelta -= pageSize;
@@ -4003,7 +4003,7 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
         getEmitter()->emitIns_R_R(INS_cmp, EA_PTRSIZE, rLimit, rOffset); // If equal, we need to probe again
         getEmitter()->emitIns_J(INS_bls, NULL, -4);
 
-        *pInitRegZeroed = false; // The initReg does not contain zero
+        *pInitRegModified = true; // The initReg does not contain zero
 
         compiler->unwindPadding();
 
@@ -4025,7 +4025,7 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
         compiler->unwindPadding();
 
         regSet.verifyRegUsed(initReg);
-        *pInitRegZeroed = false; // The initReg does not contain zero
+        *pInitRegModified = true; // The initReg does not contain zero
     }
 #endif // _TARGET_ARM64_
 

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -54,13 +54,13 @@ void CodeGen::genSetRegToIcon(regNumber reg, ssize_t val, var_types type, insFla
 //
 // Arguments:
 //     initReg        - register to use as a scratch register
-//     pInitRegZeroed - OUT parameter. *pInitRegZeroed is set to 'false' if and only if
+//     pInitRegModified - OUT parameter. *pInitRegModified is set to 'true' if and only if
 //                      this call sets 'initReg' to a non-zero value.
 //
 // Return Value:
 //     None
 //
-void CodeGen::genSetGSSecurityCookie(regNumber initReg, bool* pInitRegZeroed)
+void CodeGen::genSetGSSecurityCookie(regNumber initReg, bool* pInitRegModified)
 {
     assert(compiler->compGeneratingProlog);
 
@@ -78,7 +78,7 @@ void CodeGen::genSetGSSecurityCookie(regNumber initReg, bool* pInitRegZeroed)
             // initReg = #GlobalSecurityCookieVal64; [frame.GSSecurityCookie] = initReg
             genSetRegToIcon(initReg, compiler->gsGlobalSecurityCookieVal, TYP_I_IMPL);
             getEmitter()->emitIns_S_R(INS_mov, EA_PTRSIZE, initReg, compiler->lvaGSSecurityCookie, 0);
-            *pInitRegZeroed = false;
+            *pInitRegModified = true;
         }
         else
 #endif
@@ -99,7 +99,7 @@ void CodeGen::genSetGSSecurityCookie(regNumber initReg, bool* pInitRegZeroed)
         getEmitter()->emitIns_S_R(INS_mov, EA_PTRSIZE, REG_EAX, compiler->lvaGSSecurityCookie, 0);
         if (initReg == REG_EAX)
         {
-            *pInitRegZeroed = false;
+            *pInitRegModified = true;
         }
     }
 }
@@ -2217,7 +2217,7 @@ void CodeGen::genMultiRegCallStoreToLocal(GenTree* treeNode)
 //------------------------------------------------------------------------
 // genAllocLclFrame: Probe the stack and allocate the local stack frame: subtract from SP.
 //
-void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pInitRegZeroed, regMaskTP maskArgRegsLiveIn)
+void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pInitRegModified, regMaskTP maskArgRegsLiveIn)
 {
     assert(compiler->compGeneratingProlog);
 
@@ -2389,7 +2389,7 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
 
 #endif // _TARGET_UNIX_
 
-        *pInitRegZeroed = false; // The initReg does not contain zero
+        *pInitRegModified = true; // The initReg does not contain zero
 
         if (pushedStubParam)
         {


### PR DESCRIPTION
Renamed pInitRegZeroed to pInitRegModified. Reversed assignment of boolean values to accommodate renaming.

Fix #24985

Out of curiosity have a question why *pInitRegZeroed is set to false after rAddr           = initReg assignment (line 6125 of this pull request).

