### PR TITLE
crossgen-comparison CI job

### DIFF
--- a/eng/crossgen-comparison-job.yml
+++ b/eng/crossgen-comparison-job.yml
@@ -1,0 +1,169 @@
+parameters:
+  buildConfig: ''
+  archType: ''
+  osGroup: ''
+  osIdentifier: ''
+  container: ''
+  helixQueues: ''
+  crossrootfsDir: ''
+
+### Crossgen-comparison job
+###
+### Ensure that the output of cross-architecture, e.g. x64-hosted-arm-targeting,
+### crossgen matches that of native, e.g. arm-hosted-arm-targeting, crossgen.
+
+jobs:
+- template: xplat-job.yml
+  parameters:
+    buildConfig: ${{ parameters.buildConfig }}
+    archType: ${{ parameters.archType }}
+    osGroup: ${{ parameters.osGroup }}
+    osIdentifier: ${{ parameters.osIdentifier }}
+    helixType: 'test/crossgen-comparison'
+
+    # Compute job name from template parameters
+    name: ${{ format('test_crossgen_comparison_{0}_{1}_{2}', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+    displayName: ${{ format('Test crossgen-comparison {0} {1} {2}', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+
+    crossrootfsDir: ${{ parameters.crossrootfsDir }}
+
+    variables:
+    - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      - group: DotNet-HelixApi-Access
+    - name: hostArchType
+      value: x64
+    - name: targetFlavor
+      value: $(osGroup).$(archType).$(buildConfigUpper)
+    - name: crossFlavor
+      value: $(osGroup).$(hostArchType)_$(archType).$(buildConfigUpper)
+    - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
+      - name: binDirectory
+        value: $(Build.SourcesDirectory)/bin
+      - name: productDirectory
+        value: $(Build.SourcesDirectory)/bin/Product
+    - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+      - name: binDirectory
+        value: $(Build.SourcesDirectory)\bin
+      - name: productDirectory
+        value: $(Build.SourcesDirectory)\bin\Product
+
+    # Test job depends on the corresponding build job
+    dependsOn: ${{ format('build_{0}_{1}_{2}', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+
+    # Run all steps in the container.
+    # Note that the containers are defined in platform-matrix.yml
+    container: ${{ parameters.container }}
+
+    ${{ if eq(parameters.testGroup, 'innerloop') }}:
+      timeoutInMinutes: 120
+
+    steps:
+
+    # Download product build
+    - task: DownloadBuildArtifacts@0
+      displayName: Download product build
+      inputs:
+        buildType: current
+        downloadType: single
+        artifactName: ${{ format('{0}_{1}_{2}_build', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+        downloadPath: $(System.ArtifactsDirectory)
+
+
+    # Populate Product directory
+    - task: CopyFiles@2
+      displayName: Populate Product directory
+      inputs:
+        sourceFolder: $(System.ArtifactsDirectory)/${{ format('{0}_{1}_{2}_build', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+        contents: '**'
+        targetFolder: $(productDirectory)/$(targetFlavor)
+
+
+    # Create directories and ensure crossgen is executable
+    - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
+      - script: |
+          chmod +x $(productDirectory)/$(targetFlavor)/$(hostArchType)/crossgen
+          mkdir -p $(binDirectory)/Logs/$(crossFlavor)
+        displayName: Create directories and ensure crossgen is executable
+    - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+      - script: |
+          mkdir $(binDirectory)\Logs\$(crossFlavor)
+        displayName: Create directories
+
+
+    # Populate Core_Root
+    - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
+      - script: ./build-test.sh $(buildConfig) $(archType) $(crossArg) generatelayoutonly
+        displayName: Populate Core_Root
+    - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+      - script: build-test.cmd $(buildConfig) $(archType) generateLayoutOnly
+        displayName: Populate Core_Root
+
+
+    # Create baseline output on the host (x64) machine
+    - task: PythonScript@0
+      displayName: Create cross-platform crossgen baseline
+      inputs:
+        scriptSource: 'filePath'
+        scriptPath: $(Build.SourcesDirectory)/tests/scripts/crossgen_comparison.py
+        ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
+          arguments:
+            crossgen_framework
+            --crossgen   $(productDirectory)/$(targetFlavor)/$(hostArchType)/crossgen
+            --il_corelib $(productDirectory)/$(targetFlavor)/IL/System.Private.CoreLib.dll
+            --core_root  $(binDirectory)/tests/$(targetFlavor)/Tests/Core_Root
+            --result_dir $(binDirectory)/Logs/$(crossFlavor)
+        ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+          arguments:
+            crossgen_framework
+            --crossgen   $(productDirectory)\$(targetFlavor)\$(hostArchType)\crossgen
+            --il_corelib $(productDirectory)\$(targetFlavor)\IL\System.Private.CoreLib.dll
+            --core_root  $(binDirectory)\tests\$(targetFlavor)\Tests\Core_Root
+            --result_dir $(binDirectory)\Logs\$(crossFlavor)
+
+
+    # Send payload to Helix where the native output is generated and compared to the baseline
+    - template: /eng/common/templates/steps/send-to-helix.yml
+      parameters:
+        DisplayNamePrefix: Run native crossgen and compare output to baseline
+        HelixSource: $(_HelixSource)
+        HelixType: 'test/crossgen-comparison/'
+        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          HelixAccessToken: $(HelixApiAccessToken)
+        HelixTargetQueues: ${{ join(' ', parameters.helixQueues) }}
+        ${{ if ne(variables['System.TeamProject'], 'internal') }}:
+          Creator: $(Creator)
+        WorkItemTimeout: 1:00 # 1 hour
+        WorkItemDirectory: '$(binDirectory)'
+        CorrelationPayloadDirectory: '$(Build.SourcesDirectory)/tests/scripts'
+        ${{ if ne(parameters.osName, 'Windows_NT') }}:
+          WorkItemCommand:
+            chmod +x     $HELIX_WORKITEM_PAYLOAD/Product/$(targetFlavor)/crossgen;
+            mkdir -p     $HELIX_WORKITEM_PAYLOAD/Logs/$(targetFlavor);
+            python -u $HELIX_CORRELATION_PAYLOAD/crossgen_comparison.py crossgen_framework
+            --crossgen   $HELIX_WORKITEM_PAYLOAD/Product/$(targetFlavor)/crossgen
+            --il_corelib $HELIX_WORKITEM_PAYLOAD/Product/$(targetFlavor)/IL/System.Private.CoreLib.dll
+            --core_root  $HELIX_WORKITEM_PAYLOAD/tests/$(targetFlavor)/Tests/Core_Root
+            --result_dir $HELIX_WORKITEM_PAYLOAD/Logs/$(targetFlavor);
+            python -u $HELIX_CORRELATION_PAYLOAD/crossgen_comparison.py compare
+            --base_dir   $HELIX_WORKITEM_PAYLOAD/Logs/$(crossFlavor)
+            --diff_dir   $HELIX_WORKITEM_PAYLOAD/Logs/$(targetFlavor)
+        ${{ if eq(parameters.osName, 'Windows_NT') }}:
+          WorkItemCommand:
+            mkdir        %HELIX_WORKITEM_PAYLOAD%\Logs\$(targetFlavor);
+            python -u %HELIX_CORRELATION_PAYLOAD%\crossgen_comparison.py crossgen_framework
+            --crossgen   %HELIX_WORKITEM_PAYLOAD%\Product\$(targetFlavor)\crossgen
+            --il_corelib %HELIX_WORKITEM_PAYLOAD%\Product\$(targetFlavor)\IL\System.Private.CoreLib.dll
+            --core_root  %HELIX_WORKITEM_PAYLOAD%\tests\$(targetFlavor)\Tests\Core_Root
+            --result_dir %HELIX_WORKITEM_PAYLOAD%\Logs\$(targetFlavor);
+            python -u %HELIX_CORRELATION_PAYLOAD%\crossgen_comparison.py compare
+            --base_dir   %HELIX_WORKITEM_PAYLOAD%\Logs\$(crossFlavor)
+            --diff_dir   %HELIX_WORKITEM_PAYLOAD%\Logs\$(targetFlavor)
+
+    # Publish Logs
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Logs
+      inputs:
+        pathtoPublish: $(binDirectory)/Logs
+        artifactName: ${{ format('test_crossgen_comparison_{0}_{1}_{2}_Logs', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+      continueOnError: true
+      condition: always()

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -82,6 +82,17 @@ jobs:
       displayNameArgs: R2R
 
 #
+# Crossgen-comparison jobs
+#
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: crossgen-comparison-job.yml
+    buildConfig: release
+    platforms:
+    - Linux_arm
+    helixQueueGroup: ci
+
+#
 # Formatting
 #
 - template: /eng/platform-matrix.yml

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -107,6 +107,17 @@ jobs:
       displayNameArgs: CoreFX
 
 #
+# Crossgen-comparison jobs
+#
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: crossgen-comparison-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_arm
+    helixQueueGroup: pr
+
+#
 # Release test builds
 #
 - template: /eng/platform-matrix.yml
@@ -127,3 +138,4 @@ jobs:
     jobTemplate: format-job.yml
     platforms:
     - Linux_x64
+

--- a/tests/scripts/crossgen_comparison.py
+++ b/tests/scripts/crossgen_comparison.py
@@ -129,6 +129,7 @@ def build_argument_parser():
 
     framework_parser = subparsers.add_parser('crossgen_framework', description=framework_parser_description)
     framework_parser.add_argument('--crossgen', dest='crossgen_executable_filename', required=True)
+    framework_parser.add_argument('--il_corelib', dest='il_corelib_filename', required=True)
     framework_parser.add_argument('--core_root', dest='core_root', required=True)
     framework_parser.add_argument('--result_dir', dest='result_dirname', required=True)
     framework_parser.set_defaults(func=crossgen_framework)
@@ -358,7 +359,7 @@ class CrossGenRunner:
         """
             Runs a subprocess "{crossgen_executable_filename} /nologo /Platform_Assemblies_Paths <path[:path]> /CreatePerfMap {debugging_files_dirname} /in {il_filename}" on Unix
             or "{crossgen_executable_filename} /nologo /Platform_Assemblies_Paths <path[:path]> /CreatePdb {debugging_files_dirname} /in {il_filename}" on Windows
-            and returns returncode, stdour, stderr.
+            and returns returncode, stdout, stderr.
         """
         args = self._build_args_create_debugging_file(ni_filename, debugging_files_dirname, platform_assemblies_paths)
         return self._run_with_args(args)
@@ -535,8 +536,13 @@ def add_ni_extension(filename):
 
 def crossgen_framework(args):
     global g_Framework_Assemblies
-    platform_assemblies_paths = [args.core_root]
+
+    il_corelib_filename = args.il_corelib_filename
     ni_files_dirname, debugging_files_dirname = create_output_folders()
+    ni_corelib_filename = os.path.join(ni_files_dirname, os.path.basename(il_corelib_filename))
+    platform_assemblies_paths = [args.core_root]
+    crossgen_results = run_crossgen(args.crossgen_executable_filename, il_corelib_filename, ni_corelib_filename, platform_assemblies_paths, debugging_files_dirname)
+    save_crossgen_results_to_json_files(crossgen_results, args.result_dirname)
 
     for assembly_name in g_Framework_Assemblies:
         il_filename = os.path.join(args.core_root, assembly_name)


### PR DESCRIPTION
Add PR- and CI-triggered jobs for crossgen-comparison, which runs "cross"-crossgen on a selection of assemblies on the build host and then compares the results to the corresponding native crossgen.

Note that this change enables Linux ARM jobs only.  It attempts to support other configurations, notably Windows, but those YAML paths have not been tested because they are not needed at this point.

Part of #24358