### PR TITLE
Fix the problem with the VS2019 fix on x86

### DIFF
--- a/src/vm/exstate.cpp
+++ b/src/vm/exstate.cpp
@@ -35,6 +35,8 @@ ThreadExceptionState::ThreadExceptionState()
 {
 #ifdef FEATURE_EH_FUNCLETS
     m_pCurrentTracker = NULL;
+#else
+    m_ppBottomFrameDuringUnwind = NULL;
 #endif // FEATURE_EH_FUNCLETS
 
     m_flag = TEF_None;

--- a/src/vm/exstate.h
+++ b/src/vm/exstate.h
@@ -25,6 +25,8 @@ class EHClauseInfo;
 
 extern StackWalkAction COMPlusUnwindCallback(CrawlFrame *pCf, ThrowCallbackType *pData);
 
+typedef DPTR(PTR_Frame)                 PTR_PTR_Frame;
+
 //
 // This class serves as a forwarding and abstraction layer for the EH subsystem.
 // Since we have two different implementations, this class is needed to unify 
@@ -158,12 +160,24 @@ public:
     }
 #else
     ExInfo                  m_currentExInfo;
+    PTR_PTR_Frame           m_ppBottomFrameDuringUnwind;
 public:
     PTR_ExInfo                 GetCurrentExceptionTracker()
     {
         LIMITED_METHOD_CONTRACT;
         return PTR_ExInfo(PTR_HOST_MEMBER_TADDR(ThreadExceptionState, this, m_currentExInfo));
     }
+
+    PTR_PTR_Frame GetPtrToBottomFrameDuringUnwind()
+    {
+        return m_ppBottomFrameDuringUnwind;
+    }
+
+    void SetPtrToBottomFrameDuringUnwind(PTR_PTR_Frame framePtr)
+    {
+        m_ppBottomFrameDuringUnwind = framePtr;
+    }
+
 #endif
 
 #ifdef FEATURE_CORRUPTING_EXCEPTIONS

--- a/src/vm/i386/excepx86.cpp
+++ b/src/vm/i386/excepx86.cpp
@@ -554,7 +554,14 @@ EXCEPTION_DISPOSITION ClrDebuggerDoUnwindAndIntercept(EXCEPTION_REGISTRATION_REC
     LOG((LF_EH|LF_CORDB, LL_INFO100, "\t\t: pFunc is 0x%X\n", tct.pFunc));
     LOG((LF_EH|LF_CORDB, LL_INFO100, "\t\t: pStack is 0x%X\n", tct.pStack));
 
+    _ASSERTE(pExState->GetPtrToBottomFrameDuringUnwind() == NULL);
+    pExState->SetPtrToBottomFrameDuringUnwind(&tct.pBottomFrame);
+
     CallRtlUnwindSafe(pEstablisherFrame, RtlUnwindCallback, pExceptionRecord, 0);
+
+    _ASSERTE(pExState->GetPtrToBottomFrameDuringUnwind() == &tct.pBottomFrame);
+    _ASSERTE(*pExState->GetPtrToBottomFrameDuringUnwind() == tct.pBottomFrame);
+    pExState->SetPtrToBottomFrameDuringUnwind(NULL);
 
     ExInfo* pExInfo = pThread->GetExceptionState()->GetCurrentExceptionTracker();
     if (pExInfo->m_ValidInterceptionContext)
@@ -1234,8 +1241,16 @@ CPFH_RealFirstPassHandler(                  // ExceptionContinueSearch, etc.
 
     LOG((LF_EH, LL_INFO100, "CPFH_RealFirstPassHandler: handler found: %s\n", tct.pFunc->m_pszDebugMethodName));
 
+    ThreadExceptionState* pExState = pThread->GetExceptionState();
+    _ASSERTE(pExState->GetPtrToBottomFrameDuringUnwind() == NULL);
+    pExState->SetPtrToBottomFrameDuringUnwind(&tct.pBottomFrame);
+
     CallRtlUnwindSafe(pEstablisherFrame, RtlUnwindCallback, pExceptionRecord, 0);
     // on x86 at least, RtlUnwind always returns
+
+    _ASSERTE(pExState->GetPtrToBottomFrameDuringUnwind() == &tct.pBottomFrame);
+    _ASSERTE(*pExState->GetPtrToBottomFrameDuringUnwind() == tct.pBottomFrame);
+    pExState->SetPtrToBottomFrameDuringUnwind(NULL);
 
     // The CallRtlUnwindSafe could have popped the explicit frame that the tct.pBottomFrame points to (UMThunkPrestubHandler
     // does that). In such case, the tct.pBottomFrame needs to be updated to point to the first valid explicit frame.


### PR DESCRIPTION
The x86 was missing the same treatment of the explicit frames chain as
the other architectures. The chain needs to be repaired when a GCFrame
is destroyed and it was on a chain that is not current, but that is
still used by the exception handling stack walk.
Close #26877