### PR TITLE
Use a platform-agnostic name for coredistools lib

### DIFF
--- a/src/tools/r2rdump/CoreDisTools.cs
+++ b/src/tools/r2rdump/CoreDisTools.cs
@@ -12,7 +12,7 @@ namespace R2RDump
 {
     public class CoreDisTools
     {
-        private const string _dll = "coredistools.dll";
+        private const string _dll = "coredistools";
 
         public enum TargetArch
         {


### PR DESCRIPTION
Hi! :wave:

I've been playing with `R2RDump` on OSX and ran into an issue with the expected native library name being Windows specific.

The `coredistools` library that's actually published doesn't appear to work on non-Windows platforms yet (looks like it's old), but if I build `coredistools` locally in my OSX environment then I can use it successfully with `R2RDump`.