### PR TITLE
Fix watson bucketing/broken triage dumps

### DIFF
--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -5475,6 +5475,15 @@ MethodDesc::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
         }
     }
 
+#ifdef FEATURE_CODE_VERSIONING
+    // Make sure the active IL and native code version are in triage dumps.
+    CodeVersionManager* codeVersionManager = GetCodeVersionManager();
+    if (codeVersionManager != NULL) 
+    {
+        codeVersionManager->GetActiveILCodeVersion(PTR_MethodDesc(this)).GetActiveNativeCodeVersion(PTR_MethodDesc(this));
+    }
+#endif
+
     // Also, call DacValidateMD to dump the memory it needs. !clrstack calls 
     // DacValidateMD before it retrieves the method name. We don't expect 
     // DacValidateMD to fail, but if it does, ignore the failure and try to assemble the 


### PR DESCRIPTION
The DAC EnumMemoryRegions needs to include some missing code version manager memory.