### PR TITLE
Replace InternalLoadUnmanagedDllFromPath with NativeLibrary.Load

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -397,7 +397,7 @@ namespace System.Runtime.Loader
                 throw new ArgumentException(SR.Argument_AbsolutePathRequired, nameof(unmanagedDllPath));
             }
 
-            return InternalLoadUnmanagedDllFromPath(unmanagedDllPath);
+            return NativeLibrary.Load(unmanagedDllPath);
         }
 
         // Custom AssemblyLoadContext implementations can override this

--- a/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
@@ -79,9 +79,6 @@ namespace System.Runtime.Loader
         }
 #endif
 
-        [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
-        private static extern IntPtr InternalLoadUnmanagedDllFromPath(string unmanagedDllPath);
-
         // This method is invoked by the VM when using the host-provided assembly load context
         // implementation.
         private static IntPtr ResolveUnmanagedDll(string unmanagedDllName, IntPtr gchManagedAssemblyLoadContext)

--- a/src/vm/assemblynative.cpp
+++ b/src/vm/assemblynative.cpp
@@ -297,22 +297,6 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
     END_QCALL;
 }
 
-// static
-INT_PTR QCALLTYPE AssemblyNative::InternalLoadUnmanagedDllFromPath(LPCWSTR unmanagedLibraryPath)
-{
-    QCALL_CONTRACT;
-
-    NATIVE_LIBRARY_HANDLE moduleHandle = nullptr;
-
-    BEGIN_QCALL;
-
-    moduleHandle = NDirect::LoadLibraryFromPath(unmanagedLibraryPath, true);
-
-    END_QCALL;
-
-    return reinterpret_cast<INT_PTR>(moduleHandle);
-}
-
 /*static */
 void QCALLTYPE AssemblyNative::LoadFromStream(INT_PTR ptrNativeAssemblyLoadContext, INT_PTR ptrAssemblyArray, 
                                               INT32 cbAssemblyArrayLength, INT_PTR ptrSymbolArray, INT32 cbSymbolArrayLength, 

--- a/src/vm/assemblynative.hpp
+++ b/src/vm/assemblynative.hpp
@@ -120,7 +120,6 @@ public:
     static INT_PTR QCALLTYPE InitializeAssemblyLoadContext(INT_PTR ptrManagedAssemblyLoadContext, BOOL fRepresentsTPALoadContext, BOOL fIsCollectible);
     static void QCALLTYPE PrepareForAssemblyLoadContextRelease(INT_PTR ptrNativeAssemblyLoadContext, INT_PTR ptrManagedStrongAssemblyLoadContext);
     static void QCALLTYPE LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext, LPCWSTR pwzILPath, LPCWSTR pwzNIPath, QCall::ObjectHandleOnStack retLoadedAssembly);
-    static INT_PTR QCALLTYPE InternalLoadUnmanagedDllFromPath(LPCWSTR unmanagedLibraryPath);
     static void QCALLTYPE LoadFromStream(INT_PTR ptrNativeAssemblyLoadContext, INT_PTR ptrAssemblyArray, INT32 cbAssemblyArrayLength, INT_PTR ptrSymbolArray, INT32 cbSymbolArrayLength, QCall::ObjectHandleOnStack retLoadedAssembly);
 #ifndef FEATURE_PAL
     static void QCALLTYPE LoadFromInMemoryModule(INT_PTR ptrNativeAssemblyLoadContext, INT_PTR hModule, QCall::ObjectHandleOnStack retLoadedAssembly);

--- a/src/vm/dllimport.cpp
+++ b/src/vm/dllimport.cpp
@@ -5876,8 +5876,7 @@ private:
 };  // class LoadLibErrorTracker
 
 // Load the library directly. On Unix systems, don't register it yet with PAL. 
-// * External callers like AssemblyNative::InternalLoadUnmanagedDllFromPath() and the upcoming 
-//   System.Runtime.InteropServices.NativeLibrary.Load() need the raw system handle
+// * External callers like System.Runtime.InteropServices.NativeLibrary.Load() need the raw system handle
 // * Internal callers like LoadLibraryModule() can convert this handle to a HMODULE via PAL APIs on Unix
 static NATIVE_LIBRARY_HANDLE LocalLoadLibraryHelper( LPCWSTR name, DWORD flags, LoadLibErrorTracker *pErrorTracker )
 {

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -509,7 +509,6 @@ FCFuncStart(gAssemblyLoadContextFuncs)
     QCFuncElement("InitializeAssemblyLoadContext", AssemblyNative::InitializeAssemblyLoadContext)
     QCFuncElement("PrepareForAssemblyLoadContextRelease", AssemblyNative::PrepareForAssemblyLoadContextRelease)
     QCFuncElement("LoadFromPath", AssemblyNative::LoadFromPath)
-    QCFuncElement("InternalLoadUnmanagedDllFromPath", AssemblyNative::InternalLoadUnmanagedDllFromPath)
     QCFuncElement("LoadFromStream", AssemblyNative::LoadFromStream)
 #ifdef FEATURE_COMINTEROP_WINRT_MANAGED_ACTIVATION
     QCFuncElement("LoadTypeForWinRTTypeNameInContextInternal", AssemblyNative::LoadTypeForWinRTTypeNameInContext)


### PR DESCRIPTION
Both just call into NDirect::LoadLibraryFromPath, so this simplifies the code by removing a superfluous QCall and clarifies potential interoperability concerns between AssemblyLoadContext.LoadUnmanagedDllFromPath and NativeLibrary.Load.

This will break Mono and presumably CoreRT, but it should be an easy fix in both cases (I'll deal with Mono).

Additionally, I think the docs pages need to be updated, as it lists different possible exceptions for AssemblyLoadContext.LoadUnmanagedDllFromPath and NativeLibrary.Load despite them both calling into NDirect::LoadLibraryFromPath. The checks for ArgumentException in LoadUnmanagedDllFromPath are in managed so it makes sense that's different, but the exceptions thrown by the runtime seem like they should be the same even before this PR. I assume NativeLibrary is the accurate one due to being newer, but if someone can clarify that for me I'm happy to PR the API docs repo with the appropriate changes.

cc: @swaroop-sridhar @lambdageek 