### PR TITLE
[3.0 port] Fix a potential division by 0 in post GC counter computation

### DIFF
--- a/src/gc/gcee.cpp
+++ b/src/gc/gcee.cpp
@@ -223,8 +223,11 @@ void GCHeap::UpdatePostGCCounters()
     }
 
     // Update percent time spent in GC
-    g_percentTimeInGCSinceLastGC = (int)(g_TotalTimeInGC * 100 / _timeInGCBase);
 
+    if (_timeInGCBase != 0)
+        g_percentTimeInGCSinceLastGC = (int)(g_TotalTimeInGC * 100 / _timeInGCBase);
+    else
+        g_percentTimeInGCSinceLastGC = 0;
     g_TotalTimeSinceLastGCEnd = _currentPerfCounterTimer;
 }
 


### PR DESCRIPTION
Backport #26085 to 3.0. 

Issue: https://github.com/dotnet/coreclr/issues/25917

Code Reviewer: Maoni Stephens 

Description:
This code path is used for computing % time in GC to be reported via performance counter when needed. _timeInGCBase is computed by subtracting the timestamp received via QueryPerformanceCounter at last GC that happened from the current timestamp. Since QueryPerformanceCounter is a high-res timestamp I did not think that the subtraction of the two timestamps could ever be 0, but we have a customer reporting that in #25917. While I still wasn't able to repro the issue, I confirmed that it was this division by zero exception that happened.

Customer Impact:
While it is very hard to repro this issue, when it does happen it is deadly (it can deadlock the process if another GC kicks in during the exception processing) and is difficult to diagnose (managed debugger can't be attached). It is also in a code path that can be called even when a customer does not listen to the % time in GC counter.

Regression?
This is a regression introduced in 3.0 Preview 6.

Risk:
Low



