### PR TITLE
Fix Running .NET Core Under Windows App Compat Shim

### DIFF
--- a/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.Globalization.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.Globalization.cs
@@ -24,6 +24,9 @@ internal static partial class Interop
         internal const uint LOCALE_RETURN_NUMBER        = 0x20000000;
         internal const uint LOCALE_NOUSEROVERRIDE       = 0x80000000;
 
+        internal const uint LCMAP_SORTHANDLE            = 0x20000000;
+        internal const uint LCMAP_HASH                  = 0x00040000;
+
         internal const int  COMPARE_STRING              = 0x0001;
 
         internal const uint TIME_NOSECONDS = 0x00000002;

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Windows.cs
@@ -12,6 +12,11 @@ namespace System.Globalization
     {
         internal static unsafe IntPtr GetSortHandle(string cultureName)
         {
+            if (GlobalizationMode.Invariant)
+            {
+                return IntPtr.Zero;
+            }
+
             IntPtr handle;
             int ret = Interop.Kernel32.LCMapStringEx(cultureName, Interop.Kernel32.LCMAP_SORTHANDLE, null, 0, &handle, IntPtr.Size, null, null, IntPtr.Zero);
             if (ret > 0)
@@ -34,15 +39,7 @@ namespace System.Globalization
         private void InitSort(CultureInfo culture)
         {
             _sortName = culture.SortName;
-
-            if (GlobalizationMode.Invariant)
-            {
-                _sortHandle = IntPtr.Zero;
-            }
-            else
-            {
-                _sortHandle = GetSortHandle(_sortName);
-            }
+            _sortHandle = GetSortHandle(_sortName);
         }
 
         private static unsafe int FindStringOrdinal(

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Windows.cs
@@ -5,28 +5,23 @@
 using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Runtime.CompilerServices;
 
 namespace System.Globalization
 {
     public partial class CompareInfo
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe IntPtr GetSortHandle(string cultureName)
         {
-            const uint LCMAP_SORTHANDLE = 0x20000000;
-            const uint LCMAP_HASH = 0x00040000;
-
             IntPtr handle;
-            int ret = Interop.Kernel32.LCMapStringEx(cultureName, LCMAP_SORTHANDLE, null, 0, &handle, IntPtr.Size, null, null, IntPtr.Zero);
+            int ret = Interop.Kernel32.LCMapStringEx(cultureName, Interop.Kernel32.LCMAP_SORTHANDLE, null, 0, &handle, IntPtr.Size, null, null, IntPtr.Zero);
             if (ret > 0)
             {
-                // Even if we can get the sort handle, it is not gauranteed to work when Windows compatibility shim is applied
+                // Even if we can get the sort handle, it is not guaranteed to work when Windows compatibility shim is applied
                 // e.g. Windows 7 compatibility mode. We need to ensure it is working before using it.
                 // otherwise the whole framework app will not start.
                 int hashValue = 0;
                 char a = 'a';
-                ret = Interop.Kernel32.LCMapStringEx(null, LCMAP_HASH, &a, 1, &hashValue, sizeof(int), null, null, handle);
+                ret = Interop.Kernel32.LCMapStringEx(null, Interop.Kernel32.LCMAP_HASH, &a, 1, &hashValue, sizeof(int), null, null, handle);
                 if (ret > 1)
                 {
                     return handle;

--- a/src/System.Private.CoreLib/shared/System/Globalization/TextInfo.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/TextInfo.Windows.cs
@@ -10,12 +10,6 @@ namespace System.Globalization
     {
         private unsafe void FinishInitialization()
         {
-            if (GlobalizationMode.Invariant)
-            {
-                _sortHandle = IntPtr.Zero;
-                return;
-            }
-
             _sortHandle = CompareInfo.GetSortHandle(_textInfoName);
         }
 

--- a/src/System.Private.CoreLib/shared/System/Globalization/TextInfo.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/TextInfo.Windows.cs
@@ -16,11 +16,7 @@ namespace System.Globalization
                 return;
             }
 
-            const uint LCMAP_SORTHANDLE = 0x20000000;
-
-            IntPtr handle;
-            int ret = Interop.Kernel32.LCMapStringEx(_textInfoName, LCMAP_SORTHANDLE, null, 0, &handle, IntPtr.Size, null, null, IntPtr.Zero);
-            _sortHandle = ret > 0 ? handle : IntPtr.Zero;
+            _sortHandle = CompareInfo.GetSortHandle(_textInfoName);
         }
 
         private unsafe void ChangeCase(char* pSource, int pSourceLen, char* pResult, int pResultLen, bool toUpper)


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/26479

.NET Core uses Windows features called sort handles for perf reason to speed up the collation operations (e.g. string comparisons). When enabling Windows app compat shim (e.g. Windows 7 compatibility mode), the calls uses sort handles will fail which cause all collation operations to fail.
The fix here is to detect if the sort handles work before using it to ensure successful run.