### PR TITLE
[3.0 port] Account for quoted values in provider filter string (#26159)

### DIFF
--- a/src/vm/eventpipeprovider.cpp
+++ b/src/vm/eventpipeprovider.cpp
@@ -225,17 +225,33 @@ void EventPipeProvider::AddEvent(EventPipeEvent &event)
         // of pairs of null terminated strings. The first member of the pair is
         // the key and the second is the value.
         // To convert to this format we need to convert all '=' and ';'
-        // characters to '\0'.
+        // characters to '\0', except when in a quoted string.
         SString dstBuffer;
         SString(pFilterData).ConvertToUTF8(dstBuffer);
 
         const COUNT_T BUFFER_SIZE = dstBuffer.GetCount() + 1;
         buffer.AllocThrows(BUFFER_SIZE);
+        BOOL isQuotedValue = false;
+        COUNT_T j = 0;
         for (COUNT_T i = 0; i < BUFFER_SIZE; ++i)
-            buffer[i] = (dstBuffer[i] == '=' || dstBuffer[i] == ';') ? '\0' : dstBuffer[i];
+        {
+            // if a value is a quoted string, leave the quotes out from the destination
+            // and don't replace `=` or `;` characters until leaving the quoted section
+            // e.g., key="a;value=";foo=bar --> { key\0a;value=\0foo\0bar\0 }
+            if (dstBuffer[i] == '"')
+            {
+                isQuotedValue = !isQuotedValue;
+                continue;
+            }
+            buffer[j++] = ((dstBuffer[i] == '=' || dstBuffer[i] == ';') && !isQuotedValue) ? '\0' : dstBuffer[i];
+        }
+
+        // In case we skipped over quotes in the filter string, shrink the buffer size accordingly
+        if (j < dstBuffer.GetCount())
+            buffer.Shrink(j + 1);
 
         eventFilterDescriptor.Ptr = reinterpret_cast<ULONGLONG>(buffer.Ptr());
-        eventFilterDescriptor.Size = static_cast<ULONG>(BUFFER_SIZE);
+        eventFilterDescriptor.Size = static_cast<ULONG>(buffer.Size());
         eventFilterDescriptor.Type = 0; // EventProvider.cs: `internal enum ControllerCommand.Update`
         isEventFilterDescriptorInitialized = true;
     }


### PR DESCRIPTION
Backport #26159 to 3.0

Code Reviewers: Noah Falk, Tom McDonald, Sung Whang, Juan Hoyos

#### Description
DiagnosticSourceEventSource is used by ASP.NET Core, Visual Studio, and several other technologies for collecting diagnostics with complex types.  It consumes a filter string argument that specifies transforms to apply to objects when logging. The encoding for that includes `;` and `=` characters  (see: https://github.com/dotnet/corefx/blob/c5cb132f5ad2b938e67866cf510d3f3bc58e32c3/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs#L48-L63).  EventPipe uses `;` and `=` to specify key-value pairs in the filter string of a provider.  The double use of these characters has resulted in DiagnosticSourceEventSource `FilterAndPayloadSpec`s being incorrectly decoded by the EventSource callbacks and preventing transforms from being consumed.  These changes allow for a quoted string to be sent as a value and have the runtime preserve `;` and `=` characters inside the transform specification.

#### Customer Impact
ASP.NET Core uses DiagnosticSourceEventSource for logging and surfacing diagnostics data.  Without this fix, this data is inaccessible via EventPipe and therefore unavailable on non-Windows platforms where ETW doesn't exist as a fallback.

Verbatim from Visual Studio team:
> “The Visual Studio Profiler is committed to creating .NET Core specific tooling for ASP.NET developers, in order to do so we rely on DiagnosticSourceEventSource to retrieve data to show to our users. In Dev 16 Update 3 we are launching a Database tool which utilizes DiagnosticSourceEventSource to capture ADO.NET and Entity Framework queries and show their timing. [...] Without this fix [...] these tools [and additional future tooling won't] be functional on Linux scenarios.”


#### Regression?
No

#### Risk
Low

CC - @noahfalk @tommcdon @sywhang @karpinsn @bdigenov