### PR TITLE
Improve TimeSpan precision

### DIFF
--- a/src/System.Private.CoreLib/shared/System/TimeSpan.cs
+++ b/src/System.Private.CoreLib/shared/System/TimeSpan.cs
@@ -28,19 +28,14 @@ namespace System
     public readonly struct TimeSpan : IComparable, IComparable<TimeSpan>, IEquatable<TimeSpan>, IFormattable, ISpanFormattable
     {
         public const long TicksPerMillisecond = 10000;
-        private const double MillisecondsPerTick = 1.0 / TicksPerMillisecond;
 
         public const long TicksPerSecond = TicksPerMillisecond * 1000;   // 10,000,000
-        private const double SecondsPerTick = 1.0 / TicksPerSecond;         // 0.0000001
 
         public const long TicksPerMinute = TicksPerSecond * 60;         // 600,000,000
-        private const double MinutesPerTick = 1.0 / TicksPerMinute; // 1.6666666666667e-9
 
         public const long TicksPerHour = TicksPerMinute * 60;        // 36,000,000,000
-        private const double HoursPerTick = 1.0 / TicksPerHour; // 2.77777777777777778e-11
 
         public const long TicksPerDay = TicksPerHour * 24;          // 864,000,000,000
-        private const double DaysPerTick = 1.0 / TicksPerDay; // 1.1574074074074074074e-12
 
         internal const long MaxSeconds = long.MaxValue / TicksPerSecond;
         internal const long MinSeconds = long.MinValue / TicksPerSecond;
@@ -94,15 +89,15 @@ namespace System
 
         public int Seconds => (int)((_ticks / TicksPerSecond) % 60);
 
-        public double TotalDays => ((double)_ticks) * DaysPerTick;
+        public double TotalDays => ((double)_ticks) / TicksPerDay;
 
-        public double TotalHours => (double)_ticks * HoursPerTick;
+        public double TotalHours => (double)_ticks / TicksPerHour;
 
         public double TotalMilliseconds
         {
             get
             {
-                double temp = (double)_ticks * MillisecondsPerTick;
+                double temp = (double)_ticks / TicksPerMillisecond;
                 if (temp > MaxMilliSeconds)
                     return (double)MaxMilliSeconds;
 
@@ -113,9 +108,9 @@ namespace System
             }
         }
 
-        public double TotalMinutes => (double)_ticks * MinutesPerTick;
+        public double TotalMinutes => (double)_ticks / TicksPerMinute;
 
-        public double TotalSeconds => (double)_ticks * SecondsPerTick;
+        public double TotalSeconds => (double)_ticks / TicksPerSecond;
 
         public TimeSpan Add(TimeSpan ts)
         {
@@ -204,10 +199,10 @@ namespace System
         {
             if (double.IsNaN(value))
                 throw new ArgumentException(SR.Arg_CannotBeNaN);
-            double millis = value * scale;
-            if ((millis > long.MaxValue) || (millis < long.MinValue))
+            double ticks = value * scale;
+            if ((ticks > long.MaxValue) || (ticks < long.MinValue))
                 throw new OverflowException(SR.Overflow_TimeSpanTooLong);
-            return new TimeSpan((long)millis);
+            return new TimeSpan((long)ticks);
         }
 
         public static TimeSpan FromMilliseconds(double value)


### PR DESCRIPTION
Fixes [dotnet/corefx#41380](https://github.com/dotnet/corefx/issues/41380)

Related corefx PR [dotnet/coreclr#41499](https://github.com/dotnet/corefx/pull/41499)

Change multiplying by (x * (1.0 / BigValue)) on (x / BigValue).
