### PR TITLE
Remove some boxing from tuples with >= 8 elements

### DIFF
--- a/src/System.Private.CoreLib/shared/System/ValueTuple.cs
+++ b/src/System.Private.CoreLib/shared/System/ValueTuple.cs
@@ -2018,8 +2018,8 @@ namespace System
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
-            // We want to have a limited hash in this case.  We'll use the last 8 elements of the tuple
-            if (!(Rest is IValueTupleInternal rest))
+            // We want to have a limited hash in this case. We'll use the first 7 elements of the tuple
+            if (!(Rest is IValueTupleInternal))
             {
                 return HashCode.Combine(Item1?.GetHashCode() ?? 0,
                                         Item2?.GetHashCode() ?? 0,
@@ -2030,38 +2030,42 @@ namespace System
                                         Item7?.GetHashCode() ?? 0);
             }
 
-            int size = rest.Length;
-            if (size >= 8) { return rest.GetHashCode(); }
+            int size = ((IValueTupleInternal)Rest).Length;
+            int restHashCode = Rest.GetHashCode();
+            if (size >= 8)
+            {
+                return restHashCode;
+            }
 
-            // In this case, the rest member has less than 8 elements so we need to combine some our elements with the elements in rest
+            // In this case, the rest member has less than 8 elements so we need to combine some of our elements with the elements in rest
             int k = 8 - size;
             switch (k)
             {
                 case 1:
                     return HashCode.Combine(Item7?.GetHashCode() ?? 0,
-                                            rest.GetHashCode());
+                                            restHashCode);
                 case 2:
                     return HashCode.Combine(Item6?.GetHashCode() ?? 0,
                                             Item7?.GetHashCode() ?? 0,
-                                            rest.GetHashCode());
+                                            restHashCode);
                 case 3:
                     return HashCode.Combine(Item5?.GetHashCode() ?? 0,
                                             Item6?.GetHashCode() ?? 0,
                                             Item7?.GetHashCode() ?? 0,
-                                            rest.GetHashCode());
+                                            restHashCode);
                 case 4:
                     return HashCode.Combine(Item4?.GetHashCode() ?? 0,
                                             Item5?.GetHashCode() ?? 0,
                                             Item6?.GetHashCode() ?? 0,
                                             Item7?.GetHashCode() ?? 0,
-                                            rest.GetHashCode());
+                                            restHashCode);
                 case 5:
                     return HashCode.Combine(Item3?.GetHashCode() ?? 0,
                                             Item4?.GetHashCode() ?? 0,
                                             Item5?.GetHashCode() ?? 0,
                                             Item6?.GetHashCode() ?? 0,
                                             Item7?.GetHashCode() ?? 0,
-                                            rest.GetHashCode());
+                                            restHashCode);
                 case 6:
                     return HashCode.Combine(Item2?.GetHashCode() ?? 0,
                                             Item3?.GetHashCode() ?? 0,
@@ -2069,7 +2073,7 @@ namespace System
                                             Item5?.GetHashCode() ?? 0,
                                             Item6?.GetHashCode() ?? 0,
                                             Item7?.GetHashCode() ?? 0,
-                                            rest.GetHashCode());
+                                            restHashCode);
                 case 7:
                 case 8:
                     return HashCode.Combine(Item1?.GetHashCode() ?? 0,
@@ -2079,7 +2083,7 @@ namespace System
                                             Item5?.GetHashCode() ?? 0,
                                             Item6?.GetHashCode() ?? 0,
                                             Item7?.GetHashCode() ?? 0,
-                                            rest.GetHashCode());
+                                            restHashCode);
             }
 
             Debug.Fail("Missed all cases for computing ValueTuple hash code");
@@ -2093,7 +2097,7 @@ namespace System
 
         private int GetHashCodeCore(IEqualityComparer comparer)
         {
-            // We want to have a limited hash in this case.  We'll use the last 8 elements of the tuple
+            // We want to have a limited hash in this case. We'll use the first 7 elements of the tuple
             if (!(Rest is IValueTupleInternal rest))
             {
                 return HashCode.Combine(comparer.GetHashCode(Item1!), comparer.GetHashCode(Item2!), comparer.GetHashCode(Item3!),
@@ -2102,34 +2106,59 @@ namespace System
             }
 
             int size = rest.Length;
-            if (size >= 8) { return rest.GetHashCode(comparer); }
+            int restHashCode = rest.GetHashCode(comparer);
+            if (size >= 8)
+            {
+                return restHashCode;
+            }
 
             // In this case, the rest member has less than 8 elements so we need to combine some our elements with the elements in rest
             int k = 8 - size;
             switch (k)
             {
                 case 1:
-                    return HashCode.Combine(comparer.GetHashCode(Item7!), rest.GetHashCode(comparer));
+                    return HashCode.Combine(comparer.GetHashCode(Item7!),
+                                            restHashCode);
                 case 2:
-                    return HashCode.Combine(comparer.GetHashCode(Item6!), comparer.GetHashCode(Item7!), rest.GetHashCode(comparer));
+                    return HashCode.Combine(comparer.GetHashCode(Item6!),
+                                            comparer.GetHashCode(Item7!),
+                                            restHashCode);
                 case 3:
-                    return HashCode.Combine(comparer.GetHashCode(Item5!), comparer.GetHashCode(Item6!), comparer.GetHashCode(Item7!),
-                                            rest.GetHashCode(comparer));
+                    return HashCode.Combine(comparer.GetHashCode(Item5!),
+                                            comparer.GetHashCode(Item6!),
+                                            comparer.GetHashCode(Item7!),
+                                            restHashCode);
                 case 4:
-                    return HashCode.Combine(comparer.GetHashCode(Item4!), comparer.GetHashCode(Item5!), comparer.GetHashCode(Item6!),
-                                            comparer.GetHashCode(Item7!), rest.GetHashCode(comparer));
+                    return HashCode.Combine(comparer.GetHashCode(Item4!),
+                                            comparer.GetHashCode(Item5!),
+                                            comparer.GetHashCode(Item6!),
+                                            comparer.GetHashCode(Item7!),
+                                            restHashCode);
                 case 5:
-                    return HashCode.Combine(comparer.GetHashCode(Item3!), comparer.GetHashCode(Item4!), comparer.GetHashCode(Item5!),
-                                            comparer.GetHashCode(Item6!), comparer.GetHashCode(Item7!), rest.GetHashCode(comparer));
+                    return HashCode.Combine(comparer.GetHashCode(Item3!),
+                                            comparer.GetHashCode(Item4!),
+                                            comparer.GetHashCode(Item5!),
+                                            comparer.GetHashCode(Item6!),
+                                            comparer.GetHashCode(Item7!),
+                                            restHashCode);
                 case 6:
-                    return HashCode.Combine(comparer.GetHashCode(Item2!), comparer.GetHashCode(Item3!), comparer.GetHashCode(Item4!),
-                                            comparer.GetHashCode(Item5!), comparer.GetHashCode(Item6!), comparer.GetHashCode(Item7!),
-                                            rest.GetHashCode(comparer));
+                    return HashCode.Combine(comparer.GetHashCode(Item2!),
+                                            comparer.GetHashCode(Item3!),
+                                            comparer.GetHashCode(Item4!),
+                                            comparer.GetHashCode(Item5!),
+                                            comparer.GetHashCode(Item6!),
+                                            comparer.GetHashCode(Item7!),
+                                            restHashCode);
                 case 7:
                 case 8:
-                    return HashCode.Combine(comparer.GetHashCode(Item1!), comparer.GetHashCode(Item2!), comparer.GetHashCode(Item3!),
-                                            comparer.GetHashCode(Item4!), comparer.GetHashCode(Item5!), comparer.GetHashCode(Item6!),
-                                            comparer.GetHashCode(Item7!), rest.GetHashCode(comparer));
+                    return HashCode.Combine(comparer.GetHashCode(Item1!),
+                                            comparer.GetHashCode(Item2!),
+                                            comparer.GetHashCode(Item3!),
+                                            comparer.GetHashCode(Item4!),
+                                            comparer.GetHashCode(Item5!),
+                                            comparer.GetHashCode(Item6!),
+                                            comparer.GetHashCode(Item7!),
+                                            restHashCode);
             }
 
             Debug.Fail("Missed all cases for computing ValueTuple hash code");
@@ -2151,9 +2180,9 @@ namespace System
         /// </remarks>
         public override string ToString()
         {
-            if (Rest is IValueTupleInternal rest)
+            if (Rest is IValueTupleInternal)
             {
-                return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ", " + rest.ToStringEnd();
+                return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ", " + ((IValueTupleInternal)Rest).ToStringEnd();
             }
 
             return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ", " + Rest.ToString() + ")";
@@ -2161,9 +2190,9 @@ namespace System
 
         string IValueTupleInternal.ToStringEnd()
         {
-            if (Rest is IValueTupleInternal rest)
+            if (Rest is IValueTupleInternal)
             {
-                return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ", " + rest.ToStringEnd();
+                return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ", " + ((IValueTupleInternal)Rest).ToStringEnd();
             }
 
             return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ", " + Rest.ToString() + ")";
@@ -2172,7 +2201,7 @@ namespace System
         /// <summary>
         /// The number of positions in this data structure.
         /// </summary>
-        int ITuple.Length => Rest is IValueTupleInternal rest ? 7 + rest.Length : 8;
+        int ITuple.Length => Rest is IValueTupleInternal ? 7 + ((IValueTupleInternal)Rest).Length : 8;
 
         /// <summary>
         /// Get the element at position <param name="index"/>.
@@ -2199,9 +2228,9 @@ namespace System
                         return Item7;
                 }
 
-                if (Rest is IValueTupleInternal rest)
+                if (Rest is IValueTupleInternal)
                 {
-                    return rest[index - 7];
+                    return ((IValueTupleInternal)Rest)[index - 7];
                 }
 
 


### PR DESCRIPTION
Remove some boxing from tuples with >= 8 elements

Take advantage of https://github.com/dotnet/coreclr/pull/14698 to avoid boxing the TRest argument and improve devirtualization.

|     Method | Toolchain |       Mean |     Error | Ratio | Allocated |
|----------- |---------- |-----------:|----------:|------:|----------:|
|       GHC7 |       Old |   2.043 ns | 0.0100 ns |  1.00 |         - |
|       GHC7 |       New |   2.042 ns | 0.0135 ns |  1.00 |         - |
|            |           |            |           |       |           |
|       GHC8 |       Old |   8.489 ns | 0.0917 ns |  1.00 |      24 B |
|       GHC8 |       New |   3.230 ns | 0.0159 ns |  0.38 |         - |
|            |           |            |           |       |           |
|       GHC9 |       Old |   9.062 ns | 0.0459 ns |  1.00 |      24 B |
|       GHC9 |       New |   3.230 ns | 0.0194 ns |  0.36 |         - |
|            |           |            |           |       |           |
|      GHC10 |       Old |   9.644 ns | 0.1006 ns |  1.00 |      32 B |
|      GHC10 |       New |   3.479 ns | 0.0161 ns |  0.36 |         - |
|            |           |            |           |       |           |
|  ToString7 |       Old | 214.852 ns | 0.4342 ns |  1.00 |     208 B |
|  ToString7 |       New | 209.641 ns | 0.5081 ns |  0.98 |     208 B |
|            |           |            |           |       |           |
|  ToString8 |       Old |   257.0 ns |  4.019 ns |  1.00 |     280 B |
|  ToString8 |       New |   242.9 ns |  2.952 ns |  0.95 |     256 B |
|            |           |            |           |       |           |
|  ToString9 |       Old | 268.936 ns | 1.0210 ns |  1.00 |     288 B |
|  ToString9 |       New | 266.940 ns | 0.9469 ns |  0.99 |     264 B |
|            |           |            |           |       |           |
| ToString10 |       Old | 318.626 ns | 0.9727 ns |  1.00 |     416 B |
| ToString10 |       New | 307.865 ns | 1.2496 ns |  0.97 |     384 B |
|            |           |            |           |       |           |
|     Index7 |       Old |   4.067 ns | 0.0813 ns |  1.00 |      24 B |
|     Index7 |       New |   3.988 ns | 0.0256 ns |  0.98 |      24 B |
|            |           |            |           |       |           |
|     Index8 |       Old |   7.906 ns | 0.0354 ns |  1.00 |      48 B |
|     Index8 |       New |   5.134 ns | 0.0505 ns |  0.65 |      24 B |
|            |           |            |           |       |           |
|     Index9 |       Old |   7.607 ns | 0.0418 ns |  1.00 |      48 B |
|     Index9 |       New |   4.996 ns | 0.0926 ns |  0.66 |      24 B |
|            |           |            |           |       |           |
|    Index10 |       Old |   8.989 ns | 0.0542 ns |  1.00 |      56 B |
|    Index10 |       New |   5.113 ns | 0.0422 ns |  0.57 |      24 B |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Runtime.CompilerServices;

[MemoryDiagnoser]
public class Program
{
    public static void Main(string[] args) => BenchmarkSwitcher.FromTypes(new[] { typeof(Program) }).Run(args);

    private (int, int, int, int, int, int, int) _v7 = (1, 2, 3, 4, 5, 6, 7);
    private (int, int, int, int, int, int, int, int) _v8 = (1, 2, 3, 4, 5, 6, 7, 8);
    private (int, int, int, int, int, int, int, int, int) _v9 = (1, 2, 3, 4, 5, 6, 7, 8, 9);
    private (int, int, int, int, int, int, int, int, int, int) _v10 = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);

    [Benchmark] public int GHC7() => _v7.GetHashCode();
    [Benchmark] public int GHC8() => _v8.GetHashCode();
    [Benchmark] public int GHC9() => _v9.GetHashCode();
    [Benchmark] public int GHC10() => _v10.GetHashCode();

    [Benchmark] public string ToString7() => _v7.ToString();
    [Benchmark] public string ToString8() => _v8.ToString();
    [Benchmark] public string ToString9() => _v9.ToString();
    [Benchmark] public string ToString10() => _v10.ToString();

    [Benchmark] public object Index7() => ((ITuple)_v7)[6];
    [Benchmark] public object Index8() => ((ITuple)_v8)[7];
    [Benchmark] public object Index9() => ((ITuple)_v9)[8];
    [Benchmark] public object Index10() => ((ITuple)_v10)[9];
}
```

cc: @AndyAyersMS, @jcouv