### PR TITLE
Fix calendar instance inside the culture after cloning

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Globalization/CultureInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CultureInfo.cs
@@ -1012,7 +1012,15 @@ namespace System.Globalization
                 ci._textInfo = (TextInfo)_textInfo.Clone();
             }
 
-            if (_calendar != null)
+            if (_dateTimeInfo != null && _dateTimeInfo.Calendar == _calendar)
+            {
+                // Usually when we access CultureInfo.DateTimeFormat first time, we create the DateTimeFormatInfo object
+                // using CultureInfo.Calendar. i.e. CultureInfo.DateTimeInfo.Calendar == CultureInfo.calendar.
+                // When cloning CultureInfo, if we know this still the case CultureInfo.DateTimeInfo.Calendar == CultureInfo.calendar
+                // then we can keep the same behavior for the cloned object and no need to create another calendar object.
+                ci._calendar = ci.DateTimeFormat.Calendar;
+            }
+            else if (_calendar != null)
             {
                 ci._calendar = (Calendar)_calendar.Clone();
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/40953

When creating a new culture, we’ll have the equality CultureInfo.DateTimeInfo.Calendar == CultureInfo.calendar be true. After cloning such culture, this equality would not be true. The fix here is to ensure if the equality is true before cloning then should be true after cloning.