### PR TITLE
Enable ETW/EventSource logging of task IDs for boxed state machines

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncMethodBuilderCore.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncMethodBuilderCore.cs
@@ -123,9 +123,9 @@ namespace System.Runtime.CompilerServices
         }
 
         internal static Task? TryGetContinuationTask(Action continuation) =>
-            (continuation?.Target is ContinuationWrapper wrapper) ?
-                wrapper._innerTask :            // A wrapped continuation, created by an awaiter
-                continuation?.Target as Task;   // The continuation targets a task directly, such as with AsyncStateMachineBox
+            (continuation.Target is ContinuationWrapper wrapper) ?
+                wrapper._innerTask :           // A wrapped continuation, created by an awaiter
+                continuation.Target as Task;   // The continuation targets a task directly, such as with AsyncStateMachineBox
 
         /// <summary>
         /// Logically we pass just an Action (delegate) to a task for its action to 'ContinueWith' when it completes.

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncMethodBuilderCore.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncMethodBuilderCore.cs
@@ -123,7 +123,9 @@ namespace System.Runtime.CompilerServices
         }
 
         internal static Task? TryGetContinuationTask(Action continuation) =>
-            (continuation?.Target as ContinuationWrapper)?._innerTask;
+            (continuation?.Target is ContinuationWrapper wrapper) ?
+                wrapper._innerTask :            // A wrapped continuation, created by an awaiter
+                continuation?.Target as Task;   // The continuation targets a task directly, such as with AsyncStateMachineBox
 
         /// <summary>
         /// Logically we pass just an Action (delegate) to a task for its action to 'ContinueWith' when it completes.

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -296,8 +296,8 @@ namespace System.Runtime.CompilerServices
             {
                 Action moveNext = new Action(MoveNext);
 
-                // If logging is on, wrap the action so that the TPL event source can output 
-                // continuation info during the TaskWaitBegin event.
+                // If logging is on, wrap the action so that TaskAwaiter can find the continuation's associated task when 
+                // sending the TaskWaitBegin event to the TplEventSource
                 if (AsyncCausalityTracer.LoggingOn)
                 {
                     moveNext = AsyncMethodBuilderCore.CreateContinuationWrapper(moveNext, (continuation, task) =>

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -296,7 +296,7 @@ namespace System.Runtime.CompilerServices
             {
                 Action moveNext = new Action(MoveNext);
 
-                // If logging is on, wrap the action so that TaskAwaiter can find the continuation's associated task when 
+                // If logging is on, wrap the action so that TaskAwaiter can find the continuation's associated task when
                 // sending the TaskWaitBegin event to the TplEventSource
                 if (AsyncCausalityTracer.LoggingOn)
                 {

--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -284,12 +284,31 @@ namespace System.Runtime.CompilerServices
             public ExecutionContext? Context;
 
             /// <summary>A delegate to the <see cref="MoveNext()"/> method.</summary>
-            public Action MoveNextAction => _moveNextAction ??= new Action(MoveNext);
+            public Action MoveNextAction => _moveNextAction ??= GetMoveNextAction();
 
             internal sealed override void ExecuteFromThreadPool(Thread threadPoolThread) => MoveNext(threadPoolThread);
 
             /// <summary>Calls MoveNext on <see cref="StateMachine"/></summary>
             public void MoveNext() => MoveNext(threadPoolThread: null);
+
+            /// <summary> Creates a MoveNext action which is potentially wrapped to enable TPL etw and event source tracing. </summary>
+            private Action GetMoveNextAction()
+            {
+                Action moveNext = new Action(MoveNext);
+
+                // If logging is on, wrap the action so that the TPL event source can output 
+                // continuation info during the TaskWaitBegin event.
+                if (AsyncCausalityTracer.LoggingOn)
+                {
+                    moveNext = AsyncMethodBuilderCore.CreateContinuationWrapper(moveNext, (continuation, task) =>
+                    {
+                        // Simply call MoveNext();
+                        continuation();
+                    }, this);
+                }
+
+                return moveNext;
+            }
 
             private void MoveNext(Thread? threadPoolThread)
             {


### PR DESCRIPTION
Updates AsyncTaskMethodBuilderCore.TryGetTaskForContinuation so that it can return the task associated with the AsyncStateMachineBox.MoveNext function. This allows the TaskAwaiter to output the task id for the continuation when logging ETW.