### PR TITLE
Fix managed test artifacts to be *nix flavor-agnostic

### DIFF
--- a/src/coreclr/hosts/corerun/corerun.cpp
+++ b/src/coreclr/hosts/corerun/corerun.cpp
@@ -457,45 +457,10 @@ bool TryLoadHostPolicy(StackSString& hostPolicyPath)
     {
         return true;
     }
-
-    // Use proper prefix / extension for the host policy dynamic library
-#if defined(_WINNT_)
-    static const WCHAR LibraryPrefix[] = L"";
-    static const WCHAR LibrarySuffix[] = L".dll";
-    static const WCHAR PathSeparator = L'\\';
-#elif defined(__APPLE__)
-    static const WCHAR LibraryPrefix[] = u"lib";
-    static const WCHAR LibrarySuffix[] = u".dylib";
-    static const WCHAR PathSeparator = u'/';
-#else // Various Linux-related OS-es
-    static const WCHAR LibraryPrefix[] = u"lib";
-    static const WCHAR LibrarySuffix[] = u".so";
-    static const WCHAR PathSeparator = u'/';
-#endif
-    
-    SString::CIterator fileNamePos = hostPolicyPath.End();
-    if (hostPolicyPath.FindBack(fileNamePos, PathSeparator))
-    {
-        ++fileNamePos;
-    }
-    else
-    {
-        fileNamePos = hostPolicyPath.Begin();
-    }
-    
-    StackSString hostPolicyCompletePath(hostPolicyPath, hostPolicyPath.Begin(), fileNamePos);
-    hostPolicyCompletePath.Append(LibraryPrefix);
-    while (fileNamePos != hostPolicyPath.End())
-    {
-        hostPolicyCompletePath.Append(*fileNamePos);
-        ++fileNamePos;
-    }
-    hostPolicyCompletePath.Append(LibrarySuffix);
-
     // Check if a hostpolicy exists and if it does, load it.
-    if (INVALID_FILE_ATTRIBUTES != ::GetFileAttributesW(hostPolicyCompletePath.GetUnicode()))
+    if (INVALID_FILE_ATTRIBUTES != ::GetFileAttributesW(hostPolicyPath.GetUnicode()))
     {
-        hMod = ::LoadLibraryExW(hostPolicyCompletePath.GetUnicode(), nullptr, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+        hMod = ::LoadLibraryExW(hostPolicyPath.GetUnicode(), nullptr, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
     }
 
     return hMod != nullptr;

--- a/src/coreclr/hosts/corerun/corerun.cpp
+++ b/src/coreclr/hosts/corerun/corerun.cpp
@@ -459,18 +459,18 @@ bool TryLoadHostPolicy(StackSString& hostPolicyPath)
     }
 
     // Use proper prefix / extension for the host policy dynamic library
-#if defined(__APPLE__)
-    static const WCHAR LibraryPrefix[] = u"lib";
-    static const WCHAR LibrarySuffix[] = u".dylib";
-    static const WCHAR PathSeparator = u'/';
-#elif defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__)
-    static const WCHAR LibraryPrefix[] = u"lib";
-    static const WCHAR LibrarySuffix[] = u".so";
-    static const WCHAR PathSeparator = u'/';
-#else
+#if defined(_WINNT_)
     static const WCHAR LibraryPrefix[] = L"";
     static const WCHAR LibrarySuffix[] = L".dll";
     static const WCHAR PathSeparator = L'\\';
+#elif defined(__APPLE__)
+    static const WCHAR LibraryPrefix[] = u"lib";
+    static const WCHAR LibrarySuffix[] = u".dylib";
+    static const WCHAR PathSeparator = u'/';
+#else // Various Linux-related OS-es
+    static const WCHAR LibraryPrefix[] = u"lib";
+    static const WCHAR LibrarySuffix[] = u".so";
+    static const WCHAR PathSeparator = u'/';
 #endif
     
     SString::CIterator fileNamePos = hostPolicyPath.End();

--- a/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
+++ b/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
@@ -299,19 +299,15 @@ static void *TryLoadHostPolicy(const char *hostPolicyPath)
     static const char LibrarySuffix[] = ".so";
 #endif
 
-    size_t hostPolicyPathLength = sizeof(char) * strlen(hostPolicyPath);
-    const size_t SuffixLengthIncludingTerminatingZero = sizeof(LibrarySuffix);
-    char *hostPolicyCompletePath = (char *)malloc(hostPolicyPathLength + SuffixLengthIncludingTerminatingZero);
-    memcpy(hostPolicyCompletePath, hostPolicyPath, hostPolicyPathLength);
-    memcpy(hostPolicyCompletePath + hostPolicyPathLength, LibrarySuffix, SuffixLengthIncludingTerminatingZero);
+    std::string hostPolicyCompletePath(hostPolicyPath);
+    hostPolicyCompletePath.append(LibrarySuffix);
 
-    void *libraryPtr = dlopen(hostPolicyCompletePath, RTLD_LAZY);
+    void *libraryPtr = dlopen(hostPolicyCompletePath.c_str(), RTLD_LAZY);
     if (libraryPtr == nullptr)
     {
-        fprintf(stderr, "Failed to load mock hostpolicy at path '%s'. Error: %s", hostPolicyCompletePath, dlerror());
+        fprintf(stderr, "Failed to load mock hostpolicy at path '%s'. Error: %s", hostPolicyCompletePath.c_str(), dlerror());
     }
 
-    free(hostPolicyCompletePath);
     return libraryPtr;
 }
 

--- a/tests/src/CLRTest.MockHosting.targets
+++ b/tests/src/CLRTest.MockHosting.targets
@@ -7,15 +7,11 @@ This file contains the logic for correctly hooking up a mock hostpolicy to a tes
 ***********************************************************************************************
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <HostPolicyFileExtension>.so</HostPolicyFileExtension>
-    <HostPolicyFileExtension Condition="'$(TargetsOSX)' =='true'">.dylib</HostPolicyFileExtension>
-  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)/Common/hostpolicymock/CMakeLists.txt" />
     <!-- %28 decodes to '('. It's needed to keep MSBuild from trying to parse $(pwd) as an MSBuild property -->
-    <CLRTestBashEnvironmentVariable Include="export MOCK_HOSTPOLICY=$%28pwd)/libhostpolicy$(HostPolicyFileExtension)" />
+    <CLRTestBashEnvironmentVariable Include="export MOCK_HOSTPOLICY=$%28pwd)/hostpolicy" />
     <!-- %25 decodes to '%'. It's needed to keep %cd itself from being decoded since we want '%cd%' directly in the script. -->
-    <CLRTestBatchEnvironmentVariable Include="set MOCK_HOSTPOLICY=%25cd%\hostpolicy.dll" />
+    <CLRTestBatchEnvironmentVariable Include="set MOCK_HOSTPOLICY=%25cd%\hostpolicy" />
   </ItemGroup>
 </Project>

--- a/tests/src/CLRTest.MockHosting.targets
+++ b/tests/src/CLRTest.MockHosting.targets
@@ -10,8 +10,8 @@ This file contains the logic for correctly hooking up a mock hostpolicy to a tes
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)/Common/hostpolicymock/CMakeLists.txt" />
     <!-- %28 decodes to '('. It's needed to keep MSBuild from trying to parse $(pwd) as an MSBuild property -->
-    <CLRTestBashEnvironmentVariable Include="export MOCK_HOSTPOLICY=$%28pwd)/hostpolicy" />
+    <CLRTestBashEnvironmentVariable Include="export MOCK_HOSTPOLICY=$%28pwd)/libhostpolicy" />
     <!-- %25 decodes to '%'. It's needed to keep %cd itself from being decoded since we want '%cd%' directly in the script. -->
-    <CLRTestBatchEnvironmentVariable Include="set MOCK_HOSTPOLICY=%25cd%\hostpolicy" />
+    <CLRTestBatchEnvironmentVariable Include="set MOCK_HOSTPOLICY=%25cd%\hostpolicy.dll" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
After I finally managed to make my infra change (reuse of managed
test artifacts across various *nix flavors) work on the CoreCLR-CI
Pri0 pipeline, I proceeded to testing the official build which
uncovered a single Pri#1 test violating the independence principle:

<pre>
Loader\AssemblyDependencyResolver\AssemblyDependencyResolverTests\AssemblyDependencyResolverTests.csproj
</pre>

This test project uses the clause

<pre>
    &lt;RequiresMockHostPolicy&gt;true&lt;/RequiresMockHostPolicy&gt;
</pre>

which makes the script CLRTest.MockHosting.targets emit an
OS-specific name of the mock hosting dynamic library to the
execution .sh script which then becomes non-portable between
Linux and OSX because they use different extensions for dynamic
libraries (so / dylib).

My proposed change fixes this by modifying the targets file to
emit just the "naked" library name and CoreRun to "decorate" it
according to the targeting OS style. Please feel free to suggest
any modifications to the proposed behavior, I have no particular
preference other than to finally get the primary infra change off
my desk and this is hopefully the last hurdle.

Thanks

Tomas