### PR TITLE
Ups timeout for build-test-job as we have been seeing timeouts

### DIFF
--- a/eng/build-test-job.yml
+++ b/eng/build-test-job.yml
@@ -102,7 +102,7 @@ jobs:
       timeoutInMinutes: 90
 
     ${{ if ne(parameters.testGroup, 'innerloop') }}:
-      timeoutInMinutes: 120
+      timeoutInMinutes: 160
 
     steps:
 


### PR DESCRIPTION
/cc @dotnet/coreclr-infra 