### PR TITLE
More SuperIlc changes to enable its use in CoreCLR CI pipelines

### DIFF
--- a/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
+++ b/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
@@ -310,7 +310,11 @@ namespace ReadyToRun.SuperIlc
                 foreach (CompilerRunner runner in frameworkRunners)
                 {
                     ProcessInfo compilationProcess = kvp.Value[(int)runner.Index];
-                    if (compilationProcess.Succeeded)
+                    if (compilationProcess == null)
+                    {
+                        // No compilation process (e.g. there's no real compilation phase for the JIT mode)
+                    }
+                    else if (compilationProcess.Succeeded)
                     {
                         skipCopying.Add(compilationProcess.Parameters.InputFileName);
                         AnalyzeCompilationLog(compilationProcess, runner.Index);

--- a/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
+++ b/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
@@ -20,11 +20,13 @@ namespace ReadyToRun.SuperIlc
         {
             public readonly string SimpleName;
             public readonly string Reason;
+            public readonly bool Crossgen2Only;
 
-            public FrameworkExclusion(string simpleName, string reason)
+            public FrameworkExclusion(string simpleName, string reason, bool crossgen2Only = false)
             {
                 SimpleName = simpleName;
                 Reason = reason;
+                Crossgen2Only = crossgen2Only;
             }
         }
 
@@ -36,16 +38,16 @@ namespace ReadyToRun.SuperIlc
             new FrameworkExclusion("xunit.performance.api", "Not a framework assembly"),
 
             // TODO (DavidWr): IBC-related failures
-            new FrameworkExclusion("Microsoft.CodeAnalysis.CSharp", "Ibc TypeToken 6200019a has type token which resolves to a nil token"),
-            new FrameworkExclusion("Microsoft.CodeAnalysis", "Ibc TypeToken 620001af unable to find external typedef"),
-            new FrameworkExclusion("Microsoft.CodeAnalysis.VisualBasic", "Ibc TypeToken 620002ce unable to find external typedef"),
+            new FrameworkExclusion("Microsoft.CodeAnalysis.CSharp", "Ibc TypeToken 6200019a has type token which resolves to a nil token", crossgen2Only: true),
+            new FrameworkExclusion("Microsoft.CodeAnalysis", "Ibc TypeToken 620001af unable to find external typedef", crossgen2Only: true),
+            new FrameworkExclusion("Microsoft.CodeAnalysis.VisualBasic", "Ibc TypeToken 620002ce unable to find external typedef", crossgen2Only: true),
 
             // TODO (TRylek): problem related to devirtualization of method without IL - System.Enum.Equals(object)
-            new FrameworkExclusion("System.ComponentModel.TypeConverter", "TODO trylek - devirtualization of method without IL"),
+            new FrameworkExclusion("System.ComponentModel.TypeConverter", "TODO trylek - devirtualization of method without IL", crossgen2Only: true),
 
             // TODO: additional framework build failures
-            new FrameworkExclusion("Microsoft.Diagnostics.Tracing.TraceEvent", "Assert failure in JIT"),
-            new FrameworkExclusion("System.Private.CoreLib", "Assert failure in JIT"),
+            new FrameworkExclusion("Microsoft.Diagnostics.Tracing.TraceEvent", "Assert failure in JIT", crossgen2Only: true),
+            new FrameworkExclusion("System.Private.CoreLib", "Assert failure in JIT", crossgen2Only: true),
         };
 
         private readonly IEnumerable<BuildFolder> _buildFolders;
@@ -280,16 +282,16 @@ namespace ReadyToRun.SuperIlc
             {
                 string simpleName = Path.GetFileNameWithoutExtension(frameworkDll);
                 FrameworkExclusion exclusion = s_frameworkExclusions.FirstOrDefault(asm => asm.SimpleName.Equals(simpleName, StringComparison.OrdinalIgnoreCase));
-                if (exclusion != null)
-                {
-                    _frameworkExclusions.Add(exclusion.SimpleName, exclusion.Reason);
-                    continue;
-                }
 
                 ProcessInfo[] processes = new ProcessInfo[(int)CompilerIndex.Count];
                 compilationsPerRunner.Add(new KeyValuePair<string, ProcessInfo[]>(frameworkDll, processes));
                 foreach (CompilerRunner runner in frameworkRunners)
                 {
+                    if (exclusion != null && (!exclusion.Crossgen2Only || runner.Index == CompilerIndex.CPAOT))
+                    {
+                        _frameworkExclusions.Add(exclusion.SimpleName, exclusion.Reason);
+                        continue;
+                    }
                     ProcessInfo compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, _options.CoreRootDirectory.FullName, frameworkDll));
                     compilationsToRun.Add(compilationProcess);
                     processes[(int)runner.Index] = compilationProcess;

--- a/src/tools/ReadyToRun.SuperIlc/BuildOptions.cs
+++ b/src/tools/ReadyToRun.SuperIlc/BuildOptions.cs
@@ -14,6 +14,7 @@ namespace ReadyToRun.SuperIlc
         public DirectoryInfo OutputDirectory { get; set; }
         public DirectoryInfo CoreRootDirectory { get; set; }
         public bool Crossgen { get; set; }
+        public FileInfo CrossgenPath { get; set; }
         public bool Exe { get; set; }
         public bool NoJit { get; set; }
         public bool NoCrossgen2 { get; set; }

--- a/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
+++ b/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
@@ -30,8 +30,8 @@ namespace ReadyToRun.SuperIlc
                         InputDirectory(),
                         OutputDirectory(),
                         CoreRootDirectory(),
-                        CpaotDirectory(),
                         Crossgen(),
+                        CrossgenPath(),
                         NoJit(),
                         NoCrossgen2(),
                         Exe(),
@@ -61,8 +61,8 @@ namespace ReadyToRun.SuperIlc
                         InputDirectory(),
                         OutputDirectory(),
                         CoreRootDirectory(),
-                        CpaotDirectory(),
                         Crossgen(),
+                        CrossgenPath(),
                         NoJit(),
                         NoCrossgen2(),
                         Exe(),
@@ -87,20 +87,21 @@ namespace ReadyToRun.SuperIlc
                 new Command("compile-framework", "Compile managed framework assemblies in Core_Root",
                     new Option[]
                     {
-                            CoreRootDirectory(),
-                            Crossgen(),
-                            NoCrossgen2(),
-                            NoCleanup(),
-                            DegreeOfParallelism(),
-                            Sequential(),
-                            Release(),
-                            LargeBubble(),
-                            ReferencePath(),
-                            IssuesPath(),
-                            CompilationTimeoutMinutes(),
-                            R2RDumpPath(),
-                            MeasurePerf(),
-                            InputFileSearchString(),
+                        CoreRootDirectory(),
+                        Crossgen(),
+                        CrossgenPath(),
+                        NoCrossgen2(),
+                        NoCleanup(),
+                        DegreeOfParallelism(),
+                        Sequential(),
+                        Release(),
+                        LargeBubble(),
+                        ReferencePath(),
+                        IssuesPath(),
+                        CompilationTimeoutMinutes(),
+                        R2RDumpPath(),
+                        MeasurePerf(),
+                        InputFileSearchString(),
                     },
                     handler: CommandHandler.Create<BuildOptions>(CompileFrameworkCommand.CompileFramework));
 
@@ -114,7 +115,6 @@ namespace ReadyToRun.SuperIlc
                         PackageList(),
                         CoreRootDirectory(),
                         Crossgen(),
-                        CpaotDirectory(),
                         NoCleanup(),
                         DegreeOfParallelism(),
                         CompilationTimeoutMinutes(),
@@ -131,7 +131,6 @@ namespace ReadyToRun.SuperIlc
                         OutputDirectory(),
                         CoreRootDirectory(),
                         Crossgen(),
-                        CpaotDirectory(),
                         NoCleanup(),
                         DegreeOfParallelism(),
                         CompilationTimeoutMinutes(),
@@ -151,14 +150,14 @@ namespace ReadyToRun.SuperIlc
             Option CoreRootDirectory() =>
                 new Option(new[] { "--core-root-directory", "-cr" }, "Location of the CoreCLR CORE_ROOT folder", new Argument<DirectoryInfo>().ExistingOnly());
 
-            Option CpaotDirectory() =>
-                new Option(new[] { "--cpaot-directory", "-cpaot" }, "Folder containing the CPAOT compiler", new Argument<DirectoryInfo>().ExistingOnly());
-
             Option ReferencePath() =>
                 new Option(new[] { "--reference-path", "-r" }, "Folder containing assemblies to reference during compilation", new Argument<DirectoryInfo[]>() { Arity = ArgumentArity.ZeroOrMore }.ExistingOnly());
 
             Option Crossgen() =>
                 new Option(new[] { "--crossgen" }, "Compile the apps using Crossgen in the CORE_ROOT folder", new Argument<bool>());
+
+            Option CrossgenPath() =>
+                new Option(new[] { "--crossgen-path", "-cp" }, "Explicit Crossgen path (useful for cross-targeting)", new Argument<FileInfo>().ExistingOnly());
 
             Option NoJit() =>
                 new Option(new[] { "--nojit" }, "Don't run tests in JITted mode", new Argument<bool>());

--- a/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
+++ b/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
@@ -44,6 +44,9 @@ namespace ReadyToRun.SuperIlc
 
         protected abstract string CompilerRelativePath { get;  }
         protected abstract string CompilerFileName { get; }
+
+        protected virtual string CompilerPath => Path.Combine(_options.CoreRootDirectory.FullName, CompilerRelativePath, CompilerFileName);
+        
         protected abstract IEnumerable<string> BuildCommandLineArguments(string assemblyFileName, string outputFileName);
 
         public virtual ProcessParameters CompilationProcess(string outputRoot, string assemblyFileName)
@@ -56,7 +59,7 @@ namespace ReadyToRun.SuperIlc
             CreateResponseFile(responseFile, commandLineArgs);
 
             ProcessParameters processParameters = new ProcessParameters();
-            processParameters.ProcessPath = Path.Combine(_options.CoreRootDirectory.FullName, CompilerRelativePath, CompilerFileName);
+            processParameters.ProcessPath = CompilerPath;
             processParameters.Arguments = $"@{responseFile}";
             if (_options.CompilationTimeoutMinutes != 0)
             {

--- a/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
+++ b/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
@@ -21,6 +21,14 @@ namespace ReadyToRun.SuperIlc
 
         protected override string CompilerFileName => "crossgen".OSExeSuffix();
 
+        protected override string CompilerPath
+        {
+            get
+            {
+                return _options.CrossgenPath != null ? _options.CrossgenPath.FullName : base.CompilerPath;
+            }
+        }
+
         public CrossgenRunner(BuildOptions options, IEnumerable<string> referencePaths)
             : base(options, referencePaths) { }
 

--- a/src/tools/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.csproj
+++ b/src/tools/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.csproj
@@ -7,7 +7,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <NoWarn>8002,NU1701</NoWarn>
-    <Platforms>x64;x86</Platforms>
+    <Platform>AnyCPU</Platform>
     <OutputPath>$(BinDir)\ReadyToRun.SuperIlc</OutputPath>
   </PropertyGroup>
 


### PR DESCRIPTION
1) Support for explicit specification of Crossgen path needed for
cross-targeting scenarios;

2) Make Corelib exclusion Crossgen2-specific to avoid regressing
legacy Crossgen testing;

3) Make SuperIlc "AnyCPU" so that it can run on ARM.

Thanks

Tomas