### PR TITLE
Add ability to only copy native test files to managed tests in build-test scripts

### DIFF
--- a/build-test.cmd
+++ b/build-test.cmd
@@ -563,6 +563,8 @@ echo     ubuntu.16.10-x64: Builds overlay for Ubuntu 16.10
 echo     win-x64: Builds overlay for portable Windows
 echo     win7-x64: Builds overlay for Windows 7
 echo crossgen: Precompiles the framework managed assemblies
+echo copynativeonly: Only copy the native test binaries to the managed output. Do not build the native or managed tests.
+echo skipgeneratelayout: Do not generate the Core_Root layout or the CoreFX testhost.
 echo targetsNonWindows:
 echo Exclude- Optional parameter - specify location of default exclusion file ^(defaults to tests\issues.targets if not specified^)
 echo     Set to "" to disable default exclusion file.

--- a/build-test.cmd
+++ b/build-test.cmd
@@ -54,6 +54,8 @@ set __SkipNative=
 set __RuntimeId=
 set __TargetsWindows=1
 set __DoCrossgen=
+set __CopyNativeTestBinaries=0
+set __SkipGenerateLayout=0
 
 @REM CMD has a nasty habit of eating "=" on the argument list, so passing:
 @REM    -priority=1
@@ -94,6 +96,8 @@ if /i "%1" == "runtimeid"             (set __RuntimeId=%2&set processedArgs=!pro
 if /i "%1" == "targetsNonWindows"     (set __TargetsWindows=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "Exclude"               (set __Exclude=%2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)
 if /i "%1" == "-priority"             (set __Priority=%2&shift&set processedArgs=!processedArgs! %1=%2&shift&goto Arg_Loop)
+if /i "%1" == "copynativeonly"        (set __CopyNativeTestBinaries=1&set __SkipNative=1&set __SkipRestorePackages=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
+if /i "%1" == "skipgeneratelayout"    (set __SkipGenerateLayout=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "--"                    (set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 
 if [!processedArgs!]==[] (
@@ -256,7 +260,7 @@ REM === Restore product binaries from packages
 REM ===
 REM =========================================================================================
 
-if "%__SkipRestorePackages%" == 1 goto SkipRestoreProduct
+if "%__SkipRestorePackages%" == "1" goto SkipRestoreProduct
 
 echo %__MsgPrefix%Restoring CoreCLR product from packages
 
@@ -319,27 +323,49 @@ for /l %%G in (1, 1, %__NumberOfTestGroups%) do (
     set __Logging='!__MsbuildLog!' '!__MsbuildWrn!' '!__MsbuildErr!'
 
     set __TestGroupToBuild=%%G
-    echo Running: msbuild %__ProjectDir%\tests\build.proj !__MsbuildLog! !__MsbuildWrn! !__MsbuildErr! %TargetsWindowsMsbuildArg% %__msbuildArgs% !__PriorityArg! %__UnprocessedBuildArgs%
 
-    REM Disable warnAsError - coreclr issue 19922
-    powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -Command "%__ProjectDir%\eng\common\msbuild.ps1" %__ArcadeScriptArgs%^
-        %__ProjectDir%\tests\build.proj -warnAsError:0 !__Logging! %TargetsWindowsMsbuildArg% %__msbuildArgs% !__PriorityArg! %__UnprocessedBuildArgs%
+    if not "%__CopyNativeTestBinaries%" == "1" (
+        echo Running: msbuild %__ProjectDir%\tests\build.proj !__MsbuildLog! !__MsbuildWrn! !__MsbuildErr! %TargetsWindowsMsbuildArg% %__msbuildArgs% !__PriorityArg! %__UnprocessedBuildArgs%
 
-    if errorlevel 1 (
-        echo %__ErrMsgPrefix%%__MsgPrefix%Error: managed test build failed. Refer to the build log files for details:
-        echo     %__BuildLog%
-        echo     %__BuildWrn%
-        echo     %__BuildErr%
-        REM This is necessary because of a(n apparent) bug in the FOR /L command.  Under certain circumstances,
-        REM such as when this script is invoke with CMD /C "build-test.cmd", a non-zero exit directly from
-        REM within the loop body will not propagate to the caller.  For some reason, goto works around it.
-        goto     :Exit_Failure
+        REM Disable warnAsError - coreclr issue 19922
+        powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -Command "%__ProjectDir%\eng\common\msbuild.ps1" %__ArcadeScriptArgs%^
+            %__ProjectDir%\tests\build.proj -warnAsError:0 !__Logging! %TargetsWindowsMsbuildArg% %__msbuildArgs% !__PriorityArg! %__UnprocessedBuildArgs%
+
+        if errorlevel 1 (
+            echo %__ErrMsgPrefix%%__MsgPrefix%Error: managed test build failed. Refer to the build log files for details:
+            echo     %__BuildLog%
+            echo     %__BuildWrn%
+            echo     %__BuildErr%
+            REM This is necessary because of a(n apparent) bug in the FOR /L command.  Under certain circumstances,
+            REM such as when this script is invoke with CMD /C "build-test.cmd", a non-zero exit directly from
+            REM within the loop body will not propagate to the caller.  For some reason, goto works around it.
+            goto     :Exit_Failure
+        )
+    ) else (
+        echo Running: msbuild %__ProjectDir%\tests\build.proj !__MsbuildLog! !__MsbuildWrn! !__MsbuildErr! %TargetsWindowsMsbuildArg% %__msbuildArgs% !__PriorityArg! %__UnprocessedBuildArgs% /t:CopyAllNativeProjectReferenceBinaries
+
+        REM Disable warnAsError - coreclr issue 19922
+        powershell -NoProfile -ExecutionPolicy ByPass -NoLogo -Command "%__ProjectDir%\eng\common\msbuild.ps1" %__ArcadeScriptArgs%^
+            %__ProjectDir%\tests\build.proj -warnAsError:0 !__Logging! %TargetsWindowsMsbuildArg% %__msbuildArgs% !__PriorityArg! %__UnprocessedBuildArgs% "/t:CopyAllNativeProjectReferenceBinaries"
+
+        if errorlevel 1 (
+            echo %__ErrMsgPrefix%%__MsgPrefix%Error: copying native test binaries failed. Refer to the build log files for details:
+            echo     %__BuildLog%
+            echo     %__BuildWrn%
+            echo     %__BuildErr%
+            REM This is necessary because of a(n apparent) bug in the FOR /L command.  Under certain circumstances,
+            REM such as when this script is invoke with CMD /C "build-test.cmd", a non-zero exit directly from
+            REM within the loop body will not propagate to the caller.  For some reason, goto works around it.
+            goto     :Exit_Failure
+        )
     )
 
     set __SkipPackageRestore=true
     set __SkipTargetingPackBuild=true
     set __AppendToLog=true
 )
+
+if "%__CopyNativeTestBinaries%" == "1" goto :SkipManagedBuild
 
 REM Check that we've built about as many tests as we expect. This is primarily intended to prevent accidental changes that cause us to build
 REM drastically fewer Pri-1 tests than expected.
@@ -353,6 +379,8 @@ if errorlevel 1 (
 )
 
 :SkipManagedBuild
+
+if "%__SkipGenerateLayout%" == "1" goto TestBuildDone
 
 REM =========================================================================================
 REM ===
@@ -499,6 +527,7 @@ REM ===
 REM === All builds complete!
 REM ===
 REM =========================================================================================
+:TestBuildDone
 
 echo %__MsgPrefix%Test build succeeded.  Finished at %TIME%
 echo %__MsgPrefix%Test binaries are available at !__TestBinDir!

--- a/build-test.sh
+++ b/build-test.sh
@@ -349,15 +349,28 @@ build_Tests()
         fi
 
         echo "Managed tests build success!"
+
+        build_test_wrappers
     fi
 
-    build_test_wrappers
+    if [ $__CopyNativeTestBinaries == 1 ]; then
+        echo "Copying native test binaries to output..."
+
+        build_MSBuild_projects "Tests_Managed" "$__ProjectDir/tests/build.proj" "Managed tests build (build tests)" "/t:CopyAllNativeProjectReferenceBinaries"
+
+        if [ $? -ne 0 ]; then
+            echo "${__ErrMsgPrefix}${__MsgPrefix}Error: copying native test binaries failed. Refer to the build log files for details (above)"
+            exit 1
+        fi
+    fi
 
     if [ -n "$__UpdateInvalidPackagesArg" ]; then
         __up="/t:UpdateInvalidPackageVersions"
     fi
 
-    generate_layout
+    if [ $__SkipGenerateLayout != 1 ]; then
+        generate_layout
+    fi
 }
 
 build_MSBuild_projects()
@@ -699,6 +712,8 @@ __GenerateTestHostOnly=
 __priority1=
 __BuildTestWrappersOnly=
 __DoCrossgen=0
+__CopyNativeTestBinaries=0
+__SkipGenerateLayout=0
 CORE_ROOT=
 
 while :; do
@@ -909,6 +924,16 @@ while :; do
         priority1)
             __priority1=1
             __UnprocessedBuildArgs+=("/p:CLRTestPriorityToBuild=1")
+            ;;
+
+        copynativeonly)
+            __SkipNative=1
+            __SkipManaged=1
+            __CopyNativeTestBinaries=1
+            ;;
+
+        skipgeneratelayout)
+            __SkipGenerateLayout=1
             ;;
 
         *)

--- a/build-test.sh
+++ b/build-test.sh
@@ -584,6 +584,8 @@ usage()
     echo "bindir - output directory (defaults to $__ProjectRoot/bin)"
     echo "msbuildonunsupportedplatform - build managed binaries even if distro is not officially supported."
     echo "priority1 - include priority=1 tests in the build"
+    echo "copynativeonly: Only copy the native test binaries to the managed output. Do not build the native or managed tests."
+    echo "skipgeneratelayout: Do not generate the Core_Root layout or the CoreFX testhost."
     exit 1
 }
 

--- a/build-test.sh
+++ b/build-test.sh
@@ -930,6 +930,7 @@ while :; do
             __SkipNative=1
             __SkipManaged=1
             __CopyNativeTestBinaries=1
+            __SkipRestorePackages=1
             ;;
 
         skipgeneratelayout)

--- a/tests/dir.traversal.targets
+++ b/tests/dir.traversal.targets
@@ -74,6 +74,31 @@
     <!-- Given we ErrorAndContinue we need to propagate the error if the overall task failed -->
     <Error Condition="'$(MSBuildLastTaskResult)'=='false'" />
   </Target>
+  
+  <Target Name="CopyAllNativeTestProjectBinaries">
+    <Message Importance="High" Text="Copying native test binaries..." />
+
+    <PropertyGroup>
+      <DefaultCopyAllNativeTestProjectBinariesTarget Condition="'$(DefaultCopyAllNativeTestProjectBinariesTarget)'==''">CopyAllNativeProjectReferenceBinaries</DefaultCopyAllNativeTestProjectBinariesTarget>
+    </PropertyGroup>
+
+    <!-- To Serialize we use msbuild's batching functionality '%' to force it to batch all similar projects with the same identity 
+      however since the project names are unique it will essentially force each to run in its own batch -->
+    <MSBuild Targets="$(DefaultCopyAllNativeTestProjectBinariesTarget)"
+             Projects="@(Project)"
+             Condition="'$(SerializeProjects)'=='true'"
+             Properties="Dummy=%(Identity)"
+             ContinueOnError="ErrorAndContinue" />
+
+    <MSBuild Targets="$(DefaultCopyAllNativeTestProjectBinariesTarget)"
+             Projects="@(Project)"
+             Condition="'$(SerializeProjects)'!='true'"
+             BuildInParallel="true"
+             ContinueOnError="ErrorAndContinue" />
+
+    <!-- Given we ErrorAndContinue we need to propagate the error if the overall task failed -->
+    <Error Condition="'$(MSBuildLastTaskResult)'=='false'" />
+  </Target>
 
   <PropertyGroup>
     <TraversalBuildDependsOn>
@@ -90,6 +115,10 @@
       RestoreAllProjectPackages;
       $(TraversalRestorePackagesDependsOn)
     </TraversalRestorePackagesDependsOn>
+    <TraversalCopyAllNativeProjectReferenceBinariesDependsOn>
+      CopyAllNativeTestProjectBinaries;
+      $(TraversalCopyAllNativeProjectReferenceBinariesDependsOn)
+    </TraversalCopyAllNativeProjectReferenceBinariesDependsOn>
   </PropertyGroup>
 
   <Target Name="Build" DependsOnTargets="$(TraversalBuildDependsOn)" />
@@ -100,4 +129,5 @@
 
   <Target Name="RestorePackages" DependsOnTargets="$(TraversalRestorePackagesDependsOn)" />
 
+  <Target Name="CopyAllNativeProjectReferenceBinaries" DependsOnTargets="$(TraversalCopyAllNativeProjectReferenceBinariesDependsOn)" />
 </Project>

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -482,13 +482,6 @@ if [ ! -z "$coreClrBinDir" ]; then
     echo "Product Location              : ${coreClrBinDir}"
 fi
 
-if [ -z "$coreOverlayDir" ]; then
-    runtestPyArguments+=("--generate_layout")
-else
-    runtestPyArguments+=("-core_root" "$coreOverlayDir")
-    echo "Core Root Location            : ${coreOverlayDir}"
-fi
-
 if [ ! -z "$testNativeBinDir" ]; then
     runtestPyArguments+=("-test_native_bin_location" "$testNativeBinDir")
     echo "Test Native Bin Location      : ${testNativeBinDir}"

--- a/tests/src/dir.targets
+++ b/tests/src/dir.targets
@@ -4,6 +4,7 @@
     <CLRTestKind Condition="'$(CLRTestKind)' == '' and '$(OutputType)' == 'Library'">SharedLibrary</CLRTestKind>
     <CLRTestKind Condition="'$(CLRTestKind)' == ''">BuildAndRun</CLRTestKind>
     <CLRTestPriority Condition="'$(CLRTestPriority)' == ''">0</CLRTestPriority>
+    <CopyNativeProjectBinaries Condition="'$(CopyNativeProjectBinaries)' == ''">true</CopyNativeProjectBinaries>
   </PropertyGroup>
 
   <!-- All CLRTests need to be of a certain "kind". These kinds are enumerated below.
@@ -181,7 +182,7 @@
   </Target>
 
   <Target Name="ConsolidateNativeProjectReference"
-          Condition="'@(NativeProjectReferenceNormalized)' != ''"
+          Condition="'@(NativeProjectReferenceNormalized)' != '' and '$(CopyNativeProjectBinaries)' == 'true'"
           BeforeTargets="Build" >
      <ItemGroup>
         <NativeProjectOutputFoldersToCopy Include="$([System.String]::Copy('%(NativeProjectReferenceNormalized.RelativeDir)').Replace($(SourceDir),$(__NativeTestIntermediatesDir)\src\))" Condition="'$(RunningOnUnix)' == 'true'" />
@@ -193,6 +194,8 @@
    <MSBuild Projects="$(MSBuildProjectFile)" Targets="CopyNativeProjectBinaries" Properties="NativeProjectOutputFolder=%(NativeProjectOutputFoldersToCopy.Identity)" Condition="'@(NativeProjectReference)' != ''" />
 
   </Target>
+
+  <Target Name="CopyAllNativeProjectReferenceBinaries" DependsOnTargets="ResolveCmakeNativeProjectReference;ConsolidateNativeProjectReference" />
 
   <Target Name="UpdateReferenceItems"
           BeforeTargets="BeforeResolveReferences"

--- a/tests/src/dir.targets
+++ b/tests/src/dir.targets
@@ -4,7 +4,6 @@
     <CLRTestKind Condition="'$(CLRTestKind)' == '' and '$(OutputType)' == 'Library'">SharedLibrary</CLRTestKind>
     <CLRTestKind Condition="'$(CLRTestKind)' == ''">BuildAndRun</CLRTestKind>
     <CLRTestPriority Condition="'$(CLRTestPriority)' == ''">0</CLRTestPriority>
-    <CopyNativeProjectBinaries Condition="'$(CopyNativeProjectBinaries)' == ''">true</CopyNativeProjectBinaries>
   </PropertyGroup>
 
   <!-- All CLRTests need to be of a certain "kind". These kinds are enumerated below.
@@ -77,6 +76,11 @@
     <_WillCLRTestProjectBuild Condition="'$(_WillCLRTestProjectBuild)' == ''">false</_WillCLRTestProjectBuild>
     <_WillCLRTestProjectBuild Condition="'$(BuildAllProjects)' != 'true'">true</_WillCLRTestProjectBuild>
     <_WillCLRTestProjectBuild Condition="'$(DisableProjectBuild)' != 'true' And '$(BuildAllProjects)' == 'true' And '$(CLRTestPriority)' &lt;= '$(CLRTestPriorityToBuild)'">true</_WillCLRTestProjectBuild>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <CopyNativeProjectBinaries Condition="'$(CopyNativeProjectBinaries)' == '' And '$(_WillCLRTestProjectBuild)' == 'true' And '$(DisableProjectBuild)' != 'true'">true</CopyNativeProjectBinaries>
+    <CopyNativeProjectBinaries Condition="'$(CopyNativeProjectBinaries)' == '' And ('$(_WillCLRTestProjectBuild)' == 'false' Or '$(DisableProjectBuild)' == 'true')">false</CopyNativeProjectBinaries>
   </PropertyGroup>
     
   <!-- if we have determined that there is nothing to build, overwrite the build targets so that nothing happens -->

--- a/tests/src/dirs.proj
+++ b/tests/src/dirs.proj
@@ -12,7 +12,7 @@
     <Warning Text="Looks like there may be an update to the build tools. Please run buildtest.cmd from the root of the repo to refresh the build tools." /> 
   </Target>
 
-  <Target Name="ResolveDisabledProjects" BeforeTargets="BuildAllProjects" >
+  <Target Name="ResolveDisabledProjects" BeforeTargets="BuildAllProjects;CopyAllNativeTestProjectBinaries" >
     <ItemGroup>
       <DisabledProjects Include="TestWrappers*\**\*.csproj" />
       <DisabledProjects Include="*\**\cs_template.csproj" />


### PR DESCRIPTION
As part of supporting #26404, this PR adds additional arguments to `build-test.cmd` and `build-test.sh` to enable only copying native test binaries to their respective managed test output directory without building tests. Additionally, it adds another parameter to support skipping generating the Core_Root layout and the CoreFX test host, which can also be used as part of #26404.

To skip the native and managed builds and copy the native assets to the managed test output directory, use the `copynativeonly` parameter to `build-test`. To skip setting up Core_Root and the CoreFX test host, use `skipgeneratelayout`.

This PR also changes runtest.sh to not generate the Core_Root layout when not told where to find Core_Root.

cc: @dotnet/coreclr-infra 