### PR TITLE
Restore partial Corelib build support in VS

### DIFF
--- a/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -457,7 +457,7 @@
   </Target>
 
   <!-- This is working around dotnet/coreclr#26371 until dotnet/sourcelink#392 gets solved -->
-  <Target Name="AddUntrackedResourcesForSourceLink"
+  <Target Condition="'$(BuildingInsideVisualStudio)' != 'true'" Name="AddUntrackedResourcesForSourceLink"
     BeforeTargets="CoreCompile"
     DependsOnTargets="SetEmbeddedFilesFromSourceControlManagerUntrackedFiles;
                       _GenerateResxSource" >


### PR DESCRIPTION
Builds are still blocked from completing successfully in VS (tracked by various issues) but previously we could at least build enough to get warnings/errors from the compiler and analyzers.  The workaround in https://github.com/dotnet/coreclr/pull/26394 broke that; this works around the workaround.

cc: @ViktorHofer, @hoyosjs