### PR TITLE
Marking some EventPipe test as incompatible with runincontext.

### DIFF
--- a/tests/src/tracing/eventpipe/buffersize/buffersize.csproj
+++ b/tests/src/tracing/eventpipe/buffersize/buffersize.csproj
@@ -15,6 +15,7 @@
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">

--- a/tests/src/tracing/eventpipe/eventsvalidation/ExceptionThrown_V1.csproj
+++ b/tests/src/tracing/eventpipe/eventsvalidation/ExceptionThrown_V1.csproj
@@ -15,6 +15,7 @@
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">

--- a/tests/src/tracing/eventpipe/eventsvalidation/GCStartStop.csproj
+++ b/tests/src/tracing/eventpipe/eventsvalidation/GCStartStop.csproj
@@ -15,6 +15,7 @@
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">

--- a/tests/src/tracing/eventpipe/providervalidation/providervalidation.csproj
+++ b/tests/src/tracing/eventpipe/providervalidation/providervalidation.csproj
@@ -15,6 +15,7 @@
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">


### PR DESCRIPTION
https://github.com/dotnet/coreclr/issues/25815#issuecomment-516794116
In short:
*The `Debug.SetProvider` is in `System.Private.CoreLib` and loaded into the default context, but the `Microsoft.Diagnostics.TraceSource.dll` was loaded into the testing unloadable context. So we've created an instance of the `TraceProvider` type from that assembly living in the unloadable context and stored it into a static variable in the default context.
This changes mark the tests as incompatible with the **runincontext** testing.
In real world scenarios, the `System.Diagnostics.TraceSource.dll` which is a part of the runtime would not be loaded into the unloadable context.*

Fixes https://github.com/dotnet/coreclr/issues/25815