### PR TITLE
make sure that StartsWith checks only the beginning of the string

### DIFF
--- a/src/corefx/System.Globalization.Native/pal_collation.c
+++ b/src/corefx/System.Globalization.Native/pal_collation.c
@@ -604,12 +604,13 @@ int32_t GlobalizationNative_StartsWith(
 
     if (U_SUCCESS(err))
     {
-        UStringSearch* pSearch = usearch_openFromCollator(lpTarget, cwTargetLength, lpSource, cwSourceLength, pColl, NULL, &err);
+        int32_t searchedTextLength = cwTargetLength < cwSourceLength ? cwTargetLength : cwSourceLength;
+        UStringSearch* pSearch = usearch_openFromCollator(lpTarget, cwTargetLength, lpSource, searchedTextLength, pColl, NULL, &err);
         int32_t idx = USEARCH_DONE;
 
         if (U_SUCCESS(err))
         {
-            idx = usearch_preceding(pSearch, 1, &err);
+            idx = usearch_first(pSearch, &err);
             if (idx != USEARCH_DONE)
             {
                 if (idx == 0)

--- a/src/corefx/System.Globalization.Native/pal_collation.c
+++ b/src/corefx/System.Globalization.Native/pal_collation.c
@@ -609,7 +609,7 @@ int32_t GlobalizationNative_StartsWith(
 
         if (U_SUCCESS(err))
         {
-            idx = usearch_first(pSearch, &err);
+            idx = usearch_preceding(pSearch, 1, &err);
             if (idx != USEARCH_DONE)
             {
                 if (idx == 0)

--- a/src/corefx/System.Globalization.Native/pal_icushim.h
+++ b/src/corefx/System.Globalization.Native/pal_icushim.h
@@ -123,7 +123,6 @@
     PER_FUNCTION_BLOCK(ures_open, libicuuc) \
     PER_FUNCTION_BLOCK(usearch_close, libicui18n) \
     PER_FUNCTION_BLOCK(usearch_first, libicui18n) \
-    PER_FUNCTION_BLOCK(usearch_preceding, libicui18n) \
     PER_FUNCTION_BLOCK(usearch_getMatchedLength, libicui18n) \
     PER_FUNCTION_BLOCK(usearch_last, libicui18n) \
     PER_FUNCTION_BLOCK(usearch_openFromCollator, libicui18n)
@@ -236,7 +235,6 @@ FOR_ALL_ICU_FUNCTIONS
 #define ures_open(...) ures_open_ptr(__VA_ARGS__)
 #define usearch_close(...) usearch_close_ptr(__VA_ARGS__)
 #define usearch_first(...) usearch_first_ptr(__VA_ARGS__)
-#define usearch_preceding(...) usearch_preceding_ptr(__VA_ARGS__)
 #define usearch_getMatchedLength(...) usearch_getMatchedLength_ptr(__VA_ARGS__)
 #define usearch_last(...) usearch_last_ptr(__VA_ARGS__)
 #define usearch_openFromCollator(...) usearch_openFromCollator_ptr(__VA_ARGS__)

--- a/src/corefx/System.Globalization.Native/pal_icushim.h
+++ b/src/corefx/System.Globalization.Native/pal_icushim.h
@@ -123,6 +123,7 @@
     PER_FUNCTION_BLOCK(ures_open, libicuuc) \
     PER_FUNCTION_BLOCK(usearch_close, libicui18n) \
     PER_FUNCTION_BLOCK(usearch_first, libicui18n) \
+    PER_FUNCTION_BLOCK(usearch_preceding, libicui18n) \
     PER_FUNCTION_BLOCK(usearch_getMatchedLength, libicui18n) \
     PER_FUNCTION_BLOCK(usearch_last, libicui18n) \
     PER_FUNCTION_BLOCK(usearch_openFromCollator, libicui18n)
@@ -235,6 +236,7 @@ FOR_ALL_ICU_FUNCTIONS
 #define ures_open(...) ures_open_ptr(__VA_ARGS__)
 #define usearch_close(...) usearch_close_ptr(__VA_ARGS__)
 #define usearch_first(...) usearch_first_ptr(__VA_ARGS__)
+#define usearch_preceding(...) usearch_preceding_ptr(__VA_ARGS__)
 #define usearch_getMatchedLength(...) usearch_getMatchedLength_ptr(__VA_ARGS__)
 #define usearch_last(...) usearch_last_ptr(__VA_ARGS__)
 #define usearch_openFromCollator(...) usearch_openFromCollator_ptr(__VA_ARGS__)


### PR DESCRIPTION
So far we were using `usearch_first` which was searching the entire string if the string was not starting with a given prefix. By switching to `usearch_preceding(1)` we check if index == 0 matches by asking for the first match before index 1.

Benchmark:

```cs
public class Perf_StartsWith
{
    [Params(512, 200_000)]
    public int Length;

    [Params(true, false)]
    public bool Cached;

    private string left;
    private string Left => Cached ? left : string.Concat(new string('a', Length), "-");

    [GlobalSetup]
    public void Setup() => left = string.Concat(new string('a', Length), "-");

    [Benchmark]
    public bool StartsWith() => Left.StartsWith("i", StringComparison.CurrentCulture);
}
```

Results:

```ini
BenchmarkDotNet=v0.11.5.1159-nightly, OS=ubuntu 18.04
Intel Xeon CPU E5-2673 v4 2.30GHz, 1 CPU, 4 logical and 2 physical cores
.NET Core SDK=2.2.301
  [Host]     : .NET Core 2.2.6 (CoreCLR 4.6.27817.03, CoreFX 4.6.27818.02), X64 RyuJIT
  Job-RWHUVW : .NET Core ? (CoreCLR 5.0.19.45301, CoreFX 5.0.19.45102), X64 RyuJIT
  Job-QBRXWX : .NET Core ? (CoreCLR 5.0.19.45201, CoreFX 5.0.19.43103), X64 RyuJIT
```

|     Method |          Toolchain | Length | Cached |         Mean | Ratio |
|----------- |------------------- |------- |------- |-------------:|------:|
| StartsWith | /Core_Root/corerun |    512 |  False |     8.696 us |  0.29 |
| StartsWith |    /before/corerun |    512 |  False |    30.485 us |  1.00 |
|            |                    |        |        |              |       |
| StartsWith | /Core_Root/corerun |    512 |   True |     6.771 us |  0.23 |
| StartsWith |    /before/corerun |    512 |   True |    29.944 us |  1.00 |
|            |                    |        |        |              |       |
| StartsWith | /Core_Root/corerun | 200000 |  False |   523.546 us |  0.06 |
| StartsWith |    /before/corerun | 200000 |  False | 9,264.775 us |  1.00 |
|            |                    |        |        |              |       |
| StartsWith | /Core_Root/corerun | 200000 |   True |    45.512 us | 0.005 |
| StartsWith |    /before/corerun | 200000 |   True | 8,850.251 us | 1.000 |

This is my first attempt to solve https://github.com/dotnet/corefx/issues/40674, most probably more improvements coming soon (I am still not happy about the execution time).
