### PR TITLE
Skip the MethodRef optimization for ArrayMethod's

### DIFF
--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
@@ -58,7 +58,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             if (!_isUnboxingStub && !_isInstantiatingStub && _method.ConstrainedType == null &&
                 fixupKind == ReadyToRunFixupKind.READYTORUN_FIXUP_MethodEntry)
             {
-                if (!_method.Method.OwningType.HasInstantiation)
+                if (!_method.Method.OwningType.HasInstantiation && !_method.Method.OwningType.IsArray)
                 {
                     if (_method.Token.TokenType == CorTokenType.mdtMethodDef)
                     {


### PR DESCRIPTION
As Jan Vorlicek discovered during his investigation of the remaining
CPAOT bugs, CoreCLR runtime doesn't support the MethodRef encoding
flavor for the special array methods. My understanding is that this
is due to the fact that array types are somewhat weird as they are
kind of "generic types in disguise".

Thanks

Tomas