### PR TITLE
Fix marshalling a pinnable multi-dimensional array via a P/Invoke

### DIFF
--- a/src/vm/ilmarshalers.cpp
+++ b/src/vm/ilmarshalers.cpp
@@ -3701,7 +3701,9 @@ void ILNativeArrayMarshaler::EmitCreateMngdMarshaler(ILCodeStream* pslILEmit)
 
 bool ILNativeArrayMarshaler::CanMarshalViaPinning()
 {
-    return IsCLRToNative(m_dwMarshalFlags) && !IsByref(m_dwMarshalFlags) && (NULL == OleVariant::GetMarshalerForVarType(m_pargs->na.m_vt, TRUE));
+    // We can't pin an array if we have a marshaler for the var type
+    // or if we can't get a method-table representing the array (how we determine the offset to pin).
+    return IsCLRToNative(m_dwMarshalFlags) && !IsByref(m_dwMarshalFlags) && (NULL == m_pargs->m_pMT) && (NULL == OleVariant::GetMarshalerForVarType(m_pargs->na.m_vt, TRUE));
 }
 
 void ILNativeArrayMarshaler::EmitMarshalViaPinning(ILCodeStream* pslILEmit)
@@ -3744,7 +3746,7 @@ void ILNativeArrayMarshaler::EmitMarshalViaPinning(ILCodeStream* pslILEmit)
     pslILEmit->EmitCONV_I();
     // Optimize marshalling by emitting the data ptr offset directly into the IL stream
     // instead of doing an FCall to recalulate it each time when possible.
-    pslILEmit->EmitLDC(ArrayBase::GetDataPtrOffset(m_pargs->m_pMarshalInfo->GetArrayElementTypeHandle().MakeSZArray().GetMethodTable()));
+    pslILEmit->EmitLDC(ArrayBase::GetDataPtrOffset(m_pargs->m_pMT));
     pslILEmit->EmitADD();
     EmitStoreNativeValue(pslILEmit);
 

--- a/src/vm/mlinfo.cpp
+++ b/src/vm/mlinfo.cpp
@@ -2802,6 +2802,8 @@ MarshalInfo::MarshalInfo(Module* pModule,
                 }
             }
 
+            m_args.m_pMT = arrayTypeHnd.GetMethodTable();
+
             // Handle retrieving the information for the array type.
             IfFailGoto(HandleArrayElemType(&ParamInfo, thElement, asArray->GetRank(), mtype == ELEMENT_TYPE_SZARRAY, isParam, pAssembly), lFail);
             break;

--- a/tests/src/Interop/PInvoke/Array/MarshalArrayAsParam/AsDefault/AsDefaultTest.cs
+++ b/tests/src/Interop/PInvoke/Array/MarshalArrayAsParam/AsDefault/AsDefaultTest.cs
@@ -244,11 +244,18 @@ public class ArrayMarshal
     [DllImport("MarshalArrayLPArrayNative")]
     private static extern bool CStyle_Array_Bool_Out(
         [Out] bool[] actual, int cActual);
+
+    [DllImport("MarshalArrayLPArrayNative")]
+    private static extern int Get_Multidimensional_Array_Sum(int[,] array, int rows, int columns);
     #endregion
 
     #region Marshal ByVal
 
     private const int ARRAY_SIZE = 100;
+
+    private const int ROWS = 3;
+
+    private const int COLUMNS = 2;
 
     private static T[] InitArray<T>(int size)
     {
@@ -287,6 +294,20 @@ public class ArrayMarshal
             array[i].str = i.ToString();
         }
 
+        return array;
+    }
+
+    private static int[,] InitMultidimensionalBlittableArray(int rows, int columns)
+    {
+        int[,] array = new int[rows, columns];
+
+        for (int i = 0; i < array.GetLength(0); i++)
+        {
+            for (int j = 0; j < array.GetLength(1); j++)
+            {
+                array[i, j] = i * j;
+            }
+        }
         return array;
     }
 
@@ -619,6 +640,19 @@ public class ArrayMarshal
 
     #endregion
 
+    private static void TestMultidimensional()
+    {
+        Console.WriteLine("================== [Get_Multidimensional_Array_Sum] ============");
+        int[,] array = InitMultidimensionalBlittableArray(ROWS, COLUMNS);
+        int sum = 0;
+        foreach (int item in array)
+        {
+            sum += item;
+        }
+
+        Assert.AreEqual(sum, Get_Multidimensional_Array_Sum(array, ROWS, COLUMNS));
+    }
+
     public static int Main()
     {
         try
@@ -627,6 +661,7 @@ public class ArrayMarshal
             TestMarshalByVal_In();
             TestMarshalInOut_ByVal();
             TestMarshalOut_ByVal();
+            TestMultidimensional();
             
             Console.WriteLine("\nTest PASS.");
             return 100;

--- a/tests/src/Interop/PInvoke/Array/MarshalArrayAsParam/LPArrayNative/MarshalArrayLPArrayNative.cpp
+++ b/tests/src/Interop/PInvoke/Array/MarshalArrayAsParam/LPArrayNative/MarshalArrayLPArrayNative.cpp
@@ -1111,3 +1111,16 @@ extern "C" DLL_EXPORT BOOL MarshalArrayOfStructAsLPArrayByRefOut(S2 **pActual, i
     }
     return breturn;
 }
+
+extern "C" DLL_EXPORT int Get_Multidimensional_Array_Sum(int* array, int rows, int columns)
+{
+    int sum = 0;
+    for(int i = 0; i < rows; ++i)
+    {
+        for (int j = 0; j < columns; ++j)
+        {
+            sum += array[i * columns + j];
+        }
+    }
+    return sum;
+}


### PR DESCRIPTION
Use the exact MethodTable of the array parameter to calculate the offset into a pinned array instead of assuming that it is an SZArray (one-dimensional array).

@jeffschwMSFT We may want to port this back to something in 3.x since this is a regression from 2.x.
