### PR TITLE
JIT: add pass to merge common throw helper calls

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4612,6 +4612,9 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags
 
     if (opts.OptimizationEnabled())
     {
+        fgTailMergeThrows();
+        EndPhase(PHASE_MERGE_THROWS);
+
         optOptimizeLayout();
         EndPhase(PHASE_OPTIMIZE_LAYOUT);
 

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -1835,7 +1835,8 @@ void Compiler::compInit(ArenaAllocator* pAlloc, InlineInfo* inlineInfo)
     opts.instrCount = 0;
 
     // Used to track when we should consider running EarlyProp
-    optMethodFlags = 0;
+    optMethodFlags       = 0;
+    optNoReturnCallCount = 0;
 
 #ifdef DEBUG
     m_nodeTestData      = nullptr;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -6377,12 +6377,12 @@ public:
 
     unsigned optMethodFlags;
 
-    bool doesMethodHaveNoreturnCalls()
+    bool doesMethodHaveNoReturnCalls()
     {
         return optNoReturnCallCount > 0;
     }
 
-    void setMethodHasNoreturnCalls()
+    void setMethodHasNoReturnCalls()
     {
         optNoReturnCallCount++;
     }

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4357,6 +4357,14 @@ public:
     void fgAddFinallyTargetFlags();
 
     void fgTailMergeThrows();
+    void fgTailMergeThrowsFallThroughHelper(BasicBlock* predBlock,
+                                            BasicBlock* nonCanonicalBlock,
+                                            BasicBlock* canonicalBlock,
+                                            flowList*   predEdge);
+    void fgTailMergeThrowsJumpToHelper(BasicBlock* predBlock,
+                                       BasicBlock* nonCanonicalBlock,
+                                       BasicBlock* canonicalBlock,
+                                       flowList*   predEdge);
 
 #if defined(FEATURE_EH_FUNCLETS) && defined(_TARGET_ARM_)
     // Sometimes we need to defer updating the BBF_FINALLY_TARGET bit. fgNeedToAddFinallyTargetBits signals

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4356,6 +4356,8 @@ public:
 
     void fgAddFinallyTargetFlags();
 
+    void fgTailMergeThrows();
+
 #if defined(FEATURE_EH_FUNCLETS) && defined(_TARGET_ARM_)
     // Sometimes we need to defer updating the BBF_FINALLY_TARGET bit. fgNeedToAddFinallyTargetBits signals
     // when this is necessary.

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -6328,6 +6328,7 @@ public:
 #define OMF_HAS_FATPOINTER 0x00000020    // Method contains call, that needs fat pointer transformation.
 #define OMF_HAS_OBJSTACKALLOC 0x00000040 // Method contains an object allocated on the stack.
 #define OMF_HAS_GUARDEDDEVIRT 0x00000080 // Method contains guarded devirtualization candidate
+#define OMF_HAS_NORETURN_CALLS 0x0000010 // Method contains calls to noreturn methods
 
     bool doesMethodHaveFatPointer()
     {
@@ -6359,6 +6360,16 @@ public:
     void clearMethodHasGuardedDevirtualization()
     {
         optMethodFlags &= ~OMF_HAS_GUARDEDDEVIRT;
+    }
+
+    bool doesMethodHaveNoreturnCalls()
+    {
+        return (optMethodFlags & OMF_HAS_NORETURN_CALLS) != 0;
+    }
+
+    void setMethodHasNoreturnCalls()
+    {
+        optMethodFlags |= OMF_HAS_NORETURN_CALLS;
     }
 
     void addGuardedDevirtualizationCandidate(GenTreeCall*          call,

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -6336,7 +6336,6 @@ public:
 #define OMF_HAS_FATPOINTER 0x00000020    // Method contains call, that needs fat pointer transformation.
 #define OMF_HAS_OBJSTACKALLOC 0x00000040 // Method contains an object allocated on the stack.
 #define OMF_HAS_GUARDEDDEVIRT 0x00000080 // Method contains guarded devirtualization candidate
-#define OMF_HAS_NORETURN_CALLS 0x0000010 // Method contains calls to noreturn methods
 
     bool doesMethodHaveFatPointer()
     {
@@ -6370,16 +6369,6 @@ public:
         optMethodFlags &= ~OMF_HAS_GUARDEDDEVIRT;
     }
 
-    bool doesMethodHaveNoreturnCalls()
-    {
-        return (optMethodFlags & OMF_HAS_NORETURN_CALLS) != 0;
-    }
-
-    void setMethodHasNoreturnCalls()
-    {
-        optMethodFlags |= OMF_HAS_NORETURN_CALLS;
-    }
-
     void addGuardedDevirtualizationCandidate(GenTreeCall*          call,
                                              CORINFO_METHOD_HANDLE methodHandle,
                                              CORINFO_CLASS_HANDLE  classHandle,
@@ -6387,6 +6376,18 @@ public:
                                              unsigned              classAttr);
 
     unsigned optMethodFlags;
+
+    bool doesMethodHaveNoreturnCalls()
+    {
+        return optNoReturnCallCount > 0;
+    }
+
+    void setMethodHasNoreturnCalls()
+    {
+        optNoReturnCallCount++;
+    }
+
+    unsigned optNoReturnCallCount;
 
     // Recursion bound controls how far we can go backwards tracking for a SSA value.
     // No throughput diff was found with backward walk bound between 3-8.

--- a/src/jit/compmemkind.h
+++ b/src/jit/compmemkind.h
@@ -56,6 +56,7 @@ CompMemKindMacro(SideEffects)
 CompMemKindMacro(ObjectAllocator)
 CompMemKindMacro(VariableLiveRanges)
 CompMemKindMacro(ClassLayout)
+CompMemKindMacro(TailMergeThrows)
 //clang-format on
 
 #undef CompMemKindMacro

--- a/src/jit/compphases.h
+++ b/src/jit/compphases.h
@@ -34,6 +34,7 @@ CompPhaseNameMacro(PHASE_EMPTY_TRY,              "Remove empty try",            
 CompPhaseNameMacro(PHASE_EMPTY_FINALLY,          "Remove empty finally",           "EMPTYFIN", false, -1, false)
 CompPhaseNameMacro(PHASE_MERGE_FINALLY_CHAINS,   "Merge callfinally chains",       "MRGCFCHN", false, -1, false)
 CompPhaseNameMacro(PHASE_CLONE_FINALLY,          "Clone finally",                  "CLONEFIN", false, -1, false)
+CompPhaseNameMacro(PHASE_MERGE_THROWS,           "Merge throw blocks",             "MRGTHROW", false, -1, false)
 CompPhaseNameMacro(PHASE_STR_ADRLCL,             "Morph - Structs/AddrExp",        "MOR-STRAL",false, -1, false)
 CompPhaseNameMacro(PHASE_MORPH_IMPBYREF,         "Morph - ByRefs",                 "MOR-BYREF",false, -1, false)
 CompPhaseNameMacro(PHASE_MORPH_GLOBAL,           "Morph - Global",                 "MOR-GLOB", false, -1, false)

--- a/src/jit/compphases.h
+++ b/src/jit/compphases.h
@@ -34,7 +34,6 @@ CompPhaseNameMacro(PHASE_EMPTY_TRY,              "Remove empty try",            
 CompPhaseNameMacro(PHASE_EMPTY_FINALLY,          "Remove empty finally",           "EMPTYFIN", false, -1, false)
 CompPhaseNameMacro(PHASE_MERGE_FINALLY_CHAINS,   "Merge callfinally chains",       "MRGCFCHN", false, -1, false)
 CompPhaseNameMacro(PHASE_CLONE_FINALLY,          "Clone finally",                  "CLONEFIN", false, -1, false)
-CompPhaseNameMacro(PHASE_MERGE_THROWS,           "Merge throw blocks",             "MRGTHROW", false, -1, false)
 CompPhaseNameMacro(PHASE_STR_ADRLCL,             "Morph - Structs/AddrExp",        "MOR-STRAL",false, -1, false)
 CompPhaseNameMacro(PHASE_MORPH_IMPBYREF,         "Morph - ByRefs",                 "MOR-BYREF",false, -1, false)
 CompPhaseNameMacro(PHASE_MORPH_GLOBAL,           "Morph - Global",                 "MOR-GLOB", false, -1, false)
@@ -46,6 +45,7 @@ CompPhaseNameMacro(PHASE_COMPUTE_EDGE_WEIGHTS,   "Compute edge weights (1, false
 #if defined(FEATURE_EH_FUNCLETS)
 CompPhaseNameMacro(PHASE_CREATE_FUNCLETS,        "Create EH funclets",             "EH-FUNC",  false, -1, false)
 #endif // FEATURE_EH_FUNCLETS
+CompPhaseNameMacro(PHASE_MERGE_THROWS,           "Merge throw blocks",             "MRGTHROW", false, -1, false)
 CompPhaseNameMacro(PHASE_OPTIMIZE_LAYOUT,        "Optimize layout",                "LAYOUT",   false, -1, false)
 CompPhaseNameMacro(PHASE_COMPUTE_REACHABILITY,   "Compute blocks reachability",    "BL_REACH", false, -1, false)
 CompPhaseNameMacro(PHASE_OPTIMIZE_LOOPS,         "Optimize loops",                 "LOOP-OPT", false, -1, false)

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -25769,9 +25769,9 @@ void Compiler::fgTailMergeThrows()
     JITDUMP("\n*************** In fgTailMergeThrows\n");
 
     // Early out case for most methods. Throw helpers are rare.
-    if (!doesMethodHaveNoreturnCalls())
+    if (optNoReturnCallCount < 2)
     {
-        JITDUMP("Method does not have any noreturn calls.\n");
+        JITDUMP("Method does not have multiple noreturn calls.\n");
         return;
     }
 

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -26022,7 +26022,7 @@ void Compiler::fgTailMergeThrowsFallThroughHelper(BasicBlock* predBlock,
     newBlock->bbJumpDest = canonicalBlock;
     fgAddRefPred(canonicalBlock, newBlock, predEdge);
 
-    // Note there's now a jump to the canonical block
+    // Note there is now a jump to the canonical block
     canonicalBlock->bbFlags |= (BBF_JMP_TARGET | BBF_HAS_LABEL);
 }
 
@@ -26054,6 +26054,6 @@ void Compiler::fgTailMergeThrowsJumpToHelper(BasicBlock* predBlock,
     predBlock->bbJumpDest = canonicalBlock;
     fgAddRefPred(canonicalBlock, predBlock, predEdge);
 
-    // Note there's now a jump to the canonical block
+    // Note there is now a jump to the canonical block
     canonicalBlock->bbFlags |= (BBF_JMP_TARGET | BBF_HAS_LABEL);
 }

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -5012,7 +5012,7 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
             // Mark the call node as "no return" as it can impact caller's code quality.
             impInlineInfo->iciCall->gtCallMoreFlags |= GTF_CALL_M_DOES_NOT_RETURN;
             // Mark root method as containing a noreturn call.
-            impInlineRoot()->setMethodHasNoreturnCalls();
+            impInlineRoot()->setMethodHasNoReturnCalls();
         }
 
         // If the inline is viable and discretionary, do the
@@ -25825,13 +25825,6 @@ void Compiler::fgTailMergeThrows()
     // and there is less jumbled flow to sort out later.
     for (BasicBlock* block = fgLastBB; block != nullptr; block = block->bbPrev)
     {
-        // Hmm, odd BBJ_RETURN case when throw helper is tail called.
-        // TODO: sort this out over in morph.
-        if (block->bbJumpKind == BBJ_RETURN)
-        {
-            continue;
-        }
-
         // For throw helpers the block should have exactly one statement....
         // (this isn't guaranteed, but seems likely)
         Statement* stmt = block->firstStmt();
@@ -25871,9 +25864,6 @@ void Compiler::fgTailMergeThrows()
         ThrowHelper key(block, call);
         if (callMap.Lookup(key, &canonicalBlock))
         {
-            // Make sure we're not at risk of crossing EH boundaries
-            assert(BasicBlock::sameEHRegion(block, canonicalBlock));
-
             // Yes, this one can be optimized away...
             JITDUMP("    in " FMT_BB " can be dup'd to canonical " FMT_BB "\n", block->bbNum, canonicalBlock->bbNum);
             blockMap.Set(block, canonicalBlock);

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -25809,16 +25809,22 @@ void Compiler::fgTailMergeThrows()
     CallToBlockMap  callMap(allocator);
     BlockToBlockMap blockMap(allocator);
 
-    // We will run two passes here.
+    // We run two passes here.
     //
-    // The first pass finds candidate blocks and builds the mapping
-    // from candidates to canonical blocks, the second pass modifies flow.
+    // The first pass finds candidate blocks. The first candidate for
+    // each unique kind of throw is chosen as the canonical example of
+    // that kind of throw.  Subsequent matching candidates are mapped
+    // to that throw.
+    //
+    // The second pass modifies flow so that predecessors of
+    // non-canonical throw blocks now transfer control to the
+    // appropriate canonical block.
     int numCandidates = 0;
 
     // First pass
     //
     // Scan for THROW blocks. Note early on in compilation (before morph)
-    // noretrurn blocks are not marked as BBJ_THROW.
+    // noreturn blocks are not marked as BBJ_THROW.
     //
     // Walk blocks from last to first so that any branches we
     // introduce to the canonical blocks end up lexically forward

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -25842,7 +25842,7 @@ void Compiler::fgTailMergeThrows()
         }
 
         // ...that is a call
-        GenTree* const tree = stmt->gtStmtExpr;
+        GenTree* const tree = stmt->GetRootNode();
 
         if (!tree->IsCall())
         {

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -25818,7 +25818,7 @@ void Compiler::fgTailMergeThrows()
     // First pass
     //
     // Scan for THROW blocks. Note early on in compilation (before morph)
-    // noretrurn blcoks are not marked as BBJ_THROW.
+    // noretrurn blocks are not marked as BBJ_THROW.
     //
     // Walk blocks from last to first so that any branches we
     // introduce to the canonical blocks end up lexically forward
@@ -25988,8 +25988,11 @@ void Compiler::fgTailMergeThrows()
 //    predEdge - original flow edge
 //
 // Notes:
-//    Alters fall through flow of predBlock so it jumps to the canonicalBlock
-//    via a new basic block.
+//    Alters fall through flow of predBlock so it jumps to the
+//    canonicalBlock via a new basic block.  Does not try and fix
+//    jump-around flow; we leave that to optOptimizeFlow which runs
+//    just afterwards.
+//
 void Compiler::fgTailMergeThrowsFallThroughHelper(BasicBlock* predBlock,
                                                   BasicBlock* nonCanonicalBlock,
                                                   BasicBlock* canonicalBlock,
@@ -26026,8 +26029,8 @@ void Compiler::fgTailMergeThrowsFallThroughHelper(BasicBlock* predBlock,
 //    predEdge - original flow edge
 //
 // Notes:
-//    Alters jumpDest of predBlock so it jumps to the canonicalBlock
-
+//    Alters jumpDest of predBlock so it jumps to the canonicalBlock.
+//
 void Compiler::fgTailMergeThrowsJumpToHelper(BasicBlock* predBlock,
                                              BasicBlock* nonCanonicalBlock,
                                              BasicBlock* canonicalBlock,

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -16677,10 +16677,6 @@ void Compiler::fgMorph()
 
     EndPhase(PHASE_CLONE_FINALLY);
 
-    fgTailMergeThrows();
-
-    EndPhase(PHASE_MERGE_THROWS);
-
     /* For x64 and ARM64 we need to mark irregular parameters */
     lvaRefCountState = RCS_EARLY;
     fgResetImplicitByRefRefCount();

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -16673,12 +16673,13 @@ void Compiler::fgMorph()
     EndPhase(PHASE_MERGE_FINALLY_CHAINS);
 
     fgCloneFinally();
+    fgUpdateFinallyTargetFlags();
 
     EndPhase(PHASE_CLONE_FINALLY);
 
-    fgUpdateFinallyTargetFlags();
-
     fgTailMergeThrows();
+
+    EndPhase(PHASE_MERGE_THROWS);
 
     /* For x64 and ARM64 we need to mark irregular parameters */
     lvaRefCountState = RCS_EARLY;

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -6963,6 +6963,14 @@ GenTree* Compiler::fgMorphPotentialTailCall(GenTreeCall* call)
         return nullptr;
     }
 
+    // Heuristic: regular calls to noreturn methods can sometimes be
+    // merged, so if we have multiple such calls, we defer tail calling.
+    if (call->IsNoReturn() && (optNoReturnCallCount > 1))
+    {
+        failTailCall("Defer tail calling throw helper; anticipating merge");
+        return nullptr;
+    }
+
 #ifdef _TARGET_AMD64_
     // Needed for Jit64 compat.
     // In future, enabling tail calls from methods that need GS cookie check

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -16678,6 +16678,8 @@ void Compiler::fgMorph()
 
     fgUpdateFinallyTargetFlags();
 
+    fgTailMergeThrows();
+
     /* For x64 and ARM64 we need to mark irregular parameters */
     lvaRefCountState = RCS_EARLY;
     fgResetImplicitByRefRefCount();

--- a/tests/src/JIT/opt/ThrowHelper/ThrowHelper.cs
+++ b/tests/src/JIT/opt/ThrowHelper/ThrowHelper.cs
@@ -1,0 +1,541 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+class TestException : Exception
+{
+    int x;
+    string y;
+
+    public TestException() {}
+    public TestException(int _x) { x = _x; }
+    public TestException(string _y) { y = _y; }
+}
+
+class TestCases
+{
+    static void Throw() => throw new TestException();
+    static void Throw(int x) => throw new TestException(x);
+    static void Throw(string y) => throw new TestException(y);
+
+    static int MayThrow(int x) 
+    {
+        if (x > 0) 
+        {
+            throw new TestException(x);
+        }
+        return x;
+    }
+
+    static int ReturnThrow() => throw new TestException();
+
+    public static int OneThrowHelper(int x)
+    {
+        if (x > 0) 
+        {
+            Throw();
+        }
+
+        return x;
+    }
+
+    public static void OneThrowHelperTail(int x)
+    {
+        if (x > 0) 
+        {
+            Throw();
+            return;
+        }
+    }
+
+    public static int OneMayThrowHelper(int x)
+    {
+        if (x > 0) 
+        {
+            MayThrow(x);
+        }
+
+        return x;
+    }
+
+    public static int OneMayThrowHelperTail(int x)
+    {
+        if (x > 0) 
+        {
+            MayThrow(x);
+            return 0;
+        }
+
+        return x;
+    }
+
+    public static int OneReturnThrowHelper(int x)
+    {
+        if (x > 0) 
+        {
+            return ReturnThrow();
+        }
+
+        return x;
+    }
+
+    public static int OneReturnThrowHelperTail(int x)
+    {
+        if (x > 0) 
+        {
+            return ReturnThrow();
+        }
+
+        return x;
+    }
+
+    public static int TwoIdenticalThrowHelpers_If(int x)
+    {
+        if (x == 0) 
+        {
+            Throw();
+        }
+        
+        if (x == 1) 
+        {
+            Throw();
+        }
+
+        return x;
+    }
+
+    public static void TwoIdenticalThrowHelpers_IfOneTail(int x)
+    {
+        if (x == 0) 
+        {
+            Throw();
+            return;
+        }
+        
+        if (x == 1) 
+        {
+            Throw();
+        }
+    }
+
+    public static void TwoIdenticalThrowHelpers_IfTwoTail(int x)
+    {
+        if (x == 0) 
+        {
+            Throw();
+            return;
+        }
+        
+        if (x == 1) 
+        {
+            Throw();
+            return;
+        }
+    }
+
+    public static int ThreeIdenticalThrowHelpers_If(int x)
+    {
+        if (x == 0) 
+        {
+            Throw();
+        }
+        
+        if (x == 1) 
+        {
+            Throw();
+        }
+
+        if (x == 2) 
+        {
+            Throw();
+        }
+
+        return x;
+    }
+
+    public static void ThreeIdenticalThrowHelpers_IfOneTail(int x)
+    {
+        if (x == 0) 
+        {
+            Throw();
+            return;
+        }
+        
+        if (x == 1) 
+        {
+            Throw();
+        }
+
+        if (x == 2) 
+        {
+            Throw();
+        }
+    }
+
+    public static void ThreeIdenticalThrowHelpers_IfTwoTail(int x)
+    {
+        if (x == 0) 
+        {
+            Throw();
+            return;
+        }
+        
+        if (x == 1) 
+        {
+            Throw();
+            return;
+        }
+
+        if (x == 2) 
+        {
+            Throw();
+        }
+    }
+
+    public static void ThreeIdenticalThrowHelpers_IfThreeTail(int x)
+    {
+        if (x == 0) 
+        {
+            Throw();
+            return;
+        }
+        
+        if (x == 1) 
+        {
+            Throw();
+            return;
+        }
+
+        if (x == 2) 
+        {
+            Throw();
+            return;
+        }
+    }
+
+    public static int TwoIdenticalThrowHelpers_Goto(int x)
+    {
+        if (x == 0) 
+        {
+            goto L1;
+        }
+
+        if (x == 1) 
+        { 
+            goto L2;
+        }
+
+        return x;
+ L1:
+        Throw();
+ L2:
+        Throw();
+        
+        return x;
+    }
+
+    public static void TwoIdenticalThrowHelpers_GotoOneTail(int x)
+    {
+        if (x == 0) 
+        {
+            goto L1;
+        }
+
+        if (x == 1) 
+        { 
+            goto L2;
+        }
+
+        return;
+
+ L1:
+        Throw();
+ L2:
+        Throw();
+    }
+
+    public static void TwoIdenticalThrowHelpers_GotoTwoTail(int x)
+    {
+        if (x == 0) 
+        {
+            goto L1;
+        }
+
+        if (x == 1) 
+        { 
+            goto L2;
+        }
+
+        return;
+ L1:
+        Throw();
+        return;
+
+ L2:
+        Throw();
+    }
+
+    public static int TwoIdenticalThrowHelpers_Switch(int x)
+    {
+        switch (x)
+        {
+            case 0: 
+            {
+                Throw();
+            }
+            break;
+        
+            case 1:
+            {
+                Throw();
+            }
+            break;
+        }
+
+        return x;
+    }
+
+    public static void TwoIdenticalThrowHelpers_SwitchOneTail(int x)
+    {
+        switch (x)
+        {
+            case 0: 
+            {
+                Throw();
+                return;
+            }
+        
+            case 1:
+            {
+                Throw();
+            }
+            break;
+        }
+    }
+
+    public static void TwoIdenticalThrowHelpers_SwitchTwoTail(int x)
+    {
+        switch (x)
+        {
+            case 0: 
+            {
+                Throw();
+                return;
+            }
+        
+            case 1:
+            {
+                Throw();
+                return;
+            }
+        }
+    }
+
+    public static int TwoIdenticalThrowHelpers_SwitchGoto(int x)
+    {
+        switch (x)
+        {
+            case 0: 
+            {
+                goto L1;
+            }
+        
+            case 1:
+            {
+                goto L2;
+            }
+        }
+
+        return x;
+
+ L1:
+        Throw();
+ L2:
+        Throw();
+        
+        return x;
+    }
+
+    public static void TwoIdenticalThrowHelpers_SwitchGotoOneTail(int x)
+    {
+        switch (x)
+        {
+            case 0: 
+            {
+                goto L1;
+            }
+        
+            case 1:
+            {
+                goto L2;
+            }
+        }
+
+        return;
+
+ L1:
+        Throw();
+ L2:
+        Throw();
+    }
+
+    public static void TwoIdenticalThrowHelpers_SwitchGotoTwoTail(int x)
+    {
+        switch (x)
+        {
+            case 0: 
+            {
+                goto L1;
+            }
+        
+            case 1:
+            {
+                goto L2;
+            }
+        }
+
+        return;
+
+ L1:
+        Throw();        
+        return;
+ L2:
+        Throw();
+    }
+
+    public static int TwoDifferentThrowHelpers(int x)
+    {
+        if (x == 0) 
+        {
+            Throw();
+        }
+
+        if (x == 1) 
+        {
+            Throw(1);
+        }
+
+        return x;
+    }
+
+    public static int TwoIdenticalThrowHelpersDifferentArgs(int x)
+    {
+        if (x == 0) 
+        {
+            Throw(0);
+        }
+
+        if (x == 1) 
+        {
+            Throw(1);
+        }
+
+        return x;
+    }
+
+    public static int TwoIdenticalThrowHelpersSameArgTrees(int x, int[] y)
+    {
+        if (x == 0)
+        {
+            Throw(y[0]);
+        }
+        else if (x == 1)
+        {
+            Throw(y[0]);
+        }
+
+        return x;
+    }
+
+    public static int TwoIdenticalThrowHelpersDifferentArgTrees(int x, int[] y)
+    {
+        if (x == 0)
+        {
+            Throw(y[0]);
+        }
+        else if (x == 1)
+        {
+            Throw(y[1]);
+        }
+
+        return x;
+    }
+
+
+    static int testNumber = 0;
+    static bool failed = false;
+
+    static void Try(Func<int, int> f)
+    {
+        testNumber++;
+
+        if (f(-1) != -1)
+        {
+            Console.WriteLine($"Test {testNumber} failed\n");
+            failed = true;
+        }
+    }
+
+    static void Try(Func<int, int[], int> f)
+    {
+        testNumber++;
+
+        int[] y = new int[0];
+        if (f(-1, y) != -1)
+        {
+            Console.WriteLine($"Test {testNumber} failed\n");
+            failed = true;
+        }
+    }
+
+    static void Try(Action<int> f)
+    {
+        testNumber++;
+
+        try 
+        {
+            f(-1);
+        }
+        catch (TestException)
+        {
+            Console.WriteLine($"Test {testNumber} failed\n");
+            failed = true;
+        }
+    }
+
+    public static int Main()
+    {
+        Try(OneThrowHelper);
+        Try(OneThrowHelperTail);
+        Try(OneMayThrowHelper);
+        Try(OneMayThrowHelperTail);
+        Try(OneReturnThrowHelper);
+        Try(OneReturnThrowHelperTail);
+        Try(TwoIdenticalThrowHelpers_If);
+        Try(TwoIdenticalThrowHelpers_IfOneTail);
+        Try(TwoIdenticalThrowHelpers_IfTwoTail);
+        Try(TwoIdenticalThrowHelpers_Goto);
+        Try(TwoIdenticalThrowHelpers_GotoOneTail);
+        Try(TwoIdenticalThrowHelpers_GotoTwoTail);
+        Try(TwoIdenticalThrowHelpers_Switch);
+        Try(TwoIdenticalThrowHelpers_SwitchOneTail);
+        Try(TwoIdenticalThrowHelpers_SwitchTwoTail);
+        Try(TwoIdenticalThrowHelpers_SwitchGoto);
+        Try(TwoIdenticalThrowHelpers_SwitchGotoOneTail);
+        Try(TwoIdenticalThrowHelpers_SwitchGotoTwoTail);
+        Try(TwoDifferentThrowHelpers);
+        Try(TwoIdenticalThrowHelpersDifferentArgs);
+        Try(ThreeIdenticalThrowHelpers_If);
+        Try(ThreeIdenticalThrowHelpers_IfOneTail);
+        Try(ThreeIdenticalThrowHelpers_IfTwoTail);
+        Try(ThreeIdenticalThrowHelpers_IfThreeTail);
+        Try(TwoIdenticalThrowHelpersSameArgTrees);
+        Try(TwoIdenticalThrowHelpersDifferentArgTrees);
+
+        Console.WriteLine(failed ? "" : $"All {testNumber} tests passed");
+        return failed ? -1 : 100;
+    }
+}

--- a/tests/src/JIT/opt/ThrowHelper/ThrowHelper.csproj
+++ b/tests/src/JIT/opt/ThrowHelper/ThrowHelper.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+    <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ThrowHelper.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Look for blocks with single statement noreturn calls, and try to reroute
flow so there's just one block call that all predecessors target.

Resolves #14770.

Note this impairs debuggability of optimized code a bit, as it can change which
line of code apparently invokes a throw helper in a backtrace. But since we're
already commoning jit-inserted throw helpers (like array index OOB) this is not
breaking any new ground.

We could also handle commoning BBJ_THROW blocks, with some extra effort,
but prototyping indicates duplicate throws are pretty rare.