### PR TITLE
PHI_ARG actually has level 0, not 1

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -4275,8 +4275,8 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
             for (GenTreePhi::Use& use : tree->AsPhi()->Uses())
             {
                 lvl2 = gtSetEvalOrder(use.GetNode());
-                // PHI args should always have cost 0 and level 1
-                assert(lvl2 == 1);
+                // PHI args should always have cost 0 and level 0
+                assert(lvl2 == 0);
                 assert(use.GetNode()->gtCostEx == 0);
                 assert(use.GetNode()->gtCostSz == 0);
             }


### PR DESCRIPTION
Fixes #26424

Somehow I missed the fact that `PHI_ARG` gets "level" 0 and not 1 like typical `LCL_VAR` nodes do. Doesn't really matter, the level is ignored anyway.

The only reason this only happens during stress is that PHIs normally do not get morphed.