### PR TITLE
IBC fixes

### DIFF
--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunLibraryRootProvider.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunLibraryRootProvider.cs
@@ -37,6 +37,12 @@ namespace ILCompiler
                         {
                             continue;
                         }
+
+                        if (method.IsMethodDefinition)
+                        {
+                            continue;
+                        }
+
                         bool containsSignatureVariables = false;
                         foreach (TypeDesc t in method.Instantiation)
                         {

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -12856,6 +12856,16 @@ idMethodSpec Module::LogInstantiatedMethod(const MethodDesc * md, ULONG flagNum)
     {
         CONTRACT_VIOLATION(ThrowsViolation|FaultViolation|GCViolation);
 
+        if (!m_tokenProfileData) 
+        { 
+            CreateProfilingData(); 
+        } 
+
+        if (!m_tokenProfileData) 
+        { 
+            return idMethodSpecNil; 
+        } 
+
         // get data
         SigBuilder sigBuilder;
 

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -1449,8 +1449,18 @@ void STDMETHODCALLTYPE EEShutDownHelper(BOOL fIsDllUnloading)
             {
                 if (g_IBCLogger.InstrEnabled())
                 {
-                    Thread * pThread = GetThread();
-                    ThreadLocalIBCInfo* pInfo = pThread->GetIBCInfo();
+                    Thread * pThread = GetThreadNULLOk();
+                    ThreadLocalIBCInfo* pInfo = NULL;
+
+                    if (pThread != NULL)
+                    {
+                        if (pInfo == NULL) 
+                        { 
+                            CONTRACT_VIOLATION( ThrowsViolation | FaultViolation); 
+                            pInfo = new ThreadLocalIBCInfo(); 
+                            pThread->SetIBCInfo(pInfo); 
+                        } 
+                    }
 
                     // Acquire the Crst lock before creating the IBCLoggingDisabler object.
                     // Only one thread at a time can be processing an IBC logging event.

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -1454,6 +1454,7 @@ void STDMETHODCALLTYPE EEShutDownHelper(BOOL fIsDllUnloading)
 
                     if (pThread != NULL)
                     {
+                        pInfo = pThread->GetIBCInfo();
                         if (pInfo == NULL) 
                         { 
                             CONTRACT_VIOLATION( ThrowsViolation | FaultViolation); 


### PR DESCRIPTION
- Support IntPtr and UIntPtr element types in IBC data
- More defensive coding against structurally incorrect IBC data
- Skip compilation of open method definitions
- Generate IBC data without crashing when the first logged item is an InstantiatedMethod and not a token
- Safely shutdown and emit IBC data from a thread that hasn't been given a Thread object