### PR TITLE
Remove `readonly` from GCHandle field on Gen2GcCallback

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Gen2GcCallback.cs
+++ b/src/System.Private.CoreLib/shared/System/Gen2GcCallback.cs
@@ -16,7 +16,7 @@ namespace System
     {
         private readonly Func<bool>? _callback0;
         private readonly Func<object, bool>? _callback1;
-        private readonly GCHandle _weakTargetObj;
+        private GCHandle _weakTargetObj;
 
         private Gen2GcCallback(Func<bool> callback)
         {


### PR DESCRIPTION
GCHandle is mutable, and this type does call Free on the handle, but with it marked as readonly, the mutations performed by Free will be done on a copy rather than on the original.