### PR TITLE
Fix the loop iterator in `CheckNoTransformableIndirectCallsRemain`.

### DIFF
--- a/src/jit/indirectcalltransformer.cpp
+++ b/src/jit/indirectcalltransformer.cpp
@@ -798,7 +798,7 @@ void Compiler::CheckNoTransformableIndirectCallsRemain()
 
     for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->bbNext)
     {
-        for (GenTreeStmt* stmt = fgFirstBB->firstStmt(); stmt != nullptr; stmt = stmt->gtNextStmt)
+        for (GenTreeStmt* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->gtNextStmt)
         {
             fgWalkTreePre(&stmt->gtStmtExpr, fgDebugCheckForTransformableIndirectCalls);
         }


### PR DESCRIPTION
The error was made in my PR from 2017 https://github.com/dotnet/coreclr/commit/654fed28001085adc162de1ea3207e9a22230235 and then that function was a few times moved/renamed.