### PR TITLE
Don't fall back to min-opts based on IL size for AggressiveOptimization or Tier1

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4000,7 +4000,7 @@ void Compiler::compSetOptimizationLevel()
     // TIER1 is typically done in the background and it's typically ok to spend some extra time/resources to JIT the
     // method.
     if (!theMinOptsValue && !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PREJIT) &&
-        !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER1) && (info.compFlags & CORINFO_FLG_AGGRESSIVE_OPT) == 0 &&
+        !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER1) && ((info.compFlags & CORINFO_FLG_AGGRESSIVE_OPT) == 0) &&
         ((DEFAULT_MIN_OPTS_CODE_SIZE < info.compILCodeSize) || (DEFAULT_MIN_OPTS_INSTR_COUNT < opts.instrCount) ||
          (DEFAULT_MIN_OPTS_BB_COUNT < fgBBcount) || (DEFAULT_MIN_OPTS_LV_NUM_COUNT < lvaCount) ||
          (DEFAULT_MIN_OPTS_LV_REF_COUNT < opts.lvRefCount)))

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -3995,10 +3995,12 @@ void Compiler::compSetOptimizationLevel()
         }
     }
 #else  // !DEBUG
-    // Retail check if we should force Minopts due to the complexity of the method
-    // For PREJIT we never drop down to MinOpts
-    // unless unless CLFLG_MINOPT is set
+    // Retail check if we should force Minopts due to the complexity of the method.
+    // For PREJIT, AGGRESSIVE_OPT, and TIER1 we never drop down to MinOpts unless unless CLFLG_MINOPT is set. Jitting at
+    // TIER1 is typically done in the background and it's typically ok to spend some extra time/resources to JIT the
+    // method.
     if (!theMinOptsValue && !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PREJIT) &&
+        !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER1) && (info.compFlags & CORINFO_FLG_AGGRESSIVE_OPT) == 0 &&
         ((DEFAULT_MIN_OPTS_CODE_SIZE < info.compILCodeSize) || (DEFAULT_MIN_OPTS_INSTR_COUNT < opts.instrCount) ||
          (DEFAULT_MIN_OPTS_BB_COUNT < fgBBcount) || (DEFAULT_MIN_OPTS_LV_NUM_COUNT < lvaCount) ||
          (DEFAULT_MIN_OPTS_LV_REF_COUNT < opts.lvRefCount)))


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/26419