### PR TITLE
Implement PerfScore

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2069,9 +2069,13 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
         {
             printf("; Tier-0 compilation\n");
         }
-        if (compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER1))
+        else if (compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER1))
         {
             printf("; Tier-1 compilation\n");
+        }
+        else if (compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_READYTORUN))
+        {
+            printf("; ReadyToRun compilation\n");
         }
 
         if ((compiler->opts.compFlags & CLFLG_MAXOPT) == CLFLG_MAXOPT)
@@ -2084,11 +2088,20 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
         }
         else if (compiler->opts.MinOpts())
         {
-            printf("; compiler->opts.MinOpts() is true\n");
+            printf("; MinOpts code\n");
         }
         else
         {
             printf("; unknown optimization flags\n");
+        }
+
+        if (compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_BBINSTR))
+        {
+            printf("; instrumented for collecting profile data\n");
+        }
+        else if (compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_BBOPT) && compiler->fgHaveProfileData())
+        {
+            printf("; optimized using profile data\n");
         }
 
 #if DOUBLE_ALIGN
@@ -2231,11 +2244,17 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
 
     compiler->EndPhase(PHASE_EMIT_CODE);
 
+#if defined(DEBUG) || defined(LATE_DISASM)
+    // Add code size information into the Perf Score
+    compiler->info.compPerfScore += (compiler->info.compTotalHotCodeSize * PERFSCORE_CODESIZE_COST_HOT);
+    compiler->info.compPerfScore += (compiler->info.compTotalColdCodeSize * PERFSCORE_CODESIZE_COST_COLD);
+#endif // DEBUG || LATE_DISASM
+
 #ifdef DEBUG
-    if (compiler->opts.disAsm)
+    if (compiler->opts.disAsm || verbose)
     {
-        printf("; Total bytes of code %d, prolog size %d for method %s\n", codeSize, prologSize,
-               compiler->info.compFullName);
+        printf("; Total bytes of code %d, prolog size %d, perf score %.2f, (MethodHash=%08x) for method %s\n", codeSize,
+               prologSize, compiler->info.compPerfScore, compiler->info.compMethodHash(), compiler->info.compFullName);
         printf("; ============================================================\n");
         printf(""); // in our logic this causes a flush
     }

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -321,15 +321,15 @@ void CodeGen::genCodeForBBlist()
         }
 #endif
 
+        /* Tell everyone which basic block we're working on */
+
+        compiler->compCurBB = block;
+
         block->bbEmitCookie = nullptr;
 
-        if (block->bbFlags & (BBF_JMP_TARGET | BBF_HAS_LABEL))
-        {
-            /* Mark a label and update the current set of live GC refs */
-
-            block->bbEmitCookie = getEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur, gcInfo.gcRegGCrefSetCur,
-                                                             gcInfo.gcRegByrefSetCur, FALSE);
-        }
+        // If this block is a jump target or it requires a label then set 'needLabel' to true,
+        //
+        bool needLabel = (block->bbFlags & (BBF_JMP_TARGET | BBF_HAS_LABEL)) != 0;
 
         if (block == compiler->fgFirstColdBlock)
         {
@@ -342,6 +342,33 @@ void CodeGen::genCodeForBBlist()
             // We should never have a block that falls through into the Cold section
             noway_assert(!block->bbPrev->bbFallsThrough());
 
+            needLabel = true;
+        }
+
+#if defined(DEBUG) || defined(LATE_DISASM)
+        // We also want to start a new Instruction group by calling emitAddLabel below,
+        // when we need accurate bbWeights for this block in the emitter.  We force this
+        // whenever our previous block was a BBJ_COND and it has a different weight than us.
+        //
+        // Note: We need to have set compCurBB before calling emitAddLabel
+        //
+        if ((block->bbPrev != nullptr) && (block->bbPrev->bbJumpKind == BBJ_COND) &&
+            (block->bbWeight != block->bbPrev->bbWeight))
+        {
+            needLabel = true;
+        }
+#endif // DEBUG || LATE_DISASM
+
+        if (needLabel)
+        {
+            /* Mark a label and update the current set of live GC refs */
+
+            block->bbEmitCookie = getEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur, gcInfo.gcRegGCrefSetCur,
+                                                             gcInfo.gcRegByrefSetCur, FALSE);
+        }
+
+        if (block == compiler->fgFirstColdBlock)
+        {
             // We require the block that starts the Cold section to have a label
             noway_assert(block->bbEmitCookie);
             getEmitter()->emitSetFirstColdIGCookie(block->bbEmitCookie);
@@ -352,10 +379,6 @@ void CodeGen::genCodeForBBlist()
         SetStackLevel(0);
         genAdjustStackLevel(block);
         savedStkLvl = genStackLevel;
-
-        /* Tell everyone which basic block we're working on */
-
-        compiler->compCurBB = block;
 
         // Needed when jitting debug code
         siBeginBlock(block);

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -321,7 +321,7 @@ void CodeGen::genCodeForBBlist()
         }
 #endif
 
-        /* Tell everyone which basic block we're working on */
+        // Tell everyone which basic block we're working on
 
         compiler->compCurBB = block;
 
@@ -361,7 +361,7 @@ void CodeGen::genCodeForBBlist()
 
         if (needLabel)
         {
-            /* Mark a label and update the current set of live GC refs */
+            // Mark a label and update the current set of live GC refs
 
             block->bbEmitCookie = getEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur, gcInfo.gcRegGCrefSetCur,
                                                              gcInfo.gcRegByrefSetCur, FALSE);

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -3489,7 +3489,7 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
 
         if (jitFlags->IsSet(JitFlags::JIT_FLAG_BBOPT) && fgHaveProfileData())
         {
-            printf("OPTIONS: using real profile data\n");
+            printf("OPTIONS: optimized using profile data\n");
         }
 
         if (fgProfileData_ILSizeMismatch)
@@ -5173,7 +5173,8 @@ int Compiler::compCompile(CORINFO_METHOD_HANDLE methodHnd,
     info.compClassName  = getAllocator(CMK_DebugOnly).allocate<char>(len);
     strcpy_s((char*)info.compClassName, len, classNamePtr);
 
-    info.compFullName = eeGetMethodFullName(methodHnd);
+    info.compFullName  = eeGetMethodFullName(methodHnd);
+    info.compPerfScore = 0.0;
 #endif // defined(DEBUG) || defined(LATE_DISASM)
 
 #ifdef DEBUG

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -8732,6 +8732,7 @@ public:
         const char* compMethodName;
         const char* compClassName;
         const char* compFullName;
+        double      compPerfScore;
 #endif // defined(DEBUG) || defined(LATE_DISASM)
 
 #if defined(DEBUG) || defined(INLINE_DATA)

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -813,7 +813,8 @@ insGroup* emitter::emitSavIG(bool emitAdd)
         printf("\n      G_M%03u_IG%02u:", Compiler::s_compMethodsCount, ig->igNum);
         if (emitComp->verbose)
         {
-            printf("        ; offs=%06XH, funclet=%02u", ig->igOffs, ig->igFuncIdx);
+            printf("        ; offs=%06XH, funclet=%02u, bbWeight=%s", ig->igOffs, ig->igFuncIdx,
+                   refCntWtd2str(ig->igWeight));
         }
         else
         {
@@ -1080,6 +1081,102 @@ int emitter::instrDesc::idAddrUnion::iiaGetJitDataOffset() const
 {
     assert(iiaIsJitDataOffset());
     return Compiler::eeGetJitDataOffs(iiaFieldHnd);
+}
+
+#if defined(DEBUG) || defined(LATE_DISASM)
+
+#if 0  // ndef _TARGET_XARCH_
+//----------------------------------------------------------------------------------------
+// getInsExecutionCharacteristics: 
+//    Returns the current instruction execution characteristics
+//
+// Arguments:
+//    id  - The current instruction descriptor to be evaluated
+//
+// Return Value:
+//    A struct containing the current instruction execution characteristics
+//
+// Notes:
+//    This is the default implementation that can be used when we don't
+//    have a target specific implementation available
+//
+emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(instrDesc* id)
+{
+    insExecutionCharacteristics result;
+    result.insThroughput = PERFSCORE_THROUGHPUT_DEFAULT;
+    result.insLatency = PERFSCORE_LATENCY_DEFAULT;
+    return result;
+}
+#endif // ! _TARGET_XARCH_
+
+//----------------------------------------------------------------------------------------
+// insEvaluateExecutionCost:
+//    Returns the estimate execution cost fortyhe current instruction
+//
+// Arguments:
+//    id  - The current instruction descriptor to be evaluated
+//
+// Return Value:
+//    calls getInsExecutionCharacteristics and uses the result
+//    to compute an estimated execution cost
+//
+// Notes:
+//
+float emitter::insEvaluateExecutionCost(instrDesc* id)
+{
+    insExecutionCharacteristics result        = getInsExecutionCharacteristics(id);
+    float                       throughput    = result.insThroughput;
+    float                       latency       = result.insLatency;
+    unsigned                    memAccessKind = result.insMemoryAccessKind;
+
+    // Check for PERFSCORE_THROUGHPUT_ILLEGAL and PERFSCORE_LATENCY_ILLEGAL
+    assert(throughput > 0.0);
+    assert(latency >= 0.0);
+
+    if ((memAccessKind == PERFSCORE_MEMORY_WRITE) && (latency <= PERFSCORE_LATENCY_WR_GENERAL))
+    {
+        // We assume that we won't read back from memory for any writes
+        // Thus we don't pay latency costs for writes.
+        latency = 0.0;
+    }
+    if (latency >= 1.0)
+    {
+        // We assume that the processor's speculation will typically eliminate one cycle of latency
+        //
+        latency -= 1.0;
+    }
+
+    return max(throughput, latency);
+}
+
+#endif // defined(DEBUG) || defined(LATE_DISASM)
+
+//----------------------------------------------------------------------------------------
+// getCurrentBlockWeight: Return the block weight for the currently active block
+//
+// Arguments:
+//    None
+//
+// Return Value:
+//    The block weight for the current block
+//
+// Notes:
+//    The current block is recorded in emitComp->compCurBB by
+//    CodeGen::genCodeForBBlist() as it walks the blocks.
+//    When we are in the prolog/epilog this value is nullptr.
+//
+BasicBlock::weight_t emitter::getCurrentBlockWeight()
+{
+    // If we have a non-null compCurBB, then use it to get the current block weight
+    if (emitComp->compCurBB != nullptr)
+    {
+        return emitComp->compCurBB->getBBWeight(emitComp);
+    }
+    else // we have a null compCurBB
+    {
+        // prolog or epilog case, so just use the standard weight
+        return BB_UNITY_WEIGHT;
+    }
 }
 
 void emitter::dispIns(instrDesc* id)
@@ -2306,6 +2403,12 @@ void* emitter::emitAddLabel(VARSET_VALARG_TP GCvars, regMaskTP gcrefRegs, regMas
     {
         emitNxtIG();
     }
+#if defined(DEBUG) || defined(LATE_DISASM)
+    else
+    {
+        emitCurIG->igWeight = getCurrentBlockWeight();
+    }
+#endif
 
     VarSetOps::Assign(emitComp, emitThisGCrefVars, GCvars);
     VarSetOps::Assign(emitComp, emitInitGCrefVars, GCvars);
@@ -3206,7 +3309,7 @@ void emitter::emitDispIG(insGroup* ig, insGroup* igPrev, bool verbose)
     }
     else
     {
-        printf("offs=%06XH, size=%04XH", ig->igOffs, ig->igSize);
+        printf("offs=%06XH, size=%04XH, bbWeight=%s", ig->igOffs, ig->igSize, refCntWtd2str(ig->igWeight));
 
         if (ig->igFlags & IGF_GC_VARS)
         {
@@ -3328,6 +3431,11 @@ size_t emitter::emitIssue1Instr(insGroup* ig, instrDesc* id, BYTE** dp)
     // printf("[S=%02u] " , emitCurStackLvl);
 
     is = emitOutputInstr(ig, id, dp);
+
+#if defined(DEBUG) || defined(LATE_DISASM)
+    float insExeCost = insEvaluateExecutionCost(id);
+    emitComp->info.compPerfScore += (ig->igWeight / BB_UNITY_WEIGHT) * insExeCost;
+#endif // defined(DEBUG) || defined(LATE_DISASM)
 
 // printf("[S=%02u]\n", emitCurStackLvl);
 
@@ -4764,7 +4872,14 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
             }
             else
             {
-                printf("\nG_M%03u_IG%02u:\n", Compiler::s_compMethodsCount, ig->igNum);
+                printf("\nG_M%03u_IG%02u:", Compiler::s_compMethodsCount, ig->igNum);
+
+                // Display the block weight, but only when it isn't the standard BB_UNITY_WEIGHT
+                if (ig->igWeight != BB_UNITY_WEIGHT)
+                {
+                    printf("\t\t;; bbWeight=%s", refCntWtd2str(ig->igWeight));
+                }
+                printf("\n");
             }
         }
 
@@ -6747,6 +6862,10 @@ insGroup* emitter::emitAllocIG()
 
 #ifdef DEBUG
     ig->igSelf = ig;
+#endif
+
+#if defined(DEBUG) || defined(LATE_DISASM)
+    ig->igWeight = getCurrentBlockWeight();
 #endif
 
 #if EMITTER_STATS

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -1085,30 +1085,6 @@ int emitter::instrDesc::idAddrUnion::iiaGetJitDataOffset() const
 
 #if defined(DEBUG) || defined(LATE_DISASM)
 
-#if 0  // ndef _TARGET_XARCH_
-//----------------------------------------------------------------------------------------
-// getInsExecutionCharacteristics: 
-//    Returns the current instruction execution characteristics
-//
-// Arguments:
-//    id  - The current instruction descriptor to be evaluated
-//
-// Return Value:
-//    A struct containing the current instruction execution characteristics
-//
-// Notes:
-//    This is the default implementation that can be used when we don't
-//    have a target specific implementation available
-//
-emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(instrDesc* id)
-{
-    insExecutionCharacteristics result;
-    result.insThroughput = PERFSCORE_THROUGHPUT_DEFAULT;
-    result.insLatency = PERFSCORE_LATENCY_DEFAULT;
-    return result;
-}
-#endif // ! _TARGET_XARCH_
-
 //----------------------------------------------------------------------------------------
 // insEvaluateExecutionCost:
 //    Returns the estimate execution cost fortyhe current instruction

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -1235,7 +1235,9 @@ protected:
 #define PERFSCORE_THROUGHPUT_6C 6.0f   // slower - 6 cycles
 #define PERFSCORE_THROUGHPUT_10C 10.0f // slower - 10 cycles
 #define PERFSCORE_THROUGHPUT_13C 13.0f // slower - 13 cycles
-#define PERFSCORE_THROUGHPUT_25C 25.0f // slower - 26 cycles
+#define PERFSCORE_THROUGHPUT_25C 25.0f // slower - 25 cycles
+#define PERFSCORE_THROUGHPUT_52C 52.0f // slower - 52 cycles
+#define PERFSCORE_THROUGHPUT_57C 57.0f // slower - 57 cycles
 
 #define PERFSCORE_THROUGHPUT_DEFAULT PERFSCORE_THROUGHPUT_1C
 
@@ -1257,8 +1259,9 @@ protected:
 #define PERFSCORE_LATENCY_13C 13.0f
 #define PERFSCORE_LATENCY_16C 16.0f
 #define PERFSCORE_LATENCY_23C 23.0f
-#define PERFSCORE_LATENCY_25C 25.0f
-#define PERFSCORE_LATENCY_50C 50.0f
+#define PERFSCORE_LATENCY_26C 26.0f
+#define PERFSCORE_LATENCY_62C 62.0f
+#define PERFSCORE_LATENCY_69C 69.0f
 
 #define PERFSCORE_LATENCY_BRANCH_DIRECT 1.0f   // cost of an unconditional branch
 #define PERFSCORE_LATENCY_BRANCH_COND 2.0f     // includes cost of a possible misprediction

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -248,6 +248,9 @@ struct insGroup
 #ifdef DEBUG
     insGroup* igSelf; // for consistency checking
 #endif
+#if defined(DEBUG) || defined(LATE_DISASM)
+    BasicBlock::weight_t igWeight; // the block weight used for this insGroup
+#endif
 
     UNATIVE_OFFSET igNum;     // for ordering (and display) purposes
     UNATIVE_OFFSET igOffs;    // offset of this group within method
@@ -1208,6 +1211,99 @@ protected:
             return &this->_idAddrUnion;
         }
     }; // End of  struct instrDesc
+
+#if defined(_TARGET_XARCH_)
+    insFormat emitter::getMemoryOperation(instrDesc* id);
+#elif defined(_TARGET_ARM64_)
+    void emitter::getMemoryOperation(instrDesc* id, unsigned* pMemAccessKind, bool* pIsLocalAccess);
+#endif
+
+#if defined(DEBUG) || defined(LATE_DISASM)
+
+#define PERFSCORE_THROUGHPUT_ILLEGAL -1024.0f
+
+#define PERFSCORE_THROUGHPUT_4X 0.25f         // Fastest - Quad issue
+#define PERFSCORE_THROUGHPUT_3X (1.0f / 3.0f) // Faster - Three issue
+#define PERFSCORE_THROUGHPUT_2X 0.5f          // Faster - Dual issue
+
+#define PERFSCORE_THROUGHPUT_1C 1.0f // Single Issue
+
+#define PERFSCORE_THROUGHPUT_2C 2.0f   // slower - 2 cycles
+#define PERFSCORE_THROUGHPUT_3C 3.0f   // slower - 3 cycles
+#define PERFSCORE_THROUGHPUT_4C 4.0f   // slower - 4 cycles
+#define PERFSCORE_THROUGHPUT_5C 5.0f   // slower - 5 cycles
+#define PERFSCORE_THROUGHPUT_6C 6.0f   // slower - 6 cycles
+#define PERFSCORE_THROUGHPUT_10C 10.0f // slower - 10 cycles
+#define PERFSCORE_THROUGHPUT_13C 13.0f // slower - 13 cycles
+#define PERFSCORE_THROUGHPUT_25C 25.0f // slower - 26 cycles
+
+#define PERFSCORE_THROUGHPUT_DEFAULT PERFSCORE_THROUGHPUT_1C
+
+#define PERFSCORE_LATENCY_ILLEGAL -1024.0f
+
+#define PERFSCORE_LATENCY_DEFAULT 1.0f
+
+#define PERFSCORE_LATENCY_ZERO 0.0f
+#define PERFSCORE_LATENCY_1C 1.0f
+#define PERFSCORE_LATENCY_2C 2.0f
+#define PERFSCORE_LATENCY_3C 3.0f
+#define PERFSCORE_LATENCY_4C 4.0f
+#define PERFSCORE_LATENCY_5C 5.0f
+#define PERFSCORE_LATENCY_6C 6.0f
+#define PERFSCORE_LATENCY_7C 7.0f
+#define PERFSCORE_LATENCY_8C 8.0f
+#define PERFSCORE_LATENCY_11C 11.0f
+#define PERFSCORE_LATENCY_12C 12.0f
+#define PERFSCORE_LATENCY_13C 13.0f
+#define PERFSCORE_LATENCY_16C 16.0f
+#define PERFSCORE_LATENCY_23C 23.0f
+#define PERFSCORE_LATENCY_25C 25.0f
+#define PERFSCORE_LATENCY_50C 50.0f
+
+#define PERFSCORE_LATENCY_BRANCH_DIRECT 1.0f   // cost of an unconditional branch
+#define PERFSCORE_LATENCY_BRANCH_COND 2.0f     // includes cost of a possible misprediction
+#define PERFSCORE_LATENCY_BRANCH_INDIRECT 2.0f // includes cost of a possible misprediction
+
+// a read,write or modify from stack location, possible def to use latency from L0 cache
+#define PERFSCORE_LATENCY_RD_STACK 2.0f
+#define PERFSCORE_LATENCY_WR_STACK 2.0f
+#define PERFSCORE_LATENCY_RD_WR_STACK 5.0f
+
+// a read, write or modify from constant location, possible def to use latency from L0 cache
+#define PERFSCORE_LATENCY_RD_CONST_ADDR 2.0f
+#define PERFSCORE_LATENCY_WR_CONST_ADDR 2.0f
+#define PERFSCORE_LATENCY_RD_WR_CONST_ADDR 5.0f
+
+// a read, write or modify from memory location, possible def to use latency from L0 or L1 cache
+// plus an extra cost  (of 1.0) for a increased chance  of a cache miss
+#define PERFSCORE_LATENCY_RD_GENERAL 3.0f
+#define PERFSCORE_LATENCY_WR_GENERAL 3.0f
+#define PERFSCORE_LATENCY_RD_WR_GENERAL 6.0f
+
+#define PERFSCORE_MEMORY_NONE 0
+#define PERFSCORE_MEMORY_READ 1
+#define PERFSCORE_MEMORY_WRITE 2
+#define PERFSCORE_MEMORY_READ_WRITE 3
+
+#define PERFSCORE_CODESIZE_COST_HOT 0.10f
+#define PERFSCORE_CODESIZE_COST_COLD 0.01f
+
+#define PERFSCORE_CALLEE_SPILL_COST                                                                                    \
+    0.75f // heuristicly derived - actual cost is one push and one pop, in the prolog/epilog
+
+    struct insExecutionCharacteristics
+    {
+        float    insThroughput;
+        float    insLatency;
+        unsigned insMemoryAccessKind;
+    };
+
+    insExecutionCharacteristics getInsExecutionCharacteristics(instrDesc* id);
+    float insEvaluateExecutionCost(instrDesc* id);
+
+#endif // defined(DEBUG) || defined(LATE_DISASM)
+
+    BasicBlock::weight_t getCurrentBlockWeight();
 
     void dispIns(instrDesc* id);
 

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -7966,4 +7966,35 @@ regNumber emitter::emitInsTernary(instruction ins, emitAttr attr, GenTree* dst, 
     return dst->gtRegNum;
 }
 
+#if defined(DEBUG) || defined(LATE_DISASM)
+
+//----------------------------------------------------------------------------------------
+// getInsExecutionCharacteristics:
+//    Returns the current instruction execution characteristics
+//
+// Arguments:
+//    id  - The current instruction descriptor to be evaluated
+//
+// Return Value:
+//    A struct containing the current instruction execution characteristics
+//
+// Notes:
+//
+emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(instrDesc* id)
+{
+    insExecutionCharacteristics result;
+
+    instruction ins    = id->idIns();
+    insFormat   insFmt = id->idInsFmt();
+
+    // ToDo: Calculate actual throughput and latency values
+    //
+    result.insThroughput = PERFSCORE_THROUGHPUT_DEFAULT;
+    result.insLatency    = PERFSCORE_LATENCY_DEFAULT;
+
+    return result;
+}
+
+#endif // defined(DEBUG) || defined(LATE_DISASM)
+
 #endif // defined(_TARGET_ARM_)

--- a/src/jit/emitarm64.h
+++ b/src/jit/emitarm64.h
@@ -339,7 +339,7 @@ static bool isIntegerRegister(regNumber reg)
     return (reg >= REG_INT_FIRST) && (reg <= REG_INT_LAST);
 }
 
-//  Returns true is reg encodes for REG_SP or REG_FP
+//  Returns true if reg encodes for REG_SP or REG_FP
 static bool isStackRegister(regNumber reg)
 {
     return (reg == REG_ZR) || (reg == REG_FP);

--- a/src/jit/emitarm64.h
+++ b/src/jit/emitarm64.h
@@ -339,6 +339,12 @@ static bool isIntegerRegister(regNumber reg)
     return (reg >= REG_INT_FIRST) && (reg <= REG_INT_LAST);
 }
 
+//  Returns true is reg encodes for REG_SP or REG_FP
+static bool isStackRegister(regNumber reg)
+{
+    return (reg == REG_ZR) || (reg == REG_FP);
+} // ZR (R31) encodes the SP register
+
 // Returns true if 'value' is a legal unsigned immediate 8 bit encoding (such as for fMOV).
 static bool isValidUimm8(ssize_t value)
 {

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -13663,6 +13663,1128 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 #pragma warning(pop)
 #endif
 
+emitter::insFormat emitter::getMemoryOperation(instrDesc* id)
+{
+    insFormat   result = IF_NONE;
+    instruction ins    = id->idIns();
+    insFormat   insFmt = id->idInsFmt();
+
+    if (ins == INS_lea)
+    {
+        // an INS_lea instruction doesn't actually read memory
+        insFmt = IF_NONE;
+    }
+
+    switch (insFmt)
+    {
+        case IF_NONE:
+        case IF_LABEL:
+        case IF_RWR_LABEL:
+        case IF_METHOD:
+        case IF_CNS:
+
+        case IF_RRD:
+        case IF_RWR:
+        case IF_RRW:
+        case IF_RRD_CNS:
+        case IF_RWR_CNS:
+        case IF_RRW_CNS:
+        case IF_RRW_SHF:
+        case IF_RRD_RRD:
+        case IF_RWR_RRD:
+        case IF_RRW_RRD:
+        case IF_RRW_RRW:
+        case IF_RRW_RRW_CNS:
+        case IF_RWR_RRD_RRD:
+        case IF_RWR_RRD_RRD_CNS:
+        case IF_RWR_RRD_RRD_RRD:
+            // none, or register only
+            result = IF_NONE;
+            break;
+
+        case IF_ARD:
+        case IF_RRD_ARD:
+        case IF_RWR_ARD:
+        case IF_RRW_ARD:
+        case IF_RWR_ARD_CNS:
+        case IF_RWR_RRD_ARD:
+        case IF_RRW_ARD_CNS:
+        case IF_RWR_ARD_RRD:
+        case IF_RWR_RRD_ARD_CNS:
+        case IF_RWR_RRD_ARD_RRD:
+        case IF_ARD_CNS:
+        case IF_ARD_RRD:
+            // Address [reg+reg*scale+cns] - read
+            result = IF_ARD;
+            break;
+
+        case IF_AWR:
+        case IF_AWR_RRD:
+        case IF_AWR_CNS:
+        case IF_AWR_RRD_CNS:
+        case IF_AWR_RRD_RRD:
+            // Address [reg+reg*scale+cns] - write
+            result = IF_AWR;
+            break;
+
+        case IF_ARW:
+        case IF_ARW_RRD:
+        case IF_ARW_CNS:
+        case IF_ARW_SHF:
+            // Address [reg+reg*scale+cns] - read and write
+            result = IF_ARW;
+            break;
+
+        case IF_MRD:
+        case IF_MRD_CNS:
+        case IF_MRD_OFF:
+        case IF_MRD_RRD:
+        case IF_RRD_MRD:
+        case IF_RRW_MRD:
+        case IF_RWR_MRD:
+        case IF_RWR_MRD_CNS:
+        case IF_RWR_MRD_OFF:
+        case IF_RWR_RRD_MRD:
+        case IF_RRW_MRD_CNS:
+        case IF_RWR_RRD_MRD_CNS:
+        case IF_RWR_RRD_MRD_RRD:
+        case IF_METHPTR:
+            // Address [cns] - read
+            result = IF_MRD;
+            break;
+
+        case IF_MWR:
+        case IF_MWR_CNS:
+        case IF_MWR_RRD:
+        case IF_MWR_RRD_CNS:
+            // Address [cns] - write
+            result = IF_MWR;
+            break;
+
+        case IF_MRW:
+        case IF_MRW_CNS:
+        case IF_MRW_RRD:
+        case IF_MRW_SHF:
+            // Address [cns] - read and write
+            result = IF_MWR;
+            break;
+
+        case IF_SRD:
+        case IF_SRD_CNS:
+        case IF_SRD_RRD:
+
+        case IF_RRD_SRD:
+        case IF_RRW_SRD:
+        case IF_RWR_SRD:
+        case IF_RWR_SRD_CNS:
+        case IF_RWR_RRD_SRD:
+        case IF_RRW_SRD_CNS:
+        case IF_RWR_RRD_SRD_CNS:
+        case IF_RWR_RRD_SRD_RRD:
+            // Stack [RSP] - read
+            result = IF_SRD;
+            break;
+
+        case IF_SWR:
+        case IF_SWR_CNS:
+        case IF_SWR_RRD:
+        case IF_SWR_RRD_CNS:
+        case IF_SWR_LABEL:
+            // Stack [RSP] - write
+            result = IF_SWR;
+            break;
+
+        case IF_SRW:
+        case IF_SRW_CNS:
+        case IF_SRW_RRD:
+        case IF_SRW_SHF:
+            // Stack [RSP] - read and write
+            result = IF_SWR;
+            break;
+
+        default:
+            result = IF_NONE;
+            break;
+    }
+    return result;
+}
+
+#if defined(DEBUG) || defined(LATE_DISASM)
+
+//----------------------------------------------------------------------------------------
+// getInsExecutionCharacteristics:
+//    Returns the current instruction execution characteristics
+//
+// Arguments:
+//    id  - The current instruction descriptor to be evaluated
+//
+// Return Value:
+//    A struct containing the current instruction execution characteristics
+//
+// Notes:
+//
+emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(instrDesc* id)
+{
+    insExecutionCharacteristics result;
+    instruction                 ins    = id->idIns();
+    insFormat                   insFmt = id->idInsFmt();
+    insFormat                   memFmt = getMemoryOperation(id);
+    unsigned                    memAccessKind;
+
+    result.insThroughput = PERFSCORE_THROUGHPUT_ILLEGAL;
+    result.insLatency    = PERFSCORE_LATENCY_ILLEGAL;
+
+    // Model the memory latency
+    switch (memFmt)
+    {
+        // Model a read from stack location, possible def to use latency from L0 cache
+        case IF_SRD:
+            result.insLatency = PERFSCORE_LATENCY_RD_STACK;
+            memAccessKind     = PERFSCORE_MEMORY_READ;
+            break;
+
+        case IF_SWR:
+            result.insLatency = PERFSCORE_LATENCY_WR_STACK;
+            memAccessKind     = PERFSCORE_MEMORY_WRITE;
+            break;
+
+        case IF_SRW:
+            result.insLatency = PERFSCORE_LATENCY_RD_WR_STACK;
+            memAccessKind     = PERFSCORE_MEMORY_READ_WRITE;
+            break;
+
+        // Model a read from a constant location, possible def to use latency from L0 cache
+        case IF_MRD:
+            result.insLatency = PERFSCORE_LATENCY_RD_CONST_ADDR;
+            memAccessKind     = PERFSCORE_MEMORY_READ;
+            break;
+
+        case IF_MWR:
+            result.insLatency = PERFSCORE_LATENCY_WR_CONST_ADDR;
+            memAccessKind     = PERFSCORE_MEMORY_WRITE;
+            break;
+
+        case IF_MRW:
+            result.insLatency = PERFSCORE_LATENCY_RD_WR_CONST_ADDR;
+            memAccessKind     = PERFSCORE_MEMORY_READ_WRITE;
+            break;
+
+        // Model a read from memory location, possible def to use latency from L0 or L1 cache
+        case IF_ARD:
+            result.insLatency = PERFSCORE_LATENCY_RD_GENERAL;
+            memAccessKind     = PERFSCORE_MEMORY_READ;
+            break;
+
+        case IF_AWR:
+            result.insLatency = PERFSCORE_LATENCY_WR_GENERAL;
+            memAccessKind     = PERFSCORE_MEMORY_WRITE;
+            break;
+
+        case IF_ARW:
+            result.insLatency = PERFSCORE_LATENCY_RD_WR_GENERAL;
+            memAccessKind     = PERFSCORE_MEMORY_READ_WRITE;
+            break;
+
+        case IF_NONE:
+            result.insLatency = PERFSCORE_LATENCY_ZERO;
+            memAccessKind     = PERFSCORE_MEMORY_NONE;
+            break;
+
+        default:
+            assert(!"Unhandled insFmt for switch (memFmt)");
+            result.insLatency = PERFSCORE_LATENCY_ZERO;
+            memAccessKind     = PERFSCORE_MEMORY_NONE;
+            break;
+    }
+    result.insMemoryAccessKind = memAccessKind;
+
+    switch (ins)
+    {
+        case INS_nop:
+        case INS_int3:
+            assert(memFmt == IF_NONE);
+            result.insThroughput = PERFSCORE_THROUGHPUT_4X;
+            result.insLatency    = PERFSCORE_LATENCY_ZERO;
+            break;
+
+        case INS_push:
+        case INS_push_hide:
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            if (insFmt == IF_RRD) // push  reg
+            {
+                // For pushes (stack writes) we assume that the full latency will be covered
+                result.insLatency = PERFSCORE_LATENCY_ZERO;
+            }
+            break;
+
+        case INS_pop:
+        case INS_pop_hide:
+            if (insFmt == IF_RWR) // pop   reg
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+                // For pops (stack reads) we assume that the full latency will be covered
+                result.insLatency = PERFSCORE_LATENCY_ZERO;
+            }
+            else
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            }
+            break;
+
+        case INS_inc:
+        case INS_dec:
+        case INS_neg:
+        case INS_not:
+            if (memFmt == IF_NONE)
+            {
+                // ins   reg
+                result.insThroughput = PERFSCORE_THROUGHPUT_4X;
+                result.insLatency    = PERFSCORE_LATENCY_1C;
+            }
+            else
+            {
+                // ins   mem
+                result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            }
+            break;
+
+#ifdef _TARGET_AMD64_
+        case INS_movsxd:
+#endif
+        case INS_mov:
+        case INS_movsx:
+        case INS_movzx:
+        case INS_cmp:
+        case INS_test:
+            if (memFmt == IF_NONE)
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_4X;
+            }
+            else if (memAccessKind == PERFSCORE_MEMORY_READ)
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+            }
+            else // writes
+            {
+                assert(memAccessKind == PERFSCORE_MEMORY_WRITE);
+                result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            }
+            break;
+
+        case INS_adc:
+        case INS_sbb:
+            result.insLatency = max(PERFSCORE_LATENCY_1C, result.insLatency);
+            if (memAccessKind == PERFSCORE_MEMORY_READ_WRITE)
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            }
+            else
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+            }
+            break;
+
+        case INS_add:
+        case INS_sub:
+        case INS_and:
+        case INS_or:
+        case INS_xor:
+            result.insLatency = max(PERFSCORE_LATENCY_1C, result.insLatency);
+            if (memFmt == IF_NONE)
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_4X;
+            }
+            else if (memAccessKind == PERFSCORE_MEMORY_READ_WRITE)
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            }
+            else
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+            }
+            break;
+
+        case INS_lea:
+            // uops.info
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            result.insLatency    = PERFSCORE_LATENCY_1C;
+            break;
+
+        case INS_imul_AX:
+        case INS_imul_BX:
+        case INS_imul_CX:
+        case INS_imul_DX:
+        case INS_imul_BP:
+        case INS_imul_SI:
+        case INS_imul_DI:
+#ifdef _TARGET_AMD64_
+        case INS_imul_08:
+        case INS_imul_09:
+        case INS_imul_10:
+        case INS_imul_11:
+        case INS_imul_12:
+        case INS_imul_13:
+        case INS_imul_14:
+        case INS_imul_15:
+#endif // _TARGET_AMD64_
+        case INS_mulEAX:
+        case INS_imulEAX:
+        case INS_imul:
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            result.insLatency    = PERFSCORE_LATENCY_3C;
+            break;
+
+        case INS_div:
+        case INS_idiv:
+            result.insThroughput = PERFSCORE_THROUGHPUT_6C;
+            // The integer divide instruction has a long latency
+            if ((id->idOpSize() == EA_8BYTE))
+            {
+                result.insLatency = PERFSCORE_LATENCY_50C;
+            }
+            else
+            {
+                assert(id->idOpSize() == EA_4BYTE);
+                result.insThroughput = PERFSCORE_LATENCY_25C;
+            }
+            break;
+
+        case INS_cdq:
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            result.insLatency    = PERFSCORE_LATENCY_1C;
+            break;
+
+        case INS_shl:
+        case INS_shr:
+        case INS_sar:
+        case INS_ror:
+        case INS_rol:
+            switch (insFmt)
+            {
+                case IF_RRW_CNS:
+                    // ins   reg, cns
+                    result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+                    result.insLatency    = PERFSCORE_LATENCY_1C;
+                    break;
+
+                case IF_MRW_CNS:
+                case IF_SRW_CNS:
+                case IF_ARW_CNS:
+                    // ins   [mem], cns
+                    result.insThroughput = PERFSCORE_THROUGHPUT_2C;
+                    break;
+
+                case IF_RRW: // probably should use INS_shl_N
+                    // ins   reg, cl
+                    result.insThroughput = PERFSCORE_THROUGHPUT_2C;
+                    result.insLatency    = PERFSCORE_LATENCY_2C;
+                    break;
+
+                case IF_MRW: // probably should use INS_shr_N
+                case IF_SRW:
+                case IF_ARW:
+                    // ins   [mem], cl
+                    result.insThroughput = PERFSCORE_THROUGHPUT_4C;
+                    break;
+
+                default:
+                    // all others
+                    assert(!"unreached");
+                    result.insThroughput = PERFSCORE_THROUGHPUT_DEFAULT;
+                    result.insLatency    = PERFSCORE_LATENCY_DEFAULT;
+                    break;
+            }
+            break;
+
+        case INS_shl_1:
+        case INS_shr_1:
+        case INS_sar_1:
+            result.insLatency = PERFSCORE_LATENCY_1C;
+            switch (insFmt)
+            {
+                case IF_RRW:
+                    // ins   reg, 1
+                    result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+                    break;
+
+                case IF_MRW:
+                case IF_SRW:
+                case IF_ARW:
+                    // ins   [mem], 1
+                    result.insThroughput = PERFSCORE_THROUGHPUT_2C;
+                    break;
+
+                default:
+                    // all others
+                    assert(!"unreached");
+                    result.insThroughput = PERFSCORE_THROUGHPUT_DEFAULT;
+            }
+            break;
+
+        case INS_ror_1:
+        case INS_rol_1:
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            result.insLatency    = PERFSCORE_LATENCY_1C;
+            break;
+
+        case INS_shl_N:
+        case INS_shr_N:
+        case INS_sar_N:
+        case INS_ror_N:
+        case INS_rol_N:
+            result.insLatency = PERFSCORE_LATENCY_2C;
+            switch (insFmt)
+            {
+                case IF_RRW_SHF:
+                    // ins   reg, cl
+                    result.insThroughput = PERFSCORE_THROUGHPUT_2C;
+                    break;
+
+                case IF_MRW_SHF:
+                case IF_SRW_SHF:
+                case IF_ARW_SHF:
+                    // ins   [mem], cl
+                    result.insThroughput = PERFSCORE_THROUGHPUT_4C;
+                    break;
+
+                default:
+                    // all others
+                    assert(!"unreached");
+                    result.insThroughput = PERFSCORE_THROUGHPUT_DEFAULT;
+                    break;
+            }
+            break;
+
+        case INS_rcr:
+        case INS_rcl:
+            result.insThroughput = PERFSCORE_THROUGHPUT_6C;
+            result.insLatency    = PERFSCORE_LATENCY_6C;
+            break;
+
+        case INS_rcr_1:
+        case INS_rcl_1:
+            // uops.info
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            break;
+
+        case INS_shld:
+        case INS_shrd:
+            if (insFmt == IF_RRW_RRW_CNS)
+            {
+                // ins   reg, reg, cns
+                result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+                result.insLatency    = PERFSCORE_LATENCY_3C;
+            }
+            else
+            {
+                assert(memAccessKind == PERFSCORE_MEMORY_WRITE); // _SHF form never emitted
+                result.insThroughput = PERFSCORE_THROUGHPUT_2C;
+            }
+            break;
+
+        case INS_bt:
+            if ((insFmt == IF_RRD_RRD) || (insFmt == IF_RRD_CNS))
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+                result.insLatency    = PERFSCORE_LATENCY_1C;
+            }
+            else
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            }
+            break;
+
+        case INS_seto:
+        case INS_setno:
+        case INS_setb:
+        case INS_setae:
+        case INS_sete:
+        case INS_setne:
+        case INS_setbe:
+        case INS_seta:
+        case INS_sets:
+        case INS_setns:
+        case INS_setp:
+        case INS_setnp:
+        case INS_setl:
+        case INS_setge:
+        case INS_setle:
+        case INS_setg:
+            result.insLatency = PERFSCORE_LATENCY_1C;
+            if (insFmt == IF_RRD)
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+            }
+            else
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            }
+            break;
+
+        case INS_jo:
+        case INS_jno:
+        case INS_jb:
+        case INS_jae:
+        case INS_je:
+        case INS_jne:
+        case INS_jbe:
+        case INS_ja:
+        case INS_js:
+        case INS_jns:
+        case INS_jp:
+        case INS_jnp:
+        case INS_jl:
+        case INS_jge:
+        case INS_jle:
+        case INS_jg:
+            // conditional branch
+            result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+            result.insLatency    = PERFSCORE_LATENCY_BRANCH_COND;
+            break;
+
+        case INS_jmp:
+        case INS_l_jmp:
+            // branch to a constant address
+            result.insThroughput = PERFSCORE_THROUGHPUT_2C;
+            result.insLatency    = PERFSCORE_LATENCY_BRANCH_DIRECT;
+            break;
+
+#ifdef _TARGET_AMD64_
+        case INS_rex_jmp:
+#endif // _TARGET_AMD64_
+        case INS_i_jmp:
+            // branch to register
+            result.insThroughput = PERFSCORE_THROUGHPUT_2C;
+            result.insLatency    = PERFSCORE_LATENCY_BRANCH_INDIRECT;
+            break;
+
+        case INS_call:
+            // uops.info
+            result.insLatency = PERFSCORE_LATENCY_ZERO;
+            switch (insFmt)
+            {
+                case IF_LABEL:
+                    result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+                    break;
+
+                case IF_METHOD:
+                    result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+                    break;
+
+                case IF_METHPTR:
+                    result.insThroughput = PERFSCORE_THROUGHPUT_3C;
+                    break;
+
+                case IF_SRD:
+                    result.insThroughput = PERFSCORE_THROUGHPUT_3C;
+                    break;
+
+                case IF_ARD:
+                    result.insThroughput = PERFSCORE_THROUGHPUT_3C;
+                    break;
+
+                default:
+                    assert(!"Unhandled insFmt for INS_call");
+                    result.insThroughput = PERFSCORE_THROUGHPUT_DEFAULT;
+                    break;
+            }
+            break;
+
+        case INS_ret:
+            if (insFmt == IF_CNS)
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_2C;
+            }
+            else
+            {
+                assert(insFmt == IF_NONE);
+                result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            }
+            break;
+
+        case INS_lock:
+            result.insThroughput = PERFSCORE_THROUGHPUT_13C;
+            break;
+
+        case INS_xadd:
+            // uops.info
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            break;
+
+        case INS_cmpxchg:
+            result.insThroughput = PERFSCORE_THROUGHPUT_5C;
+            break;
+
+        case INS_xchg:
+            // uops.info
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            if (memFmt == IF_NONE)
+            {
+                result.insLatency = PERFSCORE_LATENCY_1C;
+            }
+            else
+            {
+                result.insLatency = PERFSCORE_LATENCY_23C;
+            }
+            break;
+
+#ifdef _TARGET_X86_
+        case INS_fld:
+        case INS_fstp:
+            result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+            if (memAccessKind == PERFSCORE_MEMORY_NONE)
+            {
+                result.insLatency = PERFSCORE_LATENCY_1C;
+            }
+            break;
+#endif // _TARGET_X86
+
+#ifdef _TARGET_AMD64_
+        case INS_movsq:
+        case INS_stosq:
+#endif // _TARGET_AMD64_
+        case INS_movsd:
+        case INS_stosd:
+            // uops.info
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            break;
+
+#ifdef _TARGET_AMD64_
+        case INS_r_movsq:
+        case INS_r_stosq:
+#endif // _TARGET_AMD64_
+        case INS_r_movsd:
+        case INS_r_movsb:
+        case INS_r_stosd:
+        case INS_r_stosb:
+            // Actually variable sized: rep stosd, used to zero frame slots
+            // uops.info
+            result.insThroughput = PERFSCORE_THROUGHPUT_25C;
+            break;
+
+        case INS_mov_xmm2i:
+            // movd  reg, xmm
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            result.insLatency    = PERFSCORE_LATENCY_2C;
+            break;
+
+        case INS_mov_i2xmm:
+            // movd  xmm, reg
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            result.insLatency    = PERFSCORE_LATENCY_1C;
+            break;
+
+        case INS_movq:
+            if (memAccessKind == PERFSCORE_MEMORY_NONE)
+            {
+                // movq   reg, reg
+                result.insThroughput = PERFSCORE_THROUGHPUT_3X;
+                result.insLatency    = PERFSCORE_LATENCY_1C;
+            }
+            else if (memAccessKind == PERFSCORE_MEMORY_READ)
+            {
+                // movq   reg, mem
+                result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+            }
+            else
+            {
+                // movq   mem, reg
+                assert(memAccessKind == PERFSCORE_MEMORY_WRITE);
+                result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            }
+            break;
+
+        case INS_movdqa:
+        case INS_movdqu:
+            if (memAccessKind == PERFSCORE_MEMORY_NONE)
+            {
+                // ins   reg, reg
+                result.insThroughput = PERFSCORE_THROUGHPUT_4X;
+                result.insLatency    = PERFSCORE_LATENCY_ZERO;
+            }
+            else if (memAccessKind == PERFSCORE_MEMORY_READ)
+            {
+                // ins   reg, mem
+                result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+            }
+            else
+            {
+                // ins   mem, reg
+                assert(memAccessKind == PERFSCORE_MEMORY_WRITE);
+                result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            }
+            break;
+
+        case INS_movhps:
+        case INS_movhpd:
+        case INS_movlps:
+        case INS_movlpd:
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            if (memAccessKind == PERFSCORE_MEMORY_READ)
+            {
+                result.insLatency = max(PERFSCORE_LATENCY_4C, result.insLatency);
+            }
+            else
+            {
+                assert(memAccessKind == PERFSCORE_MEMORY_WRITE);
+                result.insLatency = max(PERFSCORE_LATENCY_3C, result.insLatency);
+            }
+            break;
+
+        case INS_movhlps:
+        case INS_movlhps:
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            result.insLatency    = PERFSCORE_LATENCY_1C;
+            break;
+
+        case INS_xorps:
+            // uops.info
+            result.insThroughput = PERFSCORE_THROUGHPUT_3X;
+            result.insLatency    = PERFSCORE_LATENCY_ZERO;
+            break;
+
+        case INS_vzeroupper:
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            break;
+
+        case INS_movss:
+        case INS_movsdsse2:
+        case INS_movddup:
+            if (memAccessKind == PERFSCORE_MEMORY_NONE)
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+                result.insLatency    = PERFSCORE_LATENCY_1C;
+            }
+            else
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+                result.insLatency    = max(PERFSCORE_LATENCY_3C, result.insLatency);
+            }
+            break;
+
+        case INS_ucomiss:
+        case INS_ucomisd:
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            break;
+
+        case INS_addss:
+        case INS_addsd:
+        case INS_subss:
+        case INS_subsd:
+        case INS_mulss:
+        case INS_mulsd:
+            result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+            result.insLatency    = PERFSCORE_LATENCY_4C;
+            break;
+
+        case INS_divss:
+            result.insThroughput = PERFSCORE_THROUGHPUT_3C;
+            result.insLatency    = PERFSCORE_LATENCY_11C;
+            break;
+
+        case INS_divsd:
+            result.insThroughput = PERFSCORE_THROUGHPUT_4C;
+            result.insLatency    = PERFSCORE_LATENCY_13C;
+            break;
+
+        case INS_sqrtss:
+            result.insThroughput = PERFSCORE_THROUGHPUT_3C;
+            result.insLatency    = PERFSCORE_LATENCY_12C;
+            break;
+
+        case INS_sqrtsd:
+            result.insThroughput = PERFSCORE_THROUGHPUT_6C;
+            result.insLatency    = PERFSCORE_LATENCY_16C;
+            break;
+
+        case INS_roundsd:
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            result.insLatency    = PERFSCORE_LATENCY_8C;
+            break;
+
+        case INS_cvttsd2si:
+        case INS_cvtsd2si:
+        case INS_cvttss2si:
+        case INS_cvtss2si:
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            result.insLatency    = PERFSCORE_LATENCY_6C;
+            break;
+
+        case INS_cvtsd2ss:
+        case INS_cvtps2pd:
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            result.insLatency    = PERFSCORE_LATENCY_5C;
+            break;
+
+        case INS_cvtsi2sd:
+        case INS_cvtsi2ss:
+            result.insThroughput = PERFSCORE_THROUGHPUT_2C;
+            result.insLatency    = PERFSCORE_LATENCY_6C;
+            break;
+
+        case INS_cvtss2sd:
+            result.insThroughput = PERFSCORE_THROUGHPUT_2C;
+            result.insLatency    = PERFSCORE_LATENCY_5C;
+            break;
+
+        case INS_movaps:
+        case INS_movups:
+        case INS_movapd:
+        case INS_movupd:
+            if (memAccessKind == PERFSCORE_MEMORY_NONE)
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_4X;
+                result.insLatency    = PERFSCORE_LATENCY_1C;
+            }
+            else if (memAccessKind == PERFSCORE_MEMORY_READ)
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+                result.insLatency    = max(PERFSCORE_LATENCY_2C, result.insLatency);
+            }
+            else
+            {
+                assert(memAccessKind == PERFSCORE_MEMORY_WRITE);
+                result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+                result.insLatency    = max(PERFSCORE_LATENCY_3C, result.insLatency);
+            }
+            break;
+
+        case INS_andps:
+            if (memAccessKind == PERFSCORE_MEMORY_NONE)
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_3X;
+                result.insLatency    = PERFSCORE_LATENCY_1C;
+            }
+            else
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+            }
+            break;
+
+        case INS_lzcnt:
+        case INS_tzcnt:
+        case INS_popcnt:
+        case INS_crc32:
+        case INS_pdep:
+        case INS_pext:
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            result.insLatency    = PERFSCORE_LATENCY_3C;
+            break;
+
+        case INS_pmovmskb:
+        case INS_movmskpd:
+        case INS_movmskps:
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            result.insLatency    = PERFSCORE_LATENCY_2C;
+            break;
+
+        case INS_andn:
+            result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+            result.insLatency    = PERFSCORE_LATENCY_1C;
+            break;
+
+        case INS_blsi:
+        case INS_blsmsk:
+        case INS_blsr:
+        case INS_bextr:
+        case INS_bzhi:
+            if (memAccessKind == PERFSCORE_MEMORY_NONE)
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+                result.insLatency    = PERFSCORE_LATENCY_2C;
+            }
+            else
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            }
+            break;
+
+        case INS_extractps:
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            if (memAccessKind == PERFSCORE_MEMORY_NONE)
+            {
+                result.insLatency = PERFSCORE_LATENCY_3C;
+            }
+            else
+            {
+                result.insLatency = max(PERFSCORE_LATENCY_5C, result.insLatency);
+            }
+            break;
+
+        case INS_mulx:
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            result.insLatency    = PERFSCORE_LATENCY_4C;
+            break;
+
+        case INS_pextrb:
+        case INS_pextrd:
+        case INS_pextrq:
+        case INS_pextrw:
+        case INS_pextrw_sse41:
+            result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+            result.insLatency    = PERFSCORE_LATENCY_1C;
+            break;
+
+        case INS_minps:
+        case INS_minpd:
+        case INS_ptest:
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            result.insLatency    = PERFSCORE_LATENCY_3C;
+            break;
+
+        case INS_pminub:
+        case INS_pminsb:
+        case INS_pminuw:
+        case INS_pminsw:
+        case INS_pmaxub:
+        case INS_pmaxsb:
+        case INS_pmaxuw:
+        case INS_pmaxsw:
+        case INS_packuswb:
+        case INS_packusdw:
+        case INS_packsswb:
+        case INS_packssdw:
+        case INS_unpcklps:
+        case INS_unpckhps:
+        case INS_unpcklpd:
+        case INS_unpckhpd:
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            result.insLatency    = PERFSCORE_LATENCY_1C;
+            break;
+
+        case INS_pand:
+        case INS_pandn:
+        case INS_por:
+        case INS_pxor:
+            result.insThroughput = PERFSCORE_THROUGHPUT_3X;
+            result.insLatency    = PERFSCORE_LATENCY_1C;
+            break;
+
+        case INS_pcmpeqb:
+        case INS_pcmpeqw:
+        case INS_pcmpeqd:
+        case INS_pcmpeqq:
+        case INS_pcmpgtb:
+        case INS_pcmpgtw:
+        case INS_pcmpgtd:
+        case INS_pcmpgtq:
+        case INS_cmpps:
+        case INS_cmppd:
+        case INS_cmpss:
+        case INS_cmpsd:
+            result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+            result.insLatency    = PERFSCORE_LATENCY_1C;
+            break;
+
+        case INS_punpckldq:
+        case INS_punpcklwd:
+        case INS_punpcklbw:
+        case INS_punpckhdq:
+        case INS_punpckhwd:
+        case INS_punpckhbw:
+        case INS_punpcklqdq:
+        case INS_pshufb:
+        case INS_pshufd:
+        case INS_pshuflw:
+        case INS_pshufhw:
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            result.insLatency    = PERFSCORE_LATENCY_1C;
+            break;
+
+        case INS_vpbroadcastb:
+        case INS_vpbroadcastw:
+            if (memAccessKind == PERFSCORE_MEMORY_NONE)
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+                result.insLatency    = PERFSCORE_LATENCY_1C;
+            }
+            else
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+                result.insLatency    = max(PERFSCORE_LATENCY_7C, result.insLatency);
+            }
+            break;
+
+        case INS_vpbroadcastd:
+        case INS_vpbroadcastq:
+            if (memAccessKind == PERFSCORE_MEMORY_NONE)
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+                result.insLatency    = PERFSCORE_LATENCY_3C;
+            }
+            else
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+                result.insLatency    = max(PERFSCORE_LATENCY_4C, result.insLatency);
+            }
+            break;
+
+        case INS_shufps:
+        case INS_shufpd:
+            // uops.info
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            if (memFmt == IF_NONE)
+            {
+                result.insLatency = PERFSCORE_LATENCY_1C;
+            }
+            break;
+
+        case INS_pinsrb:
+        case INS_pinsrw:
+        case INS_pinsrd:
+        case INS_pinsrq:
+            if (memAccessKind == PERFSCORE_MEMORY_NONE)
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_2C;
+                result.insLatency    = PERFSCORE_LATENCY_3C;
+            }
+            else
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            }
+            break;
+
+        case INS_insertps:
+            if (memAccessKind == PERFSCORE_MEMORY_NONE)
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+                result.insLatency    = PERFSCORE_LATENCY_1C;
+            }
+            else
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+                result.insLatency    = max(PERFSCORE_LATENCY_4C, result.insLatency);
+            }
+            break;
+
+        case INS_bswap:
+            if ((id->idOpSize() == EA_8BYTE))
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+                result.insLatency    = PERFSCORE_LATENCY_2C;
+            }
+            else
+            {
+                assert(id->idOpSize() == EA_4BYTE);
+                result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+                result.insLatency    = PERFSCORE_LATENCY_1C;
+            }
+            break;
+
+        default:
+            // ins = ins;
+            // assert(!"Unhandled ins for getInsExecutionCharacteristics");
+            // all other ins
+            result.insThroughput = PERFSCORE_THROUGHPUT_DEFAULT;
+            result.insLatency    = PERFSCORE_LATENCY_DEFAULT;
+            break;
+    }
+
+    return result;
+}
+
+#endif // defined(DEBUG) || defined(LATE_DISASM)
+
 /*****************************************************************************/
 /*****************************************************************************/
 

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -14035,17 +14035,33 @@ emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(ins
             break;
 
         case INS_div:
-        case INS_idiv:
-            result.insThroughput = PERFSCORE_THROUGHPUT_6C;
-            // The integer divide instruction has a long latency
+            // The integer divide instructions have long latencies
             if ((id->idOpSize() == EA_8BYTE))
             {
-                result.insLatency = PERFSCORE_LATENCY_50C;
+                result.insThroughput = PERFSCORE_THROUGHPUT_52C;
+                result.insLatency    = PERFSCORE_LATENCY_62C;
             }
             else
             {
                 assert(id->idOpSize() == EA_4BYTE);
-                result.insThroughput = PERFSCORE_LATENCY_25C;
+                result.insThroughput = PERFSCORE_THROUGHPUT_6C;
+                result.insThroughput = PERFSCORE_LATENCY_26C;
+            }
+            break;
+
+        case INS_idiv:
+            result.insThroughput = PERFSCORE_THROUGHPUT_6C;
+            // The integer divide instructions have long latenies
+            if ((id->idOpSize() == EA_8BYTE))
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_57C;
+                result.insLatency    = PERFSCORE_LATENCY_69C;
+            }
+            else
+            {
+                assert(id->idOpSize() == EA_4BYTE);
+                result.insThroughput = PERFSCORE_THROUGHPUT_6C;
+                result.insThroughput = PERFSCORE_LATENCY_26C;
             }
             break;
 


### PR DESCRIPTION
 - PerfScore represents an estimate of the dynamic execution cost for the method
    emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(instrDesc* id)
 - We track the BasicBlock weight for each instruction group
 - PerfScore also uses the codesize as a minor factor, both the hot code size and the cold code size
 - Provides an x64 implementation of getInsExecutionCharacteristics.