### PR TITLE
Make Path.DirectorySeparatorChar intrinsic

### DIFF
--- a/src/System.Private.CoreLib/shared/System/IO/Path.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/Path.cs
@@ -6,6 +6,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 #if MS_IO_REDIST
@@ -24,6 +25,7 @@ namespace System.IO
     {
         // Public static readonly variant of the separators. The Path implementation itself is using
         // internal const variant of the separators for better performance.
+        [Intrinsic]
         public static readonly char DirectorySeparatorChar = PathInternal.DirectorySeparatorChar;
         public static readonly char AltDirectorySeparatorChar = PathInternal.AltDirectorySeparatorChar;
         public static readonly char VolumeSeparatorChar = PathInternal.VolumeSeparatorChar;

--- a/src/inc/corinfo.h
+++ b/src/inc/corinfo.h
@@ -1723,6 +1723,7 @@ enum CORINFO_FIELD_ACCESSOR
     CORINFO_FIELD_INTRINSIC_ZERO,           // intrinsic zero (IntPtr.Zero, UIntPtr.Zero)
     CORINFO_FIELD_INTRINSIC_EMPTY_STRING,   // intrinsic emptry string (String.Empty)
     CORINFO_FIELD_INTRINSIC_ISLITTLEENDIAN, // intrinsic BitConverter.IsLittleEndian
+    CORINFO_FIELD_INTRINSIC_DIRECTORY_SEPARATOR_CHAR, // intrinsic Path.DirectorySeparatorChar
 };
 
 // Set of flags returned in CORINFO_FIELD_INFO::fieldFlags

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -14239,6 +14239,18 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     }
                     break;
 
+                    case CORINFO_FIELD_INTRINSIC_DIRECTORY_SEPARATOR_CHAR:
+                    {
+                        assert(aflags & CORINFO_ACCESS_GET);
+#if defined(_TARGET_WINDOWS_)
+                        op1 = gtNewIconNode((ssize_t)'\\', lclTyp);
+#else
+                        op1 = gtNewIconNode((ssize_t)'/', lclTyp);
+#endif
+                        goto FIELD_DONE;
+                    }
+                    break;
+
                     default:
                         assert(!"Unexpected fieldAccessor");
                 }

--- a/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
+++ b/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
@@ -2071,6 +2071,11 @@ namespace Internal.JitInterface
             {
                 return CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_INTRINSIC_ISLITTLEENDIAN;
             }
+            else if (owningType.Name == "Path" && owningType.Namespace == "System.IO" &&
+                field.Name == "DirectorySeparatorChar")
+            {
+                return CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_INTRINSIC_DIRECTORY_SEPARATOR_CHAR;
+            }
 
             return (CORINFO_FIELD_ACCESSOR)(-1);
         }

--- a/src/tools/crossgen2/Common/JitInterface/CorInfoTypes.cs
+++ b/src/tools/crossgen2/Common/JitInterface/CorInfoTypes.cs
@@ -1129,6 +1129,7 @@ namespace Internal.JitInterface
         CORINFO_FIELD_INTRINSIC_ZERO,           // intrinsic zero (IntPtr.Zero, UIntPtr.Zero)
         CORINFO_FIELD_INTRINSIC_EMPTY_STRING,   // intrinsic emptry string (String.Empty)
         CORINFO_FIELD_INTRINSIC_ISLITTLEENDIAN, // intrinsic BitConverter.IsLittleEndian
+        CORINFO_FIELD_INTRINSIC_DIRECTORY_SEPARATOR_CHAR, // intrinsic Path.DirectorySeparatorChar
     }
 
     // Set of flags returned in CORINFO_FIELD_INFO::fieldFlags

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -1338,6 +1338,11 @@ static CORINFO_FIELD_ACCESSOR getFieldIntrinsic(FieldDesc * field)
     {
         return CORINFO_FIELD_INTRINSIC_ISLITTLEENDIAN;
     }
+    else
+    if (MscorlibBinder::GetField(FIELD__PATH__DIRECTORY_SEPARATOR_CHAR) == field)
+    {
+        return CORINFO_FIELD_INTRINSIC_DIRECTORY_SEPARATOR_CHAR;
+    }
 
     return (CORINFO_FIELD_ACCESSOR)-1;
 }

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -792,6 +792,9 @@ DEFINE_FIELD(UINTPTR,               ZERO,                   Zero)
 DEFINE_CLASS(BITCONVERTER,          System,                 BitConverter)
 DEFINE_FIELD(BITCONVERTER,          ISLITTLEENDIAN,         IsLittleEndian)
 
+DEFINE_CLASS(PATH,                  IO,                     Path)
+DEFINE_FIELD(PATH,                  DIRECTORY_SEPARATOR_CHAR, DirectorySeparatorChar)
+
 // Defined as element type alias
 // DEFINE_CLASS(STRING,                System,                 String)
 DEFINE_FIELD(STRING,                M_FIRST_CHAR,           _firstChar)

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -3196,6 +3196,7 @@ void ZapInfo::getFieldInfo (CORINFO_RESOLVED_TOKEN * pResolvedToken,
         case CORINFO_FIELD_INTRINSIC_ZERO:
         case CORINFO_FIELD_INTRINSIC_EMPTY_STRING:
         case CORINFO_FIELD_INTRINSIC_ISLITTLEENDIAN:
+        case CORINFO_FIELD_INTRINSIC_DIRECTORY_SEPARATOR_CHAR:
             break;
 
         default:


### PR DESCRIPTION
`Path.DirectorySeparatorChar` is a static readonly field, this PR makes it basically a const. CoreFX has ~45 usages. We can also remove static cctor now I think.
 I also wanted to make `Environment.NewLine` an intrinsic (requires changes in the jit interface) - let me know if it looks useful.

```csharp
internal static bool IsDirectorySeparator(char c)
{
    return c == Path.DirectorySeparatorChar;
}
```
Was:
```asm
G_M30566_IG01:
       push     rsi
       sub      rsp, 32
G_M30566_IG02:
       movzx    rsi, cx
       mov      rcx, 0xD1FFAB1E
       mov      edx, 0x630
       call     CORINFO_HELP_GETSHARED_NONGCSTATIC_BASE
       movzx    rax, word  ptr [reloc classVar[0xd1ffab1e]]
       cmp      esi, eax
       sete     al
       movzx    rax, al
G_M30566_IG03:
       add      rsp, 32
       pop      rsi
       ret      
; Total bytes of code: 49
```
Now:
```asm
G_M30566_IG01:
G_M30566_IG02:
       movzx    rax, cx
       cmp      eax, 92
       sete     al
       movzx    rax, al
G_M30566_IG03:
       ret      
; Total bytes of code: 13

```