### PR TITLE
Make "async ValueTask/ValueTask<T>" methods ammortized allocation-free

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncMethodBuilderCore.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncMethodBuilderCore.cs
@@ -62,7 +62,7 @@ namespace System.Runtime.CompilerServices
             }
         }
 
-        public static void SetStateMachine(IAsyncStateMachine stateMachine, Task task)
+        public static void SetStateMachine(IAsyncStateMachine stateMachine, Task? task)
         {
             if (stateMachine == null)
             {

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncTaskCache.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncTaskCache.cs
@@ -12,15 +12,35 @@ namespace System.Runtime.CompilerServices
     internal static class AsyncTaskCache
     {
         /// <summary>A cached Task{Boolean}.Result == true.</summary>
-        internal static readonly Task<bool> s_trueTask = CreateCacheableTask(true);
+        internal static readonly Task<bool> s_trueTask = CreateCacheableTask(result: true);
         /// <summary>A cached Task{Boolean}.Result == false.</summary>
-        internal static readonly Task<bool> s_falseTask = CreateCacheableTask(false);
+        internal static readonly Task<bool> s_falseTask = CreateCacheableTask(result: false);
         /// <summary>The cache of Task{Int32}.</summary>
         internal static readonly Task<int>[] s_int32Tasks = CreateInt32Tasks();
         /// <summary>The minimum value, inclusive, for which we want a cached task.</summary>
         internal const int InclusiveInt32Min = -1;
         /// <summary>The maximum value, exclusive, for which we want a cached task.</summary>
         internal const int ExclusiveInt32Max = 9;
+
+        /// <summary>true if we should use reusable boxes for async completions of ValueTask methods; false if we should use tasks.</summary>
+        /// <remarks>
+        /// We rely on tiered compilation turning this into a const and doing dead code elimination to make checks on this efficient.
+        /// It's also required for safety that this value never changes once observed, as Unsafe.As casts are employed based on its value.
+        /// </remarks>
+        internal static readonly bool s_valueTaskPoolingEnabled = GetPoolAsyncValueTasksSwitch();
+        /// <summary>Maximum number of boxes that are allowed to be cached per state machine type.</summary>
+        internal static readonly int s_valueTaskPoolingCacheSize = GetPoolAsyncValueTasksLimitValue();
+
+        private static bool GetPoolAsyncValueTasksSwitch()
+        {
+            string? value = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_THREADING_POOLASYNCVALUETASKS");
+            return value != null && (bool.IsTrueStringIgnoreCase(value) || value.Equals("1"));
+        }
+
+        private static int GetPoolAsyncValueTasksLimitValue() =>
+            int.TryParse(Environment.GetEnvironmentVariable("DOTNET_SYSTEM_THREADING_POOLASYNCVALUETASKSLIMIT"), out int result) && result > 0 ?
+                result :
+                Environment.ProcessorCount * 4; // arbitrary default value
 
         /// <summary>Creates a non-disposable task.</summary>
         /// <typeparam name="TResult">Specifies the result type.</typeparam>

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -3,10 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Internal.Runtime.CompilerServices;
-using System.Diagnostics.CodeAnalysis;
 
 namespace System.Runtime.CompilerServices
 {
@@ -25,17 +25,11 @@ namespace System.Runtime.CompilerServices
         internal static readonly Task<TResult> s_defaultResultTask = AsyncTaskCache.CreateCacheableTask<TResult>(default);
 
         /// <summary>The lazily-initialized built task.</summary>
-        private Task<TResult> m_task; // lazily-initialized: must not be readonly. Debugger depends on the exact name of this field.
+        private Task<TResult>? m_task; // Debugger depends on the exact name of this field.
 
         /// <summary>Initializes a new <see cref="AsyncTaskMethodBuilder"/>.</summary>
         /// <returns>The initialized <see cref="AsyncTaskMethodBuilder"/>.</returns>
-        public static AsyncTaskMethodBuilder<TResult> Create()
-        {
-            // NOTE: If this method is ever updated to perform more initialization,
-            //       other Create methods like AsyncTaskMethodBuilder.Create and
-            //       AsyncValueTaskMethodBuilder.Create must be updated to call this.
-            return default;
-        }
+        public static AsyncTaskMethodBuilder<TResult> Create() => default;
 
         /// <summary>Initiates the builder's execution with the associated state machine.</summary>
         /// <typeparam name="TStateMachine">Specifies the type of the state machine.</typeparam>
@@ -49,8 +43,8 @@ namespace System.Runtime.CompilerServices
         /// <param name="stateMachine">The heap-allocated state machine object.</param>
         /// <exception cref="System.ArgumentNullException">The <paramref name="stateMachine"/> argument was null (Nothing in Visual Basic).</exception>
         /// <exception cref="System.InvalidOperationException">The builder is incorrectly initialized.</exception>
-        public void SetStateMachine(IAsyncStateMachine stateMachine)
-            => AsyncMethodBuilderCore.SetStateMachine(stateMachine, m_task);
+        public void SetStateMachine(IAsyncStateMachine stateMachine) =>
+            AsyncMethodBuilderCore.SetStateMachine(stateMachine, m_task);
 
         /// <summary>
         /// Schedules the specified state machine to be pushed forward when the specified awaiter completes.
@@ -62,11 +56,17 @@ namespace System.Runtime.CompilerServices
         public void AwaitOnCompleted<TAwaiter, TStateMachine>(
             ref TAwaiter awaiter, ref TStateMachine stateMachine)
             where TAwaiter : INotifyCompletion
+            where TStateMachine : IAsyncStateMachine =>
+            AwaitOnCompleted(ref awaiter, ref stateMachine, ref m_task);
+
+        internal static void AwaitOnCompleted<TAwaiter, TStateMachine>(
+            ref TAwaiter awaiter, ref TStateMachine stateMachine, [NotNull] ref Task<TResult>? taskField)
+            where TAwaiter : INotifyCompletion
             where TStateMachine : IAsyncStateMachine
         {
             try
             {
-                awaiter.OnCompleted(GetStateMachineBox(ref stateMachine).MoveNextAction);
+                awaiter.OnCompleted(GetStateMachineBox(ref stateMachine, ref taskField).MoveNextAction);
             }
             catch (Exception e)
             {
@@ -81,15 +81,28 @@ namespace System.Runtime.CompilerServices
         /// <typeparam name="TStateMachine">Specifies the type of the state machine.</typeparam>
         /// <param name="awaiter">The awaiter.</param>
         /// <param name="stateMachine">The state machine.</param>
-        // AggressiveOptimization to workaround boxing allocations in Tier0 until: https://github.com/dotnet/coreclr/issues/14474
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(
             ref TAwaiter awaiter, ref TStateMachine stateMachine)
             where TAwaiter : ICriticalNotifyCompletion
+            where TStateMachine : IAsyncStateMachine =>
+            AwaitUnsafeOnCompleted(ref awaiter, ref stateMachine, ref m_task);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(
+            ref TAwaiter awaiter, ref TStateMachine stateMachine, [NotNull] ref Task<TResult>? taskField)
+            where TAwaiter : ICriticalNotifyCompletion
             where TStateMachine : IAsyncStateMachine
         {
-            IAsyncStateMachineBox box = GetStateMachineBox(ref stateMachine);
+            IAsyncStateMachineBox box = GetStateMachineBox(ref stateMachine, ref taskField);
+            AwaitUnsafeOnCompleted(ref awaiter, box);
+        }
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)] // workaround boxing allocations in Tier0: https://github.com/dotnet/coreclr/issues/14474
+        internal static void AwaitUnsafeOnCompleted<TAwaiter>(
+            ref TAwaiter awaiter, IAsyncStateMachineBox box)
+            where TAwaiter : ICriticalNotifyCompletion
+        {
             // The null tests here ensure that the jit can optimize away the interface
             // tests when TAwaiter is a ref type.
 
@@ -139,8 +152,9 @@ namespace System.Runtime.CompilerServices
         /// <typeparam name="TStateMachine">Specifies the type of the async state machine.</typeparam>
         /// <param name="stateMachine">The state machine.</param>
         /// <returns>The "boxed" state machine.</returns>
-        private IAsyncStateMachineBox GetStateMachineBox<TStateMachine>(
-            ref TStateMachine stateMachine)
+        private static IAsyncStateMachineBox GetStateMachineBox<TStateMachine>(
+            ref TStateMachine stateMachine,
+            [NotNull] ref Task<TResult>? taskField)
             where TStateMachine : IAsyncStateMachine
         {
             ExecutionContext? currentContext = ExecutionContext.Capture();
@@ -150,7 +164,7 @@ namespace System.Runtime.CompilerServices
             // a strongly-typed manner into an AsyncStateMachineBox.  It will already contain
             // the state machine as well as a MoveNextDelegate and a context.  The only thing
             // we might need to do is update the context if that's changed since it was stored.
-            if (m_task is AsyncStateMachineBox<TStateMachine> stronglyTypedBox)
+            if (taskField is AsyncStateMachineBox<TStateMachine> stronglyTypedBox)
             {
                 if (stronglyTypedBox.Context != currentContext)
                 {
@@ -168,7 +182,7 @@ namespace System.Runtime.CompilerServices
             // result in a boxing allocation when storing the TStateMachine if it's a struct, but
             // this only happens in active debugging scenarios where such performance impact doesn't
             // matter.
-            if (m_task is AsyncStateMachineBox<IAsyncStateMachine> weaklyTypedBox)
+            if (taskField is AsyncStateMachineBox<IAsyncStateMachine> weaklyTypedBox)
             {
                 // If this is the first await, we won't yet have a state machine, so store it.
                 if (weaklyTypedBox.StateMachine == null)
@@ -191,7 +205,7 @@ namespace System.Runtime.CompilerServices
             // multiple callbacks registered to push the state machine, which could result in bad behavior.
             Debugger.NotifyOfCrossThreadDependency();
 
-            // At this point, m_task should really be null, in which case we want to create the box.
+            // At this point, taskField should really be null, in which case we want to create the box.
             // However, in a variety of debugger-related (erroneous) situations, it might be non-null,
             // e.g. if the Task property is examined in a Watch window, forcing it to be lazily-intialized
             // as a Task<TResult> rather than as an AsyncStateMachineBox.  The worst that happens in such
@@ -209,7 +223,7 @@ namespace System.Runtime.CompilerServices
                 CreateDebugFinalizableAsyncStateMachineBox<TStateMachine>() :
                 new AsyncStateMachineBox<TStateMachine>();
 #endif
-            m_task = box; // important: this must be done before storing stateMachine into box.StateMachine!
+            taskField = box; // important: this must be done before storing stateMachine into box.StateMachine!
             box.StateMachine = stateMachine;
             box.Context = currentContext;
 
@@ -374,24 +388,16 @@ namespace System.Runtime.CompilerServices
             return m_task = new Task<TResult>();
         }
 
-        /// <summary>
-        /// Initializes the task, which must not yet be initialized.  Used only when the Task is being forced into
-        /// existence due to the debugger trying to enable step-out/step-over/etc. prior to the first await yielding
-        /// in an async method.  In that case, we don't know the actual TStateMachine type, so we're forced to
-        /// use IAsyncStateMachine instead.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private Task<TResult> InitializeTaskAsStateMachineBox()
+        internal static Task<TResult> CreateWeaklyTypedStateMachineBox()
         {
-            Debug.Assert(m_task == null);
 #if CORERT
             // DebugFinalizableAsyncStateMachineBox looks like a small type, but it actually is not because
             // it will have a copy of all the slots from its parent. It will add another hundred(s) bytes
             // per each async method in CoreRT / ProjectN binaries without adding much value. Avoid
             // generating this extra code until a better solution is implemented.
-            return (m_task = new AsyncStateMachineBox<IAsyncStateMachine>());
+            return new AsyncStateMachineBox<IAsyncStateMachine>());
 #else
-            return m_task = AsyncMethodBuilderCore.TrackAsyncMethodCompletion ?
+            return AsyncMethodBuilderCore.TrackAsyncMethodCompletion ?
                 CreateDebugFinalizableAsyncStateMachineBox<IAsyncStateMachine>() :
                 new AsyncStateMachineBox<IAsyncStateMachine>();
 #endif
@@ -407,7 +413,7 @@ namespace System.Runtime.CompilerServices
         {
             // Get the currently stored task, which will be non-null if get_Task has already been accessed.
             // If there isn't one, get a task and store it.
-            if (m_task == null)
+            if (m_task is null)
             {
                 m_task = GetTaskForResult(result);
                 Debug.Assert(m_task != null, $"{nameof(GetTaskForResult)} should never return null");
@@ -415,48 +421,24 @@ namespace System.Runtime.CompilerServices
             else
             {
                 // Slow path: complete the existing task.
-                SetExistingTaskResult(result);
+                SetExistingTaskResult(m_task, result);
             }
         }
 
         /// <summary>Completes the already initialized task with the specified result.</summary>
         /// <param name="result">The result to use to complete the task.</param>
-        private void SetExistingTaskResult([AllowNull] TResult result)
+        internal static void SetExistingTaskResult(Task<TResult> taskField, [AllowNull] TResult result)
         {
-            Debug.Assert(m_task != null, "Expected non-null task");
+            Debug.Assert(taskField != null, "Expected non-null task");
 
             if (AsyncCausalityTracer.LoggingOn)
             {
-                AsyncCausalityTracer.TraceOperationCompletion(m_task, AsyncCausalityStatus.Completed);
+                AsyncCausalityTracer.TraceOperationCompletion(taskField, AsyncCausalityStatus.Completed);
             }
 
-            if (!m_task.TrySetResult(result))
+            if (!taskField.TrySetResult(result))
             {
                 ThrowHelper.ThrowInvalidOperationException(ExceptionResource.TaskT_TransitionToFinal_AlreadyCompleted);
-            }
-        }
-
-        /// <summary>
-        /// Completes the builder by using either the supplied completed task, or by completing
-        /// the builder's previously accessed task using default(TResult).
-        /// </summary>
-        /// <param name="completedTask">A task already completed with the value default(TResult).</param>
-        /// <exception cref="System.InvalidOperationException">The task has already completed.</exception>
-        internal void SetResult(Task<TResult> completedTask)
-        {
-            Debug.Assert(completedTask != null, "Expected non-null task");
-            Debug.Assert(completedTask.IsCompletedSuccessfully, "Expected a successfully completed task");
-
-            // Get the currently stored task, which will be non-null if get_Task has already been accessed.
-            // If there isn't one, store the supplied completed task.
-            if (m_task == null)
-            {
-                m_task = completedTask;
-            }
-            else
-            {
-                // Otherwise, complete the task that's there.
-                SetExistingTaskResult(default!); // Remove ! when nullable attributes are respected
             }
         }
 
@@ -467,7 +449,9 @@ namespace System.Runtime.CompilerServices
         /// <param name="exception">The <see cref="System.Exception"/> to use to fault the task.</param>
         /// <exception cref="System.ArgumentNullException">The <paramref name="exception"/> argument is null (Nothing in Visual Basic).</exception>
         /// <exception cref="System.InvalidOperationException">The task has already completed.</exception>
-        public void SetException(Exception exception)
+        public void SetException(Exception exception) => SetException(exception, ref m_task);
+
+        internal static void SetException(Exception exception, ref Task<TResult>? taskField)
         {
             if (exception == null)
             {
@@ -475,7 +459,7 @@ namespace System.Runtime.CompilerServices
             }
 
             // Get the task, forcing initialization if it hasn't already been initialized.
-            Task<TResult> task = this.Task;
+            Task<TResult> task = (taskField ??= new Task<TResult>());
 
             // If the exception represents cancellation, cancel the task.  Otherwise, fault the task.
             bool successfullySet = exception is OperationCanceledException oce ?
@@ -505,10 +489,13 @@ namespace System.Runtime.CompilerServices
         /// This should only be invoked from within an asynchronous method,
         /// and only by the debugger.
         /// </remarks>
-        internal void SetNotificationForWaitCompletion(bool enabled)
+        internal void SetNotificationForWaitCompletion(bool enabled) =>
+            SetNotificationForWaitCompletion(enabled, ref m_task);
+
+        internal static void SetNotificationForWaitCompletion(bool enabled, [NotNull] ref Task<TResult>? taskField)
         {
             // Get the task (forcing initialization if not already initialized), and set debug notification
-            (m_task ?? InitializeTaskAsStateMachineBox()).SetNotificationForWaitCompletion(enabled);
+            (taskField ??= CreateWeaklyTypedStateMachineBox()).SetNotificationForWaitCompletion(enabled);
 
             // NOTE: It's important that the debugger use builder.SetNotificationForWaitCompletion
             // rather than builder.Task.SetNotificationForWaitCompletion.  Even though the latter will
@@ -529,7 +516,7 @@ namespace System.Runtime.CompilerServices
         /// It must only be used by the debugger and tracing purposes, and only in a single-threaded manner
         /// when no other threads are in the middle of accessing this or other members that lazily initialize the task.
         /// </remarks>
-        internal object ObjectIdForDebugger => m_task ?? InitializeTaskAsStateMachineBox();
+        internal object ObjectIdForDebugger => m_task ??= CreateWeaklyTypedStateMachineBox();
 
         /// <summary>
         /// Gets a task for the specified result.  This will either

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncValueTaskMethodBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncValueTaskMethodBuilder.cs
@@ -4,6 +4,9 @@
 
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using Internal.Runtime.CompilerServices;
+
+using StateMachineBox = System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder<System.Threading.Tasks.VoidTaskResult>.StateMachineBox;
 
 namespace System.Runtime.CompilerServices
 {
@@ -11,62 +14,98 @@ namespace System.Runtime.CompilerServices
     [StructLayout(LayoutKind.Auto)]
     public struct AsyncValueTaskMethodBuilder
     {
-        /// <summary>The <see cref="AsyncTaskMethodBuilder"/> to which most operations are delegated.</summary>
-        private AsyncTaskMethodBuilder _methodBuilder; // mutable struct; do not make it readonly
-        /// <summary>true if completed synchronously and successfully; otherwise, false.</summary>
-        private bool _haveResult;
-        /// <summary>true if the builder should be used for setting/getting the result; otherwise, false.</summary>
-        private bool _useBuilder;
+        /// <summary>Sentinel object used to indicate that the builder completed synchronously and successfully.</summary>
+        private static readonly object s_syncSuccessSentinel = AsyncValueTaskMethodBuilder<VoidTaskResult>.s_syncSuccessSentinel;
+
+        /// <summary>The wrapped state machine box or task, based on the value of <see cref="AsyncTaskCache.s_valueTaskPoolingEnabled"/>.</summary>
+        /// <remarks>
+        /// If the operation completed synchronously and successfully, this will be <see cref="s_syncSuccessSentinel"/>.
+        /// </remarks>
+        private object? m_task; // Debugger depends on the exact name of this field.
 
         /// <summary>Creates an instance of the <see cref="AsyncValueTaskMethodBuilder"/> struct.</summary>
         /// <returns>The initialized instance.</returns>
-        public static AsyncValueTaskMethodBuilder Create() =>
-            // _methodBuilder should be initialized to AsyncTaskMethodBuilder.Create(), but on coreclr
-            // that Create() is a nop, so we can just return the default here.
-            default;
+        public static AsyncValueTaskMethodBuilder Create() => default;
 
         /// <summary>Begins running the builder with the associated state machine.</summary>
         /// <typeparam name="TStateMachine">The type of the state machine.</typeparam>
         /// <param name="stateMachine">The state machine instance, passed by reference.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine =>
-            // will provide the right ExecutionContext semantics
+        public void Start<TStateMachine>(ref TStateMachine stateMachine)
+            where TStateMachine : IAsyncStateMachine =>
             AsyncMethodBuilderCore.Start(ref stateMachine);
 
         /// <summary>Associates the builder with the specified state machine.</summary>
         /// <param name="stateMachine">The state machine instance to associate with the builder.</param>
-        public void SetStateMachine(IAsyncStateMachine stateMachine) => _methodBuilder.SetStateMachine(stateMachine);
+        public void SetStateMachine(IAsyncStateMachine stateMachine) =>
+            AsyncMethodBuilderCore.SetStateMachine(stateMachine, task: null);
 
         /// <summary>Marks the task as successfully completed.</summary>
         public void SetResult()
         {
-            if (_useBuilder)
+            if (m_task is null)
             {
-                _methodBuilder.SetResult();
+                m_task = s_syncSuccessSentinel;
+            }
+            else if (AsyncTaskCache.s_valueTaskPoolingEnabled)
+            {
+                Unsafe.As<StateMachineBox>(m_task).SetResult(default);
             }
             else
             {
-                _haveResult = true;
+                AsyncTaskMethodBuilder<VoidTaskResult>.SetExistingTaskResult(Unsafe.As<Task<VoidTaskResult>>(m_task), default);
             }
         }
 
         /// <summary>Marks the task as failed and binds the specified exception to the task.</summary>
         /// <param name="exception">The exception to bind to the task.</param>
-        public void SetException(Exception exception) => _methodBuilder.SetException(exception);
+        public void SetException(Exception exception)
+        {
+            if (AsyncTaskCache.s_valueTaskPoolingEnabled)
+            {
+                AsyncValueTaskMethodBuilder<VoidTaskResult>.SetException(exception, ref Unsafe.As<object?, StateMachineBox?>(ref m_task));
+            }
+            else
+            {
+                AsyncTaskMethodBuilder<VoidTaskResult>.SetException(exception, ref Unsafe.As<object?, Task<VoidTaskResult>?>(ref m_task));
+            }
+        }
 
         /// <summary>Gets the task for this builder.</summary>
         public ValueTask Task
         {
             get
             {
-                if (_haveResult)
+                if (m_task == s_syncSuccessSentinel)
                 {
                     return default;
                 }
+
+                // With normal access paterns, m_task should always be non-null here: the async method should have
+                // either completed synchronously, in which case SetResult would have set m_task to a non-null object,
+                // or it should be completing asynchronously, in which case AwaitUnsafeOnCompleted would have similarly
+                // initialized m_task to a state machine object.  However, if the type is used manually (not via
+                // compiler-generated code) and accesses Task directly, we force it to be initialized.  Things will then
+                // "work" but in a degraded mode, as we don't know the TStateMachine type here, and thus we use a box around
+                // the interface instead.
+
+                if (AsyncTaskCache.s_valueTaskPoolingEnabled)
+                {
+                    var box = Unsafe.As<StateMachineBox?>(m_task);
+                    if (box is null)
+                    {
+                        m_task = box = AsyncValueTaskMethodBuilder<VoidTaskResult>.CreateWeaklyTypedStateMachineBox();
+                    }
+                    return new ValueTask(box, box.Version);
+                }
                 else
                 {
-                    _useBuilder = true;
-                    return new ValueTask(_methodBuilder.Task);
+                    var task = Unsafe.As<Task<VoidTaskResult>?>(m_task);
+                    if (task is null)
+                    {
+                        m_task = task = new Task<VoidTaskResult>(); // base task used rather than box to minimize size when used as manual promise
+                    }
+                    return new ValueTask(task);
                 }
             }
         }
@@ -80,8 +119,14 @@ namespace System.Runtime.CompilerServices
             where TAwaiter : INotifyCompletion
             where TStateMachine : IAsyncStateMachine
         {
-            _useBuilder = true;
-            _methodBuilder.AwaitOnCompleted(ref awaiter, ref stateMachine);
+            if (AsyncTaskCache.s_valueTaskPoolingEnabled)
+            {
+                AsyncValueTaskMethodBuilder<VoidTaskResult>.AwaitOnCompleted(ref awaiter, ref stateMachine, ref Unsafe.As<object?, StateMachineBox?>(ref m_task));
+            }
+            else
+            {
+                AsyncTaskMethodBuilder<VoidTaskResult>.AwaitOnCompleted(ref awaiter, ref stateMachine, ref Unsafe.As<object?, Task<VoidTaskResult>?>(ref m_task));
+            }
         }
 
         /// <summary>Schedules the state machine to proceed to the next action when the specified awaiter completes.</summary>
@@ -89,12 +134,42 @@ namespace System.Runtime.CompilerServices
         /// <typeparam name="TStateMachine">The type of the state machine.</typeparam>
         /// <param name="awaiter">The awaiter.</param>
         /// <param name="stateMachine">The state machine.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
             where TAwaiter : ICriticalNotifyCompletion
             where TStateMachine : IAsyncStateMachine
         {
-            _useBuilder = true;
-            _methodBuilder.AwaitUnsafeOnCompleted(ref awaiter, ref stateMachine);
+            if (AsyncTaskCache.s_valueTaskPoolingEnabled)
+            {
+                AsyncValueTaskMethodBuilder<VoidTaskResult>.AwaitUnsafeOnCompleted(ref awaiter, ref stateMachine, ref Unsafe.As<object?, StateMachineBox?>(ref m_task));
+            }
+            else
+            {
+                AsyncTaskMethodBuilder<VoidTaskResult>.AwaitUnsafeOnCompleted(ref awaiter, ref stateMachine, ref Unsafe.As<object?, Task<VoidTaskResult>?>(ref m_task));
+            }
+        }
+
+        /// <summary>
+        /// Gets an object that may be used to uniquely identify this builder to the debugger.
+        /// </summary>
+        /// <remarks>
+        /// This property lazily instantiates the ID in a non-thread-safe manner.
+        /// It must only be used by the debugger and tracing purposes, and only in a single-threaded manner
+        /// when no other threads are in the middle of accessing this or other members that lazily initialize the box.
+        /// </remarks>
+        internal object ObjectIdForDebugger
+        {
+            get
+            {
+                if (m_task is null)
+                {
+                    m_task = AsyncTaskCache.s_valueTaskPoolingEnabled ? (object)
+                        AsyncValueTaskMethodBuilder<VoidTaskResult>.CreateWeaklyTypedStateMachineBox() :
+                        AsyncTaskMethodBuilder<VoidTaskResult>.CreateWeaklyTypedStateMachineBox();
+                }
+
+                return m_task;
+            }
         }
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncValueTaskMethodBuilderT.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncValueTaskMethodBuilderT.cs
@@ -2,8 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
+using System.Threading.Tasks.Sources;
+using Internal.Runtime.CompilerServices;
 
 namespace System.Runtime.CompilerServices
 {
@@ -12,66 +17,115 @@ namespace System.Runtime.CompilerServices
     [StructLayout(LayoutKind.Auto)]
     public struct AsyncValueTaskMethodBuilder<TResult>
     {
-        /// <summary>The <see cref="AsyncTaskMethodBuilder{TResult}"/> to which most operations are delegated.</summary>
-        private AsyncTaskMethodBuilder<TResult> _methodBuilder; // mutable struct; do not make it readonly
-        /// <summary>The result for this builder, if it's completed before any awaits occur.</summary>
+        /// <summary>Sentinel object used to indicate that the builder completed synchronously and successfully.</summary>
+        /// <remarks>
+        /// To avoid memory safety issues even in the face of invalid race conditions, we ensure that the type of this object
+        /// is valid for the mode in which we're operating.  As such, it's cached on the generic builder per TResult
+        /// rather than having one sentinel instance for all types.
+        /// </remarks>
+        internal static readonly object s_syncSuccessSentinel = AsyncTaskCache.s_valueTaskPoolingEnabled ? (object)
+            new SyncSuccessSentinelStateMachineBox() :
+            new Task<TResult>(default(TResult)!);
+
+        /// <summary>The wrapped state machine or task.  If the operation completed synchronously and successfully, this will be a sentinel object compared by reference identity.</summary>
+        private object? m_task; // Debugger depends on the exact name of this field.
+        /// <summary>The result for this builder if it's completed synchronously, in which case <see cref="m_task"/> will be <see cref="s_syncSuccessSentinel"/>.</summary>
         private TResult _result;
-        /// <summary>true if <see cref="_result"/> contains the synchronous result for the async method; otherwise, false.</summary>
-        private bool _haveResult;
-        /// <summary>true if the builder should be used for setting/getting the result; otherwise, false.</summary>
-        private bool _useBuilder;
 
         /// <summary>Creates an instance of the <see cref="AsyncValueTaskMethodBuilder{TResult}"/> struct.</summary>
         /// <returns>The initialized instance.</returns>
-        public static AsyncValueTaskMethodBuilder<TResult> Create() =>
-            // _methodBuilder should be initialized to AsyncTaskMethodBuilder<TResult>.Create(), but on coreclr
-            // that Create() is a nop, so we can just return the default here.
-            default;
+        public static AsyncValueTaskMethodBuilder<TResult> Create() => default;
 
         /// <summary>Begins running the builder with the associated state machine.</summary>
         /// <typeparam name="TStateMachine">The type of the state machine.</typeparam>
         /// <param name="stateMachine">The state machine instance, passed by reference.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine =>
-            // will provide the right ExecutionContext semantics
             AsyncMethodBuilderCore.Start(ref stateMachine);
 
         /// <summary>Associates the builder with the specified state machine.</summary>
         /// <param name="stateMachine">The state machine instance to associate with the builder.</param>
-        public void SetStateMachine(IAsyncStateMachine stateMachine) => _methodBuilder.SetStateMachine(stateMachine);
+        public void SetStateMachine(IAsyncStateMachine stateMachine) =>
+            AsyncMethodBuilderCore.SetStateMachine(stateMachine, task: null);
 
-        /// <summary>Marks the task as successfully completed.</summary>
-        /// <param name="result">The result to use to complete the task.</param>
+        /// <summary>Marks the value task as successfully completed.</summary>
+        /// <param name="result">The result to use to complete the value task.</param>
         public void SetResult(TResult result)
         {
-            if (_useBuilder)
+            if (m_task is null)
             {
-                _methodBuilder.SetResult(result);
+                _result = result;
+                m_task = s_syncSuccessSentinel;
+            }
+            else if (AsyncTaskCache.s_valueTaskPoolingEnabled)
+            {
+                Unsafe.As<StateMachineBox>(m_task).SetResult(result);
             }
             else
             {
-                _result = result;
-                _haveResult = true;
+                AsyncTaskMethodBuilder<TResult>.SetExistingTaskResult(Unsafe.As<Task<TResult>>(m_task), result);
             }
         }
 
-        /// <summary>Marks the task as failed and binds the specified exception to the task.</summary>
-        /// <param name="exception">The exception to bind to the task.</param>
-        public void SetException(Exception exception) => _methodBuilder.SetException(exception);
+        /// <summary>Marks the value task as failed and binds the specified exception to the value task.</summary>
+        /// <param name="exception">The exception to bind to the value task.</param>
+        public void SetException(Exception exception)
+        {
+            if (AsyncTaskCache.s_valueTaskPoolingEnabled)
+            {
+                SetException(exception, ref Unsafe.As<object?, StateMachineBox?>(ref m_task));
+            }
+            else
+            {
+                AsyncTaskMethodBuilder<TResult>.SetException(exception, ref Unsafe.As<object?, Task<TResult>?>(ref m_task));
+            }
+        }
 
-        /// <summary>Gets the task for this builder.</summary>
+        internal static void SetException(Exception exception, [NotNull] ref StateMachineBox? boxFieldRef)
+        {
+            if (exception is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.exception);
+            }
+
+            (boxFieldRef ??= CreateWeaklyTypedStateMachineBox()).SetException(exception);
+        }
+
+        /// <summary>Gets the value task for this builder.</summary>
         public ValueTask<TResult> Task
         {
             get
             {
-                if (_haveResult)
+                if (m_task == s_syncSuccessSentinel)
                 {
                     return new ValueTask<TResult>(_result);
                 }
+
+                // With normal access paterns, m_task should always be non-null here: the async method should have
+                // either completed synchronously, in which case SetResult would have set m_task to a non-null object,
+                // or it should be completing asynchronously, in which case AwaitUnsafeOnCompleted would have similarly
+                // initialized m_task to a state machine object.  However, if the type is used manually (not via
+                // compiler-generated code) and accesses Task directly, we force it to be initialized.  Things will then
+                // "work" but in a degraded mode, as we don't know the TStateMachine type here, and thus we use a box around
+                // the interface instead.
+
+                if (AsyncTaskCache.s_valueTaskPoolingEnabled)
+                {
+                    var box = Unsafe.As<StateMachineBox?>(m_task);
+                    if (box is null)
+                    {
+                        m_task = box = CreateWeaklyTypedStateMachineBox();
+                    }
+                    return new ValueTask<TResult>(box, box.Version);
+                }
                 else
                 {
-                    _useBuilder = true;
-                    return new ValueTask<TResult>(_methodBuilder.Task);
+                    var task = Unsafe.As<Task<TResult>?>(m_task);
+                    if (task is null)
+                    {
+                        m_task = task = new Task<TResult>(); // base task used rather than box to minimize size when used as manual promise
+                    }
+                    return new ValueTask<TResult>(task);
                 }
             }
         }
@@ -85,8 +139,29 @@ namespace System.Runtime.CompilerServices
             where TAwaiter : INotifyCompletion
             where TStateMachine : IAsyncStateMachine
         {
-            _useBuilder = true;
-            _methodBuilder.AwaitOnCompleted(ref awaiter, ref stateMachine);
+            if (AsyncTaskCache.s_valueTaskPoolingEnabled)
+            {
+                AwaitOnCompleted(ref awaiter, ref stateMachine, ref Unsafe.As<object?, StateMachineBox?>(ref m_task));
+            }
+            else
+            {
+                AsyncTaskMethodBuilder<TResult>.AwaitOnCompleted(ref awaiter, ref stateMachine, ref Unsafe.As<object?, Task<TResult>?>(ref m_task));
+            }
+        }
+
+        internal static void AwaitOnCompleted<TAwaiter, TStateMachine>(
+            ref TAwaiter awaiter, ref TStateMachine stateMachine, [NotNull] ref StateMachineBox? box)
+            where TAwaiter : INotifyCompletion
+            where TStateMachine : IAsyncStateMachine
+        {
+            try
+            {
+                awaiter.OnCompleted(GetStateMachineBox(ref stateMachine, ref box).MoveNextAction);
+            }
+            catch (Exception e)
+            {
+                System.Threading.Tasks.Task.ThrowAsync(e, targetContext: null);
+            }
         }
 
         /// <summary>Schedules the state machine to proceed to the next action when the specified awaiter completes.</summary>
@@ -94,12 +169,345 @@ namespace System.Runtime.CompilerServices
         /// <typeparam name="TStateMachine">The type of the state machine.</typeparam>
         /// <param name="awaiter">the awaiter</param>
         /// <param name="stateMachine">The state machine.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
             where TAwaiter : ICriticalNotifyCompletion
             where TStateMachine : IAsyncStateMachine
         {
-            _useBuilder = true;
-            _methodBuilder.AwaitUnsafeOnCompleted(ref awaiter, ref stateMachine);
+            if (AsyncTaskCache.s_valueTaskPoolingEnabled)
+            {
+                AwaitUnsafeOnCompleted(ref awaiter, ref stateMachine, ref Unsafe.As<object?, StateMachineBox?>(ref m_task));
+            }
+            else
+            {
+                AsyncTaskMethodBuilder<TResult>.AwaitUnsafeOnCompleted(ref awaiter, ref stateMachine, ref Unsafe.As<object?, Task<TResult>?>(ref m_task));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(
+            ref TAwaiter awaiter, ref TStateMachine stateMachine, [NotNull] ref StateMachineBox? boxRef)
+            where TAwaiter : ICriticalNotifyCompletion
+            where TStateMachine : IAsyncStateMachine
+        {
+            IAsyncStateMachineBox box = GetStateMachineBox(ref stateMachine, ref boxRef);
+            AsyncTaskMethodBuilder<VoidTaskResult>.AwaitUnsafeOnCompleted(ref awaiter, box);
+        }
+
+        /// <summary>Gets the "boxed" state machine object.</summary>
+        /// <typeparam name="TStateMachine">Specifies the type of the async state machine.</typeparam>
+        /// <param name="stateMachine">The state machine.</param>
+        /// <param name="boxFieldRef">A reference to the field containing the initialized state machine box.</param>
+        /// <returns>The "boxed" state machine.</returns>
+        private static IAsyncStateMachineBox GetStateMachineBox<TStateMachine>(
+            ref TStateMachine stateMachine,
+            [NotNull] ref StateMachineBox? boxFieldRef)
+            where TStateMachine : IAsyncStateMachine
+        {
+            ExecutionContext? currentContext = ExecutionContext.Capture();
+
+            // Check first for the most common case: not the first yield in an async method.
+            // In this case, the first yield will have already "boxed" the state machine in
+            // a strongly-typed manner into an AsyncStateMachineBox.  It will already contain
+            // the state machine as well as a MoveNextDelegate and a context.  The only thing
+            // we might need to do is update the context if that's changed since it was stored.
+            if (boxFieldRef is StateMachineBox<TStateMachine> stronglyTypedBox)
+            {
+                if (stronglyTypedBox.Context != currentContext)
+                {
+                    stronglyTypedBox.Context = currentContext;
+                }
+
+                return stronglyTypedBox;
+            }
+
+            // The least common case: we have a weakly-typed boxed.  This results if the debugger
+            // or some other use of reflection accesses a property like ObjectIdForDebugger.  In
+            // such situations, we need to get an object to represent the builder, but we don't yet
+            // know the type of the state machine, and thus can't use TStateMachine.  Instead, we
+            // use the IAsyncStateMachine interface, which all TStateMachines implement.  This will
+            // result in a boxing allocation when storing the TStateMachine if it's a struct, but
+            // this only happens in active debugging scenarios where such performance impact doesn't
+            // matter.
+            if (boxFieldRef is StateMachineBox<IAsyncStateMachine> weaklyTypedBox)
+            {
+                // If this is the first await, we won't yet have a state machine, so store it.
+                if (weaklyTypedBox.StateMachine is null)
+                {
+                    Debugger.NotifyOfCrossThreadDependency(); // same explanation as with usage below
+                    weaklyTypedBox.StateMachine = stateMachine;
+                }
+
+                // Update the context.  This only happens with a debugger, so no need to spend
+                // extra IL checking for equality before doing the assignment.
+                weaklyTypedBox.Context = currentContext;
+                return weaklyTypedBox;
+            }
+
+            // Alert a listening debugger that we can't make forward progress unless it slips threads.
+            // If we don't do this, and a method that uses "await foo;" is invoked through funceval,
+            // we could end up hooking up a callback to push forward the async method's state machine,
+            // the debugger would then abort the funceval after it takes too long, and then continuing
+            // execution could result in another callback being hooked up.  At that point we have
+            // multiple callbacks registered to push the state machine, which could result in bad behavior.
+            Debugger.NotifyOfCrossThreadDependency();
+
+            // At this point, m_task should really be null, in which case we want to create the box.
+            // However, in a variety of debugger-related (erroneous) situations, it might be non-null,
+            // e.g. if the Task property is examined in a Watch window, forcing it to be lazily-intialized
+            // as a Task<TResult> rather than as an ValueTaskStateMachineBox.  The worst that happens in such
+            // cases is we lose the ability to properly step in the debugger, as the debugger uses that
+            // object's identity to track this specific builder/state machine.  As such, we proceed to
+            // overwrite whatever's there anyway, even if it's non-null.
+            var box = StateMachineBox<TStateMachine>.GetOrCreateBox();
+            boxFieldRef = box; // important: this must be done before storing stateMachine into box.StateMachine!
+            box.StateMachine = stateMachine;
+            box.Context = currentContext;
+
+            return box;
+        }
+
+        /// <summary>
+        /// Creates a box object for use when a non-standard access pattern is employed, e.g. when Task
+        /// is evaluated in the debugger prior to the async method yielding for the first time.
+        /// </summary>
+        internal static StateMachineBox CreateWeaklyTypedStateMachineBox() => new StateMachineBox<IAsyncStateMachine>();
+
+        /// <summary>
+        /// Gets an object that may be used to uniquely identify this builder to the debugger.
+        /// </summary>
+        /// <remarks>
+        /// This property lazily instantiates the ID in a non-thread-safe manner.
+        /// It must only be used by the debugger and tracing purposes, and only in a single-threaded manner
+        /// when no other threads are in the middle of accessing this or other members that lazily initialize the box.
+        /// </remarks>
+        internal object ObjectIdForDebugger
+        {
+            get
+            {
+                if (m_task is null)
+                {
+                    m_task = AsyncTaskCache.s_valueTaskPoolingEnabled ? (object)
+                        CreateWeaklyTypedStateMachineBox() :
+                        AsyncTaskMethodBuilder<TResult>.CreateWeaklyTypedStateMachineBox();
+                }
+
+                return m_task;
+            }
+        }
+
+        /// <summary>The base type for all value task box reusable box objects, regardless of state machine type.</summary>
+        internal abstract class StateMachineBox :
+            IValueTaskSource<TResult>, IValueTaskSource
+        {
+            /// <summary>A delegate to the MoveNext method.</summary>
+            protected Action? _moveNextAction;
+            /// <summary>Captured ExecutionContext with which to invoke MoveNext.</summary>
+            public ExecutionContext? Context;
+            /// <summary>Implementation for IValueTaskSource interfaces.</summary>
+            protected ManualResetValueTaskSourceCore<TResult> _valueTaskSource;
+
+            /// <summary>Completes the box with a result.</summary>
+            /// <param name="result">The result.</param>
+            public void SetResult(TResult result) =>
+                _valueTaskSource.SetResult(result);
+
+            /// <summary>Completes the box with an error.</summary>
+            /// <param name="error">The exception.</param>
+            public void SetException(Exception error) =>
+                _valueTaskSource.SetException(error);
+
+            /// <summary>Gets the status of the box.</summary>
+            public ValueTaskSourceStatus GetStatus(short token) => _valueTaskSource.GetStatus(token);
+
+            /// <summary>Schedules the continuation action for this box.</summary>
+            public void OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags) =>
+                _valueTaskSource.OnCompleted(continuation, state, token, flags);
+
+            /// <summary>Gets the current version number of the box.</summary>
+            public short Version => _valueTaskSource.Version;
+
+            /// <summary>Implemented by derived type.</summary>
+            TResult IValueTaskSource<TResult>.GetResult(short token) => throw NotImplemented.ByDesign;
+
+            /// <summary>Implemented by derived type.</summary>
+            void IValueTaskSource.GetResult(short token) => throw NotImplemented.ByDesign;
+        }
+
+        private sealed class SyncSuccessSentinelStateMachineBox : StateMachineBox
+        {
+            public SyncSuccessSentinelStateMachineBox() => SetResult(default!);
+        }
+
+        /// <summary>Provides a strongly-typed box object based on the specific state machine type in use.</summary>
+        private sealed class StateMachineBox<TStateMachine> :
+            StateMachineBox,
+            IValueTaskSource<TResult>, IValueTaskSource, IAsyncStateMachineBox, IThreadPoolWorkItem
+            where TStateMachine : IAsyncStateMachine
+        {
+            /// <summary>Delegate used to invoke on an ExecutionContext when passed an instance of this box type.</summary>
+            private static readonly ContextCallback s_callback = ExecutionContextCallback;
+            /// <summary>Lock used to protected the shared cache of boxes.</summary>
+            /// <remarks>The code that uses this assumes a runtime without thread aborts.</remarks>
+            private static int s_cacheLock;
+            /// <summary>Singly-linked list cache of boxes.</summary>
+            private static StateMachineBox<TStateMachine>? s_cache;
+            /// <summary>The number of items stored in <see cref="s_cache"/>.</summary>
+            private static int s_cacheSize;
+
+            // TODO:
+            // AsyncTaskMethodBuilder logs about the state machine box lifecycle; AsyncValueTaskMethodBuilder currently
+            // does not when it employs these pooled boxes.  That logging is based on Task IDs, which we lack here.
+            // We could use the box's Version, but that is very likely to conflict with the IDs of other tasks in the system.
+            // For now, we don't log, but should we choose to we'll probably want to store an int ID on the state machine box,
+            // and initialize it an ID from Task's generator.
+
+            /// <summary>If this box is stored in the cache, the next box in the cache.</summary>
+            private StateMachineBox<TStateMachine>? _next;
+            /// <summary>The state machine itself.</summary>
+            [AllowNull, MaybeNull]
+            public TStateMachine StateMachine = default;
+
+            /// <summary>Gets a box object to use for an operation.  This may be a reused, pooled object, or it may be new.</summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)] // only one caller
+            internal static StateMachineBox<TStateMachine> GetOrCreateBox()
+            {
+                // Try to acquire the lock to access the cache.  If there's any contention, don't use the cache.
+                if (Interlocked.CompareExchange(ref s_cacheLock, 1, 0) == 0)
+                {
+                    // If there are any instances cached, take one from the cache stack and use it.
+                    StateMachineBox<TStateMachine>? box = s_cache;
+                    if (!(box is null))
+                    {
+                        s_cache = box._next;
+                        box._next = null;
+                        s_cacheSize--;
+                        Debug.Assert(s_cacheSize >= 0, "Expected the cache size to be non-negative.");
+
+                        // Release the lock and return the box.
+                        Volatile.Write(ref s_cacheLock, 0);
+                        return box;
+                    }
+
+                    // No objects were cached.  We'll just create a new instance.
+                    Debug.Assert(s_cacheSize == 0, "Expected cache size to be 0.");
+
+                    // Release the lock.
+                    Volatile.Write(ref s_cacheLock, 0);
+                }
+
+                // Couldn't quickly get a cached instance, so create a new instance.
+                return new StateMachineBox<TStateMachine>();
+            }
+
+            private void ReturnOrDropBox()
+            {
+                Debug.Assert(_next is null, "Expected box to not be part of cached list.");
+
+                // Clear out the state machine and associated context to avoid keeping arbitrary state referenced by
+                // lifted locals.  We want to do this regardless of whether we end up caching the box or not, in case
+                // the caller keeps the box alive for an arbitrary period of time.
+                StateMachine = default;
+                Context = default;
+
+                // Reset the MRVTSC.  We can either do this here, in which case we may be paying the (small) overhead
+                // to reset the box even if we're going to drop it, or we could do it while holding the lock, in which
+                // case we'll only reset it if necessary but causing the lock to be held for longer, thereby causing
+                // more contention.  For now at least, we do it outside of the lock. (This must not be done after
+                // the lock is released, since at that point the instance could already be in use elsewhere.)
+                // We also want to increment the version number even if we're going to drop it, to maximize the chances
+                // that incorrectly double-awaiting a ValueTask will produce an error.
+                _valueTaskSource.Reset();
+
+                // If reusing the object would result in potentially wrapping around its version number, just throw it away.
+                // This provides a modicum of additional safety when ValueTasks are misused (helping to avoid the case where
+                // a ValueTask is illegally re-awaited and happens to do so at exactly 2^16 uses later on this exact same instance),
+                // at the expense of potentially incurring an additional allocation every 65K uses.
+                if ((ushort)_valueTaskSource.Version == ushort.MaxValue)
+                {
+                    return;
+                }
+
+                // Try to acquire the cache lock.  If there's any contention, or if the cache is full, we just throw away the object.
+                if (Interlocked.CompareExchange(ref s_cacheLock, 1, 0) == 0)
+                {
+                    if (s_cacheSize < AsyncTaskCache.s_valueTaskPoolingCacheSize)
+                    {
+                        // Push the box onto the cache stack for subsequent reuse.
+                        _next = s_cache;
+                        s_cache = this;
+                        s_cacheSize++;
+                        Debug.Assert(s_cacheSize > 0 && s_cacheSize <= AsyncTaskCache.s_valueTaskPoolingCacheSize, "Expected cache size to be within bounds.");
+                    }
+
+                    // Release the lock.
+                    Volatile.Write(ref s_cacheLock, 0);
+                }
+            }
+
+            /// <summary>
+            /// Used to initialize s_callback above. We don't use a lambda for this on purpose: a lambda would
+            /// introduce a new generic type behind the scenes that comes with a hefty size penalty in AOT builds.
+            /// </summary>
+            private static void ExecutionContextCallback(object? s)
+            {
+                // Only used privately to pass directly to EC.Run
+                Debug.Assert(s is StateMachineBox<TStateMachine>);
+                Unsafe.As<StateMachineBox<TStateMachine>>(s).StateMachine!.MoveNext();
+            }
+
+            /// <summary>A delegate to the <see cref="MoveNext()"/> method.</summary>
+            public Action MoveNextAction => _moveNextAction ??= new Action(MoveNext);
+
+            /// <summary>Invoked to run MoveNext when this instance is executed from the thread pool.</summary>
+            void IThreadPoolWorkItem.Execute() => MoveNext();
+
+            /// <summary>Calls MoveNext on <see cref="StateMachine"/></summary>
+            public void MoveNext()
+            {
+                ExecutionContext? context = Context;
+
+                if (context is null)
+                {
+                    Debug.Assert(!(StateMachine is null));
+                    StateMachine.MoveNext();
+                }
+                else
+                {
+                    ExecutionContext.RunInternal(context, s_callback, this);
+                }
+            }
+
+            /// <summary>Get the result of the operation.</summary>
+            TResult IValueTaskSource<TResult>.GetResult(short token)
+            {
+                try
+                {
+                    return _valueTaskSource.GetResult(token);
+                }
+                finally
+                {
+                    // Reuse this instance if possible, otherwise clear and drop it.
+                    ReturnOrDropBox();
+                }
+            }
+
+            /// <summary>Get the result of the operation.</summary>
+            void IValueTaskSource.GetResult(short token)
+            {
+                try
+                {
+                    _valueTaskSource.GetResult(token);
+                }
+                finally
+                {
+                    // Reuse this instance if possible, otherwise clear and drop it.
+                    ReturnOrDropBox();
+                }
+            }
+
+            /// <summary>Gets the state machine as a boxed object.  This should only be used for debugging purposes.</summary>
+            IAsyncStateMachine IAsyncStateMachineBox.GetStateMachineObject() => StateMachine!; // likely boxes, only use for debugging
         }
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/Task.cs
@@ -2550,7 +2550,6 @@ namespace System.Threading.Tasks
             // If we're unable to because the task has already completed, queue it.
             if (!AddTaskContinuation(stateMachineBox, addBeforeOthers: false))
             {
-                Debug.Assert(stateMachineBox is Task, "Every state machine box should derive from Task");
                 ThreadPool.UnsafeQueueUserWorkItemInternal(stateMachineBox, preferLocal: true);
             }
         }


### PR DESCRIPTION
Today `async ValueTask/ValueTask<T>` methods use builders that special-case the synchronously completing case (to just return a `default(ValueTask)` or `new ValueTask<T>(result)`) but defer to the equivalent of `async Task/Task<T>` for when the operation completes asynchronously.  This, however, doesn't take advantage of the fact that value tasks can wrap arbitrary `IValueTaskSource/IValueTaskSource<T>` implementations.

I've had this sitting on the shelf for a while, but finally cleaned it up.  The first three commits here are just moving around existing code.  The last two commits are the meat of this change.  This changes `AsyncValueTaskMethodBuilder` and `AsyncValueTaskMethodBuilder<T>` to use pooled `IValueTaskSource/IValueTaskSource<T>` instances, such that calls to an `async ValueTask/ValueTask<T>` method incur 0 allocations as long as there's a cached object available.

I've marked this as a draft and work-in-progress for a few reasons:
1. There's a breaking change here, in that while we say/document that `ValueTask/ValueTask<T>`s are more limited in what they can be used for, nothing in the implementation actually stops a `ValueTask` that was wrapping a `Task` from being used as permissively as `Task`, e.g. if you were to await such a `ValueTask` multiple times, it would happen to work, even though we say "never do that".  This change means that anyone who was relying on such undocumented behaviors will now be broken.  I think this is a reasonable thing to do in a major release, but I also want feedback and a lot of runway on it.  There's the potential to make it opt-in (or opt-out) as well, but that will also non-trivially complicate the implementation.
2. Policy around pooling.  This is always a difficult thing to tune.  Right now I've chosen a policy that limits the number of pooled objects per state machine type to an arbitrary multiple of the processor count, and that tries to strike a balance between contention and garbage by using a spin lock and if there's any contention while trying to get or return a pooled object, the cache is ignored.  We will need to think hard about what policy to use here.  It's also possible it could be tuned per state machine, e.g. by having an attribute that's looked up via reflection when creating the cache for a state machine, but that'll add a lot of first-access overhead to any `async ValueTask/ValueTask<T>` method.
3. Perf validation.

cc: @kouvel, @tarekgh, @benaadams 