### PR TITLE
Statements: return dumping methods.

### DIFF
--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -5163,7 +5163,7 @@ void Compiler::optAssertionPropMain()
                     break;
                 }
 
-                JITDUMP("Propagating %s assertions for " FMT_BB ", stmt [%06d], tree [%06d], tree -> %d\n",
+                JITDUMP("Propagating %s assertions for " FMT_BB ", stmt " FMT_STMT ", tree [%06d], tree -> %d\n",
                         BitVecOps::ToString(apTraits, assertions), block->bbNum, stmt->GetID(), dspTreeID(tree),
                         tree->GetAssertionInfo().GetAssertionIndex());
 

--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -4894,7 +4894,7 @@ Compiler::fgWalkResult Compiler::optVNConstantPropCurStmt(BasicBlock* block, Sta
     optAssertionProp_Update(newTree, tree, stmt);
 
     JITDUMP("After constant propagation on [%06u]:\n", tree->gtTreeID);
-    DBEXEC(VERBOSE, gtDispTree(stmt->gtStmtExpr));
+    DBEXEC(VERBOSE, gtDispStmt(stmt));
 
     return WALK_SKIP_SUBTREES;
 }
@@ -5164,8 +5164,8 @@ void Compiler::optAssertionPropMain()
                 }
 
                 JITDUMP("Propagating %s assertions for " FMT_BB ", stmt [%06d], tree [%06d], tree -> %d\n",
-                        BitVecOps::ToString(apTraits, assertions), block->bbNum, dspTreeID(stmt->gtStmtExpr),
-                        dspTreeID(tree), tree->GetAssertionInfo().GetAssertionIndex());
+                        BitVecOps::ToString(apTraits, assertions), block->bbNum, stmt->GetID(), dspTreeID(tree),
+                        tree->GetAssertionInfo().GetAssertionIndex());
 
                 GenTree* newTree = optAssertionProp(assertions, tree, stmt);
                 if (newTree)
@@ -5189,7 +5189,7 @@ void Compiler::optAssertionPropMain()
                 if (verbose)
                 {
                     printf("Re-morphing this stmt:\n");
-                    gtDispTree(stmt->gtStmtExpr);
+                    gtDispStmt(stmt);
                     printf("\n");
                 }
 #endif

--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -1037,8 +1037,6 @@ struct BasicBlock : private LIR::Range
     unsigned        bbTgtStkDepth; // Native stack depth on entry (for throw-blocks)
     static unsigned s_nMaxTrees;   // The max # of tree nodes in any BB
 
-    unsigned bbStmtNum; // The statement number of the first stmt in this block
-
     // This is used in integrity checks.  We semi-randomly pick a traversal stamp, label all blocks
     // in the BB list with that stamp (in this field); then we can tell if (e.g.) predecessors are
     // still in the BB list by whether they have the same stamp (with high probability).

--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -41,7 +41,7 @@ typedef BitVec          ASSERT_TP;
 typedef BitVec_ValArg_T ASSERT_VALARG_TP;
 typedef BitVec_ValRet_T ASSERT_VALRET_TP;
 
-// We use the following format when print the BasicBlock number: bbNum
+// We use the following format when printing the BasicBlock number: bbNum
 // This define is used with string concatenation to put this in printf format strings  (Note that %u means unsigned int)
 #define FMT_BB "BB%02u"
 

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -10650,7 +10650,7 @@ void cNodeIR(Compiler* comp, GenTree* tree)
 void cStmtIR(Compiler* comp, Statement* stmt)
 {
     cTreeIR(comp, stmt->gtStmtExpr);
-    if (comp->dumpIRNoStmts == false)
+    if (!comp->dumpIRNoStmts)
     {
         dTabStopIR(0, COLUMN_OPCODE);
         Compiler::printStmtID(stmt);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -8941,9 +8941,6 @@ public:
 
     BasicBlock* compCurBB;   // the current basic block in process
     Statement*  compCurStmt; // the current statement in process
-#ifdef DEBUG
-    unsigned compCurStmtNum; // to give all statements an increasing StmtNum when printing dumps
-#endif
 
     //  The following is used to create the 'method JIT info' block.
     size_t compInfoBlkSize;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2854,6 +2854,7 @@ public:
     int gtGetLclVarName(unsigned lclNum, char* buf, unsigned buf_remaining);
     char* gtGetLclVarName(unsigned lclNum);
     void gtDispLclVar(unsigned varNum, bool padForBiggestDisp = true);
+    void gtDispStmt(Statement* stmt, const char* msg = nullptr);
     void gtDispBlockStmts(BasicBlock* block);
     void gtGetArgMsg(GenTreeCall* call, GenTree* arg, unsigned argNum, int listCount, char* bufp, unsigned bufLength);
     void gtGetLateArgMsg(GenTreeCall* call, GenTree* arg, int argNum, int listCount, char* bufp, unsigned bufLength);
@@ -8594,6 +8595,13 @@ public:
     {
         return tree->gtTreeID;
     }
+
+    static void printStmtID(Statement* stmt)
+    {
+        assert(stmt != nullptr);
+        printf("STMT%05u", stmt->GetID());
+    }
+
     static void printTreeID(GenTree* tree)
     {
         if (tree == nullptr)
@@ -8927,6 +8935,7 @@ public:
 #ifdef DEBUG
     static unsigned s_compMethodsCount; // to produce unique label names
     unsigned        compGenTreeID;
+    unsigned        compStatementID;
     unsigned        compBasicBlockID;
 #endif
 
@@ -10562,6 +10571,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 void cBlock(Compiler* comp, BasicBlock* block);
 void cBlocks(Compiler* comp);
 void cBlocksV(Compiler* comp);
+void cStmt(Compiler* comp, Statement* statement);
 void cTree(Compiler* comp, GenTree* tree);
 void cTrees(Compiler* comp);
 void cEH(Compiler* comp);
@@ -10578,6 +10588,7 @@ void cCVarSet(Compiler* comp, VARSET_VALARG_TP vars);
 void cFuncIR(Compiler* comp);
 void cBlockIR(Compiler* comp, BasicBlock* block);
 void cLoopIR(Compiler* comp, Compiler::LoopDsc* loop);
+void cStmtIR(Compiler* comp, Statement* stmt);
 void cTreeIR(Compiler* comp, GenTree* tree);
 int cTreeTypeIR(Compiler* comp, GenTree* tree);
 int cTreeKindsIR(Compiler* comp, GenTree* tree);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -8599,7 +8599,7 @@ public:
     static void printStmtID(Statement* stmt)
     {
         assert(stmt != nullptr);
-        printf("STMT%05u", stmt->GetID());
+        printf(FMT_STMT, stmt->GetID());
     }
 
     static void printTreeID(GenTree* tree)

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -944,7 +944,7 @@ inline GenTree::GenTree(genTreeOps oper, var_types type DEBUGARG(bool largeNode)
 
 inline Statement* Compiler::gtNewStmt(GenTree* expr, IL_OFFSETX offset)
 {
-    Statement* stmt = new (this->getAllocator(CMK_ASTNode)) Statement(expr, offset);
+    Statement* stmt = new (this->getAllocator(CMK_ASTNode)) Statement(expr, offset DEBUGARG(compStatementID++));
     return stmt;
 }
 

--- a/src/jit/earlyprop.cpp
+++ b/src/jit/earlyprop.cpp
@@ -336,7 +336,7 @@ GenTree* Compiler::optEarlyPropRewriteTree(GenTree* tree)
         if (verbose)
         {
             printf("optEarlyProp Rewriting " FMT_BB "\n", compCurBB->bbNum);
-            gtDispTree(compCurStmt->gtStmtExpr);
+            gtDispStmt(compCurStmt);
             printf("\n");
         }
 #endif
@@ -368,7 +368,7 @@ GenTree* Compiler::optEarlyPropRewriteTree(GenTree* tree)
         if (verbose)
         {
             printf("to\n");
-            gtDispTree(compCurStmt->gtStmtExpr);
+            gtDispStmt(compCurStmt);
             printf("\n");
         }
 #endif

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -20525,7 +20525,7 @@ void Compiler::fgDispBasicBlocks(bool dumpTrees)
 //
 // Arguments:
 //    stmt  - the statement to dump;
-//    bbNum - The basic block number to dump.
+//    bbNum - the basic block number to dump.
 //
 void Compiler::fgDumpStmtTree(Statement* stmt, unsigned bbNum)
 {

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -20520,23 +20520,17 @@ void Compiler::fgDispBasicBlocks(bool dumpTrees)
     fgDispBasicBlocks(fgFirstBB, nullptr, dumpTrees);
 }
 
-/*****************************************************************************/
-//  Increment the stmtNum and dump the tree using gtDispTree
+//------------------------------------------------------------------------
+// fgDumpStmtTree: dump the statement and the basic block number.
+//
+// Arguments:
+//    stmt  - the statement to dump;
+//    bbNum - The basic block number to dump.
 //
 void Compiler::fgDumpStmtTree(Statement* stmt, unsigned bbNum)
 {
-    compCurStmtNum++; // Increment the current stmtNum
-
-    printf("\n***** " FMT_BB ", stmt %d\n", bbNum, compCurStmtNum);
-
-    if (fgOrder == FGOrderLinear || opts.compDbgInfo)
-    {
-        gtDispStmt(stmt);
-    }
-    else
-    {
-        gtDispTree(stmt->gtStmtExpr);
-    }
+    printf("\n***** " FMT_BB "\n", bbNum);
+    gtDispStmt(stmt);
 }
 
 //------------------------------------------------------------------------
@@ -20555,10 +20549,6 @@ void Compiler::fgDumpBlock(BasicBlock* block)
         for (Statement* stmt : block->Statements())
         {
             fgDumpStmtTree(stmt, block->bbNum);
-            if (stmt == block->firstStmt())
-            {
-                block->bbStmtNum = compCurStmtNum; // Set the block->bbStmtNum
-            }
         }
     }
     else
@@ -20572,13 +20562,10 @@ void Compiler::fgDumpBlock(BasicBlock* block)
 //
 void Compiler::fgDumpTrees(BasicBlock* firstBlock, BasicBlock* lastBlock)
 {
-    compCurStmtNum = 0; // Reset the current stmtNum
-
-    /* Walk the basic blocks */
+    // Walk the basic blocks.
 
     // Note that typically we have already called fgDispBasicBlocks()
-    //  so we don't need to print the preds and succs again here
-    //
+    // so we don't need to print the preds and succs again here.
     for (BasicBlock* block = firstBlock; block; block = block->bbNext)
     {
         fgDumpBlock(block);

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -10021,7 +10021,7 @@ void Compiler::fgRemoveStmt(BasicBlock* block, Statement* stmt)
         stmt->gtStmtExpr->gtOper != GT_NOP) // Don't print if it is a GT_NOP. Too much noise from the inliner.
     {
         printf("\nRemoving statement ");
-        gtDispTree(stmt->gtStmtExpr);
+        gtDispStmt(stmt);
         printf(" in " FMT_BB " as useless:\n", block->bbNum);
     }
 #endif // DEBUG
@@ -15056,7 +15056,7 @@ bool Compiler::fgOptimizeBranch(BasicBlock* bJump)
         printf("\nfgOptimizeBranch added these statements(s) at the end of " FMT_BB ":\n", bJump->bbNum);
         for (Statement* stmt : StatementList(newStmtList))
         {
-            gtDispTree(stmt->gtStmtExpr);
+            gtDispStmt(stmt);
         }
         printf("\nfgOptimizeBranch changed block " FMT_BB " from BBJ_ALWAYS to BBJ_COND.\n", bJump->bbNum);
 
@@ -18527,7 +18527,7 @@ BasicBlock* Compiler::fgRngChkTarget(BasicBlock* block, SpecialCodeKind kind)
         printf("*** Computing fgRngChkTarget for block " FMT_BB "\n", block->bbNum);
         if (!block->IsLIR())
         {
-            gtDispTree(compCurStmt->gtStmtExpr);
+            gtDispStmt(compCurStmt);
         }
     }
 #endif // DEBUG
@@ -20531,7 +20531,7 @@ void Compiler::fgDumpStmtTree(Statement* stmt, unsigned bbNum)
 
     if (fgOrder == FGOrderLinear || opts.compDbgInfo)
     {
-        gtDispTree(stmt->gtStmtExpr);
+        gtDispStmt(stmt);
     }
     else
     {
@@ -22988,7 +22988,7 @@ void Compiler::fgInsertInlineeBlocks(InlineInfo* pInlineInfo)
 
                         printf("\n");
 
-                        gtDispTree(currentDumpStmt->gtStmtExpr);
+                        gtDispStmt(currentDumpStmt);
                         printf("\n");
 
                     } while (currentDumpStmt != stmtAfter);
@@ -23375,7 +23375,7 @@ Statement* Compiler::fgInlinePrependStatements(InlineInfo* inlineInfo)
 #ifdef DEBUG
                     if (verbose)
                     {
-                        gtDispTree(afterStmt->gtStmtExpr);
+                        gtDispStmt(afterStmt);
                     }
 #endif // DEBUG
                 }
@@ -23496,7 +23496,7 @@ Statement* Compiler::fgInlinePrependStatements(InlineInfo* inlineInfo)
 #ifdef DEBUG
                         if (verbose)
                         {
-                            gtDispTree(afterStmt->gtStmtExpr);
+                            gtDispStmt(afterStmt);
                         }
 #endif // DEBUG
                     }
@@ -23604,7 +23604,7 @@ Statement* Compiler::fgInlinePrependStatements(InlineInfo* inlineInfo)
 #ifdef DEBUG
                 if (verbose)
                 {
-                    gtDispTree(afterStmt->gtStmtExpr);
+                    gtDispStmt(afterStmt);
                 }
 #endif // DEBUG
             }
@@ -23752,7 +23752,7 @@ void Compiler::fgInlineAppendStatements(InlineInfo* inlineInfo, BasicBlock* bloc
 #ifdef DEBUG
         if (verbose)
         {
-            gtDispTree(nullStmt->gtStmtExpr);
+            gtDispStmt(nullStmt);
         }
 #endif // DEBUG
     }

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -11468,10 +11468,20 @@ void Compiler::gtDispArgList(GenTreeCall* call, IndentStack* indentStack)
     }
 }
 
+// gtDispStmt: Print a statement to jitstdout.
+//
+// Arguments:
+//    stmt - the statement to be printed;
+//    msg  - an additional message to print before the statement.
+//
 void Compiler::gtDispStmt(Statement* stmt, const char* msg /* = nullptr */)
 {
     if (opts.compDbgInfo)
     {
+        if (msg != nullptr)
+        {
+            printf("%s ", msg);
+        }
         printStmtID(stmt);
         IL_OFFSETX firstILOffsx = stmt->gtStmtILoffsx;
         printf(" (IL ");

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -11468,6 +11468,37 @@ void Compiler::gtDispArgList(GenTreeCall* call, IndentStack* indentStack)
     }
 }
 
+void Compiler::gtDispStmt(Statement* stmt, const char* msg /* = nullptr */)
+{
+    if (opts.compDbgInfo)
+    {
+        printStmtID(stmt);
+        IL_OFFSETX firstILOffsx = stmt->gtStmtILoffsx;
+        printf(" (IL ");
+        if (firstILOffsx == BAD_IL_OFFSET)
+        {
+            printf("  ???");
+        }
+        else
+        {
+            printf("0x%03X", jitGetILoffs(firstILOffsx));
+        }
+        printf("...");
+
+        IL_OFFSET lastILOffs = stmt->gtStmtLastILoffs;
+        if (lastILOffs == BAD_IL_OFFSET)
+        {
+            printf("  ???");
+        }
+        else
+        {
+            printf("0x%03X", lastILOffs);
+        }
+        printf(")\n");
+    }
+    gtDispTree(stmt->gtStmtExpr);
+}
+
 //------------------------------------------------------------------------
 // gtDispBlockStmts: dumps all statements inside `block`.
 //
@@ -11478,7 +11509,7 @@ void Compiler::gtDispBlockStmts(BasicBlock* block)
 {
     for (Statement* stmt : block->Statements())
     {
-        gtDispTree(stmt->gtStmtExpr);
+        gtDispStmt(stmt);
         printf("\n");
     }
 }
@@ -12698,7 +12729,7 @@ GenTree* Compiler::gtTryRemoveBoxUpstreamEffects(GenTree* op, BoxRemovalOptions 
             " [%06u] (assign/newobj [%06u] copy [%06u])\n",
             (options == BR_DONT_REMOVE) ? "checking if it is possible" : "attempting",
             (options == BR_MAKE_LOCAL_COPY) ? "make local unboxed version" : "remove side effects", dspTreeID(op),
-            dspTreeID(asgStmt->gtStmtExpr), dspTreeID(copyStmt->gtStmtExpr));
+            asgStmt->GetID(), copyStmt->GetID());
 
     // If we don't recognize the form of the assign, bail.
     GenTree* asg = asgStmt->gtStmtExpr;

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -12726,7 +12726,7 @@ GenTree* Compiler::gtTryRemoveBoxUpstreamEffects(GenTree* op, BoxRemovalOptions 
     Statement*  copyStmt = box->gtCopyStmtWhenInlinedBoxValue;
 
     JITDUMP("gtTryRemoveBoxUpstreamEffects: %s to %s of BOX (valuetype)"
-            " [%06u] (assign/newobj [%06u] copy [%06u])\n",
+            " [%06u] (assign/newobj " FMT_STMT " copy " FMT_STMT "\n",
             (options == BR_DONT_REMOVE) ? "checking if it is possible" : "attempting",
             (options == BR_MAKE_LOCAL_COPY) ? "make local unboxed version" : "remove side effects", dspTreeID(op),
             asgStmt->GetID(), copyStmt->GetID());

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -5129,7 +5129,7 @@ struct GenTreeILOffset : public GenTree
 #endif
 };
 
-// We use the following format when print the Statement number: Statement->GetID()
+// We use the following format when printing the Statement number: Statement->GetID()
 // This define is used with string concatenation to put this in printf format strings  (Note that %u means unsigned int)
 #define FMT_STMT "STMT%05u"
 

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -5131,6 +5131,7 @@ struct GenTreeILOffset : public GenTree
 
 struct Statement
 {
+public:
     GenTree*       gtStmtExpr;      // root of the expression tree
     GenTree*       gtStmtList;      // first node (for forward walks)
     InlineContext* gtInlineContext; // The inline context for this statement.
@@ -5138,8 +5139,12 @@ struct Statement
 
 #ifdef DEBUG
     IL_OFFSET gtStmtLastILoffs; // instr offset at end of stmt
+
+private:
+    unsigned m_stmtID;
 #endif
 
+public:
     __declspec(property(get = getNextStmt)) Statement* gtNextStmt;
 
     __declspec(property(get = getPrevStmt)) Statement* gtPrevStmt;
@@ -5173,13 +5178,14 @@ struct Statement
         }
     }
 
-    Statement(GenTree* expr, IL_OFFSETX offset)
+    Statement(GenTree* expr, IL_OFFSETX offset DEBUGARG(unsigned stmtID))
         : gtStmtExpr(expr)
         , gtStmtList(nullptr)
         , gtInlineContext(nullptr)
         , gtStmtILoffsx(offset)
 #ifdef DEBUG
         , gtStmtLastILoffs(BAD_IL_OFFSET)
+        , m_stmtID(stmtID)
 #endif
         , gtNext(nullptr)
         , gtPrev(nullptr)
@@ -5201,6 +5207,13 @@ struct Statement
     {
         return gtStmtExpr->GetCostEx();
     }
+
+#ifdef DEBUG
+    unsigned GetID() const
+    {
+        return m_stmtID;
+    }
+#endif
 };
 
 class StatementIterator

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -5129,6 +5129,10 @@ struct GenTreeILOffset : public GenTree
 #endif
 };
 
+// We use the following format when print the Statement number: Statement->GetID()
+// This define is used with string concatenation to put this in printf format strings  (Note that %u means unsigned int)
+#define FMT_STMT "STMT%05u"
+
 struct Statement
 {
 public:

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -638,7 +638,7 @@ inline void Compiler::impAppendStmt(Statement* stmt, unsigned chkLevel)
     if (verbose)
     {
         printf("\n\n");
-        gtDispTree(stmt->gtStmtExpr);
+        gtDispStmt(stmt);
     }
 #endif
 }

--- a/src/jit/indirectcalltransformer.cpp
+++ b/src/jit/indirectcalltransformer.cpp
@@ -177,7 +177,7 @@ private:
 
         void Transform()
         {
-            JITDUMP("*** %s: transforming [%06u]\n", Name(), compiler->dspTreeID(stmt->gtStmtExpr));
+            JITDUMP("*** %s: transforming [%06u]\n", Name(), stmt->GetID());
             FixupRetExpr();
             ClearFlag();
             CreateRemainder();

--- a/src/jit/indirectcalltransformer.cpp
+++ b/src/jit/indirectcalltransformer.cpp
@@ -177,7 +177,7 @@ private:
 
         void Transform()
         {
-            JITDUMP("*** %s: transforming [%06u]\n", Name(), stmt->GetID());
+            JITDUMP("*** %s: transforming" FMT_STMT "\n", Name(), stmt->GetID());
             FixupRetExpr();
             ClearFlag();
             CreateRemainder();

--- a/src/jit/jit.h
+++ b/src/jit/jit.h
@@ -560,6 +560,9 @@ const bool dspGCtbls = true;
 #define DISPTREE(t)                                                                                                    \
     if (JitTls::GetCompiler()->verbose)                                                                                \
         JitTls::GetCompiler()->gtDispTree(t);
+#define DISPSTMT(t)                                                                                                    \
+    if (JitTls::GetCompiler()->verbose)                                                                                \
+        JitTls::GetCompiler()->gtDispStmt(t);
 #define DISPRANGE(range)                                                                                               \
     if (JitTls::GetCompiler()->verbose)                                                                                \
         JitTls::GetCompiler()->gtDispRange(range);
@@ -574,6 +577,7 @@ const bool dspGCtbls = true;
 #define DBEXEC(flg, expr)
 #define DISPNODE(t)
 #define DISPTREE(t)
+#define DISPSTMT(t)
 #define DISPRANGE(range)
 #define DISPTREERANGE(range, t)
 #define VERBOSE 0

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -3802,7 +3802,7 @@ void Compiler::lvaMarkLocalVars(BasicBlock* block, bool isRecompute)
     for (Statement* stmt : StatementList(block->FirstNonPhiDef()))
     {
         MarkLocalVarsVisitor visitor(this, block, stmt, isRecompute);
-        DISPTREE(stmt->gtStmtExpr);
+        DISPSTMT(stmt);
         visitor.WalkTree(&stmt->gtStmtExpr, nullptr);
     }
 }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -6696,7 +6696,7 @@ void Compiler::fgMorphCallInline(GenTreeCall* call, InlineResult* inlineResult)
     {
         if (call->gtReturnType != TYP_VOID)
         {
-            JITDUMP("Inlining [%06u] failed, so bashing [%06u] to NOP\n", dspTreeID(call), fgMorphStmt->GetID());
+            JITDUMP("Inlining [%06u] failed, so bashing " FMT_STMT " to NOP\n", dspTreeID(call), fgMorphStmt->GetID());
 
             // Detach the GT_CALL tree from the original statement by
             // hanging a "nothing" node to it. Later the "nothing" node will be removed
@@ -15674,7 +15674,7 @@ void Compiler::fgMorphStmts(BasicBlock* block, bool* lnot, bool* loadw)
 
         if (verbose)
         {
-            printf("\nfgMorphTree " FMT_BB ", STMT%05u (before)\n", block->bbNum, stmt->GetID());
+            printf("\nfgMorphTree " FMT_BB ", " FMT_STMT " (before)\n", block->bbNum, stmt->GetID());
             gtDispTree(tree);
         }
 #endif
@@ -15761,7 +15761,7 @@ void Compiler::fgMorphStmts(BasicBlock* block, bool* lnot, bool* loadw)
             unsigned newHash = gtHashValue(morph);
             if (newHash != oldHash)
             {
-                printf("\nfgMorphTree " FMT_BB ", STMT%05u (after)\n", block->bbNum, stmt->GetID());
+                printf("\nfgMorphTree " FMT_BB ", " FMT_STMT " (after)\n", block->bbNum, stmt->GetID());
                 gtDispTree(morph);
             }
         }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -15669,17 +15669,12 @@ void Compiler::fgMorphStmts(BasicBlock* block, bool* lnot, bool* loadw)
         GenTree* tree = stmt->gtStmtExpr;
 
 #ifdef DEBUG
-        compCurStmtNum++;
-        if (stmt == block->bbStmtList)
-        {
-            block->bbStmtNum = compCurStmtNum; // Set the block->bbStmtNum
-        }
 
         unsigned oldHash = verbose ? gtHashValue(tree) : DUMMY_INIT(~0);
 
         if (verbose)
         {
-            printf("\nfgMorphTree " FMT_BB ", stmt %d (before)\n", block->bbNum, compCurStmtNum);
+            printf("\nfgMorphTree " FMT_BB ", STMT%05u (before)\n", block->bbNum, stmt->GetID());
             gtDispTree(tree);
         }
 #endif
@@ -15766,7 +15761,7 @@ void Compiler::fgMorphStmts(BasicBlock* block, bool* lnot, bool* loadw)
             unsigned newHash = gtHashValue(morph);
             if (newHash != oldHash)
             {
-                printf("\nfgMorphTree " FMT_BB ", stmt %d (after)\n", block->bbNum, compCurStmtNum);
+                printf("\nfgMorphTree " FMT_BB ", STMT%05u (after)\n", block->bbNum, stmt->GetID());
                 gtDispTree(morph);
             }
         }
@@ -15906,10 +15901,6 @@ void Compiler::fgMorphBlocks()
 
     BasicBlock* block = fgFirstBB;
     noway_assert(block);
-
-#ifdef DEBUG
-    compCurStmtNum = 0;
-#endif
 
     do
     {

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -6696,8 +6696,7 @@ void Compiler::fgMorphCallInline(GenTreeCall* call, InlineResult* inlineResult)
     {
         if (call->gtReturnType != TYP_VOID)
         {
-            JITDUMP("Inlining [%06u] failed, so bashing [%06u] to NOP\n", dspTreeID(call),
-                    dspTreeID(fgMorphStmt->gtStmtExpr));
+            JITDUMP("Inlining [%06u] failed, so bashing [%06u] to NOP\n", dspTreeID(call), fgMorphStmt->GetID());
 
             // Detach the GT_CALL tree from the original statement by
             // hanging a "nothing" node to it. Later the "nothing" node will be removed
@@ -6771,9 +6770,9 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result)
     if (verbose)
     {
         printf("Expanding INLINE_CANDIDATE in statement ");
-        printTreeID(fgMorphStmt->gtStmtExpr);
+        printStmtID(fgMorphStmt);
         printf(" in " FMT_BB ":\n", compCurBB->bbNum);
-        gtDispTree(fgMorphStmt->gtStmtExpr);
+        gtDispStmt(fgMorphStmt);
         if (call->IsImplicitTailCall())
         {
             printf("Note: candidate is implicit tail call\n");
@@ -8455,7 +8454,7 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
             if (verbose)
             {
                 printf("\nInserting assignment of a multi-reg call result to a temp:\n");
-                gtDispTree(assgStmt->gtStmtExpr);
+                gtDispStmt(assgStmt);
             }
             result->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED;
 #endif // DEBUG
@@ -18091,7 +18090,7 @@ public:
         if (m_compiler->verbose)
         {
             printf("LocalAddressVisitor visiting statement:\n");
-            m_compiler->gtDispTree(stmt->gtStmtExpr);
+            m_compiler->gtDispStmt(stmt);
             m_stmtModified = false;
         }
 #endif // DEBUG
@@ -18123,6 +18122,7 @@ public:
             {
                 printf("LocalAddressVisitor modified statement:\n");
                 m_compiler->gtDispTree(stmt->gtStmtExpr);
+                m_compiler->gtDispStmt(stmt);
             }
 
             printf("\n");
@@ -18810,9 +18810,9 @@ bool Compiler::fgMorphCombineSIMDFieldAssignments(BasicBlock* block, Statement* 
     {
         printf("\nFound contiguous assignments from a SIMD vector to memory.\n");
         printf("From " FMT_BB ", stmt", block->bbNum);
-        printTreeID(stmt->gtStmtExpr);
+        printStmtID(stmt);
         printf(" to stmt");
-        printTreeID(lastStmt->gtStmtExpr);
+        printStmtID(lastStmt);
         printf("\n");
     }
 #endif
@@ -18853,9 +18853,9 @@ bool Compiler::fgMorphCombineSIMDFieldAssignments(BasicBlock* block, Statement* 
     if (verbose)
     {
         printf("\n" FMT_BB " stmt", block->bbNum);
-        printTreeID(stmt->gtStmtExpr);
+        printStmtID(stmt);
         printf("(before)\n");
-        gtDispTree(stmt->gtStmtExpr);
+        gtDispStmt(stmt);
     }
 #endif
 
@@ -18873,9 +18873,9 @@ bool Compiler::fgMorphCombineSIMDFieldAssignments(BasicBlock* block, Statement* 
     if (verbose)
     {
         printf("\nReplaced " FMT_BB " stmt", block->bbNum);
-        printTreeID(stmt->gtStmtExpr);
+        printStmtID(stmt);
         printf("(after)\n");
-        gtDispTree(stmt->gtStmtExpr);
+        gtDispStmt(stmt);
     }
 #endif
     return true;

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -2375,12 +2375,12 @@ public:
             if (link == nullptr)
             {
                 printf("\ngtFindLink failed: stm=");
-                Compiler::printTreeID(stmt->gtStmtExpr);
+                Compiler::printStmtID(stmt);
                 printf(", exp=");
                 Compiler::printTreeID(exp);
                 printf("\n");
                 printf("stm =");
-                m_pCompiler->gtDispTree(stmt->gtStmtExpr);
+                m_pCompiler->gtDispStmt(stmt);
                 printf("\n");
                 printf("exp =");
                 m_pCompiler->gtDispTree(exp);

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -4326,7 +4326,7 @@ void Compiler::fgOptWhileLoop(BasicBlock* block)
                block->bbNext->bbNum, bTest->bbNum);
         printf("\nEstimated code size expansion is %d\n ", estDupCostSz);
 
-        gtDispTree(copyOfCondStmt->gtStmtExpr);
+        gtDispStmt(copyOfCondStmt);
     }
 
 #endif
@@ -9098,7 +9098,7 @@ void Compiler::optOptimizeBools()
             {
                 printf("Folded %sboolean conditions of " FMT_BB " and " FMT_BB " to :\n",
                        c2->OperIsLeaf() ? "" : "non-leaf ", b1->bbNum, b2->bbNum);
-                gtDispTree(s1->gtStmtExpr);
+                gtDispStmt(s1);
                 printf("\n");
             }
 #endif

--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -507,8 +507,8 @@ void RangeCheck::SetDef(UINT64 hash, Location* loc)
     Location* loc2;
     if (m_pDefTable->Lookup(hash, &loc2))
     {
-        JITDUMP("Already have " FMT_BB ", [%06d], [%06d] for hash => %0I64X", loc2->block->bbNum,
-                Compiler::dspTreeID(loc2->stmt->gtStmtExpr), Compiler::dspTreeID(loc2->tree), hash);
+        JITDUMP("Already have " FMT_BB ", [%06d], [%06d] for hash => %0I64X", loc2->block->bbNum, loc2->stmt->GetID(),
+                Compiler::dspTreeID(loc2->tree), hash);
         assert(false);
     }
 #endif

--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -507,8 +507,8 @@ void RangeCheck::SetDef(UINT64 hash, Location* loc)
     Location* loc2;
     if (m_pDefTable->Lookup(hash, &loc2))
     {
-        JITDUMP("Already have " FMT_BB ", [%06d], [%06d] for hash => %0I64X", loc2->block->bbNum, loc2->stmt->GetID(),
-                Compiler::dspTreeID(loc2->tree), hash);
+        JITDUMP("Already have " FMT_BB ", " FMT_STMT ", [%06d] for hash => %0I64X", loc2->block->bbNum,
+                loc2->stmt->GetID(), Compiler::dspTreeID(loc2->tree), hash);
         assert(false);
     }
 #endif

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -5990,7 +5990,7 @@ void Compiler::fgValueNumberBlock(BasicBlock* blk)
 #ifdef DEBUG
         if (verbose)
         {
-            printf("\n***** " FMT_BB ", STMT%05u (before)\n", blk->bbNum, stmt->GetID());
+            printf("\n***** " FMT_BB ", " FMT_STMT "(before)\n", blk->bbNum, stmt->GetID());
             gtDispTree(stmt->gtStmtExpr);
             printf("\n");
         }
@@ -6004,7 +6004,7 @@ void Compiler::fgValueNumberBlock(BasicBlock* blk)
 #ifdef DEBUG
         if (verbose)
         {
-            printf("\n***** " FMT_BB ", STMT%05u (after)\n", blk->bbNum, stmt->GetID());
+            printf("\n***** " FMT_BB ", " FMT_STMT "(after)\n", blk->bbNum, stmt->GetID());
             gtDispTree(stmt->gtStmtExpr);
             printf("\n");
             if (stmt->gtNext)

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -5816,10 +5816,6 @@ void Compiler::fgValueNumberBlock(BasicBlock* blk)
 {
     compCurBB = blk;
 
-#ifdef DEBUG
-    compCurStmtNum = blk->bbStmtNum - 1; // Set compCurStmtNum
-#endif
-
     Statement* stmt = blk->firstStmt();
 
     // First: visit phi's.  If "newVNForPhis", give them new VN's.  If not,
@@ -5992,10 +5988,9 @@ void Compiler::fgValueNumberBlock(BasicBlock* blk)
     for (; stmt != nullptr; stmt = stmt->getNextStmt())
     {
 #ifdef DEBUG
-        compCurStmtNum++;
         if (verbose)
         {
-            printf("\n***** " FMT_BB ", stmt %d (before)\n", blk->bbNum, compCurStmtNum);
+            printf("\n***** " FMT_BB ", STMT%05u (before)\n", blk->bbNum, stmt->GetID());
             gtDispTree(stmt->gtStmtExpr);
             printf("\n");
         }
@@ -6009,7 +6004,7 @@ void Compiler::fgValueNumberBlock(BasicBlock* blk)
 #ifdef DEBUG
         if (verbose)
         {
-            printf("\n***** " FMT_BB ", stmt %d (after)\n", blk->bbNum, compCurStmtNum);
+            printf("\n***** " FMT_BB ", STMT%05u (after)\n", blk->bbNum, stmt->GetID());
             gtDispTree(stmt->gtStmtExpr);
             printf("\n");
             if (stmt->gtNext)


### PR DESCRIPTION
Part of #25899 

5e4b1248d5: Return dumping for Statement.

Return statements ID and implement dumping methods.

a0bda39c05: Delete `block->bbStmtNum` and `compiler->compCurStmtNum`.

They were duplicating `stmt->gtTreeID` in the past and it was not clear why they were added in the first place.

Delete them and use `stmt->GetID()`, with `STMT%05u` format.

21ef8c78fc: Use `FMT_STMT` for printing `Statement->GetID()`.

So you can use `STMT\d{5}` to seach them anywhere in JiDump.