### PR TITLE
Propagate errors during build to the Azure DevOps timeline

### DIFF
--- a/build-test.cmd
+++ b/build-test.cmd
@@ -239,7 +239,6 @@ set __MsbuildErr=/flp2:ErrorsOnly;LogFile="%__BuildErr%"
 set __Logging=!__MsbuildLog! !__MsbuildWrn! !__MsbuildErr!
 
 call "%__ProjectDir%\cmake_msbuild.cmd" /nologo /verbosity:minimal /clp:Summary /nodeReuse:false^
-  /l:BinClashLogger,Tools/net46/Microsoft.DotNet.Build.Tasks.dll;LogFile=binclash.log^
   /p:RestoreDefaultOptimizationDataPackage=false /p:PortableBuild=true^
   /p:UsePartialNGENOptimization=false /maxcpucount^
   "%__NativeTestIntermediatesDir%\install.vcxproj"^
@@ -279,7 +278,6 @@ set __Logging=!__MsbuildLog! !__MsbuildWrn! !__MsbuildErr!
 REM Disable warnAsError - coreclr issue 19922
 powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -Command "%__ProjectDir%\eng\common\msbuild.ps1" %__ArcadeScriptArgs%^
   %__ProjectDir%\tests\build.proj -warnAsError:0 /t:BatchRestorePackages /nodeReuse:false^
-  '/l:BinClashLogger,Tools/Microsoft.DotNet.Build.Tasks.dll;LogFile=binclash.log'^
   /p:RestoreDefaultOptimizationDataPackage=false /p:PortableBuild=true^
   /p:UsePartialNGENOptimization=false /maxcpucount^
   '!__Logging!' %__CommonMSBuildArgs% %__PriorityArg% %__UnprocessedBuildArgs%
@@ -403,7 +401,6 @@ set __Logging=!__MsbuildLog! !__MsbuildWrn! !__MsbuildErr!
 
 powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -File "%__ProjectDir%\eng\common\msbuild.ps1" %__ArcadeScriptArgs%^
   %__ProjectDir%\tests\runtest.proj /t:CreateTestOverlay /nodeReuse:false^
-  /l:BinClashLogger,Tools/Microsoft.DotNet.Build.Tasks.dll;LogFile=binclash.log^
   /p:RestoreDefaultOptimizationDataPackage=false /p:PortableBuild=true^
   /p:UsePartialNGENOptimization=false /maxcpucount^
   !__Logging! %__CommonMSBuildArgs% %RuntimeIdArg% %__PriorityArg% %__UnprocessedBuildArgs%
@@ -437,7 +434,6 @@ set __Logging=!__MsbuildLog! !__MsbuildWrn! !__MsbuildErr!
 
 powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -File "%__ProjectDir%\eng\common\msbuild.ps1" %__ArcadeScriptArgs%^
   %__ProjectDir%\tests\runtest.proj /t:CreateTestHost /nodeReuse:false^
-  /l:BinClashLogger,Tools/Microsoft.DotNet.Build.Tasks.dll;LogFile=binclash.log^
   /p:RestoreDefaultOptimizationDataPackage=false /p:PortableBuild=true^
   /p:UsePartialNGENOptimization=false /maxcpucount^
   !__Logging! %__CommonMSBuildArgs% %RuntimeIdArg% %__PriorityArg% %__UnprocessedBuildArgs%

--- a/build-test.cmd
+++ b/build-test.cmd
@@ -7,6 +7,12 @@ set "__MsgPrefix=BUILDTEST: "
 
 echo %__MsgPrefix%Starting Build at %TIME%
 
+REM Set variables used when running in an Azure DevOps task
+if defined TF_BUILD (
+    set __ArcadeScriptArgs="-ci"
+    set __ErrMsgPrefix=##vso[task.logissue type=error]
+)
+
 set __ThisScriptDir="%~dp0"
 
 call "%__ThisScriptDir%"\setup_vs_tools.cmd
@@ -181,7 +187,7 @@ REM ============================================================================
 
 call "%__TestDir%\setup-stress-dependencies.cmd" /arch %__BuildArch% /outputdir %__BinDir%
 if errorlevel 1 (
-    echo %__MsgPrefix%Error: setup-stress-dependencies failed.
+    echo %__ErrMsgPrefix%%__MsgPrefix%Error: setup-stress-dependencies failed.
     goto     :Exit_Failure
 )
 @if defined _echo @echo on
@@ -207,7 +213,7 @@ call                                 "%__VCToolsRoot%\vcvarsall.bat" %__VCBuildA
 @if defined _echo @echo on
 
 if not defined VSINSTALLDIR (
-    echo %__MsgPrefix%Error: VSINSTALLDIR variable not defined.
+    echo %__ErrMsgPrefix%%__MsgPrefix%Error: VSINSTALLDIR variable not defined.
     exit /b 1
 )
 if not exist "%VSINSTALLDIR%DIA SDK" goto NoDIA
@@ -219,7 +225,7 @@ call "%__SourceDir%\pal\tools\gen-buildsys-win.bat" ""%__ProjectFilesDir%"" %__V
 popd
 
 if not exist "%__NativeTestIntermediatesDir%\install.vcxproj" (
-    echo %__MsgPrefix%Failed to generate test native component build project!
+    echo %__ErrMsgPrefix%%__MsgPrefix%Failed to generate test native component build project!
     exit /b 1
 )
 
@@ -239,7 +245,7 @@ call "%__ProjectDir%\cmake_msbuild.cmd" /nologo /verbosity:minimal /clp:Summary 
   "%__NativeTestIntermediatesDir%\install.vcxproj"^
   !__Logging! /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% %__CommonMSBuildArgs% %__PriorityArg% %__UnprocessedBuildArgs%
 if errorlevel 1 (
-    echo %__MsgPrefix%Error: build failed. Refer to the build log files for details:
+    echo %__ErrMsgPrefix%%__MsgPrefix%Error: native test build failed. Refer to the build log files for details.
     echo     %__BuildLog%
     echo     %__BuildWrn%
     echo     %__BuildErr%
@@ -270,12 +276,13 @@ set __MsbuildWrn=/flp1:WarningsOnly;LogFile="%__BuildWrn%"
 set __MsbuildErr=/flp2:ErrorsOnly;LogFile="%__BuildErr%"
 set __Logging=!__MsbuildLog! !__MsbuildWrn! !__MsbuildErr!
 
-call "%__ProjectDir%\dotnet.cmd" msbuild /nologo /verbosity:minimal /clp:Summary /nodeReuse:false^
-  /l:BinClashLogger,Tools/Microsoft.DotNet.Build.Tasks.dll;LogFile=binclash.log^
+REM Disable warnAsError - coreclr issue 19922
+powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -Command "%__ProjectDir%\eng\common\msbuild.ps1" %__ArcadeScriptArgs%^
+  %__ProjectDir%\tests\build.proj -warnAsError:0 /t:BatchRestorePackages /nodeReuse:false^
+  '/l:BinClashLogger,Tools/Microsoft.DotNet.Build.Tasks.dll;LogFile=binclash.log'^
   /p:RestoreDefaultOptimizationDataPackage=false /p:PortableBuild=true^
   /p:UsePartialNGENOptimization=false /maxcpucount^
-  %__ProjectDir%\tests\build.proj /t:BatchRestorePackages^
-  !__Logging! %__CommonMSBuildArgs% %__PriorityArg% %__UnprocessedBuildArgs%
+  '!__Logging!' %__CommonMSBuildArgs% %__PriorityArg% %__UnprocessedBuildArgs%
 
 :SkipRestoreProduct
 
@@ -290,7 +297,7 @@ if defined __SkipManaged goto SkipManagedBuild
 echo %__MsgPrefix%Starting the Managed Tests Build
 
 if not defined VSINSTALLDIR (
-    echo %__MsgPrefix%Error: build-test.cmd should be run from a Visual Studio Command Prompt.  Please see https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/developer-guide.md for build instructions.
+    echo %__ErrMsgPrefix%%__MsgPrefix%Error: build-test.cmd should be run from a Visual Studio Command Prompt.  Please see https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/developer-guide.md for build instructions.
     exit /b 1
 )
 set __AppendToLog=false
@@ -314,14 +321,17 @@ for /l %%G in (1, 1, %__NumberOfTestGroups%) do (
     set __MsbuildLog=/flp:Verbosity=normal;LogFile="%__BuildLog%";Append=!__AppendToLog!
     set __MsbuildWrn=/flp1:WarningsOnly;LogFile="%__BuildWrn%";Append=!__AppendToLog!
     set __MsbuildErr=/flp2:ErrorsOnly;LogFile="%__BuildErr%";Append=!__AppendToLog!
+    set __Logging=!__MsbuildLog! !__MsbuildWrn! !__MsbuildErr!
 
     set __TestGroupToBuild=%%G
     echo Running: msbuild %__ProjectDir%\tests\build.proj !__MsbuildLog! !__MsbuildWrn! !__MsbuildErr! %TargetsWindowsMsbuildArg% %__msbuildArgs% !__PriorityArg! %__UnprocessedBuildArgs%
 
-    call "%__ProjectDir%\dotnet.cmd" msbuild %__ProjectDir%\tests\build.proj !__MsbuildLog! !__MsbuildWrn! !__MsbuildErr! %TargetsWindowsMsbuildArg% %__msbuildArgs% !__PriorityArg! %__UnprocessedBuildArgs%
+    REM Disable warnAsError - coreclr issue 19922
+    powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -Command "%__ProjectDir%\eng\common\msbuild.ps1" %__ArcadeScriptArgs%^
+        %__ProjectDir%\tests\build.proj -warnAsError:0 '!__Logging!' %TargetsWindowsMsbuildArg% %__msbuildArgs% !__PriorityArg! '%__UnprocessedBuildArgs%'
 
     if errorlevel 1 (
-        echo %__MsgPrefix%Error: build failed. Refer to the build log files for details:
+        echo %__ErrMsgPrefix%%__MsgPrefix%Error: managed test build failed. Refer to the build log files for details:
         echo     %__BuildLog%
         echo     %__BuildWrn%
         echo     %__BuildErr%
@@ -340,9 +350,10 @@ REM Check that we've built about as many tests as we expect. This is primarily i
 REM drastically fewer Pri-1 tests than expected.
 echo %__MsgPrefix%Check the managed tests build
 echo Running: dotnet msbuild %__ProjectDir%\tests\runtest.proj /t:CheckTestBuild /p:CLRTestPriorityToBuild=%__Priority% %__msbuildArgs% %__unprocessedBuildArgs%
-call "%__ProjectDir%\dotnet.cmd" msbuild %__ProjectDir%\tests\runtest.proj /t:CheckTestBuild /p:CLRTestPriorityToBuild=%__Priority% %__msbuildArgs% %__unprocessedBuildArgs%
+powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -File "%__ProjectDir%\eng\common\msbuild.ps1" %__ArcadeScriptArgs%^
+    %__ProjectDir%\tests\runtest.proj /t:CheckTestBuild /p:CLRTestPriorityToBuild=%__Priority% %__msbuildArgs% %__unprocessedBuildArgs%
 if errorlevel 1 (
-    echo %__MsgPrefix%Error: build failed.
+    echo %__ErrMsgPrefix%%__MsgPrefix%Error: Check Test Build failed.
     exit /b 1
 )
 
@@ -390,14 +401,14 @@ set __MsbuildWrn=/flp1:WarningsOnly;LogFile="%__BuildWrn%"
 set __MsbuildErr=/flp2:ErrorsOnly;LogFile="%__BuildErr%"
 set __Logging=!__MsbuildLog! !__MsbuildWrn! !__MsbuildErr!
 
-call %__ProjectDir%\dotnet.cmd msbuild /nologo /verbosity:minimal /clp:Summary /nodeReuse:false^
+powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -File "%__ProjectDir%\eng\common\msbuild.ps1" %__ArcadeScriptArgs%^
+  %__ProjectDir%\tests\runtest.proj /t:CreateTestOverlay /nodeReuse:false^
   /l:BinClashLogger,Tools/Microsoft.DotNet.Build.Tasks.dll;LogFile=binclash.log^
   /p:RestoreDefaultOptimizationDataPackage=false /p:PortableBuild=true^
   /p:UsePartialNGENOptimization=false /maxcpucount^
-  %__ProjectDir%\tests\runtest.proj /t:CreateTestOverlay^
   !__Logging! %__CommonMSBuildArgs% %RuntimeIdArg% %__PriorityArg% %__UnprocessedBuildArgs%
 if errorlevel 1 (
-    echo %__MsgPrefix%Error: build failed. Refer to the build log files for details:
+    echo %__ErrMsgPrefix%%__MsgPrefix%Error: Create Test Overlay failed. Refer to the build log files for details:
     echo     %__BuildLog%
     echo     %__BuildWrn%
     echo     %__BuildErr%
@@ -424,14 +435,14 @@ set __MsbuildWrn=/flp1:WarningsOnly;LogFile="%__BuildWrn%"
 set __MsbuildErr=/flp2:ErrorsOnly;LogFile="%__BuildErr%"
 set __Logging=!__MsbuildLog! !__MsbuildWrn! !__MsbuildErr!
 
-call %__ProjectDir%\dotnet.cmd msbuild /nologo /verbosity:minimal /clp:Summary /nodeReuse:false^
+powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -File "%__ProjectDir%\eng\common\msbuild.ps1" %__ArcadeScriptArgs%^
+  %__ProjectDir%\tests\runtest.proj /t:CreateTestHost /nodeReuse:false^
   /l:BinClashLogger,Tools/Microsoft.DotNet.Build.Tasks.dll;LogFile=binclash.log^
   /p:RestoreDefaultOptimizationDataPackage=false /p:PortableBuild=true^
   /p:UsePartialNGENOptimization=false /maxcpucount^
-  %__ProjectDir%\tests\runtest.proj /t:CreateTestHost^
   !__Logging! %__CommonMSBuildArgs% %RuntimeIdArg% %__PriorityArg% %__UnprocessedBuildArgs%
 if errorlevel 1 (
-    echo %__MsgPrefix%Error: build failed. Refer to the build log files for details:
+    echo %__ErrMsgPrefix%%__MsgPrefix%Error: Create Test Host failed. Refer to the build log files for details:
     echo     %__BuildLog%
     echo     %__BuildWrn%
     echo     %__BuildErr%
@@ -460,7 +471,7 @@ set __Logging=!__MsbuildLog! !__MsbuildWrn! !__MsbuildErr!
 REM Build wrappers using the local SDK's msbuild. As we move to arcade, the other builds should be moved away from run.exe as well.
 call "%__ProjectDir%\dotnet.cmd" msbuild %__ProjectDir%\tests\runtest.proj /p:RestoreAdditionalProjectSources=https://dotnet.myget.org/F/dotnet-core/  /p:BuildWrappers=true !__Logging! %__msbuildArgs% %TargetsWindowsMsbuildArg% %__UnprocessedBuildArgs%
 if errorlevel 1 (
-    echo %__MsgPrefix%Error: Xunit wrapper build failed. Refer to the build log files for details:
+    echo %__ErrMsgPrefix%%__MsgPrefix%Error: XUnit wrapper build failed. Refer to the build log files for details:
     echo     %__BuildLog%
     echo     %__BuildWrn%
     echo     %__BuildErr%
@@ -589,7 +600,7 @@ if %__exitCode% neq 0 (
 REM Delete original .dll & replace it with the Crossgened .dll
 del %1
 ren "%CORE_ROOT%\temp.ni.dll" %2
-    
+
 echo Successfully precompiled %2
 exit /b 0
 

--- a/build-test.sh
+++ b/build-test.sh
@@ -67,7 +67,7 @@ build_test_wrappers()
         eval $nextCommand
 
         if [ $? -ne 0 ]; then
-            echo "${__MsgPrefix}Error: build failed. Refer to the build log files for details (above)"
+            echo "${__ErrMsgPrefix}${__MsgPrefix}Error: XUnit wrapper build failed. Refer to the build log files for details (above)"
             exit 1
         else
             echo "XUnit Wrappers have been built."
@@ -160,7 +160,7 @@ generate_layout()
         echo "Resolve runtime dependences via $nextCommand"
         eval $nextCommand
         if [ $? != 0 ]; then
-            echo "${__MsgPrefix}Error: setup-stress-dependencies failed."
+            echo "${__ErrMsgPrefix}${__MsgPrefix}Error: setup-stress-dependencies failed."
             exit 1
         fi
     fi
@@ -324,7 +324,7 @@ build_Tests()
         build_native_projects "$__BuildArch" "${__NativeTestIntermediatesDir}"
 
         if [ $? -ne 0 ]; then
-            echo "${__MsgPrefix}Error: build failed. Refer to the build log files for details (above)"
+            echo "${__ErrMsgPrefix}${__MsgPrefix}Error: native test build failed. Refer to the build log files for details (above)"
             exit 1
         fi
     fi
@@ -335,7 +335,7 @@ build_Tests()
         build_MSBuild_projects "Tests_Managed" "$__ProjectDir/tests/build.proj" "Managed tests build (build tests)" "$__up"
 
         if [ $? -ne 0 ]; then
-            echo "${__MsgPrefix}Error: build failed. Refer to the build log files for details (above)"
+            echo "${__ErrMsgPrefix}${__MsgPrefix}Error: managed test build failed. Refer to the build log files for details (above)"
             exit 1
         else
             echo "Checking the Managed Tests Build..."
@@ -343,7 +343,7 @@ build_Tests()
             build_MSBuild_projects "Check_Test_Build" "${__ProjectDir}/tests/runtest.proj" "Check Test Build" "/t:CheckTestBuild"
 
             if [ $? -ne 0 ]; then
-                echo "${__MsgPrefix}Error: Check Test Build failed."
+                echo "${__ErrMsgPrefix}${__MsgPrefix}Error: Check Test Build failed."
                 exit 1
             fi
         fi
@@ -407,23 +407,24 @@ build_MSBuild_projects()
             export __TestGroupToBuild=$testGroupToBuild
 
             # Generate build command
-            buildArgs=("/nologo" "/verbosity:minimal" "/clp:Summary")
+            buildArgs=("$projectName")
             buildArgs+=("/p:RestoreDefaultOptimizationDataPackage=false" "/p:PortableBuild=true")
             buildArgs+=("/p:UsePartialNGENOptimization=false" "/maxcpucount")
 
-            buildArgs+=("$projectName" "${__msbuildLog}" "${__msbuildWrn}" "${__msbuildErr}")
+            buildArgs+=("${__msbuildLog}" "${__msbuildWrn}" "${__msbuildErr}")
             buildArgs+=("$__msbuildEventLogging")
             buildArgs+=("${extraBuildParameters[@]}")
             buildArgs+=("${__CommonMSBuildArgs[@]}")
             buildArgs+=("${__UnprocessedBuildArgs[@]}")
 
-            nextCommand="\"$__ProjectRoot/dotnet.sh\" msbuild ${buildArgs[@]}"
+            # Disable warnAsError - coreclr issue 19922
+            nextCommand="\"$__ProjectRoot/eng/common/msbuild.sh\" $__ArcadeScriptArgs --warnAsError false ${buildArgs[@]}"
             echo "Building step '$stepName' testGroupToBuild=$testGroupToBuild via $nextCommand"
             eval $nextCommand
 
             # Make sure everything is OK
             if [ $? -ne 0 ]; then
-                echo "${__MsgPrefix}Failed to build $stepName. See the build logs:"
+                echo "${__ErrMsgPrefix}${__MsgPrefix}Failed to build $stepName. See the build logs:"
                 echo "    $__BuildLog"
                 echo "    $__BuildWrn"
                 echo "    $__BuildErr"
@@ -439,23 +440,24 @@ build_MSBuild_projects()
         __msbuildErr="\"/flp2:ErrorsOnly;LogFile=${__BuildErr}\""
 
         # Generate build command
-        buildArgs=("/nologo" "/verbosity:minimal" "/clp:Summary")
+        buildArgs=("$projectName")
         buildArgs+=("/p:RestoreDefaultOptimizationDataPackage=false" "/p:PortableBuild=true")
         buildArgs+=("/p:UsePartialNGENOptimization=false" "/maxcpucount")
 
-        buildArgs+=("$projectName" "${__msbuildLog}" "${__msbuildWrn}" "${__msbuildErr}")
+        buildArgs+=("${__msbuildLog}" "${__msbuildWrn}" "${__msbuildErr}")
         buildArgs+=("$__msbuildEventLogging")
         buildArgs+=("${extraBuildParameters[@]}")
         buildArgs+=("${__CommonMSBuildArgs[@]}")
         buildArgs+=("${__UnprocessedBuildArgs[@]}")
 
-        nextCommand="\"$__ProjectRoot/dotnet.sh\" msbuild ${buildArgs[@]}"
+        # Disable warnAsError - coreclr issue 19922
+        nextCommand="\"$__ProjectRoot/eng/common/msbuild.sh\" $__ArcadeScriptArgs --warnAsError false ${buildArgs[@]}"
         echo "Building step '$stepName' via $nextCommand"
         eval $nextCommand
 
         # Make sure everything is OK
         if [ $? -ne 0 ]; then
-            echo "${__MsgPrefix}Failed to build $stepName. See the build logs:"
+            echo "${__ErrMsgPrefix}${__MsgPrefix}Failed to build $stepName. See the build logs:"
             echo "    $__BuildLog"
             echo "    $__BuildWrn"
             echo "    $__BuildErr"
@@ -499,7 +501,7 @@ build_native_projects()
                                                  /p:ArcadeBuild=true /t:GenerateNativeVersionFile /restore \
                                                  $__CommonMSBuildArgs $__UnprocessedBuildArgs
             if [ $? -ne 0 ]; then
-                echo "Failed to generate native version file."
+                echo "${__ErrMsgPrefix}Failed to generate native version file."
                 exit $?
             fi
         else
@@ -528,7 +530,7 @@ build_native_projects()
     fi
 
     if [ ! -f "$intermediatesForBuild/$buildFile" ]; then
-        echo "Failed to generate $message build project!"
+        echo "${__ErrMsgPrefix}Failed to generate $message build project!"
         exit 1
     fi
 
@@ -544,7 +546,7 @@ build_native_projects()
 
     $buildTool install -j $__NumProc
     if [ $? != 0 ]; then
-        echo "Failed to build $message."
+        echo "${__ErrMsgPrefix}Failed to build $message."
         exit 1
     fi
 
@@ -662,6 +664,12 @@ case $OSName in
         __HostOS=Linux
         ;;
 esac
+
+# Set variables used when running in an Azure DevOps task
+if [[ ! -z $TF_BUILD ]]; then
+  __ArcadeScriptArgs="--ci"
+  __ErrMsgPrefix="##vso[task.logissue type=error]"
+fi
 
 __BuildType=Debug
 __CodeCoverage=

--- a/build-test.sh
+++ b/build-test.sh
@@ -376,13 +376,6 @@ build_MSBuild_projects()
     __BuildWrn="$__LogsDir/${__BuildLogRootName}.${__BuildOS}.${__BuildArch}.${__BuildType}.wrn"
     __BuildErr="$__LogsDir/${__BuildLogRootName}.${__BuildOS}.${__BuildArch}.${__BuildType}.err"
 
-    # Use binclashlogger by default if no other logger is specified
-    if [[ "${extraBuildParameters[*]}" == *"/l:"* ]]; then
-        __msbuildEventLogging=
-    else
-        __msbuildEventLogging="/l:BinClashLogger,Tools/Microsoft.DotNet.Build.Tasks.dll\;LogFile=binclash.log"
-    fi
-
     if [[ "$subDirectoryName" == "Tests_Managed" ]]; then
         # Execute msbuild managed test build in stages - workaround for excessive data retention in MSBuild ConfigCache
         # See https://github.com/Microsoft/msbuild/issues/2993
@@ -412,7 +405,6 @@ build_MSBuild_projects()
             buildArgs+=("/p:UsePartialNGENOptimization=false" "/maxcpucount")
 
             buildArgs+=("${__msbuildLog}" "${__msbuildWrn}" "${__msbuildErr}")
-            buildArgs+=("$__msbuildEventLogging")
             buildArgs+=("${extraBuildParameters[@]}")
             buildArgs+=("${__CommonMSBuildArgs[@]}")
             buildArgs+=("${__UnprocessedBuildArgs[@]}")
@@ -445,7 +437,6 @@ build_MSBuild_projects()
         buildArgs+=("/p:UsePartialNGENOptimization=false" "/maxcpucount")
 
         buildArgs+=("${__msbuildLog}" "${__msbuildWrn}" "${__msbuildErr}")
-        buildArgs+=("$__msbuildEventLogging")
         buildArgs+=("${extraBuildParameters[@]}")
         buildArgs+=("${__CommonMSBuildArgs[@]}")
         buildArgs+=("${__UnprocessedBuildArgs[@]}")

--- a/src/.nuget/optdata/optdata.csproj
+++ b/src/.nuget/optdata/optdata.csproj
@@ -11,13 +11,6 @@
     <PackageReference Include="optimization.IBC.CoreCLR" Version="$(optimizationIBCCoreCLRVersion)" Condition="'$(optimizationIBCCoreCLRVersion)'!=''" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <RestoreSources>
-      https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
-      $(RestoreSources);
-    </RestoreSources>
-  </PropertyGroup>
-
   <!--                                                                       -->
   <!-- Task: DumpPgoDataPackageVersion                                       -->
   <!--                                                                       -->
@@ -25,7 +18,7 @@
   <!--                                                                       -->
   <!-- DumpPgoDataPackageVersion is used by build.sh and build.cmd to pass   -->
   <!-- the version information to cmake. The task will write a file to be    -->
-  <!-- read back by build.cmd/sh. The path for the file is:                  --> 
+  <!-- read back by build.cmd/sh. The path for the file is:                  -->
   <!-- $(PgoDataPackageVersionOutputFile)                                    -->
   <!--                                                                       -->
 
@@ -46,7 +39,7 @@
   <!--                                                                       -->
   <!-- DumpIbcDataPackageVersion is used by build.sh and build.cmd to pass   -->
   <!-- the version information to cmake. The task will write a file to be    -->
-  <!-- read back by build.cmd/sh. The path for the file is:                  --> 
+  <!-- read back by build.cmd/sh. The path for the file is:                  -->
   <!-- $(IbcDataPackageVersionOutputFile)                                    -->
   <!--                                                                       -->
   <Target Name="DumpIbcDataPackageVersion">


### PR DESCRIPTION
Propagate errors during build to the Azure DevOps timeline
- Use Arcade's msbuild script for building managed product and test projects. They include a logger when running under CI that outputs msbuild errors such that they appear in the timeline (and thus will be picked up by our telemetry)
- Prefix error messages to make them logging commands when running as an Azure DevOps task

This makes it so that the actual build/restore errors from managed projects will show up as errors in CI builds (and get classified as Code failures in telemetry). For native projects, the actual build errors are still not propagated, but we will at least have an error indicating that we failed to build the native components (instead of just Bash/Cmd exited with code 1). I also did not try to categorize our error messages - just made them propagate as errors instead of normal output.