### PR TITLE
corbbtprof: set byte alignment for CORBBTPROF structures

### DIFF
--- a/src/inc/corbbtprof.h
+++ b/src/inc/corbbtprof.h
@@ -275,6 +275,8 @@ enum SectionFormat
     SectionFormatInvalid                = -1
 };
 
+#include <pshpack1.h>
+
 struct CORBBTPROF_SECTION_TABLE_ENTRY
 {
     SectionFormat                  FormatID;
@@ -589,4 +591,7 @@ struct CORBBTPROF_BLOB_POOL_ENTRY
     DWORD                  cBuffer;
     BYTE                   buffer[0];  // actually 'cBuffer' in length
 };
+
+#include <poppack.h>
+
 #endif /* COR_BBTPROF_H_ */


### PR DESCRIPTION
This patch fixes SIGBUG that occurs due to unaligned read/write:
```
$ export COMPlus_ZapBBInstr=*
$ export COMPlus_ZapBBInstrDir=/tmp
$ gdb --args corerun /opt/usr/media/helloworld.dll 
...
Thread 1 "corerun" received signal SIGBUS, Bus error.
0xf706c890 in ProfileDataAllocateScenarioInfo (pEmitter=<optimized out>, scopeName=<optimized out>, pMvid=<optimized out>) at /opt/code/src/vm/ceeload.cpp:11968
11968               sRun->mvid        = *pMvid;
(gdb) bt
#0  0xf706c890 in ProfileDataAllocateScenarioInfo (pEmitter=<optimized out>, scopeName=<optimized out>, pMvid=<optimized out>) at /opt/code/src/vm/ceeload.cpp:11968
#1  Module::WriteMethodProfileDataLogFile (this=<optimized out>, cleanup=<optimized out>) at /opt/code/src/vm/ceeload.cpp:12324
#2  0xf70736f4 in Module::WriteAllModuleProfileData (cleanup=true) at /opt/code/src/vm/ceeload.cpp:12402
#3  0xf6fbb542 in EEShutDownHelper (fIsDllUnloading=0) at /opt/code/src/vm/ceemain.cpp:1424
#4  0xf6fbbb44 in EEShutDown (fIsDllUnloading=0) at /opt/code/src/vm/ceemain.cpp:1777
#5  0xf6f2f42c in CorHost2::UnloadAppDomain2 (this=0xdb879837, dwDomainId=<optimized out>, fWaitUntilDone=<optimized out>, pLatchedExitCode=0xfffefab0) at /opt/code/src/vm/corhost.cpp:1074
#6  0xf6f13e84 in coreclr_shutdown_2 (hostHandle=0x2c6e0, domainId=1, latchedExitCode=0xfffefab0) at /opt/code/src/dlls/mscoree/unixinterface.cpp:361
#7  0x00011eda in ?? ()
#8  0x0001134a in ?? ()
#9  0xf749863c in __libc_start_main () from /lib/libc.so.6
#10 0x0001108c in ?? ()
```