### PR TITLE
Fix Segfault in PerfInfo Image Logging

### DIFF
--- a/src/vm/perfinfo.cpp
+++ b/src/vm/perfinfo.cpp
@@ -41,8 +41,21 @@ void PerfInfo::LogImage(PEFile* pFile, WCHAR* guid)
 
     SString value;
     const SString& path = pFile->GetPath();
-    PEImageLayout *pLoadedLayout = pFile->GetLoaded();
-    SIZE_T baseAddr = (SIZE_T)pLoadedLayout->GetBase();
+    if (path.IsEmpty())
+    {
+        return;
+    }
+
+    SIZE_T baseAddr = 0;
+    if (pFile->HasOpenedILimage())
+    {
+        PEImageLayout *pLoadedLayout = pFile->GetLoaded();
+        if (pLoadedLayout)
+        {
+            baseAddr = (SIZE_T)pLoadedLayout->GetBase();
+        }
+    }
+
     value.Printf("%S%c%S%c%p", path.GetUnicode(), sDelimiter, guid, sDelimiter, baseAddr);
 
     SString command;

--- a/src/vm/perfinfo.cpp
+++ b/src/vm/perfinfo.cpp
@@ -47,7 +47,7 @@ void PerfInfo::LogImage(PEFile* pFile, WCHAR* guid)
     }
 
     SIZE_T baseAddr = 0;
-    if (pFile->HasOpenedILimage())
+    if (pFile->IsILImageReadyToRun())
     {
         PEImageLayout *pLoadedLayout = pFile->GetLoaded();
         if (pLoadedLayout)


### PR DESCRIPTION
Harden perfinfo.map image logging by skipping dynamically generated assemblies and being more robust around base address logging.

Fixes #26883 