### PR TITLE
Use function-local StackingAllocator for adding EnC methods

### DIFF
--- a/src/vm/class.cpp
+++ b/src/vm/class.cpp
@@ -605,6 +605,12 @@ HRESULT EEClass::AddMethod(MethodTable * pMT, mdMethodDef methodDef, RVA newRVA,
 
 
     // Initialize the new MethodDesc
+    // The stacking allocator being passed here as NULL replaces a silent optimization bug that was being masked before here.
+    // This was reported in https://github.com/dotnet/coreclr/issues/26016, and was caused by PR https://github.com/dotnet/coreclr/pull/24177
+    // Previously, &GetThread()->m_MarshalAlloc was being optimized into an offset from a globl thread-static. After the PR, this resulted
+    // in a field access on the thread object, but there's no Thread object as this function gets called on the RC Thread.
+    // This is not a fix, but rather a workaround to get to the state prior to the cusomer scenario regression.
+    // Any case in which the builder requires to use the allocator with AV, which is consistent with the long-existing behavior.
     MethodTableBuilder builder(pMT,
                                pClass,
                                NULL,

--- a/src/vm/class.cpp
+++ b/src/vm/class.cpp
@@ -603,12 +603,11 @@ HRESULT EEClass::AddMethod(MethodTable * pMT, mdMethodDef methodDef, RVA newRVA,
     // Get the new MethodDesc (Note: The method desc memory is zero initialized)
     MethodDesc *pNewMD = pChunk->GetFirstMethodDesc();
 
-    ACQUIRE_STACKING_ALLOCATOR(pStackingAllocator);
 
     // Initialize the new MethodDesc
     MethodTableBuilder builder(pMT,
                                pClass,
-                               pStackingAllocator,
+                               NULL,
                                &dummyAmTracker);
     EX_TRY
     {

--- a/src/vm/class.cpp
+++ b/src/vm/class.cpp
@@ -605,15 +605,14 @@ HRESULT EEClass::AddMethod(MethodTable * pMT, mdMethodDef methodDef, RVA newRVA,
 
 
     // Initialize the new MethodDesc
-    // The stacking allocator being passed here as NULL replaces a silent optimization bug that was being masked before here.
-    // This was reported in https://github.com/dotnet/coreclr/issues/26016, and was caused by PR https://github.com/dotnet/coreclr/pull/24177
-    // Previously, &GetThread()->m_MarshalAlloc was being optimized into an offset from a globl thread-static. After the PR, this resulted
-    // in a field access on the thread object, but there's no Thread object as this function gets called on the RC Thread.
-    // This is not a fix, but rather a workaround to get to the state prior to the cusomer scenario regression.
-    // Any case in which the builder requires to use the allocator with AV, which is consistent with the long-existing behavior.
+    
+     // This method runs on a debugger thread. Debugger threads do not have Thread object that caches StackingAllocator.
+     // Use a local StackingAllocator instead.
+    StackingAllocator stackingAllocator;
+
     MethodTableBuilder builder(pMT,
                                pClass,
-                               NULL,
+                               &stackingAllocator,
                                &dummyAmTracker);
     EX_TRY
     {


### PR DESCRIPTION
This reproduces old behavior. It is still a source of possible AVs in the runtime. 