### PR TITLE
Do not fast tail call if caller has multislot structs

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1004,6 +1004,11 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo)
 #endif // _TARGET_XXX_
 
 #if FEATURE_FASTTAILCALL
+            if (cSlots > 1)
+            {
+                varDscInfo->hasMultiSlotStruct = true;
+            }
+            
             varDscInfo->stackArgSize += roundUp(argSize, TARGET_POINTER_SIZE);
 #endif // FEATURE_FASTTAILCALL
         }

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1008,7 +1008,7 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo)
             {
                 varDscInfo->hasMultiSlotStruct = true;
             }
-            
+
             varDscInfo->stackArgSize += roundUp(argSize, TARGET_POINTER_SIZE);
 #endif // FEATURE_FASTTAILCALL
         }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7268,6 +7268,7 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
     // that we are not dealing with structs that are >8 bytes.
 
     bool   hasStackArgs    = false;
+    bool   calleeHasStackArgs = calleeStackSize > 0;
     size_t maxFloatRegArgs = MAX_FLOAT_REG_ARG;
 
     size_t calleeIntStackArgCount = calleeArgRegCount > maxRegArgs ? calleeArgRegCount - maxRegArgs : 0;
@@ -7296,7 +7297,7 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
     //
     // When either the caller or callee have multi-stlot stack arguments we cannot safely
     // shuffle arguments in LowerFastTailCall. See https://github.com/dotnet/coreclr/issues/12468.
-    if (hasStackArgs && hasTwoSlotSizedStruct)
+    if (calleeHasStackArgs && hasTwoSlotSizedStruct)
     {
         reportFastTailCallDecision("Will not fastTailCall calleeStackSize > 0 && hasTwoSlotSizedStruct",
                                    callerStackSize, calleeStackSize);

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7268,7 +7268,6 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
     // that we are not dealing with structs that are >8 bytes.
 
     bool   hasStackArgs    = false;
-    bool   calleeHasStackArgs = calleeStackSize > 0;
     size_t maxFloatRegArgs = MAX_FLOAT_REG_ARG;
 
     size_t calleeIntStackArgCount = calleeArgRegCount > maxRegArgs ? calleeArgRegCount - maxRegArgs : 0;
@@ -7297,7 +7296,7 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee)
     //
     // When either the caller or callee have multi-stlot stack arguments we cannot safely
     // shuffle arguments in LowerFastTailCall. See https://github.com/dotnet/coreclr/issues/12468.
-    if (calleeHasStackArgs && hasTwoSlotSizedStruct)
+    if (hasStackArgs && hasTwoSlotSizedStruct)
     {
         reportFastTailCallDecision("Will not fastTailCall calleeStackSize > 0 && hasTwoSlotSizedStruct",
                                    callerStackSize, calleeStackSize);

--- a/tests/src/JIT/opt/FastTailCall/FastTailCallCandidates.cs
+++ b/tests/src/JIT/opt/FastTailCall/FastTailCallCandidates.cs
@@ -1246,8 +1246,8 @@ public class FastTailCallCandidates
     ///
     /// On x64 linux this will not fast tail call.
     ///
-    /// The caller uses 10 integer registers 56 bytes of stack (10 args)
-    /// The callee uses 10 integer registers, 32 bytes of stack (10 args)
+    /// The caller uses 6 integer registers 56 bytes of stack (10 args)
+    /// The callee uses 6 integer registers, 32 bytes of stack (10 args)
     ///
     /// Return 100 is a pass.
     /// Return 114 is a failure.
@@ -1259,7 +1259,7 @@ public class FastTailCallCandidates
                                                         long four,
                                                         long five,
                                                         long six,
-                                                        long seven,                 // stack slot 5
+                                                        long seven,
                                                         long eight,                 // stack slot 6
                                                         long nine,                  // stack slot 7
                                                         long ten)                   // stack slot 8
@@ -1307,8 +1307,8 @@ public class FastTailCallCandidates
     ///
     /// On x64 linux this will not fast tail call.
     ///
-    /// The caller uses 2 integer registers 32 bytes of stack (3 args)
-    /// The callee uses 3 integer registers, 0 bytes of stack (3 args)
+    /// The caller uses 6 integer registers 56 bytes of stack (3 args)
+    /// The callee uses 6 integer registers, 32 bytes of stack (3 args)
     ///
     /// Return 100 is a pass.
     /// Return 113 is a failure.
@@ -1350,8 +1350,8 @@ public class FastTailCallCandidates
     ///
     /// On x64 linux this will not fast tail call.
     ///
-    /// The caller uses 2 integer registers 32 bytes of stack (3 args)
-    /// The callee uses 3 integer registers, 0 bytes of stack (3 args)
+    /// The caller uses 6 integer registers 56 bytes of stack (3 args)
+    /// The callee uses 6 integer registers, 32 bytes of stack (3 args)
     ///
     /// Return 100 is a pass.
     /// Return 113 is a failure.

--- a/tests/src/JIT/opt/FastTailCall/FastTailCallCandidates.cs
+++ b/tests/src/JIT/opt/FastTailCall/FastTailCallCandidates.cs
@@ -63,6 +63,8 @@ public class FastTailCallCandidates
         CheckOutput(CallerHFACaseCalleeOnly(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0));
         CheckOutput(CallerHFaCaseCalleeStackArgs(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0));
         CheckOutput(DoubleCountRetBuffCaller(1));
+        CheckOutput(Struct32CallerWrapper());
+        CheckOutput(Struct32CallerWrapperCalleeHasStack(2));
 
         return s_ret_value;
 
@@ -1152,6 +1154,228 @@ public class FastTailCallCandidates
                 return 112;
             }
         }
+    }
+
+    /// <summary>
+    /// Decision to fast tail call
+    /// </summary>
+    ///
+    /// On x64 linux this will fast tail call.
+    ///
+    /// The caller uses 2 integer registers 32 bytes of stack (3 args)
+    /// The callee uses 3 integer registers, 0 bytes of stack (3 args)
+    ///
+    /// Return 100 is a pass.
+    /// Return 113 is a failure.
+    ///
+    /// </remarks>
+    public static int Struct32Caller(StructSizeThirtyTwo one, long two, long three)
+    {
+        if (two % 2 == 1)
+        {
+            return Struct32Callee(two, two, three);
+        }
+        else
+        {
+            return Struct32Callee(three, two, three);
+        }
+    }
+
+    /// <summary>
+    /// Decision to fast tail call
+    /// </summary>
+    ///
+    /// On x64 linux this will fast tail call.
+    ///
+    /// The caller uses 2 integer registers 32 bytes of stack (3 args)
+    /// The callee uses 3 integer registers, 0 bytes of stack (3 args)
+    ///
+    /// Return 100 is a pass.
+    /// Return 113 is a failure.
+    ///
+    /// </remarks>
+    public static int Struct32Callee(long one, long two, long three)
+    {
+        int count = 0;
+        for (int i = 0; i < three * 100; ++i)
+        {
+            if (i % 10 == 0)
+            {
+                ++count;
+            }
+        }
+
+        if (count == 30)
+        {
+            return 84;
+        }
+        else
+        {
+            return 85;
+        }
+    }
+
+    /// <summary>
+    /// Decision to fast tail call
+    /// </summary>
+    ///
+    /// On x64 linux this will fast tail call.
+    ///
+    /// The caller uses 2 integer registers 32 bytes of stack (3 args)
+    /// The callee uses 3 integer registers, 0 bytes of stack (3 args)
+    ///
+    /// Return 100 is a pass.
+    /// Return 113 is a failure.
+    ///
+    /// </remarks>
+    public static int Struct32CallerWrapper()
+    {
+        int ret = Struct32Caller(new StructSizeThirtyTwo(1, 2, 3, 4), 2, 3);
+
+        if (ret != 84)
+        {
+            return 113;
+        }
+
+        return 100;
+    }
+
+    /// <summary>
+    /// Decision to not fast tail call
+    /// </summary>
+    ///
+    /// On x64 linux this will not fast tail call.
+    ///
+    /// The caller uses 10 integer registers 56 bytes of stack (10 args)
+    /// The callee uses 10 integer registers, 32 bytes of stack (10 args)
+    ///
+    /// Return 100 is a pass.
+    /// Return 114 is a failure.
+    ///
+    /// </remarks>
+    public static int Struct32CallerCalleeHasStackSpace(StructSizeThirtyTwo one,    // stack slot 1, 2, 3, 4
+                                                        long two, 
+                                                        long three,
+                                                        long four,
+                                                        long five,
+                                                        long six,
+                                                        long seven,                 // stack slot 5
+                                                        long eight,                 // stack slot 6
+                                                        long nine,                  // stack slot 7
+                                                        long ten)                   // stack slot 8
+    {
+        int count = 0;
+        for (int i = 0; i < two * 100; ++i)
+        {
+            if (i % 10 == 0)
+            {
+                ++count;
+            }
+        }
+
+        if (count == 20)
+        {
+            return Struct32CalleeWithStack(one.a, 
+                                           one.b, 
+                                           one.c,
+                                           one.d,
+                                           two,
+                                           three,
+                                           four,        // stack slot 1
+                                           five,        // stack slot 2
+                                           six,         // stack slot 3
+                                           seven);      // stack slot 4
+        }
+        else
+        {
+            return Struct32CalleeWithStack(one.a, 
+                                           one.b, 
+                                           one.c,
+                                           one.d,
+                                           two,
+                                           three,
+                                           four,        // stack slot 1
+                                           five,        // stack slot 2
+                                           six,         // stack slot 3
+                                           seven);      // stack slot 4
+        }
+    }
+
+    /// <summary>
+    /// Decision to not fast tail call
+    /// </summary>
+    ///
+    /// On x64 linux this will not fast tail call.
+    ///
+    /// The caller uses 2 integer registers 32 bytes of stack (3 args)
+    /// The callee uses 3 integer registers, 0 bytes of stack (3 args)
+    ///
+    /// Return 100 is a pass.
+    /// Return 113 is a failure.
+    ///
+    /// </remarks>
+    public static int Struct32CalleeWithStack(long one, 
+                                              long two, 
+                                              long three,
+                                              long four,
+                                              long five,
+                                              long six,
+                                              long seven,
+                                              long eight,
+                                              long nine,
+                                              long ten)
+    {
+        int count = 0;
+        for (int i = 0; i < one * 100; ++i)
+        {
+            if (i % 10 == 0)
+            {
+                ++count;
+            }
+        }
+
+        if (count == 10)
+        {
+            return 84;
+        }
+        else
+        {
+            return 85;
+        }
+    }
+
+    /// <summary>
+    /// Decision to not fast tail call
+    /// </summary>
+    ///
+    /// On x64 linux this will not fast tail call.
+    ///
+    /// The caller uses 2 integer registers 32 bytes of stack (3 args)
+    /// The callee uses 3 integer registers, 0 bytes of stack (3 args)
+    ///
+    /// Return 100 is a pass.
+    /// Return 113 is a failure.
+    ///
+    /// </remarks>
+    public static int Struct32CallerWrapperCalleeHasStack(int two)
+    {
+        int ret = Struct32CallerCalleeHasStackSpace(new StructSizeThirtyTwo(1, 2, 3, 4),
+                                                    5, 
+                                                    6,
+                                                    7,
+                                                    8,
+                                                    9,
+                                                    10,
+                                                    11,
+                                                    12,
+                                                    13);
+
+        if (ret != 84)
+        {
+            return 114;
+        }
+
+        return 100;
     }
 
     ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
With more eyes on LowerFastTailCall, @jakobbotsch and I have found another SBC bug. We have verified that this causes silent bad codegen on <= coreclr 3.0. Thank you @jakobbotsch for help on a functioning repro.