### PR TITLE
Delay Diagnostics IPC response till after EventPipe::Enable has completed

### DIFF
--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -281,11 +281,12 @@ void EventPipe::StartStreaming(EventPipeSessionID id)
         MODE_ANY;
     }
     CONTRACTL_END;
-    
+
+    CrstHolder _crst(GetLock());
+
     if (!IsSessionIdInCollection(id))
         return;
 
-    // If the session was not found, then there is nothing else to do.
     EventPipeSession *const pSession = reinterpret_cast<EventPipeSession *>(id);
 
     pSession->Enable();

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -269,10 +269,26 @@ bool EventPipe::EnableInternal(
     // Enable the sample profiler
     SampleProfiler::Enable(pEventPipeProviderCallbackDataQueue);
 
-    // Enable the session.
-    pSession->Enable();
-
     return true;
+}
+
+void EventPipe::StartStreaming(EventPipeSessionID id)
+{
+    CONTRACTL
+    {
+        THROWS;
+        GC_TRIGGERS;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
+    
+    if (!IsSessionIdInCollection(id))
+        return;
+
+    // If the session was not found, then there is nothing else to do.
+    EventPipeSession *const pSession = reinterpret_cast<EventPipeSession *>(id);
+
+    pSession->Enable();
 }
 
 void EventPipe::Disable(EventPipeSessionID id)

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -289,7 +289,7 @@ void EventPipe::StartStreaming(EventPipeSessionID id)
 
     EventPipeSession *const pSession = reinterpret_cast<EventPipeSession *>(id);
 
-    pSession->Enable();
+    pSession->StartStreaming();
 }
 
 void EventPipe::Disable(EventPipeSessionID id)

--- a/src/vm/eventpipe.h
+++ b/src/vm/eventpipe.h
@@ -67,6 +67,10 @@ public:
     // Get the session for the specified session ID.
     static EventPipeSession *GetSession(EventPipeSessionID id);
 
+    // start sending the required events down the pipe
+    // starting with file header info and then buffered events
+    static void StartStreaming(EventPipeSessionID id);
+
     // Specifies whether or not the event pipe is enabled.
     static bool Enabled()
     {

--- a/src/vm/eventpipefile.cpp
+++ b/src/vm/eventpipefile.cpp
@@ -77,7 +77,8 @@ DWORD GetFileMinVersion(EventPipeSerializationFormat format)
 }
 
 EventPipeFile::EventPipeFile(StreamWriter *pStreamWriter, EventPipeSerializationFormat format) :
-    FastSerializableObject(GetFileVersion(format), GetFileMinVersion(format), format >= EventPipeSerializationFormat::NetTraceV4)
+    FastSerializableObject(GetFileVersion(format), GetFileMinVersion(format), format >= EventPipeSerializationFormat::NetTraceV4), 
+    m_pStreamWriter(pStreamWriter)
 {
     CONTRACTL
     {
@@ -88,7 +89,6 @@ EventPipeFile::EventPipeFile(StreamWriter *pStreamWriter, EventPipeSerialization
     CONTRACTL_END;
 
     m_format = format;
-    m_pStreamWriter = pStreamWriter;
     m_pBlock = new EventPipeEventBlock(100 * 1024, format);
     m_pMetadataBlock = new EventPipeMetadataBlock(100 * 1024);
     m_pStackBlock = new EventPipeStackBlock(100 * 1024);
@@ -134,6 +134,7 @@ void EventPipeFile::InitializeFile()
         THROWS;
         GC_TRIGGERS;
         MODE_PREEMPTIVE;
+        PRECONDITION(m_pStreamWriter != nullptr);
     }
     CONTRACTL_END;
 
@@ -258,6 +259,7 @@ void EventPipeFile::WriteSequencePoint(EventPipeSequencePoint* pSequencePoint)
         GC_NOTRIGGER;
         MODE_ANY;
         PRECONDITION(pSequencePoint != nullptr);
+        PRECONDITION(m_pSerializer != nullptr);
     }
     CONTRACTL_END;
 
@@ -292,6 +294,10 @@ void EventPipeFile::Flush(FlushFlags flags)
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
+        PRECONDITION(m_pSerializer != nullptr);
+        PRECONDITION(m_pMetadataBlock != nullptr);
+        PRECONDITION(m_pStackBlock != nullptr);
+        PRECONDITION(m_pBlock != nullptr);
     }
     CONTRACTL_END;
 
@@ -352,6 +358,8 @@ void EventPipeFile::WriteEventToBlock(EventPipeEventInstance &instance,
         THROWS;
         GC_NOTRIGGER;
         MODE_ANY;
+        PRECONDITION(m_pBlock != nullptr);
+        PRECONDITION(m_pMetadataBlock != nullptr);
     }
     CONTRACTL_END;
 
@@ -407,6 +415,7 @@ unsigned int EventPipeFile::GetMetadataId(EventPipeEvent &event)
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
+        PRECONDITION(m_pMetadataIds != nullptr);
     }
     CONTRACTL_END;
 
@@ -428,6 +437,7 @@ void EventPipeFile::SaveMetadataId(EventPipeEvent &event, unsigned int metadataI
         GC_NOTRIGGER;
         MODE_ANY;
         PRECONDITION(metadataId > 0);
+        PRECONDITION(m_pMetadataIds != nullptr);
     }
     CONTRACTL_END;
 
@@ -448,6 +458,7 @@ unsigned int EventPipeFile::GetStackId(EventPipeEventInstance &instance)
         GC_NOTRIGGER;
         MODE_ANY;
         PRECONDITION(m_format >= EventPipeSerializationFormat::NetTraceV4);
+        PRECONDITION(m_pStackBlock != nullptr);
     }
     CONTRACTL_END;
 

--- a/src/vm/eventpipefile.cpp
+++ b/src/vm/eventpipefile.cpp
@@ -205,6 +205,8 @@ void EventPipeFile::WriteEvent(EventPipeEventInstance &instance, ULONGLONG captu
     }
     CONTRACTL_END;
 
+    ASSERT(m_isInitialized);
+
 #ifdef DEBUG
     _ASSERTE(instance.GetTimeStamp()->QuadPart >= m_lastSortedTimestamp.QuadPart);
     if (isSortedEvent)
@@ -250,6 +252,8 @@ void EventPipeFile::WriteSequencePoint(EventPipeSequencePoint* pSequencePoint)
     }
     CONTRACTL_END;
 
+    ASSERT(m_isInitialized);
+
     if (m_format < EventPipeSerializationFormat::NetTraceV4)
     {
         // sequence points aren't used in NetPerf format
@@ -279,6 +283,9 @@ void EventPipeFile::Flush(FlushFlags flags)
         MODE_ANY;
     }
     CONTRACTL_END;
+
+    ASSERT(m_isInitialized);
+
     // we write current blocks to the disk, whether they are full or not
     if ((m_pMetadataBlock->GetBytesWritten() != 0) && ((flags & FlushMetadataBlock) != 0))
     {
@@ -309,6 +316,8 @@ void EventPipeFile::WriteEnd()
     }
     CONTRACTL_END;
 
+    ASSERT(m_isInitialized);
+
     Flush();
 
     // "After the last EventBlock is emitted, the stream is ended by emitting a NullReference Tag which indicates that there are no more objects in the stream to read."
@@ -330,6 +339,8 @@ void EventPipeFile::WriteEventToBlock(EventPipeEventInstance &instance,
         MODE_ANY;
     }
     CONTRACTL_END;
+
+    ASSERT(m_isInitialized);
 
     instance.SetMetadataId(metadataId);
 

--- a/src/vm/eventpipefile.cpp
+++ b/src/vm/eventpipefile.cpp
@@ -148,14 +148,20 @@ void EventPipeFile::InitializeFile()
     {
         // Create the file stream and write the FastSerialization header.
         m_pSerializer = new FastSerializer(m_pStreamWriter);
+        
+        // Write the first object to the file.
+        m_pSerializer->WriteObject(this);
+#ifdef DEBUG
+        m_isInitialized = true;
+#endif
     }
     else
     {
         m_pSerializer = nullptr;
+#ifdef DEBUG
+        m_isInitialized = false;
+#endif
     }
-    // Write the first object to the file.
-    m_pSerializer->WriteObject(this);
-    m_isInitialized = true;
 }
 
 EventPipeFile::~EventPipeFile()
@@ -205,9 +211,8 @@ void EventPipeFile::WriteEvent(EventPipeEventInstance &instance, ULONGLONG captu
     }
     CONTRACTL_END;
 
-    ASSERT(m_isInitialized);
-
 #ifdef DEBUG
+    ASSERT(m_isInitialized);
     _ASSERTE(instance.GetTimeStamp()->QuadPart >= m_lastSortedTimestamp.QuadPart);
     if (isSortedEvent)
     {
@@ -252,7 +257,9 @@ void EventPipeFile::WriteSequencePoint(EventPipeSequencePoint* pSequencePoint)
     }
     CONTRACTL_END;
 
+#ifdef DEBUG
     ASSERT(m_isInitialized);
+#endif
 
     if (m_format < EventPipeSerializationFormat::NetTraceV4)
     {
@@ -284,7 +291,9 @@ void EventPipeFile::Flush(FlushFlags flags)
     }
     CONTRACTL_END;
 
+#ifdef DEBUG
     ASSERT(m_isInitialized);
+#endif
 
     // we write current blocks to the disk, whether they are full or not
     if ((m_pMetadataBlock->GetBytesWritten() != 0) && ((flags & FlushMetadataBlock) != 0))
@@ -316,7 +325,9 @@ void EventPipeFile::WriteEnd()
     }
     CONTRACTL_END;
 
+#ifdef DEBUG
     ASSERT(m_isInitialized);
+#endif
 
     Flush();
 
@@ -340,7 +351,9 @@ void EventPipeFile::WriteEventToBlock(EventPipeEventInstance &instance,
     }
     CONTRACTL_END;
 
+#ifdef DEBUG
     ASSERT(m_isInitialized);
+#endif
 
     instance.SetMetadataId(metadataId);
 

--- a/src/vm/eventpipefile.cpp
+++ b/src/vm/eventpipefile.cpp
@@ -78,7 +78,8 @@ DWORD GetFileMinVersion(EventPipeSerializationFormat format)
 
 EventPipeFile::EventPipeFile(StreamWriter *pStreamWriter, EventPipeSerializationFormat format) :
     FastSerializableObject(GetFileVersion(format), GetFileMinVersion(format), format >= EventPipeSerializationFormat::NetTraceV4), 
-    m_pStreamWriter(pStreamWriter)
+    m_pStreamWriter(pStreamWriter),
+    m_pSerializer(nullptr)
 {
     CONTRACTL
     {
@@ -135,6 +136,7 @@ void EventPipeFile::InitializeFile()
         GC_TRIGGERS;
         MODE_PREEMPTIVE;
         PRECONDITION(m_pStreamWriter != nullptr);
+        PRECONDITION(m_pSerializer == nullptr);
     }
     CONTRACTL_END;
 
@@ -148,14 +150,10 @@ void EventPipeFile::InitializeFile()
     if (fSuccess)
     {
         // Create the file stream and write the FastSerialization header.
-        m_pSerializer = new FastSerializer(m_pStreamWriter);
+        m_pSerializer = new (nothrow) FastSerializer(m_pStreamWriter);
         
         // Write the first object to the file.
         m_pSerializer->WriteObject(this);
-    }
-    else
-    {
-        m_pSerializer = nullptr;
     }
 }
 

--- a/src/vm/eventpipefile.cpp
+++ b/src/vm/eventpipefile.cpp
@@ -187,6 +187,10 @@ EventPipeFile::~EventPipeFile()
     delete m_pStackBlock;
     delete m_pSerializer;
     delete m_pMetadataIds;
+
+#ifdef DEBUG
+        m_isInitialized = false;
+#endif
 }
 
 EventPipeSerializationFormat EventPipeFile::GetSerializationFormat() const

--- a/src/vm/eventpipefile.cpp
+++ b/src/vm/eventpipefile.cpp
@@ -150,7 +150,7 @@ void EventPipeFile::InitializeFile()
     if (fSuccess)
     {
         // Create the file stream and write the FastSerialization header.
-        m_pSerializer = new (nothrow) FastSerializer(m_pStreamWriter);
+        m_pSerializer = new FastSerializer(m_pStreamWriter);
         
         // Write the first object to the file.
         m_pSerializer->WriteObject(this);

--- a/src/vm/eventpipefile.cpp
+++ b/src/vm/eventpipefile.cpp
@@ -77,9 +77,9 @@ DWORD GetFileMinVersion(EventPipeSerializationFormat format)
 }
 
 EventPipeFile::EventPipeFile(StreamWriter *pStreamWriter, EventPipeSerializationFormat format) :
-    FastSerializableObject(GetFileVersion(format), GetFileMinVersion(format), format >= EventPipeSerializationFormat::NetTraceV4), 
-    m_pStreamWriter(pStreamWriter),
-    m_pSerializer(nullptr)
+    FastSerializableObject(GetFileVersion(format), GetFileMinVersion(format), format >= EventPipeSerializationFormat::NetTraceV4),
+    m_pSerializer(nullptr),
+    m_pStreamWriter(pStreamWriter)
 {
     CONTRACTL
     {

--- a/src/vm/eventpipefile.cpp
+++ b/src/vm/eventpipefile.cpp
@@ -131,9 +131,9 @@ void EventPipeFile::InitializeFile()
 {
     CONTRACTL
     {
-        NOTHROW;
+        THROWS;
         GC_TRIGGERS;
-        MODE_ANY;
+        MODE_PREEMPTIVE;
     }
     CONTRACTL_END;
 

--- a/src/vm/eventpipefile.cpp
+++ b/src/vm/eventpipefile.cpp
@@ -152,16 +152,10 @@ void EventPipeFile::InitializeFile()
         
         // Write the first object to the file.
         m_pSerializer->WriteObject(this);
-#ifdef DEBUG
-        m_isInitialized = true;
-#endif
     }
     else
     {
         m_pSerializer = nullptr;
-#ifdef DEBUG
-        m_isInitialized = false;
-#endif
     }
 }
 
@@ -188,10 +182,6 @@ EventPipeFile::~EventPipeFile()
     delete m_pStackBlock;
     delete m_pSerializer;
     delete m_pMetadataIds;
-
-#ifdef DEBUG
-        m_isInitialized = false;
-#endif
 }
 
 EventPipeSerializationFormat EventPipeFile::GetSerializationFormat() const
@@ -213,11 +203,11 @@ void EventPipeFile::WriteEvent(EventPipeEventInstance &instance, ULONGLONG captu
         THROWS;
         GC_NOTRIGGER;
         MODE_ANY;
+        PRECONDITION(!HasErrors());
     }
     CONTRACTL_END;
 
 #ifdef DEBUG
-    ASSERT(m_isInitialized);
     _ASSERTE(instance.GetTimeStamp()->QuadPart >= m_lastSortedTimestamp.QuadPart);
     if (isSortedEvent)
     {
@@ -259,13 +249,9 @@ void EventPipeFile::WriteSequencePoint(EventPipeSequencePoint* pSequencePoint)
         GC_NOTRIGGER;
         MODE_ANY;
         PRECONDITION(pSequencePoint != nullptr);
-        PRECONDITION(m_pSerializer != nullptr);
+        PRECONDITION(!HasErrors());
     }
     CONTRACTL_END;
-
-#ifdef DEBUG
-    ASSERT(m_isInitialized);
-#endif
 
     if (m_format < EventPipeSerializationFormat::NetTraceV4)
     {
@@ -294,16 +280,12 @@ void EventPipeFile::Flush(FlushFlags flags)
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        PRECONDITION(m_pSerializer != nullptr);
+        PRECONDITION(!HasErrors());
         PRECONDITION(m_pMetadataBlock != nullptr);
         PRECONDITION(m_pStackBlock != nullptr);
         PRECONDITION(m_pBlock != nullptr);
     }
     CONTRACTL_END;
-
-#ifdef DEBUG
-    ASSERT(m_isInitialized);
-#endif
 
     // we write current blocks to the disk, whether they are full or not
     if ((m_pMetadataBlock->GetBytesWritten() != 0) && ((flags & FlushMetadataBlock) != 0))
@@ -332,12 +314,9 @@ void EventPipeFile::WriteEnd()
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
+        PRECONDITION(!HasErrors());
     }
     CONTRACTL_END;
-
-#ifdef DEBUG
-    ASSERT(m_isInitialized);
-#endif
 
     Flush();
 
@@ -362,10 +341,6 @@ void EventPipeFile::WriteEventToBlock(EventPipeEventInstance &instance,
         PRECONDITION(m_pMetadataBlock != nullptr);
     }
     CONTRACTL_END;
-
-#ifdef DEBUG
-    ASSERT(m_isInitialized);
-#endif
 
     instance.SetMetadataId(metadataId);
 

--- a/src/vm/eventpipefile.h
+++ b/src/vm/eventpipefile.h
@@ -75,6 +75,7 @@ public:
     EventPipeFile(StreamWriter *pStreamWriter, EventPipeSerializationFormat format);
     ~EventPipeFile();
 
+    void InitializeFile();
     EventPipeSerializationFormat GetSerializationFormat() const;
     void WriteEvent(EventPipeEventInstance &instance, ULONGLONG captureThreadId, unsigned int sequenceNumber, BOOL isSortedEvent);
     void WriteSequencePoint(EventPipeSequencePoint* pSequencePoint);
@@ -153,6 +154,8 @@ private:
     // The frequency of the timestamps used for this file.
     LARGE_INTEGER m_timeStampFrequency;
 
+    StreamWriter *m_pStreamWriter;
+
     unsigned int m_pointerSize;
 
     unsigned int m_currentProcessId;
@@ -169,6 +172,10 @@ private:
     MapSHashWithRemove<EventPipeEvent *, unsigned int> *m_pMetadataIds;
 
     Volatile<LONG> m_metadataIdCounter;
+
+    // Indicates whether the file has been initialized,
+    // e.g., has the header been sent to the stream?
+    Volatile<BOOL> m_isInitialized;
 
     unsigned int m_stackIdCounter;
     EventPipeStackHash m_stackHash;

--- a/src/vm/eventpipefile.h
+++ b/src/vm/eventpipefile.h
@@ -177,10 +177,6 @@ private:
     EventPipeStackHash m_stackHash;
 #ifdef DEBUG
     LARGE_INTEGER m_lastSortedTimestamp;
-
-    // Indicates whether the file has been initialized,
-    // e.g., has the header been sent to the stream?
-    BOOL m_isInitialized;
 #endif
 };
 

--- a/src/vm/eventpipefile.h
+++ b/src/vm/eventpipefile.h
@@ -173,14 +173,14 @@ private:
 
     Volatile<LONG> m_metadataIdCounter;
 
-    // Indicates whether the file has been initialized,
-    // e.g., has the header been sent to the stream?
-    Volatile<BOOL> m_isInitialized;
-
     unsigned int m_stackIdCounter;
     EventPipeStackHash m_stackHash;
 #ifdef DEBUG
     LARGE_INTEGER m_lastSortedTimestamp;
+
+    // Indicates whether the file has been initialized,
+    // e.g., has the header been sent to the stream?
+    BOOL m_isInitialized;
 #endif
 };
 

--- a/src/vm/eventpipefile.h
+++ b/src/vm/eventpipefile.h
@@ -154,7 +154,7 @@ private:
     // The frequency of the timestamps used for this file.
     LARGE_INTEGER m_timeStampFrequency;
 
-    StreamWriter *m_pStreamWriter;
+    StreamWriter * const m_pStreamWriter;
 
     unsigned int m_pointerSize;
 

--- a/src/vm/eventpipeinternal.cpp
+++ b/src/vm/eventpipeinternal.cpp
@@ -48,6 +48,7 @@ UINT64 QCALLTYPE EventPipeInternal::Enable(
             format,
             true,
             nullptr);
+        EventPipe::StartStreaming(sessionID);
     }
     END_QCALL;
 

--- a/src/vm/eventpipesession.cpp
+++ b/src/vm/eventpipesession.cpp
@@ -365,6 +365,7 @@ CLREvent *EventPipeSession::GetWaitEvent()
     return m_pBufferManager->GetWaitEvent();
 }
 
+// MUST be called AFTER sending the IPC response
 void EventPipeSession::Enable()
 {
     CONTRACTL
@@ -376,6 +377,8 @@ void EventPipeSession::Enable()
         PRECONDITION(EventPipe::IsLockOwnedByCurrentThread());
     }
     CONTRACTL_END;
+
+    m_pFile->InitializeFile();
 
     if (m_SessionType == EventPipeSessionType::IpcStream)
         CreateIpcStreamingThread();

--- a/src/vm/eventpipesession.cpp
+++ b/src/vm/eventpipesession.cpp
@@ -365,8 +365,7 @@ CLREvent *EventPipeSession::GetWaitEvent()
     return m_pBufferManager->GetWaitEvent();
 }
 
-// MUST be called AFTER sending the IPC response
-void EventPipeSession::Enable()
+void EventPipeSession::StartStreaming()
 {
     CONTRACTL
     {

--- a/src/vm/eventpipesession.h
+++ b/src/vm/eventpipesession.h
@@ -208,7 +208,11 @@ public:
     CLREvent *GetWaitEvent();
 
     // Enable a session in the event pipe.
-    void Enable();
+    // MUST be called AFTER sending the IPC response
+    // Side effects:
+    // - sends file header information for nettrace format
+    // - turns on IpcStreaming thread which flushes events to stream
+    void StartStreaming();
 
     // Disable a session in the event pipe.
     // side-effects: writes all buffers to stream/file

--- a/src/vm/fastserializer.cpp
+++ b/src/vm/fastserializer.cpp
@@ -27,10 +27,6 @@ IpcStreamWriter::IpcStreamWriter(uint64_t id, IpcStream *pStream) : _pStream(pSt
 
     if (_pStream == nullptr)
         return;
-
-    DiagnosticsIpc::IpcMessage successResponse;
-    if (successResponse.Initialize(DiagnosticsIpc::GenericSuccessHeader, id))
-        successResponse.Send(pStream);
 }
 
 IpcStreamWriter::~IpcStreamWriter()


### PR DESCRIPTION
This change refactors all unbuffered pipe writing (calls to `IpcStream::Write`) into their own functions, allowing `EventPipe::Enable` to run to completion without writing anything to the pipe.  This makes it possible to send the IPC response _after_ all the provider callbacks have been called.  This is a non-breaking change and should fix the reason for `SentinelEventSource` in `tests/src/eventpipe/common/IpcTraceTest.cs`.

resolves #25738