### PR TITLE
Fix R2RDump to correctly parse array lower bounds

### DIFF
--- a/src/tools/r2rdump/R2RSignature.cs
+++ b/src/tools/r2rdump/R2RSignature.cs
@@ -958,7 +958,7 @@ namespace R2RDump
                                 sizes[sizeIndex] = ReadUIntAndEmitInlineSignatureBinary(builder);
                             }
                             uint lowerBoundCount = ReadUIntAndEmitInlineSignatureBinary(builder); // number of lower bounds
-                            int[] lowerBounds = new int[sizeCount];
+                            int[] lowerBounds = new int[lowerBoundCount];
                             for (uint lowerBoundIndex = 0; lowerBoundIndex < lowerBoundCount; lowerBoundIndex++)
                             {
                                 lowerBounds[lowerBoundIndex] = ReadIntAndEmitInlineSignatureBinary(builder);


### PR DESCRIPTION
There is a an incorrect size (likely a typo) used to create lower bounds
array when parsing signatures. This results in `Index was outside the
bounds of the array.` being printed inside of the array signature
string.