### PR TITLE
add access(2) call before dlopening files

### DIFF
--- a/src/pal/src/loader/module.cpp
+++ b/src/pal/src/loader/module.cpp
@@ -1428,6 +1428,15 @@ static NATIVE_LIBRARY_HANDLE LOADLoadLibraryDirect(LPCSTR libraryNameOrPath)
     _ASSERTE(libraryNameOrPath != nullptr);
     _ASSERTE(libraryNameOrPath[0] != '\0');
 
+    if (strchr(libraryNameOrPath, '/') != nullptr)
+    {
+	    if (access(libraryNameOrPath, F_OK) == -1)
+	    {
+		    SetLastError(ERROR_MOD_NOT_FOUND);
+		    return (NATIVE_LIBRARY_HANDLE)nullptr;
+	    }
+    }
+
     NATIVE_LIBRARY_HANDLE dl_handle = dlopen(libraryNameOrPath, RTLD_LAZY);
     if (dl_handle == nullptr)
     {


### PR DESCRIPTION
In case we have many native dll search directories the runtime looks over them inefficiently: it uses dlopen with it's userspace overhead which uses open() syscall even in a case the file or any of directories above it does not exist.
We have estimated upper bound of startup time decrease in our representive application set as 2.6% and have got actual decrease as much as 2.4% with this patch.

**edit**
access(2) is used instead of stat(2)
We have also tried call GetFileAttributes() just before LoadLibraryHelper() in LoadFromNativeDllSearchDirectories() and it works fine, but startup time decrease is a little smaller. If you think this approach is more appropriate I could create another PR for consideration.