### PR TITLE
[test] Disable all EventPipe tests under GCStress

### DIFF
--- a/tests/src/tracing/eventpipe/buffersize/buffersize.csproj
+++ b/tests/src/tracing/eventpipe/buffersize/buffersize.csproj
@@ -8,6 +8,7 @@
     <CLRTestPriority>0</CLRTestPriority>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/tests/src/tracing/eventpipe/eventsvalidation/ExceptionThrown_V1.csproj
+++ b/tests/src/tracing/eventpipe/eventsvalidation/ExceptionThrown_V1.csproj
@@ -8,6 +8,7 @@
     <CLRTestPriority>1</CLRTestPriority>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ExceptionThrown_V1.cs" />

--- a/tests/src/tracing/eventpipe/providervalidation/providervalidation.csproj
+++ b/tests/src/tracing/eventpipe/providervalidation/providervalidation.csproj
@@ -8,6 +8,7 @@
     <CLRTestPriority>0</CLRTestPriority>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/tests/src/tracing/eventpipe/rundownvalidation/rundownvalidation.csproj
+++ b/tests/src/tracing/eventpipe/rundownvalidation/rundownvalidation.csproj
@@ -7,6 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
resolves #26723

Test failures such as #26723 have been happening unreported since as far back as at least July 20th.  It looks like the assert is being hit as a result of a GC stack walk happening inside an EventPipe triggered stack walk based on a local repro by @sywhang with the following stack trace:
```
    (lldb) bt
* thread #11: tid = 28717, 0x00007ffff669e011 libcoreclr.so`DBG_DebugBreak + 1 at debugbreak.S:10, name = 'corerun', stop reason = signal SIGTRAP
  * frame #0: 0x00007ffff669e011 libcoreclr.so`DBG_DebugBreak + 1 at debugbreak.S:10
    frame #1: 0x00007ffff6626de7 libcoreclr.so`::DebugBreak() + 967 at debug.cpp:405
    frame #2: 0x00007ffff60c8c46 libcoreclr.so`::DbgAssertDialog(szFile="/home/suwhang/repos/coreclr/src/vm/stackwalk.cpp", iLine=943, szExpr=<unavailable>) + 134 at debug.cpp:710
    frame #3: 0x00007ffff61a4ac8 libcoreclr.so`Thread::StackWalkFramesEx(this=0x00005555557fcf20, pRD=0x00007fff56ff6890, pCallback=(libcoreclr.so`GcStackCrawlCallBack(CrawlFrame*, void*) at gcenv.ee.common.cpp:201), pData=0x00007fff56ff79a8, flags=34048, pStartFrame=0x0000000000000000)(CrawlFrame*, void*), void*, unsigned int, Frame*) + 232 at stackwalk.cpp:943
    frame #4: 0x00007ffff61a56c5 libcoreclr.so`Thread::StackWalkFrames(this=0x00005555557fcf20, pCallback=(libcoreclr.so`GcStackCrawlCallBack(CrawlFrame*, void*) at gcenv.ee.common.cpp:201), pData=0x00007fff56ff79a8, flags=34048, pStartFrame=0x0000000000000000)(CrawlFrame*, void*), void*, unsigned int, Frame*) + 405 at stackwalk.cpp:1052
    frame #5: 0x00007ffff64e9cd6 libcoreclr.so`ScanStackRoots(pThread=<unavailable>, fn=(libcoreclr.so`WKS::GCHeap::Promote(Object**, ScanContext*, unsigned int) at gc.cpp:35172), sc=0x00007fff56ff7ab0)(Object**, ScanContext*, unsigned int), ScanContext*) + 582 at gcenv.ee.cpp:148
    frame #6: 0x00007ffff64e99c4 libcoreclr.so`GCToEEInterface::GcScanRoots(fn=(libcoreclr.so`WKS::GCHeap::Promote(Object**, ScanContext*, unsigned int) at gc.cpp:35172), condemned=<unavailable>, max_gen=<unavailable>, sc=<unavailable>)(Object**, ScanContext*, unsigned int), int, int, ScanContext*) + 484 at gcenv.ee.cpp:177
    frame #7: 0x00007ffff64c0646 libcoreclr.so`WKS::gc_heap::mark_phase(condemned_gen_number=<unavailable>, mark_only_p=NO) + 710 at gc.cpp:20698
    frame #8: 0x00007ffff64bd66d libcoreclr.so`WKS::gc_heap::gc1() + 1229 at gc.cpp:16325
    frame #9: 0x00007ffff64c809d libcoreclr.so`WKS::gc_heap::garbage_collect(n=<unavailable>) + 2109 at gc.cpp:17954
    frame #10: 0x00007ffff64b869e libcoreclr.so`WKS::GCHeap::GarbageCollectGeneration(this=<unavailable>, gen=2, reason=reason_gcstress) + 1022 at gc.cpp:36576
    frame #11: 0x00007ffff64e1e29 libcoreclr.so`WKS::GCHeap::GarbageCollect(int, bool, int) [inlined] WKS::GCHeap::GarbageCollectTry(generation=<unavailable>) + 537 at gc.cpp:36082
    frame #12: 0x00007ffff64e1e1f libcoreclr.so`WKS::GCHeap::GarbageCollect(this=<unavailable>, generation=<unavailable>, low_memory_p=<unavailable>, mode=<unavailable>) + 527 at gc.cpp:36016
    frame #13: 0x00007ffff64e1554 libcoreclr.so`WKS::GCHeap::StressHeap(this=<unavailable>, context=<unavailable>) + 1764 at gc.cpp:35522
    frame #14: 0x00007ffff632ccf4 libcoreclr.so`Thread::PerformPreemptiveGC(this=0x0000555555f02e70) + 468 at threadsuspend.cpp:2858
    frame #15: 0x00007ffff632cdc8 libcoreclr.so`Thread::RareEnablePreemptiveGC(this=0x0000555555f02e70) + 120 at threadsuspend.cpp:2900
    frame #16: 0x00007ffff60e7ad1 libcoreclr.so`void GCHolderBase::PopInternal<0>(this=0x00007fff56ff7eb0) + 177 at threads.h:5672
    frame #17: 0x00007ffff611a859 libcoreclr.so`GCCoopHackNoThread::~GCCoopHackNoThread(this=<unavailable>) + 9 at threads.h:5948
    frame #18: 0x00007ffff6119495 libcoreclr.so`HashMap::LookupValue(this=<unavailable>, key=140735285318032, value=70367642659016) + 1013 at hash.cpp:609
    frame #19: 0x00007ffff61ff75c libcoreclr.so`ReadyToRunInfo::GetMethodDescForEntryPoint(unsigned long) [inlined] PtrHashMap::LookupValue(key=<unavailable>) + 30 at hash.h:598
    frame #20: 0x00007ffff61ff73e libcoreclr.so`ReadyToRunInfo::GetMethodDescForEntryPoint(this=<unavailable>, entryPoint=<unavailable>) + 14 at readytoruninfo.cpp:63
    frame #21: 0x00007ffff60dde19 libcoreclr.so`ReadyToRunJitManager::JitCodeToMethodInfo(this=<unavailable>, pRangeSection=<unavailable>, currentPC=<unavailable>, ppMethodDesc=<unavailable>, pCodeInfo=<unavailable>) + 249 at codeman.cpp:6870
    frame #22: 0x00007ffff614761c libcoreclr.so`EECodeInfo::Init(this=0x00007fff56ff8868, codeAddress=140735285318345, scanFlag=<unavailable>) + 60 at jitinterface.cpp:14214
    frame #23: 0x00007ffff61a7d26 libcoreclr.so`StackFrameIterator::NextRaw() [inlined] StackFrameIterator::ProcessIp(this=0x00007fff56ff8630, Ip=140735285318345) + 24 at stackwalk.cpp:2807
    frame #24: 0x00007ffff61a7d0e libcoreclr.so`StackFrameIterator::NextRaw(this=0x00007fff56ff8630) + 2206 at stackwalk.cpp:2655
    frame #25: 0x00007ffff61a6e7f libcoreclr.so`StackFrameIterator::Filter(this=<unavailable>) + 4207 at stackwalk.cpp:2294
    frame #26: 0x00007ffff61a501e libcoreclr.so`StackFrameIterator::Init(this=0x00007fff56ff8630, pThread=0x0000555555f02e70, pFrame=<unavailable>, pRegDisp=0x00007fff56ff89f0, flags=<unavailable>) + 830 at stackwalk.cpp:1280
    frame #27: 0x00007ffff61a4bfd libcoreclr.so`Thread::StackWalkFramesEx(this=0x0000555555f02e70, pRD=<unavailable>, pCallback=(libcoreclr.so`EventPipe::StackWalkCallback(CrawlFrame*, StackContents*) at eventpipe.cpp:728), pData=0x00007fff56ff9b58, flags=1297, pStartFrame=0x0000000000000000)(CrawlFrame*, void*), void*, unsigned int, Frame*) + 541 at stackwalk.cpp:965
    frame #28: 0x00007ffff61a56c5 libcoreclr.so`Thread::StackWalkFrames(this=0x0000555555f02e70, pCallback=(libcoreclr.so`EventPipe::StackWalkCallback(CrawlFrame*, StackContents*) at eventpipe.cpp:728), pData=0x00007fff56ff9b58, flags=1297, pStartFrame=0x0000000000000000)(CrawlFrame*, void*), void*, unsigned int, Frame*) + 405 at stackwalk.cpp:1052
    frame #29: 0x00007ffff6249552 libcoreclr.so`EventPipe::WalkManagedStackForCurrentThread(StackContents&) [inlined] EventPipe::WalkManagedStackForThread(pThread=<unavailable>) + 33 at eventpipe.cpp:719
    frame #30: 0x00007ffff6249531 libcoreclr.so`EventPipe::WalkManagedStackForCurrentThread(stackContents=0x00007fff56ff9b58) + 33 at eventpipe.cpp:699
    frame #31: 0x00007ffff625224d libcoreclr.so`EventPipeBufferManager::WriteEvent(this=0x00007fff480012f0, pThread=<unavailable>, session=0x00007fff48000f40, event=0x00007fff44029e10, payload=0x00007fff56ffa320, pActivityId=0x0000555555f03ca4, pRelatedActivityId=<unavailable>, pEventThread=<unavailable>, pStack=<unavailable>) + 157 at eventpipebuffermanager.cpp:375
    frame #32: 0x00007ffff6254e3c libcoreclr.so`EventPipeSession::WriteEventBuffered(this=0x00007fff48000f40, pThread=0x0000555555f02e70, event=0x00007fff44029e10, payload=0x00007fff56ffa320, pActivityId=0x0000555555f03ca4, pRelatedActivityId=0x0000000000000000, pEventThread=<unavailable>, pStack=<unavailable>) + 92 at eventpipesession.cpp:327
    frame #33: 0x00007ffff62490f6 libcoreclr.so`EventPipe::WriteEventInternal(pThread=<unavailable>, event=0x00007fff44029e10, payload=<unavailable>, pActivityId=0x0000555555f03ca4, pRelatedActivityId=0x0000000000000000, pEventThread=0x0000000000000000, pStack=<unavailable>) + 358 at eventpipe.cpp:649
    frame #34: 0x00007ffff6248f45 libcoreclr.so`EventPipe::WriteEvent(EventPipeEvent&, EventData*, unsigned int, _GUID const*, _GUID const*) [inlined] EventPipe::WriteEventInternal(payload=<unavailable>, pActivityId=<unavailable>) + 133 at eventpipe.cpp:565
    frame #35: 0x00007ffff6248eec libcoreclr.so`EventPipe::WriteEvent(event=0x00007fff44029e10, pEventData=<unavailable>, eventDataCount=<unavailable>, pActivityId=0x0000000000000000, pRelatedActivityId=0x0000000000000000) + 44 at eventpipe.cpp:536
    frame #36: 0x00007ffff6442405 libcoreclr.so`EventPipeInternal::WriteEventData(eventHandle=140734334410256, eventID=<unavailable>, pEventData=0x00007fff56ffa650, eventDataCount=1, pActivityId=0x0000000000000000, pRelatedActivityId=0x0000000000000000) + 213 at eventpipeinternal.cpp:250
    frame #37: 0x00007fff7cb052e8
    frame #38: 0x00007fff7cb0fd0c
    frame #39: 0x00007fff7cb11d9c
    frame #40: 0x00007fff7cb110db
    frame #41: 0x00007fff7d562628
    frame #42: 0x00007fff7c9c4492
    frame #43: 0x00007fff7c9cb13c
    frame #44: 0x00007fff7c9a9582
    frame #45: 0x00007fff7c9c42c1
    frame #46: 0x00007fff7c9c40d8
    frame #47: 0x00007fff7c9c406b
    frame #48: 0x00007fff7c99fdeb
    frame #49: 0x00007ffff620aff9 libcoreclr.so`CallDescrWorkerWithHandler(pCallDescrData=0x0000000000000000, fCriticalCall=NO) + 377 at callhelpers.cpp:70
    frame #50: 0x00007ffff620ba59 libcoreclr.so`MethodDescCallSite::CallTargetWorker(this=<unavailable>, pArguments=0x0000000000000000, pReturnValue=<unavailable>, cbReturnValue=<unavailable>) + 1913 at callhelpers.cpp:546
    frame #51: 0x00007ffff643259c libcoreclr.so`QueueUserWorkItemManagedCallback(void*) [inlined] MethodDescCallSite::Call_RetBool(this=<unavailable>, pArguments=<unavailable>) + 173 at callhelpers.h:459
    frame #52: 0x00007ffff64324ef libcoreclr.so`QueueUserWorkItemManagedCallback(pArg=0x00007fff56ffae66) + 239 at comthreadpool.cpp:477
    frame #53: 0x00007ffff61c2e57 libcoreclr.so`ManagedThreadBase_DispatchOuter(ManagedThreadCallState*) [inlined] ManagedThreadBase_DispatchInner(pCallState=0x00007fff56ffadb0) + 535 at threads.cpp:7434
    ...
```

It also appears similar issues have been hit before (see: #16494).

The culprit seems to be this code allowing a GC to happen during the stack walk: https://github.com/dotnet/coreclr/blob/84d4ed44b5c7f1b3db6e9ae3c71e8e1bb585bbaf/src/vm/threads.h#L5917-L5920
that gets called inside `HashMap::LookupValue` in the above stack trace.  Since the comment says this is a broken code path, I'm just going to turn off the EventPipe tests entirely under GCStress for now.

resolves #26592

CC - @tommcdon 