### PR TITLE
Improve superilc test copying speed and cleanup

### DIFF
--- a/src/tools/ReadyToRun.SuperIlc/BuildFolder.cs
+++ b/src/tools/ReadyToRun.SuperIlc/BuildFolder.cs
@@ -130,7 +130,7 @@ namespace ReadyToRun.SuperIlc
                 {
                     compilationInputFiles.Add(file);
                 }
-                else
+                else if ((Path.GetExtension(file) != ".pdb") && (Path.GetExtension(file) != ".ilk")) // exclude .pdb and .ilk files that are large and not needed in the target folder
                 {
                     passThroughFiles.Add(file);
                 }

--- a/src/tools/ReadyToRun.SuperIlc/Commands/CompileDirectoryCommand.cs
+++ b/src/tools/ReadyToRun.SuperIlc/Commands/CompileDirectoryCommand.cs
@@ -41,7 +41,7 @@ namespace ReadyToRun.SuperIlc
 
             if (!options.Exe)
             {
-                PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, recursive: false);
+                PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, runners, recursive: false);
             }
 
             BuildFolder folder = BuildFolder.FromDirectory(options.InputDirectory.FullName, runners, options.OutputDirectory.FullName, options);
@@ -56,7 +56,7 @@ namespace ReadyToRun.SuperIlc
 
             if (!options.NoCleanup && !options.Exe)
             {
-                PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, recursive: false);
+                PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, runners, recursive: false);
             }
 
             return success ? 0 : 1;

--- a/src/tools/ReadyToRun.SuperIlc/Commands/CompileNugetCommand.cs
+++ b/src/tools/ReadyToRun.SuperIlc/Commands/CompileNugetCommand.cs
@@ -42,7 +42,7 @@ namespace ReadyToRun.SuperIlc
 
             if (!options.Exe)
             {
-                PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, recursive: false);
+                PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, runners, recursive: false);
             }
 
             string nugetOutputFolder = Path.Combine(options.OutputDirectory.FullName, "nuget.out");
@@ -97,7 +97,7 @@ namespace ReadyToRun.SuperIlc
 
                 if (!options.NoCleanup && !options.Exe)
                 {
-                    PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, recursive: false);
+                    PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, runners, recursive: false);
                 }
 
                 return success ? 0 : 1;

--- a/src/tools/ReadyToRun.SuperIlc/Commands/CompileSubtreeCommand.cs
+++ b/src/tools/ReadyToRun.SuperIlc/Commands/CompileSubtreeCommand.cs
@@ -44,7 +44,7 @@ namespace ReadyToRun.SuperIlc
 
             if (!options.Exe)
             {
-                PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, recursive: true);
+                PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, runners, recursive: true);
             }
 
             string[] directories = LocateSubtree(options.InputDirectory.FullName, options.CoreRootDirectory.FullName).ToArray();
@@ -107,7 +107,7 @@ namespace ReadyToRun.SuperIlc
 
             if (!options.NoCleanup)
             {
-                PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, recursive: true);
+                PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, runners, recursive: true);
             }
 
             return success ? 0 : 1;


### PR DESCRIPTION
The superilc is copying all files that are not found to be managed
assemblies from the original test folder to the target folder.
This includes .pdb and .ilk files that are huge and slow down the
copying process significantly. And they are not needed anyways. So this
change filters these files out.

During cleanup, superilc was removing all .out folders. But I've found
that in most cases, I want it to remove only these folders for crossgen or
crossgen2 based on the compiler types selected using command line
options. This allows me to keep crossgen results and keep comparing them
with new crossgen2 results as I work on fixing issues.
So I have added such a functionality.