### PR TITLE
Fix Linux compilation flags

### DIFF
--- a/configurecompiler.cmake
+++ b/configurecompiler.cmake
@@ -11,8 +11,6 @@ set(CLR_DEFINES_CHECKED_INIT            DEBUG _DEBUG _DBG URTBLDENV_FRIENDLY=Che
 set(CLR_DEFINES_RELEASE_INIT            NDEBUG URTBLDENV_FRIENDLY=Retail)
 set(CLR_DEFINES_RELWITHDEBINFO_INIT     NDEBUG URTBLDENV_FRIENDLY=Retail)
 
-include(${CMAKE_CURRENT_LIST_DIR}/configureoptimization.cmake)
-
 #----------------------------------------
 # Detect and set platform variable names
 #     - for non-windows build platform & architecture is detected using inbuilt CMAKE variables and cross target component configure
@@ -112,6 +110,9 @@ if(CMAKE_SYSTEM_NAME STREQUAL SunOS)
   endif()
   set(CLR_CMAKE_PLATFORM_SUNOS 1)
 endif(CMAKE_SYSTEM_NAME STREQUAL SunOS)
+
+# "configureoptimization.cmake" must be included after CLR_CMAKE_PLATFORM_UNIX has been set.
+include(${CMAKE_CURRENT_LIST_DIR}/configureoptimization.cmake)
 
 #--------------------------------------------
 # This repo builds two set of binaries


### PR DESCRIPTION
`configureoptimization.cmake` was being included before `CLR_CMAKE_PLATFORM_UNIX`
was set, though it depends on that variable to set Linux optimization
flags. Move the include lower, after `CLR_CMAKE_PLATFORM_UNIX` is set.

This leads to Debug builds being built with `-O0` and Checked builds built
with `-O2`, instead of the default due to no `-O` flag being passed. Release
is still built `-O3`; somehow, it was being built that way already.

Fixes #25273 (Although Alpine will still see a stack overflow in the failing
test case with Debug builds, it won't affect Checked build CI runs, which is
the primary flavor tested in coreclr CI.)