### PR TITLE
Return a missed field init to `GenTreeILOffset`.

### DIFF
--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -5113,11 +5113,11 @@ struct GenTreeILOffset : public GenTree
     IL_OFFSET gtStmtLastILoffs; // instr offset at end of stmt
 #endif
 
-    GenTreeILOffset(IL_OFFSETX offset)
+    GenTreeILOffset(IL_OFFSETX offset DEBUGARG(IL_OFFSET lastOffset = BAD_IL_OFFSET))
         : GenTree(GT_IL_OFFSET, TYP_VOID)
         , gtStmtILoffsx(offset)
 #ifdef DEBUG
-        , gtStmtLastILoffs(BAD_IL_OFFSET)
+        , gtStmtLastILoffs(lastOffset)
 #endif
     {
     }

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -951,7 +951,8 @@ void Rationalizer::DoPhase()
             if (statement->gtStmtILoffsx != BAD_IL_OFFSET)
             {
                 assert(!statement->IsPhiDefnStmt());
-                GenTreeILOffset* ilOffset = new (comp, GT_IL_OFFSET) GenTreeILOffset(statement->gtStmtILoffsx);
+                GenTreeILOffset* ilOffset = new (comp, GT_IL_OFFSET)
+                    GenTreeILOffset(statement->gtStmtILoffsx DEBUGARG(statement->gtStmtLastILoffs));
                 BlockRange().InsertBefore(statement->gtStmtList, ilOffset);
             }
 


### PR DESCRIPTION
That field is used only in dumping logic inside `genCodeForBBlist`, for some reason `gtDispTree` doesn't print it.
The init was missed in https://github.com/dotnet/coreclr/commit/39adc7843953248ffae01d28bd8e9e3bcdd3448e