### PR TITLE
Allow for interface implementations in EventSource.WriteEventVarArgs

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -2071,7 +2071,7 @@ namespace System.Diagnostics.Tracing
 
                 // Checking to see if the Parameter types (from the Event method) match the supplied argument types.
                 // Fail if one of two things hold : either the argument type is not equal or assignable to the parameter type, or the 
-                // argument is null and the parameter type is non-nullable, i.e., not derived from Nullable<T> and not a ref type.
+                // argument is null and the parameter type is a non-Nullable<T> value type.
                 if ((args[i] != null && !pType.IsAssignableFrom(argType))
                     || (args[i] == null && !((pType.IsGenericType && pType.GetGenericTypeDefinition() == typeof(Nullable<>)) || !pType.IsValueType)))
                 {

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -2070,7 +2070,7 @@ namespace System.Diagnostics.Tracing
                 // Checking to see if the Parameter types (from the Event method) match the supplied argument types.
                 // Fail if one of two things hold : either the argument type is not equal to the parameter type, or the 
                 // argument is null and the parameter type is non-nullable.
-                if ((args[i] != null && (args[i]!.GetType() != pType)) // TODO-NULLABLE: Indexer nullability tracked (https://github.com/dotnet/roslyn/issues/34644)
+                if ((args[i] != null && (args[i]!.GetType() != pType) && !args[i]!.GetType().ImplementInterface(pType)) // TODO-NULLABLE: Indexer nullability tracked (https://github.com/dotnet/roslyn/issues/34644)
                     || (args[i] == null && (!(pType.IsGenericType && pType.GetGenericTypeDefinition() == typeof(Nullable<>))))
                     )
                 {

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -2071,9 +2071,9 @@ namespace System.Diagnostics.Tracing
 
                 // Checking to see if the Parameter types (from the Event method) match the supplied argument types.
                 // Fail if one of two things hold : either the argument type is not equal or assignable to the parameter type, or the 
-                // argument is null and the parameter type is non-nullable or a ref type.
-                if (args[i] != null && !(argType!.Equals(pType) || pType.IsAssignableFrom(argType))
-                    || args[i] == null && !((pType.IsGenericType && pType.GetGenericTypeDefinition() == typeof(Nullable<>)) || !pType.IsValueType))
+                // argument is null and the parameter type is non-nullable, i.e., not derived from Nullable<T> and not a ref type.
+                if ((args[i] != null && !pType.IsAssignableFrom(argType))
+                    || (args[i] == null && !((pType.IsGenericType && pType.GetGenericTypeDefinition() == typeof(Nullable<>)) || !pType.IsValueType)))
                 {
                     typesMatch = false;
                     break;

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -2067,12 +2067,13 @@ namespace System.Diagnostics.Tracing
             {
                 Type pType = infos[i].ParameterType;
 
+                Type? argType = args[i]?.GetType();
+
                 // Checking to see if the Parameter types (from the Event method) match the supplied argument types.
-                // Fail if one of two things hold : either the argument type is not equal to the parameter type, or the 
-                // argument is null and the parameter type is non-nullable.
-                if ((args[i] != null && (args[i]!.GetType() != pType) && !args[i]!.GetType().ImplementInterface(pType)) // TODO-NULLABLE: Indexer nullability tracked (https://github.com/dotnet/roslyn/issues/34644)
-                    || (args[i] == null && (!(pType.IsGenericType && pType.GetGenericTypeDefinition() == typeof(Nullable<>))))
-                    )
+                // Fail if one of two things hold : either the argument type is not equal or assignable to the parameter type, or the 
+                // argument is null and the parameter type is non-nullable or a ref type.
+                if (args[i] != null && !(argType!.Equals(pType) || pType.IsAssignableFrom(argType))
+                    || args[i] == null && !((pType.IsGenericType && pType.GetGenericTypeDefinition() == typeof(Nullable<>)) || !pType.IsValueType))
                 {
                     typesMatch = false;
                     break;


### PR DESCRIPTION
A catch all solution that should address dotnet/corefx#39431 as well as #20493.

This should allow for implementations of interfaces to be used with calls to `WriteEvent` rather than having the type check fail.

This should align the functionality with the behavior described in the comments at the top of `EventSource`
https://github.com/dotnet/coreclr/blob/95c0dd13c80f96f450b959ed8e0df56753a82f70/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs#L51-L70

Currently, interface implementations will fail and cause additional work to be done and additional logging which reduces performance and is not the expected behavior.

CC - @brianrob 