### PR TITLE
Use Arm64Base.LeadingZeroCount in BitOperations

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Numerics/BitOperations.cs
+++ b/src/System.Private.CoreLib/shared/System/Numerics/BitOperations.cs
@@ -5,6 +5,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
+using Arm64Base = System.Runtime.Intrinsics.Arm.Arm64.Base;
 
 using Internal.Runtime.CompilerServices;
 
@@ -53,6 +54,10 @@ namespace System.Numerics
                 // LZCNT contract is 0->32
                 return (int)Lzcnt.LeadingZeroCount(value);
             }
+            else if (Arm64Base.IsSupported)
+            {
+                return Arm64Base.LeadingZeroCount(value);
+            }
 
             // Unguarded fallback contract is 0->31
             if (value == 0)
@@ -76,6 +81,10 @@ namespace System.Numerics
             {
                 // LZCNT contract is 0->64
                 return (int)Lzcnt.X64.LeadingZeroCount(value);
+            }
+            else if (Arm64Base.IsSupported)
+            {
+                return Arm64Base.LeadingZeroCount(value);
             }
 
             uint hi = (uint)(value >> 32);


### PR DESCRIPTION
I am curious if we can already use at least the Base Arm64 intrinsics 🙂 
Already implemented in CoreCLR: https://github.com/dotnet/coreclr/pull/20306
Draft in Mono-LLVM: https://github.com/mono/mono/pull/16977
