### PR TITLE
Perf improvements to char.IsWhiteSpace / char.IsUpper / char.IsLower

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Char.cs
+++ b/src/System.Private.CoreLib/shared/System/Char.cs
@@ -284,7 +284,7 @@ namespace System
         {
             if (IsLatin1(c))
             {
-                return (Latin1CharInfo[c] & IsUpperCaseLetterFlag) != 0;
+                return (Latin1CharInfo[c] & IsLowerCaseLetterFlag) != 0;
             }
             return (CharUnicodeInfo.GetUnicodeCategory(c) == UnicodeCategory.LowercaseLetter);
         }

--- a/src/System.Private.CoreLib/shared/System/Char.cs
+++ b/src/System.Private.CoreLib/shared/System/Char.cs
@@ -37,46 +37,44 @@ namespace System
         // The minimum character value.
         public const char MinValue = (char)0x00;
 
-        // Unicode category values from Unicode U+0000 ~ U+00FF. Store them in byte[] array to save space.
-        private static ReadOnlySpan<byte> CategoryForLatin1 => new byte[] { // uses C# compiler's optimization for static byte[] data
-            (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control,    // 0000 - 0007
-            (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control,    // 0008 - 000F
-            (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control,    // 0010 - 0017
-            (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control,    // 0018 - 001F
-            (byte)UnicodeCategory.SpaceSeparator, (byte)UnicodeCategory.OtherPunctuation, (byte)UnicodeCategory.OtherPunctuation, (byte)UnicodeCategory.OtherPunctuation, (byte)UnicodeCategory.CurrencySymbol, (byte)UnicodeCategory.OtherPunctuation, (byte)UnicodeCategory.OtherPunctuation, (byte)UnicodeCategory.OtherPunctuation,    // 0020 - 0027
-            (byte)UnicodeCategory.OpenPunctuation, (byte)UnicodeCategory.ClosePunctuation, (byte)UnicodeCategory.OtherPunctuation, (byte)UnicodeCategory.MathSymbol, (byte)UnicodeCategory.OtherPunctuation, (byte)UnicodeCategory.DashPunctuation, (byte)UnicodeCategory.OtherPunctuation, (byte)UnicodeCategory.OtherPunctuation,    // 0028 - 002F
-            (byte)UnicodeCategory.DecimalDigitNumber, (byte)UnicodeCategory.DecimalDigitNumber, (byte)UnicodeCategory.DecimalDigitNumber, (byte)UnicodeCategory.DecimalDigitNumber, (byte)UnicodeCategory.DecimalDigitNumber, (byte)UnicodeCategory.DecimalDigitNumber, (byte)UnicodeCategory.DecimalDigitNumber, (byte)UnicodeCategory.DecimalDigitNumber,    // 0030 - 0037
-            (byte)UnicodeCategory.DecimalDigitNumber, (byte)UnicodeCategory.DecimalDigitNumber, (byte)UnicodeCategory.OtherPunctuation, (byte)UnicodeCategory.OtherPunctuation, (byte)UnicodeCategory.MathSymbol, (byte)UnicodeCategory.MathSymbol, (byte)UnicodeCategory.MathSymbol, (byte)UnicodeCategory.OtherPunctuation,    // 0038 - 003F
-            (byte)UnicodeCategory.OtherPunctuation, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter,    // 0040 - 0047
-            (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter,    // 0048 - 004F
-            (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter,    // 0050 - 0057
-            (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.OpenPunctuation, (byte)UnicodeCategory.OtherPunctuation, (byte)UnicodeCategory.ClosePunctuation, (byte)UnicodeCategory.ModifierSymbol, (byte)UnicodeCategory.ConnectorPunctuation,    // 0058 - 005F
-            (byte)UnicodeCategory.ModifierSymbol, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter,    // 0060 - 0067
-            (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter,    // 0068 - 006F
-            (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter,    // 0070 - 0077
-            (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.OpenPunctuation, (byte)UnicodeCategory.MathSymbol, (byte)UnicodeCategory.ClosePunctuation, (byte)UnicodeCategory.MathSymbol, (byte)UnicodeCategory.Control,    // 0078 - 007F
-            (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control,    // 0080 - 0087
-            (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control,    // 0088 - 008F
-            (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control,    // 0090 - 0097
-            (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control, (byte)UnicodeCategory.Control,    // 0098 - 009F
-            (byte)UnicodeCategory.SpaceSeparator, (byte)UnicodeCategory.OtherPunctuation, (byte)UnicodeCategory.CurrencySymbol, (byte)UnicodeCategory.CurrencySymbol, (byte)UnicodeCategory.CurrencySymbol, (byte)UnicodeCategory.CurrencySymbol, (byte)UnicodeCategory.OtherSymbol, (byte)UnicodeCategory.OtherSymbol,    // 00A0 - 00A7
-            (byte)UnicodeCategory.ModifierSymbol, (byte)UnicodeCategory.OtherSymbol, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.InitialQuotePunctuation, (byte)UnicodeCategory.MathSymbol, (byte)UnicodeCategory.DashPunctuation, (byte)UnicodeCategory.OtherSymbol, (byte)UnicodeCategory.ModifierSymbol,    // 00A8 - 00AF
-            (byte)UnicodeCategory.OtherSymbol, (byte)UnicodeCategory.MathSymbol, (byte)UnicodeCategory.OtherNumber, (byte)UnicodeCategory.OtherNumber, (byte)UnicodeCategory.ModifierSymbol, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.OtherSymbol, (byte)UnicodeCategory.OtherPunctuation,    // 00B0 - 00B7
-            (byte)UnicodeCategory.ModifierSymbol, (byte)UnicodeCategory.OtherNumber, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.FinalQuotePunctuation, (byte)UnicodeCategory.OtherNumber, (byte)UnicodeCategory.OtherNumber, (byte)UnicodeCategory.OtherNumber, (byte)UnicodeCategory.OtherPunctuation,    // 00B8 - 00BF
-            (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter,    // 00C0 - 00C7
-            (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter,    // 00C8 - 00CF
-            (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.MathSymbol,    // 00D0 - 00D7
-            (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.UppercaseLetter, (byte)UnicodeCategory.LowercaseLetter,    // 00D8 - 00DF
-            (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter,    // 00E0 - 00E7
-            (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter,    // 00E8 - 00EF
-            (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.MathSymbol,    // 00F0 - 00F7
-            (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter, (byte)UnicodeCategory.LowercaseLetter,    // 00F8 - 00FF
+        private const byte IsWhiteSpaceFlag = 0x80;
+        private const byte IsUpperCaseLetterFlag = 0x40;
+        private const byte IsLowerCaseLetterFlag = 0x20;
+        private const byte UnicodeCategoryMask = 0x1F;
+
+        // Contains information about the C0, Basic Latin, C1, and Latin-1 Supplement ranges [ U+0000..U+00FF ], with:
+        // - 0x80 bit if set means 'is whitespace'
+        // - 0x40 bit if set means 'is uppercase letter'
+        // - 0x20 bit if set means 'is lowercase letter'
+        // - bottom 5 bits are the UnicodeCategory of the character
+        //
+        // n.b. This data is locked to an earlier version of the Unicode standard, so the UnicodeCategory
+        // data contained here doesn't necessarily equal the UnicodeCategory data contained within the
+        // corresponding table in the Rune type.
+        private static ReadOnlySpan<byte> Latin1CharInfo => new byte[]
+        {
+            0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x8E, 0x8E, 0x8E, 0x8E, 0x8E, 0x0E, 0x0E, // U+0000..U+000F
+            0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, // U+0010..U+001F
+            0x8B, 0x18, 0x18, 0x18, 0x1A, 0x18, 0x18, 0x18, 0x14, 0x15, 0x18, 0x19, 0x18, 0x13, 0x18, 0x18, // U+0020..U+002F
+            0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x18, 0x18, 0x19, 0x19, 0x19, 0x18, // U+0030..U+003F
+            0x18, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, // U+0040..U+004F
+            0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x14, 0x18, 0x15, 0x1B, 0x12, // U+0050..U+005F
+            0x1B, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, // U+0060..U+006F
+            0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x14, 0x19, 0x15, 0x19, 0x0E, // U+0070..U+007F
+            0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x8E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, // U+0080..U+008F
+            0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, // U+0090..U+009F
+            0x8B, 0x18, 0x1A, 0x1A, 0x1A, 0x1A, 0x1C, 0x1C, 0x1B, 0x1C, 0x21, 0x16, 0x19, 0x13, 0x1C, 0x1B, // U+00A0..U+00AF
+            0x1C, 0x19, 0x0A, 0x0A, 0x1B, 0x21, 0x1C, 0x18, 0x1B, 0x0A, 0x21, 0x17, 0x0A, 0x0A, 0x0A, 0x18, // U+00B0..U+00BF
+            0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, // U+00C0..U+00CF
+            0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x19, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x21, // U+00D0..U+00DF
+            0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, // U+00E0..U+00EF
+            0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x19, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, 0x21, // U+00F0..U+00FF
         };
 
         // Return true for all characters below or equal U+00ff, which is ASCII + Latin-1 Supplement.
         private static bool IsLatin1(char ch)
         {
-            return (uint)ch <= '\x00ff';
+            return (uint)ch < (uint)Latin1CharInfo.Length;
         }
 
         // Return true for all characters below or equal U+007f, which is ASCII.
@@ -88,8 +86,8 @@ namespace System
         // Return the Unicode category for Unicode character <= 0x00ff.
         private static UnicodeCategory GetLatin1UnicodeCategory(char ch)
         {
-            Debug.Assert(IsLatin1(ch), "char.GetLatin1UnicodeCategory(): ch should be <= 007f");
-            return (UnicodeCategory)CategoryForLatin1[(int)ch];
+            Debug.Assert(IsLatin1(ch), "char.GetLatin1UnicodeCategory(): ch should be <= 00ff");
+            return (UnicodeCategory)(Latin1CharInfo[ch] & UnicodeCategoryMask);
         }
 
         //
@@ -236,33 +234,16 @@ namespace System
         {
             if (IsLatin1(c))
             {
-                if (IsAscii(c))
-                {
-                    c |= (char)0x20;
-                    return IsInRange(c, 'a', 'z');
-                }
-                return (CheckLetter(GetLatin1UnicodeCategory(c)));
+                // The Latin-1 range doesn't include letters in categories other than "upper" and "lower"
+                return (Latin1CharInfo[c] & (IsUpperCaseLetterFlag | IsLowerCaseLetterFlag)) != 0;
             }
             return (CheckLetter(CharUnicodeInfo.GetUnicodeCategory(c)));
         }
 
         private static bool IsWhiteSpaceLatin1(char c)
         {
-            // There are characters which belong to UnicodeCategory.Control but are considered as white spaces.
-            // We use code point comparisons for these characters here as a temporary fix.
-
-            // U+0009 = <control> HORIZONTAL TAB
-            // U+000a = <control> LINE FEED
-            // U+000b = <control> VERTICAL TAB
-            // U+000c = <contorl> FORM FEED
-            // U+000d = <control> CARRIAGE RETURN
-            // U+0085 = <control> NEXT LINE
-            // U+00a0 = NO-BREAK SPACE
-            return
-                c == ' ' ||
-                (uint)(c - '\x0009') <= ('\x000d' - '\x0009') || // (c >= '\x0009' && c <= '\x000d')
-                c == '\x00a0' ||
-                c == '\x0085';
+            Debug.Assert(IsLatin1(c));
+            return (Latin1CharInfo[c] & IsWhiteSpaceFlag) != 0;
         }
 
         /*===============================ISWHITESPACE===================================
@@ -289,11 +270,7 @@ namespace System
         {
             if (IsLatin1(c))
             {
-                if (IsAscii(c))
-                {
-                    return IsInRange(c, 'A', 'Z');
-                }
-                return (GetLatin1UnicodeCategory(c) == UnicodeCategory.UppercaseLetter);
+                return (Latin1CharInfo[c] & IsUpperCaseLetterFlag) != 0;
             }
             return (CharUnicodeInfo.GetUnicodeCategory(c) == UnicodeCategory.UppercaseLetter);
         }
@@ -307,11 +284,7 @@ namespace System
         {
             if (IsLatin1(c))
             {
-                if (IsAscii(c))
-                {
-                    return IsInRange(c, 'a', 'z');
-                }
-                return (GetLatin1UnicodeCategory(c) == UnicodeCategory.LowercaseLetter);
+                return (Latin1CharInfo[c] & IsUpperCaseLetterFlag) != 0;
             }
             return (CharUnicodeInfo.GetUnicodeCategory(c) == UnicodeCategory.LowercaseLetter);
         }
@@ -554,12 +527,8 @@ namespace System
             char c = s[index];
             if (IsLatin1(c))
             {
-                if (IsAscii(c))
-                {
-                    c |= (char)0x20;
-                    return IsInRange(c, 'a', 'z');
-                }
-                return (CheckLetter(GetLatin1UnicodeCategory(c)));
+                // The Latin-1 range doesn't include letters in categories other than "upper" and "lower"
+                return (Latin1CharInfo[c] & (IsUpperCaseLetterFlag | IsLowerCaseLetterFlag)) != 0;
             }
             return (CheckLetter(CharUnicodeInfo.GetUnicodeCategory(s, index)));
         }
@@ -591,11 +560,7 @@ namespace System
             char c = s[index];
             if (IsLatin1(c))
             {
-                if (IsAscii(c))
-                {
-                    return IsInRange(c, 'a', 'z');
-                }
-                return (GetLatin1UnicodeCategory(c) == UnicodeCategory.LowercaseLetter);
+                return (Latin1CharInfo[c] & IsLowerCaseLetterFlag) != 0;
             }
 
             return (CharUnicodeInfo.GetUnicodeCategory(s, index) == UnicodeCategory.LowercaseLetter);
@@ -773,11 +738,7 @@ namespace System
             char c = s[index];
             if (IsLatin1(c))
             {
-                if (IsAscii(c))
-                {
-                    return IsInRange(c, 'A', 'Z');
-                }
-                return (GetLatin1UnicodeCategory(c) == UnicodeCategory.UppercaseLetter);
+                return (Latin1CharInfo[c] & IsUpperCaseLetterFlag) != 0;
             }
 
             return (CharUnicodeInfo.GetUnicodeCategory(s, index) == UnicodeCategory.UppercaseLetter);
@@ -792,9 +753,11 @@ namespace System
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
 
-            if (IsLatin1(s[index]))
+            char ch = s[index];
+
+            if (IsLatin1(ch))
             {
-                return IsWhiteSpaceLatin1(s[index]);
+                return IsWhiteSpaceLatin1(ch);
             }
 
             return CheckSeparator(CharUnicodeInfo.GetUnicodeCategory(s, index));

--- a/src/System.Private.CoreLib/shared/System/Char.cs
+++ b/src/System.Private.CoreLib/shared/System/Char.cs
@@ -48,9 +48,10 @@ namespace System
         // - 0x20 bit if set means 'is lowercase letter'
         // - bottom 5 bits are the UnicodeCategory of the character
         //
-        // n.b. This data is locked to an earlier version of the Unicode standard, so the UnicodeCategory
-        // data contained here doesn't necessarily equal the UnicodeCategory data contained within the
-        // corresponding table in the Rune type.
+        // n.b. This data is locked to an earlier version of the Unicode standard (2.0, perhaps?), so
+        // the UnicodeCategory data contained here doesn't necessarily reflect the UnicodeCategory data
+        // contained within the CharUnicodeInfo or Rune types, which generally follow the latest Unicode
+        // standard.
         private static ReadOnlySpan<byte> Latin1CharInfo => new byte[]
         {
             0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x0E, 0x8E, 0x8E, 0x8E, 0x8E, 0x8E, 0x0E, 0x0E, // U+0000..U+000F
@@ -234,7 +235,8 @@ namespace System
         {
             if (IsLatin1(c))
             {
-                // The Latin-1 range doesn't include letters in categories other than "upper" and "lower"
+                // For the version of the Unicode standard the Char type is locked to, the
+                // Latin-1 range doesn't include letters in categories other than "upper" and "lower".
                 return (Latin1CharInfo[c] & (IsUpperCaseLetterFlag | IsLowerCaseLetterFlag)) != 0;
             }
             return (CheckLetter(CharUnicodeInfo.GetUnicodeCategory(c)));


### PR DESCRIPTION
This is especially noticeable in benchmarks for APIs like `ReadOnlySpan.Trim()`.

|          Method | Toolchain |                input |      Mean |     Error |    StdDev |    Median | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------- |---------- |--------------------- |----------:|----------:|----------:|----------:|------:|--------:|------:|------:|------:|----------:|
|            **Trim** |    **master** |                     **{empty}** |  **3.509 ns** | **0.0475 ns** | **0.0444 ns** |  **3.501 ns** |  **1.00** |    **0.00** |     **-** |     **-** |     **-** |         **-** |
|            Trim |     proto |                    {empty}  |  3.423 ns | 0.0801 ns | 0.0710 ns |  3.399 ns |  0.98 |    0.03 |     - |     - |     - |         - |
|                 |           |                      |           |           |           |           |       |         |       |       |       |           |
|            **Trim** |    **master** |            **{spaces on both sides}** |  **9.161 ns** | **0.2052 ns** | **0.2195 ns** |  **9.091 ns** |  **1.00** |    **0.00** |     **-** |     **-** |     **-** |         **-** |
|            Trim |     proto |             {spaces on both sides}  |  7.299 ns | 0.1714 ns | 0.1519 ns |  7.287 ns |  0.79 |    0.02 |     - |     - |     - |         - |
|                 |           |                      |           |           |           |           |       |         |       |       |       |           |
| **CountLowerChars** |    **master** | **Hello(...)able! [23]** | **55.934 ns** | **0.8882 ns** | **0.8308 ns** | **55.705 ns** |  **1.00** |    **0.00** |     **-** |     **-** |     **-** |         **-** |
| CountLowerChars |     proto | Hello(...)able! [23] | 47.130 ns | 0.4410 ns | 0.4125 ns | 47.166 ns |  0.84 |    0.01 |     - |     - |     - |         - |
|                 |           |                      |           |           |           |           |       |         |       |       |       |           |
| CountUpperChars |    master | Hello(...)able! [23] | 61.556 ns | 0.6651 ns | 0.5554 ns | 61.641 ns |  1.00 |    0.00 |     - |     - |     - |         - |
| CountUpperChars |     proto | Hello(...)able! [23] | 53.805 ns | 0.3064 ns | 0.2717 ns | 53.747 ns |  0.87 |    0.01 |     - |     - |     - |         - |
|                 |           |                      |           |           |           |           |       |         |       |       |       |           |
|            **Trim** |    **master** |              **abcdefg** |  **5.753 ns** | **0.0402 ns** | **0.0376 ns** |  **5.753 ns** |  **1.00** |    **0.00** |     **-** |     **-** |     **-** |         **-** |
|            Trim |     proto |              abcdefg |  5.249 ns | 0.1380 ns | 0.2970 ns |  5.137 ns |  0.97 |    0.05 |     - |     - |     - |         - |

Benchmark code:

```cs
[Benchmark]
[ArgumentsSource(nameof(TrimArguments))]
public ReadOnlySpan<char> Trim(string input) => input.AsSpan().Trim();

[Benchmark]
[Arguments("Hello there, Constable!")]
public int CountLowerChars(string input)
{
    int count = 0;

    foreach (char ch in input)
    {
        if (char.IsLower(ch)) { count++; }
    }

    return count;
}

[Benchmark]
[Arguments("Hello there, Constable!")]
public int CountUpperChars(string input)
{
    int count = 0;

    foreach (char ch in input)
    {
        if (char.IsUpper(ch)) { count++; }
    }

    return count;
}

public static IEnumerable<object> TrimArguments()
{
    yield return "";
    yield return " abcdefg ";
    yield return "abcdefg";
}
```

The performance should improve even further when https://github.com/dotnet/coreclr/issues/26845 is fixed.