### PR TITLE
Remove remaining String.ToLower() use from corelib

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/Tracing/EventSource.cs
@@ -5675,7 +5675,7 @@ namespace System.Diagnostics.Tracing
                         sb.Append(" value=\"").Append(channel).Append("\"");
                         if (channelType != null)
                             sb.Append(" type=\"").Append(channelType).Append("\"");
-                        sb.Append(" enabled=\"").Append(enabled.ToString().ToLower()).Append("\"");
+                        sb.Append(" enabled=\"").Append(enabled ? "true" : "false").Append("\"");
 #if FEATURE_ADVANCED_MANAGED_ETW_CHANNELS
                         if (access != null)
                             sb.Append(" access=\"").Append(access).Append("\"");


### PR DESCRIPTION
This should not be culture-specific.

Also happens to save a string allocation, but that's a drop in the bucket in this function.