### PR TITLE
Some SuperIlc cleanup and improvements

### DIFF
--- a/src/tools/ReadyToRun.SuperIlc/BuildFolder.cs
+++ b/src/tools/ReadyToRun.SuperIlc/BuildFolder.cs
@@ -153,10 +153,13 @@ namespace ReadyToRun.SuperIlc
             foreach (CompilerRunner runner in compilerRunners)
             {
                 string runnerOutputPath = runner.GetOutputPath(outputRoot);
-                runnerOutputPath.RecreateDirectory();
-                foreach (string file in passThroughFiles)
+                if (!options.Exe)
                 {
-                    File.Copy(file, Path.Combine(runnerOutputPath, Path.GetFileName(file)));
+                    runnerOutputPath.RecreateDirectory();
+                    foreach (string file in passThroughFiles)
+                    {
+                        File.Copy(file, Path.Combine(runnerOutputPath, Path.GetFileName(file)));
+                    }
                 }
             }
 

--- a/src/tools/ReadyToRun.SuperIlc/BuildOptions.cs
+++ b/src/tools/ReadyToRun.SuperIlc/BuildOptions.cs
@@ -13,8 +13,8 @@ namespace ReadyToRun.SuperIlc
         public DirectoryInfo InputDirectory { get; set; }
         public DirectoryInfo OutputDirectory { get; set; }
         public DirectoryInfo CoreRootDirectory { get; set; }
-        public DirectoryInfo CpaotDirectory { get; set; }
         public bool Crossgen { get; set; }
+        public bool Exe { get; set; }
         public bool NoJit { get; set; }
         public bool NoExe { get; set; }
         public bool NoEtw { get; set; }
@@ -76,25 +76,15 @@ namespace ReadyToRun.SuperIlc
         {
             List<CompilerRunner> runners = new List<CompilerRunner>();
 
-            if (CpaotDirectory != null)
-            {
-                List<string> referencePaths = new List<string>();
-                referencePaths.Add(CoreRootOutputPath(CompilerIndex.CPAOT, isFramework));
-                referencePaths.AddRange(overrideReferencePaths != null ? overrideReferencePaths : ReferencePaths());
-                runners.Add(new CpaotRunner(this, referencePaths));
-            }
+            List<string> cpaotReferencePaths = new List<string>();
+            cpaotReferencePaths.Add(CoreRootOutputPath(CompilerIndex.CPAOT, isFramework));
+            cpaotReferencePaths.AddRange(overrideReferencePaths != null ? overrideReferencePaths : ReferencePaths());
+            runners.Add(new CpaotRunner(this, cpaotReferencePaths));
 
-            if (Crossgen)
-            {
-                if (CoreRootDirectory == null)
-                {
-                    throw new Exception("-coreroot folder not specified, cannot use Crossgen runner");
-                }
-                List<string> referencePaths = new List<string>();
-                referencePaths.Add(CoreRootOutputPath(CompilerIndex.Crossgen, isFramework));
-                referencePaths.AddRange(overrideReferencePaths != null ? overrideReferencePaths : ReferencePaths());
-                runners.Add(new CrossgenRunner(this, referencePaths));
-            }
+            List<string> crossgenReferencePaths = new List<string>();
+            crossgenReferencePaths.Add(CoreRootOutputPath(CompilerIndex.Crossgen, isFramework));
+            crossgenReferencePaths.AddRange(overrideReferencePaths != null ? overrideReferencePaths : ReferencePaths());
+            runners.Add(new CrossgenRunner(this, crossgenReferencePaths));
 
             if (!NoJit)
             {

--- a/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
+++ b/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
@@ -32,6 +32,7 @@ namespace ReadyToRun.SuperIlc
                         CpaotDirectory(),
                         Crossgen(),
                         NoJit(),
+                        Exe(),
                         NoExe(),
                         NoEtw(),
                         NoCleanup(),
@@ -59,6 +60,7 @@ namespace ReadyToRun.SuperIlc
                         CpaotDirectory(),
                         Crossgen(),
                         NoJit(),
+                        Exe(),
                         NoExe(),
                         NoEtw(),
                         NoCleanup(),
@@ -135,11 +137,14 @@ namespace ReadyToRun.SuperIlc
             Option NoJit() =>
                 new Option(new[] { "--nojit" }, "Don't run tests in JITted mode", new Argument<bool>());
 
-            Option NoEtw() =>
-                new Option(new[] { "--noetw" }, "Don't capture jitted methods using ETW", new Argument<bool>());
+            Option Exe() =>
+                new Option(new[] { "--exe" }, "Don't compile tests, just execute them", new Argument<bool>());
 
             Option NoExe() =>
                 new Option(new[] { "--noexe" }, "Compilation-only mode (don't execute the built apps)", new Argument<bool>());
+
+            Option NoEtw() =>
+                new Option(new[] { "--noetw" }, "Don't capture jitted methods using ETW", new Argument<bool>());
 
             Option NoCleanup() =>
                 new Option(new[] { "--nocleanup" }, "Don't clean up compilation artifacts after test runs", new Argument<bool>());

--- a/src/tools/ReadyToRun.SuperIlc/Commands/CompileDirectoryCommand.cs
+++ b/src/tools/ReadyToRun.SuperIlc/Commands/CompileDirectoryCommand.cs
@@ -20,6 +20,12 @@ namespace ReadyToRun.SuperIlc
                 return 1;
             }
 
+            if (options.CoreRootDirectory == null)
+            {
+                Console.Error.WriteLine("--core-root-directory (--cr) is a required argument.");
+                return 1;
+            }
+
             if (options.OutputDirectory == null)
             {
                 options.OutputDirectory = options.InputDirectory;
@@ -33,7 +39,10 @@ namespace ReadyToRun.SuperIlc
 
             IEnumerable<CompilerRunner> runners = options.CompilerRunners(isFramework: false);
 
-            PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, recursive: false);
+            if (!options.Exe)
+            {
+                PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, recursive: false);
+            }
 
             BuildFolder folder = BuildFolder.FromDirectory(options.InputDirectory.FullName, runners, options.OutputDirectory.FullName, options);
             if (folder == null)
@@ -45,7 +54,7 @@ namespace ReadyToRun.SuperIlc
             bool success = folderSet.Build(runners);
             folderSet.WriteLogs();
 
-            if (!options.NoCleanup)
+            if (!options.NoCleanup && !options.Exe)
             {
                 PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, recursive: false);
             }

--- a/src/tools/ReadyToRun.SuperIlc/Commands/CompileFromCrossgenRspCommand.cs
+++ b/src/tools/ReadyToRun.SuperIlc/Commands/CompileFromCrossgenRspCommand.cs
@@ -27,6 +27,12 @@ namespace ReadyToRun.SuperIlc
                 return 1;
             }
 
+            if (options.CoreRootDirectory == null)
+            {
+                Console.Error.WriteLine("--core-root-directory (--cr) is a required argument.");
+                return 1;
+            }
+
             if (options.OutputDirectory == null)
             {
                 if (options.InputDirectory != null)

--- a/src/tools/ReadyToRun.SuperIlc/Commands/CompileNugetCommand.cs
+++ b/src/tools/ReadyToRun.SuperIlc/Commands/CompileNugetCommand.cs
@@ -18,6 +18,12 @@ namespace ReadyToRun.SuperIlc
     {
         public static int CompileNuget(BuildOptions options)
         {
+            if (options.CoreRootDirectory == null)
+            {
+                Console.Error.WriteLine("--core-root-directory (--cr) is a required argument.");
+                return 1;
+            }
+
             // We don't want to launch these apps when building the folder set below
             options.NoExe = true;
             options.NoJit = true;
@@ -34,7 +40,10 @@ namespace ReadyToRun.SuperIlc
             IEnumerable<string> referencePaths = options.ReferencePaths();
             IEnumerable<CompilerRunner> runners = options.CompilerRunners(false);
 
-            PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, recursive: false);
+            if (!options.Exe)
+            {
+                PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, recursive: false);
+            }
 
             string nugetOutputFolder = Path.Combine(options.OutputDirectory.FullName, "nuget.out");
             Directory.CreateDirectory(nugetOutputFolder);
@@ -86,7 +95,7 @@ namespace ReadyToRun.SuperIlc
                 bool success = folderSet.Build(runners);
                 folderSet.WriteLogs();
 
-                if (!options.NoCleanup)
+                if (!options.NoCleanup && !options.Exe)
                 {
                     PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, recursive: false);
                 }

--- a/src/tools/ReadyToRun.SuperIlc/Commands/CompileSubtreeCommand.cs
+++ b/src/tools/ReadyToRun.SuperIlc/Commands/CompileSubtreeCommand.cs
@@ -23,6 +23,12 @@ namespace ReadyToRun.SuperIlc
                 return 1;
             }
 
+            if (options.CoreRootDirectory == null)
+            {
+                Console.Error.WriteLine("--core-root-directory (--cr) is a required argument.");
+                return 1;
+            }
+
             if (options.OutputDirectory == null)
             {
                 options.OutputDirectory = options.InputDirectory;
@@ -36,7 +42,10 @@ namespace ReadyToRun.SuperIlc
 
             IEnumerable<CompilerRunner> runners = options.CompilerRunners(isFramework: false);
 
-            PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, recursive: true);
+            if (!options.Exe)
+            {
+                PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, recursive: true);
+            }
 
             string[] directories = LocateSubtree(
                 options.InputDirectory.FullName,

--- a/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
+++ b/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
@@ -28,13 +28,11 @@ namespace ReadyToRun.SuperIlc
         public const int R2RDumpTimeoutMilliseconds = 60 * 1000;
 
         protected readonly BuildOptions _options;
-        protected readonly string _compilerPath;
         protected readonly IEnumerable<string> _referenceFolders;
 
-        public CompilerRunner(BuildOptions options, string compilerFolder, IEnumerable<string> referenceFolders)
+        public CompilerRunner(BuildOptions options, IEnumerable<string> referenceFolders)
         {
             _options = options;
-            _compilerPath = compilerFolder;
             _referenceFolders = referenceFolders;
         }
 
@@ -44,6 +42,7 @@ namespace ReadyToRun.SuperIlc
 
         public string CompilerName => Index.ToString();
 
+        protected abstract string CompilerRelativePath { get;  }
         protected abstract string CompilerFileName { get; }
         protected abstract IEnumerable<string> BuildCommandLineArguments(string assemblyFileName, string outputFileName);
 
@@ -57,7 +56,7 @@ namespace ReadyToRun.SuperIlc
             CreateResponseFile(responseFile, commandLineArgs);
 
             ProcessParameters processParameters = new ProcessParameters();
-            processParameters.ProcessPath = Path.Combine(_compilerPath, CompilerFileName);
+            processParameters.ProcessPath = Path.Combine(_options.CoreRootDirectory.FullName, CompilerRelativePath, CompilerFileName);
             processParameters.Arguments = $"@{responseFile}";
             if (_options.CompilationTimeoutMinutes != 0)
             {

--- a/src/tools/ReadyToRun.SuperIlc/CpaotRunner.cs
+++ b/src/tools/ReadyToRun.SuperIlc/CpaotRunner.cs
@@ -17,12 +17,14 @@ namespace ReadyToRun.SuperIlc
     {
         public override CompilerIndex Index => CompilerIndex.CPAOT;
 
+        protected override string CompilerRelativePath => "crossgen2";
+
         protected override string CompilerFileName => "crossgen2".OSExeSuffix();
 
         private List<string> _resolvedReferences;
 
         public CpaotRunner(BuildOptions options, IEnumerable<string> referencePaths)
-            : base(options, options.CpaotDirectory.FullName, referencePaths)
+            : base(options, referencePaths)
         { }
 
         protected override ProcessParameters ExecutionProcess(IEnumerable<string> modules, IEnumerable<string> folders, bool noEtw)

--- a/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
+++ b/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
@@ -17,10 +17,12 @@ namespace ReadyToRun.SuperIlc
     {
         public override CompilerIndex Index => CompilerIndex.Crossgen;
 
+        protected override string CompilerRelativePath => ".";
+
         protected override string CompilerFileName => "crossgen".OSExeSuffix();
 
         public CrossgenRunner(BuildOptions options, IEnumerable<string> referencePaths)
-            : base(options, options.CoreRootDirectory.FullName, referencePaths) { }
+            : base(options, referencePaths) { }
 
         protected override ProcessParameters ExecutionProcess(IEnumerable<string> modules, IEnumerable<string> folders, bool noEtw)
         {
@@ -40,8 +42,10 @@ namespace ReadyToRun.SuperIlc
             yield return "/out";
             yield return outputFileName;
 
-            if (_options.LargeBubble)
+            if (_options.LargeBubble && Path.GetFileNameWithoutExtension(assemblyFileName) != "System.Private.CoreLib")
             {
+                // There seems to be a bug in Crossgen on Linux we don't intend to fix -
+                // it crashes when trying to compile S.P.C in large version bubble mode.
                 yield return "/largeversionbubble";
             }
 

--- a/src/tools/ReadyToRun.SuperIlc/JitRunner.cs
+++ b/src/tools/ReadyToRun.SuperIlc/JitRunner.cs
@@ -16,10 +16,12 @@ namespace ReadyToRun.SuperIlc
     {
         public override CompilerIndex Index => CompilerIndex.Jit;
 
+        protected override string CompilerRelativePath => ".";
+
         protected override string CompilerFileName => "clrjit.dll";
 
         public JitRunner(BuildOptions options) 
-            : base(options, null, new string[] { options.CoreRootDirectory.FullName }.Concat(options.ReferencePaths())) { }
+            : base(options, new string[] { options.CoreRootDirectory.FullName }.Concat(options.ReferencePaths())) { }
 
         /// <summary>
         /// JIT runner has no compilation process as it doesn't transform the source IL code in any manner.


### PR DESCRIPTION
1) Remove the parameter -cpaot as it's no longer needed now that
Crossgen2 also resides under Core_Root.

2) Add new parameter --exe to only execute the tests without
compilation. JanV specifically asked for this to speed up his
inner testing loop on Linux.

3) Don't pass /largeversionbubble to the [legacy] Crossgen
compilation of System.Private.CoreLib as it apparently crashes
on Linux and we are no longer interested in fixing that.

Thanks

Tomas