### PR TITLE
SuperIlc improvements to facilitate its use in Crossgen2 pipeline

### DIFF
--- a/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
+++ b/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
@@ -42,6 +42,10 @@ namespace ReadyToRun.SuperIlc
 
             // TODO (TRylek): problem related to devirtualization of method without IL - System.Enum.Equals(object)
             new FrameworkExclusion("System.ComponentModel.TypeConverter", "TODO trylek - devirtualization of method without IL"),
+
+            // TODO: additional framework build failures
+            new FrameworkExclusion("Microsoft.Diagnostics.Tracing.TraceEvent", "Assert failure in JIT"),
+            new FrameworkExclusion("System.Private.CoreLib", "Assert failure in JIT"),
         };
 
         private readonly IEnumerable<BuildFolder> _buildFolders;

--- a/src/tools/ReadyToRun.SuperIlc/BuildOptions.cs
+++ b/src/tools/ReadyToRun.SuperIlc/BuildOptions.cs
@@ -16,6 +16,7 @@ namespace ReadyToRun.SuperIlc
         public bool Crossgen { get; set; }
         public bool Exe { get; set; }
         public bool NoJit { get; set; }
+        public bool NoCrossgen2 { get; set; }
         public bool NoExe { get; set; }
         public bool NoEtw { get; set; }
         public bool NoCleanup { get; set; }
@@ -78,10 +79,13 @@ namespace ReadyToRun.SuperIlc
         {
             List<CompilerRunner> runners = new List<CompilerRunner>();
 
-            List<string> cpaotReferencePaths = new List<string>();
-            cpaotReferencePaths.Add(CoreRootOutputPath(CompilerIndex.CPAOT, isFramework));
-            cpaotReferencePaths.AddRange(overrideReferencePaths != null ? overrideReferencePaths : ReferencePaths());
-            runners.Add(new CpaotRunner(this, cpaotReferencePaths));
+            if (!NoCrossgen2)
+            {
+                List<string> cpaotReferencePaths = new List<string>();
+                cpaotReferencePaths.Add(CoreRootOutputPath(CompilerIndex.CPAOT, isFramework));
+                cpaotReferencePaths.AddRange(overrideReferencePaths != null ? overrideReferencePaths : ReferencePaths());
+                runners.Add(new CpaotRunner(this, cpaotReferencePaths));
+            }
 
             if (Crossgen)
             {

--- a/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
+++ b/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
@@ -33,6 +33,7 @@ namespace ReadyToRun.SuperIlc
                         CpaotDirectory(),
                         Crossgen(),
                         NoJit(),
+                        NoCrossgen2(),
                         Exe(),
                         NoExe(),
                         NoEtw(),
@@ -63,6 +64,7 @@ namespace ReadyToRun.SuperIlc
                         CpaotDirectory(),
                         Crossgen(),
                         NoJit(),
+                        NoCrossgen2(),
                         Exe(),
                         NoExe(),
                         NoEtw(),
@@ -87,6 +89,7 @@ namespace ReadyToRun.SuperIlc
                     {
                             CoreRootDirectory(),
                             Crossgen(),
+                            NoCrossgen2(),
                             NoCleanup(),
                             DegreeOfParallelism(),
                             Sequential(),
@@ -159,6 +162,9 @@ namespace ReadyToRun.SuperIlc
 
             Option NoJit() =>
                 new Option(new[] { "--nojit" }, "Don't run tests in JITted mode", new Argument<bool>());
+
+            Option NoCrossgen2() =>
+                new Option(new[] { "--nocrossgen2" }, "Don't run tests in Crossgen2 mode", new Argument<bool>());
 
             Option Exe() =>
                 new Option(new[] { "--exe" }, "Don't compile tests, just execute them", new Argument<bool>());


### PR DESCRIPTION
1) New NoCrossgen2 option needed for using SuperIlc to build
the [legacy] Crossgen framework during native test component build;

2) Several hardenings in ProcessRunner that finally let me pass
framework build on Linux without null-refing. This would merit
a closer look at some point but for now this seems to do the trick.

3) Add exclusions for two framework assemblies that fail compiling
with Crossgen2.

Thanks

Tomas