### PR TITLE
Allow default interface methods for crossgen /createpdb

### DIFF
--- a/src/vm/classcompat.cpp
+++ b/src/vm/classcompat.cpp
@@ -2596,7 +2596,7 @@ VOID    MethodTableBuilder::EnumerateClassMethods()
         if (fIsClassInterface
 #if defined(FEATURE_DEFAULT_INTERFACES)
             // Only fragile crossgen wasn't upgraded to deal with default interface methods.
-            && !IsReadyToRunCompilation()
+            && !IsReadyToRunCompilation() && !IsNgenPDBCompilationProcess()
 #endif
             )
         {

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -2932,7 +2932,7 @@ MethodTableBuilder::EnumerateClassMethods()
             if (fIsClassInterface
 #if defined(FEATURE_DEFAULT_INTERFACES)
                 // Only fragile crossgen wasn't upgraded to deal with default interface methods.
-                && !IsReadyToRunCompilation()
+                && !IsReadyToRunCompilation() && !IsNgenPDBCompilationProcess()
 #endif
                 )
             {


### PR DESCRIPTION
The existing code was assuming we're doing fragile crossgen and blocked loading the type.