### PR TITLE
[master] Move TypeSystemLog::OnKeywordsChanged

### DIFF
--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -4269,6 +4269,12 @@ VOID EtwCallbackCommon(
 #endif // !defined(FEATURE_PAL)
         ETW::GCLog::ForceGC(l64ClientSequenceNumber);
     }
+    // TypeSystemLog needs a notification when certain keywords are modified, so
+    // give it a hook here.
+    if (g_fEEStarted && !g_fEEShutDown && bIsPublicTraceHandle)
+    {
+        ETW::TypeSystemLog::OnKeywordsChanged();
+    }
 }
 
 // Individual callbacks for each EventPipe provider.
@@ -4487,13 +4493,6 @@ extern "C"
         }
 
         EtwCallbackCommon(providerIndex, ControlCode, Level, MatchAnyKeyword, FilterData, false);
-
-        // TypeSystemLog needs a notification when certain keywords are modified, so
-        // give it a hook here.
-        if (g_fEEStarted && !g_fEEShutDown && bIsPublicTraceHandle)
-        {
-            ETW::TypeSystemLog::OnKeywordsChanged();
-        }
 
         // A manifest based provider can be enabled to multiple event tracing sessions
         // As long as there is atleast 1 enabled session, IsEnabled will be TRUE


### PR DESCRIPTION
Move TypeSystemLog::OnKeywordsChanged from EtwCallback to EtwCallbackCommon to enable this same behavior in ETW and EventPipe.   This unblocks parity for GCHeapDumps between ETW and EventPipe.  This callback modifies some state in the type logging system used by ETW and EventPipe, but is currently _only_ invoked by ETW.  These state changes affect 

I'm planning on doing some more manual testing of this change since some of the tracing scenarios may not be covered by CI.

This change is small and targeted in the event we port this to 3.x, but there are are potentially more things that only exist in `EtwCallback` that may need to be moved to `EtwCallbackCommon`.

CC- @tommcdon 