### PR TITLE
Preparatory changes for implementing Crossgen2 pipeline

### DIFF
--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -21,8 +21,9 @@ jobs:
     osGroup: ${{ parameters.osGroup }}
     osSubgroup: ${{ parameters.osSubgroup }}
     helixType: 'build/product/'
-    enableMicrobuild: true
+    testGroup: ${{ parameters.testGroup }}
     stagedBuild: ${{ parameters.stagedBuild }}
+    enableMicrobuild: true
 
     # Compute job name from template parameters
     name: ${{ format('build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -104,6 +104,12 @@ jobs:
     - name: testBuildRootFolderPath
       value: '$(binTestsPath)/$(osGroup).$(archType).$(buildConfigUpper)'
 
+    - name: productBuildArtifactName
+      value: 'BinDir_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
+
+    - name: productBuildRootFolderPath
+      value: '$(Build.SourcesDirectory)/bin/Product/$(osGroup).$(archType).$(_BuildConfig)'
+
     - name: binTestsPath
       value: '$(Build.SourcesDirectory)/bin/tests'
 
@@ -174,12 +180,12 @@ jobs:
       - script: set __TestIntermediateDir=int&&build.cmd $(buildConfig) $(archType) -ci -skiptests -skipbuildpackages $(officialBuildIdArg) $(ibcOptimizeArg) $(enforcePgoArg)
         displayName: Build product
 
-    # Build native test components
+    # Build native test components and crossgen the framework assemblies
     - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-      - script: ./build-test.sh skipmanaged $(buildConfig) $(archType) $(crossArg) $(priorityArg) $(clangArg)
+      - script: ./build-test.sh skipmanaged crossgen $(buildConfig) $(archType) $(crossArg) $(priorityArg) $(clangArg)
         displayName: Build native test components
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-      - script: build-test.cmd skipmanaged $(buildConfig) $(archType) $(priorityArg)
+      - script: build-test.cmd skipmanaged crossgen $(buildConfig) $(archType) $(priorityArg)
         displayName: Build native test components
 
     # Sign on Windows
@@ -197,11 +203,15 @@ jobs:
         condition: always()
 
     # Publish product output directory for consumption by tests.
-    - task: PublishBuildArtifacts@1
-      displayName: Publish product build
-      inputs:
-        pathtoPublish: $(Build.SourcesDirectory)/bin/Product/$(osGroup).$(archType).$(_BuildConfig)
-        artifactName: ${{ format('BinDir_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
+    - template: /eng/upload-artifact-step.yml
+      parameters:
+        rootFolder: '$(productBuildRootFolderPath)'
+        includeRootFolder: false
+        archiveFile: $(Build.StagingDirectory)/$(productBuildArtifactName)$(archiveExtension)
+        archiveType: $(archiveType)
+        tarCompression: $(tarCompression)
+        artifactName: $(productBuildArtifactName)
+        displayName: 'product build'
 
     # Publish test native components for consumption by test execution.
     - template: /eng/upload-artifact-step.yml

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -13,7 +13,7 @@ parameters:
 
 ### Product build
 jobs:
-- template: xplat-job.yml
+- template: xplat-test-job.yml
   parameters:
     buildConfig: ${{ parameters.buildConfig }}
     archType: ${{ parameters.archType }}
@@ -37,10 +37,6 @@ jobs:
 
     gatherAssetManifests: true
     variables:
-    - name: osGroup
-      value: ${{ parameters.osGroup }}
-    - name: osSubgroup
-      value: ${{ parameters.osSubgroup }}
     - name: stripSymbolsArg
       value: ''
     # Strip symbols only on the release build
@@ -88,55 +84,6 @@ jobs:
     - ${{ if and(eq(parameters.buildConfig, 'Release'), and(eq(parameters.osGroup, 'Windows_NT'), not(or(eq(parameters.archType, 'arm64'), eq(parameters.archType, 'arm'))))) }}:
       - name: enforcePgoArg
         value: '-enforcepgo'
-
-    - name: artifactRootName
-      value: $(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)
-
-    - name: testNativeArtifactName
-      value: 'NativeTestComponents_$(artifactRootName)'
-
-    - name: testNativeRootFolderPath
-      value: '$(binTestsPath)/obj/$(osGroup).$(archType).$(buildConfigUpper)'
-
-    - name: testBuildArtifactName
-      value: 'TestBuild_$(artifactRootName)'
-
-    - name: testBuildRootFolderPath
-      value: '$(binTestsPath)/$(osGroup).$(archType).$(buildConfigUpper)'
-
-    - name: productBuildArtifactName
-      value: 'BinDir_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
-
-    - name: productBuildRootFolderPath
-      value: '$(Build.SourcesDirectory)/bin/Product/$(osGroup).$(archType).$(_BuildConfig)'
-
-    - name: binTestsPath
-      value: '$(Build.SourcesDirectory)/bin/tests'
-
-    - name: archiveExtension
-      value: '.tar.gz'
-    - name: archiveType
-      value: tar
-    - name: tarCompression
-      value: gz
-
-    - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-      - name: archiveExtension
-        value: '.zip'
-      - name: archiveType
-        value: zip
-      - name: tarCompression
-        value: ''
-
-    - name: priorityArg
-      value: ''
-    - ${{ if ne(parameters.testGroup, 'innerloop') }}:
-      - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-        - name: priorityArg
-          value: 'priority1'
-      - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-        - name: priorityArg
-          value: '-priority=1'
 
     steps:
 

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -5,6 +5,7 @@ parameters:
   osSubgroup: ''
   container: ''
   testGroup: ''
+  crossgenFramework: false
   crossrootfsDir: ''
   timeoutInMinutes: ''
   signBinaries: false
@@ -84,6 +85,11 @@ jobs:
     - ${{ if and(eq(parameters.buildConfig, 'Release'), and(eq(parameters.osGroup, 'Windows_NT'), not(or(eq(parameters.archType, 'arm64'), eq(parameters.archType, 'arm'))))) }}:
       - name: enforcePgoArg
         value: '-enforcepgo'
+    - name: crossgenArg
+      value: ''
+    - ${{ if eq(parameters.crossgenFramework, true) }}:
+      - name: crossgenArg
+        value: 'crossgen'
 
     steps:
 
@@ -127,12 +133,12 @@ jobs:
       - script: set __TestIntermediateDir=int&&build.cmd $(buildConfig) $(archType) -ci -skiptests -skipbuildpackages $(officialBuildIdArg) $(ibcOptimizeArg) $(enforcePgoArg)
         displayName: Build product
 
-    # Build native test components and crossgen the framework assemblies
+    # Build native test components and optionally crossgen the framework assemblies
     - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-      - script: ./build-test.sh skipmanaged crossgen $(buildConfig) $(archType) $(crossArg) $(priorityArg) $(clangArg)
+      - script: ./build-test.sh skipmanaged $(crossgenArg) $(buildConfig) $(archType) $(crossArg) $(priorityArg) $(clangArg)
         displayName: Build native test components
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-      - script: build-test.cmd skipmanaged crossgen $(buildConfig) $(archType) $(priorityArg)
+      - script: build-test.cmd skipmanaged $(crossgenArg) $(buildConfig) $(archType) $(priorityArg)
         displayName: Build native test components
 
     # Sign on Windows

--- a/eng/build-test-job.yml
+++ b/eng/build-test-job.yml
@@ -30,6 +30,7 @@ jobs:
     osSubgroup: ${{ parameters.osSubgroup }}
     managedTestBuildOsGroup: ${{ parameters.osGroup }}
     managedTestBuildOsSubgroup: ${{ parameters.osSubgroup }}
+    managedTestBuildArchType: ${{ parameters.archType }}
     container: ${{ parameters.container }}
     testGroup: ${{ parameters.testGroup }}
     readyToRun: ${{ parameters.readyToRun }}

--- a/eng/build-test-job.yml
+++ b/eng/build-test-job.yml
@@ -112,22 +112,14 @@ jobs:
 
 
     # Download product binaries directory
-    - task: DownloadBuildArtifacts@0
-      displayName: Download product build
-      inputs:
-        buildType: current
-        downloadType: single
-        artifactName: ${{ format('BinDir_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-        downloadPath: $(System.ArtifactsDirectory)
-
-
-    # Populate Product directory
-    - task: CopyFiles@2
-      displayName: Populate Product directory
-      inputs:
-        sourceFolder: $(System.ArtifactsDirectory)/${{ format('BinDir_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-        contents: '**'
-        targetFolder: $(Build.SourcesDirectory)/bin/Product/$(osGroup).$(archType).$(buildConfigUpper)
+    - template: /eng/download-artifact-step.yml
+      parameters:
+        downloadFolder: '$(productBuildRootFolderPath)/tmp'
+        unpackFolder: '$(productBuildRootFolderPath)'
+        cleanUnpackFolder: false
+        artifactFileName: '$(productBuildArtifactName)$(archiveExtension)'
+        artifactName: '$(productBuildArtifactName)'
+        displayName: 'product build'
 
 
     # Build managed test components

--- a/eng/crossgen-comparison-job.yml
+++ b/eng/crossgen-comparison-job.yml
@@ -14,7 +14,7 @@ parameters:
 ### crossgen matches that of native, e.g. arm-hosted-arm-targeting, crossgen.
 
 jobs:
-- template: xplat-job.yml
+- template: xplat-test-job.yml
   parameters:
     buildConfig: ${{ parameters.buildConfig }}
     archType: ${{ parameters.archType }}

--- a/eng/crossgen-comparison-job.yml
+++ b/eng/crossgen-comparison-job.yml
@@ -62,22 +62,14 @@ jobs:
     steps:
 
     # Download product build
-    - task: DownloadBuildArtifacts@0
-      displayName: Download product build
-      inputs:
-        buildType: current
-        downloadType: single
-        artifactName: ${{ format('BinDir_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-        downloadPath: $(System.ArtifactsDirectory)
-
-
-    # Populate Product directory
-    - task: CopyFiles@2
-      displayName: Populate Product directory
-      inputs:
-        sourceFolder: $(System.ArtifactsDirectory)/${{ format('BinDir_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-        contents: '**'
-        targetFolder: $(productDirectory)/$(targetFlavor)
+    - template: /eng/download-artifact-step.yml
+      parameters:
+        downloadFolder: '$(productBuildRootFolderPath)/tmp'
+        unpackFolder: '$(productBuildRootFolderPath)'
+        cleanUnpackFolder: false
+        artifactFileName: '$(productBuildArtifactName)$(archiveExtension)'
+        artifactName: '$(productBuildArtifactName)'
+        displayName: 'product build'
 
 
     # Create directories and ensure crossgen is executable

--- a/eng/download-git-repository-step.yml
+++ b/eng/download-git-repository-step.yml
@@ -1,0 +1,17 @@
+parameters:
+  unix: false
+
+steps:
+  # Download the GIT repository
+  - template: /eng/download-artifact-step.yml
+    parameters:
+      displayName: 'GIT repository'
+      downloadFolder: $(Build.SourcesDirectory)/download/
+      cleanUnpackFolder: false
+      unpackFolder: $(Build.SourcesDirectory)
+      ${{ if ne(parameters.unix, true) }}:
+        artifactFileName: repo_windows.zip
+        artifactName: repo_windows
+      ${{ if eq(parameters.unix, true) }}:
+        artifactFileName: repo_unix.tar.gz
+        artifactName: repo_unix

--- a/eng/perf-job.yml
+++ b/eng/perf-job.yml
@@ -48,22 +48,14 @@ jobs:
     # Extra steps that will be passed to the performance template and run before sending the job to helix (all of which is done in the template)
 
     # Download product binaries directory
-    - task: DownloadBuildArtifacts@0
-      displayName: Download product build
-      inputs:
-        buildType: current
-        downloadType: single
-        artifactName: ${{ format('BinDir_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-        downloadPath: $(System.ArtifactsDirectory)
-
-
-    # Populate Product directory
-    - task: CopyFiles@2
-      displayName: Populate Product directory
-      inputs:
-        sourceFolder: $(System.ArtifactsDirectory)/${{ format('BinDir_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-        contents: '**'
-        targetFolder: $(Build.SourcesDirectory)/bin/Product/${{ parameters.osGroup }}.${{ parameters.archType }}.Release
+    - template: /eng/download-artifact-step.yml
+      parameters:
+        downloadFolder: '$(productBuildRootFolderPath)/tmp'
+        unpackFolder: '$(productBuildRootFolderPath)'
+        cleanUnpackFolder: false
+        artifactFileName: '$(productBuildArtifactName)$(archiveExtension)'
+        artifactName: '$(productBuildArtifactName)'
+        displayName: 'product build'
 
     # Create Core_Root
     - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -39,6 +39,7 @@ jobs:
     platformGroup: all
     jobParameters:
       testGroup: outerloop
+      crossgenFramework: true
 
 #
 # Release builds

--- a/eng/pipelines/internal.yml
+++ b/eng/pipelines/internal.yml
@@ -55,6 +55,7 @@ stages:
           signBinaries: true
           publishToBlobFeed: true
           testGroup: outerloop
+          crossgenFramework: true
 
     #
     # Publish build information to Build Assets Registry

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -45,6 +45,7 @@ jobs:
     - Windows_NT_x86
     jobParameters:
       testGroup: innerloop
+      crossgenFramework: true
 
 #
 # Release builds

--- a/eng/pipelines/r2r-extra.yml
+++ b/eng/pipelines/r2r-extra.yml
@@ -23,6 +23,7 @@ jobs:
     platformGroup: gcstress
     jobParameters:
       testGroup: r2r-extra
+      crossgenFramework: true
 
 - template: /eng/platform-matrix.yml
   parameters:

--- a/eng/pipelines/r2r.yml
+++ b/eng/pipelines/r2r.yml
@@ -20,6 +20,7 @@ jobs:
     - Windows_NT_x86
     jobParameters:
       testGroup: outerloop
+      crossgenFramework: true
 
 - template: /eng/platform-matrix.yml
   parameters:

--- a/eng/platform-matrix-combos.yml
+++ b/eng/platform-matrix-combos.yml
@@ -72,10 +72,11 @@ jobs:
       unixManagedTestBuildArchType: 'x64'
 
     ${{ if eq(parameters.windowsX86, true) }}:
-      windowsManagedTestBuildArchType: 'x86'
+      windows32bitManagedTestBuildArchType: 'x86'
     ${{ if and(ne(parameters.windowsX86, true), eq(parameters.windowsArm, true)) }}:
-      windowsManagedTestBuildArchType: 'arm'
-    ${{ if and(ne(parameters.windowsX86, true), ne(parameters.windowsArm, true), eq(parameters.windowsX64, true)) }}:
-      windowsManagedTestBuildArchType: 'x64'
-    ${{ if and(ne(parameters.windowsX86, true), ne(parameters.windowsArm, true), ne(parameters.windowsX64, true), eq(parameters.windowsArm64, true)) }}:
-      windowsManagedTestBuildArchType: 'arm64'
+      windows32bitManagedTestBuildArchType: 'arm'
+
+    ${{ if eq(parameters.windowsX64, true) }}:
+      windows64bitManagedTestBuildArchType: 'x64'
+    ${{ if and(ne(parameters.windowsX64, true), eq(parameters.windowsArm64, true)) }}:
+      windows64bitManagedTestBuildArchType: 'arm64'

--- a/eng/platform-matrix-combos.yml
+++ b/eng/platform-matrix-combos.yml
@@ -43,29 +43,39 @@ jobs:
     windowsArm: ${{ parameters.windowsArm }}
     windowsArm64: ${{ parameters.windowsArm64 }}
 
-    # Determine OS for building X86 managed test artifacts on *nix
-    # Currently no-op as we only run X86 tests on Windows
-    x86ManagedTestBuildOsGroup: ''
+    # Determine OS / arch combo for building managed test artifacts on *nix
 
     # Determine OS for building X64 managed test artifacts on *nix
     ${{ if eq(parameters.osxX64, true) }}:
-      x64ManagedTestBuildOsGroup: 'OSX'
+      unixManagedTestBuildOsGroup: 'OSX'
+      unixManagedTestBuildArchType: 'x64'
     ${{ if and(ne(parameters.osxX64, true), eq(parameters.linuxX64, true)) }}:
-      x64ManagedTestBuildOsGroup: 'Linux'
-    ${{ if and(ne(parameters.osxX64, true), ne(parameters.linuxX64, true), eq(parameters.linuxMuslX64, true)) }}:
-      x64ManagedTestBuildOsGroup: 'Linux'
-      x64ManagedTestBuildOsSubgroup: '_musl'
-    ${{ if and(ne(parameters.osxX64, true), ne(parameters.linuxX64, true), ne(parameters.linuxMuslX64, true), eq(parameters.linuxRhel6X64, true)) }}:
-      x64ManagedTestBuildOsGroup: 'Linux'
-      x64ManagedTestBuildOsSubgroup: '_rhel6'
+      unixManagedTestBuildOsGroup: 'Linux'
+      unixManagedTestBuildArchType: 'x64'
+    ${{ if and(ne(parameters.osxX64, true), ne(parameters.linuxX64, true), eq(parameters.linuxArm, true)) }}:
+      unixManagedTestBuildOsGroup: 'Linux'
+      unixManagedTestBuildArchType: 'arm'
+    ${{ if and(ne(parameters.osxX64, true), ne(parameters.linuxX64, true), ne(parameters.linuxArm, true), eq(parameters.linuxArm64, true)) }}:
+      unixManagedTestBuildOsGroup: 'Linux'
+      unixManagedTestBuildArchType: 'arm64'
+    ${{ if and(ne(parameters.osxX64, true), ne(parameters.linuxX64, true), ne(parameters.linuxArm, true), ne(parameters.linuxArm64, true), eq(parameters.linuxMuslX64, true)) }}:
+      unixManagedTestBuildOsGroup: 'Linux'
+      unixManagedTestBuildOsSubgroup: '_musl'
+      unixManagedTestBuildArchType: 'x64'
+    ${{ if and(ne(parameters.osxX64, true), ne(parameters.linuxX64, true), ne(parameters.linuxArm, true), ne(parameters.linuxArm64, true), ne(parameters.linuxMuslX64, true), eq(parameters.linuxMuslArm64, true)) }}:
+      unixManagedTestBuildOsGroup: 'Linux'
+      unixManagedTestBuildOsSubgroup: '_musl'
+      unixManagedTestBuildArchType: 'arm64'
+    ${{ if and(ne(parameters.osxX64, true), ne(parameters.linuxX64, true), ne(parameters.linuxArm, true), ne(parameters.linuxArm64, true), ne(parameters.linuxMuslX64, true), ne(parameters.linuxMuslArm64, true), eq(parameters.linuxRhel6X64, true)) }}:
+      unixManagedTestBuildOsGroup: 'Linux'
+      unixManagedTestBuildOsSubgroup: '_rhel6'
+      unixManagedTestBuildArchType: 'x64'
 
-    # Determine OS for building ARM managed test artifacts on *nix
-    ${{ if eq(parameters.linuxArm, true) }}:
-      armManagedTestBuildOsGroup: 'Linux'
-
-    # Determine OS for building ARM64 managed test artifacts on *nix
-    ${{ if eq(parameters.linuxArm64, true) }}:
-      arm64ManagedTestBuildOsGroup: 'Linux'
-    ${{ if and(ne(parameters.linuxArm64, true), eq(parameters.linuxMuslArm64, true)) }}:
-      arm64ManagedTestBuildOsGroup: 'Linux'
-      arm64ManagedTestBuildOsSubroup: '_musl'
+    ${{ if eq(parameters.windowsX86, true) }}:
+      windowsManagedTestBuildArchType: 'x86'
+    ${{ if and(ne(parameters.windowsX86, true), eq(parameters.windowsArm, true)) }}:
+      windowsManagedTestBuildArchType: 'arm'
+    ${{ if and(ne(parameters.windowsX86, true), ne(parameters.windowsArm, true), eq(parameters.windowsX64, true)) }}:
+      windowsManagedTestBuildArchType: 'x64'
+    ${{ if and(ne(parameters.windowsX86, true), ne(parameters.windowsArm, true), ne(parameters.windowsX64, true), eq(parameters.windowsArm64, true)) }}:
+      windowsManagedTestBuildArchType: 'arm64'

--- a/eng/platform-matrix-managed-test-build.yml
+++ b/eng/platform-matrix-managed-test-build.yml
@@ -27,7 +27,8 @@ parameters:
   unixManagedTestBuildOsSubgroup: ''
   unixManagedTestBuildArchType: ''
   
-  windowsManagedTestBuildArchType: ''
+  windows32bitManagedTestBuildArchType: ''
+  windows64bitManagedTestBuildArchType: ''
 
 jobs:
 
@@ -234,7 +235,7 @@ jobs:
       archType: x64
       osGroup: Windows_NT
       managedTestBuildOsGroup: 'Windows_NT'
-      managedTestBuildArchType: ${{ parameters.windowsManagedTestBuildArchType }}
+      managedTestBuildArchType: ${{ parameters.windows64bitManagedTestBuildArchType }}
       helixQueues:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'pr', 'ci', 'corefx')) }}:
         - Windows.10.Amd64.Open
@@ -261,7 +262,7 @@ jobs:
       archType: x86
       osGroup: Windows_NT
       managedTestBuildOsGroup: 'Windows_NT'
-      managedTestBuildArchType: ${{ parameters.windowsManagedTestBuildArchType }}
+      managedTestBuildArchType: ${{ parameters.windows32bitManagedTestBuildArchType }}
       helixQueues:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'pr', 'ci', 'corefx')) }}:
         - Windows.10.Amd64.Open
@@ -286,7 +287,7 @@ jobs:
       archType: arm
       osGroup: Windows_NT
       managedTestBuildOsGroup: 'Windows_NT'
-      managedTestBuildArchType: ${{ parameters.windowsManagedTestBuildArchType }}
+      managedTestBuildArchType: ${{ parameters.windows32bitManagedTestBuildArchType }}
       helixQueues:
       # NOTE: there are no queues specified for Windows_NT_arm public with helixQueueGroup='pr'. This means that specifying
       # Windows_NT_arm for a PR job causes a build, but no test run. If the test build and test runs were separate jobs,
@@ -307,7 +308,7 @@ jobs:
       archType: arm64
       osGroup: Windows_NT
       managedTestBuildOsGroup: 'Windows_NT'
-      managedTestBuildArchType: ${{ parameters.windowsManagedTestBuildArchType }}
+      managedTestBuildArchType: ${{ parameters.windows64bitManagedTestBuildArchType }}
       helixQueues:
       # TODO: Consider adding Windows.10.Arm64.Open here if capacity is enough for handling both Windows_NT/arm and Windows_NT/arm64 testing
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:

--- a/eng/platform-matrix-managed-test-build.yml
+++ b/eng/platform-matrix-managed-test-build.yml
@@ -23,14 +23,11 @@ parameters:
   windowsArm: false
   windowsArm64: false
 
-  x86ManagedTestBuildOsGroup: ''
-  x86ManagedTestBuildOsSubgroup: ''
-  x64ManagedTestBuildOsGroup: ''
-  x64ManagedTestBuildOsSubgroup: ''
-  armManagedTestBuildOsGroup: ''
-  armManagedTestBuildOsSubgroup: ''
-  arm64ManagedTestBuildOsGroup: ''
-  arm64ManagedTestBuildOsSubgroup: ''
+  unixManagedTestBuildOsGroup: ''
+  unixManagedTestBuildOsSubgroup: ''
+  unixManagedTestBuildArchType: ''
+  
+  windowsManagedTestBuildArchType: ''
 
 jobs:
 
@@ -43,8 +40,9 @@ jobs:
       buildConfig: ${{ parameters.buildConfig }}
       archType: arm
       osGroup: Linux
-      managedTestBuildOsGroup: ${{ parameters.armManagedTestBuildOsGroup }}
-      managedTestBuildOsSubgroup: ${{ parameters.armManagedTestBuildOsSubgroup }}
+      managedTestBuildOsGroup: ${{ parameters.unixManagedTestBuildOsGroup }}
+      managedTestBuildOsSubgroup: ${{ parameters.unixManagedTestBuildOsSubgroup }}
+      managedTestBuildArchType: ${{ parameters.unixManagedTestBuildArchType }}
       container:
         image: ubuntu-16.04-cross-14.04-23cacb0-20190528233931
         registry: mcr
@@ -67,8 +65,9 @@ jobs:
       buildConfig: ${{ parameters.buildConfig }}
       archType: arm64
       osGroup: Linux
-      managedTestBuildOsGroup: ${{ parameters.arm64ManagedTestBuildOsGroup }}
-      managedTestBuildOsSubgroup: ${{ parameters.arm64ManagedTestBuildOsSubgroup }}
+      managedTestBuildOsGroup: ${{ parameters.unixManagedTestBuildOsGroup }}
+      managedTestBuildOsSubgroup: ${{ parameters.unixManagedTestBuildOsSubgroup }}
+      managedTestBuildArchType: ${{ parameters.unixManagedTestBuildArchType }}
       container:
         image: ubuntu-16.04-cross-arm64-cfdd435-20190520220848
         registry: mcr
@@ -93,8 +92,9 @@ jobs:
       archType: x64
       osGroup: Linux
       osSubgroup: _musl
-      managedTestBuildOsGroup: ${{ parameters.x64ManagedTestBuildOsGroup }}
-      managedTestBuildOsSubgroup: ${{ parameters.x64ManagedTestBuildOsSubgroup }}
+      managedTestBuildOsGroup: ${{ parameters.unixManagedTestBuildOsGroup }}
+      managedTestBuildOsSubgroup: ${{ parameters.unixManagedTestBuildOsSubgroup }}
+      managedTestBuildArchType: ${{ parameters.unixManagedTestBuildArchType }}
       container:
         image: alpine-3.6-WithNode-cfdd435-20190521001804
         registry: mcr
@@ -116,8 +116,9 @@ jobs:
       archType: arm64
       osGroup: Linux
       osSubgroup: _musl
-      managedTestBuildOsGroup: ${{ parameters.arm64ManagedTestBuildOsGroup }}
-      managedTestBuildOsSubgroup: ${{ parameters.arm64ManagedTestBuildOsSubgroup }}
+      managedTestBuildOsGroup: ${{ parameters.unixManagedTestBuildOsGroup }}
+      managedTestBuildOsSubgroup: ${{ parameters.unixManagedTestBuildOsSubgroup }}
+      managedTestBuildArchType: ${{ parameters.unixManagedTestBuildArchType }}
       container:
         image: ubuntu-16.04-cross-arm64-alpine-406629a-20190520220848
         registry: mcr
@@ -139,8 +140,9 @@ jobs:
       archType: x64
       osGroup: Linux
       osSubgroup: _rhel6
-      managedTestBuildOsGroup: ${{ parameters.x64ManagedTestBuildOsGroup }}
-      managedTestBuildOsSubgroup: ${{ parameters.x64ManagedTestBuildOsSubgroup }}
+      managedTestBuildOsGroup: ${{ parameters.unixManagedTestBuildOsGroup }}
+      managedTestBuildOsSubgroup: ${{ parameters.unixManagedTestBuildOsSubgroup }}
+      managedTestBuildArchType: ${{ parameters.unixManagedTestBuildArchType }}
       container:
         image: centos-6-3e800f1-20190501005338
         registry: mcr
@@ -159,8 +161,9 @@ jobs:
       buildConfig: ${{ parameters.buildConfig }}
       archType: x64
       osGroup: Linux
-      managedTestBuildOsGroup: ${{ parameters.x64ManagedTestBuildOsGroup }}
-      managedTestBuildOsSubgroup: ${{ parameters.x64ManagedTestBuildOsSubgroup }}
+      managedTestBuildOsGroup: ${{ parameters.unixManagedTestBuildOsGroup }}
+      managedTestBuildOsSubgroup: ${{ parameters.unixManagedTestBuildOsSubgroup }}
+      managedTestBuildArchType: ${{ parameters.unixManagedTestBuildArchType }}
       container:
         image: centos-7-3e800f1-20190501005343
         registry: mcr
@@ -207,8 +210,9 @@ jobs:
       buildConfig: ${{ parameters.buildConfig }}
       archType: x64
       osGroup: OSX
-      managedTestBuildOsGroup: ${{ parameters.x64ManagedTestBuildOsGroup }}
-      managedTestBuildOsSubgroup: ${{ parameters.x64ManagedTestBuildOsSubgroup }}
+      managedTestBuildOsGroup: ${{ parameters.unixManagedTestBuildOsGroup }}
+      managedTestBuildOsSubgroup: ${{ parameters.unixManagedTestBuildOsSubgroup }}
+      managedTestBuildArchType: ${{ parameters.unixManagedTestBuildArchType }}
       helixQueues:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'pr', 'ci', 'corefx')) }}:
         - OSX.1013.Amd64.Open
@@ -229,6 +233,8 @@ jobs:
       buildConfig: ${{ parameters.buildConfig }}
       archType: x64
       osGroup: Windows_NT
+      managedTestBuildOsGroup: 'Windows_NT'
+      managedTestBuildArchType: ${{ parameters.windowsManagedTestBuildArchType }}
       helixQueues:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'pr', 'ci', 'corefx')) }}:
         - Windows.10.Amd64.Open
@@ -254,6 +260,8 @@ jobs:
       buildConfig: ${{ parameters.buildConfig }}
       archType: x86
       osGroup: Windows_NT
+      managedTestBuildOsGroup: 'Windows_NT'
+      managedTestBuildArchType: ${{ parameters.windowsManagedTestBuildArchType }}
       helixQueues:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.helixQueueGroup, 'pr', 'ci', 'corefx')) }}:
         - Windows.10.Amd64.Open
@@ -277,6 +285,8 @@ jobs:
       buildConfig: ${{ parameters.buildConfig }}
       archType: arm
       osGroup: Windows_NT
+      managedTestBuildOsGroup: 'Windows_NT'
+      managedTestBuildArchType: ${{ parameters.windowsManagedTestBuildArchType }}
       helixQueues:
       # NOTE: there are no queues specified for Windows_NT_arm public with helixQueueGroup='pr'. This means that specifying
       # Windows_NT_arm for a PR job causes a build, but no test run. If the test build and test runs were separate jobs,
@@ -296,6 +306,8 @@ jobs:
       buildConfig: ${{ parameters.buildConfig }}
       archType: arm64
       osGroup: Windows_NT
+      managedTestBuildOsGroup: 'Windows_NT'
+      managedTestBuildArchType: ${{ parameters.windowsManagedTestBuildArchType }}
       helixQueues:
       # TODO: Consider adding Windows.10.Arm64.Open here if capacity is enough for handling both Windows_NT/arm and Windows_NT/arm64 testing
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:

--- a/eng/run-test-job.yml
+++ b/eng/run-test-job.yml
@@ -113,22 +113,14 @@ jobs:
 
 
     # Download product binaries directory
-    - task: DownloadBuildArtifacts@0
-      displayName: Download product build
-      inputs:
-        buildType: current
-        downloadType: single
-        artifactName: 'BinDir_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
-        downloadPath: '$(System.ArtifactsDirectory)'
-
-
-    # Populate Product directory
-    - task: CopyFiles@2
-      displayName: Populate Product directory
-      inputs:
-        sourceFolder: '$(System.ArtifactsDirectory)/BinDir_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
-        contents: '**'
-        targetFolder: '$(Build.SourcesDirectory)/bin/Product/$(osGroup).$(archType).$(buildConfigUpper)'
+    - template: /eng/download-artifact-step.yml
+      parameters:
+        downloadFolder: '$(productBuildRootFolderPath)/tmp'
+        unpackFolder: '$(productBuildRootFolderPath)'
+        cleanUnpackFolder: false
+        artifactFileName: '$(productBuildArtifactName)$(archiveExtension)'
+        artifactName: '$(productBuildArtifactName)'
+        displayName: 'product build'
 
 
     # Download and unzip the Microsoft.NET.Sdk.IL package needed for traversing

--- a/eng/run-test-job.yml
+++ b/eng/run-test-job.yml
@@ -5,6 +5,7 @@ parameters:
   osSubgroup: ''
   managedTestBuildOsGroup: ''
   managedTestBuildOsSubgroup: ''
+  managedTestBuildArchType: ''
   container: ''
   testGroup: ''
   readyToRun: false
@@ -29,6 +30,7 @@ jobs:
     osSubgroup: ${{ parameters.osSubgroup }}
     managedTestBuildOsGroup: ${{ parameters.managedTestBuildOsGroup }}
     managedTestBuildOsSubgroup: ${{ parameters.managedTestBuildOsSubgroup }}
+    managedTestBuildArchType: ${{ parameters.managedTestBuildArchType }}
     container: ${{ parameters.container }}
     testGroup: ${{ parameters.testGroup }}
     readyToRun: ${{ parameters.readyToRun }}
@@ -44,7 +46,7 @@ jobs:
     ${{ if and(eq(parameters.testGroup, 'innerloop'), eq(parameters.displayNameArgs, '')) }}:
       name: 'run_test_p0_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'
       dependsOn:
-      - 'build_test_p0_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.archType }}_${{parameters.buildConfig }}'
+      - 'build_test_p0_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.managedTestBuildArchType }}_${{parameters.buildConfig }}'
       - ${{ if ne(parameters.stagedBuild, true) }}:
         - ${{ format('build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
       displayName: 'Run Test Pri0 ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
@@ -52,7 +54,7 @@ jobs:
     ${{ if and(ne(parameters.testGroup, 'innerloop'), eq(parameters.displayNameArgs, '')) }}:
       name: 'run_test_p1_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'
       dependsOn:
-      - 'build_test_p1_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.archType }}_${{parameters.buildConfig }}'
+      - 'build_test_p1_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.managedTestBuildArchType }}_${{parameters.buildConfig }}'
       - ${{ if ne(parameters.stagedBuild, true) }}:
         - ${{ format('build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
       displayName: 'Run Test Pri1 ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
@@ -60,7 +62,7 @@ jobs:
     ${{ if and(eq(parameters.testGroup, 'innerloop'), ne(parameters.displayNameArgs, '')) }}:
       name: 'run_test_p0_${{ parameters.displayNameArgs }}_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'
       dependsOn:
-      - 'build_test_p0_${{ parameters.displayNameArgs }}_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.archType }}_${{parameters.buildConfig }}'      
+      - 'build_test_p0_${{ parameters.displayNameArgs }}_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.managedTestBuildArchType }}_${{parameters.buildConfig }}'      
       - ${{ if ne(parameters.stagedBuild, true) }}:
         - ${{ format('build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
       displayName: 'Run Test Pri0 ${{ parameters.displayNameArgs }} ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
@@ -68,7 +70,7 @@ jobs:
     ${{ if and(ne(parameters.testGroup, 'innerloop'), ne(parameters.displayNameArgs, '')) }}:
       name: 'run_test_p1_${{ parameters.displayNameArgs }}_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'
       dependsOn:
-      - 'build_test_p1_${{ parameters.displayNameArgs }}_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.archType }}_${{parameters.buildConfig }}'      
+      - 'build_test_p1_${{ parameters.displayNameArgs }}_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.managedTestBuildArchType }}_${{parameters.buildConfig }}'      
       - ${{ if ne(parameters.stagedBuild, true) }}:
         - ${{ format('build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
       displayName: 'Run Test Pri1 ${{ parameters.displayNameArgs }} ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
@@ -98,7 +100,7 @@ jobs:
         unpackFolder: '$(testRootFolderPath)'
         artifactFileName: '$(testArtifactName)$(archiveExtension)'
         artifactName: '$(testArtifactName)'
-        displayName: 'managed test artifacts (built on ${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }})'
+        displayName: 'managed test artifacts (built on ${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }} ${{ parameters.managedTestBuildArchType }})'
 
 
     # Download and unzip test build tree

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -5,6 +5,7 @@ parameters:
   osSubgroup: ''
   managedTestBuildOsGroup: ''
   managedTestBuildOsSubgroup: ''
+  managedTestBuildArchType: ''
   container: ''
   testGroup: ''
   readyToRun: false
@@ -23,16 +24,13 @@ parameters:
 ### buildConfig and archType.
 
 jobs:
-- ${{ if and(eq(parameters.osSubgroup, parameters.managedTestBuildOsSubgroup), or(eq(parameters.osGroup, parameters.managedTestBuildOsGroup), eq(parameters.managedTestBuildOsGroup, ''))) }}:
+- ${{ if and(eq(parameters.archType, parameters.managedTestBuildArchType), eq(parameters.osSubgroup, parameters.managedTestBuildOsSubgroup), eq(parameters.osGroup, parameters.managedTestBuildOsGroup)) }}:
   - template: build-test-job.yml
     parameters:
       buildConfig: ${{ parameters.buildConfig }}
       archType: ${{ parameters.archType }}
-      ${{ if ne(parameters.managedTestBuildOsGroup, '') }}:
-        osGroup: ${{ parameters.managedTestBuildOsGroup }}
-      ${{ if eq(parameters.managedTestBuildOsGroup, '') }}:
-        osGroup: ${{ parameters.osGroup }}
-      osSubgroup: ${{ parameters.managedTestBuildOsSubgroup }}
+      osGroup: ${{ parameters.osGroup }}
+      osSubgroup: ${{ parameters.osSubgroup }}
       container: ${{ parameters.container }}
       testGroup: ${{ parameters.testGroup }}
       readyToRun: ${{ parameters.readyToRun }}
@@ -48,11 +46,9 @@ jobs:
     archType: ${{ parameters.archType }}
     osGroup: ${{ parameters.osGroup }}
     osSubgroup: ${{ parameters.osSubgroup }}
-    ${{ if ne(parameters.managedTestBuildOsGroup, '') }}:
-      managedTestBuildOsGroup: ${{ parameters.managedTestBuildOsGroup }}
-    ${{ if eq(parameters.managedTestBuildOsGroup, '') }}:
-      managedTestBuildOsGroup: ${{ parameters.osGroup }}
+    managedTestBuildOsGroup: ${{ parameters.managedTestBuildOsGroup }}
     managedTestBuildOsSubgroup: ${{ parameters.managedTestBuildOsSubgroup }}
+    managedTestBuildArchType: ${{ parameters.managedTestBuildArchType }}
     container: ${{ parameters.container }}
     testGroup: ${{ parameters.testGroup }}
     readyToRun: ${{ parameters.readyToRun }}

--- a/eng/xplat-job.yml
+++ b/eng/xplat-job.yml
@@ -165,17 +165,8 @@ jobs:
       clean: true
 
     # Download the GIT repository
-    - template: /eng/download-artifact-step.yml
+    - template: /eng/download-git-repository-step.yml
       parameters:
-        displayName: 'GIT repository'
-        downloadFolder: $(Build.SourcesDirectory)/download/
-        cleanUnpackFolder: false
-        unpackFolder: $(Build.SourcesDirectory)
-        ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-          artifactFileName: repo_windows.zip
-          artifactName: repo_windows
-        ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-          artifactFileName: repo_unix.tar.gz
-          artifactName: repo_unix
+        unix: ${{ ne(parameters.osGroup, 'Windows_NT') }}
 
     - ${{ parameters.steps }}

--- a/eng/xplat-test-job.yml
+++ b/eng/xplat-test-job.yml
@@ -84,11 +84,17 @@ jobs:
     - name: testNativeRootFolderPath
       value: $(binTestsPath)/obj/$(osGroup).$(archType).$(buildConfigUpper)
 
+    - name: testBuildArtifactName
+      value: 'TestBuild_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
+
     - name: testBuildRootFolderPath
       value: $(binTestsPath)/$(osGroup).$(archType).$(buildConfigUpper)
 
-    - name: testBuildArtifactName
-      value: 'TestBuild_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
+    - name: productBuildArtifactName
+      value: 'BinDir_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
+
+    - name: productBuildRootFolderPath
+      value: '$(Build.SourcesDirectory)/bin/Product/$(osGroup).$(archType).$(_BuildConfig)'
 
     - name: microsoftNetSdkIlFolderPath
       value: $(Build.SourcesDirectory)/.packages/microsoft.net.sdk.il

--- a/eng/xplat-test-job.yml
+++ b/eng/xplat-test-job.yml
@@ -48,14 +48,6 @@ jobs:
     gatherAssetManifests: ${{ parameters.gatherAssetManifests }}
   
     variables:
-    - ${{ if ne(parameters.testGroup, '') }}:
-      - name: testArtifactRootName
-        value: ${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}_${{ parameters.testGroup }}
-
-    - ${{ if eq(parameters.testGroup, '') }}:
-      - name: testArtifactRootName
-        value: ${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}
-
     - name: binTestsPath
       value: $(Build.SourcesDirectory)/bin/tests
 
@@ -65,18 +57,23 @@ jobs:
     - name: nativeRootFolderPath
       value: $(binTestsPath)/$(osGroup).$(archType).$(buildConfigUpper)
 
-    - ${{ if and(eq(parameters.corefxTests, true), eq(parameters.readyToRun, true)) }}:
+    - name: testArtifactName
+      value: Tests
+
+    - ${{ if eq(parameters.readyToRun, true) }}:
       - name: testArtifactName
-        value: Tests_r2r_corefx_$(testArtifactRootName)
-    - ${{ if and(eq(parameters.corefxTests, true), ne(parameters.readyToRun, true)) }}:
+        value: $(testArtifactName)_r2r
+
+    - ${{ if eq(parameters.corefxTests, true) }}:
       - name: testArtifactName
-        value: Tests_corefx_$(testArtifactRootName)
-    - ${{ if and(ne(parameters.corefxTests, true), eq(parameters.readyToRun, true)) }}:
+        value: $(testArtifactName)_corefx
+
+    - name: testArtifactName
+      value: $(testArtifactName)_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_$(archType)_$(buildConfig)
+
+    - ${{ if ne(parameters.testGroup, '') }}:
       - name: testArtifactName
-        value: Tests_r2r_$(testArtifactRootName)
-    - ${{ if and(ne(parameters.corefxTests, true), ne(parameters.readyToRun, true)) }}:
-      - name: testArtifactName
-        value: Tests_$(testArtifactRootName)
+        value: $(testArtifactName)_$(testGroup)
 
     - name: testNativeArtifactName
       value: 'NativeTestComponents_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
@@ -84,23 +81,23 @@ jobs:
     - name: testNativeRootFolderPath
       value: $(binTestsPath)/obj/$(osGroup).$(archType).$(buildConfigUpper)
 
-    - name: testBuildArtifactName
-      value: 'TestBuild_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
-
     - name: testBuildRootFolderPath
       value: $(binTestsPath)/$(osGroup).$(archType).$(buildConfigUpper)
 
-    - name: productBuildArtifactName
-      value: 'BinDir_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
-
-    - name: productBuildRootFolderPath
-      value: '$(Build.SourcesDirectory)/bin/Product/$(osGroup).$(archType).$(_BuildConfig)'
+    - name: testBuildArtifactName
+      value: 'TestBuild_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
 
     - name: microsoftNetSdkIlFolderPath
       value: $(Build.SourcesDirectory)/.packages/microsoft.net.sdk.il
-      
+
     - name: microsoftNetSdkIlArtifactName
       value: 'MicrosoftNetSdkIlPackage_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_$(archType)_$(buildConfig)'
+
+    - name: productBuildArtifactName
+      value: 'BinDir_${{ parameters.osGroup }}${{ parameters.osSugbroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'
+
+    - name: productBuildRootFolderPath
+      value: '$(Build.SourcesDirectory)/bin/Product/${{ parameters.osGroup }}.${{ parameters.archType }}.${{ parameters.buildConfig }}'
 
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
       - name: archiveExtension

--- a/eng/xplat-test-job.yml
+++ b/eng/xplat-test-job.yml
@@ -5,6 +5,7 @@ parameters:
   osSubgroup: ''
   managedTestBuildOsGroup: ''
   managedTestBuildOsSubgroup: ''
+  managedTestBuildArchType: ''
   name: ''
   helixType: '(unspecified)'
   container: ''
@@ -57,23 +58,29 @@ jobs:
     - name: nativeRootFolderPath
       value: $(binTestsPath)/$(osGroup).$(archType).$(buildConfigUpper)
 
-    - name: testArtifactName
-      value: Tests
+    - name: testArtifactNameR2RPart
+      value: ''
 
     - ${{ if eq(parameters.readyToRun, true) }}:
-      - name: testArtifactName
-        value: $(testArtifactName)_r2r
+      - name: testArtifactNameR2RPart
+        value: '_r2r'
+
+    - name: testArtifactNameCoreFxPart
+      value: ''
 
     - ${{ if eq(parameters.corefxTests, true) }}:
-      - name: testArtifactName
-        value: $(testArtifactName)_corefx
+      - name: testArtifactNameCoreFxPart
+        value: '_corefx'
 
-    - name: testArtifactName
-      value: $(testArtifactName)_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_$(archType)_$(buildConfig)
+    - name: testArtifactNameTestGroupPart
+      value: ''
 
     - ${{ if ne(parameters.testGroup, '') }}:
       - name: testArtifactName
-        value: $(testArtifactName)_$(testGroup)
+        value: _$(testGroup)
+
+    - name: testArtifactName
+      value: Tests$(testArtifactNameR2RPart)$(testArtifactNameCoreFxPart)_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.managedTestBuildArchType }}_$(buildConfig)$(testArtifactNameTestGroupPart)
 
     - name: testNativeArtifactName
       value: 'NativeTestComponents_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
@@ -91,13 +98,13 @@ jobs:
       value: $(Build.SourcesDirectory)/.packages/microsoft.net.sdk.il
 
     - name: microsoftNetSdkIlArtifactName
-      value: 'MicrosoftNetSdkIlPackage_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_$(archType)_$(buildConfig)'
+      value: 'MicrosoftNetSdkIlPackage_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.managedTestBuildArchType }}_$(buildConfig)'
 
     - name: productBuildArtifactName
-      value: 'BinDir_${{ parameters.osGroup }}${{ parameters.osSugbroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'
+      value: 'BinDir_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
 
     - name: productBuildRootFolderPath
-      value: '$(Build.SourcesDirectory)/bin/Product/${{ parameters.osGroup }}.${{ parameters.archType }}.${{ parameters.buildConfig }}'
+      value: '$(Build.SourcesDirectory)/bin/Product/$(osGroup).$(archType).$(buildConfigUpper)'
 
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
       - name: archiveExtension


### PR DESCRIPTION
1) Modify CoreCLR pipelines to use the zipping / unzipping templates
for manipulating the product build.

2) Pass the crossgen option to product build so that it crossgens the
framework assemblies.

3) Fix duplicate variable definitions in xplat-test-job vs. build-job.

4) Optimize the pipeline by reusing managed artifacts across architectures.

Based on Jan Vorlicek's explanation Crossgen compilation takes place
at execution time using a command injected to the cmd / sh execution
script so we should be good with architecture independence.

For now I'm splitting Windows builds per bitness as R2R runs have some
weird dependency on the Machine ID stored in the PE header I don't
want to waste time investigating right now, I'll tackle that in a follow-up
change.

Even with this limitation, I believe there's still overall benefit to this
additional cleanup change. Before my split of managed and native
components, PR runs included 16 test build jobs. My initial merge
reduced this to 13 and this change further gets it down to 9.

<b>Future work</b>: After fixing the R2R issue we should be able
to unify the 32/64-bit Windows test build jobs further reducing the
number of test build jobs to 7.

We should be able to get down to 3 but that requires more substantial
changes to how platform-matrix works - basically creating a custom
version of platform-matrix for test-job emitting the JIT-ted, R2R,
CoreFX and possibly CoreFX R2R (that we don't have now) at once
so that it can optimize test build jobs across all of these.

Ultimately, once we manage to unify Windows and Unix managed
test artifacts, it should be just 2 - OSX x64 debug and OSX x64
release. I don't see how to get below that.

Thanks

Tomas

P.S. I tested a slightly older version of this change earlier today on the
internal dotnet-coreclr pipeline and it was mostly passing apart from
the Windows bitness issue I have fixed since with an additional commit.