### PR TITLE
Remove useless GetLongPathNameW call

### DIFF
--- a/src/System.Private.CoreLib/shared/System/IO/PathHelper.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/PathHelper.Windows.cs
@@ -215,7 +215,6 @@ namespace System.IO
                 {
                     // Not enough space. The result count for this API does not include the null terminator.
                     outputBuilder.EnsureCapacity(checked((int)result));
-                    result = Interop.Kernel32.GetLongPathNameW(ref inputBuilder.GetPinnableReference(), ref outputBuilder.GetPinnableReference(), (uint)outputBuilder.Capacity);
                 }
                 else
                 {


### PR DESCRIPTION
It looks like immediately after calling this we're going to loop around and call it again at the beginning of the while loop.

cc: @JeremyKuhne 