### PR TITLE
Replace Ubuntu 1404 platforms with 1604 (#26302)

### DIFF
--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -33,11 +33,8 @@ jobs:
         image: ubuntu-16.04-cross-14.04-23cacb0-20190528233931
         registry: mcr
       helixQueues:
-      # Ubuntu.1404.Arm32.Open is used only by CI while Ubuntu.1604.Arm32.Open serves PRs and scheduled builds.
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'ci')) }}:
-        - Ubuntu.1404.Arm32.Open
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(parameters.helixQueueGroup, 'ci')) }}:
-        - (Ubuntu.1804.Arm32.Open)Ubuntu.1604.Arm32.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-09a60ed-20190620155854
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - (Ubuntu.1804.Arm32.Open)Ubuntu.1604.Arm32.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-30f6673-20190814153226
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - (Debian.9.Arm32)Ubuntu.1604.Arm32@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm32v7-74c9941-20190620155841
         - (Ubuntu.1604.Arm32)Ubuntu.1604.Arm32@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-helix-arm32v7-a45aeeb-20190620160312


### PR DESCRIPTION
Porting #26302 to the 3.0 branch

#### Description
Changing the Ubuntu version for arm32 testing to 16.04 instead of 14.04, so the 14.04 can be retired

/cc @jashook  @dotnet/coreclr-infra @mmitche 

#### Customer Impact
Upgraded Ubuntu OS version. The lab will be able to retire the 14.04 machines.

#### Regression?
N/A

#### Risk
Minimal.