### PR TITLE
Arm64 restore d8-d15 in ThrowExceptionFromContextInternal

### DIFF
--- a/src/pal/src/arch/arm64/exceptionhelper.S
+++ b/src/pal/src/arch/arm64/exceptionhelper.S
@@ -31,6 +31,18 @@ LEAF_ENTRY ThrowExceptionFromContextInternal, _TEXT
     ldp x26,x27, [x0, #(CONTEXT_X26)]
     ldp x28,fp,  [x0, #(CONTEXT_X28)]
     ldr lr,      [x0, #(CONTEXT_Pc)]
+
+    // Restore the lower 64 bits of v8-v15
+    add x2, x0,  CONTEXT_NEON_OFFSET
+    ldr d8,      [x2, #(CONTEXT_V8 )]
+    ldr d9,      [x2, #(CONTEXT_V9 )]
+    ldr d10,     [x2, #(CONTEXT_V10)]
+    ldr d11,     [x2, #(CONTEXT_V11)]
+    ldr d12,     [x2, #(CONTEXT_V12)]
+    ldr d13,     [x2, #(CONTEXT_V13)]
+    ldr d14,     [x2, #(CONTEXT_V14)]
+    ldr d15,     [x2, #(CONTEXT_V15)]
+
     ldr x2,      [x0, #(CONTEXT_Sp)]
     mov sp, x2
 


### PR DESCRIPTION
This is either a bug or needs a comment why we never have to restore these registers when throwing from a context.