### PR TITLE
Support managed build on linux/aarch64

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -347,19 +347,11 @@ isMSBuildOnNETCoreSupported()
         return
     fi
 
+    if [[ ("$__HostOS" == "Linux") && ("$__HostArch" == "x64" || "$__HostArch" == "arm" || "$__HostArch" == "arm64") ]]; then
+         __isMSBuildOnNETCoreSupported=1
+    fi
     if [ "$__HostArch" == "x64" ]; then
-        if [ "$__HostOS" == "Linux" ]; then
-            __isMSBuildOnNETCoreSupported=1
-            # note: the RIDs below can use globbing patterns
-            UNSUPPORTED_RIDS=("ubuntu.17.04-x64")
-            for UNSUPPORTED_RID in "${UNSUPPORTED_RIDS[@]}"
-            do
-                if [[ ${__DistroRid} == $UNSUPPORTED_RID ]]; then
-                    __isMSBuildOnNETCoreSupported=0
-                    break
-                fi
-            done
-        elif [ "$__HostOS" == "OSX" ]; then
+        if [ "$__HostOS" == "OSX" ]; then
             __isMSBuildOnNETCoreSupported=1
         elif [ "$__HostOS" == "FreeBSD" ]; then
             __isMSBuildOnNETCoreSupported=1


### PR DESCRIPTION
We have everything we need to build the native and managed components on aarch64 (hosted, not cross compiled). So lets enable building the managed components on aarch64.

<details><summary>I have tested this on RHEL 8 + aarch64</summary>
<p>

```
Commencing build of managed components for Linux.arm64.Debug                                                          
  Restore completed in 140.57 ms for /home/omajid/coreclr/src/build.proj.                                             
  Restore completed in 1.41 sec for /home/omajid/coreclr/src/tools/runincontext/runincontext.csproj.                  
  Restore completed in 9.51 sec for /home/omajid/coreclr/src/tools/r2rdump/R2RDump.csproj.                            
  Restore completed in 9.59 sec for /home/omajid/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj.

Build succeeded.                                                                                                      
    0 Warning(s)                                                                                                      
    0 Error(s)                                                                                                        

Time Elapsed 00:00:15.89                                                                                              
  runincontext -> /home/omajid/coreclr/bin/Product/Linux.arm64.Debug/runincontext.dll                                 
  R2RDump -> /home/omajid/coreclr/bin/Product/Linux.arm64.Debug/R2RDump.dll                                           
  System.Private.CoreLib -> /home/omajid/coreclr/bin/Product/Linux.arm64.Debug/IL/System.Private.CoreLib.dll

Build succeeded.                                                                                                      
    0 Warning(s)                                                                                                      
    0 Error(s)                                                                                                        

Time Elapsed 00:00:34.51                                                                                              
Generating native image of System.Private.CoreLib.dll for Linux.arm64.Debug. Logging to "/home/omajid/coreclr/bin/Logs/CrossgenCoreLib_Linux.arm64.Debug.log".                                                                              
/home/omajid/coreclr/bin/Product/Linux.arm64.Debug/crossgen /Platform_Assemblies_Paths /home/omajid/coreclr/bin/Product/Linux.arm64.Debug/IL  /out /home/omajid/coreclr/bin/Product/Linux.arm64.Debug/System.Private.CoreLib.dll /home/omajid/coreclr/bin/Product/Linux.arm64.Debug/IL/System.Private.CoreLib.dll
Generating symbol file for System.Private.CoreLib.dll                                                                 
/home/omajid/coreclr/bin/Product/Linux.arm64.Debug/crossgen /Platform_Assemblies_Paths /home/omajid/coreclr/bin/Product/Linux.arm64.Debug /CreatePerfMap /home/omajid/coreclr/bin/Product/Linux.arm64.Debug /home/omajid/coreclr/bin/Product /Linux.arm64.Debug/System.Private.CoreLib.dll                                                                         
Generating nuget packages for Linux                                                                                   
DistroRid is linux-arm64
ROOTFS_DIR is                                                                                                         
/home/omajid/coreclr/.dotnet/sdk/3.0.100-preview6-012264/MSBuild.dll /nologo -bl:/home/omajid/coreclr/bin/Logs/Nuget_Debug.binlog -distributedlogger:Microsoft.DotNet.Tools.MSBuild.MSBuildLogger,/home/omajid/coreclr/.dotnet/sdk/3.0.100-preview6-012264/dotnet.dll*Microsoft.DotNet.Tools.MSBuild.MSBuildForwardingLogger,/home/omajid/coreclr/.dotnet/sdk/3.0.100-preview6-012264/dotnet.dll -maxcpucount /m -verbosity:m /v:minimal /clp:Summary /nr:true /nodeReuse:false /p:TreatWarningsAsErrors=true /p:ContinuousIntegrationBuild=false /p:Configuration=Debug /p:RepoRoot=/home/omajid/coreclr /p:Restore=true /p:Build=true /p:Rebuild=false /p:Test=false /p:Pack=false /p:IntegrationTest=false /p:PerformanceTest=false /p:Sign=false /p:Publish=false /p:PortableBuild=true /p:ArcadeBuild=true /p:__IntermediatesDir=/home/omajid/coreclr/bin/obj/Linux.arm64.Debug /p:__RootBinDir=/home/omajid/coreclr/bin /p:__DoCrossArchBuild=0 /p:__BuildArch=arm64 /p:__BuildType=Debug /p:__BuildOS=Linux /p:RestoreDuringBuild=true /p:Projects=/home/omajid/coreclr/src/.nuget/packages.builds /warnaserror /home/omajid/coreclr/.packages/microsoft.dotnet.arcade.sdk/1.0.0-beta.19405.9/tools/Build.proj
  Restore completed in 43.99 sec for /home/omajid/coreclr/.packages/microsoft.dotnet.arcade.sdk/1.0.0-beta.19405.9/tools/Tools.proj.
  Restore completed in 72.82 ms for /home/omajid/coreclr/src/.nuget/Microsoft.NETCore.Jit/Microsoft.NETCore.Jit.builds.
  Restore completed in 72.28 ms for /home/omajid/coreclr/src/.nuget/Microsoft.NETCore.Native/Microsoft.NETCore.Native.builds.
  Restore completed in 71.72 ms for /home/omajid/coreclr/src/.nuget/Microsoft.NETCore.TestHost/Microsoft.NETCore.TestHost.builds.
  Restore completed in 76.4 ms for /home/omajid/coreclr/src/.nuget/Microsoft.NETCore.ILAsm/Microsoft.NETCore.ILAsm.builds.
  Restore completed in 76.13 ms for /home/omajid/coreclr/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.builds.
  Restore completed in 81.39 ms for /home/omajid/coreclr/src/.nuget/packages.builds.
  Restore completed in 80.07 ms for /home/omajid/coreclr/src/.nuget/Microsoft.NETCore.ILDAsm/Microsoft.NETCore.ILDAsm.builds.
  Microsoft.NETCore.Native -> /home/omajid/coreclr/bin/Product/Linux.arm64.Debug/.nuget//pkg/specs/runtime.linux-arm64.Microsoft.NETCore.Native.nuspec
  Microsoft.NETCore.TestHost -> /home/omajid/coreclr/bin/Product/Linux.arm64.Debug/.nuget//pkg/specs/runtime.linux-arm64.Microsoft.NETCore.TestHost.nuspec
  Microsoft.NETCore.ILAsm -> /home/omajid/coreclr/bin/Product/Linux.arm64.Debug/.nuget//pkg/specs/runtime.linux-arm64.Microsoft.NETCore.ILAsm.nuspec
  Microsoft.NETCore.ILDAsm -> /home/omajid/coreclr/bin/Product/Linux.arm64.Debug/.nuget//pkg/specs/runtime.linux-arm64.Microsoft.NETCore.ILDAsm.nuspec
  Microsoft.NETCore.ILDAsm -> /home/omajid/coreclr/bin/Product/Linux.arm64.Debug/.nuget//pkg/specs/Microsoft.NETCore.ILDAsm.nuspec
  Microsoft.NETCore.Native -> /home/omajid/coreclr/bin/Product/Linux.arm64.Debug/.nuget//pkg/specs/Microsoft.NETCore.Native.nuspec
  Microsoft.NETCore.ILAsm -> /home/omajid/coreclr/bin/Product/Linux.arm64.Debug/.nuget//pkg/specs/Microsoft.NETCore.ILAsm.nuspec
  Microsoft.NETCore.TestHost -> /home/omajid/coreclr/bin/Product/Linux.arm64.Debug/.nuget//pkg/specs/Microsoft.NETCore.TestHost.nuspec
  Microsoft.NETCore.Jit -> /home/omajid/coreclr/bin/Product/Linux.arm64.Debug/.nuget//pkg/specs/runtime.linux-arm64.Microsoft.NETCore.Jit.nuspec
  Microsoft.NETCore.Jit -> /home/omajid/coreclr/bin/Product/Linux.arm64.Debug/.nuget//pkg/specs/Microsoft.NETCore.Jit.nuspec
  Microsoft.NETCore.Runtime.CoreCLR -> /home/omajid/coreclr/bin/Product/Linux.arm64.Debug/.nuget//pkg/specs/runtime.linux-arm64.Microsoft.NETCore.Runtime.CoreCLR.nuspec
  Microsoft.NETCore.Runtime.CoreCLR -> /home/omajid/coreclr/bin/Product/Linux.arm64.Debug/.nuget//pkg/specs/Microsoft.NETCore.Runtime.CoreCLR.nuspec

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:02:00.11
Repo successfully built.
Product binaries are available at /home/omajid/coreclr/bin/Product/Linux.arm64.Debug
```

</p>
</details>
