### PR TITLE
Move AssemblyLoadContext VM-invoked static resolve methods to shared

### DIFF
--- a/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
@@ -190,48 +190,6 @@ namespace System.Runtime.Loader
             InternalStartProfile(profile, _nativeAssemblyLoadContext);
         }
 
-        // This method is called by the VM.
-        private static void OnAssemblyLoad(RuntimeAssembly assembly)
-        {
-            AssemblyLoad?.Invoke(AppDomain.CurrentDomain, new AssemblyLoadEventArgs(assembly));
-        }
-
-        // This method is called by the VM.
-        private static RuntimeAssembly? OnResourceResolve(RuntimeAssembly assembly, string resourceName)
-        {
-            return InvokeResolveEvent(ResourceResolve, assembly, resourceName);
-        }
-
-        // This method is called by the VM
-        private static RuntimeAssembly? OnTypeResolve(RuntimeAssembly assembly, string typeName)
-        {
-            return InvokeResolveEvent(TypeResolve, assembly, typeName);
-        }
-
-        // This method is called by the VM.
-        private static RuntimeAssembly? OnAssemblyResolve(RuntimeAssembly assembly, string assemblyFullName)
-        {
-            return InvokeResolveEvent(AssemblyResolve, assembly, assemblyFullName);
-        }
-
-        private static RuntimeAssembly? InvokeResolveEvent(ResolveEventHandler? eventHandler, RuntimeAssembly assembly, string name)
-        {
-            if (eventHandler == null)
-                return null;
-
-            var args = new ResolveEventArgs(name, assembly);
-
-            foreach (ResolveEventHandler handler in eventHandler.GetInvocationList())
-            {
-                Assembly? asm = handler(AppDomain.CurrentDomain, args);
-                RuntimeAssembly? ret = GetRuntimeAssembly(asm);
-                if (ret != null)
-                    return ret;
-            }
-
-            return null;
-        }
-
         private static RuntimeAssembly? GetRuntimeAssembly(Assembly? asm)
         {
             return


### PR DESCRIPTION
Shared between CoreCLR and Mono. Mono began using a copy of these methods with https://github.com/mono/mono/pull/16256/

cc: @lambdageek @vitek-karas 