### PR TITLE
JIT: Remove bound checks when index is Byte and array.Length >= 256

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Char.cs
+++ b/src/System.Private.CoreLib/shared/System/Char.cs
@@ -38,7 +38,7 @@ namespace System
         public const char MinValue = (char)0x00;
 
         // Unicode category values from Unicode U+0000 ~ U+00FF. Store them in byte[] array to save space.
-        private static ReadOnlySpan<byte> CategoryForLatin1 => new byte[] { // uses C# compiler's optimization for static byte[] data
+        private static ReadOnlySpan<byte> CategoryForLatin1 => new byte[256] { // uses C# compiler's optimization for static byte[] data
             (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control,    // 0000 - 0007
             (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control,    // 0008 - 000F
             (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control,    // 0010 - 0017
@@ -89,7 +89,7 @@ namespace System
         private static UnicodeCategory GetLatin1UnicodeCategory(char ch)
         {
             Debug.Assert(IsLatin1(ch), "char.GetLatin1UnicodeCategory(): ch should be <= 007f");
-            return (UnicodeCategory)CategoryForLatin1[(int)ch];
+            return (UnicodeCategory)CategoryForLatin1[(byte)ch];
         }
 
         //

--- a/src/System.Private.CoreLib/shared/System/Text/Rune.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/Rune.cs
@@ -29,7 +29,7 @@ namespace System.Text
         // - 0x40 bit if set means 'is letter or digit'
         // - 0x20 bit is reserved for future use
         // - bottom 5 bits are the UnicodeCategory of the character
-        private static ReadOnlySpan<byte> AsciiCharInfo => new byte[256]
+        private static ReadOnlySpan<byte> AsciiCharInfo => new byte[]
         {
             0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x8E, 0x8E, 0x8E, 0x8E, 0x8E, 0x0E, 0x0E,
             0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E,
@@ -38,14 +38,7 @@ namespace System.Text
             0x18, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40,
             0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x14, 0x18, 0x15, 0x1B, 0x12,
             0x1B, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
-            0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x14, 0x19, 0x15, 0x19, 0x0E,
-
-            // pad with zeros to make 256 elements so any access to AsciiCharInfo via byte index 
-            // won't generate redundant bound checks
-            0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-            0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-            0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-            0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+            0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x14, 0x19, 0x15, 0x19, 0x0E
         };
 
         private readonly uint _value;
@@ -1085,7 +1078,7 @@ namespace System.Text
         {
             if (value.IsAscii)
             {
-                return (UnicodeCategory)(AsciiCharInfo[(byte)value.Value] & UnicodeCategoryMask);
+                return (UnicodeCategory)(AsciiCharInfo[value.Value] & UnicodeCategoryMask);
             }
             else
             {
@@ -1178,7 +1171,7 @@ namespace System.Text
         {
             if (value.IsAscii)
             {
-                return ((AsciiCharInfo[(byte)value.Value] & IsLetterOrDigitFlag) != 0);
+                return ((AsciiCharInfo[value.Value] & IsLetterOrDigitFlag) != 0);
             }
             else
             {
@@ -1241,7 +1234,7 @@ namespace System.Text
         {
             if (value.IsAscii)
             {
-                return (AsciiCharInfo[(byte)value.Value] & IsWhiteSpaceFlag) != 0;
+                return (AsciiCharInfo[value.Value] & IsWhiteSpaceFlag) != 0;
             }
 
             // U+0085 is special since it's a whitespace character but is in the Control category

--- a/src/System.Private.CoreLib/shared/System/Text/Rune.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/Rune.cs
@@ -29,7 +29,7 @@ namespace System.Text
         // - 0x40 bit if set means 'is letter or digit'
         // - 0x20 bit is reserved for future use
         // - bottom 5 bits are the UnicodeCategory of the character
-        private static ReadOnlySpan<byte> AsciiCharInfo => new byte[]
+        private static ReadOnlySpan<byte> AsciiCharInfo => new byte[256]
         {
             0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x8E, 0x8E, 0x8E, 0x8E, 0x8E, 0x0E, 0x0E,
             0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E,
@@ -38,7 +38,14 @@ namespace System.Text
             0x18, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40,
             0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x14, 0x18, 0x15, 0x1B, 0x12,
             0x1B, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
-            0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x14, 0x19, 0x15, 0x19, 0x0E
+            0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x14, 0x19, 0x15, 0x19, 0x0E,
+
+            // pad with zeros to make 256 elements so any access to AsciiCharInfo via byte index 
+            // won't generate redundant bound checks
+            0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+            0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+            0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+            0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
         };
 
         private readonly uint _value;
@@ -1078,7 +1085,7 @@ namespace System.Text
         {
             if (value.IsAscii)
             {
-                return (UnicodeCategory)(AsciiCharInfo[value.Value] & UnicodeCategoryMask);
+                return (UnicodeCategory)(AsciiCharInfo[(byte)value.Value] & UnicodeCategoryMask);
             }
             else
             {
@@ -1171,7 +1178,7 @@ namespace System.Text
         {
             if (value.IsAscii)
             {
-                return ((AsciiCharInfo[value.Value] & IsLetterOrDigitFlag) != 0);
+                return ((AsciiCharInfo[(byte)value.Value] & IsLetterOrDigitFlag) != 0);
             }
             else
             {
@@ -1234,7 +1241,7 @@ namespace System.Text
         {
             if (value.IsAscii)
             {
-                return (AsciiCharInfo[value.Value] & IsWhiteSpaceFlag) != 0;
+                return (AsciiCharInfo[(byte)value.Value] & IsWhiteSpaceFlag) != 0;
             }
 
             // U+0085 is special since it's a whitespace character but is in the Control category

--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -1155,7 +1155,7 @@ Range RangeCheck::ComputeRange(BasicBlock* block, GenTree* expr, bool monotonic 
     }
     else if (expr->OperIs(GT_CAST) || varTypeIsSmallInt(expr->TypeGet()))
     {
-        var_types exprType = expr->OperIs(GT_CAST) ? expr->AsCast()->gtCastType : expr->TypeGet();
+        var_types exprType = expr->OperIs(GT_CAST) ? expr->AsCast()->CastToType() : expr->TypeGet();
 
         switch (exprType)
         {

--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -1053,7 +1053,7 @@ bool RangeCheck::ComputeDoesOverflow(BasicBlock* block, GenTree* expr)
     else if (expr->OperGet() == GT_CAST)
     {
         GenTreeCast* castExpr = expr->AsCast();
-        if (castExpr->CastToType() == TYP_UBYTE) // TODO: other types?
+        if (castExpr->CastToType() == TYP_UBYTE && castExpr->CastFromType() == TYP_INT)
         {
             overflows = false;
         }

--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -1053,7 +1053,8 @@ bool RangeCheck::ComputeDoesOverflow(BasicBlock* block, GenTree* expr)
     else if (expr->OperGet() == GT_CAST)
     {
         GenTreeCast* castExpr = expr->AsCast();
-        if (castExpr->CastToType() == TYP_UBYTE && castExpr->CastFromType() == TYP_INT)
+        if ((castExpr->CastToType() == TYP_UBYTE || castExpr->CastToType() == TYP_USHORT) &&
+            (castExpr->CastFromType() == TYP_INT))
         {
             overflows = false;
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/25894
Test case:
```csharp
static ReadOnlySpan<byte> _byteArray => new byte[256]
{
    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
};

static byte GetByte(int index)
{
    return _byteArray[(byte)index]; // System.Byte.MaxValue <= map.Length
                                    // so index will never go out of bounds
}
```
Was:
```asm
; Method Program:GetByte(int):ubyte
G_M30997_IG01:
       sub      rsp, 40

G_M30997_IG02:
       movzx    rax, cl
       cmp      eax, 256
       jae      SHORT G_M30997_IG04
       movsxd   rax, eax
       mov      rdx, 0xD1FFAB1E
       movzx    rax, byte  ptr [rax+rdx]

G_M30997_IG03:
       add      rsp, 40
       ret      

G_M30997_IG04:
       call     CORINFO_HELP_RNGCHKFAIL
       int3     

; Total bytes of code 42
```
Now:
```asm
; Method Program:GetByte(int):ubyte

G_M30997_IG01:

G_M30997_IG02:
       movzx    rax, cl
       movsxd   rax, eax
       mov      rdx, 0xD1FFAB1E
       movzx    rax, byte  ptr [rax+rdx]

G_M30997_IG03:
       ret      
; Total bytes of code: 21
```

jit-diff:
```asm
Summary:
(Lower is better)
Total bytes of diff: -361 (-0.01% of base)
    diff is an improvement.
Top file improvements by size (bytes):
        -361 : System.Private.CoreLib.dasm (-0.01% of base)
1 total files with size differences (1 improved, 0 regressed), 0 unchanged.
Top method improvements by size (bytes):
         -22 (-9.73% of base) : System.Private.CoreLib.dasm - Char:IsNumber(ref,int):bool
         -22 (-6.25% of base) : System.Private.CoreLib.dasm - CultureInfo:VerifyCultureName(ref,bool):bool (2 methods)
         -21 (-10.99% of base) : System.Private.CoreLib.dasm - Char:IsPunctuation(ref,int):bool
         -21 (-10.99% of base) : System.Private.CoreLib.dasm - Char:IsSymbol(ref,int):bool
         -18 (-40.91% of base) : System.Private.CoreLib.dasm - Char:GetLatin1UnicodeCategory(ushort):int
Top method improvements by size (percentage):
         -18 (-40.91% of base) : System.Private.CoreLib.dasm - Char:GetLatin1UnicodeCategory(ushort):int
         -14 (-21.54% of base) : System.Private.CoreLib.dasm - Rune:GetUnicodeCategory(struct):int
         -14 (-20.59% of base) : System.Private.CoreLib.dasm - Char:GetUnicodeCategory(ushort):int
         -14 (-17.72% of base) : System.Private.CoreLib.dasm - Char:IsControl(ushort):bool
         -14 (-15.73% of base) : System.Private.CoreLib.dasm - Rune:IsLetterOrDigit(struct):bool
23 total methods with size differences (23 improved, 0 regressed), 18907 unchanged.
Completed analysis in 2.76s
```
There are more candidates for this improvement.

PS: I know I have a couple of unfinished PRs, going to focus on them now.