### PR TITLE
Fix F5 experience in VS for crossgen2

### DIFF
--- a/src/tools/crossgen2/ILCompiler.DependencyAnalysisFramework/ILCompiler.DependencyAnalysisFramework.csproj
+++ b/src/tools/crossgen2/ILCompiler.DependencyAnalysisFramework/ILCompiler.DependencyAnalysisFramework.csproj
@@ -7,8 +7,13 @@
     <TargetFramework>netstandard1.3</TargetFramework>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <Platforms>x64;x86</Platforms>
-    <OutputPath>$(BinDir)/crossgen2/libs</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+
+    <!-- We're binplacing these into an existing publish layout so that F5 build in VS updates
+         the same bits tests expect to see in bin/crossgen2. That way we never need to wonder which
+         binaries are up to date and which are stale. -->
+    <OutputPath>$(BinDir)/crossgen2</OutputPath>
+    <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Xml.ReaderWriter">

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -9,8 +9,13 @@
     <DefineConstants>READYTORUN;$(DefineConstants)</DefineConstants>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <Platforms>x64;x86</Platforms>
-    <OutputPath>$(BinDir)/crossgen2/libs</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+
+    <!-- We're binplacing these into an existing publish layout so that F5 build in VS updates
+         the same bits tests expect to see in bin/crossgen2. That way we never need to wonder which
+         binaries are up to date and which are stale. -->
+    <OutputPath>$(BinDir)/crossgen2</OutputPath>
+    <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/tools/crossgen2/ILCompiler.TypeSystem.ReadyToRun/ILCompiler.TypeSystem.ReadyToRun.csproj
+++ b/src/tools/crossgen2/ILCompiler.TypeSystem.ReadyToRun/ILCompiler.TypeSystem.ReadyToRun.csproj
@@ -9,8 +9,13 @@
     <TargetFramework>netstandard1.3</TargetFramework>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <Platforms>x64;x86</Platforms>
-    <OutputPath>$(BinDir)/crossgen2/libs</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+
+    <!-- We're binplacing these into an existing publish layout so that F5 build in VS updates
+         the same bits tests expect to see in bin/crossgen2. That way we never need to wonder which
+         binaries are up to date and which are stale. -->
+    <OutputPath>$(BinDir)/crossgen2</OutputPath>
+    <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IO.MemoryMappedFiles">

--- a/src/tools/crossgen2/crossgen2/crossgen2.csproj
+++ b/src/tools/crossgen2/crossgen2/crossgen2.csproj
@@ -8,8 +8,14 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <NoWarn>8002,NU1701</NoWarn>
     <Platforms>x64;x86</Platforms>
-    <OutputPath>$(BinDir)/crossgen2</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+
+    <!-- We're binplacing these into an existing publish layout so that F5 build in VS updates
+         the same bits tests expect to see in bin/crossgen2. That way we never need to wonder which
+         binaries are up to date and which are stale. -->
+    <OutputPath>$(BinDir)/crossgen2</OutputPath>
+    <GenerateDependencyFile>false</GenerateDependencyFile>
+    <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Ever since #26792 I wasn't able to F5 launch the crossgen2 project from the src\tools\crossgen2\crossgen2.sln solution. I tried git clean, updating VS, etc. until I convinced myself this is really broken for everyone.

The error was:

```
It was not possible to find any compatible framework version
The specified framework 'Microsoft.NETCore.App', version '3.0.0' was not found.
  - No frameworks were found.
```

I narrowed this down to the various json config file gunk generated by the build. Not generating the json gunk makes the old setup work again. We likely don't need the crossgen2/libs hack anymore either.