### PR TITLE
Use function-local StackingAllocator for EnC added methods

### DIFF
--- a/src/vm/class.cpp
+++ b/src/vm/class.cpp
@@ -604,12 +604,16 @@ HRESULT EEClass::AddMethod(MethodTable * pMT, mdMethodDef methodDef, RVA newRVA,
     // Get the new MethodDesc (Note: The method desc memory is zero initialized)
     MethodDesc *pNewMD = pChunk->GetFirstMethodDesc();
 
-    ACQUIRE_STACKING_ALLOCATOR(pStackingAllocator);
 
     // Initialize the new MethodDesc
+    
+     // This method runs on a debugger thread. Debugger threads do not have Thread object that caches StackingAllocator.
+     // Use a local StackingAllocator instead.
+    StackingAllocator stackingAllocator;
+
     MethodTableBuilder builder(pMT,
                                pClass,
-                               pStackingAllocator,
+                               &stackingAllocator,
                                &dummyAmTracker);
     EX_TRY
     {


### PR DESCRIPTION
`tl;dr` Port of #26106 to solve issue #26016 caused by PR #24177

#### Description

PR #24177 made a changed the way we cached the `StackingAllocator` in the `Thread` object. Prior to this change, the compiler optimized the access by inserting the field offset; the offset was a bogus value, but the code path never uses the value so we never had any complaints. After the change, the access happened, but the code runs on the debugger thread, where the `Thread` object is not available, and this results in an AV when users try to add a method through EnC. This change adds a local `StackingAllocator` to prevent such AV and correct prior behavior. 

#### Customer Impact

This issue makes it impossible for users, directly impacting the inner loop scenarios. It's currently marked as a blocker in Visual Studio.

#### Regression?

Yes, 3.0 preview 6 was the first time this was visible to customers.

#### Risk

Very low, code path doesn't use the variable now, and fixes silent bug from before. Only possible to trigger it in Edit & Continue scenarios, and this actually correct prior behavior.