### PR TITLE
Check for nullity of the context in FuncEval setup's SP alignment checks

### DIFF
--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -15302,7 +15302,7 @@ HRESULT Debugger::FuncEvalSetup(DebuggerIPCE_FuncEvalInfo *pEvalInfo,
         return CORDBG_E_ILLEGAL_AT_GC_UNSAFE_POINT;
     }
 
-    if (::GetSP(filterContext) != ALIGN_DOWN(::GetSP(filterContext), STACK_ALIGN_SIZE))
+    if (filterContext != NULL && ::GetSP(filterContext) != ALIGN_DOWN(::GetSP(filterContext), STACK_ALIGN_SIZE))
     {
         // SP is not aligned, we cannot do a FuncEval here
         LOG((LF_CORDB, LL_INFO1000, "D::FES SP is unaligned"));


### PR DESCRIPTION
Func-evals in the case of a hijacked thread that is handling a first or second hand exception are not expected to necessarily have non-null filter contexts - this can happen during user exceptions handled by the debugger or nested func-evals. The alignment assumes this is not the case. However, the case of an exception just queues the func-eval to be executed once the exception handling logic has executed. The SP alignment check might need to be done here once the queued item starts.