### PR TITLE
[crossgen2] Attribute Presence Filter

### DIFF
--- a/src/tools/crossgen2/Common/Internal/Runtime/ModuleHeaders.cs
+++ b/src/tools/crossgen2/Common/Internal/Runtime/ModuleHeaders.cs
@@ -62,6 +62,7 @@ namespace Internal.Runtime
         InliningInfo = 110, // Added in v2.1
         ProfileDataInfo = 111, // Added in v2.2
         ManifestMetadata = 112, // Added in v2.3
+        AttributePresence = 113, // Added in V3.1
 
         //
         // CoreRT ReadyToRun sections

--- a/src/tools/crossgen2/Common/TypeSystem/Common/TypeHashingAlgorithms.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Common/TypeHashingAlgorithms.cs
@@ -251,38 +251,5 @@ namespace Internal.NativeFormat
                 return index * 0x5498341 + 0x832424;
             }
         }
-
-        private static uint XXHash32_MixEmptyState()
-        {
-            // Unlike System.HashCode, these hash values are required to be stable, so don't
-            // mixin a random process specific value
-            return 374761393U; // Prime5
-        }
-
-        private static uint XXHash32_QueueRound(uint hash, uint queuedValue)
-        {
-            return ((uint)_rotl((int)(hash + queuedValue * 3266489917U/*Prime3*/), 17)) * 668265263U/*Prime4*/;
-        }
-
-        private static uint XXHash32_MixFinal(uint hash)
-        {
-            hash ^= hash >> 15;
-            hash *= 2246822519U/*Prime2*/;
-            hash ^= hash >> 13;
-            hash *= 3266489917U/*Prime3*/;
-            hash ^= hash >> 16;
-            return hash;
-        }
-
-        public static uint CombineTwoValuesIntoHash(uint value1, uint value2)
-        {
-            // This matches the behavior of System.HashCode.Combine(value1, value2) as of the time of authoring
-            uint hash = XXHash32_MixEmptyState();
-            hash += 8;
-            hash = XXHash32_QueueRound(hash, value1);
-            hash = XXHash32_QueueRound(hash, value2);
-            hash = XXHash32_MixFinal(hash);
-            return hash;
-        }
     }
 }

--- a/src/tools/crossgen2/Common/TypeSystem/Common/TypeHashingAlgorithms.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Common/TypeHashingAlgorithms.cs
@@ -115,7 +115,7 @@ namespace Internal.NativeFormat
             return hash1 ^ hash2;
         }
 
-        // This function may be needed in a portion of the codebase which is too low level to use 
+        // This function may be needed in a portion of the codebase which is too low level to use
         // globalization, ergo, we cannot call ToString on the integer.
         private static string IntToString(int arg)
         {
@@ -145,7 +145,7 @@ namespace Internal.NativeFormat
 
         public static int ComputeArrayTypeHashCode(int elementTypeHashCode, int rank)
         {
-            // Arrays are treated as generic types in some parts of our system. The array hashcodes are 
+            // Arrays are treated as generic types in some parts of our system. The array hashcodes are
             // carefully crafted to be the same as the hashcodes of their implementation generic types.
 
             int hashCode;
@@ -250,6 +250,39 @@ namespace Internal.NativeFormat
             {
                 return index * 0x5498341 + 0x832424;
             }
+        }
+
+        private static uint XXHash32_MixEmptyState()
+        {
+            // Unlike System.HashCode, these hash values are required to be stable, so don't
+            // mixin a random process specific value
+            return 374761393U; // Prime5
+        }
+
+        private static uint XXHash32_QueueRound(uint hash, uint queuedValue)
+        {
+            return ((uint)_rotl((int)(hash + queuedValue * 3266489917U/*Prime3*/), 17)) * 668265263U/*Prime4*/;
+        }
+
+        private static uint XXHash32_MixFinal(uint hash)
+        {
+            hash ^= hash >> 15;
+            hash *= 2246822519U/*Prime2*/;
+            hash ^= hash >> 13;
+            hash *= 3266489917U/*Prime3*/;
+            hash ^= hash >> 16;
+            return hash;
+        }
+
+        public static uint CombineTwoValuesIntoHash(uint value1, uint value2)
+        {
+            // This matches the behavior of System.HashCode.Combine(value1, value2) as of the time of authoring
+            uint hash = XXHash32_MixEmptyState();
+            hash += 8;
+            hash = XXHash32_QueueRound(hash, value1);
+            hash = XXHash32_QueueRound(hash, value2);
+            hash = XXHash32_MixFinal(hash);
+            return hash;
         }
     }
 }

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/AttributePresenceFilterNode.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/AttributePresenceFilterNode.cs
@@ -244,7 +244,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         if (isEmptyEntryInBucket(bucketAIndex))
                         {
                             fillEmptyEntryInBucket(bucketAIndex, fingerprint);
-                            continue;
+                            success = true;
                         }
                     }
 

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/AttributePresenceFilterNode.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/AttributePresenceFilterNode.cs
@@ -5,14 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
-using System.Runtime.InteropServices;
-using System.Text;
 
-using Internal.JitInterface;
-using Internal.NativeFormat;
 using Internal.Text;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
@@ -22,12 +17,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
     public class AttributePresenceFilterNode : HeaderTableNode
     {
         private EcmaModule _module;
-        private ObjectData computedData;
+        private ObjectData _computedData;
 
         public override int ClassCode => 56456113;
 
-        public AttributePresenceFilterNode(EcmaModule module, TargetDetails target)
-            : base(target)
+        public AttributePresenceFilterNode(EcmaModule module)
+            : base(module.Context.Target)
         {
             this._module = module;
         }
@@ -102,7 +97,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     TypeNamespace = customAttributeTypeNamespace,
                     TypeName = customAttributeTypeName,
                     Parent = reader.GetToken(customAttribute.Parent)
-                }); ;
+                });
             }
             return customAttributeEntries;
         }
@@ -125,9 +120,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             if (relocsOnly)
                 return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this });
 
-            if (computedData != null)
+            if (_computedData != null)
             {
-                return computedData;
+                return _computedData;
             }
 
             List<CustomAttributeEntry> customAttributeEntries = GetCustomAttributeEntries();
@@ -288,8 +283,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             builder.RequireInitialAlignment(16);
             builder.AddSymbol(this);
             builder.EmitBytes(result);
-            computedData = builder.ToObjectData();
-            return computedData;
+            _computedData = builder.ToObjectData();
+            return _computedData;
         }
     }
 }

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/AttributePresenceFilterNode.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/AttributePresenceFilterNode.cs
@@ -1,0 +1,274 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Runtime.InteropServices;
+using System.Text;
+
+using Internal.JitInterface;
+using Internal.NativeFormat;
+using Internal.Text;
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public class AttributePresenceFilterNode : HeaderTableNode
+    {
+        private EcmaModule _module;
+
+        public override int ClassCode => 56456113;
+
+        public AttributePresenceFilterNode(EcmaModule module, TargetDetails target)
+            : base(target)
+        {
+            this._module = module;
+        }
+
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix);
+            sb.Append("__ReadyToRunAttributePresenceFilter");
+        }
+
+        private struct CustomAttributeEntry
+        {
+            public string TypeNamespace;
+            public string TypeName;
+            public int Parent;
+        }
+
+        private List<CustomAttributeEntry> GetCustomAttributeEntries()
+        {
+            MetadataReader reader = _module.MetadataReader;
+            List<CustomAttributeEntry> customAttributeEntries = new List<CustomAttributeEntry>();
+            foreach (var handle in reader.CustomAttributes)
+            {
+                CustomAttribute customAttribute = reader.GetCustomAttribute(handle);
+                EntityHandle customAttributeConstructorHandle = customAttribute.Constructor;
+                MethodDesc customAttributeConstructorMethodDesc = this._module.GetMethod(customAttributeConstructorHandle);
+                DefType customAttributeDefType = customAttributeConstructorMethodDesc.OwningType as DefType;
+                Debug.Assert(customAttributeDefType != null);
+                string customAttributeTypeNamespace = customAttributeDefType.Namespace;
+                string customAttributeTypeName = customAttributeDefType.Name;
+                // System.Runtime.CompilerServices.NullableAttribute is NEVER added to the table (There are *many* of these, and they provide no useful value to the runtime)
+                if (customAttributeTypeNamespace == "System.Runtime.CompilerServices" && customAttributeTypeName == "NullableAttribute")
+                {
+                    continue;
+                }
+                bool addToTable = false;
+                if (customAttributeTypeNamespace.StartsWith("System.Runtime."))
+                {
+                    addToTable = true;
+                }
+                else if (customAttributeTypeNamespace == "Windows.Foundation.Metadata")
+                {
+                    // Windows.Foundation.Metadata attributes are a similar construct to compilerservices attributes. Add them to the table
+                    addToTable = true;
+                }
+                else if (customAttributeTypeNamespace == "System")
+                {
+                    // Some historical well known attributes were placed in the System namespace. Special case them
+                    if (customAttributeTypeName == "ParamArrayAttribute")
+                    {
+                        addToTable = true;
+                    }
+                    else if (customAttributeTypeName == "ThreadStaticAttribute")
+                    {
+                        addToTable = true;
+                    }
+                }
+                else if (customAttributeTypeNamespace == "System.Reflection")
+                {
+                    // Historical attribute in the System.Reflection namespace
+                    if (customAttributeTypeName == "DefaultMemberAttribute")
+                    {
+                        addToTable = true;
+                    }
+                }
+
+                if (!addToTable)
+                    continue;
+
+                customAttributeEntries.Add(new CustomAttributeEntry
+                {
+                    TypeNamespace = customAttributeTypeNamespace,
+                    TypeName = customAttributeTypeName,
+                    Parent = reader.GetToken(customAttribute.Parent)
+                }); ;
+            }
+            return customAttributeEntries;
+        }
+
+        private uint xorshift128(uint[] state)
+        {
+            uint s, t = state[3];
+            state[3] = state[2];
+            state[2] = state[1];
+            state[1] = s = state[0];
+            t ^= t << 11;
+            t ^= t >> 8;
+            return state[0] = t ^ s ^ (s >> 19);
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // This node does not trigger generation of other nodes.
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this });
+
+            List<CustomAttributeEntry> customAttributeEntries = GetCustomAttributeEntries();
+            int countOfEntries = customAttributeEntries.Count;
+            if (countOfEntries == 0)
+            {
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this });
+            }
+
+            // Buckets have 8 entries
+            uint minTableBucketCount = (uint)(countOfEntries / 8) + 1;
+            uint bucketCount = 1;
+
+            // Bucket count must be power of two
+            while (bucketCount < minTableBucketCount)
+            {
+                bucketCount *= 2;
+            }
+
+            // Resize the array.
+            bool tryAgainWithBiggerTable = false;
+            int countOfRetries = 0;
+            ushort[] pTable;
+            do
+            {
+                tryAgainWithBiggerTable = false;
+                uint actualSizeOfTable = bucketCount * 8; // Buckets have 8 entries in them
+                pTable = new ushort[actualSizeOfTable];
+                uint[] state = new uint[] {729055690, 833774698, 218408041, 493449127};
+                // Attempt to fill table
+                foreach (var customAttributeEntry in customAttributeEntries)
+                {
+                    string szNamespace = customAttributeEntry.TypeNamespace;
+                    string szName = customAttributeEntry.TypeName;
+                    int tkParent = customAttributeEntry.Parent;
+                    string name = szNamespace + "." + szName;
+                    // This hashing algorithm MUST match exactly the logic in NativeCuckooFilter
+                    int hashOfAttribute = ReadyToRunHashCode.NameHashCode(name);
+                    uint hash = unchecked((uint)System.HashCode.Combine(hashOfAttribute, tkParent));
+                    ushort fingerprint = (ushort)(hash >> 16);
+                    if (fingerprint == 0)
+                    {
+                        fingerprint = 1;
+                    }
+                    uint bucketAIndex = hash % bucketCount;
+                    uint fingerprintHash = (uint)fingerprint;
+                    uint bucketBIndex = (bucketAIndex ^ (fingerprintHash % bucketCount));
+                    Debug.Assert(bucketAIndex == (bucketBIndex ^ (fingerprintHash % bucketCount)));
+                    if ((xorshift128(state) & 1) != 0) // Randomly choose which bucket to attempt to fill first
+                    {
+                        uint temp = bucketAIndex;
+                        bucketAIndex = bucketBIndex;
+                        bucketBIndex = temp;
+                    }
+                    Func<uint, ushort, bool> hasEntryInBucket = (uint bucketIndex, ushort fprint) =>
+                    {
+                        for (int i = 0; i < 8; i++)
+                        {
+                            if (pTable[(bucketIndex * 8) + i] == fprint)
+                            {
+                                return true;
+                            }
+                        }
+                        return false;
+                    };
+                    Func<uint, bool> isEmptyEntryInBucket = (uint bucketIndex) =>
+                    {
+                        for (int i = 0; i < 8; i++)
+                        {
+                            if (pTable[(bucketIndex * 8) + i] == 0)
+                            {
+                                return true;
+                            }
+                        }
+                        return false;
+                    };
+                    Action<uint, ushort> fillEmptyEntryInBucket = (uint bucketIndex, ushort fprint) =>
+                    {
+                        for (int i = 0; i < 8; i++)
+                        {
+                            if (pTable[(bucketIndex * 8) + i] == 0)
+                            {
+                                pTable[(bucketIndex * 8) + i] = fprint;
+                                return;
+                            }
+                        }
+                        Debug.Assert(false, "Not possible to reach here");
+                    };
+                    // Scan for pre-existing fingerprint entry in buckets
+                    if (hasEntryInBucket(bucketAIndex, fingerprint) || hasEntryInBucket(bucketBIndex, fingerprint))
+                        continue;
+
+                    // Determine if there is space in a bucket to add a new entry
+                    if (isEmptyEntryInBucket(bucketAIndex))
+                    {
+                        fillEmptyEntryInBucket(bucketAIndex, fingerprint);
+                        continue;
+                    }
+                    if (isEmptyEntryInBucket(bucketBIndex))
+                    {
+                        fillEmptyEntryInBucket(bucketBIndex, fingerprint);
+                        continue;
+                    }
+                    int MaxNumKicks = 256;
+                    // Note, that bucketAIndex itself was chosen randomly above.
+                    for (int n = 0; n < MaxNumKicks; n++)
+                    {
+                        // Randomly swap an entry in bucket bucketAIndex with fingerprint
+                        uint entryIndexInBucket = xorshift128(state) & 0x7;
+                        ushort temp = fingerprint;
+                        fingerprint = pTable[(bucketAIndex * 8) + entryIndexInBucket];
+                        pTable[(bucketAIndex * 8) + entryIndexInBucket] = temp;
+
+                        // Find other bucket
+                        fingerprintHash = (uint)fingerprint;
+                        bucketAIndex = bucketAIndex ^ (fingerprintHash % bucketCount);
+                        if (isEmptyEntryInBucket(bucketAIndex))
+                        {
+                            fillEmptyEntryInBucket(bucketAIndex, fingerprint);
+                            continue;
+                        }
+                    }
+
+                    tryAgainWithBiggerTable = true;
+                }
+
+                if (tryAgainWithBiggerTable)
+                {
+                    // bucket entry kicking path requires bucket counts to be power of two in size due to use of xor to retrieve second hash
+                    bucketCount *= 2;
+                }
+            }
+            while(tryAgainWithBiggerTable && ((countOfRetries++) < 2));
+            
+            if (tryAgainWithBiggerTable)
+            {
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this });
+            }
+            else
+            {
+                byte[] result = new byte[pTable.Length * 2];
+                for (int i = 0; i < pTable.Length; i++)
+                {
+                    result[i * 2] = (byte)(pTable[i] % 256);
+                    result[i * 2 + 1] = (byte)(pTable[i] >> 8);
+                }
+                return new ObjectData(result, Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this });
+            }
+        }
+    }
+}

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/AttributePresenceFilterNode.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/AttributePresenceFilterNode.cs
@@ -158,7 +158,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     string name = customAttributeEntry.TypeNamespace + "." + customAttributeEntry.TypeName;
                     // This hashing algorithm MUST match exactly the logic in NativeCuckooFilter
                     int hashOfAttribute = ReadyToRunHashCode.NameHashCode(name);
-                    uint hash = unchecked((uint)TypeHashingAlgorithms.CombineTwoValuesIntoHash((uint)hashOfAttribute, (uint)customAttributeEntry.Parent));
+                    uint hash = unchecked((uint)ReadyToRunHashCode.CombineTwoValuesIntoHash((uint)hashOfAttribute, (uint)customAttributeEntry.Parent));
                     ushort fingerprint = (ushort)(hash >> 16);
                     if (fingerprint == 0)
                     {

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -230,7 +230,7 @@ namespace ILCompiler.DependencyAnalysis
             Resolver = moduleTokenResolver;
             InputModuleContext = signatureContext;
             CopiedCorHeaderNode = corHeaderNode;
-            AttributePresenceFilterNode = attributePresenceFilterNode;
+            AttributePresenceFilter = attributePresenceFilterNode;
             if (!win32Resources.IsEmpty)
                 Win32ResourcesNode = new Win32ResourcesNode(win32Resources);
         }
@@ -242,8 +242,6 @@ namespace ILCompiler.DependencyAnalysis
         public CopiedCorHeaderNode CopiedCorHeaderNode;
 
         public Win32ResourcesNode Win32ResourcesNode;
-
-        public AttributePresenceFilterNode  AttributePresenceFilterNode;
 
         public HeaderNode Header;
 

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -82,6 +82,16 @@ namespace ILCompiler
             ModuleTokenResolver moduleTokenResolver = new ModuleTokenResolver(_compilationGroup, _context);
             SignatureContext signatureContext = new SignatureContext(_inputModule, moduleTokenResolver);
             CopiedCorHeaderNode corHeaderNode = new CopiedCorHeaderNode(_inputModule);
+            AttributePresenceFilterNode attributePresenceFilterNode = null;
+            
+            // Core library attributes are checked FAR more often than other dlls
+            // attributes, so produce a highly efficient table for determining if they are
+            // present. Other assemblies *MAY* benefit from this feature, but it doesn't show
+            // as useful at this time.
+            if (this._inputModule == this._inputModule.Context.SystemModule)
+            {
+                 attributePresenceFilterNode = new AttributePresenceFilterNode(_inputModule, _context.Target);
+            }
 
             // Produce a ResourceData where the IBC PROFILE_DATA entry has been filtered out
             ResourceData win32Resources = new ResourceData(_inputModule, (object type, object name, ushort language) =>
@@ -102,13 +112,13 @@ namespace ILCompiler
 
             ReadyToRunCodegenNodeFactory factory = new ReadyToRunCodegenNodeFactory(
                 _context,
-                _inputModule,
                 _compilationGroup,
                 _nameMangler,
                 moduleTokenResolver,
                 signatureContext,
                 corHeaderNode,
-                win32Resources);
+                win32Resources,
+                attributePresenceFilterNode);
 
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory);
 

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -88,9 +88,9 @@ namespace ILCompiler
             // attributes, so produce a highly efficient table for determining if they are
             // present. Other assemblies *MAY* benefit from this feature, but it doesn't show
             // as useful at this time.
-            if (this._inputModule == this._inputModule.Context.SystemModule)
+            if (_inputModule == _inputModule.Context.SystemModule)
             {
-                 attributePresenceFilterNode = new AttributePresenceFilterNode(_inputModule, _context.Target);
+                 attributePresenceFilterNode = new AttributePresenceFilterNode(_inputModule);
             }
 
             // Produce a ResourceData where the IBC PROFILE_DATA entry has been filtered out

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -102,6 +102,7 @@ namespace ILCompiler
 
             ReadyToRunCodegenNodeFactory factory = new ReadyToRunCodegenNodeFactory(
                 _context,
+                _inputModule,
                 _compilationGroup,
                 _nameMangler,
                 moduleTokenResolver,

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunHashCode.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunHashCode.cs
@@ -215,5 +215,38 @@ namespace ILCompiler
         {
             return unchecked((int)(((uint)value << bitCount) | ((uint)value >> (32 - bitCount))));
         }
+
+        private static uint XXHash32_MixEmptyState()
+        {
+            // Unlike System.HashCode, these hash values are required to be stable, so don't
+            // mixin a random process specific value
+            return 374761393U; // Prime5
+        }
+
+        private static uint XXHash32_QueueRound(uint hash, uint queuedValue)
+        {
+            return ((uint)RotateLeft((int)(hash + queuedValue * 3266489917U/*Prime3*/), 17)) * 668265263U/*Prime4*/;
+        }
+
+        private static uint XXHash32_MixFinal(uint hash)
+        {
+            hash ^= hash >> 15;
+            hash *= 2246822519U/*Prime2*/;
+            hash ^= hash >> 13;
+            hash *= 3266489917U/*Prime3*/;
+            hash ^= hash >> 16;
+            return hash;
+        }
+
+        public static uint CombineTwoValuesIntoHash(uint value1, uint value2)
+        {
+            // This matches the behavior of System.HashCode.Combine(value1, value2) as of the time of authoring
+            uint hash = XXHash32_MixEmptyState();
+            hash += 8;
+            hash = XXHash32_QueueRound(hash, value1);
+            hash = XXHash32_QueueRound(hash, value2);
+            hash = XXHash32_MixFinal(hash);
+            return hash;
+        }
     }
 }

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -96,6 +96,7 @@
     <Compile Include="CodeGen\ReadyToRunObjectWriter.cs" />
     <Compile Include="Compiler\CompilationModuleGroup.ReadyToRun.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ArgIterator.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\AttributePresenceFilterNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\CopiedFieldRvaNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\CopiedManagedResourcesNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\CopiedMetadataBlobNode.cs" />


### PR DESCRIPTION
Fixes #27021 

The change allows `crossgen2` to produce the `READYTORUN_SECTION_ATTRIBUTEPRESENCE` section that is bit-by-bit identical with what `crossgen` produced.

@dotnet/crossgen-contrib