### PR TITLE
Explicitly handle char marshalling in OleVariant::GetNativeMethodTableForVarType.

### DIFF
--- a/src/vm/olevariant.cpp
+++ b/src/vm/olevariant.cpp
@@ -839,6 +839,14 @@ MethodTable* OleVariant::GetNativeMethodTableForVarType(VARTYPE vt, MethodTable*
                 return MscorlibBinder::GetClass(CLASS__INTPTR);
             case VT_VARIANT:
                 return MscorlibBinder::GetClass(CLASS__NATIVEVARIANT);
+            case VTHACK_ANSICHAR:
+                return MscorlibBinder::GetClass(CLASS__BYTE);
+            case VT_UI2:
+                // When CharSet = CharSet.Unicode, System.Char arrays are marshaled as VT_UI2.
+                // However, since System.Char itself is CharSet.Ansi, the native size of
+                // System.Char is 1 byte instead of 2. So here we explicitly return System.UInt16's
+                // MethodTable to ensure the correct size.
+                return MscorlibBinder::GetClass(CLASS__UINT16);
             default:
                 PREFIX_ASSUME(pManagedMT != NULL);
                 return pManagedMT;

--- a/src/vm/olevariant.cpp
+++ b/src/vm/olevariant.cpp
@@ -803,57 +803,53 @@ MethodTable* OleVariant::GetNativeMethodTableForVarType(VARTYPE vt, MethodTable*
 {
     CONTRACTL
     {
-        NOTHROW;
-        GC_NOTRIGGER;
+        THROWS;
+        GC_TRIGGERS;
         MODE_ANY;
     }
     CONTRACTL_END;
 
+    if (vt & VT_ARRAY)
     {
-        GCX_COOP();
-        if (vt & VT_ARRAY)
-        {
-            return MscorlibBinder::GetClass(CLASS__INTPTR);
-        }
+        return MscorlibBinder::GetClass(CLASS__INTPTR);
+    }
 
-        switch (vt)
-        {
-            case VT_DATE:
-                return MscorlibBinder::GetClass(CLASS__DOUBLE);
-            case VT_CY:
-                return MscorlibBinder::GetClass(CLASS__CURRENCY);
-            case VTHACK_WINBOOL:
-                return MscorlibBinder::GetClass(CLASS__INT32);
-            case VT_BOOL:
-                return MscorlibBinder::GetClass(CLASS__INT16);
-            case VTHACK_CBOOL:
-                return MscorlibBinder::GetClass(CLASS__BYTE);
-            case VT_DISPATCH:
-            case VT_UNKNOWN:
-            case VT_LPSTR:
-            case VT_LPWSTR:
-            case VT_BSTR:
-            case VT_USERDEFINED:
-            case VT_SAFEARRAY:
-            case VT_CARRAY:
-                return MscorlibBinder::GetClass(CLASS__INTPTR);
-            case VT_VARIANT:
-                return MscorlibBinder::GetClass(CLASS__NATIVEVARIANT);
-            case VTHACK_ANSICHAR:
-                return MscorlibBinder::GetClass(CLASS__BYTE);
-            case VT_UI2:
-                // When CharSet = CharSet.Unicode, System.Char arrays are marshaled as VT_UI2.
-                // However, since System.Char itself is CharSet.Ansi, the native size of
-                // System.Char is 1 byte instead of 2. So here we explicitly return System.UInt16's
-                // MethodTable to ensure the correct size.
-                return MscorlibBinder::GetClass(CLASS__UINT16);
-            default:
-                PREFIX_ASSUME(pManagedMT != NULL);
-                return pManagedMT;
-        }
+    switch (vt)
+    {
+        case VT_DATE:
+            return MscorlibBinder::GetClass(CLASS__DOUBLE);
+        case VT_CY:
+            return MscorlibBinder::GetClass(CLASS__CURRENCY);
+        case VTHACK_WINBOOL:
+            return MscorlibBinder::GetClass(CLASS__INT32);
+        case VT_BOOL:
+            return MscorlibBinder::GetClass(CLASS__INT16);
+        case VTHACK_CBOOL:
+            return MscorlibBinder::GetClass(CLASS__BYTE);
+        case VT_DISPATCH:
+        case VT_UNKNOWN:
+        case VT_LPSTR:
+        case VT_LPWSTR:
+        case VT_BSTR:
+        case VT_USERDEFINED:
+        case VT_SAFEARRAY:
+        case VT_CARRAY:
+            return MscorlibBinder::GetClass(CLASS__INTPTR);
+        case VT_VARIANT:
+            return MscorlibBinder::GetClass(CLASS__NATIVEVARIANT);
+        case VTHACK_ANSICHAR:
+            return MscorlibBinder::GetClass(CLASS__BYTE);
+        case VT_UI2:
+            // When CharSet = CharSet.Unicode, System.Char arrays are marshaled as VT_UI2.
+            // However, since System.Char itself is CharSet.Ansi, the native size of
+            // System.Char is 1 byte instead of 2. So here we explicitly return System.UInt16's
+            // MethodTable to ensure the correct size.
+            return MscorlibBinder::GetClass(CLASS__UINT16);
+        default:
+            PREFIX_ASSUME(pManagedMT != NULL);
+            return pManagedMT;
     }
 }
-
 
 //
 // GetMarshalerForVarType returns the marshaler for the

--- a/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq.cs
+++ b/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq.cs
@@ -29,6 +29,7 @@ public class Managed
         SequentialDoubleWrapperId,
         AggregateSequentialWrapperId,
         FixedBufferClassificationTestId,
+        UnicodeCharArrayClassificationId,
         HFAId,
         DoubleHFAId
     }
@@ -326,6 +327,8 @@ public class Managed
     static extern bool MarshalStructAsParam_AsSeqByValFixedBufferClassificationTest(FixedBufferClassificationTestBlittable str, float f);
     [DllImport("MarshalStructAsParam")]
     static extern bool MarshalStructAsParam_AsSeqByValFixedBufferClassificationTest(FixedArrayClassificationTest str, float f);
+    [DllImport("MarshalStructAsParam")]
+    static extern bool MarshalStructAsParam_AsSeqByValUnicodeCharArrayClassification(UnicodeCharArrayClassification str, float f);
     [DllImport("MarshalStructAsParam")]
     static extern int GetStringLength(AutoString str);
 
@@ -678,6 +681,19 @@ public class Managed
                     {
                         Console.WriteLine("\tFAILED! Managed to Native failed in MarshalStructAsParam_AsSeqByValFixedBufferClassificationTest. Expected:True;Actual:False");
                         failures++;
+                    }
+                    break;
+                case StructID.UnicodeCharArrayClassificationId:
+                    Console.WriteLine("\tCalling MarshalStructAsParam_AsSeqByValUnicodeCharArrayClassification with nonblittable struct...");
+                    unsafe
+                    {
+                        UnicodeCharArrayClassification str = new UnicodeCharArrayClassification { arr = new char[6] };
+                        str.f = 56.789f;
+                        if (!MarshalStructAsParam_AsSeqByValUnicodeCharArrayClassification(str, str.f))
+                        {
+                            Console.WriteLine("\tFAILED! Managed to Native failed in MarshalStructAsParam_AsSeqByValUnicodeCharArrayClassification. Expected:True;Actual:False");
+                            failures++;
+                        }
                     }
                     break;
                 case StructID.HFAId:
@@ -2345,6 +2361,7 @@ public class Managed
         MarshalStructAsParam_AsSeqByVal(StructID.SequentialDoubleWrapperId);
         MarshalStructAsParam_AsSeqByVal(StructID.AggregateSequentialWrapperId);
         MarshalStructAsParam_AsSeqByVal(StructID.FixedBufferClassificationTestId);
+        MarshalStructAsParam_AsSeqByVal(StructID.UnicodeCharArrayClassificationId);
         MarshalStructAsParam_AsSeqByVal(StructID.HFAId);
         MarshalStructAsParam_AsSeqByVal(StructID.DoubleHFAId);
     }

--- a/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsParamDLL.cpp
+++ b/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsParamDLL.cpp
@@ -1194,6 +1194,11 @@ extern "C" DLL_EXPORT BOOL STDMETHODCALLTYPE MarshalStructAsParam_AsSeqByValFixe
     return str.f == f;
 }
 
+extern "C" DLL_EXPORT BOOL STDMETHODCALLTYPE MarshalStructAsParam_AsSeqByValUnicodeCharArrayClassification(UnicodeCharArrayClassification str, float f)
+{
+    return str.f == f;
+}
+
 ////////////////////////////////////////////////////////////////////////////////////
 extern "C" DLL_EXPORT int GetStringLength(AutoString str)
 {

--- a/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsParamDLL.h
+++ b/tests/src/Interop/StructMarshalling/PInvoke/MarshalStructAsParamDLL.h
@@ -957,3 +957,9 @@ union OverlappingMultipleEightbyteMultiple
         int i[3];
     };
 };
+
+struct UnicodeCharArrayClassification
+{
+    WCHAR arr[6];
+    float f;
+};

--- a/tests/src/Interop/StructMarshalling/PInvoke/Struct.cs
+++ b/tests/src/Interop/StructMarshalling/PInvoke/Struct.cs
@@ -485,3 +485,11 @@ public unsafe struct FixedArrayClassificationTest
     public Int32Wrapper[] arr;
     public float f;
 }
+
+[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+public struct UnicodeCharArrayClassification
+{
+    [MarshalAs(UnmanagedType.ByValArray, SizeConst = 6)]
+    public char[] arr;
+    public float f;
+}


### PR DESCRIPTION
The default handling for `char` marshalling in `OleVariant::GetNativeMethodTableForVarType()` doesn't correctly handle `char[]`s marshaled as `ByValArray`. The `MethodTable*` calculates for `char` elements doesn't correctly account for `CharSet`.

In master, this code-path is only executed as part of SystemV classification of by-val arrays, so it requires a contrived struct to encounter, such as the one below:

```csharp
[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
struct S
{
    [MarshalAs(UnmanagedType.ByValArray, SizeConst=6)]
    public char[] arr;

	public float f;
}
```

Currently, this classifies the first eight bytes as `INTEGER` and the second eight bytes as `SSE`. However, both eight bytes should be classified as `INTEGER` since the char array extends into the second eight byte.

I discovered this bug as part of my work on unifying the struct marshaling with the parameter and return value marshaling where I am using the `OleVariant::GetNativeMethodTableForVarType()` in more locations.