### PR TITLE
GC long running tests

### DIFF
--- a/eng/pipelines/gc-longrunning.yml
+++ b/eng/pipelines/gc-longrunning.yml
@@ -1,0 +1,27 @@
+trigger: none
+
+pr: none
+
+jobs:
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: build-job.yml
+    buildConfig: release
+    platforms:
+    - Linux_x64
+    - Linux_arm64
+    - Windows_NT_x64
+    - Windows_NT_arm64
+
+- template: /eng/platform-matrix.yml
+  parameters:
+    jobTemplate: test-job.yml
+    buildConfig: release
+    platforms:
+    - Linux_x64
+    - Linux_arm64
+    - Windows_NT_x64
+    - Windows_NT_arm64
+    helixQueueGroup: ci
+    jobParameters:
+      testGroup: gc-longrunning

--- a/eng/pipelines/gc-longrunning.yml
+++ b/eng/pipelines/gc-longrunning.yml
@@ -9,9 +9,9 @@ jobs:
     buildConfig: release
     platforms:
     - Linux_x64
-    - Linux_arm64
+# disable ARM for now    - Linux_arm64
     - Windows_NT_x64
-    - Windows_NT_arm64
+# disable ARM for now    - Windows_NT_arm64
 
 - template: /eng/platform-matrix.yml
   parameters:
@@ -19,9 +19,9 @@ jobs:
     buildConfig: release
     platforms:
     - Linux_x64
-    - Linux_arm64
+# disable ARM for now    - Linux_arm64
     - Windows_NT_x64
-    - Windows_NT_arm64
+# disable ARM for now    - Windows_NT_arm64
     helixQueueGroup: ci
     jobParameters:
       testGroup: gc-longrunning

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -279,6 +279,9 @@ jobs:
       osGroup: Windows_NT
       osIdentifier: Windows_NT
       helixQueues:
+      # TODO: UNDO the following two lines before merging. This is just to verify that tests can run on Win/ARM64. 
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'ci', 'corefx')) }}:
+        - Windows.10.Arm64.Open
       # TODO: Consider adding Windows.10.Arm64.Open here if capacity is enough for handling both Windows_NT/arm and Windows_NT/arm64 testing
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - Windows.10.Arm64

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -279,9 +279,6 @@ jobs:
       osGroup: Windows_NT
       osIdentifier: Windows_NT
       helixQueues:
-      # TODO: UNDO the following two lines before merging. This is just to verify that tests can run on Win/ARM64. 
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'ci', 'corefx')) }}:
-        - Windows.10.Arm64.Open
       # TODO: Consider adding Windows.10.Arm64.Open here if capacity is enough for handling both Windows_NT/arm and Windows_NT/arm64 testing
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - Windows.10.Arm64

--- a/eng/run-test-job.yml
+++ b/eng/run-test-job.yml
@@ -62,6 +62,8 @@ jobs:
       timeoutInMinutes: 150
     ${{ if in(parameters.testGroup, 'outerloop') }}:
       timeoutInMinutes: 270
+    ${{ if in(parameters.testGroup, 'gc-longrunning') }}:
+      timeoutInMinutes: 360
     ${{ if in(parameters.testGroup, 'jitstress', 'jitstress-isas-arm', 'jitstressregs-x86', 'jitstressregs', 'jitstress2-jitstressregs', 'gcstress0x3-gcstress0xc') }}:
       timeoutInMinutes: 390
     ${{ if in(parameters.testGroup, 'jitstress-isas-x86', 'gcstress-extra', 'r2r-extra') }}:
@@ -127,7 +129,10 @@ jobs:
           timeoutPerTestInMinutes: 10
         ${{ if in(parameters.testGroup, 'outerloop') }}:
           timeoutPerTestCollectionInMinutes: 120
-          timeoutPerTestInMinutes: 10
+          timeoutPerTestInMinutes: 10          
+        ${{ if in(parameters.testGroup, 'gc-longrunning') }}:
+          timeoutPerTestCollectionInMinutes: 270
+          timeoutPerTestInMinutes: 90
         ${{ if in(parameters.testGroup, 'jitstress', 'jitstress-isas-arm', 'jitstress-isas-x86', 'jitstressregs-x86', 'jitstressregs', 'jitstress2-jitstressregs' ) }}:
           timeoutPerTestCollectionInMinutes: 120
           timeoutPerTestInMinutes: 30
@@ -254,3 +259,7 @@ jobs:
           - jitminopts
           - forcerelocs
           - gcstress15
+        ${{ if in(parameters.testGroup, 'gc-longrunning') }}:
+          longRunningGcTests: true
+          scenarios:
+          - normal

--- a/eng/run-test-job.yml
+++ b/eng/run-test-job.yml
@@ -63,7 +63,7 @@ jobs:
     ${{ if in(parameters.testGroup, 'outerloop') }}:
       timeoutInMinutes: 270
     ${{ if in(parameters.testGroup, 'gc-longrunning') }}:
-      timeoutInMinutes: 360
+      timeoutInMinutes: 480
     ${{ if in(parameters.testGroup, 'jitstress', 'jitstress-isas-arm', 'jitstressregs-x86', 'jitstressregs', 'jitstress2-jitstressregs', 'gcstress0x3-gcstress0xc') }}:
       timeoutInMinutes: 390
     ${{ if in(parameters.testGroup, 'jitstress-isas-x86', 'gcstress-extra', 'r2r-extra') }}:
@@ -131,8 +131,9 @@ jobs:
           timeoutPerTestCollectionInMinutes: 120
           timeoutPerTestInMinutes: 10          
         ${{ if in(parameters.testGroup, 'gc-longrunning') }}:
-          timeoutPerTestCollectionInMinutes: 270
-          timeoutPerTestInMinutes: 90
+          timeoutPerTestCollectionInMinutes: 360
+          # gc reliability may take up to 2 hours to shutdown. Some scenarios have very long iteration times.
+          timeoutPerTestInMinutes: 240
         ${{ if in(parameters.testGroup, 'jitstress', 'jitstress-isas-arm', 'jitstress-isas-x86', 'jitstressregs-x86', 'jitstressregs', 'jitstress2-jitstressregs' ) }}:
           timeoutPerTestCollectionInMinutes: 120
           timeoutPerTestInMinutes: 30

--- a/eng/send-to-helix-step.yml
+++ b/eng/send-to-helix-step.yml
@@ -17,6 +17,7 @@ parameters:
   runCrossGen: ''
   helixProjectArguments: ''
   runInUnloadableContext: ''
+  longRunningGcTests: ''
 
 steps:
 - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
@@ -43,6 +44,7 @@ steps:
       _HelixType: ${{ parameters.helixType }}
       _RunCrossGen: ${{ parameters.runCrossGen }}
       _RunInUnloadableContext: ${{ parameters.runInUnloadableContext }}
+      _LongRunningGcTests: ${{ parameters.longRunningGcTests }}
       _Scenarios: ${{ join(',', parameters.scenarios) }}
       _TimeoutPerTestCollectionInMinutes: ${{ parameters.timeoutPerTestCollectionInMinutes }}
       _TimeoutPerTestInMinutes: ${{ parameters.timeoutPerTestInMinutes }}
@@ -79,6 +81,7 @@ steps:
       _HelixType: ${{ parameters.helixType }}
       _RunCrossGen: ${{ parameters.runCrossGen }}
       _RunInUnloadableContext: ${{ parameters.runInUnloadableContext }}
+      _LongRunningGcTests: ${{ parameters.longRunningGcTests }}
       _Scenarios: ${{ join(',', parameters.scenarios) }}
       _TimeoutPerTestCollectionInMinutes: ${{ parameters.timeoutPerTestCollectionInMinutes }}
       _TimeoutPerTestInMinutes: ${{ parameters.timeoutPerTestInMinutes }}

--- a/tests/helixpublishwitharcade.proj
+++ b/tests/helixpublishwitharcade.proj
@@ -25,6 +25,7 @@
         HelixType=$(_HelixType);
         PublishTestResults=$(_PublishTestResults);
         RunCrossGen=$(_RunCrossGen);
+        LongRunningGCTests=$(_LongRunningGCTests);
         RunInUnloadableContext=$(_RunInUnloadableContext);
         TimeoutPerTestCollectionInMinutes=$(_TimeoutPerTestCollectionInMinutes);
         TimeoutPerTestInMinutes=$(_TimeoutPerTestInMinutes)
@@ -159,6 +160,8 @@
     <MSBuild Projects="@(_ProjectsToBuild)" Targets="CreateTestEnvFiles" StopOnFirstFailure="true" />
   </Target>
 
+    
+  
   <PropertyGroup>
     <EnableAzurePipelinesReporter>$(PublishTestResults)</EnableAzurePipelinesReporter>
     <EnableAzurePipelinesReporter Condition=" '$(EnableAzurePipelinesReporter)' == '' ">false</EnableAzurePipelinesReporter>
@@ -169,12 +172,15 @@
     <HelixConfiguration Condition=" '$(Scenario)' == 'normal' ">$(BuildType)</HelixConfiguration>
     <HelixConfiguration Condition=" '$(Scenario)' != 'normal' ">$(BuildType)-$(Scenario)</HelixConfiguration>
     <RunCrossGen Condition=" '$(RunCrossGen)' != 'true' ">false</RunCrossGen>
+    <LongRunningGCTests Condition=" '$(LongRunningGCTests)' != 'true' ">false</LongRunningGCTests>
     <TestRunNamePrefix Condition=" '$(RunCrossGen)' == 'true' ">R2R </TestRunNamePrefix>
     <TestRunNamePrefix Condition=" '$(Scenario)' == 'normal' ">$(TestRunNamePrefix)$(BuildOS) $(BuildArch) $(BuildType) @ </TestRunNamePrefix>
     <TestRunNamePrefix Condition=" '$(Scenario)' != 'normal' ">$(TestRunNamePrefix)$(BuildOS) $(BuildArch) $(BuildType) $(Scenario) @ </TestRunNamePrefix>
     <TimeoutPerTestInMilliseconds Condition=" '$(TimeoutPerTestInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestInMinutes)).TotalMilliseconds)</TimeoutPerTestInMilliseconds>
     <WaitForWorkItemCompletion>true</WaitForWorkItemCompletion>
-    <XUnitRunnerArgs>-parallel collections -nocolor -noshadow -xml testResults.xml</XUnitRunnerArgs>
+    <_XUnitParallelMode>collections</_XUnitParallelMode>
+    <_XUnitParallelMode Condition=" '$(LongRunningGCTests)' == 'true' ">none</_XUnitParallelMode>
+    <XUnitRunnerArgs>-parallel $(_XUnitParallelMode) -nocolor -noshadow -xml testResults.xml</XUnitRunnerArgs>
   </PropertyGroup>
 
   <!-- WARNING: HelixPreCommand ItemGroup is intentionally minimal and should be kept that way. -->
@@ -182,6 +188,7 @@
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
     <HelixPreCommand Include="set CORE_ROOT=%HELIX_CORRELATION_PAYLOAD%" />
     <HelixPreCommand Include="set RunCrossGen=1" Condition=" '$(RunCrossGen)' == 'true' " />
+    <HelixPreCommand Include="set RunningLongGCTests=1" Condition=" '$(LongRunningGCTests)' == 'true' " />
     <HelixPreCommand Include="set RunInUnloadableContext=1" Condition=" '$(RunInUnloadableContext)' == 'true' " />
     <HelixPreCommand Include="set CLRCustomTestLauncher=%HELIX_CORRELATION_PAYLOAD%\runincontext.cmd" Condition=" '$(RunInUnloadableContext)' == 'true' " />
     <HelixPreCommand Include="set __TestEnv=%HELIX_WORKITEM_PAYLOAD%\$(TestEnvFileName)" />
@@ -192,6 +199,7 @@
   <ItemGroup Condition=" '$(TargetsWindows)' != 'true' ">
     <HelixPreCommand Include="export CORE_ROOT=$HELIX_CORRELATION_PAYLOAD" />
     <HelixPreCommand Include="export RunCrossGen=1" Condition=" '$(RunCrossGen)' == 'true' " />
+    <HelixPreCommand Include="export RunningLongGCTests=1" Condition=" '$(LongRunningGCTests)' == 'true' " />
     <HelixPreCommand Include="export RunInUnloadableContext=1" Condition=" '$(RunInUnloadableContext)' == 'true' " />
     <HelixPreCommand Include="export CLRCustomTestLauncher=$HELIX_CORRELATION_PAYLOAD/runincontext.sh" Condition=" '$(RunInUnloadableContext)' == 'true' " />
     <HelixPreCommand Include="export __TestEnv=$HELIX_WORKITEM_PAYLOAD/$(TestEnvFileName)" />

--- a/tests/src/GC/Stress/Framework/LoaderClass.cs
+++ b/tests/src/GC/Stress/Framework/LoaderClass.cs
@@ -146,7 +146,7 @@ public class LoaderClass
 #if !PROJECTK_BUILD
             assem = Assembly.Load(an);
 #else
-            LoadFrom(assemblyName + ".exe", paths);
+            LoadFrom(assemblyName + ".dll", paths);
 #endif
         }
         catch
@@ -200,7 +200,7 @@ public class LoaderClass
         }
         catch (System.Reflection.ReflectionTypeLoadException e)
         {
-            if (assembly.ToLower().IndexOf(".exe") != -1)
+            if (assembly.ToLower().IndexOf(".dll") != -1)
                 return (assembly);
             throw new Exception(String.Format("Couldn't GetTypes for {0} ({1})", assembly, e.Message));
         }

--- a/tests/src/GC/Stress/Framework/ReliabilityConfiguration.cs
+++ b/tests/src/GC/Stress/Framework/ReliabilityConfiguration.cs
@@ -187,7 +187,7 @@ public class ReliabilityConfig : IEnumerable, IEnumerator
         throw new Exception(String.Format("Unknown option value for {0}: {1}", configSettingName, value));
     }
 
-
+    // returns time in minutes
     public static int ConvertTimeValueToTestRunTime(string timeValue)
     {
         int returnValue;
@@ -381,7 +381,15 @@ public class ReliabilityConfig : IEnumerable, IEnumerator
 
                                 _curTestSet = new ReliabilityTestSet();
 
-                                while (currentXML.MoveToNextAttribute())
+                                // when running as an ordinary test, limit run time to 10 min.
+                                bool limitTime = ReliabilityFramework.IsRunningAsUnitTest && !ReliabilityFramework.IsRunningLongGCTests;
+
+                                if (limitTime)
+                                {
+                                    _curTestSet.MaximumTime = 10;
+                                }
+
+                                    while (currentXML.MoveToNextAttribute())
                                 {
                                     XmlDebugOut(" " + currentXML.Name + "=\"" + currentXML.Value + "\"");
                                     switch (currentXML.Name)
@@ -391,7 +399,12 @@ public class ReliabilityConfig : IEnumerable, IEnumerator
                                             break;
                                         case "maximumExecutionTime":
                                             string timeValue = currentXML.Value;
-                                            _curTestSet.MaximumTime = ConvertTimeValueToTestRunTime(timeValue);
+
+                                            if (!limitTime)
+                                            {
+                                                _curTestSet.MaximumTime = ConvertTimeValueToTestRunTime(timeValue);
+                                            }
+
                                             break;
                                         case "id":
                                             _curTestSet.FriendlyName = currentXML.Value;

--- a/tests/src/GC/Stress/Framework/ReliabilityFramework.csproj
+++ b/tests/src/GC/Stress/Framework/ReliabilityFramework.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestKind>BuildOnly</CLRTestKind>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestExecutionArguments>-unittest</CLRTestExecutionArguments>
     <GenerateRunScript>false</GenerateRunScript>
+    <IsLongRunningGCTest>true</IsLongRunningGCTest>
     <CLRTestPriority>0</CLRTestPriority>
     <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
   </PropertyGroup>
@@ -19,11 +21,14 @@
     <Content Include="..\testmix_gc.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\testmix_gc_ci.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <StressTests Include="..\Tests\*.csproj" />
   </ItemGroup>
-  <Target Name="AfterBuild">
+  <Target Name="CompileTests" AfterTargets="AfterBuild">
     <MSBuild Projects="@(StressTests)" Properties="OutputPath=$(OutDir)\Tests;BuildingForReliabilityFramework=true" />
   </Target>
 </Project>

--- a/tests/src/GC/Stress/Framework/ReliabilityTest.cs
+++ b/tests/src/GC/Stress/Framework/ReliabilityTest.cs
@@ -42,7 +42,7 @@ public class TestAssemblyLoadContext : AssemblyLoadContext
 
     public int ExecuteAssemblyByName(string name, string[] args)
     {
-        return ExecuteAssembly(name + ".exe", args);
+        return ExecuteAssembly(name + ".dll", args);
 
     }
 

--- a/tests/src/GC/Stress/testmix_gc_ci.config
+++ b/tests/src/GC/Stress/testmix_gc_ci.config
@@ -64,7 +64,7 @@
    <Assembly id="GCSimulator.dll" 
             successCode="100" 
             filename="GCSimulator.dll" 
-            arguments="-dp 0.05 -t 8" 
+            arguments="-dp 0.05 -t 8 -iter 50" 
             concurrentCopies="1" 
     /> 
    <Assembly id="GCVariant.dll" 
@@ -112,7 +112,7 @@
    <Assembly id="StressAllocator.dll" 
             successCode="100" 
             filename="StressAllocator.dll" 
-            arguments="" 
+            arguments="-iter 50" 
             concurrentCopies="1" 
     />    
    <Assembly id="ThdTreeGrowingObj.dll" 

--- a/tests/src/GC/Stress/testmix_gc_ci.config
+++ b/tests/src/GC/Stress/testmix_gc_ci.config
@@ -2,7 +2,7 @@
 <Test xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
             id="NightlyRun" 
             maximumTestRuns="-1" 
-            maximumExecutionTime="00:20:00" 
+            maximumExecutionTime="01:00:00" 
             defaultTestLoader="processLoader"
             minimumCPU="0" 
             minimumMem="0" 

--- a/tests/src/GC/Stress/testmix_gc_ci.config
+++ b/tests/src/GC/Stress/testmix_gc_ci.config
@@ -2,16 +2,16 @@
 <Test xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
             id="NightlyRun" 
             maximumTestRuns="-1" 
-            maximumExecutionTime="15:15:00" 
+            maximumExecutionTime="00:20:00" 
             defaultTestLoader="processLoader"
             minimumCPU="0" 
             minimumMem="0" 
             maximumTests="0" 
-            percentPassIsPass="85" 
+            percentPassIsPass="100" 
             installDetours="false" 
             minimumTests="0" 
             minMaxTestUseCPUCount="true" 
-            suppressConsoleOutputFromTests="false">
+            suppressConsoleOutputFromTests="true">
 
    <Assembly id="573277.dll" 
             successCode="100" 


### PR DESCRIPTION
 **To launch the pipeline just do: `/azp run gc-longrunning` on a PR** 

== what is included here:
- new pipeline introduced with the name "gc-longrunning". 
- the pipeline includes gc long running tests and gc reliability framework
- gc long running tests are identified by `<IsLongRunningGCTest>true</IsLongRunningGCTest>` in the proj file.   
- Reliability framework has `IsLongRunningGCTest` as well. Also it has a unit test mode that is enabled by `-unittest` cmd switch
- unit test mode primarily changes the config file selection ( we look for `*_gc_ci.config` ). Another effect of `-unittest` is **FailFast** on most failures.


== NOTE:
- 32bit platforms are not enabled yet. Some tests cause OOMs and that may be by design. We want to run a subset on 32bit eventually, but need to figure how to filter or scale down tests for which 32bit is a challenge.
- The internal timeout for reliability framework in CI configuration is 1 hour. We can easily extend that later.  For now we want to run the pipeline more frequently, for shorter duration - to evaluate how reliable the pipeline is. 
Note that this timeout controls when we _stop launching iterations_. We will still wait (up to 2 hours) for iterations in-flight to finish.

