### PR TITLE
Do not expand variant isinst check inline

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -10363,9 +10363,9 @@ GenTree* Compiler::impCastClassOrIsInstToTree(GenTree*                op1,
                 // Check the class attributes.
                 DWORD flags = info.compCompHnd->getClassAttribs(pResolvedToken->hClass);
 
-                // If the class is final and is not marshal byref or
+                // If the class is final and is not marshal byref, variant or
                 // contextful, the jit can expand the IsInst check inline.
-                DWORD flagsMask = CORINFO_FLG_FINAL | CORINFO_FLG_MARSHAL_BYREF | CORINFO_FLG_CONTEXTFUL;
+                DWORD flagsMask = CORINFO_FLG_FINAL | CORINFO_FLG_MARSHAL_BYREF | CORINFO_FLG_VARIANCE | CORINFO_FLG_CONTEXTFUL;
                 canExpandInline = ((flags & flagsMask) == CORINFO_FLG_FINAL);
             }
         }

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -10365,7 +10365,8 @@ GenTree* Compiler::impCastClassOrIsInstToTree(GenTree*                op1,
 
                 // If the class is final and is not marshal byref, variant or
                 // contextful, the jit can expand the IsInst check inline.
-                DWORD flagsMask = CORINFO_FLG_FINAL | CORINFO_FLG_MARSHAL_BYREF | CORINFO_FLG_VARIANCE | CORINFO_FLG_CONTEXTFUL;
+                DWORD flagsMask =
+                    CORINFO_FLG_FINAL | CORINFO_FLG_MARSHAL_BYREF | CORINFO_FLG_VARIANCE | CORINFO_FLG_CONTEXTFUL;
                 canExpandInline = ((flags & flagsMask) == CORINFO_FLG_FINAL);
             }
         }


### PR DESCRIPTION
This probably cannot be hit with vanilla CoreCLR right now (we seem to be using the slow helper for variant casts) but this got hit in a non-shipping configuration.