### PR TITLE
Remove assertion from Shutdown path

### DIFF
--- a/src/vm/diagnosticserver.cpp
+++ b/src/vm/diagnosticserver.cpp
@@ -210,10 +210,7 @@ bool DiagnosticServer::Shutdown()
             if (s_hServerThread != NULL)
             {
 #ifndef FEATURE_PAL
-                if (::CancelSynchronousIo(s_hServerThread) == 0)
-                {
-                    _ASSERTE(!"Failed to mark pending synchronous I/O operations issued by Diagnostics Server Thread as canceled.");
-                }
+                ::CancelSynchronousIo(s_hServerThread);
 #endif // FEATURE_PAL
 
                 // At this point, IO operations on the server thread through the


### PR DESCRIPTION
The diagnostics server is doing nothing to handle potential errors in this path.
Fixes #25755 