### PR TITLE
Code cleanup in binder

### DIFF
--- a/src/binder/assemblybinder.cpp
+++ b/src/binder/assemblybinder.cpp
@@ -592,12 +592,11 @@ namespace BINDER_SPACE
 #endif // FEATURE_VERSIONING_LOG
 
 
-                hr = BindByName(pApplicationContext,
+                IF_FAIL_GO(BindByName(pApplicationContext,
                                       pAssemblyName,
                                       BIND_CACHE_FAILURES,
                                       excludeAppPaths,
-                                      &bindResult);
-                IF_FAIL_GO(hr);
+                                      &bindResult));
             }
             else
             {
@@ -615,7 +614,7 @@ namespace BINDER_SPACE
                 BOOL fDoNgenExplicitBind = fNgenExplicitBind;
                 
                 // Only use explicit ngen binding in the new coreclr path-based binding model
-                if(!pApplicationContext->IsTpaListProvided())
+                if (!pApplicationContext->IsTpaListProvided())
                 {
                     fDoNgenExplicitBind = FALSE;
                 }
@@ -708,10 +707,10 @@ namespace BINDER_SPACE
         fExplicitBindToNativeImage = FALSE;
 #endif // FEATURE_NI_BIND_FALLBACK
         IF_FAIL_GO(AssemblyBinder::GetAssembly(sCoreLib,
-                                                   FALSE /* fInspectionOnly */,
-                                                   TRUE /* fIsInGAC */,
-                                                   fExplicitBindToNativeImage,
-                                                   &pSystemAssembly));
+                                               FALSE /* fInspectionOnly */,
+                                               TRUE /* fIsInGAC */,
+                                               fExplicitBindToNativeImage,
+                                               &pSystemAssembly));
         
         *ppSystemAssembly = pSystemAssembly.Extract();
 
@@ -948,7 +947,7 @@ namespace BINDER_SPACE
             IF_FAIL_GO(FUSION_E_INVALID_NAME);
         }
 
-       IF_FAIL_GO(BindLocked(pApplicationContext,
+        IF_FAIL_GO(BindLocked(pApplicationContext,
                               pAssemblyName,
                               dwBindFlags,
                               excludeAppPaths,
@@ -976,6 +975,7 @@ namespace BINDER_SPACE
                     goto LogExit;
                 }
             }
+
             hr = pApplicationContext->AddToFailureCache(assemblyDisplayName, hr);
         }
     LogExit:
@@ -1089,7 +1089,7 @@ namespace BINDER_SPACE
 #endif // !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
             else
             {
-                // Can't give higher serciving than already bound
+                // Can't give higher version than already bound
                 IF_FAIL_GO(IsValidAssemblyVersion(pAssemblyName, pContextEntry->GetAssemblyName(), pApplicationContext));
             }
             
@@ -1109,7 +1109,7 @@ namespace BINDER_SPACE
                 hr = IsValidAssemblyVersion(pAssemblyName, pBindResult->GetAssemblyName(), pApplicationContext);
                 if (FAILED(hr))
                 {
-                    pBindResult->SetNoResult();                    
+                    pBindResult->SetNoResult();
                 }
             }
         }
@@ -1287,7 +1287,7 @@ namespace BINDER_SPACE
     }
     
     /*
-     * BindByTpaList is the entry-point for the custom binding algorithm on the Phone.
+     * BindByTpaList is the entry-point for the custom binding algorithm in CoreCLR.
      * Platform assemblies are specified as a list of files.  This list is the only set of
      * assemblies that we will load as platform.  They can be specified as IL or NIs.
      *
@@ -1321,10 +1321,10 @@ namespace BINDER_SPACE
             //
             
             hr = BindSatelliteResourceByResourceRoots(pApplicationContext, 
-                                                            pApplicationContext->GetPlatformResourceRoots(), 
-                                                            pRequestedAssemblyName, 
-                                                            fInspectionOnly, 
-                                                            pBindResult);
+                                                      pApplicationContext->GetPlatformResourceRoots(), 
+                                                      pRequestedAssemblyName, 
+                                                      fInspectionOnly, 
+                                                      pBindResult);
             
             // We found a platform resource file with matching file name, but whose ref-def didn't match.  Fall
             // back to application resource lookup to handle case where a user creates resources with the same
@@ -1356,13 +1356,11 @@ namespace BINDER_SPACE
                 {
                     SString fileName(pTpaEntry->m_wszNIFileName);
 
-                    // A GetAssembly overload perhaps, or just another parameter to the existing method
                     hr = GetAssembly(fileName,
-                                        fInspectionOnly,
-                                        TRUE, /* fIsInGAC */
-                                        TRUE /* fExplicitBindToNativeImage */,
-                                        &pTPAAssembly
-                                        );
+                                     fInspectionOnly,
+                                     TRUE,  // fIsInGAC
+                                     TRUE,  // fExplicitBindToNativeImage
+                                     &pTPAAssembly);
                 }
                 else
                 {
@@ -1370,10 +1368,10 @@ namespace BINDER_SPACE
                     SString fileName(pTpaEntry->m_wszILFileName);
                     
                     hr = GetAssembly(fileName,
-                                        fInspectionOnly,
-                                        TRUE, /* fIsInGAC */
-                                        FALSE /* fExplicitBindToNativeImage */,
-                                        &pTPAAssembly);
+                                     fInspectionOnly,
+                                     TRUE,  // fIsInGAC
+                                     FALSE, // fExplicitBindToNativeImage
+                                     &pTPAAssembly);
                 }
 
                 // On file not found, simply fall back to app path probing
@@ -1390,7 +1388,7 @@ namespace BINDER_SPACE
                     }
                     else
                     {
-                        // We found the assembly on TPA but it didnt match the RequestedAssembly assembly-name. In this case, lets proceed to see if we find the requested
+                        // We found the assembly on TPA but it didn't match the RequestedAssembly assembly-name. In this case, lets proceed to see if we find the requested
                         // assembly in the App paths.
                         fPartialMatchOnTpa = true;
                     }
@@ -1425,23 +1423,19 @@ namespace BINDER_SPACE
                             {
                                 fileName.Append(W(".ni.dll"));
                                 hr = GetAssembly(fileName,
-                                    fInspectionOnly,
-                                    FALSE, /* fIsInGAC */
-                                    TRUE /* fExplicitBindToNativeImage */,
-                                    &pAssembly);
+                                                 fInspectionOnly,
+                                                 FALSE, // fIsInGAC
+                                                 TRUE,  // fExplicitBindToNativeImage
+                                                 &pAssembly);
                             }
                             else
                             {
-                                if (FAILED(hr))
-                                {
-                                    fileName.Append(W(".dll"));
-
-                                    hr = GetAssembly(fileName,
-                                        fInspectionOnly,
-                                        FALSE, /* fIsInGAC */
-                                        FALSE /* fExplicitBindToNativeImage */,
-                                        &pAssembly);
-                                }
+                                fileName.Append(W(".dll"));
+                                hr = GetAssembly(fileName,
+                                                 fInspectionOnly,
+                                                 FALSE, // fIsInGAC
+                                                 FALSE, // fExplicitBindToNativeImage
+                                                 &pAssembly);
                             }
                         }
 
@@ -1454,23 +1448,19 @@ namespace BINDER_SPACE
                             {
                                 fileName.Append(W(".ni.exe"));
                                 hr = GetAssembly(fileName,
-                                    fInspectionOnly,
-                                    FALSE, /* fIsInGAC */
-                                    TRUE /* fExplicitBindToNativeImage */,
-                                    &pAssembly);
+                                                 fInspectionOnly,
+                                                 FALSE, // fIsInGAC
+                                                 TRUE,  // fExplicitBindToNativeImage
+                                                 &pAssembly);
                             }
                             else
                             {
-                                if (FAILED(hr))
-                                {
-                                    fileName.Append(W(".exe"));
-
-                                    hr = GetAssembly(fileName,
-                                        fInspectionOnly,
-                                        FALSE, /* fIsInGAC */
-                                        FALSE /* fExplicitBindToNativeImage */,
-                                        &pAssembly);
-                                }
+                                fileName.Append(W(".exe"));
+                                hr = GetAssembly(fileName,
+                                                 fInspectionOnly,
+                                                 FALSE, // fIsInGAC
+                                                 FALSE, // fExplicitBindToNativeImage
+                                                 &pAssembly);
                             }
                         }
 
@@ -1511,7 +1501,7 @@ namespace BINDER_SPACE
                             }
                             else
                             {
-                                // We didnt see this assembly on TPA - so simply bind to the app instance.
+                                // We didn't see this assembly on TPA - so simply bind to the app instance.
                                 pBindResult->SetResult(pAssembly);
                                 GO_WITH_HRESULT(S_OK);
                             }
@@ -1613,7 +1603,7 @@ namespace BINDER_SPACE
             }
 
             BINDER_LOG_ENTER(W("BinderAcquireImport"));
-            if(pNativePEImage)
+            if (pNativePEImage)
                 hr = BinderAcquireImport(pNativePEImage, &pIMetaDataAssemblyImport, dwPAFlags, TRUE);
             else
                 hr = BinderAcquireImport(pPEImage, &pIMetaDataAssemblyImport, dwPAFlags, FALSE);
@@ -1650,7 +1640,7 @@ namespace BINDER_SPACE
             IF_FAIL_GO(TranslatePEToArchitectureType(dwPAFlags, &PeKind));
         }
 
-       // Initialize assembly object
+        // Initialize assembly object
         IF_FAIL_GO(pAssembly->Init(pIMetaDataAssemblyImport,
                                    PeKind,
                                    pPEImage,
@@ -1819,8 +1809,8 @@ namespace BINDER_SPACE
 #endif //CROSSGEN_COMPILE
 
 #if !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
-HRESULT AssemblyBinder::BindUsingHostAssemblyResolver (/* in */ INT_PTR pManagedAssemblyLoadContextToBindWithin,
-                                                       /* in */ AssemblyName       *pAssemblyName,
+HRESULT AssemblyBinder::BindUsingHostAssemblyResolver(/* in */ INT_PTR pManagedAssemblyLoadContextToBindWithin,
+                                                      /* in */ AssemblyName       *pAssemblyName,
                                                       /* in */ IAssemblyName      *pIAssemblyName,
                                                       /* in */ CLRPrivBinderCoreCLR *pTPABinder,
                                                       /* out */ Assembly           **ppAssembly)

--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -3818,9 +3818,9 @@ public:
 
 extern BOOL AreSameBinderInstance(ICLRPrivBinder *pBinderA, ICLRPrivBinder *pBinderB);
 
-DomainAssembly* AppDomain::LoadDomainAssembly( AssemblySpec* pSpec,
-                                                PEAssembly *pFile, 
-                                                FileLoadLevel targetLevel)
+DomainAssembly* AppDomain::LoadDomainAssembly(AssemblySpec* pSpec,
+                                              PEAssembly *pFile, 
+                                              FileLoadLevel targetLevel)
 {
     STATIC_CONTRACT_THROWS;
 
@@ -3837,7 +3837,7 @@ DomainAssembly* AppDomain::LoadDomainAssembly( AssemblySpec* pSpec,
     }
     EX_HOOK
     {
-        Exception* pEx=GET_EXCEPTION();
+        Exception* pEx = GET_EXCEPTION();
         if (!pEx->IsTransient())
         {
             // Setup the binder reference in AssemblySpec from the PEAssembly if one is not already set.
@@ -5174,15 +5174,12 @@ EndTry2:;
         HRESULT hrBindResult = S_OK;
         PEAssemblyHolder result;
         
-
         EX_TRY
         {
             if (!IsCached(pSpec))
             {
 
                 {
-                    bool fAddFileToCache = false;
-
                     // Use CoreClr's fusion alternative
                     CoreBindResult bindResult;
 
@@ -5203,18 +5200,11 @@ EndTry2:;
                             result = PEAssembly::Open(&bindResult,
                                                       FALSE);
                         }
-                        fAddFileToCache = true;
                         
                         // Setup the reference to the binder, which performed the bind, into the AssemblySpec
                         ICLRPrivBinder* pBinder = result->GetBindingContext();
                         _ASSERTE(pBinder != NULL);
                         pSpec->SetBindingContext(pBinder);
-                    }
-
-
-                    if (fAddFileToCache)
-                    {
-
 
                         if (pSpec->CanUseWithBindingCache() && result->CanUseWithBindingCache())
                         {
@@ -6575,205 +6565,195 @@ HRESULT RuntimeInvokeHostAssemblyResolver(INT_PTR pManagedAssemblyLoadContextToB
     
     HRESULT hr = E_FAIL;
 
-    // DevDiv #933506: Exceptions thrown during AssemblyLoadContext.Load should propagate
-    // EX_TRY
+    // Switch to COOP mode since we are going to work with managed references
+    GCX_COOP();
+        
+    struct 
     {
-        // Switch to COOP mode since we are going to work with managed references
-        GCX_COOP();
+        ASSEMBLYNAMEREF oRefAssemblyName;
+        ASSEMBLYREF oRefLoadedAssembly;
+    } _gcRefs;
         
-        struct 
-        {
-            ASSEMBLYNAMEREF oRefAssemblyName;
-            ASSEMBLYREF oRefLoadedAssembly;
-        } _gcRefs;
+    ZeroMemory(&_gcRefs, sizeof(_gcRefs));
         
-        ZeroMemory(&_gcRefs, sizeof(_gcRefs));
+    GCPROTECT_BEGIN(_gcRefs);
         
-        GCPROTECT_BEGIN(_gcRefs);
+    ICLRPrivAssembly *pResolvedAssembly = NULL;
         
-        ICLRPrivAssembly *pAssemblyBindingContext = NULL;
+    // Prepare to invoke System.Runtime.Loader.AssemblyLoadContext.Resolve method.
+    //
+    // First, initialize an assembly spec for the requested assembly
+    //
+    AssemblySpec spec;
+    hr = spec.Init(pIAssemblyName);
+    if (SUCCEEDED(hr))
+    {
+        bool fResolvedAssembly = false;
 
-        bool fInvokedForTPABinder = (pTPABinder == NULL)?true:false;
-        
-        // Prepare to invoke System.Runtime.Loader.AssemblyLoadContext.Resolve method.
-        //
-        // First, initialize an assembly spec for the requested assembly
-        //
-        AssemblySpec spec;
-        hr = spec.Init(pIAssemblyName);
-        if (SUCCEEDED(hr))
-        {
-            bool fResolvedAssembly = false;
-            bool fResolvedAssemblyViaTPALoadContext = false;
-
-            // Allocate an AssemblyName managed object
-            _gcRefs.oRefAssemblyName = (ASSEMBLYNAMEREF) AllocateObject(MscorlibBinder::GetClass(CLASS__ASSEMBLY_NAME));
+        // Allocate an AssemblyName managed object
+        _gcRefs.oRefAssemblyName = (ASSEMBLYNAMEREF) AllocateObject(MscorlibBinder::GetClass(CLASS__ASSEMBLY_NAME));
             
-            // Initialize the AssemblyName object from the AssemblySpec
-            spec.AssemblyNameInit(&_gcRefs.oRefAssemblyName, NULL);
+        // Initialize the AssemblyName object from the AssemblySpec
+        spec.AssemblyNameInit(&_gcRefs.oRefAssemblyName, NULL);
                 
-            bool isSatelliteAssemblyRequest = !spec.IsNeutralCulture();
+        bool isSatelliteAssemblyRequest = !spec.IsNeutralCulture();
 
-            if (!fInvokedForTPABinder)
+        if (pTPABinder != NULL)
+        {
+            // Step 2 (of CLRPrivBinderAssemblyLoadContext::BindUsingAssemblyName) - Invoke Load method
+            // This is not invoked for TPA Binder since it always returns NULL.
+
+            // Finally, setup arguments for invocation
+            MethodDescCallSite methLoadAssembly(METHOD__ASSEMBLYLOADCONTEXT__RESOLVE);
+                
+            // Setup the arguments for the call
+            ARG_SLOT args[2] =
             {
-                // Step 2 (of CLRPrivBinderAssemblyLoadContext::BindUsingAssemblyName) - Invoke Load method
-                // This is not invoked for TPA Binder since it always returns NULL.
+                PtrToArgSlot(pManagedAssemblyLoadContextToBindWithin), // IntPtr for managed assembly load context instance
+                ObjToArgSlot(_gcRefs.oRefAssemblyName), // AssemblyName instance
+            };
 
-                // Finally, setup arguments for invocation
-                BinderMethodID idHAR_Resolve = METHOD__ASSEMBLYLOADCONTEXT__RESOLVE;
-                MethodDescCallSite methLoadAssembly(idHAR_Resolve);
-                
-                // Setup the arguments for the call
-                ARG_SLOT args[2] =
-                {
-                    PtrToArgSlot(pManagedAssemblyLoadContextToBindWithin), // IntPtr for managed assembly load context instance
-                    ObjToArgSlot(_gcRefs.oRefAssemblyName), // AssemblyName instance
-                };
-
-                // Make the call
-                _gcRefs.oRefLoadedAssembly = (ASSEMBLYREF) methLoadAssembly.Call_RetOBJECTREF(args);
-                if (_gcRefs.oRefLoadedAssembly != NULL)
-                {
-                    fResolvedAssembly = true;
-                }
-
-                // Step 3 (of CLRPrivBinderAssemblyLoadContext::BindUsingAssemblyName)
-                if (!fResolvedAssembly && !isSatelliteAssemblyRequest)
-                {
-                    // If we could not resolve the assembly using Load method, then attempt fallback with TPA Binder.
-                    // Since TPA binder cannot fallback to itself, this fallback does not happen for binds within TPA binder.
-                    //
-                    // Switch to pre-emp mode before calling into the binder
-                    GCX_PREEMP();
-                    ICLRPrivAssembly *pCoreCLRFoundAssembly = NULL;
-                    hr = pTPABinder->BindAssemblyByName(pIAssemblyName, &pCoreCLRFoundAssembly);
-                    if (SUCCEEDED(hr))
-                    {
-                        pAssemblyBindingContext = pCoreCLRFoundAssembly;
-                        fResolvedAssembly = true;
-                        fResolvedAssemblyViaTPALoadContext = true;
-                    }
-                }
+            // Make the call
+            _gcRefs.oRefLoadedAssembly = (ASSEMBLYREF) methLoadAssembly.Call_RetOBJECTREF(args);
+            if (_gcRefs.oRefLoadedAssembly != NULL)
+            {
+                fResolvedAssembly = true;
             }
 
-            if (!fResolvedAssembly && isSatelliteAssemblyRequest)
+            // Step 3 (of CLRPrivBinderAssemblyLoadContext::BindUsingAssemblyName)
+            if (!fResolvedAssembly && !isSatelliteAssemblyRequest)
             {
-                // Step 4 (of CLRPrivBinderAssemblyLoadContext::BindUsingAssemblyName)
+                // If we could not resolve the assembly using Load method, then attempt fallback with TPA Binder.
+                // Since TPA binder cannot fallback to itself, this fallback does not happen for binds within TPA binder.
                 //
-                // Attempt to resolve it using the ResolveSatelliteAssembly method.
-                // Finally, setup arguments for invocation
-                BinderMethodID idHAR_ResolveSatelitteAssembly = METHOD__ASSEMBLYLOADCONTEXT__RESOLVESATELLITEASSEMBLY;
-                MethodDescCallSite methResolveSatelitteAssembly(idHAR_ResolveSatelitteAssembly);
-
-                // Setup the arguments for the call
-                ARG_SLOT args[2] =
+                // Switch to pre-emp mode before calling into the binder
+                GCX_PREEMP();
+                ICLRPrivAssembly *pCoreCLRFoundAssembly = NULL;
+                hr = pTPABinder->BindAssemblyByName(pIAssemblyName, &pCoreCLRFoundAssembly);
+                if (SUCCEEDED(hr))
                 {
-                    PtrToArgSlot(pManagedAssemblyLoadContextToBindWithin), // IntPtr for managed assembly load context instance
-                    ObjToArgSlot(_gcRefs.oRefAssemblyName), // AssemblyName instance
-                };
-
-                // Make the call
-                _gcRefs.oRefLoadedAssembly = (ASSEMBLYREF) methResolveSatelitteAssembly.Call_RetOBJECTREF(args);
-                if (_gcRefs.oRefLoadedAssembly != NULL)
-                {
-                    // Set the flag indicating we found the assembly
+                    _ASSERTE(pCoreCLRFoundAssembly != NULL);
+                    pResolvedAssembly = pCoreCLRFoundAssembly;
                     fResolvedAssembly = true;
                 }
             }
+        }
 
-            if (!fResolvedAssembly)
+        if (!fResolvedAssembly && isSatelliteAssemblyRequest)
+        {
+            // Step 4 (of CLRPrivBinderAssemblyLoadContext::BindUsingAssemblyName)
+            //
+            // Attempt to resolve it using the ResolveSatelliteAssembly method.
+            // Finally, setup arguments for invocation
+            MethodDescCallSite methResolveSatelitteAssembly(METHOD__ASSEMBLYLOADCONTEXT__RESOLVESATELLITEASSEMBLY);
+
+            // Setup the arguments for the call
+            ARG_SLOT args[2] =
             {
-                // Step 5 (of CLRPrivBinderAssemblyLoadContext::BindUsingAssemblyName)
-                //
-                // If we couldnt resolve the assembly using TPA LoadContext as well, then
-                // attempt to resolve it using the Resolving event.
-                // Finally, setup arguments for invocation
-                BinderMethodID idHAR_ResolveUsingEvent = METHOD__ASSEMBLYLOADCONTEXT__RESOLVEUSINGEVENT;
-                MethodDescCallSite methResolveUsingEvent(idHAR_ResolveUsingEvent);
-                
-                // Setup the arguments for the call
-                ARG_SLOT args[2] =
-                {
-                    PtrToArgSlot(pManagedAssemblyLoadContextToBindWithin), // IntPtr for managed assembly load context instance
-                    ObjToArgSlot(_gcRefs.oRefAssemblyName), // AssemblyName instance
-                };
+                PtrToArgSlot(pManagedAssemblyLoadContextToBindWithin), // IntPtr for managed assembly load context instance
+                ObjToArgSlot(_gcRefs.oRefAssemblyName), // AssemblyName instance
+            };
 
-                // Make the call
-                _gcRefs.oRefLoadedAssembly = (ASSEMBLYREF) methResolveUsingEvent.Call_RetOBJECTREF(args);
-                if (_gcRefs.oRefLoadedAssembly != NULL)
-                {
-                    // Set the flag indicating we found the assembly
-                    fResolvedAssembly = true;
-                }
+            // Make the call
+            _gcRefs.oRefLoadedAssembly = (ASSEMBLYREF) methResolveSatelitteAssembly.Call_RetOBJECTREF(args);
+            if (_gcRefs.oRefLoadedAssembly != NULL)
+            {
+                // Set the flag indicating we found the assembly
+                fResolvedAssembly = true;
             }
+        }
+
+        if (!fResolvedAssembly)
+        {
+            // Step 5 (of CLRPrivBinderAssemblyLoadContext::BindUsingAssemblyName)
+            //
+            // If we couldn't resolve the assembly using TPA LoadContext as well, then
+            // attempt to resolve it using the Resolving event.
+            // Finally, setup arguments for invocation
+            MethodDescCallSite methResolveUsingEvent(METHOD__ASSEMBLYLOADCONTEXT__RESOLVEUSINGEVENT);
+                
+            // Setup the arguments for the call
+            ARG_SLOT args[2] =
+            {
+                PtrToArgSlot(pManagedAssemblyLoadContextToBindWithin), // IntPtr for managed assembly load context instance
+                ObjToArgSlot(_gcRefs.oRefAssemblyName), // AssemblyName instance
+            };
+
+            // Make the call
+            _gcRefs.oRefLoadedAssembly = (ASSEMBLYREF) methResolveUsingEvent.Call_RetOBJECTREF(args);
+            if (_gcRefs.oRefLoadedAssembly != NULL)
+            {
+                // Set the flag indicating we found the assembly
+                fResolvedAssembly = true;
+            }
+        }
             
-            if (fResolvedAssembly && !fResolvedAssemblyViaTPALoadContext)
-            {
-                // If we are here, assembly was successfully resolved via Load or Resolving events.
-                _ASSERTE(_gcRefs.oRefLoadedAssembly != NULL);
+        if (fResolvedAssembly && pResolvedAssembly == NULL)
+        {
+            // If we are here, assembly was successfully resolved via Load or Resolving events.
+            _ASSERTE(_gcRefs.oRefLoadedAssembly != NULL);
                     
-                // We were able to get the assembly loaded. Now, get its name since the host could have
-                // performed the resolution using an assembly with different name.
-                DomainAssembly *pDomainAssembly = _gcRefs.oRefLoadedAssembly->GetDomainAssembly();
-                PEAssembly *pLoadedPEAssembly = NULL;
-                bool fFailLoad = false;
-                if (!pDomainAssembly)
+            // We were able to get the assembly loaded. Now, get its name since the host could have
+            // performed the resolution using an assembly with different name.
+            DomainAssembly *pDomainAssembly = _gcRefs.oRefLoadedAssembly->GetDomainAssembly();
+            PEAssembly *pLoadedPEAssembly = NULL;
+            bool fFailLoad = false;
+            if (!pDomainAssembly)
+            {
+                // Reflection emitted assemblies will not have a domain assembly.
+                fFailLoad = true;
+            }
+            else
+            {
+                pLoadedPEAssembly = pDomainAssembly->GetFile();
+                if (pLoadedPEAssembly->HasHostAssembly() != true)
                 {
                     // Reflection emitted assemblies will not have a domain assembly.
                     fFailLoad = true;
                 }
-                else
-                {
-                    pLoadedPEAssembly = pDomainAssembly->GetFile();
-                    if (pLoadedPEAssembly->HasHostAssembly() != true)
-                    {
-                        // Reflection emitted assemblies will not have a domain assembly.
-                        fFailLoad = true;
-                    }
-                }
-                
-                // The loaded assembly's ICLRPrivAssembly* is saved as HostAssembly in PEAssembly
-                if (fFailLoad)
-                {
-                    SString name;
-                    spec.GetFileOrDisplayName(0, name);
-                    COMPlusThrowHR(COR_E_INVALIDOPERATION, IDS_HOST_ASSEMBLY_RESOLVER_DYNAMICALLY_EMITTED_ASSEMBLIES_UNSUPPORTED, name);
-                }
-                
-                // Is the assembly already bound using a binding context that will be incompatible?
-                // An example is attempting to consume an assembly bound to WinRT binder.
-                pAssemblyBindingContext = pLoadedPEAssembly->GetHostAssembly();
             }
-            
-            if (fResolvedAssembly)
+                
+            // The loaded assembly's ICLRPrivAssembly* is saved as HostAssembly in PEAssembly
+            if (fFailLoad)
             {
+                SString name;
+                spec.GetFileOrDisplayName(0, name);
+                COMPlusThrowHR(COR_E_INVALIDOPERATION, IDS_HOST_ASSEMBLY_RESOLVER_DYNAMICALLY_EMITTED_ASSEMBLIES_UNSUPPORTED, name);
+            }
+                
+            // Is the assembly already bound using a binding context that will be incompatible?
+            // An example is attempting to consume an assembly bound to WinRT binder.
+            pResolvedAssembly = pLoadedPEAssembly->GetHostAssembly();
+        }
+            
+        if (fResolvedAssembly)
+        {
+            _ASSERTE(pResolvedAssembly != NULL);
+
 #ifdef FEATURE_COMINTEROP
-                if (AreSameBinderInstance(pAssemblyBindingContext, GetAppDomain()->GetWinRtBinder()))
-                {
-                    // It is invalid to return an assembly bound to an incompatible binder
-                    *ppLoadedAssembly = NULL;
-                    SString name;
-                    spec.GetFileOrDisplayName(0, name);
-                    COMPlusThrowHR(COR_E_INVALIDOPERATION, IDS_HOST_ASSEMBLY_RESOLVER_INCOMPATIBLE_BINDING_CONTEXT, name);
-                }
+            if (AreSameBinderInstance(pResolvedAssembly, GetAppDomain()->GetWinRtBinder()))
+            {
+                // It is invalid to return an assembly bound to an incompatible binder
+                *ppLoadedAssembly = NULL;
+                SString name;
+                spec.GetFileOrDisplayName(0, name);
+                COMPlusThrowHR(COR_E_INVALIDOPERATION, IDS_HOST_ASSEMBLY_RESOLVER_INCOMPATIBLE_BINDING_CONTEXT, name);
+            }
 #endif // FEATURE_COMINTEROP
 
-                // Get the ICLRPrivAssembly reference to return back to.
-                *ppLoadedAssembly = clr::SafeAddRef(pAssemblyBindingContext);
-                hr = S_OK;
-            }
-            else
-            {
-                hr = COR_E_FILENOTFOUND;
-            }
+            // Get the ICLRPrivAssembly reference to return back to.
+            *ppLoadedAssembly = clr::SafeAddRef(pResolvedAssembly);
+            hr = S_OK;
         }
-        
-        GCPROTECT_END();
+        else
+        {
+            hr = COR_E_FILENOTFOUND;
+        }
     }
-    // EX_CATCH_HRESULT(hr);
+        
+    GCPROTECT_END();
     
     return hr;
-    
 }
 #endif // !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
 

--- a/src/vm/assemblyspec.cpp
+++ b/src/vm/assemblyspec.cpp
@@ -908,11 +908,8 @@ DomainAssembly *AssemblySpec::LoadDomainAssembly(FileLoadLevel targetLevel,
 
     ETWOnStartup (LoaderCatchCall_V1, LoaderCatchCallEnd_V1);
     AppDomain* pDomain = GetAppDomain();
-
-
-    DomainAssembly *pAssembly = nullptr;
-
-    ICLRPrivBinder * pBinder = GetHostBinder();
+    
+    ICLRPrivBinder* pBinder = GetHostBinder();
     
     // If no binder was explicitly set, check if parent assembly has a binder.
     if (pBinder == nullptr)
@@ -920,7 +917,8 @@ DomainAssembly *AssemblySpec::LoadDomainAssembly(FileLoadLevel targetLevel,
         pBinder = GetBindingContextFromParentAssembly(pDomain);
     }
 
-    if ((pAssembly == nullptr) && CanUseWithBindingCache())
+    DomainAssembly* pAssembly = nullptr;
+    if (CanUseWithBindingCache())
     {
         pAssembly = pDomain->FindCachedAssembly(this);
     }
@@ -930,7 +928,6 @@ DomainAssembly *AssemblySpec::LoadDomainAssembly(FileLoadLevel targetLevel,
         pDomain->LoadDomainFile(pAssembly, targetLevel);
         RETURN pAssembly;
     }
-
 
     PEAssemblyHolder pFile(pDomain->BindAssemblySpec(this, fThrowOnFileNotFound));
     if (pFile == NULL)

--- a/src/vm/baseassemblyspec.h
+++ b/src/vm/baseassemblyspec.h
@@ -111,7 +111,6 @@ public:
     BOOL HasPublicKey() const;
     BOOL HasPublicKeyToken() const;
     BOOL IsMscorlibSatellite();
-    BOOL IsMscorlibDebugSatellite();
     BOOL IsMscorlib();
 
     //

--- a/src/vm/coreassemblyspec.cpp
+++ b/src/vm/coreassemblyspec.cpp
@@ -126,7 +126,7 @@ VOID  AssemblySpec::Bind(AppDomain      *pAppDomain,
 
     pResult->Reset();    
 
-    if (m_wszCodeBase==NULL)
+    if (m_wszCodeBase == NULL)
     {
         GetFileOrDisplayName(0, assemblyDisplayName);
     }
@@ -140,7 +140,7 @@ VOID  AssemblySpec::Bind(AppDomain      *pAppDomain,
     ReleaseHolder<ICLRPrivAssembly> pPrivAsm;
     _ASSERTE(pBinder != NULL);
 
-    if (m_wszCodeBase==NULL && IsMscorlibSatellite())
+    if (m_wszCodeBase == NULL && IsMscorlibSatellite())
     {
         StackSString sSystemDirectory(SystemDomain::System()->SystemDirectory());
         StackSString tmpString;
@@ -159,9 +159,9 @@ VOID  AssemblySpec::Bind(AppDomain      *pAppDomain,
   
         hr = CCoreCLRBinderHelper::BindToSystemSatellite(sSystemDirectory, sSimpleName, sCultureName, &pPrivAsm);
     }
-    else if(m_wszCodeBase==NULL)
+    else if (m_wszCodeBase == NULL)
     {
-        // For name based binding these arguments shouldnt have been changed from default
+        // For name based binding these arguments shouldn't have been changed from default
         _ASSERTE(!fNgenExplicitBind && !fExplicitBindToNativeImage);
         SafeComHolder<IAssemblyName> pName;
         hr = CreateAssemblyNameObject(&pName, assemblyDisplayName, CANOF_PARSE_DISPLAY_NAME, NULL);
@@ -173,11 +173,11 @@ VOID  AssemblySpec::Bind(AppDomain      *pAppDomain,
     else
     {
         hr = pTPABinder->Bind(assemblyDisplayName,
-                           m_wszCodeBase,
-                           GetParentAssembly()? GetParentAssembly()->GetFile():NULL,
-                           fNgenExplicitBind,
-                           fExplicitBindToNativeImage,
-                          &pPrivAsm);
+                              m_wszCodeBase,
+                              GetParentAssembly() ? GetParentAssembly()->GetFile() : NULL,
+                              fNgenExplicitBind,
+                              fExplicitBindToNativeImage,
+                              &pPrivAsm);
     }
 
     pResult->SetHRBindResult(hr);


### PR DESCRIPTION
I was reading through the binder and related code and fixed mostly formatting issues. There are some simple changes which remove unnecessary variables, stale comments and so on.