### PR TITLE
New SuperIlc command "compile-framework" and some fixes

### DIFF
--- a/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
+++ b/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
@@ -169,7 +169,7 @@ namespace ReadyToRun.SuperIlc
                     foreach (CompilerRunner runner in _compilerRunners)
                     {
                         ProcessInfo runnerProcess = compilation[(int)runner.Index];
-                        if (runnerProcess == null)
+                        if (runnerProcess == null || runnerProcess.IsEmpty)
                         {
                             // No runner process
                         }
@@ -1195,7 +1195,7 @@ namespace ReadyToRun.SuperIlc
                             foreach (CompilerRunner runner in _compilerRunners)
                             {
                                 ProcessInfo compilationProcess = compilation[(int)runner.Index];
-                                if (compilationProcess != null)
+                                if (compilationProcess != null && !compilationProcess.IsEmpty)
                                 {
                                     string log = $"\nCOMPILE {runner.CompilerName}:{compilationProcess.Parameters.InputFileName}";
                                     StreamWriter runnerLog = perRunnerLog[(int)runner.Index];

--- a/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
+++ b/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
@@ -8,23 +8,63 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
+using Microsoft.Diagnostics.Tracing.Parsers;
 using Microsoft.Diagnostics.Tracing.Parsers.Clr;
 
 namespace ReadyToRun.SuperIlc
 {
     public class BuildFolderSet
     {
-        private IEnumerable<BuildFolder> _buildFolders;
+        class FrameworkExclusion
+        {
+            public readonly string SimpleName;
+            public readonly string Reason;
 
-        private IEnumerable<CompilerRunner> _compilerRunners;
+            public FrameworkExclusion(string simpleName, string reason)
+            {
+                SimpleName = simpleName;
+                Reason = reason;
+            }
+        }
 
-        private BuildOptions _options;
+        private static readonly FrameworkExclusion[] s_frameworkExclusions =
+        {
+            new FrameworkExclusion("CommandLine", "Not a framework assembly"),
+            new FrameworkExclusion("R2RDump", "Not a framework assembly"),
+            new FrameworkExclusion("System.Runtime.WindowsRuntime", "WinRT is currently not supported"),
+            new FrameworkExclusion("xunit.performance.api", "Not a framework assembly"),
 
-        private Buckets _frameworkCompilationFailureBuckets;
+            // TODO (DavidWr): IBC-related failures
+            new FrameworkExclusion("Microsoft.CodeAnalysis.CSharp", "Ibc TypeToken 6200019a has type token which resolves to a nil token"),
+            new FrameworkExclusion("Microsoft.CodeAnalysis", "Ibc TypeToken 620001af unable to find external typedef"),
+            new FrameworkExclusion("Microsoft.CodeAnalysis.VisualBasic", "Ibc TypeToken 620002ce unable to find external typedef"),
 
-        private Buckets _compilationFailureBuckets;
+            // TODO (TRylek): problem related to devirtualization of method without IL - System.Enum.Equals(object)
+            new FrameworkExclusion("System.ComponentModel.TypeConverter", "TODO trylek - devirtualization of method without IL"),
+        };
 
-        private Buckets _executionFailureBuckets;
+        private readonly IEnumerable<BuildFolder> _buildFolders;
+
+        private readonly IEnumerable<CompilerRunner> _compilerRunners;
+
+        private readonly BuildOptions _options;
+
+        private readonly Buckets _frameworkCompilationFailureBuckets;
+
+        private readonly Buckets _compilationFailureBuckets;
+
+        private readonly Buckets _executionFailureBuckets;
+
+        private readonly Dictionary<string, byte> _cpaotManagedSequentialResults;
+
+        private readonly Dictionary<string, byte> _crossgenManagedSequentialResults;
+
+        private readonly Dictionary<string, byte> _cpaotRequiresMarshalingResults;
+
+        private readonly Dictionary<string, byte> _crossgenRequiresMarshalingResults;
+
+        private readonly Dictionary<string, string> _frameworkExclusions;
 
         private long _frameworkCompilationMilliseconds;
 
@@ -33,14 +73,6 @@ namespace ReadyToRun.SuperIlc
         private long _executionMilliseconds;
 
         private long _buildMilliseconds;
-
-        private Dictionary<string, byte> _cpaotManagedSequentialResults;
-
-        private Dictionary<string, byte> _crossgenManagedSequentialResults;
-
-        private Dictionary<string, byte> _cpaotRequiresMarshalingResults;
-
-        private Dictionary<string, byte> _crossgenRequiresMarshalingResults;
 
         public BuildFolderSet(
             IEnumerable<BuildFolder> buildFolders,
@@ -61,6 +93,7 @@ namespace ReadyToRun.SuperIlc
             _cpaotRequiresMarshalingResults = new Dictionary<string, byte>();
             _crossgenRequiresMarshalingResults = new Dictionary<string, byte>();
 
+            _frameworkExclusions = new Dictionary<string, string>();
         }
 
         private void WriteJittedMethodSummary(StreamWriter logWriter)
@@ -92,7 +125,10 @@ namespace ReadyToRun.SuperIlc
 
         public bool Compile()
         {
-            CompileFramework();
+            if (!CompileFramework())
+            {
+                return false;
+            }
 
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
@@ -235,8 +271,17 @@ namespace ReadyToRun.SuperIlc
 
             List<ProcessInfo> compilationsToRun = new List<ProcessInfo>();
             List<KeyValuePair<string, ProcessInfo[]>> compilationsPerRunner = new List<KeyValuePair<string, ProcessInfo[]>>();
+            List<string> excludedAssemblies = new List<string>();
             foreach (string frameworkDll in ComputeManagedAssemblies.GetManagedAssembliesInFolder(_options.CoreRootDirectory.FullName))
             {
+                string simpleName = Path.GetFileNameWithoutExtension(frameworkDll);
+                FrameworkExclusion exclusion = s_frameworkExclusions.FirstOrDefault(asm => asm.SimpleName.Equals(simpleName, StringComparison.OrdinalIgnoreCase));
+                if (exclusion != null)
+                {
+                    _frameworkExclusions.Add(exclusion.SimpleName, exclusion.Reason);
+                    continue;
+                }
+
                 ProcessInfo[] processes = new ProcessInfo[(int)CompilerIndex.Count];
                 compilationsPerRunner.Add(new KeyValuePair<string, ProcessInfo[]>(frameworkDll, processes));
                 foreach (CompilerRunner runner in frameworkRunners)
@@ -434,7 +479,7 @@ namespace ReadyToRun.SuperIlc
             return success;
         }
 
-        public bool Build(IEnumerable<CompilerRunner> runners)
+        public bool Build()
         {
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
@@ -538,6 +583,7 @@ namespace ReadyToRun.SuperIlc
             EXIT_CODE = 1,
             CRASHED = 2,
             TIMED_OUT = 3,
+            BUILD_FAILED = 4,
 
             Count
         }
@@ -620,24 +666,35 @@ namespace ReadyToRun.SuperIlc
                                 executionOutcomes[(int)outcome, (int)runner.Index]++;
                                 executionFailureOutcomeMask |= 1 << (int)outcome;
                             }
-                            if (!compilationFailed && !executionFailed)
+                            else if (compilationFailed)
+                            {
+                                executionOutcomes[(int)ExecutionOutcome.BUILD_FAILED, (int)runner.Index]++;
+                            }
+                            else
                             {
                                 executionOutcomes[(int)ExecutionOutcome.PASS, (int)runner.Index]++;
                             }
                         }
-                        if (executionFailureOutcomeMask != 0)
+                        if (!anyCompilationFailed)
                         {
-                            for (int outcomeIndex = 0; outcomeIndex < (int)ExecutionOutcome.Count; outcomeIndex++)
+                            if (executionFailureOutcomeMask != 0)
                             {
-                                if ((executionFailureOutcomeMask & (1 << outcomeIndex)) != 0)
+                                for (int outcomeIndex = 0; outcomeIndex < (int)ExecutionOutcome.Count; outcomeIndex++)
                                 {
-                                    executionOutcomes[outcomeIndex, (int)CompilerIndex.Count]++;
+                                    if ((executionFailureOutcomeMask & (1 << outcomeIndex)) != 0)
+                                    {
+                                        executionOutcomes[outcomeIndex, (int)CompilerIndex.Count]++;
+                                    }
                                 }
+                            }
+                            else
+                            {
+                                executionOutcomes[(int)ExecutionOutcome.PASS, (int)CompilerIndex.Count]++;
                             }
                         }
                         else
                         {
-                            executionOutcomes[(int)ExecutionOutcome.PASS, (int)CompilerIndex.Count]++;
+                            executionOutcomes[(int)ExecutionOutcome.BUILD_FAILED, (int)CompilerIndex.Count]++;
                         }
                     }
                 }
@@ -674,7 +731,7 @@ namespace ReadyToRun.SuperIlc
                 if (!_options.Exe)
                 {
                     logWriter.WriteLine();
-                    logWriter.Write($"{totalCompilations,7} ILC |");
+                    logWriter.Write($"{totalCompilations,8} ILC |");
                     foreach (CompilerRunner runner in _compilerRunners)
                     {
                         logWriter.Write($"{runner.CompilerName,8} |");
@@ -683,7 +740,7 @@ namespace ReadyToRun.SuperIlc
                     logWriter.WriteLine(separator);
                     for (int outcomeIndex = 0; outcomeIndex < (int)CompilationOutcome.Count; outcomeIndex++)
                     {
-                        logWriter.Write($"{((CompilationOutcome)outcomeIndex).ToString(),11} |");
+                        logWriter.Write($"{((CompilationOutcome)outcomeIndex).ToString(),12} |");
                         foreach (CompilerRunner runner in _compilerRunners)
                         {
                             logWriter.Write($"{compilationOutcomes[outcomeIndex, (int)runner.Index],8} |");
@@ -695,7 +752,7 @@ namespace ReadyToRun.SuperIlc
                 if (!_options.NoExe)
                 {
                     logWriter.WriteLine();
-                    logWriter.Write($"{totalExecutions,7} EXE |");
+                    logWriter.Write($"{totalExecutions,8} EXE |");
                     foreach (CompilerRunner runner in _compilerRunners)
                     {
                         logWriter.Write($"{runner.CompilerName,8} |");
@@ -704,7 +761,7 @@ namespace ReadyToRun.SuperIlc
                     logWriter.WriteLine(separator);
                     for (int outcomeIndex = 0; outcomeIndex < (int)ExecutionOutcome.Count; outcomeIndex++)
                     {
-                        logWriter.Write($"{((ExecutionOutcome)outcomeIndex).ToString(),11} |");
+                        logWriter.Write($"{((ExecutionOutcome)outcomeIndex).ToString(),12} |");
                         foreach (CompilerRunner runner in _compilerRunners)
                         {
                             logWriter.Write($"{executionOutcomes[outcomeIndex, (int)runner.Index],8} |");
@@ -734,6 +791,10 @@ namespace ReadyToRun.SuperIlc
                 logWriter.WriteLine();
                 logWriter.WriteLine("Framework compilation failures:");
                 FrameworkCompilationFailureBuckets.WriteToStream(logWriter, detailed: false);
+
+                logWriter.WriteLine();
+                logWriter.WriteLine("Framework exclusions:");
+                WriteFrameworkExclusions(logWriter);
             }
 
             if (foldersToBuild != 0)
@@ -753,7 +814,32 @@ namespace ReadyToRun.SuperIlc
                 }
             }
 
-            WriteFoldersBlockedWithIssues(logWriter);
+            if (_buildFolders.Count() != 0)
+            {
+                WriteFoldersBlockedWithIssues(logWriter);
+            }
+        }
+
+        private void WriteFrameworkExclusions(StreamWriter logWriter)
+        {
+            int keyLength = _frameworkExclusions.Keys.Max(key => key.Length);
+            const string SimpleNameTitle = "SIMPLE_NAME";
+            keyLength = Math.Max(keyLength, SimpleNameTitle.Length);
+            StringBuilder title = new StringBuilder();
+            title.Append(SimpleNameTitle);
+            title.Append(' ', keyLength - SimpleNameTitle.Length);
+            title.Append(" | REASON");
+            logWriter.WriteLine(title.ToString());
+            logWriter.WriteLine(new string('-', title.Length));
+            foreach (KeyValuePair<string, string> exclusion in _frameworkExclusions.OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase))
+            {
+                StringBuilder line = new StringBuilder();
+                line.Append(exclusion.Key);
+                line.Append(' ', keyLength - exclusion.Key.Length);
+                line.Append(" | ");
+                line.Append(exclusion.Value);
+                logWriter.WriteLine(line.ToString());
+            }
         }
 
         private void WritePerFolderStatistics(StreamWriter logWriter)
@@ -1205,6 +1291,15 @@ namespace ReadyToRun.SuperIlc
 
             string combinedSetLogPath = Path.Combine(_options.OutputDirectory.FullName, "combined-" + suffix);
             WriteCombinedLog(combinedSetLogPath);
+
+            if (_options.Framework)
+            {
+                string frameworkExclusionsFile = Path.Combine(_options.OutputDirectory.FullName, "framework-exclusions-" + suffix);
+                using (StreamWriter writer = new StreamWriter(frameworkExclusionsFile))
+                {
+                    WriteFrameworkExclusions(writer);
+                }
+            }
 
             if (!_options.Exe && _options.Framework)
             {

--- a/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
+++ b/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
@@ -17,6 +17,7 @@ namespace ReadyToRun.SuperIlc
             var parser = new CommandLineBuilder()
                 .AddCommand(CompileFolder())
                 .AddCommand(CompileSubtree())
+                .AddCommand(CompileFramework())
                 .AddCommand(CompileNugetPackages())
                 .AddCommand(CompileCrossgenRsp());
 
@@ -79,6 +80,26 @@ namespace ReadyToRun.SuperIlc
                         R2RDumpPath(),
                     },
                     handler: CommandHandler.Create<BuildOptions>(CompileSubtreeCommand.CompileSubtree));
+
+            Command CompileFramework() =>
+                new Command("compile-framework", "Compile managed framework assemblies in Core_Root",
+                    new Option[]
+                    {
+                            CoreRootDirectory(),
+                            Crossgen(),
+                            NoCleanup(),
+                            DegreeOfParallelism(),
+                            Sequential(),
+                            Release(),
+                            LargeBubble(),
+                            ReferencePath(),
+                            IssuesPath(),
+                            CompilationTimeoutMinutes(),
+                            R2RDumpPath(),
+                            MeasurePerf(),
+                            InputFileSearchString(),
+                    },
+                    handler: CommandHandler.Create<BuildOptions>(CompileFrameworkCommand.CompileFramework));
 
             Command CompileNugetPackages() =>
                 new Command("compile-nuget", "Restore a list of Nuget packages into an empty console app, publish, and optimize with Crossgen / CPAOT",

--- a/src/tools/ReadyToRun.SuperIlc/Commands/CompileDirectoryCommand.cs
+++ b/src/tools/ReadyToRun.SuperIlc/Commands/CompileDirectoryCommand.cs
@@ -51,7 +51,7 @@ namespace ReadyToRun.SuperIlc
             }
 
             BuildFolderSet folderSet = new BuildFolderSet(new BuildFolder[] { folder }, runners, options);
-            bool success = folderSet.Build(runners);
+            bool success = folderSet.Build();
             folderSet.WriteLogs();
 
             if (!options.NoCleanup && !options.Exe)

--- a/src/tools/ReadyToRun.SuperIlc/Commands/CompileFrameworkCommand.cs
+++ b/src/tools/ReadyToRun.SuperIlc/Commands/CompileFrameworkCommand.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace ReadyToRun.SuperIlc
+{
+    class CompileFrameworkCommand
+    {
+        public static int CompileFramework(BuildOptions options)
+        {
+            if (options.CoreRootDirectory == null)
+            {
+                Console.Error.WriteLine("--core-root-directory (--cr) is a required argument.");
+                return 1;
+            }
+
+            string logsFolder = Path.Combine(options.CoreRootDirectory.FullName, "logs");
+            Directory.CreateDirectory(logsFolder);
+            options.OutputDirectory = new DirectoryInfo(logsFolder);
+            options.Framework = true;
+            options.NoJit = true;
+            options.NoEtw = true;
+            options.NoExe = true;
+
+            IEnumerable<CompilerRunner> runners = options.CompilerRunners(isFramework: false);
+
+            BuildFolderSet folderSet = new BuildFolderSet(Array.Empty<BuildFolder>(), runners, options);
+            bool success = folderSet.Build();
+            folderSet.WriteLogs();
+
+            return success ? 0 : 1;
+        }
+    }
+}

--- a/src/tools/ReadyToRun.SuperIlc/Commands/CompileNugetCommand.cs
+++ b/src/tools/ReadyToRun.SuperIlc/Commands/CompileNugetCommand.cs
@@ -92,7 +92,7 @@ namespace ReadyToRun.SuperIlc
                 }
 
                 BuildFolderSet folderSet = new BuildFolderSet(publishedAppFoldersToCompile, runners, options);
-                bool success = folderSet.Build(runners);
+                bool success = folderSet.Build();
                 folderSet.WriteLogs();
 
                 if (!options.NoCleanup && !options.Exe)

--- a/src/tools/ReadyToRun.SuperIlc/ParallelRunner.cs
+++ b/src/tools/ReadyToRun.SuperIlc/ParallelRunner.cs
@@ -108,9 +108,11 @@ public sealed class ParallelRunner
         collectEtwTraces |= measurePerf;
         foreach (ProcessInfo process in processesToRun)
         {
-            process.Construct();
-            processList.Add(process);
-            collectEtwTraces |= process.Parameters.CollectJittedMethods;
+            if (process.Construct())
+            {
+                processList.Add(process);
+                collectEtwTraces |= process.Parameters.CollectJittedMethods;
+            }
         }
 
         processList.Sort((a, b) => b.Parameters.CompilationCostHeuristic.CompareTo(a.Parameters.CompilationCostHeuristic));

--- a/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
+++ b/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
@@ -57,6 +57,8 @@ public class ProcessInfo
     public int ExitCode;
     public Dictionary<string, HashSet<string>> JittedMethods;
 
+    public bool IsEmpty => Parameters == null;
+
     public bool Crashed => ExitCode < -1000 * 1000;
 
     public ProcessInfo(ProcessConstructor constructor)
@@ -64,10 +66,11 @@ public class ProcessInfo
         Constructor = constructor;
     }
 
-    public void Construct()
+    public bool Construct()
     {
         Parameters = Constructor.Construct();
         Constructor = null;
+        return Parameters != null;
     }
 }
 


### PR DESCRIPTION
1) New command "compile-framework" does just what it says on the tin.
My thinking is that I'll use this option to build the CPAOT
framework during product build in the envisioned pipeline. I have
added hard-coded exclusions for assemblies that fail to build right
now - about half of them aren't interesting as framework assemblies
(e.g. R2RDump.dll), some other fail with IBC bugs and one other bug
I'm about to investigate.

2) Based on JanV's suggestion I have added a somewhat hacky logic
to exclude the "testhost" folder when building the entire Pri#1
test tree. I'm open to suggestions how to tackle this in a cleaner
manner, I have shared my thoughts on the subject in code comments
next to the problematic spots.

3) I have removed the unused "runners" parameter to Build.

Thanks

Tomas