### PR TITLE
Fix duplicate key failure in SuperIlc when using multiple runners

### DIFF
--- a/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
+++ b/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
@@ -289,7 +289,7 @@ namespace ReadyToRun.SuperIlc
                 {
                     if (exclusion != null && (!exclusion.Crossgen2Only || runner.Index == CompilerIndex.CPAOT))
                     {
-                        _frameworkExclusions.Add(exclusion.SimpleName, exclusion.Reason);
+                        _frameworkExclusions[exclusion.SimpleName] = exclusion.Reason;
                         continue;
                     }
                     ProcessInfo compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, _options.CoreRootDirectory.FullName, frameworkDll));


### PR DESCRIPTION
Apologies about the inconvenience, it somehow slipped through
the cracks.

Thanks

Tomas