### PR TITLE
Use const internally in corelib for Environment.NewLine

### DIFF
--- a/src/System.Private.CoreLib/shared/System/AggregateException.cs
+++ b/src/System.Private.CoreLib/shared/System/AggregateException.cs
@@ -443,7 +443,7 @@ namespace System
                 if (m_innerExceptions[i] == InnerException)
                     continue; // Already logged in base.ToString()
 
-                text.Append(Environment.NewLine).Append(InnerExceptionPrefix);
+                text.Append(Environment.NewLineConst + InnerExceptionPrefix);
                 text.AppendFormat(CultureInfo.InvariantCulture, SR.AggregateException_InnerException, i);
                 text.Append(m_innerExceptions[i].ToString());
                 text.Append("<---");

--- a/src/System.Private.CoreLib/shared/System/AppDomain.cs
+++ b/src/System.Private.CoreLib/shared/System/AppDomain.cs
@@ -158,7 +158,7 @@ namespace System
         public bool IsFinalizingForUnload() => false;
 
         public override string ToString() =>
-            SR.AppDomain_Name + FriendlyName + Environment.NewLine + SR.AppDomain_NoContextPolicies;
+            SR.AppDomain_Name + FriendlyName + Environment.NewLineConst + SR.AppDomain_NoContextPolicies;
 
         public static void Unload(AppDomain domain)
         {

--- a/src/System.Private.CoreLib/shared/System/ArgumentOutOfRangeException.cs
+++ b/src/System.Private.CoreLib/shared/System/ArgumentOutOfRangeException.cs
@@ -81,7 +81,7 @@ namespace System
                     string valueMessage = SR.Format(SR.ArgumentOutOfRange_ActualValue, _actualValue);
                     if (s == null)
                         return valueMessage;
-                    return s + Environment.NewLine + valueMessage;
+                    return s + Environment.NewLineConst + valueMessage;
                 }
                 return s;
             }

--- a/src/System.Private.CoreLib/shared/System/BadImageFormatException.cs
+++ b/src/System.Private.CoreLib/shared/System/BadImageFormatException.cs
@@ -96,20 +96,18 @@ namespace System
             string s = GetType().ToString() + ": " + Message;
 
             if (!string.IsNullOrEmpty(_fileName))
-                s += Environment.NewLine + SR.Format(SR.IO_FileName_Name, _fileName);
+                s += Environment.NewLineConst + SR.Format(SR.IO_FileName_Name, _fileName);
 
             if (InnerException != null)
-                s = s + InnerExceptionPrefix + InnerException.ToString();
+                s += InnerExceptionPrefix + InnerException.ToString();
 
             if (StackTrace != null)
-                s += Environment.NewLine + StackTrace;
+                s += Environment.NewLineConst + StackTrace;
 
             if (_fusionLog != null)
             {
                 s ??= " ";
-                s += Environment.NewLine;
-                s += Environment.NewLine;
-                s += _fusionLog;
+                s += Environment.NewLineConst + Environment.NewLineConst + _fusionLog;
             }
 
             return s;

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/DebugProvider.cs
@@ -29,11 +29,11 @@ namespace System.Diagnostics
 
         internal void WriteAssert(string stackTrace, string? message, string? detailMessage)
         {
-            WriteLine(SR.DebugAssertBanner + Environment.NewLine
-                   + SR.DebugAssertShortMessage + Environment.NewLine
-                   + message + Environment.NewLine
-                   + SR.DebugAssertLongMessage + Environment.NewLine
-                   + detailMessage + Environment.NewLine
+            WriteLine(SR.DebugAssertBanner + Environment.NewLineConst
+                   + SR.DebugAssertShortMessage + Environment.NewLineConst
+                   + message + Environment.NewLineConst
+                   + SR.DebugAssertLongMessage + Environment.NewLineConst
+                   + detailMessage + Environment.NewLineConst
                    + stackTrace);
         }
 
@@ -52,7 +52,7 @@ namespace System.Diagnostics
                     _needIndent = false;
                 }
                 WriteCore(message);
-                if (message.EndsWith(Environment.NewLine))
+                if (message.EndsWith(Environment.NewLineConst))
                 {
                     _needIndent = true;
                 }
@@ -61,7 +61,7 @@ namespace System.Diagnostics
 
         public virtual void WriteLine(string? message)
         {
-            Write(message + Environment.NewLine);
+            Write(message + Environment.NewLineConst);
         }
 
         public virtual void OnIndentLevelChanged(int indentLevel) { }
@@ -84,7 +84,7 @@ namespace System.Diagnostics
 
                 s = s.Trim();
                 if (s.Length > 0)
-                    s += Environment.NewLine;
+                    s += Environment.NewLineConst;
 
                 return s;
             }

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/StackFrame.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/StackFrame.cs
@@ -240,7 +240,7 @@ namespace System.Diagnostics
             {
                 sb.Append("<null>");
             }
-            sb.Append(Environment.NewLine);
+            sb.Append(Environment.NewLineConst);
 
             return sb.ToString();
         }

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/StackTrace.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/StackTrace.cs
@@ -210,7 +210,7 @@ namespace System.Diagnostics
                     if (fFirstFrame)
                         fFirstFrame = false;
                     else
-                        sb.Append(Environment.NewLine);
+                        sb.Append(Environment.NewLineConst);
 
                     sb.AppendFormat(CultureInfo.InvariantCulture, "   {0} ", word_At);
 
@@ -320,14 +320,14 @@ namespace System.Diagnostics
                     // Skip EDI boundary for async
                     if (sf.IsLastFrameFromForeignExceptionStackTrace && !isAsync)
                     {
-                        sb.Append(Environment.NewLine);
+                        sb.Append(Environment.NewLineConst);
                         sb.Append(SR.Exception_EndStackTraceFromPreviousThrow);
                     }
                 }
             }
 
             if (traceFormat == TraceFormat.TrailingNewLine)
-                sb.Append(Environment.NewLine);
+                sb.Append(Environment.NewLineConst);
 
             return sb.ToString();
         }

--- a/src/System.Private.CoreLib/shared/System/Environment.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Environment.Unix.cs
@@ -295,7 +295,7 @@ namespace System
             }
         }
 
-        public static string NewLine => "\n";
+        internal const string NewLineConst = "\n";
 
         private static OperatingSystem GetOSVersion() => GetOperatingSystem(Interop.Sys.GetUnixRelease());
 

--- a/src/System.Private.CoreLib/shared/System/Environment.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Environment.Windows.cs
@@ -47,7 +47,7 @@ namespace System
 
         public static string[] GetLogicalDrives() => DriveInfoInternal.GetLogicalDrives();
 
-        public static string NewLine => "\r\n";
+        internal const string NewLineConst = "\r\n";
 
         public static int SystemPageSize
         {

--- a/src/System.Private.CoreLib/shared/System/Environment.cs
+++ b/src/System.Private.CoreLib/shared/System/Environment.cs
@@ -112,6 +112,8 @@ namespace System
 
         public static bool Is64BitOperatingSystem => Is64BitProcess || Is64BitOperatingSystemWhen32BitProcess;
 
+        public static string NewLine => NewLineConst;
+
         private static OperatingSystem? s_osVersion;
 
         public static OperatingSystem OSVersion

--- a/src/System.Private.CoreLib/shared/System/Exception.cs
+++ b/src/System.Private.CoreLib/shared/System/Exception.cs
@@ -129,14 +129,13 @@ namespace System
 
             if (_innerException != null)
             {
-                s = s + Environment.NewLine + InnerExceptionPrefix + _innerException.ToString() + Environment.NewLine +
-                "   " + SR.Exception_EndOfInnerExceptionStack;
+                s += Environment.NewLineConst + InnerExceptionPrefix + _innerException.ToString() + Environment.NewLineConst + "   " + SR.Exception_EndOfInnerExceptionStack;
             }
 
             string? stackTrace = StackTrace;
             if (stackTrace != null)
             {
-                s += Environment.NewLine + stackTrace;
+                s += Environment.NewLineConst + stackTrace;
             }
 
             return s;

--- a/src/System.Private.CoreLib/shared/System/Globalization/CultureNotFoundException.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CultureNotFoundException.cs
@@ -95,7 +95,7 @@ namespace System.Globalization
                         return valueMessage;
                     }
 
-                    return s + Environment.NewLine + valueMessage;
+                    return s + Environment.NewLineConst + valueMessage;
                 }
                 return s;
             }

--- a/src/System.Private.CoreLib/shared/System/Globalization/DateTimeParse.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/DateTimeParse.cs
@@ -5185,7 +5185,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
                 if (s.Length > MaxLineLength || (curLineLength + s.Length + 2) > MaxLineLength)
                 {
                     buffer.Append(',');
-                    buffer.Append(Environment.NewLine);
+                    buffer.Append(Environment.NewLineConst);
                     buffer.Append(' ', NewLinePadding);
                     curLineLength = 0;
                 }
@@ -5202,7 +5202,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
             s = Hex(strs[strs.Length - 1]);
             if (s.Length > MaxLineLength || (curLineLength + s.Length + 6) > MaxLineLength)
             {
-                buffer.Append(Environment.NewLine);
+                buffer.Append(Environment.NewLineConst);
                 buffer.Append(' ', NewLinePadding);
             }
             else

--- a/src/System.Private.CoreLib/shared/System/IO/FileLoadException.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileLoadException.cs
@@ -51,20 +51,18 @@ namespace System.IO
             string s = GetType().ToString() + ": " + Message;
 
             if (!string.IsNullOrEmpty(FileName))
-                s += Environment.NewLine + SR.Format(SR.IO_FileName_Name, FileName);
+                s += Environment.NewLineConst + SR.Format(SR.IO_FileName_Name, FileName);
 
             if (InnerException != null)
-                s = s + Environment.NewLine + InnerExceptionPrefix + InnerException.ToString();
+                s += Environment.NewLineConst + InnerExceptionPrefix + InnerException.ToString();
 
             if (StackTrace != null)
-                s += Environment.NewLine + StackTrace;
+                s += Environment.NewLineConst + StackTrace;
 
             if (FusionLog != null)
             {
                 s ??= " ";
-                s += Environment.NewLine;
-                s += Environment.NewLine;
-                s += FusionLog;
+                s += Environment.NewLineConst + Environment.NewLineConst + FusionLog;
             }
 
             return s;

--- a/src/System.Private.CoreLib/shared/System/IO/FileNotFoundException.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileNotFoundException.cs
@@ -74,20 +74,18 @@ namespace System.IO
             string s = GetType().ToString() + ": " + Message;
 
             if (!string.IsNullOrEmpty(FileName))
-                s += Environment.NewLine + SR.Format(SR.IO_FileName_Name, FileName);
+                s += Environment.NewLineConst + SR.Format(SR.IO_FileName_Name, FileName);
 
             if (InnerException != null)
-                s = s + Environment.NewLine + InnerExceptionPrefix + InnerException.ToString();
+                s += Environment.NewLineConst + InnerExceptionPrefix + InnerException.ToString();
 
             if (StackTrace != null)
-                s += Environment.NewLine + StackTrace;
+                s += Environment.NewLineConst + StackTrace;
 
             if (FusionLog != null)
             {
                 s ??= " ";
-                s += Environment.NewLine;
-                s += Environment.NewLine;
-                s += FusionLog;
+                s += Environment.NewLineConst + Environment.NewLineConst + FusionLog;
             }
             return s;
         }

--- a/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/TextWriter.cs
@@ -24,7 +24,7 @@ namespace System.IO
         public static readonly TextWriter Null = new NullTextWriter();
 
         // We don't want to allocate on every TextWriter creation, so cache the char array.
-        private static readonly char[] s_coreNewLine = Environment.NewLine.ToCharArray();
+        private static readonly char[] s_coreNewLine = Environment.NewLineConst.ToCharArray();
 
         /// <summary>
         /// This is the 'NewLine' property expressed as a char[].
@@ -34,7 +34,7 @@ namespace System.IO
         /// as they are shared among many instances of TextWriter.
         /// </summary>
         protected char[] CoreNewLine = s_coreNewLine;
-        private string CoreNewLineStr = Environment.NewLine;
+        private string CoreNewLineStr = Environment.NewLineConst;
 
         // Can be null - if so, ask for the Thread's CurrentCulture every time.
         private readonly IFormatProvider? _internalFormatProvider;
@@ -126,7 +126,7 @@ namespace System.IO
             {
                 if (value == null)
                 {
-                    value = Environment.NewLine;
+                    value = Environment.NewLineConst;
                 }
 
                 CoreNewLineStr = value;

--- a/src/System.Private.CoreLib/shared/System/ObjectDisposedException.cs
+++ b/src/System.Private.CoreLib/shared/System/ObjectDisposedException.cs
@@ -65,7 +65,7 @@ namespace System
                 }
 
                 string objectDisposed = SR.Format(SR.ObjectDisposed_ObjectName_Name, name);
-                return base.Message + Environment.NewLine + objectDisposed;
+                return base.Message + Environment.NewLineConst + objectDisposed;
             }
         }
 

--- a/src/System.Private.CoreLib/shared/System/Reflection/AssemblyNameFormatter.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/AssemblyNameFormatter.cs
@@ -147,7 +147,7 @@ namespace System.Reflection
             new KeyValuePair<char, string>('=', "="),
             new KeyValuePair<char, string>('\'', "'"),
             new KeyValuePair<char, string>('\"', "\""),
-            new KeyValuePair<char, string>('n', Environment.NewLine),
+            new KeyValuePair<char, string>('n', Environment.NewLineConst),
             new KeyValuePair<char, string>('t', "\t"),
         };
     }

--- a/src/System.Private.CoreLib/shared/System/Resources/FileBasedResourceGroveler.cs
+++ b/src/System.Private.CoreLib/shared/System/Resources/FileBasedResourceGroveler.cs
@@ -53,7 +53,7 @@ namespace System.Resources
                     {
                         // We really don't think this should happen - we always
                         // expect the neutral locale's resources to be present.
-                        throw new MissingManifestResourceException(SR.MissingManifestResource_NoNeutralDisk + Environment.NewLine + "baseName: " + _mediator.BaseNameField + "  locationInfo: " + (_mediator.LocationInfo == null ? "<null>" : _mediator.LocationInfo.FullName) + "  fileName: " + _mediator.GetResourceFileName(culture));
+                        throw new MissingManifestResourceException(SR.MissingManifestResource_NoNeutralDisk + Environment.NewLineConst + "baseName: " + _mediator.BaseNameField + "  locationInfo: " + (_mediator.LocationInfo == null ? "<null>" : _mediator.LocationInfo.FullName) + "  fileName: " + _mediator.GetResourceFileName(culture));
                     }
                 }
             }

--- a/src/System.Private.CoreLib/shared/System/Resources/ManifestBasedResourceGroveler.cs
+++ b/src/System.Private.CoreLib/shared/System/Resources/ManifestBasedResourceGroveler.cs
@@ -480,7 +480,7 @@ namespace System.Resources
             if (_mediator.MainAssembly == typeof(object).Assembly && _mediator.BaseName.Equals(System.CoreLib.Name))
             {
                 // This would break CultureInfo & all our exceptions.
-                Debug.Fail("Couldn't get " + System.CoreLib.Name + ResourceManager.ResFileExtension + " from " + System.CoreLib.Name + "'s assembly" + Environment.NewLine + Environment.NewLine + "Are you building the runtime on your machine?  Chances are the BCL directory didn't build correctly.  Type 'build -c' in the BCL directory.  If you get build errors, look at buildd.log.  If you then can't figure out what's wrong (and you aren't changing the assembly-related metadata code), ask a BCL dev.\n\nIf you did NOT build the runtime, you shouldn't be seeing this and you've found a bug.");
+                Debug.Fail("Couldn't get " + System.CoreLib.Name + ResourceManager.ResFileExtension + " from " + System.CoreLib.Name + "'s assembly" + Environment.NewLineConst + Environment.NewLineConst + "Are you building the runtime on your machine?  Chances are the BCL directory didn't build correctly.  Type 'build -c' in the BCL directory.  If you get build errors, look at buildd.log.  If you then can't figure out what's wrong (and you aren't changing the assembly-related metadata code), ask a BCL dev.\n\nIf you did NOT build the runtime, you shouldn't be seeing this and you've found a bug.");
 
                 // We cannot continue further - simply FailFast.
                 const string MesgFailFast = System.CoreLib.Name + ResourceManager.ResFileExtension + " couldn't be found!  Large parts of the BCL won't work!";

--- a/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/COMException.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/COMException.cs
@@ -61,12 +61,12 @@ namespace System.Runtime.InteropServices
             Exception? innerException = InnerException;
             if (innerException != null)
             {
-                s.Append(Environment.NewLine).Append(InnerExceptionPrefix).Append(innerException.ToString());
+                s.Append(Environment.NewLineConst + InnerExceptionPrefix).Append(innerException.ToString());
             }
 
             string? stackTrace = StackTrace;
             if (stackTrace != null)
-                s.Append(Environment.NewLine).Append(stackTrace);
+                s.AppendLine().Append(stackTrace);
 
             return s.ToString();
         }

--- a/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/ExternalException.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/ExternalException.cs
@@ -63,17 +63,17 @@ namespace System.Runtime.InteropServices
 
             if (!string.IsNullOrEmpty(message))
             {
-                s = s + ": " + message;
+                s += ": " + message;
             }
 
             Exception? innerException = InnerException;
             if (innerException != null)
             {
-                s = s + Environment.NewLine + InnerExceptionPrefix + innerException.ToString();
+                s += Environment.NewLineConst + InnerExceptionPrefix + innerException.ToString();
             }
 
             if (StackTrace != null)
-                s += Environment.NewLine + StackTrace;
+                s += Environment.NewLineConst + StackTrace;
 
             return s;
         }

--- a/src/System.Private.CoreLib/shared/System/Security/SecurityElement.cs
+++ b/src/System.Private.CoreLib/shared/System/Security/SecurityElement.cs
@@ -510,7 +510,7 @@ namespace System.Security
 
                     if (i != _attributes.Count - 2)
                     {
-                        write(obj, Environment.NewLine);
+                        write(obj, Environment.NewLineConst);
                     }
                 }
             }
@@ -519,7 +519,7 @@ namespace System.Security
             {
                 // If we are a single tag with no children, just add the end of tag text.
                 write(obj, "/>");
-                write(obj, Environment.NewLine);
+                write(obj, Environment.NewLineConst);
             }
             else
             {
@@ -534,7 +534,7 @@ namespace System.Security
                 {
                     ConvertSecurityElementFactories();
 
-                    write(obj, Environment.NewLine);
+                    write(obj, Environment.NewLineConst);
 
                     for (int i = 0; i < _children.Count; ++i)
                     {
@@ -546,7 +546,7 @@ namespace System.Security
                 write(obj, "</");
                 write(obj, _tag);
                 write(obj, ">");
-                write(obj, Environment.NewLine);
+                write(obj, Environment.NewLineConst);
             }
         }
 

--- a/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
@@ -982,12 +982,12 @@ namespace System.Text
             return this;
         }
 
-        public StringBuilder AppendLine() => Append(Environment.NewLine);
+        public StringBuilder AppendLine() => Append(Environment.NewLineConst);
 
         public StringBuilder AppendLine(string? value)
         {
             Append(value);
-            return Append(Environment.NewLine);
+            return Append(Environment.NewLineConst);
         }
 
         public void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count)

--- a/src/System.Private.CoreLib/src/Internal/Console.cs
+++ b/src/System.Private.CoreLib/src/Internal/Console.cs
@@ -28,9 +28,9 @@ namespace Internal
         }
 
         public static void WriteLine(string? s) =>
-            Write(s + Environment.NewLine);
+            Write(s + Environment.NewLineConst);
 
         public static void WriteLine() =>
-            Write(Environment.NewLine);
+            Write(Environment.NewLineConst);
     }
 }

--- a/src/System.Private.CoreLib/src/System/Exception.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Exception.CoreCLR.cs
@@ -236,7 +236,7 @@ namespace System
 
             if (!string.IsNullOrEmpty(tmpStackTraceString))
             {
-                _remoteStackTraceString = tmpStackTraceString + Environment.NewLine;
+                _remoteStackTraceString = tmpStackTraceString + Environment.NewLineConst;
             }
 
             _stackTrace = null;

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.cs
@@ -460,7 +460,7 @@ namespace System.Reflection.Emit
             sb.Append("Name: ").Append(m_strName).AppendLine(" ");
             sb.Append("Attributes: ").Append((int)m_iAttributes).AppendLine();
             sb.Append("Method Signature: ").Append(GetMethodSignature()).AppendLine();
-            sb.Append(Environment.NewLine);
+            sb.AppendLine();
             return sb.ToString();
         }
 


### PR DESCRIPTION
Anywhere Environment.NewLine was being used internal to corelib, instead changes it to use an internal Environment.NewLineConst, which is just a const string.  The main benefit of that is places where it's then concatenated with another const allows the C# compiler to do the concat at compile time rather than at run time.

Where I was already touching the code, fixed a few places where additional strings were being created unnecessarily, e.g. `s += a; s += b;` will do two `string.Concat` calls each with two arguments, whereas `s += a + b;` will do just one `string.Concat` call with three arguments.