### PR TITLE
Increase checkout fetchDepth to 5

### DIFF
--- a/eng/checkout-job.yml
+++ b/eng/checkout-job.yml
@@ -21,7 +21,7 @@ jobs:
   steps:
   - checkout: self
     clean: true
-    fetchDepth: 1
+    fetchDepth: 5
 
   ### Zip up downloaded repo and publish to Helix
   - template: /eng/upload-artifact-step.yml
@@ -50,7 +50,7 @@ jobs:
   steps:
   - checkout: self
     clean: true
-    fetchDepth: 1
+    fetchDepth: 5
 
   ### Zip up downloaded repo and publish to Helix
   - template: /eng/upload-artifact-step.yml


### PR DESCRIPTION
Based on recommended practice and on Jared's experience from the
Roslyn repo I propose increasing the fetchDepth constant to 5 to
prevent occasional checkout failures seen after my change from
last week to only check out the GIT branch once for Windows
and once for Linux per pipeline.

Thanks

Tomas

Expected to fix: https://github.com/dotnet/coreclr/issues/26733