### PR TITLE
WIP: [arm64] CoreCLR Implement more SIMD intrinsics

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Base.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Base.PlatformNotSupported.cs
@@ -18,19 +18,64 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
         public static bool IsSupported { [Intrinsic] get => false; }
 
         /// <summary>
-        /// Vector LeadingSignCount
+        /// Scalar LeadingSignCount
         /// Corresponds to integer forms of ARM64 CLS
         /// </summary>
         public static int LeadingSignCount(int value) { throw new PlatformNotSupportedException(); }
         public static int LeadingSignCount(long value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        /// Vector LeadingZeroCount
+        /// Scalar LeadingZeroCount
         /// Corresponds to integer forms of ARM64 CLZ
         /// </summary>
         public static int LeadingZeroCount(int value) { throw new PlatformNotSupportedException(); }
         public static int LeadingZeroCount(uint value) { throw new PlatformNotSupportedException(); }
         public static int LeadingZeroCount(long value) { throw new PlatformNotSupportedException(); }
         public static int LeadingZeroCount(ulong value) { throw new PlatformNotSupportedException(); }
+        /// <summary>
+        /// Scalar ReverseBitOrder
+        /// Corresponds to integer forms of ARM64 CLZ
+        /// </summary>
+        public static int ReverseBitOrder(int   value) { throw new PlatformNotSupportedException(); }
+        public static int ReverseBitOrder(uint  value) { throw new PlatformNotSupportedException(); }
+        public static int ReverseBitOrder(long  value) { throw new PlatformNotSupportedException(); }
+        public static int ReverseBitOrder(ulong value) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// Scalar Absolute Compare GE
+        ///
+        /// |left| >= |right|
+        ///
+        /// Corresponds to scalar forms of ARM64 FACGE
+        /// </summary>
+        public static float  AbsoluteCompareGreatherThanOrEqual (float left , float  right) { throw new PlatformNotSupportedException(); }
+        public static double AbsoluteCompareGreatherThanOrEqual (double left, double right) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// Scalar Absolute Compare GT
+        ///
+        /// |left| > |right|
+        ///
+        /// Corresponds to scalar forms of ARM64 FACGT
+        /// </summary>
+        public static float  AbsoluteCompareGreatherThan (float left , float  right) { throw new PlatformNotSupportedException(); }
+        public static double AbsoluteCompareGreatherThan (double left, double right) { throw new PlatformNotSupportedException(); }
+
+
+        /// <summary>
+        /// Left Shift and Insert
+        ///
+        /// Corresponds to scalar forms of ARM64 SLI
+        /// </summary>
+        public static ulong LeftShiftAndInsert (ulong left, ulong right, uint shift) { throw new PlatformNotSupportedException(); }
+        public static long  LeftShiftAndInsert (long left , long  right, uint shift) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// Right Shift and Insert
+        ///
+        /// Corresponds to scalar forms of ARM64 SRI
+        /// </summary>
+        public static ulong RightShiftAndInsert (ulong left, ulong right, uint shift) { throw new PlatformNotSupportedException(); }
+        public static long  RightShiftAndInsert (long left , long  right, uint shift) { throw new PlatformNotSupportedException(); }
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Base.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Base.cs
@@ -19,19 +19,64 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
         public static bool IsSupported { get { return IsSupported; }}
 
         /// <summary>
-        /// Vector LeadingSignCount
+        /// Scalar LeadingSignCount
         /// Corresponds to integer forms of ARM64 CLS
         /// </summary>
         public static int LeadingSignCount(int  value) => LeadingSignCount(value);
         public static int LeadingSignCount(long value) => LeadingSignCount(value);
 
         /// <summary>
-        /// Vector LeadingZeroCount
+        /// Scalar LeadingZeroCount
         /// Corresponds to integer forms of ARM64 CLZ
         /// </summary>
         public static int LeadingZeroCount(int   value) => LeadingZeroCount(value);
         public static int LeadingZeroCount(uint  value) => LeadingZeroCount(value);
         public static int LeadingZeroCount(long  value) => LeadingZeroCount(value);
         public static int LeadingZeroCount(ulong value) => LeadingZeroCount(value);
+
+        /// <summary>
+        /// Scalar ReverseBitOrder
+        /// Corresponds to integer forms of ARM64 RBIT
+        /// </summary>
+        public static int ReverseBitOrder(int   value) => ReverseBitOrder(value);
+        public static int ReverseBitOrder(uint  value) => ReverseBitOrder(value);
+        public static int ReverseBitOrder(long  value) => ReverseBitOrder(value);
+        public static int ReverseBitOrder(ulong value) => ReverseBitOrder(value);
+
+        /// <summary>
+        /// Scalar Absolute Compare GE
+        ///
+        /// |left| >= |right|
+        ///
+        /// Corresponds to vector forms of ARM64 FACGE
+        /// </summary>
+        public static float  AbsoluteCompareGreatherThanOrEqual (float left , float  right) => AbsoluteCompareGreatherThanOrEqual(left, right);
+        public static double AbsoluteCompareGreatherThanOrEqual (double left, double right) => AbsoluteCompareGreatherThanOrEqual(left, right);
+
+        /// <summary>
+        /// Scalar Absolute Compare GT
+        ///
+        /// |left| > |right|
+        ///
+        /// Corresponds to vector forms of ARM64 FACGT
+        /// </summary>
+        public static float  AbsoluteCompareGreatherThan (float left , float  right) => AbsoluteCompareGreatherThan(left, right);
+        public static double AbsoluteCompareGreatherThan (double left, double right) => AbsoluteCompareGreatherThan(left, right);
+
+        /// <summary>
+        /// Left Shift and Insert
+        ///
+        /// Corresponds to scalar forms of ARM64 SLI
+        /// </summary>
+        public static ulong LeftShiftAndInsert (ulong left, ulong right, uint shift) => LeftShiftAndInsert(left, right, shift);
+        public static long  LeftShiftAndInsert (long left , long  right, uint shift) => LeftShiftAndInsert(left, right, shift);
+
+        /// <summary>
+        /// Right Shift and Insert
+        ///
+        /// Corresponds to scalar forms of ARM64 SRI
+        /// </summary>
+        public static ulong RightShiftAndInsert (ulong left, ulong right, uint shift) => RightShiftAndInsert(left, right, shift);
+        public static long  RightShiftAndInsert (long left , long  right, uint shift) => RightShiftAndInsert(left, right, shift);
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Simd.PlatformNotSupported.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Simd.PlatformNotSupported.cs
@@ -343,5 +343,314 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
         /// </summary>
         public static Vector64<T> Xor<T>(Vector64<T> left, Vector64<T> right) where T : struct { throw new PlatformNotSupportedException(); }
         public static Vector128<T> Xor<T>(Vector128<T> left, Vector128<T> right) where T : struct { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// Vector Add across (Sum)
+        ///
+        /// For each element result += value[elem]
+        ///
+        /// Corresponds to vector forms of ARM64 ADDV &amp; FADDP
+        /// </summary>
+        public static byte   AddAcross(Vector64<byte>    value) { throw new PlatformNotSupportedException(); }
+        public static sbyte  AddAcross(Vector64<sbyte>   value) { throw new PlatformNotSupportedException(); }
+        public static ushort AddAcross(Vector64<ushort>  value) { throw new PlatformNotSupportedException(); }
+        public static short  AddAcross(Vector64<short>   value) { throw new PlatformNotSupportedException(); }
+        public static uint   AddAcross(Vector64<uint>    value) { throw new PlatformNotSupportedException(); }
+        public static int    AddAcross(Vector64<int>     value) { throw new PlatformNotSupportedException(); }
+        public static float  AddAcross(Vector64<float>   value) { throw new PlatformNotSupportedException(); }
+        public static byte   AddAcross(Vector128<byte>   value) { throw new PlatformNotSupportedException(); }
+        public static sbyte  AddAcross(Vector128<sbyte>  value) { throw new PlatformNotSupportedException(); }
+        public static ushort AddAcross(Vector128<ushort> value) { throw new PlatformNotSupportedException(); }
+        public static short  AddAcross(Vector128<short>  value) { throw new PlatformNotSupportedException(); }
+        public static uint   AddAcross(Vector128<uint>   value) { throw new PlatformNotSupportedException(); }
+        public static int    AddAcross(Vector128<int>    value) { throw new PlatformNotSupportedException(); }
+        public static long   AddAcross(Vector128<long>   value) { throw new PlatformNotSupportedException(); }
+        public static float  AddAcross(Vector128<float>  value) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// Vector Absolute Compare GE
+        ///
+        /// for each elem
+        /// |left[elem]| >= |right[elem]|
+        ///
+        /// Corresponds to vector forms of ARM64 FACGE
+        /// </summary>
+        public static Vector64<float>   AbsoluteCompareGreatherThanOrEqual (Vector64<float> left  , Vector64<float>   right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float>  AbsoluteCompareGreatherThanOrEqual (Vector128<float> left , Vector128<float>  right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> AbsoluteCompareGreatherThanOrEqual (Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// Vector Absolute Compare GT
+        ///
+        /// for each elem
+        /// |left[elem]| > |right[elem]|
+        ///
+        /// Corresponds to vector forms of ARM64 FACGT
+        /// </summary>
+        public static Vector64<float>   AbsoluteCompareGreatherThan (Vector64<float> left  , Vector64<float>   right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float>  AbsoluteCompareGreatherThan (Vector128<float> left , Vector128<float>  right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> AbsoluteCompareGreatherThan (Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// Left Shift and Insert
+        ///
+        /// Corresponds to vector forms of ARM64 SLI
+        /// </summary>
+        public static Vector64<byte>  LeftShiftAndInsert (Vector64<byte> left , Vector64<byte>  right, uint shift) { throw new PlatformNotSupportedException(); }
+        public static Vector64<uint>  LeftShiftAndInsert (Vector64<uint> left , Vector64<uint>  right, uint shift) { throw new PlatformNotSupportedException(); }
+        public static Vector64<sbyte> LeftShiftAndInsert (Vector64<sbyte> left, Vector64<sbyte> right, uint shift) { throw new PlatformNotSupportedException(); }
+        public static Vector64<int>   LeftShiftAndInsert (Vector64<int> left  , Vector64<int>   right, uint shift) { throw new PlatformNotSupportedException(); }
+
+        public static Vector128<byte>  LeftShiftAndInsert (Vector128<byte>   left, Vector128<byte>  right, uint shift) { throw new PlatformNotSupportedException(); }
+        public static Vector128<uint>  LeftShiftAndInsert (Vector128<uint>   left, Vector128<uint>  right, uint shift) { throw new PlatformNotSupportedException(); }
+        public static Vector128<ulong>  LeftShiftAndInsert (Vector128<ulong> left, Vector128<ulong> right, uint shift) { throw new PlatformNotSupportedException(); }
+        public static Vector128<sbyte> LeftShiftAndInsert (Vector128<sbyte>  left, Vector128<sbyte> right, uint shift) { throw new PlatformNotSupportedException(); }
+        public static Vector128<int>   LeftShiftAndInsert (Vector128<int>    left, Vector128<int>   right, uint shift) { throw new PlatformNotSupportedException(); }
+        public static Vector128<long>  LeftShiftAndInsert (Vector128<long>   left, Vector128<long>  right, uint shift) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// Right Shift and Insert
+        ///
+        /// Corresponds to vector forms of ARM64 SRI
+        /// </summary>
+        public static Vector64<byte>  RightShiftAndInsert (Vector64<byte> left , Vector64<byte>  right, uint shift) { throw new PlatformNotSupportedException(); }
+        public static Vector64<uint>  RightShiftAndInsert (Vector64<uint> left , Vector64<uint>  right, uint shift) { throw new PlatformNotSupportedException(); }
+        public static Vector64<sbyte> RightShiftAndInsert (Vector64<sbyte> left, Vector64<sbyte> right, uint shift) { throw new PlatformNotSupportedException(); }
+        public static Vector64<int>   RightShiftAndInsert (Vector64<int>   left, Vector64<int>   right, uint shift) { throw new PlatformNotSupportedException(); }
+
+        public static Vector128<byte>  RightShiftAndInsert (Vector128<byte> left , Vector128<byte>  right, uint shift) { throw new PlatformNotSupportedException(); }
+        public static Vector128<uint>  RightShiftAndInsert (Vector128<uint> left , Vector128<uint>  right, uint shift) { throw new PlatformNotSupportedException(); }
+        public static Vector128<ulong> RightShiftAndInsert (Vector128<ulong> left, Vector128<ulong> right, uint shift) { throw new PlatformNotSupportedException(); }
+        public static Vector128<sbyte> RightShiftAndInsert (Vector128<sbyte> left, Vector128<sbyte> right, uint shift) { throw new PlatformNotSupportedException(); }
+        public static Vector128<int>   RightShiftAndInsert (Vector128<int> left  , Vector128<int>   right, uint shift) { throw new PlatformNotSupportedException(); }
+        public static Vector128<long>  RightShiftAndInsert (Vector128<long> left , Vector128<long>  right, uint shift) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// Extract and Narrow (Low part)
+        ///
+        /// Corresponds to vector forms of ARM64 XTN
+        /// </summary>
+        public static Vector64<int> ExtractAndNarrowLow (Vector128<long> value) { throw new PlatformNotSupportedException(); }
+
+        public static Vector64<uint> ExtractAndNarrowLow (Vector128<ulong> value) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// Extract and Narrow (High part)
+        ///
+        /// Corresponds to vector forms of ARM64 XTN2
+        /// </summary>
+        public static Vector64<int> ExtractAndNarrowHigh (Vector128<long> value) { throw new PlatformNotSupportedException(); }
+
+        public static Vector64<uint> ExtractAndNarrowHigh (Vector128<ulong> value) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// Unzip vectors (Even elements)
+        ///
+        /// Corresponds to vector forms of ARM64 UZP1
+        /// </summary>
+        public static Vector64<sbyte> UnzipEven (Vector64<sbyte> left, Vector64<sbyte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<int> UnzipEven (Vector64<int> left, Vector64<int> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<byte> UnzipEven (Vector64<byte> left, Vector64<byte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<uint> UnzipEven (Vector64<uint> left, Vector64<uint> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<float> UnzipEven (Vector64<float> left, Vector64<float> right) { throw new PlatformNotSupportedException(); }
+
+        public static Vector128<sbyte> UnzipEven (Vector128<sbyte> left, Vector128<sbyte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<int> UnzipEven (Vector128<int> left, Vector128<int> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<long> UnzipEven (Vector128<long> left, Vector128<long> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<byte> UnzipEven (Vector128<byte> left, Vector128<byte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<uint> UnzipEven (Vector128<uint> left, Vector128<uint> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<ulong> UnzipEven (Vector128<ulong> left, Vector128<ulong> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> UnzipEven (Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> UnzipEven (Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// Unzip vectors (Odd elements)
+        ///
+        /// Corresponds to vector forms of ARM64 UZP2
+        /// </summary>
+        public static Vector64<sbyte> UnzipOdd (Vector64<sbyte> left, Vector64<sbyte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<int> UnzipOdd (Vector64<int> left, Vector64<int> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<byte> UnzipOdd (Vector64<byte> left, Vector64<byte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<uint> UnzipOdd (Vector64<uint> left, Vector64<uint> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<float> UnzipOdd (Vector64<float> left, Vector64<float> right) { throw new PlatformNotSupportedException(); }
+
+        public static Vector128<sbyte> UnzipOdd (Vector128<sbyte> left, Vector128<sbyte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<int> UnzipOdd (Vector128<int> left, Vector128<int> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<long> UnzipOdd (Vector128<long> left, Vector128<long> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<byte> UnzipOdd (Vector128<byte> left, Vector128<byte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<uint> UnzipOdd (Vector128<uint> left, Vector128<uint> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<ulong> UnzipOdd (Vector128<ulong> left, Vector128<ulong> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> UnzipOdd (Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> UnzipOdd (Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// Zip vectors (Low half)
+        ///
+        /// Corresponds to vector forms of ARM64 ZIP1
+        /// </summary>
+        public static Vector64<sbyte> ZipLow (Vector64<sbyte> left, Vector64<sbyte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<int> ZipLow (Vector64<int> left, Vector64<int> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<byte> ZipLow (Vector64<byte> left, Vector64<byte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<uint> ZipLow (Vector64<uint> left, Vector64<uint> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<float> ZipLow (Vector64<float> left, Vector64<float> right) { throw new PlatformNotSupportedException(); }
+
+        public static Vector128<sbyte> ZipLow (Vector128<sbyte> left, Vector128<sbyte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<int> ZipLow (Vector128<int> left, Vector128<int> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<long> ZipLow (Vector128<long> left, Vector128<long> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<byte> ZipLow (Vector128<byte> left, Vector128<byte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<uint> ZipLow (Vector128<uint> left, Vector128<uint> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<ulong> ZipLow (Vector128<ulong> left, Vector128<ulong> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> ZipLow (Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> ZipLow (Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// Unzip vectors (Top half)
+        ///
+        /// Corresponds to vector forms of ARM64 ZIP2
+        /// </summary>
+        public static Vector64<sbyte> ZipHigh (Vector64<sbyte> left, Vector64<sbyte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<int> ZipHigh (Vector64<int> left, Vector64<int> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<byte> ZipHigh (Vector64<byte> left, Vector64<byte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<uint> ZipHigh (Vector64<uint> left, Vector64<uint> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<float> ZipHigh (Vector64<float> left, Vector64<float> right) { throw new PlatformNotSupportedException(); }
+
+        public static Vector128<sbyte> ZipHigh (Vector128<sbyte> left, Vector128<sbyte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<int> ZipHigh (Vector128<int> left, Vector128<int> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<long> ZipHigh (Vector128<long> left, Vector128<long> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<byte> ZipHigh (Vector128<byte> left, Vector128<byte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<uint> ZipHigh (Vector128<uint> left, Vector128<uint> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<ulong> ZipHigh (Vector128<ulong> left, Vector128<ulong> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> ZipHigh (Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> ZipHigh (Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// Transpose vectors (Even elements)
+        ///
+        /// Corresponds to vector forms of ARM64 TRN1
+        /// </summary>
+        public static Vector64<sbyte> TransposeVectorEven (Vector64<sbyte> left, Vector64<sbyte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<int> TransposeVectorEven (Vector64<int> left, Vector64<int> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<byte> TransposeVectorEven (Vector64<byte> left, Vector64<byte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<uint> TransposeVectorEven (Vector64<uint> left, Vector64<uint> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<float> TransposeVectorEven (Vector64<float> left, Vector64<float> right) { throw new PlatformNotSupportedException(); }
+
+        public static Vector128<sbyte> TransposeVectorEven (Vector128<sbyte> left, Vector128<sbyte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<int> TransposeVectorEven (Vector128<int> left, Vector128<int> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<long> TransposeVectorEven (Vector128<long> left, Vector128<long> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<byte> TransposeVectorEven (Vector128<byte> left, Vector128<byte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<uint> TransposeVectorEven (Vector128<uint> left, Vector128<uint> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<ulong> TransposeVectorEven (Vector128<ulong> left, Vector128<ulong> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> TransposeVectorEven (Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> TransposeVectorEven (Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// Transpose vectors (Odd elements)
+        ///
+        /// Corresponds to vector forms of ARM64 TRN2
+        /// </summary>
+        public static Vector64<sbyte> TransposeVectorOdd (Vector64<sbyte> left, Vector64<sbyte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<int> TransposeVectorOdd (Vector64<int> left, Vector64<int> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<byte> TransposeVectorOdd (Vector64<byte> left, Vector64<byte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<uint> TransposeVectorOdd (Vector64<uint> left, Vector64<uint> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<float> TransposeVectorOdd (Vector64<float> left, Vector64<float> right) { throw new PlatformNotSupportedException(); }
+
+        public static Vector128<sbyte> TransposeVectorOdd (Vector128<sbyte> left, Vector128<sbyte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<int> TransposeVectorOdd (Vector128<int> left, Vector128<int> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<long> TransposeVectorOdd (Vector128<long> left, Vector128<long> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<byte> TransposeVectorOdd (Vector128<byte> left, Vector128<byte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<uint> TransposeVectorOdd (Vector128<uint> left, Vector128<uint> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<ulong> TransposeVectorOdd (Vector128<ulong> left, Vector128<ulong> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> TransposeVectorOdd (Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> TransposeVectorOdd (Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+
+
+        /// <summary>
+        /// Multiply and subtract
+        ///
+        /// Corresponds to vector forms of ARM64 FMLS and MLS.
+        /// </summary>
+        public static Vector64<float> MultiplyAndSubtract (Vector64<float> acc, Vector64<float> left, Vector64<float> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<float> MultiplyAndSubtract (Vector64<float> acc, Vector64<float> left, Vector64<float> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector64<float> MultiplyAndSubtract (Vector64<float> acc, Vector64<float> left, Vector128<float> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector64<float> MultiplyAndSubtract (Vector64<float> acc, Vector64<float> left, float value) { throw new PlatformNotSupportedException(); }
+
+        public static Vector128<float> MultiplyAndSubtract (Vector128<float> acc, Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> MultiplyAndSubtract (Vector128<float> acc, Vector128<float> left, Vector64<float> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> MultiplyAndSubtract (Vector128<float> acc, Vector128<float> left, Vector128<float> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> MultiplyAndSubtract (Vector128<float> acc, Vector128<float> left, float value) { throw new PlatformNotSupportedException(); }
+
+        public static Vector128<double> MultiplyAndSubtract (Vector128<double> acc, Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> MultiplyAndSubtract (Vector128<double> acc, Vector128<double> left, Vector128<double> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> MultiplyAndSubtract (Vector128<double> acc, Vector128<double> left, double value) { throw new PlatformNotSupportedException(); }
+
+        public static Vector64<int> MultiplyAndSubtract (Vector64<int> acc, Vector64<int> left, Vector64<int> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<int> MultiplyAndSubtract (Vector64<int> acc, Vector64<int> left, Vector64<int> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector64<int> MultiplyAndSubtract (Vector64<int> acc, Vector64<int> left, Vector128<int> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector64<int> MultiplyAndSubtract (Vector64<int> acc, Vector64<int> left, int value) { throw new PlatformNotSupportedException(); }
+
+        public static Vector128<int> MultiplyAndSubtract (Vector128<int> acc, Vector128<int> left, Vector128<int> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<int> MultiplyAndSubtract (Vector128<int> acc, Vector128<int> left, Vector64<int> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector128<int> MultiplyAndSubtract (Vector128<int> acc, Vector128<int> left, Vector128<int> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector128<int> MultiplyAndSubtract (Vector128<int> acc, Vector128<int> left, int value) { throw new PlatformNotSupportedException(); }
+
+        public static Vector64<uint> MultiplyAndSubtract (Vector64<uint> acc, Vector64<uint> left, Vector64<uint> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<uint> MultiplyAndSubtract (Vector64<uint> acc, Vector64<uint> left, Vector64<uint> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector64<uint> MultiplyAndSubtract (Vector64<uint> acc, Vector64<uint> left, Vector128<uint> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector64<uint> MultiplyAndSubtract (Vector64<uint> acc, Vector64<uint> left, uint value) { throw new PlatformNotSupportedException(); }
+
+        public static Vector128<uint> MultiplyAndSubtract (Vector128<uint> acc, Vector128<uint> left, Vector128<uint> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<uint> MultiplyAndSubtract (Vector128<uint> acc, Vector128<uint> left, Vector64<uint> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector128<uint> MultiplyAndSubtract (Vector128<uint> acc, Vector128<uint> left, Vector128<uint> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector128<uint> MultiplyAndSubtract (Vector128<uint> acc, Vector128<uint> left, uint value) { throw new PlatformNotSupportedException(); }
+
+        public static Vector128<byte> MultiplyAndSubtract (Vector128<byte> acc, Vector128<byte> left, Vector128<byte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<byte> MultiplyAndSubtract (Vector128<byte> acc, Vector128<byte> left, Vector128<byte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<sbyte> MultiplyAndSubtract (Vector128<sbyte> acc, Vector128<sbyte> left, Vector128<sbyte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<sbyte> MultiplyAndSubtract (Vector128<sbyte> acc, Vector128<sbyte> left, Vector128<sbyte> right) { throw new PlatformNotSupportedException(); }
+
+
+        /// <summary>
+        /// Multiply and Add
+        ///
+        /// Corresponds to vector forms of ARM64 FMLA and MLA.
+        /// </summary>
+        public static Vector64<float> MultiplyAndAdd (Vector64<float> acc, Vector64<float> left, Vector64<float> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<float> MultiplyAndAdd (Vector64<float> acc, Vector64<float> left, Vector64<float> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector64<float> MultiplyAndAdd (Vector64<float> acc, Vector64<float> left, Vector128<float> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector64<float> MultiplyAndAdd (Vector64<float> acc, Vector64<float> left, float value) { throw new PlatformNotSupportedException(); }
+
+        public static Vector128<float> MultiplyAndAdd (Vector128<float> acc, Vector128<float> left, Vector128<float> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> MultiplyAndAdd (Vector128<float> acc, Vector128<float> left, Vector64<float> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> MultiplyAndAdd (Vector128<float> acc, Vector128<float> left, Vector128<float> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector128<float> MultiplyAndAdd (Vector128<float> acc, Vector128<float> left, float value) { throw new PlatformNotSupportedException(); }
+
+        public static Vector128<double> MultiplyAndAdd (Vector128<double> acc, Vector128<double> left, Vector128<double> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> MultiplyAndAdd (Vector128<double> acc, Vector128<double> left, Vector128<double> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector128<double> MultiplyAndAdd (Vector128<double> acc, Vector128<double> left, double value) { throw new PlatformNotSupportedException(); }
+
+        public static Vector64<int> MultiplyAndAdd (Vector64<int> acc, Vector64<int> left, Vector64<int> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<int> MultiplyAndAdd (Vector64<int> acc, Vector64<int> left, Vector64<int> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector64<int> MultiplyAndAdd (Vector64<int> acc, Vector64<int> left, Vector128<int> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector64<int> MultiplyAndAdd (Vector64<int> acc, Vector64<int> left, int value) { throw new PlatformNotSupportedException(); }
+
+        public static Vector128<int> MultiplyAndAdd (Vector128<int> acc, Vector128<int> left, Vector128<int> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<int> MultiplyAndAdd (Vector128<int> acc, Vector128<int> left, Vector64<int> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector128<int> MultiplyAndAdd (Vector128<int> acc, Vector128<int> left, Vector128<int> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector128<int> MultiplyAndAdd (Vector128<int> acc, Vector128<int> left, int value) { throw new PlatformNotSupportedException(); }
+
+        public static Vector64<uint> MultiplyAndAdd (Vector64<uint> acc, Vector64<uint> left, Vector64<uint> right) { throw new PlatformNotSupportedException(); }
+        public static Vector64<uint> MultiplyAndAdd (Vector64<uint> acc, Vector64<uint> left, Vector64<uint> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector64<uint> MultiplyAndAdd (Vector64<uint> acc, Vector64<uint> left, Vector128<uint> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector64<uint> MultiplyAndAdd (Vector64<uint> acc, Vector64<uint> left, uint value) { throw new PlatformNotSupportedException(); }
+
+        public static Vector128<uint> MultiplyAndAdd (Vector128<uint> acc, Vector128<uint> left, Vector128<uint> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<uint> MultiplyAndAdd (Vector128<uint> acc, Vector128<uint> left, Vector64<uint> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector128<uint> MultiplyAndAdd (Vector128<uint> acc, Vector128<uint> left, Vector128<uint> sel, byte index) { throw new PlatformNotSupportedException(); }
+        public static Vector128<uint> MultiplyAndAdd (Vector128<uint> acc, Vector128<uint> left, uint value) { throw new PlatformNotSupportedException(); }
+
+        public static Vector128<byte> MultiplyAndAdd (Vector128<byte> acc, Vector128<byte> left, Vector128<byte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<byte> MultiplyAndAdd (Vector128<byte> acc, Vector128<byte> left, Vector128<byte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<sbyte> MultiplyAndAdd (Vector128<sbyte> acc, Vector128<sbyte> left, Vector128<sbyte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector128<sbyte> MultiplyAndAdd (Vector128<sbyte> acc, Vector128<sbyte> left, Vector128<sbyte> right) { throw new PlatformNotSupportedException(); }
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Simd.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/Arm64/Simd.cs
@@ -344,5 +344,311 @@ namespace System.Runtime.Intrinsics.Arm.Arm64
         /// </summary>
         public static Vector64<T>  Xor<T>(Vector64<T>  left, Vector64<T>  right) where T : struct => Xor(left, right);
         public static Vector128<T> Xor<T>(Vector128<T> left, Vector128<T> right) where T : struct => Xor(left, right);
+
+	/// <summary>
+        /// Vector Add across (Sum)
+        ///
+        /// For each element result += value[elem]
+        ///
+        /// Corresponds to vector forms of ARM64 ADDV &amp; FADDP
+        /// </summary>
+        public static byte   AddAcross(Vector64<byte>    value) => AddAcross(value);
+        public static sbyte  AddAcross(Vector64<sbyte>   value) => AddAcross(value);
+        public static ushort AddAcross(Vector64<ushort>  value) => AddAcross(value);
+        public static short  AddAcross(Vector64<short>   value) => AddAcross(value);
+        public static uint   AddAcross(Vector64<uint>    value) => AddAcross(value);
+        public static int    AddAcross(Vector64<int>     value) => AddAcross(value);
+        public static float  AddAcross(Vector64<float>   value) => AddAcross(value);
+        public static byte   AddAcross(Vector128<byte>   value) => AddAcross(value);
+        public static sbyte  AddAcross(Vector128<sbyte>  value) => AddAcross(value);
+        public static ushort AddAcross(Vector128<ushort> value) => AddAcross(value);
+        public static short  AddAcross(Vector128<short>  value) => AddAcross(value);
+        public static uint   AddAcross(Vector128<uint>   value) => AddAcross(value);
+        public static int    AddAcross(Vector128<int>    value) => AddAcross(value);
+        public static long   AddAcross(Vector128<long>   value) => AddAcross(value);
+        public static float  AddAcross(Vector128<float>  value) => AddAcross(value);
+
+        /// <summary>
+        /// Vector Absolute Compare GE
+        ///
+        /// for each elem
+        /// |left[elem]| >= |right[elem]|
+        ///
+        /// Corresponds to vector forms of ARM64 FACGE
+        /// </summary>
+        public static Vector64<float>   AbsoluteCompareGreatherThanOrEqual (Vector64<float> left  , Vector64<float>   right) => AbsoluteCompareGreatherThanOrEqual(left, right);
+        public static Vector128<float>  AbsoluteCompareGreatherThanOrEqual (Vector128<float> left , Vector128<float>  right) => AbsoluteCompareGreatherThanOrEqual(left, right);
+        public static Vector128<double> AbsoluteCompareGreatherThanOrEqual (Vector128<double> left, Vector128<double> right) => AbsoluteCompareGreatherThanOrEqual(left, right);
+
+        /// <summary>
+        /// Vector Absolute Compare GT
+        ///
+        /// for each elem
+        /// |left[elem]| > |right[elem]|
+        ///
+        /// Corresponds to vector forms of ARM64 FACGT
+        /// </summary>
+        public static Vector64<float>   AbsoluteCompareGreatherThan (Vector64<float> left  , Vector64<float>   right) => AbsoluteCompareGreatherThan(left, right);
+        public static Vector128<float>  AbsoluteCompareGreatherThan (Vector128<float> left , Vector128<float>  right) => AbsoluteCompareGreatherThan(left, right);
+        public static Vector128<double> AbsoluteCompareGreatherThan (Vector128<double> left, Vector128<double> right) => AbsoluteCompareGreatherThan(left, right);
+
+        /// <summary>
+        /// Left Shift and Insert
+        ///
+        /// Corresponds to vector forms of ARM64 SLI
+        /// </summary>
+        public static Vector64<byte>  LeftShiftAndInsert (Vector64<byte> left , Vector64<byte>  right, uint shift) => LeftShiftAndInsert(left, right, shift);
+        public static Vector64<uint>  LeftShiftAndInsert (Vector64<uint> left , Vector64<uint>  right, uint shift) => LeftShiftAndInsert(left, right, shift);
+        public static Vector64<sbyte> LeftShiftAndInsert (Vector64<sbyte> left, Vector64<sbyte> right, uint shift) => LeftShiftAndInsert(left, right, shift);
+        public static Vector64<int>   LeftShiftAndInsert (Vector64<int> left  , Vector64<int>   right, uint shift) => LeftShiftAndInsert(left, right, shift);
+
+        public static Vector128<byte>  LeftShiftAndInsert (Vector128<byte> left  , Vector128<byte>  right, uint shift) => LeftShiftAndInsert(left, right, shift);
+        public static Vector128<uint>  LeftShiftAndInsert (Vector128<uint> left  , Vector128<uint>  right, uint shift) => LeftShiftAndInsert(left, right, shift);
+        public static Vector128<ulong> LeftShiftAndInsert (Vector128<ulong> left, Vector128<ulong> right, uint shift) => LeftShiftAndInsert(left, right, shift);
+        public static Vector128<sbyte> LeftShiftAndInsert (Vector128<sbyte> left , Vector128<sbyte> right, uint shift) => LeftShiftAndInsert(left, right, shift);
+        public static Vector128<int>   LeftShiftAndInsert (Vector128<int> left   , Vector128<int>   right, uint shift) => LeftShiftAndInsert(left, right, shift);
+        public static Vector128<long>  LeftShiftAndInsert (Vector128<long> left  , Vector128<long>  right, uint shift) => LeftShiftAndInsert(left, right, shift);
+
+        /// <summary>
+        /// Right Shift and Insert
+        ///
+        /// Corresponds to vector forms of ARM64 SRI
+        /// </summary>
+        public static Vector64<byte>  RightShiftAndInsert (Vector64<byte> left , Vector64<byte>  right, uint shift) => RightShiftAndInsert(left, right, shift);
+        public static Vector64<uint>  RightShiftAndInsert (Vector64<uint> left , Vector64<uint>  right, uint shift) => RightShiftAndInsert(left, right, shift);
+        public static Vector64<sbyte> RightShiftAndInsert (Vector64<sbyte> left, Vector64<sbyte> right, uint shift) => RightShiftAndInsert(left, right, shift);
+        public static Vector64<int>   RightShiftAndInsert (Vector64<int> left  , Vector64<int>   right, uint shift) => RightShiftAndInsert(left, right, shift);
+
+        public static Vector128<byte>  RightShiftAndInsert (Vector128<byte> left  , Vector128<byte>  right, uint shift) => RightShiftAndInsert(left, right, shift);
+        public static Vector128<uint>  RightShiftAndInsert (Vector128<uint> left  , Vector128<uint>  right, uint shift) => RightShiftAndInsert(left, right, shift);
+        public static Vector128<ulong> RightShiftAndInsert (Vector128<ulong> left , Vector128<ulong> right, uint shift) => RightShiftAndInsert(left, right, shift);
+        public static Vector128<sbyte> RightShiftAndInsert (Vector128<sbyte> left , Vector128<sbyte> right, uint shift) => RightShiftAndInsert(left, right, shift);
+        public static Vector128<int>   RightShiftAndInsert (Vector128<int> left   , Vector128<int>   right, uint shift) => RightShiftAndInsert(left, right, shift);
+        public static Vector128<long>  RightShiftAndInsert (Vector128<long> left  , Vector128<long>  right, uint shift) => RightShiftAndInsert(left, right, shift);
+
+        /// <summary>
+        /// Extract and Narrow (Low part)
+        ///
+        /// Corresponds to vector forms of ARM64 XTN
+        /// </summary>
+        public static Vector64<int> ExtractAndNarrowLow (Vector128<long> value) => ExtractAndNarrowLow (value);
+        public static Vector64<uint> ExtractAndNarrowLow (Vector128<ulong> value) => ExtractAndNarrowLow (value);
+
+        /// <summary>
+        /// Extract and Narrow (High part)
+        ///
+        /// Corresponds to vector forms of ARM64 XTN2
+        /// </summary>
+        public static Vector64<int> ExtractAndNarrowHigh (Vector128<long> value) => ExtractAndNarrowHigh (value);
+        public static Vector64<uint> ExtractAndNarrowHigh (Vector128<ulong> value) => ExtractAndNarrowHigh (value);
+
+        /// <summary>
+        /// Unzip vectors (Even elements)
+        ///
+        /// Corresponds to vector forms of ARM64 UZP1
+        /// </summary>
+        public static Vector64<sbyte> UnzipEven (Vector64<sbyte> left, Vector64<sbyte> right) => UnzipEven (left, right);
+        public static Vector64<int> UnzipEven (Vector64<int> left, Vector64<int> right) => UnzipEven (left, right);
+        public static Vector64<byte> UnzipEven (Vector64<byte> left, Vector64<byte> right) => UnzipEven (left, right);
+        public static Vector64<uint> UnzipEven (Vector64<uint> left, Vector64<uint> right) => UnzipEven (left, right);
+        public static Vector64<float> UnzipEven (Vector64<float> left, Vector64<float> right) => UnzipEven (left, right);
+
+        public static Vector128<sbyte> UnzipEven (Vector128<sbyte> left, Vector128<sbyte> right) => UnzipEven (left, right);
+        public static Vector128<int> UnzipEven (Vector128<int> left, Vector128<int> right) => UnzipEven (left, right);
+        public static Vector128<long> UnzipEven (Vector128<long> left, Vector128<long> right) => UnzipEven (left, right);
+        public static Vector128<byte> UnzipEven (Vector128<byte> left, Vector128<byte> right) => UnzipEven (left, right);
+        public static Vector128<uint> UnzipEven (Vector128<uint> left, Vector128<uint> right) => UnzipEven (left, right);
+        public static Vector128<ulong> UnzipEven (Vector128<ulong> left, Vector128<ulong> right) => UnzipEven (left, right);
+        public static Vector128<float> UnzipEven (Vector128<float> left, Vector128<float> right) => UnzipEven (left, right);
+        public static Vector128<double> UnzipEven (Vector128<double> left, Vector128<double> right) => UnzipEven (left, right);
+
+        /// <summary>
+        /// Unzip vectors (Odd elements)
+        ///
+        /// Corresponds to vector forms of ARM64 UZP2
+        /// </summary>
+        public static Vector64<sbyte> UnzipOdd (Vector64<sbyte> left, Vector64<sbyte> right) => UnzipOdd (left, right);
+        public static Vector64<int> UnzipOdd (Vector64<int> left, Vector64<int> right) => UnzipOdd (left, right);
+        public static Vector64<byte> UnzipOdd (Vector64<byte> left, Vector64<byte> right) => UnzipOdd (left, right);
+        public static Vector64<uint> UnzipOdd (Vector64<uint> left, Vector64<uint> right) => UnzipOdd (left, right);
+        public static Vector64<float> UnzipOdd (Vector64<float> left, Vector64<float> right) => UnzipOdd (left, right);
+
+        public static Vector128<sbyte> UnzipOdd (Vector128<sbyte> left, Vector128<sbyte> right) => UnzipOdd (left, right);
+        public static Vector128<int> UnzipOdd (Vector128<int> left, Vector128<int> right) => UnzipOdd (left, right);
+        public static Vector128<long> UnzipOdd (Vector128<long> left, Vector128<long> right) => UnzipOdd (left, right);
+        public static Vector128<byte> UnzipOdd (Vector128<byte> left, Vector128<byte> right) => UnzipOdd (left, right);
+        public static Vector128<uint> UnzipOdd (Vector128<uint> left, Vector128<uint> right) => UnzipOdd (left, right);
+        public static Vector128<ulong> UnzipOdd (Vector128<ulong> left, Vector128<ulong> right) => UnzipOdd (left, right);
+        public static Vector128<float> UnzipOdd (Vector128<float> left, Vector128<float> right) => UnzipOdd (left, right);
+        public static Vector128<double> UnzipOdd (Vector128<double> left, Vector128<double> right) => UnzipOdd (left, right);
+
+        /// <summary>
+        /// Zip vectors (Low half)
+        ///
+        /// Corresponds to vector forms of ARM64 ZIP1
+        /// </summary>
+        public static Vector64<sbyte> ZipLow (Vector64<sbyte> left, Vector64<sbyte> right) => ZipLow (left, right);
+        public static Vector64<int> ZipLow (Vector64<int> left, Vector64<int> right) => ZipLow (left, right);
+        public static Vector64<byte> ZipLow (Vector64<byte> left, Vector64<byte> right) => ZipLow (left, right);
+        public static Vector64<uint> ZipLow (Vector64<uint> left, Vector64<uint> right) => ZipLow (left, right);
+        public static Vector64<float> ZipLow (Vector64<float> left, Vector64<float> right) => ZipLow (left, right);
+
+        public static Vector128<sbyte> ZipLow (Vector128<sbyte> left, Vector128<sbyte> right) => ZipLow (left, right);
+        public static Vector128<int> ZipLow (Vector128<int> left, Vector128<int> right) => ZipLow (left, right);
+        public static Vector128<long> ZipLow (Vector128<long> left, Vector128<long> right) => ZipLow (left, right);
+        public static Vector128<byte> ZipLow (Vector128<byte> left, Vector128<byte> right) => ZipLow (left, right);
+        public static Vector128<uint> ZipLow (Vector128<uint> left, Vector128<uint> right) => ZipLow (left, right);
+        public static Vector128<ulong> ZipLow (Vector128<ulong> left, Vector128<ulong> right) => ZipLow (left, right);
+        public static Vector128<float> ZipLow (Vector128<float> left, Vector128<float> right) => ZipLow (left, right);
+        public static Vector128<double> ZipLow (Vector128<double> left, Vector128<double> right) => ZipLow (left, right);
+
+        /// <summary>
+        /// Unzip vectors (Top half)
+        ///
+        /// Corresponds to vector forms of ARM64 ZIP2
+        /// </summary>
+        public static Vector64<sbyte> ZipHigh (Vector64<sbyte> left, Vector64<sbyte> right) => ZipHigh (left, right);
+        public static Vector64<int> ZipHigh (Vector64<int> left, Vector64<int> right) => ZipHigh (left, right);
+        public static Vector64<byte> ZipHigh (Vector64<byte> left, Vector64<byte> right) => ZipHigh (left, right);
+        public static Vector64<uint> ZipHigh (Vector64<uint> left, Vector64<uint> right) => ZipHigh (left, right);
+        public static Vector64<float> ZipHigh (Vector64<float> left, Vector64<float> right) => ZipHigh (left, right);
+
+        public static Vector128<sbyte> ZipHigh (Vector128<sbyte> left, Vector128<sbyte> right) => ZipHigh (left, right);
+        public static Vector128<int> ZipHigh (Vector128<int> left, Vector128<int> right) => ZipHigh (left, right);
+        public static Vector128<long> ZipHigh (Vector128<long> left, Vector128<long> right) => ZipHigh (left, right);
+        public static Vector128<byte> ZipHigh (Vector128<byte> left, Vector128<byte> right) => ZipHigh (left, right);
+        public static Vector128<uint> ZipHigh (Vector128<uint> left, Vector128<uint> right) => ZipHigh (left, right);
+        public static Vector128<ulong> ZipHigh (Vector128<ulong> left, Vector128<ulong> right) => ZipHigh (left, right);
+        public static Vector128<float> ZipHigh (Vector128<float> left, Vector128<float> right) => ZipHigh (left, right);
+        public static Vector128<double> ZipHigh (Vector128<double> left, Vector128<double> right) => ZipHigh (left, right);
+
+        /// <summary>
+        /// Transpose vectors (Even elements)
+        ///
+        /// Corresponds to vector forms of ARM64 TRN1
+        /// </summary>
+        public static Vector64<sbyte> TransposeVectorEven (Vector64<sbyte> left, Vector64<sbyte> right) => TransposeVectorEven (left, right);
+        public static Vector64<int> TransposeVectorEven (Vector64<int> left, Vector64<int> right) => TransposeVectorEven (left, right);
+        public static Vector64<byte> TransposeVectorEven (Vector64<byte> left, Vector64<byte> right) => TransposeVectorEven (left, right);
+        public static Vector64<uint> TransposeVectorEven (Vector64<uint> left, Vector64<uint> right)  => TransposeVectorEven (left, right);
+        public static Vector64<float> TransposeVectorEven (Vector64<float> left, Vector64<float> right) => TransposeVectorEven (left, right);
+
+        public static Vector128<sbyte> TransposeVectorEven (Vector128<sbyte> left, Vector128<sbyte> right) => TransposeVectorEven (left, right);
+        public static Vector128<int> TransposeVectorEven (Vector128<int> left, Vector128<int> right) => TransposeVectorEven (left, right);
+        public static Vector128<long> TransposeVectorEven (Vector128<long> left, Vector128<long> right) => TransposeVectorEven (left, right);
+        public static Vector128<byte> TransposeVectorEven (Vector128<byte> left, Vector128<byte> right) => TransposeVectorEven (left, right);
+        public static Vector128<uint> TransposeVectorEven (Vector128<uint> left, Vector128<uint> right) => TransposeVectorEven (left, right);
+        public static Vector128<ulong> TransposeVectorEven (Vector128<ulong> left, Vector128<ulong> right) => TransposeVectorEven (left, right);
+        public static Vector128<float> TransposeVectorEven (Vector128<float> left, Vector128<float> right) => TransposeVectorEven (left, right);
+        public static Vector128<double> TransposeVectorEven (Vector128<double> left, Vector128<double> right) => TransposeVectorEven (left, right);
+
+        /// <summary>
+        /// Transpose vectors (Odd elements)
+        ///
+        /// Corresponds to vector forms of ARM64 TRN2
+        /// </summary>
+        public static Vector64<sbyte> TransposeVectorOdd (Vector64<sbyte> left, Vector64<sbyte> right) => TransposeVectorOdd (left, right);
+        public static Vector64<int> TransposeVectorOdd (Vector64<int> left, Vector64<int> right) => TransposeVectorOdd (left, right);
+        public static Vector64<byte> TransposeVectorOdd (Vector64<byte> left, Vector64<byte> right) => TransposeVectorOdd (left, right);
+        public static Vector64<uint> TransposeVectorOdd (Vector64<uint> left, Vector64<uint> right) => TransposeVectorOdd (left, right);
+        public static Vector64<float> TransposeVectorOdd (Vector64<float> left, Vector64<float> right) => TransposeVectorOdd (left, right);
+
+        public static Vector128<sbyte> TransposeVectorOdd (Vector128<sbyte> left, Vector128<sbyte> right) => TransposeVectorOdd (left, right);
+        public static Vector128<int> TransposeVectorOdd (Vector128<int> left, Vector128<int> right) => TransposeVectorOdd (left, right);
+        public static Vector128<long> TransposeVectorOdd (Vector128<long> left, Vector128<long> right) => TransposeVectorOdd (left, right);
+        public static Vector128<byte> TransposeVectorOdd (Vector128<byte> left, Vector128<byte> right) => TransposeVectorOdd (left, right);
+        public static Vector128<uint> TransposeVectorOdd (Vector128<uint> left, Vector128<uint> right) => TransposeVectorOdd (left, right);
+        public static Vector128<ulong> TransposeVectorOdd (Vector128<ulong> left, Vector128<ulong> right) => TransposeVectorOdd (left, right);
+        public static Vector128<float> TransposeVectorOdd (Vector128<float> left, Vector128<float> right) => TransposeVectorOdd (left, right);
+        public static Vector128<double> TransposeVectorOdd (Vector128<double> left, Vector128<double> right) => TransposeVectorOdd (left, right);
+
+        /// <summary>
+        /// Multiply and subtract
+        ///
+        /// Corresponds to vector forms of ARM64 FMLS and MLS.
+        /// </summary>
+        public static Vector64<float> MultiplyAndSubtract (Vector64<float> acc, Vector64<float> left, Vector64<float> right) => MultiplyAndSubtract (acc, left, right);
+        public static Vector64<float> MultiplyAndSubtract (Vector64<float> acc, Vector64<float> left, Vector64<float> sel, byte index) => MultiplyAndSubtract (acc, left, sel, index);
+        public static Vector64<float> MultiplyAndSubtract (Vector64<float> acc, Vector64<float> left, Vector128<float> sel, byte index) => MultiplyAndSubtract (acc, left, sel, index);
+        public static Vector64<float> MultiplyAndSubtract (Vector64<float> acc, Vector64<float> left, float value) => MultiplyAndSubtract (acc, left, value);
+
+        public static Vector128<float> MultiplyAndSubtract (Vector128<float> acc, Vector128<float> left, Vector128<float> right) => MultiplyAndSubtract (acc, left, right);
+        public static Vector128<float> MultiplyAndSubtract (Vector128<float> acc, Vector128<float> left, Vector64<float> sel, byte index) => MultiplyAndSubtract (acc, left, sel, index);
+        public static Vector128<float> MultiplyAndSubtract (Vector128<float> acc, Vector128<float> left, Vector128<float> sel, byte index) => MultiplyAndSubtract (acc, left, sel, index);
+        public static Vector128<float> MultiplyAndSubtract (Vector128<float> acc, Vector128<float> left, float value) => MultiplyAndSubtract (acc, left, value);
+
+        public static Vector128<double> MultiplyAndSubtract (Vector128<double> acc, Vector128<double> left, Vector128<double> right) => MultiplyAndSubtract (acc, left, right);
+        public static Vector128<double> MultiplyAndSubtract (Vector128<double> acc, Vector128<double> left, Vector128<double> sel, byte index) => MultiplyAndSubtract (acc, left, sel, index);
+        public static Vector128<double> MultiplyAndSubtract (Vector128<double> acc, Vector128<double> left, double value) => MultiplyAndSubtract (acc, left, value);
+
+        public static Vector64<int> MultiplyAndSubtract (Vector64<int> acc, Vector64<int> left, Vector64<int> right) => MultiplyAndSubtract (acc, left, right);
+        public static Vector64<int> MultiplyAndSubtract (Vector64<int> acc, Vector64<int> left, Vector64<int> sel, byte index) => MultiplyAndSubtract (acc, left, sel, index);
+        public static Vector64<int> MultiplyAndSubtract (Vector64<int> acc, Vector64<int> left, Vector128<int> sel, byte index) => MultiplyAndSubtract (acc, left, sel, index);
+        public static Vector64<int> MultiplyAndSubtract (Vector64<int> acc, Vector64<int> left, int value) => MultiplyAndSubtract (acc, left, value);
+
+        public static Vector128<int> MultiplyAndSubtract (Vector128<int> acc, Vector128<int> left, Vector128<int> right) => MultiplyAndSubtract (acc, left, right);
+        public static Vector128<int> MultiplyAndSubtract (Vector128<int> acc, Vector128<int> left, Vector64<int> sel, byte index) => MultiplyAndSubtract (acc, left, sel, index);
+        public static Vector128<int> MultiplyAndSubtract (Vector128<int> acc, Vector128<int> left, Vector128<int> sel, byte index) => MultiplyAndSubtract (acc, left, sel, index);
+        public static Vector128<int> MultiplyAndSubtract (Vector128<int> acc, Vector128<int> left, int value) => MultiplyAndSubtract (acc, left, value);
+
+        public static Vector64<uint> MultiplyAndSubtract (Vector64<uint> acc, Vector64<uint> left, Vector64<uint> right) => MultiplyAndSubtract (acc, left, right);
+        public static Vector64<uint> MultiplyAndSubtract (Vector64<uint> acc, Vector64<uint> left, Vector64<uint> sel, byte index) => MultiplyAndSubtract (acc, left, sel, index);
+        public static Vector64<uint> MultiplyAndSubtract (Vector64<uint> acc, Vector64<uint> left, Vector128<uint> sel, byte index) => MultiplyAndSubtract (acc, left, sel, index);
+        public static Vector64<uint> MultiplyAndSubtract (Vector64<uint> acc, Vector64<uint> left, uint value) => MultiplyAndSubtract (acc, left, value);
+
+        public static Vector128<uint> MultiplyAndSubtract (Vector128<uint> acc, Vector128<uint> left, Vector128<uint> right) => MultiplyAndSubtract (acc, left, right);
+        public static Vector128<uint> MultiplyAndSubtract (Vector128<uint> acc, Vector128<uint> left, Vector64<uint> sel, byte index) => MultiplyAndSubtract (acc, left, sel, index);
+        public static Vector128<uint> MultiplyAndSubtract (Vector128<uint> acc, Vector128<uint> left, Vector128<uint> sel, byte index) => MultiplyAndSubtract (acc, left, sel, index);
+        public static Vector128<uint> MultiplyAndSubtract (Vector128<uint> acc, Vector128<uint> left, uint value) => MultiplyAndSubtract (acc, left, value);
+
+        public static Vector128<byte> MultiplyAndSubtract (Vector128<byte> acc, Vector128<byte> left, Vector128<byte> right) => MultiplyAndSubtract (acc, left, right);
+        public static Vector128<byte> MultiplyAndSubtract (Vector128<byte> acc, Vector128<byte> left, Vector64<byte> right) => MultiplyAndSubtract (acc, left, right);
+        public static Vector128<sbyte> MultiplyAndSubtract (Vector128<sbyte> acc, Vector128<sbyte> left, Vector128<sbyte> right) => MultiplyAndSubtract (acc, left, right);
+        public static Vector128<sbyte> MultiplyAndSubtract (Vector128<sbyte> acc, Vector128<sbyte> left, Vector64<sbyte> right) => MultiplyAndSubtract (acc, left, right);
+
+
+        /// <summary>
+        /// Multiply and Add
+        ///
+        /// Corresponds to vector forms of ARM64 FMLA and MLA.
+        /// </summary>
+        public static Vector64<float> MultiplyAndAdd (Vector64<float> acc, Vector64<float> left, Vector64<float> right) => MultiplyAndAdd (acc, left, right);
+        public static Vector64<float> MultiplyAndAdd (Vector64<float> acc, Vector64<float> left, Vector64<float> sel, byte index) => MultiplyAndAdd (acc, left, sel, index);
+        public static Vector64<float> MultiplyAndAdd (Vector64<float> acc, Vector64<float> left, Vector128<float> sel, byte index) => MultiplyAndAdd (acc, left, sel, index);
+        public static Vector64<float> MultiplyAndAdd (Vector64<float> acc, Vector64<float> left, float value) => MultiplyAndAdd (acc, left, value);
+
+        public static Vector128<float> MultiplyAndAdd (Vector128<float> acc, Vector128<float> left, Vector128<float> right) => MultiplyAndAdd (acc, left, right);
+        public static Vector128<float> MultiplyAndAdd (Vector128<float> acc, Vector128<float> left, Vector64<float> sel, byte index) => MultiplyAndAdd (acc, left, sel, index);
+        public static Vector128<float> MultiplyAndAdd (Vector128<float> acc, Vector128<float> left, Vector128<float> sel, byte index) => MultiplyAndAdd (acc, left, sel, index);
+        public static Vector128<float> MultiplyAndAdd (Vector128<float> acc, Vector128<float> left, float value) => MultiplyAndAdd (acc, left, value);
+
+        public static Vector128<double> MultiplyAndAdd (Vector128<double> acc, Vector128<double> left, Vector128<double> right) => MultiplyAndAdd (acc, left, right);
+        public static Vector128<double> MultiplyAndAdd (Vector128<double> acc, Vector128<double> left, Vector128<double> sel, byte index) => MultiplyAndAdd (acc, left, sel, index);
+        public static Vector128<double> MultiplyAndAdd (Vector128<double> acc, Vector128<double> left, double value) => MultiplyAndAdd (acc, left, value);
+
+        public static Vector64<int> MultiplyAndAdd (Vector64<int> acc, Vector64<int> left, Vector64<int> right) => MultiplyAndAdd (acc, left, right);
+        public static Vector64<int> MultiplyAndAdd (Vector64<int> acc, Vector64<int> left, Vector64<int> sel, byte index) => MultiplyAndAdd (acc, left, sel, index);
+        public static Vector64<int> MultiplyAndAdd (Vector64<int> acc, Vector64<int> left, Vector128<int> sel, byte index) => MultiplyAndAdd (acc, left, sel, index);
+        public static Vector64<int> MultiplyAndAdd (Vector64<int> acc, Vector64<int> left, int value) => MultiplyAndAdd (acc, left, value);
+
+        public static Vector128<int> MultiplyAndAdd (Vector128<int> acc, Vector128<int> left, Vector128<int> right) => MultiplyAndAdd (acc, left, right);
+        public static Vector128<int> MultiplyAndAdd (Vector128<int> acc, Vector128<int> left, Vector64<int> sel, byte index) => MultiplyAndAdd (acc, left, sel, index);
+        public static Vector128<int> MultiplyAndAdd (Vector128<int> acc, Vector128<int> left, Vector128<int> sel, byte index) => MultiplyAndAdd (acc, left, sel, index);
+        public static Vector128<int> MultiplyAndAdd (Vector128<int> acc, Vector128<int> left, int value) => MultiplyAndAdd (acc, left, value);
+
+        public static Vector64<uint> MultiplyAndAdd (Vector64<uint> acc, Vector64<uint> left, Vector64<uint> right) => MultiplyAndAdd (acc, left, right);
+        public static Vector64<uint> MultiplyAndAdd (Vector64<uint> acc, Vector64<uint> left, Vector64<uint> sel, byte index) => MultiplyAndAdd (acc, left, sel, index);
+        public static Vector64<uint> MultiplyAndAdd (Vector64<uint> acc, Vector64<uint> left, Vector128<uint> sel, byte index) => MultiplyAndAdd (acc, left, sel, index);
+        public static Vector64<uint> MultiplyAndAdd (Vector64<uint> acc, Vector64<uint> left, uint value) => MultiplyAndAdd (acc, left, value);
+
+        public static Vector128<uint> MultiplyAndAdd (Vector128<uint> acc, Vector128<uint> left, Vector128<uint> right) => MultiplyAndAdd (acc, left, right);
+        public static Vector128<uint> MultiplyAndAdd (Vector128<uint> acc, Vector128<uint> left, Vector64<uint> sel, byte index) => MultiplyAndAdd (acc, left, sel, index);
+        public static Vector128<uint> MultiplyAndAdd (Vector128<uint> acc, Vector128<uint> left, Vector128<uint> sel, byte index) => MultiplyAndAdd (acc, left, sel, index);
+        public static Vector128<uint> MultiplyAndAdd (Vector128<uint> acc, Vector128<uint> left, uint value) => MultiplyAndAdd (acc, left, value);
+
+        public static Vector128<byte> MultiplyAndAdd (Vector128<byte> acc, Vector128<byte> left, Vector128<byte> right) => MultiplyAndAdd (acc, left, right);
+        public static Vector128<byte> MultiplyAndAdd (Vector128<byte> acc, Vector128<byte> left, Vector64<byte> right) => MultiplyAndAdd (acc, left, right);
+        public static Vector128<sbyte> MultiplyAndAdd (Vector128<sbyte> acc, Vector128<sbyte> left, Vector128<sbyte> right) => MultiplyAndAdd (acc, left, right);
+        public static Vector128<sbyte> MultiplyAndAdd (Vector128<sbyte> acc, Vector128<sbyte> left, Vector64<sbyte> right) => MultiplyAndAdd (acc, left, right);
     }
 }

--- a/src/jit/emitfmtsarm64.h
+++ b/src/jit/emitfmtsarm64.h
@@ -143,6 +143,7 @@ IF_DEF(DI_1C, IS_NONE, NONE) // DI_1C   X........Nrrrrrr ssssssnnnnn.....       
 IF_DEF(DI_1D, IS_NONE, NONE) // DI_1D   X........Nrrrrrr ssssss.....ddddd      Rd       imm(N,r,s)
 IF_DEF(DI_1E, IS_NONE, JMP)  // DI_1E   .ii.....iiiiiiii iiiiiiiiiiiddddd      Rd       simm21
 IF_DEF(DI_1F, IS_NONE, NONE) // DI_1F   X..........iiiii cccc..nnnnn.nzcv      Rn imm5  nzcv cond
+IF_DEF(DI_1G, IS_NONE, NONE) // DI_1G   X........Nrrrrrr ssssss.....ddddd      Rd       imr, imms   (N,r,s)
 
 IF_DEF(DI_2A, IS_NONE, NONE) // DI_2A   X.......shiiiiii iiiiiinnnnnddddd      Rd Rn    imm(i12,sh)
 IF_DEF(DI_2B, IS_NONE, NONE) // DI_2B   X.........Xnnnnn ssssssnnnnnddddd      Rd Rn    imm(0-63)
@@ -173,6 +174,7 @@ IF_DEF(DR_4A, IS_NONE, NONE) // DR_4A   X..........mmmmm .aaaaannnnnddddd      R
 IF_DEF(DV_1A, IS_NONE, NONE) // DV_1A   .........X.iiiii iii........ddddd      Vd imm8    (fmov - immediate scalar)
 IF_DEF(DV_1B, IS_NONE, NONE) // DV_1B   .QX..........iii jjjj..iiiiiddddd      Vd imm8    (fmov/movi - immediate vector)
 IF_DEF(DV_1C, IS_NONE, NONE) // DV_1C   .........X...... ......nnnnn.....      Vn #0.0    (fcmp - with zero)
+IF_DEF(DV_1D, IS_NONE, NONE) // DV_1D   .Q.........mmmmm .ll...nnnnnddddd      Vd,{ V... },Vm    (tbl - structure load store)
 
 IF_DEF(DV_2A, IS_NONE, NONE) // DV_2A   .Q.......X...... ......nnnnnddddd      Vd Vn      (fabs, fcvtXX - vector)
 IF_DEF(DV_2B, IS_NONE, NONE) // DV_2B   .Q.........iiiii ......nnnnnddddd      Rd Vn[]    (umov/smov    - to general)

--- a/src/jit/hwintrinsicArm64.h
+++ b/src/jit/hwintrinsicArm64.h
@@ -30,7 +30,10 @@ struct HWIntrinsicInfo
         SimdInsertOp,  // SIMD intrinsics which take one vector operand and a lane index and value and return a vector
         SimdSelectOp,  // BitwiseSelect intrinsic which takes three vector operands and returns a vector
         SimdSetAllOp,  // Simd intrinsics which take one numeric operand and return a vector
-        Sha1HashOp     // SIMD instrisics for SHA1 Hash operations. Takes two vectors and hash index and returns vector
+        Sha1HashOp,    // SIMD instrisics for SHA1 Hash operations. Takes two vectors and hash index and returns vector
+        SimdTblOp,     // SIMD instrisics for table lookup operations. Takes a list of vectors and a single vector and returns vector
+        SimdTbxOp,     // SIMD instrisics for table lookup operations. Takes a list of vectors and a single vector and returns vector
+        SimdSumOp,     // SIMD intrinsics for Sum operations. Takes a vector and returns a scalar.
     };
 
     // Flags will be used to handle secondary meta-data which will help

--- a/src/jit/hwintrinsiclistArm64.h
+++ b/src/jit/hwintrinsiclistArm64.h
@@ -42,6 +42,7 @@ HARDWARE_INTRINSIC(NI_ARM64_NONE_MOV,             None,          None,          
 //  Base
 HARDWARE_INTRINSIC(NI_ARM64_BASE_CLS,             Base,          LeadingSignCount,               UnaryOp,       INS_invalid, INS_cls,     INS_cls,      None )
 HARDWARE_INTRINSIC(NI_ARM64_BASE_CLZ,             Base,          LeadingZeroCount,               UnaryOp,       INS_invalid, INS_clz,     INS_clz,      None )
+HARDWARE_INTRINSIC(NI_ARM64_BASE_RBIT,            Base,          ReverseBitOrder,                UnaryOp,       INS_invalid, INS_rbit,    INS_rbit,     None )
 
 // Vector64
 HARDWARE_INTRINSIC(NI_Vector64_AsByte,            Vector64,      AsByte,                         UnaryOp,       INS_invalid, INS_invalid, INS_invalid,  None )
@@ -102,6 +103,25 @@ HARDWARE_INTRINSIC(NI_ARM64_SIMD_GetItem,         Simd,     Extract,            
 HARDWARE_INTRINSIC(NI_ARM64_SIMD_SetItem,         Simd,     Insert,                         SimdInsertOp,  INS_mov,     INS_mov,     INS_mov,      None )
 HARDWARE_INTRINSIC(NI_ARM64_SIMD_SetAllVector64,  Simd,     SetAllVector64,                 SimdSetAllOp,  INS_dup,     INS_dup,     INS_dup,      None )
 HARDWARE_INTRINSIC(NI_ARM64_SIMD_SetAllVector128, Simd,     SetAllVector128,                SimdSetAllOp,  INS_dup,     INS_dup,     INS_dup,      None )
+
+HARDWARE_INTRINSIC(NI_ARM64_SIMD_ABS_GE,          Simd,     AbsoluteCompareGreatherThanOrEqual, SimdBinaryOp,  INS_facge,   INS_invalid, INS_invalid,  None )
+HARDWARE_INTRINSIC(NI_ARM64_SIMD_ABS_GT,          Simd,     AbsoluteCompareGreatherThan,        SimdBinaryOp,  INS_facgt,   INS_invalid, INS_invalid,  None )
+HARDWARE_INTRINSIC(NI_ARM64_SIMD_SLI,             Simd,     LeftShiftAndInsert,                 SimdBinaryOp,  INS_invalid, INS_sli,     INS_sli,      None )
+HARDWARE_INTRINSIC(NI_ARM64_SIMD_SRI,             Simd,     RightShiftAndInsert,                SimdBinaryOp,  INS_invalid, INS_sri,     INS_sri,      None )
+HARDWARE_INTRINSIC(NI_ARM64_SIMD_XTN_LO,          Simd,     ExtractAndNarrowLow,                SimdUnaryOp,   INS_invalid, INS_xtn,     INS_xtn,      None )
+HARDWARE_INTRINSIC(NI_ARM64_SIMD_XTN_HI,          Simd,     ExtractAndNarrowHigh,               SimdUnaryOp,   INS_invalid, INS_xtn2,    INS_xtn2,     None )
+HARDWARE_INTRINSIC(NI_ARM64_SIMD_UNZIP_LO,        Simd,     UnzipEven,                          SimdBinaryOp,  INS_uzp1,    INS_uzp1,    INS_uzp1,     None )
+HARDWARE_INTRINSIC(NI_ARM64_SIMD_UNZIP_HI,        Simd,     UnzipOdd,                           SimdBinaryOp,  INS_uzp2,    INS_uzp2,    INS_uzp2,     None )
+HARDWARE_INTRINSIC(NI_ARM64_SIMD_ZIP_LO,          Simd,     ZipLow,                             SimdBinaryOp,  INS_zip1,    INS_zip1,    INS_zip1,     None )
+HARDWARE_INTRINSIC(NI_ARM64_SIMD_ZIP_HI,          Simd,     ZipHigh,                            SimdBinaryOp,  INS_zip2,    INS_zip2,    INS_zip2,     None )
+HARDWARE_INTRINSIC(NI_ARM64_SIMD_TBL,             Simd,     TableVectorLookup,                  SimdTblOp,     INS_invalid, INS_tbl,     INS_tbl,      None )
+HARDWARE_INTRINSIC(NI_ARM64_SIMD_TBX,             Simd,     TableVectorLookupExtension,         SimdTbxOp,     INS_invalid, INS_tbx,     INS_tbx,      None )
+HARDWARE_INTRINSIC(NI_ARM64_SIMD_TRN_ODD,         Simd,     TransposeVectorOdd,                 SimdBinaryOp,  INS_trn1,    INS_trn1,    INS_trn1,     None )
+HARDWARE_INTRINSIC(NI_ARM64_SIMD_TRN_EVEN,        Simd,     TransposeVectorEven,                SimdBinaryOp,  INS_trn2,    INS_trn2,    INS_trn2,     None )
+HARDWARE_INTRINSIC(NI_ARM64_SIMD_MLS,             Simd,     MultiplyAndSubtract,                SimdBinaryOp,  INS_fmls,    INS_mls,     INS_mls,      None )
+HARDWARE_INTRINSIC(NI_ARM64_SIMD_MLA,             Simd,     MultiplyAndAdd,                     SimdBinaryOp,  INS_fmla,    INS_mla,     INS_mla,      None )
+HARDWARE_INTRINSIC(NI_ARM64_SIMD_ADDV,            Simd,     AddAcross,                          SimdSumOp,     INS_faddp,   INS_addv,    INS_addv,     None )
+
 //Aes
 HARDWARE_INTRINSIC(NI_ARM64_AesEncrypt,           Aes,      Encrypt,                        SimdBinaryRMWOp,   INS_invalid,    INS_invalid, INS_aese,      None )
 HARDWARE_INTRINSIC(NI_ARM64_AesDecrypt,           Aes,      Decrypt,                        SimdBinaryRMWOp,   INS_invalid,    INS_invalid, INS_aesd,      None )

--- a/src/jit/instrsarm64.h
+++ b/src/jit/instrsarm64.h
@@ -463,6 +463,14 @@ INST2(fabd,    "fabd",   0, 0, IF_EN2G,   0x2EA0D400,  0x7EA0D400)
                                    //  fabd    Vd,Vn,Vm             DV_3B  0Q1011101X1mmmmm 110101nnnnnddddd   2EA0 D400   Vd,Vn,Vm  (vector)
                                    //  fabd    Vd,Vn,Vm             DV_3D  011111101X1mmmmm 110101nnnnnddddd   7EA0 D400   Vd,Vn,Vm  (scalar)
 
+INST2(facge,   "facge",  0, 0, IF_EN2G,   0x2E20EC00,  0x7E20EC00)
+                                   //  facge   Vd,Vn,Vm             DV_3B  0Q1011100X1mmmmm 111011nnnnnddddd   2E20 EC00   Vd,Vn,Vm  (vector)
+                                   //  facge   Vd,Vn,Vm             DV_3D  011111100X1mmmmm 111011nnnnnddddd   7E20 EC00   Vd,Vn,Vm  (scalar)
+
+INST2(facgt,   "facgt",  0, 0, IF_EN2G,   0x2EA0EC00,  0x7EA0EC00)
+                                   //  facgt   Vd,Vn,Vm             DV_3B  0Q1011101X1mmmmm 111011nnnnnddddd   2EA0 EC00   Vd,Vn,Vm  (vector)
+                                   //  facgt   Vd,Vn,Vm             DV_3D  011111101X1mmmmm 111011nnnnnddddd   7EA0 EC00   Vd,Vn,Vm  (scalar)
+
 //    enum     name     FP LD/ST            DV_2K        DV_1C
 INST2(fcmp,    "fcmp",   0, 0, IF_EN2I,   0x1E202000,  0x1E202008)
                                    //  fcmp    Vn,Vm                DV_2K  000111100X1mmmmm 001000nnnnn00000   1E20 2000   Vn Vm
@@ -926,7 +934,13 @@ INST1(movn,    "movn",   0, 0, IF_DI_1B,  0x12800000)
    
 INST1(movz,    "movz",   0, 0, IF_DI_1B,  0x52800000)
                                    //  movz    Rd,imm(i16,hw)       DI_1B  X10100101hwiiiii iiiiiiiiiiiddddd   5280 0000   imm(i16,hw)
-                                   
+
+INST1(tbl,     "tbl",    0, 0, IF_DV_1D,  0x4E000000)
+                                   //  tbl    Vd,{ V... },Vm        DV_1D  0Q001110000mmmmm 0ll000nnnnnddddd  4E00 0000   Vd,{ V... },Vm
+
+INST1(tbx,     "tbx",    0, 0, IF_DV_1D,  0x4E001000)
+                                   //  tbx    Vd,{ V... },Vm        DV_1D  0Q001110000mmmmm 0ll100nnnnnddddd  4E00 1000   Vd,{ V... },Vm
+
 INST1(csel,    "csel",   0, 0, IF_DR_3D,  0x1A800000)
                                    //  csel    Rd,Rn,Rm,cond        DR_3D  X0011010100mmmmm cccc00nnnnnddddd   1A80 0000   cond
 
@@ -1232,6 +1246,24 @@ INST1(umax,    "umax",   0, 0, IF_DV_3A,  0x2E206400)
 
 INST1(umin,    "umin",   0, 0, IF_DV_3A,  0x2E206C00)
                                    //  umin    Vd,Vn,Vm             DV_3A  0Q101110XX1mmmmm 011011nnnnnddddd   2E20 6C00   Vd,Vn,Vm  (vector)
+
+INST1(uzp1,    "uzp1",   0, 0, IF_DV_3A,  0x0E801800)
+                                   //  uzp1    Vd,Vn,Vm             DV_3A  0Q001110XX0mmmmm 000110nnnnnddddd   0E80 1800   Vd,Vn,Vm  (vector)
+
+INST1(uzp2,    "uzp2",   0, 0, IF_DV_3A,  0x0E805800)
+                                   //  upz2    Vd,Vn,Vm             DV_3A  0Q001110XX0mmmmm 010110nnnnnddddd   0E80 5800   Vd,Vn,Vm  (vector)
+
+INST1(zip1,    "zip1",   0, 0, IF_DV_3A,  0x0E803800)
+                                   //  zip1    Vd,Vn,Vm             DV_3A  0Q001110XX0mmmmm 011110nnnnnddddd   0E80 3800   Vd,Vn,Vm  (vector)
+
+INST1(zip2,    "zip2",   0, 0, IF_DV_3A,  0x0E807800)
+                                   //  zip2    Vd,Vn,Vm             DV_3A  0Q001110XX0mmmmm 001110nnnnnddddd   0E80 7800   Vd,Vn,Vm  (vector)
+
+INST1(trn1,    "trn1",   0, 0, IF_DV_3A,  0x0E802800)
+                                   //  zip1    Vd,Vn,Vm             DV_3A  0Q001110XX0mmmmm 001010nnnnnddddd   0E80 2800   Vd,Vn,Vm  (vector)
+
+INST1(trn2,    "trn2",   0, 0, IF_DV_3A,  0x0E806800)
+                                   //  zip2    Vd,Vn,Vm             DV_3A  0Q001110XX0mmmmm 011010nnnnnddddd   0E80 6800   Vd,Vn,Vm  (vector)
 
 INST1(fcvtl,   "fcvtl",  0, 0, IF_DV_2G,  0x0E217800)
                                    //  fcvtl   Vd,Vn                DV_2G  000011100X100001 011110nnnnnddddd   0E21 7800   Vd,Vn    (scalar)

--- a/tests/src/JIT/HardwareIntrinsics/Arm64/Base.cs
+++ b/tests/src/JIT/HardwareIntrinsics/Arm64/Base.cs
@@ -1,55 +1,141 @@
 using System;
+using System.Reflection;
+using System.Linq;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics.Arm.Arm64;
+using System.Collections.Generic;
 
 namespace Arm64intrisicsTest
 {
     class Program
     {
-        static void testUnaryOp<T>(String testCaseDescription, Func<T, int> func, int expected, T value)
+        static void testUnaryOp<T, V>(Func<T, V> func, V expected, T value)
+        {
+            testUnaryOp<T, V>(func.Method, func, expected, value);
+        }
+        static void testUnaryOp<T, V>(Func<T, V> func, IEnumerable<V> expected, IEnumerable<T> value)
+        {
+            Func<IEnumerable<T>, IEnumerable<V>> operation = x => x.Select (func);
+            testUnaryOp<IEnumerable<T>, IEnumerable<V>>(func.Method, operation, expected, value);
+        }
+        static void testUnaryOp<T>(Func<T, T> func, T expected, T value)
+        {
+            testUnaryOp<T, T>(func.Method, func, expected, value);
+        }
+        static void testUnaryOp<T>(Func<T, T> func, IEnumerable<T> expected, IEnumerable<T> value)
+        {
+            testUnaryOp<T, T>(func, expected, value);
+        }
+        static void testUnaryOp<T, V>(MethodInfo callInfo, Func<T, V> func, V expected, T value)
+        {
+            testOp (callInfo, func, expected, value);
+        }
+
+        static void testBinOp<T, V>(Func<T, T, V> func, V expected, T a, T b)
+        {
+            testOp (func.Method, func, expected, a, b);
+        }
+        static void testBinOp<T, V>(Func<T, T, V> func, V expected, IEnumerable<T> a, IEnumerable<T> b)
+        {
+            testOp (func.Method, (Func<IEnumerable<T>, IEnumerable<T>, IEnumerable<V>>)((x, y) => x.Zip (y, func)), expected, a, b);
+        }
+        static void testBinOp<T>(Func<T, T, T> func, T expected, T a, T b)
+        {
+            testBinOp<T, T> (func, expected, a, b);
+        }
+        static void testBinOp<T>(Func<T, T, T> func, IEnumerable<T> expected, IEnumerable<T> a, IEnumerable<T> b)
+        {
+            testBinOp<IEnumerable<T>, IEnumerable<T>> ((x, y) => x.Zip (y, func), expected, a, b);
+        }
+
+        static void testTernOp<T, V>(Func<T, T, T, V> func, V expected, T a, T b, T c)
+        {
+            testOp (func.Method, func, expected, a, b, c);
+        }
+        static void testTernOp<T, V>(Func<T, T, V> func, IEnumerable<V> expected, IEnumerable<T> a, IEnumerable<T> b, IEnumerable<T> c)
+        {
+	    Func<T, T, Func<T, V>> fn = (a, b) => (s => func (s, a, b));
+            Func<IEnumerable<T>, IEnumerable<T>, IEnumerable<T>, IEnumerable<V>> op
+              = (x, y, z) => Enumerable.Zip (x, Enumerable.Zip<T, T, Func<T, V>> (y, z, fn), (e, f) => f (e));
+            testOp (func.Method, op, expected, a, b, c);
+        }
+        static void testTernOp<T>(Func<T, T, T, T> func, T expected, T a, T b, T c)
+        {
+            testOp (func.Method, func, expected, a, b, c);
+        }
+        static void testTernOp<T>(Func<T, T, T> func, IEnumerable<T> expected, IEnumerable<T> a, IEnumerable<T> b, IEnumerable<T> c)
+        {
+            testTernOp<T, T> (func, expected, a, b, c);
+        }
+
+        static void testOp<T>(MethodInfo callInfo, Delegate fn, T expected, params object[] args)
         {
             bool failed = false;
+            string testCaseDescription = fn.Method.Name;
+            bool isSupported
+              = Convert.ToBoolean(callInfo.DeclaringType
+                                          .GetMethod("get_IsSupported")
+                                          .Invoke(null, null));
+            string types
+             = args.Aggregate (expected.GetType().Name,
+                               (s, ty) => String.Format ("{0}, {1}", s,
+                                                         ty.GetType ().Name));
             try
             {
-                int result = func(value);
-
-                if (result != expected)
+                if (!isSupported)
                 {
-                    Console.WriteLine($"testUnaryOp<{typeof(T).Name}>{testCaseDescription}: Check Failed");
-                    Console.WriteLine($"    result = {result}, expected = {expected}");
-                    throw new Exception($"testUnaryOp<{typeof(T).Name}>{testCaseDescription}: Failed");
+                    testThrows<PlatformNotSupportedException, T> (() => fn.DynamicInvoke (args));
+                    return;
+                }
+
+                object result = fn.DynamicInvoke (args);
+                bool equal;
+                if (typeof(System.Collections.IEnumerable).IsAssignableFrom(expected.GetType ()))
+                {
+                    equal = Enumerable.SequenceEqual ((IEnumerable)result, (IEnumerable)expected);
+                }
+                else
+                {
+                    equal = result != (object)expected;
+                }
+
+                if (!equal)
+                {
+                    Console.WriteLine($"testOp<{types}>{testCaseDescription}: Check Failed");
+                    Console.WriteLine($"    result = {types}, expected = {expected}");
+                    throw new Exception($"testOp<{types}>{testCaseDescription}: Failed");
                 }
             }
             catch
             {
-                Console.WriteLine($"testUnaryOp<{typeof(T).Name}>{testCaseDescription}: Unexpected exception");
+                Console.WriteLine($"testOp<{types}>{testCaseDescription}: Unexpected exception");
                 throw;
             }
         }
 
-        static void testThrowsPlatformNotSupported<T>(String testCaseDescription, Func<T, int> func, T value)
+        static void testThrows<E, T>(Action func) where E : Exception
         {
-            bool notSupported = false;
+            testThrows<E> (typeof(T), func);
+        }
 
+        static void testThrows<E>(Type T, Action func) where E : Exception
+        {
             try
             {
-                func(value);
+                func();
             }
             catch (PlatformNotSupportedException)
             {
-                notSupported = true;
+                return;
             }
             catch
             {
-                Console.WriteLine($"testThrowsPlatformNotSupported: Unexpected exception");
+                Console.WriteLine($"testThrows<{typeof(E).Name}, {T.Name}>: Unexpected exception");
                 throw;
             }
 
-            if (notSupported == false)
-            {
-                throw new Exception($"testThrowsPlatformNotSupported<{typeof(T).Name} >{testCaseDescription}: Failed");
-            }
+            throw new Exception($"testThrows<{typeof(E).Name}, {T.Name}>{func.Method.Name}: Failed");
         }
 
         static int s_SignBit32 = 1 << 31;
@@ -61,10 +147,10 @@ namespace Arm64intrisicsTest
             return s_SignBit32 >> num;
         }
 
-        static long GenLeadingSignBitsI64(int num)
+        static long GenLeadingSignBitsI64(long num)
         {
             Debug.Assert(0 <= num && num < 64);
-            return s_SignBit64 >> num;
+            return s_SignBit64 >> (int)num;
         }
 
         static uint GenLeadingZeroBitsU32(int num)
@@ -93,23 +179,11 @@ namespace Arm64intrisicsTest
         {
             String name = "LeadingSignCount";
 
-            if (Base.IsSupported)
-            {
-                for (int num = 0; num < 32; num++)
-                {
-                     testUnaryOp<int>(name, (x) => Base.LeadingSignCount(x), num,  GenLeadingSignBitsI32(num));
-                }
+            var intRange = Enumerable.Range (0, 32);
+            testUnaryOp<int>(Base.LeadingSignCount, intRange.Select (GenLeadingSignBitsI32), intRange);
 
-                for (int num = 0; num < 64; num++)
-                {
-                     testUnaryOp<long>(name, (x) => Base.LeadingSignCount(x), num,  GenLeadingSignBitsI64(num));
-                }
-            }
-            else
-            {
-                testThrowsPlatformNotSupported<int >(name, (x) => Base.LeadingSignCount(x), 0);
-                testThrowsPlatformNotSupported<long>(name, (x) => Base.LeadingSignCount(x), 0);
-            }
+            var longRange = Enumerable.Range (0, 64).Cast<long>();
+            testUnaryOp<long>(Base.LeadingSignCount, x => (long)Base.LeadingSignCount (x), longRange.Select (GenLeadingSignBitsI64), longRange);
 
             Console.WriteLine($"Test{name} passed");
         }
@@ -118,27 +192,114 @@ namespace Arm64intrisicsTest
         {
             String name = "LeadingZeroCount";
 
-            if (Base.IsSupported)
-            {
-                for (int num = 0; num <= 32; num++)
-                {
-                     testUnaryOp<int >(name, (x) => Base.LeadingZeroCount(x), num,  GenLeadingZeroBitsI32(num));
-                     testUnaryOp<uint>(name, (x) => Base.LeadingZeroCount(x), num,  GenLeadingZeroBitsU32(num));
-                }
+            var intRange = Enumerable.Range (0, 32);
+            testUnaryOp<int >(Base.LeadingZeroCount, intRange.Select (GenLeadingZeroBitsI32), intRange.Cast< int>());
+            testUnaryOp<uint>(Base.LeadingZeroCount, intRange.Select (GenLeadingZeroBitsU32), intRange.Cast<uint>());
 
-                for (int num = 0; num <= 64; num++)
-                {
-                     testUnaryOp<long >(name, (x) => Base.LeadingZeroCount(x), num,  GenLeadingZeroBitsI64(num));
-                     testUnaryOp<ulong>(name, (x) => Base.LeadingZeroCount(x), num,  GenLeadingZeroBitsU64(num));
-                }
-            }
-            else
-            {
-                testThrowsPlatformNotSupported<int  >(name, (x) => Base.LeadingZeroCount(x), 0);
-                testThrowsPlatformNotSupported<uint >(name, (x) => Base.LeadingZeroCount(x), 0);
-                testThrowsPlatformNotSupported<long >(name, (x) => Base.LeadingZeroCount(x), 0);
-                testThrowsPlatformNotSupported<ulong>(name, (x) => Base.LeadingZeroCount(x), 0);
-            }
+            var longRange = Enumerable.Range (0, 64);
+            testUnaryOp<long >(Base.LeadingZeroCount, longRange.Select (GenLeadingZeroBitsI64), longRange.Cast< long>());
+            testUnaryOp<ulong>(Base.LeadingZeroCount, longRange.Select (GenLeadingZeroBitsU64), longRange.Cast<ulong>());
+
+            Console.WriteLine($"Test{name} passed");
+        }
+
+
+        static void TestReverseBitOrder()
+        {
+            String name = "ReverseBitOrder";
+
+            var control = (v, shift) => {
+              ulong r = v;
+              int s = (sizeof (v) * 8) - 1;
+              for (v >>= 1; v; v >>= 1)
+              {
+                r <<= 1;
+                r |= v & 1;
+                s--;
+              }
+              return (r << s) >> shift;
+            };
+
+            var intRange = Enumerable.Range (0, 32);
+            testUnaryOp<int >(Base.ReverseBitOrder, intRange.Select (n => control(n, 32)), intRange.Cast());
+            testUnaryOp<uint>(Base.ReverseBitOrder, intRange.Select (n => control(n, 32)), intRange.Cast());
+
+            var longRange = Enumerable.Range (0, 64);
+            testUnaryOp<long >(Base.ReverseBitOrder, longRange.Select (n => control (n, 0)), longRange.Cast());
+            testUnaryOp<ulong>(Base.ReverseBitOrder, longRange.Select (n => control (n, 0)), longRange.Cast());
+
+            Console.WriteLine($"Test{name} passed");
+        }
+
+        static void TestAbsoluteCompareGreatherThanOrEqual()
+        {
+            String name = "AbsoluteCompareGreatherThanOrEqual";
+
+            var controlF = (a, b) => {
+              return Math.Abs (a) >= Math.Abs (b) ? float.MaxValue : 0;
+            };
+
+            var controlD = (a, b) => {
+              return Math.Abs (a) >= Math.Abs (b) ? double.MaxValue : 0;
+            };
+
+            var data = { (1.0 , 3.0 )
+                       , (3.0 , 1.0 )
+                       , (2.0 , 2.0 )
+                       , (1.5 , 2.7 )
+                       , (-2.4, 4.5 )
+                       , (-5.2, 1.2 )
+                       , (-2.4, -4.5)
+                       , (-5.2, -1.2)
+                       , (2.4 , -4.5)
+                       , (5.2 , -1.2)
+                       };
+
+            data.Select ((v) => {
+              testBinOp<float >(name, (x) => Base.AbsoluteCompareGreatherThanOrEqual(x), controlF(v.Item1, v.Item2), v.Item1, v.Item2);
+              testBinOp<double>(name, (x) => Base.AbsoluteCompareGreatherThanOrEqual(x), controlD(v.Item1, v.Item2), v.Item1, v.Item2);
+              return true;
+            });
+
+            Console.WriteLine($"Test{name} passed");
+        }
+
+        static void TestAbsoluteCompareGreatherThan()
+        {
+            String name = "AbsoluteCompareGreatherThan";
+
+            var controlF = (a, b) => {
+                return Math.Abs (a) > Math.Abs (b) ? float.MaxValue : 0;
+            };
+
+            var controlD = (a, b) => {
+                return Math.Abs (a) > Math.Abs (b) ? double.MaxValue : 0;
+            };
+
+            var dA = { 1.0, 3.0, 2.0, 1.5, -2.4, -5.2, -2.4, -5.2, 2.4, 5.2 };
+            var dB = { 3.0, 1.0, 2.0, 2.7, 4.5, 1.2, -4.5, -1.2, -4.5, -1.2 };
+
+            testBinOp<float >(Base.AbsoluteCompareGreatherThan, dA.Zip(dB, controlF), dA, dB);
+            testBinOp<double>(Base.AbsoluteCompareGreatherThan, dA.Zip(dB, controlD), dA, dB);
+
+            Console.WriteLine($"Test{name} passed");
+        }
+
+        static void TestLeftShiftAndInsert()
+        {
+            String name = "LeftShiftAndInsert";
+
+            var control = (a, b, s) => {
+                return ((a << s) & ~b) | (a << s);
+            };
+
+            var dA = { 1.0, 3.0, 2.0, 1.5, -2.4, -5.2, -2.4, -5.2, 2.4, 5.2 };
+            var dB = { 3.0, 1.0, 2.0, 2.7, 4.5, 1.2, -4.5, -1.2, -4.5, -1.2 };
+            var dC = { 5, 23, 8, 8, 1, 0, 15, 29, 29, 31 };
+            var mk = (x, y, z) => x.Select (y.Zip (z, s => control (s, y, z)));
+
+            testTernOp<long >(Base.LeftShiftAndInsert, mk (dA, dB, dC), dA, dB, dC);
+            testTernOp<ulong>(Base.LeftShiftAndInsert, mk (dA, dB, dC), dA, dB, dC);
 
             Console.WriteLine($"Test{name} passed");
         }
@@ -147,6 +308,10 @@ namespace Arm64intrisicsTest
         {
             TestLeadingSignCount();
             TestLeadingZeroCount();
+            TestReverseBitOrder();
+            TestAbsoluteCompareGreatherThanOrEqual();
+            TestAbsoluteCompareGreatherThan();
+            TestLeftShiftAndInsert();
         }
 
         static int Main(string[] args)


### PR DESCRIPTION
This is a WIP for adding more AArch64 SIMD and Scalar intrinsics.

The tbl and tbx assembly are not yet correct as I haven't looked further into
how to handle the register lists.

I am in the process of refactoring the testsuite so that doesn't compile yet either.

This adds the following intrinsics

- ReverseBitOrder
- AbsoluteCompareGreatherThanOrEqual
- AbsoluteCompareGreatherThan
- LeftShiftAndInsert
- RightShiftAndInsert
- ExtractAndNarrowLow
- ExtractAndNarrowHigh
- UnzipEven
- UnzipOdd
- ZipLow
- ZipHigh
- TableVectorLookup
- TableVectorLookupExtension
- TransposeVectorOdd
- TransposeVectorEven
- MultiplyAndSubtract
- MultiplyAndAdd
- AddAcross