### PR TITLE
Save corefx test build artifacts to unique folder

### DIFF
--- a/eng/build-test-job.yml
+++ b/eng/build-test-job.yml
@@ -26,6 +26,7 @@ jobs:
     osGroup: ${{ parameters.osGroup }}
     osIdentifier: ${{ parameters.osIdentifier }}
     readyToRun: ${{ parameters.readyToRun }}
+    corefxTests: ${{ parameters.corefxTests }}
 
     # Test jobs should continue on error for internal builds
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:

--- a/eng/run-test-job.yml
+++ b/eng/run-test-job.yml
@@ -25,6 +25,7 @@ jobs:
     osGroup: ${{ parameters.osGroup }}
     osIdentifier: ${{ parameters.osIdentifier }}
     readyToRun: ${{ parameters.readyToRun }}
+    corefxTests: ${{ parameters.corefxTests }}
     helixType: 'build/tests/'
 
     # Test jobs should continue on error for internal builds

--- a/eng/xplat-test-job.yml
+++ b/eng/xplat-test-job.yml
@@ -7,6 +7,7 @@ parameters:
   helixType: '(unspecified)'
   container: ''
   crossrootfsDir: ''
+  corefxTests: false
   readyToRun: false
 
   # arcade-specific parameters
@@ -56,13 +57,18 @@ jobs:
     - name: testRootFolderPath
       value: $(binTestsPath)/$(osGroup).$(archType).$(buildConfigUpper)
 
-    - ${{ if ne(parameters.readyToRun, true) }}:
+    ${{ if and(eq(parameters.corefxTests, true), eq(parameters.readyToRun, true)) }}:
       - name: testArtifactName
-        value: Tests_$(testArtifactRootName)
-
-    - ${{ if eq(parameters.readyToRun, true) }}:
+        value: Tests_r2r_corefx_$(testArtifactRootName)
+    ${{ if and(eq(parameters.corefxTests, true), ne(parameters.readyToRun, true)) }}:
+      - name: testArtifactName
+        value: Tests_corefx_$(testArtifactRootName)
+    ${{ if and(ne(parameters.corefxTests, true), eq(parameters.readyToRun, true)) }}:
       - name: testArtifactName
         value: Tests_r2r_$(testArtifactRootName)
+    ${{ if and(ne(parameters.corefxTests, true), ne(parameters.readyToRun, true)) }}:
+      - name: testArtifactName
+        value: Tests_$(testArtifactRootName)
 
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
       - name: archiveExtension


### PR DESCRIPTION
It would be better to also include the `r2r` and `corefx` tags
in the archive filename, for clarity, but that is a bigger change
and not necessary to fix the current failing jobs due to the
existing name conflict.

Fixes a problem identified in https://github.com/dotnet/coreclr/pull/26392