### PR TITLE
WIP: Refactoring the ReadyToRun flag to allow reuse of managed artifacts

### DIFF
--- a/eng/build-test-job.yml
+++ b/eng/build-test-job.yml
@@ -5,13 +5,14 @@ parameters:
   osSubgroup: ''
   container: ''
   testGroup: ''
-  readyToRun: false
   crossrootfsDir: ''
   # If true, run the corefx tests instead of the coreclr ones
   corefxTests: false
   displayNameArgs: ''
   condition: true
   stagedBuild: false
+  priBuildNamePart: ''
+  priDisplayNamePart: ''
 
 ### Build managed test components (native components are getting built as part
 ### of the the product build job).
@@ -33,7 +34,6 @@ jobs:
     managedTestBuildArchType: ${{ parameters.archType }}
     container: ${{ parameters.container }}
     testGroup: ${{ parameters.testGroup }}
-    readyToRun: ${{ parameters.readyToRun }}
     corefxTests: ${{ parameters.corefxTests }}
     stagedBuild: ${{ parameters.stagedBuild }}
 
@@ -42,42 +42,12 @@ jobs:
       continueOnError: true
 
     # Compute job name from template parameters
-    ${{ if and(eq(parameters.testGroup, 'innerloop'), eq(parameters.displayNameArgs, '')) }}:
-      name: 'build_test_p0_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'      
-      displayName: 'Build Test Pri0 ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
-
-    ${{ if and(ne(parameters.testGroup, 'innerloop'), eq(parameters.displayNameArgs, '')) }}:
-      name: 'build_test_p1_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'      
-      displayName: 'Build Test Pri1 ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
-
-    ${{ if and(eq(parameters.testGroup, 'innerloop'), ne(parameters.displayNameArgs, '')) }}:
-      name: 'build_test_p0_${{ parameters.displayNameArgs }}_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'      
-      displayName: 'Build Test Pri0 ${{ parameters.displayNameArgs }} ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
-
-    ${{ if and(ne(parameters.testGroup, 'innerloop'), ne(parameters.displayNameArgs, '')) }}:
-      name: 'build_test_p1_${{ parameters.displayNameArgs }}_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'      
-      displayName: 'Build Test Pri1 ${{ parameters.displayNameArgs }} ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
+    name: 'build_test_${{ parameters.priBuildNamePart }}${{ parameters.displayNameArgs }}_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'
+    displayName: 'Build Test ${{ parameters.priDisplayNamePart }}${{ parameters.displayNameArgs }} ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
 
     crossrootfsDir: ${{ parameters.crossrootfsDir }}
 
     variables:
-    # Map template parameters to command line arguments
-    - name: crossgenArg
-      value: ''
-    - ${{ if eq(parameters.readyToRun, true) }}:
-      - name: crossgenArg
-        value: 'crossgen'
-
-    - name: clangArg
-      value: ''
-    # Our FreeBSD doesn't yet detect available clang versions, so pass it explicitly.
-    - ${{ if eq(parameters.osGroup, 'FreeBSD') }}:
-      - name: clangArg
-        value: '-clang6.0'
-    - ${{ if eq(parameters.archType, 'arm64') }}:
-      - name: clangArg
-        value: '-clang5.0'
-
     - name: testhostArg
       value: ''
     - ${{ if eq(parameters.corefxTests, true) }}:
@@ -129,10 +99,10 @@ jobs:
 
     # Build managed test components
     - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
-      - script: ./build-test.sh skipnative skipgeneratelayout $(buildConfig) $(archType) $(crossArg) $(priorityArg) $(crossgenArg) $(clangArg) $(testhostArg) ci
+      - script: ./build-test.sh skipnative skipgeneratelayout $(buildConfig) $(archType) $(crossArg) $(priorityArg) $(testhostArg) ci
         displayName: Build managed test components
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-      - script: build-test.cmd skipnative skipgeneratelayout $(buildConfig) $(archType) $(priorityArg) $(crossgenArg) $(testhostArg) ci
+      - script: build-test.cmd skipnative skipgeneratelayout $(buildConfig) $(archType) $(priorityArg) $(testhostArg) ci
         displayName: Build managed test components
 
 
@@ -167,13 +137,9 @@ jobs:
       displayName: Publish Logs
       inputs:
         pathtoPublish: $(Build.SourcesDirectory)/bin/Logs
-        ${{ if and(eq(parameters.corefxTests, true), eq(parameters.readyToRun, true)) }}:
-          artifactName: ${{ format('TestBuildLogs_r2r_corefx_{0}{1}_{2}_{3}_{4}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, parameters.testGroup) }}
-        ${{ if and(eq(parameters.corefxTests, true), ne(parameters.readyToRun, true)) }}:
-          artifactName: ${{ format('TestBuildLogs_corefx_{0}{1}_{2}_{3}_{4}',     parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, parameters.testGroup) }}
-        ${{ if and(ne(parameters.corefxTests, true), eq(parameters.readyToRun, true)) }}:
-          artifactName: ${{ format('TestBuildLogs_r2r_{0}{1}_{2}_{3}_{4}',        parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, parameters.testGroup) }}
-        ${{ if and(ne(parameters.corefxTests, true), ne(parameters.readyToRun, true)) }}:
-          artifactName: ${{ format('TestBuildLogs_{0}{1}_{2}_{3}_{4}',            parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, parameters.testGroup) }}
+        ${{ if eq(parameters.corefxTests, true) }}:
+          artifactName: ${{ format('TestBuildLogs_corefx_{0}{1}_{2}_{3}_{4}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, parameters.testGroup) }}
+        ${{ if ne(parameters.corefxTests, true) }}:
+          artifactName: ${{ format('TestBuildLogs_{0}{1}_{2}_{3}_{4}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, parameters.testGroup) }}
       continueOnError: true
       condition: always()

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -58,7 +58,7 @@ jobs:
       testGroup: outerloop
 
 #
-# Checked test builds
+# Checked JIT + ReadyToRun test jobs
 #
 - template: /eng/platform-matrix.yml
   parameters:
@@ -68,30 +68,19 @@ jobs:
     helixQueueGroup: ci
     jobParameters:
       testGroup: outerloop
-
-#
-# ReadyToRun test jobs
-#
-- template: /eng/platform-matrix.yml
-  parameters:
-    jobTemplate: test-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_arm64
-    - Linux_musl_x64
-    - Linux_musl_arm64
-    - Linux_rhel6_x64
-    - Linux_x64
-    - OSX_x64
-    - Windows_NT_x64
-    - Windows_NT_x86
-    - Windows_NT_arm
-    - Windows_NT_arm64
-    helixQueueGroup: ci
-    jobParameters:
-      testGroup: outerloop
-      readyToRun: true
-      displayNameArgs: R2R
+      jitPlatforms:
+      - all
+      r2rPlatforms:
+      - Linux_arm64
+      - Linux_musl_x64
+      - Linux_musl_arm64
+      - Linux_rhel6_x64
+      - Linux_x64
+      - OSX_x64
+      - Windows_NT_x64
+      - Windows_NT_x86
+      - Windows_NT_arm
+      - Windows_NT_arm64
 
 #
 # Crossgen-comparison jobs

--- a/eng/pipelines/internal.yml
+++ b/eng/pipelines/internal.yml
@@ -90,7 +90,7 @@ stages:
     dependsOn: build
     jobs:
     #
-    # Release test builds
+    # Release JIT + ReadyToRun test builds
     #
     - template: /eng/platform-matrix.yml
       parameters:
@@ -101,21 +101,8 @@ stages:
         stagedBuild: true
         jobParameters:
           testGroup: outerloop
+          jitPlatforms:
+          - all
+          r2rPlatforms:
+          - all
           condition: ne(variables['_BypassTesting'], 'true')
-
-    #
-    # ReadyToRun test builds
-    #
-    - template: /eng/platform-matrix.yml
-      parameters:
-        jobTemplate: test-job.yml
-        buildConfig: release
-        platformGroup: all
-        helixQueueGroup: all
-        stagedBuild: true
-        jobParameters:
-          testGroup: outerloop
-          readyToRun: true
-          displayNameArgs: R2R
-          condition: ne(variables['_BypassTesting'], 'true')
-          

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -65,7 +65,7 @@ jobs:
       testGroup: innerloop
 
 #
-# Checked test builds
+# Checked JIT + ReadyToRun test jobs
 #
 - template: /eng/platform-matrix.yml
   parameters:
@@ -84,24 +84,13 @@ jobs:
     helixQueueGroup: pr
     jobParameters:
       testGroup: innerloop
-
-#
-# ReadyToRun test jobs
-#
-- template: /eng/platform-matrix.yml
-  parameters:
-    jobTemplate: test-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_x64
-    - OSX_x64
-    - Windows_NT_x64
-    - Windows_NT_x86
-    helixQueueGroup: pr
-    jobParameters:
-      testGroup: innerloop
-      readyToRun: true
-      displayNameArgs: R2R
+      jitPlatforms:
+      - all
+      r2rPlatforms:
+      - Linux_x64
+      - OSX_x64
+      - Windows_NT_x64
+      - Windows_NT_x86
 
 #
 # CoreFX test runs against CoreCLR

--- a/eng/pipelines/r2r-extra.yml
+++ b/eng/pipelines/r2r-extra.yml
@@ -33,5 +33,5 @@ jobs:
     helixQueueGroup: ci
     jobParameters:
       testGroup: r2r-extra
-      readyToRun: true
-      displayNameArgs: R2R
+      r2rPlatforms:
+      - all

--- a/eng/pipelines/r2r.yml
+++ b/eng/pipelines/r2r.yml
@@ -35,5 +35,5 @@ jobs:
     helixQueueGroup: ci
     jobParameters:
       testGroup: outerloop
-      readyToRun: true
-      displayNameArgs: R2R
+      r2rPlatforms:
+      - all

--- a/eng/run-test-job.yml
+++ b/eng/run-test-job.yml
@@ -9,12 +9,16 @@ parameters:
   container: ''
   testGroup: ''
   readyToRun: false
+  readyToRunNamePart: ''
+  readyToRunDisplayNamePart: ''
   helixQueues: ''
   # If true, run the corefx tests instead of the coreclr ones
   corefxTests: false
   stagedBuild: false
   displayNameArgs: ''
   runInUnloadableContext: false
+  priBuildNamePart: ''
+  priDisplayNamePart: ''
 
 ### Test run job
 
@@ -33,7 +37,6 @@ jobs:
     managedTestBuildArchType: ${{ parameters.managedTestBuildArchType }}
     container: ${{ parameters.container }}
     testGroup: ${{ parameters.testGroup }}
-    readyToRun: ${{ parameters.readyToRun }}
     corefxTests: ${{ parameters.corefxTests }}
     stagedBuild: ${{ parameters.stagedBuild }}
     helixType: 'build/tests/'
@@ -43,37 +46,12 @@ jobs:
       continueOnError: true
 
     # Compute job name from template parameters
-    ${{ if and(eq(parameters.testGroup, 'innerloop'), eq(parameters.displayNameArgs, '')) }}:
-      name: 'run_test_p0_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'
-      dependsOn:
-      - 'build_test_p0_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.managedTestBuildArchType }}_${{parameters.buildConfig }}'
-      - ${{ if ne(parameters.stagedBuild, true) }}:
-        - ${{ format('build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-      displayName: 'Run Test Pri0 ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
-
-    ${{ if and(ne(parameters.testGroup, 'innerloop'), eq(parameters.displayNameArgs, '')) }}:
-      name: 'run_test_p1_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'
-      dependsOn:
-      - 'build_test_p1_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.managedTestBuildArchType }}_${{parameters.buildConfig }}'
-      - ${{ if ne(parameters.stagedBuild, true) }}:
-        - ${{ format('build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-      displayName: 'Run Test Pri1 ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
-
-    ${{ if and(eq(parameters.testGroup, 'innerloop'), ne(parameters.displayNameArgs, '')) }}:
-      name: 'run_test_p0_${{ parameters.displayNameArgs }}_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'
-      dependsOn:
-      - 'build_test_p0_${{ parameters.displayNameArgs }}_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.managedTestBuildArchType }}_${{parameters.buildConfig }}'      
-      - ${{ if ne(parameters.stagedBuild, true) }}:
-        - ${{ format('build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-      displayName: 'Run Test Pri0 ${{ parameters.displayNameArgs }} ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
-
-    ${{ if and(ne(parameters.testGroup, 'innerloop'), ne(parameters.displayNameArgs, '')) }}:
-      name: 'run_test_p1_${{ parameters.displayNameArgs }}_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'
-      dependsOn:
-      - 'build_test_p1_${{ parameters.displayNameArgs }}_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.managedTestBuildArchType }}_${{parameters.buildConfig }}'      
-      - ${{ if ne(parameters.stagedBuild, true) }}:
-        - ${{ format('build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-      displayName: 'Run Test Pri1 ${{ parameters.displayNameArgs }} ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
+    name: 'run_test_${{ parameters.priBuildNamePart }}${{ parameters.readyToRunNamePart }}${{ parameters.displayNameArgs }}_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'
+    dependsOn:
+    - 'build_test_${{ parameters.priBuildNamePart }}${{ parameters.displayNameArgs }}_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.managedTestBuildArchType }}_${{parameters.buildConfig }}'
+    - ${{ if ne(parameters.stagedBuild, true) }}:
+      - ${{ format('build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
+    displayName: 'Run Test ${{ parameters.priDisplayNamePart }}${{ parameters.readyToRunDisplayNamePart }}${{ parameters.displayNameArgs }} ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
 
     variables:
     - ${{ if eq(variables['System.TeamProject'], 'internal') }}:

--- a/eng/test-job.yml
+++ b/eng/test-job.yml
@@ -8,7 +8,8 @@ parameters:
   managedTestBuildArchType: ''
   container: ''
   testGroup: ''
-  readyToRun: false
+  jitPlatforms: []
+  r2rPlatforms: []
   helixQueues: ''
   crossrootfsDir: ''
   # If true, run the corefx tests instead of the coreclr ones
@@ -33,27 +34,71 @@ jobs:
       osSubgroup: ${{ parameters.osSubgroup }}
       container: ${{ parameters.container }}
       testGroup: ${{ parameters.testGroup }}
-      readyToRun: ${{ parameters.readyToRun }}
       crossrootfsDir: ${{ parameters.crossrootfsDir }}
       corefxTests: ${{ parameters.coreFxTests }}
       displayNameArgs: ${{ parameters.displayNameArgs }}
       condition: ${{ parameters.condition }}
       stagedBuild: ${{ parameters.stagedBuild }}
 
-- template: run-test-job.yml
-  parameters:
-    buildConfig: ${{ parameters.buildConfig }}
-    archType: ${{ parameters.archType }}
-    osGroup: ${{ parameters.osGroup }}
-    osSubgroup: ${{ parameters.osSubgroup }}
-    managedTestBuildOsGroup: ${{ parameters.managedTestBuildOsGroup }}
-    managedTestBuildOsSubgroup: ${{ parameters.managedTestBuildOsSubgroup }}
-    managedTestBuildArchType: ${{ parameters.managedTestBuildArchType }}
-    container: ${{ parameters.container }}
-    testGroup: ${{ parameters.testGroup }}
-    readyToRun: ${{ parameters.readyToRun }}
-    helixQueues: ${{ parameters.helixQueues }}
-    corefxTests: ${{ parameters.coreFxTests }}
-    displayNameArgs: ${{ parameters.displayNameArgs }}
-    stagedBuild: ${{ parameters.stagedBuild }}
-    runInUnloadableContext: ${{ parameters.runInUnloadableContext }}
+      ${{ if eq(parameters.testGroup, 'innerloop') }}:
+        priBuildNamePart: 'p0_'
+        priDisplayNamePart: 'Pri0 '
+      ${{ if ne(parameters.testGroup, 'innerloop') }}:
+        priBuildNamePart: 'p1_'
+        priDisplayNamePart: 'Pri1 '
+
+- ${{ if or(containsValue(parameters.jitPlatforms, 'all'), containsValue(parameters.jitPlatforms, format('{0}{1}_{2}', parameters.osGroup, parameters.osSubgroup, parameters.archType))) }}:
+  - template: run-test-job.yml
+    parameters:
+      buildConfig: ${{ parameters.buildConfig }}
+      archType: ${{ parameters.archType }}
+      osGroup: ${{ parameters.osGroup }}
+      osSubgroup: ${{ parameters.osSubgroup }}
+      managedTestBuildOsGroup: ${{ parameters.managedTestBuildOsGroup }}
+      managedTestBuildOsSubgroup: ${{ parameters.managedTestBuildOsSubgroup }}
+      managedTestBuildArchType: ${{ parameters.managedTestBuildArchType }}
+      container: ${{ parameters.container }}
+      testGroup: ${{ parameters.testGroup }}
+      readyToRun: false
+      readyToRunNamePart: ''
+      readyToRunDisplayNamePart: ''
+      helixQueues: ${{ parameters.helixQueues }}
+      corefxTests: ${{ parameters.coreFxTests }}
+      displayNameArgs: ${{ parameters.displayNameArgs }}
+      stagedBuild: ${{ parameters.stagedBuild }}
+      runInUnloadableContext: ${{ parameters.runInUnloadableContext }}
+
+      ${{ if eq(parameters.testGroup, 'innerloop') }}:
+        priBuildNamePart: 'p0_'
+        priDisplayNamePart: 'Pri0 '
+      ${{ if ne(parameters.testGroup, 'innerloop') }}:
+        priBuildNamePart: 'p1_'
+        priDisplayNamePart: 'Pri1 '
+
+- ${{ if or(containsValue(parameters.r2rPlatforms, 'all'), containsValue(parameters.r2rPlatforms, format('{0}{1}_{2}', parameters.osGroup, parameters.osSubgroup, parameters.archType))) }}:
+  - template: run-test-job.yml
+    parameters:
+      buildConfig: ${{ parameters.buildConfig }}
+      archType: ${{ parameters.archType }}
+      osGroup: ${{ parameters.osGroup }}
+      osSubgroup: ${{ parameters.osSubgroup }}
+      managedTestBuildOsGroup: ${{ parameters.managedTestBuildOsGroup }}
+      managedTestBuildOsSubgroup: ${{ parameters.managedTestBuildOsSubgroup }}
+      managedTestBuildArchType: ${{ parameters.managedTestBuildArchType }}
+      container: ${{ parameters.container }}
+      testGroup: ${{ parameters.testGroup }}
+      readyToRun: true
+      readyToRunNamePart: 'r2r_'
+      readyToRunDisplayNamePart: 'R2R '
+      helixQueues: ${{ parameters.helixQueues }}
+      corefxTests: ${{ parameters.coreFxTests }}
+      displayNameArgs: ${{ parameters.displayNameArgs }}
+      stagedBuild: ${{ parameters.stagedBuild }}
+      runInUnloadableContext: ${{ parameters.runInUnloadableContext }}
+
+      ${{ if eq(parameters.testGroup, 'innerloop') }}:
+        priBuildNamePart: 'p0_'
+        priDisplayNamePart: 'Pri0 '
+      ${{ if ne(parameters.testGroup, 'innerloop') }}:
+        priBuildNamePart: 'p1_'
+        priDisplayNamePart: 'Pri1 '

--- a/eng/xplat-test-job.yml
+++ b/eng/xplat-test-job.yml
@@ -12,7 +12,6 @@ parameters:
   testGroup: ''
   crossrootfsDir: ''
   corefxTests: false
-  readyToRun: false
   stagedBuild: false
 
   # arcade-specific parameters
@@ -58,13 +57,6 @@ jobs:
     - name: nativeRootFolderPath
       value: $(binTestsPath)/$(osGroup).$(archType).$(buildConfigUpper)
 
-    - name: testArtifactNameR2RPart
-      value: ''
-
-    - ${{ if eq(parameters.readyToRun, true) }}:
-      - name: testArtifactNameR2RPart
-        value: '_r2r'
-
     - name: testArtifactNameCoreFxPart
       value: ''
 
@@ -80,7 +72,7 @@ jobs:
         value: _$(testGroup)
 
     - name: testArtifactName
-      value: Tests$(testArtifactNameR2RPart)$(testArtifactNameCoreFxPart)_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.managedTestBuildArchType }}_$(buildConfig)$(testArtifactNameTestGroupPart)
+      value: Tests$(testArtifactNameCoreFxPart)_${{ parameters.managedTestBuildOsGroup }}${{ parameters.managedTestBuildOsSubgroup }}_${{ parameters.managedTestBuildArchType }}_$(buildConfig)$(testArtifactNameTestGroupPart)
 
     - name: testNativeArtifactName
       value: 'NativeTestComponents_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'


### PR DESCRIPTION
Today, R2R compilation of test MSIL using Crossgen happens during
test execution in Helix. This means that both the managed and
native artifacts for a given OS / architecture / config combo
are identical for a R2R / non-R2R job. We can exploit this fact
to further reduce the number of test build jobs.

To achieve this goal, I have paired up platform-matrix expansions
for test-job.yml treating with JIT-ted (non-R2R) vs. ReadyToRun
jobs for the same build configuration. What typically happens is
that R2R testing is a subset of the JIT testing (PR runs), both
test the same thing (internal.yml) or there's only R2R testing
in a R2R-specific test pipeline (r2r.yml, r2r-extra.yml).

For these expansions, I have modified test-job so that, instead
of the readyToRun flag it accepts subsets of the entire build
set to use for R2R / non-R2R execution. (To simplify the scripts
a special combo value 'all' is accepted as meaning all platforms
in the expansion.)

Thanks

Tomas