### PR TITLE
Remove unused CMake command to build native test assets as part of product test build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,13 +179,6 @@ if(WIN32)
   add_compile_options(/Zl) # omit default library name in .OBJ
 endif(WIN32)
 
-#------------------------------
-# Add Test Directory
-#------------------------------
-if(CLR_CMAKE_BUILD_TESTS)
-  add_subdirectory(tests)
-endif(CLR_CMAKE_BUILD_TESTS)
-
 #--------------------------------
 # Definition directives
 #  - all clr specific compile definitions should be included in this file


### PR DESCRIPTION
We never want to build the native test assets when building our product build. We build them separately.

We also don't currently ever pass in `CLR_CMAKE_BUILD_TESTS` into the build script (#26176 removed the only place it was passed in).