### PR TITLE
[3.0 port] Clean up diagnosticserver socket on unexpected shutdown

### DIFF
--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -890,15 +890,6 @@ ShutdownTransport()
         g_pDbgTransport = NULL;
     }
 }
-
-void
-AbortTransport()
-{
-    if (g_pDbgTransport != NULL)
-    {
-        g_pDbgTransport->AbortConnection();
-    }
-}
 #endif // FEATURE_DBGIPC_TRANSPORT_VM
 
 
@@ -1895,6 +1886,16 @@ void NotifyDebuggerOfStartup()
 
 #endif // !FEATURE_PAL
 
+void Debugger::CleanupTransportSocket(void)
+{
+#if defined(FEATURE_PAL) && defined(FEATURE_DBGIPC_TRANSPORT_VM)
+    if (g_pDbgTransport != NULL)
+    {
+        g_pDbgTransport->AbortConnection();
+    }
+#endif // FEATURE_PAL && FEATURE_DBGIPC_TRANSPORT_VM
+}
+
 //---------------------------------------------------------------------------------------
 //
 // Initialize Left-Side debugger object
@@ -2047,9 +2048,6 @@ HRESULT Debugger::Startup(void)
             ShutdownTransport();
             ThrowHR(hr);
         }
-    #ifdef FEATURE_PAL
-        PAL_SetShutdownCallback(AbortTransport);
-    #endif // FEATURE_PAL
     #endif // FEATURE_DBGIPC_TRANSPORT_VM
 
         RaiseStartupNotification();

--- a/src/debug/ee/debugger.h
+++ b/src/debug/ee/debugger.h
@@ -1852,6 +1852,8 @@ public:
 
     HRESULT StartupPhase2(Thread * pThread);
 
+    void CleanupTransportSocket();
+
     void InitializeLazyDataIfNecessary();
 
     void LazyInit(); // will throw

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -596,6 +596,31 @@ do { \
 #define IfFailGoLog(EXPR) IfFailGotoLog(EXPR, ErrExit)
 #endif
 
+
+#ifndef CROSSGEN_COMPILE
+#ifdef FEATURE_PAL
+void EESocketCleanupHelper()
+{
+    CONTRACTL
+    {
+        GC_NOTRIGGER;
+        MODE_ANY;
+    } CONTRACTL_END;
+
+    // Close the debugger transport socket first
+    if (g_pDebugInterface != NULL)
+    {
+        g_pDebugInterface->CleanupTransportSocket();
+    }
+
+    // Close the diagnostic server socket.
+#ifdef FEATURE_PERFTRACING
+    DiagnosticServer::Shutdown();
+#endif // FEATURE_PERFTRACING
+}
+#endif // FEATURE_PAL
+#endif // CROSSGEN_COMPILE
+
 void EEStartupHelper(COINITIEE fFlags)
 {
     CONTRACTL
@@ -653,7 +678,12 @@ void EEStartupHelper(COINITIEE fFlags)
 #ifdef FEATURE_PERFTRACING
         // Initialize the event pipe.
         EventPipe::Initialize();
+
 #endif // FEATURE_PERFTRACING
+
+#ifdef FEATURE_PAL
+        PAL_SetShutdownCallback(EESocketCleanupHelper);
+#endif // FEATURE_PAL
 
 #ifdef FEATURE_GDBJIT
         // Initialize gdbjit

--- a/src/vm/dbginterface.h
+++ b/src/vm/dbginterface.h
@@ -399,6 +399,9 @@ public:
     virtual LONG FirstChanceSuspendHijackWorker(PCONTEXT pContext, PEXCEPTION_RECORD pExceptionRecord) = 0;
 #endif
 
+    // Helper method for cleaning up transport socket
+    virtual void CleanupTransportSocket(void) = 0;
+
 #endif // #ifndef DACCESS_COMPILE
 
 #ifdef DACCESS_COMPILE


### PR DESCRIPTION
Backport #25976 to 3.0.

Issue: #25968 

Code Reviewer: Noah Falk 

Description:
In 3.0 we introduced EventPipe IPC to the runtime which creates a socket during runtime startup, which gets destroyed under normal shutdown path. But if the runtime quits through something like SIGINT, the socket is left in the file system. This adds shutting down the socket in the runtime's signal handler so that it can properly cleaned up.

Customer Impact:
For customers using .NET under limited resources in scenarios like containers, disk space might be of a concern if these socket files are left not cleaned up. There can be a workaround like setting up a cron job to clean these up regularly, but it creates an additional hassle for them and is not a good customer experience. 

Regression?
This is a regression introduced in 3.0 Preview 5 with the addition of EventPipe IPC to the runtime.

Risk:
Low

