### PR TITLE
More SuperIlc fixes and improvements

### DIFF
--- a/src/tools/ReadyToRun.SuperIlc/Buckets.cs
+++ b/src/tools/ReadyToRun.SuperIlc/Buckets.cs
@@ -172,6 +172,14 @@ namespace ReadyToRun.SuperIlc
                         }
                         return line;
                     }
+                    else if (line.StartsWith("Fatal error", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (lineIndex + 1 < lines.Length && lines[lineIndex + 1].TrimStart().StartsWith("at "))
+                        {
+                            line += lines[lineIndex + 1];
+                        }
+                        return line;
+                    }
                 }
 
                 return $"Exit code: {process.ExitCode} = 0x{process.ExitCode:X8}, expected {process.Parameters.ExpectedExitCode}";

--- a/src/tools/ReadyToRun.SuperIlc/Buckets.cs
+++ b/src/tools/ReadyToRun.SuperIlc/Buckets.cs
@@ -55,7 +55,7 @@ namespace ReadyToRun.SuperIlc
             IEnumerable<KeyValuePair<string, List<ProcessInfo>>> orderedBuckets = _bucketMap.OrderByDescending(bucket => bucket.Value.Count);
             foreach (KeyValuePair<string, List<ProcessInfo>> bucketKvp in orderedBuckets)
             {
-                bucketKvp.Value.Sort((a, b) => a.Parameters.InputFileName.CompareTo(b.Parameters.InputFileName));
+                bucketKvp.Value.Sort((a, b) => a.Parameters.OutputFileName.CompareTo(b.Parameters.OutputFileName));
                 output.WriteLine($@"    [{bucketKvp.Value.Count} failures] {bucketKvp.Key}");
             }
 
@@ -70,7 +70,7 @@ namespace ReadyToRun.SuperIlc
 
                 foreach (ProcessInfo failure in bucketKvp.Value)
                 {
-                    output.WriteLine($@"   {failure.Parameters.InputFileName}");
+                    output.WriteLine($@"   {failure.Parameters.OutputFileName}");
                 }
 
                 if (detailed)
@@ -80,7 +80,7 @@ namespace ReadyToRun.SuperIlc
 
                     foreach (ProcessInfo failure in bucketKvp.Value)
                     {
-                        output.WriteLine($@"Test: {failure.Parameters.InputFileName}");
+                        output.WriteLine($@"Test: {failure.Parameters.OutputFileName}");
                         try
                         {
                             output.WriteLine(File.ReadAllText(failure.Parameters.LogPath));

--- a/src/tools/ReadyToRun.SuperIlc/BuildOptions.cs
+++ b/src/tools/ReadyToRun.SuperIlc/BuildOptions.cs
@@ -81,10 +81,13 @@ namespace ReadyToRun.SuperIlc
             cpaotReferencePaths.AddRange(overrideReferencePaths != null ? overrideReferencePaths : ReferencePaths());
             runners.Add(new CpaotRunner(this, cpaotReferencePaths));
 
-            List<string> crossgenReferencePaths = new List<string>();
-            crossgenReferencePaths.Add(CoreRootOutputPath(CompilerIndex.Crossgen, isFramework));
-            crossgenReferencePaths.AddRange(overrideReferencePaths != null ? overrideReferencePaths : ReferencePaths());
-            runners.Add(new CrossgenRunner(this, crossgenReferencePaths));
+            if (Crossgen)
+            {
+                List<string> crossgenReferencePaths = new List<string>();
+                crossgenReferencePaths.Add(CoreRootOutputPath(CompilerIndex.Crossgen, isFramework));
+                crossgenReferencePaths.AddRange(overrideReferencePaths != null ? overrideReferencePaths : ReferencePaths());
+                runners.Add(new CrossgenRunner(this, crossgenReferencePaths));
+            }
 
             if (!NoJit)
             {

--- a/src/tools/ReadyToRun.SuperIlc/Commands/CompileSubtreeCommand.cs
+++ b/src/tools/ReadyToRun.SuperIlc/Commands/CompileSubtreeCommand.cs
@@ -47,10 +47,7 @@ namespace ReadyToRun.SuperIlc
                 PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, recursive: true);
             }
 
-            string[] directories = LocateSubtree(
-                options.InputDirectory.FullName,
-                (options.Framework || options.UseFramework) ? options.CoreRootDirectory.FullName : null)
-                .ToArray();
+            string[] directories = LocateSubtree(options.InputDirectory.FullName, options.CoreRootDirectory.FullName).ToArray();
 
             ConcurrentBag<BuildFolder> folders = new ConcurrentBag<BuildFolder>();
             int relativePathOffset = options.InputDirectory.FullName.Length;
@@ -125,12 +122,10 @@ namespace ReadyToRun.SuperIlc
 
         private static async Task LocateSubtreeAsync(string folder, string coreRootFolder, ConcurrentBag<string> directories)
         {
-            if (!Path.GetExtension(folder).Equals(".out", StringComparison.OrdinalIgnoreCase))
+            if (!Path.GetExtension(folder).Equals(".out", StringComparison.OrdinalIgnoreCase) &&
+                !folder.Equals(coreRootFolder, StringComparison.OrdinalIgnoreCase))
             {
-                if (coreRootFolder == null || !folder.Equals(coreRootFolder, StringComparison.OrdinalIgnoreCase))
-                {
-                    directories.Add(folder);
-                }
+                directories.Add(folder);
                 List<Task> subfolderTasks = new List<Task>();
                 foreach (string subdir in Directory.EnumerateDirectories(folder))
                 {

--- a/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
+++ b/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
@@ -178,6 +178,7 @@ namespace ReadyToRun.SuperIlc
             }
 
             processParameters.InputFileName = scriptToRun;
+            processParameters.OutputFileName = scriptToRun;
             processParameters.LogPath = scriptToRun + ".log";
             processParameters.EnvironmentOverrides["CORE_ROOT"] = _options.CoreRootOutputPath(Index, isFramework: false);
             return processParameters;
@@ -190,6 +191,7 @@ namespace ReadyToRun.SuperIlc
             processParameters.ProcessPath = _options.CoreRunPath(Index, isFramework: false);
             processParameters.Arguments = exeToRun;
             processParameters.InputFileName = exeToRun;
+            processParameters.OutputFileName = exeToRun;
             processParameters.LogPath = exeToRun + ".log";
             processParameters.ExpectedExitCode = 100;
             return processParameters;
@@ -219,7 +221,7 @@ namespace ReadyToRun.SuperIlc
 
         // <input>\a.dll -> <output>\a.dll
         public string GetOutputFileName(string outputRoot, string fileName) =>
-            Path.Combine(GetOutputPath(outputRoot), $"{Path.GetFileName(fileName)}");
+            Path.Combine(GetOutputPath(outputRoot), Path.GetFileName(fileName));
 
         public string GetResponseFileName(string outputRoot, string assemblyFileName) =>
             Path.Combine(GetOutputPath(outputRoot), Path.GetFileName(assemblyFileName) + ".rsp");


### PR DESCRIPTION
1) Set OutputFileName to the same value as InputFileName for
execution runs. This lets me use the output file name as a common
test key for both phases.

2) Exclude Core_Root subtree in compile-subtree - this is needed
to avoid compiling Crossgen2.

3) As Anubhav pointed out, I messed up one of my previous
refactorings so that running the legacy Crossgen was no longer
optional based on the --crossgen switch.

4) I removed an unnecessary formatting string I randomly noticed.

Thanks

Tomas