### PR TITLE
Fix read ordering bug between buckets pointer and counter

### DIFF
--- a/src/vm/ngenhash.inl
+++ b/src/vm/ngenhash.inl
@@ -151,7 +151,7 @@ void NgenHashTable<NGEN_HASH_ARGS>::BaseInsertEntry(NgenHashValue iHash, VALUE *
     pVolatileEntry->m_iHashValue = iHash;
 
     // Compute which bucket the entry belongs in based on the hash.
-    DWORD dwBucket = iHash % m_cWarmBuckets;
+    DWORD dwBucket = iHash % VolatileLoad(&m_cWarmBuckets);
 
     // Prepare to link the new entry at the head of the bucket chain.
     pVolatileEntry->m_pNextEntry = (GetWarmBuckets())[dwBucket];
@@ -1264,7 +1264,7 @@ DPTR(VALUE) NgenHashTable<NGEN_HASH_ARGS>::FindVolatileEntryByHash(NgenHashValue
     _ASSERTE(m_cWarmBuckets > 0);
 
     // Compute which bucket the entry belongs in based on the hash.
-    DWORD dwBucket = iHash % m_cWarmBuckets;
+    DWORD dwBucket = iHash % VolatileLoad(&m_cWarmBuckets);
 
     // Point at the first entry in the bucket chain which would contain any entries with the given hash code.
     PTR_VolatileEntry pEntry = (GetWarmBuckets())[dwBucket];

--- a/src/vm/ngenhash.inl
+++ b/src/vm/ngenhash.inl
@@ -151,7 +151,7 @@ void NgenHashTable<NGEN_HASH_ARGS>::BaseInsertEntry(NgenHashValue iHash, VALUE *
     pVolatileEntry->m_iHashValue = iHash;
 
     // Compute which bucket the entry belongs in based on the hash.
-    DWORD dwBucket = iHash % VolatileLoad(&m_cWarmBuckets);
+    DWORD dwBucket = iHash % m_cWarmBuckets;
 
     // Prepare to link the new entry at the head of the bucket chain.
     pVolatileEntry->m_pNextEntry = (GetWarmBuckets())[dwBucket];

--- a/src/vm/ngenhash.inl
+++ b/src/vm/ngenhash.inl
@@ -1263,8 +1263,11 @@ DPTR(VALUE) NgenHashTable<NGEN_HASH_ARGS>::FindVolatileEntryByHash(NgenHashValue
     // Since there is at least one entry there must be at least one bucket.
     _ASSERTE(m_cWarmBuckets > 0);
 
+    // Compute which bucket the entry belongs in based on the hash.
+    DWORD dwBucket = iHash % m_cWarmBuckets;
+
     // Point at the first entry in the bucket chain which would contain any entries with the given hash code.
-    PTR_VolatileEntry pEntry = (GetWarmBuckets())[iHash % m_cWarmBuckets];
+    PTR_VolatileEntry pEntry = (GetWarmBuckets())[dwBucket];
 
     // Walk the bucket chain one entry at a time.
     while (pEntry)


### PR DESCRIPTION
Fixes #26870 where there is a read ordering issue on this line:
``` c++
    // Point at the first entry in the bucket chain which would contain any entries with the given hash code.
    PTR_VolatileEntry pEntry = (GetWarmBuckets())[iHash % m_cWarmBuckets];
```

I confirmed the fix should work by comparing the disasm. The buckets pointer is read after `m_cWarmBuckets` is read and the division executed:

Before:
``` asm
  353 1008b9ba 8b4e08          mov     ecx,dword ptr [esi+8]
  353 1008b9bd 33d2            xor     edx,edx
  353 1008b9bf 8bc3            mov     eax,ebx
  353 1008b9c1 f7760c          div     eax,dword ptr [esi+0Ch]
  353 1008b9c4 8b3c91          mov     edi,dword ptr [ecx+edx*4]
  353 1008b9c7 85ff            test    edi,edi
```

After:
``` asm
  353 10086dea 8bc3            mov     eax,ebx
  353 10086dec 33d2            xor     edx,edx
  353 10086dee f7710c          div     eax,dword ptr [ecx+0Ch]
  353 10086df1 8b4108          mov     eax,dword ptr [ecx+8]
  353 10086df4 8b3c90          mov     edi,dword ptr [eax+edx*4]
  353 10086df7 85ff            test    edi,edi
```

Based on a conversation with @janvorli, a memory barrier could also help, but would be an overkill. The instruction ordering is a good enough guarantee here, especially that there is another place in the code with a similar pattern that never crashed:
``` c++
    // Compute which bucket the entry belongs in based on the hash.
    DWORD dwBucket = iHash % m_cWarmBuckets;

    // Prepare to link the new entry at the head of the bucket chain.
    pVolatileEntry->m_pNextEntry = (GetWarmBuckets())[dwBucket];
```

I'll also run the repro on a dedicated machine for a few 1000's of iterations to make sure it doesn't crash. This is a dedicated machine where I was able to get it to crash before.