### PR TITLE
Remove unused flags on ArrayMarshalInfo only used for type library exporting.

### DIFF
--- a/src/vm/mlinfo.cpp
+++ b/src/vm/mlinfo.cpp
@@ -5009,7 +5009,7 @@ void ArrayMarshalInfo::InitElementInfo(CorNativeType arrayNativeType, MarshalInf
                 case NATIVE_TYPE_LPTSTR:
                 {
 #ifdef FEATURE_COMINTEROP
-                    if (ms == MarshalInfo::MARSHAL_SCENARIO_COMINTEROP || IsAMIExport(m_flags))
+                    if (ms == MarshalInfo::MARSHAL_SCENARIO_COMINTEROP)
                     {
                         // We disallow NATIVE_TYPE_LPTSTR for COM or if we are exporting. 
                         ReportInvalidArrayMarshalInfo(IDS_EE_BADMARSHALPARAM_NO_LPTSTR);
@@ -5100,22 +5100,7 @@ void ArrayMarshalInfo::InitElementInfo(CorNativeType arrayNativeType, MarshalInf
             }
             else
             {
-                // When exporting, we need to handle enums specially.
-                if (IsAMIExport(m_flags) && m_thElement.IsEnum())
-                {
-                    // Get the element type of the underlying type.
-                    CorElementType et = m_thElement.GetInternalCorElementType();
-                    
-                    // If it is not a 32-bit type, convert as the underlying type.
-                    if ((et == ELEMENT_TYPE_I4) || (et == ELEMENT_TYPE_U4))
-                        m_vtElement = VT_RECORD;             
-                    else
-                        m_vtElement = OleVariant::GetVarTypeForTypeHandle(m_thElement);
-                }             
-                else
-                {                   
-                    m_vtElement = OleVariant::GetVarTypeForTypeHandle(m_thElement);
-                }
+                m_vtElement = OleVariant::GetVarTypeForTypeHandle(m_thElement);
             }
         }
 #ifdef FEATURE_COMINTEROP
@@ -5163,18 +5148,6 @@ void ArrayMarshalInfo::InitElementInfo(CorNativeType arrayNativeType, MarshalInf
        }
         if (set_error)
             COMPlusThrow(kPlatformNotSupportedException, m_resID);
-    }
-
-    // If we are exporting, we need to substitute the VTHACK_* VARTYPE with the actual
-    // types as expressed in the type library.
-    if (IsAMIExport(m_flags))
-    {
-        if (m_vtElement == VTHACK_ANSICHAR)
-            m_vtElement = VT_UI1;
-        else if (m_vtElement == VTHACK_WINBOOL)
-            m_vtElement = VT_I4;
-		else if (m_vtElement == VTHACK_CBOOL)
-		    m_vtElement = VT_UI1;
     }
 
 LExit:;

--- a/src/vm/mlinfo.h
+++ b/src/vm/mlinfo.h
@@ -738,16 +738,11 @@ private:
 enum ArrayMarshalInfoFlags
 {
     amiRuntime                                  = 0x0001,
-    amiExport32Bit                              = 0x0002,
-    amiExport64Bit                              = 0x0004,
     amiIsPtr                                    = 0x0008,
     amiSafeArraySubTypeExplicitlySpecified      = 0x0010
 };
 
 #define IsAMIRuntime(flags) (flags & amiRuntime)
-#define IsAMIExport(flags) (flags & (amiExport32Bit | amiExport64Bit))
-#define IsAMIExport32Bit(flags) (flags & amiExport32Bit)
-#define IsAMIExport64Bit(flags) (flags & amiExport64Bit)
 #define IsAMIPtr(flags) (flags & amiIsPtr)
 #define IsAMISafeArraySubTypeExplicitlySpecified(flags) (flags & amiSafeArraySubTypeExplicitlySpecified)
 //
@@ -860,14 +855,7 @@ protected:
     {
         LIMITED_METHOD_CONTRACT;
 
-        // If we are exporting, use the pointer size specified via the flags, otherwise use
-        // the current size of a pointer.
-        if (IsAMIExport32Bit(m_flags))
-            return 4;
-        else if (IsAMIExport64Bit(m_flags))
-            return 8;
-        else 
-            return sizeof(LPVOID);
+        return sizeof(LPVOID);
     }
 
 protected:


### PR DESCRIPTION
Since exporting a type library from a .NET assembly via a runtime-integrated TLBExp is not supported on .NET Core, this code is dead code.