### PR TITLE
Add a config knob for importing ibc files

### DIFF
--- a/Documentation/project-docs/clr-configuration-knobs.md
+++ b/Documentation/project-docs/clr-configuration-knobs.md
@@ -283,6 +283,7 @@ Name | Description | Type | Class | Default Value | Flags
 `DisableHotCold` | Master hot/cold splitting switch in Jit64 | `DWORD` | `UNSUPPORTED` | |
 `DisableIBC` | Disables the use of IBC data | `DWORD` | `UNSUPPORTED` | `0` | REGUTIL_default
 `UseIBCFile` |  | `DWORD` | `EXTERNAL` | `0` | REGUTIL_default
+`IBCFileDir` | Directory to search for IBC files | `STRING` | `EXTERNAL` | |
 
 #### Interop Configuration Knobs
 

--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -325,7 +325,7 @@ RETAIL_CONFIG_DWORD_INFO_EX(UNSUPPORTED_ConvertIbcData, W("ConvertIbcData"), 1, 
 RETAIL_CONFIG_DWORD_INFO_DIRECT_ACCESS(UNSUPPORTED_DisableHotCold, W("DisableHotCold"), "Master hot/cold splitting switch in Jit64")
 RETAIL_CONFIG_DWORD_INFO_EX(UNSUPPORTED_DisableIBC, W("DisableIBC"), 0, "Disables the use of IBC data", CLRConfig::REGUTIL_default)
 RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_UseIBCFile, W("UseIBCFile"), 0, "", CLRConfig::REGUTIL_default)
-
+RETAIL_CONFIG_STRING_INFO(EXTERNAL_IBCFileDir, W("IBCFileDir"), "Directory to search for IBC files")
 
 ///
 /// JIT

--- a/src/zap/zapimage.cpp
+++ b/src/zap/zapimage.cpp
@@ -2475,7 +2475,20 @@ HRESULT ZapImage::LocateProfileData()
     // Couldn't find profile resource--let's see if there's an ibc file to use instead
     //
 
-    SString path(m_pModuleFileName);
+    SString path;
+
+    LPWSTR ibcDir = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_IBCFileDir);
+    if (ibcDir != NULL)
+    {
+        LPCWSTR moduleFileName = wcsrchr(m_pModuleFileName, DIRECTORY_SEPARATOR_CHAR_W);
+        path.Set(ibcDir);
+        path.Append(DIRECTORY_SEPARATOR_CHAR_W);
+        path.Append(moduleFileName);
+    }
+    else
+    {
+        path.Set(m_pModuleFileName); // the same directory as the IL dll
+    }
 
     SString::Iterator dot = path.End();
     if (path.FindBack(dot, '.'))


### PR DESCRIPTION
- Suggests a new configuration knob `IBCFileDir` for specifying a directory containing IBC files.
- This knos is used by crossgen when profile data is not in PE resource section and `UseIBCFile` is set.
- cf. `ZapBBInstrDir` is used by EE to produce profile data in a particular directory, while this new knob does the opposite for the consumer (crossgen).
- Could this possibly impose vulnerability? (Should we verify untrusted IBC data?)

cc @jkotas @briansull 