### PR TITLE
Remove use of non-generic WeakReference from corelib

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Resources/ResourceReader.cs
+++ b/src/System.Private.CoreLib/shared/System/Resources/ResourceReader.cs
@@ -28,7 +28,7 @@ namespace System.Resources
 
     internal struct ResourceLocator
     {
-        internal object? _value;  // Can be null.  Consider WeakReference instead?
+        internal object? _value;  // Can be null.
         internal int _dataPos;
 
         internal ResourceLocator(int dataPos, object? value)

--- a/src/System.Private.CoreLib/src/System/Internal.cs
+++ b/src/System.Private.CoreLib/src/System/Internal.cs
@@ -85,7 +85,6 @@ namespace System
             new Dictionary<object, Guid>();
             new Dictionary<object, int>();
             new Dictionary<object, long>(); // Added for Visual Studio 2010
-            new Dictionary<uint, WeakReference>();  // NCL team needs this
             new Dictionary<object, uint>();
             new Dictionary<uint, object>();
             new Dictionary<long, object>();
@@ -133,7 +132,6 @@ namespace System
             new List<ulong>();
             new List<IntPtr>();
             new List<KeyValuePair<object, object>>();
-            new List<GCHandle>();  // NCL team needs this
             new List<DateTimeOffset>();
 
             new KeyValuePair<char, ushort>('\0', ushort.MinValue);


### PR DESCRIPTION
Only remaining use is the one place it shows up in public API, in GC.GetGeneration(WeakReference).