### PR TITLE
Unblock official build publish

### DIFF
--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -4,6 +4,7 @@ Param(
   [string] $task,
   [string] $verbosity = "minimal",
   [string] $msbuildEngine = $null,
+  [switch] $warnAsError = $true,
   [switch] $restore,
   [switch] $prepareMachine,
   [switch] $help,
@@ -12,7 +13,6 @@ Param(
 
 $ci = $true
 $binaryLog = $true
-$warnAsError = $true
 
 . $PSScriptRoot\tools.ps1
 

--- a/eng/common/templates/post-build/channels/netcore-tools-latest.yml
+++ b/eng/common/templates/post-build/channels/netcore-tools-latest.yml
@@ -29,7 +29,7 @@ stages:
         displayName: Publish
         inputs:
           filePath: eng\common\sdk-task.ps1
-          arguments: -task PublishToSymbolServers -restore -msbuildEngine dotnet
+          arguments: -task PublishToSymbolServers -restore -msbuildEngine dotnet -warnAsError:$false
             /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat) 
             /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat) 
             /p:PDBArtifactsDirectory='$(Build.ArtifactStagingDirectory)/PDBArtifacts/'

--- a/eng/pipelines/internal.yml
+++ b/eng/pipelines/internal.yml
@@ -20,6 +20,11 @@ schedules:
     - master
   always: true
 
+# Remove this variable when fixed: https://github.com/dotnet/arcade/issues/3661
+variables:
+- name: _DotNetArtifactsCategory
+  value: .NETCore
+
 stages:
   - stage: build
     jobs:


### PR DESCRIPTION
- Address issue in Arcade for publishing artifact category.
- Create mechanism to indicate warnings should not be treated as errors.
    - This will be automatically reverted on the next Arcade insertion.

/cc @dotnet/coreclr-infra @JohnTortugo @riarenas 
