### PR TITLE
Optimize ToString() for byte, ushort, uint and ulong

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Byte.cs
+++ b/src/System.Private.CoreLib/shared/System/Byte.cs
@@ -166,7 +166,7 @@ namespace System
 
         public override string ToString()
         {
-            return Number.FormatUInt32(m_value, null, null);
+            return Number.UInt32ToDecStr(m_value, -1);
         }
 
         public string ToString(string? format)

--- a/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
@@ -1205,7 +1205,8 @@ namespace System
         {
             while (--digits >= 0 || value != 0)
             {
-                *(--bufferEnd) = (byte)(Math.DivRem(value, 10, out value) + '0');
+                value = Math.DivRem(value, 10, out uint remainder);
+                *(--bufferEnd) = (byte)(remainder + '0');
             }
             return bufferEnd;
         }
@@ -1214,7 +1215,8 @@ namespace System
         {
             while (--digits >= 0 || value != 0)
             {
-                *(--bufferEnd) = (char)(Math.DivRem(value, 10, out value) + '0');
+                value = Math.DivRem(value, 10, out uint remainder);
+                *(--bufferEnd) = (char)(remainder + '0');
             }
             return bufferEnd;
         }
@@ -1237,7 +1239,8 @@ namespace System
                 {
                     do
                     {
-                        *(--p) = (char)('0' + Math.DivRem(value, 10, out value));
+                        value = Math.DivRem(value, 10, out uint remainder);
+                        *(--p) = (char)(remainder + '0');
                     }
                     while (value != 0);
                 }
@@ -1267,7 +1270,8 @@ namespace System
                 {
                     do
                     {
-                        *(--p) = (char)('0' + Math.DivRem(value, 10, out value));
+                        value = Math.DivRem(value, 10, out uint remainder);
+                        *(--p) = (char)(remainder + '0');
                     }
                     while (value != 0);
                 }

--- a/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
@@ -1225,7 +1225,7 @@ namespace System
             return bufferEnd;
         }
 
-        private static unsafe string UInt32ToDecStr(uint value, int digits)
+        internal static unsafe string UInt32ToDecStr(uint value, int digits)
         {
             int bufferLength = Math.Max(digits, FormattingHelpers.CountDigits(value));
 
@@ -1481,7 +1481,7 @@ namespace System
             number.CheckConsistency();
         }
 
-        private static unsafe string UInt64ToDecStr(ulong value, int digits)
+        internal static unsafe string UInt64ToDecStr(ulong value, int digits)
         {
             if (digits < 1)
                 digits = 1;

--- a/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
@@ -1205,9 +1205,7 @@ namespace System
         {
             while (--digits >= 0 || value != 0)
             {
-                // TODO https://github.com/dotnet/coreclr/issues/3439
-                uint newValue = value / 10;
-                *(--bufferEnd) = (byte)(value - (newValue * 10) + '0');
+                *(--bufferEnd) = (byte)(Math.DivRem(value, 10, out uint newValue) + '0');
                 value = newValue;
             }
             return bufferEnd;
@@ -1217,9 +1215,7 @@ namespace System
         {
             while (--digits >= 0 || value != 0)
             {
-                // TODO https://github.com/dotnet/coreclr/issues/3439
-                uint newValue = value / 10;
-                *(--bufferEnd) = (char)(value - (newValue * 10) + '0');
+                *(--bufferEnd) = (char)(Math.DivRem(value, 10, out uint newValue) + '0');
                 value = newValue;
             }
             return bufferEnd;
@@ -1243,9 +1239,7 @@ namespace System
                 {
                     do
                     {
-                        // TODO https://github.com/dotnet/coreclr/issues/3439
-                        uint div = value / 10;
-                        *(--p) = (char)('0' + value - (div * 10));
+                        *(--p) = (char)('0' + Math.DivRem(value, 10, out uint div));
                         value = div;
                     }
                     while (value != 0);
@@ -1276,9 +1270,7 @@ namespace System
                 {
                     do
                     {
-                        // TODO https://github.com/dotnet/coreclr/issues/3439
-                        uint div = value / 10;
-                        *(--p) = (char)('0' + value - (div * 10));
+                        *(--p) = (char)('0' + Math.DivRem(value, 10, out uint div));
                         value = div;
                     }
                     while (value != 0);

--- a/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
+++ b/src/System.Private.CoreLib/shared/System/Number.Formatting.cs
@@ -1205,8 +1205,7 @@ namespace System
         {
             while (--digits >= 0 || value != 0)
             {
-                *(--bufferEnd) = (byte)(Math.DivRem(value, 10, out uint newValue) + '0');
-                value = newValue;
+                *(--bufferEnd) = (byte)(Math.DivRem(value, 10, out value) + '0');
             }
             return bufferEnd;
         }
@@ -1215,8 +1214,7 @@ namespace System
         {
             while (--digits >= 0 || value != 0)
             {
-                *(--bufferEnd) = (char)(Math.DivRem(value, 10, out uint newValue) + '0');
-                value = newValue;
+                *(--bufferEnd) = (char)(Math.DivRem(value, 10, out value) + '0');
             }
             return bufferEnd;
         }
@@ -1239,8 +1237,7 @@ namespace System
                 {
                     do
                     {
-                        *(--p) = (char)('0' + Math.DivRem(value, 10, out uint div));
-                        value = div;
+                        *(--p) = (char)('0' + Math.DivRem(value, 10, out value));
                     }
                     while (value != 0);
                 }
@@ -1270,8 +1267,7 @@ namespace System
                 {
                     do
                     {
-                        *(--p) = (char)('0' + Math.DivRem(value, 10, out uint div));
-                        value = div;
+                        *(--p) = (char)('0' + Math.DivRem(value, 10, out value));
                     }
                     while (value != 0);
                 }

--- a/src/System.Private.CoreLib/shared/System/UInt16.cs
+++ b/src/System.Private.CoreLib/shared/System/UInt16.cs
@@ -68,7 +68,7 @@ namespace System
         // Converts the current value to a String in base-10 with no extra padding.
         public override string ToString()
         {
-            return Number.FormatUInt32(m_value, null, null);
+            return Number.UInt32ToDecStr(m_value, -1);
         }
 
         public string ToString(IFormatProvider? provider)

--- a/src/System.Private.CoreLib/shared/System/UInt32.cs
+++ b/src/System.Private.CoreLib/shared/System/UInt32.cs
@@ -78,7 +78,7 @@ namespace System
         // The base 10 representation of the number with no extra padding.
         public override string ToString()
         {
-            return Number.FormatUInt32(m_value, null, null);
+            return Number.UInt32ToDecStr(m_value, -1);
         }
 
         public string ToString(IFormatProvider? provider)

--- a/src/System.Private.CoreLib/shared/System/UInt64.cs
+++ b/src/System.Private.CoreLib/shared/System/UInt64.cs
@@ -77,7 +77,7 @@ namespace System
 
         public override string ToString()
         {
-            return Number.FormatUInt64(m_value, null, null);
+            return Number.UInt64ToDecStr(m_value, -1);
         }
 
         public string ToString(IFormatProvider? provider)


### PR DESCRIPTION
E.g. `byte.ToString()` currently calls `Number.FormatUInt32(m_value, null, null);` method which for `ToString()` just [redirects](https://github.com/dotnet/coreclr/blob/master/src/System.Private.CoreLib/shared/System/Number.Formatting.cs#L783-L786) it to [UInt32ToDecStr](https://github.com/dotnet/coreclr/blob/master/src/System.Private.CoreLib/shared/System/Number.Formatting.cs#L1228-L1260) so it's better to call it directly.
Same for `ushort`, `uint` and `ulong`.

Example:
```csharp
static string Test(byte b) => b.ToString();
```
Was:
```asm
G_M64984_IG01:
       sub      rsp, 56
       xor      rax, rax
       mov      qword ptr [rsp+28H], rax
       mov      dword ptr [rsp+40H], ecx
G_M64984_IG02:
       movzx    rcx, byte  ptr [rsp+40H]
       xor      rdx, rdx
       xor      r8d, r8d
       lea      rax, bword ptr [rsp+28H]
       mov      bword ptr [rax], rdx
       mov      dword ptr [rax+8], r8d
       lea      rdx, bword ptr [rsp+28H]
       xor      r8, r8
       call     System.Number:FormatUInt32(int,struct,ref):ref
       nop      
G_M64984_IG03:
       add      rsp, 56
       ret      
; Total bytes of code: 56
```
Now:
```asm
G_M64982_IG01:
       sub      rsp, 40
       mov      dword ptr [rsp+30H], ecx
G_M64982_IG02:
       movzx    rcx, byte  ptr [rsp+30H]
       mov      edx, -1
       call     System.Number:UInt32ToDecStr(int,int):ref
       nop      
G_M64982_IG03:
       add      rsp, 40
       ret      
; Total bytes of code: 29
```
(because passing `null` to Span/ReadOnlySpan argument is not cheap)

### What else can be improved:
1) [UInt32ToDecStr](https://github.com/dotnet/coreclr/blob/master/src/System.Private.CoreLib/shared/System/Number.Formatting.cs#L1228-L1260) looks a bit overkill for `byte` (which is just a 1,2 or 3 chars string)
2) I'd add a branchless internal `Math.MaxFast` for various BCL scenarious like [this](https://github.com/dotnet/coreclr/blob/master/src/System.Private.CoreLib/shared/System/Number.Formatting.cs#L1230).
3) `<const>.ToString()` can be replaced with string literals in JIT for positive constants (I have a prototype) 
4) [Redundant](https://github.com/dotnet/coreclr/blob/master/src/System.Private.CoreLib/shared/System/Number.Formatting.cs#L1235) bounds check