### PR TITLE
Fix ADDR(IND(tree))=>tree transformation in morph.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -13188,6 +13188,14 @@ DONE_MORPHING_CHILDREN:
                     // Perform the transform ADDR(IND(...)) == (...).
                     GenTree* addr = op1->gtOp.gtOp1;
 
+                    // If tree has a zero field sequence annotation, update the annotation
+                    // on addr node.
+                    FieldSeqNode* zeroFieldSeq = nullptr;
+                    if (GetZeroOffsetFieldMap()->Lookup(tree, &zeroFieldSeq))
+                    {
+                        fgAddFieldSeqForZeroOffset(addr, zeroFieldSeq);
+                    }
+
                     noway_assert(varTypeIsGC(addr->gtType) || addr->gtType == TYP_I_IMPL);
 
                     DEBUG_DESTROY_NODE(op1);

--- a/tests/src/JIT/Regression/JitBlue/GitHub_99999/GitHub_99999.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_99999/GitHub_99999.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+struct S
+{
+    public Program p;
+    public int i;
+}
+
+struct T
+{
+    public S s;
+}
+
+class Program
+{
+    public T t;
+    public T t1;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    int Test()
+    {
+        // The bug was that a field sequence annotation was lost
+        // when morph was transforming ADDR(IND(tree)) into tree
+        // when processing this.t.s.p.
+        if (this.t.s.p == this.t1.s.p)
+        {
+            return 0;
+        }
+        this.t1.s = this.t.s;
+        int result = Helper(this.t.s);
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Helper(S s)
+    {
+        return s.i;
+    }
+
+    static int Main()
+    {
+        Program p = new Program();
+        p.t.s.i = 100;
+        p.t.s.p = p;
+
+        return p.Test();
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_99999/GitHub_99999.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_99999/GitHub_99999.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
ADDR(IND(tree)) => tree transformation was losing zero field
sequence annotation that was causing incorrect value numbering
and asserts in the CSE optimization.

Fixes #27107.