### PR TITLE
Delete TRANSLATE_PDB.

### DIFF
--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -15,19 +15,6 @@
 #include "jitgcinfo.h"
 
 /*****************************************************************************/
-#ifdef TRANSLATE_PDB
-#ifndef _ADDRMAP_INCLUDED_
-#include "addrmap.h"
-#endif
-#ifndef _LOCALMAP_INCLUDED_
-#include "localmap.h"
-#endif
-#ifndef _PDBREWRITE_H_
-#include "pdbrewrite.h"
-#endif
-#endif // TRANSLATE_PDB
-
-/*****************************************************************************/
 #ifdef _MSC_VER
 #pragma warning(disable : 4200) // allow arrays of 0 size inside structs
 #endif
@@ -542,13 +529,10 @@ protected:
 
     struct instrDescDebugInfo
     {
-        unsigned idNum;
-        size_t   idSize;       // size of the instruction descriptor
-        unsigned idVarRefOffs; // IL offset for LclVar reference
-        size_t   idMemCookie;  // for display of method name  (also used by switch table)
-#ifdef TRANSLATE_PDB
-        unsigned int idilStart; // instruction descriptor source information for PDB translation
-#endif
+        unsigned          idNum;
+        size_t            idSize;        // size of the instruction descriptor
+        unsigned          idVarRefOffs;  // IL offset for LclVar reference
+        size_t            idMemCookie;   // for display of method name  (also used by switch table)
         bool              idFinallyCall; // Branch instruction is a call to finally
         bool              idCatchRet;    // Instruction is for a catch 'return'
         CORINFO_SIG_INFO* idCallSig;     // Used to report native call site signatures to the EE
@@ -1453,36 +1437,6 @@ public:
     void emitEndFuncletEpilog();
 
 #endif // FEATURE_EH_FUNCLETS
-
-/************************************************************************/
-/*           Members and methods used in PDB translation                */
-/************************************************************************/
-
-#ifdef TRANSLATE_PDB
-
-    void MapCode(int ilOffset, BYTE* imgDest);
-    void MapFunc(int                imgOff,
-                 int                procLen,
-                 int                dbgStart,
-                 int                dbgEnd,
-                 short              frameReg,
-                 int                stkAdjust,
-                 int                lvaCount,
-                 OptJit::LclVarDsc* lvaTable,
-                 bool               framePtr);
-
-private:
-    int              emitInstrDescILBase; // code offset of IL that produced this instruction desctriptor
-    int              emitInstrDescILBase; // code offset of IL that produced this instruction desctriptor
-    static AddrMap*  emitPDBOffsetTable;  // translation table for mapping IL addresses to native addresses
-    static LocalMap* emitPDBLocalTable;   // local symbol translation table
-    static bool      emitIsPDBEnabled;    // flag to disable PDB translation code when a PDB is not found
-    static BYTE*     emitILBaseOfCode;    // start of IL .text section
-    static BYTE*     emitILMethodBase;    // beginning of IL method (start of header)
-    static BYTE*     emitILMethodStart;   // beginning of IL method code (right after the header)
-    static BYTE*     emitImgBaseOfCode;   // start of the image .text section
-
-#endif
 
     /************************************************************************/
     /*    Methods to record a code position and later convert to offset     */

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -13636,14 +13636,6 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
     }
 #endif
 
-#ifdef TRANSLATE_PDB
-    if (*dp != dst)
-    {
-        // only map instruction groups to instruction groups
-        MapCode(id->idDebugOnlyInfo()->idilStart, *dp);
-    }
-#endif
-
     *dp = dst;
 
 #ifdef DEBUG


### PR DESCRIPTION
Does anybody know what it was for and if it is still used?
I have not found any references in desktop sources.
I see that `TRANSLATE_PDB` existed before 2001, but can't find when it was introduced and how it was used.

When you enable it there are many compile errors.


PTAL @dotnet/jit-contrib 