### PR TITLE
Fix issue with locals overlapping out of scope GCFrame

### DIFF
--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -4020,6 +4020,13 @@ void ExceptionTracker::ResetLimitFrame()
     m_pLimitFrame = m_pThread->GetFrame();
 }
 
+void ExceptionTracker::ResetInitialExplicitFrame()
+{
+    LIMITED_METHOD_CONTRACT;
+
+    m_pInitialExplicitFrame = m_pThread->GetFrame();
+}
+
 //
 // static
 void ExceptionTracker::ResumeExecution(

--- a/src/vm/exceptionhandling.h
+++ b/src/vm/exceptionhandling.h
@@ -299,6 +299,8 @@ public:
         return m_pInitialExplicitFrame;
     }
 
+    void ResetInitialExplicitFrame();
+
 #ifdef FEATURE_PAL
     // Reset the range of explicit frames, the limit frame and the scanned
     // stack range before unwinding a sequence of native frames. These frames

--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -1001,6 +1001,84 @@ VOID GCFrame::Pop()
 #endif
 }
 
+#ifndef CROSSGEN_COMPILE
+// GCFrame destructor removes the GCFrame from the current thread's explicit frame list.
+// This prevents issues in functions that have HELPER_METHOD_FRAME_BEGIN / END around 
+// GCPROTECT_BEGIN / END and where the C++ compiler places some local variables over 
+// the stack location of the GCFrame local variable after the variable goes out of scope. 
+GCFrame::~GCFrame()
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
+
+    if (m_Next != NULL)
+    {
+        GCX_COOP_THREAD_EXISTS(m_pCurThread);
+        // When the frame is destroyed, make sure it is no longer in the
+        // frame chain managed by the Thread.
+
+        Pop();
+
+#if defined(FEATURE_EH_FUNCLETS) && !defined(FEATURE_PAL)
+        PTR_ExceptionTracker pCurrentTracker = m_pCurThread->GetExceptionState()->GetCurrentExceptionTracker();
+        if (pCurrentTracker != NULL)
+        {
+            if (pCurrentTracker->GetLimitFrame() == this)
+            {
+                // The current frame that was just popped was the EH limit frame. We need to reset the EH limit frame
+                // to the current frame so that it stays on the frame chain from initial explicit frame.
+                // The ExceptionTracker::HasFrameBeenUnwoundByAnyActiveException needs that to correctly detect
+                // frames that were unwound.
+                pCurrentTracker->ResetLimitFrame();
+            }
+
+            PTR_Frame frame = pCurrentTracker->GetInitialExplicitFrame();
+            if (frame != NULL)
+            {
+                while ((frame != FRAME_TOP) && (frame != this))
+                {
+                    PTR_Frame nextFrame = frame->PtrNextFrame();
+                    if (nextFrame == this)
+                    {
+                        // Repair frame chain from the initial explicit frame to the current frame,
+                        // skipping the current GCFrame that was destroyed
+                        frame->m_Next = m_pCurThread->m_pFrame;
+                        break;
+                    }
+                    frame = nextFrame;
+                }
+            }
+        }
+#endif // FEATURE_EH_FUNCLETS && !FEATURE_PAL
+    }
+}
+
+ExceptionFilterFrame::~ExceptionFilterFrame()
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
+
+    if (m_Next != NULL)
+    {
+        GCX_COOP();
+        // When the frame is destroyed, make sure it is no longer in the
+        // frame chain managed by the Thread.
+        Pop();
+    }
+}
+
+#endif // !CROSSGEN_COMPILE
+
 #ifdef FEATURE_INTERPRETER
 // Methods of IntepreterFrame.
 InterpreterFrame::InterpreterFrame(Interpreter* interp) 

--- a/src/vm/frames.h
+++ b/src/vm/frames.h
@@ -409,6 +409,7 @@ public:
 class Frame : public FrameBase
 {
     friend class CheckAsmOffsets;
+    friend class GCFrame;
 #ifdef DACCESS_COMPILE
     friend void Thread::EnumMemoryRegions(CLRDataEnumMemoryFlags flags);
 #endif
@@ -2530,7 +2531,11 @@ private:
     BOOL          m_MaybeInterior;
 
     // Keep as last entry in class
-    DEFINE_VTABLE_GETTER_AND_DTOR(GCFrame)
+    DEFINE_VTABLE_GETTER(GCFrame)
+
+#if !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
+    ~GCFrame();
+#endif
 };
 
 #ifdef FEATURE_INTERPRETER
@@ -3260,11 +3265,16 @@ public:
             *m_pShadowSP |= ICodeManager::SHADOW_SP_FILTER_DONE;
         }
     }
+
+#ifndef CROSSGEN_COMPILE
+    ~ExceptionFilterFrame();
+#endif
+
 #endif
 
 private:
     // Keep as last entry in class
-    DEFINE_VTABLE_GETTER_AND_CTOR_AND_DTOR(ExceptionFilterFrame)
+    DEFINE_VTABLE_GETTER_AND_CTOR(ExceptionFilterFrame)
 };
 
 #ifdef _DEBUG
@@ -3582,7 +3592,7 @@ public:
 
 #define GCPROTECT_END()                                                 \
                 DEBUG_ASSURE_NO_RETURN_END(GCPROTECT) }                 \
-                __gcframe.Pop(); } while(0)
+                } while(0)
 
 
 #else // #ifndef DACCESS_COMPILE


### PR DESCRIPTION
More aggressive C/C++ optimizations done by VS2019 are breaking fragile
assumptions of the CoreCLR "manually managed code".

Unwinding of Frame chains accesses stack local variables after the stack
frame has been unwound, but it depends on their content to be left
intact. The new compiler is breaking this assumption by stack-packing a
different variable over it.

This change fixes the problem by adding a destructor to GCFrame that
pops the frame from the per-thread Frame list.

I also had to refactor two functions where the compiler was complaining
about mixing SEH and C++ EH in single function.

With these changes applied, there was still a problem that I've discovered
when running CoreCLR tests with GCStress 3. When the
ExceptionTracker::m_pInitialExplicitFrame was still pointing to a frame
that was already removed from the explicit Frame chain. When the
ExceptionTracker::HasFrameBeenUnwoundByAnyActiveException was walking
the frame chain starting at m_pInitialExplicitFrame to figure out if a given
frame was already unwound, it has walked to the destroyed GCFrame and
crashed.

To fix that, the chain from the initial explicit frame is updated so
that it stays valid (effectively, the destroyed GCFrame is removed from
it). It was also necessary to handle the case when the destroyed GCFrame
was the ExceptionTracker::m_pLimitFrame. The limit frame needs to be
updated to the next frame so that it can be reached on the chain from
the initial explicit frame.