### PR TITLE
[test] Mark EventPipe tests JITStress Incompatible and Partially GC Stress Incompatible

### DIFF
--- a/tests/src/tracing/eventpipe/buffersize/buffersize.csproj
+++ b/tests/src/tracing/eventpipe/buffersize/buffersize.csproj
@@ -7,6 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/tests/src/tracing/eventpipe/eventsvalidation/ExceptionThrown_V1.cs
+++ b/tests/src/tracing/eventpipe/eventsvalidation/ExceptionThrown_V1.cs
@@ -27,7 +27,7 @@ namespace Tracing.Tests.ExceptionThrown_V1
 
         private static Dictionary<string, ExpectedEventCount> _expectedEventCounts = new Dictionary<string, ExpectedEventCount>()
         {
-            { "Microsoft-Windows-DotNETRuntime", 1000 },
+            { "Microsoft-Windows-DotNETRuntime", 1000, 0.2 },
             { "Microsoft-Windows-DotNETRuntimeRundown", -1 },
             { "Microsoft-DotNETCore-SampleProfiler", -1 }
         };

--- a/tests/src/tracing/eventpipe/eventsvalidation/ExceptionThrown_V1.cs
+++ b/tests/src/tracing/eventpipe/eventsvalidation/ExceptionThrown_V1.cs
@@ -27,7 +27,7 @@ namespace Tracing.Tests.ExceptionThrown_V1
 
         private static Dictionary<string, ExpectedEventCount> _expectedEventCounts = new Dictionary<string, ExpectedEventCount>()
         {
-            { "Microsoft-Windows-DotNETRuntime", 1000, 0.2 },
+            { "Microsoft-Windows-DotNETRuntime", new ExpectedEventCount(1000, 0.2f) },
             { "Microsoft-Windows-DotNETRuntimeRundown", -1 },
             { "Microsoft-DotNETCore-SampleProfiler", -1 }
         };

--- a/tests/src/tracing/eventpipe/eventsvalidation/ExceptionThrown_V1.csproj
+++ b/tests/src/tracing/eventpipe/eventsvalidation/ExceptionThrown_V1.csproj
@@ -7,6 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ExceptionThrown_V1.cs" />

--- a/tests/src/tracing/eventpipe/eventsvalidation/GCEvents.cs
+++ b/tests/src/tracing/eventpipe/eventsvalidation/GCEvents.cs
@@ -35,9 +35,9 @@ namespace Tracing.Tests.GCEvents
 
         private static Action _eventGeneratingAction = () => 
         {
-            for (int i = 0; i < 1000; i++)
+            for (int i = 0; i < 50; i++)
             {
-                if (i % 100 == 0)
+                if (i % 10 == 0)
                     Logger.logger.Log($"Called GC.Collect() {i} times...");
                 ProviderValidation providerValidation = new ProviderValidation();
                 providerValidation = null;
@@ -67,17 +67,17 @@ namespace Tracing.Tests.GCEvents
 
                 Logger.logger.Log("GCStartEvents: " + GCStartEvents);
                 Logger.logger.Log("GCEndEvents: " + GCEndEvents);
-                bool GCStartStopResult = GCStartEvents >= 1000 && GCEndEvents >= 1000 && GCStartEvents == GCEndEvents;
+                bool GCStartStopResult = GCStartEvents >= 50 && GCEndEvents >= 50 && Math.Abs(GCStartEvents - GCEndEvents) <=2;
                 Logger.logger.Log("GCStartStopResult check: " + GCStartStopResult);
 
                 Logger.logger.Log("GCRestartEEStartEvents: " + GCRestartEEStartEvents);
                 Logger.logger.Log("GCRestartEEStopEvents: " + GCRestartEEStopEvents);
-                bool GCRestartEEStartStopResult = GCRestartEEStartEvents >= 1000 && GCRestartEEStopEvents >= 1000;
+                bool GCRestartEEStartStopResult = GCRestartEEStartEvents >= 50 && GCRestartEEStopEvents >= 50;
                 Logger.logger.Log("GCRestartEEStartStopResult check: " + GCRestartEEStartStopResult);
 
                 Logger.logger.Log("GCSuspendEEEvents: " + GCSuspendEEEvents);
                 Logger.logger.Log("GCSuspendEEEndEvents: " + GCSuspendEEEndEvents);
-                bool GCSuspendEEStartStopResult = GCSuspendEEEvents >= 1000 && GCSuspendEEEndEvents >= 1000;
+                bool GCSuspendEEStartStopResult = GCSuspendEEEvents >= 50 && GCSuspendEEEndEvents >= 50;
                 Logger.logger.Log("GCSuspendEEStartStopResult check: " + GCSuspendEEStartStopResult);
 
                 return GCStartStopResult && GCRestartEEStartStopResult && GCSuspendEEStartStopResult ? 100 : -1;

--- a/tests/src/tracing/eventpipe/eventsvalidation/GCEvents.csproj
+++ b/tests/src/tracing/eventpipe/eventsvalidation/GCEvents.csproj
@@ -7,6 +7,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GCEvents.cs" />

--- a/tests/src/tracing/eventpipe/eventsvalidation/GCFinalizers.cs
+++ b/tests/src/tracing/eventpipe/eventsvalidation/GCFinalizers.cs
@@ -35,9 +35,9 @@ namespace Tracing.Tests.GCFinalizers
 
         private static Action _eventGeneratingAction = () => 
         {
-            for (int i = 0; i < 1000; i++)
+            for (int i = 0; i < 50; i++)
             {
-                if (i % 100 == 0)
+                if (i % 10 == 0)
                     Logger.logger.Log($"Called GC.WaitForPendingFinalizers() {i} times...");
                 ProviderValidation providerValidation = new ProviderValidation();
                 providerValidation = null;
@@ -58,7 +58,7 @@ namespace Tracing.Tests.GCFinalizers
                 Logger.logger.Log("Event counts validation");
                 Logger.logger.Log("GCFinalizersEndEvents: " + GCFinalizersEndEvents);
                 Logger.logger.Log("GCFinalizersStartEvents: " + GCFinalizersStartEvents);
-                return GCFinalizersEndEvents >= 1000 && GCFinalizersStartEvents >= 1000 ? 100 : -1;
+                return GCFinalizersEndEvents >= 50 && GCFinalizersStartEvents >= 50 ? 100 : -1;
             };
         };
     }

--- a/tests/src/tracing/eventpipe/eventsvalidation/GCFinalizers.csproj
+++ b/tests/src/tracing/eventpipe/eventsvalidation/GCFinalizers.csproj
@@ -7,6 +7,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GCFinalizers.cs" />

--- a/tests/src/tracing/eventpipe/providervalidation/providervalidation.csproj
+++ b/tests/src/tracing/eventpipe/providervalidation/providervalidation.csproj
@@ -7,6 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/tests/src/tracing/eventpipe/rundownvalidation/rundownvalidation.csproj
+++ b/tests/src/tracing/eventpipe/rundownvalidation/rundownvalidation.csproj
@@ -6,6 +6,7 @@
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
* Mark all EventPipe tests as JitOptimizationSensitive
* Mark EventPipe GC tests as GCStressIncompatible
* Reduce number of GCs triggered for EventPipe GC tests to make them more diagnosable in the event of failure

Changes in response to #26590.  This should mitigate some recurring test failures.

JIT stress would cause EventSource to write and process events much slower than usual which would cause timing issues on release builds, e.g., the test would run in <1s but it could take longer than a second for a custom EventSource to write the first event.

GC Stress seems to be either changing the behavior of the GC such that it doesn't match the test's checks or is causing issues with the trace.  For now, we will disable the relevant tests under GC stress and investigate.

CC - @tommcdon 