### PR TITLE
Port to 3.0 - Fix ARM64 HFA arguments passing via reflection

### DIFF
--- a/src/vm/callingconvention.h
+++ b/src/vm/callingconvention.h
@@ -1320,7 +1320,11 @@ int ArgIteratorTemplate<ARGITERATOR_BASE>::GetNextOffset()
             cFPRegs = argSize/m_argLocDescForStructInRegs.m_hfaFieldSize;
             m_argLocDescForStructInRegs.m_cFloatReg = cFPRegs;
 
-            m_hasArgLocDescForStructInRegs = true;
+            // Check if we have enough registers available for the HFA passing
+            if ((cFPRegs + m_idxFPReg) <= 8)
+            {
+                m_hasArgLocDescForStructInRegs = true;
+            }
         }
         else 
         {


### PR DESCRIPTION
#### Description
There was an issue happening in case there were not enough floating point
registers for passing a HFA argument. The argument iterator was returning
confusing result for such argument. The offset was correctly pointing to
stack, but the state indicated that the arguments should be passed in
registers. That caused the argument to be passed incorrectly.

The fix is to not set m_hasArgLocDescForStructInRegs when the HFA doesn't
fit into registers.

#### Customer Impact
If an application is invoking functions with HFA arguments (packed structures of 2-4 floats or doubles) that should be passed on stack **via reflection**, the callee will receive incorrect values in the arguments. 

#### Regression
No

#### Risk
None

Issue #25993