### PR TITLE
Mark emitted types assembly as collectible in ABI stress

### DIFF
--- a/tests/src/JIT/Stress/ABI/Program.cs
+++ b/tests/src/JIT/Stress/ABI/Program.cs
@@ -601,7 +601,7 @@ namespace ABIStress
 
                 if (s_delegateTypesModule == null)
                 {
-                    AssemblyBuilder delegates = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("ABIStress_Delegates"), AssemblyBuilderAccess.Run);
+                    AssemblyBuilder delegates = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("ABIStress_Delegates"), AssemblyBuilderAccess.RunAndCollect);
                     s_delegateTypesModule = delegates.DefineDynamicModule("ABIStress_Delegates");
                 }
 


### PR DESCRIPTION
This makes it compatible with RunInContext.

cc @janvorli 

Fixes #26242 