### PR TITLE
Update null ref annotation for object.Equals(object?)

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Object.cs
+++ b/src/System.Private.CoreLib/shared/System/Object.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -44,7 +45,7 @@ namespace System
         // Equal to this.  Equality is defined as object equality for reference
         // types and bitwise equality for value types using a loader trick to
         // replace Equals with EqualsValue for value types).
-        public virtual bool Equals(object? obj)
+        public virtual bool Equals([NotNullWhen(true)] object? obj)
         {
             return RuntimeHelpers.Equals(this, obj);
         }


### PR DESCRIPTION
The `object.Equals(object)` method accepts a null argument, but if the method returns `true`, it's a guarantee to the caller that the argument is *not* null, since an instance can never be equal to a null reference. This annotation reflects this guarantee so the compiler can not generate a warning when `#nullable` features are used.

Granted, someone could override `Equals` in their own type and make it return `true` even if the argument is `null`. But that would be breaking the contract. And this annotation won't break them either, but it's a great help for the expected case.