### PR TITLE
Fix GenerateShuffleArray to support cyclic shuffles

### DIFF
--- a/src/vm/comdelegate.h
+++ b/src/vm/comdelegate.h
@@ -194,6 +194,7 @@ struct ShuffleEntry
         OFSMASK      = 0x7fff, // Mask to get stack offset
         OFSREGMASK   = 0x1fff, // Mask to get register index
         SENTINEL     = 0xffff, // Indicates end of shuffle array
+        HELPERREG    = 0xcfff, // Use a helper register as source or destination (used to handle cycles in the shuffling)
     };
 
 #if defined(_TARGET_AMD64_) && !defined(UNIX_AMD64_ABI)

--- a/src/vm/i386/stublinkerx86.h
+++ b/src/vm/i386/stublinkerx86.h
@@ -200,8 +200,11 @@ class StubLinkerCPU : public StubLinker
         VOID X64EmitMovSDToMem(X86Reg Xmmreg, X86Reg baseReg, __int32 ofs = 0);
         VOID X64EmitMovSSFromMem(X86Reg Xmmreg, X86Reg baseReg, __int32 ofs = 0);
         VOID X64EmitMovSSToMem(X86Reg Xmmreg, X86Reg baseReg, __int32 ofs = 0);
+        VOID X64EmitMovqRegXmm(X86Reg reg, X86Reg Xmmreg);
+        VOID X64EmitMovqXmmReg(X86Reg Xmmreg, X86Reg reg);
 
         VOID X64EmitMovXmmWorker(BYTE prefix, BYTE opcode, X86Reg Xmmreg, X86Reg baseReg, __int32 ofs = 0);
+        VOID X64EmitMovqWorker(BYTE opcode, X86Reg Xmmreg, X86Reg reg);
 #endif
 
         VOID X86EmitZeroOutReg(X86Reg reg);        

--- a/tests/src/JIT/Stress/ABI/Program.cs
+++ b/tests/src/JIT/Stress/ABI/Program.cs
@@ -122,18 +122,12 @@ namespace ABIStress
             return 100 + mismatches;
         }
 
-        // https://github.com/dotnet/coreclr/issues/26054
-        private static readonly HashSet<int> s_pinvokeInfiniteLoops = new HashSet<int>
-        {
-            56, 113, 173, 611, 734, 863, 897, 960
-        };
-
         private static bool DoCall(int index)
         {
             bool result = true;
             if (Config.StressModes.HasFlag(StressModes.TailCalls))
                 result &= DoTailCall(index);
-            if (Config.StressModes.HasFlag(StressModes.PInvokes) && !s_pinvokeInfiniteLoops.Contains(index))
+            if (Config.StressModes.HasFlag(StressModes.PInvokes))
                 result &= DoPInvokes(index);
 
             return result;


### PR DESCRIPTION
The GenerateShuffleArray was not handling case when there was a cycle in
the register / stack slots shuffle and it resulted in an infinite loop
in this function. This issue is Unix Amd64 ABI specific.
To fix that, this change reworks the algorithm completely. Besides
fixing the issue, it has also better performance in some cases.
To fix the cyclic shuffling, I needed an extra helper register. However,
there was no available general purpose register available, so I had to
use xmm8 for this purpose and implement code emission for the movq 
instruction.

Close #26054