### PR TITLE
Port #25972 to 3.0 - Fix WSL alternate stack check

### DIFF
--- a/src/pal/src/include/pal/signal.hpp
+++ b/src/pal/src/include/pal/signal.hpp
@@ -30,6 +30,7 @@ struct SignalHandlerWorkerReturnPoint
 };
 
 extern bool g_registered_signal_handlers;
+extern bool g_enable_alternate_stack_check;
 
 /*++
 Function :


### PR DESCRIPTION
#### Description
On WSL, the alternate stack check in sigsegv_handler doesn't work. The
uc_stack members are always zero no matter whether the handler is
executed on an alternate or default stack. So the check to detect
whether we are running on an alternate stack or not is always returning
false on WSL and it prevents NULL reference exceptions from being
handled.
The fix is to introduce an env variable COMPlus_EnableAlternateStackCheck
that can be used to enable the alternate stack check. By default, the
sigsegv_handler is considered to always run on an alternate stack.
#### Customer Impact
.NET Core applications running on the WSL (Windows subsystem for Linux)
crash whenever a null reference happens instead of converting that into
NullReferenceException.
#### Regression
Yes, regression on WSL in preview 7 
#### Risk
None - default behavior reverts to the previous state that was there since release/2.0. 
The COMPlus_EnableAlternateStackCheck can be used to explicitly enable the new
behavior that was added in preview 7 on non-WSL systems when needed.
The need for that is very rare and specific to applications that use third party native 
libraries that register their own SIGSEGV handlers.

Issue #25945