### PR TITLE
Don't allow the hoisting of GT_CLS_VARs that were assigned a constant value.

### DIFF
--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -6800,7 +6800,7 @@ void Compiler::optHoistLoopBlocks(unsigned loopNum, ArrayStack<BasicBlock*>* blo
             if (m_compiler->vnStore->IsVNConstant(vn))
             {
                 // It is unsafe to allow a GT_CLS_VAR that has been assigned a constant.
-                // The logic in optVNIsLoopInvariant woudl consider it to be loop-invariant, even
+                // The logic in optVNIsLoopInvariant would consider it to be loop-invariant, even
                 // if the assignment of the constant to the GT_CLS_VAR was inside the loop.
                 //
                 if (tree->OperIs(GT_CLS_VAR))

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -6795,8 +6795,21 @@ void Compiler::optHoistLoopBlocks(unsigned loopNum, ArrayStack<BasicBlock*>* blo
 
         bool IsTreeVNInvariant(GenTree* tree)
         {
-            return m_compiler->optVNIsLoopInvariant(tree->gtVNPair.GetLiberal(), m_loopNum,
-                                                    &m_hoistContext->m_curLoopVnInvariantCache);
+            ValueNum vn = tree->gtVNPair.GetLiberal();
+
+            if (m_compiler->vnStore->IsVNConstant(vn))
+            {
+                // It is unsafe to allow a GT_CLS_VAR that has been assigned a constant.
+                // The logic in optVNIsLoopInvariant woudl consider it to be loop-invariant, even
+                // if the assignment of the constant to the GT_CLS_VAR was inside the loop.
+                //
+                if (tree->OperIs(GT_CLS_VAR))
+                {
+                    return false;
+                }
+            }
+
+            return m_compiler->optVNIsLoopInvariant(vn, m_loopNum, &m_hoistContext->m_curLoopVnInvariantCache);
         }
 
     public:

--- a/tests/src/JIT/Regression/JitBlue/GitHub_26417/GitHub_26417.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_26417/GitHub_26417.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+class GitHub_26417
+{
+    static int   _a;
+
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
+    static void MyWriteLine(int v)
+    {
+        Console.WriteLine(v);
+        if (v == 0)
+        {
+            throw new Exception();
+        }
+    }
+
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
+    static void Test()
+    {
+        _a = 1;
+        
+        while (_a == 1)
+        {
+            MyWriteLine(_a);
+            _a = 0;
+        }
+    }
+
+    static int Main()
+    {
+        int result = 100;
+        try {
+            Test();
+        }
+        catch (Exception)
+        {
+            Console.WriteLine("FAILED");
+            result = -1;
+        }
+        return result;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_26417/GitHub_26417.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_26417/GitHub_26417.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes Issue #26417