### PR TITLE
Fix assert while compiling CoreLib with optimizations

### DIFF
--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -769,6 +769,8 @@ namespace Internal.JitInterface
             {
                 if (field.IsStatic &&
                     !field.IsLiteral &&
+                    !field.HasRva &&
+                    !field.IsThreadStatic &&
                     field.FieldType.IsValueType &&
                     !field.FieldType.UnderlyingType.IsPrimitive)
                 {


### PR DESCRIPTION
The thing that lead to the assert was the fact that we reported a containing type for an RVA static field as not being preinitialized.

The `!field.HasRva` is the bugfix. `!field.IsThreadStatic` is just something that we also should do to match crossgen.