### PR TITLE
Print tier in DumpJittedMethods.

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4229,6 +4229,26 @@ bool Compiler::compRsvdRegCheck(FrameLayoutState curState)
 }
 #endif // _TARGET_ARMARCH_
 
+const char* Compiler::compGetTieringName() const
+{
+    bool tier0 = opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER0);
+    bool tier1 = opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER1);
+    assert(!tier0 || !tier1); // We don't expect multiple TIER flags to be set at one time.
+
+    if (tier0)
+    {
+        return "Tier-0";
+    }
+    else if (tier1)
+    {
+        return "Tier-1";
+    }
+    else
+    {
+        return "No-Tier";
+    }
+}
+
 void Compiler::compFunctionTraceStart()
 {
 #ifdef DEBUG
@@ -4249,8 +4269,9 @@ void Compiler::compFunctionTraceStart()
         {
             printf("  ");
         }
-        printf("{ Start Jitting Method %4d %s (MethodHash=%08x)\n", Compiler::jitTotalMethodCompiled, info.compFullName,
-               info.compMethodHash()); /* } editor brace matching workaround for this printf */
+        printf("{ Start Jitting Method %4d %s (MethodHash=%08x) %s\n", Compiler::jitTotalMethodCompiled,
+               info.compFullName, info.compMethodHash(),
+               compGetTieringName()); /* } editor brace matching workaround for this printf */
     }
 #endif // DEBUG
 }
@@ -5946,17 +5967,9 @@ int Compiler::compCompileHelper(CORINFO_MODULE_HANDLE            classPtr,
 #ifdef DEBUG
     if (JitConfig.DumpJittedMethods() == 1 && !compIsForInlining())
     {
-        printf("Compiling %4d %s::%s, IL size = %u, hsh=0x%x", Compiler::jitTotalMethodCompiled, info.compClassName,
-               info.compMethodName, info.compILCodeSize, info.compMethodHash());
-        if (opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER0))
-        {
-            printf(" for Tier-0");
-        }
-        else if (opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER1))
-        {
-            printf(" for Tier-1");
-        }
-        printf("\n");
+        printf("Compiling %4d %s::%s, IL size = %u, hsh=0x%x %s\n", Compiler::jitTotalMethodCompiled,
+               info.compClassName, info.compMethodName, info.compILCodeSize, info.compMethodHash(),
+               compGetTieringName());
     }
     if (compIsForInlining())
     {

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4249,7 +4249,7 @@ void Compiler::compFunctionTraceStart()
         {
             printf("  ");
         }
-        printf("{ Start Jitting Method %d %s (MethodHash=%08x)\n", Compiler::jitTotalMethodCompiled, info.compFullName,
+        printf("{ Start Jitting Method %4d %s (MethodHash=%08x)\n", Compiler::jitTotalMethodCompiled, info.compFullName,
                info.compMethodHash()); /* } editor brace matching workaround for this printf */
     }
 #endif // DEBUG
@@ -4272,10 +4272,14 @@ void Compiler::compFunctionTraceEnd(void* methodCodePtr, ULONG methodCodeSize, b
         {
             printf("  ");
         }
+
+        // Note: that is incorrect if we are compiling several methods at the same time.
+        unsigned methodNumber = Compiler::jitTotalMethodCompiled - 1;
+
         /* { editor brace-matching workaround for following printf */
-        printf("} Jitted Method %03x at" FMT_ADDR "method %s size %08x%s%s\n", Compiler::jitTotalMethodCompiled,
-               DBG_ADDR(methodCodePtr), info.compFullName, methodCodeSize,
-               isNYI ? " NYI" : (compIsForImportOnly() ? " import only" : ""), opts.altJit ? " altjit" : "");
+        printf("} Jitted Method %4d at" FMT_ADDR "method %s size %08x%s%s\n", methodNumber, DBG_ADDR(methodCodePtr),
+               info.compFullName, methodCodeSize, isNYI ? " NYI" : (compIsForImportOnly() ? " import only" : ""),
+               opts.altJit ? " altjit" : "");
     }
 #endif // DEBUG
 }

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -5942,8 +5942,17 @@ int Compiler::compCompileHelper(CORINFO_MODULE_HANDLE            classPtr,
 #ifdef DEBUG
     if (JitConfig.DumpJittedMethods() == 1 && !compIsForInlining())
     {
-        printf("Compiling %4d %s::%s, IL size = %u, hsh=0x%x\n", Compiler::jitTotalMethodCompiled, info.compClassName,
+        printf("Compiling %4d %s::%s, IL size = %u, hsh=0x%x", Compiler::jitTotalMethodCompiled, info.compClassName,
                info.compMethodName, info.compILCodeSize, info.compMethodHash());
+        if (opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER0))
+        {
+            printf(" for Tier-0");
+        }
+        else if (opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER1))
+        {
+            printf(" for Tier-1");
+        }
+        printf("\n");
     }
     if (compIsForInlining())
     {

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -8706,6 +8706,8 @@ public:
 #endif
     }
 
+    const char* compGetTieringName() const;
+
     codeOptimize compCodeOpt()
     {
 #if 0


### PR DESCRIPTION
I found that useful when reproducing bugs that require `complus_TieredCompilation=1`.

Example:
```
Compiling    0 System.SpanHelpers::IndexOf, IL size = 902, hsh=0xda613814 for Tier-1
Compiling    1 System.Text.Unicode.Utf16Utility::GetPointerToFirstInvalidChar, IL size = 1107, hsh=0xe576e43d
Compiling    2 System.Runtime.Intrinsics.Vector128::CreateScalarUnsafe, IL size = 21, hsh=0x6746a268 for Tier-0
```