### PR TITLE
oom (#26457)

### DIFF
--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -2908,6 +2908,17 @@ public:
 
     // End DAC zone
 
+#define max_oom_history_count 4
+
+    PER_HEAP
+    int oomhist_index_per_heap;
+
+    PER_HEAP
+    oom_history oomhist_per_heap[max_oom_history_count];
+
+    PER_HEAP
+    void add_to_oom_history_per_heap();
+
     PER_HEAP
     BOOL expanded_in_fgc;
 


### PR DESCRIPTION
Bug impact:
  in Server GC, when a user specifies a hardlimit but actually uses more memory than what the hardlimit specifies, if we hit the LOH alloc path we would go into an infinite loop trying to allocate on other heaps of course only to find that we fail there too. 

PR Risks:

    Change is limited to large object alloc path, only in Server GC and only when the user is actually using more memory than the hardlimit they specified.

This is #26457 from master for 3.1

+ when hardlimit is specified we should only retry when we didn't fail due to commit failure - if commit failed it means we simply didn't have as much memory as what the hardlimit specified. we should throw OOM in this case.

+ added some diag info around OOM history to help with future diagnostics.

(cherry picked from commit 7dca41fd36721068e610c537654765e8e42275d7)