### PR TITLE
Fix typo: `_TARGET_X86` -> `_TARGET_X86_`

### DIFF
--- a/src/vm/util.cpp
+++ b/src/vm/util.cpp
@@ -1817,7 +1817,7 @@ size_t GetCacheSizePerLogicalCpu(BOOL bTrueSize)
     maxSize = maxTrueSize = GetLogicalProcessorCacheSizeFromOS() ; // Returns the size of the highest level processor cache
 #endif
 
-#if defined (_TARGET_X86) || defined(_TARGET_AMD64_)
+#if defined (_TARGET_X86_) || defined(_TARGET_AMD64_)
     if (maxSize == 0)
     {
         maxSize = maxTrueSize = GetCacheSizeFromCpuId();


### PR DESCRIPTION
This typo was in #24989 so would be a new regression in 3.0.
In an x86 build, it causes us to not get the cache size correct,
leading us to use a smaller default cache size and do more GCs.

Tested with GCPerfSim and this PR reduces TotalNumberGCs by 33% using an x86 build.

I believe this is an "Unacceptable performance regression from 2.2 that is not a corner case" so meets the bar for 3.0.

Thanks @jkotas for discovering this in https://github.com/dotnet/coreclr/pull/25781#discussion_r305127079