### PR TITLE
Fix undefined references with FEATURE_PREJIT=true

### DIFF
--- a/src/ilasm/CMakeLists.txt
+++ b/src/ilasm/CMakeLists.txt
@@ -76,8 +76,8 @@ _add_executable(ilasm
 set(ILASM_LINK_LIBRARIES
   utilcodestaticnohost
   mscorpe
-  mdhotdata_full
   ${START_LIBRARY_GROUP} # Start group of libraries that have circular references
+  mdhotdata_full
   mdcompiler_wks
   mdruntime_wks
   mdruntimerw_wks


### PR DESCRIPTION
Fix undefined references to methods from `MetaData::HotTable` during ilasm build with `FEATURE_PREJIT=true`, which started to appear after #25144. 

```
undefined reference to `MetaData::HotTable::GetData(unsigned int, unsigned char**, unsigned int, MetaData::HotTableHeader*)'
undefined reference to `MetaData::HotTable::CheckTables(MetaData::HotTablesDirectory*)'
```

cc @alpencolt @jkotas