### PR TITLE
JIT: Recognize FMA patterns (x*y+z)

### DIFF
--- a/Documentation/project-docs/clr-configuration-knobs.md
+++ b/Documentation/project-docs/clr-configuration-knobs.md
@@ -355,6 +355,7 @@ Name | Description | Type | Class | Default Value | Flags
 `JITBreakOnMinOpts` | Halt if jit switches to MinOpts | `DWORD` | `JitBreakOnMinOpts` | `0` |
 `JitBreakOnUnsafeCode` |  | `DWORD` | | `0` |
 `JitCanUseSSE2` |  | `DWORD` | | `-1` |
+`JitInsertFma` | If 1, Jit is allowed to replace a * b + c patterns with FMA instructions. | `DWORD` | | `0` |
 `JitCloneLoops` | If 0, don't clone. Otherwise clone loops for optimizations. | `DWORD` | | `1` |
 `JitComponentUnitTests` | Run JIT component unit tests | `DWORD` | `RunComponentUnitTests` | `0` |
 `JitDebugBreak` |  | `SSV` | | |

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5319,6 +5319,7 @@ private:
 #endif // FEATURE_SIMD
     GenTree* fgMorphArrayIndex(GenTree* tree);
     GenTree* fgMorphCast(GenTree* tree);
+    GenTree* fgMorphFmadd(GenTree* tree);
     GenTree* fgUnwrapProxy(GenTree* objRef);
     GenTreeFieldList* fgMorphLclArgToFieldlist(GenTreeLclVarCommon* lcl);
     void fgInitArgInfo(GenTreeCall* call);

--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -35,6 +35,7 @@ CONFIG_INTEGER(JitBreakOnBadCode, W("JitBreakOnBadCode"), 0)
 CONFIG_INTEGER(JitBreakOnMinOpts, W("JITBreakOnMinOpts"), 0) // Halt if jit switches to MinOpts
 CONFIG_INTEGER(JitBreakOnUnsafeCode, W("JitBreakOnUnsafeCode"), 0)
 CONFIG_INTEGER(JitCanUseSSE2, W("JitCanUseSSE2"), -1)
+CONFIG_INTEGER(JitInsertFma, W("JitInsertFma"), 0) // If 1, Jit is allowed to replace a * b + c patterns with FMA instructions
 CONFIG_INTEGER(JitCloneLoops, W("JitCloneLoops"), 1) // If 0, don't clone. Otherwise clone loops for optimizations.
 CONFIG_INTEGER(JitDebugLogLoopCloning, W("JitDebugLogLoopCloning"), 0) // In debug builds log places where loop cloning
                                                                        // optimizations are performed on the fast path.

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -122,15 +122,16 @@ GenTree* Compiler::fgMorphIntoHelperCall(GenTree* tree, int helper, GenTreeArgLi
 
 /*****************************************************************************
  *
- *  Morph X * Y + Z into FMA intrinsic
- *  X *  Y + Z  ->  NI_FMA_MultiplyAddScalar
- *  X * -Y + Z  ->  NI_FMA_MultiplyAddNegatedScalar
- * -X *  Y + Z  ->  NI_FMA_MultiplyAddNegatedScalar
- * -X * -Y + Z  ->  NI_FMA_MultiplyAddScalar
- *  X *  Y - Z  ->  NI_FMA_MultiplySubtractScalar
- *  X * -Y - Z  ->  NI_FMA_MultiplySubtractNegatedScalar
- * -X *  Y - Z  ->  NI_FMA_MultiplySubtractNegatedScalar
- * -X * -Y - Z  ->  NI_FMA_MultiplySubtractScalar
+ *  Morph X * Y + Z into FMA intrinsics:
+ *
+ *   X *  Y + Z  ->  NI_FMA_MultiplyAddScalar
+ *   X * -Y + Z  ->  NI_FMA_MultiplyAddNegatedScalar
+ *  -X *  Y + Z  ->  NI_FMA_MultiplyAddNegatedScalar
+ *  -X * -Y + Z  ->  NI_FMA_MultiplyAddScalar
+ *   X *  Y - Z  ->  NI_FMA_MultiplySubtractScalar
+ *   X * -Y - Z  ->  NI_FMA_MultiplySubtractNegatedScalar
+ *  -X *  Y - Z  ->  NI_FMA_MultiplySubtractNegatedScalar
+ *  -X * -Y - Z  ->  NI_FMA_MultiplySubtractScalar
  */
 
 GenTree* Compiler::fgMorphFmadd(GenTree* tree)
@@ -178,12 +179,16 @@ GenTree* Compiler::fgMorphFmadd(GenTree* tree)
         return tree;
     }
 
-    // TODO: fix
     if (gtIsActiveCSE_Candidate(mull) || !fgGlobalMorph)
     {
-        // shouldn't generate fmadd here:
-        // _z = a * b;
-        // return a * b + c;
+        // TODO: should not insert fmadd here and let the CSE phase do its work
+        //
+        // double Foo(double a, double b, double c, out double z)
+        // {
+        //     z = a * b;         // a * b
+        //     return a * b + c;  // z + c
+        // }
+        //
         return tree;
     }
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -146,7 +146,7 @@ GenTree* Compiler::fgMorphFmadd(GenTree* tree)
     {
         return tree;
     }
-    if (!JitConfig.JitInsertFma || !compSupports(InstructionSet_FMA))
+    if (!JitConfig.JitInsertFma() || !compSupports(InstructionSet_FMA))
     {
         return tree;
     }
@@ -175,6 +175,15 @@ GenTree* Compiler::fgMorphFmadd(GenTree* tree)
         a->TypeGet() != b->TypeGet() ||
         a->TypeGet() != c->TypeGet())
     {
+        return tree;
+    }
+
+    // TODO: fix
+    if (gtIsActiveCSE_Candidate(mull) || !fgGlobalMorph)
+    {
+        // shouldn't generate fmadd here:
+        // _z = a * b;
+        // return a * b + c;
         return tree;
     }
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -148,7 +148,6 @@ GenTree* Compiler::fgMorphFmadd(GenTree* tree)
     }
     if (!JitConfig.JitInsertFma || !compSupports(InstructionSet_FMA))
     {
-        // TODO: check for COMPlus_InsertFma=1
         return tree;
     }
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -146,7 +146,7 @@ GenTree* Compiler::fgMorphFmadd(GenTree* tree)
     {
         return tree;
     }
-    if (!compSupports(InstructionSet_FMA))
+    if (!JitConfig.JitInsertFma || !compSupports(InstructionSet_FMA))
     {
         // TODO: check for COMPlus_InsertFma=1
         return tree;


### PR DESCRIPTION
I know, such features certainly require design and discussions, so it's just a do-not-merge PR to show how it could be done (this is how I learn how the RuyJIT actually works 🙂 thanks to your feedback/comments).
So the PR teaches JIT to recognize `a * b + c` patterns (see https://github.com/dotnet/coreclr/issues/17541) and replace them with, basically, `Fma.MultiplyAddScalar` intrinsics (depending on signs and types):

![image](https://user-images.githubusercontent.com/523221/61794095-263dfe80-ae29-11e9-80f0-09c7fd26f47c.png)

[Benchmark](https://gist.github.com/EgorBo/bbebdfee917e00575c43dafe12f7b5f0#file-fastmathbenchmarks-cs-L31-L52): (Coffee Lake i7 8700K)

| Method |      Mean | Ratio |
|------- |----------:|------:|
|    Old | 129.41 ns |  1.00 |
|    New |  64.95 ns |  0.50 |

So it morphs:
```asm
fgMorphTree BB01, stmt 1 (before)
    [000005] ------------              *  RETURN    float 
    [000004] ------------              \--*  ADD       float 
    [000002] ------------                 +--*  MUL       float 
    [000000] ------------                 |  +--*  LCL_VAR   float  V01 arg1     
    [000001] ------------                 |  \--*  LCL_VAR   float  V02 arg2      
    [000003] ------------                 \--*  LCL_VAR   float  V03 arg3       
```
into
```asm
fgMorphTree BB01, stmt 1 (after)
    [000005] -----+------              *  RETURN    float 
    [000014] -----+------              \--*  HWIntrinsic float  float ToScalar
    [000013] -----+------                 \--*  HWIntrinsic simd16 float MultiplyAddScalar
    [000012] -----+------                    \--*  LIST      void  
    [000007] -----+------                       +--*  HWIntrinsic simd16 float CreateScalarUnsafe
    [000000] -----+------                       |  \--*  LCL_VAR   float  V01 arg1         
    [000011] ------------                       \--*  LIST      void  
    [000008] -----+------                          +--*  HWIntrinsic simd16 float CreateScalarUnsafe
    [000001] -----+------                          |  \--*  LCL_VAR   float  V02 arg2         
    [000010] ------------                          \--*  LIST      void  
    [000009] -----+------                             \--*  HWIntrinsic simd16 float CreateScalarUnsafe
    [000003] -----+------                                \--*  LCL_VAR   float  V03 arg3         
```
(`Math.FusedMultiplyAdd()` generates the same IR tree)

However, I suspect this transformation should be done in `lower.cpp` instead (I tried but it was too complicated to figure out how to do that)

## Issues
```csharp
static double NoMadd(double a, double b, double c, out double z)
{
    z = a * b;         // a * b
    return a * b + c;  // z + c
}
```
^ currently generates `mul` and `fmadd` here instead of `mul` and `add` because, I suspect, CSE happens after morphing (moving this transformation to lowering will help).

  <br/>
  
```csharp
static float Madd(float a)
{
    return a * a + a;
}
```
^ generates redundant movs. (while could be just `vfmadd231ss  xmm0, xmm0, xmm0`) - jit-diff shows some size regressions because of that.

Also, If an FMADD candidate is prejitted (R2R'd) then if we re-compile it with FMA it might return different values for the same input (however, it already happens in .NET Core: https://github.com/dotnet/coreclr/issues/25857)
  <br/>

PS: `mono` supports it thanks to `LLVM` (if `-fp-contract=fast` is set) see https://twitter.com/EgorBo/status/1063468884257316865/photo/1
