### PR TITLE
Change test stage to only depend on the build stage

### DIFF
--- a/eng/pipelines/internal.yml
+++ b/eng/pipelines/internal.yml
@@ -73,6 +73,7 @@ stages:
 
   - stage: test
     displayName: Test
+    dependsOn: build
     jobs:
     #
     # Release test builds


### PR DESCRIPTION
Change the test stage to only depend on the build stage instead of on the internal servicing publishing (the last stage in the post-build.yml template). This enables our builds to run in parallel of deployment instead of either test or deployment being blocked on the other.

Official build from this branch with test signing: https://dev.azure.com/dnceng/internal/_build/results?buildId=327583&view=results

Fixes #26401