### PR TITLE
Add regularly scheduled runs for additional pipelines

### DIFF
--- a/eng/pipelines/jitstress-isas-arm.yml
+++ b/eng/pipelines/jitstress-isas-arm.yml
@@ -2,6 +2,14 @@ trigger: none
 
 pr: none
 
+schedules:
+- cron: "0 19 * * 6"
+  displayName: Sat at 11:00 AM (UTC-8:00)
+  branches:
+    include:
+    - master
+  always: true
+
 jobs:
 - template: /eng/platform-matrix.yml
   parameters:

--- a/eng/pipelines/jitstress-isas-x86.yml
+++ b/eng/pipelines/jitstress-isas-x86.yml
@@ -2,6 +2,14 @@ trigger: none
 
 pr: none
 
+schedules:
+- cron: "30 19 * * 6"
+  displayName: Sat at 11:30 AM (UTC-8:00)
+  branches:
+    include:
+    - master
+  always: true
+
 jobs:
 - template: /eng/platform-matrix.yml
   parameters:

--- a/eng/pipelines/jitstressregs-x86.yml
+++ b/eng/pipelines/jitstressregs-x86.yml
@@ -2,6 +2,14 @@ trigger: none
 
 pr: none
 
+schedules:
+- cron: "0 19 * * 0"
+  displayName: Sun at 11:00 AM (UTC-8:00)
+  branches:
+    include:
+    - master
+  always: true
+
 jobs:
 - template: /eng/platform-matrix.yml
   parameters:


### PR DESCRIPTION
Pipelines: jitstress-isas-arm, jitstress-isas-x86, jitstressregs-x86.

Only once per week currently, on weekends.

Fixes #26339