### PR TITLE
Dictionary optimization after deserialization

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
@@ -688,6 +688,12 @@ namespace System.Collections.Generic
             int hashsize = siInfo.GetInt32(HashSizeName);
             _comparer = (IEqualityComparer<TKey>)siInfo.GetValue(ComparerName, typeof(IEqualityComparer<TKey>))!; // When serialized if comparer is null, we use the default.
 
+            // "==" would fail since they're different instances
+            if (Equals(_comparer, EqualityComparer<TKey>.Default))
+            {
+                _comparer = null;
+            }
+
             if (hashsize != 0)
             {
                 Initialize(hashsize);


### PR DESCRIPTION
The optimization in `Dictionary<,>` around `_comparer` will be
nullified if it's created via deserialization.

If `_comparer` is `null`, the comparer will be serialized using
`EqualityComparer<T>.Default`, so when it's being deserialized,
it should be assigned back to `null` to run into the faster branch
when lookup.

Fix dotnet/corefx#40150