### PR TITLE
Avoid assert if there's SafeArray marshalling

### DIFF
--- a/src/tools/crossgen2/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
@@ -349,6 +349,24 @@ namespace Internal.TypeSystem.Ecma
                         }
                     }
                     break;
+                case NativeTypeKind.SafeArray:
+                    {
+                        // There's nobody to consume SafeArrays, so let's just parse the data
+                        // to avoid asserting later.
+
+                        // Get optional VARTYPE for the element
+                        if (_reader.RemainingBytes != 0)
+                        {
+                            _reader.ReadCompressedInteger();
+                        }
+
+                        // VARTYPE can be followed by optional type name
+                        if (_reader.RemainingBytes != 0)
+                        {
+                            _reader.ReadSerializedString();
+                        }
+                    }
+                    break;
                 default:
                     break;
             }

--- a/src/tools/crossgen2/Common/TypeSystem/Interop/MarshalAsDescriptor.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Interop/MarshalAsDescriptor.cs
@@ -7,7 +7,6 @@ using System;
 
 namespace Internal.TypeSystem
 {
-    [Flags]
     public enum NativeTypeKind : byte
     {
         Boolean = 0x2,
@@ -26,6 +25,7 @@ namespace Internal.TypeSystem
         LPTStr = 0x16,        // Ptr to OS preferred (SBCS/Unicode) string
         ByValTStr = 0x17,     // OS preferred (SBCS/Unicode) inline string (only valid in structs)
         Struct = 0x1b,
+        SafeArray = 0x1d,
         ByValArray = 0x1e,
         SysInt = 0x1f,
         SysUInt = 0x20,


### PR DESCRIPTION
VarType is deprecated so it's unlikely we would want to support pregenerating this, ever, but we don't want to assert the compiler.