### PR TITLE
Fix couple of generic context tests

### DIFF
--- a/src/tools/crossgen2/Common/Compiler/TypeExtensions.cs
+++ b/src/tools/crossgen2/Common/Compiler/TypeExtensions.cs
@@ -54,7 +54,7 @@ namespace ILCompiler
         public static bool RequiresInstArg(this MethodDesc method)
         {
             return method.IsSharedByGenericInstantiations &&
-                (method.HasInstantiation || method.Signature.IsStatic || method.ImplementationType.IsValueType);
+                (method.HasInstantiation || method.Signature.IsStatic || method.ImplementationType.IsValueType || (method.OwningType.IsInterface && !method.IsAbstract));
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace ILCompiler
         /// </summary>
         public static bool RequiresInstMethodTableArg(this MethodDesc method)
         {
-            return (method.Signature.IsStatic || method.ImplementationType.IsValueType) &&
+            return (method.Signature.IsStatic || method.ImplementationType.IsValueType || (method.OwningType.IsInterface && !method.IsAbstract)) &&
                 method.IsSharedByGenericInstantiations &&
                 !method.HasInstantiation;
         }

--- a/src/tools/crossgen2/Common/Compiler/TypeExtensions.cs
+++ b/src/tools/crossgen2/Common/Compiler/TypeExtensions.cs
@@ -54,7 +54,7 @@ namespace ILCompiler
         public static bool RequiresInstArg(this MethodDesc method)
         {
             return method.IsSharedByGenericInstantiations &&
-                (method.HasInstantiation || method.Signature.IsStatic || method.ImplementationType.IsValueType || (method.OwningType.IsInterface && !method.IsAbstract));
+                (method.HasInstantiation || method.Signature.IsStatic || method.ImplementationType.IsValueType || (method.ImplementationType.IsInterface && !method.IsAbstract));
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace ILCompiler
         /// </summary>
         public static bool RequiresInstMethodTableArg(this MethodDesc method)
         {
-            return (method.Signature.IsStatic || method.ImplementationType.IsValueType || (method.OwningType.IsInterface && !method.IsAbstract)) &&
+            return (method.Signature.IsStatic || method.ImplementationType.IsValueType || (method.ImplementationType.IsInterface && !method.IsAbstract)) &&
                 method.IsSharedByGenericInstantiations &&
                 !method.HasInstantiation;
         }
@@ -85,7 +85,8 @@ namespace ILCompiler
             return method.IsSharedByGenericInstantiations &&
                 !method.HasInstantiation &&
                 !method.Signature.IsStatic &&
-                !method.ImplementationType.IsValueType;
+                !method.ImplementationType.IsValueType &&
+                !(method.ImplementationType.IsInterface && !method.IsAbstract);
         }
 
         /// <summary>


### PR DESCRIPTION
This change fixes a couple of generic context related tests that were
crashing with access violation.
The tests include:
* reflection\DefaultInterfaceMethods\InvokeConsumer
* Regressions\coreclr\15241\genericcontext
* Regressions\coreclr\16355\variance
* Regressions\coreclr\16775\sharedinterfacemethod
* Regressions\coreclr\20452\twopassvariance
* Regressions\coreclr\22386\debug3