### PR TITLE
Port fix done in pre 2.1 version to show managed type names in dump files instead of UNKNOWN

### DIFF
--- a/src/debug/createdump/crashinfo.cpp
+++ b/src/debug/createdump/crashinfo.cpp
@@ -202,6 +202,11 @@ CrashInfo::GatherCrashInfo(MINIDUMP_TYPE minidumpType)
     // the heap regions are marked RWX instead of just RW.
     else if (minidumpType & MiniDumpWithPrivateReadWriteMemory)
     {
+        for (const MemoryRegion& region : m_moduleMappings)
+        {
+            InsertMemoryBackedRegion(region);
+        }
+
         for (const MemoryRegion& region : m_otherMappings)
         {
             uint32_t permissions = region.Permissions();


### PR DESCRIPTION
Fix for https://github.com/dotnet/coreclr/issues/27061
Should be back-ported to 2.1.x, 2.2.x and 3.0.x