### PR TITLE
dlopen on Linux seems to not check the current working directory

### DIFF
--- a/src/ToolBox/superpmi/superpmi/neardiffer.cpp
+++ b/src/ToolBox/superpmi/superpmi/neardiffer.cpp
@@ -67,14 +67,51 @@ bool NearDiffer::InitAsmDiff()
 
     if (UseCoreDisTools)
     {
-        const char* coreDisToolsLibrary = MAKEDLLNAME_A("coredistools");
+#ifdef PLATFORM_UNIX
+        // Unix will require the full path to coredistools. Assume that the
+        // location is next to the full path to the superpmi.so.
+        
+        wchar_t coreCLRLoadedPath[MAX_LONGPATH];
+        HMODULE result = 0;
+        int returnVal = ::GetModuleFileNameW(result, coreCLRLoadedPath, MAX_LONGPATH);
 
+        if (returnVal == 0)
+        {
+            LogError("GetModuleFileNameW failed (0x%08x)", ::GetLastError());
+            return false;
+        }
+
+        wchar_t* ptr;
+        for (ptr = coreCLRLoadedPath + ::wcsnlen(coreCLRLoadedPath, MAX_LONGPATH) - 1; ptr != coreCLRLoadedPath; --ptr)
+        {
+            if (*ptr == '/')
+            {
+                ++ptr;
+                break;
+            }
+        }
+
+        const wchar_t* coreDisToolsLibrary = MAKEDLLNAME_W("coredistools");
+        ::wcscpy_s(ptr, ::wcsnlen(coreDisToolsLibrary, MAX_LONGPATH) + 1, coreDisToolsLibrary);
+
+        HMODULE hCoreDisToolsLib = ::LoadLibraryW(coreCLRLoadedPath);
+        if (hCoreDisToolsLib == 0)
+        {
+            LogError("LoadLibrary(%s) failed (0x%08x)", ::GetLastError());
+            return false;
+        }
+
+#else
+        const char* coreDisToolsLibrary = MAKEDLLNAME_A("coredistools");
         HMODULE hCoreDisToolsLib = ::LoadLibraryA(coreDisToolsLibrary);
         if (hCoreDisToolsLib == 0)
         {
             LogError("LoadLibrary(%s) failed (0x%08x)", coreDisToolsLibrary, ::GetLastError());
             return false;
         }
+
+#endif // PLATFORM_UNIX
+        
         g_PtrNewDiffer = (NewDiffer_t*)::GetProcAddress(hCoreDisToolsLib, "NewDiffer");
         if (g_PtrNewDiffer == nullptr)
         {

--- a/src/ToolBox/superpmi/superpmi/neardiffer.cpp
+++ b/src/ToolBox/superpmi/superpmi/neardiffer.cpp
@@ -88,6 +88,7 @@ bool NearDiffer::InitAsmDiff()
 
         const wchar_t* coreDisToolsLibrary = MAKEDLLNAME_W("coredistools");
         ::wcscpy_s(ptr, &coreCLRLoadedPath[MAX_LONGPATH] - ptr, coreDisToolsLibrary);
+        const wchar_t* coreDisToolsLibraryPath = coreCLRLoadedPath;
 
 #else
         const wchar_t* coreDisToolsLibrary = MAKEDLLNAME_W("coredistools");

--- a/src/ToolBox/superpmi/superpmi/neardiffer.cpp
+++ b/src/ToolBox/superpmi/superpmi/neardiffer.cpp
@@ -67,6 +67,7 @@ bool NearDiffer::InitAsmDiff()
 
     if (UseCoreDisTools)
     {
+        const wchar_t* coreDisToolsLibrary = MAKEDLLNAME_W("coredistools");
 #ifdef PLATFORM_UNIX
         // Unix will require the full path to coredistools. Assume that the
         // location is next to the full path to the superpmi.so.
@@ -86,15 +87,12 @@ bool NearDiffer::InitAsmDiff()
         // Move past the / character.
         ptr = ptr + 1;
 
-        const wchar_t* coreDisToolsLibrary = MAKEDLLNAME_W("coredistools");
-        ::wcscpy_s(ptr, &coreCLRLoadedPath[MAX_LONGPATH] - ptr, coreDisToolsLibrary);
-        const wchar_t* coreDisToolsLibraryPath = coreCLRLoadedPath;
+        const wchar_t* coreDisToolsLibraryName = MAKEDLLNAME_W("coredistools");
+        ::wcscpy_s(ptr, &coreCLRLoadedPath[MAX_LONGPATH] - ptr, coreDisToolsLibraryName);
+        coreDisToolsLibrary = coreCLRLoadedPath;
+#endif // PLATFORM_UNIX
 
-#else
-        const wchar_t* coreDisToolsLibrary = MAKEDLLNAME_W("coredistools");
-#endif // !PLATFORM_UNIX
-
-        HMODULE hCoreDisToolsLib = ::LoadLibraryW(coreCLRLoadedPath);
+        HMODULE hCoreDisToolsLib = ::LoadLibraryW(coreDisToolsLibrary);
         if (hCoreDisToolsLib == 0)
         {
             LogError("LoadLibrary(%s) failed (0x%08x)", ::GetLastError());

--- a/src/ToolBox/superpmi/superpmi/neardiffer.cpp
+++ b/src/ToolBox/superpmi/superpmi/neardiffer.cpp
@@ -83,6 +83,9 @@ bool NearDiffer::InitAsmDiff()
 
         wchar_t* ptr = ::wcsrchr(coreCLRLoadedPath, '/');
 
+        // Move past the / character.
+        ptr = ptr + 1;
+
         const wchar_t* coreDisToolsLibrary = MAKEDLLNAME_W("coredistools");
         ::wcscpy_s(ptr, &coreCLRLoadedPath[MAX_LONGPATH] - ptr, coreDisToolsLibrary);
 

--- a/src/ToolBox/superpmi/superpmi/neardiffer.cpp
+++ b/src/ToolBox/superpmi/superpmi/neardiffer.cpp
@@ -81,18 +81,14 @@ bool NearDiffer::InitAsmDiff()
             return false;
         }
 
-        wchar_t* ptr;
-        for (ptr = coreCLRLoadedPath + ::wcsnlen(coreCLRLoadedPath, MAX_LONGPATH) - 1; ptr != coreCLRLoadedPath; --ptr)
-        {
-            if (*ptr == '/')
-            {
-                ++ptr;
-                break;
-            }
-        }
+        wchar_t* ptr = ::wcsrchr(coreCLRLoadedPath, '/');
 
         const wchar_t* coreDisToolsLibrary = MAKEDLLNAME_W("coredistools");
-        ::wcscpy_s(ptr, ::wcsnlen(coreDisToolsLibrary, MAX_LONGPATH) + 1, coreDisToolsLibrary);
+        ::wcscpy_s(ptr, &coreCLRLoadedPath[MAX_LONGPATH] - ptr, coreDisToolsLibrary);
+
+#else
+        const wchar_t* coreDisToolsLibrary = MAKEDLLNAME_W("coredistools");
+#endif // !PLATFORM_UNIX
 
         HMODULE hCoreDisToolsLib = ::LoadLibraryW(coreCLRLoadedPath);
         if (hCoreDisToolsLib == 0)
@@ -100,17 +96,6 @@ bool NearDiffer::InitAsmDiff()
             LogError("LoadLibrary(%s) failed (0x%08x)", ::GetLastError());
             return false;
         }
-
-#else
-        const char* coreDisToolsLibrary = MAKEDLLNAME_A("coredistools");
-        HMODULE hCoreDisToolsLib = ::LoadLibraryA(coreDisToolsLibrary);
-        if (hCoreDisToolsLib == 0)
-        {
-            LogError("LoadLibrary(%s) failed (0x%08x)", coreDisToolsLibrary, ::GetLastError());
-            return false;
-        }
-
-#endif // PLATFORM_UNIX
         
         g_PtrNewDiffer = (NewDiffer_t*)::GetProcAddress(hCoreDisToolsLib, "NewDiffer");
         if (g_PtrNewDiffer == nullptr)


### PR DESCRIPTION
Therefore change the path of coredistools to an absolute path and
calculate it  based on the path of the current dll.

/cc @dotnet/jit-contrib 