### PR TITLE
Fix issue with locals overlapping out of scope GCFrame

### DIFF
--- a/src/vm/amd64/ComCallPreStub.asm
+++ b/src/vm/amd64/ComCallPreStub.asm
@@ -33,6 +33,7 @@ NESTED_ENTRY ComCallPreStub, _TEXT
 ; rcx
 ; ComPrestubMethodFrame::m_ReturnAddress
 ; ComPrestubMethodFrame::m_pFuncDesc
+; Frame::m_WasUnwound
 ; Frame::m_Next
 ; __VFN_table                                   <-- rsp + ComCallPreStub_ComPrestubMethodFrame_OFFSET
 ; gsCookie
@@ -67,7 +68,7 @@ ComCallPreStub_STACK_FRAME_SIZE = ComCallPreStub_STACK_FRAME_SIZE + 8
 ComCallPreStub_ERRORRETVAL_NEGOFFSET = ComCallPreStub_STACK_FRAME_SIZE
 
 ; Ensure that the offset of the XMM save area will be 16-byte aligned.
-if ((ComCallPreStub_STACK_FRAME_SIZE + SIZEOF__Frame + 8) mod 16) ne 0
+if ((ComCallPreStub_STACK_FRAME_SIZE + 8) mod 16) ne 0
 ComCallPreStub_STACK_FRAME_SIZE = ComCallPreStub_STACK_FRAME_SIZE + 8
 endif
 

--- a/src/vm/amd64/GenericComCallStubs.asm
+++ b/src/vm/amd64/GenericComCallStubs.asm
@@ -35,6 +35,7 @@ NESTED_ENTRY GenericComCallStub, _TEXT, ReverseComUnwindFrameChainHandler
 ; rcx
 ; UnmanagedToManagedFrame::m_ReturnAddress
 ; UnmanagedToManagedFrame::m_Datum
+; Frame::m_WasUnwound
 ; Frame::m_Next
 ; __VFN_table                                   <-- rsp + GenericComCallStub_ComMethodFrame_OFFSET
 ; GSCookie

--- a/src/vm/amd64/InstantiatingStub.asm
+++ b/src/vm/amd64/InstantiatingStub.asm
@@ -17,14 +17,13 @@ extern s_gsCookie:qword
 
 
 OFFSETOF_SECRET_PARAMS              equ 0h
+SIZEOF_SECRET_PARAMS                equ 3 * 8h
 OFFSETOF_GSCOOKIE                   equ OFFSETOF_SECRET_PARAMS + \
-                                        18h + 8h ; +8 for stack alignment padding
+                                        SIZEOF_SECRET_PARAMS
 OFFSETOF_FRAME                      equ OFFSETOF_GSCOOKIE + \
-                                        8h
-OFFSETOF_FRAME_REGISTERS            equ OFFSETOF_FRAME + \
-                                        SIZEOF__Frame
-SIZEOF_FIXED_FRAME                  equ OFFSETOF_FRAME_REGISTERS + \
-                                        SIZEOF_CalleeSavedRegisters + 8h ; +8 for return address
+                                        SIZEOF_GSCookie
+OFFSETOF_FRAME_REGISTERS            equ OFFSETOF_FRAME + OFFSETOF__StubHelperFrame__m_TransitionBlock + OFFSETOF__TransitionBlock__m_calleeSavedRegisters;
+SIZEOF_FIXED_FRAME                  equ OFFSETOF_FRAME + SIZEOF__StubHelperFrame
 
 .errnz SIZEOF_FIXED_FRAME mod 16, SIZEOF_FIXED_FRAME not aligned
 
@@ -59,12 +58,13 @@ SIZEOF_FIXED_FRAME                  equ OFFSETOF_FRAME_REGISTERS + \
 ; +20h      gsCookie
 ; +28h      __VFN_table
 ; +30h      m_Next
-; +38h      m_calleeSavedRegisters
-; +98h      m_ReturnAddress
-; +a0h  rcx home
-; +a8h  rdx home
-; +b0h  r8 home
-; +b8h  r9 home
+; +38h      m_WasUnwound
+; +40h      m_calleeSavedRegisters
+; +a0h      m_ReturnAddress
+; +a8h  rcx home
+; +b0h  rdx home
+; +b8h  r8 home
+; +c0h  r9 home
 ; 
 NESTED_ENTRY InstantiatingMethodStubWorker, _TEXT
         .allocstack             SIZEOF_FIXED_FRAME - 8h     ; -8 for return address
@@ -75,8 +75,6 @@ NESTED_ENTRY InstantiatingMethodStubWorker, _TEXT
 
         set_frame               rbp, 0
     END_PROLOGUE
-
-        sub     rsp, SIZEOF_MAX_OUTGOING_ARGUMENT_HOMES
 
         ;
         ; fully initialize the StubHelperFrame
@@ -95,8 +93,6 @@ NESTED_ENTRY InstantiatingMethodStubWorker, _TEXT
         mov     [rbp + OFFSETOF_FRAME + OFFSETOF__Frame__m_Next], rdx
         lea     rcx, [rbp + OFFSETOF_FRAME]
         mov     [r12 + OFFSETOF__Thread__m_pFrame], rcx
-
-        add     rsp, SIZEOF_MAX_OUTGOING_ARGUMENT_HOMES
 
         mov     rcx, [rbp + OFFSETOF_SECRET_PARAMS + 0h]        ; nStackSlots (includes padding for stack alignment)
 

--- a/src/vm/amd64/JitHelpers_Fast.asm
+++ b/src/vm/amd64/JitHelpers_Fast.asm
@@ -873,8 +873,8 @@ OFFSETOF_FRAME                      equ OFFSETOF_GSCOOKIE + \
 ; r13-> gsCookie
 ; + 8h      __VFN_table
 ; +10h      m_Next
-; +18h      m_pGCLayout
-; +20h      m_padding
+; +18h      m_WasUnwound
+; +20h      m_pGCLayout
 ; +28h      m_rdi
 ; +30h      m_rsi
 ; +38h      m_rbx
@@ -892,7 +892,7 @@ OFFSETOF_FRAME                      equ OFFSETOF_GSCOOKIE + \
 NESTED_ENTRY TailCallHelperStub, _TEXT
         PUSH_CALLEE_SAVED_REGISTERS
 
-        alloc_stack             48h     ; m_padding, m_pGCLayout, m_Next, __VFN_table, gsCookie, outgoing shadow area
+        alloc_stack             48h     ; m_pGCLayout, m_WasUnwound, m_Next, __VFN_table, gsCookie, outgoing shadow area
 
         set_frame               r13, 20h
     END_PROLOGUE

--- a/src/vm/amd64/PInvokeStubs.asm
+++ b/src/vm/amd64/PInvokeStubs.asm
@@ -156,6 +156,7 @@ LEAF_ENTRY JIT_PInvokeBegin, _TEXT
         lea             rax,[??_7InlinedCallFrame@@6B@]
         mov             qword ptr [rcx], rax
 
+        mov             dword ptr [rcx + OFFSETOF__Frame__m_WasUnwound], 0
         mov             qword ptr [rcx + OFFSETOF__InlinedCallFrame__m_Datum], 0
 
         mov             rax, rsp

--- a/src/vm/amd64/asmconstants.h
+++ b/src/vm/amd64/asmconstants.h
@@ -88,14 +88,30 @@ ASMCONSTANTS_C_ASSERT(SIZEOF_GSCookie == sizeof(GSCookie));
 ASMCONSTANTS_C_ASSERT(OFFSETOF__Frame__m_Next
                     == offsetof(Frame, m_Next));
 
-#define               SIZEOF__Frame                 0x10
+#define               OFFSETOF__Frame__m_WasUnwound 0x10
+ASMCONSTANTS_C_ASSERT(OFFSETOF__Frame__m_WasUnwound
+                    == offsetof(Frame, m_WasUnwound));
+
+#define               SIZEOF__Frame                 0x18
+ASMCONSTANTS_C_ASSERT(SIZEOF__Frame == sizeof(Frame));
+
+#ifndef UNIX_AMD64_ABI
+#define OFFSETOF__StubHelperFrame__m_TransitionBlock 0x18
+ASMCONSTANTS_C_ASSERT(OFFSETOF__StubHelperFrame__m_TransitionBlock == offsetof(StubHelperFrame, m_TransitionBlock));
+#define SIZEOF__StubHelperFrame 0x60
+ASMCONSTANTS_C_ASSERT(SIZEOF__StubHelperFrame == sizeof(StubHelperFrame));
+#define OFFSETOF__TransitionBlock__m_calleeSavedRegisters 0
+ASMCONSTANTS_C_ASSERT(OFFSETOF__TransitionBlock__m_calleeSavedRegisters == offsetof(TransitionBlock, m_calleeSavedRegisters));
+#define SIZEOF__TransitionBlock 0x48
+ASMCONSTANTS_C_ASSERT(SIZEOF__TransitionBlock == sizeof(TransitionBlock));
+#endif
 
 #ifdef FEATURE_COMINTEROP
-#define               SIZEOF__ComPrestubMethodFrame                 0x20
+#define               SIZEOF__ComPrestubMethodFrame                 0x28
 ASMCONSTANTS_C_ASSERT(SIZEOF__ComPrestubMethodFrame
                     == sizeof(ComPrestubMethodFrame));
 
-#define               SIZEOF__ComMethodFrame                        0x20
+#define               SIZEOF__ComMethodFrame                        0x28
 ASMCONSTANTS_C_ASSERT(SIZEOF__ComMethodFrame
                     == sizeof(ComMethodFrame));
 #endif // FEATURE_COMINTEROP
@@ -473,11 +489,11 @@ ASMCONSTANTS_C_ASSERT(OFFSETOF__CONTEXT__Xmm14
 ASMCONSTANTS_C_ASSERT(OFFSETOF__CONTEXT__Xmm15
                     == offsetof(CONTEXT, Xmm15));
 
-#define               SIZEOF__FaultingExceptionFrame  (0x20 + SIZEOF__CONTEXT)
+#define               SIZEOF__FaultingExceptionFrame  (0x30 + SIZEOF__CONTEXT)
 ASMCONSTANTS_C_ASSERT(SIZEOF__FaultingExceptionFrame 
                     == sizeof(FaultingExceptionFrame));
 
-#define               OFFSETOF__FaultingExceptionFrame__m_fFilterExecuted 0x10
+#define               OFFSETOF__FaultingExceptionFrame__m_fFilterExecuted 0x18
 ASMCONSTANTS_C_ASSERT(OFFSETOF__FaultingExceptionFrame__m_fFilterExecuted 
                     == offsetof(FaultingExceptionFrame, m_fFilterExecuted));
 
@@ -537,23 +553,23 @@ ASMCONSTANTS_C_ASSERT(OFFSETOF__ArrayTypeDesc__m_Arg
                     == offsetof(ArrayTypeDesc, m_Arg));
 
 // For JIT_PInvokeBegin and JIT_PInvokeEnd helpers
-#define               OFFSETOF__InlinedCallFrame__m_Datum 0x10
+#define               OFFSETOF__InlinedCallFrame__m_Datum 0x18
 ASMCONSTANTS_C_ASSERT(OFFSETOF__InlinedCallFrame__m_Datum
                     == offsetof(InlinedCallFrame, m_Datum));
 
-#define               OFFSETOF__InlinedCallFrame__m_pCallSiteSP 0x20
+#define               OFFSETOF__InlinedCallFrame__m_pCallSiteSP 0x28
 ASMCONSTANTS_C_ASSERT(OFFSETOF__InlinedCallFrame__m_pCallSiteSP
                     == offsetof(InlinedCallFrame, m_pCallSiteSP));
 
-#define               OFFSETOF__InlinedCallFrame__m_pCallerReturnAddress 0x28
+#define               OFFSETOF__InlinedCallFrame__m_pCallerReturnAddress 0x30
 ASMCONSTANTS_C_ASSERT(OFFSETOF__InlinedCallFrame__m_pCallerReturnAddress
                     == offsetof(InlinedCallFrame, m_pCallerReturnAddress));
 
-#define               OFFSETOF__InlinedCallFrame__m_pCalleeSavedFP 0x30
+#define               OFFSETOF__InlinedCallFrame__m_pCalleeSavedFP 0x38
 ASMCONSTANTS_C_ASSERT(OFFSETOF__InlinedCallFrame__m_pCalleeSavedFP
                     == offsetof(InlinedCallFrame, m_pCalleeSavedFP));
 
-#define               OFFSETOF__InlinedCallFrame__m_pThread 0x38
+#define               OFFSETOF__InlinedCallFrame__m_pThread 0x40
 ASMCONSTANTS_C_ASSERT(OFFSETOF__InlinedCallFrame__m_pThread
                     == offsetof(InlinedCallFrame, m_pThread));
 

--- a/src/vm/amd64/pinvokestubs.S
+++ b/src/vm/amd64/pinvokestubs.S
@@ -149,6 +149,7 @@ NESTED_ENTRY JIT_PInvokeBegin, _TEXT, NoHandler
         add             rax, 0x10
         mov             qword ptr [rdi], rax
 
+        mov             dword ptr [rdi + OFFSETOF__Frame__m_WasUnwound], 0
         mov             qword ptr [rdi + OFFSETOF__InlinedCallFrame__m_Datum], 0
 
         lea             rax, [rsp + 0x10]

--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -5740,23 +5740,6 @@ void AppDomain::DetachRCWs()
 
 #endif // FEATURE_COMINTEROP
 
-void AppDomain::ExceptionUnwind(Frame *pFrame)
-{
-    CONTRACTL
-    {
-        DISABLED(GC_TRIGGERS);  // EEResourceException
-        DISABLED(THROWS);   // EEResourceException
-        MODE_ANY;
-    }
-    CONTRACTL_END;
-
-    LOG((LF_APPDOMAIN, LL_INFO10, "AppDomain::ExceptionUnwind for %8.8x\n", pFrame));
-    Thread *pThread = GetThread();
-    _ASSERTE(pThread);
-
-    LOG((LF_APPDOMAIN, LL_INFO10, "AppDomain::ExceptionUnwind: not first transition or abort\n"));
-}
-
 #endif // CROSSGEN_COMPILE
 
 #endif // !DACCESS_COMPILE

--- a/src/vm/arm/PInvokeStubs.asm
+++ b/src/vm/arm/PInvokeStubs.asm
@@ -134,6 +134,7 @@ __PInvokeGenStubFuncName SETS "$__PInvokeGenStubFuncName":CC:"_RetBuffArg"
             str     r1, [r0]
 
             mov     r1, 0
+            str     r1, [r0, #Frame__m_WasUnwound]
             str     r1, [r0, #InlinedCallFrame__m_Datum]
         
             str     sp, [r0, #InlinedCallFrame__m_pCallSiteSP]

--- a/src/vm/arm/asmconstants.h
+++ b/src/vm/arm/asmconstants.h
@@ -109,7 +109,7 @@ ASMCONSTANTS_C_ASSERT(PtrArray__m_Array == offsetof(PtrArray, m_Array));
 #define SIZEOF__GSCookie              0x4
 ASMCONSTANTS_C_ASSERT(SIZEOF__GSCookie == sizeof(GSCookie));
 
-#define SIZEOF__Frame                 0x8
+#define SIZEOF__Frame                 0xC
 ASMCONSTANTS_C_ASSERT(SIZEOF__Frame == sizeof(Frame));
 
 #define SIZEOF__CONTEXT               0x1a0
@@ -151,10 +151,10 @@ ASMCONSTANTS_C_ASSERT(MethodDesc__mcComInterop == mcComInterop)
 #define Stub__m_pCode DBG_FRE(0x10, 0x0c)
 ASMCONSTANTS_C_ASSERT(Stub__m_pCode == sizeof(Stub))
 
-#define SIZEOF__ComMethodFrame 0x24
+#define SIZEOF__ComMethodFrame 0x28
 ASMCONSTANTS_C_ASSERT(SIZEOF__ComMethodFrame == sizeof(ComMethodFrame))
 
-#define UnmanagedToManagedFrame__m_pvDatum 0x08
+#define UnmanagedToManagedFrame__m_pvDatum 0x0C
 ASMCONSTANTS_C_ASSERT(UnmanagedToManagedFrame__m_pvDatum == offsetof(UnmanagedToManagedFrame, m_pvDatum))
 
 // In ComCallPreStub and GenericComPlusCallStub, we setup R12 to contain address of ComCallMethodDesc after doing the following:
@@ -215,7 +215,7 @@ ASMCONSTANTS_C_ASSERT(CallDescrData__fpReturnSize         == offsetof(CallDescrD
 ASMCONSTANTS_C_ASSERT(CallDescrData__pTarget              == offsetof(CallDescrData, pTarget))
 ASMCONSTANTS_C_ASSERT(CallDescrData__returnValue          == offsetof(CallDescrData, returnValue))
 
-#define SIZEOF__FaultingExceptionFrame                  (SIZEOF__Frame + 0x8 + SIZEOF__CONTEXT)
+#define SIZEOF__FaultingExceptionFrame                  (SIZEOF__Frame + 0xC + SIZEOF__CONTEXT)
 #define FaultingExceptionFrame__m_fFilterExecuted       SIZEOF__Frame
 ASMCONSTANTS_C_ASSERT(SIZEOF__FaultingExceptionFrame        == sizeof(FaultingExceptionFrame))
 ASMCONSTANTS_C_ASSERT(FaultingExceptionFrame__m_fFilterExecuted == offsetof(FaultingExceptionFrame, m_fFilterExecuted))
@@ -224,22 +224,25 @@ ASMCONSTANTS_C_ASSERT(FaultingExceptionFrame__m_fFilterExecuted == offsetof(Faul
 #define               Frame__m_Next 0x04
 ASMCONSTANTS_C_ASSERT(Frame__m_Next == offsetof(Frame, m_Next))
 
-#define               InlinedCallFrame__m_Datum 0x08
+#define               Frame__m_WasUnwound 0x08
+ASMCONSTANTS_C_ASSERT(Frame__m_WasUnwound == offsetof(Frame, m_WasUnwound));
+
+#define               InlinedCallFrame__m_Datum 0x0C
 ASMCONSTANTS_C_ASSERT(InlinedCallFrame__m_Datum == offsetof(InlinedCallFrame, m_Datum))
 
-#define               InlinedCallFrame__m_pCallSiteSP 0x0C
+#define               InlinedCallFrame__m_pCallSiteSP 0x10
 ASMCONSTANTS_C_ASSERT(InlinedCallFrame__m_pCallSiteSP == offsetof(InlinedCallFrame, m_pCallSiteSP))
 
-#define               InlinedCallFrame__m_pCallerReturnAddress 0x10
+#define               InlinedCallFrame__m_pCallerReturnAddress 0x14
 ASMCONSTANTS_C_ASSERT(InlinedCallFrame__m_pCallerReturnAddress == offsetof(InlinedCallFrame, m_pCallerReturnAddress))
 
-#define               InlinedCallFrame__m_pCalleeSavedFP 0x14
+#define               InlinedCallFrame__m_pCalleeSavedFP 0x18
 ASMCONSTANTS_C_ASSERT(InlinedCallFrame__m_pCalleeSavedFP == offsetof(InlinedCallFrame, m_pCalleeSavedFP))
 
-#define               InlinedCallFrame__m_pThread 0x18
+#define               InlinedCallFrame__m_pThread 0x1C
 ASMCONSTANTS_C_ASSERT(InlinedCallFrame__m_pThread == offsetof(InlinedCallFrame, m_pThread))
 
-#define               InlinedCallFrame__m_pSPAfterProlog 0x1C
+#define               InlinedCallFrame__m_pSPAfterProlog 0x20
 ASMCONSTANTS_C_ASSERT(InlinedCallFrame__m_pSPAfterProlog == offsetof(InlinedCallFrame, m_pSPAfterProlog))
 
 #undef ASMCONSTANTS_RUNTIME_ASSERT

--- a/src/vm/arm/asmhelpers.S
+++ b/src/vm/arm/asmhelpers.S
@@ -181,25 +181,25 @@ LOCAL_LABEL(LReturnDone):
         // like the C++ helper does before calling RtlRestoreContext
         //
         // Allocate space for the rest of the frame and GSCookie.
-        // PROLOG_STACK_ALLOC  0x0C
+        // PROLOG_STACK_ALLOC  SIZEOF__Frame + SIZEOF__GSCookie
         //
         // Set r11 for frame chain
         //add     r11, r7, 0x1C 
         //
         // Set the vtable for TailCallFrame
         //bl      TCF_GETMETHODFRAMEVPTR
-        //str     r0, [r7, #-8]
+        //str     r0, [r7, #-SIZEOF__Frame]
         //
         // Initialize the GSCookie within the Frame
         //ldr     r0, =s_gsCookie
-        //str     r0, [r7, #-0x0C]
+        //str     r0, [r7, #-SIZEOF__Frame - SIZEOF__GSCookie]
         //
         // Link the TailCallFrameinto the Frame chain
         // and initialize r5 & r6 for unlinking later
         //CALL_GETTHREAD
         //mov     r6, r0
         //ldr     r5, [r6, #Thread__m_pFrame]        
-        //str     r5, [r7, #-4]
+        //str     r5, [r7, #-SIZEOF__Frame + Frame__m_Next]
         //sub     r0, r7, 8
         //str     r0, [r6, #Thread__m_pFrame]
         //
@@ -226,7 +226,7 @@ C_FUNC(JIT_TailCallHelperStub_ReturnAddress):
 #ifdef _DEBUG
         ldr     r3, =s_gsCookie
         ldr     r3, [r3]
-        ldr     r2, [r7, #-0x0C]
+        ldr     r2, [r7, #-SIZEOF__Frame - SIZEOF__GSCookie]
         cmp     r2, r3
         beq     LOCAL_LABEL(GoodGSCookie)
         bl      C_FUNC(DoJITFailFast)

--- a/src/vm/arm/pinvokestubs.S
+++ b/src/vm/arm/pinvokestubs.S
@@ -97,6 +97,7 @@
         str     r1, [r4]
 
         mov     r1, 0
+        str     r1, [r4, #Frame__m_WasUnwound]
         str     r1, [r4, #InlinedCallFrame__m_Datum]
     
         add     r1, sp, 8

--- a/src/vm/arm64/PInvokeStubs.asm
+++ b/src/vm/arm64/PInvokeStubs.asm
@@ -134,6 +134,7 @@ __PInvokeStubWorkerName SETS "$FuncPrefix":CC:"StubWorker"
             ldr     x9, =$InlinedCallFrame_vftable
             str     x9, [x10]
 
+            str     wzr, [x10, #Frame__m_WasUnwound]
             str     xzr, [x10, #InlinedCallFrame__m_Datum]
         
             mov     x9, sp

--- a/src/vm/arm64/asmconstants.h
+++ b/src/vm/arm64/asmconstants.h
@@ -117,7 +117,7 @@ ASMCONSTANTS_C_ASSERT(DelegateObject___target == offsetof(DelegateObject, _targe
 #define SIZEOF__GSCookie 0x8
 ASMCONSTANTS_C_ASSERT(SIZEOF__GSCookie == sizeof(GSCookie));
 
-#define SIZEOF__Frame                 0x10
+#define SIZEOF__Frame                 0x18
 ASMCONSTANTS_C_ASSERT(SIZEOF__Frame == sizeof(Frame));
 
 #define SIZEOF__CONTEXT               0x390
@@ -148,10 +148,10 @@ ASMCONSTANTS_C_ASSERT(PtrArray__m_Array == offsetof(PtrArray, m_Array));
 
 #ifdef FEATURE_COMINTEROP
 
-#define SIZEOF__ComMethodFrame 0x70
+#define SIZEOF__ComMethodFrame 0x78
 ASMCONSTANTS_C_ASSERT(SIZEOF__ComMethodFrame == sizeof(ComMethodFrame));
 
-#define UnmanagedToManagedFrame__m_pvDatum 0x10
+#define UnmanagedToManagedFrame__m_pvDatum 0x18
 ASMCONSTANTS_C_ASSERT(UnmanagedToManagedFrame__m_pvDatum == offsetof(UnmanagedToManagedFrame, m_pvDatum));
 
 #endif // FEATURE_COMINTEROP
@@ -171,7 +171,7 @@ ASMCONSTANTS_C_ASSERT(UMThunkMarshInfo__m_cbActualArgSize == offsetof(UMThunkMar
 #define CONTEXT_Pc 0x108
 ASMCONSTANTS_C_ASSERT(CONTEXT_Pc == offsetof(T_CONTEXT,Pc))
 
-#define SIZEOF__FaultingExceptionFrame                  (SIZEOF__Frame + 0x10 + SIZEOF__CONTEXT)
+#define SIZEOF__FaultingExceptionFrame                  (SIZEOF__Frame + 0x18 + SIZEOF__CONTEXT)
 #define FaultingExceptionFrame__m_fFilterExecuted       SIZEOF__Frame
 ASMCONSTANTS_C_ASSERT(SIZEOF__FaultingExceptionFrame        == sizeof(FaultingExceptionFrame));
 ASMCONSTANTS_C_ASSERT(FaultingExceptionFrame__m_fFilterExecuted == offsetof(FaultingExceptionFrame, m_fFilterExecuted));
@@ -206,19 +206,22 @@ ASMCONSTANTS_C_ASSERT(DomainLocalModule__m_pGCStatics == offsetof(DomainLocalMod
 #define               Frame__m_Next 0x08
 ASMCONSTANTS_C_ASSERT(Frame__m_Next == offsetof(Frame, m_Next))
 
-#define               InlinedCallFrame__m_Datum 0x10
+#define               Frame__m_WasUnwound 0x10
+ASMCONSTANTS_C_ASSERT(Frame__m_WasUnwound == offsetof(Frame, m_WasUnwound));
+
+#define               InlinedCallFrame__m_Datum 0x18
 ASMCONSTANTS_C_ASSERT(InlinedCallFrame__m_Datum == offsetof(InlinedCallFrame, m_Datum))
 
-#define               InlinedCallFrame__m_pCallSiteSP 0x20
+#define               InlinedCallFrame__m_pCallSiteSP 0x28
 ASMCONSTANTS_C_ASSERT(InlinedCallFrame__m_pCallSiteSP == offsetof(InlinedCallFrame, m_pCallSiteSP))
 
-#define               InlinedCallFrame__m_pCallerReturnAddress 0x28
+#define               InlinedCallFrame__m_pCallerReturnAddress 0x30
 ASMCONSTANTS_C_ASSERT(InlinedCallFrame__m_pCallerReturnAddress == offsetof(InlinedCallFrame, m_pCallerReturnAddress))
 
-#define               InlinedCallFrame__m_pCalleeSavedFP 0x30
+#define               InlinedCallFrame__m_pCalleeSavedFP 0x38
 ASMCONSTANTS_C_ASSERT(InlinedCallFrame__m_pCalleeSavedFP == offsetof(InlinedCallFrame, m_pCalleeSavedFP))
 
-#define               InlinedCallFrame__m_pThread 0x38
+#define               InlinedCallFrame__m_pThread 0x40
 ASMCONSTANTS_C_ASSERT(InlinedCallFrame__m_pThread == offsetof(InlinedCallFrame, m_pThread))
 
 

--- a/src/vm/arm64/pinvokestubs.S
+++ b/src/vm/arm64/pinvokestubs.S
@@ -109,6 +109,7 @@ LOCAL_LABEL(\__PInvokeStubFuncName\()_0):
         add     x9, x9, 16
         str     x9, [x19]
 
+        str     wzr, [x19, #Frame__m_WasUnwound]
         str     xzr, [x19, #InlinedCallFrame__m_Datum]
     
         add     x9, sp, 32

--- a/src/vm/exceptionhandling.h
+++ b/src/vm/exceptionhandling.h
@@ -95,7 +95,6 @@ public:
 
         m_sfCurrentEstablisherFrame.Clear();
         m_sfLastUnwoundEstablisherFrame.Clear();
-        m_pInitialExplicitFrame = NULL;
         m_pLimitFrame = NULL;
         m_csfEHClauseOfCollapsedTracker.Clear();
 
@@ -155,7 +154,6 @@ public:
 
         m_sfCurrentEstablisherFrame.Clear();
         m_sfLastUnwoundEstablisherFrame.Clear();
-        m_pInitialExplicitFrame = NULL;
         m_csfEHClauseOfCollapsedTracker.Clear();
 
 #ifdef FEATURE_PAL
@@ -292,20 +290,12 @@ public:
         return m_sfLastUnwoundEstablisherFrame;
     }
 
-    PTR_Frame GetInitialExplicitFrame()
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        return m_pInitialExplicitFrame;
-    }
-
 #ifdef FEATURE_PAL
     // Reset the range of explicit frames, the limit frame and the scanned
     // stack range before unwinding a sequence of native frames. These frames
     // will be in the unwound part of the stack.
     void CleanupBeforeNativeFramesUnwind()
     {
-        m_pInitialExplicitFrame = NULL;
         m_pLimitFrame = NULL;
         m_ScannedStackRange.Reset();
     }
@@ -768,7 +758,6 @@ private: ;
 
     StackFrame              m_sfCurrentEstablisherFrame;
     StackFrame              m_sfLastUnwoundEstablisherFrame;
-    PTR_Frame               m_pInitialExplicitFrame;
     CallerStackFrame        m_csfEHClauseOfCollapsedTracker;
     EnclosingClauseInfo     m_EnclosingClauseInfoOfCollapsedTracker;
 };

--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -1001,6 +1001,51 @@ VOID GCFrame::Pop()
 #endif
 }
 
+#ifndef CROSSGEN_COMPILE
+// GCFrame destructor removes the GCFrame from the current thread's explicit frame list.
+// This prevents issues in functions that have HELPER_METHOD_FRAME_BEGIN / END around 
+// GCPROTECT_BEGIN / END and where the C++ compiler places some local variables over 
+// the stack location of the GCFrame local variable after the variable goes out of scope. 
+GCFrame::~GCFrame()
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
+
+    if (m_Next != NULL)
+    {
+        GCX_COOP_THREAD_EXISTS(m_pCurThread);
+        // When the frame is destroyed, make sure it is no longer in the
+        // frame chain managed by the Thread.
+        Pop();
+    }
+}
+
+ExceptionFilterFrame::~ExceptionFilterFrame()
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
+
+    if (m_Next != NULL)
+    {
+        GCX_COOP();
+        // When the frame is destroyed, make sure it is no longer in the
+        // frame chain managed by the Thread.
+        Pop();
+    }
+}
+
+#endif // !CROSSGEN_COMPILE
+
 #ifdef FEATURE_INTERPRETER
 // Methods of IntepreterFrame.
 InterpreterFrame::InterpreterFrame(Interpreter* interp) 
@@ -1937,15 +1982,6 @@ VOID InlinedCallFrame::Init()
     m_Datum = NULL;
     m_pCallSiteSP = NULL;
     m_pCallerReturnAddress = NULL;
-}
-
-
-
-void UnmanagedToManagedFrame::ExceptionUnwind()
-{
-    WRAPPER_NO_CONTRACT;
-
-    AppDomain::ExceptionUnwind(this);
 }
 
 #endif // !DACCESS_COMPILE

--- a/src/vm/i386/PInvokeStubs.asm
+++ b/src/vm/i386/PInvokeStubs.asm
@@ -46,8 +46,8 @@ _JIT_PInvokeBegin@4 PROC public
         lea             eax,[??_7InlinedCallFrame@@6B@]
         mov             dword ptr [ecx], eax
 
+        mov             dword ptr [ecx + Frame__m_WasUnwound], 0
         mov             dword ptr [ecx + InlinedCallFrame__m_Datum], 0
-
         
         mov             eax, esp
         add             eax, 4

--- a/src/vm/i386/asmconstants.h
+++ b/src/vm/i386/asmconstants.h
@@ -143,7 +143,7 @@ ASMCONSTANTS_C_ASSERT(LazyMachState_captureEip == offsetof(LazyMachState, captur
 #define VASigCookie__StubOffset 4
 ASMCONSTANTS_C_ASSERT(VASigCookie__StubOffset == offsetof(VASigCookie, pNDirectILStub))
 
-#define SIZEOF_TailCallFrame 32
+#define SIZEOF_TailCallFrame 36
 ASMCONSTANTS_C_ASSERT(SIZEOF_TailCallFrame == sizeof(TailCallFrame))
 
 #define SIZEOF_GSCookie 4
@@ -308,21 +308,48 @@ ASMCONSTANTS_C_ASSERT(UMThunkMarshInfo__m_cbActualArgSize == offsetof(UMThunkMar
 ASMCONSTANTS_C_ASSERT(UMThunkMarshInfo__m_cbRetPop == offsetof(UMThunkMarshInfo, m_cbRetPop))
 #endif //FEATURE_STUBS_AS_IL
 
+#define SIZEOF__Frame                 0x0C
+ASMCONSTANTS_C_ASSERT(SIZEOF__Frame == sizeof(Frame));
+
 // For JIT_PInvokeBegin and JIT_PInvokeEnd helpers
 #define               Frame__m_Next 0x04
 ASMCONSTANTS_C_ASSERT(Frame__m_Next == offsetof(Frame, m_Next));
 
-#define               InlinedCallFrame__m_Datum 0x08
+#define               Frame__m_WasUnwound 0x08
+ASMCONSTANTS_C_ASSERT(Frame__m_WasUnwound == offsetof(Frame, m_WasUnwound));
+
+#define               InlinedCallFrame__m_Datum 0x0C
 ASMCONSTANTS_C_ASSERT(InlinedCallFrame__m_Datum == offsetof(InlinedCallFrame, m_Datum));
 
-#define               InlinedCallFrame__m_pCallSiteSP 0x0C
+#define               InlinedCallFrame__m_pCallSiteSP 0x10
 ASMCONSTANTS_C_ASSERT(InlinedCallFrame__m_pCallSiteSP == offsetof(InlinedCallFrame, m_pCallSiteSP));
 
-#define               InlinedCallFrame__m_pCallerReturnAddress 0x10
+#define               InlinedCallFrame__m_pCallerReturnAddress 0x14
 ASMCONSTANTS_C_ASSERT(InlinedCallFrame__m_pCallerReturnAddress == offsetof(InlinedCallFrame, m_pCallerReturnAddress));
 
-#define               InlinedCallFrame__m_pCalleeSavedFP 0x14
+#define               InlinedCallFrame__m_pCalleeSavedFP 0x18
 ASMCONSTANTS_C_ASSERT(InlinedCallFrame__m_pCalleeSavedFP == offsetof(InlinedCallFrame, m_pCalleeSavedFP));
+
+#define TailCallFrame__m_CallerAddress 0x0c
+ASMCONSTANTS_C_ASSERT(TailCallFrame__m_CallerAddress == offsetof(TailCallFrame, m_CallerAddress));
+
+#define TailCallFrame__m_regs 0x10
+ASMCONSTANTS_C_ASSERT(TailCallFrame__m_regs == offsetof(TailCallFrame, m_regs));
+
+#define CalleeSavedRegisters__edi 0x00
+ASMCONSTANTS_C_ASSERT(CalleeSavedRegisters__edi == offsetof(CalleeSavedRegisters, Edi));
+
+#define CalleeSavedRegisters__esi 0x04
+ASMCONSTANTS_C_ASSERT(CalleeSavedRegisters__esi == offsetof(CalleeSavedRegisters, Esi));
+
+#define CalleeSavedRegisters__ebx 0x08
+ASMCONSTANTS_C_ASSERT(CalleeSavedRegisters__ebx == offsetof(CalleeSavedRegisters, Ebx));
+
+#define CalleeSavedRegisters__ebp 0x0c
+ASMCONSTANTS_C_ASSERT(CalleeSavedRegisters__ebp == offsetof(CalleeSavedRegisters, Ebp));
+
+#define TailCallFrame__m_ReturnAddress 0x20
+ASMCONSTANTS_C_ASSERT(TailCallFrame__m_ReturnAddress == offsetof(TailCallFrame, m_ReturnAddress));
 
 #ifdef FEATURE_STUBS_AS_IL
 // DelegateObject from src/vm/object.h

--- a/src/vm/i386/asmhelpers.asm
+++ b/src/vm/i386/asmhelpers.asm
@@ -1667,7 +1667,7 @@ _ComCallPreStub@0 proc public
     push        edi
 
     push        eax         ; ComCallMethodDesc*
-    sub         esp, 5*4    ; next, vtable, gscookie, 64-bit error return
+    sub         esp, SIZEOF__Frame + 4 + 8    ; Frame, gscookie, 64-bit error return
 
     lea     edi, [esp]
     lea     esi, [esp+3*4]
@@ -1680,7 +1680,7 @@ _ComCallPreStub@0 proc public
     cmp eax, 0
     je nostub                   ; oops we could not create a stub
 
-    add     esp, 6*4
+    add     esp, 4 + SIZEOF__Frame + 4 + 8    ; ComCallMethodDesc*, Frame, gscookie, 64-bit error return
 
     ; pop CalleeSavedRegisters
     pop edi
@@ -1703,7 +1703,7 @@ nostub:
     mov     eax, [edi]
     mov     edx, [edi+4]
 
-    add     esp, 6*4
+    add     esp, 4 + SIZEOF__Frame + 4 + 8; ComCallMethodDesc*, Frame, gscookie, 64-bit error return
 
     ; pop CalleeSavedRegisters
     pop edi

--- a/src/vm/i386/stublinkerx86.cpp
+++ b/src/vm/i386/stublinkerx86.cpp
@@ -2580,6 +2580,9 @@ void StubLinkerCPU::EmitComMethodStubProlog(TADDR pFrameVptr,
     // push eax ; datum
     X86EmitPushReg(kEAX);
 
+    // push edx ;leave room for m_WasUnwound (edx is an arbitrary choice)
+    X86EmitPushReg(kEDX);
+
     // push edx ;leave room for m_next (edx is an arbitrary choice)
     X86EmitPushReg(kEDX);
 
@@ -2962,6 +2965,9 @@ VOID StubLinkerCPU::EmitMethodStubProlog(TADDR pFrameVptr, int transitionBlockOf
     // Push m_datum
     X86EmitPushReg(SCRATCH_REGISTER_X86REG);
 
+    // push edx ;leave room for m_WasUnwound (edx is an arbitrary choice)
+    X86EmitPushReg(kEDX);
+
     // push edx ;leave room for m_next (edx is an arbitrary choice)
     X86EmitPushReg(kEDX);
 
@@ -3005,6 +3011,9 @@ VOID StubLinkerCPU::EmitMethodStubProlog(TADDR pFrameVptr, int transitionBlockOf
 
     // Push m_datum
     X86EmitPushReg(kEAX);
+
+    // push edx ;leave room for m_WasUnwound (edx is an arbitrary choice)
+    X86EmitPushReg(kEDX);
 
     // push edx ;leave room for m_next (edx is an arbitrary choice)
     X86EmitPushReg(kEDX);

--- a/src/vm/jithelpers.cpp
+++ b/src/vm/jithelpers.cpp
@@ -5629,6 +5629,7 @@ Thread * __stdcall JIT_InitPInvokeFrame(InlinedCallFrame *pFrame, PTR_VOID StubS
     pFrame->Init();
     pFrame->m_StubSecretArg = StubSecretArg;
     pFrame->m_Next = pThread->GetFrame();
+    pFrame->m_WasUnwound = FALSE;
 
     return pThread;
 }

--- a/src/vm/threadsuspend.cpp
+++ b/src/vm/threadsuspend.cpp
@@ -3042,6 +3042,8 @@ void RedirectedThreadFrame::ExceptionUnwind()
 
     STRESS_LOG1(LF_SYNC, LL_INFO1000, "In RedirectedThreadFrame::ExceptionUnwind pFrame = %p\n", this);
 
+    Frame::ExceptionUnwind();
+
     Thread* pThread = GetThread();
 
     if (pThread->GetSavedRedirectContext())


### PR DESCRIPTION
More aggressive C/C++ optimizations done by VS2019 are breaking fragile
assumptions of the CoreCLR "manually managed code".

Unwinding of Frame chains accesses stack local variables after the stack
frame has been unwound, but it depends on their content to be left
intact. The new compiler is breaking this assumption by stack-packing a
different variable over it.

This change fixes the problem by adding a destructor to GCFrame that
pops the frame from the per-thread Frame list.

I also had to refactor two functions where the compiler was complaining about
mixing SEH and C++ EH in single function.

With these changes applied, there was still a problem that I've discovered
when running CoreCLR tests with GCStress 3. When the
ExceptionTracker::m_pInitialExplicitFrame was still pointing to a frame
that was already removed from the explicit Frame chain. When the
ExceptionTracker::HasFrameBeenUnwoundByAnyActiveException was walking the
frame chain starting at m_pInitialExplicitFrame to figure out if a given
frame was already unwound, it has walked to the destryoyed GCFrame and
crashed.
After various attempts to update the m_pInitialExplicitFrame during the
exception handling so that the explicit frames chain starting at it doesn't
contain the destroyed GC frames, I have decided to drop the m_pInitialExplicitFrame
completely and rather add a flag to the Frame indicating whether it was already
unwound by an exception or not. The Frame already had a method ExceptionUnwind
that is called when the unwinding happens, so I could just set the flag in
there.
Due to this change, I had to fix a couple of ASM helpers and some places in
native code generators in the runtime. There were places where we were using
numeric constants for various offsets and sizes instead of constants defined
in asmconstants.h and verified at build time.