### PR TITLE
[Linux/x86] Fix OOPStackUnwinderX86::Unwind

### DIFF
--- a/src/debug/ee/i386/x86walker.cpp
+++ b/src/debug/ee/i386/x86walker.cpp
@@ -307,7 +307,7 @@ DWORD NativeWalker::GetRegisterValue(int registerNumber)
         return m_registers->SP;
         break;
     case 5:
-        return *m_registers->GetEbpLocation();
+        return GetRegdisplayFP(m_registers);
         break;
     case 6:
         return *m_registers->GetEsiLocation();

--- a/src/inc/regdisp.h
+++ b/src/inc/regdisp.h
@@ -95,7 +95,11 @@ struct REGDISPLAY : public REGDISPLAY_BASE {
 
 #define REG_METHODS(reg) \
     inline PDWORD Get##reg##Location(void) { return pCurrentContextPointers->reg; } \
-    inline void   Set##reg##Location(PDWORD p##reg) { pCurrentContextPointers->reg = p##reg; }
+    inline void   Set##reg##Location(PDWORD p##reg) \
+    { \
+        pCurrentContextPointers->reg = p##reg; \
+        pCurrentContext->reg = *p##reg; \
+    }
 
 #endif // FEATURE_EH_FUNCLETS
 
@@ -115,8 +119,11 @@ struct REGDISPLAY : public REGDISPLAY_BASE {
 
 inline TADDR GetRegdisplayFP(REGDISPLAY *display) {
     LIMITED_METHOD_DAC_CONTRACT;
-
+#ifdef FEATURE_EH_FUNCLETS
+    return (TADDR)display->pCurrentContext->Ebp;
+#else
     return (TADDR)*display->GetEbpLocation();
+#endif
 }
 
 inline LPVOID GetRegdisplayFPAddress(REGDISPLAY *display) {

--- a/src/vm/proftoeeinterfaceimpl.cpp
+++ b/src/vm/proftoeeinterfaceimpl.cpp
@@ -7747,7 +7747,7 @@ Loop:
                 CodeManState codeManState;
                 codeManState.dwIsSet = 0;
                 REGDISPLAY rd;
-                ZeroMemory(&rd, sizeof(rd));
+                FillRegDisplay(&rd, &ctxCur);
 
                 rd.SetEbpLocation(&ctxCur.Ebp);
                 rd.SP = ctxCur.Esp;


### PR DESCRIPTION
Use ebp from current context during unwinding. `pCurrentContextPointers` in `REGDISPLAY` can contain NULLs so we need to use ebp value from `pCurrentContext`. This patch contains following changes:
- `GetRegdisplayFP` returns ebp from `pCurrentContext`
- `GetRegdisplayFP` is used instead of `*GetEbpLocation()`
- `Set##reg##Location` also updates register value in `pCurrentContext`

It fixes https://github.com/dotnet/coreclr/issues/26788