### PR TITLE
WIP Correct GetFramePointerForDebugger

### DIFF
--- a/src/debug/di/module.cpp
+++ b/src/debug/di/module.cpp
@@ -1550,7 +1550,8 @@ HRESULT CordbModule::GetFunctionFromToken(mdMethodDef token,
         RSLockHolder lockHolder(GetProcess()->GetProcessLock());
 
         // Check token is valid.
-        if ((token == mdMethodDefNil) || 
+        if ((token == mdMethodDefNil) ||
+            (TypeFromToken(token) != mdtMethodDef) ||
             (!GetMetaDataImporter()->IsValidToken(token)))
         {
             ThrowHR(E_INVALIDARG);

--- a/src/debug/di/rsfunction.cpp
+++ b/src/debug/di/rsfunction.cpp
@@ -49,6 +49,7 @@ CordbFunction::CordbFunction(CordbModule * m,
     m_methodSigParserCached = SigParser(NULL, 0);
 
     _ASSERTE(enCVersion >= CorDB_DEFAULT_ENC_FUNCTION_VERSION);
+    _ASSERTE(TypeFromToken(m_MDToken) == mdtMethodDef);
 }
 
 

--- a/src/debug/di/rspriv.h
+++ b/src/debug/di/rspriv.h
@@ -5537,7 +5537,7 @@ private:
     RSSmartPtr<CordbNativeCode> m_nativeCode;
 
     // Metadata Token for the IL function. Scoped to m_module.
-    mdMethodDef              m_MDToken;
+    const mdMethodDef        m_MDToken;
 
     // EnC version number of this instance
     SIZE_T                   m_dwEnCVersionNumber; 

--- a/src/debug/ee/frameinfo.cpp
+++ b/src/debug/ee/frameinfo.cpp
@@ -1269,7 +1269,7 @@ FramePointer GetFramePointerForDebugger(DebuggerFrameData* pData, CrawlFrame* pC
     if (pData->info.frame == NULL)
     {
         // This is a managed method frame.
-        fpResult = FramePointer::MakeFramePointer((LPVOID)GetRegdisplayStackMark(&pData->info.registers));
+        fpResult = FramePointer::MakeFramePointer((LPVOID)GetRegdisplayStackMark(&pData->regDisplay));
     }
     else
     {


### PR DESCRIPTION
Calculate the FramePointer from the parent frame's SP.

This fixes our debug/ee `FramePointers` to be actual frame pointers rather that stack pointers. 

The comments all treat the `FramePointer` as if it is a pointer to the caller's SP. The `FUNCLET` implementation broke this **years** ago. 

It is not clear if there are work arounds for this bug elsewhere in the code. If so, these will need to be removed.

Fixes #14926