### PR TITLE
Fix PInvoke transition frame in CPAOT

### DIFF
--- a/src/inc/readytorun.h
+++ b/src/inc/readytorun.h
@@ -360,4 +360,9 @@ struct READYTORUN_EXCEPTION_CLAUSE
     };  
 };
 
+enum ReadyToRunRuntimeConstants : DWORD
+{
+    READYTORUN_RUNTIME_CONSTANT_PInvokeTransitionFrameSize = 11 * sizeof(void *)
+};
+
 #endif // __READYTORUN_H__

--- a/src/inc/readytorun.h
+++ b/src/inc/readytorun.h
@@ -362,7 +362,7 @@ struct READYTORUN_EXCEPTION_CLAUSE
 
 enum ReadyToRunRuntimeConstants : DWORD
 {
-    READYTORUN_RUNTIME_CONSTANT_PInvokeTransitionFrameSize = 11 * sizeof(void *)
+    READYTORUN_PInvokeTransitionFrameSizeInPointerUnits = 11
 };
 
 #endif // __READYTORUN_H__

--- a/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
+++ b/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
@@ -2389,30 +2389,6 @@ namespace Internal.JitInterface
         private void ThrowExceptionForHelper(ref CORINFO_HELPER_DESC throwHelper)
         { throw new NotImplementedException("ThrowExceptionForHelper"); }
 
-        private uint SizeOfPInvokeTransitionFrame
-        {
-            get
-            {
-                // struct PInvokeTransitionFrame:
-                // #ifdef _TARGET_ARM_
-                //  m_ChainPointer
-                // #endif
-                //  m_RIP
-                //  m_FramePointer
-                //  m_pThread
-                //  m_Flags + align (no align for ARM64 that has 64 bit m_Flags)
-                //  m_PreserverRegs - RSP
-                //      No need to save other preserved regs because of the JIT ensures that there are
-                //      no live GC references in callee saved registers around the PInvoke callsite.
-                int size = 5 * this.PointerSize;
-
-                if (_compilation.TypeSystemContext.Target.Architecture == TargetArchitecture.ARM)
-                    size += this.PointerSize; // m_ChainPointer
-
-                return (uint)size;
-            }
-        }
-
         private void getEEInfo(ref CORINFO_EE_INFO pEEInfoOut)
         {
             pEEInfoOut = new CORINFO_EE_INFO();
@@ -2426,7 +2402,7 @@ namespace Internal.JitInterface
 
             int pointerSize = this.PointerSize;
 
-            pEEInfoOut.inlinedCallFrameInfo.size = this.SizeOfPInvokeTransitionFrame;
+            pEEInfoOut.inlinedCallFrameInfo.size = (uint)SizeOfPInvokeTransitionFrame;
 
             pEEInfoOut.offsetOfDelegateInstance = (uint)pointerSize;            // Delegate::m_firstParameter
             pEEInfoOut.offsetOfDelegateFirstTarget = OffsetOfDelegateFirstTarget;

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/FixupConstants.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/FixupConstants.cs
@@ -173,4 +173,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         ELEMENT_TYPE_SENTINEL = 65,
         ELEMENT_TYPE_PINNED = 69
     }
+
+    public static class ReadyToRunRuntimeConstants
+    {
+        public const int READYTORUN_PInvokeTransitionFrameSizeInPointerUnits = 11;
+    }
 }

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
@@ -52,6 +52,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public bool IsARM => Architecture == TargetArchitecture.ARM;
         public bool IsARM64 => Architecture == TargetArchitecture.ARM64;
 
+        public bool Is64Bit => PointerSize == sizeof(long);
+
         /// <summary>
         /// This property is only overridden in AMD64 Unix variant of the transition block.
         /// </summary>
@@ -72,6 +74,22 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public int SizeOfCalleeSavedRegisters => NumCalleeSavedRegisters * PointerSize;
 
         public abstract int SizeOfTransitionBlock { get; }
+
+        public int SizeOfPInvokeTransitionBlock => SizeOfGSCookie + SizeOfInlinedTransitionFrame;
+
+        private int SizeOfGSCookie => PointerSize;
+
+        private int SizeOfInlinedTransitionFrame => SizeOfFrame + SizeOfInlinedCallFrame; // base class size + inlined call frame fields
+
+        private int SizeOfFrame => 2 * PointerSize; // vtable, m_Next
+
+        private int SizeOfInlinedCallFrameOnAllPlatforms => 5 * PointerSize; // m_Datum, m_pCallSiteSP, m_pCallerReturnAddress, m_pCalleeSavedFP, m_pThread
+
+        private int SizeOfInlinedCallFrameStubSecretArg => (Is64Bit ? 1 : 0) * PointerSize;
+
+        private int SizeOfInlinedCallFrameSPAfterProlog => (IsARM || IsARM64 ? 1 : 0) * PointerSize;
+
+        private int SizeOfInlinedCallFrame => SizeOfInlinedCallFrameOnAllPlatforms + SizeOfInlinedCallFrameStubSecretArg + SizeOfInlinedCallFrameSPAfterProlog;
 
         public abstract int OffsetOfArgumentRegisters { get; }
 
@@ -329,6 +347,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             public override int NumCalleeSavedRegisters => 4;
             // Argument registers, callee-save registers, return address
             public override int SizeOfTransitionBlock => SizeOfArgumentRegisters + SizeOfCalleeSavedRegisters + PointerSize;
+
             public override int OffsetOfArgumentRegisters => 0;
             // CALLDESCR_FPARGREGS is not set for X86
             public override int OffsetOfFloatArgumentRegisters => 0;

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
@@ -329,7 +329,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             public override int NumCalleeSavedRegisters => 4;
             // Argument registers, callee-save registers, return address
             public override int SizeOfTransitionBlock => SizeOfArgumentRegisters + SizeOfCalleeSavedRegisters + PointerSize;
-
             public override int OffsetOfArgumentRegisters => 0;
             // CALLDESCR_FPARGREGS is not set for X86
             public override int OffsetOfFloatArgumentRegisters => 0;

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
@@ -52,8 +52,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public bool IsARM => Architecture == TargetArchitecture.ARM;
         public bool IsARM64 => Architecture == TargetArchitecture.ARM64;
 
-        public bool Is64Bit => PointerSize == sizeof(long);
-
         /// <summary>
         /// This property is only overridden in AMD64 Unix variant of the transition block.
         /// </summary>
@@ -74,22 +72,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public int SizeOfCalleeSavedRegisters => NumCalleeSavedRegisters * PointerSize;
 
         public abstract int SizeOfTransitionBlock { get; }
-
-        public int SizeOfPInvokeTransitionBlock => SizeOfGSCookie + SizeOfInlinedTransitionFrame;
-
-        private int SizeOfGSCookie => PointerSize;
-
-        private int SizeOfInlinedTransitionFrame => SizeOfFrame + SizeOfInlinedCallFrame; // base class size + inlined call frame fields
-
-        private int SizeOfFrame => 2 * PointerSize; // vtable, m_Next
-
-        private int SizeOfInlinedCallFrameOnAllPlatforms => 5 * PointerSize; // m_Datum, m_pCallSiteSP, m_pCallerReturnAddress, m_pCalleeSavedFP, m_pThread
-
-        private int SizeOfInlinedCallFrameStubSecretArg => (Is64Bit ? 1 : 0) * PointerSize;
-
-        private int SizeOfInlinedCallFrameSPAfterProlog => (IsARM || IsARM64 ? 1 : 0) * PointerSize;
-
-        private int SizeOfInlinedCallFrame => SizeOfInlinedCallFrameOnAllPlatforms + SizeOfInlinedCallFrameStubSecretArg + SizeOfInlinedCallFrameSPAfterProlog;
 
         public abstract int OffsetOfArgumentRegisters { get; }
 

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1842,5 +1842,7 @@ namespace Internal.JitInterface
 
             return false;
         }
+
+        private int SizeOfPInvokeTransitionFrame => TransitionBlock.FromTarget(_compilation.NodeFactory.Target).SizeOfPInvokeTransitionBlock;
     }
 }

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1843,6 +1843,6 @@ namespace Internal.JitInterface
             return false;
         }
 
-        private int SizeOfPInvokeTransitionFrame => TransitionBlock.FromTarget(_compilation.NodeFactory.Target).SizeOfPInvokeTransitionBlock;
+        private int SizeOfPInvokeTransitionFrame => 11 * _compilation.NodeFactory.Target.PointerSize;
     }
 }

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1843,6 +1843,6 @@ namespace Internal.JitInterface
             return false;
         }
 
-        private int SizeOfPInvokeTransitionFrame => 11 * _compilation.NodeFactory.Target.PointerSize;
+        private int SizeOfPInvokeTransitionFrame => ReadyToRunRuntimeConstants.READYTORUN_PInvokeTransitionFrameSizeInPointerUnits * _compilation.NodeFactory.Target.PointerSize;
     }
 }

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -10255,7 +10255,7 @@ void InlinedCallFrame::GetEEInfo(CORINFO_EE_INFO::InlinedCallFrameInfo *pInfo)
 {
     LIMITED_METHOD_CONTRACT;
 
-    pInfo->size                          = READYTORUN_RUNTIME_CONSTANT_PInvokeTransitionFrameSize;
+    pInfo->size                          = sizeof(GSCookie) + sizeof(InlinedCallFrame);
 
     pInfo->offsetOfGSCookie              = 0;
     pInfo->offsetOfFrameVptr             = sizeof(GSCookie);
@@ -10301,7 +10301,7 @@ void CEEInfo::getEEInfo(CORINFO_EE_INFO *pEEInfoOut)
         // ** IMPORTANT ** If you ever need to change the value of this fixed size, make sure to change the R2R
         // version number, otherwise older R2R images will probably crash when used.
 
-        const int r2rInlinedCallFrameSize = TARGET_POINTER_SIZE * 11;
+        const int r2rInlinedCallFrameSize = TARGET_POINTER_SIZE * READYTORUN_PInvokeTransitionFrameSizeInPointerUnits;
 
 #if defined(_DEBUG) && !defined(CROSSBITNESS_COMPILE)
         InlinedCallFrame::GetEEInfo(&pEEInfoOut->inlinedCallFrameInfo);

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -10255,7 +10255,7 @@ void InlinedCallFrame::GetEEInfo(CORINFO_EE_INFO::InlinedCallFrameInfo *pInfo)
 {
     LIMITED_METHOD_CONTRACT;
 
-    pInfo->size                          = sizeof(GSCookie) + sizeof(InlinedCallFrame);
+    pInfo->size                          = READYTORUN_RUNTIME_CONSTANT_PInvokeTransitionFrameSize;
 
     pInfo->offsetOfGSCookie              = 0;
     pInfo->offsetOfFrameVptr             = sizeof(GSCookie);


### PR DESCRIPTION
During investigation of Linux CPAOT failures Jan Vorlicek discovered
that we were using the wrong constant for the PInvoke transition
frame. I have verified that the change fixes all tests under
JIT\methodical\explicit\basic I was previously seeing; I am running
the complete Pri#1 test suite to get an overall picture.

Thanks

Tomas