### PR TITLE
Small cleaning in JIT32_GCENCODER functions.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -378,7 +378,7 @@ public:
     var_types lvType : 5; // TYP_INT/LONG/FLOAT/DOUBLE/REF
 
     unsigned char lvIsParam : 1;           // is this a parameter?
-    unsigned char lvIsRegArg : 1;          // is this a register argument?
+    unsigned char lvIsRegArg : 1;          // is this an argument that was passed by register?
     unsigned char lvFramePointerBased : 1; // 0 = off of REG_SPBASE (e.g., ESP), 1 = off of REG_FPBASE (e.g., EBP)
 
     unsigned char lvStructGcCount : 3; // if struct, how many GC pointer (stop counting at 7). The only use of values >1

--- a/src/jit/gcencode.cpp
+++ b/src/jit/gcencode.cpp
@@ -2206,72 +2206,10 @@ size_t GCInfo::gcMakeRegPtrTable(BYTE* dest, int mask, const InfoHdr& header, un
 
             if (varTypeIsGC(varDsc->TypeGet()))
             {
-                /* Do we have an argument or local variable? */
-                if (!varDsc->lvIsParam)
+                if (!gcIsUntrackedLocalOrNonEnregisteredArg(varNum, &thisKeptAliveIsInUntracked))
                 {
-                    // If is pinned, it must be an untracked local
-                    assert(!varDsc->lvPinned || !varDsc->lvTracked);
-
-                    if (varDsc->lvTracked || !varDsc->lvOnFrame)
-                        continue;
-                }
-                else
-                {
-                    /* Stack-passed arguments which are not enregistered
-                     * are always reported in this "untracked stack
-                     * pointers" section of the GC info even if lvTracked==true
-                     */
-
-                    /* Has this argument been fully enregistered ? */
-                    if (!varDsc->lvOnFrame)
-                    {
-                        /* if a CEE_JMP has been used, then we need to report all the arguments
-                           even if they are enregistered, since we will be using this value
-                           in JMP call.  Note that this is subtle as we require that
-                           argument offsets are always fixed up properly even if lvRegister
-                           is set */
-                        if (!compiler->compJmpOpUsed)
-                        {
-                            continue;
-                        }
-                    }
-                    else
-                    {
-                        if (!varDsc->lvOnFrame)
-                        {
-                            /* If this non-enregistered pointer arg is never
-                             * used, we don't need to report it
-                             */
-                            assert(varDsc->lvRefCnt() == 0);
-                            continue;
-                        }
-                        else if (varDsc->lvIsRegArg && varDsc->lvTracked)
-                        {
-                            /* If this register-passed arg is tracked, then
-                             * it has been allocated space near the other
-                             * pointer variables and we have accurate life-
-                             * time info. It will be reported with
-                             * gcVarPtrList in the "tracked-pointer" section
-                             */
-
-                            continue;
-                        }
-                    }
-                }
-
-#ifndef FEATURE_EH_FUNCLETS
-                // For FEATURE_EH_FUNCLETS, "this" must always be in untracked variables
-                // so we cannot have "this" in variable lifetimes
-                if (compiler->lvaIsOriginalThisArg(varNum) && compiler->lvaKeepAliveAndReportThis())
-                {
-                    // Encoding of untracked variables does not support reporting
-                    // "this". So report it as a tracked variable with a liveness
-                    // extending over the entire method.
-
-                    thisKeptAliveIsInUntracked = true;
                     continue;
                 }
-#endif // !WIN64EXCEPTIONS
 
                 if (pass == 0)
                     count++;

--- a/src/jit/gcinfo.cpp
+++ b/src/jit/gcinfo.cpp
@@ -571,8 +571,14 @@ bool GCInfo::gcIsUntrackedLocalOrNonEnregisteredArg(unsigned varNum, bool* pKeep
     if (compiler->lvaIsOriginalThisArg(varNum) && compiler->lvaKeepAliveAndReportThis())
     {
         // "this" is in the untracked variable area, but encoding of untracked variables does not support reporting
-        // "this".
-        // So report it as a tracked variable with a liveness extending over the entire method.
+        // "this". So report it as a tracked variable with a liveness extending over the entire method.
+        //
+        // TODO-x86-Cleanup: the semantic here is not clear, it would be useful to check different cases and 
+        // add a description where "this" is saved and how it is tracked in each of them:
+        // 1) when FEATURE_EH_FUNCLETS defined (x86 Linux);
+        // 2) when FEATURE_EH_FUNCLETS not defined, lvaKeepAliveAndReportThis == true, compJmpOpUsed == true;
+        // 3) when there is regPtrDsc for "this", but keepThisAlive == true;
+        // etc.
 
         if (pKeepThisAlive != nullptr)
         {

--- a/src/jit/gcinfo.cpp
+++ b/src/jit/gcinfo.cpp
@@ -573,7 +573,7 @@ bool GCInfo::gcIsUntrackedLocalOrNonEnregisteredArg(unsigned varNum, bool* pKeep
         // "this" is in the untracked variable area, but encoding of untracked variables does not support reporting
         // "this". So report it as a tracked variable with a liveness extending over the entire method.
         //
-        // TODO-x86-Cleanup: the semantic here is not clear, it would be useful to check different cases and 
+        // TODO-x86-Cleanup: the semantic here is not clear, it would be useful to check different cases and
         // add a description where "this" is saved and how it is tracked in each of them:
         // 1) when FEATURE_EH_FUNCLETS defined (x86 Linux);
         // 2) when FEATURE_EH_FUNCLETS not defined, lvaKeepAliveAndReportThis == true, compJmpOpUsed == true;

--- a/src/jit/gcinfo.cpp
+++ b/src/jit/gcinfo.cpp
@@ -549,27 +549,16 @@ bool GCInfo::gcIsUntrackedLocalOrNonEnregisteredArg(unsigned varNum, bool* pThis
                 return false;
             }
         }
-        else
+        else if (varDsc->lvIsRegArg && varDsc->lvTracked)
         {
-            if (!varDsc->lvOnFrame)
-            {
-                /* If this non-enregistered pointer arg is never
-                 * used, we don't need to report it
-                 */
-                assert(varDsc->lvRefCnt() == 0);
-                return false;
-            }
-            else if (varDsc->lvIsRegArg && varDsc->lvTracked)
-            {
-                /* If this register-passed arg is tracked, then
-                 * it has been allocated space near the other
-                 * pointer variables and we have accurate life-
-                 * time info. It will be reported with
-                 * gcVarPtrList in the "tracked-pointer" section
-                 */
+            /* If this register-passed arg is tracked, then
+             * it has been allocated space near the other
+             * pointer variables and we have accurate life-
+             * time info. It will be reported with
+             * gcVarPtrList in the "tracked-pointer" section
+             */
 
-                return false;
-            }
+            return false;
         }
     }
 

--- a/src/jit/gcinfo.cpp
+++ b/src/jit/gcinfo.cpp
@@ -359,6 +359,8 @@ GCInfo::regPtrDsc* GCInfo::gcRegPtrAllocDsc()
     return regPtrNext;
 }
 
+#ifdef JIT32_GCENCODER
+
 /*****************************************************************************
  *
  *  Compute the various counts that get stored in the info block header.
@@ -440,8 +442,8 @@ void GCInfo::gcCountForHeader(UNALIGNED unsigned int* untrackedCount, UNALIGNED 
                 }
             }
 
-#if !defined(JIT32_GCENCODER) || !defined(FEATURE_EH_FUNCLETS)
-            // For x86/FEATURE_EH_FUNCLETS, "this" must always be in untracked variables
+#if !(FEATURE_EH_FUNCLETS)
+            // For FEATURE_EH_FUNCLETS, "this" must always be in untracked variables
             // so we cannot have "this" in variable lifetimes
             if (compiler->lvaIsOriginalThisArg(varNum) && compiler->lvaKeepAliveAndReportThis())
             {
@@ -573,7 +575,6 @@ void GCInfo::gcCountForHeader(UNALIGNED unsigned int* untrackedCount, UNALIGNED 
     *varPtrTableSize = count;
 }
 
-#ifdef JIT32_GCENCODER
 /*****************************************************************************
  *
  *  Shutdown the 'pointer value' register tracking logic and save the necessary
@@ -588,7 +589,8 @@ BYTE* GCInfo::gcPtrTableSave(BYTE* destPtr, const InfoHdr& header, unsigned code
 
     return destPtr + gcMakeRegPtrTable(destPtr, -1, header, codeSize, pArgTabOffset);
 }
-#endif
+
+#endif // JIT32_GCENCODER
 
 /*****************************************************************************
  *

--- a/src/jit/jitgcinfo.h
+++ b/src/jit/jitgcinfo.h
@@ -276,11 +276,11 @@ public:
     CallDsc* gcCallDescList;
     CallDsc* gcCallDescLast;
 
-    //-------------------------------------------------------------------------
-
-    void gcCountForHeader(UNALIGNED unsigned int* untrackedCount, UNALIGNED unsigned int* varPtrTableSize);
+//-------------------------------------------------------------------------
 
 #ifdef JIT32_GCENCODER
+    void gcCountForHeader(UNALIGNED unsigned int* untrackedCount, UNALIGNED unsigned int* varPtrTableSize);
+
     size_t gcMakeRegPtrTable(BYTE* dest, int mask, const InfoHdr& header, unsigned codeSize, size_t* pArgTabOffset);
 #else
     RegSlotMap*   m_regSlotMap;

--- a/src/jit/jitgcinfo.h
+++ b/src/jit/jitgcinfo.h
@@ -281,6 +281,8 @@ public:
 #ifdef JIT32_GCENCODER
     void gcCountForHeader(UNALIGNED unsigned int* untrackedCount, UNALIGNED unsigned int* varPtrTableSize);
 
+    bool gcIsUntrackedLocalOrNonEnregisteredArg(unsigned varNum, bool* pThisKeptAliveIsInUntracked = nullptr);
+
     size_t gcMakeRegPtrTable(BYTE* dest, int mask, const InfoHdr& header, unsigned codeSize, size_t* pArgTabOffset);
 #else
     RegSlotMap*   m_regSlotMap;

--- a/src/jit/jitgcinfo.h
+++ b/src/jit/jitgcinfo.h
@@ -279,7 +279,7 @@ public:
 //-------------------------------------------------------------------------
 
 #ifdef JIT32_GCENCODER
-    void gcCountForHeader(UNALIGNED unsigned int* untrackedCount, UNALIGNED unsigned int* varPtrTableSize);
+    void gcCountForHeader(UNALIGNED unsigned int* pUntrackedCount, UNALIGNED unsigned int* pVarPtrTableSize);
 
     bool gcIsUntrackedLocalOrNonEnregisteredArg(unsigned varNum, bool* pThisKeptAliveIsInUntracked = nullptr);
 


### PR DESCRIPTION
Working on another fix I found that after the legacy backend was deleted we ended up with:
```
if (!varDsc->lvOnFrame)
{}
else
{
  if (!varDsc->lvOnFrame)
  {}
}
```

so I decided to fix that but found that there were two occurrences of this code and the second was an old copy-paste, so I fixed that as well.

Also, I deleted a useless iteration in `gcMakeRegPtrTable` so it does less in Release now.

The change affects only x86 Windows (where  `JIT32_GCENCODER` defined) and there are no diffs there (-c/f -crossgen/pmi).

The full list of changes:
391bcb6d39: Put `gcCountForHeader` under `JIT32_GCENCODER`.

3257ed3b9a: Prepare to extract `gcIsVarUntracked`.

Move `lvaIsFieldOfDependentlyPromotedStruct` up so we skip struct fields that have struct type (would be a bug if we have recursive struct promotion).

Move `if (varDsc->lvType == TYP_STRUCT`) under else, because the parent `if (varTypeIsGC(varDsc->TypeGet()) )` always skips `TYP_STRUCT`.

That is a good example of why you should not copy-paste!

f82bc27cce: Extract `gcIsUntrackedLocalOrNonEnregisteredArg`.

e8914352e0: Update `gcCountForHeader`.

2fab3fc827: Delete useless first pass in `gcMakeRegPtrTable`.

Use `gcCountForHeader` for checking purposes.
Extract logic for `WIN64EXCEPTIONS`.

ced19b79b4: Delete `if (!varDsc->lvOnFrame)` under `if (varDsc->lvOnFrame)`.
The issue that started this PR.

c2ef8972eb: Update the comment about `lvIsRegArg`.

474ac53b41: Update the header for the new function.