### PR TITLE
Fix Segfault in PerfInfo Image Logging

### DIFF
--- a/src/vm/perfinfo.cpp
+++ b/src/vm/perfinfo.cpp
@@ -41,8 +41,21 @@ void PerfInfo::LogImage(PEFile* pFile, WCHAR* guid)
 
     SString value;
     const SString& path = pFile->GetPath();
-    PEImageLayout *pLoadedLayout = pFile->GetLoaded();
-    SIZE_T baseAddr = (SIZE_T)pLoadedLayout->GetBase();
+    if (path.IsEmpty())
+    {
+        return;
+    }
+
+    SIZE_T baseAddr = 0;
+    if (pFile->IsILImageReadyToRun())
+    {
+        PEImageLayout *pLoadedLayout = pFile->GetLoaded();
+        if (pLoadedLayout)
+        {
+            baseAddr = (SIZE_T)pLoadedLayout->GetBase();
+        }
+    }
+
     value.Printf("%S%c%S%c%p", path.GetUnicode(), sDelimiter, guid, sDelimiter, baseAddr);
 
     SString command;


### PR DESCRIPTION
## Description

Limits entries in the perfinfo-<pid>.map file to disk-based assemblies that are ready to run images.

## Customer Impact

Fixes an AV that occurred when dynamically generated assemblies are loaded when `COMPlus_PerfMapEnabled=1`.  The result of profiling on Linux should be unchanged.

## Regression

This is a regression from 3.0-preview9 which occurred due to the fact that new versions of perf_events are now emitting virtual addresses instead of file offsets.  The change that caused this regression was a reaction to the perf_events change.

## Risk

Minimal, and should be limited to when `COMPlus_PerfMapEnabled=1`.

## Tests

No tests added as part of this change.  It would be useful to do so, but will require a mechanism to set environment variables before the process starts.  Recommend following up on this.

Fixes #26883