### PR TITLE
Temporarily make a default interface method test incompatible for GCStress

### DIFF
--- a/tests/src/Loader/classloader/DefaultInterfaceMethods/sharedgenerics/sharedgenerics_d.ilproj
+++ b/tests/src/Loader/classloader/DefaultInterfaceMethods/sharedgenerics/sharedgenerics_d.ilproj
@@ -15,6 +15,8 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
+    <!-- See https://github.com/dotnet/coreclr/issues/25690 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/src/Loader/classloader/DefaultInterfaceMethods/sharedgenerics/sharedgenerics_r.ilproj
+++ b/tests/src/Loader/classloader/DefaultInterfaceMethods/sharedgenerics/sharedgenerics_r.ilproj
@@ -15,6 +15,8 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
+    <!-- See https://github.com/dotnet/coreclr/issues/25690 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Related to https://github.com/dotnet/coreclr/issues/25690
Port of https://github.com/dotnet/coreclr/pull/25746

To make test run with GCStress clean for 3.0. Issue will be fixed separately in master.