### PR TITLE
Fix Issue 20262 for release/3.0 -  ildasm/ilasm roundtrip - detect and mark the System assemblies

### DIFF
--- a/src/ilasm/assembler.cpp
+++ b/src/ilasm/assembler.cpp
@@ -276,6 +276,14 @@ mdToken Assembler::GetAsmRef(__in __nullterminated const char* szName)
 
 mdToken Assembler::GetBaseAsmRef()
 {
+    // First we check for "System.Private.CoreLib" as the base or System assembly
+    //
+    AsmManAssembly* coreLibAsm = m_pManifest->GetAsmRefByAsmName("System.Private.CoreLib");
+    if(coreLibAsm != NULL)
+    {
+        return GetAsmRef(coreLibAsm->szAlias ? coreLibAsm->szAlias : coreLibAsm->szName);
+    }
+
     AsmManAssembly* sysRuntime = m_pManifest->GetAsmRefByAsmName("System.Runtime");
     if(sysRuntime != NULL)
     {

--- a/src/ildasm/dasm.cpp
+++ b/src/ildasm/dasm.cpp
@@ -928,50 +928,51 @@ bool HasSuppressingAttribute()
 #endif
 void DumpMscorlib(void* GUICookie)
 {
-    if(g_pAssemblyImport==NULL) g_pAssemblyImport = GetAssemblyImport(GUICookie);
-    if(g_pAssemblyImport!=NULL)
+    // In the CoreCLR with reference assemblies and redirection it is more difficult to determine if
+    // a particular Assembly is the System assembly, like mscorlib.dll is for the Desktop CLR.
+    // In the CoreCLR runtimes, the System assembly can be System.Private.CoreLib.dll, System.Runtime.dll
+    // or netstandard.dll and in the future a different Assembly name could be used.
+    // We now determine the identity of the System assembly by querying if the Assembly defines the
+    // well known type System.Object as that type must be defined by the System assembly
+    // If this type is defined then we will output the ".mscorlib" directive to indicate that this 
+    // assembly is the System assembly.
+    //
+    mdTypeDef tkObjectTypeDef = mdTypeDefNil;
+
+    // Lookup the type System.Object and see it it has a type definition in this assembly
+    if (SUCCEEDED(g_pPubImport->FindTypeDefByName(W("System.Object"), mdTypeDefNil, &tkObjectTypeDef)))
     {
-        mdAssembly  tkAsm;
-        if(SUCCEEDED(g_pAssemblyImport->GetAssemblyFromScope(&tkAsm))&&(tkAsm != mdAssemblyNil))
+        if (tkObjectTypeDef != mdTypeDefNil)
         {
-            const void* pPublicKey;
-            ULONG       cbPublicKey = 0;
-            ULONG       ulHashAlgId;
-            WCHAR       wzName[1024];
-            ULONG       ulNameLen=0;
-            ASSEMBLYMETADATA    md;
-            WCHAR       wzLocale[1024];
-            DWORD       dwFlags;
-            //char        szString[4096];
-            
-            md.szLocale = wzLocale;
-            md.cbLocale = 1024;
-            md.rProcessor = NULL;
-            md.ulProcessor = 0;
-            md.rOS = NULL;
-            md.ulOS = 0;
-    
-            if(SUCCEEDED(g_pAssemblyImport->GetAssemblyProps(            // S_OK or error.
-                                                            tkAsm,       // [IN] The Assembly for which to get the properties.
-                                                            &pPublicKey, // [OUT] Pointer to the public key.
-                                                            &cbPublicKey,// [OUT] Count of bytes in the public key.
-                                                            &ulHashAlgId,// [OUT] Hash Algorithm.
-                                                            wzName,      // [OUT] Buffer to fill with name.
-                                                            1024,        // [IN] Size of buffer in wide chars.
-                                                            &ulNameLen,  // [OUT] Actual # of wide chars in name.
-                                                            &md,         // [OUT] Assembly MetaData.
-                                                            &dwFlags)))  // [OUT] Flags.
+            // We do have a type definition for System.Object in this assembly
+            //
+            DWORD dwClassAttrs = 0;
+            mdToken tkExtends = mdTypeDefNil;
+
+            // Retrieve the type def properties as well, so that we can check a few more things about 
+            // the System.Object type
+            //
+            if (SUCCEEDED(g_pPubImport->GetTypeDefProps(tkObjectTypeDef, NULL, NULL, 0, &dwClassAttrs, &tkExtends)))
             {
-                if(wcscmp(wzName,W("mscorlib")) == 0)
+                bool bExtends = g_pPubImport->IsValidToken(tkExtends);
+                bool isClass = ((dwClassAttrs & tdClassSemanticsMask) == tdClass);
+
+                // We also check the type properties to make sure that we have a class and not a Value type definition
+                // and that this type definition isn't extending another type.
+                // 
+                if (isClass & !bExtends)
                 {
-                    printLine(GUICookie,"");
-                    sprintf_s(szString,SZSTRING_SIZE,"%s%s ",g_szAsmCodeIndent,KEYWORD(".mscorlib"));
-                    printLine(GUICookie,szString);
-                    printLine(GUICookie,"");
+                    // We will mark this assembly with the System assembly directive: .mscorlib
+                    //
+                    printLine(GUICookie, "");
+                    sprintf_s(szString, SZSTRING_SIZE, "%s%s ", g_szAsmCodeIndent, KEYWORD(".mscorlib"));
+                    printLine(GUICookie, szString);
+                    printLine(GUICookie, "");                
                 }
             }
         }
     }
+
 }
 void DumpTypelist(void* GUICookie)
 {


### PR DESCRIPTION
#### Description

In order to properly roundtrip the System assemblies using `ildasm/ilasm` the System assembly must be marked with the `.mscorlib` directive.  In the CoreCLR runtimes, the System assembly can be System.Private.CoreLib.dll, System.Runtime.dll or netstandard.dll. 
Prior to this fix  `ildasm`  was using a string compare against `mscorlib` to mark the  System assembly. This would cause a failure to round tripping on CoreCLR where a different name is used for the System assembly.
With this fix we now determine the identity of the System assembly by querying if the Assembly defines the well known type System.Object as that type must be defined by the System assembly.
This allows us to successfully round trip the System assembly on CoreCLR.
For ilasm we also now have added System.Private.CoreLib.dll to list of assemblies that are accepted as the base System assembly.

#### Customer Impact

This issue was impacting source build which is using IL as a source for several cases.  
They have requested that the tools  `ildasm/ilasm`  support round tripping of the various System assemblies on CoreCLR.  These include System.Private.CoreLib.dll, System.Runtime.dll or netstandard.dll. 
With this fix the source build team is no longer blocked.

#### Regression

Not a regression.  This has never worked properly on CoreCLR.

#### Risk

Very Low - This check fixes defect in the `ildasm` tool and adds System.Private.CoreLib.dll to the set of System assemblies in `ilasm`.

Issue #20262 

**Details:**
In the CoreCLR with reference assemblies and redirection it is more difficult to determine if
a particular Assembly is the System assembly, like mscorlib.dll is for the Desktop CLR.
In the CoreCLR runtimes, the System assembly can be System.Private.CoreLib.dll, System.Runtime.dll
or netstandard.dll and in the future a different Assembly name could be used.
We now determine the identity of the System assembly by querying if the Assembly defines the
well known type System.Object as that type must be defined by the System assembly
If this type is defined then we will output the ".mscorlib" directive to indicate that this
assembly is the System assembly.