### PR TITLE
Resource writing for crossgen2

### DIFF
--- a/src/tools/crossgen2/Common/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
+++ b/src/tools/crossgen2/Common/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
@@ -256,6 +256,15 @@ namespace ILCompiler.DependencyAnalysis
             _data[offset + 3] = (byte)((emit >> 24) & 0xFF);
         }
 
+        public void EmitUInt(Reservation reservation, uint emit)
+        {
+            int offset = ReturnReservationTicket(reservation);
+            _data[offset] = (byte)(emit & 0xFF);
+            _data[offset + 1] = (byte)((emit >> 8) & 0xFF);
+            _data[offset + 2] = (byte)((emit >> 16) & 0xFF);
+            _data[offset + 3] = (byte)((emit >> 24) & 0xFF);
+        }
+
         public void EmitReloc(ISymbolNode symbol, RelocType relocType, int delta = 0)
         {
 #if DEBUG
@@ -320,6 +329,16 @@ namespace ILCompiler.DependencyAnalysis
         public void AddSymbol(ISymbolDefinitionNode node)
         {
             _definedSymbols.Add(node);
+        }
+
+        public void PadAlignment(int align)
+        {
+            Debug.Assert((align == 2) || (align == 4) || (align == 8) || (align == 16));
+            int misalignment = _data.Count & (align - 1);
+            if (misalignment != 0)
+            {
+                EmitZeros(align - misalignment);
+            }
         }
     }
 }

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/CodeGen/ReadyToRunObjectWriter.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/CodeGen/ReadyToRunObjectWriter.cs
@@ -114,6 +114,12 @@ namespace ILCompiler.DependencyAnalysis
 
                 r2rPeBuilder.SetCorHeader(_nodeFactory.CopiedCorHeaderNode, _nodeFactory.CopiedCorHeaderNode.Size);
 
+                if (_nodeFactory.Win32ResourcesNode != null)
+                {
+                    Debug.Assert(_nodeFactory.Win32ResourcesNode.Size != 0);
+                    r2rPeBuilder.SetWin32Resources(_nodeFactory.Win32ResourcesNode, _nodeFactory.Win32ResourcesNode.Size);
+                }
+
                 using (var peStream = File.Create(_objectFilePath))
                 {
                     r2rPeBuilder.Write(peStream);

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Win32ResourcesNode.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Win32ResourcesNode.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+using Internal.NativeFormat;
+using Internal.Text;
+using ILCompiler.Win32Resources;
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public class Win32ResourcesNode : ObjectNode, ISymbolDefinitionNode
+    {
+        private ResourceData _resourceData;
+        private int _size;
+
+        public Win32ResourcesNode(ResourceData resourceData)
+        {
+            _resourceData = resourceData;
+        }
+
+        public override ObjectNodeSection Section => ObjectNodeSection.TextSection;
+
+        public override bool IsShareable => false;
+
+        public override int ClassCode => 315358339;
+
+        public override bool StaticDependenciesAreComputed => true;
+
+        public int Offset => 0;
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append("____Win32Resources");
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            ObjectDataBuilder builder = new ObjectDataBuilder();
+            builder.AddSymbol(this);
+            _resourceData.WriteResources(this, ref builder);
+            _size = builder.CountBytes;
+            return builder.ToObjectData();
+        }
+
+        protected override string GetName(NodeFactory context)
+        {
+            return "____Win32Resources";
+        }
+
+        public int Size => _size;
+    }
+}

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -15,6 +15,7 @@ using Internal.JitInterface;
 using Internal.TypeSystem;
 using Internal.Text;
 using Internal.TypeSystem.Ecma;
+using ILCompiler.Win32Resources;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -214,7 +215,8 @@ namespace ILCompiler.DependencyAnalysis
             NameMangler nameMangler,
             ModuleTokenResolver moduleTokenResolver,
             SignatureContext signatureContext,
-            CopiedCorHeaderNode corHeaderNode)
+            CopiedCorHeaderNode corHeaderNode,
+            ResourceData win32Resources)
             : base(context,
                   compilationModuleGroup,
                   nameMangler,
@@ -225,6 +227,8 @@ namespace ILCompiler.DependencyAnalysis
             Resolver = moduleTokenResolver;
             InputModuleContext = signatureContext;
             CopiedCorHeaderNode = corHeaderNode;
+            if (!win32Resources.IsEmpty)
+                Win32ResourcesNode = new Win32ResourcesNode(win32Resources);
         }
 
         public SignatureContext InputModuleContext;
@@ -232,6 +236,8 @@ namespace ILCompiler.DependencyAnalysis
         public ModuleTokenResolver Resolver;
 
         public CopiedCorHeaderNode CopiedCorHeaderNode;
+
+        public Win32ResourcesNode Win32ResourcesNode;
 
         public HeaderNode Header;
 
@@ -556,6 +562,9 @@ namespace ILCompiler.DependencyAnalysis
             graph.AddRoot(StringImports, "String imports are always generated");
             graph.AddRoot(Header, "ReadyToRunHeader is always generated");
             graph.AddRoot(CopiedCorHeaderNode, "MSIL COR header is always generated");
+
+            if (Win32ResourcesNode != null)
+                graph.AddRoot(Win32ResourcesNode, "Win32 Resources are placed if not empty");
 
             MetadataManager.AttachToDependencyGraph(graph);
         }

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -157,6 +157,7 @@
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\TransitionBlock.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\TypeFixupSignature.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\TypesTableNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\Win32ResourcesNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRunSymbolNodeFactory.cs" />
     <Compile Include="Compiler\DependencyAnalysis\TypeAndMethod.cs" />
     <Compile Include="Compiler\IRootingServiceProvider.cs" />

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/ObjectWriter/SectionBuilder.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/ObjectWriter/SectionBuilder.cs
@@ -252,6 +252,16 @@ namespace ILCompiler.PEWriter
         int _corHeaderSize;
 
         /// <summary>
+        /// Symbol representing the start of the win32 resources
+        /// </summary>
+        ISymbolNode _win32ResourcesSymbol;
+
+        /// <summary>
+        /// Size of the win32 resources
+        /// </summary>
+        int _win32ResourcesSize;
+
+        /// <summary>
         /// Padding 4-byte sequence to use in code section. Typically corresponds
         /// to some interrupt to be thrown at "invalid" IP addresses.
         /// </summary>
@@ -370,6 +380,12 @@ namespace ILCompiler.PEWriter
         {
             _corHeaderSymbol = symbol;
             _corHeaderSize = headerSize;
+        }
+
+        public void SetWin32Resources(ISymbolNode symbol, int resourcesSize)
+        {
+            _win32ResourcesSymbol = symbol;
+            _win32ResourcesSize = resourcesSize;
         }
 
         private CoreRTNameMangler _nameMangler;
@@ -737,6 +753,14 @@ namespace ILCompiler.PEWriter
                 Section section = _sections[symbolTarget.SectionIndex];
                 Debug.Assert(section.RVAWhenPlaced != 0);
                 directoriesBuilder.CorHeaderTable = new DirectoryEntry(section.RVAWhenPlaced + symbolTarget.Offset, _corHeaderSize);
+            }
+
+            if (_win32ResourcesSymbol != null)
+            {
+                SymbolTarget symbolTarget = _symbolMap[_win32ResourcesSymbol];
+                Section section = _sections[symbolTarget.SectionIndex];
+                Debug.Assert(section.RVAWhenPlaced != 0);
+                directoriesBuilder.ResourceTable = new DirectoryEntry(section.RVAWhenPlaced + symbolTarget.Offset, _win32ResourcesSize);
             }
 
             if (_exportDirectoryEntry.Size != 0)

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Win32Resources/ResourceData.ResourcesDataModel.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Win32Resources/ResourceData.ResourcesDataModel.cs
@@ -2,81 +2,37 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 
 namespace ILCompiler.Win32Resources
 {
     public unsafe partial class ResourceData
     {
-        private readonly List<ResType_Ordinal> _resTypeHeadID = new List<ResType_Ordinal>();
-        private readonly List<ResType_Name> _resTypeHeadName = new List<ResType_Name>();
+        private readonly SortedDictionary<ushort, ResType> _resTypeHeadID = new SortedDictionary<ushort, ResType>();
+        private readonly SortedDictionary<string, ResType> _resTypeHeadName = new SortedDictionary<string, ResType>(StringComparer.Ordinal);
 
-        private class OrdinalName
+        private class ResLanguage
         {
-            public OrdinalName(ushort ordinal) { Ordinal = ordinal; }
-            public readonly ushort Ordinal;
-        }
+            public ResLanguage(byte[] data)
+            {
+                DataEntry = data;
+            }
 
-        private interface IUnderlyingName<T>
-        {
-            T Name { get; }
+            public uint DataSize => (uint)DataEntry.Length;
+            public byte[] DataEntry;
         }
 
         private class ResName
         {
-            public uint DataSize => (uint)DataEntry.Length;
-            public byte[] DataEntry;
-            public ushort NumberOfLanguages;
-            public ushort LanguageId;
-        }
-
-        private class ResName_Name : ResName, IUnderlyingName<string>
-        {
-            public ResName_Name(string name)
-            {
-                Name = name;
-            }
-
-            public string Name { get; }
-        }
-
-        private class ResName_Ordinal : ResName, IUnderlyingName<ushort>
-        {
-            public ResName_Ordinal(ushort name)
-            {
-                Name = new OrdinalName(name);
-            }
-
-            public OrdinalName Name;
-            ushort IUnderlyingName<ushort>.Name => Name.Ordinal;
+            public SortedDictionary<ushort, ResLanguage> Languages = new SortedDictionary<ushort, ResLanguage>();
         }
 
         private class ResType
         {
-            public List<ResName_Name> NameHeadName = new List<ResName_Name>();
-            public List<ResName_Ordinal> NameHeadID = new List<ResName_Ordinal>();
+            public SortedDictionary<string, ResName> NameHeadName = new SortedDictionary<string, ResName>(StringComparer.Ordinal);
+            public SortedDictionary<ushort, ResName> NameHeadID = new SortedDictionary<ushort, ResName>();
         }
 
-        private class ResType_Ordinal : ResType, IUnderlyingName<ushort>
-        {
-            public ResType_Ordinal(ushort type)
-            {
-                Type = new OrdinalName(type);
-            }
-
-            public OrdinalName Type;
-            ushort IUnderlyingName<ushort>.Name => Type.Ordinal;
-        }
-
-        private class ResType_Name : ResType, IUnderlyingName<string>
-        {
-            public ResType_Name(string type)
-            {
-                Type = type;
-            }
-
-            public string Type { get; set; }
-            string IUnderlyingName<string>.Name => Type;
-        }
     }
 }

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Win32Resources/ResourceData.UpdateResourceDataModel.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Win32Resources/ResourceData.UpdateResourceDataModel.cs
@@ -11,161 +11,45 @@ namespace ILCompiler.Win32Resources
     {
         private void AddResource(object type, object name, ushort language, byte[] data)
         {
-            ResType resType = null;
-            // Allocate new object in case it is needed.
-            ResType newResType;
-            int newIndex;
+            ResType resType;
 
-            IList typeList;
-            bool updateExisting;
             if (type is ushort)
             {
-                ResType_Ordinal newOrdinalType = new ResType_Ordinal((ushort)type);
-                newResType = newOrdinalType;
-                typeList = _resTypeHeadID;
-
-                newIndex = GetIndexOfFirstItemMatchingInListOrInsertionPoint(typeList, (ushort left, ushort right) => (int)left - (int)right, (ushort)type, out updateExisting);
+                if (!_resTypeHeadID.TryGetValue((ushort)type, out resType))
+                {
+                    resType = new ResType();
+                    _resTypeHeadID[(ushort)type] = resType;
+                }
             }
             else
             {
-                ResType_Name newStringType = new ResType_Name((string)type);
-                newResType = newStringType;
-                typeList = _resTypeHeadName;
-
-                newIndex = GetIndexOfFirstItemMatchingInListOrInsertionPoint(typeList, string.CompareOrdinal, (string)type, out updateExisting);
+                if (!_resTypeHeadName.TryGetValue((string)type, out resType))
+                {
+                    resType = new ResType();
+                    _resTypeHeadName[(string)type] = resType;
+                }
             }
 
-            if (updateExisting)
-            {
-                resType = (ResType)typeList[newIndex];
-            }
-            else
-            {
-                // This is a new type
-                if (newIndex == -1)
-                    typeList.Add(newResType);
-                else
-                    typeList.Insert(newIndex, newResType);
-
-                resType = newResType;
-            }
-
-            Type resNameType;
-            IList nameList;
-            int nameIndex;
+            ResName resName;
 
             if (name is ushort)
             {
-                nameList = resType.NameHeadID;
-                resNameType = typeof(ResName_Ordinal);
-                nameIndex = GetIndexOfFirstItemMatchingInListOrInsertionPoint(nameList, (ushort left, ushort right) => (int)left - (int)right, (ushort)name, out updateExisting);
-            }
-            else
-            {
-                nameList = resType.NameHeadName;
-                resNameType = typeof(ResName_Name);
-                nameIndex = GetIndexOfFirstItemMatchingInListOrInsertionPoint(nameList, string.CompareOrdinal, (string)name, out updateExisting);
-            }
-
-            if (updateExisting)
-            {
-                // We have at least 1 language with the same type/name. Insert/delete from language list
-                ResName resName = (ResName)nameList[nameIndex];
-                int newNumberOfLanguages = (int)resName.NumberOfLanguages + (data != null ? 1 : -1);
-
-                int newIndexForNewOrUpdatedNameWithMatchingLanguage = GetIndexOfFirstItemMatchingInListOrInsertionPoint(nameList, nameIndex,
-                    resName.NumberOfLanguages, (object o) => ((ResName)o).LanguageId, (ushort left, ushort right) => (int)left - (int)right, language, out bool exactLanguageExists);
-
-                if (exactLanguageExists)
+                if (!resType.NameHeadID.TryGetValue((ushort)name, out resName))
                 {
-                    if (data == null)
-                    {
-                        // delete item
-                        nameList.RemoveAt(newIndexForNewOrUpdatedNameWithMatchingLanguage);
-
-                        if (newNumberOfLanguages > 0)
-                        {
-                            // if another name is still present, update the number of languages counter
-                            resName = (ResName)nameList[nameIndex];
-                            resName.NumberOfLanguages = (ushort)newNumberOfLanguages;
-                        }
-
-                        if ((resType.NameHeadID.Count == 0) && (resType.NameHeadName.Count == 0))
-                        {
-                            /* type list completely empty? */
-                            typeList.Remove(resType);
-                        }
-                    }
-                    else
-                    {
-                        // Resource file has two copies of same resource... ignore second copy
-                        return;
-                    }
-                }
-                else
-                {
-                    // Insert a new name at the new spot
-                    AddNewName(nameList, resNameType, newIndexForNewOrUpdatedNameWithMatchingLanguage, name, language, data);
-                    // Update the NumberOfLanguages for the language list
-                    resName = (ResName)nameList[nameIndex];
-                    resName.NumberOfLanguages = (ushort)newNumberOfLanguages;
+                    resName = new ResName();
+                    resType.NameHeadID[(ushort)name] = resName;
                 }
             }
             else
             {
-                // This is a new name in a new language list
-                if (data == null)
+                if (!resType.NameHeadName.TryGetValue((string)name, out resName))
                 {
-                    // Can't delete new name
-                    throw new ArgumentException();
-                }
-
-                AddNewName(nameList, resNameType, nameIndex, name, language, data);
-            }
-        }
-
-        private static int GetIndexOfFirstItemMatchingInListOrInsertionPoint<T>(IList list, Func<T, T, int> compareFunction, T comparand, out bool exists)
-        {
-            return GetIndexOfFirstItemMatchingInListOrInsertionPoint(list, 0, list.Count, (object o) => ((IUnderlyingName<T>)o).Name, compareFunction, comparand, out exists);
-        }
-
-        private static int GetIndexOfFirstItemMatchingInListOrInsertionPoint<T>(IList list, int start, int count, Func<object, T> getComparandFromListElem, Func<T, T, int> compareFunction, T comparand, out bool exists)
-        {
-            int i = start;
-            for (; i < (start + count); i++)
-            {
-                int iCompare = compareFunction(comparand, getComparandFromListElem(list[i]));
-                if (iCompare == 0)
-                {
-                    exists = true;
-                    return i;
-                }
-                else if (iCompare < 0)
-                {
-                    exists = false;
-                    return i;
+                    resName = new ResName();
+                    resType.NameHeadName[(string)name] = resName;
                 }
             }
 
-            exists = false;
-            if ((start + count) < list.Count)
-            {
-                return start + count;
-            }
-            return -1;
-        }
-
-        private void AddNewName(IList list, Type resNameType, int insertPoint, object name, ushort language, byte[] data)
-        {
-            ResName newResName = (ResName)Activator.CreateInstance(resNameType, name);
-            newResName.LanguageId = language;
-            newResName.NumberOfLanguages = 1;
-            newResName.DataEntry = data;
-
-            if (insertPoint == -1)
-                list.Add(newResName);
-            else
-                list.Insert(insertPoint, newResName);
+            resName.Languages[language] = new ResLanguage(data);
         }
 
         private byte[] FindResourceInternal(object name, object type, ushort language)
@@ -174,58 +58,34 @@ namespace ILCompiler.Win32Resources
 
             if (type is ushort)
             {
-                foreach (ResType_Ordinal candidate in _resTypeHeadID)
-                {
-                    if (candidate.Type.Ordinal == (ushort)type)
-                    {
-                        resType = candidate;
-                        break;
-                    }
-                }
+                _resTypeHeadID.TryGetValue((ushort)type, out resType);
             }
             if (type is string)
             {
-                foreach (ResType_Name candidate in _resTypeHeadName)
-                {
-                    if (candidate.Type == (string)type)
-                    {
-                        resType = candidate;
-                        break;
-                    }
-                }
+                _resTypeHeadName.TryGetValue((string)type, out resType);
             }
 
             if (resType == null)
                 return null;
 
+            ResName resName = null;
+
             if (name is ushort)
             {
-                foreach (ResName_Ordinal candidate in resType.NameHeadID)
-                {
-                    if (candidate.Name.Ordinal != (ushort)type)
-                        continue;
-
-                    if (candidate.LanguageId != language)
-                        continue;
-
-                    return (byte[])candidate.DataEntry.Clone();
-                }
+                resType.NameHeadID.TryGetValue((ushort)name, out resName);
             }
             if (name is string)
             {
-                foreach (ResName_Name candidate in resType.NameHeadName)
-                {
-                    if (candidate.Name != (string)name)
-                        continue;
-
-                    if (candidate.LanguageId != language)
-                        continue;
-
-                    return (byte[])candidate.DataEntry.Clone();
-                }
+                resType.NameHeadName.TryGetValue((string)name, out resName);
             }
 
-            return null;
+            if (resName == null)
+                return null;
+
+            if (!resName.Languages.TryGetValue(language, out ResLanguage resLanguage))
+                return null;
+
+            return (byte[])resLanguage.DataEntry.Clone();
         }
     }
 }

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Win32Resources/ResourceData.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Win32Resources/ResourceData.cs
@@ -2,9 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Internal.TypeSystem.Ecma;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+
+using ILCompiler.DependencyAnalysis;
+using Internal.TypeSystem.Ecma;
 
 namespace ILCompiler.Win32Resources
 {
@@ -14,23 +19,20 @@ namespace ILCompiler.Win32Resources
     /// </summary>
     public unsafe partial class ResourceData
     {
-        BlobReader _resourceDataBlob;
-        PEReader _peFile;
-
         /// <summary>
         /// Initialize a ResourceData instance from a PE file
         /// </summary>
         /// <param name="ecmaModule"></param>
-        public ResourceData(EcmaModule ecmaModule)
+        public ResourceData(EcmaModule ecmaModule, Func<object, object, ushort, bool> resourceFilter = null)
         {
-            var ecmaData = ecmaModule.PEReader.GetEntireImage().GetContent();
-            _peFile = ecmaModule.PEReader;
+            System.Collections.Immutable.ImmutableArray<byte> ecmaData = ecmaModule.PEReader.GetEntireImage().GetContent();
+            PEReader peFile = ecmaModule.PEReader;
 
-            DirectoryEntry resourceDirectory = _peFile.PEHeaders.PEHeader.ResourceTableDirectory;
+            DirectoryEntry resourceDirectory = peFile.PEHeaders.PEHeader.ResourceTableDirectory;
             if (resourceDirectory.Size != 0)
             {
-                _resourceDataBlob = ecmaModule.PEReader.GetSectionData(resourceDirectory.RelativeVirtualAddress).GetReader(0, resourceDirectory.Size);
-                ReadResourceData();
+                BlobReader resourceDataBlob = ecmaModule.PEReader.GetSectionData(resourceDirectory.RelativeVirtualAddress).GetReader(0, resourceDirectory.Size);
+                ReadResourceData(resourceDataBlob, peFile, resourceFilter);
             }
         }
 
@@ -64,6 +66,98 @@ namespace ILCompiler.Win32Resources
         public byte[] FindResource(ushort name, ushort type, ushort language)
         {
             return FindResourceInternal(name, type, language);
+        }
+
+        public bool IsEmpty
+        {
+            get
+            {
+                if (_resTypeHeadID.Count > 0)
+                    return false;
+
+                if (_resTypeHeadName.Count > 0)
+                    return false;
+
+                return true;
+            }
+        }
+
+        public void WriteResources(ISymbolNode nodeAssociatedWithDataBuilder, ref ObjectDataBuilder dataBuilder)
+        {
+            Debug.Assert(dataBuilder.CountBytes == 0);
+
+            SortedDictionary<string, List<ObjectDataBuilder.Reservation>> nameTable = new SortedDictionary<string, List<ObjectDataBuilder.Reservation>>();
+            Dictionary<ResLanguage, int> dataEntryTable = new Dictionary<ResLanguage, int>();
+            List<Tuple<ResType, ObjectDataBuilder.Reservation>> resTypes = new List<Tuple<ResType, ObjectDataBuilder.Reservation>>();
+            List<Tuple<ResName, ObjectDataBuilder.Reservation>> resNames = new List<Tuple<ResName, ObjectDataBuilder.Reservation>>();
+            List<Tuple<ResLanguage, ObjectDataBuilder.Reservation>> resLanguages = new List<Tuple<ResLanguage, ObjectDataBuilder.Reservation>>();
+
+            IMAGE_RESOURCE_DIRECTORY.Write(ref dataBuilder, checked((ushort)_resTypeHeadName.Count), checked((ushort)_resTypeHeadID.Count));
+            foreach (KeyValuePair<string, ResType> res in _resTypeHeadName)
+            {
+                resTypes.Add(new Tuple<ResType, ObjectDataBuilder.Reservation>(res.Value, IMAGE_RESOURCE_DIRECTORY_ENTRY.Write(ref dataBuilder, res.Key, nameTable)));
+            }
+            foreach (KeyValuePair<ushort, ResType> res in _resTypeHeadID)
+            {
+                resTypes.Add(new Tuple<ResType, ObjectDataBuilder.Reservation>(res.Value, IMAGE_RESOURCE_DIRECTORY_ENTRY.Write(ref dataBuilder, res.Key)));
+            }
+
+            foreach (Tuple<ResType, ObjectDataBuilder.Reservation> type in resTypes)
+            {
+                dataBuilder.EmitUInt(type.Item2, (uint)dataBuilder.CountBytes | 0x80000000);
+                IMAGE_RESOURCE_DIRECTORY.Write(ref dataBuilder, checked((ushort)type.Item1.NameHeadName.Count), checked((ushort)type.Item1.NameHeadID.Count));
+
+                foreach (KeyValuePair<string, ResName> res in type.Item1.NameHeadName)
+                {
+                    resNames.Add(new Tuple<ResName, ObjectDataBuilder.Reservation>(res.Value, IMAGE_RESOURCE_DIRECTORY_ENTRY.Write(ref dataBuilder, res.Key, nameTable)));
+                }
+                foreach (KeyValuePair<ushort, ResName> res in type.Item1.NameHeadID)
+                {
+                    resNames.Add(new Tuple<ResName, ObjectDataBuilder.Reservation>(res.Value, IMAGE_RESOURCE_DIRECTORY_ENTRY.Write(ref dataBuilder, res.Key)));
+                }
+            }
+
+            foreach (Tuple<ResName, ObjectDataBuilder.Reservation> type in resNames)
+            {
+                dataBuilder.EmitUInt(type.Item2, (uint)dataBuilder.CountBytes | 0x80000000);
+                IMAGE_RESOURCE_DIRECTORY.Write(ref dataBuilder, 0, checked((ushort)type.Item1.Languages.Count));
+                foreach (KeyValuePair<ushort, ResLanguage> res in type.Item1.Languages)
+                {
+                    resLanguages.Add(new Tuple<ResLanguage, ObjectDataBuilder.Reservation>(res.Value, IMAGE_RESOURCE_DIRECTORY_ENTRY.Write(ref dataBuilder, res.Key)));
+                }
+            }
+
+            // Emit name table
+            dataBuilder.PadAlignment(2); // name table is 2 byte aligned
+            foreach (KeyValuePair<string, List<ObjectDataBuilder.Reservation>> name in nameTable)
+            {
+                foreach (ObjectDataBuilder.Reservation reservation in name.Value)
+                {
+                    dataBuilder.EmitUInt(reservation, (uint)dataBuilder.CountBytes | 0x80000000);
+                }
+
+                dataBuilder.EmitUShort(checked((ushort)name.Key.Length));
+                foreach (char c in name.Key)
+                {
+                    dataBuilder.EmitUShort((ushort)c);
+                }
+            }
+
+            // Emit byte arrays of resource data, capture the offsets
+            foreach (Tuple<ResLanguage, ObjectDataBuilder.Reservation> language in resLanguages)
+            {
+                dataBuilder.PadAlignment(4); // Data in resource files is 4 byte aligned
+                dataEntryTable.Add(language.Item1, dataBuilder.CountBytes);
+                dataBuilder.EmitBytes(language.Item1.DataEntry);
+            }
+
+            dataBuilder.PadAlignment(4); // resource data entries are 4 byte aligned
+            foreach (Tuple<ResLanguage, ObjectDataBuilder.Reservation> language in resLanguages)
+            {
+                dataBuilder.EmitInt(language.Item2, dataBuilder.CountBytes);
+                IMAGE_RESOURCE_DATA_ENTRY.Write(ref dataBuilder, nodeAssociatedWithDataBuilder, dataEntryTable[language.Item1], language.Item1.DataEntry.Length);
+            }
+            dataBuilder.PadAlignment(4); // resource data entries are 4 byte aligned
         }
     }
 }


### PR DESCRIPTION
- Refactor the win32 resource reading code to use more natural managed data structures
- Build a Win32 resource emitter on top of refactored data structures
- Replace resource section copy logic with new node to generate win32 resources