### PR TITLE
Add "inline" labels and rename IGF_EMIT_ADD to IGF_EXTEND

### DIFF
--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -219,7 +219,12 @@ protected:
 
     BasicBlock* genCreateTempLabel();
 
+private:
+    void genLogLabel(BasicBlock* bb);
+
+protected:
     void genDefineTempLabel(BasicBlock* label);
+    void genDefineInlineTempLabel(BasicBlock* label);
 
     void genAdjustSP(target_ssize_t delta);
 

--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -2530,7 +2530,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
     if (genPendingCallLabel)
     {
         assert(call->IsUnmanaged());
-        genDefineTempLabel(genPendingCallLabel);
+        genDefineInlineTempLabel(genPendingCallLabel);
         genPendingCallLabel = nullptr;
     }
 

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -316,12 +316,7 @@ void CodeGen::genCodeForBBlist()
         }
 #endif
 
-#ifdef DEBUG
-        if (compiler->opts.dspCode)
-        {
-            printf("\n      L_M%03u_" FMT_BB ":\n", Compiler::s_compMethodsCount, block->bbNum);
-        }
-#endif
+        genLogLabel(block);
 
         // Tell everyone which basic block we're working on
 

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -5755,7 +5755,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
     if (genPendingCallLabel)
     {
         assert(call->IsUnmanaged());
-        genDefineTempLabel(genPendingCallLabel);
+        genDefineInlineTempLabel(genPendingCallLabel);
         genPendingCallLabel = nullptr;
     }
 


### PR DESCRIPTION
This flag conceptually represents that the instruction group extends the
previous instruction group and means that the emitter will continue to
track GC info as if there was no new block.

@CarolEidt suggested I factor this change out of #26418.

cc @dotnet/jit-contrib 