### PR TITLE
Fix check for no affinitization in GC on Unix

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -34782,7 +34782,7 @@ HRESULT GCHeap::Initialize()
     }
 
     if ((cpu_index_ranges_holder.Get() != nullptr)
-#ifndef FEATURE_PAL
+#ifdef PLATFORM_WINDOWS
         || (config_affinity_mask != 0)
 #endif
     )
@@ -34820,10 +34820,10 @@ HRESULT GCHeap::Initialize()
         {
             nhp = min(nhp, num_affinitized_processors);
         }
-#ifdef FEATURE_PAL
+#ifndef PLATFORM_WINDOWS
         // Limit the GC heaps to the number of processors available in the system.
         nhp = min (nhp, GCToOSInterface::GetTotalProcessorCount());
-#endif // FEATURE_PAL
+#endif // !PLATFORM_WINDOWS
     }
 #endif //!FEATURE_REDHAWK
 #endif //MULTIPLE_HEAPS

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -34805,12 +34805,7 @@ HRESULT GCHeap::Initialize()
 
     nhp = min (nhp, MAX_SUPPORTED_CPUS);
 #ifndef FEATURE_REDHAWK
-    gc_heap::gc_thread_no_affinitize_p = (gc_heap::heap_hard_limit ? false : (GCConfig::GetNoAffinitize() != 0));
-
-    if (gc_heap::heap_hard_limit)
-    {
-        gc_heap::gc_thread_no_affinitize_p = ((config_affinity_set.Count() == 0) && (config_affinity_mask == 0));
-    }
+    gc_heap::gc_thread_no_affinitize_p = (gc_heap::heap_hard_limit ? !affinity_config_specified_p : (GCConfig::GetNoAffinitize() != 0));
 
     if (!(gc_heap::gc_thread_no_affinitize_p))
     {

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -34781,7 +34781,11 @@ HRESULT GCHeap::Initialize()
         return CLR_E_GC_BAD_AFFINITY_CONFIG;
     }
 
-    if ((cpu_index_ranges_holder.Get() != nullptr) || (config_affinity_mask != 0))
+    if ((cpu_index_ranges_holder.Get() != nullptr)
+#ifndef FEATURE_PAL
+        || (config_affinity_mask != 0)
+#endif
+    )
     {
         affinity_config_specified_p = true;
     }


### PR DESCRIPTION
While the affinitization mask setting is not used for affinity setting
on Unix, it was still being checked for non-zero as one of the
indicators that GC heap affinity was specified. This change removes
that check for Unix builds.