### PR TITLE
Add test coverage for casting to pointers

### DIFF
--- a/tests/src/Loader/classloader/Casting/castclasspointer.il
+++ b/tests/src/Loader/classloader/Casting/castclasspointer.il
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly castclasspointer { }
+.assembly extern mscorlib { }
+
+.method public static int32 Main()
+{
+  .entrypoint
+
+  ldnull
+  castclass void*
+  pop
+
+  newobj instance void [mscorlib]System.Object::.ctor()
+  isinst void*
+  brtrue BAD
+
+  .try
+  {
+    newobj instance void [mscorlib]System.Object::.ctor()
+    castclass void*
+    pop
+    leave BAD
+  }
+  catch [mscorlib]System.InvalidCastException
+  {
+    pop
+    leave OK
+  }
+
+BAD:
+  ldc.i4 1
+  ret
+
+OK:
+  ldc.i4 100
+  ret
+}

--- a/tests/src/Loader/classloader/Casting/castclasspointer.ilproj
+++ b/tests/src/Loader/classloader/Casting/castclasspointer.ilproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="castclasspointer.il" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
I was fixing a customer-reported bug related to this in .NET Native and decided to check whether there's any test coverage for this in CoreCLR. There isn't, so adding a test I wrote for .NET Native.