### PR TITLE
[3.0 port] Allow for interface implementations in EventSource.WriteEventVarArgs

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -2067,12 +2067,13 @@ namespace System.Diagnostics.Tracing
             {
                 Type pType = infos[i].ParameterType;
 
+                Type? argType = args[i]?.GetType();
+
                 // Checking to see if the Parameter types (from the Event method) match the supplied argument types.
-                // Fail if one of two things hold : either the argument type is not equal to the parameter type, or the 
-                // argument is null and the parameter type is non-nullable.
-                if ((args[i] != null && (args[i]!.GetType() != pType)) // TODO-NULLABLE: Indexer nullability tracked (https://github.com/dotnet/roslyn/issues/34644)
-                    || (args[i] == null && (!(pType.IsGenericType && pType.GetGenericTypeDefinition() == typeof(Nullable<>))))
-                    )
+                // Fail if one of two things hold : either the argument type is not equal or assignable to the parameter type, or the 
+                // argument is null and the parameter type is a non-Nullable<T> value type.
+                if ((args[i] != null && !pType.IsAssignableFrom(argType))
+                    || (args[i] == null && !((pType.IsGenericType && pType.GetGenericTypeDefinition() == typeof(Nullable<>)) || !pType.IsValueType)))
                 {
                     typesMatch = false;
                     break;


### PR DESCRIPTION
Backport #25844 to 3.0. Creating on behalf of @josalem who is OOF this week. 

Author: John Salem

Issue: https://github.com/dotnet/coreclr/issues/20493, https://github.com/dotnet/corefx/issues/39431 (related)

Code Reviewer: Noah Falk, Sung Yoon Whang, Tom McDonald

Description
There is a type check in the runtime that fires a warning message in the debugger log when user tries to log an type that contains an interface implementation through EventSource.

Customer Impact
ASP.NET enabled EventSource logging by default so any customer that attaches a debugger and any tracing session (EventListener, EventPipe, ETW, etc.) to *any* ASP.NET application will get flooded with the debug message.
Customers have been reporting this issue and providing feedback that the frequent warning messages disrupt their workflow (ex. https://github.com/aspnet/Extensions/issues/651) .

Regression?
No

Risk
This is a fairly small change. I believe the risk is minimal.

/cc @shirhatti @anurse 