### PR TITLE
[single-exe] Loader: Fix an assertion failure when running from corbundle

### DIFF
--- a/src/pal/src/loader/module.cpp
+++ b/src/pal/src/loader/module.cpp
@@ -1557,8 +1557,7 @@ Return value:
 static MODSTRUCT *LOADAddModule(NATIVE_LIBRARY_HANDLE dl_handle, LPCSTR libraryNameOrPath)
 {
     _ASSERTE(dl_handle != nullptr);
-    _ASSERTE(libraryNameOrPath != nullptr);
-    _ASSERTE(libraryNameOrPath[0] != '\0');
+    _ASSERTE(g_running_in_exe || (libraryNameOrPath != nullptr && libraryNameOrPath[0] != '\0'));
 
 #if !RETURNS_NEW_HANDLES_ON_REPEAT_DLOPEN
     /* search module list for a match. */
@@ -1582,6 +1581,8 @@ static MODSTRUCT *LOADAddModule(NATIVE_LIBRARY_HANDLE dl_handle, LPCSTR libraryN
 
     } while (module != &exe_module);
 #endif
+
+    _ASSERTE(!g_running_in_exe);
 
     TRACE("Module doesn't exist : creating %s.\n", libraryNameOrPath);
 


### PR DESCRIPTION
In LOADAddModule(), libraryNameOrPath is null when running from exe.
Fix the asserion to accomodate it.
Checked runs of corebundle fail without this fix.