### PR TITLE
Sort debug info to allow diffing

### DIFF
--- a/src/tools/r2rdump/DebugInfo.cs
+++ b/src/tools/r2rdump/DebugInfo.cs
@@ -21,10 +21,12 @@ namespace R2RDump
         private List<DebugInfoBoundsEntry> _boundsList = new List<DebugInfoBoundsEntry>();
         private List<NativeVarInfo> _variablesList = new List<NativeVarInfo>();
         private Machine _machine;
+        private bool _normalize;
 
-        public DebugInfo(byte[] image, int offset, Machine machine)
+        public DebugInfo(byte[] image, int offset, Machine machine, bool normalize)
         {
             _machine = machine;
+            _normalize = normalize;
 
             // Get the id of the runtime function from the NativeArray
             uint lookback = 0;
@@ -229,7 +231,36 @@ namespace R2RDump
                 }
 
                 entry.VariableLocation = varLoc;
-                _variablesList.Add(entry);
+                _variablesList.Add(entry);                
+            }
+
+            if (_normalize)
+            {
+                _variablesList.Sort(CompareNativeVarInfo);
+            }
+        }
+        
+        private static int CompareNativeVarInfo(NativeVarInfo left, NativeVarInfo right)
+        {
+            if (left.VariableNumber < right.VariableNumber)
+            {
+                return -1;
+            }
+            else if (left.VariableNumber > right.VariableNumber)
+            {
+                return 1;
+            }
+            else if (left.StartOffset < right.StartOffset)
+            {
+                return -1;
+            }
+            else if (left.StartOffset > right.StartOffset)
+            {
+                return 1;
+            }
+            else
+            {
+                return 0;
             }
         }
 

--- a/src/tools/r2rdump/R2RReader.cs
+++ b/src/tools/r2rdump/R2RReader.cs
@@ -757,7 +757,7 @@ namespace R2RDump
                     continue;
                 }
 
-                var debugInfo = new DebugInfo(Image, offset, Machine);
+                var debugInfo = new DebugInfo(Image, offset, Machine, Options.Normalize);
                 _runtimeFunctionToDebugInfo.Add((int)i, debugInfo);
             }
         }


### PR DESCRIPTION
As Simon noted in the code, the NativeVarInfo doesn't come with any order, and it doesn't matter because the debugger is simply doing a linear search on these non-overlapping ranges.

However, when we make changes to debug info generation, we need to be able to compare them. So I added this flag in R2RDump so that we sort them according to the variable number first and then compare by the start offset, that allows the debug info of two R2R binaries to be compared using a simple textual diff tool. For example, I arrived at the conclusion that all the differences are immaterial reordering for #25822 by using this change.

FYI @BruceForstall 