### PR TITLE
Explicitly make our minimum ICU version be the version available in Alpine 3.6

### DIFF
--- a/src/corefx/System.Globalization.Native/CMakeLists.txt
+++ b/src/corefx/System.Globalization.Native/CMakeLists.txt
@@ -52,10 +52,6 @@ set(NATIVEGLOBALIZATION_SOURCES
 
 include_directories(${UTYPES_H})
 
-if(CLR_CMAKE_PLATFORM_ALPINE_LINUX)
-    add_compile_definitions(MinICUVersion=58)
-endif()
-
 _add_library(System.Globalization.Native
     SHARED
     ${NATIVEGLOBALIZATION_SOURCES}

--- a/src/corefx/System.Globalization.Native/CMakeLists.txt
+++ b/src/corefx/System.Globalization.Native/CMakeLists.txt
@@ -52,6 +52,10 @@ set(NATIVEGLOBALIZATION_SOURCES
 
 include_directories(${UTYPES_H})
 
+if(CLR_CMAKE_PLATFORM_ALPINE_LINUX)
+    add_compile_definitions(MinICUVersion=58)
+endif()
+
 _add_library(System.Globalization.Native
     SHARED
     ${NATIVEGLOBALIZATION_SOURCES}

--- a/src/corefx/System.Globalization.Native/pal_icushim.c
+++ b/src/corefx/System.Globalization.Native/pal_icushim.c
@@ -54,12 +54,16 @@ static int FindICULibs(const char* versionPrefix, char* symbolName, char* symbol
 // equal to the version we are built against and less or equal to that version
 // plus 20 to give us enough headspace. The ICU seems to version about twice
 // a year.
-#define MinICUVersion  U_ICU_VERSION_MAJOR_NUM
+// The minimum ICU version is the version from Alpine Linux 3.6, which is
+// the minimum version we know works for the product.
+#define MinICUVersion  58
 #define MaxICUVersion  (MinICUVersion + 20)
 #define MinMinorICUVersion  1
 #define MaxMinorICUVersion  5
 #define MinSubICUVersion 1
 #define MaxSubICUVersion 5
+
+static_assert(MaxICUVersion >= U_ICU_VERSION_MAJOR_NUM, "The max supported ICU version is less than the version we are building against.");
 
 // Get filename of an ICU library with the requested version in the name
 // There are three possible cases of the version components values:

--- a/src/corefx/System.Globalization.Native/pal_icushim.c
+++ b/src/corefx/System.Globalization.Native/pal_icushim.c
@@ -63,7 +63,9 @@ static int FindICULibs(const char* versionPrefix, char* symbolName, char* symbol
 #define MinSubICUVersion 1
 #define MaxSubICUVersion 5
 
-static_assert(MaxICUVersion >= U_ICU_VERSION_MAJOR_NUM, "The max supported ICU version is less than the version we are building against.");
+#if MaxICUVersion < U_ICU_VERSION_MAJOR_NUM || U_ICU_VERSION_MAJOR_NUM < MinICUVersion
+#error "The ICU version we are compiling against is not in our supported ICU version range."
+#endif
 
 // Get filename of an ICU library with the requested version in the name
 // There are three possible cases of the version components values:

--- a/src/corefx/System.Globalization.Native/pal_icushim.c
+++ b/src/corefx/System.Globalization.Native/pal_icushim.c
@@ -54,9 +54,11 @@ static int FindICULibs(const char* versionPrefix, char* symbolName, char* symbol
 // equal to the version we are built against and less or equal to that version
 // plus 20 to give us enough headspace. The ICU seems to version about twice
 // a year.
-// The minimum ICU version is the version from Alpine Linux 3.6, which is
-// the minimum version we know works for the product.
-#define MinICUVersion  58
+// On some platforms (mainly Alpine Linux) we want to make our minimum version
+// an earlier version than what we build that we know we support.
+#ifndef MinICUVersion
+#define MinICUVersion  U_ICU_VERSION_MAJOR_NUM
+#endif
 #define MaxICUVersion  (MinICUVersion + 20)
 #define MinMinorICUVersion  1
 #define MaxMinorICUVersion  5

--- a/src/corefx/System.Globalization.Native/pal_icushim.c
+++ b/src/corefx/System.Globalization.Native/pal_icushim.c
@@ -56,18 +56,12 @@ static int FindICULibs(const char* versionPrefix, char* symbolName, char* symbol
 // a year.
 // On some platforms (mainly Alpine Linux) we want to make our minimum version
 // an earlier version than what we build that we know we support.
-#ifndef MinICUVersion
-#define MinICUVersion  U_ICU_VERSION_MAJOR_NUM
-#endif
-#define MaxICUVersion  (MinICUVersion + 20)
+#define MinICUVersion  50
+#define MaxICUVersion  (U_ICU_VERSION_MAJOR_NUM + 20)
 #define MinMinorICUVersion  1
 #define MaxMinorICUVersion  5
 #define MinSubICUVersion 1
 #define MaxSubICUVersion 5
-
-#if MaxICUVersion < U_ICU_VERSION_MAJOR_NUM || U_ICU_VERSION_MAJOR_NUM < MinICUVersion
-#error "The ICU version we are compiling against is not in our supported ICU version range."
-#endif
 
 // Get filename of an ICU library with the requested version in the name
 // There are three possible cases of the version components values:


### PR DESCRIPTION
Fixes #27018 

cc: @janvorli @wfurt 