### PR TITLE
Remove unnecessary file handle parameter in PEImageLayout methods

### DIFF
--- a/src/vm/peimage.cpp
+++ b/src/vm/peimage.cpp
@@ -1077,7 +1077,7 @@ PTR_PEImageLayout PEImage::CreateLayoutMapped()
     }
     else if (IsFile())
     {
-        PEImageLayoutHolder pLayout(PEImageLayout::Map(GetFileHandle(),this));
+        PEImageLayoutHolder pLayout(PEImageLayout::Map(this));
 
         bool fMarkAnyCpuImageAsLoaded = false;
         // Avoid mapping another image if we can. We can only do this for IL-ONLY images
@@ -1131,7 +1131,7 @@ PTR_PEImageLayout PEImage::CreateLayoutFlat(BOOL bPermitWriteableSections)
 
     _ASSERTE(m_pLayouts[IMAGE_FLAT] == NULL);
 
-    PTR_PEImageLayout pFlatLayout = PEImageLayout::LoadFlat(GetFileHandle(),this);
+    PTR_PEImageLayout pFlatLayout = PEImageLayout::LoadFlat(this);
 
     if (!bPermitWriteableSections
         && pFlatLayout->CheckNTHeaders()
@@ -1321,7 +1321,7 @@ void PEImage::LoadNoMetaData()
     else
     {
         _ASSERTE(!m_path.IsEmpty());
-        SetLayout(IMAGE_LOADED,PEImageLayout::LoadFlat(GetFileHandle(),this));
+        SetLayout(IMAGE_LOADED,PEImageLayout::LoadFlat(this));
     }
 }
 

--- a/src/vm/peimagelayout.h
+++ b/src/vm/peimagelayout.h
@@ -50,12 +50,11 @@ public:
 public:
 #ifndef DACCESS_COMPILE
     static PEImageLayout* CreateFlat(const void *flat, COUNT_T size,PEImage* pOwner);
-    static PEImageLayout* CreateFromStream(IStream* pIStream, PEImage* pOwner);
     static PEImageLayout* CreateFromHMODULE(HMODULE mappedbase,PEImage* pOwner, BOOL bTakeOwnership);
     static PEImageLayout* LoadFromFlat(PEImageLayout* pflatimage);
     static PEImageLayout* Load(PEImage* pOwner, BOOL bNTSafeLoad, BOOL bThrowOnError = TRUE);
-    static PEImageLayout* LoadFlat(HANDLE hFile, PEImage* pOwner);
-    static PEImageLayout* Map (HANDLE hFile, PEImage* pOwner);
+    static PEImageLayout* LoadFlat(PEImage* pOwner);
+    static PEImageLayout* Map(PEImage* pOwner);
 #endif    
     PEImageLayout();
     virtual ~PEImageLayout();
@@ -126,7 +125,7 @@ protected:
 #endif
 public:
 #ifndef DACCESS_COMPILE    
-    MappedImageLayout(HANDLE hFile, PEImage* pOwner);    
+    MappedImageLayout(PEImage* pOwner);    
 #endif
 };
 
@@ -164,7 +163,7 @@ protected:
     CLRMapViewHolder m_FileView;
 public:
 #ifndef DACCESS_COMPILE    
-    FlatImageLayout(HANDLE hFile, PEImage* pOwner);   
+    FlatImageLayout(PEImage* pOwner);   
 #endif
 
 };


### PR DESCRIPTION
The handle is always the owner's PEImage->GetFileHandle, and so the PEImageLayout can call that instead of passing it around through parameters.