### PR TITLE
Remove duplicate call to SetProfilerMayHaveActivatedNonDefaultCodeVersion

### DIFF
--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -2089,8 +2089,6 @@ public:
     void SetProfilerMayHaveActivatedNonDefaultCodeVersion()
     {
         WRAPPER_NO_CONTRACT;
-        _ASSERTE(!m_profilerMayHaveActivatedNonDefaultCodeVersion);
-
         m_profilerMayHaveActivatedNonDefaultCodeVersion = true;
     }
 

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -896,11 +896,6 @@ PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, J
             {
                 g_profControlBlock.pProfInterface->DynamicMethodJITCompilationFinished((FunctionID)this, pEntry->m_hrResultCode, TRUE);
             }
-
-            if (nativeCodeVersion.IsDefaultVersion())
-            {
-                pConfig->SetProfilerMayHaveActivatedNonDefaultCodeVersion();
-            }
         }
         END_PIN_PROFILER();
     }

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -896,6 +896,11 @@ PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, J
             {
                 g_profControlBlock.pProfInterface->DynamicMethodJITCompilationFinished((FunctionID)this, pEntry->m_hrResultCode, TRUE);
             }
+
+            if (nativeCodeVersion.IsDefaultVersion())
+            {
+                pConfig->SetProfilerMayHaveActivatedNonDefaultCodeVersion();
+            }
         }
         END_PIN_PROFILER();
     }


### PR DESCRIPTION
The second call was causing SetProfilerMayHaveActivatedNonDefaultCodeVersion to assert since it was already set