### PR TITLE
Continue cleaning GenTreeStmt.

### DIFF
--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -4512,7 +4512,7 @@ ASSERT_TP* Compiler::optComputeAssertionGen()
         GenTree*  jtrue    = nullptr;
 
         // Walk the statement trees in this basic block.
-        for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt : block->Statements())
         {
             for (GenTree* tree = stmt->gtStmtList; tree != nullptr; tree = tree->gtNext)
             {

--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -277,8 +277,8 @@ void Compiler::optAddCopies()
             continue;
         }
 
-        GenTreeStmt* stmt;
-        unsigned     copyLclNum = lvaGrabTemp(false DEBUGARG("optAddCopies"));
+        Statement* stmt;
+        unsigned   copyLclNum = lvaGrabTemp(false DEBUGARG("optAddCopies"));
 
         // Because lvaGrabTemp may have reallocated the lvaTable, ensure varDsc
         // is still in sync with lvaTable[lclNum];
@@ -2591,7 +2591,7 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
  */
 GenTree* Compiler::optConstantAssertionProp(AssertionDsc* curAssertion,
                                             GenTree*      tree,
-                                            GenTreeStmt* stmt DEBUGARG(AssertionIndex index))
+                                            Statement* stmt DEBUGARG(AssertionIndex index))
 {
     unsigned lclNum = tree->gtLclVarCommon.gtLclNum;
 
@@ -2780,7 +2780,7 @@ bool Compiler::optAssertionProp_LclVarTypeCheck(GenTree* tree, LclVarDsc* lclVar
  */
 GenTree* Compiler::optCopyAssertionProp(AssertionDsc* curAssertion,
                                         GenTree*      tree,
-                                        GenTreeStmt* stmt DEBUGARG(AssertionIndex index))
+                                        Statement* stmt DEBUGARG(AssertionIndex index))
 {
     const AssertionDsc::AssertionDscOp1& op1 = curAssertion->op1;
     const AssertionDsc::AssertionDscOp2& op2 = curAssertion->op2;
@@ -2849,7 +2849,7 @@ GenTree* Compiler::optCopyAssertionProp(AssertionDsc* curAssertion,
  *  be nullptr. Returns the modified tree, or nullptr if no assertion prop took place.
  */
 
-GenTree* Compiler::optAssertionProp_LclVar(ASSERT_VALARG_TP assertions, GenTree* tree, GenTreeStmt* stmt)
+GenTree* Compiler::optAssertionProp_LclVar(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt)
 {
     assert(tree->gtOper == GT_LCL_VAR);
     // If we have a var definition then bail or
@@ -3046,7 +3046,7 @@ AssertionIndex Compiler::optGlobalAssertionIsEqualOrNotEqualZero(ASSERT_VALARG_T
  *  Returns the modified tree, or nullptr if no assertion prop took place
  */
 
-GenTree* Compiler::optAssertionProp_RelOp(ASSERT_VALARG_TP assertions, GenTree* tree, GenTreeStmt* stmt)
+GenTree* Compiler::optAssertionProp_RelOp(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt)
 {
     assert(tree->OperKind() & GTK_RELOP);
 
@@ -3075,7 +3075,7 @@ GenTree* Compiler::optAssertionProp_RelOp(ASSERT_VALARG_TP assertions, GenTree* 
  *  perform Value numbering based relop assertion propagation on the tree.
  *
  */
-GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, GenTree* tree, GenTreeStmt* stmt)
+GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt)
 {
     GenTree* newTree = tree;
     GenTree* op1     = tree->gtOp.gtOp1;
@@ -3295,7 +3295,7 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
  *  perform local variable name based relop assertion propagation on the tree.
  *
  */
-GenTree* Compiler::optAssertionPropLocal_RelOp(ASSERT_VALARG_TP assertions, GenTree* tree, GenTreeStmt* stmt)
+GenTree* Compiler::optAssertionPropLocal_RelOp(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt)
 {
     assert(tree->OperGet() == GT_EQ || tree->OperGet() == GT_NE);
 
@@ -3389,7 +3389,7 @@ GenTree* Compiler::optAssertionPropLocal_RelOp(ASSERT_VALARG_TP assertions, GenT
  *
  *  Returns the modified tree, or nullptr if no assertion prop took place.
  */
-GenTree* Compiler::optAssertionProp_Cast(ASSERT_VALARG_TP assertions, GenTree* tree, GenTreeStmt* stmt)
+GenTree* Compiler::optAssertionProp_Cast(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt)
 {
     assert(tree->gtOper == GT_CAST);
 
@@ -3493,7 +3493,7 @@ GenTree* Compiler::optAssertionProp_Cast(ASSERT_VALARG_TP assertions, GenTree* t
  *  Given a tree with an array bounds check node, eliminate it because it was
  *  checked already in the program.
  */
-GenTree* Compiler::optAssertionProp_Comma(ASSERT_VALARG_TP assertions, GenTree* tree, GenTreeStmt* stmt)
+GenTree* Compiler::optAssertionProp_Comma(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt)
 {
     // Remove the bounds check as part of the GT_COMMA node since we need parent pointer to remove nodes.
     // When processing visits the bounds check, it sets the throw kind to None if the check is redundant.
@@ -3516,7 +3516,7 @@ GenTree* Compiler::optAssertionProp_Comma(ASSERT_VALARG_TP assertions, GenTree* 
  *
  */
 
-GenTree* Compiler::optAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* tree, GenTreeStmt* stmt)
+GenTree* Compiler::optAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt)
 {
     assert(tree->OperIsIndir());
 
@@ -3708,7 +3708,7 @@ GenTree* Compiler::optNonNullAssertionProp_Call(ASSERT_VALARG_TP assertions, Gen
  *
  */
 
-GenTree* Compiler::optAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCall* call, GenTreeStmt* stmt)
+GenTree* Compiler::optAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCall* call, Statement* stmt)
 {
     if (optNonNullAssertionProp_Call(assertions, call))
     {
@@ -3900,7 +3900,7 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions, GenTree
  *
  */
 
-GenTree* Compiler::optAssertionProp_Update(GenTree* newTree, GenTree* tree, GenTreeStmt* stmt)
+GenTree* Compiler::optAssertionProp_Update(GenTree* newTree, GenTree* tree, Statement* stmt)
 {
     assert(newTree != nullptr);
     assert(tree != nullptr);
@@ -3960,7 +3960,7 @@ GenTree* Compiler::optAssertionProp_Update(GenTree* newTree, GenTree* tree, GenT
  *  Returns the modified tree, or nullptr if no assertion prop took place.
  */
 
-GenTree* Compiler::optAssertionProp(ASSERT_VALARG_TP assertions, GenTree* tree, GenTreeStmt* stmt)
+GenTree* Compiler::optAssertionProp(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt)
 {
     switch (tree->gtOper)
     {
@@ -4512,7 +4512,7 @@ ASSERT_TP* Compiler::optComputeAssertionGen()
         GenTree*  jtrue    = nullptr;
 
         // Walk the statement trees in this basic block.
-        for (GenTreeStmt* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
         {
             for (GenTree* tree = stmt->gtStmtList; tree != nullptr; tree = tree->gtNext)
             {
@@ -4644,10 +4644,10 @@ ASSERT_TP* Compiler::optInitAssertionDataflowFlags()
 // Callback data for the VN based constant prop visitor.
 struct VNAssertionPropVisitorInfo
 {
-    Compiler*    pThis;
-    GenTreeStmt* stmt;
-    BasicBlock*  block;
-    VNAssertionPropVisitorInfo(Compiler* pThis, BasicBlock* block, GenTreeStmt* stmt)
+    Compiler*   pThis;
+    Statement*  stmt;
+    BasicBlock* block;
+    VNAssertionPropVisitorInfo(Compiler* pThis, BasicBlock* block, Statement* stmt)
         : pThis(pThis), stmt(stmt), block(block)
     {
     }
@@ -4770,7 +4770,7 @@ GenTree* Compiler::optVNConstantPropOnJTrue(BasicBlock* block, GenTree* test)
     // these side effects from the JTrue stmt before insert them back here.
     while (sideEffList != nullptr)
     {
-        GenTreeStmt* newStmt;
+        Statement* newStmt;
         if (sideEffList->OperGet() == GT_COMMA)
         {
             newStmt     = fgNewStmtNearEnd(block, sideEffList->gtGetOp1());
@@ -4809,7 +4809,7 @@ GenTree* Compiler::optVNConstantPropOnJTrue(BasicBlock* block, GenTree* test)
 //    evaluates to constant, then the tree is replaced by its side effects and
 //    the constant node.
 //
-Compiler::fgWalkResult Compiler::optVNConstantPropCurStmt(BasicBlock* block, GenTreeStmt* stmt, GenTree* tree)
+Compiler::fgWalkResult Compiler::optVNConstantPropCurStmt(BasicBlock* block, Statement* stmt, GenTree* tree)
 {
     // Don't propagate floating-point constants into a TYP_STRUCT LclVar
     // This can occur for HFA return values (see hfa_sf3E_r.exe)
@@ -4919,7 +4919,7 @@ Compiler::fgWalkResult Compiler::optVNConstantPropCurStmt(BasicBlock* block, Gen
 //    indirections. This is different from flow based assertions and helps
 //    unify VN based constant prop and non-null prop in a single pre-order walk.
 //
-void Compiler::optVnNonNullPropCurStmt(BasicBlock* block, GenTreeStmt* stmt, GenTree* tree)
+void Compiler::optVnNonNullPropCurStmt(BasicBlock* block, Statement* stmt, GenTree* tree)
 {
     ASSERT_TP empty   = BitVecOps::UninitVal();
     GenTree*  newTree = nullptr;
@@ -4973,7 +4973,7 @@ Compiler::fgWalkResult Compiler::optVNAssertionPropCurStmtVisitor(GenTree** ppTr
  *   Returns the skipped next stmt if the current statement or next few
  *   statements got removed, else just returns the incoming stmt.
  */
-GenTreeStmt* Compiler::optVNAssertionPropCurStmt(BasicBlock* block, GenTreeStmt* stmt)
+Statement* Compiler::optVNAssertionPropCurStmt(BasicBlock* block, Statement* stmt)
 {
     // TODO-Review: EH successor/predecessor iteration seems broken.
     // See: SELF_HOST_TESTS_ARM\jit\Directed\ExcepFilters\fault\fault.exe
@@ -4983,7 +4983,7 @@ GenTreeStmt* Compiler::optVNAssertionPropCurStmt(BasicBlock* block, GenTreeStmt*
     }
 
     // Preserve the prev link before the propagation and morph.
-    GenTreeStmt* prev = (stmt == block->firstStmt()) ? nullptr : stmt->getPrevStmt();
+    Statement* prev = (stmt == block->firstStmt()) ? nullptr : stmt->getPrevStmt();
 
     // Perform VN based assertion prop first, in case we don't find
     // anything in assertion gen.
@@ -4999,7 +4999,7 @@ GenTreeStmt* Compiler::optVNAssertionPropCurStmt(BasicBlock* block, GenTreeStmt*
 
     // Check if propagation removed statements starting from current stmt.
     // If so, advance to the next good statement.
-    GenTreeStmt* nextStmt = (prev == nullptr) ? block->firstStmt() : prev->getNextStmt();
+    Statement* nextStmt = (prev == nullptr) ? block->firstStmt() : prev->getNextStmt();
     return nextStmt;
 }
 
@@ -5034,7 +5034,7 @@ void Compiler::optAssertionPropMain()
 
         fgRemoveRestOfBlock = false;
 
-        GenTreeStmt* stmt = block->firstStmt();
+        Statement* stmt = block->firstStmt();
         while (stmt != nullptr)
         {
             // We need to remove the rest of the block.
@@ -5047,7 +5047,7 @@ void Compiler::optAssertionPropMain()
             else
             {
                 // Perform VN based assertion prop before assertion gen.
-                GenTreeStmt* nextStmt = optVNAssertionPropCurStmt(block, stmt);
+                Statement* nextStmt = optVNAssertionPropCurStmt(block, stmt);
 
                 // Propagation resulted in removal of the remaining stmts, perform it.
                 if (fgRemoveRestOfBlock)
@@ -5137,7 +5137,7 @@ void Compiler::optAssertionPropMain()
         fgRemoveRestOfBlock = false;
 
         // Walk the statement trees in this basic block
-        GenTreeStmt* stmt = block->FirstNonPhiDef();
+        Statement* stmt = block->FirstNonPhiDef();
         while (stmt != nullptr)
         {
             // Propagation tells us to remove the rest of the block. Remove it.
@@ -5150,7 +5150,7 @@ void Compiler::optAssertionPropMain()
 
             // Preserve the prev link before the propagation and morph, to check if propagation
             // removes the current stmt.
-            GenTreeStmt* prevStmt = (stmt == block->firstStmt()) ? nullptr : stmt->getPrevStmt();
+            Statement* prevStmt = (stmt == block->firstStmt()) ? nullptr : stmt->getPrevStmt();
 
             optAssertionPropagatedCurrentStmt = false; // set to true if a assertion propagation took place
                                                        // and thus we must morph, set order, re-link
@@ -5199,8 +5199,8 @@ void Compiler::optAssertionPropMain()
 
             // Check if propagation removed statements starting from current stmt.
             // If so, advance to the next good statement.
-            GenTreeStmt* nextStmt = (prevStmt == nullptr) ? block->firstStmt() : prevStmt->getNextStmt();
-            stmt                  = (stmt == nextStmt) ? stmt->getNextStmt() : nextStmt;
+            Statement* nextStmt = (prevStmt == nullptr) ? block->firstStmt() : prevStmt->getNextStmt();
+            stmt                = (stmt == nextStmt) ? stmt->getNextStmt() : nextStmt;
         }
         optAssertionPropagatedCurrentStmt = false; // clear it back as we are done with stmts.
     }

--- a/src/jit/block.cpp
+++ b/src/jit/block.cpp
@@ -631,7 +631,7 @@ bool BasicBlock::CloneBlockState(
     to->bbTgtStkDepth = from->bbTgtStkDepth;
 #endif // DEBUG
 
-    for (GenTreeStmt* fromStmt = from->firstStmt(); fromStmt != nullptr; fromStmt = fromStmt->getNextStmt())
+    for (Statement* fromStmt = from->firstStmt(); fromStmt != nullptr; fromStmt = fromStmt->getNextStmt())
     {
         auto newExpr = compiler->gtCloneExpr(fromStmt->gtStmtExpr, 0, varNum, varVal);
         if (!newExpr)
@@ -674,7 +674,7 @@ bool BasicBlock::IsLIR()
 // Return Value:
 //    The first statement in the block's bbStmtList.
 //
-GenTreeStmt* BasicBlock::firstStmt() const
+Statement* BasicBlock::firstStmt() const
 {
     return bbStmtList;
 }
@@ -688,14 +688,14 @@ GenTreeStmt* BasicBlock::firstStmt() const
 // Return Value:
 //    The last statement in the block's bbStmtList.
 //
-GenTreeStmt* BasicBlock::lastStmt() const
+Statement* BasicBlock::lastStmt() const
 {
     if (bbStmtList == nullptr)
     {
         return nullptr;
     }
 
-    GenTreeStmt* result = bbStmtList->gtPrevStmt;
+    Statement* result = bbStmtList->gtPrevStmt;
     assert(result != nullptr && result->gtNext == nullptr);
     return result;
 }
@@ -823,9 +823,9 @@ bool BasicBlock::isValid()
     }
 }
 
-GenTreeStmt* BasicBlock::FirstNonPhiDef()
+Statement* BasicBlock::FirstNonPhiDef()
 {
-    GenTreeStmt* stmt = firstStmt();
+    Statement* stmt = firstStmt();
     if (stmt == nullptr)
     {
         return nullptr;
@@ -844,9 +844,9 @@ GenTreeStmt* BasicBlock::FirstNonPhiDef()
     return stmt;
 }
 
-GenTreeStmt* BasicBlock::FirstNonPhiDefOrCatchArgAsg()
+Statement* BasicBlock::FirstNonPhiDefOrCatchArgAsg()
 {
-    GenTreeStmt* stmt = FirstNonPhiDef();
+    Statement* stmt = FirstNonPhiDef();
     if (stmt == nullptr)
     {
         return nullptr;

--- a/src/jit/block.cpp
+++ b/src/jit/block.cpp
@@ -631,7 +631,7 @@ bool BasicBlock::CloneBlockState(
     to->bbTgtStkDepth = from->bbTgtStkDepth;
 #endif // DEBUG
 
-    for (Statement* fromStmt = from->firstStmt(); fromStmt != nullptr; fromStmt = fromStmt->getNextStmt())
+    for (Statement* fromStmt : from->Statements())
     {
         auto newExpr = compiler->gtCloneExpr(fromStmt->gtStmtExpr, 0, varNum, varVal);
         if (!newExpr)

--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -73,7 +73,7 @@ enum BBjumpKinds : BYTE
 // clang-format on
 
 struct GenTree;
-struct GenTreeStmt;
+struct Statement;
 struct BasicBlock;
 class Compiler;
 class typeInfo;
@@ -745,7 +745,7 @@ struct BasicBlock : private LIR::Range
 
     __declspec(property(get = getBBTreeList, put = setBBTreeList)) GenTree* bbTreeList; // the body of the block.
 
-    GenTreeStmt* bbStmtList;
+    Statement* bbStmtList;
 
     GenTree* getBBTreeList() const
     {
@@ -1060,8 +1060,8 @@ struct BasicBlock : private LIR::Range
         return bbNum - 1;
     }
 
-    GenTreeStmt* firstStmt() const;
-    GenTreeStmt* lastStmt() const;
+    Statement* firstStmt() const;
+    Statement* lastStmt() const;
 
     GenTree* firstNode();
     GenTree* lastNode();
@@ -1079,8 +1079,8 @@ struct BasicBlock : private LIR::Range
 
     // Returns the first statement in the statement list of "this" that is
     // not an SSA definition (a lcl = phi(...) assignment).
-    GenTreeStmt* FirstNonPhiDef();
-    GenTreeStmt* FirstNonPhiDefOrCatchArgAsg();
+    Statement* FirstNonPhiDef();
+    Statement* FirstNonPhiDefOrCatchArgAsg();
 
     BasicBlock() : bbStmtList(nullptr), bbLiveIn(VarSetOps::UninitVal()), bbLiveOut(VarSetOps::UninitVal())
     {

--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -1063,6 +1063,11 @@ struct BasicBlock : private LIR::Range
     Statement* firstStmt() const;
     Statement* lastStmt() const;
 
+    StatementList Statements() const
+    {
+        return StatementList(firstStmt());
+    }
+
     GenTree* firstNode();
     GenTree* lastNode();
 

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -11408,7 +11408,7 @@ void CodeGen::genIPmappingGen()
         //block has an IL offset and appears in eeBoundaries.
         for (BasicBlock * block = compiler->fgFirstBB; block != nullptr; block = block->bbNext)
         {
-            GenTreeStmt* stmt = block->firstStmt();
+            Statement* stmt = block->firstStmt();
             if ((block->bbRefs > 1) && (stmt != nullptr))
             {
                 bool found = false;

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4692,7 +4692,7 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags
         compCycleEstimate = 0;
         for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->bbNext)
         {
-            for (GenTreeStmt* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+            for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
             {
                 compSizeEstimate += stmt->GetCostSz();
                 compCycleEstimate += stmt->GetCostEx();
@@ -4823,7 +4823,7 @@ void Compiler::ResetOptAnnotations()
 
     for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->bbNext)
     {
-        for (GenTreeStmt* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
         {
             for (GenTree* tree = stmt->gtStmtList; tree != nullptr; tree = tree->gtNext)
             {
@@ -6856,7 +6856,7 @@ Compiler::NodeToIntMap* Compiler::FindReachableNodesInNodeTestData()
 
     for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->bbNext)
     {
-        for (GenTreeStmt* stmt = block->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt = block->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->getNextStmt())
         {
             for (GenTree* tree = stmt->gtStmtList; tree != nullptr; tree = tree->gtNext)
             {
@@ -6987,7 +6987,7 @@ void Compiler::compCallArgStats()
 
     for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->bbNext)
     {
-        for (GenTreeStmt* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
         {
             for (GenTree* call = stmt->gtStmtList; call != nullptr; call = call->gtNext)
             {
@@ -8341,10 +8341,10 @@ void dBlockList(BasicBlockList* list)
 // Trees, Stmts, and/or Blocks using id or bbNum.
 // That can be used in watch window or as a way to get address of fields for data break points.
 
-GenTree*     dbTree;
-GenTreeStmt* dbStmt;
-BasicBlock*  dbTreeBlock;
-BasicBlock*  dbBlock;
+GenTree*    dbTree;
+Statement*  dbStmt;
+BasicBlock* dbTreeBlock;
+BasicBlock* dbBlock;
 
 // Debug APIs for finding Trees, Stmts, and/or Blocks.
 // As a side effect, they set the debug variables above.
@@ -8389,7 +8389,7 @@ GenTree* dFindTree(unsigned id)
 
     for (block = comp->fgFirstBB; block != nullptr; block = block->bbNext)
     {
-        for (GenTreeStmt* stmt = block->firstStmt(); stmt; stmt = stmt->gtNextStmt)
+        for (Statement* stmt = block->firstStmt(); stmt; stmt = stmt->gtNextStmt)
         {
             tree = dFindTree(stmt->gtStmtExpr, id);
             if (tree != nullptr)
@@ -8403,7 +8403,7 @@ GenTree* dFindTree(unsigned id)
     return nullptr;
 }
 
-GenTreeStmt* dFindStmt(unsigned id)
+Statement* dFindStmt(unsigned id)
 {
     Compiler*   comp = JitTls::GetCompiler();
     BasicBlock* block;
@@ -8413,7 +8413,7 @@ GenTreeStmt* dFindStmt(unsigned id)
     unsigned stmtId = 0;
     for (block = comp->fgFirstBB; block != nullptr; block = block->bbNext)
     {
-        for (GenTreeStmt* stmt = block->firstStmt(); stmt; stmt = stmt->gtNextStmt)
+        for (Statement* stmt = block->firstStmt(); stmt; stmt = stmt->gtNextStmt)
         {
             stmtId++;
             if (stmtId == id)
@@ -8606,7 +8606,7 @@ void cBlockIR(Compiler* comp, BasicBlock* block)
 
     if (!block->IsLIR())
     {
-        for (GenTreeStmt* stmt = block->firstStmt(); stmt; stmt = stmt->gtNextStmt)
+        for (Statement* stmt = block->firstStmt(); stmt; stmt = stmt->gtNextStmt)
         {
             // Print current stmt.
 

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4692,7 +4692,7 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags
         compCycleEstimate = 0;
         for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->bbNext)
         {
-            for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+            for (Statement* stmt : block->Statements())
             {
                 compSizeEstimate += stmt->GetCostSz();
                 compCycleEstimate += stmt->GetCostEx();
@@ -4823,7 +4823,7 @@ void Compiler::ResetOptAnnotations()
 
     for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->bbNext)
     {
-        for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt : block->Statements())
         {
             for (GenTree* tree = stmt->gtStmtList; tree != nullptr; tree = tree->gtNext)
             {
@@ -6987,7 +6987,7 @@ void Compiler::compCallArgStats()
 
     for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->bbNext)
     {
-        for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt : block->Statements())
         {
             for (GenTree* call = stmt->gtStmtList; call != nullptr; call = call->gtNext)
             {
@@ -8389,7 +8389,7 @@ GenTree* dFindTree(unsigned id)
 
     for (block = comp->fgFirstBB; block != nullptr; block = block->bbNext)
     {
-        for (Statement* stmt = block->firstStmt(); stmt; stmt = stmt->gtNextStmt)
+        for (Statement* stmt : block->Statements())
         {
             tree = dFindTree(stmt->gtStmtExpr, id);
             if (tree != nullptr)
@@ -8413,7 +8413,7 @@ Statement* dFindStmt(unsigned id)
     unsigned stmtId = 0;
     for (block = comp->fgFirstBB; block != nullptr; block = block->bbNext)
     {
-        for (Statement* stmt = block->firstStmt(); stmt; stmt = stmt->gtNextStmt)
+        for (Statement* stmt : block->Statements())
         {
             stmtId++;
             if (stmtId == id)
@@ -8606,7 +8606,7 @@ void cBlockIR(Compiler* comp, BasicBlock* block)
 
     if (!block->IsLIR())
     {
-        for (Statement* stmt = block->firstStmt(); stmt; stmt = stmt->gtNextStmt)
+        for (Statement* stmt : block->Statements())
         {
             // Print current stmt.
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -856,9 +856,9 @@ private:
 
 public:
 #if ASSERTION_PROP
-    BlockSet     lvRefBlks;          // Set of blocks that contain refs
-    GenTreeStmt* lvDefStmt;          // Pointer to the statement with the single definition
-    void         lvaDisqualifyVar(); // Call to disqualify a local variable from use in optAddCopies
+    BlockSet   lvRefBlks;          // Set of blocks that contain refs
+    Statement* lvDefStmt;          // Pointer to the statement with the single definition
+    void       lvaDisqualifyVar(); // Call to disqualify a local variable from use in optAddCopies
 #endif
     var_types TypeGet() const
     {
@@ -2444,7 +2444,7 @@ public:
     */
 
     // Functions to create nodes
-    GenTreeStmt* gtNewStmt(GenTree* expr = nullptr, IL_OFFSETX offset = BAD_IL_OFFSET);
+    Statement* gtNewStmt(GenTree* expr = nullptr, IL_OFFSETX offset = BAD_IL_OFFSET);
 
     // For unary opers.
     GenTree* gtNewOperNode(genTreeOps oper, var_types type, GenTree* op1, bool doSimplifications = TRUE);
@@ -2604,11 +2604,11 @@ public:
 
     GenTree* gtNewAssignNode(GenTree* dst, GenTree* src);
 
-    GenTree* gtNewTempAssign(unsigned      tmp,
-                             GenTree*      val,
-                             GenTreeStmt** pAfterStmt = nullptr,
-                             IL_OFFSETX    ilOffset   = BAD_IL_OFFSET,
-                             BasicBlock*   block      = nullptr);
+    GenTree* gtNewTempAssign(unsigned    tmp,
+                             GenTree*    val,
+                             Statement** pAfterStmt = nullptr,
+                             IL_OFFSETX  ilOffset   = BAD_IL_OFFSET,
+                             BasicBlock* block      = nullptr);
 
     GenTree* gtNewRefCOMfield(GenTree*                objPtr,
                               CORINFO_RESOLVED_TOKEN* pResolvedToken,
@@ -2653,7 +2653,7 @@ public:
         return gtCloneExpr(tree, addFlags, varNum, varVal, varNum, varVal);
     }
 
-    GenTreeStmt* gtCloneStmt(GenTreeStmt* stmt)
+    Statement* gtCloneStmt(Statement* stmt)
     {
         GenTree* exprClone = gtCloneExpr(stmt->gtStmtExpr);
         return gtNewStmt(exprClone, stmt->gtStmtILoffsx);
@@ -2668,13 +2668,13 @@ public:
     // Create copy of an inline or guarded devirtualization candidate tree.
     GenTreeCall* gtCloneCandidateCall(GenTreeCall* call);
 
-    GenTree* gtReplaceTree(GenTreeStmt* stmt, GenTree* tree, GenTree* replacementTree);
+    GenTree* gtReplaceTree(Statement* stmt, GenTree* tree, GenTree* replacementTree);
 
-    void gtUpdateSideEffects(GenTreeStmt* stmt, GenTree* tree);
+    void gtUpdateSideEffects(Statement* stmt, GenTree* tree);
 
     void gtUpdateTreeAncestorsSideEffects(GenTree* tree);
 
-    void gtUpdateStmtSideEffects(GenTreeStmt* stmt);
+    void gtUpdateStmtSideEffects(Statement* stmt);
 
     void gtUpdateNodeSideEffects(GenTree* tree);
 
@@ -2719,7 +2719,7 @@ public:
 
     unsigned gtSetEvalOrder(GenTree* tree);
 
-    void gtSetStmtInfo(GenTreeStmt* stmt);
+    void gtSetStmtInfo(Statement* stmt);
 
     // Returns "true" iff "node" has any of the side effects in "flags".
     bool gtNodeHasSideEffects(GenTree* node, unsigned flags);
@@ -2854,7 +2854,7 @@ public:
     int gtGetLclVarName(unsigned lclNum, char* buf, unsigned buf_remaining);
     char* gtGetLclVarName(unsigned lclNum);
     void gtDispLclVar(unsigned varNum, bool padForBiggestDisp = true);
-    void gtDispStmtList(GenTreeStmt* stmts, IndentStack* indentStack = nullptr);
+    void gtDispStmtList(Statement* stmts, IndentStack* indentStack = nullptr);
     void gtGetArgMsg(GenTreeCall* call, GenTree* arg, unsigned argNum, int listCount, char* bufp, unsigned bufLength);
     void gtGetLateArgMsg(GenTreeCall* call, GenTree* arg, int argNum, int listCount, char* bufp, unsigned bufLength);
     void gtDispArgList(GenTreeCall* call, IndentStack* indentStack);
@@ -2892,7 +2892,7 @@ public:
         GenTree*  parent;
     };
 
-    FindLinkData gtFindLink(GenTreeStmt* stmt, GenTree* node);
+    FindLinkData gtFindLink(Statement* stmt, GenTree* node);
     bool gtHasCatchArg(GenTree* tree);
 
     typedef ArrayStack<GenTree*> GenTreeStack;
@@ -3223,7 +3223,7 @@ public:
 
     void lvaAllocOutgoingArgSpaceVar(); // Set up lvaOutgoingArgSpaceVar
 
-    VARSET_VALRET_TP lvaStmtLclMask(GenTreeStmt* stmt);
+    VARSET_VALRET_TP lvaStmtLclMask(Statement* stmt);
 
 #ifdef DEBUG
     struct lvaStressLclFldArgs
@@ -3447,7 +3447,7 @@ public:
 protected:
     //---------------- Local variable ref-counting ----------------------------
 
-    void lvaMarkLclRefs(GenTree* tree, BasicBlock* block, GenTreeStmt* stmt, bool isRecompute);
+    void lvaMarkLclRefs(GenTree* tree, BasicBlock* block, Statement* stmt, bool isRecompute);
     bool IsDominatedByExceptionalEntry(BasicBlock* block);
     void SetVolatileHint(LclVarDsc* varDsc);
 
@@ -3694,8 +3694,8 @@ protected:
 
     //----------------- Manipulating the trees and stmts ----------------------
 
-    GenTreeStmt* impStmtList; // Statements for the BB being imported.
-    GenTreeStmt* impLastStmt; // The last statement for the current BB.
+    Statement* impStmtList; // Statements for the BB being imported.
+    Statement* impLastStmt; // The last statement for the current BB.
 
 public:
     enum
@@ -3705,46 +3705,46 @@ public:
     };
 
     void impBeginTreeList();
-    void impEndTreeList(BasicBlock* block, GenTreeStmt* firstStmt, GenTreeStmt* lastStmt);
+    void impEndTreeList(BasicBlock* block, Statement* firstStmt, Statement* lastStmt);
     void impEndTreeList(BasicBlock* block);
-    void impAppendStmtCheck(GenTreeStmt* stmt, unsigned chkLevel);
-    void impAppendStmt(GenTreeStmt* stmt, unsigned chkLevel);
-    void impAppendStmt(GenTreeStmt* stmt);
-    void impInsertStmtBefore(GenTreeStmt* stmt, GenTreeStmt* stmtBefore);
-    GenTreeStmt* impAppendTree(GenTree* tree, unsigned chkLevel, IL_OFFSETX offset);
-    void impInsertTreeBefore(GenTree* tree, IL_OFFSETX offset, GenTreeStmt* stmtBefore);
-    void impAssignTempGen(unsigned      tmp,
-                          GenTree*      val,
-                          unsigned      curLevel,
-                          GenTreeStmt** pAfterStmt = nullptr,
-                          IL_OFFSETX    ilOffset   = BAD_IL_OFFSET,
-                          BasicBlock*   block      = nullptr);
+    void impAppendStmtCheck(Statement* stmt, unsigned chkLevel);
+    void impAppendStmt(Statement* stmt, unsigned chkLevel);
+    void impAppendStmt(Statement* stmt);
+    void impInsertStmtBefore(Statement* stmt, Statement* stmtBefore);
+    Statement* impAppendTree(GenTree* tree, unsigned chkLevel, IL_OFFSETX offset);
+    void impInsertTreeBefore(GenTree* tree, IL_OFFSETX offset, Statement* stmtBefore);
+    void impAssignTempGen(unsigned    tmp,
+                          GenTree*    val,
+                          unsigned    curLevel,
+                          Statement** pAfterStmt = nullptr,
+                          IL_OFFSETX  ilOffset   = BAD_IL_OFFSET,
+                          BasicBlock* block      = nullptr);
     void impAssignTempGen(unsigned             tmpNum,
                           GenTree*             val,
                           CORINFO_CLASS_HANDLE structHnd,
                           unsigned             curLevel,
-                          GenTreeStmt**        pAfterStmt = nullptr,
+                          Statement**          pAfterStmt = nullptr,
                           IL_OFFSETX           ilOffset   = BAD_IL_OFFSET,
                           BasicBlock*          block      = nullptr);
 
-    GenTreeStmt* impExtractLastStmt();
+    Statement* impExtractLastStmt();
     GenTree* impCloneExpr(GenTree*             tree,
                           GenTree**            clone,
                           CORINFO_CLASS_HANDLE structHnd,
                           unsigned             curLevel,
-                          GenTreeStmt** pAfterStmt DEBUGARG(const char* reason));
+                          Statement** pAfterStmt DEBUGARG(const char* reason));
     GenTree* impAssignStruct(GenTree*             dest,
                              GenTree*             src,
                              CORINFO_CLASS_HANDLE structHnd,
                              unsigned             curLevel,
-                             GenTreeStmt**        pAfterStmt = nullptr,
+                             Statement**          pAfterStmt = nullptr,
                              IL_OFFSETX           ilOffset   = BAD_IL_OFFSET,
                              BasicBlock*          block      = nullptr);
     GenTree* impAssignStructPtr(GenTree*             dest,
                                 GenTree*             src,
                                 CORINFO_CLASS_HANDLE structHnd,
                                 unsigned             curLevel,
-                                GenTreeStmt**        pAfterStmt = nullptr,
+                                Statement**          pAfterStmt = nullptr,
                                 IL_OFFSETX           ilOffset   = BAD_IL_OFFSET,
                                 BasicBlock*          block      = nullptr);
 
@@ -3814,8 +3814,8 @@ private:
     bool        impNestedStackSpill;
 
     // For displaying instrs with generated native code (-n:B)
-    GenTreeStmt* impLastILoffsStmt; // oldest stmt added for which we did not gtStmtLastILoffs
-    void         impNoteLastILoffs();
+    Statement* impLastILoffsStmt; // oldest stmt added for which we did not gtStmtLastILoffs
+    void       impNoteLastILoffs();
 #endif
 
     /* IL offset of the stmt currently being imported. It gets set to
@@ -4394,7 +4394,7 @@ public:
     void fgMorphStmts(BasicBlock* block, bool* lnot, bool* loadw);
     void fgMorphBlocks();
 
-    bool fgMorphBlockStmt(BasicBlock* block, GenTreeStmt* stmt DEBUGARG(const char* msg));
+    bool fgMorphBlockStmt(BasicBlock* block, Statement* stmt DEBUGARG(const char* msg));
 
     void fgSetOptions();
 
@@ -4409,18 +4409,18 @@ public:
 
     BasicBlock* fgSplitBlockAtBeginning(BasicBlock* curr);
     BasicBlock* fgSplitBlockAtEnd(BasicBlock* curr);
-    BasicBlock* fgSplitBlockAfterStatement(BasicBlock* curr, GenTreeStmt* stmt);
+    BasicBlock* fgSplitBlockAfterStatement(BasicBlock* curr, Statement* stmt);
     BasicBlock* fgSplitBlockAfterNode(BasicBlock* curr, GenTree* node); // for LIR
     BasicBlock* fgSplitEdge(BasicBlock* curr, BasicBlock* succ);
 
-    GenTreeStmt* fgNewStmtFromTree(GenTree* tree, BasicBlock* block, IL_OFFSETX offs);
-    GenTreeStmt* fgNewStmtFromTree(GenTree* tree);
-    GenTreeStmt* fgNewStmtFromTree(GenTree* tree, BasicBlock* block);
-    GenTreeStmt* fgNewStmtFromTree(GenTree* tree, IL_OFFSETX offs);
+    Statement* fgNewStmtFromTree(GenTree* tree, BasicBlock* block, IL_OFFSETX offs);
+    Statement* fgNewStmtFromTree(GenTree* tree);
+    Statement* fgNewStmtFromTree(GenTree* tree, BasicBlock* block);
+    Statement* fgNewStmtFromTree(GenTree* tree, IL_OFFSETX offs);
 
     GenTree* fgGetTopLevelQmark(GenTree* expr, GenTree** ppDst = nullptr);
-    void fgExpandQmarkForCastInstOf(BasicBlock* block, GenTreeStmt* stmt);
-    void fgExpandQmarkStmt(BasicBlock* block, GenTreeStmt* stmt);
+    void fgExpandQmarkForCastInstOf(BasicBlock* block, Statement* stmt);
+    void fgExpandQmarkStmt(BasicBlock* block, Statement* stmt);
     void fgExpandQmarkNodes();
 
     void fgMorph();
@@ -4972,9 +4972,9 @@ public:
 
     void fgRemoveEmptyBlocks();
 
-    void fgRemoveStmt(BasicBlock* block, GenTreeStmt* stmt);
+    void fgRemoveStmt(BasicBlock* block, Statement* stmt);
 
-    bool fgCheckRemoveStmt(BasicBlock* block, GenTreeStmt* stmt);
+    bool fgCheckRemoveStmt(BasicBlock* block, Statement* stmt);
 
     void fgCreateLoopPreHeader(unsigned lnum);
 
@@ -5100,7 +5100,7 @@ public:
     void fgTableDispBasicBlock(BasicBlock* block, int ibcColWidth = 0);
     void fgDispBasicBlocks(BasicBlock* firstBlock, BasicBlock* lastBlock, bool dumpTrees);
     void fgDispBasicBlocks(bool dumpTrees = false);
-    void fgDumpStmtTree(GenTreeStmt* stmt, unsigned bbNum);
+    void fgDumpStmtTree(Statement* stmt, unsigned bbNum);
     void fgDumpBlock(BasicBlock* block);
     void fgDumpTrees(BasicBlock* firstBlock, BasicBlock* lastBlock);
 
@@ -5111,7 +5111,7 @@ public:
     void fgDebugCheckBlockLinks();
     void fgDebugCheckLinks(bool morphTrees = false);
     void fgDebugCheckStmtsList(BasicBlock* block, bool morphTrees);
-    void fgDebugCheckNodeLinks(BasicBlock* block, GenTreeStmt* stmt);
+    void fgDebugCheckNodeLinks(BasicBlock* block, Statement* stmt);
     void fgDebugCheckNodesUniqueness();
 
     void fgDebugCheckFlags(GenTree* tree);
@@ -5254,29 +5254,27 @@ public:
 
 #ifdef DEBUG
 public:
-    static bool fgBlockContainsStatementBounded(BasicBlock*  block,
-                                                GenTreeStmt* stmt,
-                                                bool         answerOnBoundExceeded = true);
+    static bool fgBlockContainsStatementBounded(BasicBlock* block, Statement* stmt, bool answerOnBoundExceeded = true);
 #endif
 
 public:
-    GenTreeStmt* fgInsertStmtAtEnd(BasicBlock* block, GenTreeStmt* stmt);
-    GenTreeStmt* fgNewStmtAtEnd(BasicBlock* block, GenTree* tree);
+    Statement* fgInsertStmtAtEnd(BasicBlock* block, Statement* stmt);
+    Statement* fgNewStmtAtEnd(BasicBlock* block, GenTree* tree);
 
 private:
-    GenTreeStmt* fgInsertStmtNearEnd(BasicBlock* block, GenTreeStmt* stmt);
-    GenTreeStmt* fgNewStmtNearEnd(BasicBlock* block, GenTree* tree);
+    Statement* fgInsertStmtNearEnd(BasicBlock* block, Statement* stmt);
+    Statement* fgNewStmtNearEnd(BasicBlock* block, GenTree* tree);
 
-    GenTreeStmt* fgInsertStmtAtBeg(BasicBlock* block, GenTreeStmt* stmt);
-    GenTreeStmt* fgNewStmtAtBeg(BasicBlock* block, GenTree* tree);
+    Statement* fgInsertStmtAtBeg(BasicBlock* block, Statement* stmt);
+    Statement* fgNewStmtAtBeg(BasicBlock* block, GenTree* tree);
 
-    GenTreeStmt* fgInsertStmtAfter(BasicBlock* block, GenTreeStmt* insertionPoint, GenTreeStmt* stmt);
+    Statement* fgInsertStmtAfter(BasicBlock* block, Statement* insertionPoint, Statement* stmt);
 
 public: // Used by linear scan register allocation
-    GenTreeStmt* fgInsertStmtBefore(BasicBlock* block, GenTreeStmt* insertionPoint, GenTreeStmt* stmt);
+    Statement* fgInsertStmtBefore(BasicBlock* block, Statement* insertionPoint, Statement* stmt);
 
 private:
-    GenTreeStmt* fgInsertStmtListAfter(BasicBlock* block, GenTreeStmt* stmtAfter, GenTreeStmt* stmtList);
+    Statement* fgInsertStmtListAfter(BasicBlock* block, Statement* stmtAfter, Statement* stmtList);
 
     //                  Create a new temporary variable to hold the result of *ppTree,
     //                  and transform the graph accordingly.
@@ -5297,7 +5295,7 @@ private:
     GenTree* fgSetTreeSeq(GenTree* tree, GenTree* prev = nullptr, bool isLIR = false);
     void fgSetTreeSeqHelper(GenTree* tree, bool isLIR);
     void fgSetTreeSeqFinish(GenTree* tree, bool isLIR);
-    void fgSetStmtSeq(GenTreeStmt* stmt);
+    void fgSetStmtSeq(Statement* stmt);
     void fgSetBlockOrder(BasicBlock* block);
 
     //------------------------- Morphing --------------------------------------
@@ -5389,12 +5387,12 @@ private:
                                     bool       ignoreUsedInSIMDIntrinsic = false);
     GenTree* fgMorphFieldAssignToSIMDIntrinsicSet(GenTree* tree);
     GenTree* fgMorphFieldToSIMDIntrinsicGet(GenTree* tree);
-    bool fgMorphCombineSIMDFieldAssignments(BasicBlock* block, GenTreeStmt* stmt);
-    void impMarkContiguousSIMDFieldAssignments(GenTreeStmt* stmt);
+    bool fgMorphCombineSIMDFieldAssignments(BasicBlock* block, Statement* stmt);
+    void impMarkContiguousSIMDFieldAssignments(Statement* stmt);
 
     // fgPreviousCandidateSIMDFieldAsgStmt is only used for tracking previous simd field assignment
     // in function: Complier::impMarkContiguousSIMDFieldAssignments.
-    GenTreeStmt* fgPreviousCandidateSIMDFieldAsgStmt;
+    Statement* fgPreviousCandidateSIMDFieldAsgStmt;
 
 #endif // FEATURE_SIMD
     GenTree* fgMorphArrayIndex(GenTree* tree);
@@ -5424,18 +5422,18 @@ private:
     GenTree* fgMorphPotentialTailCall(GenTreeCall* call);
     GenTree* fgGetStubAddrArg(GenTreeCall* call);
     void fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCall* recursiveTailCall);
-    GenTreeStmt* fgAssignRecursiveCallArgToCallerParam(GenTree*       arg,
-                                                       fgArgTabEntry* argTabEntry,
-                                                       BasicBlock*    block,
-                                                       IL_OFFSETX     callILOffset,
-                                                       GenTreeStmt*   tmpAssignmentInsertionPoint,
-                                                       GenTreeStmt*   paramAssignmentInsertionPoint);
+    Statement* fgAssignRecursiveCallArgToCallerParam(GenTree*       arg,
+                                                     fgArgTabEntry* argTabEntry,
+                                                     BasicBlock*    block,
+                                                     IL_OFFSETX     callILOffset,
+                                                     Statement*     tmpAssignmentInsertionPoint,
+                                                     Statement*     paramAssignmentInsertionPoint);
     static int fgEstimateCallStackSize(GenTreeCall* call);
     GenTree* fgMorphCall(GenTreeCall* call);
     void fgMorphCallInline(GenTreeCall* call, InlineResult* result);
     void fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result);
 #if DEBUG
-    void fgNoteNonInlineCandidate(GenTreeStmt* stmt, GenTreeCall* call);
+    void fgNoteNonInlineCandidate(Statement* stmt, GenTreeCall* call);
     static fgWalkPreFn fgFindNonInlineCandidate;
 #endif
     GenTree* fgOptimizeDelegateConstructor(GenTreeCall*            call,
@@ -5471,7 +5469,7 @@ private:
 #endif
     void fgMorphTreeDone(GenTree* tree, GenTree* oldTree = nullptr DEBUGARG(int morphNum = 0));
 
-    GenTreeStmt* fgMorphStmt;
+    Statement* fgMorphStmt;
 
     unsigned fgGetBigOffsetMorphingTemp(var_types type); // We cache one temp per type to be
                                                          // used when morphing big offset.
@@ -5556,8 +5554,8 @@ private:
     unsigned fgCheckInlineDepthAndRecursion(InlineInfo* inlineInfo);
     void fgInvokeInlineeCompiler(GenTreeCall* call, InlineResult* result);
     void fgInsertInlineeBlocks(InlineInfo* pInlineInfo);
-    GenTreeStmt* fgInlinePrependStatements(InlineInfo* inlineInfo);
-    void fgInlineAppendStatements(InlineInfo* inlineInfo, BasicBlock* block, GenTreeStmt* stmt);
+    Statement* fgInlinePrependStatements(InlineInfo* inlineInfo);
+    void fgInlineAppendStatements(InlineInfo* inlineInfo, BasicBlock* block, Statement* stmt);
 
 #if FEATURE_MULTIREG_RET
     GenTree* fgGetStructAsStructPtr(GenTree* tree);
@@ -5640,7 +5638,7 @@ private:
 public:
     void optInit();
 
-    void optRemoveRangeCheck(GenTree* tree, GenTreeStmt* stmt);
+    void optRemoveRangeCheck(GenTree* tree, Statement* stmt);
     bool optIsRangeCheckRemovable(GenTree* tree);
 
 protected:
@@ -6013,7 +6011,7 @@ protected:
 
     void optUpdateLoopsBeforeRemoveBlock(BasicBlock* block, bool skipUnmarkLoop = false);
 
-    bool optIsLoopTestEvalIntoTemp(GenTreeStmt* testStmt, GenTreeStmt** newTestStmt);
+    bool optIsLoopTestEvalIntoTemp(Statement* testStmt, Statement** newTestStmt);
     unsigned optIsLoopIncrTree(GenTree* incr);
     bool optCheckIterInLoopTest(unsigned loopInd, GenTree* test, BasicBlock* from, BasicBlock* to, unsigned iterVar);
     bool optComputeIterInfo(GenTree* incr, BasicBlock* from, BasicBlock* to, unsigned* pIterVar);
@@ -6132,7 +6130,7 @@ protected:
     {
         treeStmtLst* tslNext;
         GenTree*     tslTree;  // tree node
-        GenTreeStmt* tslStmt;  // statement containing the tree
+        Statement*   tslStmt;  // statement containing the tree
         BasicBlock*  tslBlock; // block containing the statement
     };
 
@@ -6153,9 +6151,9 @@ protected:
         unsigned csdDefWtCnt; // weighted def count
         unsigned csdUseWtCnt; // weighted use count  (excluding the implicit uses at defs)
 
-        GenTree*     csdTree;  // treenode containing the 1st occurance
-        GenTreeStmt* csdStmt;  // stmt containing the 1st occurance
-        BasicBlock*  csdBlock; // block containing the 1st occurance
+        GenTree*    csdTree;  // treenode containing the 1st occurance
+        Statement*  csdStmt;  // stmt containing the 1st occurance
+        BasicBlock* csdBlock; // block containing the 1st occurance
 
         treeStmtLst* csdTreeList; // list of matching tree nodes: head
         treeStmtLst* csdTreeLast; // list of matching tree nodes: tail
@@ -6226,7 +6224,7 @@ public:
 
 protected:
     void     optValnumCSE_Init();
-    unsigned optValnumCSE_Index(GenTree* tree, GenTreeStmt* stmt);
+    unsigned optValnumCSE_Index(GenTree* tree, Statement* stmt);
     unsigned optValnumCSE_Locate();
     void     optValnumCSE_InitDataFlow();
     void     optValnumCSE_DataFlow();
@@ -6293,7 +6291,7 @@ public:
     VARSET_TP optCopyPropKillSet;
 
     // Copy propagation functions.
-    void optCopyProp(BasicBlock* block, GenTreeStmt* stmt, GenTree* tree, LclNumToGenTreePtrStack* curSsaName);
+    void optCopyProp(BasicBlock* block, Statement* stmt, GenTree* tree, LclNumToGenTreePtrStack* curSsaName);
     void optBlockCopyPropPopStacks(BasicBlock* block, LclNumToGenTreePtrStack* curSsaName);
     void optBlockCopyProp(BasicBlock* block, LclNumToGenTreePtrStack* curSsaName);
     bool optIsSsaLocal(GenTree* tree);
@@ -6671,8 +6669,8 @@ protected:
     AssertionIndex optMaxAssertionCount;
 
 public:
-    void optVnNonNullPropCurStmt(BasicBlock* block, GenTreeStmt* stmt, GenTree* tree);
-    fgWalkResult optVNConstantPropCurStmt(BasicBlock* block, GenTreeStmt* stmt, GenTree* tree);
+    void optVnNonNullPropCurStmt(BasicBlock* block, Statement* stmt, GenTree* tree);
+    fgWalkResult optVNConstantPropCurStmt(BasicBlock* block, Statement* stmt, GenTree* tree);
     GenTree* optVNConstantPropOnJTrue(BasicBlock* block, GenTree* test);
     GenTree* optVNConstantPropOnTree(BasicBlock* block, GenTree* tree);
     GenTree* optExtractSideEffListFromConst(GenTree* tree);
@@ -6696,8 +6694,8 @@ public:
 #endif
 
     // Assertion prop data flow functions.
-    void         optAssertionPropMain();
-    GenTreeStmt* optVNAssertionPropCurStmt(BasicBlock* block, GenTreeStmt* stmt);
+    void       optAssertionPropMain();
+    Statement* optVNAssertionPropCurStmt(BasicBlock* block, Statement* stmt);
     bool optIsTreeKnownIntValue(bool vnBased, GenTree* tree, ssize_t* pConstant, unsigned* pIconFlags);
     ASSERT_TP* optInitAssertionDataflowFlags();
     ASSERT_TP* optComputeAssertionGen();
@@ -6752,23 +6750,23 @@ public:
     bool optAssertionProp_LclVarTypeCheck(GenTree* tree, LclVarDsc* lclVarDsc, LclVarDsc* copyVarDsc);
     GenTree* optCopyAssertionProp(AssertionDsc* curAssertion,
                                   GenTree*      tree,
-                                  GenTreeStmt* stmt DEBUGARG(AssertionIndex index));
+                                  Statement* stmt DEBUGARG(AssertionIndex index));
     GenTree* optConstantAssertionProp(AssertionDsc* curAssertion,
                                       GenTree*      tree,
-                                      GenTreeStmt* stmt DEBUGARG(AssertionIndex index));
+                                      Statement* stmt DEBUGARG(AssertionIndex index));
 
     // Assertion propagation functions.
-    GenTree* optAssertionProp(ASSERT_VALARG_TP assertions, GenTree* tree, GenTreeStmt* stmt);
-    GenTree* optAssertionProp_LclVar(ASSERT_VALARG_TP assertions, GenTree* tree, GenTreeStmt* stmt);
-    GenTree* optAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* tree, GenTreeStmt* stmt);
-    GenTree* optAssertionProp_Cast(ASSERT_VALARG_TP assertions, GenTree* tree, GenTreeStmt* stmt);
-    GenTree* optAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCall* call, GenTreeStmt* stmt);
-    GenTree* optAssertionProp_RelOp(ASSERT_VALARG_TP assertions, GenTree* tree, GenTreeStmt* stmt);
-    GenTree* optAssertionProp_Comma(ASSERT_VALARG_TP assertions, GenTree* tree, GenTreeStmt* stmt);
+    GenTree* optAssertionProp(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt);
+    GenTree* optAssertionProp_LclVar(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt);
+    GenTree* optAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt);
+    GenTree* optAssertionProp_Cast(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt);
+    GenTree* optAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCall* call, Statement* stmt);
+    GenTree* optAssertionProp_RelOp(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt);
+    GenTree* optAssertionProp_Comma(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt);
     GenTree* optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions, GenTree* tree);
-    GenTree* optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, GenTree* tree, GenTreeStmt* stmt);
-    GenTree* optAssertionPropLocal_RelOp(ASSERT_VALARG_TP assertions, GenTree* tree, GenTreeStmt* stmt);
-    GenTree* optAssertionProp_Update(GenTree* newTree, GenTree* tree, GenTreeStmt* stmt);
+    GenTree* optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt);
+    GenTree* optAssertionPropLocal_RelOp(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt);
+    GenTree* optAssertionProp_Update(GenTree* newTree, GenTree* tree, Statement* stmt);
     GenTree* optNonNullAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCall* call);
 
     // Implied assertion functions.
@@ -6794,8 +6792,8 @@ public:
     {
         LoopCloneContext* context;
         unsigned          loopNum;
-        GenTreeStmt*      stmt;
-        LoopCloneVisitorInfo(LoopCloneContext* context, unsigned loopNum, GenTreeStmt* stmt)
+        Statement*        stmt;
+        LoopCloneVisitorInfo(LoopCloneContext* context, unsigned loopNum, Statement* stmt)
             : context(context), loopNum(loopNum), stmt(nullptr)
         {
         }
@@ -6813,7 +6811,7 @@ public:
     bool optCanCloneLoops();
 
 #ifdef DEBUG
-    void optDebugLogLoopCloning(BasicBlock* block, GenTreeStmt* insertBefore);
+    void optDebugLogLoopCloning(BasicBlock* block, Statement* insertBefore);
 #endif
     void optPerformStaticOptimizations(unsigned loopNum, LoopCloneContext* context DEBUGARG(bool fastPath));
     bool optComputeDerefConditions(unsigned loopNum, LoopCloneContext* context);
@@ -8925,8 +8923,8 @@ public:
     unsigned        compBasicBlockID;
 #endif
 
-    BasicBlock*  compCurBB;   // the current basic block in process
-    GenTreeStmt* compCurStmt; // the current statement in process
+    BasicBlock* compCurBB;   // the current basic block in process
+    Statement*  compCurStmt; // the current statement in process
 #ifdef DEBUG
     unsigned compCurStmtNum; // to give all statements an increasing StmtNum when printing dumps
 #endif
@@ -10623,7 +10621,7 @@ void dFormatIR();
 
 GenTree* dFindTree(GenTree* tree, unsigned id);
 GenTree* dFindTree(unsigned id);
-GenTreeStmt* dFindStmt(unsigned id);
+Statement* dFindStmt(unsigned id);
 BasicBlock* dFindBlock(unsigned bbNum);
 
 #endif // DEBUG

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5262,7 +5262,7 @@ public:
     Statement* fgNewStmtAtEnd(BasicBlock* block, GenTree* tree);
 
 private:
-    Statement* fgInsertStmtNearEnd(BasicBlock* block, Statement* stmt);
+    void fgInsertStmtNearEnd(BasicBlock* block, Statement* stmt);
     Statement* fgNewStmtNearEnd(BasicBlock* block, GenTree* tree);
 
     void fgInsertStmtAtBeg(BasicBlock* block, Statement* stmt);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5265,7 +5265,7 @@ private:
     Statement* fgInsertStmtNearEnd(BasicBlock* block, Statement* stmt);
     Statement* fgNewStmtNearEnd(BasicBlock* block, GenTree* tree);
 
-    Statement* fgInsertStmtAtBeg(BasicBlock* block, Statement* stmt);
+    void fgInsertStmtAtBeg(BasicBlock* block, Statement* stmt);
     Statement* fgNewStmtAtBeg(BasicBlock* block, GenTree* tree);
 
     Statement* fgInsertStmtAfter(BasicBlock* block, Statement* insertionPoint, Statement* stmt);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2854,7 +2854,7 @@ public:
     int gtGetLclVarName(unsigned lclNum, char* buf, unsigned buf_remaining);
     char* gtGetLclVarName(unsigned lclNum);
     void gtDispLclVar(unsigned varNum, bool padForBiggestDisp = true);
-    void gtDispStmtList(Statement* stmts, IndentStack* indentStack = nullptr);
+    void gtDispBlockStmts(BasicBlock* block);
     void gtGetArgMsg(GenTreeCall* call, GenTree* arg, unsigned argNum, int listCount, char* bufp, unsigned bufLength);
     void gtGetLateArgMsg(GenTreeCall* call, GenTree* arg, int argNum, int listCount, char* bufp, unsigned bufLength);
     void gtDispArgList(GenTreeCall* call, IndentStack* indentStack);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5268,10 +5268,10 @@ private:
     void fgInsertStmtAtBeg(BasicBlock* block, Statement* stmt);
     Statement* fgNewStmtAtBeg(BasicBlock* block, GenTree* tree);
 
-    Statement* fgInsertStmtAfter(BasicBlock* block, Statement* insertionPoint, Statement* stmt);
+    void fgInsertStmtAfter(BasicBlock* block, Statement* insertionPoint, Statement* stmt);
 
-public: // Used by linear scan register allocation
-    Statement* fgInsertStmtBefore(BasicBlock* block, Statement* insertionPoint, Statement* stmt);
+public: // Used by objectalloc.
+    void fgInsertStmtBefore(BasicBlock* block, Statement* insertionPoint, Statement* stmt);
 
 private:
     Statement* fgInsertStmtListAfter(BasicBlock* block, Statement* stmtAfter, Statement* stmtList);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5257,8 +5257,8 @@ public:
     static bool fgBlockContainsStatementBounded(BasicBlock* block, Statement* stmt, bool answerOnBoundExceeded = true);
 #endif
 
-public:
-    Statement* fgInsertStmtAtEnd(BasicBlock* block, Statement* stmt);
+public: // Used by indirectcalltransformer.
+    void fgInsertStmtAtEnd(BasicBlock* block, Statement* stmt);
     Statement* fgNewStmtAtEnd(BasicBlock* block, GenTree* tree);
 
 private:

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5257,7 +5257,7 @@ public:
     static bool fgBlockContainsStatementBounded(BasicBlock* block, Statement* stmt, bool answerOnBoundExceeded = true);
 #endif
 
-public: // Used by indirectcalltransformer.
+public:
     void fgInsertStmtAtEnd(BasicBlock* block, Statement* stmt);
     Statement* fgNewStmtAtEnd(BasicBlock* block, GenTree* tree);
 
@@ -5270,7 +5270,7 @@ private:
 
     void fgInsertStmtAfter(BasicBlock* block, Statement* insertionPoint, Statement* stmt);
 
-public: // Used by objectalloc.
+public:
     void fgInsertStmtBefore(BasicBlock* block, Statement* insertionPoint, Statement* stmt);
 
 private:

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -942,9 +942,9 @@ inline GenTree::GenTree(genTreeOps oper, var_types type DEBUGARG(bool largeNode)
 
 /*****************************************************************************/
 
-inline GenTreeStmt* Compiler::gtNewStmt(GenTree* expr, IL_OFFSETX offset)
+inline Statement* Compiler::gtNewStmt(GenTree* expr, IL_OFFSETX offset)
 {
-    GenTreeStmt* stmt = new (this->getAllocator(CMK_ASTNode)) GenTreeStmt(expr, offset);
+    Statement* stmt = new (this->getAllocator(CMK_ASTNode)) Statement(expr, offset);
     return stmt;
 }
 
@@ -1310,7 +1310,7 @@ inline GenTree* Compiler::gtUnusedValNode(GenTree* expr)
  * operands
  */
 
-inline void Compiler::gtSetStmtInfo(GenTreeStmt* stmt)
+inline void Compiler::gtSetStmtInfo(Statement* stmt)
 {
     GenTree* expr = stmt->gtStmtExpr;
 
@@ -1837,7 +1837,7 @@ inline void LclVarDsc::incRefCnts(BasicBlock::weight_t weight, Compiler* comp, R
  *  referenced in a statement.
  */
 
-inline VARSET_VALRET_TP Compiler::lvaStmtLclMask(GenTreeStmt* stmt)
+inline VARSET_VALRET_TP Compiler::lvaStmtLclMask(Statement* stmt)
 {
     unsigned   varNum;
     LclVarDsc* varDsc;

--- a/src/jit/copyprop.cpp
+++ b/src/jit/copyprop.cpp
@@ -29,7 +29,7 @@
  */
 void Compiler::optBlockCopyPropPopStacks(BasicBlock* block, LclNumToGenTreePtrStack* curSsaName)
 {
-    for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+    for (Statement* stmt : block->Statements())
     {
         for (GenTree* tree = stmt->gtStmtList; tree != nullptr; tree = tree->gtNext)
         {
@@ -326,7 +326,7 @@ void Compiler::optBlockCopyProp(BasicBlock* block, LclNumToGenTreePtrStack* curS
     // There are no definitions at the start of the block. So clear it.
     compCurLifeTree = nullptr;
     VarSetOps::Assign(this, compCurLife, block->bbLiveIn);
-    for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+    for (Statement* stmt : block->Statements())
     {
         VarSetOps::ClearD(this, optCopyPropKillSet);
 

--- a/src/jit/copyprop.cpp
+++ b/src/jit/copyprop.cpp
@@ -29,7 +29,7 @@
  */
 void Compiler::optBlockCopyPropPopStacks(BasicBlock* block, LclNumToGenTreePtrStack* curSsaName)
 {
-    for (GenTreeStmt* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+    for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
     {
         for (GenTree* tree = stmt->gtStmtList; tree != nullptr; tree = tree->gtNext)
         {
@@ -128,7 +128,7 @@ int Compiler::optCopyProp_LclVarScore(LclVarDsc* lclVarDsc, LclVarDsc* copyVarDs
 //    tree        -  The tree to perform copy propagation on
 //    curSsaName  -  The map from lclNum to its recently live definitions as a stack
 
-void Compiler::optCopyProp(BasicBlock* block, GenTreeStmt* stmt, GenTree* tree, LclNumToGenTreePtrStack* curSsaName)
+void Compiler::optCopyProp(BasicBlock* block, Statement* stmt, GenTree* tree, LclNumToGenTreePtrStack* curSsaName)
 {
     // TODO-Review: EH successor/predecessor iteration seems broken.
     if (block->bbCatchTyp == BBCT_FINALLY || block->bbCatchTyp == BBCT_FAULT)
@@ -326,7 +326,7 @@ void Compiler::optBlockCopyProp(BasicBlock* block, LclNumToGenTreePtrStack* curS
     // There are no definitions at the start of the block. So clear it.
     compCurLifeTree = nullptr;
     VarSetOps::Assign(this, compCurLife, block->bbLiveIn);
-    for (GenTreeStmt* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+    for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
     {
         VarSetOps::ClearD(this, optCopyPropKillSet);
 

--- a/src/jit/earlyprop.cpp
+++ b/src/jit/earlyprop.cpp
@@ -185,10 +185,10 @@ void Compiler::optEarlyProp()
 
         compCurBB = block;
 
-        for (GenTreeStmt* stmt = block->firstStmt(); stmt != nullptr;)
+        for (Statement* stmt = block->firstStmt(); stmt != nullptr;)
         {
             // Preserve the next link before the propagation and morph.
-            GenTreeStmt* next = stmt->gtNextStmt;
+            Statement* next = stmt->gtNextStmt;
 
             compCurStmt = stmt;
 
@@ -607,8 +607,8 @@ void Compiler::optFoldNullCheck(GenTree* tree)
                                                 // Then walk the statement list in reverse execution order
                                                 // until we get to the statement containing the null check.
                                                 // We only need to check the side effects at the root of each statement.
-                                                GenTreeStmt* curStmt = compCurStmt->getPrevStmt();
-                                                currentTree          = curStmt->gtStmtExpr;
+                                                Statement* curStmt = compCurStmt->getPrevStmt();
+                                                currentTree        = curStmt->gtStmtExpr;
                                                 while (canRemoveNullCheck && (currentTree != defParent))
                                                 {
                                                     if ((nodesWalked++ > maxNodesWalked) ||

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -613,7 +613,7 @@ Statement* Compiler::fgNewStmtAtBeg(BasicBlock* block, GenTree* tree)
 //   stmt  - the statement to be inserted.
 //
 // Note:
-//   If the block can be a conditional block, use fgNewStmtNearEnd.
+//   If the block can be a conditional block, use fgInsertStmtNearEnd.
 //
 void Compiler::fgInsertStmtAtEnd(BasicBlock* block, Statement* stmt)
 {

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -783,16 +783,18 @@ Statement* Compiler::fgInsertStmtBefore(BasicBlock* block, Statement* insertionP
     return stmt;
 }
 
-/*****************************************************************************
- *
- *  Insert the list of statements stmtList after the stmtAfter in block.
- *  Return the last statement stmtList.
- */
-
-Statement* Compiler::fgInsertStmtListAfter(BasicBlock* block,     // the block where stmtAfter is in.
-                                           Statement*  stmtAfter, // the statement where stmtList should be inserted
-                                                                  // after.
-                                           Statement* stmtList)
+//------------------------------------------------------------------------
+// fgInsertStmtListAfter: Insert the list of statements stmtList after the stmtAfter in block.
+//
+// Arguments:
+//   block - the block where stmtAfter is in;
+//   stmtAfter - the statement where stmtList should be inserted after;
+//   stmtList - the statement list to insert.
+//
+// Return value:
+//   the last statement in the united list.
+//
+Statement* Compiler::fgInsertStmtListAfter(BasicBlock* block, Statement* stmtAfter, Statement* stmtList)
 {
     // Currently we can handle when stmtAfter and stmtList are non-NULL. This makes everything easy.
     noway_assert(stmtAfter);
@@ -809,16 +811,15 @@ Statement* Compiler::fgInsertStmtListAfter(BasicBlock* block,     // the block w
         stmtAfter->gtNext         = stmtList;
         stmtList->gtPrev          = stmtAfter;
         block->bbStmtList->gtPrev = stmtLast;
-        goto _Done;
     }
+    else
+    {
+        stmtAfter->gtNext = stmtList;
+        stmtList->gtPrev  = stmtAfter;
 
-    stmtAfter->gtNext = stmtList;
-    stmtList->gtPrev  = stmtAfter;
-
-    stmtLast->gtNext = stmtNext;
-    stmtNext->gtPrev = stmtLast;
-
-_Done:
+        stmtLast->gtNext = stmtNext;
+        stmtNext->gtPrev = stmtLast;
+    }
 
     noway_assert(block->bbStmtList == nullptr || block->bbStmtList->gtPrev->gtNext == nullptr);
 

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -645,14 +645,15 @@ Statement* Compiler::fgNewStmtAtEnd(BasicBlock* block, GenTree* tree)
     return fgInsertStmtAtEnd(block, stmt);
 }
 
-/*****************************************************************************
- *
- *  Insert the given tree or statement at the end of the given basic block, but before
- *  the GT_JTRUE, if present.
- *  Returns the (potentially) new statement.
- */
-
-Statement* Compiler::fgInsertStmtNearEnd(BasicBlock* block, Statement* stmt)
+//------------------------------------------------------------------------
+// fgInsertStmtNearEnd: Insert the given statement at the end of the given basic block,
+//   but before the GT_JTRUE, if present.
+//
+// Arguments:
+//   block - the block into which 'stmt' will be inserted;
+//   stmt  - the statement to be inserted.
+//
+void Compiler::fgInsertStmtNearEnd(BasicBlock* block, Statement* stmt)
 {
     // This routine can only be used when in tree order.
     assert(fgOrder == FGOrderTree);
@@ -704,19 +705,29 @@ Statement* Compiler::fgInsertStmtNearEnd(BasicBlock* block, Statement* stmt)
             insertionPoint->gtNext = stmt;
             stmt->gtPrev           = insertionPoint;
         }
-
-        return stmt;
     }
     else
     {
-        return fgInsertStmtAtEnd(block, stmt);
+        fgInsertStmtAtEnd(block, stmt);
     }
 }
 
+//------------------------------------------------------------------------
+// fgNewStmtNearEnd: Insert the given tree as a new statement at the end of the given basic block,
+//   but before the GT_JTRUE, if present.
+//
+// Arguments:
+//   block - the block into which 'stmt' will be inserted;
+//   tree  - the tree to be inserted.
+//
+// Return Value:
+//    The new created statement with `tree` inserted into `block`.
+//
 Statement* Compiler::fgNewStmtNearEnd(BasicBlock* block, GenTree* tree)
 {
     Statement* stmt = gtNewStmt(tree);
-    return fgInsertStmtNearEnd(block, stmt);
+    fgInsertStmtNearEnd(block, stmt);
+    return stmt;
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -605,14 +605,17 @@ Statement* Compiler::fgNewStmtAtBeg(BasicBlock* block, GenTree* tree)
     return stmt;
 }
 
-/*****************************************************************************
- *
- *  Insert the given tree or statement at the end of the given basic block.
- *  Returns the (potentially) new statement.
- *  If the block can be a conditional block, use fgInsertStmtNearEnd.
- */
-
-Statement* Compiler::fgInsertStmtAtEnd(BasicBlock* block, Statement* stmt)
+//------------------------------------------------------------------------
+// fgInsertStmtAtEnd: Insert the given statement at the end of the given basic block.
+//
+// Arguments:
+//   block - the block into which 'stmt' will be inserted;
+//   stmt  - the statement to be inserted.
+//
+// Note:
+//   If the block can be a conditional block, use fgNewStmtNearEnd.
+//
+void Compiler::fgInsertStmtAtEnd(BasicBlock* block, Statement* stmt)
 {
 
     assert(stmt->gtNext == nullptr); // We don't set it, and it needs to be this after the insert
@@ -635,14 +638,26 @@ Statement* Compiler::fgInsertStmtAtEnd(BasicBlock* block, Statement* stmt)
         block->bbStmtList = stmt;
         stmt->gtPrev      = stmt;
     }
-
-    return stmt;
 }
 
+//------------------------------------------------------------------------
+// fgNewStmtAtEnd: Insert the given tree as a new statement at the end of the given basic block.
+//
+// Arguments:
+//   block - the block into which 'stmt' will be inserted;
+//   tree  - the tree to be inserted.
+//
+// Return Value:
+//    The new created statement with `tree` inserted into `block`.
+//
+// Note:
+//   If the block can be a conditional block, use fgNewStmtNearEnd.
+//
 Statement* Compiler::fgNewStmtAtEnd(BasicBlock* block, GenTree* tree)
 {
     Statement* stmt = gtNewStmt(tree);
-    return fgInsertStmtAtEnd(block, stmt);
+    fgInsertStmtAtEnd(block, stmt);
+    return stmt;
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -535,67 +535,74 @@ bool Compiler::fgBlockContainsStatementBounded(BasicBlock* block,
 #endif // DEBUG
 
 //------------------------------------------------------------------------
-// fgInsertStmtAtBeg: Insert the given tree or statement at the start of the given basic block.
+// fgInsertStmtAtBeg: Insert the given statement at the start of the given basic block.
 //
 // Arguments:
-//    block     - The block into which 'stmt' will be inserted.
-//    node      - The node to be inserted.
-//
-// Return Value:
-//    Returns the new (potentially) statement.
+//   block - the block into which 'stmt' will be inserted;
+//   stmt  - the statement to be inserted.
 //
 // Notes:
-//    If 'stmt' is not already a statement, a new statement is created from it.
 //    We always insert phi statements at the beginning.
 //    In other cases, if there are any phi assignments and/or an assignment of
 //    the GT_CATCH_ARG, we insert after those.
-
-Statement* Compiler::fgInsertStmtAtBeg(BasicBlock* block, Statement* stmt)
+//
+void Compiler::fgInsertStmtAtBeg(BasicBlock* block, Statement* stmt)
 {
     Statement* firstStmt = block->firstStmt();
 
-    if (!stmt->IsPhiDefnStmt())
+    if (stmt->IsPhiDefnStmt())
+    {
+        // The new tree will now be the first one of the block.
+        block->bbStmtList = stmt;
+        stmt->gtNext      = firstStmt;
+
+        // Are there any statements in the block?
+        if (firstStmt != nullptr)
+        {
+            // There is at least one statement already.
+            Statement* lastStmt = firstStmt->gtPrev;
+            noway_assert(lastStmt != nullptr && lastStmt->gtNext == nullptr);
+
+            // Insert the statement in front of the first one.
+            firstStmt->gtPrev = stmt;
+            stmt->gtPrev      = lastStmt;
+        }
+        else
+        {
+            // The block was completely empty.
+            stmt->gtPrev = stmt;
+        }
+    }
+    else
     {
         Statement* insertBeforeStmt = block->FirstNonPhiDefOrCatchArgAsg();
         if (insertBeforeStmt != nullptr)
         {
-            return fgInsertStmtBefore(block, insertBeforeStmt, stmt);
+            fgInsertStmtBefore(block, insertBeforeStmt, stmt);
         }
-        else if (firstStmt != nullptr)
+        else
         {
-            return fgInsertStmtAtEnd(block, stmt);
+            // There were no non-phi/non-catch arg statements, insert `stmt` at the end.
+            fgInsertStmtAtEnd(block, stmt);
         }
-        // Otherwise, we will simply insert at the beginning, below.
     }
-
-    // The new tree will now be the first one of the block.
-    block->bbStmtList = stmt;
-    stmt->gtNext      = firstStmt;
-
-    // Are there any statements in the block?
-    if (firstStmt != nullptr)
-    {
-        // There is at least one statement already.
-        Statement* lastStmt = firstStmt->getPrevStmt();
-        noway_assert(lastStmt != nullptr && lastStmt->gtNext == nullptr);
-
-        // Insert the statement in front of the first one.
-        firstStmt->gtPrev = stmt;
-        stmt->gtPrev      = lastStmt;
-    }
-    else
-    {
-        // The block was completely empty.
-        stmt->gtPrev = stmt;
-    }
-
-    return stmt;
 }
 
+//------------------------------------------------------------------------
+// fgNewStmtAtBeg: Insert the given tree as a new statement at the start of the given basic block.
+//
+// Arguments:
+//   block - the block into which 'tree' will be inserted;
+//   tree  - the tree to be inserted.
+//
+// Return Value:
+//    The new created statement with `tree` inserted into `block`.
+//
 Statement* Compiler::fgNewStmtAtBeg(BasicBlock* block, GenTree* tree)
 {
     Statement* stmt = gtNewStmt(tree);
-    return fgInsertStmtAtBeg(block, stmt);
+    fgInsertStmtAtBeg(block, stmt);
+    return stmt;
 }
 
 /*****************************************************************************
@@ -23696,12 +23703,13 @@ void Compiler::fgInlineAppendStatements(InlineInfo* inlineInfo, BasicBlock* bloc
 
         if (stmtAfter == nullptr)
         {
-            stmtAfter = fgInsertStmtAtBeg(block, nullStmt);
+            fgInsertStmtAtBeg(block, nullStmt);
         }
         else
         {
-            stmtAfter = fgInsertStmtAfter(block, stmtAfter, nullStmt);
+            fgInsertStmtAfter(block, stmtAfter, nullStmt);
         }
+        stmtAfter = nullStmt;
 
 #ifdef DEBUG
         if (verbose)

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -719,14 +719,18 @@ Statement* Compiler::fgNewStmtNearEnd(BasicBlock* block, GenTree* tree)
     return fgInsertStmtNearEnd(block, stmt);
 }
 
-/*****************************************************************************
- *
- *  Insert the given statement "stmt" after "insertionPoint" statement.
- *  Returns the newly inserted statement.
- *  Note that the gtPrev list of statement nodes is circular, but the gtNext list is not.
- */
-
-Statement* Compiler::fgInsertStmtAfter(BasicBlock* block, Statement* insertionPoint, Statement* stmt)
+//------------------------------------------------------------------------
+// fgInsertStmtAfter: Insert the given statement after the insertion point in the given basic block.
+//
+// Arguments:
+//   block - the block into which 'stmt' will be inserted;
+//   insertionPoint - the statement after which `stmt` will be inserted;
+//   stmt  - the statement to be inserted.
+//
+// Note:
+//   `block` is needed to update the last statement pointer and for debugging checks.
+//
+void Compiler::fgInsertStmtAfter(BasicBlock* block, Statement* insertionPoint, Statement* stmt)
 {
     assert(block->bbStmtList != nullptr);
     assert(fgBlockContainsStatementBounded(block, insertionPoint));
@@ -753,14 +757,20 @@ Statement* Compiler::fgInsertStmtAfter(BasicBlock* block, Statement* insertionPo
         insertionPoint->gtNext->gtPrev = stmt;
         insertionPoint->gtNext         = stmt;
     }
-
-    return stmt;
 }
 
-//  Insert the given tree or statement before "insertionPoint" statement.
-//  Returns the newly inserted statement.
-
-Statement* Compiler::fgInsertStmtBefore(BasicBlock* block, Statement* insertionPoint, Statement* stmt)
+//------------------------------------------------------------------------
+// fgInsertStmtBefore: Insert the given statement before the insertion point in the given basic block.
+//
+// Arguments:
+//   block - the block into which 'stmt' will be inserted;
+//   insertionPoint - the statement before which `stmt` will be inserted;
+//   stmt  - the statement to be inserted.
+//
+// Note:
+//   `block` is needed to update the first statement pointer and for debugging checks.
+//
+void Compiler::fgInsertStmtBefore(BasicBlock* block, Statement* insertionPoint, Statement* stmt)
 {
     assert(block->bbStmtList != nullptr);
     assert(fgBlockContainsStatementBounded(block, insertionPoint));
@@ -786,8 +796,6 @@ Statement* Compiler::fgInsertStmtBefore(BasicBlock* block, Statement* insertionP
         insertionPoint->gtPrev->gtNext = stmt;
         insertionPoint->gtPrev         = stmt;
     }
-
-    return stmt;
 }
 
 //------------------------------------------------------------------------
@@ -23457,7 +23465,8 @@ Statement* Compiler::fgInlinePrependStatements(InlineInfo* inlineInfo)
                             newStmt = gtNewStmt(gtUnusedValNode(argNode), callILOffset);
                         }
 
-                        afterStmt = fgInsertStmtAfter(block, afterStmt, newStmt);
+                        fgInsertStmtAfter(block, afterStmt, newStmt);
+                        afterStmt = newStmt;
 #ifdef DEBUG
                         if (verbose)
                         {
@@ -23497,16 +23506,18 @@ Statement* Compiler::fgInlinePrependStatements(InlineInfo* inlineInfo)
                 CORINFO_METHOD_HANDLE((SIZE_T)exactContext & ~CORINFO_CONTEXTFLAGS_MASK));
         }
 
-        tree      = fgGetSharedCCtor(exactClass);
-        newStmt   = gtNewStmt(tree, callILOffset);
-        afterStmt = fgInsertStmtAfter(block, afterStmt, newStmt);
+        tree    = fgGetSharedCCtor(exactClass);
+        newStmt = gtNewStmt(tree, callILOffset);
+        fgInsertStmtAfter(block, afterStmt, newStmt);
+        afterStmt = newStmt;
     }
 
     // Insert the nullcheck statement now.
     if (nullcheck)
     {
-        newStmt   = gtNewStmt(nullcheck, callILOffset);
-        afterStmt = fgInsertStmtAfter(block, afterStmt, newStmt);
+        newStmt = gtNewStmt(nullcheck, callILOffset);
+        fgInsertStmtAfter(block, afterStmt, newStmt);
+        afterStmt = newStmt;
     }
 
     //
@@ -23558,8 +23569,9 @@ Statement* Compiler::fgInlinePrependStatements(InlineInfo* inlineInfo)
                                               false,                                      // isVolatile
                                               false);                                     // not copyBlock
 
-                        newStmt   = gtNewStmt(tree, callILOffset);
-                        afterStmt = fgInsertStmtAfter(block, afterStmt, newStmt);
+                        newStmt = gtNewStmt(tree, callILOffset);
+                        fgInsertStmtAfter(block, afterStmt, newStmt);
+                        afterStmt = newStmt;
                     }
                 }
 

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -15521,12 +15521,6 @@ bool GenTree::IsPhiDefn()
     return res;
 }
 
-bool Statement::IsPhiDefnStmt()
-{
-    GenTree* asg = gtStmtExpr;
-    return asg->IsPhiDefn();
-}
-
 // IsPartialLclFld: Check for a GT_LCL_FLD whose type is a different size than the lclVar.
 //
 // Arguments:

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -11468,6 +11468,12 @@ void Compiler::gtDispArgList(GenTreeCall* call, IndentStack* indentStack)
     }
 }
 
+//------------------------------------------------------------------------
+// gtDispBlockStmts: dumps all statements inside `block`.
+//
+// Arguments:
+//    block - the block to display statements for.
+//
 void Compiler::gtDispBlockStmts(BasicBlock* block)
 {
     for (Statement* stmt : block->Statements())

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -569,7 +569,7 @@ void Compiler::fgWalkAllTreesPre(fgWalkPreFn* visitor, void* pCallBackData)
 {
     for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->bbNext)
     {
-        for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt : block->Statements())
         {
             fgWalkTreePre(&stmt->gtStmtExpr, visitor, pCallBackData);
         }
@@ -11468,24 +11468,11 @@ void Compiler::gtDispArgList(GenTreeCall* call, IndentStack* indentStack)
     }
 }
 
-//------------------------------------------------------------------------
-// gtDispArgList: Dump the tree for a call arg list
-//
-// Arguments:
-//    tree         - The call for which 'arg' is an argument
-//    indentStack  - the specification for the current level of indentation & arcs
-//
-// Return Value:
-//    None.
-//
-// Assumptions:
-//    'tree' must be a GT_LIST node
-
-void Compiler::gtDispStmtList(Statement* stmts, IndentStack* indentStack /* = nullptr */)
+void Compiler::gtDispBlockStmts(BasicBlock* block)
 {
-    for (Statement* stmt = stmts; stmt != nullptr; stmt = stmt->getNextStmt())
+    for (Statement* stmt : block->Statements())
     {
-        gtDispTree(stmt->gtStmtExpr, indentStack);
+        gtDispTree(stmt->gtStmtExpr);
         printf("\n");
     }
 }

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -328,7 +328,7 @@ void GenTree::InitNodeSize()
     static_assert_no_msg(sizeof(GenTreeDynBlk)       <= TREE_NODE_SZ_LARGE); // *** large node
     static_assert_no_msg(sizeof(GenTreeRetExpr)      <= TREE_NODE_SZ_LARGE); // *** large node
     static_assert_no_msg(sizeof(GenTreeILOffset)     <= TREE_NODE_SZ_SMALL);
-    static_assert_no_msg(sizeof(GenTreeStmt)         <= TREE_NODE_SZ_LARGE); // *** large node
+    static_assert_no_msg(sizeof(Statement)         <= TREE_NODE_SZ_LARGE); // *** large node
     static_assert_no_msg(sizeof(GenTreeClsVar)       <= TREE_NODE_SZ_SMALL);
     static_assert_no_msg(sizeof(GenTreeArgPlace)     <= TREE_NODE_SZ_SMALL);
     static_assert_no_msg(sizeof(GenTreePhiArg)       <= TREE_NODE_SZ_SMALL);
@@ -569,7 +569,7 @@ void Compiler::fgWalkAllTreesPre(fgWalkPreFn* visitor, void* pCallBackData)
 {
     for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->bbNext)
     {
-        for (GenTreeStmt* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
         {
             fgWalkTreePre(&stmt->gtStmtExpr, visitor, pCallBackData);
         }
@@ -7728,7 +7728,7 @@ GenTreeCall* Compiler::gtCloneCandidateCall(GenTreeCall* call)
 //    but this method will sequence 'replacementTree', and insert it into the
 //    proper place in the statement sequence.
 
-GenTree* Compiler::gtReplaceTree(GenTreeStmt* stmt, GenTree* tree, GenTree* replacementTree)
+GenTree* Compiler::gtReplaceTree(Statement* stmt, GenTree* tree, GenTree* replacementTree)
 {
     assert(fgStmtListThreaded);
     assert(tree != nullptr);
@@ -7817,7 +7817,7 @@ GenTree* Compiler::gtReplaceTree(GenTreeStmt* stmt, GenTree* tree, GenTree* repl
 // Note: If tree's order hasn't been established, the method updates side effect
 //       flags on all statement's nodes.
 
-void Compiler::gtUpdateSideEffects(GenTreeStmt* stmt, GenTree* tree)
+void Compiler::gtUpdateSideEffects(Statement* stmt, GenTree* tree)
 {
     if (fgStmtListThreaded)
     {
@@ -7852,7 +7852,7 @@ void Compiler::gtUpdateTreeAncestorsSideEffects(GenTree* tree)
 // Arguments:
 //    stmt            - The statement to update side effects on
 
-void Compiler::gtUpdateStmtSideEffects(GenTreeStmt* stmt)
+void Compiler::gtUpdateStmtSideEffects(Statement* stmt)
 {
     fgWalkTree(&stmt->gtStmtExpr, fgUpdateSideEffectsPre, fgUpdateSideEffectsPost);
 }
@@ -11481,9 +11481,9 @@ void Compiler::gtDispArgList(GenTreeCall* call, IndentStack* indentStack)
 // Assumptions:
 //    'tree' must be a GT_LIST node
 
-void Compiler::gtDispStmtList(GenTreeStmt* stmts, IndentStack* indentStack /* = nullptr */)
+void Compiler::gtDispStmtList(Statement* stmts, IndentStack* indentStack /* = nullptr */)
 {
-    for (GenTreeStmt* stmt = stmts; stmt != nullptr; stmt = stmt->getNextStmt())
+    for (Statement* stmt = stmts; stmt != nullptr; stmt = stmt->getNextStmt())
     {
         gtDispTree(stmt->gtStmtExpr, indentStack);
         printf("\n");
@@ -12697,9 +12697,9 @@ GenTree* Compiler::gtTryRemoveBoxUpstreamEffects(GenTree* op, BoxRemovalOptions 
     assert(op->IsBoxedValue());
 
     // grab related parts for the optimization
-    GenTreeBox*  box      = op->AsBox();
-    GenTreeStmt* asgStmt  = box->gtAsgStmtWhenInlinedBoxValue;
-    GenTreeStmt* copyStmt = box->gtCopyStmtWhenInlinedBoxValue;
+    GenTreeBox* box      = op->AsBox();
+    Statement*  asgStmt  = box->gtAsgStmtWhenInlinedBoxValue;
+    Statement*  copyStmt = box->gtCopyStmtWhenInlinedBoxValue;
 
     JITDUMP("gtTryRemoveBoxUpstreamEffects: %s to %s of BOX (valuetype)"
             " [%06u] (assign/newobj [%06u] copy [%06u])\n",
@@ -13085,7 +13085,7 @@ GenTree* Compiler::gtOptimizeEnumHasFlag(GenTree* thisOp, GenTree* flagOp)
     {
         const unsigned thisTmp     = lvaGrabTemp(true DEBUGARG("Enum:HasFlag this temp"));
         GenTree*       thisAsg     = gtNewTempAssign(thisTmp, thisVal);
-        GenTreeStmt*   thisAsgStmt = thisOp->AsBox()->gtCopyStmtWhenInlinedBoxValue;
+        Statement*     thisAsgStmt = thisOp->AsBox()->gtCopyStmtWhenInlinedBoxValue;
         thisAsgStmt->gtStmtExpr    = thisAsg;
         thisValOpt                 = gtNewLclvNode(thisTmp, type);
     }
@@ -13101,7 +13101,7 @@ GenTree* Compiler::gtOptimizeEnumHasFlag(GenTree* thisOp, GenTree* flagOp)
     {
         const unsigned flagTmp     = lvaGrabTemp(true DEBUGARG("Enum:HasFlag flag temp"));
         GenTree*       flagAsg     = gtNewTempAssign(flagTmp, flagVal);
-        GenTreeStmt*   flagAsgStmt = flagOp->AsBox()->gtCopyStmtWhenInlinedBoxValue;
+        Statement*     flagAsgStmt = flagOp->AsBox()->gtCopyStmtWhenInlinedBoxValue;
         flagAsgStmt->gtStmtExpr    = flagAsg;
         flagValOpt                 = gtNewLclvNode(flagTmp, type);
         flagValOptCopy             = gtNewLclvNode(flagTmp, type);
@@ -14564,7 +14564,7 @@ DONE:
 //    May set compFloatingPointUsed.
 
 GenTree* Compiler::gtNewTempAssign(
-    unsigned tmp, GenTree* val, GenTreeStmt** pAfterStmt, IL_OFFSETX ilOffset, BasicBlock* block)
+    unsigned tmp, GenTree* val, Statement** pAfterStmt, IL_OFFSETX ilOffset, BasicBlock* block)
 {
     // Self-assignment is a nop.
     if (val->OperGet() == GT_LCL_VAR && val->gtLclVarCommon.gtLclNum == tmp)
@@ -15285,7 +15285,7 @@ static Compiler::fgWalkResult gtFindLinkCB(GenTree** pTree, Compiler::fgWalkData
     return Compiler::WALK_CONTINUE;
 }
 
-Compiler::FindLinkData Compiler::gtFindLink(GenTreeStmt* stmt, GenTree* node)
+Compiler::FindLinkData Compiler::gtFindLink(Statement* stmt, GenTree* node)
 {
     FindLinkData data = {node, nullptr, nullptr};
 
@@ -15521,7 +15521,7 @@ bool GenTree::IsPhiDefn()
     return res;
 }
 
-bool GenTreeStmt::IsPhiDefnStmt()
+bool Statement::IsPhiDefnStmt()
 {
     GenTree* asg = gtStmtExpr;
     return asg->IsPhiDefn();

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -304,7 +304,7 @@ public:
 class GenTreeUseEdgeIterator;
 class GenTreeOperandIterator;
 
-struct GenTreeStmt;
+struct Statement;
 
 /*****************************************************************************/
 
@@ -2977,14 +2977,14 @@ struct GenTreeBox : public GenTreeUnOp
     }
     // This is the statement that contains the assignment tree when the node is an inlined GT_BOX on a value
     // type
-    GenTreeStmt* gtAsgStmtWhenInlinedBoxValue;
+    Statement* gtAsgStmtWhenInlinedBoxValue;
     // And this is the statement that copies from the value being boxed to the box payload
-    GenTreeStmt* gtCopyStmtWhenInlinedBoxValue;
+    Statement* gtCopyStmtWhenInlinedBoxValue;
 
-    GenTreeBox(var_types    type,
-               GenTree*     boxOp,
-               GenTreeStmt* asgStmtWhenInlinedBoxValue,
-               GenTreeStmt* copyStmtWhenInlinedBoxValue)
+    GenTreeBox(var_types  type,
+               GenTree*   boxOp,
+               Statement* asgStmtWhenInlinedBoxValue,
+               Statement* copyStmtWhenInlinedBoxValue)
         : GenTreeUnOp(GT_BOX, type, boxOp)
         , gtAsgStmtWhenInlinedBoxValue(asgStmtWhenInlinedBoxValue)
         , gtCopyStmtWhenInlinedBoxValue(copyStmtWhenInlinedBoxValue)
@@ -5129,7 +5129,7 @@ struct GenTreeILOffset : public GenTree
 #endif
 };
 
-struct GenTreeStmt
+struct Statement
 {
     GenTree*       gtStmtExpr;      // root of the expression tree
     GenTree*       gtStmtList;      // first node (for forward walks)
@@ -5140,16 +5140,16 @@ struct GenTreeStmt
     IL_OFFSET gtStmtLastILoffs; // instr offset at end of stmt
 #endif
 
-    __declspec(property(get = getNextStmt)) GenTreeStmt* gtNextStmt;
+    __declspec(property(get = getNextStmt)) Statement* gtNextStmt;
 
-    __declspec(property(get = getPrevStmt)) GenTreeStmt* gtPrevStmt;
+    __declspec(property(get = getPrevStmt)) Statement* gtPrevStmt;
 
-    GenTreeStmt* gtNext;
-    GenTreeStmt* gtPrev;
+    Statement* gtNext;
+    Statement* gtPrev;
 
     bool compilerAdded;
 
-    GenTreeStmt* getNextStmt()
+    Statement* getNextStmt()
     {
         if (gtNext == nullptr)
         {
@@ -5161,7 +5161,7 @@ struct GenTreeStmt
         }
     }
 
-    GenTreeStmt* getPrevStmt()
+    Statement* getPrevStmt()
     {
         if (gtPrev == nullptr)
         {
@@ -5173,7 +5173,7 @@ struct GenTreeStmt
         }
     }
 
-    GenTreeStmt(GenTree* expr, IL_OFFSETX offset)
+    Statement(GenTree* expr, IL_OFFSETX offset)
         : gtStmtExpr(expr)
         , gtStmtList(nullptr)
         , gtInlineContext(nullptr)

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -5187,7 +5187,10 @@ struct Statement
     {
     }
 
-    bool IsPhiDefnStmt();
+    bool IsPhiDefnStmt()
+    {
+        return gtStmtExpr->IsPhiDefn();
+    }
 
     unsigned char GetCostSz() const
     {

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -5203,6 +5203,52 @@ struct Statement
     }
 };
 
+class StatementIterator
+{
+    Statement* m_stmt;
+
+public:
+    StatementIterator(Statement* stmt) : m_stmt(stmt)
+    {
+    }
+
+    Statement* operator*() const
+    {
+        return m_stmt;
+    }
+
+    StatementIterator& operator++()
+    {
+        m_stmt = m_stmt->gtNext;
+        return *this;
+    }
+
+    bool operator!=(const StatementIterator& i) const
+    {
+        return m_stmt != i.m_stmt;
+    }
+};
+
+class StatementList
+{
+    Statement* m_stmts;
+
+public:
+    StatementList(Statement* stmts) : m_stmts(stmts)
+    {
+    }
+
+    StatementIterator begin() const
+    {
+        return StatementIterator(m_stmts);
+    }
+
+    StatementIterator end() const
+    {
+        return StatementIterator(nullptr);
+    }
+};
+
 /*  NOTE: Any tree nodes that are larger than 8 bytes (two ints or
     pointers) must be flagged as 'large' in GenTree::InitNodeSize().
  */

--- a/src/jit/gschecks.cpp
+++ b/src/jit/gschecks.cpp
@@ -491,7 +491,7 @@ void Compiler::gsParamsToShadows()
 
     for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->bbNext)
     {
-        for (GenTreeStmt* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->gtNextStmt)
+        for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->gtNextStmt)
         {
             ReplaceShadowParamsVisitor replaceShadowParamsVisitor(this);
             replaceShadowParamsVisitor.WalkTree(&stmt->gtStmtExpr, nullptr);

--- a/src/jit/gschecks.cpp
+++ b/src/jit/gschecks.cpp
@@ -491,7 +491,7 @@ void Compiler::gsParamsToShadows()
 
     for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->bbNext)
     {
-        for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->gtNextStmt)
+        for (Statement* stmt : block->Statements())
         {
             ReplaceShadowParamsVisitor replaceShadowParamsVisitor(this);
             replaceShadowParamsVisitor.WalkTree(&stmt->gtStmtExpr, nullptr);

--- a/src/jit/gtlist.h
+++ b/src/jit/gtlist.h
@@ -244,7 +244,7 @@ GTNODE(CALL             , GenTreeCall        ,0,(GTK_SPECIAL|GTK_NOCONTAIN))
 //-----------------------------------------------------------------------------
 //  Statement operator nodes:
 //-----------------------------------------------------------------------------
-GTNODE(STMT             , GenTreeStmt        ,0,(GTK_SPECIAL|GTK_NOVALUE))// top-level list nodes in bbTreeList
+GTNODE(STMT             , Statement        ,0,(GTK_SPECIAL|GTK_NOVALUE))// top-level list nodes in bbTreeList
 
 GTNODE(RETURN           , GenTreeOp          ,0,(GTK_UNOP|GTK_NOVALUE))   // return from current function
 GTNODE(SWITCH           , GenTreeOp          ,0,(GTK_UNOP|GTK_NOVALUE))   // switch
@@ -299,7 +299,7 @@ GTNODE(PUTARG_SPLIT     , GenTreePutArgSplit ,0,GTK_UNOP)                       
 #endif // FEATURE_ARG_SPLIT
 GTNODE(RETURNTRAP       , GenTreeOp          ,0,GTK_UNOP|GTK_NOVALUE)            // a conditional call to wait on gc
 GTNODE(SWAP             , GenTreeOp          ,0,GTK_BINOP|GTK_NOVALUE)           // op1 and op2 swap (registers)
-GTNODE(IL_OFFSET        , GenTreeStmt        ,0,GTK_LEAF|GTK_NOVALUE)            // marks an IL offset for debugging purposes
+GTNODE(IL_OFFSET        , Statement        ,0,GTK_LEAF|GTK_NOVALUE)            // marks an IL offset for debugging purposes
 
 /*****************************************************************************/
 #undef  GTNODE

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -771,7 +771,8 @@ void Compiler::impAssignTempGen(unsigned    tmp,
         if (pAfterStmt)
         {
             Statement* asgStmt = gtNewStmt(asg, ilOffset);
-            *pAfterStmt        = fgInsertStmtAfter(block, *pAfterStmt, asgStmt);
+            fgInsertStmtAfter(block, *pAfterStmt, asgStmt);
+            *pAfterStmt = asgStmt;
         }
         else
         {
@@ -831,7 +832,8 @@ void Compiler::impAssignTempGen(unsigned             tmpNum,
         if (pAfterStmt)
         {
             Statement* asgStmt = gtNewStmt(asg, ilOffset);
-            *pAfterStmt        = fgInsertStmtAfter(block, *pAfterStmt, asgStmt);
+            fgInsertStmtAfter(block, *pAfterStmt, asgStmt);
+            *pAfterStmt = asgStmt;
         }
         else
         {
@@ -1102,7 +1104,9 @@ GenTree* Compiler::impAssignStruct(GenTree*             dest,
         // Append all the op1 of GT_COMMA trees before we evaluate op2 of the GT_COMMA tree.
         if (pAfterStmt)
         {
-            *pAfterStmt = fgInsertStmtAfter(block, *pAfterStmt, gtNewStmt(dest->gtOp.gtOp1, ilOffset));
+            Statement* newStmt = gtNewStmt(dest->gtOp.gtOp1, ilOffset);
+            fgInsertStmtAfter(block, *pAfterStmt, newStmt);
+            *pAfterStmt = newStmt;
         }
         else
         {
@@ -1353,7 +1357,9 @@ GenTree* Compiler::impAssignStructPtr(GenTree*             destAddr,
         GenTree* asg = gtNewAssignNode(ptrSlot, src->gtOp.gtOp1);
         if (pAfterStmt)
         {
-            *pAfterStmt = fgInsertStmtAfter(block, *pAfterStmt, gtNewStmt(asg, ilOffset));
+            Statement* newStmt = gtNewStmt(asg, ilOffset);
+            fgInsertStmtAfter(block, *pAfterStmt, newStmt);
+            *pAfterStmt = newStmt;
         }
         else
         {
@@ -1370,7 +1376,9 @@ GenTree* Compiler::impAssignStructPtr(GenTree*             destAddr,
         if (pAfterStmt)
         {
             // Insert op1 after '*pAfterStmt'
-            *pAfterStmt = fgInsertStmtAfter(block, *pAfterStmt, gtNewStmt(src->gtOp.gtOp1, ilOffset));
+            Statement* newStmt = gtNewStmt(src->gtOp.gtOp1, ilOffset);
+            fgInsertStmtAfter(block, *pAfterStmt, newStmt);
+            *pAfterStmt = newStmt;
         }
         else if (impLastStmt != nullptr)
         {

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -19452,7 +19452,7 @@ BOOL Compiler::impInlineIsGuaranteedThisDerefBeforeAnySideEffects(GenTree*      
         }
     }
 
-    for (Statement* stmt = impStmtList; stmt != nullptr; stmt = stmt->gtNextStmt)
+    for (Statement* stmt : StatementList(impStmtList))
     {
         GenTree* expr = stmt->gtStmtExpr;
         if (GTF_GLOBALLY_VISIBLE_SIDE_EFFECTS(expr->gtFlags))

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -422,7 +422,7 @@ inline void Compiler::impBeginTreeList()
  *  directly only for handling CEE_LEAVEs out of finally-protected try's.
  */
 
-inline void Compiler::impEndTreeList(BasicBlock* block, GenTreeStmt* firstStmt, GenTreeStmt* lastStmt)
+inline void Compiler::impEndTreeList(BasicBlock* block, Statement* firstStmt, Statement* lastStmt)
 {
     /* Make the list circular, so that we can easily walk it backwards */
 
@@ -475,7 +475,7 @@ inline void Compiler::impEndTreeList(BasicBlock* block)
  *  that this has only limited value as we can only check [0..chkLevel).
  */
 
-inline void Compiler::impAppendStmtCheck(GenTreeStmt* stmt, unsigned chkLevel)
+inline void Compiler::impAppendStmtCheck(Statement* stmt, unsigned chkLevel)
 {
 #ifndef DEBUG
     return;
@@ -540,7 +540,7 @@ inline void Compiler::impAppendStmtCheck(GenTreeStmt* stmt, unsigned chkLevel)
  *    interference with stmt and spill if needed.
  */
 
-inline void Compiler::impAppendStmt(GenTreeStmt* stmt, unsigned chkLevel)
+inline void Compiler::impAppendStmt(Statement* stmt, unsigned chkLevel)
 {
     if (chkLevel == (unsigned)CHECK_SPILL_ALL)
     {
@@ -649,7 +649,7 @@ inline void Compiler::impAppendStmt(GenTreeStmt* stmt, unsigned chkLevel)
 // Arguments:
 //    stmt - the statement to add.
 //
-inline void Compiler::impAppendStmt(GenTreeStmt* stmt)
+inline void Compiler::impAppendStmt(Statement* stmt)
 {
     if (impStmtList == nullptr)
     {
@@ -674,12 +674,12 @@ inline void Compiler::impAppendStmt(GenTreeStmt* stmt)
 // Notes:
 //    It assumes that the stmt will be reinserted later.
 //
-GenTreeStmt* Compiler::impExtractLastStmt()
+Statement* Compiler::impExtractLastStmt()
 {
     assert(impLastStmt != nullptr);
 
-    GenTreeStmt* stmt = impLastStmt;
-    impLastStmt       = impLastStmt->gtPrevStmt;
+    Statement* stmt = impLastStmt;
+    impLastStmt     = impLastStmt->gtPrevStmt;
     if (impLastStmt == nullptr)
     {
         impStmtList = nullptr;
@@ -694,7 +694,7 @@ GenTreeStmt* Compiler::impExtractLastStmt()
 //    stmt       - a statement to insert;
 //    stmtBefore - an insertion point to insert "stmt" before.
 //
-inline void Compiler::impInsertStmtBefore(GenTreeStmt* stmt, GenTreeStmt* stmtBefore)
+inline void Compiler::impInsertStmtBefore(Statement* stmt, Statement* stmtBefore)
 {
     assert(stmt != nullptr);
     assert(stmtBefore != nullptr);
@@ -705,9 +705,9 @@ inline void Compiler::impInsertStmtBefore(GenTreeStmt* stmt, GenTreeStmt* stmtBe
     }
     else
     {
-        GenTreeStmt* stmtPrev = stmtBefore->getPrevStmt();
-        stmt->gtPrev          = stmtPrev;
-        stmtPrev->gtNext      = stmt;
+        Statement* stmtPrev = stmtBefore->getPrevStmt();
+        stmt->gtPrev        = stmtPrev;
+        stmtPrev->gtNext    = stmt;
     }
     stmt->gtNext       = stmtBefore;
     stmtBefore->gtPrev = stmt;
@@ -719,13 +719,13 @@ inline void Compiler::impInsertStmtBefore(GenTreeStmt* stmt, GenTreeStmt* stmtBe
  *  Return the newly created statement.
  */
 
-GenTreeStmt* Compiler::impAppendTree(GenTree* tree, unsigned chkLevel, IL_OFFSETX offset)
+Statement* Compiler::impAppendTree(GenTree* tree, unsigned chkLevel, IL_OFFSETX offset)
 {
     assert(tree);
 
     /* Allocate an 'expression statement' node */
 
-    GenTreeStmt* stmt = gtNewStmt(tree, offset);
+    Statement* stmt = gtNewStmt(tree, offset);
 
     /* Append the statement to the current block's stmt list */
 
@@ -739,11 +739,11 @@ GenTreeStmt* Compiler::impAppendTree(GenTree* tree, unsigned chkLevel, IL_OFFSET
  *  Insert the given expression tree before "stmtBefore"
  */
 
-void Compiler::impInsertTreeBefore(GenTree* tree, IL_OFFSETX offset, GenTreeStmt* stmtBefore)
+void Compiler::impInsertTreeBefore(GenTree* tree, IL_OFFSETX offset, Statement* stmtBefore)
 {
     /* Allocate an 'expression statement' node */
 
-    GenTreeStmt* stmt = gtNewStmt(tree, offset);
+    Statement* stmt = gtNewStmt(tree, offset);
 
     /* Append the statement to the current block's stmt list */
 
@@ -756,12 +756,12 @@ void Compiler::impInsertTreeBefore(GenTree* tree, IL_OFFSETX offset, GenTreeStmt
  *  curLevel is the stack level for which the spill to the temp is being done.
  */
 
-void Compiler::impAssignTempGen(unsigned      tmp,
-                                GenTree*      val,
-                                unsigned      curLevel,
-                                GenTreeStmt** pAfterStmt, /* = NULL */
-                                IL_OFFSETX    ilOffset,   /* = BAD_IL_OFFSET */
-                                BasicBlock*   block       /* = NULL */
+void Compiler::impAssignTempGen(unsigned    tmp,
+                                GenTree*    val,
+                                unsigned    curLevel,
+                                Statement** pAfterStmt, /* = NULL */
+                                IL_OFFSETX  ilOffset,   /* = BAD_IL_OFFSET */
+                                BasicBlock* block       /* = NULL */
                                 )
 {
     GenTree* asg = gtNewTempAssign(tmp, val);
@@ -770,8 +770,8 @@ void Compiler::impAssignTempGen(unsigned      tmp,
     {
         if (pAfterStmt)
         {
-            GenTreeStmt* asgStmt = gtNewStmt(asg, ilOffset);
-            *pAfterStmt          = fgInsertStmtAfter(block, *pAfterStmt, asgStmt);
+            Statement* asgStmt = gtNewStmt(asg, ilOffset);
+            *pAfterStmt        = fgInsertStmtAfter(block, *pAfterStmt, asgStmt);
         }
         else
         {
@@ -788,7 +788,7 @@ void Compiler::impAssignTempGen(unsigned             tmpNum,
                                 GenTree*             val,
                                 CORINFO_CLASS_HANDLE structType,
                                 unsigned             curLevel,
-                                GenTreeStmt**        pAfterStmt, /* = NULL */
+                                Statement**          pAfterStmt, /* = NULL */
                                 IL_OFFSETX           ilOffset,   /* = BAD_IL_OFFSET */
                                 BasicBlock*          block       /* = NULL */
                                 )
@@ -830,8 +830,8 @@ void Compiler::impAssignTempGen(unsigned             tmpNum,
     {
         if (pAfterStmt)
         {
-            GenTreeStmt* asgStmt = gtNewStmt(asg, ilOffset);
-            *pAfterStmt          = fgInsertStmtAfter(block, *pAfterStmt, asgStmt);
+            Statement* asgStmt = gtNewStmt(asg, ilOffset);
+            *pAfterStmt        = fgInsertStmtAfter(block, *pAfterStmt, asgStmt);
         }
         else
         {
@@ -1082,7 +1082,7 @@ GenTree* Compiler::impAssignStruct(GenTree*             dest,
                                    GenTree*             src,
                                    CORINFO_CLASS_HANDLE structHnd,
                                    unsigned             curLevel,
-                                   GenTreeStmt**        pAfterStmt, /* = nullptr */
+                                   Statement**          pAfterStmt, /* = nullptr */
                                    IL_OFFSETX           ilOffset,   /* = BAD_IL_OFFSET */
                                    BasicBlock*          block       /* = nullptr */
                                    )
@@ -1161,7 +1161,7 @@ GenTree* Compiler::impAssignStructPtr(GenTree*             destAddr,
                                       GenTree*             src,
                                       CORINFO_CLASS_HANDLE structHnd,
                                       unsigned             curLevel,
-                                      GenTreeStmt**        pAfterStmt, /* = NULL */
+                                      Statement**          pAfterStmt, /* = NULL */
                                       IL_OFFSETX           ilOffset,   /* = BAD_IL_OFFSET */
                                       BasicBlock*          block       /* = NULL */
                                       )
@@ -1478,9 +1478,9 @@ GenTree* Compiler::impGetStructAddr(GenTree*             structVal,
     {
         assert(structVal->gtOp.gtOp2->gtType == type); // Second thing is the struct
 
-        GenTreeStmt* oldLastStmt = impLastStmt;
-        structVal->gtOp.gtOp2    = impGetStructAddr(structVal->gtOp.gtOp2, structHnd, curLevel, willDeref);
-        structVal->gtType        = TYP_BYREF;
+        Statement* oldLastStmt = impLastStmt;
+        structVal->gtOp.gtOp2  = impGetStructAddr(structVal->gtOp.gtOp2, structHnd, curLevel, willDeref);
+        structVal->gtType      = TYP_BYREF;
 
         if (oldLastStmt != impLastStmt)
         {
@@ -1488,7 +1488,7 @@ GenTree* Compiler::impGetStructAddr(GenTree*             structVal,
             // for Op2, but that would be out of order with op1, so we need to
             // spill op1 onto the statement list after whatever was last
             // before we recursed on Op2 (i.e. before whatever Op2 appended).
-            GenTreeStmt* beforeStmt;
+            Statement* beforeStmt;
             if (oldLastStmt == nullptr)
             {
                 // The op1 stmt should be the first in the list.
@@ -2515,7 +2515,7 @@ BasicBlock* Compiler::impPushCatchArgOnStack(BasicBlock* hndBlk, CORINFO_CLASS_H
     if ((hndBlk->bbFlags & (BBF_IMPORTED | BBF_INTERNAL | BBF_DONT_REMOVE | BBF_HAS_LABEL | BBF_JMP_TARGET)) ==
         (BBF_IMPORTED | BBF_INTERNAL | BBF_DONT_REMOVE | BBF_HAS_LABEL | BBF_JMP_TARGET))
     {
-        GenTreeStmt* stmt = hndBlk->firstStmt();
+        Statement* stmt = hndBlk->firstStmt();
 
         if (stmt != nullptr)
         {
@@ -2575,7 +2575,7 @@ BasicBlock* Compiler::impPushCatchArgOnStack(BasicBlock* hndBlk, CORINFO_CLASS_H
 
         hndBlk->bbStkTempsIn = tempNum;
 
-        GenTreeStmt* argStmt;
+        Statement* argStmt;
 
         if (info.compStmtOffsetsImplicit & ICorDebugInfo::CALL_SITE_BOUNDARIES)
         {
@@ -2609,7 +2609,7 @@ GenTree* Compiler::impCloneExpr(GenTree*             tree,
                                 GenTree**            pClone,
                                 CORINFO_CLASS_HANDLE structHnd,
                                 unsigned             curLevel,
-                                GenTreeStmt** pAfterStmt DEBUGARG(const char* reason))
+                                Statement** pAfterStmt DEBUGARG(const char* reason))
 {
     if (!(tree->gtFlags & GTF_GLOB_EFFECT))
     {
@@ -2647,8 +2647,8 @@ inline void Compiler::impCurStmtOffsSet(IL_OFFSET offs)
 {
     if (compIsForInlining())
     {
-        GenTreeStmt* callStmt = impInlineInfo->iciStmt;
-        impCurStmtOffs        = callStmt->gtStmtILoffsx;
+        Statement* callStmt = impInlineInfo->iciStmt;
+        impCurStmtOffs      = callStmt->gtStmtILoffsx;
     }
     else
     {
@@ -5974,7 +5974,7 @@ void Compiler::impImportAndPushBox(CORINFO_RESOLVED_TOKEN* pResolvedToken)
 
         GenTree* asg = gtNewTempAssign(impBoxTemp, op1);
 
-        GenTreeStmt* asgStmt = impAppendTree(asg, (unsigned)CHECK_SPILL_NONE, impCurStmtOffs);
+        Statement* asgStmt = impAppendTree(asg, (unsigned)CHECK_SPILL_NONE, impCurStmtOffs);
 
         op1 = gtNewLclvNode(impBoxTemp, TYP_REF);
         op2 = gtNewIconNode(TARGET_POINTER_SIZE, TYP_I_IMPL);
@@ -6015,7 +6015,7 @@ void Compiler::impImportAndPushBox(CORINFO_RESOLVED_TOKEN* pResolvedToken)
         impSpillSideEffects(true, (unsigned)CHECK_SPILL_ALL DEBUGARG("impImportAndPushBox"));
 
         // Set up this copy as a second assignment.
-        GenTreeStmt* copyStmt = impAppendTree(op1, (unsigned)CHECK_SPILL_NONE, impCurStmtOffs);
+        Statement* copyStmt = impAppendTree(op1, (unsigned)CHECK_SPILL_NONE, impCurStmtOffs);
 
         op1 = gtNewLclvNode(impBoxTemp, TYP_REF);
 
@@ -9178,10 +9178,10 @@ void Compiler::impImportLeave(BasicBlock* block)
     assert(block->bbJumpKind == BBJ_LEAVE);
     assert(fgBBs == (BasicBlock**)0xCDCD || fgLookupBB(jmpAddr) != NULL); // should be a BB boundary
 
-    BasicBlock*  step         = DUMMY_INIT(NULL);
-    unsigned     encFinallies = 0; // Number of enclosing finallies.
-    GenTree*     endCatches   = NULL;
-    GenTreeStmt* endLFinStmt  = NULL; // The statement tree to indicate the end of locally-invoked finally.
+    BasicBlock* step         = DUMMY_INIT(NULL);
+    unsigned    encFinallies = 0; // Number of enclosing finallies.
+    GenTree*    endCatches   = NULL;
+    Statement*  endLFinStmt  = NULL; // The statement tree to indicate the end of locally-invoked finally.
 
     unsigned  XTnum;
     EHblkDsc* HBtab;
@@ -9280,7 +9280,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                 }
 #endif
 
-                GenTreeStmt* lastStmt;
+                Statement* lastStmt;
 
                 if (endCatches)
                 {
@@ -9371,7 +9371,7 @@ void Compiler::impImportLeave(BasicBlock* block)
         }
 #endif
 
-        GenTreeStmt* lastStmt;
+        Statement* lastStmt;
 
         if (endCatches)
         {
@@ -16996,7 +16996,7 @@ SPILLSTACK:
                                   // on the stack, its lifetime is hard to determine, simply
                                   // don't reuse such temps.
 
-        GenTreeStmt* addStmt = nullptr;
+        Statement* addStmt = nullptr;
 
         /* Do the successors of 'block' have any other predecessors ?
            We do not want to do some of the optimizations related to multiRef
@@ -19452,7 +19452,7 @@ BOOL Compiler::impInlineIsGuaranteedThisDerefBeforeAnySideEffects(GenTree*      
         }
     }
 
-    for (GenTreeStmt* stmt = impStmtList; stmt != nullptr; stmt = stmt->gtNextStmt)
+    for (Statement* stmt = impStmtList; stmt != nullptr; stmt = stmt->gtNextStmt)
     {
         GenTree* expr = stmt->gtStmtExpr;
         if (GTF_GLOBALLY_VISIBLE_SIDE_EFFECTS(expr->gtFlags))

--- a/src/jit/indirectcalltransformer.cpp
+++ b/src/jit/indirectcalltransformer.cpp
@@ -101,7 +101,7 @@ private:
     {
         int count = 0;
 
-        for (GenTreeStmt* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->gtNextStmt)
+        for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->gtNextStmt)
         {
             if (ContainsFatCalli(stmt))
             {
@@ -129,7 +129,7 @@ private:
     // Return Value:
     //    true if contains, false otherwise.
     //
-    bool ContainsFatCalli(GenTreeStmt* stmt)
+    bool ContainsFatCalli(Statement* stmt)
     {
         GenTree* fatPointerCandidate = stmt->gtStmtExpr;
         if (fatPointerCandidate->OperIs(GT_ASG))
@@ -148,7 +148,7 @@ private:
     //
     // Notes:
     //    calls are hoisted to top level ... (we hope)
-    bool ContainsGuardedDevirtualizationCandidate(GenTreeStmt* stmt)
+    bool ContainsGuardedDevirtualizationCandidate(Statement* stmt)
     {
         GenTree* candidate = stmt->gtStmtExpr;
         return candidate->IsCall() && candidate->AsCall()->IsGuardedDevirtualizationCandidate();
@@ -157,7 +157,7 @@ private:
     class Transformer
     {
     public:
-        Transformer(Compiler* compiler, BasicBlock* block, GenTreeStmt* stmt)
+        Transformer(Compiler* compiler, BasicBlock* block, Statement* stmt)
             : compiler(compiler), currBlock(block), stmt(stmt)
         {
             remainderBlock = nullptr;
@@ -190,10 +190,10 @@ private:
         }
 
     protected:
-        virtual const char*  Name()                         = 0;
-        virtual void         ClearFlag()                    = 0;
-        virtual GenTreeCall* GetCall(GenTreeStmt* callStmt) = 0;
-        virtual void FixupRetExpr()                         = 0;
+        virtual const char*  Name()                       = 0;
+        virtual void         ClearFlag()                  = 0;
+        virtual GenTreeCall* GetCall(Statement* callStmt) = 0;
+        virtual void FixupRetExpr()                       = 0;
 
         //------------------------------------------------------------------------
         // CreateRemainder: split current block at the call stmt and
@@ -267,7 +267,7 @@ private:
         BasicBlock*  checkBlock;
         BasicBlock*  thenBlock;
         BasicBlock*  elseBlock;
-        GenTreeStmt* stmt;
+        Statement*   stmt;
         GenTreeCall* origCall;
 
         const int HIGH_PROBABILITY = 80;
@@ -276,7 +276,7 @@ private:
     class FatPointerCallTransformer final : public Transformer
     {
     public:
-        FatPointerCallTransformer(Compiler* compiler, BasicBlock* block, GenTreeStmt* stmt)
+        FatPointerCallTransformer(Compiler* compiler, BasicBlock* block, Statement* stmt)
             : Transformer(compiler, block, stmt)
         {
             doesReturnValue = stmt->gtStmtExpr->OperIs(GT_ASG);
@@ -299,7 +299,7 @@ private:
         //
         // Return Value:
         //    call tree node pointer.
-        virtual GenTreeCall* GetCall(GenTreeStmt* callStmt)
+        virtual GenTreeCall* GetCall(Statement* callStmt)
         {
             GenTree*     tree = callStmt->gtStmtExpr;
             GenTreeCall* call = nullptr;
@@ -333,14 +333,14 @@ private:
         //
         virtual void CreateCheck()
         {
-            checkBlock                   = CreateAndInsertBasicBlock(BBJ_COND, currBlock);
-            GenTree*     fatPointerMask  = new (compiler, GT_CNS_INT) GenTreeIntCon(TYP_I_IMPL, FAT_POINTER_MASK);
-            GenTree*     fptrAddressCopy = compiler->gtCloneExpr(fptrAddress);
-            GenTree*     fatPointerAnd   = compiler->gtNewOperNode(GT_AND, TYP_I_IMPL, fptrAddressCopy, fatPointerMask);
-            GenTree*     zero            = new (compiler, GT_CNS_INT) GenTreeIntCon(TYP_I_IMPL, 0);
-            GenTree*     fatPointerCmp   = compiler->gtNewOperNode(GT_NE, TYP_INT, fatPointerAnd, zero);
-            GenTree*     jmpTree         = compiler->gtNewOperNode(GT_JTRUE, TYP_VOID, fatPointerCmp);
-            GenTreeStmt* jmpStmt         = compiler->fgNewStmtFromTree(jmpTree, stmt->gtStmtILoffsx);
+            checkBlock                 = CreateAndInsertBasicBlock(BBJ_COND, currBlock);
+            GenTree*   fatPointerMask  = new (compiler, GT_CNS_INT) GenTreeIntCon(TYP_I_IMPL, FAT_POINTER_MASK);
+            GenTree*   fptrAddressCopy = compiler->gtCloneExpr(fptrAddress);
+            GenTree*   fatPointerAnd   = compiler->gtNewOperNode(GT_AND, TYP_I_IMPL, fptrAddressCopy, fatPointerMask);
+            GenTree*   zero            = new (compiler, GT_CNS_INT) GenTreeIntCon(TYP_I_IMPL, 0);
+            GenTree*   fatPointerCmp   = compiler->gtNewOperNode(GT_NE, TYP_INT, fatPointerAnd, zero);
+            GenTree*   jmpTree         = compiler->gtNewOperNode(GT_JTRUE, TYP_VOID, fatPointerCmp);
+            Statement* jmpStmt         = compiler->fgNewStmtFromTree(jmpTree, stmt->gtStmtILoffsx);
             compiler->fgInsertStmtAtEnd(checkBlock, jmpStmt);
         }
 
@@ -350,8 +350,8 @@ private:
         //
         virtual void CreateThen()
         {
-            thenBlock                       = CreateAndInsertBasicBlock(BBJ_ALWAYS, checkBlock);
-            GenTreeStmt* copyOfOriginalStmt = compiler->gtCloneStmt(stmt);
+            thenBlock                     = CreateAndInsertBasicBlock(BBJ_ALWAYS, checkBlock);
+            Statement* copyOfOriginalStmt = compiler->gtCloneStmt(stmt);
             compiler->fgInsertStmtAtEnd(thenBlock, copyOfOriginalStmt);
         }
 
@@ -366,7 +366,7 @@ private:
             GenTree* actualCallAddress = compiler->gtNewOperNode(GT_IND, pointerType, fixedFptrAddress);
             GenTree* hiddenArgument    = GetHiddenArgument(fixedFptrAddress);
 
-            GenTreeStmt* fatStmt = CreateFatCallStmt(actualCallAddress, hiddenArgument);
+            Statement* fatStmt = CreateFatCallStmt(actualCallAddress, hiddenArgument);
             compiler->fgInsertStmtAtEnd(elseBlock, fatStmt);
         }
 
@@ -409,9 +409,9 @@ private:
         //
         // Return Value:
         //    created call node.
-        GenTreeStmt* CreateFatCallStmt(GenTree* actualCallAddress, GenTree* hiddenArgument)
+        Statement* CreateFatCallStmt(GenTree* actualCallAddress, GenTree* hiddenArgument)
         {
-            GenTreeStmt* fatStmt = compiler->gtCloneStmt(stmt);
+            Statement*   fatStmt = compiler->gtCloneStmt(stmt);
             GenTree*     fatTree = fatStmt->gtStmtExpr;
             GenTreeCall* fatCall = GetCall(fatStmt);
             fatCall->gtCallAddr  = actualCallAddress;
@@ -471,7 +471,7 @@ private:
     class GuardedDevirtualizationTransformer final : public Transformer
     {
     public:
-        GuardedDevirtualizationTransformer(Compiler* compiler, BasicBlock* block, GenTreeStmt* stmt)
+        GuardedDevirtualizationTransformer(Compiler* compiler, BasicBlock* block, Statement* stmt)
             : Transformer(compiler, block, stmt), returnTemp(BAD_VAR_NUM)
         {
         }
@@ -529,7 +529,7 @@ private:
         //
         // Return Value:
         //    call tree node pointer.
-        virtual GenTreeCall* GetCall(GenTreeStmt* callStmt)
+        virtual GenTreeCall* GetCall(Statement* callStmt)
         {
             GenTree* tree = callStmt->gtStmtExpr;
             assert(tree->IsCall());
@@ -560,8 +560,8 @@ private:
             {
                 const unsigned thisTempNum = compiler->lvaGrabTemp(true DEBUGARG("guarded devirt this temp"));
                 // lvaSetClass(thisTempNum, ...);
-                GenTree*     asgTree = compiler->gtNewTempAssign(thisTempNum, thisTree);
-                GenTreeStmt* asgStmt = compiler->fgNewStmtFromTree(asgTree, stmt->gtStmtILoffsx);
+                GenTree*   asgTree = compiler->gtNewTempAssign(thisTempNum, thisTree);
+                Statement* asgStmt = compiler->fgNewStmtFromTree(asgTree, stmt->gtStmtILoffsx);
                 compiler->fgInsertStmtAtEnd(checkBlock, asgStmt);
 
                 thisTree = compiler->gtNewLclvNode(thisTempNum, TYP_REF);
@@ -580,9 +580,9 @@ private:
             GenTree*                              targetMethodTable = compiler->gtNewIconEmbClsHndNode(clsHnd);
 
             // Compare and jump to else (which does the indirect call) if NOT equal
-            GenTree*     methodTableCompare = compiler->gtNewOperNode(GT_NE, TYP_INT, targetMethodTable, methodTable);
-            GenTree*     jmpTree            = compiler->gtNewOperNode(GT_JTRUE, TYP_VOID, methodTableCompare);
-            GenTreeStmt* jmpStmt            = compiler->fgNewStmtFromTree(jmpTree, stmt->gtStmtILoffsx);
+            GenTree*   methodTableCompare = compiler->gtNewOperNode(GT_NE, TYP_INT, targetMethodTable, methodTable);
+            GenTree*   jmpTree            = compiler->gtNewOperNode(GT_JTRUE, TYP_VOID, methodTableCompare);
+            Statement* jmpStmt            = compiler->fgNewStmtFromTree(jmpTree, stmt->gtStmtILoffsx);
             compiler->fgInsertStmtAtEnd(checkBlock, jmpStmt);
         }
 
@@ -725,7 +725,7 @@ private:
         {
             elseBlock            = CreateAndInsertBasicBlock(BBJ_NONE, thenBlock);
             GenTreeCall* call    = origCall;
-            GenTreeStmt* newStmt = compiler->gtNewStmt(call);
+            Statement*   newStmt = compiler->gtNewStmt(call);
 
             call->gtFlags &= ~GTF_CALL_INLINE_CANDIDATE;
             call->SetIsGuarded();
@@ -792,7 +792,7 @@ void Compiler::CheckNoTransformableIndirectCallsRemain()
 
     for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->bbNext)
     {
-        for (GenTreeStmt* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->gtNextStmt)
+        for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->gtNextStmt)
         {
             fgWalkTreePre(&stmt->gtStmtExpr, fgDebugCheckForTransformableIndirectCalls);
         }

--- a/src/jit/indirectcalltransformer.cpp
+++ b/src/jit/indirectcalltransformer.cpp
@@ -101,7 +101,7 @@ private:
     {
         int count = 0;
 
-        for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->gtNextStmt)
+        for (Statement* stmt : block->Statements())
         {
             if (ContainsFatCalli(stmt))
             {
@@ -792,7 +792,7 @@ void Compiler::CheckNoTransformableIndirectCallsRemain()
 
     for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->bbNext)
     {
-        for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->gtNextStmt)
+        for (Statement* stmt : block->Statements())
         {
             fgWalkTreePre(&stmt->gtStmtExpr, fgDebugCheckForTransformableIndirectCalls);
         }

--- a/src/jit/inline.cpp
+++ b/src/jit/inline.cpp
@@ -568,7 +568,7 @@ void InlineContext::DumpXml(FILE* file, unsigned indent)
 //   stmt          - statement containing the call (if known)
 //   description   - string describing the context of the decision
 
-InlineResult::InlineResult(Compiler* compiler, GenTreeCall* call, GenTreeStmt* stmt, const char* description)
+InlineResult::InlineResult(Compiler* compiler, GenTreeCall* call, Statement* stmt, const char* description)
     : m_RootCompiler(nullptr)
     , m_Policy(nullptr)
     , m_Call(call)
@@ -1197,7 +1197,7 @@ InlineContext* InlineStrategy::NewRoot()
 InlineContext* InlineStrategy::NewSuccess(InlineInfo* inlineInfo)
 {
     InlineContext* calleeContext = new (m_Compiler, CMK_Inlining) InlineContext(this);
-    GenTreeStmt*   stmt          = inlineInfo->iciStmt;
+    Statement*     stmt          = inlineInfo->iciStmt;
     BYTE*          calleeIL      = inlineInfo->inlineCandidateInfo->methInfo.ILCode;
     unsigned       calleeILSize  = inlineInfo->inlineCandidateInfo->methInfo.ILCodeSize;
     InlineContext* parentContext = stmt->gtInlineContext;
@@ -1259,7 +1259,7 @@ InlineContext* InlineStrategy::NewSuccess(InlineInfo* inlineInfo)
 // Return Value:
 //    A new InlineContext for diagnostic purposes
 
-InlineContext* InlineStrategy::NewFailure(GenTreeStmt* stmt, InlineResult* inlineResult)
+InlineContext* InlineStrategy::NewFailure(Statement* stmt, InlineResult* inlineResult)
 {
     // Check for a parent context first. We should now have a parent
     // context for all statements.

--- a/src/jit/inline.h
+++ b/src/jit/inline.h
@@ -308,7 +308,7 @@ class InlineResult
 public:
     // Construct a new InlineResult to help evaluate a
     // particular call for inlining.
-    InlineResult(Compiler* compiler, GenTreeCall* call, GenTreeStmt* stmt, const char* description);
+    InlineResult(Compiler* compiler, GenTreeCall* call, Statement* stmt, const char* description);
 
     // Construct a new InlineResult to evaluate a particular
     // method to see if it is inlineable.
@@ -610,7 +610,7 @@ struct InlineInfo
 #endif // FEATURE_SIMD
 
     GenTreeCall* iciCall;  // The GT_CALL node to be inlined.
-    GenTreeStmt* iciStmt;  // The statement iciCall is in.
+    Statement*   iciStmt;  // The statement iciCall is in.
     BasicBlock*  iciBlock; // The basic block iciStmt is in.
 };
 
@@ -767,7 +767,7 @@ public:
     InlineContext* NewSuccess(InlineInfo* inlineInfo);
 
     // Create context for a failing inline.
-    InlineContext* NewFailure(GenTreeStmt* stmt, InlineResult* inlineResult);
+    InlineContext* NewFailure(Statement* stmt, InlineResult* inlineResult);
 
     // Compiler associated with this strategy
     Compiler* GetCompiler() const

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -3627,7 +3627,7 @@ var_types LclVarDsc::lvaArgType()
 //     Verifies that local accesses are consistenly typed.
 //     Verifies that casts remain in bounds.
 
-void Compiler::lvaMarkLclRefs(GenTree* tree, BasicBlock* block, GenTreeStmt* stmt, bool isRecompute)
+void Compiler::lvaMarkLclRefs(GenTree* tree, BasicBlock* block, Statement* stmt, bool isRecompute)
 {
     const BasicBlock::weight_t weight = block->getBBWeight(this);
 
@@ -3874,9 +3874,9 @@ void Compiler::lvaMarkLocalVars(BasicBlock* block, bool isRecompute)
     class MarkLocalVarsVisitor final : public GenTreeVisitor<MarkLocalVarsVisitor>
     {
     private:
-        BasicBlock*  m_block;
-        GenTreeStmt* m_stmt;
-        bool         m_isRecompute;
+        BasicBlock* m_block;
+        Statement*  m_stmt;
+        bool        m_isRecompute;
 
     public:
         enum
@@ -3884,7 +3884,7 @@ void Compiler::lvaMarkLocalVars(BasicBlock* block, bool isRecompute)
             DoPreOrder = true,
         };
 
-        MarkLocalVarsVisitor(Compiler* compiler, BasicBlock* block, GenTreeStmt* stmt, bool isRecompute)
+        MarkLocalVarsVisitor(Compiler* compiler, BasicBlock* block, Statement* stmt, bool isRecompute)
             : GenTreeVisitor<MarkLocalVarsVisitor>(compiler), m_block(block), m_stmt(stmt), m_isRecompute(isRecompute)
         {
         }
@@ -3899,7 +3899,7 @@ void Compiler::lvaMarkLocalVars(BasicBlock* block, bool isRecompute)
     JITDUMP("\n*** %s local variables in block " FMT_BB " (weight=%s)\n", isRecompute ? "recomputing" : "marking",
             block->bbNum, refCntWtd2str(block->getBBWeight(this)));
 
-    for (GenTreeStmt* stmt = block->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->getNextStmt())
+    for (Statement* stmt = block->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->getNextStmt())
     {
         MarkLocalVarsVisitor visitor(this, block, stmt, isRecompute);
         DISPTREE(stmt->gtStmtExpr);

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -3899,7 +3899,7 @@ void Compiler::lvaMarkLocalVars(BasicBlock* block, bool isRecompute)
     JITDUMP("\n*** %s local variables in block " FMT_BB " (weight=%s)\n", isRecompute ? "recomputing" : "marking",
             block->bbNum, refCntWtd2str(block->getBBWeight(this)));
 
-    for (Statement* stmt = block->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->getNextStmt())
+    for (Statement* stmt : StatementList(block->FirstNonPhiDef()))
     {
         MarkLocalVarsVisitor visitor(this, block, stmt, isRecompute);
         DISPTREE(stmt->gtStmtExpr);

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -494,7 +494,7 @@ void Compiler::fgPerBlockLocalVarLiveness()
         }
         else
         {
-            for (GenTreeStmt* stmt = block->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->getNextStmt())
+            for (Statement* stmt = block->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->getNextStmt())
             {
                 compCurStmt = stmt;
                 for (GenTree* node = stmt->gtStmtList; node != nullptr; node = node->gtNext)
@@ -992,7 +992,7 @@ void Compiler::fgExtendDbgLifetimes()
                     GenTree* initNode = gtNewAssignNode(varNode, zero);
 
                     // Create a statement for the initializer, sequence it, and append it to the current BB.
-                    GenTreeStmt* initStmt = gtNewStmt(initNode);
+                    Statement* initStmt = gtNewStmt(initNode);
                     gtSetStmtInfo(initStmt);
                     fgSetStmtSeq(initStmt);
                     fgInsertStmtNearEnd(block, initStmt);
@@ -2597,7 +2597,7 @@ void Compiler::fgInterBlockLocalVarLiveness()
         {
             /* Get the first statement in the block */
 
-            GenTreeStmt* firstStmt = block->FirstNonPhiDef();
+            Statement* firstStmt = block->FirstNonPhiDef();
 
             if (firstStmt == nullptr)
             {
@@ -2606,7 +2606,7 @@ void Compiler::fgInterBlockLocalVarLiveness()
 
             /* Walk all the statements of the block backwards - Get the LAST stmt */
 
-            GenTreeStmt* nextStmt = block->lastStmt();
+            Statement* nextStmt = block->lastStmt();
 
             do
             {

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -494,7 +494,7 @@ void Compiler::fgPerBlockLocalVarLiveness()
         }
         else
         {
-            for (Statement* stmt = block->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->getNextStmt())
+            for (Statement* stmt : StatementList(block->FirstNonPhiDef()))
             {
                 compCurStmt = stmt;
                 for (GenTree* node = stmt->gtStmtList; node != nullptr; node = node->gtNext)

--- a/src/jit/loopcloning.cpp
+++ b/src/jit/loopcloning.cpp
@@ -687,8 +687,8 @@ void LoopCloneContext::CondToStmtInBlock(Compiler*                          comp
     cond = comp->gtNewOperNode(reverse ? GT_NE : GT_EQ, TYP_INT, cond, comp->gtNewIconNode(0));
 
     // Add jmpTrue "cond == 0" to slow path.
-    GenTree*     jmpTrueTree = comp->gtNewOperNode(GT_JTRUE, TYP_VOID, cond);
-    GenTreeStmt* stmt        = comp->fgNewStmtFromTree(jmpTrueTree);
+    GenTree*   jmpTrueTree = comp->gtNewOperNode(GT_JTRUE, TYP_VOID, cond);
+    Statement* stmt        = comp->fgNewStmtFromTree(jmpTrueTree);
 
     // Add stmt to the block.
     comp->fgInsertStmtAtEnd(block, stmt);

--- a/src/jit/loopcloning.h
+++ b/src/jit/loopcloning.h
@@ -208,13 +208,13 @@ struct LcMdArrayOptInfo : public LcOptInfo
  */
 struct LcJaggedArrayOptInfo : public LcOptInfo
 {
-    unsigned dim;          // "dim" represents upto what level of the rank this optimization applies to.
-                           //    For example, a[i][j][k] could be the jagged array but if "dim" is 2,
-                           //    then this node is treated as though it were a[i][j]
-    ArrIndex     arrIndex; // ArrIndex representation of the array.
-    GenTreeStmt* stmt;     // "stmt" where the optimization opportunity occurs.
+    unsigned dim;        // "dim" represents upto what level of the rank this optimization applies to.
+                         //    For example, a[i][j][k] could be the jagged array but if "dim" is 2,
+                         //    then this node is treated as though it were a[i][j]
+    ArrIndex   arrIndex; // ArrIndex representation of the array.
+    Statement* stmt;     // "stmt" where the optimization opportunity occurs.
 
-    LcJaggedArrayOptInfo(ArrIndex& arrIndex, unsigned dim, GenTreeStmt* stmt)
+    LcJaggedArrayOptInfo(ArrIndex& arrIndex, unsigned dim, Statement* stmt)
         : LcOptInfo(this, LcJaggedArray), dim(dim), arrIndex(arrIndex), stmt(stmt)
     {
     }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7587,12 +7587,12 @@ GenTree* Compiler::fgMorphPotentialTailCall(GenTreeCall* call)
         assert(treeWithCall == call);
     }
 #endif
-    GenTreeStmt* nextMorphStmt = fgMorphStmt->gtNextStmt;
+    Statement* nextMorphStmt = fgMorphStmt->gtNextStmt;
     // Remove all stmts after the call.
     while (nextMorphStmt != nullptr)
     {
-        GenTreeStmt* stmtToRemove = nextMorphStmt;
-        nextMorphStmt             = stmtToRemove->gtNextStmt;
+        Statement* stmtToRemove = nextMorphStmt;
+        nextMorphStmt           = stmtToRemove->gtNextStmt;
         fgRemoveStmt(compCurBB, stmtToRemove);
     }
 
@@ -8108,19 +8108,19 @@ GenTree* Compiler::fgGetStubAddrArg(GenTreeCall* call)
 void Compiler::fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCall* recursiveTailCall)
 {
     assert(recursiveTailCall->IsTailCallConvertibleToLoop());
-    GenTreeStmt* lastStmt = block->lastStmt();
+    Statement* lastStmt = block->lastStmt();
     assert(recursiveTailCall == lastStmt->gtStmtExpr);
 
     // Transform recursive tail call into a loop.
 
-    GenTreeStmt* earlyArgInsertionPoint = lastStmt;
-    IL_OFFSETX   callILOffset           = lastStmt->gtStmtILoffsx;
+    Statement* earlyArgInsertionPoint = lastStmt;
+    IL_OFFSETX callILOffset           = lastStmt->gtStmtILoffsx;
 
     // Hoist arg setup statement for the 'this' argument.
     GenTree* thisArg = recursiveTailCall->gtCallObjp;
     if (thisArg && !thisArg->IsNothingNode() && !thisArg->IsArgPlaceHolderNode())
     {
-        GenTreeStmt* thisArgStmt = gtNewStmt(thisArg, callILOffset);
+        Statement* thisArgStmt = gtNewStmt(thisArg, callILOffset);
         fgInsertStmtBefore(block, earlyArgInsertionPoint, thisArgStmt);
     }
 
@@ -8163,8 +8163,8 @@ void Compiler::fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCa
     //  [000057] - A----------             \--* = int
     //  [000056] D------N----                \--*  lclVar    int    V01 arg1
 
-    GenTreeStmt* tmpAssignmentInsertionPoint   = lastStmt;
-    GenTreeStmt* paramAssignmentInsertionPoint = lastStmt;
+    Statement* tmpAssignmentInsertionPoint   = lastStmt;
+    Statement* paramAssignmentInsertionPoint = lastStmt;
 
     // Process early args. They may contain both setup statements for late args and actual args.
     // Early args don't include 'this' arg. We need to account for that so that the call to gtArgEntryByArgNum
@@ -8178,14 +8178,14 @@ void Compiler::fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCa
             if ((earlyArg->gtFlags & GTF_LATE_ARG) != 0)
             {
                 // This is a setup node so we need to hoist it.
-                GenTreeStmt* earlyArgStmt = gtNewStmt(earlyArg, callILOffset);
+                Statement* earlyArgStmt = gtNewStmt(earlyArg, callILOffset);
                 fgInsertStmtBefore(block, earlyArgInsertionPoint, earlyArgStmt);
             }
             else
             {
                 // This is an actual argument that needs to be assigned to the corresponding caller parameter.
                 fgArgTabEntry* curArgTabEntry = gtArgEntryByArgNum(recursiveTailCall, earlyArgIndex);
-                GenTreeStmt*   paramAssignStmt =
+                Statement*     paramAssignStmt =
                     fgAssignRecursiveCallArgToCallerParam(earlyArg, curArgTabEntry, block, callILOffset,
                                                           tmpAssignmentInsertionPoint, paramAssignmentInsertionPoint);
                 if ((tmpAssignmentInsertionPoint == lastStmt) && (paramAssignStmt != nullptr))
@@ -8205,7 +8205,7 @@ void Compiler::fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCa
         // A late argument is an actual argument that needs to be assigned to the corresponding caller's parameter.
         GenTree*       lateArg        = use.GetNode();
         fgArgTabEntry* curArgTabEntry = gtArgEntryByLateArgIndex(recursiveTailCall, lateArgIndex);
-        GenTreeStmt*   paramAssignStmt =
+        Statement*     paramAssignStmt =
             fgAssignRecursiveCallArgToCallerParam(lateArg, curArgTabEntry, block, callILOffset,
                                                   tmpAssignmentInsertionPoint, paramAssignmentInsertionPoint);
 
@@ -8222,10 +8222,10 @@ void Compiler::fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCa
     // block won't be in the loop (it's assumed to have no predecessors), we need to update the special local here.
     if (!info.compIsStatic && (lvaArg0Var != info.compThisArg))
     {
-        var_types    thisType           = lvaTable[info.compThisArg].TypeGet();
-        GenTree*     arg0               = gtNewLclvNode(lvaArg0Var, thisType);
-        GenTree*     arg0Assignment     = gtNewAssignNode(arg0, gtNewLclvNode(info.compThisArg, thisType));
-        GenTreeStmt* arg0AssignmentStmt = gtNewStmt(arg0Assignment, callILOffset);
+        var_types  thisType           = lvaTable[info.compThisArg].TypeGet();
+        GenTree*   arg0               = gtNewLclvNode(lvaArg0Var, thisType);
+        GenTree*   arg0Assignment     = gtNewAssignNode(arg0, gtNewLclvNode(info.compThisArg, thisType));
+        Statement* arg0AssignmentStmt = gtNewStmt(arg0Assignment, callILOffset);
         fgInsertStmtBefore(block, paramAssignmentInsertionPoint, arg0AssignmentStmt);
     }
 
@@ -8266,7 +8266,7 @@ void Compiler::fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCa
                         GenTree* zero = gtNewZeroConNode(genActualType(lclType));
                         init          = gtNewAssignNode(lcl, zero);
                     }
-                    GenTreeStmt* initStmt = gtNewStmt(init, callILOffset);
+                    Statement* initStmt = gtNewStmt(init, callILOffset);
                     fgInsertStmtBefore(block, lastStmt, initStmt);
                 }
             }
@@ -8303,12 +8303,12 @@ void Compiler::fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCa
 // Return Value:
 //    parameter assignment statement if one was inserted; nullptr otherwise.
 
-GenTreeStmt* Compiler::fgAssignRecursiveCallArgToCallerParam(GenTree*       arg,
-                                                             fgArgTabEntry* argTabEntry,
-                                                             BasicBlock*    block,
-                                                             IL_OFFSETX     callILOffset,
-                                                             GenTreeStmt*   tmpAssignmentInsertionPoint,
-                                                             GenTreeStmt*   paramAssignmentInsertionPoint)
+Statement* Compiler::fgAssignRecursiveCallArgToCallerParam(GenTree*       arg,
+                                                           fgArgTabEntry* argTabEntry,
+                                                           BasicBlock*    block,
+                                                           IL_OFFSETX     callILOffset,
+                                                           Statement*     tmpAssignmentInsertionPoint,
+                                                           Statement*     paramAssignmentInsertionPoint)
 {
     // Call arguments should be assigned to temps first and then the temps should be assigned to parameters because
     // some argument trees may reference parameters directly.
@@ -8346,7 +8346,7 @@ GenTreeStmt* Compiler::fgAssignRecursiveCallArgToCallerParam(GenTree*       arg,
     // any caller parameters. Some common cases are handled above but we may be able to eliminate
     // more temp assignments.
 
-    GenTreeStmt* paramAssignStmt = nullptr;
+    Statement* paramAssignStmt = nullptr;
     if (needToAssignParameter)
     {
         if (argInTemp == nullptr)
@@ -8354,12 +8354,12 @@ GenTreeStmt* Compiler::fgAssignRecursiveCallArgToCallerParam(GenTree*       arg,
             // The argument is not assigned to a temp. We need to create a new temp and insert an assignment.
             // TODO: we can avoid a temp assignment if we can prove that the argument tree
             // doesn't involve any caller parameters.
-            unsigned tmpNum            = lvaGrabTemp(true DEBUGARG("arg temp"));
-            lvaTable[tmpNum].lvType    = arg->gtType;
-            GenTree*     tempSrc       = arg;
-            GenTree*     tempDest      = gtNewLclvNode(tmpNum, tempSrc->gtType);
-            GenTree*     tmpAssignNode = gtNewAssignNode(tempDest, tempSrc);
-            GenTreeStmt* tmpAssignStmt = gtNewStmt(tmpAssignNode, callILOffset);
+            unsigned tmpNum          = lvaGrabTemp(true DEBUGARG("arg temp"));
+            lvaTable[tmpNum].lvType  = arg->gtType;
+            GenTree*   tempSrc       = arg;
+            GenTree*   tempDest      = gtNewLclvNode(tmpNum, tempSrc->gtType);
+            GenTree*   tmpAssignNode = gtNewAssignNode(tempDest, tempSrc);
+            Statement* tmpAssignStmt = gtNewStmt(tmpAssignNode, callILOffset);
             fgInsertStmtBefore(block, tmpAssignmentInsertionPoint, tmpAssignStmt);
             argInTemp = gtNewLclvNode(tmpNum, tempSrc->gtType);
         }
@@ -8434,7 +8434,7 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
             assg = fgMorphTree(assg);
 
             // Create the assignment statement and insert it before the current statement.
-            GenTreeStmt* assgStmt = gtNewStmt(assg, compCurStmt->gtStmtILoffsx);
+            Statement* assgStmt = gtNewStmt(assg, compCurStmt->gtStmtILoffsx);
             fgInsertStmtBefore(compCurBB, compCurStmt, assgStmt);
 
             // Return the temp.
@@ -15157,7 +15157,7 @@ bool Compiler::fgFoldConditional(BasicBlock* block)
     {
         noway_assert(block->bbStmtList != nullptr && block->bbStmtList->gtPrev != nullptr);
 
-        GenTreeStmt* lastStmt = block->lastStmt();
+        Statement* lastStmt = block->lastStmt();
 
         noway_assert(lastStmt->gtNext == nullptr);
 
@@ -15365,7 +15365,7 @@ bool Compiler::fgFoldConditional(BasicBlock* block)
     {
         noway_assert(block->bbStmtList != nullptr && block->bbStmtList->gtPrev != nullptr);
 
-        GenTreeStmt* lastStmt = block->lastStmt();
+        Statement* lastStmt = block->lastStmt();
 
         noway_assert(lastStmt->gtNext == nullptr);
 
@@ -15496,7 +15496,7 @@ bool Compiler::fgFoldConditional(BasicBlock* block)
 // Returns false if 'stmt' is still in the block (even if other statements were removed).
 //
 
-bool Compiler::fgMorphBlockStmt(BasicBlock* block, GenTreeStmt* stmt DEBUGARG(const char* msg))
+bool Compiler::fgMorphBlockStmt(BasicBlock* block, Statement* stmt DEBUGARG(const char* msg))
 {
     assert(block != nullptr);
     assert(stmt != nullptr);
@@ -15638,8 +15638,8 @@ void Compiler::fgMorphStmts(BasicBlock* block, bool* lnot, bool* loadw)
 
     fgCurrentlyInUseArgTemps = hashBv::Create(this);
 
-    GenTreeStmt* stmt = block->firstStmt();
-    GenTree*     prev = nullptr;
+    Statement* stmt = block->firstStmt();
+    GenTree*   prev = nullptr;
     for (; stmt != nullptr; prev = stmt->gtStmtExpr, stmt = stmt->gtNextStmt)
     {
         if (fgRemoveRestOfBlock)
@@ -15805,9 +15805,9 @@ void Compiler::fgMorphStmts(BasicBlock* block, bool* lnot, bool* loadw)
     {
         if ((block->bbJumpKind == BBJ_COND) || (block->bbJumpKind == BBJ_SWITCH))
         {
-            GenTreeStmt* first = block->firstStmt();
+            Statement* first = block->firstStmt();
             noway_assert(first);
-            GenTreeStmt* lastStmt = block->lastStmt();
+            Statement* lastStmt = block->lastStmt();
             noway_assert(lastStmt && lastStmt->gtNext == nullptr);
             GenTree* last = lastStmt->gtStmtExpr;
 
@@ -15951,8 +15951,8 @@ void Compiler::fgMorphBlocks()
                 //
                 // TODO: Need to characterize the last top level stmt of a block ending with BBJ_RETURN.
 
-                GenTreeStmt* lastStmt = block->lastStmt();
-                GenTree*     ret      = (lastStmt != nullptr) ? lastStmt->gtStmtExpr : nullptr;
+                Statement* lastStmt = block->lastStmt();
+                GenTree*   ret      = (lastStmt != nullptr) ? lastStmt->gtStmtExpr : nullptr;
 
                 if ((ret != nullptr) && (ret->OperGet() == GT_RETURN) && ((ret->gtFlags & GTF_RET_MERGED) != 0))
                 {
@@ -15992,9 +15992,9 @@ void Compiler::fgMorphBlocks()
                         noway_assert(ret->OperGet() == GT_RETURN);
                         noway_assert(ret->gtGetOp1() != nullptr);
 
-                        GenTreeStmt* pAfterStatement = lastStmt;
-                        IL_OFFSETX   offset          = lastStmt->gtStmtILoffsx;
-                        GenTree*     tree =
+                        Statement* pAfterStatement = lastStmt;
+                        IL_OFFSETX offset          = lastStmt->gtStmtILoffsx;
+                        GenTree*   tree =
                             gtNewTempAssign(genReturnLocal, ret->gtGetOp1(), &pAfterStatement, offset, block);
                         if (tree->OperIsCopyBlkOp())
                         {
@@ -16379,7 +16379,7 @@ GenTree* Compiler::fgGetTopLevelQmark(GenTree* expr, GenTree** ppDst /* = NULL *
  *     tmp has the result.
  *
  */
-void Compiler::fgExpandQmarkForCastInstOf(BasicBlock* block, GenTreeStmt* stmt)
+void Compiler::fgExpandQmarkForCastInstOf(BasicBlock* block, Statement* stmt)
 {
 #ifdef DEBUG
     if (verbose)
@@ -16489,8 +16489,8 @@ void Compiler::fgExpandQmarkForCastInstOf(BasicBlock* block, GenTreeStmt* stmt)
     helperBlock->inheritWeightPercentage(cond2Block, 50);
 
     // Append cond1 as JTRUE to cond1Block
-    GenTree*     jmpTree = gtNewOperNode(GT_JTRUE, TYP_VOID, condExpr);
-    GenTreeStmt* jmpStmt = fgNewStmtFromTree(jmpTree, stmt->gtStmtILoffsx);
+    GenTree*   jmpTree = gtNewOperNode(GT_JTRUE, TYP_VOID, condExpr);
+    Statement* jmpStmt = fgNewStmtFromTree(jmpTree, stmt->gtStmtILoffsx);
     fgInsertStmtAtEnd(cond1Block, jmpStmt);
 
     // Append cond2 as JTRUE to cond2Block
@@ -16499,14 +16499,14 @@ void Compiler::fgExpandQmarkForCastInstOf(BasicBlock* block, GenTreeStmt* stmt)
     fgInsertStmtAtEnd(cond2Block, jmpStmt);
 
     // AsgBlock should get tmp = op1 assignment.
-    trueExpr              = gtNewTempAssign(dst->AsLclVarCommon()->GetLclNum(), trueExpr);
-    GenTreeStmt* trueStmt = fgNewStmtFromTree(trueExpr, stmt->gtStmtILoffsx);
+    trueExpr            = gtNewTempAssign(dst->AsLclVarCommon()->GetLclNum(), trueExpr);
+    Statement* trueStmt = fgNewStmtFromTree(trueExpr, stmt->gtStmtILoffsx);
     fgInsertStmtAtEnd(asgBlock, trueStmt);
 
     // Since we are adding helper in the JTRUE false path, reverse the cond2 and add the helper.
     gtReverseCond(cond2Expr);
-    GenTree*     helperExpr = gtNewTempAssign(dst->AsLclVarCommon()->GetLclNum(), true2Expr);
-    GenTreeStmt* helperStmt = fgNewStmtFromTree(helperExpr, stmt->gtStmtILoffsx);
+    GenTree*   helperExpr = gtNewTempAssign(dst->AsLclVarCommon()->GetLclNum(), true2Expr);
+    Statement* helperStmt = fgNewStmtFromTree(helperExpr, stmt->gtStmtILoffsx);
     fgInsertStmtAtEnd(helperBlock, helperStmt);
 
     // Finally remove the nested qmark stmt.
@@ -16571,7 +16571,7 @@ void Compiler::fgExpandQmarkForCastInstOf(BasicBlock* block, GenTreeStmt* stmt)
  *  If the qmark assigns to a variable, then create tmps for "then"
  *  and "else" results and assign the temp to the variable as a writeback step.
  */
-void Compiler::fgExpandQmarkStmt(BasicBlock* block, GenTreeStmt* stmt)
+void Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
 {
     GenTree* expr = stmt->gtStmtExpr;
 
@@ -16704,8 +16704,8 @@ void Compiler::fgExpandQmarkStmt(BasicBlock* block, GenTreeStmt* stmt)
         elseBlock->inheritWeightPercentage(condBlock, 50);
     }
 
-    GenTree*     jmpTree = gtNewOperNode(GT_JTRUE, TYP_VOID, qmark->gtGetOp1());
-    GenTreeStmt* jmpStmt = fgNewStmtFromTree(jmpTree, stmt->gtStmtILoffsx);
+    GenTree*   jmpTree = gtNewOperNode(GT_JTRUE, TYP_VOID, qmark->gtGetOp1());
+    Statement* jmpStmt = fgNewStmtFromTree(jmpTree, stmt->gtStmtILoffsx);
     fgInsertStmtAtEnd(condBlock, jmpStmt);
 
     // Remove the original qmark statement.
@@ -16731,7 +16731,7 @@ void Compiler::fgExpandQmarkStmt(BasicBlock* block, GenTreeStmt* stmt)
         {
             trueExpr = gtNewTempAssign(lclNum, trueExpr);
         }
-        GenTreeStmt* trueStmt = fgNewStmtFromTree(trueExpr, stmt->gtStmtILoffsx);
+        Statement* trueStmt = fgNewStmtFromTree(trueExpr, stmt->gtStmtILoffsx);
         fgInsertStmtAtEnd(thenBlock, trueStmt);
     }
 
@@ -16742,7 +16742,7 @@ void Compiler::fgExpandQmarkStmt(BasicBlock* block, GenTreeStmt* stmt)
         {
             falseExpr = gtNewTempAssign(lclNum, falseExpr);
         }
-        GenTreeStmt* falseStmt = fgNewStmtFromTree(falseExpr, stmt->gtStmtILoffsx);
+        Statement* falseStmt = fgNewStmtFromTree(falseExpr, stmt->gtStmtILoffsx);
         fgInsertStmtAtEnd(elseBlock, falseStmt);
     }
 
@@ -16767,7 +16767,7 @@ void Compiler::fgExpandQmarkNodes()
     {
         for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->bbNext)
         {
-            for (GenTreeStmt* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+            for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
             {
                 GenTree* expr = stmt->gtStmtExpr;
 #ifdef DEBUG
@@ -16793,7 +16793,7 @@ void Compiler::fgPostExpandQmarkChecks()
 {
     for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->bbNext)
     {
-        for (GenTreeStmt* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
         {
             GenTree* expr = stmt->gtStmtExpr;
             fgWalkTreePre(&expr, Compiler::fgAssertNoQmark, nullptr);
@@ -18073,7 +18073,7 @@ public:
     {
     }
 
-    void VisitStmt(GenTreeStmt* stmt)
+    void VisitStmt(Statement* stmt)
     {
 #ifdef DEBUG
         if (m_compiler->verbose)
@@ -18713,7 +18713,7 @@ void Compiler::fgMarkAddressExposedLocals()
         // Make the current basic block address available globally
         compCurBB = block;
 
-        for (GenTreeStmt* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
         {
             visitor.VisitStmt(stmt);
         }
@@ -18731,13 +18731,13 @@ void Compiler::fgMarkAddressExposedLocals()
 //
 // Argument:
 //  block - BasicBlock*. block which stmt belongs to
-//  stmt  - GenTreeStmt*. the stmt node we want to check
+//  stmt  - Statement*. the stmt node we want to check
 //
 // return value:
 //  if this funciton successfully optimized the stmts, then return true. Otherwise
 //  return false;
 
-bool Compiler::fgMorphCombineSIMDFieldAssignments(BasicBlock* block, GenTreeStmt* stmt)
+bool Compiler::fgMorphCombineSIMDFieldAssignments(BasicBlock* block, Statement* stmt)
 {
 
     GenTree* tree = stmt->gtStmtExpr;
@@ -18757,11 +18757,11 @@ bool Compiler::fgMorphCombineSIMDFieldAssignments(BasicBlock* block, GenTreeStmt
         return false;
     }
 
-    var_types    simdType             = getSIMDTypeForSize(simdSize);
-    int          assignmentsCount     = simdSize / genTypeSize(baseType) - 1;
-    int          remainingAssignments = assignmentsCount;
-    GenTreeStmt* curStmt              = stmt->getNextStmt();
-    GenTreeStmt* lastStmt             = stmt;
+    var_types  simdType             = getSIMDTypeForSize(simdSize);
+    int        assignmentsCount     = simdSize / genTypeSize(baseType) - 1;
+    int        remainingAssignments = assignmentsCount;
+    Statement* curStmt              = stmt->getNextStmt();
+    Statement* lastStmt             = stmt;
 
     while (curStmt != nullptr && remainingAssignments > 0)
     {
@@ -18872,7 +18872,7 @@ bool Compiler::fgMorphCombineSIMDFieldAssignments(BasicBlock* block, GenTreeStmt
 #endif // FEATURE_SIMD
 
 #if !defined(FEATURE_CORECLR) && defined(_TARGET_AMD64_)
-GenTreeStmt* SkipNopStmts(GenTreeStmt* stmt)
+Statement* SkipNopStmts(Statement* stmt)
 {
     while ((stmt != nullptr) && !stmt->IsNothingNode())
     {
@@ -18899,9 +18899,9 @@ bool Compiler::fgCheckStmtAfterTailCall()
     // For debuggable code, it would be an assignment of the call to a temp
     // We want to get rid of any of this extra trees, and just leave
     // the call.
-    GenTreeStmt* callStmt = fgMorphStmt;
+    Statement* callStmt = fgMorphStmt;
 
-    GenTreeStmt* nextMorphStmt = callStmt->gtNextStmt;
+    Statement* nextMorphStmt = callStmt->gtNextStmt;
 
 #if !defined(FEATURE_CORECLR) && defined(_TARGET_AMD64_)
     // Legacy Jit64 Compat:
@@ -18930,7 +18930,7 @@ bool Compiler::fgCheckStmtAfterTailCall()
             // impImportBlockCode()). Hence, it is not possible to assert about the IR
             // form generated by pop but pop tree must be side-effect free so that we can
             // delete it safely.
-            GenTreeStmt* popStmt = nextMorphStmt;
+            Statement* popStmt = nextMorphStmt;
 
             // Side effect flags on a GT_COMMA may be overly pessimistic, so examine
             // the constituent nodes.
@@ -18962,8 +18962,8 @@ bool Compiler::fgCheckStmtAfterTailCall()
         {
             // The next stmt can be GT_RETURN(TYP_VOID) or GT_RETURN(lclVar),
             // where lclVar was return buffer in the call for structs or simd.
-            GenTreeStmt* retStmt = nextMorphStmt;
-            GenTree*     retExpr = retStmt->gtStmtExpr;
+            Statement* retStmt = nextMorphStmt;
+            GenTree*   retExpr = retStmt->gtStmtExpr;
             noway_assert(retExpr->gtOper == GT_RETURN);
 
             nextMorphStmt = retStmt->gtNextStmt;
@@ -18979,8 +18979,8 @@ bool Compiler::fgCheckStmtAfterTailCall()
             // However, we can't check that this assignment was created there.
             if (nextMorphStmt->gtStmtExpr->gtOper == GT_ASG)
             {
-                GenTreeStmt* moveStmt = nextMorphStmt;
-                GenTree*     moveExpr = nextMorphStmt->gtStmtExpr;
+                Statement* moveStmt = nextMorphStmt;
+                GenTree*   moveExpr = nextMorphStmt->gtStmtExpr;
                 noway_assert(moveExpr->gtGetOp1()->OperIsLocal() && moveExpr->gtGetOp2()->OperIsLocal());
 
                 unsigned srcLclNum = moveExpr->gtGetOp2()->AsLclVarCommon()->gtLclNum;
@@ -18993,8 +18993,8 @@ bool Compiler::fgCheckStmtAfterTailCall()
             if (nextMorphStmt != nullptr)
 #endif
             {
-                GenTreeStmt* retStmt = nextMorphStmt;
-                GenTree*     retExpr = nextMorphStmt->gtStmtExpr;
+                Statement* retStmt = nextMorphStmt;
+                GenTree*   retExpr = nextMorphStmt->gtStmtExpr;
                 noway_assert(retExpr->gtOper == GT_RETURN);
 
                 GenTree* treeWithLcl = retExpr->gtGetOp1();

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -16009,7 +16009,9 @@ void Compiler::fgMorphBlocks()
                         {
                             // gtNewTempAssign inserted additional statements after last
                             fgRemoveStmt(block, lastStmt);
-                            lastStmt = fgInsertStmtAfter(block, pAfterStatement, gtNewStmt(tree, offset));
+                            Statement* newStmt = gtNewStmt(tree, offset);
+                            fgInsertStmtAfter(block, pAfterStatement, newStmt);
+                            lastStmt = newStmt;
                         }
 
                         // make sure that copy-prop ignores this assignment.

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -15589,9 +15589,9 @@ bool Compiler::fgMorphBlockStmt(BasicBlock* block, Statement* stmt DEBUGARG(cons
     if (fgRemoveRestOfBlock)
     {
         // Remove the rest of the stmts in the block
-        for (stmt = stmt->getNextStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* removeStmt : StatementList(stmt->gtNext))
         {
-            fgRemoveStmt(block, stmt);
+            fgRemoveStmt(block, removeStmt);
         }
 
         // The rest of block has been removed and we will always throw an exception.
@@ -16767,7 +16767,7 @@ void Compiler::fgExpandQmarkNodes()
     {
         for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->bbNext)
         {
-            for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+            for (Statement* stmt : block->Statements())
             {
                 GenTree* expr = stmt->gtStmtExpr;
 #ifdef DEBUG
@@ -16793,7 +16793,7 @@ void Compiler::fgPostExpandQmarkChecks()
 {
     for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->bbNext)
     {
-        for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt : block->Statements())
         {
             GenTree* expr = stmt->gtStmtExpr;
             fgWalkTreePre(&expr, Compiler::fgAssertNoQmark, nullptr);
@@ -18713,7 +18713,7 @@ void Compiler::fgMarkAddressExposedLocals()
         // Make the current basic block address available globally
         compCurBB = block;
 
-        for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt : block->Statements())
         {
             visitor.VisitStmt(stmt);
         }

--- a/src/jit/objectalloc.cpp
+++ b/src/jit/objectalloc.cpp
@@ -211,7 +211,7 @@ void ObjectAllocator::MarkEscapingVarsAndBuildConnGraph()
 
     foreach_block(comp, block)
     {
-        for (GenTreeStmt* stmt = block->firstStmt(); stmt; stmt = stmt->gtNextStmt)
+        for (Statement* stmt = block->firstStmt(); stmt; stmt = stmt->gtNextStmt)
         {
             BuildConnGraphVisitor buildConnGraphVisitor(this);
             buildConnGraphVisitor.WalkTree(&stmt->gtStmtExpr, nullptr);
@@ -347,7 +347,7 @@ bool ObjectAllocator::MorphAllocObjNodes()
         }
 #endif // DEBUG
 
-        for (GenTreeStmt* stmt = block->firstStmt(); stmt; stmt = stmt->gtNextStmt)
+        for (Statement* stmt = block->firstStmt(); stmt; stmt = stmt->gtNextStmt)
         {
             GenTree* stmtExpr = stmt->gtStmtExpr;
             GenTree* op2      = nullptr;
@@ -500,7 +500,7 @@ GenTree* ObjectAllocator::MorphAllocObjNodeIntoHelperCall(GenTreeAllocObj* alloc
 
 unsigned int ObjectAllocator::MorphAllocObjNodeIntoStackAlloc(GenTreeAllocObj* allocObj,
                                                               BasicBlock*      block,
-                                                              GenTreeStmt*     stmt)
+                                                              Statement*       stmt)
 {
     assert(allocObj != nullptr);
     assert(m_AnalysisDone);
@@ -527,7 +527,7 @@ unsigned int ObjectAllocator::MorphAllocObjNodeIntoStackAlloc(GenTreeAllocObj* a
         const bool isCopyBlock = false;
         tree = comp->gtNewBlkOpNode(tree, comp->gtNewIconNode(0), structSize, isVolatile, isCopyBlock);
 
-        GenTreeStmt* newStmt = comp->gtNewStmt(tree);
+        Statement* newStmt = comp->gtNewStmt(tree);
 
         comp->fgInsertStmtBefore(block, stmt, newStmt);
     }
@@ -549,7 +549,7 @@ unsigned int ObjectAllocator::MorphAllocObjNodeIntoStackAlloc(GenTreeAllocObj* a
     tree = comp->gtNewFieldRef(TYP_I_IMPL, FieldSeqStore::FirstElemPseudoField, tree, 0);
     tree = comp->gtNewAssignNode(tree, allocObj->gtGetOp1());
 
-    GenTreeStmt* newStmt = comp->gtNewStmt(tree);
+    Statement* newStmt = comp->gtNewStmt(tree);
 
     comp->fgInsertStmtBefore(block, stmt, newStmt);
 
@@ -908,7 +908,7 @@ void ObjectAllocator::RewriteUses()
 
     foreach_block(comp, block)
     {
-        for (GenTreeStmt* stmt = block->firstStmt(); stmt; stmt = stmt->gtNextStmt)
+        for (Statement* stmt = block->firstStmt(); stmt; stmt = stmt->gtNextStmt)
         {
             RewriteUsesVisitor rewriteUsesVisitor(this);
             rewriteUsesVisitor.WalkTree(&stmt->gtStmtExpr, nullptr);

--- a/src/jit/objectalloc.cpp
+++ b/src/jit/objectalloc.cpp
@@ -211,7 +211,7 @@ void ObjectAllocator::MarkEscapingVarsAndBuildConnGraph()
 
     foreach_block(comp, block)
     {
-        for (Statement* stmt = block->firstStmt(); stmt; stmt = stmt->gtNextStmt)
+        for (Statement* stmt : block->Statements())
         {
             BuildConnGraphVisitor buildConnGraphVisitor(this);
             buildConnGraphVisitor.WalkTree(&stmt->gtStmtExpr, nullptr);
@@ -347,7 +347,7 @@ bool ObjectAllocator::MorphAllocObjNodes()
         }
 #endif // DEBUG
 
-        for (Statement* stmt = block->firstStmt(); stmt; stmt = stmt->gtNextStmt)
+        for (Statement* stmt : block->Statements())
         {
             GenTree* stmtExpr = stmt->gtStmtExpr;
             GenTree* op2      = nullptr;
@@ -908,7 +908,7 @@ void ObjectAllocator::RewriteUses()
 
     foreach_block(comp, block)
     {
-        for (Statement* stmt = block->firstStmt(); stmt; stmt = stmt->gtNextStmt)
+        for (Statement* stmt : block->Statements())
         {
             RewriteUsesVisitor rewriteUsesVisitor(this);
             rewriteUsesVisitor.WalkTree(&stmt->gtStmtExpr, nullptr);

--- a/src/jit/objectalloc.h
+++ b/src/jit/objectalloc.h
@@ -63,7 +63,7 @@ private:
     bool     MorphAllocObjNodes();
     void     RewriteUses();
     GenTree* MorphAllocObjNodeIntoHelperCall(GenTreeAllocObj* allocObj);
-    unsigned int MorphAllocObjNodeIntoStackAlloc(GenTreeAllocObj* allocObj, BasicBlock* block, GenTreeStmt* stmt);
+    unsigned int MorphAllocObjNodeIntoStackAlloc(GenTreeAllocObj* allocObj, BasicBlock* block, Statement* stmt);
     struct BuildConnGraphVisitorCallbackData;
     bool CanLclVarEscapeViaParentStack(ArrayStack<GenTree*>* parentStack, unsigned int lclNum);
     void UpdateAncestorTypes(GenTree* tree, ArrayStack<GenTree*>* parentStack, var_types newType);

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -622,7 +622,7 @@ unsigned Compiler::optValnumCSE_Locate()
         noway_assert((block->bbFlags & (BBF_VISITED | BBF_MARKED)) == 0);
 
         /* Walk the statement trees in this basic block */
-        for (Statement* stmt = block->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt : StatementList(block->FirstNonPhiDef()))
         {
             /* We walk the tree in the forwards direction (bottom up) */
             bool stmtHasArrLenCandidate = false;
@@ -1007,7 +1007,7 @@ void Compiler::optValnumCSE_Availablity()
 
         // Walk the statement trees in this basic block
 
-        for (Statement* stmt = block->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt : StatementList(block->FirstNonPhiDef()))
         {
             // We walk the tree in the forwards direction (bottom up)
 
@@ -2889,7 +2889,7 @@ void Compiler::optCleanupCSEs()
         block->bbFlags &= ~(BBF_VISITED | BBF_MARKED);
 
         // Walk the statement trees in this basic block.
-        for (Statement* stmt = block->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt : StatementList(block->FirstNonPhiDef()))
         {
             // We must clear the gtCSEnum field.
             for (GenTree* tree = stmt->gtStmtExpr; tree; tree = tree->gtPrev)
@@ -2915,9 +2915,8 @@ void Compiler::optEnsureClearCSEInfo()
         assert((block->bbFlags & (BBF_VISITED | BBF_MARKED)) == 0);
 
         // Initialize 'stmt' to the first non-Phi statement
-        Statement* stmt = block->FirstNonPhiDef();
         // Walk the statement trees in this basic block
-        for (; stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt : StatementList(block->FirstNonPhiDef()))
         {
             for (GenTree* tree = stmt->gtStmtExpr; tree; tree = tree->gtPrev)
             {

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -394,7 +394,7 @@ void Compiler::optValnumCSE_Init()
 //          we return that index.  There currently is a limit on the number of CSEs
 //          that we can have of MAX_CSE_CNT (64)
 //
-unsigned Compiler::optValnumCSE_Index(GenTree* tree, GenTreeStmt* stmt)
+unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
 {
     unsigned key;
     unsigned hash;
@@ -622,7 +622,7 @@ unsigned Compiler::optValnumCSE_Locate()
         noway_assert((block->bbFlags & (BBF_VISITED | BBF_MARKED)) == 0);
 
         /* Walk the statement trees in this basic block */
-        for (GenTreeStmt* stmt = block->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt = block->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->getNextStmt())
         {
             /* We walk the tree in the forwards direction (bottom up) */
             bool stmtHasArrLenCandidate = false;
@@ -1007,7 +1007,7 @@ void Compiler::optValnumCSE_Availablity()
 
         // Walk the statement trees in this basic block
 
-        for (GenTreeStmt* stmt = block->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt = block->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->getNextStmt())
         {
             // We walk the tree in the forwards direction (bottom up)
 
@@ -2130,9 +2130,9 @@ public:
         do
         {
             /* Process the next node in the list */
-            GenTree*     exp  = lst->tslTree;
-            GenTreeStmt* stmt = lst->tslStmt;
-            BasicBlock*  blk  = lst->tslBlock;
+            GenTree*    exp  = lst->tslTree;
+            Statement*  stmt = lst->tslStmt;
+            BasicBlock* blk  = lst->tslBlock;
 
             /* Advance to the next node in the list */
             lst = lst->tslNext;
@@ -2889,7 +2889,7 @@ void Compiler::optCleanupCSEs()
         block->bbFlags &= ~(BBF_VISITED | BBF_MARKED);
 
         // Walk the statement trees in this basic block.
-        for (GenTreeStmt* stmt = block->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt = block->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->getNextStmt())
         {
             // We must clear the gtCSEnum field.
             for (GenTree* tree = stmt->gtStmtExpr; tree; tree = tree->gtPrev)
@@ -2915,7 +2915,7 @@ void Compiler::optEnsureClearCSEInfo()
         assert((block->bbFlags & (BBF_VISITED | BBF_MARKED)) == 0);
 
         // Initialize 'stmt' to the first non-Phi statement
-        GenTreeStmt* stmt = block->FirstNonPhiDef();
+        Statement* stmt = block->FirstNonPhiDef();
         // Walk the statement trees in this basic block
         for (; stmt != nullptr; stmt = stmt->getNextStmt())
         {

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -1302,7 +1302,7 @@ bool Compiler::optRecordLoop(BasicBlock*   head,
             do
             {
                 block = block->bbNext;
-                for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->gtNextStmt)
+                for (Statement* stmt : block->Statements())
                 {
                     if (stmt->gtStmtExpr == incr)
                     {
@@ -3692,7 +3692,7 @@ void Compiler::optUnrollLoops()
 
                 // Visit all the statements in the block.
 
-                for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->gtNextStmt)
+                for (Statement* stmt : block->Statements())
                 {
                     /* Calculate gtCostSz */
                     gtSetStmtInfo(stmt);
@@ -6018,7 +6018,7 @@ bool Compiler::optIsVarAssigned(BasicBlock* beg, BasicBlock* end, GenTree* skip,
     {
         noway_assert(beg != nullptr);
 
-        for (Statement* stmt = beg->firstStmt(); stmt != nullptr; stmt = stmt->gtNextStmt)
+        for (Statement* stmt : beg->Statements())
         {
             if (fgWalkTreePre(&stmt->gtStmtExpr, optIsVarAssgCB, &desc))
             {
@@ -6082,7 +6082,7 @@ int Compiler::optIsSetAssgLoop(unsigned lnum, ALLVARSET_VALARG_TP vars, varRefKi
         {
             noway_assert(beg);
 
-            for (Statement* stmt = beg->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->gtNextStmt)
+            for (Statement* stmt : StatementList(beg->FirstNonPhiDef()))
             {
                 fgWalkTreePre(&stmt->gtStmtExpr, optIsVarAssgCB, &desc);
 
@@ -6820,7 +6820,7 @@ void Compiler::optHoistLoopBlocks(unsigned loopNum, ArrayStack<BasicBlock*>* blo
 
         void HoistBlock(BasicBlock* block)
         {
-            for (Statement* stmt = block->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->gtNextStmt)
+            for (Statement* stmt : StatementList(block->FirstNonPhiDef()))
             {
                 WalkTree(&stmt->gtStmtExpr, nullptr);
                 assert(m_valueStack.TopRef().Node() == stmt->gtStmtExpr);
@@ -7382,7 +7382,7 @@ void Compiler::fgCreateLoopPreHeader(unsigned lnum)
     // into the phi via the loop header block will now flow through the preheader
     // block from the header block.
 
-    for (Statement* stmt = top->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+    for (Statement* stmt : top->Statements())
     {
         GenTree* tree = stmt->gtStmtExpr;
         if (tree->OperGet() != GT_ASG)
@@ -7622,7 +7622,7 @@ void Compiler::optComputeLoopSideEffectsOfBlock(BasicBlock* blk)
     MemoryKindSet memoryHavoc = emptyMemoryKindSet;
 
     // Now iterate over the remaining statements, and their trees.
-    for (Statement* stmt = blk->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->getNextStmt())
+    for (Statement* stmt : StatementList(blk->FirstNonPhiDef()))
     {
         for (GenTree* tree = stmt->gtStmtList; tree != nullptr; tree = tree->gtNext)
         {
@@ -8155,7 +8155,7 @@ bool Compiler::optIdentifyLoopOptInfo(unsigned loopNum, LoopCloneContext* contex
     for (BasicBlock* block = beg; block != end->bbNext; block = block->bbNext)
     {
         compCurBB = block;
-        for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt : block->Statements())
         {
             info.stmt               = stmt;
             const bool lclVarsOnly  = false;

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -939,7 +939,7 @@ bool Compiler::optComputeIterInfo(GenTree* incr, BasicBlock* from, BasicBlock* t
 //      This method just retrieves what it thinks is the "test" node,
 //      the callers are expected to verify that "iterVar" is used in the test.
 //
-bool Compiler::optIsLoopTestEvalIntoTemp(GenTreeStmt* testStmt, GenTreeStmt** newTestStmt)
+bool Compiler::optIsLoopTestEvalIntoTemp(Statement* testStmt, Statement** newTestStmt)
 {
     GenTree* test = testStmt->gtStmtExpr;
 
@@ -960,7 +960,7 @@ bool Compiler::optIsLoopTestEvalIntoTemp(GenTreeStmt* testStmt, GenTreeStmt** ne
     {
         // Get the previous statement to get the def (rhs) of Vtmp to see
         // if the "test" is evaluated into Vtmp.
-        GenTreeStmt* prevStmt = testStmt->getPrevStmt();
+        Statement* prevStmt = testStmt->getPrevStmt();
         if (prevStmt == nullptr)
         {
             return false;
@@ -1031,10 +1031,10 @@ bool Compiler::optExtractInitTestIncr(
     // Check if last two statements in the loop body are the increment of the iterator
     // and the loop termination test.
     noway_assert(bottom->bbStmtList != nullptr);
-    GenTreeStmt* testStmt = bottom->lastStmt();
+    Statement* testStmt = bottom->lastStmt();
     noway_assert(testStmt != nullptr && testStmt->gtNext == nullptr);
 
-    GenTreeStmt* newTestStmt;
+    Statement* newTestStmt;
     if (optIsLoopTestEvalIntoTemp(testStmt, &newTestStmt))
     {
         testStmt = newTestStmt;
@@ -1042,7 +1042,7 @@ bool Compiler::optExtractInitTestIncr(
 
     // Check if we have the incr stmt before the test stmt, if we don't,
     // check if incr is part of the loop "top".
-    GenTreeStmt* incrStmt = testStmt->getPrevStmt();
+    Statement* incrStmt = testStmt->getPrevStmt();
     if (incrStmt == nullptr || optIsLoopIncrTree(incrStmt->gtStmtExpr) == BAD_VAR_NUM)
     {
         if (top == nullptr || top->bbStmtList == nullptr || top->bbStmtList->gtPrev == nullptr)
@@ -1051,7 +1051,7 @@ bool Compiler::optExtractInitTestIncr(
         }
 
         // If the prev stmt to loop test is not incr, then check if we have loop test evaluated into a tmp.
-        GenTreeStmt* toplastStmt = top->lastStmt();
+        Statement* toplastStmt = top->lastStmt();
         if (optIsLoopIncrTree(toplastStmt->gtStmtExpr) != BAD_VAR_NUM)
         {
             incrStmt = toplastStmt;
@@ -1066,13 +1066,13 @@ bool Compiler::optExtractInitTestIncr(
 
     // Find the last statement in the loop pre-header which we expect to be the initialization of
     // the loop iterator.
-    GenTreeStmt* phdrStmt = head->firstStmt();
+    Statement* phdrStmt = head->firstStmt();
     if (phdrStmt == nullptr)
     {
         return false;
     }
 
-    GenTreeStmt* initStmt = phdrStmt->getPrevStmt();
+    Statement* initStmt = phdrStmt->getPrevStmt();
     noway_assert(initStmt != nullptr && (initStmt->gtNext == nullptr));
 
     // If it is a duplicated loop condition, skip it.
@@ -1302,7 +1302,7 @@ bool Compiler::optRecordLoop(BasicBlock*   head,
             do
             {
                 block = block->bbNext;
-                for (GenTreeStmt* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->gtNextStmt)
+                for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->gtNextStmt)
                 {
                     if (stmt->gtStmtExpr == incr)
                     {
@@ -3605,12 +3605,12 @@ void Compiler::optUnrollLoops()
         }
 
         // Locate/initialize the increment/test statements.
-        GenTreeStmt* initStmt = head->lastStmt();
+        Statement* initStmt = head->lastStmt();
         noway_assert((initStmt != nullptr) && (initStmt->gtNext == nullptr));
 
-        GenTreeStmt* testStmt = bottom->lastStmt();
+        Statement* testStmt = bottom->lastStmt();
         noway_assert((testStmt != nullptr) && (testStmt->gtNext == nullptr));
-        GenTreeStmt* incrStmt = testStmt->gtPrevStmt;
+        Statement* incrStmt = testStmt->gtPrevStmt;
         noway_assert(incrStmt != nullptr);
 
         if (initStmt->compilerAdded)
@@ -3692,7 +3692,7 @@ void Compiler::optUnrollLoops()
 
                 // Visit all the statements in the block.
 
-                for (GenTreeStmt* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->gtNextStmt)
+                for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->gtNextStmt)
                 {
                     /* Calculate gtCostSz */
                     gtSetStmtInfo(stmt);
@@ -3778,8 +3778,8 @@ void Compiler::optUnrollLoops()
                     {
                         // Remove the test; we're doing a full unroll.
 
-                        GenTreeStmt* testCopyStmt = newBlock->lastStmt();
-                        GenTree*     testCopyExpr = testCopyStmt->gtStmtExpr;
+                        Statement* testCopyStmt = newBlock->lastStmt();
+                        GenTree*   testCopyExpr = testCopyStmt->gtStmtExpr;
                         assert(testCopyExpr->gtOper == GT_JTRUE);
                         GenTree* sideEffList = nullptr;
                         gtExtractSideEffList(testCopyExpr, &sideEffList, GTF_SIDE_EFFECT | GTF_ORDER_SIDEEFF);
@@ -3850,7 +3850,7 @@ void Compiler::optUnrollLoops()
 
             if (head->bbJumpKind == BBJ_COND)
             {
-                GenTreeStmt* preHeaderStmt = head->firstStmt();
+                Statement* preHeaderStmt = head->firstStmt();
                 noway_assert(preHeaderStmt != nullptr);
                 testStmt = preHeaderStmt->gtPrevStmt;
 
@@ -4005,13 +4005,13 @@ bool Compiler::optReachWithoutCall(BasicBlock* topBB, BasicBlock* botBB)
  * Find the loop termination test at the bottom of the loop
  */
 
-static GenTreeStmt* optFindLoopTermTest(BasicBlock* bottom)
+static Statement* optFindLoopTermTest(BasicBlock* bottom)
 {
-    GenTreeStmt* testStmt = bottom->firstStmt();
+    Statement* testStmt = bottom->firstStmt();
 
     assert(testStmt != nullptr);
 
-    GenTreeStmt* result = testStmt->getPrevStmt();
+    Statement* result = testStmt->getPrevStmt();
 
 #ifdef DEBUG
     while (testStmt->gtNext != nullptr)
@@ -4113,7 +4113,7 @@ void Compiler::fgOptWhileLoop(BasicBlock* block)
         return;
     }
 
-    GenTreeStmt* condStmt = optFindLoopTermTest(bTest);
+    Statement* condStmt = optFindLoopTermTest(bTest);
 
     // bTest must only contain only a jtrue with no other stmts, we will only clone
     // the conditional, so any other statements will not get cloned
@@ -4246,7 +4246,7 @@ void Compiler::fgOptWhileLoop(BasicBlock* block)
     /* Create a statement entry out of the condition and
        append the condition test at the end of 'block' */
 
-    GenTreeStmt* copyOfCondStmt = fgNewStmtAtEnd(block, condTree);
+    Statement* copyOfCondStmt = fgNewStmtAtEnd(block, condTree);
 
     copyOfCondStmt->compilerAdded = true;
 
@@ -4866,14 +4866,14 @@ bool Compiler::optComputeDerefConditions(unsigned loopNum, LoopCloneContext* con
 //      block        - the block in which the helper call needs to be inserted.
 //      insertBefore - the stmt before which the helper call will be inserted.
 //
-void Compiler::optDebugLogLoopCloning(BasicBlock* block, GenTreeStmt* insertBefore)
+void Compiler::optDebugLogLoopCloning(BasicBlock* block, Statement* insertBefore)
 {
     if (JitConfig.JitDebugLogLoopCloning() == 0)
     {
         return;
     }
-    GenTree*     logCall = gtNewHelperCallNode(CORINFO_HELP_DEBUG_LOG_LOOP_CLONING, TYP_VOID);
-    GenTreeStmt* stmt    = fgNewStmtFromTree(logCall);
+    GenTree*   logCall = gtNewHelperCallNode(CORINFO_HELP_DEBUG_LOG_LOOP_CLONING, TYP_VOID);
+    Statement* stmt    = fgNewStmtFromTree(logCall);
     fgInsertStmtBefore(block, insertBefore, stmt);
     fgMorphBlockStmt(block, stmt DEBUGARG("Debug log loop cloning"));
 }
@@ -6018,7 +6018,7 @@ bool Compiler::optIsVarAssigned(BasicBlock* beg, BasicBlock* end, GenTree* skip,
     {
         noway_assert(beg != nullptr);
 
-        for (GenTreeStmt* stmt = beg->firstStmt(); stmt != nullptr; stmt = stmt->gtNextStmt)
+        for (Statement* stmt = beg->firstStmt(); stmt != nullptr; stmt = stmt->gtNextStmt)
         {
             if (fgWalkTreePre(&stmt->gtStmtExpr, optIsVarAssgCB, &desc))
             {
@@ -6082,7 +6082,7 @@ int Compiler::optIsSetAssgLoop(unsigned lnum, ALLVARSET_VALARG_TP vars, varRefKi
         {
             noway_assert(beg);
 
-            for (GenTreeStmt* stmt = beg->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->gtNextStmt)
+            for (Statement* stmt = beg->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->gtNextStmt)
             {
                 fgWalkTreePre(&stmt->gtStmtExpr, optIsVarAssgCB, &desc);
 
@@ -6215,18 +6215,18 @@ void Compiler::optPerformHoistExpr(GenTree* origExpr, unsigned lnum)
     compCurBB = preHead;
     hoist     = fgMorphTree(hoist);
 
-    GenTreeStmt* hoistStmt   = gtNewStmt(hoist);
+    Statement* hoistStmt     = gtNewStmt(hoist);
     hoistStmt->compilerAdded = true;
 
     /* simply append the statement at the end of the preHead's list */
 
-    GenTreeStmt* firstStmt = preHead->firstStmt();
+    Statement* firstStmt = preHead->firstStmt();
 
     if (firstStmt != nullptr)
     {
         /* append after last statement */
 
-        GenTreeStmt* lastStmt = preHead->lastStmt();
+        Statement* lastStmt = preHead->lastStmt();
         assert(lastStmt->gtNext == nullptr);
 
         lastStmt->gtNext  = hoistStmt;
@@ -6820,7 +6820,7 @@ void Compiler::optHoistLoopBlocks(unsigned loopNum, ArrayStack<BasicBlock*>* blo
 
         void HoistBlock(BasicBlock* block)
         {
-            for (GenTreeStmt* stmt = block->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->gtNextStmt)
+            for (Statement* stmt = block->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->gtNextStmt)
             {
                 WalkTree(&stmt->gtStmtExpr, nullptr);
                 assert(m_valueStack.TopRef().Node() == stmt->gtStmtExpr);
@@ -7382,7 +7382,7 @@ void Compiler::fgCreateLoopPreHeader(unsigned lnum)
     // into the phi via the loop header block will now flow through the preheader
     // block from the header block.
 
-    for (GenTreeStmt* stmt = top->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+    for (Statement* stmt = top->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
     {
         GenTree* tree = stmt->gtStmtExpr;
         if (tree->OperGet() != GT_ASG)
@@ -7622,7 +7622,7 @@ void Compiler::optComputeLoopSideEffectsOfBlock(BasicBlock* blk)
     MemoryKindSet memoryHavoc = emptyMemoryKindSet;
 
     // Now iterate over the remaining statements, and their trees.
-    for (GenTreeStmt* stmt = blk->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->getNextStmt())
+    for (Statement* stmt = blk->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->getNextStmt())
     {
         for (GenTree* tree = stmt->gtStmtList; tree != nullptr; tree = tree->gtNext)
         {
@@ -7945,7 +7945,7 @@ void Compiler::AddModifiedElemTypeAllContainingLoops(unsigned lnum, CORINFO_CLAS
 //    tree   -  Range check tree
 //    stmt   -  Statement the tree belongs to
 
-void Compiler::optRemoveRangeCheck(GenTree* tree, GenTreeStmt* stmt)
+void Compiler::optRemoveRangeCheck(GenTree* tree, Statement* stmt)
 {
 #if !REARRANGE_ADDS
     noway_assert(!"can't remove range checks without REARRANGE_ADDS right now");
@@ -8155,7 +8155,7 @@ bool Compiler::optIdentifyLoopOptInfo(unsigned loopNum, LoopCloneContext* contex
     for (BasicBlock* block = beg; block != end->bbNext; block = block->bbNext)
     {
         compCurBB = block;
-        for (GenTreeStmt* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
         {
             info.stmt               = stmt;
             const bool lclVarsOnly  = false;
@@ -8834,7 +8834,7 @@ void Compiler::optOptimizeBools()
 
             /* The second block must contain a single statement */
 
-            GenTreeStmt* s2 = b2->firstStmt();
+            Statement* s2 = b2->firstStmt();
             if (s2->gtPrev != s2)
             {
                 continue;
@@ -8845,7 +8845,7 @@ void Compiler::optOptimizeBools()
 
             /* Find the condition for the first block */
 
-            GenTreeStmt* s1 = b1->lastStmt();
+            Statement* s1 = b1->lastStmt();
 
             GenTree* t1 = s1->gtStmtExpr;
             noway_assert(t1->gtOper == GT_JTRUE);

--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -188,7 +188,7 @@ bool RangeCheck::BetweenBounds(Range& range, int lower, GenTree* upper)
     return false;
 }
 
-void RangeCheck::OptimizeRangeCheck(BasicBlock* block, GenTreeStmt* stmt, GenTree* treeParent)
+void RangeCheck::OptimizeRangeCheck(BasicBlock* block, Statement* stmt, GenTree* treeParent)
 {
     // Check if we are dealing with a bounds check node.
     if (treeParent->OperGet() != GT_COMMA)
@@ -1257,11 +1257,11 @@ void RangeCheck::MapStmtDefs(const Location& loc)
 
 struct MapMethodDefsData
 {
-    RangeCheck*  rc;
-    BasicBlock*  block;
-    GenTreeStmt* stmt;
+    RangeCheck* rc;
+    BasicBlock* block;
+    Statement*  stmt;
 
-    MapMethodDefsData(RangeCheck* rc, BasicBlock* block, GenTreeStmt* stmt) : rc(rc), block(block), stmt(stmt)
+    MapMethodDefsData(RangeCheck* rc, BasicBlock* block, Statement* stmt) : rc(rc), block(block), stmt(stmt)
     {
     }
 };
@@ -1284,7 +1284,7 @@ void RangeCheck::MapMethodDefs()
     // First, gather where all definitions occur in the program and store it in a map.
     for (BasicBlock* block = m_pCompiler->fgFirstBB; block != nullptr; block = block->bbNext)
     {
-        for (GenTreeStmt* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
         {
             MapMethodDefsData data(this, block, stmt);
             m_pCompiler->fgWalkTreePre(&stmt->gtStmtExpr, MapMethodDefsVisitor, &data, false, true);
@@ -1313,7 +1313,7 @@ void RangeCheck::OptimizeRangeChecks()
     // Walk through trees looking for arrBndsChk node and check if it can be optimized.
     for (BasicBlock* block = m_pCompiler->fgFirstBB; block; block = block->bbNext)
     {
-        for (GenTreeStmt* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
         {
             for (GenTree* tree = stmt->gtStmtList; tree; tree = tree->gtNext)
             {

--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -1284,7 +1284,7 @@ void RangeCheck::MapMethodDefs()
     // First, gather where all definitions occur in the program and store it in a map.
     for (BasicBlock* block = m_pCompiler->fgFirstBB; block != nullptr; block = block->bbNext)
     {
-        for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt : block->Statements())
         {
             MapMethodDefsData data(this, block, stmt);
             m_pCompiler->fgWalkTreePre(&stmt->gtStmtExpr, MapMethodDefsVisitor, &data, false, true);
@@ -1313,7 +1313,7 @@ void RangeCheck::OptimizeRangeChecks()
     // Walk through trees looking for arrBndsChk node and check if it can be optimized.
     for (BasicBlock* block = m_pCompiler->fgFirstBB; block; block = block->bbNext)
     {
-        for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt : block->Statements())
         {
             for (GenTree* tree = stmt->gtStmtList; tree; tree = tree->gtNext)
             {

--- a/src/jit/rangecheck.h
+++ b/src/jit/rangecheck.h
@@ -415,10 +415,10 @@ public:
     struct Location
     {
         BasicBlock*          block;
-        GenTreeStmt*         stmt;
+        Statement*           stmt;
         GenTreeLclVarCommon* tree;
         GenTree*             parent;
-        Location(BasicBlock* block, GenTreeStmt* stmt, GenTreeLclVarCommon* tree, GenTree* parent)
+        Location(BasicBlock* block, Statement* stmt, GenTreeLclVarCommon* tree, GenTree* parent)
             : block(block), stmt(stmt), tree(tree), parent(parent)
         {
         }
@@ -463,7 +463,7 @@ public:
     // Given a "tree" node, check if it contains array bounds check node and
     // optimize to remove it, if possible. Requires "stmt" and "block" that
     // contain the tree.
-    void OptimizeRangeCheck(BasicBlock* block, GenTreeStmt* stmt, GenTree* tree);
+    void OptimizeRangeCheck(BasicBlock* block, Statement* stmt, GenTree* tree);
 
     // Given the index expression try to find its range.
     // The range of a variable depends on its rhs which in turn depends on its constituent variables.

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -240,7 +240,7 @@ void Rationalizer::SanityCheck()
     BasicBlock* block;
     foreach_block(comp, block)
     {
-        for (Statement* statement = block->firstStmt(); statement != nullptr; statement = statement->getNextStmt())
+        for (Statement* statement : block->Statements())
         {
             ValidateStatement(statement, block);
 
@@ -937,7 +937,7 @@ void Rationalizer::DoPhase()
             continue;
         }
 
-        for (Statement* statement = firstStatement; statement != nullptr; statement = statement->getNextStmt())
+        for (Statement* statement : StatementList(firstStatement))
         {
             assert(statement->gtStmtList != nullptr);
             assert(statement->gtStmtList->gtPrev == nullptr);

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -228,7 +228,7 @@ void Rationalizer::RewriteIntrinsicAsUserCall(GenTree** use, ArrayStack<GenTree*
 
 #ifdef DEBUG
 
-void Rationalizer::ValidateStatement(GenTreeStmt* stmt, BasicBlock* block)
+void Rationalizer::ValidateStatement(Statement* stmt, BasicBlock* block)
 {
     DBEXEC(TRUE, JitTls::GetCompiler()->fgDebugCheckNodeLinks(block, stmt));
 }
@@ -240,7 +240,7 @@ void Rationalizer::SanityCheck()
     BasicBlock* block;
     foreach_block(comp, block)
     {
-        for (GenTreeStmt* statement = block->firstStmt(); statement != nullptr; statement = statement->getNextStmt())
+        for (Statement* statement = block->firstStmt(); statement != nullptr; statement = statement->getNextStmt())
         {
             ValidateStatement(statement, block);
 
@@ -930,14 +930,14 @@ void Rationalizer::DoPhase()
 
         // Establish the first and last nodes for the block. This is necessary in order for the LIR
         // utilities that hang off the BasicBlock type to work correctly.
-        GenTreeStmt* firstStatement = block->firstStmt();
+        Statement* firstStatement = block->firstStmt();
         if (firstStatement == nullptr)
         {
             // No statements in this block; skip it.
             continue;
         }
 
-        for (GenTreeStmt* statement = firstStatement; statement != nullptr; statement = statement->getNextStmt())
+        for (Statement* statement = firstStatement; statement != nullptr; statement = statement->getNextStmt())
         {
             assert(statement->gtStmtList != nullptr);
             assert(statement->gtStmtList->gtPrev == nullptr);

--- a/src/jit/rationalize.h
+++ b/src/jit/rationalize.h
@@ -8,14 +8,14 @@
 class Rationalizer : public Phase
 {
 private:
-    BasicBlock*  m_block;
-    GenTreeStmt* m_statement;
+    BasicBlock* m_block;
+    Statement*  m_statement;
 
 public:
     Rationalizer(Compiler* comp);
 
 #ifdef DEBUG
-    static void ValidateStatement(GenTreeStmt* stmt, BasicBlock* block);
+    static void ValidateStatement(Statement* stmt, BasicBlock* block);
 
     // general purpose sanity checking of de facto standard GenTree
     void SanityCheck();

--- a/src/jit/simd.cpp
+++ b/src/jit/simd.cpp
@@ -2274,7 +2274,7 @@ GenTree* Compiler::createAddressNodeForSIMDInit(GenTree* tree, unsigned simdSize
 // Arguments:
 //      stmt - GenTree*. Input statement node.
 
-void Compiler::impMarkContiguousSIMDFieldAssignments(GenTreeStmt* stmt)
+void Compiler::impMarkContiguousSIMDFieldAssignments(Statement* stmt)
 {
     if (!featureSIMD || opts.OptimizationDisabled())
     {

--- a/src/jit/ssabuilder.cpp
+++ b/src/jit/ssabuilder.cpp
@@ -99,8 +99,8 @@ void Compiler::fgResetForSsa()
         }
         if (blk->bbStmtList != nullptr)
         {
-            GenTreeStmt* last = blk->lastStmt();
-            blk->bbStmtList   = blk->FirstNonPhiDef();
+            Statement* last = blk->lastStmt();
+            blk->bbStmtList = blk->FirstNonPhiDef();
             if (blk->bbStmtList != nullptr)
             {
                 blk->bbStmtList->gtPrev = last;
@@ -111,7 +111,7 @@ void Compiler::fgResetForSsa()
         // but only for reachable code, so clear them to avoid analysis getting confused
         // by stale annotations in unreachable code.
         blk->bbPostOrderNum = 0;
-        for (GenTreeStmt* stmt = blk->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+        for (Statement* stmt = blk->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
         {
             for (GenTree* tree = stmt->gtStmtList; tree != nullptr; tree = tree->gtNext)
             {
@@ -652,7 +652,7 @@ void SsaBuilder::ComputeIteratedDominanceFrontier(BasicBlock* b, const BlkToBlkV
 static GenTree* GetPhiNode(BasicBlock* block, unsigned lclNum)
 {
     // Walk the statements for phi nodes.
-    for (GenTreeStmt* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+    for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
     {
         // A prefix of the statements of the block are phi definition nodes. If we complete processing
         // that prefix, exit.
@@ -697,12 +697,12 @@ void SsaBuilder::InsertPhi(BasicBlock* block, unsigned lclNum)
     asg->SetCosts(0, 0);
 
     // Create the statement and chain everything in linear order - PHI, LCL_VAR, ASG
-    GenTreeStmt* stmt = m_pCompiler->gtNewStmt(asg);
-    stmt->gtStmtList  = phi;
-    phi->gtNext       = lhs;
-    lhs->gtPrev       = phi;
-    lhs->gtNext       = asg;
-    asg->gtPrev       = lhs;
+    Statement* stmt  = m_pCompiler->gtNewStmt(asg);
+    stmt->gtStmtList = phi;
+    phi->gtNext      = lhs;
+    lhs->gtPrev      = phi;
+    lhs->gtNext      = asg;
+    asg->gtPrev      = lhs;
 
 #ifdef DEBUG
     unsigned seqNum = 1;
@@ -728,7 +728,7 @@ void SsaBuilder::InsertPhi(BasicBlock* block, unsigned lclNum)
 //    pred   - The predecessor block
 //
 void SsaBuilder::AddPhiArg(
-    BasicBlock* block, GenTreeStmt* stmt, GenTreePhi* phi, unsigned lclNum, unsigned ssaNum, BasicBlock* pred)
+    BasicBlock* block, Statement* stmt, GenTreePhi* phi, unsigned lclNum, unsigned ssaNum, BasicBlock* pred)
 {
 #ifdef DEBUG
     // Make sure it isn't already present: we should only add each definition once.
@@ -1067,7 +1067,7 @@ void SsaBuilder::AddDefToHandlerPhis(BasicBlock* block, unsigned lclNum, unsigne
                 bool phiFound = false;
 #endif
                 // A prefix of blocks statements will be SSA definitions.  Search those for "lclNum".
-                for (GenTreeStmt* stmt = handler->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+                for (Statement* stmt = handler->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
                 {
                     // If the tree is not an SSA def, break out of the loop: we're done.
                     if (!stmt->IsPhiDefnStmt())
@@ -1226,9 +1226,9 @@ void SsaBuilder::BlockRenameVariables(BasicBlock* block, SsaRenameState* pRename
     // We need to iterate over phi definitions, to give them SSA names, but we need
     // to know which are which, so we don't add phi definitions to handler phi arg lists.
     // Statements are phi defns until they aren't.
-    bool         isPhiDefn   = true;
-    GenTreeStmt* firstNonPhi = block->FirstNonPhiDef();
-    for (GenTreeStmt* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+    bool       isPhiDefn   = true;
+    Statement* firstNonPhi = block->FirstNonPhiDef();
+    for (Statement* stmt = block->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
     {
         if (stmt == firstNonPhi)
         {
@@ -1293,8 +1293,7 @@ void SsaBuilder::AssignPhiNodeRhsVariables(BasicBlock* block, SsaRenameState* pR
     for (BasicBlock* succ : block->GetAllSuccs(m_pCompiler))
     {
         // Walk the statements for phi nodes.
-        for (GenTreeStmt* stmt = succ->firstStmt(); stmt != nullptr && stmt->IsPhiDefnStmt();
-             stmt              = stmt->getNextStmt())
+        for (Statement* stmt = succ->firstStmt(); stmt != nullptr && stmt->IsPhiDefnStmt(); stmt = stmt->getNextStmt())
         {
             GenTree* tree = stmt->gtStmtExpr;
             assert(tree->IsPhiDefn());
@@ -1420,7 +1419,7 @@ void SsaBuilder::AssignPhiNodeRhsVariables(BasicBlock* block, SsaRenameState* pR
                 // For a filter, we consider the filter to be the "real" handler.
                 BasicBlock* handlerStart = succTry->ExFlowBlock();
 
-                for (GenTreeStmt* stmt = handlerStart->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
+                for (Statement* stmt = handlerStart->firstStmt(); stmt != nullptr; stmt = stmt->getNextStmt())
                 {
                     GenTree* tree = stmt->gtStmtExpr;
 

--- a/src/jit/ssabuilder.h
+++ b/src/jit/ssabuilder.h
@@ -99,7 +99,7 @@ private:
 
     // Add a new GT_PHI_ARG node to an existing GT_PHI node
     void AddPhiArg(
-        BasicBlock* block, GenTreeStmt* stmt, GenTreePhi* phi, unsigned lclNum, unsigned ssaNum, BasicBlock* pred);
+        BasicBlock* block, Statement* stmt, GenTreePhi* phi, unsigned lclNum, unsigned ssaNum, BasicBlock* pred);
 
     // Requires "postOrder" to hold the blocks of the flowgraph in topologically sorted order. Requires
     // count to be the valid entries in the "postOrder" array. Inserts GT_PHI nodes at the beginning

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -5657,7 +5657,7 @@ void Compiler::fgValueNumber()
         for (BasicBlock* blk = fgFirstBB; blk != nullptr; blk = blk->bbNext)
         {
             // Now iterate over the block's statements, and their trees.
-            for (GenTreeStmt* stmt = blk->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->getNextStmt())
+            for (Statement* stmt = blk->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->getNextStmt())
             {
                 for (GenTree* tree = stmt->gtStmtList; tree != nullptr; tree = tree->gtNext)
                 {
@@ -5820,7 +5820,7 @@ void Compiler::fgValueNumberBlock(BasicBlock* blk)
     compCurStmtNum = blk->bbStmtNum - 1; // Set compCurStmtNum
 #endif
 
-    GenTreeStmt* stmt = blk->firstStmt();
+    Statement* stmt = blk->firstStmt();
 
     // First: visit phi's.  If "newVNForPhis", give them new VN's.  If not,
     // first check to see if all phi args have the same value.

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -5657,7 +5657,7 @@ void Compiler::fgValueNumber()
         for (BasicBlock* blk = fgFirstBB; blk != nullptr; blk = blk->bbNext)
         {
             // Now iterate over the block's statements, and their trees.
-            for (Statement* stmt = blk->FirstNonPhiDef(); stmt != nullptr; stmt = stmt->getNextStmt())
+            for (Statement* stmt : StatementList(blk->FirstNonPhiDef()))
             {
                 for (GenTree* tree = stmt->gtStmtList; tree != nullptr; tree = tree->gtNext)
                 {


### PR DESCRIPTION
This is one of the final set of changes. Contributes to #25899.
No asm diffs, no PIN diffs.

In this PR:
- Rename `GenTreeStmt` to `Statement`;
- Add iterators for statements;
- Return void from GenTreeStmt* fgInsertStmtSomewhere.

Fix comments/headers along the way.

I have a PR that has more upcoming changes #26610, but it is too big to be reviewed/merged, so I split it.

As usual, I recommend to review by commits:
c2f67b7c54: Rename `GenTreeStmt` to `Statement`.                                     
                                                                                     
096ef85f59: Move `Statements::IsPhiDefnStmt` implementation to the header.           
                                                                                     
3f04470c3f: Add iterators for statements.                                            
                                                                                     
So we have fewer places where we access Statement's fields.                           
                                                                                     
1281108bd1: Add a header for `fgInsertStmtListAfter`.
                                                                                     
46d67ffd7c: Change `fgInsertStmtAtBeg` not to return a value.                        
                                                                                     
and add headers for `fgInsertStmtAtBeg` and `fgNewStmtAtBeg`.                        
                                                                                     
720d135b1b: Change `fgInsertStmtBefore` and `fgInsertStmtAfter` not to return.       
                                                                                     
56d5db1403: Change `fgInsertStmtNearEnd` not to return.                              
                                                                                     
3bdd7bb727: Change `fgInsertStmtAtEnd` not to return.                                
