### PR TITLE
[WIP] Various IL stub changes

### DIFF
--- a/src/vm/ilstubcache.cpp
+++ b/src/vm/ilstubcache.cpp
@@ -464,10 +464,6 @@ MethodDesc* ILStubCache::GetStubMethodDesc(
 
     if (!pMD)
     {
-        size_t cbSizeOfBlob = pParams->m_cbSizeOfBlob;
-        AllocMemHolder<ILStubHashBlob> pBlobHolder( m_heap->AllocMem(S_SIZE_T(cbSizeOfBlob)) );
-
-
         //
         // Couldn't find it, let's make a new one.
         //
@@ -491,6 +487,8 @@ MethodDesc* ILStubCache::GetStubMethodDesc(
 
         if (SF_IsSharedStub(dwStubFlags))
         {
+            size_t cbSizeOfBlob = pParams->m_cbSizeOfBlob;
+            AllocMemHolder<ILStubHashBlob> pBlobHolder( m_heap->AllocMem(S_SIZE_T(cbSizeOfBlob)) );
 
             CrstHolder ch(&m_crst);
 

--- a/src/vm/ilstubresolver.cpp
+++ b/src/vm/ilstubresolver.cpp
@@ -151,7 +151,10 @@ void ILStubResolver::ResolveToken(mdToken token, TypeHandle * pTH, MethodDesc **
     {
     case mdtMethodDef:
         {
-            MethodDesc* pMD = m_pCompileTimeState->m_tokenLookupMap.LookupMethodDef(token);
+            MethodDesc* pMD = m_pStubMD;
+            if (token != TOKEN_ILSTUB_METHODDEF)
+                pMD = m_pCompileTimeState->m_tokenLookupMap.LookupMethodDef(token);
+
             _ASSERTE(pMD);
             *ppMD = pMD;
             *pTH = TypeHandle(pMD->GetMethodTable());

--- a/src/vm/ilstubresolver.cpp
+++ b/src/vm/ilstubresolver.cpp
@@ -187,9 +187,12 @@ ILStubResolver::ResolveSignature(
     mdToken token)
 {
     STANDARD_VM_CONTRACT;
-    CONSISTENCY_CHECK_MSG(token == TOKEN_ILSTUB_TARGET_SIG, "IL stubs do not support any other signature tokens!");
 
-    return m_pCompileTimeState->m_StubTargetMethodSig;
+    if (token == TOKEN_ILSTUB_TARGET_SIG)
+        return m_pCompileTimeState->m_StubTargetMethodSig;
+    
+    SigPointer sig = m_pCompileTimeState->m_tokenLookupMap.LookupSig(token);
+    return sig;
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/vm/siginfo.cpp
+++ b/src/vm/siginfo.cpp
@@ -144,7 +144,7 @@ const ElementTypeInfo* GetElementTypeInfo(CorElementType etyp)
 
 #ifndef DACCESS_COMPILE
 
-void SigPointer::ConvertToInternalExactlyOne(Module* pSigModule, SigTypeContext *pTypeContext, SigBuilder * pSigBuilder, BOOL bSkipCustomModifier)
+void SigPointer::ConvertToInternalExactlyOne(Module* pSigModule, const SigTypeContext *pTypeContext, SigBuilder * pSigBuilder, BOOL bSkipCustomModifier)
 {
     CONTRACTL
     {
@@ -331,7 +331,7 @@ void SigPointer::ConvertToInternalExactlyOne(Module* pSigModule, SigTypeContext 
     }
 }
 
-void SigPointer::ConvertToInternalSignature(Module* pSigModule, SigTypeContext *pTypeContext, SigBuilder * pSigBuilder, BOOL bSkipCustomModifier)
+void SigPointer::ConvertToInternalSignature(Module* pSigModule, const SigTypeContext *pTypeContext, SigBuilder * pSigBuilder, BOOL bSkipCustomModifier)
 {
     CONTRACTL
     {

--- a/src/vm/siginfo.hpp
+++ b/src/vm/siginfo.hpp
@@ -139,8 +139,8 @@ public:
     //=========================================================================
 
 
-        void ConvertToInternalExactlyOne(Module* pSigModule, SigTypeContext *pTypeContext, SigBuilder * pSigBuilder, BOOL bSkipCustomModifier = TRUE);
-        void ConvertToInternalSignature(Module* pSigModule, SigTypeContext *pTypeContext, SigBuilder * pSigBuilder, BOOL bSkipCustomModifier = TRUE);
+        void ConvertToInternalExactlyOne(Module* pSigModule, const SigTypeContext *pTypeContext, SigBuilder * pSigBuilder, BOOL bSkipCustomModifier = TRUE);
+        void ConvertToInternalSignature(Module* pSigModule, const SigTypeContext *pTypeContext, SigBuilder * pSigBuilder, BOOL bSkipCustomModifier = TRUE);
 
 
     //=========================================================================

--- a/src/vm/stubgen.cpp
+++ b/src/vm/stubgen.cpp
@@ -67,11 +67,21 @@ void ILStubLinker::DumpIL_FormatToken(mdToken token, SString &strTokenFormatting
     {
         if (TypeFromToken(token) == mdtMethodDef)
         {
-            MethodDesc* pMD = pTokenMap->LookupMethodDef(token);
-            pvLookupRetVal = pMD;
-            CONSISTENCY_CHECK(CheckPointer(pMD));
+            if (token == TOKEN_ILSTUB_METHODDEF)
+            {
+                if (m_pMD != NULL)
+                    m_pMD->GetFullMethodInfo(strTokenFormatting);
+                else
+                    strTokenFormatting.Append(W("ILStub"));
+            }
+            else
+            {
+                MethodDesc* pMD = m_tokenMap.LookupMethodDef(token);
+                pvLookupRetVal = pMD;
+                CONSISTENCY_CHECK(CheckPointer(pMD));
 
-            pMD->GetFullMethodInfo(strTokenFormatting);
+                pMD->GetFullMethodInfo(strTokenFormatting);
+            }
         }
         else if (TypeFromToken(token) == mdtTypeDef)
         {

--- a/src/vm/stubgen.cpp
+++ b/src/vm/stubgen.cpp
@@ -1064,6 +1064,11 @@ void ILCodeStream::EmitBLT(ILCodeLabel* pCodeLabel)
     WRAPPER_NO_CONTRACT;
     Emit(CEE_BLT, -2, (UINT_PTR)pCodeLabel);
 }
+void ILCodeStream::EmitBNE_UN(ILCodeLabel* pCodeLabel)
+{
+    WRAPPER_NO_CONTRACT;
+    Emit(CEE_BNE_UN, -2, (UINT_PTR)pCodeLabel);
+}
 void ILCodeStream::EmitBR(ILCodeLabel* pCodeLabel)
 {
     WRAPPER_NO_CONTRACT;
@@ -1328,6 +1333,11 @@ void ILCodeStream::EmitLDFLD(int token)
 {
     WRAPPER_NO_CONTRACT;
     Emit(CEE_LDFLD, 0, token);
+}
+void ILCodeStream::EmitLDFLD(BinderFieldID id)
+{
+    STANDARD_VM_CONTRACT;
+    Emit(CEE_LDFLD, 0, GetToken(MscorlibBinder::GetField(id)));
 }
 void ILCodeStream::EmitLDFLDA(int token)
 {
@@ -1645,6 +1655,11 @@ void ILCodeStream::EmitSTFLD(int token)
     WRAPPER_NO_CONTRACT;
     Emit(CEE_STFLD, -2, token);
 }
+void ILCodeStream::EmitSTFLD(BinderFieldID id)
+{
+    STANDARD_VM_CONTRACT;
+    Emit(CEE_STFLD, 0, GetToken(MscorlibBinder::GetField(id)));
+}
 void ILCodeStream::EmitSTLOC(DWORD dwLocalNum)
 {
     WRAPPER_NO_CONTRACT;
@@ -1664,6 +1679,11 @@ void ILCodeStream::EmitSUB()
 {
     WRAPPER_NO_CONTRACT;
     Emit(CEE_SUB, -1, 0);
+}
+void ILCodeStream::EmitTAIL()
+{
+    WRAPPER_NO_CONTRACT;
+    Emit(CEE_TAILCALL, 0, 0);
 }
 void ILCodeStream::EmitTHROW()
 {

--- a/src/vm/stubgen.h
+++ b/src/vm/stubgen.h
@@ -594,6 +594,7 @@ public:
     void EmitBLE        (ILCodeLabel* pCodeLabel);
     void EmitBLE_UN     (ILCodeLabel* pCodeLabel);
     void EmitBLT        (ILCodeLabel* pCodeLabel);
+    void EmitBNE_UN     (ILCodeLabel* pCodeLabel);
     void EmitBR         (ILCodeLabel* pCodeLabel);
     void EmitBREAK      ();
     void EmitBRFALSE    (ILCodeLabel* pCodeLabel);
@@ -634,6 +635,7 @@ public:
     void EmitLDELEMA    (int token);
     void EmitLDELEM_REF ();
     void EmitLDFLD      (int token);
+    void EmitLDFLD      (BinderFieldID id);
     void EmitLDFLDA     (int token);
     void EmitLDFTN      (int token);
     void EmitLDIND_I    ();
@@ -677,10 +679,12 @@ public:
     void EmitSTIND_REF  ();
     void EmitSTIND_T    (LocalDesc* pType);
     void EmitSTFLD      (int token);
+    void EmitSTFLD      (BinderFieldID id);
     void EmitSTLOC      (DWORD dwLocalNum);
     void EmitSTOBJ      (int token);
     void EmitSTSFLD     (int token);
     void EmitSUB        ();
+    void EmitTAIL       ();
     void EmitTHROW      ();
 
     // Overloads to simplify common usage patterns

--- a/src/vm/stubgen.h
+++ b/src/vm/stubgen.h
@@ -834,6 +834,10 @@ protected:
 #endif // BIT64
 };
 
+// Represents the signature of the target method for an IL stub
 #define TOKEN_ILSTUB_TARGET_SIG (TokenFromRid(0xFFFFFF, mdtSignature))
+// Represents the token for the IL stub method, useful for instance for
+// recursive calls.
+#define TOKEN_ILSTUB_METHODDEF (TokenFromRid(0xFFFFFF, mdtMethodDef))
 
 #endif  // __STUBGEN_H__


### PR DESCRIPTION
Some various IL stub changes that I will need/am using for my prototype of portable tailcall helpers. I have extracted this out as I expect that PR to be relatively large. This is easiest to review commit by commit.

* Allocate IL stub hash blobs only for shared stubs
* Mark some args as const in `SigPointer::ConvertToInternalExactlyOne` and `SigPointer::ConvertToInternalSignature`
* Add `ILCodeStream::EmitBNE_UN`, `ILCodeStream::EmitTAIL`
* Add versions of `ILCodeStream::EmitLDFLD` and `ILCodeStream::EmitSTFLD` that take mscorlib fields
* Add support for having IL stubs with multiple signatures because of multiple `calli` instructions
* Add a token representing the IL stub being emitted

**Please rebase instead of squashing when pulling this!**

cc @jkoritzinsky @janvorli 