### PR TITLE
[release/3.0-preview9] Unblock p9 builds by having correct extension on manifests

### DIFF
--- a/src/publishwitharcade.proj
+++ b/src/publishwitharcade.proj
@@ -47,7 +47,7 @@
 
 
     <PropertyGroup>
-      <AssetManifestFilePath>$(ArtifactsLogDir)AssetManifest\$(OSIdentifier)-$(BuildArch)</AssetManifestFilePath>
+      <AssetManifestFilePath>$(ArtifactsLogDir)AssetManifest\$(OSIdentifier)-$(BuildArch).xml</AssetManifestFilePath>
       <!-- Work around an issue where the repo URI is different on
            OSX, causing the manifests to have different headers, which
            makes publishing to BAR fail later when it tries to merge


### PR DESCRIPTION
#### Description

Preview9 builds are blocked because the asset manifests are not suffixed with .xml.
		
#### Customer Impact

No build