### PR TITLE
apply StartsWith optimizations to EndsWith

### DIFF
--- a/src/corefx/System.Globalization.Native/pal_icushim.h
+++ b/src/corefx/System.Globalization.Native/pal_icushim.h
@@ -59,6 +59,7 @@
     PER_FUNCTION_BLOCK(ucol_getStrength, libicui18n) \
     PER_FUNCTION_BLOCK(ucol_getVersion, libicui18n) \
     PER_FUNCTION_BLOCK(ucol_next, libicui18n) \
+    PER_FUNCTION_BLOCK(ucol_previous, libicui18n) \
     PER_FUNCTION_BLOCK(ucol_open, libicui18n) \
     PER_FUNCTION_BLOCK(ucol_openElements, libicui18n) \
     PER_FUNCTION_BLOCK(ucol_openRules, libicui18n) \
@@ -166,6 +167,7 @@ FOR_ALL_ICU_FUNCTIONS
 #define ucol_getStrength(...) ucol_getStrength_ptr(__VA_ARGS__)
 #define ucol_getVersion(...) ucol_getVersion_ptr(__VA_ARGS__)
 #define ucol_next(...) ucol_next_ptr(__VA_ARGS__)
+#define ucol_previous(...) ucol_previous_ptr(__VA_ARGS__)
 #define ucol_open(...) ucol_open_ptr(__VA_ARGS__)
 #define ucol_openElements(...) ucol_openElements_ptr(__VA_ARGS__)
 #define ucol_openRules(...) ucol_openRules_ptr(__VA_ARGS__)


### PR DESCRIPTION
By reusing the code from #26621 I was able to get similar improvements for `EndsWith/IsSuffix`.

Using [these](https://github.com/dotnet/performance/blob/24092eb7d6da8d9ea2b018b9b2908b710650c965/src/benchmarks/micro/corefx/System.Globalization/StringSearch.cs#L93-L97) benchmarks from performance repo we can see that:

* "hit" - given string ends with given suffix is on average 4 times faster
* "miss" - last chars are different is now O(1)

 BenchmarkDotNet=v0.11.5.1188-nightly, OS=ubuntu 18.04
 Intel Xeon CPU E5-2673 v4 2.30GHz, 1 CPU, 4 logical and 2 physical cores
 .NET Core SDK=3.1.100-preview1-014415
   [Host]     : .NET Core 3.1.0 (CoreCLR 4.700.19.50102, CoreFX 4.700.19.50108), X64 RyuJIT
   Job-OCNEHW : .NET Core 5.0.0 (CoreCLR 5.0.19.50201, CoreFX 5.0.19.47707), X64 RyuJIT
   Job-GGISEQ : .NET Core 5.0.0 (CoreCLR 5.0.19.48001, CoreFX 5.0.19.47707), X64 RyuJIT

 PowerPlanMode=00000000-0000-0000-0000-000000000000  IterationTime=250.0000 ms  MaxIterationCount=20
 MinIterationCount=15  WarmupCount=1

 |                     Method |                 Toolchain |                           Options |         Mean | Ratio |
 |--------------------------- |-------------------------- |---------------------------------- |-------------:|------:|
 |        IsSuffix_SecondHalf |  /after/Core_Root/corerun |              (, IgnoreCase, True) |  5,363.90 ns |  0.23 |
 |        IsSuffix_SecondHalf | /before/Core_Root/corerun |              (, IgnoreCase, True) | 23,270.77 ns |  1.00 |
 |                            |                           |                                   |              |       |
 | IsSuffix_DifferentLastChar |  /after/Core_Root/corerun |              (, IgnoreCase, True) |    592.83 ns |  0.01 |
 | IsSuffix_DifferentLastChar | /before/Core_Root/corerun |              (, IgnoreCase, True) | 41,711.35 ns |  1.00 |
 |                            |                           |                                   |              |       |
 |        IsSuffix_SecondHalf |  /after/Core_Root/corerun |                    (, None, True) |  5,372.84 ns |  0.23 |
 |        IsSuffix_SecondHalf | /before/Core_Root/corerun |                    (, None, True) | 23,449.03 ns |  1.00 |
 |                            |                           |                                   |              |       |
 | IsSuffix_DifferentLastChar |  /after/Core_Root/corerun |                    (, None, True) |    498.15 ns |  0.01 |
 | IsSuffix_DifferentLastChar | /before/Core_Root/corerun |                    (, None, True) | 42,484.52 ns |  1.00 |
 |                            |                           |                                   |              |       |
 |        IsSuffix_SecondHalf |  /after/Core_Root/corerun |         (en-US, IgnoreCase, True) |  5,423.07 ns |  0.24 |
 |        IsSuffix_SecondHalf | /before/Core_Root/corerun |         (en-US, IgnoreCase, True) | 22,742.24 ns |  1.00 |
 |                            |                           |                                   |              |       |
 | IsSuffix_DifferentLastChar |  /after/Core_Root/corerun |         (en-US, IgnoreCase, True) |    490.05 ns |  0.01 |
 | IsSuffix_DifferentLastChar | /before/Core_Root/corerun |         (en-US, IgnoreCase, True) | 41,173.58 ns |  1.00 |
 |                            |                           |                                   |              |       |
 |        IsSuffix_SecondHalf |  /after/Core_Root/corerun |               (en-US, None, True) |  5,369.36 ns |  0.22 |
 |        IsSuffix_SecondHalf | /before/Core_Root/corerun |               (en-US, None, True) | 24,275.39 ns |  1.00 |
 |                            |                           |                                   |              |       |
 | IsSuffix_DifferentLastChar |  /after/Core_Root/corerun |               (en-US, None, True) |    487.19 ns |  0.01 |
 | IsSuffix_DifferentLastChar | /before/Core_Root/corerun |               (en-US, None, True) | 41,989.54 ns |  1.00 |
 |                            |                           |                                   |              |       |
 |        IsSuffix_SecondHalf |  /after/Core_Root/corerun |              (pl-PL, None, False) |  6,944.76 ns |  0.26 |
 |        IsSuffix_SecondHalf | /before/Core_Root/corerun |              (pl-PL, None, False) | 26,560.62 ns |  1.00 |
 |                            |                           |                                   |              |       |
 | IsSuffix_DifferentLastChar |  /after/Core_Root/corerun |              (pl-PL, None, False) |    436.11 ns | 0.009 |
 | IsSuffix_DifferentLastChar | /before/Core_Root/corerun |              (pl-PL, None, False) | 50,161.53 ns | 1.000 |