### PR TITLE
Fix a potential division by 0 in post GC counter computation

### DIFF
--- a/src/gc/gcee.cpp
+++ b/src/gc/gcee.cpp
@@ -223,7 +223,6 @@ void GCHeap::UpdatePostGCCounters()
     }
 
     // Update percent time spent in GC
-    //
 
     if (_timeInGCBase != 0)
         g_percentTimeInGCSinceLastGC = (int)(g_TotalTimeInGC * 100 / _timeInGCBase);

--- a/src/gc/gcee.cpp
+++ b/src/gc/gcee.cpp
@@ -223,8 +223,12 @@ void GCHeap::UpdatePostGCCounters()
     }
 
     // Update percent time spent in GC
-    g_percentTimeInGCSinceLastGC = (int)(g_TotalTimeInGC * 100 / _timeInGCBase);
+    //
 
+    if (_timeInGCBase != 0)
+        g_percentTimeInGCSinceLastGC = (int)(g_TotalTimeInGC * 100 / _timeInGCBase);
+    else
+        g_percentTimeInGCSinceLastGC = 0;
     g_TotalTimeSinceLastGCEnd = _currentPerfCounterTimer;
 }
 


### PR DESCRIPTION
Fix #25917. 

This code path is used for computing % in time GC to be reported via performance counter when needed. `_timeInGCBase` is computed by subtracting the timestamp received via `QueryPerformanceCounter` at last GC that happened from the current timestamp. Since `QueryPerformanceCounter` is a high-res timestamp I did not think that the subtraction of the two timestamps could ever be 0, but we have a customer reporting that in #25917. While I still wasn't able to repro the issue, I confirmed that it was this division by zero exception that happened. 