### PR TITLE
Fix EventCounter regression test

### DIFF
--- a/tests/src/tracing/eventcounter/regression-25709.cs
+++ b/tests/src/tracing/eventcounter/regression-25709.cs
@@ -100,8 +100,10 @@ namespace EventCounterRegressionTests
                 // The number below is supposed to be 2 at maximum, but in debug builds, the calls to 
                 // EventSource.Write() takes a lot longer than we thought, and the reflection in 
                 // workingset counter also adds a huge amount of time, which makes the test fail in 
-                // debug CIs. Setting the check to 3 to compensate for these.
-                if (myListener.MaxIncrement > 3)
+                // debug CIs. 
+                // This gives us 2 + 1 (EventSource delay) + 1 (Reflection delay) = 4 maximum possible increments 
+                // for the very first callback we get in EventListener. Setting the check to 4 to compensate for these.
+                if (myListener.MaxIncrement > 4)
                 {
                     Console.WriteLine($"Test Failed - Saw more than 3 exceptions / sec {myListener.MaxIncrement}");
                     return 1;


### PR DESCRIPTION
Fix #25850. In some unfortunate cases, we might be landing between two exceptions being thrown, and the timer isn't "perfect" so it may sleep for a little bit longer than 1 second. That means we may record 2 exceptions.  Plus we have enough delay for 2 additional exceptions to be thrown for the first callback we get because of EventSource.write delay and reflection.

