### PR TITLE
Add JitELTHookEnabled scenarios and testGroup in CI

### DIFF
--- a/eng/run-test-job.yml
+++ b/eng/run-test-job.yml
@@ -136,7 +136,7 @@ jobs:
           timeoutPerTestCollectionInMinutes: 360
           # gc reliability may take up to 2 hours to shutdown. Some scenarios have very long iteration times.
           timeoutPerTestInMinutes: 240
-        ${{ if in(parameters.testGroup, 'jitstress', 'jitstress-isas-arm', 'jitstress-isas-x86', 'jitstressregs-x86', 'jitstressregs', 'jitstress2-jitstressregs' ) }}:
+        ${{ if in(parameters.testGroup, 'jitstress', 'jitstress-isas-arm', 'jitstress-isas-x86', 'jitstressregs-x86', 'jitstressregs', 'jitstress2-jitstressregs', 'jitelthookenabled' ) }}:
           timeoutPerTestCollectionInMinutes: 120
           timeoutPerTestInMinutes: 30
         ${{ if in(parameters.testGroup, 'gcstress0x3-gcstress0xc') }}:
@@ -266,3 +266,7 @@ jobs:
           longRunningGcTests: true
           scenarios:
           - normal
+        ${{ if in(parameters.testGroup, 'jitelthookenabled') }}:
+          scenarios:
+          - jitelthookenabled
+          - jitelthookenabled_tiered

--- a/tests/testenvironment.proj
+++ b/tests/testenvironment.proj
@@ -35,6 +35,7 @@
       COMPlus_GCStress;
       COMPlus_HeapVerify;
       COMPlus_JITMinOpts;
+      COMPlus_JitELTHookEnabled;
       COMPlus_JitStress;
       COMPlus_JitStressRegs;
       COMPlus_TailcallStress;
@@ -112,6 +113,8 @@
     <TestEnvironment Include="jitstress2_jitstressregs0x10" JitStress="2" JitStressRegs="0x10" />
     <TestEnvironment Include="jitstress2_jitstressregs0x80" JitStress="2" JitStressRegs="0x80" />
     <TestEnvironment Include="jitstress2_jitstressregs0x1000" JitStress="2" JitStressRegs="0x1000" />
+    <TestEnvironment Include="jitelthookenabled" JitELTHookEnabled="1" />
+    <TestEnvironment Include="jitelthookenabled_tiered" JitELTHookEnabled="1" TieredCompilation="1" />
     <TestEnvironment Include="tailcallstress" TailcallStress="1" />
     <TestEnvironment Include="gcstress0x3" GCStress="0x3" />
     <TestEnvironment Include="gcstress0xc" GCStress="0xC" />


### PR DESCRIPTION
This adds two test scenarios that are defined as follows:

**jitelthookenabled_tiered**
- COMPlus_JitELTHookEnabled=1
- COMPlus_TieredCompilation=1

**jitelthookenabled**
- COMPlus_JitELTHookEnabled=1
- COMPlus_TieredCompilation=0

This also defines testGroup jitelthookenabled