### PR TITLE
Move testing jobs to a separate stage after the validation/publishing stage (#26334)

### DIFF
--- a/eng/pipelines/internal.yml
+++ b/eng/pipelines/internal.yml
@@ -43,32 +43,6 @@ stages:
           timeoutInMinutes: 120
 
     #
-    # Release test builds
-    #
-    - template: /eng/platform-matrix.yml
-      parameters:
-        jobTemplate: test-job.yml
-        buildConfig: release
-        platformGroup: all
-        helixQueueGroup: all
-        jobParameters:
-          testGroup: outerloop
-
-    #
-    # ReadyToRun test builds
-    #
-    - template: /eng/platform-matrix.yml
-      parameters:
-        jobTemplate: test-job.yml
-        buildConfig: release
-        platformGroup: all
-        helixQueueGroup: all
-        jobParameters:
-          testGroup: outerloop
-          readyToRun: true
-          displayNameArgs: R2R
-
-    #
     # Publish build information to Build Assets Registry
     #
     # This job gathers build assets from the pipeline (from each official
@@ -95,3 +69,34 @@ stages:
       parameters:
         # Symbol validation is not entirely reliable as of yet, so should be turned off until https://github.com/dotnet/arcade/issues/2871 is resolved.
         enableSymbolValidation: false
+
+  - stage: test
+    displayName: Test
+    jobs:
+    #
+    # Release test builds
+    #
+    - template: /eng/platform-matrix.yml
+      parameters:
+        jobTemplate: test-job.yml
+        buildConfig: release
+        platformGroup: all
+        helixQueueGroup: all
+        ignoreDependencyOnBuildJobs: true
+        jobParameters:
+          testGroup: outerloop
+
+    #
+    # ReadyToRun test builds
+    #
+    - template: /eng/platform-matrix.yml
+      parameters:
+        jobTemplate: test-job.yml
+        buildConfig: release
+        platformGroup: all
+        helixQueueGroup: all
+        ignoreDependencyOnBuildJobs: true
+        jobParameters:
+          testGroup: outerloop
+          readyToRun: true
+          displayNameArgs: R2R

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -13,6 +13,7 @@ parameters:
   # 'all' - the queues used for non-PR, non-CI test runs, e.g., Manual or Scheduled runs. Typically this is all available queues.
   # 'corefx' - the queues used for a corefx test run.
   helixQueueGroup: 'pr'
+  ignoreDependencyOnBuildJobs: false
   jobParameters: {}
 
 jobs:
@@ -25,6 +26,7 @@ jobs:
 - ${{ if or(containsValue(parameters.platforms, 'Linux_arm'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
+      ignoreDependencyOnBuildJobs: ${{ parameters.ignoreDependencyOnBuildJobs }}
       buildConfig: ${{ parameters.buildConfig }}
       archType: arm
       osGroup: Linux
@@ -50,6 +52,7 @@ jobs:
 - ${{ if or(containsValue(parameters.platforms, 'Linux_arm64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
+      ignoreDependencyOnBuildJobs: ${{ parameters.ignoreDependencyOnBuildJobs }}
       buildConfig: ${{ parameters.buildConfig }}
       archType: arm64
       osGroup: Linux
@@ -73,6 +76,7 @@ jobs:
 - ${{ if or(containsValue(parameters.platforms, 'Linux_musl_x64'), eq(parameters.platformGroup, 'all')) }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
+      ignoreDependencyOnBuildJobs: ${{ parameters.ignoreDependencyOnBuildJobs }}
       buildConfig: ${{ parameters.buildConfig }}
       archType: x64
       osGroup: Linux
@@ -93,6 +97,7 @@ jobs:
 - ${{ if or(containsValue(parameters.platforms, 'Linux_musl_arm64'), eq(parameters.platformGroup, 'all')) }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
+      ignoreDependencyOnBuildJobs: ${{ parameters.ignoreDependencyOnBuildJobs }}
       buildConfig: ${{ parameters.buildConfig }}
       archType: arm64
       osGroup: Linux
@@ -113,6 +118,7 @@ jobs:
 - ${{ if or(containsValue(parameters.platforms, 'Linux_rhel6_x64'), eq(parameters.platformGroup, 'all')) }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
+      ignoreDependencyOnBuildJobs: ${{ parameters.ignoreDependencyOnBuildJobs }}
       buildConfig: ${{ parameters.buildConfig }}
       archType: x64
       osGroup: Linux
@@ -131,6 +137,7 @@ jobs:
 - ${{ if or(containsValue(parameters.platforms, 'Linux_x64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
+      ignoreDependencyOnBuildJobs: ${{ parameters.ignoreDependencyOnBuildJobs }}
       buildConfig: ${{ parameters.buildConfig }}
       archType: x64
       osGroup: Linux
@@ -178,6 +185,7 @@ jobs:
 - ${{ if or(containsValue(parameters.platforms, 'OSX_x64'), eq(parameters.platformGroup, 'all')) }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
+      ignoreDependencyOnBuildJobs: ${{ parameters.ignoreDependencyOnBuildJobs }}
       buildConfig: ${{ parameters.buildConfig }}
       archType: x64
       osGroup: OSX
@@ -200,6 +208,7 @@ jobs:
 - ${{ if or(containsValue(parameters.platforms, 'Windows_NT_x64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
+      ignoreDependencyOnBuildJobs: ${{ parameters.ignoreDependencyOnBuildJobs }}
       buildConfig: ${{ parameters.buildConfig }}
       archType: x64
       osGroup: Windows_NT
@@ -225,6 +234,7 @@ jobs:
 - ${{ if or(containsValue(parameters.platforms, 'Windows_NT_x86'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
+      ignoreDependencyOnBuildJobs: ${{ parameters.ignoreDependencyOnBuildJobs }}
       buildConfig: ${{ parameters.buildConfig }}
       archType: x86
       osGroup: Windows_NT
@@ -248,6 +258,7 @@ jobs:
 - ${{ if or(containsValue(parameters.platforms, 'Windows_NT_arm'), eq(parameters.platformGroup, 'all')) }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
+      ignoreDependencyOnBuildJobs: ${{ parameters.ignoreDependencyOnBuildJobs }}
       buildConfig: ${{ parameters.buildConfig }}
       archType: arm
       osGroup: Windows_NT
@@ -267,6 +278,7 @@ jobs:
 - ${{ if or(containsValue(parameters.platforms, 'Windows_NT_arm64'), eq(parameters.platformGroup, 'all')) }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
+      ignoreDependencyOnBuildJobs: ${{ parameters.ignoreDependencyOnBuildJobs }}
       buildConfig: ${{ parameters.buildConfig }}
       archType: arm64
       osGroup: Windows_NT

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -12,6 +12,7 @@ parameters:
   corefxTests: false
   displayNameArgs: ''
   runInUnloadableContext: false
+  ignoreDependencyOnBuildJobs: false
 
 ### Test job
 
@@ -96,7 +97,8 @@ jobs:
       condition: false
 
     # Test job depends on the corresponding build job
-    dependsOn: ${{ format('build_{0}_{1}_{2}', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+    ${{ if ne(parameters.ignoreDependencyOnBuildJobs, true) }}:
+      dependsOn: ${{ format('build_{0}_{1}_{2}', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
 
     # Run all steps in the container.
     # Note that the containers are defined in platform-matrix.yml


### PR DESCRIPTION
Porting #26334 to the 3.0 branch

#### Description
Moves testing stage after the publish/validate stage, so that any upstack job can quickly pickup the coreclr build as soon as the build/publish/validate stages are complete, without having to wait for testing to complete.

/cc @jashook  @dotnet/coreclr-infra @mmitche 

#### Customer Impact
Enables faster build consumption

#### Regression?
N/A

#### Risk
Minimal. This just changes the order of jobs that execute in the pipeline.