### PR TITLE
Arm64 support SIMD registers context to/from native context

### DIFF
--- a/src/pal/src/thread/context.cpp
+++ b/src/pal/src/thread/context.cpp
@@ -465,6 +465,17 @@ void CONTEXTToNativeContext(CONST CONTEXT *lpContext, native_context_t *native)
         {
             FPREG_Xmm(native, i) = lpContext->FltSave.XmmRegisters[i];
         }
+#elif defined(_ARM64_)
+        fpsimd_context* fp = GetNativeSigSimdContext(native);
+        if (fp)
+        {
+            fp->fpsr = lpContext->Fpsr;
+            fp->fpcr = lpContext->Fpcr;
+            for (int i = 0; i < 32; i++)
+            {
+                *(NEON128*) &fp->vregs[i] = lpContext->V[i];
+            }
+        }
 #endif
     }
 
@@ -562,6 +573,17 @@ void CONTEXTFromNativeContext(const native_context_t *native, LPCONTEXT lpContex
         for (int i = 0; i < 16; i++)
         {
             lpContext->FltSave.XmmRegisters[i] = FPREG_Xmm(native, i);
+        }
+#elif defined(_ARM64_)
+        const fpsimd_context* fp = GetConstNativeSigSimdContext(native);
+        if (fp)
+        {
+            lpContext->Fpsr = fp->fpsr;
+            lpContext->Fpcr = fp->fpcr;
+            for (int i = 0; i < 32; i++)
+            {
+                lpContext->V[i] = *(NEON128*) &fp->vregs[i];
+            }
         }
 #endif
     }


### PR DESCRIPTION
This is my draft of the FPSIMD_MAGIG change for arm64.

It compiles. I haven't started debugging it.

It may need stylistic feedback.