### PR TITLE
Copy live sets when splitting blocks

### DIFF
--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -600,8 +600,8 @@ void CodeGen::genCodeForBBlist()
         }
         if (foundMismatchedRegVar)
         {
-            assert(!"Found mismatched live reg var(s) after block");
             JITDUMP("\n");
+            assert(!"Found mismatched live reg var(s) after block");
         }
 #endif
 

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4249,7 +4249,7 @@ void Compiler::compFunctionTraceStart()
         {
             printf("  ");
         }
-        printf("{ Start Jitting %s (MethodHash=%08x)\n", info.compFullName,
+        printf("{ Start Jitting Method %d %s (MethodHash=%08x)\n", Compiler::jitTotalMethodCompiled, info.compFullName,
                info.compMethodHash()); /* } editor brace matching workaround for this printf */
     }
 #endif // DEBUG
@@ -4273,7 +4273,7 @@ void Compiler::compFunctionTraceEnd(void* methodCodePtr, ULONG methodCodeSize, b
             printf("  ");
         }
         /* { editor brace-matching workaround for following printf */
-        printf("} Jitted Entry %03x at" FMT_ADDR "method %s size %08x%s%s\n", Compiler::jitTotalMethodCompiled,
+        printf("} Jitted Method %03x at" FMT_ADDR "method %s size %08x%s%s\n", Compiler::jitTotalMethodCompiled,
                DBG_ADDR(methodCodePtr), info.compFullName, methodCodeSize,
                isNYI ? " NYI" : (compIsForImportOnly() ? " import only" : ""), opts.altJit ? " altjit" : "");
     }

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -19529,7 +19529,7 @@ void Compiler::impMarkInlineCandidate(GenTree*               callNode,
     if (call->IsVirtualStub())
     {
         JITDUMP("Restoring stub addr %p from guarded devirt candidate info\n",
-                call->gtGuardedDevirtualizationCandidateInfo->stubAddr);
+                dspPtr(call->gtGuardedDevirtualizationCandidateInfo->stubAddr));
         call->gtStubCallStubAddr = call->gtGuardedDevirtualizationCandidateInfo->stubAddr;
     }
 }
@@ -20126,11 +20126,11 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
 
         if (uniqueImplementingClass == NO_CLASS_HANDLE)
         {
-            JITDUMP("No unique implementor of interface %p (%s), sorry\n", objClass, objClassName);
+            JITDUMP("No unique implementor of interface %p (%s), sorry\n", dspPtr(objClass), objClassName);
             return;
         }
 
-        JITDUMP("Only known implementor of interface %p (%s) is %p (%s)!\n", objClass, objClassName,
+        JITDUMP("Only known implementor of interface %p (%s) is %p (%s)!\n", dspPtr(objClass), objClassName,
                 uniqueImplementingClass, eeGetClassName(uniqueImplementingClass));
 
         bool guessUniqueInterface = true;
@@ -20713,7 +20713,7 @@ void Compiler::addGuardedDevirtualizationCandidate(GenTreeCall*          call,
     // Save off the stub address since it shares a union with the candidate info.
     if (call->IsVirtualStub())
     {
-        JITDUMP("Saving stub addr %p in candidate info\n", call->gtStubCallStubAddr);
+        JITDUMP("Saving stub addr %p in candidate info\n", dspPtr(call->gtStubCallStubAddr));
         pInfo->stubAddr = call->gtStubCallStubAddr;
     }
     else

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -6853,6 +6853,10 @@ void Compiler::lvaDumpEntry(unsigned lclNum, FrameLayoutState curState, size_t r
     {
         printf(" exact");
     }
+    if (varDsc->lvLiveInOutOfHndlr)
+    {
+        printf(" EH-live");
+    }
 #ifndef _TARGET_64BIT_
     if (varDsc->lvStructDoubleAlign)
         printf(" double-align");

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -5852,7 +5852,7 @@ void LinearScan::allocateRegisters()
     }
 
 #ifdef JIT32_GCENCODER
-    // For the JIT32_GCENCODER, when lvaKeepAliveAndReportThis is true, we must either keep this "this" pointer
+    // For the JIT32_GCENCODER, when lvaKeepAliveAndReportThis is true, we must either keep the "this" pointer
     // in the same register for the entire method, or keep it on the stack. Rather than imposing this constraint
     // as we allocate, we will force all refs to the stack if it is split or spilled.
     if (enregisterLocalVars && compiler->lvaKeepAliveAndReportThis())
@@ -8174,6 +8174,11 @@ void LinearScan::resolveEdges()
                 }
                 SplitEdgeInfo info = {predBBNum, succBBNum};
                 getSplitBBNumToTargetBBNumMap()->Set(block->bbNum, info);
+
+                // Set both the live-in and live-out to the live-in of the successor (by construction liveness
+                // doesn't change in a split block).
+                VarSetOps::Assign(compiler, block->bbLiveIn, succBlock->bbLiveIn);
+                VarSetOps::Assign(compiler, block->bbLiveOut, succBlock->bbLiveIn);
             }
         }
     }

--- a/src/jit/lsrabuild.cpp
+++ b/src/jit/lsrabuild.cpp
@@ -2079,7 +2079,7 @@ void LinearScan::buildIntervals()
         {
             JITDUMP("\n\nSetting " FMT_BB " as the predecessor for determining incoming variable registers of " FMT_BB
                     "\n",
-                    block->bbNum, predBlock->bbNum);
+                    predBlock->bbNum, block->bbNum);
             assert(predBlock->bbNum <= bbNumMaxBeforeResolution);
             blockInfo[block->bbNum].predBBNum = predBlock->bbNum;
         }


### PR DESCRIPTION
With #26456 we may generate labels for split blocks (even though there's no associated code). Therefore we need to ensure that the live sets are correct.
Also, cleanup some miscellaneous dumping code.

Fix #26795