### PR TITLE
Fix ARM64 HFA arguments passing via reflection

### DIFF
--- a/src/vm/callingconvention.h
+++ b/src/vm/callingconvention.h
@@ -1320,7 +1320,11 @@ int ArgIteratorTemplate<ARGITERATOR_BASE>::GetNextOffset()
             cFPRegs = argSize/m_argLocDescForStructInRegs.m_hfaFieldSize;
             m_argLocDescForStructInRegs.m_cFloatReg = cFPRegs;
 
-            m_hasArgLocDescForStructInRegs = true;
+            // Check if we have enough registers available for the HFA passing
+            if ((cFPRegs + m_idxFPReg) <= 8)
+            {
+                m_hasArgLocDescForStructInRegs = true;
+            }
         }
         else 
         {

--- a/tests/src/JIT/Stress/ABI/Program.cs
+++ b/tests/src/JIT/Stress/ABI/Program.cs
@@ -400,8 +400,7 @@ namespace ABIStress
                 }
             }
 
-            //object callerResult = caller.Invoke(null, outerArgs);
-            object callerResult = InvokeMethodDynamicallyButWithoutReflection(caller, outerArgs);
+            object callerResult = caller.Invoke(null, outerArgs);
 
             if (Config.Verbose)
             {
@@ -412,30 +411,9 @@ namespace ABIStress
                     DumpObject(innerArgs[j]);
                 }
             }
-            //object calleeResult = callee.Method.Invoke(null, innerArgs);
-            object calleeResult = InvokeMethodDynamicallyButWithoutReflection(callee, innerArgs);
+            object calleeResult = callee.Method.Invoke(null, innerArgs);
 
             return (callerResult, calleeResult);
-        }
-
-        // This function works around a reflection bug on ARM64:
-        // https://github.com/dotnet/coreclr/issues/25993
-        private static object InvokeMethodDynamicallyButWithoutReflection(MethodInfo mi, object[] args)
-        {
-            DynamicMethod dynCaller = new DynamicMethod(
-                $"DynCaller", typeof(object), new Type[0], typeof(Program).Module);
-
-            ILGenerator g = dynCaller.GetILGenerator();
-            foreach (var arg in args)
-                new ConstantValue(new TypeEx(arg.GetType()), arg).Emit(g);
-
-            g.Emit(OpCodes.Call, mi);
-            if (mi.ReturnType.IsValueType)
-                g.Emit(OpCodes.Box, mi.ReturnType);
-            g.Emit(OpCodes.Ret);
-
-            Func<object> f = (Func<object>)dynCaller.CreateDelegate(typeof(Func<object>));
-            return f();
         }
 
         private static void WriteSignature(MethodInfo mi)

--- a/tests/src/JIT/Stress/ABI/Program.cs
+++ b/tests/src/JIT/Stress/ABI/Program.cs
@@ -411,7 +411,7 @@ namespace ABIStress
                     DumpObject(innerArgs[j]);
                 }
             }
-            object calleeResult = callee.Method.Invoke(null, innerArgs);
+            object calleeResult = callee.Invoke(null, innerArgs);
 
             return (callerResult, calleeResult);
         }


### PR DESCRIPTION
There was an issue happening in case there were not enough floating point
registers for passing a HFA argument. The argument iterator was returning
confusing result for such argument. The offset was correctly pointing to
stack, but the state indicated that the arguments should be passed in
registers. That caused the argument to be passed incorrectly.

The fix is to not set m_hasArgLocDescForStructInRegs when the HFA doesn't
fit into registers.

Close #25993