### PR TITLE
Do not create diagnostics server thread and pipe if EnableDiagnostics is set to 0

### DIFF
--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -158,7 +158,7 @@ CONFIG_DWORD_INFO_EX(INTERNAL_BreakOnUncaughtException, W("BreakOnUncaughtExcept
 
 /// Debugger
 ///
-RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_EnableDiagnostics, W("EnableDiagnostics"), 1, "Allows the debugger and profiler diagnostics to be disabled", CLRConfig::REGUTIL_default)
+RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_EnableDiagnostics, W("EnableDiagnostics"), 1, "Allows the debugger, profiler, and EventPipe diagnostics to be disabled", CLRConfig::REGUTIL_default)
 CONFIG_DWORD_INFO_EX(INTERNAL_D__FCE, W("D::FCE"), 0, "Allows an assert when crawling the managed stack for an exception handler", CLRConfig::REGUTIL_default)
 CONFIG_DWORD_INFO_EX(INTERNAL_DbgBreakIfLocksUnavailable, W("DbgBreakIfLocksUnavailable"), 0, "Allows an assert when the debugger can't take a lock ", CLRConfig::REGUTIL_default)
 CONFIG_DWORD_INFO_EX(INTERNAL_DbgBreakOnErr, W("DbgBreakOnErr"), 0, "Allows an assert when we get a failing hresult", CLRConfig::REGUTIL_default)

--- a/src/vm/diagnosticserver.cpp
+++ b/src/vm/diagnosticserver.cpp
@@ -117,6 +117,12 @@ bool DiagnosticServer::Initialize()
     }
     CONTRACTL_END;
 
+    // COMPlus_EnableDiagnostics==0 disables diagnostics so we don't create the diagnostics pipe/socket or diagnostics server thread
+    if (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_EnableDiagnostics) == 0)
+    {
+        return true;
+    }
+
     bool fSuccess = false;
 
     EX_TRY
@@ -188,6 +194,12 @@ bool DiagnosticServer::Shutdown()
         MODE_ANY;
     }
     CONTRACTL_END;
+
+    // COMPlus_EnableDiagnostics==0 disables diagnostics so there is nothing to do here.
+    if (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_EnableDiagnostics) == 0)
+    {
+        return true;
+    }
 
     bool fSuccess = false;
 

--- a/src/vm/diagnosticserver.cpp
+++ b/src/vm/diagnosticserver.cpp
@@ -195,12 +195,6 @@ bool DiagnosticServer::Shutdown()
     }
     CONTRACTL_END;
 
-    // COMPlus_EnableDiagnostics==0 disables diagnostics so there is nothing to do here.
-    if (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_EnableDiagnostics) == 0)
-    {
-        return true;
-    }
-
     bool fSuccess = false;
 
     s_shuttingDown = true;


### PR DESCRIPTION
We already have the environment variable `COMPlus_EnableDiagnostics` that disables the debugger when it is set to 0. We should disable diagnostics server as well if this environment variable is set to 0. 

This fixes https://github.com/dotnet/coreclr/issues/27134. 
