### PR TITLE
Mark crossgen2 smoke test GCStressIncompatible

### DIFF
--- a/tests/src/readytorun/crossgen2/crossgen2smoke.csproj
+++ b/tests/src/readytorun/crossgen2/crossgen2smoke.csproj
@@ -8,6 +8,9 @@
     <!-- Crossgen2 currently targets only x64 -->
     <DisableProjectBuild Condition="'$(Platform)' != 'x64'">true</DisableProjectBuild>
 
+    <!-- Known not to work with GCStress for now: https://github.com/dotnet/coreclr/issues/26633 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
+
     <!-- Generate ILDLL so that the DLL can be the crossgenned assembly -->
     <TargetExt>.ildll</TargetExt>
 


### PR DESCRIPTION
This is known not to work with GCStress (see #26633).

Fixes #26826.