### PR TITLE
Fix read ordering bug between buckets pointer and counter (#26997)

### DIFF
--- a/src/vm/ngenhash.inl
+++ b/src/vm/ngenhash.inl
@@ -1263,8 +1263,11 @@ DPTR(VALUE) NgenHashTable<NGEN_HASH_ARGS>::FindVolatileEntryByHash(NgenHashValue
     // Since there is at least one entry there must be at least one bucket.
     _ASSERTE(m_cWarmBuckets > 0);
 
+    // Compute which bucket the entry belongs in based on the hash.
+    DWORD dwBucket = iHash % VolatileLoad(&m_cWarmBuckets);
+
     // Point at the first entry in the bucket chain which would contain any entries with the given hash code.
-    PTR_VolatileEntry pEntry = (GetWarmBuckets())[iHash % m_cWarmBuckets];
+    PTR_VolatileEntry pEntry = (GetWarmBuckets())[dwBucket];
 
     // Walk the bucket chain one entry at a time.
     while (pEntry)


### PR DESCRIPTION
Bug impact:

#26870 can cause an AV when the bucket table and bucket count is updated by another thread while the current thread has already read the old bucket table pointer and stored it in a register, and start using it with the updated bucket count.
This is an ordering issue between 2 read operations that was uncovered by a compiler update.
The fix is to order the reads by using a VolatileLoad, which uses a memory barrier

PR Risks: None

This is #26997 from master for 3.1
Fixes #26870 for 3.1


cc @MeiChin-Tsai 