### PR TITLE
Add ExceptionDispatchInfo.SetCurrentStackTrace

### DIFF
--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -2228,7 +2228,7 @@
     <value>--- End of inner exception stack trace ---</value>
   </data>
   <data name="Exception_EndStackTraceFromPreviousThrow" xml:space="preserve">
-    <value>--- End of stack trace from previous location where exception was thrown ---</value>
+    <value>--- End of stack trace from previous location ---</value>
   </data>
   <data name="Exception_WasThrown" xml:space="preserve">
     <value>Exception of type '{0}' was thrown.</value>

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/StackTrace.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/StackTrace.cs
@@ -194,11 +194,16 @@ namespace System.Diagnostics
         /// </summary>
         internal string ToString(TraceFormat traceFormat)
         {
+            var sb = new StringBuilder(256);
+            ToString(traceFormat, sb);
+            return sb.ToString();
+        }
+
+        internal void ToString(TraceFormat traceFormat, StringBuilder sb)
+        {
             string word_At = SR.Word_At;
             string inFileLineNum = SR.StackTrace_InFileLineNumber;
-
             bool fFirstFrame = true;
-            StringBuilder sb = new StringBuilder(255);
             for (int iFrameIndex = 0; iFrameIndex < _numOfFrames; iFrameIndex++)
             {
                 StackFrame? sf = GetFrame(iFrameIndex);
@@ -210,7 +215,7 @@ namespace System.Diagnostics
                     if (fFirstFrame)
                         fFirstFrame = false;
                     else
-                        sb.Append(Environment.NewLineConst);
+                        sb.AppendLine();
 
                     sb.AppendFormat(CultureInfo.InvariantCulture, "   {0} ", word_At);
 
@@ -320,16 +325,14 @@ namespace System.Diagnostics
                     // Skip EDI boundary for async
                     if (sf.IsLastFrameFromForeignExceptionStackTrace && !isAsync)
                     {
-                        sb.Append(Environment.NewLineConst);
+                        sb.AppendLine();
                         sb.Append(SR.Exception_EndStackTraceFromPreviousThrow);
                     }
                 }
             }
 
             if (traceFormat == TraceFormat.TrailingNewLine)
-                sb.Append(Environment.NewLineConst);
-
-            return sb.ToString();
+                sb.AppendLine();
         }
 #endif // !CORERT
 

--- a/src/System.Private.CoreLib/shared/System/Exception.cs
+++ b/src/System.Private.CoreLib/shared/System/Exception.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.Diagnostics;
 using System.Runtime.Serialization;
 
 namespace System
@@ -158,5 +159,22 @@ namespace System
         public new Type GetType() => base.GetType();
 
         partial void RestoreRemoteStackTrace(SerializationInfo info, StreamingContext context);
+
+        [StackTraceHidden]
+        internal void SetCurrentStackTrace()
+        {
+            if (_stackTrace != null || _remoteStackTraceString != null)
+            {
+                ThrowHelper.ThrowInvalidOperationException();
+            }
+
+            if (!IsImmutableAgileException(this))
+            {
+                SetCurrentStackTraceCore();
+            }
+        }
+
+        [StackTraceHidden]
+        partial void SetCurrentStackTraceCore();
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Exception.cs
+++ b/src/System.Private.CoreLib/shared/System/Exception.cs
@@ -159,22 +159,5 @@ namespace System
         public new Type GetType() => base.GetType();
 
         partial void RestoreRemoteStackTrace(SerializationInfo info, StreamingContext context);
-
-        [StackTraceHidden]
-        internal void SetCurrentStackTrace()
-        {
-            if (_stackTrace != null || _remoteStackTraceString != null)
-            {
-                ThrowHelper.ThrowInvalidOperationException();
-            }
-
-            if (!IsImmutableAgileException(this))
-            {
-                SetCurrentStackTraceCore();
-            }
-        }
-
-        [StackTraceHidden]
-        partial void SetCurrentStackTraceCore();
     }
 }

--- a/src/System.Private.CoreLib/shared/System/IO/FileStreamCompletionSource.Win32.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileStreamCompletionSource.Win32.cs
@@ -4,6 +4,7 @@
 
 using System.Buffers;
 using System.Diagnostics;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -186,7 +187,9 @@ namespace System.IO
                     }
                     else
                     {
-                        TrySetException(Win32Marshal.GetExceptionForWin32Error(errorCode));
+                        Exception e = Win32Marshal.GetExceptionForWin32Error(errorCode);
+                        e.SetCurrentStackTrace();
+                        TrySetException(e);
                     }
                 }
                 else

--- a/src/System.Private.CoreLib/shared/System/Runtime/ExceptionServices/ExceptionDispatchInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/ExceptionServices/ExceptionDispatchInfo.cs
@@ -61,5 +61,23 @@ namespace System.Runtime.ExceptionServices
         // rather than replacing the original stack trace.
         [DoesNotReturn]
         public static void Throw(Exception source) => Capture(source).Throw();
+
+        /// <summary>Stores the current stack trace into the specified <see cref="Exception"/> instance.</summary>
+        /// <param name="source">The unthrown <see cref="Exception"/> instance.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="source"/> argument was null.</exception>
+        /// <exception cref="InvalidOperationException">The <paramref name="source"/> argument was previously thrown or previously had a stack trace stored into it..</exception>
+        /// <returns>The <paramref name="source"/> exception instance.</returns>
+        [StackTraceHidden]
+        public static Exception SetCurrentStackTrace(Exception source)
+        {
+            if (source is null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            source.SetCurrentStackTrace();
+
+            return source;
+        }
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Threading/Tasks/Task.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Tasks/Task.cs
@@ -1802,6 +1802,7 @@ namespace System.Threading.Tasks
                 // may not contain a TCE, but an OCE or any OCE-derived type, which would mean we'd be
                 // propagating an exception of a different type.
                 canceledException = new TaskCanceledException(this);
+                canceledException.SetCurrentStackTrace();
             }
 
             if (ExceptionRecorded)

--- a/src/System.Private.CoreLib/shared/System/Threading/Timer.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/Timer.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 
 namespace System.Threading
@@ -533,7 +534,9 @@ namespace System.Threading
                         // returning false if you use it multiple times. Since first calling Timer.Dispose(WaitHandle)
                         // and then calling Timer.DisposeAsync is not something anyone is likely to or should do, we
                         // simplify by just failing in that case.
-                        return new ValueTask(Task.FromException(new InvalidOperationException(SR.InvalidOperation_TimerAlreadyClosed)));
+                        var e = new InvalidOperationException(SR.InvalidOperation_TimerAlreadyClosed);
+                        e.SetCurrentStackTrace();
+                        return new ValueTask(Task.FromException(e));
                     }
                 }
                 else

--- a/src/System.Private.CoreLib/src/System/Exception.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Exception.CoreCLR.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
+using System.Text;
 
 namespace System
 {
@@ -421,14 +422,29 @@ namespace System
                 _remoteStackTraceString, _ipForWatsonBuckets, _watsonBuckets);
         }
 
-        partial void SetCurrentStackTraceCore()
+        [StackTraceHidden]
+        internal void SetCurrentStackTrace()
         {
-            // Store the current stack trace into the "remote" stack trace, which was originally introduced
-            // to support remoting of exceptions across app-domain boundaries, and is thus concatenated into
-            // Exception.StackTrace when it's retrieved.
-            _remoteStackTraceString =
-                Environment.StackTrace + Environment.NewLine +
-                SR.Exception_EndStackTraceFromPreviousThrow + Environment.NewLine;
+            // If this is a preallocated singleton exception, silently skip the operation,
+            // regardless of the value of throwIfHasExistingStack.
+            if (IsImmutableAgileException(this))
+            {
+                return;
+            }
+
+            // Check to see if the exception already has a stack set in it.
+            if (_stackTrace != null || _stackTraceString != null || _remoteStackTraceString != null)
+            {
+                ThrowHelper.ThrowInvalidOperationException();
+            }
+
+            // Store the current stack trace into the "remote" stack trace, which was originally introduced to support
+            // remoting of exceptions cross app-domain boundaries, and is thus concatenated into Exception.StackTrace
+            // when it's retrieved.
+            var sb = new StringBuilder(256);
+            new StackTrace(fNeedFileInfo: true).ToString(System.Diagnostics.StackTrace.TraceFormat.TrailingNewLine, sb);
+            sb.AppendLine(SR.Exception_EndStackTraceFromPreviousThrow);
+            _remoteStackTraceString = sb.ToString();
         }
     }
 }

--- a/src/System.Private.CoreLib/src/System/Exception.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Exception.CoreCLR.cs
@@ -420,5 +420,15 @@ namespace System
             return new DispatchState(stackTrace, dynamicMethods,
                 _remoteStackTraceString, _ipForWatsonBuckets, _watsonBuckets);
         }
+
+        partial void SetCurrentStackTraceCore()
+        {
+            // Store the current stack trace into the "remote" stack trace, which was originally introduced
+            // to support remoting of exceptions across app-domain boundaries, and is thus concatenated into
+            // Exception.StackTrace when it's retrieved.
+            _remoteStackTraceString =
+                Environment.StackTrace + Environment.NewLine +
+                SR.Exception_EndStackTraceFromPreviousThrow + Environment.NewLine;
+        }
     }
 }


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/19416

Two open questions from me as I was doing this tonight:
1. Based on all of the places I ended up using this in corefx in https://github.com/dotnet/corefx/pull/41514, it made the code much simpler to have SetCurrentStackTrace return the passed in instance.  @terrajobst, @bartonjs, any concerns with that from an API design perspective?
2. I currently have the method checking/throwing if the Exception was previously thrown or if SetCurrentStackTrace was previously used, but I went back and forth on whether that was a good idea, and could be convinced otherwise.  Opinions?

cc: @jkotas

Here's an example of how this manifest.  This C# program:
```C#
using System;
using System.Diagnostics;
using System.Net;
using System.Net.Http;
using System.Net.Sockets;
using System.Threading;
using System.Threading.Tasks;

class Program
{
    public static async Task Main()
    {
        using Socket listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
        listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
        listener.Listen(1);

        using Socket tmp = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
        tmp.Connect(listener.LocalEndPoint);

        using var c = new HttpClient();
        var cts = new CancellationTokenSource();
        Task<HttpResponseMessage> t = c.GetAsync("http://localhost:" + ((IPEndPoint)listener.LocalEndPoint).Port, cts.Token);
        await Task.Delay(1);
        cts.Cancel();
        await t;
    }
}
```
On .NET Core 3.0, it outputs this:
```
Unhandled exception. System.Threading.Tasks.TaskCanceledException: The operation was canceled.
   at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.ConnectAsync(HttpRequestMessage request, Boolean allowHttp2, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.CreateHttp11ConnectionAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.GetHttpConnectionAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.SendWithRetryAsync(HttpRequestMessage request, Boolean doRequestAuth, CancellationToken cancellationToken)
   at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.FinishSendAsyncBuffered(Task`1 sendTask, HttpRequestMessage request, CancellationTokenSource cts, Boolean disposeCts)
   at Program.Main() in c:\Users\stoub\Desktop\tmpapp\Program.cs:line 25
   at Program.<Main>()
```
With this API and the corresponding changes in corefx, it now results in:
```
Unhandled exception. System.Threading.Tasks.TaskCanceledException: The operation was canceled.
   at System.Environment.get_StackTrace()
   at System.Net.Http.ConnectHelper.ConnectEventArgs.OnCompleted(SocketAsyncEventArgs _) in D:\repos\corefx\src\System.Net.Http\src\System\Net\Http\SocketsHttpHandler\ConnectHelper.cs:line 110
   at System.Net.Sockets.SocketAsyncEventArgs.ExecutionCallback(Object state) in D:\repos\corefx\src\System.Net.Sockets\src\System\Net\Sockets\SocketAsyncEventArgs.cs:line 423
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Net.Sockets.SocketAsyncEventArgs.FinishConnectByNameAsyncFailure(Exception exception, Int32 bytesTransferred, SocketFlags flags) in D:\repos\corefx\src\System.Net.Sockets\src\System\Net\Sockets\SocketAsyncEventArgs.cs:line 648
   at System.Net.Sockets.MultipleConnectAsync.AsyncFail(Exception e) in D:\repos\corefx\src\System.Net.Sockets\src\System\Net\Sockets\MultipleConnectAsync.cs:line 338
   at System.Net.Sockets.MultipleConnectAsync.InternalConnectCallback(Object sender, SocketAsyncEventArgs args) in D:\repos\corefx\src\System.Net.Sockets\src\System\Net\Sockets\MultipleConnectAsync.cs:line 223
   at System.Net.Sockets.SocketAsyncEventArgs.OnCompleted(SocketAsyncEventArgs e) in D:\repos\corefx\src\System.Net.Sockets\src\System\Net\Sockets\SocketAsyncEventArgs.cs:line 203
   at System.Net.Sockets.SocketAsyncEventArgs.ExecutionCallback(Object state) in D:\repos\corefx\src\System.Net.Sockets\src\System\Net\Sockets\SocketAsyncEventArgs.cs:line 423
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Net.Sockets.SocketAsyncEventArgs.FinishOperationAsyncFailure(SocketError socketError, Int32 bytesTransferred, SocketFlags flags) in D:\repos\corefx\src\System.Net.Sockets\src\System\Net\Sockets\SocketAsyncEventArgs.cs:line 632
   at System.Net.Sockets.SocketAsyncEventArgs.HandleCompletionPortCallbackError(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* nativeOverlapped) in D:\repos\corefx\src\System.Net.Sockets\src\System\Net\Sockets\SocketAsyncEventArgs.Windows.cs:line 1305
   at System.Net.Sockets.SocketAsyncEventArgs.<>c.<.cctor>b__177_0(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* nativeOverlapped) in D:\repos\corefx\src\System.Net.Sockets\src\System\Net\Sockets\SocketAsyncEventArgs.Windows.cs:line 1267
   at System.Threading.ThreadPoolBoundHandleOverlapped.CompletionCallback(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* nativeOverlapped)
   at System.Threading._IOCompletionCallback.PerformIOCompletionCallback(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* pNativeOverlapped)
--- End of stack trace from previous location ---
   at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken) in D:\repos\corefx\src\System.Net.Http\src\System\Net\Http\SocketsHttpHandler\ConnectHelper.cs:line 55
   at System.Net.Http.HttpConnectionPool.ConnectAsync(HttpRequestMessage request, Boolean allowHttp2, CancellationToken cancellationToken) in D:\repos\corefx\src\System.Net.Http\src\System\Net\Http\SocketsHttpHandler\HttpConnectionPool.cs:line 625
   at System.Net.Http.HttpConnectionPool.CreateHttp11ConnectionAsync(HttpRequestMessage request, CancellationToken cancellationToken) in D:\repos\corefx\src\System.Net.Http\src\System\Net\Http\SocketsHttpHandler\HttpConnectionPool.cs:line 665
   at System.Net.Http.HttpConnectionPool.GetHttpConnectionAsync(HttpRequestMessage request, CancellationToken cancellationToken) in D:\repos\corefx\src\System.Net.Http\src\System\Net\Http\SocketsHttpHandler\HttpConnectionPool.cs:line 331
   at System.Net.Http.HttpConnectionPool.SendWithRetryAsync(HttpRequestMessage request, Boolean doRequestAuth, CancellationToken cancellationToken) in D:\repos\corefx\src\System.Net.Http\src\System\Net\Http\SocketsHttpHandler\HttpConnectionPool.cs:line 523
   at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) in D:\repos\corefx\src\System.Net.Http\src\System\Net\Http\SocketsHttpHandler\RedirectHandler.cs:line 33
   at System.Net.Http.HttpClient.FinishSendAsyncBuffered(Task`1 sendTask, HttpRequestMessage request, CancellationTokenSource cts, Boolean disposeCts) in D:\repos\corefx\src\System.Net.Http\src\System\Net\Http\HttpClient.cs:line 521
   at Program.Main() in d:\CoreClrTest\test.cs:line 25
   at Program.<Main>()
```
which provides a lot more details about why this happened.