### PR TITLE
Mark CoreLib as .NET Framework assembly

### DIFF
--- a/src/System.Private.CoreLib/src/System/Internal.cs
+++ b/src/System.Private.CoreLib/src/System/Internal.cs
@@ -32,6 +32,9 @@ using System.Runtime.InteropServices.WindowsRuntime;
 // Add Serviceable attribute to the assembly metadata
 [assembly: AssemblyMetadata("Serviceable", "True")]
 
+// Mark the library as a .NET Framework assembly
+[assembly: AssemblyMetadata(".NETFrameworkAssembly", "")]
+
 namespace System
 {
     static class CommonlyUsedGenericInstantiations


### PR DESCRIPTION
Noticed this is missing while enabling some new code paths in the CPAOT compiler. We need some way to mark assemblies that are part of the platform. This attribute is used to determine if assembly is part of the platform in full AOT mode. It would be convenient for CoreCLR's CoreLib to also have this.

Not critical to have this, but it would help me avoid special casing CoreLib.