### PR TITLE
BGC tuning using the free list with PI loops

### DIFF
--- a/src/gc/gc.h
+++ b/src/gc/gc.h
@@ -70,6 +70,9 @@ enum gc_reason
     reason_lowmemory_host = 11,
     reason_pm_full_gc = 12, // provisional mode requested to trigger full GC
     reason_lowmemory_host_blocking = 13,
+    reason_bgc_tuning_soh = 14,
+    reason_bgc_tuning_loh = 15,
+    reason_bgc_stepping = 16,
     reason_max
 };
 

--- a/src/gc/gcconfig.h
+++ b/src/gc/gcconfig.h
@@ -50,71 +50,105 @@ public:
     const char* Get() const { return m_str; }
 };
 
+// Note that the configs starting BGCFLTuningEnabled ending BGCG2RatioStep are for BGC servo
+// tuning which is currently an experimental feature which is why I'm not putting any of these
+// in clrconfigvalues.h (yet). 
+// The only public facing configs are BGCFLTuningEnabled and BGCMemGoal. 
+// Currently the set point is the BGCMemGoal you specify, which indicates what physical memory
+// load you'd like GC to maintain. And BGCFLTuningEnabled is to enable/disable this tuning.
+// 
+// The value for BGCG2RatioStep, BGCFLkd and BGCFLSmoothFactor and BGCFLff will be divided by 100.
+// The value for BGCMLkp and BGCMLki will be divided by 1000.
+// The value for BGCFLkp and BGCFLki will be divided by 1000000.
+
 // Each one of these keys produces a method on GCConfig with the name "Get{name}", where {name}
 // is the first parameter of the *_CONFIG macros below.
 #define GC_CONFIGURATION_KEYS \
-  BOOL_CONFIG(ServerGC,     "gcServer",     false, "Whether we should be using Server GC")     \
-  BOOL_CONFIG(ConcurrentGC, "gcConcurrent", true,  "Whether we should be using Concurrent GC") \
-  BOOL_CONFIG(ConservativeGC, "gcConservative", false, "Enables/Disables conservative GC")     \
-  BOOL_CONFIG(ForceCompact, "gcForceCompact", false,                                           \
-      "When set to true, always do compacting GC")                                             \
-  BOOL_CONFIG(RetainVM,     "GCRetainVM",   false,                                             \
-      "When set we put the segments that should be deleted on a standby list (instead of "     \
-      "releasing them back to the OS) which will be considered to satisfy new segment requests"\
-     " (note that the same thing can be specified via API which is the supported way)")        \
-  BOOL_CONFIG(StressMix,    "GCStressMix",  false,                                             \
-      "Specifies whether the GC mix mode is enabled or not")                                   \
-  BOOL_CONFIG(BreakOnOOM,   "GCBreakOnOOM", false,                                             \
-      "Does a DebugBreak at the soonest time we detect an OOM")                                \
-  BOOL_CONFIG(NoAffinitize, "GCNoAffinitize", false,                                           \
-      "If set, do not affinitize server GC threads")                                           \
-  BOOL_CONFIG(LogEnabled,   "GCLogEnabled", false,                                             \
-      "Specifies if you want to turn on logging in GC")                                        \
-  BOOL_CONFIG(ConfigLogEnabled, "GCConfigLogEnabled", false,                                   \
-      "Specifies the name of the GC config log file")                                          \
-  BOOL_CONFIG(GCNumaAware,   "GCNumaAware", true, "Enables numa allocations in the GC")        \
-  BOOL_CONFIG(GCCpuGroup,    "GCCpuGroup", false, "Enables CPU groups in the GC")              \
-  BOOL_CONFIG(GCLargePages,  "GCLargePages", false, "Enables using Large Pages in the GC")     \
-  INT_CONFIG(HeapVerifyLevel, "HeapVerify", HEAPVERIFY_NONE,                                   \
-      "When set verifies the integrity of the managed heap on entry and exit of each GC")      \
-  INT_CONFIG(LOHCompactionMode, "GCLOHCompact", 0, "Specifies the LOH compaction mode")        \
-  INT_CONFIG(LOHThreshold, "GCLOHThreshold", LARGE_OBJECT_SIZE,                                \
-      "Specifies the size that will make objects go on LOH")                                   \
-  INT_CONFIG(BGCSpinCount,  "BGCSpinCount", 140, "Specifies the bgc spin count")               \
-  INT_CONFIG(BGCSpin,       "BGCSpin",      2,   "Specifies the bgc spin time")                \
-  INT_CONFIG(HeapCount,     "GCHeapCount",  0,   "Specifies the number of server GC heaps")    \
-  INT_CONFIG(Gen0Size,      "GCgen0size",   0, "Specifies the smallest gen0 size")             \
-  INT_CONFIG(SegmentSize,   "GCSegmentSize", 0, "Specifies the managed heap segment size")     \
-  INT_CONFIG(LatencyMode,   "GCLatencyMode", -1,                                               \
-      "Specifies the GC latency mode - batch, interactive or low latency (note that the same " \
-      "thing can be specified via API which is the supported way")                             \
-  INT_CONFIG(LatencyLevel,  "GCLatencyLevel", 1,                                               \
-      "Specifies the GC latency level that you want to optimize for. Must be a number from 0"  \
-      "3. See documentation for more details on each level.")                                  \
-  INT_CONFIG(LogFileSize,   "GCLogFileSize", 0, "Specifies the GC log file size")              \
-  INT_CONFIG(CompactRatio,  "GCCompactRatio", 0,                                               \
-      "Specifies the ratio compacting GCs vs sweeping")                                        \
-  INT_CONFIG(GCHeapAffinitizeMask, "GCHeapAffinitizeMask", 0,                                  \
-      "Specifies processor mask for Server GC threads")                                        \
-  STRING_CONFIG(GCHeapAffinitizeRanges, "GCHeapAffinitizeRanges",                              \
-      "Specifies list of processors for Server GC threads. The format is a comma separated "   \
-      "list of processor numbers or ranges of processor numbers. On Windows, each entry is "   \
-      "prefixed by the CPU group number. Example: Unix - 1,3,5,7-9,12, Windows - 0:1,1:7-9")   \
-  INT_CONFIG(GCHighMemPercent, "GCHighMemPercent", 0,                                          \
-      "The percent for GC to consider as high memory")                                         \
-  INT_CONFIG(GCProvModeStress, "GCProvModeStress", 0,                                          \
-      "Stress the provisional modes")                                                          \
-  INT_CONFIG(GCGen0MaxBudget, "GCGen0MaxBudget", 0,                                            \
-      "Specifies the largest gen0 allocation budget")                                          \
-  INT_CONFIG(GCHeapHardLimit, "GCHeapHardLimit", 0,                                            \
-      "Specifies a hard limit for the GC heap")                                                \
-  INT_CONFIG(GCHeapHardLimitPercent, "GCHeapHardLimitPercent", 0,                              \
-      "Specifies the GC heap usage as a percentage of the total memory")                       \
-  STRING_CONFIG(LogFile,    "GCLogFile",    "Specifies the name of the GC log file")           \
-  STRING_CONFIG(ConfigLogFile, "GCConfigLogFile",                                              \
-      "Specifies the name of the GC config log file")                                          \
-  STRING_CONFIG(MixLogFile, "GCMixLog",                                                        \
-      "Specifies the name of the log file for GC mix statistics")
+    BOOL_CONFIG(ServerGC,     "gcServer",     false, "Whether we should be using Server GC")     \
+    BOOL_CONFIG(ConcurrentGC, "gcConcurrent", true,  "Whether we should be using Concurrent GC") \
+    BOOL_CONFIG(ConservativeGC, "gcConservative", false, "Enables/Disables conservative GC")     \
+    BOOL_CONFIG(ForceCompact, "gcForceCompact", false,                                           \
+        "When set to true, always do compacting GC")                                             \
+    BOOL_CONFIG(RetainVM,     "GCRetainVM",   false,                                             \
+        "When set we put the segments that should be deleted on a standby list (instead of "     \
+        "releasing them back to the OS) which will be considered to satisfy new segment requests"\
+        " (note that the same thing can be specified via API which is the supported way)")        \
+    BOOL_CONFIG(StressMix,    "GCStressMix",  false,                                             \
+        "Specifies whether the GC mix mode is enabled or not")                                   \
+    BOOL_CONFIG(BreakOnOOM,   "GCBreakOnOOM", false,                                             \
+        "Does a DebugBreak at the soonest time we detect an OOM")                                \
+    BOOL_CONFIG(NoAffinitize, "GCNoAffinitize", false,                                           \
+        "If set, do not affinitize server GC threads")                                           \
+    BOOL_CONFIG(LogEnabled,   "GCLogEnabled", false,                                             \
+        "Specifies if you want to turn on logging in GC")                                        \
+    BOOL_CONFIG(ConfigLogEnabled, "GCConfigLogEnabled", false,                                   \
+        "Specifies the name of the GC config log file")                                          \
+    BOOL_CONFIG(GCNumaAware,   "GCNumaAware", true, "Enables numa allocations in the GC")        \
+    BOOL_CONFIG(GCCpuGroup,    "GCCpuGroup", false, "Enables CPU groups in the GC")              \
+    BOOL_CONFIG(GCLargePages,  "GCLargePages", false, "Enables using Large Pages in the GC")     \
+    INT_CONFIG(HeapVerifyLevel, "HeapVerify", HEAPVERIFY_NONE,                                   \
+        "When set verifies the integrity of the managed heap on entry and exit of each GC")      \
+    INT_CONFIG(LOHCompactionMode, "GCLOHCompact", 0, "Specifies the LOH compaction mode")        \
+    INT_CONFIG(LOHThreshold, "GCLOHThreshold", LARGE_OBJECT_SIZE,                                \
+        "Specifies the size that will make objects go on LOH")                                   \
+    INT_CONFIG(BGCSpinCount,  "BGCSpinCount", 140, "Specifies the bgc spin count")               \
+    INT_CONFIG(BGCSpin,       "BGCSpin",      2,   "Specifies the bgc spin time")                \
+    INT_CONFIG(HeapCount,     "GCHeapCount",  0,   "Specifies the number of server GC heaps")    \
+    INT_CONFIG(Gen0Size,      "GCgen0size",   0, "Specifies the smallest gen0 size")             \
+    INT_CONFIG(SegmentSize,   "GCSegmentSize", 0, "Specifies the managed heap segment size")     \
+    INT_CONFIG(LatencyMode,   "GCLatencyMode", -1,                                               \
+        "Specifies the GC latency mode - batch, interactive or low latency (note that the same " \
+        "thing can be specified via API which is the supported way")                             \
+    INT_CONFIG(LatencyLevel,  "GCLatencyLevel", 1,                                               \
+        "Specifies the GC latency level that you want to optimize for. Must be a number from 0"  \
+        "3. See documentation for more details on each level.")                                  \
+    INT_CONFIG(LogFileSize,   "GCLogFileSize", 0, "Specifies the GC log file size")              \
+    INT_CONFIG(CompactRatio,  "GCCompactRatio", 0,                                               \
+        "Specifies the ratio compacting GCs vs sweeping")                                        \
+    INT_CONFIG(GCHeapAffinitizeMask, "GCHeapAffinitizeMask", 0,                                  \
+        "Specifies processor mask for Server GC threads")                                        \
+    STRING_CONFIG(GCHeapAffinitizeRanges, "GCHeapAffinitizeRanges",                              \
+        "Specifies list of processors for Server GC threads. The format is a comma separated "   \
+        "list of processor numbers or ranges of processor numbers. On Windows, each entry is "   \
+        "prefixed by the CPU group number. Example: Unix - 1,3,5,7-9,12, Windows - 0:1,1:7-9")   \
+    INT_CONFIG(GCHighMemPercent, "GCHighMemPercent", 0,                                          \
+        "The percent for GC to consider as high memory")                                         \
+    INT_CONFIG(GCProvModeStress, "GCProvModeStress", 0,                                          \
+        "Stress the provisional modes")                                                          \
+    INT_CONFIG(GCGen0MaxBudget, "GCGen0MaxBudget", 0,                                            \
+        "Specifies the largest gen0 allocation budget")                                          \
+    INT_CONFIG(GCHeapHardLimit, "GCHeapHardLimit", 0,                                            \
+        "Specifies a hard limit for the GC heap")                                                \
+    INT_CONFIG(GCHeapHardLimitPercent, "GCHeapHardLimitPercent", 0,                              \
+        "Specifies the GC heap usage as a percentage of the total memory")                       \
+    STRING_CONFIG(LogFile,    "GCLogFile",    "Specifies the name of the GC log file")           \
+    STRING_CONFIG(ConfigLogFile, "GCConfigLogFile",                                              \
+        "Specifies the name of the GC config log file")                                          \
+    STRING_CONFIG(MixLogFile, "GCMixLog",                                                        \
+        "Specifies the name of the log file for GC mix statistics")                              \
+    INT_CONFIG(BGCFLTuningEnabled, "BGCFLTuningEnabled", 0, "Enables FL tuning")                 \
+    INT_CONFIG(BGCMemGoal, "BGCMemGoal", 75, "Specifies the physical memory load goal")          \
+    INT_CONFIG(BGCMemGoalSlack, "BGCMemGoalSlack", 10,                                           \
+        "Specifies comfort zone of going above goal")                                            \
+    INT_CONFIG(BGCFLSweepGoal, "BGCFLSweepGoal", 0,                                              \
+        "Specifies the gen2 sweep FL ratio goal")                                                \
+    INT_CONFIG(BGCFLSweepGoalLOH, "BGCFLSweepGoalLOH", 0,                                        \
+        "Specifies the LOH sweep FL ratio goal")                                                 \
+    INT_CONFIG(BGCFLkp, "BGCFLkp", 6000, "Specifies kp for above goal tuning")                   \
+    INT_CONFIG(BGCFLki, "BGCFLki", 1000, "Specifies ki for above goal tuning")                   \
+    INT_CONFIG(BGCFLkd, "BGCFLkd", 11, "Specifies kd for above goal tuning")                     \
+    INT_CONFIG(BGCFLff, "BGCFLff", 100, "Specifies ff ratio")                                    \
+    INT_CONFIG(BGCFLSmoothFactor, "BGCFLSmoothFactor", 150, "Smoothing over these")              \
+    INT_CONFIG(BGCFLGradualD, "BGCFLGradualD", 0,                                                \
+        "Enable gradual D instead of cutting of at the value")                                   \
+    INT_CONFIG(BGCMLkp, "BGCMLkp", 1000, "Specifies kp for ML tuning")                           \
+    INT_CONFIG(BGCMLki, "BGCMLki", 16, "Specifies ki for ML tuning")                          \
+    INT_CONFIG(BGCFLEnableKi, "BGCFLEnableKi", 1, "Enables ki for above goal tuning")            \
+    INT_CONFIG(BGCFLEnableKd, "BGCFLEnableKd", 0, "Enables kd for above goal tuning")            \
+    INT_CONFIG(BGCFLEnableSmooth, "BGCFLEnableSmooth", 0, "Enables smoothing")                   \
+    INT_CONFIG(BGCFLEnableTBH, "BGCFLEnableTBH", 0, "Enables TBH")                               \
+    INT_CONFIG(BGCFLEnableFF, "BGCFLEnableFF", 0, "Enables FF")                                  \
+    INT_CONFIG(BGCG2RatioStep, "BGCG2RatioStep", 5, "Ratio correction factor for ML loop")
 
 // This class is responsible for retreiving configuration information
 // for how the GC should operate.

--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -122,6 +122,7 @@ inline void FATAL_GC_ERROR()
 
 #ifdef BACKGROUND_GC
 #define MARK_ARRAY      //Mark bit in an array
+#define BGC_SERVO_TUNING
 #endif //BACKGROUND_GC
 
 #if defined(BACKGROUND_GC) || defined (CARD_BUNDLE) || defined(FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP)
@@ -255,7 +256,7 @@ const int policy_expand  = 2;
 #define SEG_REUSE_LOG_0 7
 #define SEG_REUSE_LOG_1 (SEG_REUSE_LOG_0 + 1)
 #define DT_LOG_0 (SEG_REUSE_LOG_1 + 1)
-#define BGC_LOG (DT_LOG_0 + 1)
+#define BGC_TUNING_LOG (DT_LOG_0 + 1)
 #define GTC_LOG (DT_LOG_0 + 2)
 #define GC_TABLE_LOG (DT_LOG_0 + 3)
 #define JOIN_LOG (DT_LOG_0 + 4)
@@ -518,6 +519,7 @@ public:
 
     // These are opportunistically set
     uint32_t entry_memory_load;
+    uint64_t entry_available_physical_mem;
     uint32_t exit_memory_load;
 
     void init_mechanisms(); //for each GC
@@ -763,6 +765,7 @@ public:
     size_t          end_seg_allocated;
     BOOL            allocate_end_seg_p;
     size_t          condemned_allocated;
+    size_t          sweep_allocated;
     size_t          free_list_space;
     size_t          free_obj_space;
     size_t          allocation_size;
@@ -979,7 +982,8 @@ enum msl_take_state
     mt_alloc_small_cant,
     mt_alloc_large_cant,
     mt_try_alloc,
-    mt_try_budget
+    mt_try_budget,
+    mt_try_servo_budget
 };
 
 enum msl_enter_state
@@ -1276,6 +1280,13 @@ public:
 
     PER_HEAP_ISOLATED
     void do_post_gc();
+
+#ifdef BGC_SERVO_TUNING
+    PER_HEAP_ISOLATED
+    void check_and_adjust_bgc_tuning (int gen_number, size_t physical_size, ptrdiff_t virtual_fl_size);
+    PER_HEAP_ISOLATED
+    void get_and_reset_loh_alloc_info();
+#endif //BGC_SERVO_TUNING
 
     PER_HEAP
     BOOL expand_soh_with_minimal_gc();
@@ -2125,6 +2136,257 @@ protected:
     void verify_mark_bits_cleared (uint8_t* obj, size_t s);
     PER_HEAP
     void clear_all_mark_array();
+
+#ifdef BGC_SERVO_TUNING
+
+    // Currently BGC servo tuning is an experimental feature.
+    class bgc_tuning
+    {
+    public:
+        struct tuning_calculation
+        {
+            // We use this virtual size that represents the generation 
+            // size at goal. We calculate the flr based on this.
+            size_t end_gen_size_goal;
+
+            // sweep goal is expressed as flr as we want to avoid 
+            // expanding the gen size.
+            double sweep_flr_goal;
+
+            // gen2 size at the end of last bgc.
+            size_t last_bgc_size;
+
+            //
+            // these need to be double so we don't loose so much accurancy
+            // they are *100.0
+            //
+            // the FL ratio at the start of current bgc sweep.
+            double current_bgc_sweep_flr; 
+            // the FL ratio at the end of last bgc.
+            // Only used for FF.
+            double last_bgc_flr; 
+            // the FL ratio last time we started a bgc
+            double current_bgc_start_flr;
+
+            double above_goal_accu_error;
+
+            // We will trigger the next BGC if this much 
+            // alloc has been consumed between the last
+            // bgc end and now.
+            size_t alloc_to_trigger;
+            // actual consumed alloc
+            size_t actual_alloc_to_trigger;
+
+            // the alloc between last bgc sweep start and end.
+            size_t last_bgc_end_alloc;
+
+            //
+            // For smoothing calc
+            // 
+            size_t smoothed_alloc_to_trigger;
+
+            //
+            // For TBH 
+            //
+            // last time we checked, were we above sweep flr goal?
+            bool last_sweep_above_p;
+            size_t alloc_to_trigger_0;
+
+            // This is to get us started. It's set when we observe in a gen1
+            // GC when the memory load is high enough and is used to seed the first
+            // BGC triggered due to this tuning.
+            size_t first_alloc_to_trigger;
+        };
+
+        struct tuning_stats
+        {
+            size_t last_bgc_physical_size;
+
+            size_t last_alloc_end_to_start;
+            size_t last_alloc_start_to_sweep;
+            size_t last_alloc_sweep_to_end;
+            // records the alloc at the last significant point,
+            // used to calculate the 3 alloc's above.
+            // It's reset at bgc sweep start as that's when we reset 
+            // all the allocation data (sweep_allocated/condemned_allocated/etc)
+            size_t last_alloc;
+
+            // the FL size at the end of last bgc.
+            size_t last_bgc_fl_size;
+
+            // last gen2 surv rate
+            double last_bgc_surv_rate;
+
+            // the FL ratio last time gen size increased.
+            double last_gen_increase_flr; 
+        };
+
+        // This is just so that I don't need to calculate things multiple
+        // times. Only used during bgc end calculations. Everything that 
+        // needs to be perserved across GCs will be saved in the other 2 
+        // structs.
+        struct bgc_size_data
+        {
+            size_t gen_size;
+            size_t gen_physical_size;
+            size_t gen_fl_size;
+            // The actual physical fl size, unadjusted
+            size_t gen_actual_phys_fl_size;
+            // I call this physical_fl but really it's adjusted based on alloc
+            // that we haven't consumed because the other generation consumed
+            // its alloc and triggered the BGC. See init_bgc_end_data.
+            // We don't allow it to go negative.
+            ptrdiff_t gen_physical_fl_size;
+            double gen_physical_flr;
+            double gen_flr;
+        };
+
+        static bool enable_fl_tuning;
+        // the memory load we aim to maintain.
+        static uint32_t memory_load_goal;
+
+        // if we are BGCMemGoalSlack above BGCMemGoal, this is where we 
+        // panic and start to see if we should do NGC2.
+        static uint32_t memory_load_goal_slack;
+        // This is calculated based on memory_load_goal.
+        static uint64_t available_memory_goal;
+        // If we are above (ml goal + slack), we need to panic.
+        // Currently we just trigger the next GC as an NGC2, but 
+        // we do track the accumulated error and could be more
+        // sophisticated about triggering NGC2 especially when 
+        // slack is small. We could say unless we see the error
+        // is large enough would we actually trigger an NGC2.
+        static bool panic_activated_p;
+        static double accu_error_panic;
+
+        static double above_goal_kp;
+        static double above_goal_ki;
+        static bool enable_ki;
+        static bool enable_kd;
+        static bool enable_smooth;
+        static bool enable_tbh;
+        static bool enable_ff;
+        static bool enable_gradual_d;
+        static double above_goal_kd;
+        static double above_goal_ff;
+        static double num_gen1s_smooth_factor;
+
+        // for ML servo loop
+        static double ml_kp;
+        static double ml_ki;
+
+        // for ML loop ki
+        static double accu_error;
+
+        // did we start tuning with FL yet?
+        static bool fl_tuning_triggered;
+
+        // ==================================================
+        // ============what's used in calculation============
+        // ==================================================
+        //
+        // only used in smoothing.
+        static size_t num_bgcs_since_tuning_trigger;
+
+        // gen1 GC setting the next GC as a BGC when it observes the
+        // memory load is high enough for the first time.
+        static bool next_bgc_p;
+
+        // this is organized as:
+        // element 0 is for max_generation
+        // element 1 is for max_generation+1
+        static tuning_calculation gen_calc[2];
+
+        // ======================================================
+        // ============what's used to only show stats============
+        // ======================================================
+        //
+        // how many gen1's actually happened before triggering next bgc.
+        static size_t actual_num_gen1s_to_trigger;
+
+        static size_t gen1_index_last_bgc_end;
+        static size_t gen1_index_last_bgc_start;
+        static size_t gen1_index_last_bgc_sweep;
+
+        static tuning_stats gen_stats[2];
+        // ============end of stats============
+
+        static bgc_size_data current_bgc_end_data[2];
+
+        static size_t last_stepping_bgc_count;
+        static uint32_t last_stepping_mem_load;
+        static uint32_t stepping_interval;
+
+        // When we are in the initial stage before fl tuning is triggered.
+        static bool use_stepping_trigger_p;
+
+        // the gen2 correction factor is used to put more emphasis
+        // on the gen2 when it triggered the BGC.
+        // If the BGC was triggered due to gen3, we decrease this 
+        // factor.
+        static double gen2_ratio_correction;
+        static double ratio_correction_step;
+
+        // Since we have 2 loops, this BGC was caused by one of them; for the other loop we know
+        // we didn't reach the goal so use the output from last time.
+        static void calculate_tuning (int gen_number, bool use_this_loop_p);
+
+        static void init_bgc_end_data (int gen_number, bool use_this_loop_p);
+        static void calc_end_bgc_fl (int gen_number);
+
+        static void convert_to_fl (bool use_gen2_loop_p, bool use_gen3_loop_p);
+        static double calculate_ml_tuning (uint64_t current_available_physical, bool reduce_p, ptrdiff_t* _vfl_from_kp, ptrdiff_t* _vfl_from_ki);
+
+        // This invokes the ml tuning loop and sets the total gen sizes, ie
+        // including vfl.
+        static void set_total_gen_sizes (bool use_gen2_loop_p, bool use_gen3_loop_p);
+
+        static bool should_trigger_bgc_loh();
+
+        // This is only called when we've already stopped for GC.
+        // For LOH we'd be doing this in the alloc path.
+        static bool should_trigger_bgc();
+
+        // If we keep being above ml goal, we need to compact.
+        static bool should_trigger_ngc2();
+
+        // Only implemented for gen2 now while we are in sweep.
+        // Before we could build up enough fl, we delay gen1 consuming 
+        // gen2 alloc so we don't get into panic.
+        // When we maintain the fl instead of building a new one, this
+        // can be eliminated.
+        static bool should_delay_alloc (int gen_number);
+
+        // When we are under the memory load goal, we'd like to do 10 BGCs
+        // before we reach the goal. 
+        static bool stepping_trigger (uint32_t current_memory_load, size_t current_gen2_count);
+
+        static void update_bgc_start (int gen_number, size_t num_gen1s_since_end);
+        // Updates the following:
+        // current_bgc_start_flr
+        // actual_alloc_to_trigger
+        // last_alloc_end_to_start
+        // last_alloc
+        // actual_num_gen1s_to_trigger
+        // gen1_index_last_bgc_start
+        static void record_bgc_start();
+
+        static void update_bgc_sweep_start (int gen_number, size_t num_gen1s_since_start);
+        // Updates the following:
+        // current_bgc_sweep_flr
+        // last_alloc_start_to_sweep
+        // last_alloc
+        // gen1_index_last_bgc_sweep
+        static void record_bgc_sweep_start();
+        // Updates the rest
+        static void record_and_adjust_bgc_end();
+    };
+
+    // This tells us why we chose to do a bgc in tuning.
+    PER_HEAP_ISOLATED
+    int saved_bgc_tuning_reason;
+#endif //BGC_SERVO_TUNING
+
 #endif //BACKGROUND_GC
 
     PER_HEAP
@@ -2604,6 +2866,22 @@ protected:
     size_t get_current_allocated();
     PER_HEAP_ISOLATED
     size_t get_total_allocated();
+#ifdef BGC_SERVO_TUNING
+    PER_HEAP_ISOLATED
+    size_t get_total_generation_size (int gen_number);
+    PER_HEAP_ISOLATED
+    size_t get_total_servo_alloc (int gen_number);
+    PER_HEAP_ISOLATED
+    size_t get_total_bgc_promoted();
+    PER_HEAP_ISOLATED
+    size_t get_total_surv_size (int gen_number);
+    PER_HEAP_ISOLATED
+    size_t get_total_begin_data_size (int gen_number);
+    PER_HEAP_ISOLATED
+    size_t get_total_generation_fl_size (int gen_number);
+    PER_HEAP_ISOLATED
+    size_t get_current_gc_index (int gen_number);
+#endif //BGC_SERVO_TUNING
     PER_HEAP
     size_t current_generation_size (int gen_number);
     PER_HEAP
@@ -2644,8 +2922,6 @@ protected:
                                    gc_tuning_point tp);
     PER_HEAP
     BOOL ephemeral_gen_fit_p (gc_tuning_point tp);
-    PER_HEAP
-    void reset_large_object (uint8_t* o);
     PER_HEAP
     void sweep_large_objects ();
     PER_HEAP
@@ -3444,6 +3720,25 @@ protected:
     size_t     bgc_begin_loh_size;
     PER_HEAP
     size_t     end_loh_size;
+
+#ifdef BGC_SERVO_TUNING
+    PER_HEAP
+    uint64_t   loh_a_no_bgc;
+
+    PER_HEAP
+    uint64_t   loh_a_bgc_marking;
+
+    PER_HEAP
+    uint64_t   loh_a_bgc_planning;
+
+    // Total allocated last BGC's plan + between last and this bgc +
+    // this bgc's mark
+    PER_HEAP_ISOLATED
+    uint64_t   total_loh_a_last_bgc;
+
+    PER_HEAP
+    size_t     bgc_maxgen_end_fl_size;
+#endif //BGC_SERVO_TUNING
 
     // We need to throttle the LOH allocations during BGC since we can't
     // collect LOH when BGC is in progress. 
@@ -4319,6 +4614,11 @@ inline
 size_t& generation_condemned_allocated (generation* inst)
 {
     return inst->condemned_allocated;
+}
+inline
+size_t& generation_sweep_allocated (generation* inst)
+{
+    return inst->sweep_allocated;
 }
 #ifdef FREE_USAGE_STATS
 inline


### PR DESCRIPTION
This is the 1st part of BGC tuning using FL (free list) with a PID loop. Historically the most significant factor for triggering a BGC is based on the allocation budget. This experimental feature triggers based on the FL in gen2/3 with a PID loop (by default we only use PI, no D) so we use the allocation calculated based on the FL to determine when to trigger the next BGC.

+ The goal of the PI feedback loop

The end goal of the tuning is keep a const physical ML (memory load). The ML goal is specified as a percentage (meaning the percent of physical memory in use). And we aim to do as few BGCs as possible to achieve this memory load.

+ Enable the FL tuning PI loop

Since this is an experimental feature, by default it's disabled. To enable set this env var:

set COMPlus_BGCFLTuningEnabled=1

When the FL tuning is enabled, by default we set the ML load to 75%. You can change it with this env var:

set COMPlus_BGCMemGoal=X

Note as with any COMPlus var, the value is interpreted as a hex number, not dec.

+ Perf consideration of the current PI loop

Of course there’s always perturbation. From BGC’s POV there are 2 categories of perturbation –

1) from GC’s own perf characteristics changes, for example, suddenly we see a lot of pins from gen1 that get promoted into gen2. 
2) non GC factors – this could be due to sudden increase of native memory usage in the process; or other processes on the same machine simply increase/decrease their memory usage.

And generally we don’t want to do something very high like 90% ‘cause it’s hard to react when the memory is tight – GC would need to compact and currently BGC does not compact. So for now we have to assume that “retracting the heap is difficult” which means we want our PI loop to be fairly conservative. 

So we actually have another PI loop (the inner loop) to make sure the “sweep flr” is at a reasonable value. “Sweep flr” is the FLR (Free List Ratio) before BGC rebuilds the free list – so you can think of this as the smallest flr during a BGC. So the inner loop has a “sweep flr” goal of 20% by default which is pretty conservative. And when we can incrementally compact I would expect to reduce this by a fair amount. Another possibility is we do not set this as a fixed number and rather calculate a reasonable one dynamically based on what we observe how the free list is used.

Of course just because BGC does not compact it doesn’t mean that the total gen2 size cannot get smaller. It could get smaller just by objects at the end of gen2 naturally dying.

+Initialization of the PI loops

We have to have some way to get this whole thing started so I usually do a few BGCs to reach 2/3 mem load goal then start using PI loops to decide when to trigger the next BGC. 

+ Panic mode

I use a very simple rule to see if I should panic, ie, do an NGC2. If we observe the memory load is (goal + N%) where N is just a number we determine, we do an NGC2. This actually turned out to give decent results because we give it ample opportunity to allow some oscillation around goal (instead of panicking prematurely). 

+ Implementation notes 

When FL tuning is not enabled there should be no effect. 

Record things when BGC starts, BGC sweep ends and BGC end.

I have other mechanisms like the D term, FF (feed forward) and smoothing. I have experimented with them in the past. Currently they are not enabled by default but can be enabled with COMPlus env vars. 

Currently this doesn't work great with LOH because we have a fundamental limitation which is if we give free space to gen2 it's difficult to give it to LOH. One thing the user could do is to adjust the LOH threshold so most of the large object allocations happen in gen2.
