### PR TITLE
Disable all arm pr testing

### DIFF
--- a/eng/crossgen-comparison-job.yml
+++ b/eng/crossgen-comparison-job.yml
@@ -25,6 +25,10 @@ jobs:
     name: ${{ format('test_crossgen_comparison_{0}_{1}_{2}', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
     displayName: ${{ format('Test crossgen-comparison {0} {1} {2}', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
 
+    # Force arm jobs off for public ci
+    ${{ if eq(variables['System.TeamProject'], 'public'}}:
+      condition: false
+
     crossrootfsDir: ${{ parameters.crossrootfsDir }}
 
     variables:

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -35,8 +35,9 @@ jobs:
         image: ubuntu-16.04-cross-14.04-23cacb0-20190528233931
         registry: mcr
       helixQueues:
-      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        - (Ubuntu.1804.Arm32.Open)Ubuntu.1604.Arm32.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-30f6673-20190814153226
+      # Renable when https://github.com/dotnet/core-eng/issues/7557 is fixed
+      #- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      #  - (Ubuntu.1804.Arm32.Open)Ubuntu.1604.Arm32.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-30f6673-20190814153226
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - (Debian.9.Arm32)Ubuntu.1604.Arm32@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm32v7-74c9941-20190620155841
         - (Ubuntu.1604.Arm32)Ubuntu.1604.Arm32@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-helix-arm32v7-30f6673-20190814153219
@@ -58,8 +59,9 @@ jobs:
         image: ubuntu-16.04-cross-arm64-cfdd435-20190520220848
         registry: mcr
       helixQueues:
-      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        - (Ubuntu.1804.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-a45aeeb-20190620155855
+      # Renable when https://github.com/dotnet/core-eng/issues/7557 is fixed
+      # - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      #   - (Ubuntu.1804.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-a45aeeb-20190620155855
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(parameters.helixQueueGroup, 'pr', 'ci', 'corefx')) }}:
         - (Debian.9.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-74c9941-20190620155840
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:


### PR DESCRIPTION
Once https://github.com/dotnet/core-eng/i…ssues/7557 is fixed, this can be re-enabled. Until then, failure to submit to helix is covering real regressions and checkins are happening that break inner-loop.

See https://github.com/dotnet/coreclr/issues/26345

Note that outerloop job will still be failing until the issue is fixed.