### PR TITLE
Add function to mark clean pages of PE files as not needed

### DIFF
--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -12,6 +12,9 @@ namespace System.Runtime.CompilerServices
     public static partial class RuntimeHelpers
     {
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        public static extern void FlushPECaches();
+
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
         public static extern void InitializeArray(Array array, RuntimeFieldHandle fldHandle);
 
         // GetObjectValue is intended to allow value classes to be manipulated as 'Object'

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -2706,6 +2706,25 @@ BOOL
 PALAPI
 PAL_LOADMarkSectionAsNotNeeded(void * ptr);
 
+/*++
+    PAL_LOADMarkDontNeedCleanPages
+
+    Try to mark clean pages from range as not needed.
+
+Parameters:
+    IN base - base address of pe image
+    IN ptr - start address of range
+    IN size - size of range in bytes
+
+Return value:
+    TRUE - success
+    FALSE - failure
+--*/
+PALIMPORT
+BOOL
+PALAPI
+PAL_LOADMarkDontNeedCleanPages(PVOID base, PVOID ptr, SIZE_T size);
+
 #ifdef UNICODE
 #define LoadLibrary LoadLibraryW
 #define LoadLibraryEx LoadLibraryExW

--- a/src/pal/src/include/pal/map.hpp
+++ b/src/pal/src/include/pal/map.hpp
@@ -101,6 +101,20 @@ extern "C"
         returns TRUE if successful, FALSE otherwise
     --*/
     BOOL MAPMarkSectionAsNotNeeded(LPCVOID lpAddress);
+
+    /*++
+        MAPMarkDontNeedCleanPages - try to mark clean pages from range as not needed
+
+    Parameters:
+        IN lpBase - base address of pe image
+        IN lpAddress - start address of range
+        IN size - size of range in bytes
+
+    Return value:
+        TRUE - success
+        FALSE - failure
+    --*/
+    BOOL MAPMarkDontNeedCleanPages(LPCVOID lpBase, LPCVOID lpAddress, SIZE_T size);
 }
 
 namespace CorUnix

--- a/src/pal/src/include/pal/module.h
+++ b/src/pal/src/include/pal/module.h
@@ -167,6 +167,22 @@ Return value:
 BOOL PAL_LOADUnloadPEFile(void * ptr);
 
 /*++
+    PAL_LOADMarkDontNeedCleanPages
+
+    Try to mark clean pages from range as not needed.
+
+Parameters:
+    IN base - base address of pe image
+    IN ptr - start address of range
+    IN size - size of range in bytes
+
+Return value:
+    TRUE - success
+    FALSE - failure
+--*/
+BOOL PAL_LOADMarkDontNeedCleanPages(PVOID base, PVOID ptr, SIZE_T size);
+
+/*++
     LOADInitializeCoreCLRModule
 
     Run the initialization methods for CoreCLR module.

--- a/src/pal/src/loader/module.cpp
+++ b/src/pal/src/loader/module.cpp
@@ -858,6 +858,40 @@ PAL_LOADMarkSectionAsNotNeeded(void * ptr)
 }
 
 /*++
+    PAL_LOADMarkDontNeedCleanPages
+
+    Try to mark clean pages from range as not needed.
+
+Parameters:
+    IN base - base address of pe image
+    IN ptr - start address of range
+    IN size - size of range in bytes
+
+Return value:
+    TRUE - success
+    FALSE - failure
+--*/
+BOOL
+PALAPI
+PAL_LOADMarkDontNeedCleanPages(PVOID base, PVOID ptr, SIZE_T size)
+{
+    BOOL retval = FALSE;
+    ENTRY("PAL_LOADMarkDontNeedCleanPages (base=%p, ptr=%p)\n", base, ptr);
+
+    if (nullptr == ptr || size == 0)
+    {
+        ERROR( "Invalid pointer value or invalid size\n" );
+    }
+    else
+    {
+        retval = MAPMarkDontNeedCleanPages(base, ptr, size);
+    }
+
+    LOGEXIT("PAL_LOADMarkDontNeedCleanPages returns %d\n", retval);
+    return retval;
+}
+
+/*++
     PAL_GetSymbolModuleBase
 
     Get base address of the module containing a given symbol

--- a/src/vm/comutilnative.cpp
+++ b/src/vm/comutilnative.cpp
@@ -2450,3 +2450,9 @@ FCIMPL1(FC_BOOL_RET, StreamNative::HasOverriddenBeginEndWrite, Object *stream)
     FC_RETURN_BOOL(HasOverriddenStreamMethod(pMT, g_slotBeginWrite) || HasOverriddenStreamMethod(pMT, g_slotEndWrite));
 }
 FCIMPLEND
+
+FCIMPL0(void, ImageInterface::FlushPECaches)
+{
+    PEImage::CleanAllReadOnlyPages();
+}
+FCIMPLEND

--- a/src/vm/comutilnative.h
+++ b/src/vm/comutilnative.h
@@ -216,4 +216,9 @@ public:
     static FCDECL1(FC_BOOL_RET, HasOverriddenBeginEndWrite, Object *stream);
 };
 
+class ImageInterface {
+public:
+    static FCDECL0(void, FlushPECaches);
+};
+
 #endif // _COMUTILNATIVE_H_

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -925,6 +925,7 @@ FCFuncStart(gOverlappedFuncs)
 FCFuncEnd()
 
 FCFuncStart(gRuntimeHelpers)
+    FCFuncElement("FlushPECaches", ImageInterface::FlushPECaches)
     FCFuncElement("GetObjectValue", ObjectNative::GetObjectValue)
     FCIntrinsic("InitializeArray", ArrayNative::InitializeArray, CORINFO_INTRINSIC_InitializeArray)
     FCFuncElement("_RunClassConstructor", ReflectionInvocation::RunClassConstructor)

--- a/src/vm/peimage.cpp
+++ b/src/vm/peimage.cpp
@@ -155,6 +155,29 @@ void PEImage::GetAll(SArray<PEImage*> &images)
     }
 }
 
+void PEImage::CleanAllReadOnlyPages()
+{
+    CONTRACTL
+    {
+        THROWS;
+        GC_TRIGGERS;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
+
+    CrstHolder holder(&s_hashLock);
+
+    for (PtrHashMap::PtrIterator i = s_Images->begin(); !i.end(); ++i)
+    {
+        PEImage *image = (PEImage*) i.GetValue();
+        PEImageLayoutHolder pLayout(image->GetLayout(PEImageLayout::LAYOUT_ANY, 0));
+        if ((PEImageLayout*)pLayout != NULL)
+        {
+            pLayout->CleanAllReadOnlyPages();
+        }
+    }
+}
+
 PEImage::~PEImage()
 {
     CONTRACTL

--- a/src/vm/peimage.h
+++ b/src/vm/peimage.h
@@ -73,6 +73,8 @@ public:
     BOOL IsOpened();
     BOOL HasLoadedLayout();
 
+    static void CleanAllReadOnlyPages();
+
 public:
     // ------------------------------------------------------------
     // Public API

--- a/src/vm/peimagelayout.h
+++ b/src/vm/peimagelayout.h
@@ -70,6 +70,8 @@ public:
 
     void ApplyBaseRelocations();
 
+    void CleanAllReadOnlyPages();
+
 public:
 #ifdef DACCESS_COMPILE
     void EnumMemoryRegions(CLRDataEnumMemoryFlags flags);


### PR DESCRIPTION
This PR provides function, which can be called from managed code (`System.Runtime.CompilerServices.FlushPECaches`) to flush caches for PE images. It marks read only pages of PE files as not needed. 

Using this on startup of Xamarin GUI application allows to reduce PSS on ~4.1 Mb and RSS on ~6.4 Mb.

Average reduction is next:
```
private: -13.1%
shared: -13.9%
pss: -15.9%
rss: -13.6%
```

All these clean pages are not loaded back to memory immediately, when user interaction starts to happen. Also, no startup regression.

cc @alpencolt 