### PR TITLE
Fix passing of framework parameter in perf pipeline

### DIFF
--- a/eng/perf-job.yml
+++ b/eng/perf-job.yml
@@ -38,10 +38,12 @@ jobs:
         container: ${{ format('{0}:{1}', parameters.container.registry, parameters.container.image) }}
       
     ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-      extraSetupParameters: -CoreRootDirectory $(Build.SourcesDirectory)\bin\tests\${{ parameters.osGroup }}.${{ parameters.archType }}.Release\Tests\Core_Root -Architecture ${{ parameters.archType }} -Framework ${{ parameters.framework }}
+      extraSetupParameters: -CoreRootDirectory $(Build.SourcesDirectory)\bin\tests\${{ parameters.osGroup }}.${{ parameters.archType }}.Release\Tests\Core_Root -Architecture ${{ parameters.archType }}
     ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-      extraSetupParameters: --corerootdirectory $(Build.SourcesDirectory)/bin/tests/${{ parameters.osGroup }}.${{ parameters.archType }}.Release/Tests/Core_Root --architecture ${{ parameters.archType }} -Framework ${{ parameters.framework }}
+      extraSetupParameters: --corerootdirectory $(Build.SourcesDirectory)/bin/tests/${{ parameters.osGroup }}.${{ parameters.archType }}.Release/Tests/Core_Root --architecture ${{ parameters.archType }}
 
+    frameworks:
+      - ${{ parameters.framework }}
     steps:
     # Extra steps that will be passed to the performance template and run before sending the job to helix (all of which is done in the template)
 


### PR DESCRIPTION
We were incorrectly passing the framework parameter to the performance template. This change fixes that.