### PR TITLE
Handle AV caused by invalid IBC data (#27029)

### DIFF
--- a/src/vm/genmeth.cpp
+++ b/src/vm/genmeth.cpp
@@ -802,7 +802,11 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
     // Some callers pass a pExactMT that is a subtype of a parent type of pDefMD.
     // Find the actual exact parent of pDefMD.
     pExactMT = pDefMD->GetExactDeclaringType(pExactMT);
-    _ASSERTE(pExactMT != NULL);
+    if (pExactMT == NULL)
+    {
+        _ASSERTE(false);
+        COMPlusThrowHR(COR_E_TYPELOAD);
+    }
 
     if (pDefMD->HasClassOrMethodInstantiation() || !methodInst.IsEmpty())
     {


### PR DESCRIPTION
Bug Description:

EX_TRY/EX_CATCH do not handle AVs (by choice/design) on Unix systems. This particular bug is caused by old/invalid IBC data on an assembly that requests to load a method on a certain type, but the method really doesn't exist on that type. This causes an AV that is handled on Windows systems and the IBC entry is ignored, but on Unix, it required some hardening of the code to make it throw a typeload exception instead of letting it AV. The exception is correctly handled by the EX_CATCH block, and the IBC entry is ignored. We now have the same behavior as on Windows, and crossgen no longer crashes.

Bug Impact:
Any customer publishing R2R images from a Unix host, and referencing assemblies with invalid/old IBC will see crossgen crashes.

PR Risks: None

Porting #27029 from master for 3.1
Fixes #26799 for 3.1

cc @MeiChin-Tsai @jkotas