### PR TITLE
Do not set source for CoreDisTools.

### DIFF
--- a/tests/setup-stress-dependencies.cmd
+++ b/tests/setup-stress-dependencies.cmd
@@ -79,7 +79,7 @@ REM ============================================================================
 
 REM Download the package
 echo Downloading CoreDisTools package
-set DOTNETCMD="%__DotNetCmd%" restore "%__CsprojPath%" --source https://dotnet.myget.org/F/dotnet-core/ --packages "%__PackageDir%"
+set DOTNETCMD="%__DotNetCmd%" restore "%__CsprojPath%" --packages "%__PackageDir%"
 echo %DOTNETCMD%
 call %DOTNETCMD%
 if errorlevel 1 goto Fail

--- a/tests/setup-stress-dependencies.sh
+++ b/tests/setup-stress-dependencies.sh
@@ -177,7 +177,7 @@ fi
 
 # Download the package
 echo Downloading CoreDisTools package
-bash -c -x "$dotnet restore $csprojPath --source https://dotnet.myget.org/F/dotnet-core/ --packages $packageDir"
+bash -c -x "$dotnet restore $csprojPath --packages $packageDir"
 if [ $? -ne 0 ]
 then
     exit_with_error 1 "Failed to restore the package"


### PR DESCRIPTION
We do not set it when we restore other packages so unify that.

dotnet -restore will search for nuget.config and find https://github.com/dotnet/coreclr/blob/master/NuGet.config that contains https://dotnet.myget.org/F/dotnet-core/api/v3/index.json that is needed here.


I will monitor if it fixes issues like https://dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_apis/build/builds/277007/logs/482.