### PR TITLE
Refactor call counting for tiering and some other things

### DIFF
--- a/src/inc/clrtypes.h
+++ b/src/inc/clrtypes.h
@@ -25,10 +25,8 @@
 
 #if BIT64
     #define POINTER_BITS (64)
-    #define POINTER_HASH_SHIFT (3)
 #else
     #define POINTER_BITS (32)
-    #define POINTER_HASH_SHIFT (2)
 #endif
 
 // ================================================================================

--- a/src/inc/clrtypes.h
+++ b/src/inc/clrtypes.h
@@ -24,9 +24,11 @@
 #include "static_assert.h"
 
 #if BIT64
-    #define POINTER_BITS 64
+    #define POINTER_BITS (64)
+    #define POINTER_HASH_SHIFT (3)
 #else
-    #define POINTER_BITS 32
+    #define POINTER_BITS (32)
+    #define POINTER_HASH_SHIFT (2)
 #endif
 
 // ================================================================================

--- a/src/vm/callcounter.cpp
+++ b/src/vm/callcounter.cpp
@@ -36,21 +36,11 @@ CallCounter::CallCounter()
 
 #endif // !DACCESS_COMPILE
 
-bool CallCounter::IsEligibleForCallCounting(PTR_MethodDesc pMethodDesc)
-{
-    WRAPPER_NO_CONTRACT;
-    _ASSERTE(pMethodDesc != NULL);
-    _ASSERTE(pMethodDesc->IsEligibleForTieredCompilation());
-
-    return g_pConfig->TieredCompilation_CallCounting() && !pMethodDesc->RequestedAggressiveOptimization();
-}
-
 bool CallCounter::IsCallCountingEnabled(PTR_MethodDesc pMethodDesc)
 {
     WRAPPER_NO_CONTRACT;
     _ASSERTE(pMethodDesc != PTR_NULL);
     _ASSERTE(pMethodDesc->IsEligibleForTieredCompilation());
-    _ASSERTE(IsEligibleForCallCounting(pMethodDesc));
 
 #ifndef DACCESS_COMPILE
     SpinLockHolder holder(&m_lock);
@@ -68,7 +58,6 @@ void CallCounter::DisableCallCounting(MethodDesc* pMethodDesc)
     WRAPPER_NO_CONTRACT;
     _ASSERTE(pMethodDesc != NULL);
     _ASSERTE(pMethodDesc->IsEligibleForTieredCompilation());
-    _ASSERTE(IsEligibleForCallCounting(pMethodDesc));
 
     // Disabling call counting will affect the tier of the MethodDesc's first native code version. Callers must ensure that this
     // change is made deterministically and prior to or while jitting the first native code version such that the tier would not
@@ -91,16 +80,32 @@ void CallCounter::DisableCallCounting(MethodDesc* pMethodDesc)
     m_methodToCallCount.Add(CallCounterEntry::CreateWithCallCountingDisabled(pMethodDesc));
 }
 
-bool CallCounter::WasCalledAtMostOnce(MethodDesc* pMethodDesc)
+NOINLINE bool CallCounter::OnMethodCalledSubsequently(NativeCodeVersion nativeCodeVersion, bool *doPublishRef)
 {
-    WRAPPER_NO_CONTRACT;
+    STANDARD_VM_CONTRACT;
+    _ASSERTE(!nativeCodeVersion.IsNull());
+    _ASSERTE(nativeCodeVersion.GetNativeCode() != NULL);
+    _ASSERTE(doPublishRef != nullptr);
+    _ASSERTE(*doPublishRef);
 
-    SpinLockHolder holder(&m_lock);
+    MethodDesc *methodDesc = nativeCodeVersion.GetMethodDesc();
+    if (!methodDesc->IsEligibleForTieredCompilation() ||
+        nativeCodeVersion.GetOptimizationTier() != NativeCodeVersion::OptimizationTier0)
+    {
+        return false;
+    }
 
-    const CallCounterEntry *existingEntry = m_methodToCallCount.LookupPtr(pMethodDesc);
-    return
-        existingEntry == nullptr ||
-        existingEntry->callCountLimit >= (int)g_pConfig->TieredCompilation_CallCountThreshold() - 1;
+    TieredCompilationManager *tieredCompilationManager = GetAppDomain()->GetTieredCompilationManager();
+    if (tieredCompilationManager->OnMethodCalledSubsequently(methodDesc))
+    {
+        return true;
+    }
+
+    if (methodDesc->GetCallCounter()->IncrementCount(methodDesc))
+    {
+        *doPublishRef = false;
+    }
+    return true;
 }
 
 // This is called by the prestub each time the method is invoked in a particular
@@ -108,21 +113,16 @@ bool CallCounter::WasCalledAtMostOnce(MethodDesc* pMethodDesc)
 // calls continue until we backpatch the prestub to avoid future calls. This allows
 // us to track the number of calls to each method and use it as a trigger for tiered
 // compilation.
-void CallCounter::OnMethodCalled(
-    MethodDesc* pMethodDesc,
-    TieredCompilationManager *pTieredCompilationManager,
-    BOOL* shouldStopCountingCallsRef,
-    BOOL* wasPromotedToNextTierRef)
+bool CallCounter::IncrementCount(MethodDesc* pMethodDesc)
 {
     STANDARD_VM_CONTRACT;
 
     _ASSERTE(pMethodDesc->IsEligibleForTieredCompilation());
-    _ASSERTE(pTieredCompilationManager != nullptr);
-    _ASSERTE(shouldStopCountingCallsRef != nullptr);
-    _ASSERTE(wasPromotedToNextTierRef != nullptr);
 
-    // At the moment, call counting is only done for tier 0 code
-    _ASSERTE(IsEligibleForCallCounting(pMethodDesc));
+    if (!g_pConfig->TieredCompilation_CallCounting())
+    {
+        return false; // stop counting calls
+    }
 
     // PERF: This as a simple to implement, but not so performant, call counter
     // Currently this is only called until we reach a fixed call count and then
@@ -137,7 +137,6 @@ void CallCounter::OnMethodCalled(
     // leaving the prestub unpatched, but may not be good overall as it increases
     // the size of the jitted code.
 
-    bool isFirstCall = false;
     int callCountLimit;
     {
         //Be careful if you convert to something fully lock/interlocked-free that
@@ -150,7 +149,6 @@ void CallCounter::OnMethodCalled(
         CallCounterEntry* pEntry = const_cast<CallCounterEntry*>(m_methodToCallCount.LookupPtr(pMethodDesc));
         if (pEntry == NULL)
         {
-            isFirstCall = true;
             callCountLimit = (int)g_pConfig->TieredCompilation_CallCountThreshold() - 1;
             _ASSERTE(callCountLimit >= 0);
             m_methodToCallCount.Add(CallCounterEntry(pMethodDesc, callCountLimit));
@@ -161,18 +159,19 @@ void CallCounter::OnMethodCalled(
         }
         else
         {
-            *shouldStopCountingCallsRef = true;
-            *wasPromotedToNextTierRef = true;
-            return;
+            return false; // stop counting calls
         }
     }
 
-    pTieredCompilationManager->OnMethodCalled(
-        pMethodDesc,
-        isFirstCall,
-        callCountLimit,
-        shouldStopCountingCallsRef,
-        wasPromotedToNextTierRef);
+    if (callCountLimit > 0)
+    {
+        return true; // continue counting calls
+    }
+    if (callCountLimit == 0)
+    {
+        GetAppDomain()->GetTieredCompilationManager()->AsyncPromoteMethodToTier1(pMethodDesc);
+    }
+    return false; // stop counting calls
 }
 
 #endif // !DACCESS_COMPILE

--- a/src/vm/callcounter.cpp
+++ b/src/vm/callcounter.cpp
@@ -80,7 +80,7 @@ void CallCounter::DisableCallCounting(MethodDesc* pMethodDesc)
     m_methodToCallCount.Add(CallCounterEntry::CreateWithCallCountingDisabled(pMethodDesc));
 }
 
-NOINLINE bool CallCounter::OnMethodCalledSubsequently(NativeCodeVersion nativeCodeVersion, bool *doPublishRef)
+NOINLINE bool CallCounter::OnMethodCodeVersionCalledSubsequently(NativeCodeVersion nativeCodeVersion, bool *doPublishRef)
 {
     STANDARD_VM_CONTRACT;
     _ASSERTE(!nativeCodeVersion.IsNull());
@@ -96,7 +96,7 @@ NOINLINE bool CallCounter::OnMethodCalledSubsequently(NativeCodeVersion nativeCo
     }
 
     TieredCompilationManager *tieredCompilationManager = GetAppDomain()->GetTieredCompilationManager();
-    if (tieredCompilationManager->OnMethodCalledSubsequently(methodDesc))
+    if (tieredCompilationManager->OnMethodCodeVersionCalledSubsequently(methodDesc))
     {
         return true;
     }

--- a/src/vm/callcounter.h
+++ b/src/vm/callcounter.h
@@ -65,7 +65,7 @@ public:
     static count_t Hash(key_t k)
     {
         LIMITED_METHOD_CONTRACT;
-        return (count_t)(dac_cast<TADDR>(k) >> POINTER_HASH_SHIFT);
+        return (count_t)dac_cast<TADDR>(k);
     }
 
     static const element_t Null() { LIMITED_METHOD_CONTRACT; return element_t(PTR_NULL, 0); }
@@ -95,7 +95,7 @@ public:
     void DisableCallCounting(MethodDesc* pMethodDesc);
 #endif
 
-    static bool OnMethodCalledSubsequently(NativeCodeVersion nativeCodeVersion, bool *doPublishRef);
+    static bool OnMethodCodeVersionCalledSubsequently(NativeCodeVersion nativeCodeVersion, bool *doPublishRef);
     bool IncrementCount(MethodDesc* pMethodDesc);
 
 private:

--- a/src/vm/callcounter.h
+++ b/src/vm/callcounter.h
@@ -65,7 +65,7 @@ public:
     static count_t Hash(key_t k)
     {
         LIMITED_METHOD_CONTRACT;
-        return (count_t)dac_cast<TADDR>(k);
+        return (count_t)(dac_cast<TADDR>(k) >> POINTER_HASH_SHIFT);
     }
 
     static const element_t Null() { LIMITED_METHOD_CONTRACT; return element_t(PTR_NULL, 0); }
@@ -90,14 +90,13 @@ public:
     CallCounter();
 #endif
 
-    static bool IsEligibleForCallCounting(PTR_MethodDesc pMethodDesc);
     bool IsCallCountingEnabled(PTR_MethodDesc pMethodDesc);
 #ifndef DACCESS_COMPILE
     void DisableCallCounting(MethodDesc* pMethodDesc);
-    bool WasCalledAtMostOnce(MethodDesc* pMethodDesc);
 #endif
 
-    void OnMethodCalled(MethodDesc* pMethodDesc, TieredCompilationManager *pTieredCompilationManager, BOOL* shouldStopCountingCallsRef, BOOL* wasPromotedToNextTierRef);
+    static bool OnMethodCalledSubsequently(NativeCodeVersion nativeCodeVersion, bool *doPublishRef);
+    bool IncrementCount(MethodDesc* pMethodDesc);
 
 private:
 

--- a/src/vm/codeversion.cpp
+++ b/src/vm/codeversion.cpp
@@ -353,6 +353,13 @@ void NativeCodeVersion::SetActiveChildFlag(BOOL isActive)
     LIMITED_METHOD_DAC_CONTRACT;
     if (m_storageKind == StorageKind::Explicit)
     {
+        if (isActive &&
+            !CodeVersionManager::InitialNativeCodeVersionMayNotBeTheDefaultNativeCodeVersion() &&
+            GetMethodDesc()->GetNativeCode() == NULL)
+        {
+            CodeVersionManager::SetInitialNativeCodeVersionMayNotBeTheDefaultNativeCodeVersion();
+        }
+
         AsNode()->SetActiveChildFlag(isActive);
     }
     else
@@ -1869,6 +1876,10 @@ void ILCodeVersioningState::LinkILCodeVersionNode(ILCodeVersionNode* pILCodeVers
 }
 #endif
 
+#ifndef DACCESS_COMPILE
+bool CodeVersionManager::s_initialNativeCodeVersionMayNotBeTheDefaultNativeCodeVersion = false;
+#endif
+
 CodeVersionManager::CodeVersionManager()
 {}
 
@@ -2146,6 +2157,10 @@ HRESULT CodeVersionManager::SetActiveILCodeVersions(ILCodeVersion* pActiveVersio
     }
 #endif
 
+    // Assume that a new IL code version will be added for a method def, and that an instantiation may not yet have native code
+    // for the default native code version
+    CodeVersionManager::SetInitialNativeCodeVersionMayNotBeTheDefaultNativeCodeVersion();
+
     // step 1 - mark the IL versions as being active, this ensures that
     // any new method instantiations added after this point will bind to
     // the correct version
@@ -2277,12 +2292,185 @@ HRESULT CodeVersionManager::AddNativeCodeVersion(
     return S_OK;
 }
 
-PCODE CodeVersionManager::PublishVersionableCodeIfNecessary(MethodDesc* pMethodDesc, BOOL fCanBackpatchPrestub)
+PCODE CodeVersionManager::PublishNonJumpStampVersionableCodeIfNecessary(
+    MethodDesc* pMethodDesc,
+    bool *doBackpatchRef,
+    bool *doFullBackpatchRef)
 {
     STANDARD_VM_CONTRACT;
     _ASSERTE(!LockOwnedByCurrentThread());
-    _ASSERTE(pMethodDesc->IsVersionable());
-    _ASSERTE(!pMethodDesc->IsPointingToPrestub() || !pMethodDesc->IsVersionableWithJumpStamp());
+    _ASSERTE(pMethodDesc->IsVersionableWithoutJumpStamp());
+    _ASSERTE(doBackpatchRef != nullptr);
+    _ASSERTE(*doBackpatchRef);
+    _ASSERTE(doFullBackpatchRef != nullptr);
+    _ASSERTE(!*doFullBackpatchRef);
+
+    HRESULT hr = S_OK;
+    PCODE pCode;
+    NativeCodeVersion activeVersion;
+    do
+    {
+        // Try a faster check to see if the default native code version would be the active one. If any method gets a new IL or
+        // native code version when the method's default native code version does not have native code, the global flag on
+        // CodeVersionManager is set (not a typical case, may be possible with profilers). So, if the flag is not set and the
+        // default native code version does not have native code, then it must be the active code version.
+        pCode = pMethodDesc->GetNativeCode();
+        if (pCode == NULL && !CodeVersionManager::InitialNativeCodeVersionMayNotBeTheDefaultNativeCodeVersion())
+        {
+            activeVersion = NativeCodeVersion(pMethodDesc);
+            break;
+        }
+
+        if (!pMethodDesc->IsPointingToPrestub())
+        {
+            *doFullBackpatchRef = true;
+            return NULL;
+        }
+
+        TableLockHolder lock(this);
+
+        if (SUCCEEDED(hr = GetActiveILCodeVersion(pMethodDesc).GetOrCreateActiveNativeCodeVersion(pMethodDesc, &activeVersion)))
+        {
+            pCode = activeVersion.GetNativeCode();
+            break;
+        }
+
+        _ASSERTE(hr == E_OUTOFMEMORY);
+        ReportCodePublishError(pMethodDesc, hr);
+        *doBackpatchRef = false;
+        return pCode != NULL ? pCode : pMethodDesc->PrepareInitialCode();
+    } while (false);
+
+#ifdef FEATURE_TIERED_COMPILATION
+    bool shouldCountCalls = true;
+#endif
+    while (true)
+    {
+        // Compile the code if needed
+        bool doPublish = true;
+        bool profilerMayHaveActivatedNonDefaultCodeVersion = false;
+        if (pCode == NULL)
+        {
+            PrepareCodeConfigBuffer configBuffer(activeVersion);
+            PrepareCodeConfig *config = configBuffer.GetConfig();
+            pCode = pMethodDesc->PrepareCode(config);
+
+        #ifdef FEATURE_CODE_VERSIONING
+            if (config->ProfilerMayHaveActivatedNonDefaultCodeVersion())
+            {
+                profilerMayHaveActivatedNonDefaultCodeVersion = true;
+            }
+        #endif
+
+            if (config->GeneratedOrLoadedNewCode())
+            {
+            #ifdef FEATURE_TIERED_COMPILATION
+                _ASSERTE(!config->ShouldCountCalls() || pMethodDesc->IsEligibleForTieredCompilation());
+                _ASSERTE(
+                    !config->ShouldCountCalls() ||
+                    activeVersion.GetOptimizationTier() == NativeCodeVersion::OptimizationTier0);
+                if (shouldCountCalls &&
+                    config->ShouldCountCalls() && // the generated code was at a tier that is call-counted
+                    activeVersion.IsDefaultVersion()) // this is the first call to the method
+                {
+                    if (!GetAppDomain()->GetTieredCompilationManager()->OnMethodCalledFirstTime(pMethodDesc))
+                    {
+                        doPublish = false;
+                    }
+
+                    shouldCountCalls = false;
+                }
+            #endif
+            }
+            else
+            {
+                _ASSERTE(!config->ShouldCountCalls());
+
+                // The thread that generated or loaded the new code will publish the code and backpatch if necessary
+                doPublish = false;
+            }
+        }
+    #ifdef FEATURE_TIERED_COMPILATION
+        else if (shouldCountCalls && CallCounter::OnMethodCalledSubsequently(activeVersion, &doPublish))
+        {
+            shouldCountCalls = false;
+        }
+    #endif
+
+        bool mayHaveEntryPointSlotsToBackpatch = doPublish && pMethodDesc->MayHaveEntryPointSlotsToBackpatch();
+        MethodDescBackpatchInfoTracker::ConditionalLockHolder lockHolder(mayHaveEntryPointSlotsToBackpatch);
+
+        // Try a faster check to see if we can avoid checking the currently active code version
+        // - For the default code version, if a profiler is attached it may be notified of JIT events and may request rejit
+        //   synchronously on the same thread. In that case, for back-compat as described below, the returned code must be for
+        //   the rejitted or newer code.
+        // - It must be ensured that there are no races that could cause an older entry point to replace a newer entry point.
+        //   For non-default code versions, it's necessary to check the currently active code version and publish under the
+        //   CodeVersionManager's lock. For default code versions, the entry point is atomically updated and only if it is
+        //   pointing to the prestub.
+        if (activeVersion.IsDefaultVersion() && !profilerMayHaveActivatedNonDefaultCodeVersion)
+        {
+            if (doPublish)
+            {
+                pMethodDesc->TrySetInitialCodeEntryPointForNonJumpStampVersionableMethod(pCode, mayHaveEntryPointSlotsToBackpatch);
+            }
+            else
+            {
+                *doBackpatchRef = false;
+            }
+            return pCode;
+        }
+
+        // Backpatching entry point slots requires cooperative GC mode, see
+        // MethodDescBackpatchInfoTracker::Backpatch_Locked(). The code version manager's table lock is an unsafe lock that
+        // may be taken in any GC mode. The lock is taken in cooperative GC mode on some other paths, so the same ordering
+        // must be used here to prevent deadlock.
+        GCX_MAYBE_COOP(mayHaveEntryPointSlotsToBackpatch);
+        TableLockHolder lock(this);
+
+        NativeCodeVersion newActiveVersion;
+        if (FAILED(hr = GetActiveILCodeVersion(pMethodDesc).GetOrCreateActiveNativeCodeVersion(pMethodDesc, &newActiveVersion)))
+        {
+            break;
+        }
+
+        // The common case is that newActiveCode == activeCode, however we did leave the lock so there is
+        // possibility that the active version has changed. If it has we need to restart the compilation
+        // and publishing process with the new active version instead.
+        //
+        // In theory it should be legitimate to break out of this loop and run the less recent active version,
+        // because ultimately this is a race between one thread that is updating the version and another thread
+        // trying to run the current version. However for back-compat with ReJIT we need to guarantee that
+        // a versioning update at least as late as the profiler JitCompilationFinished callback wins the race.
+        if (newActiveVersion == activeVersion)
+        {
+            if (doPublish)
+            {
+                pMethodDesc->SetCodeEntryPoint(pCode);
+            }
+            else
+            {
+                *doBackpatchRef = false;
+            }
+            return pCode;
+        }
+
+        activeVersion = newActiveVersion;
+        pCode = activeVersion.GetNativeCode();
+    }
+
+    _ASSERTE(hr == E_OUTOFMEMORY);
+    ReportCodePublishError(pMethodDesc, hr);
+    *doBackpatchRef = false;
+    return pCode;
+}
+
+PCODE CodeVersionManager::PublishJumpStampVersionableCodeIfNecessary(MethodDesc* pMethodDesc)
+{
+    STANDARD_VM_CONTRACT;
+    _ASSERTE(!LockOwnedByCurrentThread());
+    _ASSERTE(pMethodDesc->IsVersionableWithJumpStamp());
+    _ASSERTE(!pMethodDesc->IsPointingToPrestub());
 
     HRESULT hr = S_OK;
     PCODE pCode = NULL;
@@ -2293,7 +2481,7 @@ PCODE CodeVersionManager::PublishVersionableCodeIfNecessary(MethodDesc* pMethodD
         if (FAILED(hr = GetActiveILCodeVersion(pMethodDesc).GetOrCreateActiveNativeCodeVersion(pMethodDesc, &activeVersion)))
         {
             _ASSERTE(hr == E_OUTOFMEMORY);
-            ReportCodePublishError(pMethodDesc->GetModule(), pMethodDesc->GetMemberDef(), pMethodDesc, hr);
+            ReportCodePublishError(pMethodDesc, hr);
             return NULL;
         }
     }
@@ -2305,11 +2493,11 @@ PCODE CodeVersionManager::PublishVersionableCodeIfNecessary(MethodDesc* pMethodD
         pCode = activeVersion.GetNativeCode();
         if (pCode == NULL)
         {
-            pCode = pMethodDesc->PrepareCode(activeVersion);
+            PrepareCodeConfigBuffer configBuffer(activeVersion);
+            pCode = pMethodDesc->PrepareCode(configBuffer.GetConfig());
         }
 
-        bool mayHaveEntryPointSlotsToBackpatch = pMethodDesc->MayHaveEntryPointSlotsToBackpatch();
-        MethodDescBackpatchInfoTracker::ConditionalLockHolder lockHolder(mayHaveEntryPointSlotsToBackpatch);
+        _ASSERTE(!pMethodDesc->MayHaveEntryPointSlotsToBackpatch());
 
         // suspend in preparation for publishing if needed
         if (fEESuspend)
@@ -2318,11 +2506,6 @@ PCODE CodeVersionManager::PublishVersionableCodeIfNecessary(MethodDesc* pMethodD
         }
 
         {
-            // Backpatching entry point slots requires cooperative GC mode, see
-            // MethodDescBackpatchInfoTracker::Backpatch_Locked(). The code version manager's table lock is an unsafe lock that
-            // may be taken in any GC mode. The lock is taken in cooperative GC mode on some other paths, so the same ordering
-            // must be used here to prevent deadlock.
-            GCX_MAYBE_COOP(mayHaveEntryPointSlotsToBackpatch);
             TableLockHolder lock(this);
 
             // The common case is that newActiveCode == activeCode, however we did leave the lock so there is
@@ -2337,7 +2520,7 @@ PCODE CodeVersionManager::PublishVersionableCodeIfNecessary(MethodDesc* pMethodD
             if (FAILED(hr = GetActiveILCodeVersion(pMethodDesc).GetOrCreateActiveNativeCodeVersion(pMethodDesc, &newActiveVersion)))
             {
                 _ASSERTE(hr == E_OUTOFMEMORY);
-                ReportCodePublishError(pMethodDesc->GetModule(), pMethodDesc->GetMemberDef(), pMethodDesc, hr);
+                ReportCodePublishError(pMethodDesc, hr);
                 pCode = NULL;
                 break;
             }
@@ -2347,12 +2530,6 @@ PCODE CodeVersionManager::PublishVersionableCodeIfNecessary(MethodDesc* pMethodD
             }
             else
             {
-                // if we aren't allowed to backpatch we are done
-                if (!fCanBackpatchPrestub)
-                {
-                    break;
-                }
-
                 // attempt to publish the active version still under the lock
                 if (FAILED(hr = PublishNativeCodeVersion(pMethodDesc, activeVersion, fEESuspend)))
                 {
@@ -2367,7 +2544,7 @@ PCODE CodeVersionManager::PublishVersionableCodeIfNecessary(MethodDesc* pMethodD
                     }
                     else
                     {
-                        ReportCodePublishError(pMethodDesc->GetModule(), pMethodDesc->GetMemberDef(), pMethodDesc, hr);
+                        ReportCodePublishError(pMethodDesc, hr);
                         pCode = NULL;
                         break;
                     }
@@ -2385,7 +2562,7 @@ PCODE CodeVersionManager::PublishVersionableCodeIfNecessary(MethodDesc* pMethodD
             ThreadSuspend::RestartEE(FALSE, TRUE);
         }
     }
-    
+
     // if the EE is still suspended from breaking in the middle of the loop, resume it
     if (fEESuspend)
     {
@@ -2872,6 +3049,20 @@ void CodeVersionManager::ReportCodePublishError(CodePublishError* pErrorRecord)
     ReportCodePublishError(pErrorRecord->pModule, pErrorRecord->methodDef, pErrorRecord->pMethodDesc, pErrorRecord->hrStatus);
 }
 
+NOINLINE void CodeVersionManager::ReportCodePublishError(MethodDesc* pMD, HRESULT hrStatus)
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_TRIGGERS;
+        CAN_TAKE_LOCK;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
+
+    ReportCodePublishError(pMD->GetModule(), pMD->GetMemberDef(), pMD, hrStatus);
+}
+
 void CodeVersionManager::ReportCodePublishError(Module* pModule, mdMethodDef methodDef, MethodDesc* pMD, HRESULT hrStatus)
 {
     CONTRACTL
@@ -2992,7 +3183,7 @@ PublishMethodHolder::~PublishMethodHolder()
         pCodeVersionManager->LeaveLock();
         if (FAILED(m_hr))
         {
-            pCodeVersionManager->ReportCodePublishError(m_pMD->GetModule(), m_pMD->GetMemberDef(), m_pMD, m_hr);
+            pCodeVersionManager->ReportCodePublishError(m_pMD, m_hr);
         }
     }
 }

--- a/src/vm/codeversion.h
+++ b/src/vm/codeversion.h
@@ -527,7 +527,7 @@ public:
     static count_t Hash(key_t k)
     {
         LIMITED_METHOD_CONTRACT;
-        return (count_t)(size_t)dac_cast<TADDR>(k);
+        return (count_t)(dac_cast<TADDR>(k) >> POINTER_HASH_SHIFT);
     }
 
     static element_t Null() { LIMITED_METHOD_CONTRACT; return dac_cast<PTR_MethodDescVersioningState>(nullptr); }
@@ -647,7 +647,8 @@ public:
     HRESULT AddILCodeVersion(Module* pModule, mdMethodDef methodDef, ReJITID rejitId, ILCodeVersion* pILCodeVersion);
     HRESULT AddNativeCodeVersion(ILCodeVersion ilCodeVersion, MethodDesc* pClosedMethodDesc, NativeCodeVersion::OptimizationTier optimizationTier, NativeCodeVersion* pNativeCodeVersion);
     HRESULT DoJumpStampIfNecessary(MethodDesc* pMD, PCODE pCode);
-    PCODE PublishVersionableCodeIfNecessary(MethodDesc* pMethodDesc, BOOL fCanBackpatchPrestub);
+    PCODE PublishNonJumpStampVersionableCodeIfNecessary(MethodDesc* pMethodDesc, bool *doBackpatchRef, bool *doFullBackpatchRef);
+    PCODE PublishJumpStampVersionableCodeIfNecessary(MethodDesc* pMethodDesc);
     HRESULT PublishNativeCodeVersion(MethodDesc* pMethodDesc, NativeCodeVersion nativeCodeVersion, BOOL fEESuspended);
     HRESULT GetOrCreateMethodDescVersioningState(MethodDesc* pMethod, MethodDescVersioningState** ppMethodDescVersioningState);
     HRESULT GetOrCreateILCodeVersioningState(Module* pModule, mdMethodDef methodDef, ILCodeVersioningState** ppILCodeVersioningState);
@@ -658,6 +659,20 @@ public:
 #endif
 
     static bool IsMethodSupported(PTR_MethodDesc pMethodDesc);
+
+#ifndef DACCESS_COMPILE
+    static bool InitialNativeCodeVersionMayNotBeTheDefaultNativeCodeVersion()
+    {
+        LIMITED_METHOD_CONTRACT;
+        return s_initialNativeCodeVersionMayNotBeTheDefaultNativeCodeVersion;
+    }
+
+    static void SetInitialNativeCodeVersionMayNotBeTheDefaultNativeCodeVersion()
+    {
+        LIMITED_METHOD_CONTRACT;
+        s_initialNativeCodeVersionMayNotBeTheDefaultNativeCodeVersion = true;
+    }
+#endif
 
 private:
 
@@ -671,7 +686,10 @@ private:
         CDynArray<CodePublishError> * pUnsupportedMethodErrors);
     static HRESULT GetNonVersionableError(MethodDesc* pMD);
     void ReportCodePublishError(CodePublishError* pErrorRecord);
+    void ReportCodePublishError(MethodDesc* pMD, HRESULT hrStatus);
     void ReportCodePublishError(Module* pModule, mdMethodDef methodDef, MethodDesc* pMD, HRESULT hrStatus);
+
+    static bool s_initialNativeCodeVersionMayNotBeTheDefaultNativeCodeVersion;
 #endif
 
     //Module,MethodDef -> ILCodeVersioningState

--- a/src/vm/codeversion.h
+++ b/src/vm/codeversion.h
@@ -527,7 +527,7 @@ public:
     static count_t Hash(key_t k)
     {
         LIMITED_METHOD_CONTRACT;
-        return (count_t)(dac_cast<TADDR>(k) >> POINTER_HASH_SHIFT);
+        return (count_t)dac_cast<TADDR>(k);
     }
 
     static element_t Null() { LIMITED_METHOD_CONTRACT; return dac_cast<PTR_MethodDescVersioningState>(nullptr); }

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -1405,27 +1405,40 @@ private:
     void RecordAndBackpatchEntryPointSlot_Locked(LoaderAllocator *mdLoaderAllocator, LoaderAllocator *slotLoaderAllocator, TADDR slot, EntryPointSlots::SlotType slotType, PCODE currentEntryPoint);
 
 public:
+    bool TryBackpatchEntryPointSlotsFromPrestub(PCODE entryPoint)
+    {
+        WRAPPER_NO_CONTRACT;
+        return TryBackpatchEntryPointSlots(entryPoint, false /* isPrestubEntryPoint */, true /* onlyFromPrestubEntryPoint */);
+    }
+
     void BackpatchEntryPointSlots(PCODE entryPoint)
     {
         WRAPPER_NO_CONTRACT;
-        _ASSERTE(entryPoint != GetPrestubEntryPointToBackpatch());
-        _ASSERTE(MayHaveEntryPointSlotsToBackpatch());
-
         BackpatchEntryPointSlots(entryPoint, false /* isPrestubEntryPoint */);
     }
 
     void BackpatchToResetEntryPointSlots()
     {
         WRAPPER_NO_CONTRACT;
-        _ASSERTE(MayHaveEntryPointSlotsToBackpatch());
-
         BackpatchEntryPointSlots(GetPrestubEntryPointToBackpatch(), true /* isPrestubEntryPoint */);
     }
 
 private:
-    void BackpatchEntryPointSlots(PCODE entryPoint, bool isPrestubEntryPoint);
+    void BackpatchEntryPointSlots(PCODE entryPoint, bool isPrestubEntryPoint)
+    {
+        WRAPPER_NO_CONTRACT;
+
+#ifdef _DEBUG // workaround for release build unused variable error
+        bool success =
+#endif
+            TryBackpatchEntryPointSlots(entryPoint, isPrestubEntryPoint, false /* onlyFromPrestubEntryPoint */);
+        _ASSERTE(success);
+    }
+
+    bool TryBackpatchEntryPointSlots(PCODE entryPoint, bool isPrestubEntryPoint, bool onlyFromPrestubEntryPoint);
 
 public:
+    void TrySetInitialCodeEntryPointForNonJumpStampVersionableMethod(PCODE entryPoint, bool mayHaveEntryPointSlotsToBackpatch);
     void SetCodeEntryPoint(PCODE entryPoint);
     void ResetCodeEntryPoint();
 
@@ -2022,7 +2035,6 @@ public:
 #ifndef DACCESS_COMPILE
 public:
     PCODE PrepareInitialCode();
-    PCODE PrepareCode(NativeCodeVersion codeVersion);
     PCODE PrepareCode(PrepareCodeConfig* pConfig);
 
 private:
@@ -2066,6 +2078,54 @@ public:
     BOOL ReadyToRunRejectedPrecompiledCode();
     void SetProfilerRejectedPrecompiledCode();
     void SetReadyToRunRejectedPrecompiledCode();
+
+#ifdef FEATURE_CODE_VERSIONING
+public:
+    bool ProfilerMayHaveActivatedNonDefaultCodeVersion() const
+    {
+        WRAPPER_NO_CONTRACT;
+        return m_profilerMayHaveActivatedNonDefaultCodeVersion;
+    }
+
+    void SetProfilerMayHaveActivatedNonDefaultCodeVersion()
+    {
+        WRAPPER_NO_CONTRACT;
+        _ASSERTE(!m_profilerMayHaveActivatedNonDefaultCodeVersion);
+
+        m_profilerMayHaveActivatedNonDefaultCodeVersion = true;
+    }
+
+    bool GeneratedOrLoadedNewCode() const
+    {
+        WRAPPER_NO_CONTRACT;
+        return m_generatedOrLoadedNewCode;
+    }
+
+    void SetGeneratedOrLoadedNewCode()
+    {
+        WRAPPER_NO_CONTRACT;
+        _ASSERTE(!m_generatedOrLoadedNewCode);
+
+        m_generatedOrLoadedNewCode = true;
+    }
+#endif
+
+#ifdef FEATURE_TIERED_COMPILATION
+public:
+    bool ShouldCountCalls() const
+    {
+        WRAPPER_NO_CONTRACT;
+        return m_shouldCountCalls;
+    }
+
+    void SetShouldCountCalls()
+    {
+        WRAPPER_NO_CONTRACT;
+        _ASSERTE(!m_shouldCountCalls);
+
+        m_shouldCountCalls = true;
+    }
+#endif
 
 #ifndef CROSSGEN_COMPILE
 public:
@@ -2142,6 +2202,17 @@ protected:
     BOOL m_ProfilerRejectedPrecompiledCode;
     BOOL m_ReadyToRunRejectedPrecompiledCode;
 
+#ifdef FEATURE_CODE_VERSIONING
+private:
+    bool m_profilerMayHaveActivatedNonDefaultCodeVersion;
+    bool m_generatedOrLoadedNewCode;
+#endif
+
+#ifdef FEATURE_TIERED_COMPILATION
+private:
+    bool m_shouldCountCalls;
+#endif
+
 #ifndef CROSSGEN_COMPILE
 private:
     bool m_jitSwitchedToMinOpt; // when it wasn't requested
@@ -2165,6 +2236,25 @@ public:
     virtual CORJIT_FLAGS GetJitCompilationFlags();
 private:
     ILCodeVersion m_ilCodeVersion;
+};
+
+class PrepareCodeConfigBuffer
+{
+private:
+    UINT8 m_buffer[sizeof(VersionedPrepareCodeConfig)];
+
+public:
+    PrepareCodeConfigBuffer(NativeCodeVersion codeVersion);
+
+public:
+    PrepareCodeConfig *GetConfig() const
+    {
+        WRAPPER_NO_CONTRACT;
+        return (PrepareCodeConfig *)m_buffer;
+    }
+
+    PrepareCodeConfigBuffer(const PrepareCodeConfigBuffer &) = delete;
+    PrepareCodeConfigBuffer &operator =(const PrepareCodeConfigBuffer &) = delete;
 };
 #endif // FEATURE_CODE_VERSIONING
 #endif // DACCESS_COMPILE

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -1979,8 +1979,7 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT)
     // See if the addr of code has changed from the pre-stub
 
 #ifdef FEATURE_CODE_VERSIONING
-    bool isVersionableWithoutJumpStamp = IsVersionableWithoutJumpStamp();
-    if (isVersionableWithoutJumpStamp)
+    if (IsVersionableWithoutJumpStamp())
     {
         bool doBackpatch = true;
         bool doFullBackpatch = false;
@@ -1995,13 +1994,13 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT)
         _ASSERTE(!doFullBackpatch);
         RETURN pCode;
     }
-    else
 #endif
+
     if (!IsPointingToPrestub())
     {
         bool doFullBackpatch = true;
     #ifdef FEATURE_CODE_VERSIONING
-        if (!isVersionableWithoutJumpStamp && IsVersionableWithJumpStamp())
+        if (IsVersionableWithJumpStamp())
         {
             _ASSERTE(IsVersionableWithJumpStamp());
             pCode = GetCodeVersionManager()->PublishJumpStampVersionableCodeIfNecessary(this);

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -320,34 +320,6 @@ PCODE MethodDesc::PrepareInitialCode()
     return pCode;
 }
 
-PCODE MethodDesc::PrepareCode(NativeCodeVersion codeVersion)
-{
-    STANDARD_VM_CONTRACT;
-    
-#ifdef FEATURE_CODE_VERSIONING
-    if (codeVersion.IsDefaultVersion())
-    {
-#endif
-        // fast path
-        PrepareCodeConfig config(codeVersion, TRUE, TRUE);
-        return PrepareCode(&config);
-#ifdef FEATURE_CODE_VERSIONING
-    }
-    else
-    {
-        // a bit slower path (+1 usec?)
-        VersionedPrepareCodeConfig config;
-        {
-            CodeVersionManager::TableLockHolder lock(GetCodeVersionManager());
-            config = VersionedPrepareCodeConfig(codeVersion);
-        }
-        config.FinishConfiguration();
-        return PrepareCode(&config);
-    }
-#endif
-    
-}
-
 PCODE MethodDesc::PrepareCode(PrepareCodeConfig* pConfig)
 {
     STANDARD_VM_CONTRACT;
@@ -416,17 +388,6 @@ PCODE MethodDesc::PrepareILBasedCode(PrepareCodeConfig* pConfig)
 
     if (pCode == NULL)
     {
-#ifdef FEATURE_TIERED_COMPILATION
-        if (!g_pConfig->TieredCompilation_QuickJit() &&
-            IsEligibleForTieredCompilation() &&
-            pConfig->GetCodeVersion().GetOptimizationTier() == NativeCodeVersion::OptimizationTier0 &&
-            CallCounter::IsEligibleForCallCounting(this))
-        {
-            GetCallCounter()->DisableCallCounting(this);
-            pConfig->GetCodeVersion().SetOptimizationTier(NativeCodeVersion::OptimizationTierOptimized);
-        }
-#endif
-
         LOG((LF_CLASSLOADER, LL_INFO1000000,
             "    In PrepareILBasedCode, calling JitCompileCode\n"));
         pCode = JitCompileCode(pConfig);
@@ -451,8 +412,14 @@ PCODE MethodDesc::GetPrecompiledCode(PrepareCodeConfig* pConfig)
     pCode = GetPrecompiledNgenCode(pConfig);
 #endif
 
+    if (pCode != NULL)
+    {
+    #ifdef FEATURE_CODE_VERSIONING
+        pConfig->SetGeneratedOrLoadedNewCode();
+    #endif
+    }
 #ifdef FEATURE_READYTORUN
-    if (pCode == NULL)
+    else
     {
         pCode = GetPrecompiledR2RCode(pConfig);
         if (pCode != NULL)
@@ -465,7 +432,19 @@ PCODE MethodDesc::GetPrecompiledCode(PrepareCodeConfig* pConfig)
                     m_pszDebugMethodSignature,
                     GetMemberDef()));
 
-            pConfig->SetNativeCode(pCode, &pCode);
+            if (pConfig->SetNativeCode(pCode, &pCode))
+            {
+            #ifdef FEATURE_CODE_VERSIONING
+                pConfig->SetGeneratedOrLoadedNewCode();
+            #endif
+            #ifdef FEATURE_TIERED_COMPILATION
+                if (pConfig->GetMethodDesc()->IsEligibleForTieredCompilation())
+                {
+                    _ASSERTE(pConfig->GetCodeVersion().GetOptimizationTier() == NativeCodeVersion::OptimizationTier0);
+                    pConfig->SetShouldCountCalls();
+                }
+            #endif
+            }
         }
     }
 #endif // FEATURE_READYTORUN
@@ -764,7 +743,19 @@ PCODE MethodDesc::JitCompileCode(PrepareCodeConfig* pConfig)
             pCode = GetMulticoreJitCode();
             if (pCode != NULL)
             {
-                pConfig->SetNativeCode(pCode, &pCode);
+                if (pConfig->SetNativeCode(pCode, &pCode))
+                {
+                #ifdef FEATURE_CODE_VERSIONING
+                    pConfig->SetGeneratedOrLoadedNewCode();
+                #endif
+                #ifdef FEATURE_TIERED_COMPILATION
+                    if (pConfig->GetMethodDesc()->IsEligibleForTieredCompilation() &&
+                        pConfig->GetCodeVersion().GetOptimizationTier() == NativeCodeVersion::OptimizationTier0)
+                    {
+                        pConfig->SetShouldCountCalls();
+                    }
+                #endif
+                }
                 pEntry->m_hrResultCode = S_OK;
                 return pCode;
             }
@@ -790,9 +781,11 @@ PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, J
         // For methods with non-zero rejit id we send ReJITCompilationStarted, otherwise
         // JITCompilationStarted. It isn't clear if this is the ideal policy for these
         // notifications yet.
-        ReJITID rejitId = pConfig->GetCodeVersion().GetILCodeVersionId();
+        NativeCodeVersion nativeCodeVersion = pConfig->GetCodeVersion();
+        ReJITID rejitId = nativeCodeVersion.GetILCodeVersionId();
         if (rejitId != 0)
         {
+            _ASSERTE(!nativeCodeVersion.IsDefaultVersion());
             g_profControlBlock.pProfInterface->ReJITCompilationStarted((FunctionID)this,
                 rejitId,
                 TRUE);
@@ -814,6 +807,11 @@ PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, J
                 LPCBYTE ilHeaderPointer = this->AsDynamicMethodDesc()->GetResolver()->GetCodeInfo(&ilSize, &unused, &corOptions, &unused);
 
                 g_profControlBlock.pProfInterface->DynamicMethodJITCompilationStarted((FunctionID)this, TRUE, ilHeaderPointer, ilSize);
+            }
+
+            if (nativeCodeVersion.IsDefaultVersion())
+            {
+                pConfig->SetProfilerMayHaveActivatedNonDefaultCodeVersion();
             }
         }
         END_PIN_PROFILER();
@@ -872,10 +870,11 @@ PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, J
         // For methods with non-zero rejit id we send ReJITCompilationFinished, otherwise
         // JITCompilationFinished. It isn't clear if this is the ideal policy for these
         // notifications yet.
-        ReJITID rejitId = pConfig->GetCodeVersion().GetILCodeVersionId();
+        NativeCodeVersion nativeCodeVersion = pConfig->GetCodeVersion();
+        ReJITID rejitId = nativeCodeVersion.GetILCodeVersionId();
         if (rejitId != 0)
         {
-
+            _ASSERTE(!nativeCodeVersion.IsDefaultVersion());
             g_profControlBlock.pProfInterface->ReJITCompilationFinished((FunctionID)this,
                 rejitId,
                 S_OK,
@@ -896,6 +895,11 @@ PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, J
             else
             {
                 g_profControlBlock.pProfInterface->DynamicMethodJITCompilationFinished((FunctionID)this, pEntry->m_hrResultCode, TRUE);
+            }
+
+            if (nativeCodeVersion.IsDefaultVersion())
+            {
+                pConfig->SetProfilerMayHaveActivatedNonDefaultCodeVersion();
             }
         }
         END_PIN_PROFILER();
@@ -1038,18 +1042,29 @@ PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEn
         return pOtherCode;
     }
 
+#ifdef FEATURE_CODE_VERSIONING
+    pConfig->SetGeneratedOrLoadedNewCode();
+#endif
+
 #ifdef FEATURE_TIERED_COMPILATION
-    if (pConfig->JitSwitchedToOptimized())
+    if (pFlags->IsSet(CORJIT_FLAGS::CORJIT_FLAG_TIER0))
     {
-        _ASSERTE(pFlags->IsSet(CORJIT_FLAGS::CORJIT_FLAG_TIER0));
+        _ASSERTE(pConfig->GetCodeVersion().GetOptimizationTier() == NativeCodeVersion::OptimizationTier0);
+        _ASSERTE(pConfig->GetMethodDesc()->IsEligibleForTieredCompilation());
+        _ASSERTE(pConfig->GetMethodDesc()->GetCallCounter()->IsCallCountingEnabled(pConfig->GetMethodDesc()));
 
-        MethodDesc *methodDesc = pConfig->GetMethodDesc();
-        _ASSERTE(methodDesc->IsEligibleForTieredCompilation());
-
-        // Update the tier in the code version. The JIT may have decided to switch from tier 0 to optimized, in which case call
-        // counting would have to be disabled for the method.
-        methodDesc->GetCallCounter()->DisableCallCounting(methodDesc);
-        pConfig->GetCodeVersion().SetOptimizationTier(NativeCodeVersion::OptimizationTierOptimized);
+        if (pConfig->JitSwitchedToOptimized())
+        {
+            // Update the tier in the code version. The JIT may have decided to switch from tier 0 to optimized, in which case
+            // call counting would have to be disabled for the method.
+            MethodDesc *methodDesc = pConfig->GetMethodDesc();
+            methodDesc->GetCallCounter()->DisableCallCounting(methodDesc);
+            pConfig->GetCodeVersion().SetOptimizationTier(NativeCodeVersion::OptimizationTierOptimized);
+        }
+        else
+        {
+            pConfig->SetShouldCountCalls();
+        }
     }
 #endif
 
@@ -1074,6 +1089,13 @@ PrepareCodeConfig::PrepareCodeConfig(NativeCodeVersion codeVersion, BOOL needsMu
     m_mayUsePrecompiledCode(mayUsePrecompiledCode),
     m_ProfilerRejectedPrecompiledCode(FALSE),
     m_ReadyToRunRejectedPrecompiledCode(FALSE),
+#ifdef FEATURE_CODE_VERSIONING
+    m_profilerMayHaveActivatedNonDefaultCodeVersion(false),
+    m_generatedOrLoadedNewCode(false),
+#endif
+#ifdef FEATURE_TIERED_COMPILATION
+    m_shouldCountCalls(false),
+#endif
     m_jitSwitchedToMinOpt(false),
 #ifdef FEATURE_TIERED_COMPILATION
     m_jitSwitchedToOptimized(false),
@@ -1326,6 +1348,26 @@ CORJIT_FLAGS VersionedPrepareCodeConfig::GetJitCompilationFlags()
 #endif
 
     return flags;
+}
+
+PrepareCodeConfigBuffer::PrepareCodeConfigBuffer(NativeCodeVersion codeVersion)
+{
+    WRAPPER_NO_CONTRACT;
+
+    if (codeVersion.IsDefaultVersion())
+    {
+        // fast path
+        new(m_buffer) PrepareCodeConfig(codeVersion, TRUE, TRUE);
+        return;
+    }
+
+    // a bit slower path (+1 usec?)
+    VersionedPrepareCodeConfig *config;
+    {
+        CodeVersionManager::TableLockHolder lock(codeVersion.GetMethodDesc()->GetCodeVersionManager());
+        config = new(m_buffer) VersionedPrepareCodeConfig(codeVersion);
+    }
+    config->FinishConfiguration();
 }
 
 #endif //FEATURE_CODE_VERSIONING
@@ -1933,67 +1975,54 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT)
         pThread->HandleThreadAbort();
     }
 
-    /***************************   CALL COUNTER    ***********************/
-    // If we are counting calls for tiered compilation, leave the prestub
-    // in place so that we can continue intercepting method invocations.
-    // When the TieredCompilationManager has received enough call notifications
-    // for this method only then do we back-patch it.
-    BOOL fCanBackpatchPrestub = TRUE;
-#ifdef FEATURE_TIERED_COMPILATION
-    BOOL fNeedsCallCounting = FALSE;
-    TieredCompilationManager* pTieredCompilationManager = nullptr;
-    if (IsEligibleForTieredCompilation() && CallCounter::IsEligibleForCallCounting(this))
-    {
-        pTieredCompilationManager = GetAppDomain()->GetTieredCompilationManager();
-        BOOL fWasPromotedToNextTier = FALSE;
-        GetCallCounter()->OnMethodCalled(this, pTieredCompilationManager, &fCanBackpatchPrestub, &fWasPromotedToNextTier);
-        fNeedsCallCounting = !fWasPromotedToNextTier;
-    }
-#endif
-
-    /***************************  VERSIONABLE CODE    *********************/
-
-    BOOL fIsPointingToPrestub = IsPointingToPrestub();
-    bool fIsVersionableWithoutJumpStamp = false;
-#ifdef FEATURE_CODE_VERSIONING
-    fIsVersionableWithoutJumpStamp = IsVersionableWithoutJumpStamp();
-    if (fIsVersionableWithoutJumpStamp ||
-        (!fIsPointingToPrestub && IsVersionableWithJumpStamp()))
-    {
-        pCode = GetCodeVersionManager()->PublishVersionableCodeIfNecessary(this, fCanBackpatchPrestub);
-
-#ifdef FEATURE_TIERED_COMPILATION
-        if (pTieredCompilationManager != nullptr && fNeedsCallCounting && fCanBackpatchPrestub && pCode != NULL)
-        {
-            pTieredCompilationManager->OnMethodCallCountingStoppedWithoutTierPromotion(this);
-        }
-#endif
-
-        fIsPointingToPrestub = IsPointingToPrestub();
-    }
-#endif
-
     /**************************   BACKPATCHING   *************************/
     // See if the addr of code has changed from the pre-stub
-    if (!fIsPointingToPrestub)
+
+#ifdef FEATURE_CODE_VERSIONING
+    bool isVersionableWithoutJumpStamp = IsVersionableWithoutJumpStamp();
+    if (isVersionableWithoutJumpStamp)
     {
-        LOG((LF_CLASSLOADER, LL_INFO10000,
-                "    In PreStubWorker, method already jitted, backpatching call point\n"));
-#if defined(FEATURE_JIT_PITCHING)
-        MarkMethodNotPitchingCandidate(this);
-#endif
-        RETURN DoBackpatch(pMT, pDispatchingMT, TRUE);
-    }
-    
-    if (pCode)
-    {
-        // The only reasons we are still pointing to prestub is because the call counter
-        // prevented it or this thread lost the race with another thread in updating the
-        // entry point. We should still short circuit and return the code without
-        // backpatching.
+        bool doBackpatch = true;
+        bool doFullBackpatch = false;
+        pCode = GetCodeVersionManager()->PublishNonJumpStampVersionableCodeIfNecessary(this, &doBackpatch, &doFullBackpatch);
+
+        if (doBackpatch)
+        {
+            RETURN DoBackpatch(pMT, pDispatchingMT, doFullBackpatch);
+        }
+
+        _ASSERTE(pCode != NULL);
+        _ASSERTE(!doFullBackpatch);
         RETURN pCode;
     }
-    
+    else
+#endif
+    if (!IsPointingToPrestub())
+    {
+        bool doFullBackpatch = true;
+    #ifdef FEATURE_CODE_VERSIONING
+        if (!isVersionableWithoutJumpStamp && IsVersionableWithJumpStamp())
+        {
+            _ASSERTE(IsVersionableWithJumpStamp());
+            pCode = GetCodeVersionManager()->PublishJumpStampVersionableCodeIfNecessary(this);
+            if (pCode == NULL)
+            {
+                doFullBackpatch = false;
+            }
+        }
+    #endif
+
+        if (doFullBackpatch)
+        {
+            LOG((LF_CLASSLOADER, LL_INFO10000,
+                "    In PreStubWorker, method already jitted, backpatching call point\n"));
+        #if defined(FEATURE_JIT_PITCHING)
+            MarkMethodNotPitchingCandidate(this);
+        #endif
+            RETURN DoBackpatch(pMT, pDispatchingMT, TRUE);
+        }
+    }
+
     /**************************   CODE CREATION  *************************/
     if (IsUnboxingStub())
     {
@@ -2007,7 +2036,7 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT)
 #endif // defined(FEATURE_SHARE_GENERIC_CODE)
     else if (IsIL() || IsNoMetadata())
     {
-        if (!IsNativeCodeStableAfterInit() && (!fIsVersionableWithoutJumpStamp || IsVersionableWithPrecode()))
+        if (!IsNativeCodeStableAfterInit())
         {
             GetOrCreatePrecode();
         }
@@ -2078,13 +2107,6 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT)
 
     if (pCode != NULL)
     {
-        if (fIsVersionableWithoutJumpStamp)
-        {
-            // Methods versionable without a jump stamp should not get here unless there was a failure. There may have been a
-            // failure to update the code versions above for some reason. Don't backpatch this time and try again next time.
-            return pCode;
-        }
-
         _ASSERTE(!MayHaveEntryPointSlotsToBackpatch()); // This path doesn't lock the MethodDescBackpatchTracker as it should only
                                                         // happen for jump-stampable or non-versionable methods
         SetCodeEntryPoint(pCode);

--- a/src/vm/tieredcompilation.cpp
+++ b/src/vm/tieredcompilation.cpp
@@ -198,7 +198,7 @@ bool TieredCompilationManager::OnMethodCodeVersionCalledSubsequently(MethodDesc*
         // This is to prevent a race where the method get recorded below, the delay timer callback resets the method's entry
         // point to begin call counting, and then the method's entry point is set by this thread to the tier 0 entry point. In
         // that case the method would not be counted or tiered-up anymore. So, stop call counting only when the delay timer will
-        // be extended, the extra delay makes the issue near-impossible to occur. This is a great solution and is temporary,
+        // be extended, the extra delay makes the issue near-impossible to occur. This is not a great solution and is temporary,
         // once the call counting scheme is changed this code and issue will disappear.
         return false;
     }

--- a/src/vm/tieredcompilation.cpp
+++ b/src/vm/tieredcompilation.cpp
@@ -120,7 +120,7 @@ NativeCodeVersion::OptimizationTier TieredCompilationManager::GetInitialOptimiza
 
 #if defined(FEATURE_TIERED_COMPILATION) && !defined(DACCESS_COMPILE)
 
-bool TieredCompilationManager::OnMethodCalledFirstTime(MethodDesc* pMethodDesc)
+bool TieredCompilationManager::OnMethodCodeVersionCalledFirstTime(MethodDesc* pMethodDesc)
 {
     WRAPPER_NO_CONTRACT;
     _ASSERTE(pMethodDesc != nullptr);
@@ -180,7 +180,7 @@ bool TieredCompilationManager::OnMethodCalledFirstTime(MethodDesc* pMethodDesc)
     }
 }
 
-bool TieredCompilationManager::OnMethodCalledSubsequently(MethodDesc* pMethodDesc)
+bool TieredCompilationManager::OnMethodCodeVersionCalledSubsequently(MethodDesc* pMethodDesc)
 {
     WRAPPER_NO_CONTRACT;
     _ASSERTE(pMethodDesc != nullptr);

--- a/src/vm/tieredcompilation.cpp
+++ b/src/vm/tieredcompilation.cpp
@@ -66,6 +66,7 @@ TieredCompilationManager::TieredCompilationManager() :
     m_countOfMethodsToOptimize(0),
     m_isAppDomainShuttingDown(FALSE),
     m_countOptimizationThreadsRunning(0),
+    m_countOfNewMethodsCalledDuringDelay(0),
     m_methodsPendingCountingForTier1(nullptr),
     m_tieringDelayTimerHandle(nullptr),
     m_tier1CallCountingCandidateMethodRecentlyRecorded(false)
@@ -97,19 +98,13 @@ NativeCodeVersion::OptimizationTier TieredCompilationManager::GetInitialOptimiza
     if (!pMethodDesc->IsEligibleForTieredCompilation())
     {
         // The optimization tier is not used
-        return NativeCodeVersion::OptimizationTier0;
+        return NativeCodeVersion::OptimizationTierOptimized;
     }
 
     if (pMethodDesc->RequestedAggressiveOptimization())
     {
         // Methods flagged with MethodImplOptions.AggressiveOptimization start with and stay at tier 1
         return NativeCodeVersion::OptimizationTier1;
-    }
-
-    if (!g_pConfig->TieredCompilation_CallCounting())
-    {
-        // Call counting is disabled altogether through config, the intention is to remain at the initial tier
-        return NativeCodeVersion::OptimizationTier0;
     }
 
     if (!pMethodDesc->GetCallCounter()->IsCallCountingEnabled(pMethodDesc))
@@ -125,50 +120,16 @@ NativeCodeVersion::OptimizationTier TieredCompilationManager::GetInitialOptimiza
 
 #if defined(FEATURE_TIERED_COMPILATION) && !defined(DACCESS_COMPILE)
 
-// Called each time code in this AppDomain has been run. This is our sole entrypoint to begin
-// tiered compilation for now. Returns TRUE if no more notifications are necessary, but
-// more notifications may come anyways.
-//
-// currentCallCountLimit is pre-decremented, that is to say the value is <= 0 when the
-//      threshold for promoting to tier 1 is reached.
-void TieredCompilationManager::OnMethodCalled(
-    MethodDesc* pMethodDesc,
-    bool isFirstCall,
-    int currentCallCountLimit,
-    BOOL* shouldStopCountingCallsRef,
-    BOOL* wasPromotedToNextTierRef)
-{
-    WRAPPER_NO_CONTRACT;
-    _ASSERTE(pMethodDesc->IsEligibleForTieredCompilation());
-    _ASSERTE(shouldStopCountingCallsRef != nullptr);
-    _ASSERTE(wasPromotedToNextTierRef != nullptr);
-
-    *shouldStopCountingCallsRef =
-        // Stop call counting when the delay is in effect
-        IsTieringDelayActive() ||
-        // Initiate the delay on tier 0 activity (when a new eligible method is called the first time)
-        (isFirstCall && g_pConfig->TieredCompilation_CallCountingDelayMs() != 0) ||
-        // Stop call counting when ready for tier 1 promotion
-        currentCallCountLimit <= 0;
-
-    *wasPromotedToNextTierRef = currentCallCountLimit <= 0;
-
-    if (currentCallCountLimit == 0)
-    {
-        AsyncPromoteMethodToTier1(pMethodDesc);
-    }
-}
-
-void TieredCompilationManager::OnMethodCallCountingStoppedWithoutTierPromotion(MethodDesc* pMethodDesc)
+bool TieredCompilationManager::OnMethodCalledFirstTime(MethodDesc* pMethodDesc)
 {
     WRAPPER_NO_CONTRACT;
     _ASSERTE(pMethodDesc != nullptr);
     _ASSERTE(pMethodDesc->IsEligibleForTieredCompilation());
+    _ASSERTE(pMethodDesc->GetCallCounter()->IsCallCountingEnabled(pMethodDesc));
 
-    if (g_pConfig->TieredCompilation_CallCountingDelayMs() == 0 ||
-        !pMethodDesc->GetCallCounter()->IsCallCountingEnabled(pMethodDesc))
+    if (g_pConfig->TieredCompilation_CallCountingDelayMs() == 0)
     {
-        return;
+        return false;
     }
 
     while (true)
@@ -178,47 +139,90 @@ void TieredCompilationManager::OnMethodCallCountingStoppedWithoutTierPromotion(M
         {
             if (!TryInitiateTieringDelay())
             {
-                break;
+                return false;
             }
             attemptedToInitiateDelay = true;
         }
 
+        CrstHolder holder(&m_lock);
+
+        SArray<MethodDesc*>* methodsPendingCountingForTier1 = m_methodsPendingCountingForTier1;
+        if (methodsPendingCountingForTier1 == nullptr)
         {
-            CrstHolder holder(&m_lock);
-
-            SArray<MethodDesc*>* methodsPendingCountingForTier1 = m_methodsPendingCountingForTier1;
-            if (methodsPendingCountingForTier1 == nullptr)
-            {
-                // Timer tick callback race, try again
-                continue;
-            }
-
-            // Record the method to resume counting later (see Tier1DelayTimerCallback)
-            bool success = false;
-            EX_TRY
-            {
-                methodsPendingCountingForTier1->Append(pMethodDesc);
-                success = true;
-            }
-            EX_CATCH
-            {
-            }
-            EX_END_CATCH(RethrowTerminalExceptions);
-            if (!success)
-            {
-                break;
-            }
-
-            if (!attemptedToInitiateDelay)
-            {
-                // Delay call counting for currently recoded methods further
-                m_tier1CallCountingCandidateMethodRecentlyRecorded = true;
-            }
+            // Timer tick callback race, try again
+            continue;
         }
-        return;
+
+        // Record the method to resume counting later (see TieringDelayTimerCallback)
+        bool success = false;
+        EX_TRY
+        {
+            methodsPendingCountingForTier1->Append(pMethodDesc);
+            success = true;
+        }
+        EX_CATCH
+        {
+        }
+        EX_END_CATCH(RethrowTerminalExceptions);
+        if (!success)
+        {
+            return false;
+        }
+
+        ++m_countOfNewMethodsCalledDuringDelay;
+
+        if (!attemptedToInitiateDelay)
+        {
+            // Delay call counting for currently recoded methods further
+            m_tier1CallCountingCandidateMethodRecentlyRecorded = true;
+        }
+        return true;
+    }
+}
+
+bool TieredCompilationManager::OnMethodCalledSubsequently(MethodDesc* pMethodDesc)
+{
+    WRAPPER_NO_CONTRACT;
+    _ASSERTE(pMethodDesc != nullptr);
+    _ASSERTE(pMethodDesc->GetCallCounter()->IsCallCountingEnabled(pMethodDesc));
+
+    if (!IsTieringDelayActive() || g_pConfig->TieredCompilation_CallCountingDelayMs() == 0)
+    {
+        return false;
     }
 
-    ResumeCountingCalls(pMethodDesc);
+    CrstHolder holder(&m_lock);
+
+    if (!m_tier1CallCountingCandidateMethodRecentlyRecorded)
+    {
+        // This is to prevent a race where the method get recorded below, the delay timer callback resets the method's entry
+        // point to begin call counting, and then the method's entry point is set by this thread to the tier 0 entry point. In
+        // that case the method would not be counted or tiered-up anymore. So, stop call counting only when the delay timer will
+        // be extended, the extra delay makes the issue near-impossible to occur. This is a great solution and is temporary,
+        // once the call counting scheme is changed this code and issue will disappear.
+        return false;
+    }
+
+    SArray<MethodDesc*>* methodsPendingCountingForTier1 = m_methodsPendingCountingForTier1;
+    if (methodsPendingCountingForTier1 == nullptr)
+    {
+        // Timer tick callback race
+        _ASSERTE(!IsTieringDelayActive());
+        return false;
+    }
+
+    // Record the method to resume counting later (see TieringDelayTimerCallback)
+    bool success = false;
+    EX_TRY
+    {
+        methodsPendingCountingForTier1->Append(pMethodDesc);
+        success = true;
+    }
+    EX_CATCH
+    {
+    }
+    EX_END_CATCH(RethrowTerminalExceptions);
+    return success;
 }
 
 void TieredCompilationManager::AsyncPromoteMethodToTier1(MethodDesc* pMethodDesc)
@@ -382,6 +386,7 @@ bool TieredCompilationManager::TryInitiateTieringDelay()
         }
 
         m_methodsPendingCountingForTier1 = methodsPendingCountingHolder.Extract();
+        _ASSERTE(!m_tier1CallCountingCandidateMethodRecentlyRecorded);
         _ASSERTE(IsTieringDelayActive());
     }
 
@@ -406,7 +411,7 @@ void WINAPI TieredCompilationManager::TieringDelayTimerCallback(PVOID parameter,
     }
     EX_CATCH
     {
-        STRESS_LOG1(LF_TIEREDCOMPILATION, LL_ERROR, "TieredCompilationManager::Tier1DelayTimerCallback: "
+        STRESS_LOG1(LF_TIEREDCOMPILATION, LL_ERROR, "TieredCompilationManager::TieringDelayTimerCallback: "
             "Unhandled exception, hr=0x%x\n",
             GET_EXCEPTION()->GetHR());
     }
@@ -426,87 +431,94 @@ void TieredCompilationManager::TieringDelayTimerCallbackWorker()
     WRAPPER_NO_CONTRACT;
 
     HANDLE tieringDelayTimerHandle;
-    bool tier1CallCountingCandidateMethodRecentlyRecorded;
+    SArray<MethodDesc*>* methodsPendingCountingForTier1;
+    UINT32 countOfNewMethodsCalledDuringDelay;
+    bool optimizeMethods;
+    while (true)
     {
-        // It's possible for the timer to tick before it is recorded that the delay is in effect. This lock guarantees that the
-        // delay is in effect.
-        CrstHolder holder(&m_lock);
-        _ASSERTE(IsTieringDelayActive());
+        bool tier1CallCountingCandidateMethodRecentlyRecorded;
+        {
+            // It's possible for the timer to tick before it is recorded that the delay is in effect. This lock guarantees that
+            // the delay is in effect.
+            CrstHolder holder(&m_lock);
+            _ASSERTE(IsTieringDelayActive());
 
-        tieringDelayTimerHandle = m_tieringDelayTimerHandle;
-        _ASSERTE(tieringDelayTimerHandle != nullptr);
+            tieringDelayTimerHandle = m_tieringDelayTimerHandle;
+            _ASSERTE(tieringDelayTimerHandle != nullptr);
 
-        tier1CallCountingCandidateMethodRecentlyRecorded = m_tier1CallCountingCandidateMethodRecentlyRecorded;
+            tier1CallCountingCandidateMethodRecentlyRecorded = m_tier1CallCountingCandidateMethodRecentlyRecorded;
+            if (tier1CallCountingCandidateMethodRecentlyRecorded)
+            {
+                m_tier1CallCountingCandidateMethodRecentlyRecorded = false;
+            }
+            else
+            {
+                // Exchange information into locals inside the lock
+
+                methodsPendingCountingForTier1 = m_methodsPendingCountingForTier1;
+                _ASSERTE(methodsPendingCountingForTier1 != nullptr);
+                m_methodsPendingCountingForTier1 = nullptr;
+
+                _ASSERTE(tieringDelayTimerHandle == m_tieringDelayTimerHandle);
+                m_tieringDelayTimerHandle = nullptr;
+
+                countOfNewMethodsCalledDuringDelay = m_countOfNewMethodsCalledDuringDelay;
+                m_countOfNewMethodsCalledDuringDelay = 0;
+
+                _ASSERTE(!IsTieringDelayActive());
+                optimizeMethods = IncrementWorkerThreadCountIfNeeded();
+
+                break;
+            }
+        }
+
+        // Reschedule the timer if there has been recent tier 0 activity (when a new eligible method is called the first time) to
+        // further delay call counting
         if (tier1CallCountingCandidateMethodRecentlyRecorded)
         {
-            m_tier1CallCountingCandidateMethodRecentlyRecorded = false;
+            bool success = false;
+            EX_TRY
+            {
+                if (ThreadpoolMgr::ChangeTimerQueueTimer(
+                        tieringDelayTimerHandle,
+                        g_pConfig->TieredCompilation_CallCountingDelayMs(),
+                        (DWORD)-1 /* Period, non-repeating */))
+                {
+                    success = true;
+                }
+            }
+            EX_CATCH
+            {
+            }
+            EX_END_CATCH(RethrowTerminalExceptions);
+            if (success)
+            {
+                return;
+            }
         }
     }
 
-    // Reschedule the timer if there has been recent tier 0 activity (when a new eligible method is called the first time) to
-    // further delay call counting
-    if (tier1CallCountingCandidateMethodRecentlyRecorded)
+    if (ETW::CompilationLog::TieredCompilation::Runtime::IsEnabled())
     {
-        bool success = false;
+        ETW::CompilationLog::TieredCompilation::Runtime::SendResume(countOfNewMethodsCalledDuringDelay);
+    }
+
+    // Install call counters
+    MethodDesc** methods = methodsPendingCountingForTier1->GetElements();
+    COUNT_T methodCount = methodsPendingCountingForTier1->GetCount();
+    for (COUNT_T i = 0; i < methodCount; ++i)
+    {
+        MethodDesc *methodDesc = methods[i];
+        MethodDescBackpatchInfoTracker::ConditionalLockHolder lockHolder(methodDesc->MayHaveEntryPointSlotsToBackpatch());
+
         EX_TRY
         {
-            if (ThreadpoolMgr::ChangeTimerQueueTimer(
-                    tieringDelayTimerHandle,
-                    g_pConfig->TieredCompilation_CallCountingDelayMs(),
-                    (DWORD)-1 /* Period, non-repeating */))
-            {
-                success = true;
-            }
+            methodDesc->ResetCodeEntryPoint();
         }
         EX_CATCH
         {
         }
         EX_END_CATCH(RethrowTerminalExceptions);
-        if (success)
-        {
-            return;
-        }
-    }
-
-    // Exchange information into locals inside the lock
-    SArray<MethodDesc*>* methodsPendingCountingForTier1;
-    bool optimizeMethods;
-    {
-        CrstHolder holder(&m_lock);
-
-        methodsPendingCountingForTier1 = m_methodsPendingCountingForTier1;
-        _ASSERTE(methodsPendingCountingForTier1 != nullptr);
-        m_methodsPendingCountingForTier1 = nullptr;
-
-        _ASSERTE(tieringDelayTimerHandle == m_tieringDelayTimerHandle);
-        m_tieringDelayTimerHandle = nullptr;
-
-        _ASSERTE(!IsTieringDelayActive());
-        optimizeMethods = IncrementWorkerThreadCountIfNeeded();
-    }
-
-    MethodDesc** methods = methodsPendingCountingForTier1->GetElements();
-    COUNT_T methodCount = methodsPendingCountingForTier1->GetCount();
-
-    if (ETW::CompilationLog::TieredCompilation::Runtime::IsEnabled())
-    {
-        // TODO: Avoid scanning the list in the future
-        UINT32 newMethodCount = 0;
-        for (COUNT_T i = 0; i < methodCount; ++i)
-        {
-            MethodDesc *methodDesc = methods[i];
-            if (methodDesc->GetCallCounter()->WasCalledAtMostOnce(methodDesc))
-            {
-                ++newMethodCount;
-            }
-        }
-        ETW::CompilationLog::TieredCompilation::Runtime::SendResume(newMethodCount);
-    }
-
-    // Install call counters
-    for (COUNT_T i = 0; i < methodCount; ++i)
-    {
-        ResumeCountingCalls(methods[i]);
     }
     delete methodsPendingCountingForTier1;
 
@@ -516,22 +528,6 @@ void TieredCompilationManager::TieringDelayTimerCallbackWorker()
     {
         OptimizeMethods();
     }
-}
-
-void TieredCompilationManager::ResumeCountingCalls(MethodDesc* pMethodDesc)
-{
-    WRAPPER_NO_CONTRACT;
-    _ASSERTE(pMethodDesc != nullptr);
-    MethodDescBackpatchInfoTracker::ConditionalLockHolder lockHolder(pMethodDesc->MayHaveEntryPointSlotsToBackpatch());
-
-    EX_TRY
-    {
-        pMethodDesc->ResetCodeEntryPoint();
-    }
-    EX_CATCH
-    {
-    }
-    EX_END_CATCH(RethrowTerminalExceptions);
 }
 
 bool TieredCompilationManager::TryAsyncOptimizeMethods()
@@ -713,7 +709,8 @@ BOOL TieredCompilationManager::CompileCodeVersion(NativeCodeVersion nativeCodeVe
     MethodDesc* pMethod = nativeCodeVersion.GetMethodDesc();
     EX_TRY
     {
-        pCode = pMethod->PrepareCode(nativeCodeVersion);
+        PrepareCodeConfigBuffer configBuffer(nativeCodeVersion);
+        pCode = pMethod->PrepareCode(configBuffer.GetConfig());
         LOG((LF_TIEREDCOMPILATION, LL_INFO10000, "TieredCompilationManager::CompileCodeVersion Method=0x%pM (%s::%s), code version id=0x%x, code ptr=0x%p\n",
             pMethod, pMethod->m_pszDebugClassName, pMethod->m_pszDebugMethodName,
             nativeCodeVersion.GetVersionId(),
@@ -858,7 +855,8 @@ CORJIT_FLAGS TieredCompilationManager::GetJitFlags(NativeCodeVersion nativeCodeV
     LIMITED_METHOD_CONTRACT;
 
     CORJIT_FLAGS flags;
-    if (!nativeCodeVersion.GetMethodDesc()->IsEligibleForTieredCompilation())
+    MethodDesc *methodDesc = nativeCodeVersion.GetMethodDesc();
+    if (!methodDesc->IsEligibleForTieredCompilation())
     {
 #ifdef FEATURE_INTERPRETER
         flags.Set(CORJIT_FLAGS::CORJIT_FLAG_MAKEFINALCODE);
@@ -866,9 +864,34 @@ CORJIT_FLAGS TieredCompilationManager::GetJitFlags(NativeCodeVersion nativeCodeV
         return flags;
     }
 
+    if (nativeCodeVersion.IsDefaultVersion()) // slightly faster common path during startup compared to below
+    {
+        if (!methodDesc->RequestedAggressiveOptimization())
+        {
+            if (g_pConfig->TieredCompilation_QuickJit())
+            {
+                flags.Set(CORJIT_FLAGS::CORJIT_FLAG_TIER0);
+                return flags;
+            }
+        }
+        else
+        {
+            flags.Set(CORJIT_FLAGS::CORJIT_FLAG_TIER1);
+        }
+
+    #ifdef FEATURE_INTERPRETER
+        flags.Set(CORJIT_FLAGS::CORJIT_FLAG_MAKEFINALCODE);
+    #endif
+        return flags;
+    }
+
     switch (nativeCodeVersion.GetOptimizationTier())
     {
         case NativeCodeVersion::OptimizationTier0:
+            if (!g_pConfig->TieredCompilation_QuickJit())
+            {
+                goto OptTierOptimized;
+            }
             flags.Set(CORJIT_FLAGS::CORJIT_FLAG_TIER0);
             break;
 
@@ -877,6 +900,7 @@ CORJIT_FLAGS TieredCompilationManager::GetJitFlags(NativeCodeVersion nativeCodeV
             // fall through
 
         case NativeCodeVersion::OptimizationTierOptimized:
+        OptTierOptimized:
 #ifdef FEATURE_INTERPRETER
             flags.Set(CORJIT_FLAGS::CORJIT_FLAG_MAKEFINALCODE);
 #endif

--- a/src/vm/tieredcompilation.h
+++ b/src/vm/tieredcompilation.h
@@ -34,8 +34,8 @@ public:
 #ifdef FEATURE_TIERED_COMPILATION
 
 public:
-    bool OnMethodCalledFirstTime(MethodDesc* pMethodDesc);
-    bool OnMethodCalledSubsequently(MethodDesc* pMethodDesc);
+    bool OnMethodCodeVersionCalledFirstTime(MethodDesc* pMethodDesc);
+    bool OnMethodCodeVersionCalledSubsequently(MethodDesc* pMethodDesc);
     void AsyncPromoteMethodToTier1(MethodDesc* pMethodDesc);
     void Shutdown();
     static CORJIT_FLAGS GetJitFlags(NativeCodeVersion nativeCodeVersion);

--- a/src/vm/tieredcompilation.h
+++ b/src/vm/tieredcompilation.h
@@ -34,8 +34,8 @@ public:
 #ifdef FEATURE_TIERED_COMPILATION
 
 public:
-    void OnMethodCalled(MethodDesc* pMethodDesc, bool isFirstCall, int currentCallCountLimit, BOOL* shouldStopCountingCallsRef, BOOL* wasPromotedToNextTierRef);
-    void OnMethodCallCountingStoppedWithoutTierPromotion(MethodDesc* pMethodDesc);
+    bool OnMethodCalledFirstTime(MethodDesc* pMethodDesc);
+    bool OnMethodCalledSubsequently(MethodDesc* pMethodDesc);
     void AsyncPromoteMethodToTier1(MethodDesc* pMethodDesc);
     void Shutdown();
     static CORJIT_FLAGS GetJitFlags(NativeCodeVersion nativeCodeVersion);
@@ -46,7 +46,6 @@ private:
     static void WINAPI TieringDelayTimerCallback(PVOID parameter, BOOLEAN timerFired);
     static void TieringDelayTimerCallbackInAppDomain(LPVOID parameter);
     void TieringDelayTimerCallbackWorker();
-    static void ResumeCountingCalls(MethodDesc* pMethodDesc);
 
     bool TryAsyncOptimizeMethods();
     static DWORD StaticOptimizeMethodsCallback(void* args);
@@ -68,6 +67,7 @@ private:
     UINT32 m_countOfMethodsToOptimize;
     BOOL m_isAppDomainShuttingDown;
     DWORD m_countOptimizationThreadsRunning;
+    UINT32 m_countOfNewMethodsCalledDuringDelay;
     SArray<MethodDesc*>* m_methodsPendingCountingForTier1;
     HANDLE m_tieringDelayTimerHandle;
     bool m_tier1CallCountingCandidateMethodRecentlyRecorded;


### PR DESCRIPTION
- Moved call counting to after jitting is done, when the tier of the code becomes clear. Passed info back about whether the method should be recorded for call counting through the `PrepareCodeConfig` to avoid some more expensive rechecks.
- Moved checks for aggressive optimization and QuickJit to the point when JIT flags are determined
- Specialized `PublishVersionalbeCodeIfNecessary` for methods versionable with and without a jump stamp
- Added fast paths for cases operating on the default native code version to avoid some code versioning overhead during startup
- Methods are not counted on first call, only recorded for counting later. First call to a method is determined by whether the thread generated or loaded code for the method. Threads that wait for jitting to complete don't count calls either. Once the method already has native code and goes through the prestub, its calls are counted.
- Overall, time spent in DoPrestub decreased noticeably when tiering is enabled, almost the same as with tiering disabled typically. Small improvement to startup time, seems to decrease by a few milliseconds.
- Fixed a bug where, when call counting for a method stops due to the tiering delay being activated, it was extending the delay as though it were the first call to the method
  - This was noticeably increasing time taken to reach steady-state perf by keeping the delay active for longer than necessary. After the fix, steady-state perf is reached sooner without any noticeable overhead in-between.
  - A fix creates a potential race between thread A recording a method to be counted later, thread B resetting the method's entry point for counting calls, then thread A setting the tier 0 code as the entry point, and the method would not be tiered up. For now I decided to stop call counting only when a flag that would extend the delay timer is set, with other planned work this code and issue would go away.
- Miscellaneous small changes