### PR TITLE
Handle AV caused by invalid IBC data

### DIFF
--- a/src/vm/genmeth.cpp
+++ b/src/vm/genmeth.cpp
@@ -802,7 +802,11 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
     // Some callers pass a pExactMT that is a subtype of a parent type of pDefMD.
     // Find the actual exact parent of pDefMD.
     pExactMT = pDefMD->GetExactDeclaringType(pExactMT);
-    _ASSERTE(pExactMT != NULL);
+    if (pExactMT == NULL)
+    {
+        _ASSERTE(false);
+        COMPlusThrowHR(COR_E_TYPELOAD);
+    }
 
     if (pDefMD->HasClassOrMethodInstantiation() || !methodInst.IsEmpty())
     {


### PR DESCRIPTION
Make FindOrCreateAssociatedMethodDesc throw a type load exception instead of an AV, which can't be handled by EX_TRY/EX_CATCH on Unix systems.

Fixes crossgen failures reported in #26799 

Handling of AVs on Unix systems seem to be unsupported by choice