### PR TITLE
[JIT/x86] Fix LinearScan::allocateRegisters

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -5857,7 +5857,7 @@ void LinearScan::allocateRegisters()
     if (enregisterLocalVars && compiler->lvaKeepAliveAndReportThis())
     {
         LclVarDsc* thisVarDsc = compiler->lvaGetDesc(compiler->info.compThisArg);
-        if (!thisVarDsc->lvDoNotEnregister)
+        if (thisVarDsc->lvLRACandidate)
         {
             Interval* interval = getIntervalForLocalVar(thisVarDsc->lvVarIndex);
             if (interval->isSplit)


### PR DESCRIPTION
Check local var interval because it can be null for this parameter that is used as generic context.

This patch fixes https://github.com/dotnet/coreclr/issues/26648