### PR TITLE
Add PR testing for single-exe branch

### DIFF
--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -5,6 +5,7 @@ pr:
 - release/2.1
 - release/2.2
 - release/3.0
+- single-exe
 
 jobs:
 #


### PR DESCRIPTION
The `single-exe` branch is created for prototyping runtime changes
to support loading assemblies from single-exe.

This change adds PR testing on this branch.