### PR TITLE
[WIP] Significantly improve performance of Utf8String / Utf8Span GetCharCount method

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Text/Unicode/Utf8Utility.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/Unicode/Utf8Utility.cs
@@ -66,7 +66,6 @@ namespace System.Text.Unicode
         /// to UTF-16. The behavior of this method is undefined if <paramref name="utf8Data"/> contains
         /// any ill-formed UTF-8 subsequences.
         /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe int GetUtf16CharCountFromKnownWellFormedUtf8(ReadOnlySpan<byte> utf8Data)
         {
             // Remember: the number of resulting UTF-16 chars will never be greater than the number

--- a/src/System.Private.CoreLib/shared/System/Text/Unicode/Utf8Utility.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/Unicode/Utf8Utility.cs
@@ -7,7 +7,18 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
 using Internal.Runtime.CompilerServices;
+
+#pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
+#if BIT64
+using nint = System.Int64;
+using nuint = System.UInt64;
+#else
+using nint = System.Int32;
+using nuint = System.UInt32;
+#endif
 
 namespace System.Text.Unicode
 {
@@ -23,6 +34,11 @@ namespace System.Text.Unicode
         /// The UTF-8 representation of <see cref="UnicodeUtility.ReplacementChar"/>.
         /// </summary>
         private static ReadOnlySpan<byte> ReplacementCharSequence => new byte[] { 0xEF, 0xBF, 0xBD };
+
+        /// <summary>
+        /// A <see cref="Vector128{SByte}"/> where each element has a value corresponding to its index.
+        /// </summary>
+        private static readonly Vector128<sbyte> VectorOfElementIndices = Vector128.Create(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
 
         /// <summary>
         /// Returns the byte index in <paramref name="utf8Data"/> where the first invalid UTF-8 sequence begins,
@@ -44,6 +60,144 @@ namespace System.Text.Unicode
         }
 
 #if FEATURE_UTF8STRING
+        /// <summary>
+        /// Given a buffer <paramref name="utf8Data"/> which represents guaranteed well-formed UTF-8 data,
+        /// returns the number of <see langword="char"/>s which would result from transcoding the buffer
+        /// to UTF-16. The behavior of this method is undefined if <paramref name="utf8Data"/> contains
+        /// any ill-formed UTF-8 subsequences.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe int GetUtf16CharCountFromKnownWellFormedUtf8(ReadOnlySpan<byte> utf8Data)
+        {
+            // Remember: the number of resulting UTF-16 chars will never be greater than the number
+            // of UTF-8 bytes given well-formed input, so we can get away with casting the final
+            // result to an 'int'.
+
+            fixed (byte* pPinnedUtf8Data = &MemoryMarshal.GetReference(utf8Data))
+            {
+                if (Sse2.IsSupported && Popcnt.IsSupported)
+                {
+                    // Optimizations via SSE2 & POPCNT are available - use them.
+
+                    Debug.Assert(BitConverter.IsLittleEndian, "SSE2 only supported on little-endian platforms.");
+                    Debug.Assert(sizeof(nint) == IntPtr.Size, "nint defined incorrectly.");
+                    Debug.Assert(sizeof(nuint) == IntPtr.Size, "nuint defined incorrectly.");
+
+                    byte* pBuffer = pPinnedUtf8Data;
+                    nuint bufferLength = (uint)utf8Data.Length;
+
+                    // Optimization: Can we stay in the all-ASCII code paths?
+
+                    nuint utf16CharCount = ASCIIUtility.GetIndexOfFirstNonAsciiByte(pBuffer, bufferLength);
+
+                    if (utf16CharCount != bufferLength)
+                    {
+                        // Found at least one non-ASCII byte, so fall down the slower (but still vectorized) code paths.
+                        // Given well-formed UTF-8 input, we can compute the number of resulting UTF-16 code units
+                        // using the following formula:
+                        //
+                        // utf16CharCount = utf8ByteCount - numUtf8ContinuationBytes + numUtf8FourByteHeaders
+
+                        utf16CharCount = bufferLength;
+
+                        Vector128<sbyte> vecAllC0 = Vector128.Create(unchecked((sbyte)0xC0));
+                        Vector128<sbyte> vecAll80 = Vector128.Create(unchecked((sbyte)0x80));
+                        Vector128<sbyte> vecAll6F = Vector128.Create(unchecked((sbyte)0x6F));
+
+                        {
+                            // Perform an aligned read of the first part of the buffer.
+                            // We'll mask out any data at the start of the buffer we don't care about.
+                            //
+                            // For example, if (pBuffer MOD 16) = 2:
+                            // [ AA BB CC DD ... ] <-- original vector
+                            // [ 00 00 CC DD ... ] <-- after PANDN operation
+
+                            nint offset = -((nint)pBuffer & (sizeof(Vector128<sbyte>) - 1));
+                            Vector128<sbyte> shouldBeMaskedOut = Sse2.CompareGreaterThan(Vector128.Create((byte)((int)offset + sizeof(Vector128<sbyte>) - 1)).AsSByte(), VectorOfElementIndices);
+                            Vector128<sbyte> thisVector = Sse2.AndNot(shouldBeMaskedOut, Unsafe.Read<Vector128<sbyte>>(pBuffer + offset));
+
+                            // If there's any data at the end of the buffer we don't care about, mask it out now.
+                            // If this happens the 'bufferLength' value will be a lie, but it'll cause all of the
+                            // branches later in the method to be skipped, so it's not a huge problem.
+
+                            if (bufferLength < (nuint)offset + (uint)sizeof(Vector128<sbyte>))
+                            {
+                                Vector128<sbyte> shouldBeAllowed = Sse2.CompareLessThan(VectorOfElementIndices, Vector128.Create((byte)((int)bufferLength - (int)offset)).AsSByte());
+                                thisVector = Sse2.And(shouldBeAllowed, thisVector);
+                                bufferLength = (nuint)offset + (uint)sizeof(Vector128<sbyte>);
+                            }
+
+                            uint maskOfContinuationBytes = (uint)Sse2.MoveMask(Sse2.CompareGreaterThan(vecAllC0, thisVector));
+                            uint countOfContinuationBytes = Popcnt.PopCount(maskOfContinuationBytes);
+                            utf16CharCount -= countOfContinuationBytes;
+
+                            uint maskOfFourByteHeaders = (uint)Sse2.MoveMask(Sse2.CompareGreaterThan(Sse2.Xor(thisVector, vecAll80), vecAll6F));
+                            uint countOfFourByteHeaders = Popcnt.PopCount(maskOfFourByteHeaders);
+                            utf16CharCount += countOfFourByteHeaders;
+
+                            bufferLength -= (nuint)offset;
+                            bufferLength -= (uint)sizeof(Vector128<sbyte>);
+
+                            pBuffer += offset;
+                            pBuffer += (uint)sizeof(Vector128<sbyte>);
+                        }
+
+                        // At this point, pBuffer is guaranteed aligned.
+
+                        Debug.Assert((nuint)pBuffer % (uint)sizeof(Vector128<sbyte>) == 0, "pBuffer should have been aligned.");
+
+                        while (bufferLength >= (uint)sizeof(Vector128<sbyte>))
+                        {
+                            Vector128<sbyte> thisVector = Sse2.LoadAlignedVector128((sbyte*)pBuffer);
+
+                            uint maskOfContinuationBytes = (uint)Sse2.MoveMask(Sse2.CompareGreaterThan(vecAllC0, thisVector));
+                            uint countOfContinuationBytes = Popcnt.PopCount(maskOfContinuationBytes);
+                            utf16CharCount -= countOfContinuationBytes;
+
+                            uint maskOfFourByteHeaders = (uint)Sse2.MoveMask(Sse2.CompareGreaterThan(Sse2.Xor(thisVector, vecAll80), vecAll6F));
+                            uint countOfFourByteHeaders = Popcnt.PopCount(maskOfFourByteHeaders);
+                            utf16CharCount += countOfFourByteHeaders;
+
+                            pBuffer += sizeof(Vector128<sbyte>);
+                            bufferLength -= (uint)sizeof(Vector128<sbyte>);
+                        }
+
+                        if ((uint)bufferLength > 0)
+                        {
+                            // There's still more data to be read.
+                            // We need to mask out elements of the vector we don't care about.
+                            // These elements will occur at the end of the vector.
+                            //
+                            // For example, if 14 bytes remain in the input stream:
+                            // [ ... CC DD EE FF ] <-- original vector
+                            // [ ... CC DD 00 00 ] <-- after PANDN operation
+
+                            Vector128<sbyte> shouldBeMaskedOut = Sse2.CompareGreaterThan(VectorOfElementIndices, Vector128.Create((byte)((int)bufferLength - 1)).AsSByte());
+                            Vector128<sbyte> thisVector = Sse2.AndNot(shouldBeMaskedOut, *(Vector128<sbyte>*)pBuffer);
+
+                            uint maskOfContinuationBytes = (uint)Sse2.MoveMask(Sse2.CompareGreaterThan(vecAllC0, thisVector));
+                            uint countOfContinuationBytes = Popcnt.PopCount(maskOfContinuationBytes);
+                            utf16CharCount -= countOfContinuationBytes;
+
+                            uint maskOfFourByteHeaders = (uint)Sse2.MoveMask(Sse2.CompareGreaterThan(Sse2.Xor(thisVector, vecAll80), vecAll6F));
+                            uint countOfFourByteHeaders = Popcnt.PopCount(maskOfFourByteHeaders);
+                            utf16CharCount += countOfFourByteHeaders;
+                        }
+                    }
+
+                    return (int)utf16CharCount;
+                }
+                else
+                {
+                    // Cannot use SSE2 & POPCNT. Fall back to slower code paths.
+
+                    byte* pbFirstInvalid = GetPointerToFirstInvalidByte(pPinnedUtf8Data, utf8Data.Length, out int utf16CodeUnitCountAdjustment, out _);
+                    Debug.Assert(pbFirstInvalid == pPinnedUtf8Data + utf8Data.Length, "The input was not well-formed UTF-8!");
+                    return utf8Data.Length + utf16CodeUnitCountAdjustment;
+                }
+            }
+        }
+
         /// <summary>
         /// Returns a value stating whether <paramref name="utf8Data"/> contains only well-formed UTF-8 data.
         /// </summary>

--- a/src/System.Private.CoreLib/src/System/Text/Utf8Span.cs
+++ b/src/System.Private.CoreLib/src/System/Text/Utf8Span.cs
@@ -148,6 +148,13 @@ namespace System.Text
             return StringComparer.FromComparison(comparison).Equals(left.ToString(), right.ToString());
         }
 
+        /// <summary>
+        /// Returns the number of <see langword="char"/>s that would result from transcoding this
+        /// <see cref="Utf8Span"/> instance to a <see cref="string"/>. This is also the length
+        /// of the <see cref="string"/> that is returned by the <see cref="ToString"/> method.
+        /// </summary>
+        public int GetCharCount() => Utf8Utility.GetUtf16CharCountFromKnownWellFormedUtf8(Bytes);
+
         public override int GetHashCode()
         {
             // TODO_UTF8STRING: Consider whether this should use a different seed than String.GetHashCode.

--- a/src/System.Private.CoreLib/src/System/Utf8String.cs
+++ b/src/System.Private.CoreLib/src/System/Utf8String.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.Unicode;
 using Internal.Runtime.CompilerServices;
 
 namespace System
@@ -166,6 +167,13 @@ namespace System
                 && left.Length == right.Length
                 && SpanHelpers.SequenceEqual(ref left.DangerousGetMutableReference(), ref right.DangerousGetMutableReference(), (uint)left.Length);
         }
+
+        /// <summary>
+        /// Returns the number of <see langword="char"/>s that would result from transcoding this
+        /// <see cref="Utf8String"/> instance to a <see cref="string"/>. This is also the length
+        /// of the <see cref="string"/> that is returned by the <see cref="ToString"/> method.
+        /// </summary>
+        public int GetCharCount() => Utf8Utility.GetUtf16CharCountFromKnownWellFormedUtf8(this.AsBytes());
 
         /// <summary>
         /// Returns a hash code using a <see cref="StringComparison.Ordinal"/> comparison.


### PR DESCRIPTION
This is marked __WIP__ because it's not yet fully tested, but I wanted to demonstrate what was possible due to the design of the `Utf8String` and `Utf8Span` types.

Since these types are contracted to carry only well-formed UTF-8 data, we can make certain optimizations that wouldn't be allowable in more generalized APIs like `UTF8Encoding`. For example, when computing the number of `char`s that would result from a particular `Utf8String` or `Utf8Span` instance, we can suppress all error checking and go down highly optimized code paths.

The table below shows the comparison between the baseline `Encoding.UTF8.GetChars(ReadOnlySpan<byte>)` method and the `GetCharCount` methods introduced as part of this PR. The difference is substantial, especially for code paths which weren't previously vectorized.

|            Method |      Corpus |       Mean |     Error |    StdDev | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------ |------------ |-----------:|----------:|----------:|------:|--------:|------:|------:|------:|----------:|
| **GetCharCount_Base** |    **11-0.txt** |  **41.112 us** | **0.7052 us** | **0.6596 us** |  **1.00** |    **0.00** |     **-** |     **-** |     **-** |         **-** |
| GetCharCount_Exp1 |    11-0.txt |  10.576 us | 0.1957 us | 0.1831 us |  0.26 |    0.01 |     - |     - |     - |         - |
|                   |             |            |           |           |       |         |       |       |       |           |
| **GetCharCount_Base** |      **11.txt** |   **3.574 us** | **0.0469 us** | **0.0439 us** |  **1.00** |    **0.00** |     **-** |     **-** |     **-** |         **-** |
| GetCharCount_Exp1 |      11.txt |   3.446 us | 0.0598 us | 0.0530 us |  0.96 |    0.02 |     - |     - |     - |         - |
|                   |             |            |           |           |       |         |       |       |       |           |
| **GetCharCount_Base** | **25249-0.txt** |  **74.032 us** | **1.3925 us** | **1.2344 us** |  **1.00** |    **0.00** |     **-** |     **-** |     **-** |         **-** |
| GetCharCount_Exp1 | 25249-0.txt |  10.977 us | 0.2190 us | 0.2769 us |  0.15 |    0.00 |     - |     - |     - |         - |
|                   |             |            |           |           |       |         |       |       |       |           |
| **GetCharCount_Base** | **30774-0.txt** |  **82.685 us** | **0.8982 us** | **0.8402 us** |  **1.00** |    **0.00** |     **-** |     **-** |     **-** |         **-** |
| GetCharCount_Exp1 | 30774-0.txt |   6.412 us | 0.1154 us | 0.2080 us |  0.08 |    0.00 |     - |     - |     - |         - |
|                   |             |            |           |           |       |         |       |       |       |           |
| **GetCharCount_Base** | **39251-0.txt** | **136.402 us** | **2.4733 us** | **2.3136 us** |  **1.00** |    **0.00** |     **-** |     **-** |     **-** |         **-** |
| GetCharCount_Exp1 | 39251-0.txt |   8.044 us | 0.1570 us | 0.1392 us |  0.06 |    0.00 |     - |     - |     - |         - |

Even small non-English texts see notable improvement. For example, pulling the word "αδαμάντινης" from one sample text and running the benchmark just on that one word results in around twice the throughput.

|            Method |      Mean |     Error |    StdDev | Ratio | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------ |----------:|----------:|----------:|------:|------:|------:|------:|----------:|
| GetCharCount_Base | 18.665 ns | 0.3949 ns | 0.5135 ns |  1.00 |     - |     - |     - |         - |
| GetCharCount_Exp1 |  8.796 ns | 0.1680 ns | 0.1489 ns |  0.48 |     - |     - |     - |         - |

This PR only concerns itself with counting chars, not with performing the actual transcoding (creating the `string` instance) step. But it's not a giant leap to imagine having an optimized transcoder that gives `Utf8String.ToString()` markedly better performance than `Encoding.UTF8.GetString(ReadOnlySpan<byte>)`.