### PR TITLE
Delete TRACK_GC_TEMP_LIFETIMES.

### DIFF
--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -6643,11 +6643,7 @@ void emitter::emitGCvarLiveUpd(int offs, int varNum, GCtype gcType, BYTE* addr)
                     LclVarDsc* varDsc = &emitComp->lvaTable[varNum];
                     isTracked         = emitComp->lvaIsGCTracked(varDsc);
                 }
-                else
-                {
-                    // Is it an untracked spill temp?
-                    isTracked = TRACK_GC_TEMP_LIFETIMES;
-                }
+
                 if (!isTracked)
                 {
 #if DOUBLE_ALIGN

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -18,7 +18,6 @@
 #ifdef _MSC_VER
 #pragma warning(disable : 4200) // allow arrays of 0 size inside structs
 #endif
-#define TRACK_GC_TEMP_LIFETIMES 0
 
 /*****************************************************************************/
 

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -6695,46 +6695,15 @@ int Compiler::lvaAllocateTemps(int stkOffs, bool mustDoubleAlign)
 #ifdef _TARGET_ARM_
         preSpillSize = genCountBits(codeGen->regSet.rsMaskPreSpillRegs(true)) * TARGET_POINTER_SIZE;
 #endif
-        bool assignDone;
-        bool assignNptr;
-        bool assignPtrs = true;
 
         /* Allocate temps */
 
-        if (TRACK_GC_TEMP_LIFETIMES)
-        {
-            /* first pointers, then non-pointers in second pass */
-            assignNptr = false;
-            assignDone = false;
-        }
-        else
-        {
-            /* Pointers and non-pointers together in single pass */
-            assignNptr = true;
-            assignDone = true;
-        }
-
         assert(codeGen->regSet.tmpAllFree());
-
-    AGAIN2:
 
         for (TempDsc* temp = codeGen->regSet.tmpListBeg(); temp != nullptr; temp = codeGen->regSet.tmpListNxt(temp))
         {
             var_types tempType = temp->tdTempType();
-            unsigned  size;
-
-            /* Make sure the type is appropriate */
-
-            if (!assignPtrs && varTypeIsGC(tempType))
-            {
-                continue;
-            }
-            if (!assignNptr && !varTypeIsGC(tempType))
-            {
-                continue;
-            }
-
-            size = temp->tdTempSize();
+            unsigned  size     = temp->tdTempSize();
 
             /* Figure out and record the stack offset of the temp */
 
@@ -6782,17 +6751,6 @@ int Compiler::lvaAllocateTemps(int stkOffs, bool mustDoubleAlign)
         // Only required for the ARM platform that we have an accurate estimate for the spillTempSize
         noway_assert(spillTempSize <= lvaGetMaxSpillTempSize());
 #endif
-
-        /* If we've only assigned some temps, go back and do the rest now */
-
-        if (!assignDone)
-        {
-            assignNptr = !assignNptr;
-            assignPtrs = !assignPtrs;
-            assignDone = true;
-
-            goto AGAIN2;
-        }
     }
     else // We haven't run codegen, so there are no Spill temps yet!
     {


### PR DESCRIPTION
I was able to track this define back to 2005 and it was never set to 1.

Probably it was a debug/diagnostic switch, does anybody think that it is still useful/working?

PTAL @dotnet/jit-contrib .