### PR TITLE
Fix issue with out-of-scope GCFrame in Frame list

### DIFF
--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -1024,6 +1024,26 @@ GCFrame::~GCFrame()
         Pop();
     }
 }
+
+ExceptionFilterFrame::~ExceptionFilterFrame()
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
+
+    if (m_Next != NULL)
+    {
+        GCX_COOP();
+        // When the frame is destroyed, make sure it is no longer in the
+        // frame chain managed by the Thread.
+        Pop();
+    }
+}
+
 #endif // !CROSSGEN_COMPILE
 
 #ifdef FEATURE_INTERPRETER

--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -1001,6 +1001,31 @@ VOID GCFrame::Pop()
 #endif
 }
 
+#ifndef FEATURE_PAL
+// GCFrame destructor removes the GCFrame from the current thread's explicit frame list.
+// This prevents issues in functions that have HELPER_METHOD_FRAME_BEGIN / END around 
+// GCPROTECT_BEGIN / END and where the C++ compiler places some local variables over 
+// the stack location of the GCFrame local variable after the variable goes out of scope. 
+GCFrame::~GCFrame()
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
+
+    if (m_Next != NULL)
+    {
+        GCX_COOP();
+        // When the frame is destroyed, make sure it is no longer in the
+        // frame chain managed by the Thread.
+        Pop();
+    }
+}
+#endif // FEATURE_PAL
+
 #ifdef FEATURE_INTERPRETER
 // Methods of IntepreterFrame.
 InterpreterFrame::InterpreterFrame(Interpreter* interp) 

--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -1001,7 +1001,7 @@ VOID GCFrame::Pop()
 #endif
 }
 
-#ifndef FEATURE_PAL
+#if !defined(FEATURE_PAL) && !defined(CROSSGEN_COMPILE)
 // GCFrame destructor removes the GCFrame from the current thread's explicit frame list.
 // This prevents issues in functions that have HELPER_METHOD_FRAME_BEGIN / END around 
 // GCPROTECT_BEGIN / END and where the C++ compiler places some local variables over 
@@ -1024,7 +1024,7 @@ GCFrame::~GCFrame()
         Pop();
     }
 }
-#endif // FEATURE_PAL
+#endif // !FEATURE_PAL && !CROSSGEN_COMPILE
 
 #ifdef FEATURE_INTERPRETER
 // Methods of IntepreterFrame.

--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -1001,7 +1001,7 @@ VOID GCFrame::Pop()
 #endif
 }
 
-#if !defined(FEATURE_PAL) && !defined(CROSSGEN_COMPILE)
+#ifndef CROSSGEN_COMPILE
 // GCFrame destructor removes the GCFrame from the current thread's explicit frame list.
 // This prevents issues in functions that have HELPER_METHOD_FRAME_BEGIN / END around 
 // GCPROTECT_BEGIN / END and where the C++ compiler places some local variables over 
@@ -1018,13 +1018,13 @@ GCFrame::~GCFrame()
 
     if (m_Next != NULL)
     {
-        GCX_COOP();
+        GCX_COOP_THREAD_EXISTS(m_pCurThread);
         // When the frame is destroyed, make sure it is no longer in the
         // frame chain managed by the Thread.
         Pop();
     }
 }
-#endif // !FEATURE_PAL && !CROSSGEN_COMPILE
+#endif // !CROSSGEN_COMPILE
 
 #ifdef FEATURE_INTERPRETER
 // Methods of IntepreterFrame.

--- a/src/vm/frames.h
+++ b/src/vm/frames.h
@@ -3325,11 +3325,16 @@ public:
             *m_pShadowSP |= ICodeManager::SHADOW_SP_FILTER_DONE;
         }
     }
+
+#ifndef CROSSGEN_COMPILE
+    ~ExceptionFilterFrame();
+#endif
+
 #endif
 
 private:
     // Keep as last entry in class
-    DEFINE_VTABLE_GETTER_AND_CTOR_AND_DTOR(ExceptionFilterFrame)
+    DEFINE_VTABLE_GETTER_AND_CTOR(ExceptionFilterFrame)
 };
 
 #ifdef _DEBUG

--- a/src/vm/frames.h
+++ b/src/vm/frames.h
@@ -2534,9 +2534,9 @@ private:
     BOOL          m_MaybeInterior;
 
     // Keep as last entry in class
-    DEFINE_VTABLE_GETTER_AND_DTOR(GCFrame)
+    DEFINE_VTABLE_GETTER(GCFrame)
 
-#if !defined(FEATURE_PAL) && !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
+#if !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
     ~GCFrame();
 #endif
 };

--- a/src/vm/frames.h
+++ b/src/vm/frames.h
@@ -2536,7 +2536,7 @@ private:
     // Keep as last entry in class
     DEFINE_VTABLE_GETTER_AND_DTOR(GCFrame)
 
-#ifndef FEATURE_PAL
+#if !defined(FEATURE_PAL) && !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
     ~GCFrame();
 #endif
 };
@@ -3647,7 +3647,7 @@ public:
 
 #define GCPROTECT_END()                                                 \
                 DEBUG_ASSURE_NO_RETURN_END(GCPROTECT) }                 \
-                __gcframe.Pop(); } while(0)
+                } while(0)
 
 
 #else // #ifndef DACCESS_COMPILE

--- a/src/vm/frames.h
+++ b/src/vm/frames.h
@@ -2535,6 +2535,10 @@ private:
 
     // Keep as last entry in class
     DEFINE_VTABLE_GETTER_AND_DTOR(GCFrame)
+
+#ifndef FEATURE_PAL
+    ~GCFrame();
+#endif
 };
 
 #ifdef FEATURE_INTERPRETER

--- a/src/vm/syncblk.cpp
+++ b/src/vm/syncblk.cpp
@@ -2564,42 +2564,6 @@ double ComputeElapsedTimeInNanosecond(LARGE_INTEGER startTicks, LARGE_INTEGER en
     return (elapsedTicks * NsPerSecond) / freq.QuadPart;
 }
 
-DWORD AwareLock::WaitForSemEvent(INT32 timeOut)
-{
-    // We might be interrupted during the wait (Thread.Interrupt), so we need an
-    // exception handler round the call.
-    struct Param
-    {
-        AwareLock *pThis;
-        INT32 timeOut;
-        DWORD ret;
-    } param;
-    param.pThis = this;
-    param.timeOut = timeOut;
-
-    EE_TRY_FOR_FINALLY(Param *, pParam, &param)
-    {
-        pParam->ret = pParam->pThis->m_SemEvent.Wait(pParam->timeOut, TRUE);
-        _ASSERTE((pParam->ret == WAIT_OBJECT_0) || (pParam->ret == WAIT_TIMEOUT));
-    }
-    EE_FINALLY
-    {
-        if (GOT_EXCEPTION())
-        {
-            // It is likely the case that An APC threw an exception, for instance Thread.Interrupt(). The wait subsystem
-            // guarantees that if a signal to the event being waited upon is observed by the woken thread, that thread's
-            // wait will return WAIT_OBJECT_0. So in any race between m_SemEvent being signaled and the wait throwing an
-            // exception, a thread that is woken by an exception would not observe the signal, and the signal would wake
-            // another thread as necessary.
-
-            // We must decrement the waiter count.
-            m_lockState.InterlockedUnregisterWaiter();
-        }
-    } EE_END_FINALLY;
-
-    return param.ret;
-}
-
 BOOL AwareLock::EnterEpilogHelper(Thread* pCurThread, INT32 timeOut)
 {
     STATIC_CONTRACT_THROWS;
@@ -2654,13 +2618,46 @@ BOOL AwareLock::EnterEpilogHelper(Thread* pCurThread, INT32 timeOut)
             // accordingly.
             ULONGLONG start = CLRGetTickCount64();
 
-            ret = WaitForSemEvent(timeOut);
+            // It is likely the case that An APC threw an exception, for instance Thread.Interrupt(). The wait subsystem
+            // guarantees that if a signal to the event being waited upon is observed by the woken thread, that thread's
+            // wait will return WAIT_OBJECT_0. So in any race between m_SemEvent being signaled and the wait throwing an
+            // exception, a thread that is woken by an exception would not observe the signal, and the signal would wake
+            // another thread as necessary.
+
+            // We must decrement the waiter count in the case an exception happened. This holder takes care of that
+            class UnregisterWaiterHolder
+            {
+                LockState* m_pLockState;
+            public:
+                UnregisterWaiterHolder(LockState* pLockState) : m_pLockState(pLockState)
+                {
+                }
+
+                ~UnregisterWaiterHolder()
+                {
+                    if (m_pLockState != NULL)
+                    {
+                        m_pLockState->InterlockedUnregisterWaiter();
+                    }
+                }
+
+                void SuppressRelease()
+                {
+                    m_pLockState = NULL;
+                }
+            } unregisterWaiterHolder(&m_lockState);
+
+            ret = m_SemEvent.Wait(timeOut, TRUE);
+            _ASSERTE((ret == WAIT_OBJECT_0) || (ret == WAIT_TIMEOUT));
+
             if (ret != WAIT_OBJECT_0)
             {
-                // We timed out, decrement waiter count.
-                m_lockState.InterlockedUnregisterWaiter();
+                // We timed out
+                // (the holder unregisters the waiter here)
                 break;
             }
+
+            unregisterWaiterHolder.SuppressRelease();
 
             // Spin a bit while trying to acquire the lock. This has a few benefits:
             // - Spinning helps to reduce waiter starvation. Since other non-waiter threads can take the lock while there are

--- a/src/vm/syncblk.h
+++ b/src/vm/syncblk.h
@@ -540,6 +540,8 @@ private: // friend access is required for this unsafe function
         m_HoldingThread = holdingThread;
     }
 
+    DWORD WaitForSemEvent(INT32 timeOut);
+
 public:
     static void SpinWait(const YieldProcessorNormalizationInfo &normalizationInfo, DWORD spinIteration);
 

--- a/src/vm/syncblk.h
+++ b/src/vm/syncblk.h
@@ -540,8 +540,6 @@ private: // friend access is required for this unsafe function
         m_HoldingThread = holdingThread;
     }
 
-    DWORD WaitForSemEvent(INT32 timeOut);
-
 public:
     static void SpinWait(const YieldProcessorNormalizationInfo &normalizationInfo, DWORD spinIteration);
 


### PR DESCRIPTION
More aggressive C/C++ optimizations done by VS2019 are breaking fragile
assumptions of the CoreCLR "manually managed code".

Unwinding of Frame chains accesses stack local variables after the stack
frame has been unwound, but it depends on their content to be left
intact. The new compiler is breaking this assumption by stack-packing a
different variable over it.

This change fixes the problem by adding a destructor to GCFrame that
pops the frame from the per-thread Frame list.

I also had to refactor two functions where the compiler was complaining about 
mixing SEH and C++ EH in single function.

Close #25481