### PR TITLE
Complete the filtering for MethodImpl.AggressiveOptimization

### DIFF
--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunLibraryRootProvider.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunLibraryRootProvider.cs
@@ -101,9 +101,6 @@ namespace ILCompiler
                 if (method.IsInternalCall)
                     continue;
 
-                if (method.IsAggressiveOptimization)
-                    continue;
-
                 try
                 {
                     CheckCanGenerateMethod(method);

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -148,11 +148,23 @@ namespace Internal.JitInterface
             throw new NotSupportedException();
         }
 
+        private bool ShouldSkipCompilation(IMethodNode methodCodeNodeNeedingCode)
+        {
+            return methodCodeNodeNeedingCode.Method.IsAggressiveOptimization;
+        }
+
         public void CompileMethod(IReadyToRunMethodCodeNode methodCodeNodeNeedingCode)
         {
             _methodCodeNode = methodCodeNodeNeedingCode;
 
-            CompileMethodInternal(methodCodeNodeNeedingCode);
+            if (!ShouldSkipCompilation(methodCodeNodeNeedingCode))
+            {
+                CompileMethodInternal(methodCodeNodeNeedingCode);
+            }
+            else
+            {
+                PublishEmptyCode();
+            }
         }
 
         private SignatureContext GetSignatureContext()


### PR DESCRIPTION
Porting from https://github.com/dotnet/corert/pull/7775.

The code is tested by the improved test harness developed in 7775. 

To do that, I ran this to make sure the binaries used to run the CoreRT tests are using CoreCLR bits. 

First, I built the CoreCLR repo with this change and CoreRT repo with 7775.
Then I overwrite the binaries as follow:
```
xcopy /s C:\Dev\coreclr\bin\Product\Windows_NT.x64.Debug\crossgen2\* C:\Dev\corert\bin\Windows_NT.x64.Debug\tools
```

and then I ran this on the CoreRT side.

```
test\runtest.cmd /mode readytorun
```

It passes, the `DoNotCompile` method is not pre-compiled and jitted at runtime. My test harness changes in 7775 confirmed it has to be jitted at runtime or it will fail to test.

I don't think the test harness is ported over to CoreCLR, so I just left the changes there, wonder if I should merge those.

@dotnet/crossgen-contrib 