### PR TITLE
Fixing AdvSimd.Arm64 to have an internal constructor in the "supported" file.

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/AdvSimd.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Intrinsics/Arm/AdvSimd.cs
@@ -20,6 +20,8 @@ namespace System.Runtime.Intrinsics.Arm
         [Intrinsic]
         public new abstract class Arm64 : ArmBase.Arm64
         {
+            internal Arm64() { }
+
             public static new bool IsSupported { get => IsSupported; }
 
             /// <summary>


### PR DESCRIPTION
This was out of sync with the PlatformNotSupported.cs file