### PR TITLE
Test set continueOnError to 'true' only on internal builds.

### DIFF
--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -28,8 +28,9 @@ jobs:
     osIdentifier: ${{ parameters.osIdentifier }}
     helixType: 'build/tests/'
 
-    # Test jobs should continue on error
-    continueOnError: true
+    # Test jobs should continue on error for internal builds
+    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      continueOnError: true
 
     # Compute job name from template parameters
     ${{ if and(eq(parameters.testGroup, 'innerloop'), eq(parameters.displayNameArgs, '')) }}:


### PR DESCRIPTION
Done to enable publishing regardless of test failures.

/cc @dotnet/coreclr-infra @jeffschwMSFT 