### PR TITLE
Mark nogc as a long running gc test

### DIFF
--- a/tests/src/GC/API/NoGCRegion/NoGC.csproj
+++ b/tests/src/GC/API/NoGCRegion/NoGC.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <CLRTestExecutionArguments />
     <GCStressIncompatible>true</GCStressIncompatible>
+    <IsLongRunningGCTest>true</IsLongRunningGCTest>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->


### PR DESCRIPTION
This test has been repeatedly flaky in CI.

/cc @BruceForstall @Maoni0 
/cc @dotnet/coreclr-infra 