### PR TITLE
Add perf pipeline

### DIFF
--- a/eng/perf-job.yml
+++ b/eng/perf-job.yml
@@ -34,7 +34,6 @@ jobs:
     dependsOn: ${{ format('build_{0}_{1}_{2}', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
 
     # Run all steps in the container.
-    # Note that the containers are resources defined in azure-pipelines.yml
     ${{ if ne(parameters.container, '') }}:
       ${{ if eq(parameters.container.registry, 'mcr') }}:
         container: ${{ format('{0}:{1}', 'mcr.microsoft.com/dotnet-buildtools/prereqs', parameters.container.image) }}

--- a/eng/perf-job.yml
+++ b/eng/perf-job.yml
@@ -46,6 +46,7 @@ jobs:
       extraSetupParameters: --corerootdirectory $(Build.SourcesDirectory)/bin/tests/${{ parameters.osGroup }}.${{ parameters.archType }}.Release/Tests/Core_Root --architecture ${{ parameters.archType }} -Framework ${{ parameters.framework }}
 
     steps:
+    # Extra steps that will be passed to the performance template and run before sending the job to helix (all of which is done in the template)
 
     # Download product build
     - task: DownloadBuildArtifacts@0

--- a/eng/perf-job.yml
+++ b/eng/perf-job.yml
@@ -1,0 +1,76 @@
+parameters:
+  buildConfig: ''
+  archType: ''
+  osGroup: ''
+  osIdentifier: ''
+  readyToRun: true
+  helixQueues: ''
+  container: ''
+  crossrootfsDir: ''
+
+### Test job
+
+### Each test job depends on a corresponding build job with the same
+### buildConfig and archType.
+
+jobs:
+- template: /eng/common/templates/job/performance.yml
+  parameters:
+    # Compute job name from template parameters
+    jobName: ${{ format('perfbuild_{0}_{1}_{2}', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+    pool: 
+      # Public Linux Build Pool
+      ${{ if and(eq(parameters.osGroup, 'Linux'), eq(variables['System.TeamProject'], 'public')) }}:
+        name:  NetCorePublic-Pool
+        queue: BuildPool.Ubuntu.1604.Amd64.Open
+      # Public Windows Build Pool
+      ${{ if and(eq(parameters.osGroup, 'Windows_NT'), eq(variables['System.TeamProject'], 'public')) }}:
+        name: NetCorePublic-Pool
+        queue: BuildPool.Windows.10.Amd64.VS2017.Open
+
+    # Test job depends on the corresponding build job
+    dependsOn: ${{ format('build_{0}_{1}_{2}', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+
+    # Run all steps in the container.
+    # Note that the containers are resources defined in azure-pipelines.yml
+    ${{ if ne(parameters.container, '') }}:
+      ${{ if eq(parameters.container.registry, 'mcr') }}:
+        container: ${{ format('{0}:{1}', 'mcr.microsoft.com/dotnet-buildtools/prereqs', parameters.container.image) }}
+      ${{ if ne(parameters.container.registry, 'mcr') }}:
+        container: ${{ format('{0}:{1}', parameters.container.registry, parameters.container.image) }}
+      
+    ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+      extraSetupParameters: -CoreRootDirectory $(Build.SourcesDirectory)\bin\tests\${{ parameters.osGroup }}.${{ parameters.archType }}.Release\Tests\Core_Root -Architecture ${{ parameters.archType }}
+    ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
+      extraSetupParameters: --corerootdirectory $(Build.SourcesDirectory)/bin/tests/${{ parameters.osGroup }}.${{ parameters.archType }}.Release/Tests/Core_Root --architecture ${{ parameters.archType }}
+
+    steps:
+
+    # Download product build
+    - task: DownloadBuildArtifacts@0
+      displayName: Download product build
+      inputs:
+        buildType: current
+        downloadType: single
+        artifactName: ${{ format('{0}_{1}_{2}_build', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+        downloadPath: $(System.ArtifactsDirectory)
+
+    # Populate Product directory
+    - task: CopyFiles@2
+      displayName: Populate Product directory
+      inputs:
+        sourceFolder: $(System.ArtifactsDirectory)/${{ format('{0}_{1}_{2}_build', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+        contents: '**'
+        targetFolder: $(Build.SourcesDirectory)/bin/Product/${{ parameters.osGroup }}.${{ parameters.archType }}.Release
+
+    
+    # Create Core_Root
+    - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
+      - script: ./build-test.sh ${{ parameters.buildConfig }} ${{ parameters.archType }} generatelayoutonly
+        displayName: Create Core_Root
+    - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+      # TODO: add generatelayoutonly to build-test.cmd.
+      - script: build-test.cmd ${{ parameters.buildConfig }} ${{ parameters.archType }} skipmanaged skipnative
+        displayName: Create Core_Root
+
+    # TODO: Crossgen the framework

--- a/eng/perf-job.yml
+++ b/eng/perf-job.yml
@@ -7,6 +7,7 @@ parameters:
   helixQueues: ''
   container: ''
   crossrootfsDir: ''
+  framework: netcoreapp5.0 # Specify the appropriate framework when running release branches (ie netcoreapp3.0 for release/3.0)
 
 ### Test job
 
@@ -40,9 +41,9 @@ jobs:
         container: ${{ format('{0}:{1}', parameters.container.registry, parameters.container.image) }}
       
     ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-      extraSetupParameters: -CoreRootDirectory $(Build.SourcesDirectory)\bin\tests\${{ parameters.osGroup }}.${{ parameters.archType }}.Release\Tests\Core_Root -Architecture ${{ parameters.archType }}
+      extraSetupParameters: -CoreRootDirectory $(Build.SourcesDirectory)\bin\tests\${{ parameters.osGroup }}.${{ parameters.archType }}.Release\Tests\Core_Root -Architecture ${{ parameters.archType }} -Framework ${{ parameters.framework }}
     ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-      extraSetupParameters: --corerootdirectory $(Build.SourcesDirectory)/bin/tests/${{ parameters.osGroup }}.${{ parameters.archType }}.Release/Tests/Core_Root --architecture ${{ parameters.archType }}
+      extraSetupParameters: --corerootdirectory $(Build.SourcesDirectory)/bin/tests/${{ parameters.osGroup }}.${{ parameters.archType }}.Release/Tests/Core_Root --architecture ${{ parameters.archType }} -Framework ${{ parameters.framework }}
 
     steps:
 
@@ -63,7 +64,6 @@ jobs:
         contents: '**'
         targetFolder: $(Build.SourcesDirectory)/bin/Product/${{ parameters.osGroup }}.${{ parameters.archType }}.Release
 
-    
     # Create Core_Root
     - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
       - script: ./build-test.sh ${{ parameters.buildConfig }} ${{ parameters.archType }} generatelayoutonly
@@ -72,5 +72,3 @@ jobs:
       # TODO: add generatelayoutonly to build-test.cmd.
       - script: build-test.cmd ${{ parameters.buildConfig }} ${{ parameters.archType }} skipmanaged skipnative
         displayName: Create Core_Root
-
-    # TODO: Crossgen the framework

--- a/eng/perf-job.yml
+++ b/eng/perf-job.yml
@@ -9,9 +9,9 @@ parameters:
   crossrootfsDir: ''
   framework: netcoreapp5.0 # Specify the appropriate framework when running release branches (ie netcoreapp3.0 for release/3.0)
 
-### Test job
+### Perf job
 
-### Each test job depends on a corresponding build job with the same
+### Each perf job depends on a corresponding build job with the same
 ### buildConfig and archType.
 
 jobs:
@@ -19,6 +19,7 @@ jobs:
   parameters:
     # Compute job name from template parameters
     jobName: ${{ format('perfbuild_{0}_{1}_{2}', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+    displayName: ${{ format('Performance {0} {1} {2}', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
     pool: 
       # Public Linux Build Pool
       ${{ if and(eq(parameters.osGroup, 'Linux'), eq(variables['System.TeamProject'], 'public')) }}:
@@ -48,20 +49,21 @@ jobs:
     steps:
     # Extra steps that will be passed to the performance template and run before sending the job to helix (all of which is done in the template)
 
-    # Download product build
+    # Download product binaries directory
     - task: DownloadBuildArtifacts@0
       displayName: Download product build
       inputs:
         buildType: current
         downloadType: single
-        artifactName: ${{ format('{0}_{1}_{2}_build', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+        artifactName: ${{ format('BinDir_{0}_{1}_{2}', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
         downloadPath: $(System.ArtifactsDirectory)
+
 
     # Populate Product directory
     - task: CopyFiles@2
       displayName: Populate Product directory
       inputs:
-        sourceFolder: $(System.ArtifactsDirectory)/${{ format('{0}_{1}_{2}_build', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+        sourceFolder: $(System.ArtifactsDirectory)/${{ format('BinDir_{0}_{1}_{2}', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
         contents: '**'
         targetFolder: $(Build.SourcesDirectory)/bin/Product/${{ parameters.osGroup }}.${{ parameters.archType }}.Release
 

--- a/eng/perf-job.yml
+++ b/eng/perf-job.yml
@@ -3,10 +3,7 @@ parameters:
   archType: ''
   osGroup: ''
   osIdentifier: ''
-  readyToRun: true
-  helixQueues: ''
   container: ''
-  crossrootfsDir: ''
   framework: netcoreapp5.0 # Specify the appropriate framework when running release branches (ie netcoreapp3.0 for release/3.0)
 
 ### Perf job

--- a/eng/pipelines/perf.yml
+++ b/eng/pipelines/perf.yml
@@ -3,7 +3,6 @@ trigger:
   branches:
     include:
     - master
-    - release/3.0
 
 pr: none
 

--- a/eng/pipelines/perf.yml
+++ b/eng/pipelines/perf.yml
@@ -13,6 +13,7 @@ pr: none
     platforms:
     - Linux_x64
     - Windows_NT_x64
+    - Windows_NT_x86
     
 - template: /eng/platform-matrix.yml
   parameters:
@@ -21,3 +22,4 @@ pr: none
     platforms:
     - Linux_x64
     - Windows_NT_x64
+    - Windows_NT_x86

--- a/eng/pipelines/perf.yml
+++ b/eng/pipelines/perf.yml
@@ -1,0 +1,24 @@
+trigger:
+  batch: true
+  branches:
+    include:
+    - master
+    - release/3.0
+
+pr: none
+
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: build-job.yml
+    buildConfig: release
+    platforms:
+    - Linux_x64
+    - Windows_NT_x64
+    
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: perf-job.yml
+    buildConfig: release
+    platforms:
+    - Linux_x64
+    - Windows_NT_x64


### PR DESCRIPTION
This change will add a performance pipeline to run performance testing on internal builds. After this change is checked in, we will need to create the perf pipeline in AzDO.

This change enables performance testing per-commit on internal builds for Windows x64 and x86, and Ubuntu x64.

This change was tested as part of #25390, and has been tested in the performance repo to make sure the change works on internal runs.

This change will need to wait until https://github.com/dotnet/arcade/pull/3680 has been checked in and the arcade changes brought over to coreclr before we can enable perf testing (that change updates the default framework to netcoreapp5.0 and fixes a bug in the linux build).

Note: this change is only for ci testing. I have only enabled it for master, but we can discuss enabling it for release/3.0 until we ship (at which point, we will disable it). Enabling per-commit perf testing for release/3.0 will require us to set the framework to netcoreapp3.0.