### PR TITLE
src/inc/apithreadstress.cpp: resolve possible null pointer dereference

### DIFF
--- a/src/inc/apithreadstress.cpp
+++ b/src/inc/apithreadstress.cpp
@@ -67,10 +67,10 @@ APIThreadStress::~APIThreadStress()
     if (m_threadCount > 0)
     {
         HANDLE *p = m_hThreadArray;
-        HANDLE *pEnd = p + m_threadCount;
 
         if (p != NULL)
         {
+            HANDLE *pEnd = p + m_threadCount;
             while (p < pEnd)
             {
                 if (*p != NULL)


### PR DESCRIPTION
found by cppcheck

[src/inc/apithreadstress.cpp:72] -> [src/inc/apithreadstress.cpp:70]: (warning) Either the condition 'p!=NULL' is redundant or there is pointer arithmetic with NULL pointer.