### PR TITLE
[release/2.1] Replace hex number representation in ASM files

### DIFF
--- a/src/debug/ee/amd64/dbghelpers.S
+++ b/src/debug/ee/amd64/dbghelpers.S
@@ -29,7 +29,7 @@ NESTED_ENTRY FuncEvalHijack, _TEXT, UnhandledExceptionHandlerUnix
         //
         // epilogue
         //
-        add     rsp, 20h
+        add     rsp, 0x20
         TAILJMP_RAX
 NESTED_END FuncEvalHijack, _TEXT
 
@@ -65,14 +65,14 @@ NESTED_ENTRY ExceptionHijack, _TEXT, UnhandledExceptionHandlerUnix
         // its arguments on the stack. In x64, it gets its arguments in
         // registers (set up for us by DacDbiInterfaceImpl::Hijack),
         // and this stack space may be reused.
-        mov     rax, [rsp + 20h]
+        mov     rax, [rsp + 0x20]
         mov     [rsp], rax
-        mov     rax, [rsp + 28h]
-        mov     [rsp + 8h], rax
-        mov     rax, [rsp + 30h]
-        mov     [rsp + 10h], rax
-        mov     rax, [rsp + 38h]
-        mov     [rsp + 18h], rax
+        mov     rax, [rsp + 0x28]
+        mov     [rsp + 0x8], rax
+        mov     rax, [rsp + 0x30]
+        mov     [rsp + 0x10], rax
+        mov     rax, [rsp + 0x38]
+        mov     [rsp + 0x18], rax
         
         // DD Hijack primitive already set the stack. So just make the call now.
         call    C_FUNC(ExceptionHijackWorker)
@@ -93,7 +93,7 @@ NESTED_ENTRY ExceptionHijack, _TEXT, UnhandledExceptionHandlerUnix
         //
         // epilogue
         //
-        add     rsp, 20h
+        add     rsp, 0x20
         TAILJMP_RAX
 
 // Put a label here to tell the debugger where the end of this function is.

--- a/src/pal/inc/unixasmmacros.inc
+++ b/src/pal/inc/unixasmmacros.inc
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#define INVALIDGCVALUE 0CCCCCCCDh
+#define INVALIDGCVALUE 0xCCCCCCCD
 
 #if defined(__APPLE__)
 #define C_FUNC(name) _##name

--- a/src/vm/amd64/jithelpers_fast.S
+++ b/src/vm/amd64/jithelpers_fast.S
@@ -81,14 +81,14 @@ LEAF_ENTRY JIT_WriteBarrier, _TEXT
         // Update the write watch table if necessary
         mov     rax, rdi
         movabs  r10, 0xF0F0F0F0F0F0F0F0
-        shr     rax, 0Ch // SoftwareWriteWatch::AddressToTableByteIndexShift
+        shr     rax, 0xC // SoftwareWriteWatch::AddressToTableByteIndexShift
         NOP_2_BYTE // padding for alignment of constant
         movabs  r11, 0xF0F0F0F0F0F0F0F0
         add     rax, r10
-        cmp     byte ptr [rax], 0h
+        cmp     byte ptr [rax], 0x0
         .byte 0x75, 0x06
         // jne     CheckCardTable
-        mov     byte ptr [rax], 0FFh
+        mov     byte ptr [rax], 0xFF
 
         NOP_3_BYTE // padding for alignment of constant
 
@@ -112,27 +112,27 @@ LEAF_ENTRY JIT_WriteBarrier, _TEXT
 
         // Touch the card table entry, if not already dirty.
         shr     rdi, 0x0B
-        cmp     byte ptr [rdi + rax], 0FFh
+        cmp     byte ptr [rdi + rax], 0xFF
         .byte 0x75, 0x02
         // jne     UpdateCardTable
         REPRET
 
     UpdateCardTable:
-        mov     byte ptr [rdi + rax], 0FFh
+        mov     byte ptr [rdi + rax], 0xFF
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
         NOP_2_BYTE // padding for alignment of constant
         shr     rdi, 0x0A
 
         movabs  rax, 0xF0F0F0F0F0F0F0F0
-        cmp     byte ptr [rdi + rax], 0FFh
+        cmp     byte ptr [rdi + rax], 0xFF
 
         .byte 0x75, 0x02
         // jne     UpdateCardBundle_WriteWatch_PostGrow64
         REPRET
 
     UpdateCardBundle_WriteWatch_PostGrow64:
-        mov     byte ptr [rdi + rax], 0FFh
+        mov     byte ptr [rdi + rax], 0xFF
 #endif
 
         ret
@@ -177,14 +177,14 @@ LEAF_ENTRY JIT_WriteBarrier, _TEXT
         movabs  rax, 0xF0F0F0F0F0F0F0F0
 
         // Touch the card table entry, if not already dirty.
-        shr     rdi, 0Bh
-        cmp     byte ptr [rdi + rax], 0FFh
+        shr     rdi, 0x0B
+        cmp     byte ptr [rdi + rax], 0xFF
         .byte 0x75, 0x02
         // jne     UpdateCardTable
         REPRET
 
     UpdateCardTable:
-        mov     byte ptr [rdi + rax], 0FFh
+        mov     byte ptr [rdi + rax], 0xFF
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
         NOP_6_BYTE // padding for alignment of constant
@@ -194,14 +194,14 @@ LEAF_ENTRY JIT_WriteBarrier, _TEXT
         // Touch the card bundle, if not already dirty.
         // rdi is already shifted by 0xB, so shift by 0xA more
         shr     rdi, 0x0A
-        cmp     byte ptr [rdi + rax], 0FFh
+        cmp     byte ptr [rdi + rax], 0xFF
 
         .byte 0x75, 0x02 
         // jne     UpdateCardBundle
         REPRET
 
     UpdateCardBundle:
-        mov     byte ptr [rdi + rax], 0FFh
+        mov     byte ptr [rdi + rax], 0xFF
 #endif
 
         ret
@@ -312,15 +312,15 @@ LEAF_ENTRY JIT_ByRefWriteBarrier, _TEXT
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
         // Update the write watch table if necessary
         PREPARE_EXTERNAL_VAR g_sw_ww_enabled_for_gc_heap, rax
-        cmp     byte ptr [rax], 0h
+        cmp     byte ptr [rax], 0x0
         je      CheckCardTable_ByRefWriteBarrier
         mov     rax, rdi
-        shr     rax, 0Ch // SoftwareWriteWatch::AddressToTableByteIndexShift
+        shr     rax, 0xC // SoftwareWriteWatch::AddressToTableByteIndexShift
         PREPARE_EXTERNAL_VAR g_sw_ww_table, r10
         add     rax, qword ptr [r10]
-        cmp     byte ptr [rax], 0h
+        cmp     byte ptr [rax], 0x0
         jne     CheckCardTable_ByRefWriteBarrier
-        mov     byte ptr [rax], 0FFh
+        mov     byte ptr [rax], 0xFF
 #endif
 
     CheckCardTable_ByRefWriteBarrier:
@@ -334,8 +334,8 @@ LEAF_ENTRY JIT_ByRefWriteBarrier, _TEXT
 
         // move current rdi value into rcx and then increment the pointers
         mov     rcx, rdi
-        add     rsi, 8h
-        add     rdi, 8h
+        add     rsi, 0x8
+        add     rdi, 0x8
 
         // Check if we need to update the card table
         // Calc pCardByte
@@ -345,13 +345,13 @@ LEAF_ENTRY JIT_ByRefWriteBarrier, _TEXT
         mov     rax, [rax]
 
         // Check if this card is dirty
-        cmp     byte ptr [rcx + rax], 0FFh
+        cmp     byte ptr [rcx + rax], 0xFF
 
         jne     UpdateCardTable_ByRefWriteBarrier
         REPRET
 
     UpdateCardTable_ByRefWriteBarrier:
-        mov     byte ptr [rcx + rax], 0FFh
+        mov     byte ptr [rcx + rax], 0xFF
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
         // Shift rcx by 0x0A more to get the card bundle byte (we shifted by 0x0B already)
@@ -361,13 +361,13 @@ LEAF_ENTRY JIT_ByRefWriteBarrier, _TEXT
         add     rcx, [rax]
 
         // Check if this bundle byte is dirty
-        cmp     byte ptr [rcx], 0FFh
+        cmp     byte ptr [rcx], 0xFF
 
         jne     UpdateCardBundle_ByRefWriteBarrier
         REPRET
 
     UpdateCardBundle_ByRefWriteBarrier:
-        mov     byte ptr [rcx], 0FFh
+        mov     byte ptr [rcx], 0xFF
 #endif
 
         ret
@@ -383,8 +383,8 @@ LEAF_ENTRY JIT_ByRefWriteBarrier, _TEXT
 #endif
     Exit_ByRefWriteBarrier:
         // Increment the pointers before leaving
-        add     rdi, 8h
-        add     rsi, 8h
+        add     rdi, 0x8
+        add     rsi, 0x8
         ret
 LEAF_END JIT_ByRefWriteBarrier, _TEXT
 

--- a/src/vm/amd64/jithelpers_fastwritebarriers.S
+++ b/src/vm/amd64/jithelpers_fastwritebarriers.S
@@ -38,13 +38,13 @@ PATCH_LABEL JIT_WriteBarrier_PreGrow64_Patch_Label_CardTable
 
         // Touch the card table entry, if not already dirty.
         shr     rdi, 0x0B
-        cmp     byte ptr [rdi + rax], 0FFh
+        cmp     byte ptr [rdi + rax], 0xFF
         .byte 0x75, 0x02
         // jne     UpdateCardTable_PreGrow64
         REPRET
 
     UpdateCardTable_PreGrow64:
-        mov     byte ptr [rdi + rax], 0FFh
+        mov     byte ptr [rdi + rax], 0xFF
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
         NOP_6_BYTE // padding for alignment of constant
@@ -55,14 +55,14 @@ PATCH_LABEL JIT_WriteBarrier_PreGrow64_Patch_Label_CardBundleTable
         // Touch the card bundle, if not already dirty.
         // rdi is already shifted by 0xB, so shift by 0xA more
         shr     rdi, 0x0A
-        cmp     byte ptr [rdi + rax], 0FFh
+        cmp     byte ptr [rdi + rax], 0xFF
 
         .byte 0x75, 0x02 
         // jne     UpdateCardBundle_PreGrow64
         REPRET
 
     UpdateCardBundle_PreGrow64:
-        mov     byte ptr [rdi + rax], 0FFh
+        mov     byte ptr [rdi + rax], 0xFF
 #endif
 
         ret
@@ -123,13 +123,13 @@ PATCH_LABEL JIT_WriteBarrier_PostGrow64_Patch_Label_CardTable
 
         // Touch the card table entry, if not already dirty.
         shr     rdi, 0x0B
-        cmp     byte ptr [rdi + rax], 0FFh
+        cmp     byte ptr [rdi + rax], 0xFF
         .byte 0x75, 0x02
         // jne     UpdateCardTable_PostGrow64
         REPRET
 
     UpdateCardTable_PostGrow64:
-        mov     byte ptr [rdi + rax], 0FFh
+        mov     byte ptr [rdi + rax], 0xFF
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
         NOP_6_BYTE // padding for alignment of constant
@@ -140,14 +140,14 @@ PATCH_LABEL JIT_WriteBarrier_PostGrow64_Patch_Label_CardBundleTable
         // Touch the card bundle, if not already dirty.
         // rdi is already shifted by 0xB, so shift by 0xA more
         shr     rdi, 0x0A
-        cmp     byte ptr [rdi + rax], 0FFh
+        cmp     byte ptr [rdi + rax], 0xFF
 
         .byte 0x75, 0x02 
         // jne     UpdateCardBundle_PostGrow64
         REPRET
 
     UpdateCardBundle_PostGrow64:
-        mov     byte ptr [rdi + rax], 0FFh
+        mov     byte ptr [rdi + rax], 0xFF
 #endif
 
         ret
@@ -182,13 +182,13 @@ PATCH_LABEL JIT_WriteBarrier_SVR64_PatchLabel_CardTable
 
         shr     rdi, 0x0B
 
-        cmp     byte ptr [rdi + rax], 0FFh
+        cmp     byte ptr [rdi + rax], 0xFF
         .byte 0x75, 0x02
         // jne     UpdateCardTable_SVR64
         REPRET
 
     UpdateCardTable_SVR64:
-        mov     byte ptr [rdi + rax], 0FFh
+        mov     byte ptr [rdi + rax], 0xFF
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
         NOP_6_BYTE // padding for alignment of constant
@@ -198,14 +198,14 @@ PATCH_LABEL JIT_WriteBarrier_SVR64_PatchLabel_CardBundleTable
 
         // Shift the address by 0xA more since already shifted by 0xB
         shr     rdi, 0x0A
-        cmp     byte ptr [rdi + rax], 0FFh
+        cmp     byte ptr [rdi + rax], 0xFF
 
         .byte 0x75, 0x02 
         // jne     UpdateCardBundle_SVR64
         REPRET
 
     UpdateCardBundle_SVR64:
-        mov     byte ptr [rdi + rax], 0FFh
+        mov     byte ptr [rdi + rax], 0xFF
 #endif
 
         ret
@@ -236,15 +236,15 @@ LEAF_ENTRY JIT_WriteBarrier_WriteWatch_PreGrow64, _TEXT
         mov     rax, rdi
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_PreGrow64_Patch_Label_WriteWatchTable
         movabs  r10, 0xF0F0F0F0F0F0F0F0
-        shr     rax, 0Ch // SoftwareWriteWatch::AddressToTableByteIndexShift
+        shr     rax, 0x0C // SoftwareWriteWatch::AddressToTableByteIndexShift
         NOP_2_BYTE // padding for alignment of constant
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_PreGrow64_Patch_Label_Lower
         movabs  r11, 0xF0F0F0F0F0F0F0F0
         add     rax, r10
-        cmp     byte ptr [rax], 0h
+        cmp     byte ptr [rax], 0x0
         .byte 0x75, 0x03
         // jne     CheckCardTable_WriteWatch_PreGrow64
-        mov     byte ptr [rax], 0FFh
+        mov     byte ptr [rax], 0xFF
 
     CheckCardTable_WriteWatch_PreGrow64:
         // Check the lower ephemeral region bound.
@@ -263,13 +263,13 @@ PATCH_LABEL JIT_WriteBarrier_WriteWatch_PreGrow64_Patch_Label_Lower
         NOP_2_BYTE // padding for alignment of constant
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_PreGrow64_Patch_Label_CardTable
         movabs  rax, 0xF0F0F0F0F0F0F0F0
-        cmp     byte ptr [rdi + rax], 0FFh
+        cmp     byte ptr [rdi + rax], 0xFF
         .byte 0x75, 0x02
         // jne     UpdateCardTable_WriteWatch_PreGrow64
         REPRET
 
     UpdateCardTable_WriteWatch_PreGrow64:
-        mov     byte ptr [rdi + rax], 0FFh
+        mov     byte ptr [rdi + rax], 0xFF
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
         NOP_2_BYTE // padding for alignment of constant
@@ -277,14 +277,14 @@ PATCH_LABEL JIT_WriteBarrier_WriteWatch_PreGrow64_Patch_Label_CardBundleTable
         movabs  rax, 0xF0F0F0F0F0F0F0F0
 
         shr     rdi, 0x0A
-        cmp     byte ptr [rdi + rax], 0FFh
+        cmp     byte ptr [rdi + rax], 0xFF
 
         .byte 0x75, 0x02
         // jne     UpdateCardBundle_WriteWatch_PreGrow64
         REPRET
 
     UpdateCardBundle_WriteWatch_PreGrow64:
-        mov     byte ptr [rdi + rax], 0FFh
+        mov     byte ptr [rdi + rax], 0xFF
 #endif
 
         ret
@@ -314,15 +314,15 @@ LEAF_ENTRY JIT_WriteBarrier_WriteWatch_PostGrow64, _TEXT
         mov     rax, rdi
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_PostGrow64_Patch_Label_WriteWatchTable
         movabs  r10, 0xF0F0F0F0F0F0F0F0
-        shr     rax, 0Ch // SoftwareWriteWatch::AddressToTableByteIndexShift
+        shr     rax, 0x0C // SoftwareWriteWatch::AddressToTableByteIndexShift
         NOP_2_BYTE // padding for alignment of constant
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_PostGrow64_Patch_Label_Lower
         movabs  r11, 0xF0F0F0F0F0F0F0F0
         add     rax, r10
-        cmp     byte ptr [rax], 0h
+        cmp     byte ptr [rax], 0x0
         .byte 0x75, 0x06
         // jne     CheckCardTable_WriteWatch_PostGrow64
-        mov     byte ptr [rax], 0FFh
+        mov     byte ptr [rax], 0xFF
 
         NOP_3_BYTE // padding for alignment of constant
 
@@ -358,13 +358,13 @@ PATCH_LABEL JIT_WriteBarrier_WriteWatch_PostGrow64_Patch_Label_CardTable
 
         // Touch the card table entry, if not already dirty.
         shr     rdi, 0x0B
-        cmp     byte ptr [rdi + rax], 0FFh
+        cmp     byte ptr [rdi + rax], 0xFF
         .byte 0x75, 0x02
         // jne     UpdateCardTable_WriteWatch_PostGrow64
         REPRET
 
     UpdateCardTable_WriteWatch_PostGrow64:
-        mov     byte ptr [rdi + rax], 0FFh
+        mov     byte ptr [rdi + rax], 0xFF
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
         NOP_2_BYTE // padding for alignment of constant
@@ -372,14 +372,14 @@ PATCH_LABEL JIT_WriteBarrier_WriteWatch_PostGrow64_Patch_Label_CardTable
 
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_PostGrow64_Patch_Label_CardBundleTable
         movabs  rax, 0xF0F0F0F0F0F0F0F0
-        cmp     byte ptr [rdi + rax], 0FFh
+        cmp     byte ptr [rdi + rax], 0xFF
 
         .byte 0x75, 0x02
         // jne     UpdateCardBundle_WriteWatch_PostGrow64
         REPRET
 
     UpdateCardBundle_WriteWatch_PostGrow64:
-        mov     byte ptr [rdi + rax], 0FFh
+        mov     byte ptr [rdi + rax], 0xFF
 #endif
 
         ret
@@ -417,25 +417,25 @@ LEAF_ENTRY JIT_WriteBarrier_WriteWatch_SVR64, _TEXT
         mov     rax, rdi
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_SVR64_PatchLabel_WriteWatchTable
         movabs  r10, 0xF0F0F0F0F0F0F0F0
-        shr     rax, 0Ch // SoftwareWriteWatch::AddressToTableByteIndexShift
+        shr     rax, 0xC // SoftwareWriteWatch::AddressToTableByteIndexShift
         NOP_2_BYTE // padding for alignment of constant
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_SVR64_PatchLabel_CardTable
         movabs  r11, 0xF0F0F0F0F0F0F0F0
         add     rax, r10
-        cmp     byte ptr [rax], 0h
+        cmp     byte ptr [rax], 0x0
         .byte 0x75, 0x03
         // jne     CheckCardTable_WriteWatch_SVR64
-        mov     byte ptr [rax], 0FFh
+        mov     byte ptr [rax], 0xFF
 
     CheckCardTable_WriteWatch_SVR64:
         shr     rdi, 0x0B
-        cmp     byte ptr [rdi + r11], 0FFh
+        cmp     byte ptr [rdi + r11], 0xFF
         .byte 0x75, 0x02
         // jne     UpdateCardTable_WriteWatch_SVR64
         REPRET
 
     UpdateCardTable_WriteWatch_SVR64:
-        mov     byte ptr [rdi + r11], 0FFh
+        mov     byte ptr [rdi + r11], 0xFF
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
         NOP // padding for alignment of constant
@@ -444,13 +444,13 @@ PATCH_LABEL JIT_WriteBarrier_WriteWatch_SVR64_PatchLabel_CardBundleTable
         movabs  r11, 0xF0F0F0F0F0F0F0F0
 
         shr     rdi, 0x0A
-        cmp     byte ptr [rdi + r11], 0FFh
+        cmp     byte ptr [rdi + r11], 0xFF
         .byte 0x75, 0x02
         // jne     UpdateCardBundle_WriteWatch_SVR64
         REPRET
 
     UpdateCardBundle_WriteWatch_SVR64:
-        mov     byte ptr [rdi + r11], 0FFh
+        mov     byte ptr [rdi + r11], 0xFF
 #endif
 
         ret

--- a/src/vm/amd64/jithelpers_slow.S
+++ b/src/vm/amd64/jithelpers_slow.S
@@ -71,15 +71,15 @@ LEAF_ENTRY JIT_WriteBarrier_Debug, _TEXT
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
         // Update the write watch table if necessary
         PREPARE_EXTERNAL_VAR g_sw_ww_enabled_for_gc_heap, r10
-        cmp     byte ptr [r10], 0h
+        cmp     byte ptr [r10], 0x0
         je      CheckCardTable_Debug
         mov     r10, rdi
-        shr     r10, 0Ch // SoftwareWriteWatch::AddressToTableByteIndexShift
+        shr     r10, 0xC // SoftwareWriteWatch::AddressToTableByteIndexShift
         PREPARE_EXTERNAL_VAR g_sw_ww_table, r11
         add     r10, qword ptr [r11]
-        cmp     byte ptr [r10], 0h
+        cmp     byte ptr [r10], 0x0
         jne     CheckCardTable_Debug
-        mov     byte ptr [r10], 0FFh
+        mov     byte ptr [r10], 0xFF
 #endif
 
     CheckCardTable_Debug:
@@ -99,13 +99,13 @@ LEAF_ENTRY JIT_WriteBarrier_Debug, _TEXT
         mov     r10, [r10]
 
         // Check if this card is dirty
-        cmp     byte ptr [rdi + r10], 0FFh
+        cmp     byte ptr [rdi + r10], 0xFF
 
         jne     UpdateCardTable_Debug
         REPRET
 
     UpdateCardTable_Debug:
-        mov     byte ptr [rdi + r10], 0FFh
+        mov     byte ptr [rdi + r10], 0xFF
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
         // Shift rdi by 0x0A more to get the card bundle byte (we shifted by 0x0B already)
@@ -115,13 +115,13 @@ LEAF_ENTRY JIT_WriteBarrier_Debug, _TEXT
         add     rdi, [r10]
 
         // Check if this bundle byte is dirty
-        cmp     byte ptr [rdi], 0FFh
+        cmp     byte ptr [rdi], 0xFF
 
         jne     UpdateCardBundle_Debug
         REPRET
 
     UpdateCardBundle_Debug:
-        mov     byte ptr [rdi], 0FFh
+        mov     byte ptr [rdi], 0xFF
 #endif
 
         ret

--- a/src/vm/amd64/virtualcallstubamd64.S
+++ b/src/vm/amd64/virtualcallstubamd64.S
@@ -59,19 +59,19 @@ LEAF_ENTRY ResolveWorkerChainLookupAsmStub, _TEXT
         jnz     Fail_RWCLAS          // If the BACKPATCH_FLAGS is set we will go directly to the ResolveWorkerAsmStub
         
 MainLoop_RWCLAS:
-        mov     rax, [rax+18h]   // get the next entry in the chain (don't bother checking the first entry again)
+        mov     rax, [rax+0x18]  // get the next entry in the chain (don't bother checking the first entry again)
         test    rax,rax          // test if we hit a terminating NULL
         jz      Fail_RWCLAS
 
-        cmp    rdx, [rax+00h]    // compare our MT with the one in the ResolveCacheElem
+        cmp    rdx, [rax+0x00]   // compare our MT with the one in the ResolveCacheElem
         jne    MainLoop_RWCLAS
-        cmp    r10, [rax+08h]    // compare our DispatchToken with one in the ResolveCacheElem
+        cmp    r10, [rax+0x08]   // compare our DispatchToken with one in the ResolveCacheElem
         jne    MainLoop_RWCLAS
 Success_RWCLAS:        
         PREPARE_EXTERNAL_VAR CHAIN_SUCCESS_COUNTER, rdx
         sub    qword ptr [rdx],1 // decrement success counter 
         jl     Promote_RWCLAS
-        mov    rax, [rax+10h]    // get the ImplTarget
+        mov    rax, [rax+0x10]   // get the ImplTarget
         pop    rdx
         jmp    rax
         

--- a/src/vm/i386/asmhelpers.S
+++ b/src/vm/i386/asmhelpers.S
@@ -99,8 +99,8 @@ LEAF_ENTRY ResetCurrentContext, _TEXT
     mov     ax, [esp - 2]
 
     fninit                // reset FPU
-    and     ax, 0f00h     // preserve precision and rounding control
-    or      ax, 007fh     // mask all exceptions
+    and     ax, 0xf00     // preserve precision and rounding control
+    or      ax, 0x07f     // mask all exceptions
 
     // preserve precision control
     mov     ax, [esp - 2]
@@ -135,7 +135,7 @@ LEAF_ENTRY GetSpecificCpuTypeAsm, _TEXT
     pushfd
     pop     ecx           // Get the EFLAGS
     mov     eax, ecx      // Save for later testing
-    xor     ecx, 200000h  // Invert the ID bit
+    xor     ecx, 0x200000 // Invert the ID bit
     push    ecx
     popfd                 // Save the updated flags
     pushfd
@@ -144,7 +144,7 @@ LEAF_ENTRY GetSpecificCpuTypeAsm, _TEXT
     push    eax
     popfd                 // Restore the flags
 
-    test    ecx, 200000h
+    test    ecx, 0x200000
     jz      LOCAL_LABEL(Assume486)
 
     xor     eax, eax
@@ -158,12 +158,12 @@ LEAF_ENTRY GetSpecificCpuTypeAsm, _TEXT
 
     // filter out everything except family and model
     // Note that some multi-procs have different stepping number for each proc
-    and     eax, 0ff0h
+    and     eax, 0xff0
 
     jmp     LOCAL_LABEL(CpuTypeDone)
 
 LOCAL_LABEL(Assume486):
-    mov     eax, 0400h   // report 486
+    mov     eax, 0x400   // report 486
 
 LOCAL_LABEL(CpuTypeDone):
     pop     ebx
@@ -178,7 +178,7 @@ LEAF_ENTRY GetSpecificCpuFeaturesAsm, _TEXT
     pushfd
     pop     ecx          // Get the EFLAGS
     mov     eax, ecx     // Save for later testing
-    xor     ecx, 200000h // Invert the ID bit.
+    xor     ecx, 0x200000 // Invert the ID bit.
     push    ecx
     popfd                // Save the updated flags.
     pushfd
@@ -187,7 +187,7 @@ LEAF_ENTRY GetSpecificCpuFeaturesAsm, _TEXT
     push    eax
     popfd                // Restore the flags
 
-    test    ecx, 200000h
+    test    ecx, 0x200000
     jz      LOCAL_LABEL(CpuFeaturesFail)
 
     xor     eax, eax

--- a/src/vm/i386/jithelp.S
+++ b/src/vm/i386/jithelp.S
@@ -184,12 +184,12 @@ LOCAL_LABEL(WriteBarrier_ShadowCheckEnd_\rg):
     PREPARE_EXTERNAL_VAR g_card_table, eax
     add     edx, [eax]
     pop     eax
-    cmp     BYTE PTR [edx], 0FFh
+    cmp     BYTE PTR [edx], 0xFF
     jne     LOCAL_LABEL(WriteBarrier_UpdateCardTable_\rg)
     ret
 
 LOCAL_LABEL(WriteBarrier_UpdateCardTable_\rg):
-    mov     BYTE PTR [edx], 0FFh
+    mov     BYTE PTR [edx], 0xFF
     ret
 
 LOCAL_LABEL(WriteBarrier_NotInHeap_\rg):
@@ -351,11 +351,11 @@ LOCAL_LABEL(ByRefWriteBarrier_ShadowCheckEnd):
     PREPARE_EXTERNAL_VAR g_card_table, eax
     add     ecx, [eax]
     pop     eax
-    cmp     BYTE PTR [ecx], 0FFh
+    cmp     BYTE PTR [ecx], 0xFF
     jne     LOCAL_LABEL(ByRefWriteBarrier_UpdateCardTable)
     ret
 LOCAL_LABEL(ByRefWriteBarrier_UpdateCardTable):
-    mov     BYTE PTR [ecx], 0FFh
+    mov     BYTE PTR [ecx], 0xFF
     ret
 
 LOCAL_LABEL(ByRefWriteBarrier_NotInHeap):
@@ -542,11 +542,11 @@ LEAF_ENTRY JIT_Dbl2LngP4x87, _TEXT
     // get some local space
     sub 	esp, 8
 
-    #define arg1 [esp + 0Ch]
+    #define arg1 [esp + 0xC]
     fld     QWORD PTR arg1          // fetch arg
     fnstcw  WORD PTR arg1           // store FPCW
     movzx   eax, WORD PTR arg1      // zero extend - wide
-    or      ah, 0Ch                 // turn on OE and DE flags
+    or      0xa, 0xC                // turn on OE and DE flags
     mov     DWORD PTR [esp], eax    // store new FPCW bits
     fldcw   WORD PTR  [esp]         // reload FPCW with new bits
     fistp   QWORD PTR [esp]         // convert
@@ -580,7 +580,7 @@ LEAF_ENTRY JIT_Dbl2LngSSE3, _TEXT
     // get some local space
     sub     esp, 8
 
-    fld     QWORD PTR [esp + 0Ch]   // fetch arg
+    fld     QWORD PTR [esp + 0xC]   // fetch arg
     fisttp  QWORD PTR [esp]         // convert
     mov     eax, DWORD PTR [esp]    // reload FP result
     mov     edx, DWORD PTR [esp + 4]
@@ -624,12 +624,12 @@ LEAF_END JIT_Dbl2IntSSE2, _TEXT
 //
 LEAF_ENTRY JIT_WriteBarrierReg_PreGrow, _TEXT
     mov     DWORD PTR [edx], ecx
-    cmp     ecx, 0F0F0F0F0h
+    cmp     ecx, 0xF0F0F0F0
     jb      LOCAL_LABEL(NoWriteBarrierPre)
 
     shr     edx, 10
     nop     // padding for alignment of constant
-    cmp     BYTE PTR [edx + 0F0F0F0F0h], 0FFh
+    cmp     BYTE PTR [edx + 0xF0F0F0F0], 0xFF
     jne     LOCAL_LABEL(WriteBarrierPre)
 
 LOCAL_LABEL(NoWriteBarrierPre):
@@ -638,7 +638,7 @@ LOCAL_LABEL(NoWriteBarrierPre):
     nop     // padding for alignment of constant
 
 LOCAL_LABEL(WriteBarrierPre):
-    mov     BYTE PTR [edx+0F0F0F0F0h], 0FFh
+    mov     BYTE PTR [edx+0xF0F0F0F0], 0xFF
     ret
 LEAF_END JIT_WriteBarrierReg_PreGrow, _TEXT
 
@@ -654,14 +654,14 @@ LEAF_END JIT_WriteBarrierReg_PreGrow, _TEXT
 .align 4
 LEAF_ENTRY JIT_WriteBarrierReg_PostGrow, _TEXT
     mov     DWORD PTR [edx], ecx
-    cmp     ecx, 0F0F0F0F0h
+    cmp     ecx, 0xF0F0F0F0
     jb      LOCAL_LABEL(NoWriteBarrierPost)
-    cmp     ecx, 0F0F0F0F0h
+    cmp     ecx, 0xF0F0F0F0
     jae     LOCAL_LABEL(NoWriteBarrierPost)
 
     shr     edx, 10
     nop     // padding for alignment of constant
-    cmp     BYTE PTR [edx + 0F0F0F0F0h], 0FFh
+    cmp     BYTE PTR [edx + 0xF0F0F0F0], 0xFF
     jne     LOCAL_LABEL(WriteBarrierPost)
 
 LOCAL_LABEL(NoWriteBarrierPost):
@@ -670,7 +670,7 @@ LOCAL_LABEL(NoWriteBarrierPost):
     nop     // padding for alignment of constant
 
 LOCAL_LABEL(WriteBarrierPost):
-    mov     BYTE PTR [edx + 0F0F0F0F0h], 0FFh
+    mov     BYTE PTR [edx + 0xF0F0F0F0], 0xFF
     ret
 LEAF_END JIT_WriteBarrierReg_PostGrow,_TEXT
 
@@ -692,7 +692,7 @@ LEAF_END JIT_PatchedWriteBarrierGroup, _TEXT
 .align 8
 LEAF_ENTRY JIT_WriteBarrier\rg, _TEXT
     // Just allocate space that will be filled in at runtime
-    .space 0CCH, 48
+    .space 0xCC, 48
 LEAF_END JIT_WriteBarrier\rg, _TEXT
 
 .endm


### PR DESCRIPTION
#### Description 

.NET Core 2.1 does not build with new LLVM versions (e.g. llvm 8 on Fedora 30).

#### Customer Impact 

Anybody who wants to build .NET Core 2.1 from source on newer distros needs to carry and maintain patch with workaround. It would be beneficial for everybody to have this patch included in release/2.1 (see comment from Red Hat below https://github.com/dotnet/coreclr/pull/26136#issuecomment-528452188)

#### Regression? 

No.

#### Risk 

Low. This is trivial find&replace for constant literals format in asm code.

---

This commit fixes coreclr to build in newer versions of llvm (tested with llvm 8 on Fedora 30).

These recent versions of llvm (as well as GCC) do not accept values like `20h` as valid integer literals:

    src/debug/ee/amd64/dbghelpers.S:32:21: error: unknown token in expression
            add rsp, 20h
                        ^

This was reported as a bug to llvm upstream and they explicitly rejected supporting these literals: https://reviews.llvm.org/D59810

This is partial backport of cbd672eb2735d583ee6fa46aaf599241fdf6face (PR #22810), with some modifications to compile, which was about adding compatibility with GCC 5.

One open question: this is enough on my machine to compile, but there are several other uses of constants with suffix `h` in various files. Should I replace them with `0x`-prefix style too?