### PR TITLE
[CPAOT] Generating code for hardware intrinsic

### DIFF
--- a/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
+++ b/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
@@ -689,26 +689,19 @@ namespace Internal.JitInterface
                 // and we might not have set the bit in the code above.
                 result |= CorInfoFlag.CORINFO_FLG_FINAL;
             }
-            
+
             // Check for hardware intrinsics
             if (HardwareIntrinsicHelpers.IsHardwareIntrinsic(method))
             {
+#if !READYTORUN
                 // Do not report the get_IsSupported method as an intrinsic - RyuJIT would expand it to
                 // a constant depending on the code generation flags passed to it, but we would like to
                 // do a dynamic check instead.
                 if (!HardwareIntrinsicHelpers.IsIsSupportedMethod(method)
-#if !READYTORUN
-                    || HardwareIntrinsicHelpers.IsKnownSupportedIntrinsicAtCompileTime(method)
+                    || HardwareIntrinsicHelpers.IsKnownSupportedIntrinsicAtCompileTime(method))
 #endif
-                   )
                 {
                     result |= CorInfoFlag.CORINFO_FLG_JIT_INTRINSIC;
-                }
-                else
-                {
-#if READYTORUN
-                    result |= CorInfoFlag.CORINFO_FLG_DONT_INLINE;
-#endif
                 }
             }
 

--- a/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
+++ b/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
@@ -689,7 +689,7 @@ namespace Internal.JitInterface
                 // and we might not have set the bit in the code above.
                 result |= CorInfoFlag.CORINFO_FLG_FINAL;
             }
-
+            
             // Check for hardware intrinsics
             if (HardwareIntrinsicHelpers.IsHardwareIntrinsic(method))
             {
@@ -898,13 +898,8 @@ namespace Internal.JitInterface
                 CORJIT_FLAGS flags = default(CORJIT_FLAGS);
                 getJitFlags(ref flags, (uint)sizeof(CORJIT_FLAGS));
 
-#if READYTORUN
-                if (((DefType)type).InstanceFieldSize.IsIndeterminate)
-                {
-                    throw new RequiresRuntimeJitException("Ooops");
-                }
-#endif
                 Debug.Assert(!_simdHelper.IsVectorOfT(type)
+                    || ((DefType)type).InstanceFieldSize.IsIndeterminate /* This would happen in the ReadyToRun case */
                     || ((DefType)type).InstanceFieldSize.AsInt == GetMaxIntrinsicSIMDVectorLength(_jit, &flags));
 #endif
 

--- a/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
+++ b/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
@@ -2517,10 +2517,10 @@ namespace Internal.JitInterface
         {
             MethodDesc method = HandleToObject(ftn);
 
-            string result = null;
-            string classResult = null;
-            string namespaceResult = null;
-            string enclosingResult = null;
+            string result;
+            string classResult;
+            string namespaceResult;
+            string enclosingResult;
 
             result = getMethodNameFromMetadataImpl(method, out classResult, out namespaceResult, out enclosingResult);
 

--- a/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
+++ b/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
@@ -3016,7 +3016,6 @@ namespace Internal.JitInterface
             flags.Set(CorJitFlag.CORJIT_FLAG_PREJIT);
             flags.Set(CorJitFlag.CORJIT_FLAG_USE_PINVOKE_HELPERS);
 
-#if !READYTORUN
             if (_compilation.TypeSystemContext.Target.Architecture == TargetArchitecture.X86
                 || _compilation.TypeSystemContext.Target.Architecture == TargetArchitecture.X64)
             {
@@ -3028,7 +3027,6 @@ namespace Internal.JitInterface
                 flags.Set(CorJitFlag.CORJIT_FLAG_USE_SSSE3);
                 flags.Set(CorJitFlag.CORJIT_FLAG_USE_LZCNT);
             }
-#endif
 
             if (this.MethodBeingCompiled.IsNativeCallable)
                 flags.Set(CorJitFlag.CORJIT_FLAG_REVERSE_PINVOKE);

--- a/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
+++ b/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
@@ -693,15 +693,22 @@ namespace Internal.JitInterface
             // Check for hardware intrinsics
             if (HardwareIntrinsicHelpers.IsHardwareIntrinsic(method))
             {
-#if !READYTORUN
                 // Do not report the get_IsSupported method as an intrinsic - RyuJIT would expand it to
                 // a constant depending on the code generation flags passed to it, but we would like to
                 // do a dynamic check instead.
                 if (!HardwareIntrinsicHelpers.IsIsSupportedMethod(method)
-                    || HardwareIntrinsicHelpers.IsKnownSupportedIntrinsicAtCompileTime(method))
+#if !READYTORUN
+                    || HardwareIntrinsicHelpers.IsKnownSupportedIntrinsicAtCompileTime(method)
 #endif
+                   )
                 {
                     result |= CorInfoFlag.CORINFO_FLG_JIT_INTRINSIC;
+                }
+                else
+                {
+#if READYTORUN
+                    result |= CorInfoFlag.CORINFO_FLG_DONT_INLINE;
+#endif
                 }
             }
 
@@ -891,6 +898,12 @@ namespace Internal.JitInterface
                 CORJIT_FLAGS flags = default(CORJIT_FLAGS);
                 getJitFlags(ref flags, (uint)sizeof(CORJIT_FLAGS));
 
+#if READYTORUN
+                if (((DefType)type).InstanceFieldSize.IsIndeterminate)
+                {
+                    throw new RequiresRuntimeJitException("Ooops");
+                }
+#endif
                 Debug.Assert(!_simdHelper.IsVectorOfT(type)
                     || ((DefType)type).InstanceFieldSize.AsInt == GetMaxIntrinsicSIMDVectorLength(_jit, &flags));
 #endif

--- a/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
+++ b/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
@@ -710,11 +710,6 @@ namespace Internal.JitInterface
             return (uint)result;
         }
 
-        private uint getMethodAttribs(CORINFO_METHOD_STRUCT_* ftn)
-        {
-            return getMethodAttribsInternal(HandleToObject(ftn));
-        }
-
         private void setMethodAttribs(CORINFO_METHOD_STRUCT_* ftn, CorInfoMethodRuntimeFlags attribs)
         {
             // TODO: Inlining

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -135,7 +135,6 @@ namespace ILCompiler
             if (_ibcTuning)
                 corJitFlags.Add(CorJitFlag.CORJIT_FLAG_BBINSTR);
 
-            // _context.Target.MaximumSimdVectorLength?
             corJitFlags.Add(CorJitFlag.CORJIT_FLAG_FEATURE_SIMD);
             var jitConfig = new JitConfigProvider(corJitFlags, _ryujitOptions);
 

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -135,6 +135,8 @@ namespace ILCompiler
             if (_ibcTuning)
                 corJitFlags.Add(CorJitFlag.CORJIT_FLAG_BBINSTR);
 
+            // _context.Target.MaximumSimdVectorLength?
+            corJitFlags.Add(CorJitFlag.CORJIT_FLAG_FEATURE_SIMD);
             var jitConfig = new JitConfigProvider(corJitFlags, _ryujitOptions);
 
             return new ReadyToRunCodegenCompilation(

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -150,7 +150,15 @@ namespace Internal.JitInterface
 
         private bool ShouldSkipCompilation(IMethodNode methodCodeNodeNeedingCode)
         {
-            return methodCodeNodeNeedingCode.Method.IsAggressiveOptimization;
+            if (methodCodeNodeNeedingCode.Method.IsAggressiveOptimization)
+            {
+                return true;
+            }
+            if (HardwareIntrinsicHelpers.IsHardwareIntrinsic(methodCodeNodeNeedingCode.Method) && HardwareIntrinsicHelpers.IsIsSupportedMethod(methodCodeNodeNeedingCode.Method))
+            {
+                return true;
+            }
+            return false;
         }
 
         public void CompileMethod(IReadyToRunMethodCodeNode methodCodeNodeNeedingCode)

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -806,8 +806,7 @@ namespace Internal.JitInterface
             out TypeDesc exactType,
             out MethodDesc callerMethod,
             out EcmaModule callerModule,
-            out bool useInstantiatingStub,
-            out MethodDesc pResultHmethodDesc)
+            out bool useInstantiatingStub)
         {
 #if DEBUG
             // In debug, write some bogus data to the struct to ensure we have filled everything
@@ -1141,7 +1140,6 @@ namespace Internal.JitInterface
             }
 
             pResult->hMethod = ObjectToHandle(methodToDescribe);
-            pResultHmethodDesc = methodToDescribe;
 
             // TODO: access checks
             pResult->accessAllowed = CorInfoIsAccessAllowedResult.CORINFO_ACCESS_ALLOWED;
@@ -1267,7 +1265,6 @@ namespace Internal.JitInterface
             MethodDesc callerMethod;
             EcmaModule callerModule;
             bool useInstantiatingStub;
-            MethodDesc pResultHmethodDesc;
             ceeInfoGetCallInfo(
                 ref pResolvedToken, 
                 pConstrainedResolvedToken, 
@@ -1281,10 +1278,9 @@ namespace Internal.JitInterface
                 out exactType,
                 out callerMethod,
                 out callerModule,
-                out useInstantiatingStub,
-                out pResultHmethodDesc);
+                out useInstantiatingStub);
 
-            pResult->methodFlags = FilterNamedIntrinsicMethodAttribs(pResult->methodFlags, pResultHmethodDesc);
+            pResult->methodFlags = FilterNamedIntrinsicMethodAttribs(pResult->methodFlags, methodToCall);
 
             if (pResult->thisTransform == CORINFO_THIS_TRANSFORM.CORINFO_BOX_THIS)
             {

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1184,14 +1184,14 @@ namespace Internal.JitInterface
 
                 if (_TARGET_X86_ || _TARGET_AMD64_)
                 {
-                    fIsPlatformHWIntrinsic = string.Equals(namespaceName, "System.Runtime.Intrinsics.X86");
+                    fIsPlatformHWIntrinsic = (namespaceName == "System.Runtime.Intrinsics.X86");
                 }
                 else if (_TARGET_ARM64_)
                 {
-                    fIsPlatformHWIntrinsic = string.Equals(namespaceName, "System.Runtime.Intrinsics.Arm.Arm64");
+                    fIsPlatformHWIntrinsic = (namespaceName == "System.Runtime.Intrinsics.Arm.Arm64");
                 }
 
-                fIsHWIntrinsic = fIsPlatformHWIntrinsic || (string.Equals(namespaceName, "System.Runtime.Intrinsics"));
+                fIsHWIntrinsic = fIsPlatformHWIntrinsic || (namespaceName == "System.Runtime.Intrinsics");
 
                 // By default, we want to treat the get_IsSupported method for platform specific HWIntrinsic ISAs as
                 // method calls. This will be modified as needed below based on what ISAs are considered baseline.
@@ -1201,7 +1201,7 @@ namespace Internal.JitInterface
                 // but we don't know what the target machine will support.
                 //
                 // Additionally, we make sure none of the hardware intrinsic method bodies get pregenerated in crossgen
-                // (see ZapInfo::CompileMethod) but get JITted instead. The JITted method will have the correct
+                // (see ShouldSkipCompilation) but get JITted instead. The JITted method will have the correct
                 // answer for the CPU the code is running on.
                 fTreatAsRegularMethodCall = (fIsGetIsSupportedMethod && fIsPlatformHWIntrinsic) || (!fIsPlatformHWIntrinsic && fIsHWIntrinsic);
 
@@ -1211,16 +1211,16 @@ namespace Internal.JitInterface
                     {
                         // Simplify the comparison logic by grabbing the name of the ISA
                         string isaName = (enclosingClassName == null) ? className : enclosingClassName;
-                        if ((string.Equals(isaName, "Sse")) || (string.Equals(isaName, "Sse2")))
+                        if ((isaName == "Sse") || (isaName == "Sse2"))
                         {
-                            if ((enclosingClassName == null) || (string.Equals(className, "X64")))
+                            if ((enclosingClassName == null) || (className == "X64"))
                             {
                                 // If it's anything related to Sse/Sse2, we can expand unconditionally since this is
                                 // a baseline requirement of CoreCLR.
                                 fTreatAsRegularMethodCall = false;
                             }
                         }
-                        else if ((string.Equals(className, "Avx")) || (string.Equals(className, "Fma")) || (string.Equals(className, "Avx2")) || (string.Equals(className, "Bmi1")) || (string.Equals(className, "Bmi2")))
+                        else if ((className == "Avx") || (className == "Fma") || (className == "Avx2") || (className == "Bmi1") || (className == "Bmi2"))
                         {
                             if ((enclosingClassName == null) || (string.Equals(className, "X64")))
                             {
@@ -1236,14 +1236,14 @@ namespace Internal.JitInterface
                             }
                         }
                     }
-                    else if (string.Equals(namespaceName, "System"))
+                    else if (namespaceName == "System")
                     {
-                        if ((string.Equals(className, "Math")) || (string.Equals(className, "MathF")))
+                        if ((className == "Math") || (className == "MathF"))
                         {
                             // These are normally handled via the SSE4.1 instructions ROUNDSS/ROUNDSD.
                             // However, we don't know the ISAs the target machine supports so we should
                             // fallback to the method call implementation instead.
-                            fTreatAsRegularMethodCall = string.Equals(methodName, "Round");
+                            fTreatAsRegularMethodCall = (methodName == "Round");
                         }
                     }
                 }

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -159,7 +159,6 @@ namespace Internal.JitInterface
             {
                 return true;
             }
-            Console.WriteLine("Andrew said we should be compiling: " + method.ToString());
             return false;
         }
 

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -155,7 +155,7 @@ namespace Internal.JitInterface
             {
                 return true;
             }
-            if (HardwareIntrinsicHelpers.IsHardwareIntrinsic(method) && HardwareIntrinsicHelpers.IsIsSupportedMethod(method))
+            if (HardwareIntrinsicHelpers.IsHardwareIntrinsic(method))
             {
                 return true;
             }
@@ -1152,6 +1152,14 @@ namespace Internal.JitInterface
 
             pResult->methodFlags = getMethodAttribsInternal(methodToDescribe);
             Get_CORINFO_SIG_INFO(methodToDescribe, &pResult->sig, useInstantiatingStub);
+        }
+
+        private uint getMethodAttribs(CORINFO_METHOD_STRUCT_* ftn)
+        {
+            MethodDesc method = HandleToObject(ftn);
+            uint attribs = getMethodAttribsInternal(method);
+            attribs = FilterNamedIntrinsicMethodAttribs(attribs, method);
+            return attribs;
         }
 
         private uint FilterNamedIntrinsicMethodAttribs(uint attribs, MethodDesc method)

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -150,14 +150,16 @@ namespace Internal.JitInterface
 
         private bool ShouldSkipCompilation(IMethodNode methodCodeNodeNeedingCode)
         {
-            if (methodCodeNodeNeedingCode.Method.IsAggressiveOptimization)
+            MethodDesc method = methodCodeNodeNeedingCode.Method;
+            if (method.IsAggressiveOptimization)
             {
                 return true;
             }
-            if (HardwareIntrinsicHelpers.IsHardwareIntrinsic(methodCodeNodeNeedingCode.Method) && HardwareIntrinsicHelpers.IsIsSupportedMethod(methodCodeNodeNeedingCode.Method))
+            if (HardwareIntrinsicHelpers.IsHardwareIntrinsic(method) && HardwareIntrinsicHelpers.IsIsSupportedMethod(method))
             {
                 return true;
             }
+            Console.WriteLine("Andrew said we should be compiling: " + method.ToString());
             return false;
         }
 


### PR DESCRIPTION
- [x] Testing
- [ ] Restrict generation to CoreLib only 

Some testing is in progress for validating this change:

1. Compiling `System.Private.CoreLib` with the assert causing failure in #12093 commented out. The compilation succeeded.

2. `R2RDump` verification of the generated binary. 

- Avx related artifacts are NOT generated.
- `get_IsSupported` for x86/x64 hardware intrinsics are not pre-compiled (the ARM64 ones are generated, which is weird but doesn't hurt)
- The hardware intrinsic method themselves are not generated. This fact turns out to be important. We had the code to filter the method attributes so that the hardware intrinsic bit is taken away, if the unsupported Avx methods are precompiled, the infinite recursion code would be precompiled as is into the binary, causing stack overflow.
- The hardware intrinsic instructions are used in code path guard by `get_IsSupported`.
- The fallback path is generated. 

Below is a snippet showing the case where the hardware intrinsic instruction is generated and guarded by IsSupported with the fallback path generated as well:

```
Int32 System.Decimal+DecCalc.ScaleResult(System.Decimal+DecCalc+Buf24*, UInt32, Int32)
...
  338ad5: ff 15 1d 4e 55 00     call qword ptr [0x88d8f8]     // Boolean System.Runtime.Intrinsics.X86.Lzcnt.get_IsSupported() (METHOD_ENTRY_DEF_TOKEN)
  338adb: 0f b6 c8              movzx ecx, al
  338ade: 85 c9                 test ecx, ecx
  338ae0: 74 0a                 je 0x338aec
  338ae2: 45 33 ff              xor r15d, r15d
  338ae5: f3 45 0f bd fe        lzcnt r15d, r14d
  338aea: eb 28                 jmp 0x338b14
  338aec: 45 85 f6              test r14d, r14d
  338aef: 0f 94 c1              sete cl
  338af2: 0f b6 c9              movzx ecx, cl
  338af5: 85 c9                 test ecx, ecx
  338af7: 74 08                 je 0x338b01
  338af9: 41 bf 20 00 00 00     mov r15d, 32
  338aff: eb 13                 jmp 0x338b14
  338b01: 41 8b ce              mov ecx, r14d
  338b04: ff 15 8e d2 54 00     call qword ptr [0x885d98]     // Int32 System.Numerics.BitOperations.Log2SoftwareFallback(UInt32) (METHOD_ENTRY_DEF_TOKEN)
  338b0a: 44 8b f8              mov r15d, eax
  338b0d: 41 f7 df              neg r15d
  338b10: 41 83 c7 1f           add r15d, 31
  338b14: 41 2b ef              sub ebp, r15d
...
```

3. `test.cmd` - following the standard procedure, the test binaries are built. I replaced all copies of `System.Private.CoreLib.dll` compiled with crossgen with the one compiled with crossgen2 and ran all the tests, 3 tests out of 2600+ tests failed, and they were failing before my changes.

4. CI passes

@dotnet/crossgen-contrib 