### PR TITLE
Account for quoted values in provider filter string

### DIFF
--- a/src/vm/eventpipeprovider.cpp
+++ b/src/vm/eventpipeprovider.cpp
@@ -224,7 +224,7 @@ void EventPipeProvider::AddEvent(EventPipeEvent &event)
         // of pairs of null terminated strings. The first member of the pair is
         // the key and the second is the value.
         // To convert to this format we need to convert all '=' and ';'
-        // characters to '\0'.
+        // characters to '\0', except when in a quoted string.
         SString dstBuffer;
         SString(pFilterData).ConvertToUTF8(dstBuffer);
 
@@ -234,6 +234,9 @@ void EventPipeProvider::AddEvent(EventPipeEvent &event)
         COUNT_T j = 0;
         for (COUNT_T i = 0; i < BUFFER_SIZE; ++i)
         {
+            // if a value is a quoted string, leave the quotes out from the destination
+            // and don't replace `=` or `;` characters until leaving the quoted section
+            // e.g., key="a;value=";foo=bar --> { key\0a;value=\0foo\0bar\0 }
             if (dstBuffer[i] == '"')
             {
                 isQuotedValue = !isQuotedValue;


### PR DESCRIPTION
Filter strings for ETW-style providers are formatted as `keyword=value[;keyword=value]...`.  DiagnosticSourceEventSource uses the filter string to specify transforms and other metadata, the encoding of which uses `;`.  This change fixes EventPipe's parsing of the string to account for quoted values, e.g., `filterarrgs="blah;blah;blah/foo";otherarg=blah`.  This fixes enabling DiagnosticSourceEventSource with complex filter strings.

copy/paste of my comment in review:
> In the interest of keeping the change minimal and targeted, I'm going to say that filter string values sent via EventPipe should be wrapped in quotes (`"`) if they contain `=` or `;` characters and that they **cannot** have nested quotes (`"`) in them, e.g., `name:keywords:level:key="value;=";key2=foobar;key3=5`.  
>
> This will need to be documented and will be EventPipe specific since this code _only_ affects EventPipe calling `EventSource.OnEventCommand`.
>
> Therefore, the following char array input to EventPipe via the Diagnostics IPC server
> ```
> Microsoft-DotNETCore-Runtime:0:0:CustomFilter="my;custom=encoding";key=value
> ```
> would result in the following array of `char` for the filter
> ```
> CustomFilter\0my;custom=encoding\0key\0value\0
> ```

I am intending to cherry-pick this change into release/3.0 once it has passed review in master.  This change unblocks work being done by other teams such as ASP.NET Core which uses DiagnosticSourceEventSource for diagnostics.

CC - @tommcdon 