### PR TITLE
Remove unnecessary cleanup on diagnostics server thread during shutdown

### DIFF
--- a/src/vm/diagnosticserver.cpp
+++ b/src/vm/diagnosticserver.cpp
@@ -207,26 +207,8 @@ bool DiagnosticServer::Shutdown()
             };
             s_pIpc->Close(ErrorCallback); // This will break the accept waiting for client connection.
 
-            if (s_hServerThread != NULL)
-            {
-#ifndef FEATURE_PAL
-                ::CancelSynchronousIo(s_hServerThread);
-#endif // FEATURE_PAL
-
-                // At this point, IO operations on the server thread through the
-                // IPC channel has been closed/cancelled.
-
-                // On non-Windows, this function is blocking on threads that already exit.
-                // ::WaitForSingleObject(s_hServerThread, INFINITE);
-
-                // Close the thread handle (dispose OS resource).
-                ::CloseHandle(s_hServerThread);
-                s_hServerThread = INVALID_HANDLE_VALUE;
-            }
-
-            // If we do not wait for thread to teardown, then we cannot delete this object.
-            // delete s_pIpc;
-            // s_pIpc = nullptr;
+            delete s_pIpc;
+            s_pIpc = nullptr;
         }
         fSuccess = true;
     }

--- a/src/vm/diagnosticserver.cpp
+++ b/src/vm/diagnosticserver.cpp
@@ -206,9 +206,6 @@ bool DiagnosticServer::Shutdown()
                     szMessage);                                           // data2
             };
             s_pIpc->Close(ErrorCallback); // This will break the accept waiting for client connection.
-
-            delete s_pIpc;
-            s_pIpc = nullptr;
         }
         fSuccess = true;
     }


### PR DESCRIPTION
During shutdown, we are doing unnecessary cleanup of the process by cleaning up threads, etc when this could be done by the OS with the process exit. 

This should fix https://github.com/dotnet/coreclr/issues/27128. 

cc @jkotas 
