### PR TITLE
[release/3.1] Enable optimized single-proc allocation helpers for single-proc x86/x64 systems only (#27014)

### DIFF
--- a/src/vm/gcheaputilities.h
+++ b/src/vm/gcheaputilities.h
@@ -122,12 +122,12 @@ public:
 
     static bool UseThreadAllocationContexts()
     {
-        // When running on a single-proc system, it's more efficient to use a single global
+        // When running on a single-proc Intel system, it's more efficient to use a single global
         // allocation context for SOH allocations than to use one for every thread.
-#if defined(_TARGET_ARM_) || defined(FEATURE_PAL) || defined(FEATURE_REDHAWK)
-        return true;
+#if (defined(_TARGET_X86_) || defined(_TARGET_AMD64_)) && !defined(FEATURE_PAL)
+        return IsServerHeap() || ::g_SystemInfo.dwNumberOfProcessors != 1 || CPUGroupInfo::CanEnableGCCPUGroups();
 #else
-        return IsServerHeap() || ::GetCurrentProcessCpuCount() != 1;
+        return true;
 #endif
 
     }


### PR DESCRIPTION
Description
Regression introduce as side-effect of refactoring for local GC. The GC uses incorrectly uses current processor count instead of total processor count to determine whether it is safe to use special uniprocessor allocation helpers.

Customer impact
Changing process affinity from 1 processor to more processor after the process starts will lead to intermittent crashes.

Regression?
Yes (2.0 -> 2.1,3.0)

Risk
Small. Undo the bad change.

----

Use maximum number of processors the process may run on to determine whether it is ok to use
single-proc allocation helpers. It is not sufficient to depend on current process affinity since
that can change during the process lifetime.

Also, the single-proc allocation helpers work well on x86/x64 systems only because of they depend
on atomic non-interlocked increment instruction for good performance. Such instruction is available
on x86/x64 only. Disable them everywhere else.

Fixes #26990