### PR TITLE
Fix JustMyCode stepping into jumps

### DIFF
--- a/src/debug/ee/controller.h
+++ b/src/debug/ee/controller.h
@@ -1562,7 +1562,8 @@ protected:
     virtual bool TrapStepInHelper(ControllerStackInfo * pInfo,
                                   const BYTE * ipCallTarget,
                                   const BYTE * ipNext,
-                                  bool fCallingIntoFunclet);
+                                  bool fCallingIntoFunclet,
+                                  bool fIsJump);
     virtual bool IsInterestingFrame(FrameInfo * pFrame);
     virtual bool DetectHandleNonUserCode(ControllerStackInfo *info, DebuggerMethodInfo * pInfo);
     
@@ -1736,7 +1737,8 @@ protected:
     virtual bool TrapStepInHelper(ControllerStackInfo * pInfo,
                                   const BYTE * ipCallTarget,
                                   const BYTE * ipNext,
-                                  bool fCallingIntoFunclet);
+                                  bool fCallingIntoFunclet,
+                                  bool fIsJump);
     virtual bool IsInterestingFrame(FrameInfo * pFrame);
     virtual void TriggerMethodEnter(Thread * thread, DebuggerJitInfo * dji, const BYTE * ip, FramePointer fp);
     virtual bool DetectHandleNonUserCode(ControllerStackInfo *info, DebuggerMethodInfo * pInfo);


### PR DESCRIPTION
For the following code (using InlineIL.Fody):
```csharp
static bool IsEven(int x)
{
    if (x == 0 || x == 2 || x == 4 || x == 6)
        return true;

    IL.Push(x - 1);
    IL.Emit.Tail();
    IL.Emit.Call(new MethodRef(typeof(Program), nameof(IsOdd)));
    return IL.Return<bool>();
}

static bool IsOdd(int x)
{
    if (x == 0 || x == 2 || x == 4 || x == 6)
        return false;

    IL.Push(x - 1);
    IL.Emit.Tail();
    IL.Emit.Call(new MethodRef(typeof(Program), nameof(IsEven)));
    return IL.Return<bool>();
}
```
attempting to step into one of the fast tailcalls with JMC enabled would fail an assertion. The problem is that the JMC stepper tries to patch the next instruction after the jump, but this instruction does not belong to the function.

I am not sure if this is a complete solution. For this case we should perhaps try to capture the process when it returns. However it at least fixes the assertion failure and I don't think this patching should be done after a jump in any case.

cc @noahfalk 