### PR TITLE
We need to reset the scope list for the USING_VARIABLE_LIVE_RANGE case

### DIFF
--- a/src/jit/scopeinfo.cpp
+++ b/src/jit/scopeinfo.cpp
@@ -925,10 +925,9 @@ void CodeGen::siInit()
         {
             siLatestTrackedScopes = new (compiler->getAllocator(CMK_SiScope)) siScope* [scopeCount] {};
         }
-
-        compiler->compResetScopeLists();
     }
 #endif // USING_SCOPE_INFO
+    compiler->compResetScopeLists();
 }
 
 /*****************************************************************************


### PR DESCRIPTION
This change addresses the major difference in the generated debug info for non-optimized code between the `USING_SCOPE_INFO` and the `USING_VARIABLE_LIVE_RANGE` case.

After the fix, the debug info (as dumped by `r2rdump` for `crossgen` images) look significantly more similar now than before the fix.

We are still seeing differences, but it is much closer after the fix. It appears the majority of the remaining differences are immaterial re-ordering of variable lifetimes. 