### PR TITLE
Pass HRESULT instead of Win32 error code

### DIFF
--- a/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.QueryUnbiasedInterruptTime.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.QueryUnbiasedInterruptTime.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, SetLastError = true)]
+        [DllImport(Libraries.Kernel32, SetLastError = false)]
         internal static extern bool QueryUnbiasedInterruptTime(out ulong UnbiasedTime);
     }
 }

--- a/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.QueryUnbiasedInterruptTime.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.QueryUnbiasedInterruptTime.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, SetLastError = false)]
+        [DllImport(Libraries.Kernel32)]
         internal static extern bool QueryUnbiasedInterruptTime(out ulong UnbiasedTime);
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Threading/TimerQueue.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/TimerQueue.Windows.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace System.Threading
@@ -21,7 +22,11 @@ namespace System.Threading
                 // in sleep/hibernate mode.
                 if (Environment.IsWindows8OrAbove)
                 {
-                    Interop.Kernel32.QueryUnbiasedInterruptTime(out ulong time100ns);
+                    // Based on its documentation the QueryUnbiasedInterruptTime() function validates
+                    // the argument is non-null. In this case we are always supplying an argument,
+                    // so will skip return value validation.
+                    bool success = Interop.Kernel32.QueryUnbiasedInterruptTime(out ulong time100ns);
+                    Debug.Assert(success);
                     return (long)(time100ns / 10_000); // convert from 100ns to milliseconds
                 }
                 else

--- a/src/System.Private.CoreLib/shared/System/Threading/TimerQueue.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/TimerQueue.Windows.cs
@@ -22,7 +22,7 @@ namespace System.Threading
                 if (Environment.IsWindows8OrAbove)
                 {
                     if (!Interop.Kernel32.QueryUnbiasedInterruptTime(out ulong time100ns))
-                        Marshal.ThrowExceptionForHR(Marshal.GetLastWin32Error());
+                        Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
 
                     return (long)(time100ns / 10_000); // convert from 100ns to milliseconds
                 }

--- a/src/System.Private.CoreLib/shared/System/Threading/TimerQueue.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/TimerQueue.Windows.cs
@@ -21,9 +21,7 @@ namespace System.Threading
                 // in sleep/hibernate mode.
                 if (Environment.IsWindows8OrAbove)
                 {
-                    if (!Interop.Kernel32.QueryUnbiasedInterruptTime(out ulong time100ns))
-                        Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
-
+                    Interop.Kernel32.QueryUnbiasedInterruptTime(out ulong time100ns);
                     return (long)(time100ns / 10_000); // convert from 100ns to milliseconds
                 }
                 else


### PR DESCRIPTION
A Win32 error code was being passed to `Marshal.ThrowExceptionForHR()` in [`TimerQueue.TickCount64`](https://github.com/dotnet/coreclr/blob/48ff0937552e540f21835391b693daf47ffabece/src/System.Private.CoreLib/shared/System/Threading/TimerQueue.Windows.cs#L25), but the API indicates it should be an `HRESULT`. The call to `Marshal.GetHRForLastWin32Error()` is basically identical to `Marshal.GetLastWin32Error()` except that it ensures the error code has the [error bit set](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/0642cb2f-2075-4469-918c-4441e69c548a), thus creating a valid error `HRESULT`.

Fixes: https://github.com/dotnet/coreclr/issues/26081

/cc @stephentoub 