### PR TITLE
Crossgen2 fixes for single-exe

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -448,6 +448,10 @@ build_CoreLib()
         "$__ProjectRoot/dotnet.sh" publish --self-contained -r $__DistroRid -c $__BuildType -o "$__BinDir/crossgen2" "$__ProjectRoot/src/tools/crossgen2/crossgen2/crossgen2.csproj"
         rm $__BinDir/crossgen2/crossgen2.runtimeconfig.json
 
+        echo "Publishing tibcmgr for $__DistroRid"
+        "$__ProjectRoot/dotnet.sh" publish --self-contained -r $__DistroRid -c $__BuildType -o "$__BinDir/tibcmgr" "$__ProjectRoot/src/tools/crossgen2/tibcmgr/tibcmgr.csproj"
+        rm $__BinDir/tibcmgr/tibcmgr.runtimeconfig.json
+
         if [ "$__HostOS" == "OSX" ]; then
             cp "$__BinDir/libclrjit.dylib" "$__BinDir/crossgen2/libclrjitilc.dylib"
             cp "$__BinDir/libjitinterface.dylib" "$__BinDir/crossgen2/libjitinterface.dylib"

--- a/src/tools/crossgen2/Common/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Interop/IL/Marshaller.cs
@@ -1533,7 +1533,14 @@ namespace Internal.TypeSystem.Interop
         protected override void TransformNativeToManaged(ILCodeStream codeStream)
         {
             ILEmitter emitter = _ilCodeStreams.Emitter;
+
+#if READYTORUN
+            var ansiToString =
+                Context.SystemModule.GetKnownType("System.StubHelpers", "AnsiBSTRMarshaler")
+                .GetKnownMethod("ConvertToManaged", null);
+#else
             var ansiToString = Context.GetHelperEntryPoint("InteropHelpers", "AnsiStringToString");
+#endif
             LoadNativeValue(codeStream);
             codeStream.Emit(ILOpcode.call, emitter.NewToken(ansiToString));
             StoreManagedValue(codeStream);


### PR DESCRIPTION
* Publish tibcmgr stand-alone in the build so it's usable in-situ
* Swallow BadImageFormatExceptions in Crossgen2. This should stay in single-exe branch and works around a bug in Linker on aggressive mode which leaves a dangling AssemblyRef in the metadata
* Add a missing IL marshaller stub generator