### PR TITLE
Moved misplaced assert in StompWriteBarrier for safety.

### DIFF
--- a/src/vm/gcenv.ee.cpp
+++ b/src/vm/gcenv.ee.cpp
@@ -802,10 +802,10 @@ void GCToEEInterface::DiagWalkBGCSurvivors(void* gcContext)
 
 void GCToEEInterface::StompWriteBarrier(WriteBarrierParameters* args)
 {
+    assert(args != nullptr);
     int stompWBCompleteActions = SWB_PASS;
     bool is_runtime_suspended = args->is_runtime_suspended;
 
-    assert(args != nullptr);
     switch (args->operation)
     {
     case WriteBarrierOp::StompResize:


### PR DESCRIPTION
The args parameter was being accessed prior to asserting it was indeed not a nullptr. The assert was moved to the beginning to avoid a potential problem should args be null under any circumstances.