### PR TITLE
allow ASCII equality ordinal fast path for en-* cultures

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
@@ -32,7 +32,7 @@ namespace System.Globalization
             }
             else
             {
-                _isAsciiEqualityOrdinal = _sortName == "" || (_sortName.Length >= 2 && _sortName[0] == 'e' && _sortName[1] == 'n');
+                _isAsciiEqualityOrdinal = _sortName == "" || _sortName.StartsWith("en-", StringComparison.Ordinal) || _sortName == "en";
 
                 _sortHandle = SortHandleCache.GetCachedSortHandle(_sortName);
             }

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
@@ -32,7 +32,12 @@ namespace System.Globalization
             }
             else
             {
-                _isAsciiEqualityOrdinal = _sortName == "" || _sortName == "en" || (_sortName.Length > 3 && _sortName[0] == 'e' && _sortName[1] == 'n' && _sortName[2] == '-');
+	                // Inline the following condition to avoid potential implementation cycles within globalization
+	                //
+	                // _isAsciiEqualityOrdinal = _sortName == "" || _sortName == "en" || _sortName.StartsWith("en-", StringComparison.Ordinal);
+	                //
+	                _isAsciiEqualityOrdinal = _sortName.Length == 0 ||
+	                    (_sortName.Length >= 2 && _sortName[0] == 'e' && _sortName[1] == 'n' && (_sortName.Length == 2 || _sortName[2] == '-'));
 
                 _sortHandle = SortHandleCache.GetCachedSortHandle(_sortName);
             }

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
@@ -32,12 +32,12 @@ namespace System.Globalization
             }
             else
             {
-	                // Inline the following condition to avoid potential implementation cycles within globalization
-	                //
-	                // _isAsciiEqualityOrdinal = _sortName == "" || _sortName == "en" || _sortName.StartsWith("en-", StringComparison.Ordinal);
-	                //
-	                _isAsciiEqualityOrdinal = _sortName.Length == 0 ||
-	                    (_sortName.Length >= 2 && _sortName[0] == 'e' && _sortName[1] == 'n' && (_sortName.Length == 2 || _sortName[2] == '-'));
+                // Inline the following condition to avoid potential implementation cycles within globalization
+                //
+                // _isAsciiEqualityOrdinal = _sortName == "" || _sortName == "en" || _sortName.StartsWith("en-", StringComparison.Ordinal);
+                //
+                _isAsciiEqualityOrdinal = _sortName.Length == 0 ||
+                    (_sortName.Length >= 2 && _sortName[0] == 'e' && _sortName[1] == 'n' && (_sortName.Length == 2 || _sortName[2] == '-'));
 
                 _sortHandle = SortHandleCache.GetCachedSortHandle(_sortName);
             }

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
@@ -32,7 +32,7 @@ namespace System.Globalization
             }
             else
             {
-                _isAsciiEqualityOrdinal = _sortName == "" || _sortName.StartsWith("en-", StringComparison.Ordinal) || _sortName == "en";
+                _isAsciiEqualityOrdinal = _sortName == "" || _sortName == "en" || (_sortName.Length > 3 && _sortName[0] == 'e' && _sortName[1] == 'n' && _sortName[2] == '-');
 
                 _sortHandle = SortHandleCache.GetCachedSortHandle(_sortName);
             }

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
@@ -32,7 +32,7 @@ namespace System.Globalization
             }
             else
             {
-                _isAsciiEqualityOrdinal = (_sortName == "en-US" || _sortName == "");
+                _isAsciiEqualityOrdinal = (_sortName == "en-US" || _sortName == "" || _sortName == "en-GB");
 
                 _sortHandle = SortHandleCache.GetCachedSortHandle(_sortName);
             }

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.Unix.cs
@@ -32,7 +32,7 @@ namespace System.Globalization
             }
             else
             {
-                _isAsciiEqualityOrdinal = (_sortName == "en-US" || _sortName == "" || _sortName == "en-GB");
+                _isAsciiEqualityOrdinal = _sortName == "" || (_sortName.Length >= 2 && _sortName[0] == 'e' && _sortName[1] == 'n');
 
                 _sortHandle = SortHandleCache.GetCachedSortHandle(_sortName);
             }


### PR DESCRIPTION
IMHO we should allow the `en-GB` culture to use the fast path on Unix as well. 

Motivation: it uses the same set of characters as `en-US` and it should bring nice perf boost for our "en-GB" customers for free.

/cc @danmosemsft 