### PR TITLE
Port The Fix When Enabling Windows Compatibilty Mode

### DIFF
--- a/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.Globalization.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.Globalization.cs
@@ -24,6 +24,9 @@ internal static partial class Interop
         internal const uint LOCALE_RETURN_NUMBER        = 0x20000000;
         internal const uint LOCALE_NOUSEROVERRIDE       = 0x80000000;
 
+        internal const uint LCMAP_SORTHANDLE            = 0x20000000;
+        internal const uint LCMAP_HASH                  = 0x00040000;
+
         internal const int  COMPARE_STRING              = 0x0001;
 
         internal const uint TIME_NOSECONDS = 0x00000002;
@@ -115,7 +118,7 @@ internal static partial class Interop
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
         internal static extern bool EnumTimeFormatsEx(EnumTimeFormatsProcEx lpTimeFmtEnumProcEx, string lpLocaleName, uint dwFlags, void* lParam);
-  
+
         internal delegate BOOL EnumTimeFormatsProcEx(char* lpTimeFormatString, void* lParam);
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
@@ -126,7 +129,7 @@ internal static partial class Interop
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
         internal static extern bool EnumCalendarInfoExEx(EnumCalendarInfoProcExEx pCalInfoEnumProcExEx, string lpLocaleName, uint Calendar, string? lpReserved, uint CalType, void* lParam);
-        
+
         internal delegate BOOL EnumCalendarInfoProcExEx(char* lpCalendarInfoString, uint Calendar, IntPtr lpReserved, void* lParam);
 
         [StructLayout(LayoutKind.Sequential)]
@@ -138,7 +141,7 @@ internal static partial class Interop
             internal int dwEffectiveId;
             internal Guid guidCustomVersion;
         }
-        
+
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
         internal static extern unsafe bool GetNLSVersionEx(int function, string localeName, NlsVersionInfoEx* lpVersionInformation);
     }

--- a/src/System.Private.CoreLib/shared/System/Globalization/TextInfo.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/TextInfo.Windows.cs
@@ -10,17 +10,7 @@ namespace System.Globalization
     {
         private unsafe void FinishInitialization()
         {
-            if (GlobalizationMode.Invariant)
-            {
-                _sortHandle = IntPtr.Zero;
-                return;
-            }
-
-            const uint LCMAP_SORTHANDLE = 0x20000000;
-
-            IntPtr handle;
-            int ret = Interop.Kernel32.LCMapStringEx(_textInfoName, LCMAP_SORTHANDLE, null, 0, &handle, IntPtr.Size, null, null, IntPtr.Zero);
-            _sortHandle = ret > 0 ? handle : IntPtr.Zero;
+            _sortHandle = CompareInfo.GetSortHandle(_textInfoName);
         }
 
         private unsafe void ChangeCase(char* pSource, int pSourceLen, char* pResult, int pResultLen, bool toUpper)


### PR DESCRIPTION
### **Description**
Enabling Windows compatibility mode on any .NET Core app causes the app not starting at all. Basically, we throw exception very early during the app booting. This problem happens because of a bug in Windows shim layer when calling some Windows APIs and using some parameter called sort handle. We reported the issue to Windows, but it is not expected to get a fix in the shipped versions of Windows. The fix in .NET Core is very simple as we detect early if the sort handles are supported and working fine before we try to use it.
The example of the customer scenario is mentioned in the comment https://github.com/dotnet/coreclr/issues/26479#issuecomment-527236626

The reported issues for this problem are:  
https://github.com/dotnet/core-setup/issues/7872
https://github.com/dotnet/coreclr/issues/26479
https://github.com/dotnet/coreclr/issues/15021

### **Customer** Impact
Customer wanted to run their net core app under Windows compatibility mode will be able to do so.

### **Regression?**
No.

### **Code** Review
Jan Kotas @jkotas

### **Testing**
I have done manual testing ensuring now net core app can start and run under Windows compatibility mode. This change is merged in masters for a few weeks too. 

### **Risk**
Very small, we are not changing any behavior. Also, the apps were not be able to run at all under compatibility mode.

