### PR TITLE
Re-enable incremental linking

### DIFF
--- a/configurecompiler.cmake
+++ b/configurecompiler.cmake
@@ -243,12 +243,6 @@ if (WIN32)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG /PDBCOMPRESS")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:1572864")
 
-  # Temporarily disable incremental link due to incremental linking CFG bug crashing crossgen.
-  # See https://github.com/dotnet/coreclr/issues/12592
-  # This has been fixed in VS 2017 Update 5 but we're keeping this around until everyone is off
-  # the versions that have the bug. The bug manifests itself as a bad crash.
-  set(NO_INCREMENTAL_LINKER_FLAGS "/INCREMENTAL:NO")
-
   # Debug build specific flags
   set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "/NOVCFEATURE ${NO_INCREMENTAL_LINKER_FLAGS}")
   set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${NO_INCREMENTAL_LINKER_FLAGS}")


### PR DESCRIPTION
This was disabled due to a linker bug that was fixed in 2017. Maybe it's time to re-enable this.

Fixes #13344.