### PR TITLE
Remove sub-array allocation from GetManifestResourceNamesList

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Resources/ManifestBasedResourceGroveler.cs
+++ b/src/System.Private.CoreLib/shared/System/Resources/ManifestBasedResourceGroveler.cs
@@ -462,16 +462,19 @@ namespace System.Resources
         {
             try
             {
-                string postfix = "\"";
                 string[] resourceSetNames = assembly.GetManifestResourceNames();
+                int length = resourceSetNames.Length;
+                string postfix = "\"";
 
                 // If we have more than 10 resource sets, we just print the first 10 for the sake of the exception message readability.
-                if (resourceSetNames.Length > 10)
+                const int MaxLength = 10;
+                if (length > MaxLength)
                 {
-                    resourceSetNames = resourceSetNames[..10];
+                    length = MaxLength;
                     postfix = "\", ...";
                 }
-                return "\"" + string.Join("\", \"", resourceSetNames) + postfix;
+
+                return "\"" + string.Join("\", \"", resourceSetNames, 0, length) + postfix;
             }
             catch
             {


### PR DESCRIPTION
Also removes dependency on System.Range and RuntimeHelpers.GetSubArray in a simple console app such that they can be trimmed away.