### PR TITLE
Don't validate empty TransitionTimes on deserialization.

### DIFF
--- a/src/System.Private.CoreLib/shared/System/TimeZoneInfo.TransitionTime.cs
+++ b/src/System.Private.CoreLib/shared/System/TimeZoneInfo.TransitionTime.cs
@@ -111,13 +111,19 @@ namespace System
                 // OnDeserialization is called after each instance of this class is deserialized.
                 // This callback method performs TransitionTime validation after being deserialized.
 
-                try
+                // On Unix, TimeZoneInfos are created with empty/default TransitionTimes, since
+                // TransitionTimes are not used on Unix. When deserializing TransitionTimes, only
+                // validate it if it isn't an empty/default instance.
+                if (this != default)
                 {
-                    ValidateTransitionTime(_timeOfDay, _month, _week, _day, _dayOfWeek);
-                }
-                catch (ArgumentException e)
-                {
-                    throw new SerializationException(SR.Serialization_InvalidData, e);
+                    try
+                    {
+                        ValidateTransitionTime(_timeOfDay, _month, _week, _day, _dayOfWeek);
+                    }
+                    catch (ArgumentException e)
+                    {
+                        throw new SerializationException(SR.Serialization_InvalidData, e);
+                    }
                 }
             }
 


### PR DESCRIPTION
On Unix, TransitionTimes are not used, so they are left empty. When deserializing an empty TransitionTime, it is throwing an exception because those are not normally valid. Fix deserialization to not validate empty TransitionTimes.

Fix https://github.com/dotnet/corefx/issues/40578

Note: tests are added in https://github.com/dotnet/corefx/pull/40637