### PR TITLE
Add csproj and bash script for crossgen2 ThunkGenerator

### DIFF
--- a/Documentation/project-docs/updating-jitinterface.md
+++ b/Documentation/project-docs/updating-jitinterface.md
@@ -17,6 +17,7 @@ The JitInterface is versioned by a GUID. Any change to JitInterface is required 
 Crossgen2 is the AOT compiler for CoreCLR. It generates native code for .NET apps ahead of time and uses the JIT to do that. Since crossgen2 is written in managed code, it doesn't consume the C++ headers and maintains a managed copy of them. Changes to JitInterface need to be ported managed code.
 
 1. If an enum/struct was modified or added, port the change to CorInfoTypes.cs.
-2. If a method was added or modified in ICorStaticInfo or ICorDynamicInfo, port the change to ThunkInput.txt. Run gen.bat to regenerate CorInfoBase.cs and jitinterface.h from ThunkInput.txt. Provide a managed implementation of the method in CorInfoImpl.cs. If the managed implementation is specific to CoreCLR ReadyToRun (and doesn't apply to full AOT compilation), provide the implementation in CorInfoImpl.ReadyToRun.cs instead.
+2. If a method was added or modified in ICorStaticInfo or ICorDynamicInfo, port the change to ThunkInput.txt.
+   Run gen.bat or gen.sh to regenerate CorInfoBase.cs and jitinterface.h from ThunkInput.txt. Provide a managed implementation of the method in CorInfoImpl.cs. If the managed implementation is specific to CoreCLR ReadyToRun (and doesn't apply to full AOT compilation), provide the implementation in CorInfoImpl.ReadyToRun.cs instead.
 3. Update JitInterface GUID in jitwrapper.cpp.
 

--- a/src/tools/crossgen2/Common/JitInterface/ThunkGenerator/ThunkGenerator.csproj
+++ b/src/tools/crossgen2/Common/JitInterface/ThunkGenerator/ThunkGenerator.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/tools/crossgen2/Common/JitInterface/ThunkGenerator/gen.bat
+++ b/src/tools/crossgen2/Common/JitInterface/ThunkGenerator/gen.bat
@@ -1,1 +1,2 @@
+cd /d %~dp0
 dotnet run -- ThunkInput.txt ..\CorInfoBase.cs ..\..\..\jitinterface\jitinterface.h

--- a/src/tools/crossgen2/Common/JitInterface/ThunkGenerator/gen.bat
+++ b/src/tools/crossgen2/Common/JitInterface/ThunkGenerator/gen.bat
@@ -1,3 +1,1 @@
-csc Program.cs
-Program.exe ThunkInput.txt ..\CorInfoBase.cs ..\..\..\jitinterface\jitinterface.h
-del Program.exe
+dotnet run -- ThunkInput.txt ..\CorInfoBase.cs ..\..\..\jitinterface\jitinterface.h

--- a/src/tools/crossgen2/Common/JitInterface/ThunkGenerator/gen.sh
+++ b/src/tools/crossgen2/Common/JitInterface/ThunkGenerator/gen.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+cd "$(dirname ${BASH_SOURCE[0]})"
+dotnet run -- ThunkInput.txt ../CorInfoBase.cs ../../../jitinterface/jitinterface.h


### PR DESCRIPTION
I have had to run this from Linux twice and both times I have had to create a csproj first because even using the `csc` that comes with the SDK does not automatically add the needed references.

PTAL @MichalStrehovsky 