### PR TITLE
Mark remaining counter test as JIT sensitive

### DIFF
--- a/tests/src/tracing/eventcounter/regression-25709.csproj
+++ b/tests/src/tracing/eventcounter/regression-25709.csproj
@@ -6,6 +6,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- This test is timing sensitive and JIT timing affects the results of the test -->
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <!-- This test has a secondary thread with an infinite loop -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>


### PR DESCRIPTION
There was one remaining counter test that hasn't been marked as JIT sensitive from https://github.com/dotnet/coreclr/pull/26666, so this marks it as JIT sensitive.