### PR TITLE
Update netcore-dev-5.yml

### DIFF
--- a/eng/common/templates/post-build/channels/netcore-dev-5.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-5.yml
@@ -29,7 +29,7 @@ stages:
         displayName: Publish
         inputs:
           filePath: eng\common\sdk-task.ps1
-          arguments: -task PublishToSymbolServers -restore -msbuildEngine dotnet
+          arguments: -task PublishToSymbolServers -restore -msbuildEngine dotnet -warnAsError:$false
             /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat) 
             /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat) 
             /p:PDBArtifactsDirectory='$(Build.ArtifactStagingDirectory)/PDBArtifacts/'


### PR DESCRIPTION
Disable `warnAsError` for the .NET 5 channel