### PR TITLE
Allow creating typehandles to `TypedReference*`

### DIFF
--- a/src/vm/clsload.cpp
+++ b/src/vm/clsload.cpp
@@ -3339,8 +3339,7 @@ TypeHandle ClassLoader::CreateTypeHandleForTypeKey(TypeKey* pKey, AllocMemTracke
         else 
         {
             // no parameterized type allowed on a reference
-            if (paramType.GetInternalCorElementType() == ELEMENT_TYPE_BYREF ||
-                paramType.GetInternalCorElementType() == ELEMENT_TYPE_TYPEDBYREF)
+            if (paramType.GetInternalCorElementType() == ELEMENT_TYPE_BYREF)
             {
                 ThrowTypeLoadException(pKey, IDS_CLASSLOAD_GENERAL);
             }

--- a/tests/src/reflection/regression/github_25697/25697.cs
+++ b/tests/src/reflection/regression/github_25697/25697.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+
+unsafe class Program
+{
+    public static void AsTypedReference<T>(ref T value, TypedReference* output)
+    {
+        *output = __makeref(value);
+        value = (T)(object)"Hello";
+    }
+
+    static int Main()
+    {
+        // In this test, we try to reflect on a signature of a method that takes a TypedReference*.
+        // This is not useful for much else than Reflection.Emit or Delegate.CreateDelegate.
+        // (Do not Reflection.Invoke this - the TypedReference is likely going to point to a dead
+        // temporary when the method returns.)
+        var method = typeof(Program).GetMethod(nameof(Program.AsTypedReference));
+        var s = method.ToString();
+        Console.WriteLine(s);
+        if (s != "Void AsTypedReference[T](T ByRef, TypedReference*)")
+            return 1;
+
+        return 100;
+    }
+}

--- a/tests/src/reflection/regression/github_25697/25697.csproj
+++ b/tests/src/reflection/regression/github_25697/25697.csproj
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{CE893CE4-177E-47D3-A5DA-DF4D64E76812}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="25697.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
It's unclear why this was disallowed - we allow them in method signatures and there's a comment a couple lines below the code I'm touching saying we thought about blocking this for byref-like types, but there's no reason to do that.

`TypedReference` is the original byref-like type.

Fixes #25697.