### PR TITLE
Fixes Issue #20262 for CoreCLR 5.0

### DIFF
--- a/src/ilasm/assembler.cpp
+++ b/src/ilasm/assembler.cpp
@@ -276,6 +276,14 @@ mdToken Assembler::GetAsmRef(__in __nullterminated const char* szName)
 
 mdToken Assembler::GetBaseAsmRef()
 {
+    // First we check for "System.Private.CoreLib" as the base or System assembly
+    //
+    AsmManAssembly* coreLibAsm = m_pManifest->GetAsmRefByAsmName("System.Private.CoreLib");
+    if(coreLibAsm != NULL)
+    {
+        return GetAsmRef(coreLibAsm->szAlias ? coreLibAsm->szAlias : coreLibAsm->szName);
+    }
+
     AsmManAssembly* sysRuntime = m_pManifest->GetAsmRefByAsmName("System.Runtime");
     if(sysRuntime != NULL)
     {


### PR DESCRIPTION
Disassembler:  ildasm/dasm.cpp

 In the CoreCLR with reference assemblies and redirection it is more difficult to determine if
 a particular Assembly is the System assembly, like mscorlib.dll is for the Desktop CLR.
 In the CoreCLR runtimes, the System assembly can be System.Private.CoreLib.dll, System.Runtime.dll
 or netstandard.dll and in the future a different Assembly name could be used.
 We now determine the identity of the System assembly by querying if the Assembly defines the
 well known type System.Object as that type must be defined by the System assembly
 If this type is defined then we will output the ".mscorlib" directive to indicate that this
 assembly is the System assembly.

Assembler:  ilasm/assembler.cpp

 In Assembler:GetBaseAsmRef() add a check for System.Private.CoreLib as the System or Base assembly.