### PR TITLE
RestoreSources cleanup

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -13,6 +13,9 @@
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-corefxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
+    <add key="dotnet-core-internal-tooling" value="https://devdiv.pkgs.visualstudio.com/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json" />
+    <add key="VS_internal" value="https://devdiv.pkgs.visualstudio.com/_packaging/VS/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/dependencies.props
+++ b/dependencies.props
@@ -1,16 +1,5 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- NuGet package restore sources. -->
-  <PropertyGroup>
-    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
-      https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
-      https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json;
-      https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
-      https://api.nuget.org/v3/index.json;
-      $(RestoreSources)
-    </RestoreSources>
-  </PropertyGroup>
-
   <!-- [ARCADE REMOVE] Versions.props is imported by Arcade SDK targets when building with Arcade -->
   <Import Project="eng/Versions.props" Condition="'$(ArcadeBuild)' != 'true'" />
 

--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <PropertyGroup>
-    <RestoreSources Condition="'$(AdditionalRestoreSources)' != ''">
-        $(RestoreSources);
-        $(AdditionalRestoreSources)
-    </RestoreSources>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Packaging" Version="$(MicrosoftDotNetBuildTasksPackagingVersion)" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="$(MicrosoftNETCorePlatformsVersion)" />

--- a/eng/common/internal/Tools.csproj
+++ b/eng/common/internal/Tools.csproj
@@ -11,16 +11,6 @@
     <PackageReference Include="Microsoft.DotNet.IBCMerge" Version="$(MicrosoftDotNetIBCMergeVersion)" Condition="'$(UsingToolIbcOptimization)' == 'true'" />
     <PackageReference Include="Drop.App" Version="$(DropAppVersion)" ExcludeAssets="all" Condition="'$(UsingToolVisualStudioIbcTraining)' == 'true'"/>
   </ItemGroup>
-  <PropertyGroup>
-    <RestoreSources></RestoreSources>
-    <RestoreSources Condition="'$(UsingToolIbcOptimization)' == 'true'">
-      https://devdiv.pkgs.visualstudio.com/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json;
-    </RestoreSources>
-    <RestoreSources Condition="'$(UsingToolVisualStudioIbcTraining)' == 'true'">
-      $(RestoreSources);
-      https://devdiv.pkgs.visualstudio.com/_packaging/VS/nuget/v3/index.json;
-    </RestoreSources>
-  </PropertyGroup>
 
   <!-- Repository extensibility point -->
   <Import Project="$(RepositoryEngineeringDir)InternalTools.props" Condition="Exists('$(RepositoryEngineeringDir)InternalTools.props')" />

--- a/src/.nuget/optdata/optdata.csproj
+++ b/src/.nuget/optdata/optdata.csproj
@@ -11,13 +11,6 @@
     <PackageReference Include="optimization.IBC.CoreCLR" Version="$(optimizationIBCCoreCLRVersion)" Condition="'$(optimizationIBCCoreCLRVersion)'!=''" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <RestoreSources>
-      https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
-      $(RestoreSources);
-    </RestoreSources>
-  </PropertyGroup>
-
   <!--                                                                       -->
   <!-- Task: DumpPgoDataPackageVersion                                       -->
   <!--                                                                       -->

--- a/tests/dir.props
+++ b/tests/dir.props
@@ -87,18 +87,6 @@
   <!-- Provides properties for dependency versions and configures dependency verification/auto-upgrade. -->
   <Import Project="$(ProjectDir)..\dependencies.props" />
 
-  <!-- Add test-specific package restore sources. -->
-  <PropertyGroup>
-    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
-      https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json;
-      $(RestoreSources)
-    </RestoreSources>
-    <RestoreSources Condition="'$(IntermediateAzureFeed)' != ''">
-      $(IntermediateAzureFeed);
-      $(RestoreSources)
-    </RestoreSources>
-  </PropertyGroup>
-
   <!-- Use Roslyn Compilers to build -->
   <Import Project="$(RoslynPropsFile)" Condition="Exists('$(RoslynPropsFile)')" />
 


### PR DESCRIPTION
Remove `RestoreSources` from Versions.props in order to complete [step 2](https://github.com/dotnet/arcade/blob/master/Documentation/RestoreSourcesUpdateStatus.md#part-2)