### PR TITLE
Disable signing and publishing on perf builds

### DIFF
--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -6,7 +6,7 @@ parameters:
   container: ''
   crossrootfsDir: ''
   timeoutInMinutes: ''
-  perfBuild: ''
+  perfBuild: false
 
 ### Product build
 jobs:

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -6,7 +6,8 @@ parameters:
   container: ''
   crossrootfsDir: ''
   timeoutInMinutes: ''
-  perfBuild: false
+  signBinaries: false
+  publishToBlobFeed: false
 
 ### Product build
 jobs:
@@ -126,7 +127,7 @@ jobs:
         displayName: Build product
 
     # Sign on Windows
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest'), eq(parameters.osGroup, 'Windows_NT'), ne(parameters.perfBuild, 'true')) }}:
+    - ${{ if and(eq(parameters.osGroup, 'Windows_NT'), eq(parameters.signBinaries, 'true')) }}:
       - powershell: eng\common\build.ps1 -ci -sign -restore -configuration:$(buildConfig) -warnaserror:0 /p:ArcadeBuild=true /p:OfficialBuild=true /p:BuildOS=$(osGroup) /p:BuildArch=$(archType) /p:BuildType=$(_BuildConfig) /p:DotNetSignType=$env:_SignType -projects $(Build.SourcesDirectory)\eng\empty.csproj
         displayName: Sign Binaries
 
@@ -163,7 +164,7 @@ jobs:
         displayName: Build packages
 
     # Publish official build
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest'), ne(parameters.perfBuild, 'true')) }}:
+    - ${{ if eq(parameters.publishToBlobFeed, 'true') }}:
       - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
         - script: ./eng/common/build.sh --ci --restore --publish --configuration $(_BuildConfig) /p:DotNetPublishUsingPipelines=true /p:DotNetPublishToBlobFeed=true /p:DotNetPublishBlobFeedUrl=$(dotnetfeedUrl) /p:DotNetPublishBlobFeedKey=$(dotnetfeedPAT) /p:__BuildType=$(_BuildConfig) /p:__BuildArch=$(archType) /p:__BuildOS=$(osGroup) /p:OSIdentifier=$(osIdentifier) /bl:"$(Build.SourcesDirectory)/bin/Logs/publish-pkgs.binlog" --projects $(Build.SourcesDirectory)/eng/empty.csproj
           displayName: Publish packages to blob feed

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -6,6 +6,7 @@ parameters:
   container: ''
   crossrootfsDir: ''
   timeoutInMinutes: ''
+  perfBuild: ''
 
 ### Product build
 jobs:
@@ -125,7 +126,7 @@ jobs:
         displayName: Build product
 
     # Sign on Windows
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest'), eq(parameters.osGroup, 'Windows_NT')) }}:
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest'), eq(parameters.osGroup, 'Windows_NT'), ne(parameters.perfBuild, 'true')) }}:
       - powershell: eng\common\build.ps1 -ci -sign -restore -configuration:$(buildConfig) -warnaserror:0 /p:ArcadeBuild=true /p:OfficialBuild=true /p:BuildOS=$(osGroup) /p:BuildArch=$(archType) /p:BuildType=$(_BuildConfig) /p:DotNetSignType=$env:_SignType -projects $(Build.SourcesDirectory)\eng\empty.csproj
         displayName: Sign Binaries
 
@@ -162,7 +163,7 @@ jobs:
         displayName: Build packages
 
     # Publish official build
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest'), ne(parameters.perfBuild, 'true')) }}:
       - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
         - script: ./eng/common/build.sh --ci --restore --publish --configuration $(_BuildConfig) /p:DotNetPublishUsingPipelines=true /p:DotNetPublishToBlobFeed=true /p:DotNetPublishBlobFeedUrl=$(dotnetfeedUrl) /p:DotNetPublishBlobFeedKey=$(dotnetfeedPAT) /p:__BuildType=$(_BuildConfig) /p:__BuildArch=$(archType) /p:__BuildOS=$(osGroup) /p:OSIdentifier=$(osIdentifier) /bl:"$(Build.SourcesDirectory)/bin/Logs/publish-pkgs.binlog" --projects $(Build.SourcesDirectory)/eng/empty.csproj
           displayName: Publish packages to blob feed

--- a/eng/pipelines/internal.yml
+++ b/eng/pipelines/internal.yml
@@ -42,6 +42,8 @@ stages:
           # due to waiting for an exclusive lock on the feed.
           # See https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/AsyncPublishing.md
           timeoutInMinutes: 120
+          signBinaries: true
+          publishToBlobFeed: true
 
     #
     # Publish build information to Build Assets Registry

--- a/eng/pipelines/perf.yml
+++ b/eng/pipelines/perf.yml
@@ -15,8 +15,6 @@ jobs:
     - Linux_x64
     - Windows_NT_x64
     - Windows_NT_x86
-    jobParameters:
-      perfBuild: true
     
 - template: /eng/platform-matrix.yml
   parameters:

--- a/eng/pipelines/perf.yml
+++ b/eng/pipelines/perf.yml
@@ -15,6 +15,8 @@ jobs:
     - Linux_x64
     - Windows_NT_x64
     - Windows_NT_x86
+    jobParameters:
+      perfBuild: true
     
 - template: /eng/platform-matrix.yml
   parameters:


### PR DESCRIPTION
The perf runs are meant to track regressions in coreclr. They should not publish their bits, and they do not need to be signed.