### PR TITLE
Use 18.04 arm64 queue for outerloop jobs

### DIFF
--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -58,8 +58,10 @@ jobs:
         image: ubuntu-16.04-cross-arm64-cfdd435-20190520220848
         registry: mcr
       helixQueues:
-      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(parameters.helixQueueGroup, 'pr')) }}:
         - (Ubuntu.1804.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-a45aeeb-20190620155855
+      - ${{ if and(eq(variables['System.TeamProject'], 'public'), ne(parameters.helixQueueGroup, 'pr')) }}:
+        - (Ubuntu.1804.Arm64.Open)Ubuntu.1804.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-a45aeeb-20190620155855
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(parameters.helixQueueGroup, 'pr', 'ci', 'corefx')) }}:
         - (Debian.9.Arm64.Open)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-74c9941-20190620155840
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:


### PR DESCRIPTION
This will have the outerloop arm64 jobs use the ubuntu 18.04 arm64 queue.