### PR TITLE
[release/3.1] Do not clip CPU count when CPU quota is used. (#26153)

### DIFF
--- a/src/classlibnative/bcltype/system.cpp
+++ b/src/classlibnative/bcltype/system.cpp
@@ -352,13 +352,6 @@ INT32 QCALLTYPE SystemNative::GetProcessorCount()
         processorCount = systemInfo.dwNumberOfProcessors;
     }
 
-#ifdef FEATURE_PAL
-    uint32_t cpuLimit;
-
-    if (PAL_GetCpuLimit(&cpuLimit) && cpuLimit < (uint32_t)processorCount)
-        processorCount = cpuLimit;
-#endif
-
     END_QCALL;
 
     return processorCount;

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -2558,12 +2558,6 @@ PAL_GetCPUBusyTime(
         {
             return 0;
         }
-
-        UINT cpuLimit;
-        if (PAL_GetCpuLimit(&cpuLimit) && cpuLimit < dwNumberOfProcessors)
-        {
-            dwNumberOfProcessors = cpuLimit;
-        }
     }
 
     if (getrusage(RUSAGE_SELF, &resUsage) == -1)

--- a/src/utilcode/util.cpp
+++ b/src/utilcode/util.cpp
@@ -1289,10 +1289,6 @@ int GetCurrentProcessCpuCount()
 
 #else // !FEATURE_PAL
     count = PAL_GetLogicalCpuCountFromOS();
-
-    uint32_t cpuLimit;
-    if (PAL_GetCpuLimit(&cpuLimit) && cpuLimit < count)
-        count = cpuLimit;
 #endif // !FEATURE_PAL
 
     cCPUs = count;


### PR DESCRIPTION
Description
We have heard from multiple customers deploying .NET Core micro-services in Kubernetes that clipping of CPU count when CPU quota is used results into a performance cliff in commonly used configuration.

We have added this clipping late during 3.0. It was controversial change and the data supporting the change were not very strong. This change reverts change. The change was reverted in master already. 

Regression?
Yes (2.x -> 3.0)

Risk
Small chance that .NET Core 3.0 deployments may started depending on the broken behavior. They will need to be reconfigured.