### PR TITLE
Fix test error reporting

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -2088,8 +2088,7 @@ def parse_test_results(host_os, arch, build_type, coreclr_repo_location, test_lo
 
                 if failed == "1":
                     failure_info = collection[0][0]
-
-                    test_output = failure_info[0].text
+                    test_output = failure_info.text
 
                 test_location_on_filesystem = find_test_from_name(host_os, test_location, test_name)
 


### PR DESCRIPTION
I attempted to run the CoreCLR test suite on OSX and a few of the tests hit errors. The mechanism for reporting that appeared to index one layer too deep - with this, it continues and reports them correctly.