### PR TITLE
Fix DecoderExceptionFallbackBuffer message

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Text/DecoderExceptionFallback.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/DecoderExceptionFallback.cs
@@ -77,13 +77,13 @@ namespace System.Text
         [DoesNotReturn]
         private void Throw(byte[] bytesUnknown, int index)
         {
-            bytesUnknown = bytesUnknown ?? Array.Empty<byte>();
+            bytesUnknown ??= Array.Empty<byte>();
 
             // Create a string representation of our bytes.
-            StringBuilder strBytes = new StringBuilder(bytesUnknown.Length * 3);
+            StringBuilder strBytes = new StringBuilder(bytesUnknown.Length * 4);
 
-            int i;
-            for (i = 0; i < bytesUnknown.Length && i < 20; i++)
+            const int MaxLength = 20;
+            for (int i = 0; i < bytesUnknown.Length && i < MaxLength; i++)
             {
                 strBytes.Append('[');
                 strBytes.Append(bytesUnknown[i].ToString("X2", CultureInfo.InvariantCulture));
@@ -91,8 +91,10 @@ namespace System.Text
             }
 
             // In case the string's really long
-            if (i == 20)
+            if (bytesUnknown.Length > MaxLength)
+            {
                 strBytes.Append(" ...");
+            }
 
             // Known index
             throw new DecoderFallbackException(


### PR DESCRIPTION
When the number of unknown bytes is exactly 20, the message includes a misleading " ..." at the end.

You can see the error with a repro like:
```C#
using System;
using System.Linq;
using System.Text;

class Program
{
    static void Main()
    {
        foreach (int length in new[] { 19, 20, 21 })
        {
            byte[] bytes = Enumerable.Range(0, length).Select(i => (byte)i).ToArray();
            try { new DecoderExceptionFallback().CreateFallbackBuffer().Fallback(bytes, 0); }
            catch (Exception e) { Console.WriteLine($"{length}: {e.Message}"); }
        }
    }
}
```
which outputs:
```
19: Unable to translate bytes [00][01][02][03][04][05][06][07][08][09][0A][0B][0C][0D][0E][0F][10][11][12] at index 0 from specified code page to Unicode.
20: Unable to translate bytes [00][01][02][03][04][05][06][07][08][09][0A][0B][0C][0D][0E][0F][10][11][12][13] ... at index 0 from specified code page to Unicode.
21: Unable to translate bytes [00][01][02][03][04][05][06][07][08][09][0A][0B][0C][0D][0E][0F][10][11][12][13] ... at index 0 from specified code page to Unicode.
```

cc: @tarekgh, @krwq 