### PR TITLE
Update FCall comment

### DIFF
--- a/src/vm/fcall.h
+++ b/src/vm/fcall.h
@@ -378,7 +378,7 @@ LPVOID __FCThrowArgument(LPVOID me, enum RuntimeExceptionKind reKind, LPCWSTR ar
 #ifdef __GNUC__
 #define F_CALL_CONV __attribute__((cdecl, regparm(3)))
 
-// GCC FCALL convention (simulated via cdecl) is different from MSVC FCALL convention. GCC can use up
+// GCC FCALL convention (simulated via cdecl, regparm(3)) is different from MSVC FCALL convention. GCC can use up
 // to 3 registers to store parameters. The registers used are EAX, EDX, ECX. Dummy parameters and reordering
 // of the actual parameters in the FCALL signature is used to make the calling convention to look like in MSVC.
 #define SWIZZLE_REGARG_ORDER

--- a/src/vm/fcall.h
+++ b/src/vm/fcall.h
@@ -378,7 +378,7 @@ LPVOID __FCThrowArgument(LPVOID me, enum RuntimeExceptionKind reKind, LPCWSTR ar
 #ifdef __GNUC__
 #define F_CALL_CONV __attribute__((cdecl, regparm(3)))
 
-// GCC fastcall convention (simulated via stdcall) is different from MSVC fastcall convention. GCC can use up
+// GCC FCALL convention (simulated via cdecl) is different from MSVC FCALL convention. GCC can use up
 // to 3 registers to store parameters. The registers used are EAX, EDX, ECX. Dummy parameters and reordering
 // of the actual parameters in the FCALL signature is used to make the calling convention to look like in MSVC.
 #define SWIZZLE_REGARG_ORDER


### PR DESCRIPTION
https://github.com/dotnet/coreclr/issues/26989#issuecomment-537528244

> The comment is a bit misleading. It is not talking about fastcall calling convention that compiler understands, but rather about calling convention for calls that coreclr runtime calls FCalls (or fast calls).