### PR TITLE
Fix printf when failing to load coredistools.

### DIFF
--- a/src/ToolBox/superpmi/superpmi/neardiffer.cpp
+++ b/src/ToolBox/superpmi/superpmi/neardiffer.cpp
@@ -95,7 +95,7 @@ bool NearDiffer::InitAsmDiff()
         HMODULE hCoreDisToolsLib = ::LoadLibraryW(coreDisToolsLibrary);
         if (hCoreDisToolsLib == 0)
         {
-            LogError("LoadLibrary(%s) failed (0x%08x)", ::GetLastError());
+            LogError("LoadLibrary(%s) failed (0x%08x)", MAKEDLLNAME_A("coredistools"), ::GetLastError());
             return false;
         }
         


### PR DESCRIPTION
In #26235 a call to `LogError` (a `printf`-like macro) was changed so that the arguments no longer match the format specifiers. This adds back a parameter.