### PR TITLE
Mark counter tests as JITStress incompatible

### DIFF
--- a/tests/src/tracing/eventcounter/eventcounter.csproj
+++ b/tests/src/tracing/eventcounter/eventcounter.csproj
@@ -6,6 +6,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- This test is timing sensitive and JIT timing affects the results of the test -->
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <!-- This test has a secondary thread with an infinite loop -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>

--- a/tests/src/tracing/eventcounter/incrementingeventcounter.csproj
+++ b/tests/src/tracing/eventcounter/incrementingeventcounter.csproj
@@ -6,6 +6,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- This test is timing sensitive and JIT timing affects the results of the test -->
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <!-- This test has a secondary thread with an infinite loop -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>

--- a/tests/src/tracing/eventcounter/incrementingpollingcounter.csproj
+++ b/tests/src/tracing/eventcounter/incrementingpollingcounter.csproj
@@ -6,6 +6,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- This test is timing sensitive and JIT timing affects the results of the test -->
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <!-- This test has a secondary thread with an infinite loop -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>

--- a/tests/src/tracing/eventcounter/pollingcounter.csproj
+++ b/tests/src/tracing/eventcounter/pollingcounter.csproj
@@ -6,6 +6,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- This test is timing sensitive and JIT timing affects the results of the test -->
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <!-- This test has a secondary thread with an infinite loop -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>


### PR DESCRIPTION
These tests are timing-sensitive and are affected by JIT timing (since EventSource has a lot of code to JIT, it affects the timing especially under checked mode), making them fail under jitstress.

This should resolve issues like https://github.com/dotnet/coreclr/issues/25559 and https://github.com/dotnet/coreclr/issues/26645#issuecomment-530506375. 

cc @tommcdon 