### PR TITLE
Add ci argument to build script instead of checking environment variable

### DIFF
--- a/build-test.cmd
+++ b/build-test.cmd
@@ -7,11 +7,6 @@ set "__MsgPrefix=BUILDTEST: "
 
 echo %__MsgPrefix%Starting Build at %TIME%
 
-REM Set variables used when running in an Azure DevOps task
-if defined TF_BUILD (
-    set __ArcadeScriptArgs="-ci"
-    set __ErrMsgPrefix=##vso[task.logissue type=error]
-)
 
 set __ThisScriptDir="%~dp0"
 
@@ -86,6 +81,8 @@ if /i "%1" == "arm64"                 (set __BuildArch=arm64&set processedArgs=!
 if /i "%1" == "debug"                 (set __BuildType=Debug&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "release"               (set __BuildType=Release&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "checked"               (set __BuildType=Checked&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
+
+if /i "%1" == "ci"                    (set __ArcadeScriptArgs="-ci"&set __ErrMsgPrefix=##vso[task.logissue type=error]&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 
 if /i "%1" == "skipmanaged"           (set __SkipManaged=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "skipnative"            (set __SkipNative=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)

--- a/build-test.sh
+++ b/build-test.sh
@@ -656,12 +656,6 @@ case $OSName in
         ;;
 esac
 
-# Set variables used when running in an Azure DevOps task
-if [[ ! -z $TF_BUILD ]]; then
-  __ArcadeScriptArgs="--ci"
-  __ErrMsgPrefix="##vso[task.logissue type=error]"
-fi
-
 __BuildType=Debug
 __CodeCoverage=
 __IncludeTests=INCLUDE_TESTS
@@ -749,6 +743,11 @@ while :; do
 
         release)
             __BuildType=Release
+            ;;
+
+        ci|-ci)
+            __ArcadeScriptArgs="--ci"
+            __ErrMsgPrefix="##vso[task.logissue type=error]"
             ;;
 
         coverage)

--- a/build.cmd
+++ b/build.cmd
@@ -7,12 +7,6 @@ set "__MsgPrefix=BUILD: "
 
 echo %__MsgPrefix%Starting Build at %TIME%
 
-REM Set variables used when running in an Azure DevOps task
-if defined TF_BUILD (
-    set __ArcadeScriptArgs="-ci"
-    set __ErrMsgPrefix=##vso[task.logissue type=error]
-)
-
 set __ThisScriptFull="%~f0"
 set __ThisScriptDir="%~dp0"
 
@@ -137,6 +131,8 @@ if /i "%1" == "-arm64"               (set __BuildArchArm64=1&set processedArgs=!
 if /i "%1" == "-debug"               (set __BuildTypeDebug=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "-checked"             (set __BuildTypeChecked=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "-release"             (set __BuildTypeRelease=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
+
+if /i "%1" == "-ci"                  (set __ArcadeScriptArgs="-ci"&set __ErrMsgPrefix=##vso[task.logissue type=error]&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 
 REM TODO these are deprecated remove them eventually
 REM don't add more, use the - syntax instead

--- a/build.sh
+++ b/build.sh
@@ -612,12 +612,6 @@ case $OSName in
         ;;
 esac
 
-# Set variables used when running in an Azure DevOps task
-if [[ ! -z $TF_BUILD ]]; then
-  __ArcadeScriptArgs="--ci"
-  __ErrMsgPrefix="##vso[task.logissue type=error]"
-fi
-
 __BuildType=Debug
 __CodeCoverage=
 __IgnoreWarnings=0
@@ -723,6 +717,11 @@ while :; do
 
         release|-release)
             __BuildType=Release
+            ;;
+
+        ci|-ci)
+            __ArcadeScriptArgs="--ci"
+            __ErrMsgPrefix="##vso[task.logissue type=error]"
             ;;
 
         coverage|-coverage)

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -123,10 +123,10 @@ jobs:
 
     # Build
     - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-      - script: ./build.sh $(buildConfig) $(archType) $(crossArg) -ci -skiptests -skipnuget $(clangArg) $(stripSymbolsArg) $(officialBuildIdArg) /p:ContinuousIntegrationBuild=true
+      - script: ./build.sh $(buildConfig) $(archType) $(crossArg) -ci -skiptests -skipnuget $(clangArg) $(stripSymbolsArg) $(officialBuildIdArg)
         displayName: Build product
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-      - script: set __TestIntermediateDir=int&&build.cmd $(buildConfig) $(archType) -ci -skiptests -skipbuildpackages $(officialBuildIdArg) $(ibcOptimizeArg) $(enforcePgoArg) /p:ContinuousIntegrationBuild=true
+      - script: set __TestIntermediateDir=int&&build.cmd $(buildConfig) $(archType) -ci -skiptests -skipbuildpackages $(officialBuildIdArg) $(ibcOptimizeArg) $(enforcePgoArg)
         displayName: Build product
 
     # Sign on Windows

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -123,10 +123,10 @@ jobs:
 
     # Build
     - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-      - script: ./build.sh $(buildConfig) $(archType) $(crossArg) -skiptests -skipnuget $(clangArg) $(stripSymbolsArg) $(officialBuildIdArg) /p:ContinuousIntegrationBuild=true
+      - script: ./build.sh $(buildConfig) $(archType) $(crossArg) -ci -skiptests -skipnuget $(clangArg) $(stripSymbolsArg) $(officialBuildIdArg) /p:ContinuousIntegrationBuild=true
         displayName: Build product
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-      - script: set __TestIntermediateDir=int&&build.cmd $(buildConfig) $(archType) -skiptests -skipbuildpackages $(officialBuildIdArg) $(ibcOptimizeArg) $(enforcePgoArg) /p:ContinuousIntegrationBuild=true
+      - script: set __TestIntermediateDir=int&&build.cmd $(buildConfig) $(archType) -ci -skiptests -skipbuildpackages $(officialBuildIdArg) $(ibcOptimizeArg) $(enforcePgoArg) /p:ContinuousIntegrationBuild=true
         displayName: Build product
 
     # Sign on Windows

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -143,10 +143,10 @@ jobs:
 
     # Build tests
     - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-      - script: ./build-test.sh $(buildConfig) $(archType) $(crossArg) $(priorityArg) $(crossgenArg) $(clangArg) $(testhostArg)
+      - script: ./build-test.sh $(buildConfig) $(archType) $(crossArg) $(priorityArg) $(crossgenArg) $(clangArg) $(testhostArg) ci
         displayName: Build tests
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-      - script: build-test.cmd $(buildConfig) $(archType) $(priorityArg) $(crossgenArg) $(testhostArg)
+      - script: build-test.cmd $(buildConfig) $(archType) $(priorityArg) $(crossgenArg) $(testhostArg) ci
         displayName: Build tests
 
 
@@ -341,7 +341,7 @@ jobs:
           ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
             archiveType: zip
             archiveFile: $(Build.SourcesDirectory)/bin/tests/$(osGroup).$(archType).$(buildConfigUpper).zip
-          includeRootFolder: true 
+          includeRootFolder: true
 
     - ${{ if and(eq(parameters.publishTestArtifacts, true), ne(parameters.corefxTests, true)) }}:
       - task: PublishBuildArtifacts@1

--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -17,11 +17,6 @@ set INIT_TOOLS_RESTORE_PROJECT=%~dp0init-tools.msbuild
 set BUILD_TOOLS_SEMAPHORE_DIR=%TOOLRUNTIME_DIR%\%BUILDTOOLS_VERSION%
 set BUILD_TOOLS_SEMAPHORE=%BUILD_TOOLS_SEMAPHORE_DIR%\init-tools.completed
 
-REM Set variables used when running in an Azure DevOps task
-if defined TF_BUILD (
-    set __ErrMsgPrefix=##vso[task.logissue type=error]
-)
-
 :: if force option is specified then clean the tool runtime and build tools package directory to force it to get recreated
 if [%1]==[force] (
   if exist "%TOOLRUNTIME_DIR%" rmdir /S /Q "%TOOLRUNTIME_DIR%"

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -15,11 +15,6 @@ __BUILD_TOOLS_PATH="$__PACKAGES_DIR/microsoft.dotnet.buildtools/$__BUILD_TOOLS_P
 __INIT_TOOLS_RESTORE_PROJECT="$__scriptpath/init-tools.msbuild"
 __BUILD_TOOLS_SEMAPHORE="$__TOOLRUNTIME_DIR/$__BUILD_TOOLS_PACKAGE_VERSION/init-tools.complete"
 
-# Set variables used when running in an Azure DevOps task
-if [[ ! -z $TF_BUILD ]]; then
-  __ErrMsgPrefix="##vso[task.logissue type=error]"
-fi
-
 if [ -e "$__BUILD_TOOLS_SEMAPHORE" ]; then
     echo "Tools are already initialized"
     return #return instead of exit because this script is inlined in other scripts which we don't want to exit


### PR DESCRIPTION
Make `build` / `build-test` scripts check for a `ci` argument instead of the `TF_BUILD` environment variable.

The `init-tools` script is just relying on `build-test` to set the `__ErrMsgPrefix`. It doesn't currently parse arguments and it should be going away entirely soon, so I didn't add arguments to it.

cc @dotnet/coreclr-infra 