### PR TITLE
Feature: dynamic expansion for generic dictionaries

### DIFF
--- a/Documentation/botr/shared-generics.md
+++ b/Documentation/botr/shared-generics.md
@@ -169,6 +169,8 @@ Resizing of the dictionary layouts takes place in `DictionaryLayout::ExpandDicti
 
 Resizing of the dictionaries of all related types or methods takes place in `Module::ExpandTypeDictionaries_Locked` and `Module::ExpandMethodDictionaries_Locked`. New dictionaries are allocated for each affected type or method, and the contents of their old dictionaries are copied over. These new dictionaries then get published on the corresponding `MethodTable` or `InstantiatedMethodDesc` structures (the "PerInstInfo" field). Great care is taken to perform all the dictionary allocations and initializations first before publishing them, with a call to `FlushProcessWriteBuffers()` in the middle to ensure correct ordering of read/write operations in multi-threading.
 
+One thing to note is that old dictionaries are not deallocated, but once a new dictionary gets published on a MethodTable or MethodDesc, any subsequent dictionary lookup by generic code will make use of that newly allocated dictionary. Deallocating old dictionaries would be extremely complicated, especially in a multi-threaded environment, and won't give any useful benefit.
+
 Finally, after resizing all generic dictionaries, the last step is to publish the newly allocated `DictionaryLayout` structure by associating it with the canonical instantiation.
 
 ### Diagnostics

--- a/Documentation/botr/shared-generics.md
+++ b/Documentation/botr/shared-generics.md
@@ -19,7 +19,7 @@ string Func<T>()
 ```
 
 Without shared generics, the code for instantiations like `Func<object>` or `Func<string>` would look identical except for one single instruction: the one that loads the correct TypeHandle of type `List<T>`:
-```
+``` asm
     mov rcx, type handle of List<string> or List<object>
     call ToString()
     ret

--- a/Documentation/botr/shared-generics.md
+++ b/Documentation/botr/shared-generics.md
@@ -1,0 +1,183 @@
+Shared Generics Design
+===
+
+Author: Fadi Hanna - 2019
+
+# Introduction
+
+Shared generics is a runtime+JIT feature aimed at reducing the amount of code the runtime generates for generic methods of various instantiations (supports methods on generic types and generic methods). The idea is that for certain instantiations, the generated code will almost be identical with the exception of a few instructions, so in order to reduce the memory footprint, and the amount of time we spend jitting these generic methods, the runtime will generate a single special canonical version of the code, which can be used by all compatible instantiations of the method.
+
+### Canonical Codegen and Generic Dictionaries
+
+Consider the following C# code sample:
+
+``` c#
+string Func<T>()
+{
+    return typeof(List<T>).ToString();
+}
+```
+
+Without shared generics, the code for instantiations like `Func<object>` or `Func<string>` would look identical except for one single instruction: the one that loads the correct TypeHandle of type `List<T>`:
+```
+    mov rcx, type handle of List<string> or List<object>
+    call ToString()
+    ret
+```
+
+With shared generics, the canonical code will not have any hard-coded versions of the type handle of List<T>, but instead looks up the exact type handle either through a call to a runtime helper API, or by loading it up from the *generic dictionary* of the instantiation of Func<T> that is executing. The code would look more like the following:
+``` asm
+    mov rcx, generic context                                                // MethodDesc of Func<string> or Func<object>
+    mov rcx, [rcx + offset of InstantiatedMethodDesc::m_pPerInstInfo]       // This is the generic dictionary
+    mov rcx, [rcx + dictionary slot containing type handle of List<T>]
+    call ToString()
+    ret
+```
+
+The generic context in this example is the InstantiatedMethodDesc of `Func<object>` or `Func<string>`. The generic dictionary is a data structure used by shared generic code to fetch instantiation-specific information. It is basically an array where the entries are instantiation-specific type handles, method handles, field handles, method entry points, etc... The "PerInstInfo" fields on MethodTable and InstantiatedMethodDesc structures point at the generic dictionary structure for a generic type and method respectively.
+
+In this example, the generic dictionary for Func<object> will contain a slot with the type handle for type List<object>, and the generic dictionary for Func<string> will contain a slot with the type handle for type List<string>.
+
+This feature is currently only supported for instantiations over reference types because they all have the same size/properties/layout/etc... For instantiations over primitive types or value types, the runtime will generate separate code bodies for each instantiation.
+
+
+# Layouts and Algorithms
+
+### Dictionaries Pointers on Types and Methods
+
+The dictionary used by any given generic method is pointed at by the `m_pPerInstInfo` field on the `InstantiatedMethodDesc` structure of that method. It's a direct pointer to the contents of the generic dictionary data.
+
+On generic types, there's an extra level of indirection: the 'm_pPerInstInfo' field on the `MethodTable` structure is a pointer to a table of dictionaries, and each entry in that table is a pointer to the actual generic dictionary data. This is because types have inheritance, and derived generic types inherit the dictionary pointers of their base types. 
+
+Here's an example:
+```c#
+class BaseClass<T> { }
+
+class DerivedClass<U> : BaseClass<U> { }
+
+class AnotherDerivedClass : DerivedClass<string> { }
+```
+
+The MethodTables of each of these types will look like the following:
+
+| **BaseClass[T]'s MethodTable** |
+|--------------------------|
+| ...      |
+| `m_PerInstInfo`: points at dictionary table below     |
+| ...      |
+| `dictionaryTable[0]`: points at dictionary data below      |
+| `BaseClass's dictionary data here`  |
+
+| **DerivedClass[U]'s MethodTable ** |
+|--------------------------|
+| ...      |
+| `m_PerInstInfo`: points at dictionary table below     |
+| ...      |
+| `dictionaryTable[0]`: points at dictionary data of `BaseClass`      |
+| `dictionaryTable[1]`: points at dictionary data below      |
+| `DerivedClass's dictionary data here`  |
+
+| **AnotherDerivedClass's MethodTable** |
+|--------------------------|
+| ...      |
+| `m_PerInstInfo`: points at dictionary table below     |
+| ...      |
+| `dictionaryTable[0]`: points at dictionary data of `BaseClass`      |
+| `dictionaryTable[1]`: points at dictionary data of `DerivedClass`      |
+
+Note that `AnotherDerivedClass` doesn't have a dictionary of its own given that it is not a generic type, but inherits the dictionary pointers of its base types.
+
+### Dictionary Slots
+
+As described earlier, a generic dictionary is an array of multiple slots containing instantiation-specific information. When a dictionary is initially allocated for a certain generic type or method, all of its slots are initialized to NULL, and are lazily populated on demand as code executes (see: `Dictionary::PopulateEntry(...)`).
+
+The first N slots in an instantiation of N arguments are always going to be the type handles of the instantiation type arguments (this is kind of an optimization as well). The slots that follow contain instantiation-based information.
+
+For instance, here is an example of the contents of the generic dictionary for our `Func<string>` example:
+
+| `Func<string>'s dicionary` |
+|--------------------------|
+| slot[0]: TypeHandle(`string`)      |
+| slot[1]: Total dictionary size  |
+| slot[2]: TypeHandle(`List<string>`)  |
+| slot[3]: NULL (not used)  |
+| slot[4]: NULL (not used)  |
+
+Note: the size slot is never used by generic code, and is part of the dynamic dictionary expansion feature. More on that below.
+
+When this dictionary is first allocated, only slot[0] is initialized because it contains the instantiation type arguments (and of course the size slot after the dictionary expansion feature), but the rest of the slots (example slot[2]) are NULL, and get lazily populated with values if we ever hit a code path that attempts to use them.
+
+When loading information from a slot that is still NULL, the generic code will call one of these runtime helper functions to populate the dictionary slot with a value:
+- `JIT_GenericHandleClass`: Used to lookup a value in a generic type dictionary. This helper is used by all instance methods on generic types.
+- `JIT_GenericHandleMethod`: Used to lookup a value in a generic method dictionary. This helper used by all generic methods, or non-generic static methods on generic types.
+
+When generating shared generic code, the JIT knows which slots to use for the various lookups, and the kind of information contained in each slot using the help of the `DictionaryLayout` implementation (https://github.com/dotnet/coreclr/blob/master/src/vm/genericdict.cpp).
+
+### Dictionary Layouts
+
+The `DictionaryLayout` structure is what tells the JIT which slot to use when performing a dictionary lookup. This `DictionaryLayout` structure has a couple of important properties:
+- It is shared accross all compatible instantiations of a certain type of method. In other words, a dictionary layout is associated with the canonical instantiation of a type or a method. For instance, in our example above, `Func<object>` and `Func<string>` are compatible instantiations, each with their own **separate dictionaries**, however they all share the **same dictionary layout**, which is associated with the canonical instantiation `Func<__Canon>`.
+- The dictionaries of generic types or methods have the same number of slots as their dictionary layouts. Note: historically before the introduction of the dynamic dictionary expansion feature, the generic dictionaries could be smaller than their layouts, meaning that for certain lookups, we had to use invoke some runtime helper APIs (slow path).
+
+When a generic type or method is first created, its dictionary layout contains 'unassigned' slots. Assignments happen as part of code generation, whenever the JIT needs to emit a dictionary lookup sequence. This assignment happens during the calls to the `DictionaryLayout::FindToken(...)` APIs. Once a slot has been assigned, it becomes associated with a certain signature, which describes the kind of value that will go in every instantiatied dictionary at that slot index.
+
+Given an input signature, slot assignment is performed with the following algorithm:
+
+```
+Begin with slot = 0
+Foreach entry in dictionary layout
+    If entry.signature != NULL
+        If entry.signature == inputSignature
+            return slot
+        EndIf
+    Else
+        entry.signature = inputSignature
+        return slot
+    EndIf
+    slot++
+EndForeach
+```
+
+So what happens when the above algorithm runs, but no existing slot with the same signature is found, and we're out of 'unassigned' slots? This is where the dynamic dictionary expansion kicks in to resize the layout by adding more slots to it, and resizing all dictionaries associated with this layout.
+
+# Dynamic Dictionary Expansion
+
+### History
+
+Before the dynamic dictionary expansion feature, dictionary layouts were organized into buckets (a linked list of fixed-size `DictionaryLayout` structures). The size of the initial layout bucket was always fixed to some number which was computed based on some heuristics for generic types, and always fixed to 4 slots for generic methods. The generic types and methods also had fixed-size generic dictionaries which could be used for lookups (also known as "fast lookup slots").
+
+When a bucket gets filled with entries, we would just allocate a new `DictionaryLayout` bucket, and add it to the list. The problem however is that we couldn't resize the generic dictionaries of types or methods, because they have already been allocated with a fixed size, and the JIT does not support generating instructions that could indirect into a linked-list of dictionaries. Given that limitation, we could only lookup a generic dictionary for a fixed number of values (the ones associated with the entries of the first `DictionaryLayout` bucket), and were forced to go through a slower runtime helper for additional lookups.
+
+This was acceptable, until we introduced the [ReadyToRun](https://github.com/dotnet/coreclr/blob/master/Documentation/botr/readytorun-overview.md) and the Tiered Compilation technologies. Slots were getting assigned quickly when used by ReadyToRun code, and when the runtime decided re-jitted certain methods for better performance, it could not in some cases find any remaining "fast lookup slots", and was forced to generate code that goes through the slower runtime helpers. This ended up hurting performance in some scenarios, and a decision was made to not use the fast lookup slots for ReadyToRun code, and instead keep them reserved for re-jitted code. This decision however hurt the ReadyToRun performance, but it was a necessary compromise since we cared more about re-jitted code throughput over R2R throughput.
+
+For this reason, the dynamic dictionary expansion feature was introduced.
+
+### Description and Algorithms
+
+The feature is simple in concept: change dictionary layouts from a linked list of buckets into dynamically expandable arrays instead. Sounds simple, but great care had to be taken when impementing it, because:
+- We can't just resize `DictionaryLayout` structures alone. If the size of the layout is larger than the size of the actual generic dictionary, this would cause the JIT to generate indirection instructions that do not match the size of the dictionary data, leading to access violations.
+- We can't just resize generic dictionaries on types and methods:
+    - For types, the generic dictionary is part of the `MethodTable` structure, which can't be reallocated (already in use by managed code)
+    - For methods, the generic dictionary is not part of the `MethodDesc` structure, but can still be in use by some generic code.
+    - We can't have multiple MethodTables or MethodDescs for the same type or method anyways, so reallocations are not an option.
+- We can't just resize the generic dictionary for a single instantiation. For instance, in our example above, let's say we wanted to expand the dictionary for `Func<string>`. The resizing of the layout would have an impact on the shared canonical code that the JIT generates for `Func<__Canon>`. If we only resized the dictionary of `Func<string>`, the shared generic code would work for that instantiation only, but when we attempt to use it with another instantiation like `Func<object>`, the jitted instructions would no longer match the size of the dictionary structure, and would cause access violations.
+- The runtime is multithreaded, which adds to the complexity.
+
+The first step in this feature is to insert all generic types and methods with dictionaries into a hashtable, where the key is the canonical instantiation. For instance, with our example, `Func<string>` and `Func<object>` would be added to the hashtable as values under the `Func<__Canon>` key. This ensures that if we ever need to resize the dictionary layout, we would have a way of finding all existing instantiations to resize their dictionaries as well (remember, a dictionary size has to match the size of the layout now). This is achieved by calls to the `Module::RecordTypeForDictionaryExpansion_Locked` and `Module::RecordMethodForDictionaryExpansion_Locked` APIs, every time a new generic type or method is created, just before they get published for usage by other threads.
+
+Resizing of the dictionary layouts takes place in `DictionaryLayout::ExpandDictionaryLayout`. A new `DictionaryLayout` structure is allocated with a larger size, and the contents of the old layout are copied over. At this point, we **cannot yet** associate that new layout with the canonical instantiation: we need to resize the dictionaries of all related instantiations (because of multi-threading).
+
+Resizing of the dictionaries of all related types or methods takes place in `Module::ExpandTypeDictionaries_Locked` and `Module::ExpandMethodDictionaries_Locked`. New dictionaries are allocated for each affected type or method, and the contents of their old dictionaries are copied over. These new dictionaries then get published on the corresponding `MethodTable` or `InstantiatedMethodDesc` structures (the "PerInstInfo" field). Great care is taken to perform all the dictionary allocations and initializations first before publishing them, with a call to `FlushProcessWriteBuffers()` in the middle to ensure correct ordering of read/write operations in multi-threading.
+
+Finally, after resizing all generic dictionaries, the last step is to publish the newly allocated `DictionaryLayout` structure by associating it with the canonical instantiation.
+
+### Diagnostics
+
+During feature development, an interesting set of bugs were hit, all having to do with multi-threaded executions. The main root cause behind these bugs was that some threads started to make use of newly allocated generic MethodTables or MethodDescs, and started to expand their dictionary layouts before we ever got a chance to insert these new types/methods into the hashtable to correctly track them for dictionary resizing. In other words, some thread was still in the process of constructing these MethodTables/MethodDescs, got them to a usable state and published them, making them available for other threads to start using, but did not yet reach the point of recording them into the hashtable of dictionary expansion tracking. The effect is that some shared generic code started accessing slots beyond the size limits of the generic dictionaries of these types/methods, causing access violations.
+
+The most useful piece of data that made it easy to diagnose these access violations was a pointer in each dynamically allocated dictionary to its predecessor. Tracking back dictionaries using these pointers led to the location in memory where the incorrect lookup value was loaded from, and helped root cause the bug.
+
+These predecessor pointers are allocated at the begining of each dynamically allocated dictionary, but are not part of the dictionary itself (so think of it as slot[-1]). 
+
+The plan is to also add an SOS command that could help diagnose dictionary contents accross the chain of dynamically allocated dictionaries (dotnet/diagnostics#588).
+

--- a/src/debug/daccess/nidump.cpp
+++ b/src/debug/daccess/nidump.cpp
@@ -6562,7 +6562,7 @@ void NativeImageDumper::MethodDescToString( PTR_MethodDesc md,
             {
                 PTR_InstantiatedMethodDesc imd(PTR_TO_TADDR(md));
                 unsigned numArgs = imd->m_wNumGenericArgs;
-                PTR_Dictionary dict(imd->IMD_GetMethodDictionary());
+                PTR_Dictionary dict(imd->IMD_GetMethodDictionary_Unsafe());
                 if( dict != NULL )
                 {
                     DictionaryToArgString( dict, numArgs, tempName );
@@ -6812,7 +6812,7 @@ NativeImageDumper::DumpMethodTable( PTR_MethodTable mt, const char * name,
     if( !mt->IsCanonicalMethodTable() && CORCOMPILE_IS_POINTER_TAGGED(PTR_TO_TADDR(mt->GetCanonicalMethodTable())) )
     {
         /* REVISIT_TODO Wed 02/01/2006
-         * GetExtent requires the class in order to compute GetInstAndDictSize.
+         * GetExtent requires the class in order to compute GetInstAndDictSize_Unsafe.
          * If the EEClass isn't present, I cannot compute the size.  If we are
          * in this case, skip all of the generic dictionaries.
          */
@@ -6980,12 +6980,12 @@ NativeImageDumper::DumpMethodTable( PTR_MethodTable mt, const char * name,
          * only print the last one, which is the one for this class).
          * cloned from Genericdict.cpp
          */
-        PTR_Dictionary currentDictionary(mt->GetDictionary());
+        PTR_Dictionary currentDictionary(mt->GetDictionary_Unsafe());
         if( currentDictionary != NULL )
         {
             PTR_DictionaryEntry entry(currentDictionary->EntryAddr(0));
-
-            PTR_DictionaryLayout layout( clazz->GetDictionaryLayout() );
+            
+            PTR_DictionaryLayout layout( clazz->GetDictionaryLayout_Unsafe() );
 
             DisplayStartStructure( "Dictionary",
                                    DPtrToPreferredAddr(currentDictionary),
@@ -7994,7 +7994,7 @@ void NativeImageDumper::DumpMethodDesc( PTR_MethodDesc md, PTR_Module module )
         }
         //now handle the contents of the m_pMethInst/m_pPerInstInfo union.
         unsigned numSlots = imd->m_wNumGenericArgs;
-        PTR_Dictionary inst(imd->IMD_GetMethodDictionary());
+        PTR_Dictionary inst(imd->IMD_GetMethodDictionary_Unsafe());
         unsigned dictSize;
         if( kind == InstantiatedMethodDesc::SharedMethodInstantiation )
         {

--- a/src/debug/daccess/nidump.cpp
+++ b/src/debug/daccess/nidump.cpp
@@ -6562,7 +6562,7 @@ void NativeImageDumper::MethodDescToString( PTR_MethodDesc md,
             {
                 PTR_InstantiatedMethodDesc imd(PTR_TO_TADDR(md));
                 unsigned numArgs = imd->m_wNumGenericArgs;
-                PTR_Dictionary dict(imd->IMD_GetMethodDictionary_Unsafe());
+                PTR_Dictionary dict(imd->IMD_GetMethodDictionary());
                 if( dict != NULL )
                 {
                     DictionaryToArgString( dict, numArgs, tempName );
@@ -6812,7 +6812,7 @@ NativeImageDumper::DumpMethodTable( PTR_MethodTable mt, const char * name,
     if( !mt->IsCanonicalMethodTable() && CORCOMPILE_IS_POINTER_TAGGED(PTR_TO_TADDR(mt->GetCanonicalMethodTable())) )
     {
         /* REVISIT_TODO Wed 02/01/2006
-         * GetExtent requires the class in order to compute GetInstAndDictSize_Unsafe.
+         * GetExtent requires the class in order to compute GetInstAndDictSize.
          * If the EEClass isn't present, I cannot compute the size.  If we are
          * in this case, skip all of the generic dictionaries.
          */
@@ -6980,19 +6980,19 @@ NativeImageDumper::DumpMethodTable( PTR_MethodTable mt, const char * name,
          * only print the last one, which is the one for this class).
          * cloned from Genericdict.cpp
          */
-        PTR_Dictionary currentDictionary(mt->GetDictionary_Unsafe());
+        PTR_Dictionary currentDictionary(mt->GetDictionary());
         if( currentDictionary != NULL )
         {
             PTR_DictionaryEntry entry(currentDictionary->EntryAddr(0));
             
-            PTR_DictionaryLayout layout( clazz->GetDictionaryLayout_Unsafe() );
+            PTR_DictionaryLayout layout( clazz->GetDictionaryLayout() );
 
             DisplayStartStructure( "Dictionary",
                                    DPtrToPreferredAddr(currentDictionary),
                                    //if there is a layout, use it to compute
                                    //the size, otherwise there is just the one
                                    //entry.
-                                   DictionaryLayout::GetFirstDictionaryBucketSize(mt->GetNumGenericArgs(), layout),
+                                   DictionaryLayout::GetDictionarySizeFromLayout(mt->GetNumGenericArgs(), layout),
                                    METHODTABLES );
 
             DisplayStartArrayWithOffset( m_pEntries, NULL, Dictionary,
@@ -7994,7 +7994,7 @@ void NativeImageDumper::DumpMethodDesc( PTR_MethodDesc md, PTR_Module module )
         }
         //now handle the contents of the m_pMethInst/m_pPerInstInfo union.
         unsigned numSlots = imd->m_wNumGenericArgs;
-        PTR_Dictionary inst(imd->IMD_GetMethodDictionary_Unsafe());
+        PTR_Dictionary inst(imd->IMD_GetMethodDictionary());
         unsigned dictSize;
         if( kind == InstantiatedMethodDesc::SharedMethodInstantiation )
         {
@@ -8018,7 +8018,7 @@ void NativeImageDumper::DumpMethodDesc( PTR_MethodDesc md, PTR_Module module )
             {
                 PTR_DictionaryLayout layout(wrapped->IsSharedByGenericMethodInstantiations()
                                             ? dac_cast<TADDR>(wrapped->GetDictLayoutRaw()) : NULL );
-                dictSize = DictionaryLayout::GetFirstDictionaryBucketSize(imd->GetNumGenericMethodArgs(),
+                dictSize = DictionaryLayout::GetDictionarySizeFromLayout(imd->GetNumGenericMethodArgs(), 
                                                                           layout);
             }
         }

--- a/src/inc/corinfo.h
+++ b/src/inc/corinfo.h
@@ -1373,9 +1373,6 @@ struct CORINFO_RUNTIME_LOOKUP
     // 1 means that value stored at second offset (offsets[1]) from pointer is offset2, and the next pointer is
     // stored at pointer+offsets[1]+offset2.
     bool                indirectSecondOffset;
-
-    // Dictionary slot index result for a dictionary lookup
-    WORD                slot;
 } ;
 
 // Result of calling embedGenericHandle

--- a/src/inc/corinfo.h
+++ b/src/inc/corinfo.h
@@ -1373,6 +1373,9 @@ struct CORINFO_RUNTIME_LOOKUP
     // 1 means that value stored at second offset (offsets[1]) from pointer is offset2, and the next pointer is
     // stored at pointer+offsets[1]+offset2.
     bool                indirectSecondOffset;
+
+    // Dictionary slot index result for a dictionary lookup
+    WORD                slot;
 } ;
 
 // Result of calling embedGenericHandle

--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -2068,6 +2068,10 @@ void SystemDomain::LoadBaseSystemClasses()
     g_pDelegateClass = MscorlibBinder::GetClass(CLASS__DELEGATE);
     g_pMulticastDelegateClass = MscorlibBinder::GetClass(CLASS__MULTICAST_DELEGATE);
 
+#ifndef CROSSGEN_COMPILE
+    CrossLoaderAllocatorHashSetup::EnsureTypesLoaded();
+#endif
+
     // used by IsImplicitInterfaceOfSZArray
     MscorlibBinder::GetClass(CLASS__IENUMERABLEGENERIC);
     MscorlibBinder::GetClass(CLASS__ICOLLECTIONGENERIC);
@@ -2082,10 +2086,6 @@ void SystemDomain::LoadBaseSystemClasses()
     // Load Utf8String
     g_pUtf8StringClass = MscorlibBinder::GetClass(CLASS__UTF8_STRING);
 #endif // FEATURE_UTF8STRING
-
-#ifndef CROSSGEN_COMPILE
-    CrossLoaderAllocatorHashSetup::EnsureTypesLoaded();
-#endif
 
 #ifndef CROSSGEN_COMPILE
     ECall::PopulateManagedStringConstructors();

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -13314,7 +13314,7 @@ void Module::ExpandTypeDictionaries_Locked(MethodTable* pMT, DictionaryLayout* p
 
     m_dynamicSlotsHashForTypes.VisitValuesOfKey(pCanonMT, expandPerInstInfos);
 
-    auto updateDependentDicts = [pCanonMT](OBJECTREF obj, MethodTable* pMTKey, MethodTable* pMTToUpdate)
+    auto updateDependentDicts = [](OBJECTREF obj, MethodTable* pMTKey, MethodTable* pMTToUpdate)
     {
         if (pMTToUpdate->HasSameTypeDefAs(pMTKey))
             return true;

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -13294,12 +13294,12 @@ void Module::ExpandTypeDictionaries_Locked(MethodTable* pMT, DictionaryLayout* p
     //      allocated one.
     //
 
-    auto expandPerInstInfos = [oldInfoSize, newInfoSize, pCanonMT](OBJECTREF obj, MethodTable* pMTKey, MethodTable* pMTToUpdate)
+    auto expandPerInstInfos = [oldInfoSize, newInfoSize](OBJECTREF obj, MethodTable* pMTKey, MethodTable* pMTToUpdate)
     {
         if (!pMTToUpdate->HasSameTypeDefAs(pMTKey))
             return true;
 
-        _ASSERTE(pMTToUpdate != pMTToUpdate->GetCanonicalMethodTable() && pMTToUpdate->GetCanonicalMethodTable() == pMTKey && pMTKey == pCanonMT);
+        _ASSERTE(pMTToUpdate != pMTToUpdate->GetCanonicalMethodTable() && pMTToUpdate->GetCanonicalMethodTable() == pMTKey);
 
         TypeHandle* pInstOrPerInstInfo = (TypeHandle*)(void*)pMTToUpdate->GetLoaderAllocator()->GetHighFrequencyHeap()->AllocMem(S_SIZE_T(newInfoSize));
         ZeroMemory(pInstOrPerInstInfo, newInfoSize);
@@ -13358,10 +13358,10 @@ void Module::ExpandMethodDictionaries_Locked(MethodDesc* pMD, DictionaryLayout* 
     DWORD oldInfoSize = DictionaryLayout::GetFirstDictionaryBucketSize(pMD->GetNumGenericMethodArgs(), pOldLayout);
     DWORD newInfoSize = DictionaryLayout::GetFirstDictionaryBucketSize(pMD->GetNumGenericMethodArgs(), pNewLayout);
 
-    auto lambda = [oldInfoSize, newInfoSize, pCanonMD](OBJECTREF obj, MethodDesc* pMDKey, MethodDesc* pMDToUpdate)
+    auto lambda = [oldInfoSize, newInfoSize](OBJECTREF obj, MethodDesc* pMDKey, MethodDesc* pMDToUpdate)
     {
         // Update m_pPerInstInfo for the pMethodDesc being visited here
-        _ASSERTE(pMDToUpdate->IsInstantiatingStub() && pMDToUpdate->GetWrappedMethodDesc() == pMDKey && pMDKey == pCanonMD);
+        _ASSERTE(pMDToUpdate->IsInstantiatingStub() && pMDToUpdate->GetWrappedMethodDesc() == pMDKey);
 
         InstantiatedMethodDesc* pInstantiatedMD = pMDToUpdate->AsInstantiatedMethodDesc();
 

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -556,6 +556,7 @@ void Module::Initialize(AllocMemTracker *pamTracker, LPCWSTR szName)
     m_FixupCrst.Init(CrstModuleFixup, (CrstFlags)(CRST_HOST_BREAKABLE|CRST_REENTRANCY));
     m_InstMethodHashTableCrst.Init(CrstInstMethodHashTable, CRST_REENTRANCY);
     m_ISymUnmanagedReaderCrst.Init(CrstISymUnmanagedReader, CRST_DEBUGGER_THREAD);
+    m_DictionaryCrst.Init(CrstDomainLocalBlock);
 
     if (!m_file->HasNativeImage())
     {
@@ -13245,7 +13246,7 @@ void Module::RecordTypeForDictionaryExpansion_Locked(MethodTable* pGenericParent
         GC_TRIGGERS;
         PRECONDITION(CheckPointer(pGenericParentMT) && CheckPointer(pDependencyMT));
         PRECONDITION(pGenericParentMT->HasInstantiation() && pGenericParentMT != pGenericParentMT->GetCanonicalMethodTable());
-        PRECONDITION(SystemDomain::IsUnderDomainLock());
+        PRECONDITION(SystemDomain::SystemModule()->m_DictionaryCrst.OwnedByCurrentThread());
     }
     CONTRACTL_END
 
@@ -13259,7 +13260,7 @@ void Module::RecordMethodForDictionaryExpansion_Locked(MethodDesc* pDependencyMD
     {
         GC_TRIGGERS;
         PRECONDITION(CheckPointer(pDependencyMD) && pDependencyMD->HasMethodInstantiation() && pDependencyMD->IsInstantiatingStub());
-        PRECONDITION(SystemDomain::IsUnderDomainLock());
+        PRECONDITION(SystemDomain::SystemModule()->m_DictionaryCrst.OwnedByCurrentThread());
     }
     CONTRACTL_END
         
@@ -13275,8 +13276,7 @@ void Module::ExpandTypeDictionaries_Locked(MethodTable* pMT, DictionaryLayout* p
         INJECT_FAULT(ThrowOutOfMemory(););
         PRECONDITION(CheckPointer(pOldLayout) && CheckPointer(pNewLayout));
         PRECONDITION(CheckPointer(pMT) && pMT->HasInstantiation() && pMT->GetClass()->GetDictionaryLayout() == pOldLayout);
-        PRECONDITION(SystemDomain::IsUnderDomainLock());
-
+        PRECONDITION(SystemDomain::SystemModule()->m_DictionaryCrst.OwnedByCurrentThread());
     }
     CONTRACTL_END
 
@@ -13348,7 +13348,7 @@ void Module::ExpandMethodDictionaries_Locked(MethodDesc* pMD, DictionaryLayout* 
         PRECONDITION(CheckPointer(pOldLayout) && CheckPointer(pNewLayout));
         PRECONDITION(CheckPointer(pMD));
         PRECONDITION(pMD->HasMethodInstantiation() && pMD->GetDictionaryLayout() == pOldLayout);
-        PRECONDITION(SystemDomain::IsUnderDomainLock());
+        PRECONDITION(SystemDomain::SystemModule()->m_DictionaryCrst.OwnedByCurrentThread());
     }
     CONTRACTL_END
 

--- a/src/vm/ceeload.h
+++ b/src/vm/ceeload.h
@@ -3240,6 +3240,25 @@ public:
 
     void SetNativeMetadataAssemblyRefInCache(DWORD rid, PTR_Assembly pAssembly);
 #endif // !defined(DACCESS_COMPILE)
+
+#ifndef CROSSGEN_COMPILE
+private:
+    class DynamicDictSlotsForTypesTrackerHashTraits : public NoRemoveDefaultCrossLoaderAllocatorHashTraits<MethodTable*, MethodTable*> { };
+    typedef CrossLoaderAllocatorHash<DynamicDictSlotsForTypesTrackerHashTraits> DynamicDictSlotsForTypesTrackerHash;
+
+    class DynamicDictSlotsForMethodsTrackerHashTraits : public NoRemoveDefaultCrossLoaderAllocatorHashTraits<MethodDesc*, MethodDesc*> { };
+    typedef CrossLoaderAllocatorHash<DynamicDictSlotsForMethodsTrackerHashTraits> DynamicDictSlotsForMethodsTrackerHash;
+
+    DynamicDictSlotsForTypesTrackerHash m_dynamicSlotsHashForTypes;
+    DynamicDictSlotsForMethodsTrackerHash m_dynamicSlotsHashForMethods;
+
+public:
+    void RecordTypeForDictionaryExpansion_Locked(MethodTable* pGenericParentMT, MethodTable* pDependencyMT);
+    void RecordMethodForDictionaryExpansion_Locked(MethodDesc* pDependencyMD);
+
+    void ExpandTypeDictionaries_Locked(MethodTable* pMT, DictionaryLayout* pOldLayout, DictionaryLayout* pNewLayout);
+    void ExpandMethodDictionaries_Locked(MethodDesc* pMD, DictionaryLayout* pOldLayout, DictionaryLayout* pNewLayout);
+#endif //!CROSSGEN_COMPILE
 };
 
 //

--- a/src/vm/ceeload.h
+++ b/src/vm/ceeload.h
@@ -3261,6 +3261,11 @@ public:
 
     void ExpandTypeDictionaries_Locked(MethodTable* pMT, DictionaryLayout* pOldLayout, DictionaryLayout* pNewLayout);
     void ExpandMethodDictionaries_Locked(MethodDesc* pMD, DictionaryLayout* pOldLayout, DictionaryLayout* pNewLayout);
+
+#ifdef _DEBUG
+    void EnsureTypeRecorded(MethodTable* pMT);
+    void EnsureMethodRecorded(MethodDesc* pMD);
+#endif
 #endif //!CROSSGEN_COMPILE
 };
 

--- a/src/vm/ceeload.h
+++ b/src/vm/ceeload.h
@@ -3241,6 +3241,9 @@ public:
     void SetNativeMetadataAssemblyRefInCache(DWORD rid, PTR_Assembly pAssembly);
 #endif // !defined(DACCESS_COMPILE)
 
+    // For protecting dictionary layout slot additions, and additions to the m_dynamicSlotsHashFor{Types/Methods} below
+    CrstExplicitInit        m_DictionaryCrst;
+
 #ifndef CROSSGEN_COMPILE
 private:
     class DynamicDictSlotsForTypesTrackerHashTraits : public NoRemoveDefaultCrossLoaderAllocatorHashTraits<MethodTable*, MethodTable*> { };

--- a/src/vm/class.cpp
+++ b/src/vm/class.cpp
@@ -1026,7 +1026,6 @@ void ClassLoader::RecordDependenciesForDictionaryExpansion(MethodTable* pMT)
             {
                 if (pMT->GetPerInstInfo()[iDict].GetValueMaybeNull() != pParentMT->GetPerInstInfo()[iDict].GetValueMaybeNull())
                 {
-                    EnsureWritablePages(&pMT->GetPerInstInfo()[iDict]);
                     pMT->GetPerInstInfo()[iDict].SetValueMaybeNull(pParentMT->GetPerInstInfo()[iDict].GetValueMaybeNull());
                 }
             }

--- a/src/vm/class.cpp
+++ b/src/vm/class.cpp
@@ -967,6 +967,9 @@ void ClassLoader::LoadExactParents(MethodTable *pMT)
 
     MethodTableBuilder::CopyExactParentSlots(pMT, pApproxParentMT);
 
+    // Record this type for dynamic dictionary expansion (if applicable)
+    RecordDependenciesForDictionaryExpansion(pMT);
+
     // We can now mark this type as having exact parents
     pMT->SetHasExactParent();
 

--- a/src/vm/class.cpp
+++ b/src/vm/class.cpp
@@ -1008,8 +1008,9 @@ void ClassLoader::RecordDependenciesForDictionaryExpansion(MethodTable* pMT)
             RETURN;
     }
 
-    SystemDomain::LockHolder lh;
     {
+        CrstHolder ch(&SystemDomain::SystemModule()->m_DictionaryCrst);
+
         // Update all inherited dictionary pointers which we could not embed, in case they got updated by some 
         // other thread during a dictionary expansion before taking this current lock.
         MethodTable* pParentMT = pMT->GetParentMethodTable();

--- a/src/vm/class.cpp
+++ b/src/vm/class.cpp
@@ -901,7 +901,7 @@ ClassLoader::LoadExactParentAndInterfacesTransitively(MethodTable *pMT)
     }
 
 
-    /*if (pParentMT != NULL && pParentMT->HasPerInstInfo())
+    if (pParentMT != NULL && pParentMT->HasPerInstInfo())
     {
         // Copy down all inherited dictionary pointers which we
         // could not embed.
@@ -913,7 +913,7 @@ ClassLoader::LoadExactParentAndInterfacesTransitively(MethodTable *pMT)
                 pMT->GetPerInstInfo()[iDict].SetValueMaybeNull(pParentMT->GetPerInstInfo()[iDict].GetValueMaybeNull());
             }
         }
-    }*/
+    }
 
 #ifdef FEATURE_PREJIT
     // Restore action, not in MethodTable::Restore because we may have had approx parents at that point
@@ -1014,7 +1014,7 @@ void ClassLoader::RecordDependenciesForDictionaryExpansion(MethodTable* pMT)
         MethodTable* pParentMT = pMT->GetParentMethodTable();
         if (pParentMT != NULL && pParentMT->HasPerInstInfo())
         {
-            // Copy down all inherited dictionary pointers which we could not embed.
+            // Copy/update down all inherited dictionary pointers which we could not embed.
             // This step has to be done under the dictionary lock, to prevent other threads from making updates
             // the the dictionaries of the parent types while we're also copying them over to the derived type here.
 
@@ -2800,7 +2800,7 @@ void EEClass::Save(DataImage *image, MethodTable *pMT)
     }
 
     // Save dictionary layout information
-    DictionaryLayout *pDictLayout = GetDictionaryLayout_Unsafe();
+    DictionaryLayout *pDictLayout = GetDictionaryLayout();
     if (pMT->IsSharedByGenericInstantiations() && pDictLayout != NULL)
     {
         pDictLayout->Save(image);
@@ -2919,7 +2919,7 @@ void EEClass::Fixup(DataImage *image, MethodTable *pMT)
     }
 #endif // FEATURE_COMINTEROP
 
-    DictionaryLayout *pDictLayout = GetDictionaryLayout_Unsafe();
+    DictionaryLayout *pDictLayout = GetDictionaryLayout();
     if (pDictLayout != NULL)
     {
         pDictLayout->Fixup(image, FALSE);

--- a/src/vm/class.h
+++ b/src/vm/class.h
@@ -1799,7 +1799,7 @@ public:
 public:
     // This API is not multi-threaded safe: the dictionary layout pointer can be updated by another
     // thread during a generic dictionary size expansion.
-    PTR_DictionaryLayout GetDictionaryLayout_Unsafe()
+    PTR_DictionaryLayout GetDictionaryLayout()
     {
         SUPPORTS_DAC;
         WRAPPER_NO_CONTRACT;

--- a/src/vm/class.h
+++ b/src/vm/class.h
@@ -1797,7 +1797,9 @@ public:
 
 
 public:
-    PTR_DictionaryLayout GetDictionaryLayout()
+    // This API is not multi-threaded safe: the dictionary layout pointer can be updated by another
+    // thread during a generic dictionary size expansion.
+    PTR_DictionaryLayout GetDictionaryLayout_Unsafe()
     {
         SUPPORTS_DAC;
         WRAPPER_NO_CONTRACT;

--- a/src/vm/clsload.cpp
+++ b/src/vm/clsload.cpp
@@ -3219,7 +3219,6 @@ TypeHandle ClassLoader::DoIncrementalLoad(TypeKey *pTypeKey, TypeHandle typeHnd,
             if (!typeHnd.IsTypeDesc())
             {
                 LoadExactParents(typeHnd.AsMethodTable());
-                RecordDependenciesForDictionaryExpansion(typeHnd.AsMethodTable());
             }
             break;
 

--- a/src/vm/clsload.cpp
+++ b/src/vm/clsload.cpp
@@ -3219,6 +3219,7 @@ TypeHandle ClassLoader::DoIncrementalLoad(TypeKey *pTypeKey, TypeHandle typeHnd,
             if (!typeHnd.IsTypeDesc())
             {
                 LoadExactParents(typeHnd.AsMethodTable());
+                RecordDependenciesForDictionaryExpansion(typeHnd.AsMethodTable());
             }
             break;
 
@@ -3268,14 +3269,13 @@ TypeHandle ClassLoader::CreateTypeHandleForTypeKey(TypeKey* pKey, AllocMemTracke
         if (IsCanonicalGenericInstantiation(pKey->GetInstantiation()))
         {
             typeHnd = CreateTypeHandleForTypeDefThrowing(pKey->GetModule(),
-                                                            pKey->GetTypeToken(),
-                                                            pKey->GetInstantiation(),
-                                                            pamTracker);
+                                                         pKey->GetTypeToken(),
+                                                         pKey->GetInstantiation(),
+                                                         pamTracker);
         }
         else
         {
-            typeHnd = CreateTypeHandleForNonCanonicalGenericInstantiation(pKey,
-                                                                                        pamTracker);
+            typeHnd = CreateTypeHandleForNonCanonicalGenericInstantiation(pKey, pamTracker);
         }
 #if defined(_DEBUG) && !defined(CROSSGEN_COMPILE)
         if (Nullable::IsNullableType(typeHnd))

--- a/src/vm/clsload.hpp
+++ b/src/vm/clsload.hpp
@@ -1007,6 +1007,8 @@ private:
     // Load exact parents and interfaces and dependent structures (generics dictionary, vtable fixes)
     static void LoadExactParents(MethodTable *pMT);
 
+    static void RecordDependenciesForDictionaryExpansion(MethodTable* pMT);
+
     static void LoadExactParentAndInterfacesTransitively(MethodTable *pMT);
 
     // Create a non-canonical instantiation of a generic type based off the canonical instantiation

--- a/src/vm/genericdict.cpp
+++ b/src/vm/genericdict.cpp
@@ -225,8 +225,8 @@ BOOL DictionaryLayout::FindTokenWorker(LoaderAllocator*                 pAllocat
             _ASSERT(SystemDomain::SystemModule()->m_DictionaryCrst.OwnedByCurrentThread());
 
             PVOID pResultSignature = pSigBuilder == NULL ? pSig : CreateSignatureWithSlotData(pSigBuilder, pAllocator, slot);
-            *EnsureWritablePages(&(pDictLayout->m_slots[iSlot].m_signature)) = pResultSignature;
-            *EnsureWritablePages(&(pDictLayout->m_slots[iSlot].m_signatureSource)) = signatureSource;
+            pDictLayout->m_slots[iSlot].m_signature = pResultSignature;
+            pDictLayout->m_slots[iSlot].m_signatureSource = signatureSource;
 
             pResult->signature = pDictLayout->m_slots[iSlot].m_signature;
 
@@ -268,9 +268,6 @@ DictionaryLayout* DictionaryLayout::ExpandDictionaryLayout(LoaderAllocator*     
     // There shouldn't be any empty slots remaining in the current dictionary.
     _ASSERTE(pCurrentDictLayout->m_slots[pCurrentDictLayout->m_numSlots - 1].m_signature != NULL);
 
-    // Expand the dictionary layout to add more slots
-    DWORD newNumSlots = (DWORD)pCurrentDictLayout->m_numSlots * 2;
-
 #ifdef _DEBUG
     // Stress debug mode by increasing size by only 1 slot
     if (!FitsIn<WORD>((DWORD)pCurrentDictLayout->m_numSlots + 1))
@@ -289,8 +286,8 @@ DictionaryLayout* DictionaryLayout::ExpandDictionaryLayout(LoaderAllocator*     
     WORD slot = static_cast<WORD>(numGenericArgs) + 1 + layoutSlotIndex;
 
     PVOID pResultSignature = pSigBuilder == NULL ? pSig : CreateSignatureWithSlotData(pSigBuilder, pAllocator, slot);
-    *EnsureWritablePages(&(pNewDictionaryLayout->m_slots[layoutSlotIndex].m_signature)) = pResultSignature;
-    *EnsureWritablePages(&(pNewDictionaryLayout->m_slots[layoutSlotIndex].m_signatureSource)) = signatureSource;
+    pNewDictionaryLayout->m_slots[layoutSlotIndex].m_signature = pResultSignature;
+    pNewDictionaryLayout->m_slots[layoutSlotIndex].m_signatureSource = signatureSource;
 
     pResult->signature = pNewDictionaryLayout->m_slots[layoutSlotIndex].m_signature;
 
@@ -527,7 +524,7 @@ DictionaryLayout::Trim()
     // Trim down the size to what's actually used
     DWORD dwSlots = GetNumUsedSlots();
     _ASSERTE(FitsIn<WORD>(dwSlots));
-    *EnsureWritablePages(&m_numSlots) = static_cast<WORD>(dwSlots);
+    m_numSlots = static_cast<WORD>(dwSlots);
 
 }
 
@@ -1391,7 +1388,7 @@ Dictionary::PopulateEntry(
 
             Dictionary* pDictionary = pMT != NULL ? pMT->GetDictionary() : pMD->GetMethodDictionary();
 
-            *EnsureWritablePages(pDictionary->GetSlotAddr(0, slotIndex)) = result;
+            *(pDictionary->GetSlotAddr(0, slotIndex)) = result;
             *ppSlot = pDictionary->GetSlotAddr(0, slotIndex);
         }
     }

--- a/src/vm/genericdict.cpp
+++ b/src/vm/genericdict.cpp
@@ -1389,6 +1389,13 @@ Dictionary::PopulateEntry(
             // Lock is needed because dictionary pointers can get updated during dictionary size expansion
             CrstHolder ch(&SystemDomain::SystemModule()->m_DictionaryCrst);
 
+#if !defined(CROSSGEN_COMPILE) && defined(_DEBUG)
+            if (pMT != NULL)
+                pMT->GetModule()->EnsureTypeRecorded(pMT);
+            else
+                pMD->GetModule()->EnsureMethodRecorded(pMD);
+#endif
+
             Dictionary* pDictionary = pMT != NULL ? pMT->GetDictionary() : pMD->GetMethodDictionary();
 
             *EnsureWritablePages(pDictionary->GetSlotAddr(0, slotIndex)) = result;

--- a/src/vm/genericdict.cpp
+++ b/src/vm/genericdict.cpp
@@ -32,12 +32,6 @@
 #include "sigbuilder.h"
 #include "compile.h"
 
-#ifdef _DEBUG
-#define NUM_DEBUG_SLOTS 1
-#else
-#define NUM_DEBUG_SLOTS 0
-#endif 
-
 #ifndef DACCESS_COMPILE 
 
 //---------------------------------------------------------------------------------------
@@ -95,7 +89,6 @@ DictionaryLayout::GetDictionarySizeFromLayout(
     if (pDictLayout != NULL)
     {
         bytes += sizeof(ULONG_PTR*);                            // Slot for dictionary size
-        bytes += (sizeof(void*) * NUM_DEBUG_SLOTS);             // Slots for debug purposes
         bytes += pDictLayout->m_numSlots * sizeof(void*);       // Slots for dictionary slots based on a dictionary layout
     }
 
@@ -143,8 +136,8 @@ BOOL DictionaryLayout::FindTokenWorker(LoaderAllocator*                 pAllocat
     CONTRACTL_END
 
     // First slots contain the type parameters
-    _ASSERTE(FitsIn<WORD>(numGenericArgs + 1 + NUM_DEBUG_SLOTS + scanFromSlot));
-    WORD slot = static_cast<WORD>(numGenericArgs + 1 + NUM_DEBUG_SLOTS + scanFromSlot);
+    _ASSERTE(FitsIn<WORD>(numGenericArgs + 1 + scanFromSlot));
+    WORD slot = static_cast<WORD>(numGenericArgs + 1 + scanFromSlot);
 
 #if _DEBUG
     if (scanFromSlot > 0)
@@ -293,7 +286,7 @@ DictionaryLayout* DictionaryLayout::ExpandDictionaryLayout(LoaderAllocator*     
         pNewDictionaryLayout->m_slots[iSlot] = pCurrentDictLayout->m_slots[iSlot];
 
     WORD layoutSlotIndex = pCurrentDictLayout->m_numSlots;
-    WORD slot = static_cast<WORD>(numGenericArgs) + 1 + NUM_DEBUG_SLOTS + layoutSlotIndex;
+    WORD slot = static_cast<WORD>(numGenericArgs) + 1 + layoutSlotIndex;
 
     PVOID pResultSignature = pSigBuilder == NULL ? pSig : CreateSignatureWithSlotData(pSigBuilder, pAllocator, slot);
     *EnsureWritablePages(&(pNewDictionaryLayout->m_slots[layoutSlotIndex].m_signature)) = pResultSignature;

--- a/src/vm/genericdict.cpp
+++ b/src/vm/genericdict.cpp
@@ -32,7 +32,13 @@
 #include "sigbuilder.h"
 #include "compile.h"
 
-#ifndef DACCESS_COMPILE
+#ifdef _DEBUG
+#define NUM_DEBUG_SLOTS 1
+#else
+#define NUM_DEBUG_SLOTS 0
+#endif 
+
+#ifndef DACCESS_COMPILE 
 
 //---------------------------------------------------------------------------------------
 //
@@ -89,6 +95,7 @@ DictionaryLayout::GetDictionarySizeFromLayout(
     if (pDictLayout != NULL)
     {
         bytes += sizeof(ULONG_PTR*);                            // Slot for dictionary size
+        bytes += (sizeof(void*) * NUM_DEBUG_SLOTS);             // Slots for debug purposes
         bytes += pDictLayout->m_numSlots * sizeof(void*);       // Slots for dictionary slots based on a dictionary layout
     }
 
@@ -136,8 +143,8 @@ BOOL DictionaryLayout::FindTokenWorker(LoaderAllocator*                 pAllocat
     CONTRACTL_END
 
     // First slots contain the type parameters
-    _ASSERTE(FitsIn<WORD>(numGenericArgs + 1 + scanFromSlot));
-    WORD slot = static_cast<WORD>(numGenericArgs + 1 + scanFromSlot);
+    _ASSERTE(FitsIn<WORD>(numGenericArgs + 1 + NUM_DEBUG_SLOTS + scanFromSlot));
+    WORD slot = static_cast<WORD>(numGenericArgs + 1 + NUM_DEBUG_SLOTS + scanFromSlot);
 
 #if _DEBUG
     if (scanFromSlot > 0)
@@ -286,7 +293,7 @@ DictionaryLayout* DictionaryLayout::ExpandDictionaryLayout(LoaderAllocator*     
         pNewDictionaryLayout->m_slots[iSlot] = pCurrentDictLayout->m_slots[iSlot];
 
     WORD layoutSlotIndex = pCurrentDictLayout->m_numSlots;
-    WORD slot = static_cast<WORD>(numGenericArgs) + 1 + layoutSlotIndex;
+    WORD slot = static_cast<WORD>(numGenericArgs) + 1 + NUM_DEBUG_SLOTS + layoutSlotIndex;
 
     PVOID pResultSignature = pSigBuilder == NULL ? pSig : CreateSignatureWithSlotData(pSigBuilder, pAllocator, slot);
     *EnsureWritablePages(&(pNewDictionaryLayout->m_slots[layoutSlotIndex].m_signature)) = pResultSignature;

--- a/src/vm/genericdict.cpp
+++ b/src/vm/genericdict.cpp
@@ -347,9 +347,6 @@ BOOL DictionaryLayout::FindToken(MethodTable*                       pMT,
         // First, expand the PerInstInfo dictionaries on types that were using the dictionary layout that just got expanded, and expand their slots
         pMT->GetModule()->ExpandTypeDictionaries_Locked(pMT, pOldLayout, pNewLayout);
 
-        // Ensure no other thread uses old dictionary pointers
-        FlushProcessWriteBuffers();
-
         // Finally, update the dictionary layout pointer after all dictionaries of instantiated types have expanded, so that subsequent calls to 
         // DictionaryLayout::FindToken can use this. It is important to update the dictionary layout at the very last step, otherwise some other threads
         // can start using newly added dictionary layout slots on types where the PerInstInfo hasn't expanded yet, and cause runtime failures.
@@ -405,9 +402,6 @@ BOOL DictionaryLayout::FindToken(MethodDesc*                        pMD,
 
         // First, expand the PerInstInfo dictionaries on methods that were using the dictionary layout that just got expanded, and expand their slots
         pMD->GetModule()->ExpandMethodDictionaries_Locked(pMD, pOldLayout, pNewLayout);
-
-        // Ensure no other thread uses old dictionary pointers
-        FlushProcessWriteBuffers();
 
         // Finally, update the dictionary layout pointer after all dictionaries of instantiated methods have expanded, so that subsequent calls to 
         // DictionaryLayout::FindToken can use this. It is important to update the dictionary layout at the very last step, otherwise some other threads

--- a/src/vm/genericdict.cpp
+++ b/src/vm/genericdict.cpp
@@ -338,6 +338,9 @@ BOOL DictionaryLayout::FindToken(MethodTable*                       pMT,
         // can start using newly added dictionary layout slots on types where the PerInstInfo hasn't expanded yet, and cause runtime failures.
         pMT->GetClass()->SetDictionaryLayout(pNewLayout);
 
+        // Ensure no other thread uses old dictionary pointers
+        FlushProcessWriteBuffers();
+
         return TRUE;
 #else
         pResult->signature = pSigBuilder == NULL ? pSig : CreateSignatureWithSlotData(pSigBuilder, pAllocator, 0);
@@ -393,6 +396,9 @@ BOOL DictionaryLayout::FindToken(MethodDesc*                        pMD,
         // DictionaryLayout::FindToken can use this. It is important to update the dictionary layout at the very last step, otherwise some other threads
         // can start using newly added dictionary layout slots on methods where the PerInstInfo hasn't expanded yet, and cause runtime failures.
         pMD->AsInstantiatedMethodDesc()->IMD_SetDictionaryLayout(pNewLayout);
+
+        // Ensure no other thread uses old dictionary pointers
+        FlushProcessWriteBuffers();
 
         return TRUE;
 #else

--- a/src/vm/genericdict.cpp
+++ b/src/vm/genericdict.cpp
@@ -124,7 +124,7 @@ BOOL DictionaryLayout::FindTokenWorker(LoaderAllocator*                 pAllocat
     {
         STANDARD_VM_CHECK;
         PRECONDITION(numGenericArgs > 0);
-        PRECONDITION(scanFromSlot >= 0 && scanFromSlot < pDictLayout->m_numSlots);
+        PRECONDITION(scanFromSlot >= 0 && scanFromSlot <= pDictLayout->m_numSlots);
         PRECONDITION(CheckPointer(pDictLayout));
         PRECONDITION(CheckPointer(pResult) && CheckPointer(pSlotOut));
         PRECONDITION(CheckPointer(pSig));
@@ -237,6 +237,7 @@ BOOL DictionaryLayout::FindTokenWorker(LoaderAllocator*                 pAllocat
         slot++;
     }
 
+    *pSlotOut = pDictLayout->m_numSlots;
     return FALSE;
 }
 

--- a/src/vm/genericdict.h
+++ b/src/vm/genericdict.h
@@ -125,6 +125,7 @@ private:
                                 DictionaryEntrySignatureSource      signatureSource,
                                 CORINFO_RUNTIME_LOOKUP*             pResult,
                                 WORD*                               pSlotOut,
+                                DWORD                               scanFromSlot = 0,
                                 BOOL                                useEmptySlotIfFound = FALSE);
 
 

--- a/src/vm/genericdict.h
+++ b/src/vm/genericdict.h
@@ -120,6 +120,7 @@ private:
                                 int                                 nFirstOffset,
                                 DictionaryEntrySignatureSource      signatureSource,
                                 CORINFO_RUNTIME_LOOKUP*             pResult,
+                                WORD*                               pSlotOut,
                                 BOOL                                useEmptySlotIfFound = FALSE);
 
 
@@ -130,7 +131,8 @@ private:
                                                     BYTE*                           pSig,
                                                     int                             nFirstOffset,
                                                     DictionaryEntrySignatureSource  signatureSource,
-                                                    CORINFO_RUNTIME_LOOKUP*         pResult);
+                                                    CORINFO_RUNTIME_LOOKUP*         pResult,
+                                                    WORD*                           pSlotOut);
      
     static PVOID CreateSignatureWithSlotData(SigBuilder* pSigBuilder, LoaderAllocator* pAllocator, WORD slot);
 
@@ -148,7 +150,8 @@ public:
                           SigBuilder*                       pSigBuilder,
                           BYTE*                             pSig,
                           DictionaryEntrySignatureSource    signatureSource,
-                          CORINFO_RUNTIME_LOOKUP*           pResult);
+                          CORINFO_RUNTIME_LOOKUP*           pResult,
+                          WORD*                             pSlotOut);
 
     static BOOL FindToken(MethodDesc*                       pMD,
                           LoaderAllocator*                  pAllocator,
@@ -156,7 +159,8 @@ public:
                           SigBuilder*                       pSigBuilder,
                           BYTE*                             pSig,
                           DictionaryEntrySignatureSource    signatureSource,
-                          CORINFO_RUNTIME_LOOKUP*           pResult);
+                          CORINFO_RUNTIME_LOOKUP*           pResult,
+                          WORD*                             pSlotOut);
 
     DWORD GetMaxSlots();
     DWORD GetNumUsedSlots();

--- a/src/vm/genericdict.h
+++ b/src/vm/genericdict.h
@@ -94,7 +94,11 @@ typedef DPTR(DictionaryLayout) PTR_DictionaryLayout;
 
 // Number of slots to initially allocate in a generic method dictionary layout.
 // Also the number of additional slots to add to an existing dictionary layout when expanding its size
-#define NUM_DICTIONARY_SLOTS 8
+#if _DEBUG
+#define NUM_DICTIONARY_SLOTS 1  // Smaller number to stress the dictionary expansion logic
+#else
+#define NUM_DICTIONARY_SLOTS 4
+#endif
 
 // The type of dictionary layouts. We don't include the number of type
 // arguments as this is obtained elsewhere

--- a/src/vm/genericdict.h
+++ b/src/vm/genericdict.h
@@ -125,8 +125,8 @@ private:
                                 DictionaryEntrySignatureSource      signatureSource,
                                 CORINFO_RUNTIME_LOOKUP*             pResult,
                                 WORD*                               pSlotOut,
-                                DWORD                               scanFromSlot = 0,
-                                BOOL                                useEmptySlotIfFound = FALSE);
+                                DWORD                               scanFromSlot,
+                                BOOL                                useEmptySlotIfFound);
 
 
     static DictionaryLayout* ExpandDictionaryLayout(LoaderAllocator*                pAllocator,

--- a/src/vm/genericdict.h
+++ b/src/vm/genericdict.h
@@ -93,7 +93,6 @@ class DictionaryLayout;
 typedef DPTR(DictionaryLayout) PTR_DictionaryLayout;
 
 // Number of slots to initially allocate in a generic method dictionary layout.
-// Also the number of additional slots to add to an existing dictionary layout when expanding its size
 #if _DEBUG
 #define NUM_DICTIONARY_SLOTS 1  // Smaller number to stress the dictionary expansion logic
 #else
@@ -145,9 +144,9 @@ public:
     // Create an initial dictionary layout with a single bucket containing numSlots slots
     static DictionaryLayout* Allocate(WORD numSlots, LoaderAllocator *pAllocator, AllocMemTracker *pamTracker);
 
-    // Bytes used for the first bucket of this dictionary, which might be stored inline in
+    // Bytes used for this dictionary, which might be stored inline in
     // another structure (e.g. MethodTable)
-    static DWORD GetFirstDictionaryBucketSize(DWORD numGenericArgs, PTR_DictionaryLayout pDictLayout);
+    static DWORD GetDictionarySizeFromLayout(DWORD numGenericArgs, PTR_DictionaryLayout pDictLayout);
 
     static BOOL FindToken(MethodTable*                      pMT,
                           LoaderAllocator*                  pAllocator,

--- a/src/vm/generics.cpp
+++ b/src/vm/generics.cpp
@@ -283,7 +283,7 @@ ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation(
     // this rare race condition, right before registering this type for dictionary expansions, we will check that its
     // dictionary has enough slots to match its dictionary layout if it got updated.
     // See: Module::RecordTypeForDictionaryExpansion_Locked.
-    DWORD cbInstAndDict = pOldMT->GetInstAndDictSize_Unsafe();
+    DWORD cbInstAndDict = pOldMT->GetInstAndDictSize();
 
     // Allocate from the high frequence heap of the correct domain
     S_SIZE_T allocSize = safe_cbMT;
@@ -493,10 +493,10 @@ ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation(
         pInstDest[iArg] = inst[iArg];
     }
 
-    if (cbInstAndDict != 0 && pOldMT->GetClass()->GetDictionaryLayout_Unsafe() != NULL && pOldMT->GetClass()->GetDictionaryLayout_Unsafe()->GetMaxSlots() > 0)
+    if (cbInstAndDict != 0 && pOldMT->GetClass()->GetDictionaryLayout() != NULL && pOldMT->GetClass()->GetDictionaryLayout()->GetMaxSlots() > 0)
     {
-        UINT_PTR* pDictionarySlots = (UINT_PTR*)pMT->GetPerInstInfo()[pOldMT->GetNumDicts() - 1].GetValue();
-        UINT_PTR* pSizeSlot = pDictionarySlots + ntypars;
+        ULONG_PTR* pDictionarySlots = (ULONG_PTR*)pMT->GetPerInstInfo()[pOldMT->GetNumDicts() - 1].GetValue();
+        ULONG_PTR* pSizeSlot = pDictionarySlots + ntypars;
         *pSizeSlot = cbInstAndDict;
     }
 

--- a/src/vm/genmeth.cpp
+++ b/src/vm/genmeth.cpp
@@ -1188,7 +1188,7 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
 #ifndef CROSSGEN_COMPILE
                 if (pInstMD->HasMethodInstantiation())
                 {
-                    SystemDomain::LockHolder lh;
+                    CrstHolder ch(&SystemDomain::SystemModule()->m_DictionaryCrst);
                     pInstMD->GetModule()->RecordMethodForDictionaryExpansion_Locked(pInstMD);
                 }
 #endif

--- a/src/vm/genmeth.cpp
+++ b/src/vm/genmeth.cpp
@@ -63,7 +63,6 @@
 // should be the normalized representative genericMethodArgs (see typehandle.h)
 //
 
-
 // Helper method that creates a method-desc off a template method desc
 static MethodDesc* CreateMethodDesc(LoaderAllocator *pAllocator,
                                     MethodTable *pMT,
@@ -378,9 +377,8 @@ InstantiatedMethodDesc::NewInstantiatedMethodDesc(MethodTable *pExactMT,
             }
             else if (getWrappedCode)
             {
-                // 4 seems like a good number
-                pDL = DictionaryLayout::Allocate(4, pAllocator, &amt);
-#ifdef _DEBUG
+                pDL = DictionaryLayout::Allocate(NUM_DICTIONARY_SLOTS, pAllocator, &amt);
+#ifdef _DEBUG 
                 {
                     SString name;
                     TypeString::AppendMethodDebug(name, pGenericMDescInRepMT);
@@ -1186,6 +1184,14 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
                                                                             pWrappedMD,
                                                                             methodInst,
                                                                             FALSE);
+
+#ifndef CROSSGEN_COMPILE
+                if (pInstMD->HasMethodInstantiation())
+                {
+                    SystemDomain::LockHolder lh;
+                    pInstMD->GetModule()->RecordMethodForDictionaryExpansion_Locked(pInstMD);
+                }
+#endif
             }
         }
         else

--- a/src/vm/interoputil.cpp
+++ b/src/vm/interoputil.cpp
@@ -5833,7 +5833,7 @@ MethodDesc *WinRTInterfaceRedirector::GetStubMethodForRedirectedInterface(WinMDA
 
                 if (interfaceIndex == WinMDAdapter::RedirectedTypeIndex_System_Collections_Generic_IDictionary ||
                     interfaceIndex == WinMDAdapter::RedirectedTypeIndex_System_Collections_Generic_IReadOnlyDictionary)
-                {
+                {                
                     thKvPair = TypeHandle(MscorlibBinder::GetClass(CLASS__KEYVALUEPAIRGENERIC)).Instantiate(inst);
                     inst = Instantiation(&thKvPair, 1);
                 }

--- a/src/vm/interoputil.cpp
+++ b/src/vm/interoputil.cpp
@@ -5833,7 +5833,7 @@ MethodDesc *WinRTInterfaceRedirector::GetStubMethodForRedirectedInterface(WinMDA
 
                 if (interfaceIndex == WinMDAdapter::RedirectedTypeIndex_System_Collections_Generic_IDictionary ||
                     interfaceIndex == WinMDAdapter::RedirectedTypeIndex_System_Collections_Generic_IReadOnlyDictionary)
-                {                
+                {
                     thKvPair = TypeHandle(MscorlibBinder::GetClass(CLASS__KEYVALUEPAIRGENERIC)).Instantiate(inst);
                     inst = Instantiation(&thKvPair, 1);
                 }

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -3488,13 +3488,15 @@ NoSpecialCase:
 
     DictionaryEntrySignatureSource signatureSource = (IsCompilationProcess() ? FromZapImage : FromJIT);
 
+    WORD dummySlot;
+
     // It's a method dictionary lookup
     if (pResultLookup->lookupKind.runtimeLookupKind == CORINFO_LOOKUP_METHODPARAM)
     {
         _ASSERTE(pContextMD != NULL);
         _ASSERTE(pContextMD->HasMethodInstantiation());
 
-        if (DictionaryLayout::FindToken(pContextMD, pContextMD->GetLoaderAllocator(), 1, &sigBuilder, NULL, signatureSource, pResult))
+        if (DictionaryLayout::FindToken(pContextMD, pContextMD->GetLoaderAllocator(), 1, &sigBuilder, NULL, signatureSource, pResult, &dummySlot))
         {
             pResult->testForNull = 1;
             pResult->testForFixup = 0;
@@ -3512,7 +3514,7 @@ NoSpecialCase:
     // It's a class dictionary lookup (CORINFO_LOOKUP_CLASSPARAM or CORINFO_LOOKUP_THISOBJ)
     else
     {
-        if (DictionaryLayout::FindToken(pContextMT, pContextMT->GetLoaderAllocator(), 2, &sigBuilder, NULL, signatureSource, pResult))
+        if (DictionaryLayout::FindToken(pContextMT, pContextMT->GetLoaderAllocator(), 2, &sigBuilder, NULL, signatureSource, pResult, &dummySlot))
         {
             pResult->testForNull = 1;
             pResult->testForFixup = 0;

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -3494,7 +3494,7 @@ NoSpecialCase:
         _ASSERTE(pContextMD != NULL);
         _ASSERTE(pContextMD->HasMethodInstantiation());
 
-        if (DictionaryLayout::FindToken(pContextMD->GetLoaderAllocator(), pContextMD->GetNumGenericMethodArgs(), pContextMD->GetDictionaryLayout(), pResult, &sigBuilder, 1, signatureSource))
+        if (DictionaryLayout::FindToken(pContextMD, pContextMD->GetLoaderAllocator(), 1, &sigBuilder, NULL, signatureSource, pResult))
         {
             pResult->testForNull = 1;
             pResult->testForFixup = 0;
@@ -3512,7 +3512,7 @@ NoSpecialCase:
     // It's a class dictionary lookup (CORINFO_LOOKUP_CLASSPARAM or CORINFO_LOOKUP_THISOBJ)
     else
     {
-        if (DictionaryLayout::FindToken(pContextMT->GetLoaderAllocator(), pContextMT->GetNumGenericArgs(), pContextMT->GetClass()->GetDictionaryLayout(), pResult, &sigBuilder, 2, signatureSource))
+        if (DictionaryLayout::FindToken(pContextMT, pContextMT->GetLoaderAllocator(), 2, &sigBuilder, NULL, signatureSource, pResult))
         {
             pResult->testForNull = 1;
             pResult->testForFixup = 0;

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -1594,9 +1594,7 @@ MethodDesc *MethodDesc::GetWrappedMethodDesc()
                                                             this->GetMethodTable(),
                                                             FALSE, /* no unboxing entrypoint */
                                                             this->GetMethodInstantiation(),
-                                                            TRUE, /* get shared code */ 
-                                                            FALSE /* forceRemotableMethod */, 
-                                                            FALSE /* allowCreate */);
+                                                            TRUE /* get shared code */ );
         _ASSERTE(pAltMD == pRet);
 #endif // _DEBUG
         return pRet;

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -1594,7 +1594,9 @@ MethodDesc *MethodDesc::GetWrappedMethodDesc()
                                                             this->GetMethodTable(),
                                                             FALSE, /* no unboxing entrypoint */
                                                             this->GetMethodInstantiation(),
-                                                            TRUE /* get shared code */ );
+                                                            TRUE, /* get shared code */ 
+                                                            FALSE /* forceRemotableMethod */, 
+                                                            FALSE /* allowCreate */);
         _ASSERTE(pAltMD == pRet);
 #endif // _DEBUG
         return pRet;

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -3690,7 +3690,8 @@ private:
                                                              MethodDesc* pGenericMDescInRepMT,
                                                              MethodDesc* pSharedMDescForStub,
                                                              Instantiation methodInst,
-                                                             BOOL getSharedNotStub);
+                                                             BOOL getSharedNotStub,
+                                                             BOOL recordForDictionaryExpansion);
 
 };
 

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -502,8 +502,8 @@ public:
     // Return NULL if not an instantiated method
     // These APIs are not multi-threaded safe: the dictionary and dictionary layout pointers
     // can be updated by other threads during a dictionary size expansion.
-    Dictionary* GetMethodDictionary_Unsafe();
-    DictionaryLayout* GetDictionaryLayout_Unsafe();
+    Dictionary* GetMethodDictionary();
+    DictionaryLayout* GetDictionaryLayout();
 
     InstantiatedMethodDesc* AsInstantiatedMethodDesc() const;
 
@@ -3473,12 +3473,12 @@ public:
         
         // No lock needed here. This is considered a safe operation here because in the case of a generic dictionary
         // expansion, the values of the old dictionary slots are copied to the newly allocated dictionary, and the old
-        // dictionary is kept around, so whether IMD_GetMethodDictionary_Unsafe returns the new or old dictionaries, the
+        // dictionary is kept around, so whether IMD_GetMethodDictionary returns the new or old dictionaries, the
         // values of the instantiation arguments will always be the same.
-        return Instantiation(IMD_GetMethodDictionary_Unsafe()->GetInstantiation(), m_wNumGenericArgs);
+        return Instantiation(IMD_GetMethodDictionary()->GetInstantiation(), m_wNumGenericArgs);
     }
 
-    PTR_Dictionary IMD_GetMethodDictionary_Unsafe()
+    PTR_Dictionary IMD_GetMethodDictionary()
     {
         LIMITED_METHOD_DAC_CONTRACT;
 
@@ -3489,7 +3489,7 @@ public:
     DWORD GetDictionarySlotsSize();
 #endif
 
-    PTR_Dictionary IMD_GetMethodDictionaryNonNull_Unsafe()
+    PTR_Dictionary IMD_GetMethodDictionaryNonNull()
     {
         LIMITED_METHOD_DAC_CONTRACT;
 

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -3574,11 +3574,24 @@ public:
             InstantiatedMethodDesc* pIMD = IMD_GetWrappedMethodDesc()->AsInstantiatedMethodDesc();
             return pIMD->m_pDictLayout.GetValueMaybeNull();
         }
-        else
-        if (IMD_IsSharedByGenericMethodInstantiations())
+        else if (IMD_IsSharedByGenericMethodInstantiations())
             return m_pDictLayout.GetValueMaybeNull();
         else
             return NULL;
+    }
+
+    void IMD_SetDictionaryLayout(DictionaryLayout* pNewLayout)
+    {
+        WRAPPER_NO_CONTRACT;
+        if (IMD_IsWrapperStubWithInstantiations() && IMD_HasMethodInstantiation())
+        {
+            InstantiatedMethodDesc* pIMD = IMD_GetWrappedMethodDesc()->AsInstantiatedMethodDesc();
+            pIMD->m_pDictLayout.SetValueMaybeNull(pNewLayout);
+        }
+        else if (IMD_IsSharedByGenericMethodInstantiations())
+        {
+            m_pDictLayout.SetValueMaybeNull(pNewLayout);
+        }
     }
 #endif // !DACCESS_COMPILE
 

--- a/src/vm/methodtable.cpp
+++ b/src/vm/methodtable.cpp
@@ -475,6 +475,25 @@ void MethodTable::SetModule(Module * pModule)
 
     _ASSERTE(GetModule() == pModule);
 }
+
+DWORD MethodTable::GetDictionarySlotsSize()
+{
+    CONTRACTL
+    {
+        PRECONDITION(SystemDomain::SystemModule()->m_DictionaryCrst.OwnedByCurrentThread());
+    }
+    CONTRACTL_END
+
+    if (!HasPerInstInfo() || GetGenericsDictInfo()->m_wNumTyPars == 0 || GetClass()->GetDictionaryLayout_Unsafe() == NULL)
+        return 0;
+
+    if (GetClass()->GetDictionaryLayout_Unsafe()->GetMaxSlots() == 0)
+        return 0;
+
+    UINT_PTR* pDictionarySlots = (UINT_PTR*)GetPerInstInfo()[GetGenericsDictInfo()->m_wNumDicts - 1].GetValue();
+    UINT_PTR* pSizeSlot = pDictionarySlots + GetGenericsDictInfo()->m_wNumTyPars;
+    return (DWORD)* pSizeSlot;
+}
 #endif // DACCESS_COMPILE
 
 //==========================================================================================
@@ -3972,7 +3991,7 @@ void MethodTable::PrepopulateDictionary(DataImage * image, BOOL nonExpansive)
 {
      STANDARD_VM_CONTRACT;
 
-     if (GetDictionary())
+     if (GetDictionary_Unsafe())
      {
          // We can only save elements of the dictionary if we are sure of its
          // layout, which means we must be either tightly-knit to the EEClass
@@ -3984,7 +4003,7 @@ void MethodTable::PrepopulateDictionary(DataImage * image, BOOL nonExpansive)
          if (!IsCanonicalMethodTable() && image->CanEagerBindToMethodTable(GetCanonicalMethodTable()))
          {
              LOG((LF_JIT, LL_INFO10000, "GENERICS: Prepopulating dictionary for MT %s\n",  GetDebugClassName()));
-             GetDictionary()->PrepopulateDictionary(NULL, this, nonExpansive);
+             GetDictionary_Unsafe()->PrepopulateDictionary(NULL, this, nonExpansive);
          }
      }
 }
@@ -4056,11 +4075,11 @@ void MethodTable::Save(DataImage *image, DWORD profilingFlags)
 
     // Be careful about calling DictionaryLayout::Trim - strict conditions apply.
     // See note on that method.
-    if (GetDictionary() &&
-        GetClass()->GetDictionaryLayout() &&
+    if (GetDictionary_Unsafe() &&
+        GetClass()->GetDictionaryLayout_Unsafe() &&
         image->CanEagerBindToMethodTable(GetCanonicalMethodTable()))
     {
-        GetClass()->GetDictionaryLayout()->Trim();
+        GetClass()->GetDictionaryLayout_Unsafe()->Trim();
     }
 
     // Set the "restore" flags. They may not have been set yet.
@@ -4222,7 +4241,7 @@ void MethodTable::Save(DataImage *image, DWORD profilingFlags)
         image->BindPointer(GetPerInstInfo(), pPerInstInfoNode, sizeof(GenericsDictInfo));
     }
 
-    Dictionary * pDictionary = GetDictionary();
+    Dictionary * pDictionary = GetDictionary_Unsafe();
     if (pDictionary != NULL)
     {
         BOOL fIsWriteable;
@@ -4236,7 +4255,7 @@ void MethodTable::Save(DataImage *image, DWORD profilingFlags)
             fIsWriteable = pDictionary->IsWriteable(image, canSaveSlots,
                                        GetNumGenericArgs(),
                                        GetModule(),
-                                       GetClass()->GetDictionaryLayout());
+                                       GetClass()->GetDictionaryLayout_Unsafe());
         }
         else
         {
@@ -4246,11 +4265,11 @@ void MethodTable::Save(DataImage *image, DWORD profilingFlags)
 
         if (!fIsWriteable)
         {
-            image->StoreInternedStructure(pDictionary, GetInstAndDictSize(), DataImage::ITEM_DICTIONARY);
+            image->StoreInternedStructure(pDictionary, GetInstAndDictSize_Unsafe(), DataImage::ITEM_DICTIONARY);
         }
         else
         {
-            image->StoreStructure(pDictionary, GetInstAndDictSize(), DataImage::ITEM_DICTIONARY_WRITEABLE);
+            image->StoreStructure(pDictionary, GetInstAndDictSize_Unsafe(), DataImage::ITEM_DICTIONARY_WRITEABLE);
         }
     }
 
@@ -4445,9 +4464,9 @@ BOOL MethodTable::ComputeNeedsRestoreWorker(DataImage *image, TypeHandleList *pV
     }
 
     // Now check if the dictionary (if any) owned by this methodtable needs a restore.
-    if (GetDictionary())
+    if (GetDictionary_Unsafe())
     {
-        if (GetDictionary()->ComputeNeedsRestore(image, pVisited, GetNumGenericArgs()))
+        if (GetDictionary_Unsafe()->ComputeNeedsRestore(image, pVisited, GetNumGenericArgs()))
         {
             UPDATE_RESTORE_REASON(GenericsDictionaryNeedsRestore);
             return TRUE;
@@ -4969,7 +4988,7 @@ void MethodTable::Fixup(DataImage *image)
     //
     // Fixup instantiation+dictionary for this method table (if any)
     //
-    if (GetDictionary())
+    if (GetDictionary_Unsafe())
     {
         LOG((LF_JIT, LL_INFO10000, "GENERICS: Fixup dictionary for MT %s\n",  GetDebugClassName()));
 
@@ -4978,12 +4997,12 @@ void MethodTable::Fixup(DataImage *image)
         BOOL canSaveSlots = !IsCanonicalMethodTable() && (image->GetModule() == GetCanonicalMethodTable()->GetLoaderModule());
 
         // See comment on Dictionary::Fixup
-        GetDictionary()->Fixup(image,
+        GetDictionary_Unsafe()->Fixup(image,
                                TRUE,
                                canSaveSlots,
                                GetNumGenericArgs(),
                                GetModule(),
-                               GetClass()->GetDictionaryLayout());
+                               GetClass()->GetDictionaryLayout_Unsafe());
     }
 
     // Fixup per-inst statics info
@@ -6118,7 +6137,7 @@ BOOL MethodTable::IsWinRTObjectType()
 //==========================================================================================
 // Return a pointer to the dictionary for an instantiated type
 // Return NULL if not instantiated
-PTR_Dictionary MethodTable::GetDictionary()
+PTR_Dictionary MethodTable::GetDictionary_Unsafe()
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
@@ -9429,9 +9448,9 @@ MethodTable::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
         DacEnumMemoryRegion(dac_cast<TADDR>(GetPerInstInfo()) - sizeof(GenericsDictInfo), GetPerInstInfoSize() + sizeof(GenericsDictInfo));
     }
 
-    if (GetDictionary() != NULL)
+    if (GetDictionary_Unsafe() != NULL)
     {
-        DacEnumMemoryRegion(dac_cast<TADDR>(GetDictionary()), GetInstAndDictSize());
+        DacEnumMemoryRegion(dac_cast<TADDR>(GetDictionary_Unsafe()), GetInstAndDictSize_Unsafe());
     }
 
     VtableIndirectionSlotIterator it = IterateVtableIndirectionSlots();

--- a/src/vm/methodtable.h
+++ b/src/vm/methodtable.h
@@ -2907,7 +2907,7 @@ public:
     //    Advantage: no need to deallocate when growing dictionaries.
     //    Disadvantage: more indirections required at run-time.)
     //
-    // The layout of dictionaries is determined by GetClass()->GetDictionaryLayout_Unsafe()
+    // The layout of dictionaries is determined by GetClass()->GetDictionaryLayout()
     // Thus the layout can vary between incompatible instantiations. This is sometimes useful because individual type
     // parameters may or may not be shared. For example, consider a two parameter class Dict<K,D>. In instantiations shared with
     // Dict<double,string> any reference to K is known at JIT-compile-time (it's double) but any token containing D
@@ -2973,7 +2973,7 @@ public:
     // If not instantiated, return NULL
     // This operation is not multi-threaded safe: other thread can update the 
     // dictionary pointer during a dictionary size expansion.
-    PTR_Dictionary GetDictionary_Unsafe();
+    PTR_Dictionary GetDictionary();
 
 #ifdef FEATURE_PREJIT
     //
@@ -4081,7 +4081,7 @@ private:
     // This operation is not multi-threaded safe: it uses the dictionary layout to compute
     // the size, and the dictionary layout can be updated by other threads in the case of a
     // generic dictionary size expansion.
-    inline DWORD GetInstAndDictSize_Unsafe();
+    inline DWORD GetInstAndDictSize();
 
 private:
     // Helper template to compute the offsets at compile time

--- a/src/vm/methodtable.inl
+++ b/src/vm/methodtable.inl
@@ -1254,14 +1254,14 @@ inline DWORD MethodTable::GetInterfaceMapSize()
 //==========================================================================================
 // These are the generic dictionaries themselves and are come after
 //  the interface map.  In principle they need not be inline in the method table.
-inline DWORD MethodTable::GetInstAndDictSize_Unsafe()
+inline DWORD MethodTable::GetInstAndDictSize()
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
     if (!HasInstantiation())
         return 0;
     else
-        return DictionaryLayout::GetFirstDictionaryBucketSize(GetNumGenericArgs(), GetClass()->GetDictionaryLayout_Unsafe());
+        return DictionaryLayout::GetDictionarySizeFromLayout(GetNumGenericArgs(), GetClass()->GetDictionaryLayout());
 }
 
 //==========================================================================================

--- a/src/vm/methodtable.inl
+++ b/src/vm/methodtable.inl
@@ -1254,14 +1254,14 @@ inline DWORD MethodTable::GetInterfaceMapSize()
 //==========================================================================================
 // These are the generic dictionaries themselves and are come after
 //  the interface map.  In principle they need not be inline in the method table.
-inline DWORD MethodTable::GetInstAndDictSize()
+inline DWORD MethodTable::GetInstAndDictSize_Unsafe()
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
     if (!HasInstantiation())
         return 0;
     else
-        return DictionaryLayout::GetFirstDictionaryBucketSize(GetNumGenericArgs(), GetClass()->GetDictionaryLayout());
+        return DictionaryLayout::GetFirstDictionaryBucketSize(GetNumGenericArgs(), GetClass()->GetDictionaryLayout_Unsafe());
 }
 
 //==========================================================================================

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -10164,7 +10164,7 @@ MethodTableBuilder::SetupMethodTable2(
 
     DWORD cbDict = bmtGenerics->HasInstantiation()
                    ?  DictionaryLayout::GetFirstDictionaryBucketSize(
-                          bmtGenerics->GetNumGenericArgs(), pClass->GetDictionaryLayout())
+                          bmtGenerics->GetNumGenericArgs(), pClass->GetDictionaryLayout_Unsafe())
                    : 0;
 
 #ifdef FEATURE_COLLECTIBLE_TYPES
@@ -10460,6 +10460,13 @@ MethodTableBuilder::SetupMethodTable2(
         for (DWORD j = 0; j < bmtGenerics->GetNumGenericArgs(); j++)
         {
             pInstDest[j] = inst[j];
+        }
+
+        if (pClass->GetDictionaryLayout_Unsafe() != NULL && pClass->GetDictionaryLayout_Unsafe()->GetMaxSlots() > 0)
+        {
+            UINT_PTR* pDictionarySlots = (UINT_PTR*)pMT->GetPerInstInfo()[bmtGenerics->numDicts - 1].GetValue();
+            UINT_PTR* pSizeSlot = pDictionarySlots + bmtGenerics->GetNumGenericArgs();
+            *pSizeSlot = cbDict;
         }
     }
 

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -10163,8 +10163,8 @@ MethodTableBuilder::SetupMethodTable2(
     EEClass *pClass = GetHalfBakedClass();
 
     DWORD cbDict = bmtGenerics->HasInstantiation()
-                   ?  DictionaryLayout::GetFirstDictionaryBucketSize(
-                          bmtGenerics->GetNumGenericArgs(), pClass->GetDictionaryLayout_Unsafe())
+                   ?  DictionaryLayout::GetDictionarySizeFromLayout(
+                          bmtGenerics->GetNumGenericArgs(), pClass->GetDictionaryLayout())
                    : 0;
 
 #ifdef FEATURE_COLLECTIBLE_TYPES
@@ -10462,10 +10462,10 @@ MethodTableBuilder::SetupMethodTable2(
             pInstDest[j] = inst[j];
         }
 
-        if (pClass->GetDictionaryLayout_Unsafe() != NULL && pClass->GetDictionaryLayout_Unsafe()->GetMaxSlots() > 0)
+        if (pClass->GetDictionaryLayout() != NULL && pClass->GetDictionaryLayout()->GetMaxSlots() > 0)
         {
-            UINT_PTR* pDictionarySlots = (UINT_PTR*)pMT->GetPerInstInfo()[bmtGenerics->numDicts - 1].GetValue();
-            UINT_PTR* pSizeSlot = pDictionarySlots + bmtGenerics->GetNumGenericArgs();
+            ULONG_PTR* pDictionarySlots = (ULONG_PTR*)pMT->GetPerInstInfo()[bmtGenerics->numDicts - 1].GetValue();
+            ULONG_PTR* pSizeSlot = pDictionarySlots + bmtGenerics->GetNumGenericArgs();
             *pSizeSlot = cbDict;
         }
     }

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -2887,9 +2887,11 @@ void ProcessDynamicDictionaryLookup(TransitionBlock *           pTransitionBlock
     *pDictionaryIndexAndSlot = (pContextMT == NULL ? 0 : pContextMT->GetNumDicts() - 1);
     *pDictionaryIndexAndSlot <<= 16;
     
+    WORD dictionarySlot;
+
     if (kind == ENCODE_DICTIONARY_LOOKUP_METHOD)
     {
-        if (DictionaryLayout::FindToken(pContextMD, pModule->GetLoaderAllocator(), 1, NULL, (BYTE*)pBlobStart, FromReadyToRunImage, pResult))
+        if (DictionaryLayout::FindToken(pContextMD, pModule->GetLoaderAllocator(), 1, NULL, (BYTE*)pBlobStart, FromReadyToRunImage, pResult, &dictionarySlot))
         {
             pResult->testForNull = 1;
 
@@ -2901,14 +2903,14 @@ void ProcessDynamicDictionaryLookup(TransitionBlock *           pTransitionBlock
                 pResult->indirectFirstOffset = 1;
             }
 
-            *pDictionaryIndexAndSlot |= pResult->slot;
+            *pDictionaryIndexAndSlot |= dictionarySlot;
         }
     }
 
     // It's a class dictionary lookup (CORINFO_LOOKUP_CLASSPARAM or CORINFO_LOOKUP_THISOBJ)
     else
     {
-        if (DictionaryLayout::FindToken(pContextMT, pModule->GetLoaderAllocator(), 2, NULL, (BYTE*)pBlobStart, FromReadyToRunImage, pResult))
+        if (DictionaryLayout::FindToken(pContextMT, pModule->GetLoaderAllocator(), 2, NULL, (BYTE*)pBlobStart, FromReadyToRunImage, pResult, &dictionarySlot))
         {
             pResult->testForNull = 1;
 
@@ -2924,7 +2926,7 @@ void ProcessDynamicDictionaryLookup(TransitionBlock *           pTransitionBlock
                 pResult->indirectSecondOffset = 1;
             }
 
-            *pDictionaryIndexAndSlot |= pResult->slot;
+            *pDictionaryIndexAndSlot |= dictionarySlot;
         }
     }
 }

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -2886,12 +2886,10 @@ void ProcessDynamicDictionaryLookup(TransitionBlock *           pTransitionBlock
     // are used for the dictionary index, and the lower 16 bits for the slot number.
     *pDictionaryIndexAndSlot = (pContextMT == NULL ? 0 : pContextMT->GetNumDicts() - 1);
     *pDictionaryIndexAndSlot <<= 16;
-
-    WORD dictionarySlot;
-
+    
     if (kind == ENCODE_DICTIONARY_LOOKUP_METHOD)
     {
-        if (DictionaryLayout::FindToken(pModule->GetLoaderAllocator(), numGenericArgs, pContextMD->GetDictionaryLayout(), pResult, (BYTE*)pBlobStart, 1, FromReadyToRunImage, &dictionarySlot))
+        if (DictionaryLayout::FindToken(pContextMD, pModule->GetLoaderAllocator(), 1, NULL, (BYTE*)pBlobStart, FromReadyToRunImage, pResult))
         {
             pResult->testForNull = 1;
 
@@ -2903,14 +2901,14 @@ void ProcessDynamicDictionaryLookup(TransitionBlock *           pTransitionBlock
                 pResult->indirectFirstOffset = 1;
             }
 
-            *pDictionaryIndexAndSlot |= dictionarySlot;
+            *pDictionaryIndexAndSlot |= pResult->slot;
         }
     }
 
     // It's a class dictionary lookup (CORINFO_LOOKUP_CLASSPARAM or CORINFO_LOOKUP_THISOBJ)
     else
     {
-        if (DictionaryLayout::FindToken(pModule->GetLoaderAllocator(), numGenericArgs, pContextMT->GetClass()->GetDictionaryLayout(), pResult, (BYTE*)pBlobStart, 2, FromReadyToRunImage, &dictionarySlot))
+        if (DictionaryLayout::FindToken(pContextMT, pModule->GetLoaderAllocator(), 2, NULL, (BYTE*)pBlobStart, FromReadyToRunImage, pResult))
         {
             pResult->testForNull = 1;
 
@@ -2926,7 +2924,7 @@ void ProcessDynamicDictionaryLookup(TransitionBlock *           pTransitionBlock
                 pResult->indirectSecondOffset = 1;
             }
 
-            *pDictionaryIndexAndSlot |= dictionarySlot;
+            *pDictionaryIndexAndSlot |= pResult->slot;
         }
     }
 }


### PR DESCRIPTION
These changes introduce dynamic size expansion for generic dictionary layouts when we run out of slots.
The original implementation allowed for an expansion, but using a linked list structure, which made it
impossible to use fast lookup slots once we're out of slots in the first bucket.

This new implementation allows for the usage of fast lookup slots always, for all generic lookups.

This also removes the constraint we had on R2R, where we disabled the usage of fast slots all-together.