### PR TITLE
[WIP] Support Write-Thru of EH variables in LSRA

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncMethodBuilderCore.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncMethodBuilderCore.cs
@@ -25,17 +25,14 @@ namespace System.Runtime.CompilerServices
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.stateMachine);
             }
 
-            // enregistrer variables with 0 post-fix so they can be used in registers without EH forcing them to stack
             // Capture references to Thread Contexts
-            Thread currentThread0 = Thread.CurrentThread;
-            Thread currentThread = currentThread0;
-            ExecutionContext? previousExecutionCtx0 = currentThread0._executionContext;
+            Thread currentThread = Thread.CurrentThread;
 
             // Store current ExecutionContext and SynchronizationContext as "previousXxx".
             // This allows us to restore them and undo any Context changes made in stateMachine.MoveNext
             // so that they won't "leak" out of the first await.
-            ExecutionContext? previousExecutionCtx = previousExecutionCtx0;
-            SynchronizationContext? previousSyncCtx = currentThread0._synchronizationContext;
+            ExecutionContext? previousExecutionCtx = currentThread._executionContext;
+            SynchronizationContext? previousSyncCtx = currentThread._synchronizationContext;
 
             try
             {
@@ -43,21 +40,17 @@ namespace System.Runtime.CompilerServices
             }
             finally
             {
-                // Re-enregistrer variables post EH with 1 post-fix so they can be used in registers rather than from stack
-                SynchronizationContext? previousSyncCtx1 = previousSyncCtx;
-                Thread currentThread1 = currentThread;
                 // The common case is that these have not changed, so avoid the cost of a write barrier if not needed.
-                if (previousSyncCtx1 != currentThread1._synchronizationContext)
+                if (previousSyncCtx != currentThread._synchronizationContext)
                 {
                     // Restore changed SynchronizationContext back to previous
-                    currentThread1._synchronizationContext = previousSyncCtx1;
+                    currentThread._synchronizationContext = previousSyncCtx;
                 }
 
-                ExecutionContext? previousExecutionCtx1 = previousExecutionCtx;
-                ExecutionContext? currentExecutionCtx1 = currentThread1._executionContext;
-                if (previousExecutionCtx1 != currentExecutionCtx1)
+                ExecutionContext? currentExecutionCtx = currentThread._executionContext;
+                if (previousExecutionCtx != currentExecutionCtx)
                 {
-                    ExecutionContext.RestoreChangedContextToThread(currentThread1, previousExecutionCtx1, currentExecutionCtx1);
+                    ExecutionContext.RestoreChangedContextToThread(currentThread, previousExecutionCtx, currentExecutionCtx);
                 }
             }
         }

--- a/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ExecutionContext.cs
@@ -134,26 +134,24 @@ namespace System.Threading
         internal static void RunInternal(ExecutionContext? executionContext, ContextCallback callback, object? state)
         {
             // Note: ExecutionContext.RunInternal is an extremely hot function and used by every await, ThreadPool execution, etc.
-            // Note: Manual enregistering may be addressed by "Exception Handling Write Through Optimization"
-            //       https://github.com/dotnet/coreclr/blob/master/Documentation/design-docs/eh-writethru.md
 
-            // Enregister variables with 0 post-fix so they can be used in registers without EH forcing them to stack
             // Capture references to Thread Contexts
-            Thread currentThread0 = Thread.CurrentThread;
-            Thread currentThread = currentThread0;
-            ExecutionContext? previousExecutionCtx0 = currentThread0._executionContext;
+            Thread currentThread = Thread.CurrentThread;
+            // previousExecutionCtx is live across an EH boundary. It is conditionally defined, thus has two
+            // definition points. In order to avoid forcing both of those to the stack, we define a temporary
+            // variable and then store that to the value that lives across the EH boundary.
+            ExecutionContext? previousExecutionCtx0 = currentThread._executionContext;
             if (previousExecutionCtx0 != null && previousExecutionCtx0.m_isDefault)
             {
                 // Default is a null ExecutionContext internally
                 previousExecutionCtx0 = null;
             }
+            ExecutionContext? previousExecutionCtx = previousExecutionCtx0;
 
             // Store current ExecutionContext and SynchronizationContext as "previousXxx".
             // This allows us to restore them and undo any Context changes made in callback.Invoke
             // so that they won't "leak" back into caller.
-            // These variables will cross EH so be forced to stack
-            ExecutionContext? previousExecutionCtx = previousExecutionCtx0;
-            SynchronizationContext? previousSyncCtx = currentThread0._synchronizationContext;
+            SynchronizationContext? previousSyncCtx = currentThread._synchronizationContext;
 
             if (executionContext != null && executionContext.m_isDefault)
             {
@@ -161,9 +159,9 @@ namespace System.Threading
                 executionContext = null;
             }
 
-            if (previousExecutionCtx0 != executionContext)
+            if (previousExecutionCtx != executionContext)
             {
-                RestoreChangedContextToThread(currentThread0, executionContext, previousExecutionCtx0);
+                RestoreChangedContextToThread(currentThread, executionContext, previousExecutionCtx);
             }
 
             ExceptionDispatchInfo? edi = null;
@@ -179,21 +177,17 @@ namespace System.Threading
                 edi = ExceptionDispatchInfo.Capture(ex);
             }
 
-            // Re-enregistrer variables post EH with 1 post-fix so they can be used in registers rather than from stack
-            SynchronizationContext? previousSyncCtx1 = previousSyncCtx;
-            Thread currentThread1 = currentThread;
             // The common case is that these have not changed, so avoid the cost of a write barrier if not needed.
-            if (currentThread1._synchronizationContext != previousSyncCtx1)
+            if (currentThread._synchronizationContext != previousSyncCtx)
             {
                 // Restore changed SynchronizationContext back to previous
-                currentThread1._synchronizationContext = previousSyncCtx1;
+                currentThread._synchronizationContext = previousSyncCtx;
             }
 
-            ExecutionContext? previousExecutionCtx1 = previousExecutionCtx;
-            ExecutionContext? currentExecutionCtx1 = currentThread1._executionContext;
-            if (currentExecutionCtx1 != previousExecutionCtx1)
+            ExecutionContext? currentExecutionCtx = currentThread._executionContext;
+            if (currentExecutionCtx != previousExecutionCtx)
             {
-                RestoreChangedContextToThread(currentThread1, previousExecutionCtx1, currentExecutionCtx1);
+                RestoreChangedContextToThread(currentThread, previousExecutionCtx, currentExecutionCtx);
             }
 
             // If exception was thrown by callback, rethrow it now original contexts are restored
@@ -204,26 +198,25 @@ namespace System.Threading
         internal static void RunInternal<TState>(ExecutionContext? executionContext, ContextCallback<TState> callback, ref TState state)
         {
             // Note: ExecutionContext.RunInternal is an extremely hot function and used by every await, ThreadPool execution, etc.
-            // Note: Manual enregistering may be addressed by "Exception Handling Write Through Optimization"
-            //       https://github.com/dotnet/coreclr/blob/master/Documentation/design-docs/eh-writethru.md
 
-            // Enregister variables with 0 post-fix so they can be used in registers without EH forcing them to stack
             // Capture references to Thread Contexts
-            Thread currentThread0 = Thread.CurrentThread;
-            Thread currentThread = currentThread0;
-            ExecutionContext? previousExecutionCtx0 = currentThread0._executionContext;
+            Thread currentThread = Thread.CurrentThread;
+            // previousExecutionCtx is live across an EH boundary. It is conditionally defined, thus has two
+            // definition points. In order to avoid forcing both of those to the stack, we define a temporary
+            // variable and then store that to the value that lives across the EH boundary.
+            ExecutionContext? previousExecutionCtx0 = currentThread._executionContext;
             if (previousExecutionCtx0 != null && previousExecutionCtx0.m_isDefault)
             {
                 // Default is a null ExecutionContext internally
                 previousExecutionCtx0 = null;
             }
+            ExecutionContext? previousExecutionCtx = previousExecutionCtx0;
 
             // Store current ExecutionContext and SynchronizationContext as "previousXxx".
             // This allows us to restore them and undo any Context changes made in callback.Invoke
             // so that they won't "leak" back into caller.
             // These variables will cross EH so be forced to stack
-            ExecutionContext? previousExecutionCtx = previousExecutionCtx0;
-            SynchronizationContext? previousSyncCtx = currentThread0._synchronizationContext;
+            SynchronizationContext? previousSyncCtx = currentThread._synchronizationContext;
 
             if (executionContext != null && executionContext.m_isDefault)
             {
@@ -231,9 +224,9 @@ namespace System.Threading
                 executionContext = null;
             }
 
-            if (previousExecutionCtx0 != executionContext)
+            if (previousExecutionCtx != executionContext)
             {
-                RestoreChangedContextToThread(currentThread0, executionContext, previousExecutionCtx0);
+                RestoreChangedContextToThread(currentThread, executionContext, previousExecutionCtx);
             }
 
             ExceptionDispatchInfo? edi = null;
@@ -249,21 +242,17 @@ namespace System.Threading
                 edi = ExceptionDispatchInfo.Capture(ex);
             }
 
-            // Re-enregistrer variables post EH with 1 post-fix so they can be used in registers rather than from stack
-            SynchronizationContext? previousSyncCtx1 = previousSyncCtx;
-            Thread currentThread1 = currentThread;
             // The common case is that these have not changed, so avoid the cost of a write barrier if not needed.
-            if (currentThread1._synchronizationContext != previousSyncCtx1)
+            if (currentThread._synchronizationContext != previousSyncCtx)
             {
                 // Restore changed SynchronizationContext back to previous
-                currentThread1._synchronizationContext = previousSyncCtx1;
+                currentThread._synchronizationContext = previousSyncCtx;
             }
 
-            ExecutionContext? previousExecutionCtx1 = previousExecutionCtx;
-            ExecutionContext? currentExecutionCtx1 = currentThread1._executionContext;
-            if (currentExecutionCtx1 != previousExecutionCtx1)
+            ExecutionContext? currentExecutionCtx = currentThread._executionContext;
+            if (currentExecutionCtx != previousExecutionCtx)
             {
-                RestoreChangedContextToThread(currentThread1, previousExecutionCtx1, currentExecutionCtx1);
+                RestoreChangedContextToThread(currentThread, previousExecutionCtx, currentExecutionCtx);
             }
 
             // If exception was thrown by callback, rethrow it now original contexts are restored

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -504,7 +504,10 @@ void CodeGenInterface::genUpdateRegLife(const LclVarDsc* varDsc, bool isBorn, bo
     }
     else
     {
-        assert((regSet.GetMaskVars() & regMask) == 0);
+        // If this is going live, the register must not have a variable in it, except
+        // in the case of an exception variable, which may be already treated as live
+        // in the register.
+        assert(varDsc->lvLiveInOutOfHndlr || ((regSet.GetMaskVars() & regMask) == 0));
         regSet.AddMaskVars(regMask);
     }
 }
@@ -681,12 +684,14 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
     unsigned        deadVarIndex = 0;
     while (deadIter.NextElem(&deadVarIndex))
     {
-        unsigned   varNum  = lvaTrackedIndexToLclNum(deadVarIndex);
-        LclVarDsc* varDsc  = lvaGetDesc(varNum);
-        bool       isGCRef = (varDsc->TypeGet() == TYP_REF);
-        bool       isByRef = (varDsc->TypeGet() == TYP_BYREF);
+        unsigned   varNum     = lvaTrackedIndexToLclNum(deadVarIndex);
+        LclVarDsc* varDsc     = lvaGetDesc(varNum);
+        bool       isGCRef    = (varDsc->TypeGet() == TYP_REF);
+        bool       isByRef    = (varDsc->TypeGet() == TYP_BYREF);
+        bool       isInReg    = varDsc->lvIsInReg();
+        bool       isInMemory = !isInReg || varDsc->lvLiveInOutOfHndlr;
 
-        if (varDsc->lvIsInReg())
+        if (isInReg)
         {
             // TODO-Cleanup: Move the code from compUpdateLifeVar to genUpdateRegLife that updates the
             // gc sets
@@ -701,8 +706,8 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
             }
             codeGen->genUpdateRegLife(varDsc, false /*isBorn*/, true /*isDying*/ DEBUGARG(nullptr));
         }
-        // This isn't in a register, so update the gcVarPtrSetCur.
-        else if (isGCRef || isByRef)
+        // Update the gcVarPtrSetCur if it is in memory.
+        if (isInMemory && (isGCRef || isByRef))
         {
             VarSetOps::RemoveElemD(this, codeGen->gcInfo.gcVarPtrSetCur, deadVarIndex);
             JITDUMP("\t\t\t\t\t\t\tV%02u becoming dead\n", varNum);
@@ -724,13 +729,16 @@ void Compiler::compChangeLife(VARSET_VALARG_TP newLife)
 
         if (varDsc->lvIsInReg())
         {
-#ifdef DEBUG
-            if (VarSetOps::IsMember(this, codeGen->gcInfo.gcVarPtrSetCur, bornVarIndex))
+            if (!varDsc->lvLiveInOutOfHndlr)
             {
-                JITDUMP("\t\t\t\t\t\t\tRemoving V%02u from gcVarPtrSetCur\n", varNum);
-            }
+#ifdef DEBUG
+                if (VarSetOps::IsMember(this, codeGen->gcInfo.gcVarPtrSetCur, bornVarIndex))
+                {
+                    JITDUMP("\t\t\t\t\t\t\tRemoving V%02u from gcVarPtrSetCur\n", varNum);
+                }
 #endif // DEBUG
-            VarSetOps::RemoveElemD(this, codeGen->gcInfo.gcVarPtrSetCur, bornVarIndex);
+                VarSetOps::RemoveElemD(this, codeGen->gcInfo.gcVarPtrSetCur, bornVarIndex);
+            }
             codeGen->genUpdateRegLife(varDsc, true /*isBorn*/, false /*isDying*/ DEBUGARG(nullptr));
             regMaskTP regMask = varDsc->lvRegMask();
             if (isGCRef)
@@ -3263,6 +3271,7 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
                           // 1 means the first part of a register argument
                           // 2, 3 or 4  means the second,third or fourth part of a multireg argument
         bool stackArg;    // true if the argument gets homed to the stack
+        bool writeThru;   // true if the argument gets homed to both stack and register
         bool processed;   // true after we've processed the argument (and it is in its final location)
         bool circular;    // true if this register participates in a circular dependency loop.
 
@@ -3599,6 +3608,7 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
             }
 
             regArgTab[regArgNum + i].processed = false;
+            regArgTab[regArgNum + i].writeThru = (varDsc->lvIsInReg() && varDsc->lvLiveInOutOfHndlr);
 
             /* mark stack arguments since we will take care of those first */
             regArgTab[regArgNum + i].stackArg = (varDsc->lvIsInReg()) ? false : true;
@@ -3759,9 +3769,9 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
     noway_assert(((regArgMaskLive & RBM_FLTARG_REGS) == 0) &&
                  "Homing of float argument registers with circular dependencies not implemented.");
 
-    /* Now move the arguments to their locations.
-     * First consider ones that go on the stack since they may
-     * free some registers. */
+    // Now move the arguments to their locations.
+    // First consider ones that go on the stack since they may free some registers.
+    // Also home writeThru args, since they're also homed to the stack.
 
     regArgMaskLive = regState->rsCalleeRegArgMaskLiveIn; // reset the live in to what it was at the start
     for (argNum = 0; argNum < argMax; argNum++)
@@ -3799,7 +3809,7 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
         // If not a stack arg go to the next one
         if (varDsc->lvType == TYP_LONG)
         {
-            if (regArgTab[argNum].slot == 1 && !regArgTab[argNum].stackArg)
+            if (regArgTab[argNum].slot == 1 && !regArgTab[argNum].stackArg && !regArgTab[argNum].writeThru)
             {
                 continue;
             }
@@ -3812,7 +3822,7 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
 #endif // !_TARGET_64BIT_
         {
             // If not a stack arg go to the next one
-            if (!regArgTab[argNum].stackArg)
+            if (!regArgTab[argNum].stackArg && !regArgTab[argNum].writeThru)
             {
                 continue;
             }
@@ -3833,7 +3843,7 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
 
         noway_assert(varDsc->lvIsParam);
         noway_assert(varDsc->lvIsRegArg);
-        noway_assert(varDsc->lvIsInReg() == false ||
+        noway_assert(varDsc->lvIsInReg() == false || varDsc->lvLiveInOutOfHndlr ||
                      (varDsc->lvType == TYP_LONG && varDsc->GetOtherReg() == REG_STK && regArgTab[argNum].slot == 2));
 
         var_types storeType = TYP_UNDEF;
@@ -3900,13 +3910,15 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
 #endif // USING_SCOPE_INFO
         }
 
-        /* mark the argument as processed */
-
-        regArgTab[argNum].processed = true;
-        regArgMaskLive &= ~genRegMask(srcRegNum);
+        // Mark the argument as processed.
+        if (!regArgTab[argNum].writeThru)
+        {
+            regArgTab[argNum].processed = true;
+            regArgMaskLive &= ~genRegMask(srcRegNum);
+        }
 
 #if defined(_TARGET_ARM_)
-        if (storeType == TYP_DOUBLE)
+        if ((storeType == TYP_DOUBLE) && !regArgTab[argNum].writeThru)
         {
             regArgTab[argNum + 1].processed = true;
             regArgMaskLive &= ~genRegMask(REG_NEXT(srcRegNum));
@@ -4602,7 +4614,7 @@ void CodeGen::genCheckUseBlockInit()
                     {
                         if (!varDsc->lvRegister)
                         {
-                            if (!varDsc->lvIsInReg())
+                            if (!varDsc->lvIsInReg() || varDsc->lvLiveInOutOfHndlr)
                             {
                                 // Var is on the stack at entry.
                                 initStkLclCnt +=
@@ -7229,7 +7241,9 @@ void CodeGen::genFnProlog()
             continue;
         }
 
-        if (varDsc->lvIsInReg())
+        bool isInReg    = varDsc->lvIsInReg();
+        bool isInMemory = !isInReg || varDsc->lvLiveInOutOfHndlr;
+        if (isInReg)
         {
             regMaskTP regMask = genRegMask(varDsc->GetRegNum());
             if (!varDsc->IsFloatRegType())
@@ -7260,7 +7274,7 @@ void CodeGen::genFnProlog()
                 initFltRegs |= regMask;
             }
         }
-        else
+        if (isInMemory)
         {
         INIT_STK:
 

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -239,15 +239,18 @@ void CodeGen::genCodeForBBlist()
                 {
                     newRegByrefSet |= varDsc->lvRegMask();
                 }
-#ifdef DEBUG
-                if (verbose && VarSetOps::IsMember(compiler, gcInfo.gcVarPtrSetCur, varIndex))
+                if (!varDsc->lvLiveInOutOfHndlr)
                 {
-                    VarSetOps::AddElemD(compiler, removedGCVars, varIndex);
-                }
+#ifdef DEBUG
+                    if (verbose && VarSetOps::IsMember(compiler, gcInfo.gcVarPtrSetCur, varIndex))
+                    {
+                        VarSetOps::AddElemD(compiler, removedGCVars, varIndex);
+                    }
 #endif // DEBUG
-                VarSetOps::RemoveElemD(compiler, gcInfo.gcVarPtrSetCur, varIndex);
+                    VarSetOps::RemoveElemD(compiler, gcInfo.gcVarPtrSetCur, varIndex);
+                }
             }
-            else if (compiler->lvaIsGCTracked(varDsc))
+            if ((!varDsc->lvIsInReg() || varDsc->lvLiveInOutOfHndlr) && compiler->lvaIsGCTracked(varDsc))
             {
 #ifdef DEBUG
                 if (verbose && !VarSetOps::IsMember(compiler, gcInfo.gcVarPtrSetCur, varIndex))
@@ -823,10 +826,20 @@ void CodeGen::genSpillVar(GenTree* tree)
         var_types lclTyp = genActualType(varDsc->TypeGet());
         emitAttr  size   = emitTypeSize(lclTyp);
 
-        instruction storeIns = ins_Store(lclTyp, compiler->isSIMDTypeLocalAligned(varNum));
-        assert(varDsc->GetRegNum() == tree->GetRegNum());
-        inst_TT_RV(storeIns, tree, tree->GetRegNum(), 0, size);
+        // If this is a write-thru variable, we don't actually spill at a use, but we will kill the var in the reg
+        // (below).
+        if (!varDsc->lvLiveInOutOfHndlr)
+        {
+            instruction storeIns = ins_Store(lclTyp, compiler->isSIMDTypeLocalAligned(varNum));
+            assert(varDsc->GetRegNum() == tree->GetRegNum());
+            inst_TT_RV(storeIns, tree, tree->GetRegNum(), 0, size);
+        }
 
+        // We should only have both GTF_SPILL (i.e. the flag causing this method to be called) and
+        // GTF_SPILLED on a write-thru def, for which we should not be calling this method.
+        assert((tree->gtFlags & GTF_SPILLED) == 0);
+
+        // Remove the live var from the register.
         genUpdateRegLife(varDsc, /*isBorn*/ false, /*isDying*/ true DEBUGARG(tree));
         gcInfo.gcMarkRegSetNpt(varDsc->lvRegMask());
 
@@ -847,10 +860,19 @@ void CodeGen::genSpillVar(GenTree* tree)
     }
 
     tree->gtFlags &= ~GTF_SPILL;
-    varDsc->SetRegNum(REG_STK);
-    if (varTypeIsMultiReg(tree))
+    // If this is NOT a write-thru, reset the var location.
+    if ((tree->gtFlags & GTF_SPILLED) == 0)
     {
-        varDsc->SetOtherReg(REG_STK);
+        varDsc->SetRegNum(REG_STK);
+        if (varTypeIsMultiReg(tree))
+        {
+            varDsc->SetOtherReg(REG_STK);
+        }
+    }
+    else
+    {
+        // We only have 'GTF_SPILL' and 'GTF_SPILLED' on a def of a write-thru lclVar.
+        assert(varDsc->lvLiveInOutOfHndlr && ((tree->gtFlags & GTF_VAR_DEF) != 0));
     }
 
 #ifdef USING_VARIABLE_LIVE_RANGE
@@ -1030,13 +1052,16 @@ void CodeGen::genUnspillRegIfNeeded(GenTree* tree)
                 }
 #endif // USING_VARIABLE_LIVE_RANGE
 
-#ifdef DEBUG
-                if (VarSetOps::IsMember(compiler, gcInfo.gcVarPtrSetCur, varDsc->lvVarIndex))
+                if (!varDsc->lvLiveInOutOfHndlr)
                 {
-                    JITDUMP("\t\t\t\t\t\t\tRemoving V%02u from gcVarPtrSetCur\n", lcl->GetLclNum());
-                }
+#ifdef DEBUG
+                    if (VarSetOps::IsMember(compiler, gcInfo.gcVarPtrSetCur, varDsc->lvVarIndex))
+                    {
+                        JITDUMP("\t\t\t\t\t\t\tRemoving V%02u from gcVarPtrSetCur\n", lcl->GetLclNum());
+                    }
 #endif // DEBUG
-                VarSetOps::RemoveElemD(compiler, gcInfo.gcVarPtrSetCur, varDsc->lvVarIndex);
+                    VarSetOps::RemoveElemD(compiler, gcInfo.gcVarPtrSetCur, varDsc->lvVarIndex);
+                }
 
 #ifdef DEBUG
                 if (compiler->verbose)
@@ -1316,14 +1341,14 @@ regNumber CodeGen::genConsumeReg(GenTree* tree)
         LclVarDsc*           varDsc = &compiler->lvaTable[lcl->GetLclNum()];
         assert(varDsc->lvLRACandidate);
 
-        if ((tree->gtFlags & GTF_VAR_DEATH) != 0)
-        {
-            gcInfo.gcMarkRegSetNpt(genRegMask(varDsc->GetRegNum()));
-        }
-        else if (varDsc->GetRegNum() == REG_STK)
+        if (varDsc->GetRegNum() == REG_STK)
         {
             // We have loaded this into a register only temporarily
             gcInfo.gcMarkRegSetNpt(genRegMask(tree->GetRegNum()));
+        }
+        else if ((tree->gtFlags & GTF_VAR_DEATH) != 0)
+        {
+            gcInfo.gcMarkRegSetNpt(genRegMask(varDsc->GetRegNum()));
         }
     }
     else
@@ -1848,12 +1873,20 @@ void CodeGen::genProduceReg(GenTree* tree)
 
         if (genIsRegCandidateLocal(tree))
         {
-            // Store local variable to its home location.
-            // Ensure that lclVar stores are typed correctly.
-            unsigned varNum = tree->AsLclVarCommon()->GetLclNum();
-            assert(!compiler->lvaTable[varNum].lvNormalizeOnStore() ||
-                   (tree->TypeGet() == genActualType(compiler->lvaTable[varNum].TypeGet())));
-            inst_TT_RV(ins_Store(tree->gtType, compiler->isSIMDTypeLocalAligned(varNum)), tree, tree->GetRegNum());
+            unsigned   varNum = tree->AsLclVarCommon()->GetLclNum();
+            LclVarDsc* varDsc = compiler->lvaGetDesc(varNum);
+            assert(!varDsc->lvNormalizeOnStore() || (tree->TypeGet() == genActualType(varDsc->TypeGet())));
+
+            // First, check for the case of an EH var that is being "spilled" to the stack, indicated
+            // by a non-def GT_LCL_VAR that is marked GTF_SPILL.
+            // This case occurs at the end of a block when its register is going dead.
+            // It is already valid on the stack.
+            if (((tree->gtFlags & GTF_VAR_DEF) != 0) || !varDsc->lvLiveInOutOfHndlr)
+            {
+                // Store local variable to its home location.
+                // Ensure that lclVar stores are typed correctly.
+                inst_TT_RV(ins_Store(tree->gtType, compiler->isSIMDTypeLocalAligned(varNum)), tree, tree->GetRegNum());
+            }
         }
         else
         {

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4592,6 +4592,37 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags
 
     NewBasicBlockEpoch();
 
+#if DEBUG
+    if (lvaEnregEHVars)
+    {
+        unsigned methHash   = info.compMethodHash();
+        char*    lostr      = getenv("JitEHWTHashLo");
+        unsigned methHashLo = 0;
+        bool     dump       = false;
+        if (lostr != nullptr)
+        {
+            sscanf_s(lostr, "%x", &methHashLo);
+            dump = true;
+        }
+        char*    histr      = getenv("JitEHWTHashHi");
+        unsigned methHashHi = UINT32_MAX;
+        if (histr != nullptr)
+        {
+            sscanf_s(histr, "%x", &methHashHi);
+            dump = true;
+        }
+        if (methHash < methHashLo || methHash > methHashHi)
+        {
+            lvaEnregEHVars = false;
+        }
+        else if (dump)
+        {
+            printf("Enregistering EH Vars for method %s, hash = 0x%x.\n", info.compFullName, info.compMethodHash());
+            printf(""); // flush
+        }
+    }
+#endif
+
     /* Massage the trees so that we can generate code out of them */
 
     fgMorph();

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -6170,8 +6170,9 @@ int Compiler::compCompileHelper(CORINFO_MODULE_HANDLE            classPtr,
 #ifdef DEBUG
     if (JitConfig.DumpJittedMethods() == 1 && !compIsForInlining())
     {
-        printf("Compiling %4d %s::%s, IL size = %u, hash=%08x %s\n", Compiler::jitTotalMethodCompiled, info.compClassName,
-               info.compMethodName, info.compILCodeSize, info.compMethodHash(), compGetTieringName());
+        printf("Compiling %4d %s::%s, IL size = %u, hash=%08x %s\n", Compiler::jitTotalMethodCompiled,
+               info.compClassName, info.compMethodName, info.compILCodeSize, info.compMethodHash(),
+               compGetTieringName());
     }
     if (compIsForInlining())
     {

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -415,6 +415,8 @@ public:
     unsigned char lvDoNotEnregister : 1; // Do not enregister this variable.
     unsigned char lvFieldAccessed : 1;   // The var is a struct local, and a field of the variable is accessed.  Affects
                                          // struct promotion.
+    unsigned char lvLiveInOutOfHndlr : 1; // The variable is live in or out of an exception handler, and therefore must
+                                          // be on the stack (at least at those boundaries.)
 
     unsigned char lvInSsa : 1; // The variable is in SSA form (set by SsaBuilder)
 
@@ -424,9 +426,6 @@ public:
     // also, lvType == TYP_STRUCT prevents enregistration.  At least one of the reasons should be true.
     unsigned char lvVMNeedsStackAddr : 1; // The VM may have access to a stack-relative address of the variable, and
                                           // read/write its value.
-    unsigned char lvLiveInOutOfHndlr : 1; // The variable was live in or out of an exception handler, and this required
-                                          // the variable to be
-                                          // in the stack (at least at those boundaries.)
     unsigned char lvLclFieldExpr : 1;     // The variable is not a struct, but was accessed like one (e.g., reading a
                                           // particular byte from an int).
     unsigned char lvLclBlockOpAddr : 1;   // The variable was written to via a block operation that took its address.
@@ -3008,7 +3007,11 @@ public:
     // Getters and setters for address-exposed and do-not-enregister local var properties.
     bool lvaVarAddrExposed(unsigned varNum);
     void lvaSetVarAddrExposed(unsigned varNum);
+    void lvaSetVarLiveInOutOfHandler(unsigned varNum);
     bool lvaVarDoNotEnregister(unsigned varNum);
+
+    bool lvaEnregEHVars;
+
 #ifdef DEBUG
     // Reasons why we can't enregister.  Some of these correspond to debug properties of local vars.
     enum DoNotEnregisterReason
@@ -3031,6 +3034,7 @@ public:
         DNER_PinningRef,
 #endif
     };
+
 #endif
     void lvaSetVarDoNotEnregister(unsigned varNum DEBUGARG(DoNotEnregisterReason reason));
 

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -2755,6 +2755,13 @@ bool Compiler::gtIsLikelyRegVar(GenTree* tree)
         return false;
     }
 
+    // If this is an EH-live var, return false if it is a def,
+    // as it will have to go to memory.
+    if (varDsc->lvLiveInOutOfHndlr && ((tree->gtFlags & GTF_VAR_DEF) != 0))
+    {
+        return false;
+    }
+
     // Be pessimistic if ref counts are not yet set up.
     //
     // Perhaps we should be optimistic though.

--- a/src/jit/instr.cpp
+++ b/src/jit/instr.cpp
@@ -661,9 +661,18 @@ void CodeGen::inst_TT_RV(instruction ins, GenTree* tree, regNumber reg, unsigned
 
 AGAIN:
 
-    /* Is this a spilled value? */
-
-    if (tree->gtFlags & GTF_SPILLED)
+    // Is this a spilled value?
+    bool isSpilledValue = ((tree->gtFlags & GTF_SPILLED) != 0);
+    if (isSpilledValue)
+    {
+        // Is this the special case of a write-thru lclVar?
+        // We mark it as SPILLED to denote that its value is valid in memroy.
+        if (((tree->gtFlags & GTF_SPILL) != 0) && tree->gtOper == GT_STORE_LCL_VAR)
+        {
+            isSpilledValue = false;
+        }
+    }
+    if (isSpilledValue)
     {
         assert(!"ISSUE: If this can happen, we need to generate 'ins [ebp+spill]'");
     }
@@ -685,6 +694,7 @@ AGAIN:
         unsigned varNum;
 
         case GT_LCL_VAR:
+        case GT_STORE_LCL_VAR:
 
             inst_set_SV_var(tree);
             goto LCL;

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -2477,17 +2477,16 @@ void Compiler::fgInterBlockLocalVarLiveness()
         if (VarSetOps::IsMember(this, exceptVars, varDsc->lvVarIndex) ||
             VarSetOps::IsMember(this, filterVars, varDsc->lvVarIndex))
         {
-            /* Mark the variable appropriately */
-            lvaSetVarDoNotEnregister(varNum DEBUGARG(DNER_LiveInOutOfHandler));
+            // Mark the variable appropriately.
+            lvaSetVarLiveInOutOfHandler(varNum);
         }
 
-        /* Mark all pointer variables live on exit from a 'finally'
-           block as either volatile for non-GC ref types or as
-           'explicitly initialized' (volatile and must-init) for GC-ref types */
+        // Mark all pointer variables live on exit from a 'finally' block as lvLiveInOutOfHndlr.
+        // and as 'explicitly initialized' (must-init) for GC-ref types.
 
         if (VarSetOps::IsMember(this, finallyVars, varDsc->lvVarIndex))
         {
-            lvaSetVarDoNotEnregister(varNum DEBUGARG(DNER_LiveInOutOfHandler));
+            lvaSetVarLiveInOutOfHandler(varNum);
 
             /* Don't set lvMustInit unless we have a non-arg, GC pointer */
 

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -4795,6 +4795,7 @@ void LinearScan::processBlockStartLocations(BasicBlock* currentBlock)
     // If this block enters an exception region, all incoming vars are on the stack.
     if (predBBNum == 0)
     {
+#if DEBUG
         if (blockInfo[currentBlock->bbNum].hasEHBoundaryIn)
         {
 #if DEBUG

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -613,6 +613,7 @@ LinearScan::LinearScan(Compiler* theCompiler)
 {
 #ifdef DEBUG
     maxNodeLocation   = 0;
+    firstColdLoc      = MaxLocation;
     activeRefPosition = nullptr;
 
     // Get the value of the environment variable that controls stress for register allocation
@@ -1723,6 +1724,12 @@ void LinearScan::identifyCandidates()
                 newInt->isStructField = true;
             }
 
+            if (varDsc->lvLiveInOutOfHndlr)
+            {
+                newInt->isWriteThru = true;
+                setIntervalAsSpilled(newInt);
+            }
+
             INTRACK_STATS(regCandidateVarCount++);
 
             // We maintain two sets of FP vars - those that meet the first threshold of weighted ref Count,
@@ -2160,6 +2167,11 @@ void LinearScan::checkLastUses(BasicBlock* block)
 
     VARSET_TP liveInNotComputedLive(VarSetOps::Diff(compiler, block->bbLiveIn, computedLive));
 
+    // We may have exception vars in the liveIn set of exception blocks that are not computed live.
+    if (compiler->ehBlockHasExnFlowDsc(block))
+    {
+        VarSetOps::DiffD(compiler, liveInNotComputedLive, compiler->fgGetHandlerLiveVars(block));
+    }
     VarSetOps::Iter liveInNotComputedLiveIter(compiler, liveInNotComputedLive);
     unsigned        liveInNotComputedLiveIndex = 0;
     while (liveInNotComputedLiveIter.NextElem(&liveInNotComputedLiveIndex))
@@ -2782,8 +2794,10 @@ regNumber LinearScan::tryAllocateFreeReg(Interval* currentInterval, RefPosition*
     Interval* rangeEndInterval     = relatedInterval;
     regMaskTP relatedPreferences   = (relatedInterval == nullptr) ? RBM_NONE : relatedInterval->getCurrentPreferences();
     LsraLocation rangeEndLocation  = refPosition->getRangeEndLocation();
-    bool         preferCalleeSave  = currentInterval->preferCalleeSave;
-    bool         avoidByteRegs     = false;
+    LsraLocation relatedLastLocation = rangeEndLocation;
+
+    bool preferCalleeSave = currentInterval->preferCalleeSave;
+    bool avoidByteRegs    = false;
 #ifdef _TARGET_X86_
     if ((relatedPreferences & ~RBM_BYTE_REGS) != RBM_NONE)
     {
@@ -2851,6 +2865,11 @@ regNumber LinearScan::tryAllocateFreeReg(Interval* currentInterval, RefPosition*
         rangeEndRefPosition = refPosition;
         preferCalleeSave    = currentInterval->preferCalleeSave;
     }
+    else if (currentInterval->isWriteThru && refPosition->spillAfter)
+    {
+        // This is treated as a last use of the register, as there is an upcoming EH boundary.
+        rangeEndRefPosition = refPosition;
+    }
     else
     {
         rangeEndRefPosition = refPosition->getRangeEndRef();
@@ -2858,9 +2877,14 @@ regNumber LinearScan::tryAllocateFreeReg(Interval* currentInterval, RefPosition*
         // is not currently occupying a register, and whose lifetime begins after this one,
         // we want to try to select a register that will cover its lifetime.
         if ((rangeEndInterval != nullptr) && (rangeEndInterval->assignedReg == nullptr) &&
+            !rangeEndInterval->isWriteThru &&
             (rangeEndInterval->getNextRefLocation() >= rangeEndRefPosition->nodeLocation))
         {
             lastRefPosition = rangeEndInterval->lastRefPosition;
+        }
+        if ((relatedInterval != nullptr) && !relatedInterval->isWriteThru)
+        {
+            relatedLastLocation = relatedInterval->lastRefPosition->nodeLocation;
         }
     }
 
@@ -3045,7 +3069,7 @@ regNumber LinearScan::tryAllocateFreeReg(Interval* currentInterval, RefPosition*
         if ((candidateBit & relatedPreferences) != RBM_NONE)
         {
             score |= RELATED_PREFERENCE;
-            if (nextPhysRefLocation > relatedInterval->lastRefPosition->nodeLocation)
+            if (nextPhysRefLocation > relatedLastLocation)
             {
                 score |= COVERS_RELATED;
             }
@@ -4075,7 +4099,8 @@ void LinearScan::spillInterval(Interval* interval, RefPosition* fromRefPosition 
     if (!fromRefPosition->lastUse)
     {
         // If not allocated a register, Lcl var def/use ref positions even if reg optional
-        // should be marked as spillAfter.
+        // should be marked as spillAfter. Note that if it is a WriteThru interval, the value is always
+        // written to the stack, but the WriteThru indicates that the register is no longer live.
         if (fromRefPosition->RegOptional() && !(interval->isLocalVar && fromRefPosition->IsActualRef()))
         {
             fromRefPosition->registerAssignment = RBM_NONE;
@@ -4784,11 +4809,34 @@ void LinearScan::processBlockStartLocations(BasicBlock* currentBlock)
         regNumber    targetReg;
         Interval*    interval        = getIntervalForLocalVar(varIndex);
         RefPosition* nextRefPosition = interval->getNextRefPosition();
-        assert(nextRefPosition != nullptr);
+        assert((nextRefPosition != nullptr) || (interval->isWriteThru));
+
+        bool leaveOnStack = false;
+
+        // Special handling for variables live in/out of exception handlers.
+        if (interval->isWriteThru)
+        {
+            if (predBBNum == 0)
+            {
+                leaveOnStack = true;
+            }
+            // Variables that are live in or out of exception handlers may be conservatively live in other
+            // liveness sets. This can cause problems if we allocate a register for the regions where
+            // it is not actually live, because there isn't actually an associated end to the live range,
+            // so there is no place for codegen to record that the register is no longer occupied.
+            else if ((nextRefPosition == nullptr) || (RefTypeIsDef(nextRefPosition->refType)))
+            {
+                leaveOnStack = true;
+            }
+        }
 
         if (!allocationPassComplete)
         {
             targetReg = getVarReg(predVarToRegMap, varIndex);
+            if (leaveOnStack)
+            {
+                targetReg = REG_STK;
+            }
 #ifdef DEBUG
             regNumber newTargetReg = rotateBlockStartLocation(interval, targetReg, (~liveRegs | inactiveRegs));
             if (newTargetReg != targetReg)
@@ -4853,9 +4901,9 @@ void LinearScan::processBlockStartLocations(BasicBlock* currentBlock)
         {
             // This can happen if we are using the locations from a basic block other than the
             // immediately preceding one - where the variable was in a different location.
-            if (targetReg != REG_STK)
+            if ((targetReg != REG_STK) || leaveOnStack)
             {
-                // Unassign it from the register (it will get a new register below).
+                // Unassign it from the register (it may get a new register below).
                 if (interval->assignedReg != nullptr && interval->assignedReg->assignedInterval == interval)
                 {
                     interval->isActive = false;
@@ -5161,9 +5209,18 @@ void LinearScan::allocateRegisters()
         }
     }
 
-#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+    bool firstBBExceptionEdge = enregisterLocalVars && blockInfo[compiler->fgFirstBB->bbNum].hasEHBoundaryIn;
     if (enregisterLocalVars)
     {
+#if DEBUG
+        BasicBlock* firstBB = compiler->fgFirstBB;
+        for (flowList* pred = firstBB->bbPreds; pred != nullptr; pred = pred->flNext)
+        {
+            assert(!blockInfo[pred->flBlock->bbNum].hasEHBoundaryOut || firstBBExceptionEdge);
+        }
+#endif // DEBUG
+
+#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
         VarSetOps::Iter largeVectorVarsIter(compiler, largeVectorVars);
         unsigned        largeVectorVarIndex = 0;
         while (largeVectorVarsIter.NextElem(&largeVectorVarIndex))
@@ -5171,8 +5228,8 @@ void LinearScan::allocateRegisters()
             Interval* lclVarInterval           = getIntervalForLocalVar(largeVectorVarIndex);
             lclVarInterval->isPartiallySpilled = false;
         }
-    }
 #endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+    }
 
     for (regNumber reg = REG_FIRST; reg < ACTUAL_REG_COUNT; reg = REG_NEXT(reg))
     {
@@ -5397,12 +5454,14 @@ void LinearScan::allocateRegisters()
                 // inserting a store.
                 LclVarDsc* varDsc = currentInterval->getLocalVar(compiler);
                 assert(varDsc != nullptr);
+                if (firstBBExceptionEdge)
+                {
+                    assert(currentInterval->isWriteThru);
+                    allocate = false;
+                }
                 if (refType == RefTypeParamDef && varDsc->lvRefCntWtd() <= BB_UNITY_WEIGHT)
                 {
-                    INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_NO_ENTRY_REG_ALLOCATED, currentInterval));
-                    didDump  = true;
                     allocate = false;
-                    setIntervalAsSpilled(currentInterval);
                 }
                 // If it has no actual references, mark it as "lastUse"; since they're not actually part
                 // of any flow they won't have been marked during dataflow.  Otherwise, if we allocate a
@@ -5411,6 +5470,12 @@ void LinearScan::allocateRegisters()
                 {
                     INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_ZERO_REF, currentInterval));
                     currentRefPosition->lastUse = true;
+                }
+                if (!allocate)
+                {
+                    INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_NO_ENTRY_REG_ALLOCATED, currentInterval));
+                    didDump = true;
+                    setIntervalAsSpilled(currentInterval);
                 }
             }
 #ifdef FEATURE_SIMD
@@ -5702,8 +5767,29 @@ void LinearScan::allocateRegisters()
                     regNumber copyReg = assignCopyReg(currentRefPosition);
                     assert(copyReg != REG_NA);
                     INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_COPY_REG, currentInterval, copyReg));
-                    lastAllocatedRefPosition = currentRefPosition;
+                    lastAllocatedRefPosition     = currentRefPosition;
+                    bool         unassign        = false;
+                    RefPosition* nextRefPosition = currentRefPosition->nextRefPosition;
+                    if (currentInterval->isWriteThru)
+                    {
+                        if (currentRefPosition->refType == RefTypeDef)
+                        {
+                            currentRefPosition->writeThru = true;
+                        }
+                        if (!currentRefPosition->lastUse)
+                        {
+                            if (currentRefPosition->spillAfter)
+                            {
+                                unassign = true;
+                            }
+                        }
+                    }
                     if (currentRefPosition->lastUse)
+                    {
+                        assert(currentRefPosition->isIntervalRef());
+                        unassign = true;
+                    }
+                    if (unassign)
                     {
                         if (currentRefPosition->delayRegFree)
                         {
@@ -5749,6 +5835,14 @@ void LinearScan::allocateRegisters()
                 if (currentRefPosition->lastUse && currentRefPosition->reload)
                 {
                     allocateReg = false;
+                }
+                else if (currentInterval->isWriteThru)
+                {
+                    // Don't allocate if the next reference is in a cold block.
+                    if (nextRefPosition == nullptr || (nextRefPosition->nodeLocation >= firstColdLoc))
+                    {
+                        allocateReg = false;
+                    }
                 }
 
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE && defined(_TARGET_XARCH_)
@@ -5870,36 +5964,53 @@ void LinearScan::allocateRegisters()
             // (it will be freed when it is used).
             if (!currentInterval->IsUpperVector())
             {
+                bool unassign = false;
+                if (currentInterval->isWriteThru)
+                {
+                    if (currentRefPosition->refType == RefTypeDef)
+                    {
+                        currentRefPosition->writeThru = true;
+                    }
+                    if (!currentRefPosition->lastUse)
+                    {
+                        if (currentRefPosition->spillAfter)
+                        {
+                            unassign = true;
+                        }
+                    }
+                }
                 if (currentRefPosition->lastUse || currentRefPosition->nextRefPosition == nullptr)
                 {
                     assert(currentRefPosition->isIntervalRef());
 
                     if (refType != RefTypeExpUse && currentRefPosition->nextRefPosition == nullptr)
                     {
-                        if (currentRefPosition->delayRegFree)
-                        {
-                            delayRegsToFree |= assignedRegBit;
+                        unassign = true;
+                    }
+                }
+                if (unassign)
+                {
+                    if (currentRefPosition->delayRegFree)
+                    {
+                        delayRegsToFree |= assignedRegBit;
 
-                            INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_LAST_USE_DELAYED));
-                        }
-                        else
-                        {
-                            regsToFree |= assignedRegBit;
-
-                            INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_LAST_USE));
-                        }
+                        INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_LAST_USE_DELAYED));
                     }
                     else
                     {
-                        currentInterval->isActive = false;
+                        regsToFree |= assignedRegBit;
+
+                        INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_LAST_USE));
                     }
-                    // Update the register preferences for the relatedInterval, if this is 'preferencedToDef'.
-                    // Don't propagate to subsequent relatedIntervals; that will happen as they are allocated, and we
-                    // don't know yet whether the register will be retained.
-                    if (currentInterval->relatedInterval != nullptr)
-                    {
-                        currentInterval->relatedInterval->updateRegisterPreferences(assignedRegBit);
-                    }
+                }
+
+                // Update the register preferences for the relatedInterval, if this is 'preferencedToDef'.
+                // Don't propagate to subsequent relatedIntervals; that will happen as they are allocated, and we
+                // don't know yet whether the register will be retained.
+                if ((currentRefPosition->lastUse || nextRefPosition == nullptr) &&
+                    (currentInterval->relatedInterval != nullptr))
+                {
+                    currentInterval->relatedInterval->updateRegisterPreferences(assignedRegBit);
                 }
             }
 
@@ -6164,8 +6275,9 @@ void LinearScan::resolveLocalRef(BasicBlock* block, GenTree* treeNode, RefPositi
         }
         interval->assignedReg = nullptr;
         interval->physReg     = REG_NA;
-        if (treeNode != nullptr)
+        if (currentRefPosition->refType == RefTypeUse)
         {
+            assert(treeNode != nullptr);
             treeNode->SetContained();
         }
 
@@ -6205,6 +6317,7 @@ void LinearScan::resolveLocalRef(BasicBlock* block, GenTree* treeNode, RefPositi
 
     bool reload     = currentRefPosition->reload;
     bool spillAfter = currentRefPosition->spillAfter;
+    bool writeThru  = currentRefPosition->writeThru;
 
     // In the reload case we either:
     // - Set the register to REG_STK if it will be referenced only from the home location, or
@@ -6329,6 +6442,20 @@ void LinearScan::resolveLocalRef(BasicBlock* block, GenTree* treeNode, RefPositi
             assert(interval->isSpilled);
             interval->physReg = REG_NA;
             varDsc->SetRegNum(REG_STK);
+        }
+        if (writeThru && (treeNode != nullptr))
+        {
+            // This is a def of a write-thru EH var (only defs are marked 'writeThru').
+            treeNode->gtFlags |= GTF_SPILL;
+            // We also mark writeThru defs that are not last-use with GTF_SPILLED to indicate that they are conceptually
+            // spilled and immediately "reloaded", i.e. the register remains live.
+            // Note that we can have a "last use" write that has no exposed uses in the standard
+            // (non-eh) control flow, but that may be used on an exception path. Hence the need
+            // to retain these defs, and to ensure that they write.
+            if (!currentRefPosition->lastUse)
+            {
+                treeNode->gtFlags |= GTF_SPILLED;
+            }
         }
     }
 
@@ -7517,11 +7644,12 @@ void LinearScan::insertMove(
     else
     {
         // Put the copy at the bottom
+        GenTree* lastNode = blockRange.LastNode();
         if (block->bbJumpKind == BBJ_COND || block->bbJumpKind == BBJ_SWITCH)
         {
             noway_assert(!blockRange.IsEmpty());
 
-            GenTree* branch = blockRange.LastNode();
+            GenTree* branch = lastNode;
             assert(branch->OperIsConditionalJump() || branch->OperGet() == GT_SWITCH_TABLE ||
                    branch->OperGet() == GT_SWITCH);
 
@@ -7529,7 +7657,9 @@ void LinearScan::insertMove(
         }
         else
         {
-            assert(block->bbJumpKind == BBJ_NONE || block->bbJumpKind == BBJ_ALWAYS);
+            // These block kinds don't have a branch at the end.
+            assert((lastNode == nullptr) || (!lastNode->OperIsConditionalJump() &&
+                                             !lastNode->OperIs(GT_SWITCH_TABLE, GT_SWITCH, GT_RETURN, GT_RETFILT)));
             blockRange.InsertAtEnd(std::move(treeRange));
         }
     }
@@ -8262,14 +8392,19 @@ void LinearScan::resolveEdges()
                 regNumber toReg   = getVarReg(toVarToRegMap, varIndex);
                 if (fromReg != toReg)
                 {
-                    if (!foundMismatch)
+                    Interval* interval = getIntervalForLocalVar(varIndex);
+                    // The fromReg and toReg may not match for a write-thru interval where the toReg is
+                    // REG_STK, since the stack value is always valid for that case (so no move is needed).
+                    if (!interval->isWriteThru || (toReg != REG_STK))
                     {
-                        foundMismatch = true;
-                        printf("Found mismatched var locations after resolution!\n");
+                        if (!foundMismatch)
+                        {
+                            foundMismatch = true;
+                            printf("Found mismatched var locations after resolution!\n");
+                        }
+                        printf(" V%02u: " FMT_BB " to " FMT_BB ": %s to %s\n", interval->varNum, predBlock->bbNum,
+                               block->bbNum, getRegName(fromReg), getRegName(toReg));
                     }
-
-                    printf(" V%02u: " FMT_BB " to " FMT_BB ": %s to %s\n", compiler->lvaTrackedIndexToLclNum(varIndex),
-                           predBlock->bbNum, block->bbNum, getRegName(fromReg), getRegName(toReg));
                 }
             }
         }
@@ -8413,6 +8548,29 @@ void LinearScan::resolveEdge(BasicBlock*      fromBlock,
         insertionPoint = LIR::AsRange(block).FirstNonPhiNode();
     }
 
+    // If this is an edge between EH regions, we may have "extra" live-out EH vars.
+    // If we are adding resolution at the end of the block, we need to create "virtual" moves
+    // for these so that their registers are freed and can be reused.
+    if ((resolveType == ResolveJoin) && (compiler->compHndBBtabCount > 0))
+    {
+        VARSET_TP extraLiveSet(VarSetOps::Diff(compiler, block->bbLiveOut, toBlock->bbLiveIn));
+        VarSetOps::IntersectionD(compiler, extraLiveSet, registerCandidateVars);
+        VarSetOps::Iter iter(compiler, extraLiveSet);
+        unsigned        extraVarIndex = 0;
+        while (iter.NextElem(&extraVarIndex))
+        {
+            Interval* interval = getIntervalForLocalVar(extraVarIndex);
+            assert(interval->isWriteThru);
+            regNumber fromReg = getVarReg(fromVarToRegMap, extraVarIndex);
+            if (fromReg != REG_STK)
+            {
+                addResolution(block, insertionPoint, interval, REG_STK, fromReg);
+                JITDUMP(" (EH DUMMY)\n");
+                setVarReg(fromVarToRegMap, extraVarIndex, REG_STK);
+            }
+        }
+    }
+
     // First:
     //   - Perform all moves from reg to stack (no ordering needed on these)
     //   - For reg to reg moves, record the current location, associating their
@@ -8426,13 +8584,24 @@ void LinearScan::resolveEdge(BasicBlock*      fromBlock,
     unsigned        varIndex = 0;
     while (iter.NextElem(&varIndex))
     {
-        regNumber fromReg = getVarReg(fromVarToRegMap, varIndex);
-        regNumber toReg   = getVarReg(toVarToRegMap, varIndex);
+        Interval* interval = getIntervalForLocalVar(varIndex);
+        regNumber fromReg  = getVarReg(fromVarToRegMap, varIndex);
+        regNumber toReg    = getVarReg(toVarToRegMap, varIndex);
         if (fromReg == toReg)
         {
             continue;
         }
-
+        if (interval->isWriteThru && (toReg == REG_STK))
+        {
+            // We don't actually move a writeThru var back to the stack, as its stack value is always valid.
+            // However, if this is a Join edge (i.e. the move is happening at the bottom of the block),
+            // and it is a "normal" flow edge, we will go ahead and generate a mov instruction, which will be
+            // a NOP but will cause the variable to be removed from being live in the register.
+            if ((resolveType == ResolveSplit) || block->hasEHBoundaryOut())
+            {
+                continue;
+            }
+        }
         // For Critical edges, the location will not change on either side of the edge,
         // since we'll add a new block to do the move.
         if (resolveType == ResolveSplit)
@@ -8446,8 +8615,6 @@ void LinearScan::resolveEdge(BasicBlock*      fromBlock,
 
         assert(fromReg < UCHAR_MAX && toReg < UCHAR_MAX);
 
-        Interval* interval = getIntervalForLocalVar(varIndex);
-
         if (fromReg == REG_STK)
         {
             stackToRegIntervals[toReg] = interval;
@@ -8457,7 +8624,8 @@ void LinearScan::resolveEdge(BasicBlock*      fromBlock,
         {
             // Do the reg to stack moves now
             addResolution(block, insertionPoint, interval, REG_STK, fromReg);
-            JITDUMP(" (%s)\n", resolveTypeName[resolveType]);
+            JITDUMP(" (%s)\n",
+                    (interval->isWriteThru && (toReg == REG_STK)) ? "EH DUMMY" : resolveTypeName[resolveType]);
         }
         else
         {
@@ -8937,6 +9105,10 @@ void RefPosition::dump()
     {
         printf(" spillAfter");
     }
+    if (this->writeThru)
+    {
+        printf(" writeThru");
+    }
     if (this->moveReg)
     {
         printf(" move");
@@ -9023,6 +9195,10 @@ void Interval::dump()
     if (isConstant)
     {
         printf(" (constant)");
+    }
+    if (isWriteThru)
+    {
+        printf(" (writeThru)");
     }
 
     printf(" RefPositions {");
@@ -10331,7 +10507,11 @@ void LinearScan::verifyFinalAllocation()
                             }
                             regNumber regNum = getVarReg(outVarToRegMap, varIndex);
                             interval         = getIntervalForLocalVar(varIndex);
-                            assert(interval->physReg == regNum || (interval->physReg == REG_NA && regNum == REG_STK));
+                            if (interval->physReg != regNum)
+                            {
+                                assert(regNum == REG_STK);
+                                assert((interval->physReg == REG_NA) || interval->isWriteThru);
+                            }
                             interval->physReg     = REG_NA;
                             interval->assignedReg = nullptr;
                             interval->isActive    = false;
@@ -10488,7 +10668,7 @@ void LinearScan::verifyFinalAllocation()
                 {
                     dumpLsraAllocationEvent(LSRA_EVENT_KEPT_ALLOCATION, nullptr, regRecord->regNum, currentBlock);
                 }
-                if (currentRefPosition->lastUse || currentRefPosition->spillAfter)
+                if (currentRefPosition->lastUse || (currentRefPosition->spillAfter && !currentRefPosition->writeThru))
                 {
                     interval->isActive = false;
                 }
@@ -10509,7 +10689,14 @@ void LinearScan::verifyFinalAllocation()
                             }
                             dumpRegRecords();
                             dumpEmptyRefPosition();
-                            printf("Spill %-4s ", getRegName(spillReg));
+                            if (currentRefPosition->writeThru)
+                            {
+                                printf("WThru %-4s ", getRegName(spillReg));
+                            }
+                            else
+                            {
+                                printf("Spill %-4s ", getRegName(spillReg));
+                            }
                         }
                     }
                     else if (currentRefPosition->copyReg)
@@ -10670,7 +10857,10 @@ void LinearScan::verifyFinalAllocation()
                     }
                     regNumber regNum   = getVarReg(outVarToRegMap, varIndex);
                     Interval* interval = getIntervalForLocalVar(varIndex);
-                    assert(interval->physReg == regNum || (interval->physReg == REG_NA && regNum == REG_STK));
+                    // Either the register assignments match, or the outgoing assignment is on the stack
+                    // and this is a write-thru interval.
+                    assert(interval->physReg == regNum || (interval->physReg == REG_NA && regNum == REG_STK) ||
+                           (interval->isWriteThru && regNum == REG_STK));
                     interval->physReg     = REG_NA;
                     interval->assignedReg = nullptr;
                     interval->isActive    = false;

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -2894,7 +2894,7 @@ regNumber LinearScan::tryAllocateFreeReg(Interval* currentInterval, RefPosition*
         {
             // We'll only prefer a callee-save register if it's already been used.
             regMaskTP unusedCalleeSaves = calleeSaveCandidates & ~(compiler->codeGen->regSet.rsGetModifiedRegsMask());
-            callerCalleePrefs = calleeSaveCandidates & ~unusedCalleeSaves;
+            callerCalleePrefs           = calleeSaveCandidates & ~unusedCalleeSaves;
             preferences &= ~unusedCalleeSaves;
         }
         else

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -2795,7 +2795,7 @@ regNumber LinearScan::tryAllocateFreeReg(Interval* currentInterval, RefPosition*
 
     bool preferCalleeSave = currentInterval->preferCalleeSave;
 
-    bool avoidByteRegs    = false;
+    bool avoidByteRegs = false;
 #ifdef _TARGET_X86_
     if ((relatedPreferences & ~RBM_BYTE_REGS) != RBM_NONE)
     {
@@ -2894,7 +2894,7 @@ regNumber LinearScan::tryAllocateFreeReg(Interval* currentInterval, RefPosition*
         {
             // We'll only prefer a callee-save register if it's already been used.
             regMaskTP unusedCalleeSaves = calleeSaveCandidates & ~(compiler->codeGen->regSet.rsGetModifiedRegsMask());
-            callerCalleePrefs &= ~unusedCalleeSaves;
+            callerCalleePrefs = calleeSaveCandidates & ~unusedCalleeSaves;
             preferences &= ~unusedCalleeSaves;
         }
         else

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -6068,8 +6068,16 @@ void LinearScan::allocateRegisters()
             }
             if (interval->isSpilled)
             {
+                unsigned prevBBNum = 0;
                 for (RefPosition* ref = interval->firstRefPosition; ref != nullptr; ref = ref->nextRefPosition)
                 {
+                    // For the resolution phase, we need to ensure that any block with exposed uses has the
+                    // incoming reg for 'this' as REG_STK.
+                    if (RefTypeIsUse(ref->refType) && (ref->bbNum != prevBBNum))
+                    {
+                        VarToRegMap inVarToRegMap = getInVarToRegMap(ref->bbNum);
+                        setVarReg(inVarToRegMap, thisVarDsc->lvVarIndex, REG_STK);
+                    }
                     if (ref->RegOptional())
                     {
                         ref->registerAssignment = RBM_NONE;
@@ -6096,6 +6104,7 @@ void LinearScan::allocateRegisters()
                         default:
                             break;
                     }
+                    prevBBNum = ref->bbNum;
                 }
             }
         }

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -2240,6 +2240,13 @@ BasicBlock* LinearScan::findPredBlockForLiveIn(BasicBlock* block,
         return nullptr;
     }
 
+    // We may have throw blocks with no predecessors, or unreachable blocks.
+    if (block->bbPreds == nullptr)
+    {
+        JITDUMP("\n\nNo predecessor; ");
+        return nullptr;
+    }
+
 #ifdef DEBUG
     assert(*pPredBlockIsAllocated == false);
     if (getLsraBlockBoundaryLocations() == LSRA_BLOCK_BOUNDARY_LAYOUT)
@@ -4788,6 +4795,8 @@ void LinearScan::processBlockStartLocations(BasicBlock* currentBlock)
     // If this block enters an exception region, all incoming vars are on the stack.
     if (predBBNum == 0)
     {
+        if (blockInfo[currentBlock->bbNum].hasEHBoundaryIn)
+        {
 #if DEBUG
         // This should still be in its initialized empty state.
         for (unsigned varIndex = 0; varIndex < compiler->lvaTrackedCount; varIndex++)

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -5987,6 +5987,10 @@ void LinearScan::allocateRegisters()
                     {
                         unassign = true;
                     }
+                    else
+                    {
+                        currentInterval->isActive = false;
+                    }
                 }
                 if (unassign)
                 {

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -79,6 +79,14 @@ inline regMaskTP calleeSaveRegs(RegisterType rt)
 }
 
 //------------------------------------------------------------------------
+// registerTypesEquivalent: Get the set of callee-save registers of the given RegisterType
+//
+inline regMaskTP callerSaveRegs(RegisterType rt)
+{
+    return varTypeIsIntegralOrI(rt) ? RBM_INT_CALLEE_TRASH : RBM_FLT_CALLEE_TRASH;
+}
+
+//------------------------------------------------------------------------
 // RefInfo: Captures the necessary information for a definition that is "in-flight"
 //          during `buildIntervals` (i.e. a tree-node definition has been encountered,
 //          but not its use). This includes the RefPosition and its associated

--- a/src/jit/lsrabuild.cpp
+++ b/src/jit/lsrabuild.cpp
@@ -2399,7 +2399,9 @@ void LinearScan::buildIntervals()
                     // Given that we also don't have a good way to tell whether the variable is live
                     // across a call in the non-EH code, we'll be extra conservative about this.
                     // Note that for writeThru intervals we don't update the preferences to be only callee-save.
-                    if (weight <= (BB_UNITY_WEIGHT * 7))
+                    unsigned calleeSaveCount =
+                        (varTypeIsFloating(interval->registerType)) ? CNT_CALLEE_SAVED_FLOAT : CNT_CALLEE_ENREG;
+                    if ((weight <= (BB_UNITY_WEIGHT * 7)) || varDsc->lvVarIndex >= calleeSaveCount)
                     {
                         // If this is relatively low weight, don't prefer callee-save at all.
                         interval->preferCalleeSave = false;

--- a/src/jit/lsrabuild.cpp
+++ b/src/jit/lsrabuild.cpp
@@ -2124,23 +2124,21 @@ void LinearScan::buildIntervals()
                     }
                 }
             }
-            else
+            else if (block != compiler->fgFirstBB)
             {
                 // Any lclVars live-in on a non-EH boundary edge are resolution candidates.
                 VarSetOps::UnionD(compiler, resolutionCandidateVars, currentLiveVars);
 
                 VARSET_TP newLiveIn(VarSetOps::MakeCopy(compiler, currentLiveVars));
-                bool      needsDummyDefs = false;
                 if (predBlock != nullptr)
                 {
                     // Compute set difference: newLiveIn = currentLiveVars - predBlock->bbLiveOut
                     VarSetOps::DiffD(compiler, newLiveIn, predBlock->bbLiveOut);
-                    needsDummyDefs = (!VarSetOps::IsEmpty(compiler, newLiveIn) && block != compiler->fgFirstBB);
                 }
 
                 // Create dummy def RefPositions
 
-                if (needsDummyDefs)
+                if (!VarSetOps::IsEmpty(compiler, newLiveIn))
                 {
                     // If we are using locations from a predecessor, we should never require DummyDefs.
                     assert(!predBlockIsAllocated);

--- a/src/jit/lsrabuild.cpp
+++ b/src/jit/lsrabuild.cpp
@@ -3106,6 +3106,12 @@ int LinearScan::BuildStoreLoc(GenTreeLclVarCommon* storeLoc)
             // get a register.
             def->regOptional = true;
         }
+#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+        if (varTypeNeedsPartialCalleeSave(varDefInterval->registerType))
+        {
+            varDefInterval->isPartiallySpilled = false;
+        }
+#endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
     }
     else
     {

--- a/src/jit/lsrabuild.cpp
+++ b/src/jit/lsrabuild.cpp
@@ -2400,15 +2400,17 @@ void LinearScan::buildIntervals()
                     // so we won't break even until we have at least 4 * BB_UNITY_WEIGHT.
                     // Given that we also don't have a good way to tell whether the variable is live
                     // across a call in the non-EH code, we'll be extra conservative about this.
-                    // Note that for writeThru intervals we haven't updated the callee-saves preferences.
-                    // We'll do so only if we keep the preferCalleeSave.
+                    // Note that for writeThru intervals we don't update the preferences to be only callee-save.
                     if (weight <= (BB_UNITY_WEIGHT * 7))
                     {
+                        // If this is relatively low weight, don't prefer callee-save at all.
                         interval->preferCalleeSave = false;
                     }
                     else
                     {
-                        interval->updateRegisterPreferences(RBM_CALLEE_SAVED);
+                        // In other cases, we'll add in the callee-save regs to the preferences, but not clear
+                        // the non-callee-save regs . We also handle this case specially in tryAllocateFreeReg().
+                        interval->registerPreferences |= calleeSaveRegs(interval->registerType);
                     }
                 }
             }

--- a/src/jit/treelifeupdater.cpp
+++ b/src/jit/treelifeupdater.cpp
@@ -96,11 +96,13 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
                 {
                     compiler->codeGen->genUpdateVarReg(varDsc, tree);
                 }
-                if (varDsc->lvIsInReg() && tree->GetRegNum() != REG_NA)
+                bool isInReg    = varDsc->lvIsInReg() && tree->GetRegNum() != REG_NA;
+                bool isInMemory = !isInReg || varDsc->lvLiveInOutOfHndlr;
+                if (isInReg)
                 {
                     compiler->codeGen->genUpdateRegLife(varDsc, isBorn, isDying DEBUGARG(tree));
                 }
-                else
+                if (isInMemory)
                 {
                     VarSetOps::AddElemD(compiler, stackVarDeltaSet, varDsc->lvVarIndex);
                 }
@@ -131,6 +133,8 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
                 if (fldVarDsc->lvTracked)
                 {
                     unsigned fldVarIndex = fldVarDsc->lvVarIndex;
+                    bool     isInReg     = fldVarDsc->lvIsInReg();
+                    bool     isInMemory  = !isInReg || fldVarDsc->lvLiveInOutOfHndlr;
                     noway_assert(fldVarIndex < compiler->lvaTrackedCount);
                     if (!hasDeadTrackedFieldVars)
                     {
@@ -139,7 +143,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
                         {
                             // We repeat this call here and below to avoid the VarSetOps::IsMember
                             // test in this, the common case, where we have no deadTrackedFieldVars.
-                            if (fldVarDsc->lvIsInReg())
+                            if (isInReg)
                             {
                                 if (isBorn)
                                 {
@@ -147,7 +151,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
                                 }
                                 compiler->codeGen->genUpdateRegLife(fldVarDsc, isBorn, isDying DEBUGARG(tree));
                             }
-                            else
+                            if (isInMemory)
                             {
                                 VarSetOps::AddElemD(compiler, stackVarDeltaSet, fldVarIndex);
                             }
@@ -155,7 +159,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
                     }
                     else if (ForCodeGen && VarSetOps::IsMember(compiler, varDeltaSet, fldVarIndex))
                     {
-                        if (compiler->lvaTable[i].lvIsInReg())
+                        if (isInReg)
                         {
                             if (isBorn)
                             {
@@ -163,7 +167,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
                             }
                             compiler->codeGen->genUpdateRegLife(fldVarDsc, isBorn, isDying DEBUGARG(tree));
                         }
-                        else
+                        if (isInMemory)
                         {
                             VarSetOps::AddElemD(compiler, stackVarDeltaSet, fldVarIndex);
                         }

--- a/tests/src/JIT/Regression/JitBlue/GitHub_21973/GitHub_21973.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_21973/GitHub_21973.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+
+public class Test
+{
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static async Task CompletedTask()
+    {
+        for (int i = 0; i < 100; i++)
+            await Task.CompletedTask;
+    }
+
+    public static int Main()
+    {
+        CompletedTask();
+        return 100;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_21973/GitHub_21973.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_21973/GitHub_21973.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType />
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Mark EH variables (those that are live in or out of exception regions) only as lvLiveInOutOfHndlr, not necessarily lvDoNotEnregister
During register allocation, mark these as write-thru, and mark all defs as write-thru, ensuring that the stack value is always valid.
Mark those defs with GTF_SPILLED (this the "reload" flag and is not currently used for pure defs) to indicate that it should be kept in the register.
Mark blocks that enter EH regions as having no predecessor, and set the location of all live-in vars to be on the stack.
Change genFnPrologCalleeRegArgs to store EH vars also to the stack if they have a register assignment.