### PR TITLE
Fix assert when CORECLR_PROFILER is set but CORECLR_PROFILER_PATH is not

### DIFF
--- a/src/vm/profilinghelper.cpp
+++ b/src/vm/profilinghelper.cpp
@@ -841,7 +841,6 @@ HRESULT ProfilingAPIUtility::DoPreInitialization(
         PRECONDITION(pEEProf != NULL);
         PRECONDITION(pClsid != NULL);
         PRECONDITION(wszClsid != NULL);
-        PRECONDITION(wszProfilerDLL != NULL);
     }
     CONTRACTL_END;
 


### PR DESCRIPTION
The null DLL name is eventually passed to FakeCoCallDllGetClassObject which
knowns how to look up the DLL name based on the CLSID specified by
CORECLR_PROFILER.