### PR TITLE
Avoid race condition in DiagnosticCounter

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/DiagnosticCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/DiagnosticCounter.cs
@@ -42,11 +42,24 @@ namespace System.Diagnostics.Tracing
                 throw new ArgumentNullException(nameof(EventSource));
             }
 
-            _group = CounterGroup.GetCounterGroup(eventSource);
-            _group.Add(this);
             Name = name;
-            DisplayUnits = string.Empty;
             EventSource = eventSource;
+        }
+
+        /// <summary>Adds the counter to the set that the EventSource will report on.</summary>
+        /// <remarks>
+        /// Must only be invoked once, and only after the instance has been fully initialized.
+        /// This should be invoked by a derived type's ctor as the last thing it does.
+        /// </remarks>
+        private protected void Publish()
+        {
+#if DEBUG
+            Debug.Assert(_group is null);
+            Debug.Assert(Name != null);
+            Debug.Assert(EventSource != null);
+#endif
+            _group = CounterGroup.GetCounterGroup(EventSource);
+            _group.Add(this);
         }
 
         /// <summary>
@@ -60,7 +73,7 @@ namespace System.Diagnostics.Tracing
             if (_group != null)
             {
                 _group.Remove(this);
-                _group = null!; // TODO-NULLABLE: Avoid nulling out in Dispose
+                _group = null;
             }
         }
 
@@ -106,7 +119,7 @@ namespace System.Diagnostics.Tracing
 
         #region private implementation
 
-        private CounterGroup _group;
+        private CounterGroup? _group;
         private Dictionary<string, string?>? _metadata;
 
         internal abstract void WritePayload(float intervalSec, int pollingIntervalMillisec);

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/DiagnosticCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/DiagnosticCounter.cs
@@ -53,11 +53,10 @@ namespace System.Diagnostics.Tracing
         /// </remarks>
         private protected void Publish()
         {
-#if DEBUG
             Debug.Assert(_group is null);
             Debug.Assert(Name != null);
             Debug.Assert(EventSource != null);
-#endif
+
             _group = CounterGroup.GetCounterGroup(EventSource);
             _group.Add(this);
         }

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventCounter.cs
@@ -41,6 +41,7 @@ namespace System.Diagnostics.Tracing
             _max = double.NegativeInfinity;
 
             InitializeBuffer();
+            Publish();
         }
 
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/IncrementingEventCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/IncrementingEventCounter.cs
@@ -34,6 +34,7 @@ namespace System.Diagnostics.Tracing
         /// <param name="eventSource">The event source.</param>
         public IncrementingEventCounter(string name, EventSource eventSource) : base(name, eventSource)
         {
+            Publish();
         }
 
         /// <summary>

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/IncrementingPollingCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/IncrementingPollingCounter.cs
@@ -40,6 +40,7 @@ namespace System.Diagnostics.Tracing
                 throw new ArgumentNullException(nameof(totalValueProvider));
 
             _totalValueProvider = totalValueProvider;
+            Publish();
         }
 
         public override string ToString() => $"IncrementingPollingCounter '{Name}' Increment {_increment}";

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/PollingCounter.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/PollingCounter.cs
@@ -38,6 +38,7 @@ namespace System.Diagnostics.Tracing
                 throw new ArgumentNullException(nameof(metricProvider));
 
             _metricProvider = metricProvider;
+            Publish();
         }
 
         public override string ToString() => $"PollingCounter '{Name}' Count {1} Mean {_lastVal.ToString("n3")}";


### PR DESCRIPTION
If while a DiagnosticCounter instance is being created the timer fires to process counters, the timer may end up evaluating a DiagnosticCounter whose constructor or derived types' constructor hasn't finished configuring the instance's state yet.

Fixes https://github.com/dotnet/coreclr/issues/26254

(Note this issue was based on code inspection rather than a repro.  If there's something that's preventing this from actually being a problem, I'm happy for this to be closed instead.)