### PR TITLE
Optimize Math.Pow(x, c) in JIT

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -3580,6 +3580,8 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
         case CORINFO_INTRINSIC_Ceiling:
         case CORINFO_INTRINSIC_Floor:
             retNode = impMathIntrinsic(method, sig, callType, intrinsicID, tailCall);
+            // Can be optimized during morph
+            isSpecial = intrinsicID == CORINFO_INTRINSIC_Pow;
             break;
 
 #if defined(_TARGET_XARCH_) || defined(_TARGET_ARM64_)

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8707,7 +8707,7 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
         GenTree* arg1    = gtArgEntryByArgNum(call, 1)->node;
         GenTree* newNode = nullptr;
 
-        if (arg1->IsCnsFltOrDbl())
+        if (!arg0->IsCnsFltOrDbl() && arg1->IsCnsFltOrDbl())
         {
             GenTreeDblCon* powerCon = arg1->AsDblCon();
             if (powerCon->gtDconVal == 2.0) // or should I compare int64 with 0x4000000000000000 ?

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8703,31 +8703,36 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
         info.compCompHnd->getIntrinsicID(call->gtCallMethHnd) == CORINFO_INTRINSIC_Pow)
     {
         noway_assert(call->fgArgInfo->ArgCount() == 2);
-        GenTree*       arg     = gtArgEntryByArgNum(call, 0)->node;
-        GenTreeDblCon* dblCon  = gtArgEntryByArgNum(call, 1)->node->AsDblCon();
-        GenTree*       newNode = nullptr;
+        GenTree* arg0    = gtArgEntryByArgNum(call, 0)->node;
+        GenTree* arg1    = gtArgEntryByArgNum(call, 1)->node;
+        GenTree* newNode = nullptr;
 
-        if (dblCon->gtDconVal == 2.0)
+        if (arg1->IsCnsFltOrDbl())
         {
-            // Math.Pow(x, 2) -> x*x
-            newNode = gtNewOperNode(GT_MUL, dblCon->TypeGet(), arg, gtNewLclvNode(arg->gtLclVar.gtLclNum, arg->TypeGet()));
-        }
-        else if (dblCon->gtDconVal == 1.0)
-        {
-            // Math.Pow(x, 1) -> x
-            newNode = arg;
-        }
-        else if (dblCon->gtDconVal == -1.0)
-        {
-            // Math.Pow(x, -1) -> 1/x
-            newNode = gtNewOperNode(GT_DIV, dblCon->TypeGet(), gtNewDconNode(1, dblCon->TypeGet()), arg);
-        }
+            GenTreeDblCon* powerCon = gtArgEntryByArgNum(call, 1)->node->AsDblCon();
+            if (powerCon->gtDconVal == 2.0)
+            {
+                // Math.Pow(x, 2) -> x*x
+                newNode =
+                    gtNewOperNode(GT_MUL, powerCon->TypeGet(), arg0, gtNewLclvNode(arg0->gtLclVar.gtLclNum, arg0->TypeGet()));
+            }
+            else if (powerCon->gtDconVal == 1.0)
+            {
+                // Math.Pow(x, 1) -> x
+                newNode = arg0;
+            }
+            else if (powerCon->gtDconVal == -1.0)
+            {
+                // Math.Pow(x, -1) -> 1/x
+                newNode = gtNewOperNode(GT_DIV, powerCon->TypeGet(), gtNewDconNode(1, powerCon->TypeGet()), arg0);
+            }
 
-        if (newNode != nullptr)
-        {
-            INDEBUG(newNode->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED);
-            DEBUG_DESTROY_NODE(call);
-            return newNode;
+            if (newNode != nullptr)
+            {
+                INDEBUG(newNode->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED);
+                DEBUG_DESTROY_NODE(call);
+                return newNode;
+            }
         }
     }
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8712,7 +8712,7 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
             noway_assert(arg0->TypeGet() == arg1->TypeGet());
             GenTreeDblCon* powerCon = arg1->AsDblCon();
 
-            if ((powerCon->gtDconVal == 2.0))
+            if (powerCon->gtDconVal == 2.0)
             {
                 if (arg0->OperIs(GT_LCL_VAR))
                 {

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8709,8 +8709,8 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
 
         if (arg1->IsCnsFltOrDbl())
         {
-            GenTreeDblCon* powerCon = gtArgEntryByArgNum(call, 1)->node->AsDblCon();
-            if (powerCon->gtDconVal == 2.0)
+            GenTreeDblCon* powerCon = arg1->AsDblCon();
+            if (powerCon->gtDconVal == 2.0) // or should I compare int64 with 0x4000000000000000 ?
             {
                 // Math.Pow(x, 2) -> x*x
                 newNode =

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8707,15 +8707,15 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
         GenTree* arg1    = gtArgEntryByArgNum(call, 1)->node;
         GenTree* newNode = nullptr;
 
-        if (arg0->OperIs(GT_LCL_VAR) && arg1->IsCnsFltOrDbl())
+        if (arg1->IsCnsFltOrDbl())
         {
             noway_assert(arg0->TypeGet() == arg1->TypeGet());
             GenTreeDblCon* powerCon = arg1->AsDblCon();
-            if (powerCon->gtDconVal == 2.0) // or should I compare int64 with 0x4000000000000000 ?
+
+            if ((arg0->OperIs(GT_IND) || arg0->OperIs(GT_LCL_VAR)) && (powerCon->gtDconVal == 2.0))
             {
-                // Math.Pow(x, 2) -> x*x
-                newNode = gtNewOperNode(GT_MUL, powerCon->TypeGet(), arg0,
-                                        gtNewLclvNode(arg0->gtLclVar.gtLclNum, arg0->TypeGet()));
+                // Math.Pow(x, 2) -> x*x where x is a local variable or a field
+                newNode = gtNewOperNode(GT_MUL, powerCon->TypeGet(), arg0, gtCloneExpr(arg0));
             }
             else if (powerCon->gtDconVal == 1.0)
             {

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8713,8 +8713,8 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
             if (powerCon->gtDconVal == 2.0) // or should I compare int64 with 0x4000000000000000 ?
             {
                 // Math.Pow(x, 2) -> x*x
-                newNode =
-                    gtNewOperNode(GT_MUL, powerCon->TypeGet(), arg0, gtNewLclvNode(arg0->gtLclVar.gtLclNum, arg0->TypeGet()));
+                newNode = gtNewOperNode(GT_MUL, powerCon->TypeGet(), arg0,
+                                        gtNewLclvNode(arg0->gtLclVar.gtLclNum, arg0->TypeGet()));
             }
             else if (powerCon->gtDconVal == 1.0)
             {

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8698,6 +8698,23 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
         }
     }
 
+    if (call->fgArgInfo->ArgCount() == 2)
+    {
+        GenTree* arg0 = gtArgEntryByArgNum(call, 0)->node;
+        GenTree* arg1 = gtArgEntryByArgNum(call, 1)->node;
+        if (arg1->OperIs(GT_CNS_DBL))
+        {
+            GenTreeDblCon* dblCon = arg1->AsDblCon();
+            if (dblCon->gtDconVal == 2.0)
+            {
+                GenTree* result = gtNewOperNode(GT_MUL, TYP_DOUBLE, arg0, gtNewLclvNode(arg0->gtLclVar.gtLclNum, arg0->TypeGet()));
+                INDEBUG(result->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED);
+                DEBUG_DESTROY_NODE(call);
+                return result;
+            }
+        }
+    }
+
     // Optimize get_ManagedThreadId(get_CurrentThread)
     if ((call->gtCallMoreFlags & GTF_CALL_M_SPECIAL_INTRINSIC) &&
         info.compCompHnd->getIntrinsicID(call->gtCallMethHnd) == CORINFO_INTRINSIC_GetManagedThreadId)

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8707,8 +8707,9 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
         GenTree* arg1    = gtArgEntryByArgNum(call, 1)->node;
         GenTree* newNode = nullptr;
 
-        if (!arg0->IsCnsFltOrDbl() && arg1->IsCnsFltOrDbl())
+        if (arg0->OperIs(GT_LCL_VAR) && arg1->IsCnsFltOrDbl())
         {
+            noway_assert(arg0->TypeGet() == arg1->TypeGet());
             GenTreeDblCon* powerCon = arg1->AsDblCon();
             if (powerCon->gtDconVal == 2.0) // or should I compare int64 with 0x4000000000000000 ?
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/26434

Converts:
`Math.Pow(x,  2)` to `x*x`
`Math.Pow(x,  1)` to `x`
`Math.Pow(x, -1)` to `1/x`
(same for MathF and floats)

Can be added:
`Math.Pow(c1, c2)` to `c3` (call PAL_pow?)
`Math.Pow(1, x)` to `1`
`Math.Pow(2, x)` to `exp2(x)`
`Math.Pow(x, 0)` to `1`
`Math.Pow(x, -0)` to `1`
`Math.Pow(x, 0.5)` to `sqrt(x)` 
`Math.Pow(x, -2)` to `1/(x*x)`  (probably is not safe)

### Test
```csharp
static double Pow2(double x) => Math.Pow(x, 2);

static double Pow1(double x) => Math.Pow(x, 1);

static double PowN1(double x) => Math.Pow(x, -1);
```
### Before (tier1):
```asm
; Pow2(double):double
G_M37400_IG01:
       sub      rsp, 40
       vzeroupper 
G_M37400_IG02:
       vmovsd   xmm1, qword ptr [reloc @RWD00]
       call     System.Math:Pow(double,double):double
       nop      
G_M37400_IG03:
       add      rsp, 40
       ret      
RWD00  dq	4000000000000000h
; Total bytes of code: 26


; Pow1(double):double
G_M37403_IG01:
       sub      rsp, 40
       vzeroupper 
G_M37403_IG02:
       vmovsd   xmm1, qword ptr [reloc @RWD00]
       call     System.Math:Pow(double,double):double
       nop      
G_M37403_IG03:
       add      rsp, 40
       ret      
RWD00  dq	3FF0000000000000h
; Total bytes of code: 26


; PowN1(double):double
G_M24053_IG01:
       sub      rsp, 40
       vzeroupper 
G_M24053_IG02:
       vmovsd   xmm1, qword ptr [reloc @RWD00]
       call     System.Math:Pow(double,double):double
       nop      
G_M24053_IG03:
       add      rsp, 40
       ret      
RWD00  dq	BFF0000000000000h
; Total bytes of code: 26
```
### After (tier1):
```asm
; Pow2(double):double
G_M37400_IG01:
       vzeroupper 
G_M37400_IG02:
       vmulsd   xmm0, xmm0
G_M37400_IG03:
       ret      
; Total bytes of code: 8


; Pow1(double):double
G_M37403_IG01:
       vzeroupper 
G_M37403_IG02:
       ret      
; Total bytes of code: 4


; PowN1(double):double
G_M24053_IG01:
       vzeroupper 
G_M24053_IG02:
       vmovsd   xmm1, qword ptr [reloc @RWD00]
       vdivsd   xmm1, xmm0
       vmovaps  xmm0, xmm1
G_M24053_IG03:
       ret      
RWD00  dq	3FF0000000000000h
; Total bytes of code: 20
```

Will run the jit-diff tools but I suspect it won't find anything in the BCL (**UPD** there are actually two cases). But I did see such usages in different applications. E.g. `Xenko` (a game engine): https://github.com/xenko3d/xenko/search?q=Math.Pow&unscoped_q=Math.Pow

Also, once some sort of ffast-math mode is implemented - we can unroll other constants (gcc unrolls up to 100, clang - 32)