### PR TITLE
Keep tokenScope consistent during devirtualization

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -20460,7 +20460,7 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
         // First, cons up a suitable resolved token.
         CORINFO_RESOLVED_TOKEN derivedResolvedToken = {};
 
-        derivedResolvedToken.tokenScope   = info.compScopeHnd;
+        derivedResolvedToken.tokenScope   = info.compCompHnd->getMethodModule(derivedMethod);
         derivedResolvedToken.tokenContext = *contextHandle;
         derivedResolvedToken.token        = info.compCompHnd->getMethodDefFromMethod(derivedMethod);
         derivedResolvedToken.tokenType    = CORINFO_TOKENKIND_Method;


### PR DESCRIPTION
Previously, when we were constructing the CORINFO_RESOLVED_TOKEN
to represent a devirtualized method, we reused the previous
tokenScope so that the tokenScope effectively went out of sync
with the token value.

Based on Andy's advice I have changed this logic to update the
tokenScope by calling the JIT interface method getMethodModule
for the resolved virtual method. I have verified locally that
(with a bit of counterpart CPAOT changes) this logic fixes the
bug I was previously hitting due to this inconsistency.

This is the first time I'm trying to make a change in JIT (albeit
small) so I'll be grateful for any advice as to how to make sure
I don't break the world, so to say. I'm also unsure about some
of the related logistics:

1) The change requires a counterpart CoreRT change (CPAOT / RyuJIT)
I have just sent out for PR. Once that I [hopefully] manage to
merge both changes in, I'm not sure about the subsequent logistics
to update the JIT drop in CoreRT.

2) Does this change merit bumping up the JITEEVersionIdentifier?
I mean, it technically doesn't introduce a change in the JIT
interface but it brings in slightly modified semantics in the sense
that the getMethodModule method is now actually getting called
(I haven't found any pre-existing JIT code calling the method
and it was throwing a NotImplementedException in CoreRT).

Thanks

Tomas

P.S. You can find the counterpart CoreRT change at

https://github.com/dotnet/corert/pull/7755
