### PR TITLE
Fix out of range access in GetRecycleMemoryInfo (#26873)

### DIFF
--- a/src/vm/win32threadpool.h
+++ b/src/vm/win32threadpool.h
@@ -749,7 +749,9 @@ public:
 #else // !FEATURE_PAL
             if (PAL_HasGetCurrentProcessorNumber())
             {
-                processorNumber = GetCurrentProcessorNumber();
+                // On linux, GetCurrentProcessorNumber which uses sched_getcpu() can return a value greater than the number
+                // of processors reported by sysconf(_SC_NPROCESSORS_ONLN) when using OpenVZ kernel.
+                processorNumber = GetCurrentProcessorNumber()%NumberOfProcessors;
             }
 #endif // !FEATURE_PAL
             return pRecycledListPerProcessor[processorNumber][memType];


### PR DESCRIPTION
Related to #26873 

On linux, GetCurrentProcessorNumber which uses sched_getcpu() can return a value greater than the number of processors reported by sched_getaffinity with CPU_COUNT or sysconf(_SC_NPROCESSORS_ONLN). For example, `taskset -c 2,3 ./MyApp` will make CPU_COUNT be 2 but sched_getcpu() can return 2 or 3, and OpenVZ kernel can make `sysconf(_SC_NPROCESSORS_ONLN)` return a limited cpu count but sched_getcpu() still report the real processor number.

We should use `GetCurrentProcessorNumber()%NumberOfProcessors` for the array index of pRecycledListPerProcessor to avoid out of range access.

------

Also I hope it could merge to 3.0.x release so my openvz vps can upgrade .NET Core to 3.0 sooner :|