### PR TITLE
Remove tailcall limitations on unix64 and arm64

### DIFF
--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -1644,8 +1644,8 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk, unsigned outArg
         unsigned thisFieldOffset = argOffset + fieldListPtr->gtFieldOffset;
         getEmitter()->emitIns_S_R(ins_Store(type), attr, reg, outArgVarNum, thisFieldOffset);
 
-        // We can't write beyond the arg area unless this is a tail call, in which case we use
-        // the first stack arg as the base of the incoming arg area.
+// We can't write beyond the arg area unless this is a tail call, in which case we use
+// the first stack arg as the base of the incoming arg area.
 #ifdef DEBUG
         size_t areaSize = compiler->lvaLclSize(outArgVarNum);
 #if FEATURE_FASTTAILCALL

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -1644,8 +1644,19 @@ void CodeGen::genPutArgStkFieldList(GenTreePutArgStk* putArgStk, unsigned outArg
         unsigned thisFieldOffset = argOffset + fieldListPtr->gtFieldOffset;
         getEmitter()->emitIns_S_R(ins_Store(type), attr, reg, outArgVarNum, thisFieldOffset);
 
-        // We can't write beyond the arg area
-        assert((thisFieldOffset + EA_SIZE_IN_BYTES(attr)) <= compiler->lvaLclSize(outArgVarNum));
+        // We can't write beyond the arg area unless this is a tail call, in which case we use
+        // the first stack arg as the base of the incoming arg area.
+#ifdef DEBUG
+        size_t areaSize = compiler->lvaLclSize(outArgVarNum);
+#if FEATURE_FASTTAILCALL
+        if (putArgStk->gtCall->IsFastTailCall())
+        {
+            areaSize = compiler->info.compArgStackSize;
+        }
+#endif
+
+        assert((thisFieldOffset + EA_SIZE_IN_BYTES(attr)) <= areaSize);
+#endif
     }
 }
 #endif // !_TARGET_X86_

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -8777,9 +8777,8 @@ public:
         unsigned  compArgsCount;     // Number of arguments (incl. implicit and     hidden)
 
 #if FEATURE_FASTTAILCALL
-        size_t compArgStackSize;     // Incoming argument stack size in bytes
-        bool   compHasMultiSlotArgs; // Caller has >8 byte sized struct parameter
-#endif                               // FEATURE_FASTTAILCALL
+        size_t compArgStackSize; // Incoming argument stack size in bytes
+#endif                           // FEATURE_FASTTAILCALL
 
         unsigned compRetBuffArg; // position of hidden return param var (0, 1) (BAD_VAR_NUM means not present);
         int compTypeCtxtArg; // position of hidden param for type context for generic code (CORINFO_CALLCONV_PARAMTYPE)

--- a/src/jit/jit.h
+++ b/src/jit/jit.h
@@ -276,15 +276,14 @@
 #define UNIX_AMD64_ABI_ONLY(x)
 #endif // defined(UNIX_AMD64_ABI)
 
-#if defined(UNIX_AMD64_ABI) || !defined(_TARGET_64BIT_) || (defined(_TARGET_WINDOWS_) && defined(_TARGET_ARM64_))
+#if defined(UNIX_AMD64_ABI) || !defined(_TARGET_64BIT_) || defined(_TARGET_ARM64_)
 #define FEATURE_PUT_STRUCT_ARG_STK 1
 #define PUT_STRUCT_ARG_STK_ONLY_ARG(x) , x
 #define PUT_STRUCT_ARG_STK_ONLY(x) x
-#else // !(defined(UNIX_AMD64_ABI) && defined(_TARGET_64BIT_) && !(defined(_TARGET_WINDOWS_) && defined(_TARGET_ARM64_))
+#else
 #define PUT_STRUCT_ARG_STK_ONLY_ARG(x)
 #define PUT_STRUCT_ARG_STK_ONLY(x)
-#endif // !(defined(UNIX_AMD64_ABI) && defined(_TARGET_64BIT_) && !(defined(_TARGET_WINDOWS_) &&
-       // defined(_TARGET_ARM64_))
+#endif
 
 #if defined(UNIX_AMD64_ABI)
 #define UNIX_AMD64_ABI_ONLY_ARG(x) , x

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -378,8 +378,7 @@ void Compiler::lvaInitArgs(InitVarDscInfo* varDscInfo)
     // Save the stack usage information
     // We can get register usage information using codeGen->intRegState and
     // codeGen->floatRegState
-    info.compArgStackSize     = varDscInfo->stackArgSize;
-    info.compHasMultiSlotArgs = varDscInfo->hasMultiSlotStruct;
+    info.compArgStackSize = varDscInfo->stackArgSize;
 #endif // FEATURE_FASTTAILCALL
 
     // The total argument size must be aligned.
@@ -852,8 +851,7 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo)
                 varDsc->lvArgReg = genMapRegArgNumToRegNum(firstAllocatedRegArgNum, TYP_I_IMPL);
                 if (cSlots == 2)
                 {
-                    varDsc->lvOtherArgReg          = genMapRegArgNumToRegNum(firstAllocatedRegArgNum + 1, TYP_I_IMPL);
-                    varDscInfo->hasMultiSlotStruct = true;
+                    varDsc->lvOtherArgReg = genMapRegArgNumToRegNum(firstAllocatedRegArgNum + 1, TYP_I_IMPL);
                 }
             }
 #elif defined(UNIX_AMD64_ABI)
@@ -864,9 +862,8 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo)
                 // If there is a second eightbyte, get a register for it too and map the arg to the reg number.
                 if (structDesc.eightByteCount >= 2)
                 {
-                    secondEightByteType            = GetEightByteType(structDesc, 1);
-                    secondAllocatedRegArgNum       = varDscInfo->allocRegArg(secondEightByteType, 1);
-                    varDscInfo->hasMultiSlotStruct = true;
+                    secondEightByteType      = GetEightByteType(structDesc, 1);
+                    secondAllocatedRegArgNum = varDscInfo->allocRegArg(secondEightByteType, 1);
                 }
 
                 if (secondEightByteType != TYP_UNDEF)
@@ -1006,11 +1003,7 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo)
 #endif // _TARGET_XXX_
 
 #if FEATURE_FASTTAILCALL
-            if (cSlots > 1)
-            {
-                varDscInfo->hasMultiSlotStruct = true;
-            }
-
+            varDsc->lvStkOffs = varDscInfo->stackArgSize;
             varDscInfo->stackArgSize += roundUp(argSize, TARGET_POINTER_SIZE);
 #endif // FEATURE_FASTTAILCALL
         }
@@ -1104,6 +1097,7 @@ void Compiler::lvaInitGenericsCtxt(InitVarDscInfo* varDscInfo)
             // returns false.
             varDsc->lvOnFrame = true;
 #if FEATURE_FASTTAILCALL
+            varDsc->lvStkOffs = varDscInfo->stackArgSize;
             varDscInfo->stackArgSize += TARGET_POINTER_SIZE;
 #endif // FEATURE_FASTTAILCALL
         }
@@ -1173,6 +1167,7 @@ void Compiler::lvaInitVarArgsHandle(InitVarDscInfo* varDscInfo)
             // returns false.
             varDsc->lvOnFrame = true;
 #if FEATURE_FASTTAILCALL
+            varDsc->lvStkOffs = varDscInfo->stackArgSize;
             varDscInfo->stackArgSize += TARGET_POINTER_SIZE;
 #endif // FEATURE_FASTTAILCALL
         }

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -138,6 +138,10 @@ private:
     GenTree* LowerNonvirtPinvokeCall(GenTreeCall* call);
     GenTree* LowerTailCallViaHelper(GenTreeCall* callNode, GenTree* callTarget);
     void LowerFastTailCall(GenTreeCall* callNode);
+    void RehomeArgForFastTailCall(unsigned int lclNum,
+                                  GenTree*     insertTempBefore,
+                                  GenTree*     lookForUsesStart,
+                                  GenTreeCall* callNode);
     void InsertProfTailCallHook(GenTreeCall* callNode, GenTree* insertionPoint);
     GenTree* LowerVirtualVtableCall(GenTreeCall* call);
     GenTree* LowerVirtualStubCall(GenTreeCall* call);

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -6963,55 +6963,18 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee, const char** failReason)
     fgInitArgInfo(callee);
     fgArgInfo* argInfo = callee->fgArgInfo;
 
-    // Count user args while tracking whether any of them has a larger than one
-    // stack slot sized requirement. This requirement is required to support
-    // lowering the fast tail call, which, currently only supports copying
-    // stack slot arguments which have only one stack slot.
-    //
-    // For each struct arg, determine whether the argument would have  > 1 stack
-    // slot if on the stack. If it has > 1 stack slot we will not fastTailCall.
-    // This is an implementation limitation of LowerFastTailCall that is tracked by:
-    // https://github.com/dotnet/coreclr/issues/12644.
-
-    bool   hasLargerThanOneStackSlotSizedStruct = false;
-    bool   hasNonEnregisterableStructs          = false;
-    bool   hasByrefParameter                    = false;
-    size_t calleeStackSize                      = 0;
-    size_t callerStackSize                      = info.compArgStackSize;
+    bool   hasByrefParameter  = false;
+    size_t calleeArgStackSize = 0;
+    size_t callerArgStackSize = info.compArgStackSize;
 
     for (unsigned index = 0; index < argInfo->ArgCount(); ++index)
     {
         fgArgTabEntry* arg = argInfo->GetArgEntry(index, false);
 
-        unsigned argStackSize     = arg->stackSize();
-        unsigned argFloatRegCount = arg->floatRegCount();
-        unsigned argIntRegCount   = arg->intRegCount();
+        calleeArgStackSize += arg->stackSize();
 
-#if !defined(FEATURE_ARG_SPLIT)
-        if (argStackSize > 0)
-        {
-            assert(argFloatRegCount == 0 && argIntRegCount == 0);
-        }
-#endif // !defined(FEATURE_ARG_SPLIT)
-
-        unsigned countRegistersUsedForArg = argIntRegCount + argFloatRegCount;
-
-        calleeStackSize += argStackSize;
-
-        // This exists to account for special case situations where we will not
-        // fast tail call.
         if (arg->isStruct)
         {
-            if (argStackSize > 0)
-            {
-                hasNonEnregisterableStructs = true;
-            }
-
-            if (countRegistersUsedForArg > 1)
-            {
-                hasLargerThanOneStackSlotSizedStruct = true;
-            }
-
             // Byref struct arguments are not allowed to fast tail call as the information
             // of the caller's stack is lost when the callee is compiled.
             if (arg->passedByRef)
@@ -7056,7 +7019,7 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee, const char** failReason)
                 printf("Will not fast tailcall (%s)", thisFailReason);
             }
 
-            printf(" (CallerStackSize: %d, CalleeStackSize: %d)\n\n", callerStackSize, calleeStackSize);
+            printf(" (CallerArgStackSize: %d, CalleeArgStackSize: %d)\n\n", callerArgStackSize, calleeArgStackSize);
         }
         else
         {
@@ -7069,9 +7032,6 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee, const char** failReason)
                 JITDUMP("[Fast tailcall decision]: Will not fast tailcall (%s)\n", thisFailReason);
             }
         }
-#else
-        (void)this;
-        (void)callee;
 #endif // DEBUG
     };
 
@@ -7090,7 +7050,7 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee, const char** failReason)
 #if (defined(_TARGET_WINDOWS_) && defined(_TARGET_ARM_)) || (defined(_TARGET_WINDOWS_) && defined(_TARGET_ARM64_))
     if (info.compIsVarArgs || callee->IsVarargs())
     {
-        reportFastTailCallDecision("Fast tail calls with varargs are not supported");
+        reportFastTailCallDecision("Fast tail calls with varargs not supported on Windows ARM/ARM64");
         return false;
     }
 #endif // (defined(_TARGET_WINDOWS_) && defined(_TARGET_ARM_)) || defined(_TARGET_WINDOWS_) && defined(_TARGET_ARM64_))
@@ -7106,83 +7066,25 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee, const char** failReason)
         }
     }
 
-    const unsigned maxRegArgs            = MAX_REG_ARG;
-    hasLargerThanOneStackSlotSizedStruct = hasLargerThanOneStackSlotSizedStruct || info.compHasMultiSlotArgs;
-
-    bool hasStackArgs = false;
-    if (callerStackSize > 0 || calleeStackSize > 0)
-    {
-        hasStackArgs = true;
-    }
-
+    // For Windows some struct parameters are copied on the local frame
+    // and then passed by reference. We cannot fast tail call in these situation
+    // as we need to keep our frame around.
     if (hasByrefParameter)
     {
         reportFastTailCallDecision("Callee has a byref parameter");
         return false;
     }
 
-// If we reached here means that callee has only those argument types which can be passed in
-// a register and if passed on stack will occupy exactly one stack slot in out-going arg area.
-// If we are passing args on stack for the callee and it has a larger stack size than
-// the caller, then fast tail call cannot be performed.
-//
-// Note that the GC'ness of on stack args need not match since the arg setup area is marked
-// as non-interruptible for fast tail calls.
-
-#ifdef WINDOWS_AMD64_ABI
-    // x64 Windows: If we have stack args then make sure the callee's incoming
-    // arguments is less than the caller's
-    if (hasStackArgs && (calleeStackSize > callerStackSize))
+    // For a fast tail call the caller will use its incoming arg stack space to place
+    // arguments, so if the callee requires more arg stack space than is available here
+    // the fast tail call cannot be performed. This is common to all platforms.
+    // Note that the GC'ness of on stack args need not match since the arg setup area is marked
+    // as non-interruptible for fast tail calls.
+    if (calleeArgStackSize > callerArgStackSize)
     {
         reportFastTailCallDecision("Not enough incoming arg space");
         return false;
     }
-
-#elif (defined(_TARGET_AMD64_) && defined(UNIX_AMD64_ABI)) || defined(_TARGET_ARM64_)
-
-    // For unix Amd64 and Arm64 check to see if all arguments for the callee
-    // and caller are passing in registers. If not, ensure that the outgoing argument stack size
-    // requirement for the callee is less than or equal to the caller's entire stack frame usage.
-    //
-    // Also, in the case that we have to pass arguments on the stack make sure
-    // that we are not dealing with structs that are >8 bytes.
-
-    // Either the caller or callee has a >8 and <=16 byte struct and arguments that has to go on the stack. Do not
-    // fastTailCall.
-    //
-    // When either the caller or callee have multi-stlot stack arguments we cannot safely
-    // shuffle arguments in LowerFastTailCall. See https://github.com/dotnet/coreclr/issues/12468.
-    if (hasLargerThanOneStackSlotSizedStruct && calleeStackSize > 0)
-    {
-        reportFastTailCallDecision(
-            "Caller or callee has multi-slot arg and callee takes stack args (unsupported scenario)");
-        return false;
-    }
-
-    if (hasNonEnregisterableStructs)
-    {
-        reportFastTailCallDecision("Callee has non-enregisterable struct arg (unsupported scenario)");
-        return false;
-    }
-
-    // TODO-AMD64-Unix
-    // TODO-ARM64
-    //
-    // LowerFastTailCall currently assumes nCalleeArgs <= nCallerArgs. This is
-    // not true in many cases on x64 linux, remove this pessimization when
-    // LowerFastTailCall is fixed. See https://github.com/dotnet/coreclr/issues/12468
-    // for more information.
-    if (hasStackArgs && (calleeStackSize > callerStackSize))
-    {
-        reportFastTailCallDecision("Not enough incoming arg space");
-        return false;
-    }
-
-#else
-
-    NYI("fastTailCall not supported on this Architecture.");
-
-#endif //  WINDOWS_AMD64_ABI
 
     reportFastTailCallDecision(nullptr);
     return true;


### PR DESCRIPTION
Fast tailcalls have their arguments passed in the incoming argument area
of the caller. This can cause problems when a previous argument might
end up overwriting the stack slot for an incoming argument that is later
used. To resolve this problem, we have logic that detects and introduces
temps in this situation. This logic was originally written for Windows
x64 where it is simple to know what argument is being overwritten, since
every argument always takes up a single slot on the stack. I.e. we know
that outgoing argument 7 can only overwrite incoming argument 7.

On unix x64 and arm64 this assumption does not hold. We previously tried
to workaround this by limiting our fast tailcalls to simple situations
where this assumption held, but this caused many missed fast tailcall
opportunities (for example, when arguments requires two slots or more).

This change removes those limitations. Instead of finding the argument
overwritten using the argument index, it keeps track of which stack
slots are used by each incoming and outgoing argument, allowing us to
more robustly check if an outgoing argument will overwrite an incoming
argument that will be used later.

To do this, we need to set the stack offset during init of args so that
we can use this info to determine whether it is necessary to introduce
temps for fast tailcalls. For arm64 we now define
FEATURE_PUT_STRUCT_ARG_STK to have access to the number of slots in
PUTARG_STK needed for this transformation.

There are also some corner cases we must consider. Since arguments now
consume multiple stack slots we can no longer move them with a single
atomic move instruction. Thus it is possible for us to get into cases
where we need to move an argument that is larger than 8 bytes and where
the move overlaps. This is a problem because codegen cannot handle
partially overlapping struct copies. We see this on unix64 in the
following case (assuming all args are on the stack):
void callee(S16 a, S32 b) { ... }
void caller(S32 a) { callee(default, a); }

Here 'caller' will need to move 'a' 16 bytes ahead in the arg list, and
we thus need a temp because we cannot do this atomically. Fix this by
detecting the partially overlapping case and looking for uses of the arg
from the current PUTARG_STK node's operand (instead of only starting
after).

Fixes #12468 
Fixes #20726
Fixes #12644
Fixes #11717