### PR TITLE
Package native test assets into a NuGet package for use in performance testing

### DIFF
--- a/build-packages.sh
+++ b/build-packages.sh
@@ -70,6 +70,7 @@ esac
 
 buildArgs=
 unprocessedBuildArgs=
+buildNativeTestPackage=0
 
 # TODO: get rid of argument processing entirely once we remove the
 # uses of -Arg=Value style in buildpipeline.
@@ -99,6 +100,9 @@ while :; do
             __CrossBuild=$(echo $1| cut -d'=' -f 2)
             buildArgs="$buildArgs /p:__DoCrossArchBuild=$__CrossBuild"
             ;;
+        -BuildNativeTestPackage)
+            buildNativeTestPackage=1
+            ;;
         -portablebuild=false)
             buildArgs="$buildArgs /p:PortableBuild=false"
             __IsPortableBuild=0
@@ -125,8 +129,14 @@ if [ "${__DistroRid}" = "linux-musl-arm64" ]; then
     export OutputRID=${__DistroRid}
 fi
 
+packagesProject=packages.builds
+
+if [ $buildNativeTestPackage = 1 ]; then
+    packagesProject=testpackages.builds
+fi
+
 logFile=$__ProjectRoot/bin/Logs/build-packages.binlog
-$__ProjectRoot/eng/common/build.sh -r -b -projects $__ProjectRoot/src/.nuget/packages.builds \
+$__ProjectRoot/eng/common/build.sh -r -b -projects $__ProjectRoot/src/.nuget/$packagesProject \
                                    -verbosity minimal -bl:$logFile \
                                    /p:__BuildOS=$__BuildOS /p:ArcadeBuild=true \
                                    /p:PortableBuild=true /p:__DistroRid=$__DistroRid \

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -69,13 +69,9 @@ jobs:
       # Variables used by arcade to gather asset manifests
       - name: _DotNetPublishToBlobFeed
         value: true
-    - name: officialBuildIdArg
-      value: ''
     - name: ibcOptimizeArg
       value: ''
     - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
-      - name: officialBuildIdArg
-        value: '-officialbuildid=$(Build.BuildNumber)'
       # IBCMerge is currently Windows-only and x86/x64-only
       - ${{ if and(eq(parameters.osGroup, 'Windows_NT'), or(eq(parameters.archType, 'x64'), eq(parameters.archType, 'x86'))) }}:
         - name: ibcOptimizeArg

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -151,6 +151,15 @@ jobs:
         displayName: Build tests
 
 
+    # Build test packages
+    - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
+      - script: ./build-packages.sh -BuildArch=$(archType) -BuildType=$(buildConfigUpper) $(crossPackagesArg) $(officialBuildIdArg) $(portableBuildArg) -BuildNativeTestPackage -ci
+        displayName: Build native test assets package
+    - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+      - script: build-packages.cmd -BuildArch=$(archType) -BuildType=$(buildConfigUpper) $(officialBuildIdArg) -BuildNativeTestPackage -ci
+        displayName: Build native test assets package
+
+
     # Send tests to Helix
     - template: /eng/send-to-helix-step.yml
       parameters:

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -81,7 +81,15 @@ jobs:
     - ${{ if eq(parameters.archType, 'arm64') }}:
       - name: clangArg
         value: '-clang5.0'
-
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+      # Variables used to publish packages to blob feed
+      - name: dotnetfeedUrl
+        value: https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json
+      - name: dotnetfeedPAT
+        value: $(dotnetfeed-storage-access-key-1)
+      # Variables used by arcade to gather asset manifests
+      - name: _DotNetPublishToBlobFeed
+        value: true
     - name: testhostArg
       value: ''
     - ${{ if eq(parameters.corefxTests, true) }}:
@@ -158,7 +166,6 @@ jobs:
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
       - script: build-packages.cmd -BuildArch=$(archType) -BuildType=$(buildConfigUpper) $(officialBuildIdArg) -BuildNativeTestPackage -ci
         displayName: Build native test assets package
-
 
     # Send tests to Helix
     - template: /eng/send-to-helix-step.yml
@@ -366,6 +373,25 @@ jobs:
             artifactName: ${{ format('Tests_r2r_{0}_{1}_{2}_{3}', parameters.osIdentifier, parameters.archType, parameters.buildConfig, parameters.testGroup) }}
           ${{ if ne(parameters.readyToRun, true) }}:
             artifactName: ${{ format('Tests_{0}_{1}_{2}_{3}',     parameters.osIdentifier, parameters.archType, parameters.buildConfig, parameters.testGroup) }}
+
+    # Publish native test assets package
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+      - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
+        - script: ./eng/common/build.sh --ci --restore --publish --configuration $(_BuildConfig) /p:DotNetPublishUsingPipelines=true /p:DotNetPublishToBlobFeed=true /p:DotNetPublishBlobFeedUrl=$(dotnetfeedUrl) /p:DotNetPublishBlobFeedKey=$(dotnetfeedPAT) /p:__BuildType=$(_BuildConfig) /p:__BuildArch=$(archType) /p:__BuildOS=$(osGroup) /p:OSIdentifier=$(osIdentifier) /bl:"$(Build.SourcesDirectory)/bin/Logs/publish-test-pkgs.binlog" --projects $(Build.SourcesDirectory)/eng/empty.csproj
+          displayName: Publish packages to blob feed
+          env:
+            # TODO: remove NUGET_PACKAGES once https://github.com/dotnet/arcade/issues/1578 is fixed
+            NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
+            ${{ if eq(parameters.osGroup, 'FreeBSD') }}:
+              # Arcade uses this SDK instead of trying to restore one.
+              DotNetCoreSdkDir: /usr/local/dotnet
+      - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+        # TODO: pass publish feed url and access token in from the internal pipeline
+        - powershell: eng\common\build.ps1 -ci -restore -publish -configuration $(_BuildConfig) /p:DotNetPublishUsingPipelines=true /p:DotNetPublishToBlobFeed=true /p:DotNetPublishBlobFeedUrl=$(dotnetfeedUrl) /p:DotNetPublishBlobFeedKey=$(dotnetfeedPAT) /p:__BuildType=$(_BuildConfig) /p:__BuildArch=$(archType) /p:__BuildOS=$(osGroup) /p:OSIdentifier=$(osIdentifier) /bl:"$(Build.SourcesDirectory)\bin\Logs\publish-test-pkgs.binlog" -projects $(Build.SourcesDirectory)\eng\empty.csproj
+          displayName: Publish packages to blob feed
+          env:
+            # TODO: remove NUGET_PACKAGES once https://github.com/dotnet/arcade/issues/1578 is fixed
+            NUGET_PACKAGES: $(Build.SourcesDirectory)\.packages
 
     # Publish Logs
     - task: PublishBuildArtifacts@1

--- a/eng/xplat-job.yml
+++ b/eng/xplat-job.yml
@@ -147,6 +147,17 @@ jobs:
         value: ''
       - name: crossPackagesArg
         value: ''
+    - name: officialBuildIdArg
+      value: ''
+    - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+      - name: officialBuildIdArg
+        value: '-officialbuildid=$(Build.BuildNumber)'
+    - name: portableBuildArg
+      value: ''
+    # Ensure that we produce os-specific packages for the following distros:
+    - ${{ if in(parameters.osIdentifier, 'Linux_rhel6') }}:
+      - name: portableBuildArg
+        value: '-portablebuild=false'
 
     - ${{ each variable in parameters.variables }}:
       - ${{insert}}: ${{ variable }}

--- a/src/.nuget/Microsoft.Private.Tests.Native.CoreCLR/Microsoft.Private.Tests.Native.CoreCLR.builds
+++ b/src/.nuget/Microsoft.Private.Tests.Native.CoreCLR/Microsoft.Private.Tests.Native.CoreCLR.builds
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.Build.Traversal">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <ItemGroup>
+    <!-- identity project, runtime specific projects are included by props above -->
+    <Project Include="$(MSBuildProjectName).pkgproj" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), builds.targets))\builds.targets" />
+</Project>

--- a/src/.nuget/Microsoft.Private.Tests.Native.CoreCLR/Microsoft.Private.Tests.Native.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.Private.Tests.Native.CoreCLR/Microsoft.Private.Tests.Native.CoreCLR.pkgproj
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup Condition="'$(PackageTargetRuntime)' == ''">
+    <IsLineupPackage Condition="'$(IsLineupPackage)' == ''">true</IsLineupPackage>
+  </PropertyGroup>
+
+  <Import Condition="'$(_packageTargetOSGroup)' != ''" Project="$(MSBuildThisFileDirectory)runtime.$(_packageTargetOSGroup).$(MSBuildProjectName).props" />
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/.nuget/Microsoft.Private.Tests.Native.CoreCLR/runtime.FreeBSD.Microsoft.Private.Tests.Native.CoreCLR.props
+++ b/src/.nuget/Microsoft.Private.Tests.Native.CoreCLR/runtime.FreeBSD.Microsoft.Private.Tests.Native.CoreCLR.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <NativeBinary Include="$(RootBinDir)tests\$(BuildOS).$(BuildArch).$(BuildType)\bin\*.so" />
+    <NativeBinary Include="$(RootBinDir)tests\$(BuildOS).$(BuildArch).$(BuildType)\bin\nativeassets\*.so" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.Private.Tests.Native.CoreCLR/runtime.FreeBSD.Microsoft.Private.Tests.Native.CoreCLR.props
+++ b/src/.nuget/Microsoft.Private.Tests.Native.CoreCLR/runtime.FreeBSD.Microsoft.Private.Tests.Native.CoreCLR.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <NativeBinary Include="$(RootBinDir)tests\$(BuildOS).$(BuildArch).$(BuildType)\bin\*.so" />
+  </ItemGroup>
+</Project>

--- a/src/.nuget/Microsoft.Private.Tests.Native.CoreCLR/runtime.Linux.Microsoft.Private.Tests.Native.CoreCLR.props
+++ b/src/.nuget/Microsoft.Private.Tests.Native.CoreCLR/runtime.Linux.Microsoft.Private.Tests.Native.CoreCLR.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <NativeBinary Include="$(RootBinDir)tests\$(BuildOS).$(BuildArch).$(BuildType)\bin\*.so" />
+    <NativeBinary Include="$(RootBinDir)tests\$(BuildOS).$(BuildArch).$(BuildType)\bin\nativeassets\*.so" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.Private.Tests.Native.CoreCLR/runtime.Linux.Microsoft.Private.Tests.Native.CoreCLR.props
+++ b/src/.nuget/Microsoft.Private.Tests.Native.CoreCLR/runtime.Linux.Microsoft.Private.Tests.Native.CoreCLR.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <NativeBinary Include="$(RootBinDir)tests\$(BuildOS).$(BuildArch).$(BuildType)\bin\*.so" />
+  </ItemGroup>
+</Project>

--- a/src/.nuget/Microsoft.Private.Tests.Native.CoreCLR/runtime.OSX.Microsoft.Private.Tests.Native.CoreCLR.props
+++ b/src/.nuget/Microsoft.Private.Tests.Native.CoreCLR/runtime.OSX.Microsoft.Private.Tests.Native.CoreCLR.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <NativeBinary Include="$(RootBinDir)tests\$(BuildOS).$(BuildArch).$(BuildType)\bin\*.dylib" />
+  </ItemGroup>
+</Project>

--- a/src/.nuget/Microsoft.Private.Tests.Native.CoreCLR/runtime.OSX.Microsoft.Private.Tests.Native.CoreCLR.props
+++ b/src/.nuget/Microsoft.Private.Tests.Native.CoreCLR/runtime.OSX.Microsoft.Private.Tests.Native.CoreCLR.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <NativeBinary Include="$(RootBinDir)tests\$(BuildOS).$(BuildArch).$(BuildType)\bin\*.dylib" />
+    <NativeBinary Include="$(RootBinDir)tests\$(BuildOS).$(BuildArch).$(BuildType)\bin\nativeassets\*.dylib" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.Private.Tests.Native.CoreCLR/runtime.Windows_NT.Microsoft.Private.Tests.Native.CoreCLR.props
+++ b/src/.nuget/Microsoft.Private.Tests.Native.CoreCLR/runtime.Windows_NT.Microsoft.Private.Tests.Native.CoreCLR.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <NativeBinary Include="$(RootBinDir)tests\$(BuildOS).$(BuildArch).$(BuildType)\bin\*.dll" />
-    <NativeBinary Include="$(RootBinDir)tests\$(BuildOS).$(BuildArch).$(BuildType)\bin\*.exe" />
+    <NativeBinary Include="$(RootBinDir)tests\$(BuildOS).$(BuildArch).$(BuildType)\bin\nativeassets\*.dll" />
+    <NativeBinary Include="$(RootBinDir)tests\$(BuildOS).$(BuildArch).$(BuildType)\bin\nativeassets\*.exe" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.Private.Tests.Native.CoreCLR/runtime.Windows_NT.Microsoft.Private.Tests.Native.CoreCLR.props
+++ b/src/.nuget/Microsoft.Private.Tests.Native.CoreCLR/runtime.Windows_NT.Microsoft.Private.Tests.Native.CoreCLR.props
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <NativeBinary Include="$(RootBinDir)tests\$(BuildOS).$(BuildArch).$(BuildType)\bin\*.dll" />
+    <NativeBinary Include="$(RootBinDir)tests\$(BuildOS).$(BuildArch).$(BuildType)\bin\*.exe" />
+  </ItemGroup>
+</Project>

--- a/src/.nuget/descriptions.json
+++ b/src/.nuget/descriptions.json
@@ -45,8 +45,13 @@
         "CommonTypes": [ ]
     },
     {
-	"Name": "Microsoft.NETCore.Native",
-	"Description": "Native shims for .NET Core runtime",
-	"CommonTypes": [ ]
+        "Name": "Microsoft.NETCore.Native",
+        "Description": "Native shims for .NET Core runtime",
+        "CommonTypes": [ ]
+    },
+    {
+        "Name": "Microsoft.Private.Tests.Native.CoreCLR",
+        "Description": "Native test assets for CoreCLR",
+        "CommonTypes": [ ]
     }
 ]

--- a/src/.nuget/packages.builds
+++ b/src/.nuget/packages.builds
@@ -24,33 +24,5 @@
     <ProjectReference Include="Microsoft.NETCore.ILDAsm\Microsoft.NETCore.ILDAsm.builds" />
   </ItemGroup>
 
-  <!-- Generate a version.txt file we include in our packages
-       The InitializeSourceControlInformationFromSourceControlManager is part of Microsoft.Build.Tasks.Git
-       and is responsible for setting SourceRevisionId -->
-  <Target Name="GenerateVersionInfoFileForPackages"
-          BeforeTargets="Build"
-          DependsOnTargets="InitializeSourceControlInformationFromSourceControlManager">
-
-    <Error Condition="'$(SourceRevisionId)' == ''" Text="SourceRevisionId is not set, which means the SourceLink targets are not included in the build. Those are needed to produce a correct sha for our build outputs." />
-
-    <MakeDir Directories="$([System.IO.Path]::GetDirectoryName($(VersionTxtFile)))" />
-    <WriteLinesToFile
-      File="$(VersionTxtFile)"
-      Lines="$(SourceRevisionId)"
-      Overwrite="true" />
-  </Target>
-
-  <!-- Update the project references with additional properties calculated during the execution phase.
-       _InitializeAssemblyVersion is provided by Arcade. It sets the AssemblyVersion and FileVersion properties.
-       We depend on this private Arcade target instead of the SDK-defined GetAssemblyVersion since the packaging
-       build does not use the .NET SDK -->
-  <Target Name="UpdateAdditionalProperties"
-          BeforeTargets="Build"
-          DependsOnTargets="_InitializeAssemblyVersion">
-    <ItemGroup>
-      <!-- Pass the FileVersion calculated by _InitializeAssemblyVersion to referenced projects -->
-      <ProjectReference Update="@(ProjectReference)"
-                        AdditionalProperties="%(AdditionalProperties);FileVersion=$(FileVersion)" />
-    </ItemGroup>
-  </Target>
+  <Import Project="packaging.targets" />
 </Project>

--- a/src/.nuget/packaging.targets
+++ b/src/.nuget/packaging.targets
@@ -1,0 +1,31 @@
+<Project>
+  <!-- Generate a version.txt file we include in our packages
+       The InitializeSourceControlInformationFromSourceControlManager is part of Microsoft.Build.Tasks.Git
+       and is responsible for setting SourceRevisionId -->
+  <Target Name="GenerateVersionInfoFileForPackages"
+          BeforeTargets="Build"
+          DependsOnTargets="InitializeSourceControlInformationFromSourceControlManager">
+
+    <Error Condition="'$(SourceRevisionId)' == ''" Text="SourceRevisionId is not set, which means the SourceLink targets are not included in the build. Those are needed to produce a correct sha for our build outputs." />
+
+    <MakeDir Directories="$([System.IO.Path]::GetDirectoryName($(VersionTxtFile)))" />
+    <WriteLinesToFile
+      File="$(VersionTxtFile)"
+      Lines="$(SourceRevisionId)"
+      Overwrite="true" />
+  </Target>
+
+  <!-- Update the project references with additional properties calculated during the execution phase.
+       _InitializeAssemblyVersion is provided by Arcade. It sets the AssemblyVersion and FileVersion properties.
+       We depend on this private Arcade target instead of the SDK-defined GetAssemblyVersion since the packaging
+       build does not use the .NET SDK -->
+  <Target Name="UpdateAdditionalProperties"
+          BeforeTargets="Build"
+          DependsOnTargets="_InitializeAssemblyVersion">
+    <ItemGroup>
+      <!-- Pass the FileVersion calculated by _InitializeAssemblyVersion to referenced projects -->
+      <ProjectReference Update="@(ProjectReference)"
+                        AdditionalProperties="%(AdditionalProperties);FileVersion=$(FileVersion)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/.nuget/testpackages.builds
+++ b/src/.nuget/testpackages.builds
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.Build.Traversal">
+    <Import Project="packaging.props" />
+
+    <ItemGroup>
+        <ProjectReference Include="Microsoft.Private.Tests.Native.CoreCLR/Microsoft.Private.Tests.Native.CoreCLR.builds" />
+    </ItemGroup>
+
+    <Import Project="packaging.targets" />
+</Project>

--- a/tests/src/Common/Platform/CMakeLists.txt
+++ b/tests/src/Common/Platform/CMakeLists.txt
@@ -4,6 +4,3 @@ set(SOURCES platformdefines.cpp)
 
 # add the executable
 add_library(platformdefines STATIC ${SOURCES})
-
-# add the install targets
-install (TARGETS platformdefines DESTINATION bin)

--- a/tests/src/Interop/DllImportAttribute/DllImportPath/CMakeLists.txt
+++ b/tests/src/Interop/DllImportAttribute/DllImportPath/CMakeLists.txt
@@ -20,7 +20,4 @@ target_link_libraries(DllImportPath_ExeFile ${LINK_LIBRARIES_ADDITIONAL})
 
 target_compile_definitions(DllImportPath_ExeFile PRIVATE EXE)
 # add the install targets 
-install (TARGETS DllImportPath_Local DESTINATION bin) 
-install (TARGETS DllImportPath.Local DESTINATION bin) 
-install (TARGETS DllImportPath_PathEnv DESTINATION bin) 
-install (TARGETS DllImportPath_Relative DESTINATION bin) 
+install (TARGETS DllImportPath_Local DESTINATION bin/nativeassets)

--- a/tests/src/Interop/DllImportAttribute/DllImportPath/CMakeLists.txt
+++ b/tests/src/Interop/DllImportAttribute/DllImportPath/CMakeLists.txt
@@ -21,3 +21,6 @@ target_link_libraries(DllImportPath_ExeFile ${LINK_LIBRARIES_ADDITIONAL})
 target_compile_definitions(DllImportPath_ExeFile PRIVATE EXE)
 # add the install targets 
 install (TARGETS DllImportPath_Local DESTINATION bin/nativeassets)
+if (WIN32)
+  install (FILES $<TARGET_PDB_FILE:DllImportPath_Local> DESTINATION bin/nativeassets/PDB)
+endif()

--- a/tests/src/Interop/LayoutClass/CMakeLists.txt
+++ b/tests/src/Interop/LayoutClass/CMakeLists.txt
@@ -8,4 +8,4 @@ add_library (LayoutClassNative SHARED ${SOURCES})
 target_link_libraries(LayoutClassNative ${LINK_LIBRARIES_ADDITIONAL}) 
 
 # add the install targets
-install (TARGETS LayoutClassNative DESTINATION bin)
+install (TARGETS LayoutClassNative DESTINATION bin/nativeassets)

--- a/tests/src/Interop/LayoutClass/CMakeLists.txt
+++ b/tests/src/Interop/LayoutClass/CMakeLists.txt
@@ -9,3 +9,7 @@ target_link_libraries(LayoutClassNative ${LINK_LIBRARIES_ADDITIONAL})
 
 # add the install targets
 install (TARGETS LayoutClassNative DESTINATION bin/nativeassets)
+if (WIN32)
+  install (FILES $<TARGET_PDB_FILE:LayoutClassNative> DESTINATION bin/nativeassets/PDB)
+endif()
+

--- a/tests/src/Interop/PInvoke/Delegate/CMakeLists.txt
+++ b/tests/src/Interop/PInvoke/Delegate/CMakeLists.txt
@@ -13,3 +13,7 @@ endif()
 add_library (DelegateTestNative SHARED ${SOURCES})
 target_link_libraries(DelegateTestNative ${LINK_LIBRARIES_ADDITIONAL}) 
 install (TARGETS DelegateTestNative DESTINATION bin/nativeassets) 
+
+if (WIN32)
+  install (FILES $<TARGET_PDB_FILE:DelegateTestNative> DESTINATION bin/nativeassets/PDB)
+endif()

--- a/tests/src/Interop/PInvoke/Delegate/CMakeLists.txt
+++ b/tests/src/Interop/PInvoke/Delegate/CMakeLists.txt
@@ -12,3 +12,4 @@ endif()
 # add the executable 
 add_library (DelegateTestNative SHARED ${SOURCES})
 target_link_libraries(DelegateTestNative ${LINK_LIBRARIES_ADDITIONAL}) 
+install (TARGETS DelegateTestNative DESTINATION bin/nativeassets) 

--- a/tests/src/Interop/PInvoke/SafeHandles/CMakeLists.txt
+++ b/tests/src/Interop/PInvoke/SafeHandles/CMakeLists.txt
@@ -6,4 +6,4 @@ set(SOURCES
 ) 
 add_library (SafeHandleNative SHARED ${SOURCES}) 
 target_link_libraries(SafeHandleNative ${LINK_LIBRARIES_ADDITIONAL})
-install (TARGETS SafeHandleNative DESTINATION bin) 
+install (TARGETS SafeHandleNative DESTINATION bin/nativeassets) 

--- a/tests/src/Interop/PInvoke/SafeHandles/CMakeLists.txt
+++ b/tests/src/Interop/PInvoke/SafeHandles/CMakeLists.txt
@@ -7,3 +7,7 @@ set(SOURCES
 add_library (SafeHandleNative SHARED ${SOURCES}) 
 target_link_libraries(SafeHandleNative ${LINK_LIBRARIES_ADDITIONAL})
 install (TARGETS SafeHandleNative DESTINATION bin/nativeassets) 
+
+if (WIN32)
+  install (FILES $<TARGET_PDB_FILE:SafeHandleNative> DESTINATION bin/nativeassets/PDB)
+endif()

--- a/tests/src/Interop/StringMarshalling/BSTR/CMakeLists.txt
+++ b/tests/src/Interop/StringMarshalling/BSTR/CMakeLists.txt
@@ -15,3 +15,7 @@ target_link_libraries(BStrTestNative ${LINK_LIBRARIES_ADDITIONAL})
 
 # add the install targets
 install (TARGETS BStrTestNative DESTINATION bin/nativeassets)
+
+if (WIN32)
+  install (FILES $<TARGET_PDB_FILE:BStrTestNative> DESTINATION bin/nativeassets/PDB)
+endif()

--- a/tests/src/Interop/StringMarshalling/BSTR/CMakeLists.txt
+++ b/tests/src/Interop/StringMarshalling/BSTR/CMakeLists.txt
@@ -14,4 +14,4 @@ endif(WIN32)
 target_link_libraries(BStrTestNative ${LINK_LIBRARIES_ADDITIONAL}) 
 
 # add the install targets
-install (TARGETS BStrTestNative DESTINATION bin)
+install (TARGETS BStrTestNative DESTINATION bin/nativeassets)

--- a/tests/src/Interop/StringMarshalling/LPSTR/CMakeLists.txt
+++ b/tests/src/Interop/StringMarshalling/LPSTR/CMakeLists.txt
@@ -8,3 +8,7 @@ target_link_libraries(LPStrTestNative ${LINK_LIBRARIES_ADDITIONAL})
 
 # add the install targets
 install (TARGETS LPStrTestNative DESTINATION bin/nativeassets)
+
+if (WIN32)
+  install (FILES $<TARGET_PDB_FILE:LPStrTestNative> DESTINATION bin/nativeassets/PDB)
+endif()

--- a/tests/src/Interop/StringMarshalling/LPSTR/CMakeLists.txt
+++ b/tests/src/Interop/StringMarshalling/LPSTR/CMakeLists.txt
@@ -7,4 +7,4 @@ add_library (LPStrTestNative SHARED ${SOURCES})
 target_link_libraries(LPStrTestNative ${LINK_LIBRARIES_ADDITIONAL}) 
 
 # add the install targets
-install (TARGETS LPStrTestNative DESTINATION bin)
+install (TARGETS LPStrTestNative DESTINATION bin/nativeassets)

--- a/tests/src/Interop/StringMarshalling/LPTSTR/CMakeLists.txt
+++ b/tests/src/Interop/StringMarshalling/LPTSTR/CMakeLists.txt
@@ -8,3 +8,7 @@ target_link_libraries(LPTStrTestNative ${LINK_LIBRARIES_ADDITIONAL})
 
 # add the install targets
 install (TARGETS LPTStrTestNative DESTINATION bin/nativeassets)
+
+if (WIN32)
+  install (FILES $<TARGET_PDB_FILE:LPTStrTestNative> DESTINATION bin/nativeassets/PDB)
+endif()

--- a/tests/src/Interop/StringMarshalling/LPTSTR/CMakeLists.txt
+++ b/tests/src/Interop/StringMarshalling/LPTSTR/CMakeLists.txt
@@ -7,4 +7,4 @@ add_library (LPTStrTestNative SHARED ${SOURCES})
 target_link_libraries(LPTStrTestNative ${LINK_LIBRARIES_ADDITIONAL}) 
 
 # add the install targets
-install (TARGETS LPTStrTestNative DESTINATION bin)
+install (TARGETS LPTStrTestNative DESTINATION bin/nativeassets)

--- a/tests/src/Interop/StringMarshalling/UTF8/CMakeLists.txt
+++ b/tests/src/Interop/StringMarshalling/UTF8/CMakeLists.txt
@@ -9,3 +9,7 @@ target_link_libraries(UTF8TestNative ${LINK_LIBRARIES_ADDITIONAL})
 
 # add the install targets
 install (TARGETS UTF8TestNative DESTINATION bin/nativeassets)
+
+if (WIN32)
+  install (FILES $<TARGET_PDB_FILE:UTF8TestNative> DESTINATION bin/nativeassets/PDB)
+endif()

--- a/tests/src/Interop/StringMarshalling/UTF8/CMakeLists.txt
+++ b/tests/src/Interop/StringMarshalling/UTF8/CMakeLists.txt
@@ -8,4 +8,4 @@ add_library (UTF8TestNative SHARED ${SOURCES})
 target_link_libraries(UTF8TestNative ${LINK_LIBRARIES_ADDITIONAL})
 
 # add the install targets
-install (TARGETS UTF8TestNative DESTINATION bin)
+install (TARGETS UTF8TestNative DESTINATION bin/nativeassets)

--- a/tests/src/Interop/StringMarshalling/VBByRefStr/CMakeLists.txt
+++ b/tests/src/Interop/StringMarshalling/VBByRefStr/CMakeLists.txt
@@ -8,4 +8,4 @@ add_library (VBByRefStrNative SHARED ${SOURCES})
 target_link_libraries(VBByRefStrNative ${LINK_LIBRARIES_ADDITIONAL}) 
 
 # add the install targets
-install (TARGETS VBByRefStrNative DESTINATION bin)
+install (TARGETS VBByRefStrNative DESTINATION bin/nativeassets)

--- a/tests/src/Interop/StringMarshalling/VBByRefStr/CMakeLists.txt
+++ b/tests/src/Interop/StringMarshalling/VBByRefStr/CMakeLists.txt
@@ -9,3 +9,7 @@ target_link_libraries(VBByRefStrNative ${LINK_LIBRARIES_ADDITIONAL})
 
 # add the install targets
 install (TARGETS VBByRefStrNative DESTINATION bin/nativeassets)
+
+if (WIN32)
+  install (FILES $<TARGET_PDB_FILE:VBByRefStrNative> DESTINATION bin/nativeassets/PDB)
+endif()

--- a/tests/src/Interop/StructMarshalling/PInvoke/CMakeLists.txt
+++ b/tests/src/Interop/StructMarshalling/PInvoke/CMakeLists.txt
@@ -8,4 +8,4 @@ add_library (MarshalStructAsParam SHARED ${SOURCES})
 target_link_libraries(MarshalStructAsParam ${LINK_LIBRARIES_ADDITIONAL}) 
 
 # add the install targets
-install (TARGETS MarshalStructAsParam DESTINATION bin)
+install (TARGETS MarshalStructAsParam DESTINATION bin/nativeassets)

--- a/tests/src/Interop/StructMarshalling/PInvoke/CMakeLists.txt
+++ b/tests/src/Interop/StructMarshalling/PInvoke/CMakeLists.txt
@@ -9,3 +9,7 @@ target_link_libraries(MarshalStructAsParam ${LINK_LIBRARIES_ADDITIONAL})
 
 # add the install targets
 install (TARGETS MarshalStructAsParam DESTINATION bin/nativeassets)
+
+if (WIN32)
+  install (FILES $<TARGET_PDB_FILE:MarshalStructAsParam> DESTINATION bin/nativeassets/PDB)
+endif()

--- a/tests/src/Interop/StructMarshalling/ReversePInvoke/MarshalExpStruct/CMakeLists.txt
+++ b/tests/src/Interop/StructMarshalling/ReversePInvoke/MarshalExpStruct/CMakeLists.txt
@@ -9,4 +9,4 @@ set(SOURCES
 add_library (ReversePInvokeNative SHARED ${SOURCES})
 target_link_libraries(ReversePInvokeNative ${LINK_LIBRARIES_ADDITIONAL})  
 # add the install targets 
-install (TARGETS ReversePInvokeNative DESTINATION bin) 
+install (TARGETS ReversePInvokeNative DESTINATION bin/nativeassets) 

--- a/tests/src/Interop/StructMarshalling/ReversePInvoke/MarshalExpStruct/CMakeLists.txt
+++ b/tests/src/Interop/StructMarshalling/ReversePInvoke/MarshalExpStruct/CMakeLists.txt
@@ -10,3 +10,7 @@ add_library (ReversePInvokeNative SHARED ${SOURCES})
 target_link_libraries(ReversePInvokeNative ${LINK_LIBRARIES_ADDITIONAL})  
 # add the install targets 
 install (TARGETS ReversePInvokeNative DESTINATION bin/nativeassets) 
+
+if (WIN32)
+  install (FILES $<TARGET_PDB_FILE:ReversePInvokeNative> DESTINATION bin/nativeassets/PDB)
+endif()

--- a/tests/src/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/CMakeLists.txt
+++ b/tests/src/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/CMakeLists.txt
@@ -7,4 +7,4 @@ set(SOURCES
 add_library (SeqPInvokeNative SHARED ${SOURCES}) 
 target_link_libraries(SeqPInvokeNative ${LINK_LIBRARIES_ADDITIONAL}) 
 # add the install targets 
-install (TARGETS SeqPInvokeNative DESTINATION bin) 
+install (TARGETS SeqPInvokeNative DESTINATION bin/nativeassets) 

--- a/tests/src/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/CMakeLists.txt
+++ b/tests/src/Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/CMakeLists.txt
@@ -8,3 +8,7 @@ add_library (SeqPInvokeNative SHARED ${SOURCES})
 target_link_libraries(SeqPInvokeNative ${LINK_LIBRARIES_ADDITIONAL}) 
 # add the install targets 
 install (TARGETS SeqPInvokeNative DESTINATION bin/nativeassets) 
+
+if (WIN32)
+  install (FILES $<TARGET_PDB_FILE:SeqPInvokeNative> DESTINATION bin/nativeassets/PDB)
+endif()


### PR DESCRIPTION
The dotnet/performance repo doesn't have any infrastructure to build native assets for the performance testing. Since native test assets are needed to accurately benchmark our interop stack, this PR creates a new NuGet package (Microsoft.Private.Tests.Native.CoreCLR) that is published as part of the test build jobs in the official build.

With this package, we can add microbenchmarks in the dotnet/performance repo that use the packaged native assets by simply referencing the NuGet package.

In this PR, the package contains the native assets for the following Interop scenarios:

- P/Invoke native DLL load
- String marshalling
- General struct marshalling
- LayoutClass marshalling
- SafeHandle marshalling

cc: @dotnet/coreclr-infra 