### PR TITLE
Switching to the new OSX pool

### DIFF
--- a/buildpipeline/DotNet-CoreClr-Trusted-Mac.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Mac.json
@@ -338,7 +338,7 @@
   "quality": "definition",
   "drafts": [],
   "queue": {
-    "id": 330,
+    "id": 120,
     "name": "DotNetCore-Build",
     "pool": {
       "id": 97,

--- a/buildpipeline/DotNet-CoreClr-Trusted-Mac.json
+++ b/buildpipeline/DotNet-CoreClr-Trusted-Mac.json
@@ -338,11 +338,11 @@
   "quality": "definition",
   "drafts": [],
   "queue": {
-    "id": 120,
-    "name": "DotNetCore-Build",
+    "id": 681,
+    "name": "VSEng-MicroBuildMacSierra",
     "pool": {
-      "id": 97,
-      "name": "DotNetCore-Build"
+      "id": 120,
+      "name": "VSEng-MicroBuildMacSierra"
     }
   },
   "id": 1680,


### PR DESCRIPTION
We moved the OSX machines to a new pool.  Updating the json file to use the new pool.