### PR TITLE
Fix crossgen2 for methods with StackCrawlMark

### DIFF
--- a/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
+++ b/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
@@ -661,10 +661,12 @@ namespace Internal.JitInterface
                 result |= CorInfoFlag.CORINFO_FLG_PINVOKE;
             }
 
+#if READYTORUN
             if (method.RequireSecObject)
             {
                 result |= CorInfoFlag.CORINFO_FLG_DONT_INLINE_CALLER;
             }
+#endif
 
             if (method.IsAggressiveOptimization)
             {

--- a/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
+++ b/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
@@ -661,6 +661,11 @@ namespace Internal.JitInterface
                 result |= CorInfoFlag.CORINFO_FLG_PINVOKE;
             }
 
+            if (method.RequireSecObject)
+            {
+                result |= CorInfoFlag.CORINFO_FLG_DONT_INLINE_CALLER;
+            }
+
             if (method.IsAggressiveOptimization)
             {
                 result |= CorInfoFlag.CORINFO_FLG_AGGRESSIVE_OPT;

--- a/src/tools/crossgen2/Common/TypeSystem/CodeGen/MethodDelegator.CodeGen.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/CodeGen/MethodDelegator.CodeGen.cs
@@ -38,6 +38,14 @@ namespace Internal.TypeSystem
             }
         }
 
+        public override bool RequireSecObject
+        {
+            get
+            {
+                return _wrappedMethod.RequireSecObject;
+            }
+        }
+
         public override bool IsNoOptimization
         {
             get

--- a/src/tools/crossgen2/Common/TypeSystem/CodeGen/MethodDesc.CodeGen.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/CodeGen/MethodDesc.CodeGen.cs
@@ -57,6 +57,12 @@ namespace Internal.TypeSystem
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this method was marked with the
+        /// System.Security.DynamicSecurityMethod attribute. For such methods
+        /// runtime needs to be able to find their caller, their caller's caller
+        /// or the method itself on the call stack using stack walking.
+        /// </summary>
         public virtual bool RequireSecObject
         {
             get

--- a/src/tools/crossgen2/Common/TypeSystem/CodeGen/MethodDesc.CodeGen.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/CodeGen/MethodDesc.CodeGen.cs
@@ -57,6 +57,14 @@ namespace Internal.TypeSystem
             }
         }
 
+        public virtual bool RequireSecObject
+        {
+            get
+            {
+                return false;
+            }
+        }
+
         /// <summary>
         /// Gets a value specifying whether this method should not be optimized.
         /// </summary>
@@ -168,6 +176,14 @@ namespace Internal.TypeSystem
             }
         }
 
+        public override bool RequireSecObject
+        {
+            get
+            {
+                return _methodDef.RequireSecObject;
+            }
+        }
+
         public override bool IsNoOptimization
         {
             get
@@ -249,6 +265,14 @@ namespace Internal.TypeSystem
             get
             {
                 return _typicalMethodDef.IsAggressiveOptimization;
+            }
+        }
+
+        public override bool RequireSecObject
+        {
+            get
+            {
+                return _typicalMethodDef.RequireSecObject;
             }
         }
 

--- a/src/tools/crossgen2/Common/TypeSystem/Ecma/EcmaMethod.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Ecma/EcmaMethod.cs
@@ -26,13 +26,12 @@ namespace Internal.TypeSystem.Ecma
             public const int Synchronized           = 0x00200;
             public const int AggressiveOptimization = 0x00400;
             public const int NoOptimization         = 0x00800;
+            public const int RequireSecObject       = 0x01000;
 
-            public const int AttributeMetadataCache = 0x01000;
-            public const int Intrinsic              = 0x02000;
-            public const int NativeCallable         = 0x04000;
-            public const int RuntimeExport          = 0x08000;
-
-            public const int RequireSecObject       = 0x10000;
+            public const int AttributeMetadataCache = 0x02000;
+            public const int Intrinsic              = 0x04000;
+            public const int NativeCallable         = 0x08000;
+            public const int RuntimeExport          = 0x10000;
         };
 
         private EcmaType _type;

--- a/src/tools/crossgen2/Common/TypeSystem/Ecma/EcmaMethod.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Ecma/EcmaMethod.cs
@@ -14,23 +14,25 @@ namespace Internal.TypeSystem.Ecma
     {
         private static class MethodFlags
         {
-            public const int BasicMetadataCache     = 0x0001;
-            public const int Virtual                = 0x0002;
-            public const int NewSlot                = 0x0004;
-            public const int Abstract               = 0x0008;
-            public const int Final                  = 0x0010;
-            public const int NoInlining             = 0x0020;
-            public const int AggressiveInlining     = 0x0040;
-            public const int RuntimeImplemented     = 0x0080;
-            public const int InternalCall           = 0x0100;
-            public const int Synchronized           = 0x0200;
-            public const int AggressiveOptimization = 0x0400;
-            public const int NoOptimization         = 0x0800;
+            public const int BasicMetadataCache     = 0x00001;
+            public const int Virtual                = 0x00002;
+            public const int NewSlot                = 0x00004;
+            public const int Abstract               = 0x00008;
+            public const int Final                  = 0x00010;
+            public const int NoInlining             = 0x00020;
+            public const int AggressiveInlining     = 0x00040;
+            public const int RuntimeImplemented     = 0x00080;
+            public const int InternalCall           = 0x00100;
+            public const int Synchronized           = 0x00200;
+            public const int AggressiveOptimization = 0x00400;
+            public const int NoOptimization         = 0x00800;
 
-            public const int AttributeMetadataCache = 0x1000;
-            public const int Intrinsic              = 0x2000;
-            public const int NativeCallable         = 0x4000;
-            public const int RuntimeExport          = 0x8000;
+            public const int AttributeMetadataCache = 0x01000;
+            public const int Intrinsic              = 0x02000;
+            public const int NativeCallable         = 0x04000;
+            public const int RuntimeExport          = 0x08000;
+
+            public const int RequireSecObject       = 0x10000;
         };
 
         private EcmaType _type;
@@ -142,6 +144,9 @@ namespace Internal.TypeSystem.Ecma
 
                 if ((methodAttributes & MethodAttributes.Final) != 0)
                     flags |= MethodFlags.Final;
+
+                if ((methodAttributes & MethodAttributes.RequireSecObject) != 0)
+                    flags |= MethodFlags.RequireSecObject;
 
                 if ((methodImplAttributes & MethodImplAttributes.NoInlining) != 0)
                     flags |= MethodFlags.NoInlining;
@@ -263,6 +268,14 @@ namespace Internal.TypeSystem.Ecma
             get
             {
                 return (GetMethodFlags(MethodFlags.BasicMetadataCache | MethodFlags.NoInlining) & MethodFlags.NoInlining) != 0;
+            }
+        }
+
+        public override bool RequireSecObject
+        {
+            get
+            {
+                return (GetMethodFlags(MethodFlags.BasicMetadataCache | MethodFlags.RequireSecObject) & MethodFlags.RequireSecObject) != 0;
             }
         }
 

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -63,6 +63,13 @@ namespace ILCompiler
 
         public bool CanInline(MethodDesc caller, MethodDesc callee)
         {
+            // Check to see if the method requires a security object.  This means they call demand and
+            // shouldn't be inlined.
+            if (callee.RequireSecObject)
+            {
+                return false;
+            }
+
             return NodeFactory.CompilationModuleGroup.CanInline(caller, callee);
         }
 

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -585,6 +585,12 @@ namespace Internal.JitInterface
                 throw new RequiresRuntimeJitException(nameof(fIsTailPrefix));
             }
 
+            MethodDesc exactCallee = HandleToObject(exactCalleeHnd);
+            if (exactCallee != null && exactCallee.RequireSecObject)
+            {
+                return false;
+            }
+
             return false;
         }
 

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -585,12 +585,6 @@ namespace Internal.JitInterface
                 throw new RequiresRuntimeJitException(nameof(fIsTailPrefix));
             }
 
-            MethodDesc exactCallee = HandleToObject(exactCalleeHnd);
-            if (exactCallee != null && exactCallee.RequireSecObject)
-            {
-                return false;
-            }
-
             return false;
         }
 


### PR DESCRIPTION
Methods using StackCrawlMark (like Assembly.GetExecutingAssembly)
require that the method is not inlined. Such methods are marked by
System.Security.DynamicSecurityMethod attribute.

This change adds proper handling of such methods, mimicking exactly what
old crossgen does.

I've also added handling of the related method flag to the canTailCall although it doesn't have any effect now. I wanted to make sure that once we implement handling tailcalls, we don't forget that.

It fixes execution time failure in Regressions\coreclr\GitHub_22888