### PR TITLE
Don't try to publish build logs in finalize-publish

### DIFF
--- a/eng/finalize-publish.yml
+++ b/eng/finalize-publish.yml
@@ -60,21 +60,3 @@ jobs:
         /p:ShippedNuGetPackageGlobPath="${{ parameters.artifactsDir }}/nuget/*.nupkg"
 
       displayName: Update dotnet/versions
-
-    - task: CopyFiles@2
-      displayName: Copy Files to $(Build.StagingDirectory)\BuildLogs
-      inputs:
-        SourceFolder: '$(Build.SourcesDirectory)'
-        Contents: |
-          *.log
-          *.binlog
-        TargetFolder: '$(Build.StagingDirectory)\BuildLogs'
-      continueOnError: true
-      condition: succeededOrFailed()
-
-    - task: PublishBuildArtifacts@1
-      displayName: Publish Artifact BuildLogs
-      inputs:
-        PathtoPublish: '$(Build.StagingDirectory)\BuildLogs'
-        ArtifactName: Finalize_Publish_Versions
-      condition: succeededOrFailed()


### PR DESCRIPTION
After https://github.com/dotnet/coreclr/pull/26768, the dotnet/versions update succeeds, but the official build still fails on a subsequent step when it tries to publish missing build logs: https://dev.azure.com/dnceng/internal/_build/results?buildId=359539&view=logs&s=6884a131-87da-5381-61f3-d7acc3b91d76&j=47825067-ac8c-572d-1871-7f52798b9d86

This should fix the problem. I could be missing something, but it looks like this only ever published the binclash log produced by the old update versions script, which I don't think we needed anyway. @dotnet/coreclr-infra PTAL.