### PR TITLE
Mark GC_TRANSITION(FALSE) for EventPipe stack sampling

### DIFF
--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -716,7 +716,10 @@ bool EventPipe::WalkManagedStackForThread(Thread *pThread, StackContents &stackC
 
     stackContents.Reset();
 
-    bool gcOnTransitions = GC_ON_TRANSITIONS(FALSE);                // dont do GC for GCStress 3
+    // Before we call into StackWalkFrames we need to mark GC_ON_TRANSITIONS as FALSE
+    // because under GCStress runs (GCStress=0x3), a GC will be triggered for every transition,
+    // which will cause the GC to try to walk the stack while we are in the middle of walking the stack.
+    bool gcOnTransitions = GC_ON_TRANSITIONS(FALSE);
 
     StackWalkAction swaRet = pThread->StackWalkFrames(
         (PSTACKWALKFRAMESCALLBACK)&StackWalkCallback,

--- a/src/vm/eventpipe.cpp
+++ b/src/vm/eventpipe.cpp
@@ -716,11 +716,14 @@ bool EventPipe::WalkManagedStackForThread(Thread *pThread, StackContents &stackC
 
     stackContents.Reset();
 
+    bool gcOnTransitions = GC_ON_TRANSITIONS(FALSE);                // dont do GC for GCStress 3
+
     StackWalkAction swaRet = pThread->StackWalkFrames(
         (PSTACKWALKFRAMESCALLBACK)&StackWalkCallback,
         &stackContents,
         ALLOW_ASYNC_STACK_WALK | FUNCTIONSONLY | HANDLESKIPPEDFRAMES | ALLOW_INVALID_OBJECTS);
 
+    GC_ON_TRANSITIONS(gcOnTransitions);
     return ((swaRet == SWA_DONE) || (swaRet == SWA_CONTINUE));
 }
 


### PR DESCRIPTION
When GCStress=0x3 is specified it will trigger a GC per transition which causes a GC to happen while we are collecting a stack trace, which will hit an assert like the one in https://github.com/dotnet/coreclr/issues/26723. Marking GC_ON_TRANSITION as false between stack trace collection to prevent this from happening.

