### PR TITLE
Optimise 'Math.CopySign' and 'MathF.CopySign'

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Math.cs
+++ b/src/System.Private.CoreLib/shared/System/Math.cs
@@ -167,7 +167,7 @@ namespace System
 
         public static unsafe double CopySign(double x, double y)
         {
-            const long signMask 
+            const long signMask
                 = unchecked((long)0b_1000_0000__0000_0000__0000_0000__0000_0000__0000_0000__0000_0000__0000_0000__0000_0000);
 
             if (Sse.IsSupported)

--- a/src/System.Private.CoreLib/shared/System/Math.cs
+++ b/src/System.Private.CoreLib/shared/System/Math.cs
@@ -18,6 +18,8 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
 using System.Runtime.Versioning;
 
 namespace System

--- a/src/System.Private.CoreLib/shared/System/Math.cs
+++ b/src/System.Private.CoreLib/shared/System/Math.cs
@@ -170,7 +170,7 @@ namespace System
 
             if (Sse.IsSupported)
             {
-                // Create vectors of the elements, and make them float to allow using SSE rather than SSE instructions
+                // Create vectors of the elements, and make them float to allow using SSE rather than SSE2 instructions
                 var xvec = Vector128.CreateScalarUnsafe(x).AsSingle();
                 var yvec = Vector128.CreateScalarUnsafe(y).AsSingle();
 

--- a/src/System.Private.CoreLib/shared/System/Math.cs
+++ b/src/System.Private.CoreLib/shared/System/Math.cs
@@ -180,8 +180,8 @@ namespace System
                 // Remove the sign from x, and remove everything but the sign from y
                 // Creating from a 'const long' is better than from the correct 'const float/double'
                 var mask = Vector128.CreateScalarUnsafe(signMask).AsSingle();
+                yvec = Sse.And(yvec, mask);
                 xvec = Sse.AndNot(mask, xvec);
-                yvec = Sse.And(mask, yvec);
 
                 // Simply OR them to get the correct sign
                 return Sse.Or(xvec, yvec).AsDouble().ToScalar();

--- a/src/System.Private.CoreLib/shared/System/Math.cs
+++ b/src/System.Private.CoreLib/shared/System/Math.cs
@@ -165,22 +165,39 @@ namespace System
 
         public static unsafe double CopySign(double x, double y)
         {
-            // This method is required to work for all inputs,
-            // including NaN, so we operate on the raw bits.
+            const long signMask 
+                = unchecked((long)0b_1000_0000__0000_0000__0000_0000__0000_0000__0000_0000__0000_0000__0000_0000__0000_0000);
 
-            long xbits = BitConverter.DoubleToInt64Bits(x);
-            long ybits = BitConverter.DoubleToInt64Bits(y);
-
-            // If the sign bits of x and y are not the same,
-            // flip the sign bit of x and return the new value;
-            // otherwise, just return x
-
-            if ((xbits ^ ybits) < 0)
+            if (Sse.IsSupported)
             {
-                return BitConverter.Int64BitsToDouble(xbits ^ long.MinValue);
-            }
+                // Create vectors of the elements, and make them float to allow using SSE rather than SSE instructions
+                var xvec = Vector128.CreateScalarUnsafe(x).AsSingle();
+                var yvec = Vector128.CreateScalarUnsafe(y).AsSingle();
 
-            return x;
+                // Remove the sign from x, and remove everything but the sign from y
+                // Creating from a 'const long' is better than from the correct 'const float/double'
+                xvec = Sse.And(xvec, Vector128.CreateScalarUnsafe(~signMask).AsSingle());
+                yvec = Sse.And(yvec, Vector128.CreateScalarUnsafe(signMask).AsSingle());
+
+                // Simply OR them to get the correct sign
+                return Sse.Or(xvec, yvec).AsDouble().ToScalar();
+            }
+            else
+            {
+                // This method is required to work for all inputs,
+                // including NaN, so we operate on the raw bits.
+
+                long xbits = BitConverter.DoubleToInt64Bits(x);
+                long ybits = BitConverter.DoubleToInt64Bits(y);
+
+                // Remove the sign from x, and remove everything but the sign from y
+
+                xbits &= ~signMask;
+                ybits &= signMask;
+
+                // Simply OR them to get the correct sign
+                return BitConverter.Int64BitsToDouble(xbits | ybits);
+            }
         }
 
         public static int DivRem(int a, int b, out int result)

--- a/src/System.Private.CoreLib/shared/System/Math.cs
+++ b/src/System.Private.CoreLib/shared/System/Math.cs
@@ -165,6 +165,7 @@ namespace System
             return BitConverter.Int64BitsToDouble(bits);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe double CopySign(double x, double y)
         {
             const long signMask
@@ -187,6 +188,14 @@ namespace System
             }
             else
             {
+                return SoftwareFallback(x, y);
+            }
+
+            static double SoftwareFallback(double x, double y)
+            {
+                const long signMask
+                                = unchecked((long)0b_1000_0000__0000_0000__0000_0000__0000_0000__0000_0000__0000_0000__0000_0000__0000_0000);
+
                 // This method is required to work for all inputs,
                 // including NaN, so we operate on the raw bits.
 

--- a/src/System.Private.CoreLib/shared/System/Math.cs
+++ b/src/System.Private.CoreLib/shared/System/Math.cs
@@ -176,8 +176,9 @@ namespace System
 
                 // Remove the sign from x, and remove everything but the sign from y
                 // Creating from a 'const long' is better than from the correct 'const float/double'
-                xvec = Sse.And(xvec, Vector128.CreateScalarUnsafe(~signMask).AsSingle());
-                yvec = Sse.And(yvec, Vector128.CreateScalarUnsafe(signMask).AsSingle());
+                var mask = Vector128.CreateScalarUnsafe(signMask).AsSingle();
+                xvec = Sse.AndNot(mask, xvec);
+                yvec = Sse.And(mask, yvec);
 
                 // Simply OR them to get the correct sign
                 return Sse.Or(xvec, yvec).AsDouble().ToScalar();

--- a/src/System.Private.CoreLib/shared/System/Math.cs
+++ b/src/System.Private.CoreLib/shared/System/Math.cs
@@ -171,7 +171,7 @@ namespace System
             const long signMask
                 = unchecked((long)0b_1000_0000__0000_0000__0000_0000__0000_0000__0000_0000__0000_0000__0000_0000__0000_0000);
 
-            if (Sse.IsSupported)
+            if (Sse.X64.IsSupported)
             {
                 // Create vectors of the elements, and make them float to allow using SSE rather than SSE2 instructions
                 var xvec = Vector128.CreateScalarUnsafe(x).AsSingle();

--- a/src/System.Private.CoreLib/shared/System/MathF.cs
+++ b/src/System.Private.CoreLib/shared/System/MathF.cs
@@ -14,6 +14,8 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
 
 namespace System
 {

--- a/src/System.Private.CoreLib/shared/System/MathF.cs
+++ b/src/System.Private.CoreLib/shared/System/MathF.cs
@@ -95,7 +95,7 @@ namespace System
         {
             const int signMask = unchecked((int)0b_1000_0000__0000_0000__0000_0000__0000_0000);
 
-            if (Sse.IsSupported)
+            if (Sse.X64.IsSupported)
             {
                 var xvec = Vector128.CreateScalarUnsafe(x);
                 var yvec = Vector128.CreateScalarUnsafe(y);

--- a/src/System.Private.CoreLib/shared/System/MathF.cs
+++ b/src/System.Private.CoreLib/shared/System/MathF.cs
@@ -94,7 +94,6 @@ namespace System
 
             if (Sse.IsSupported)
             {
-                // Create vectors of the elements, and make them float to allow using SSE rather than SSE instructions
                 var xvec = Vector128.CreateScalarUnsafe(x);
                 var yvec = Vector128.CreateScalarUnsafe(y);
 

--- a/src/System.Private.CoreLib/shared/System/MathF.cs
+++ b/src/System.Private.CoreLib/shared/System/MathF.cs
@@ -103,8 +103,8 @@ namespace System
                 // Remove the sign from x, and remove everything but the sign from y
                 // Creating from a 'const long' is better than from the correct 'const float/double'
                 var mask = Vector128.CreateScalarUnsafe(signMask).AsSingle();
+                yvec = Sse.And(yvec, mask);
                 xvec = Sse.AndNot(mask, xvec);
-                yvec = Sse.And(mask, yvec);
 
                 // Simply OR them to get the correct sign
                 return Sse.Or(xvec, yvec).ToScalar();

--- a/src/System.Private.CoreLib/shared/System/MathF.cs
+++ b/src/System.Private.CoreLib/shared/System/MathF.cs
@@ -90,6 +90,7 @@ namespace System
             return BitConverter.Int32BitsToSingle(bits);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe float CopySign(float x, float y)
         {
             const int signMask = unchecked((int)0b_1000_0000__0000_0000__0000_0000__0000_0000);
@@ -110,6 +111,13 @@ namespace System
             }
             else
             {
+                return SoftwareFallback(x, y);
+            }
+
+            static float SoftwareFallback(float x, float y)
+            {
+                const int signMask = unchecked((int)0b_1000_0000__0000_0000__0000_0000__0000_0000);
+
                 // This method is required to work for all inputs,
                 // including NaN, so we operate on the raw bits.
 

--- a/src/System.Private.CoreLib/shared/System/MathF.cs
+++ b/src/System.Private.CoreLib/shared/System/MathF.cs
@@ -100,8 +100,9 @@ namespace System
 
                 // Remove the sign from x, and remove everything but the sign from y
                 // Creating from a 'const long' is better than from the correct 'const float/double'
-                xvec = Sse.And(xvec, Vector128.CreateScalarUnsafe(~signMask).AsSingle());
-                yvec = Sse.And(yvec, Vector128.CreateScalarUnsafe(signMask).AsSingle());
+                var mask = Vector128.CreateScalarUnsafe(signMask).AsSingle();
+                xvec = Sse.AndNot(mask, xvec);
+                yvec = Sse.And(mask, yvec);
 
                 // Simply OR them to get the correct sign
                 return Sse.Or(xvec, yvec).ToScalar();


### PR DESCRIPTION
([now in the correct repo 🥇](https://github.com/dotnet/corefx/pull/40782))

Optimise 'Math.CopySign' and 'MathF.CopySign'. Both of these methods can be improved from their current implementation. The new implementation uses SSE intrinsics which are faster, as well as having a faster intrinsic-free branch.

The SSE pathway doesn't spill to the stack, unlike the others, and is branch free. The fallback is also branch free but does spill to the stack (the current implementation spills and contains a branch). These are faster in every scenario, except for the non-SSE fallback for double precision being marginally (10%) slower on x64 in the Same scenario - however, windows (and x64) requires SSE2 so it is unlikely this code is ever going to be run on x86. I haven't profiled on ARM as I don't have access to an ARM system.

Benchmark sources [here](https://gist.github.com/john-h-k/6afa22a904ed81c8e1c0e82b3e5b7600)

Scenarios:
Same - every sign is the same (e.g `x == 1f, y == 2f`)
Different - every sign is different (e.g `x == 1f, y == -2f`)
Alternating - alternates between same and different
Random - randomly same or different

Single precision (`MathF`):

|         Method |    Scenario |      Mean |     Error |    StdDev |
|--------------- |------------ |----------:|----------:|----------:|
|       Standard |      Random | 181.14 us | 1.0300 us | 0.8601 us |
|           John |      Random |  47.49 us | 0.1613 us | 0.1347 us |
| John_Intrinsic |      Random |  39.79 us | 0.4956 us | 0.4636 us |
|       Standard |        Same |  43.59 us | 0.2158 us | 0.2019 us |
|           John |        Same |  49.11 us | 0.6777 us | 0.6339 us |
| John_Intrinsic |        Same |  39.74 us | 0.2084 us | 0.1949 us |
|       Standard |   Different |  56.04 us | 0.6402 us | 0.5988 us |
|           John |   Different |  49.58 us | 0.9119 us | 0.8529 us |
| John_Intrinsic |   Different |  39.80 us | 0.2419 us | 0.1889 us |
|       Standard | Alternating |  48.89 us | 0.1422 us | 0.1330 us |
|           John | Alternating |  47.48 us | 0.0766 us | 0.0717 us |
| John_Intrinsic | Alternating |  39.05 us | 0.0289 us | 0.0226 us |

Double precision (`Math`):

|         Method |    Scenario |      Mean |     Error |    StdDev |
|--------------- |------------ |----------:|----------:|----------:|
|       Standard |      Random | 176.77 us | 0.3537 us | 0.2954 us |
|           John |      Random |  53.74 us | 0.1543 us | 0.1443 us |
| John_Intrinsic |      Random |  41.22 us | 0.1321 us | 0.1236 us |
|       Standard |        Same |  48.64 us | 0.1322 us | 0.1237 us |
|           John |        Same |  53.85 us | 0.1499 us | 0.1402 us |
| John_Intrinsic |        Same |  41.44 us | 0.2931 us | 0.2742 us |
|       Standard |   Different |  59.91 us | 0.0642 us | 0.0569 us |
|           John |   Different |  53.72 us | 0.1779 us | 0.1664 us |
| John_Intrinsic |   Different |  41.09 us | 0.0346 us | 0.0289 us |
|       Standard | Alternating |  54.06 us | 0.1293 us | 0.1210 us |
|           John | Alternating |  53.84 us | 0.1772 us | 0.1658 us |
| John_Intrinsic | Alternating |  41.11 us | 0.0681 us | 0.0604 us |