### PR TITLE
[3.1 port] Do not create diagnostics server thread and pipe if EnableDiagnostics is set to 0

### DIFF
--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -159,7 +159,7 @@ CONFIG_DWORD_INFO_EX(INTERNAL_BreakOnUncaughtException, W("BreakOnUncaughtExcept
 
 /// Debugger
 ///
-RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_EnableDiagnostics, W("EnableDiagnostics"), 1, "Allows the debugger and profiler diagnostics to be disabled", CLRConfig::REGUTIL_default)
+RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_EnableDiagnostics, W("EnableDiagnostics"), 1, "Allows the debugger, profiler, and EventPipe diagnostics to be disabled", CLRConfig::REGUTIL_default)
 CONFIG_DWORD_INFO_EX(INTERNAL_D__FCE, W("D::FCE"), 0, "Allows an assert when crawling the managed stack for an exception handler", CLRConfig::REGUTIL_default)
 CONFIG_DWORD_INFO_EX(INTERNAL_DbgBreakIfLocksUnavailable, W("DbgBreakIfLocksUnavailable"), 0, "Allows an assert when the debugger can't take a lock ", CLRConfig::REGUTIL_default)
 CONFIG_DWORD_INFO_EX(INTERNAL_DbgBreakOnErr, W("DbgBreakOnErr"), 0, "Allows an assert when we get a failing hresult", CLRConfig::REGUTIL_default)

--- a/src/vm/diagnosticserver.cpp
+++ b/src/vm/diagnosticserver.cpp
@@ -116,6 +116,12 @@ bool DiagnosticServer::Initialize()
     }
     CONTRACTL_END;
 
+    // COMPlus_EnableDiagnostics==0 disables diagnostics so we don't create the diagnostics pipe/socket or diagnostics server thread
+    if (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_EnableDiagnostics) == 0)
+    {
+        return true;
+    }
+
     bool fSuccess = false;
 
     EX_TRY


### PR DESCRIPTION
*Description*

This fixes https://github.com/dotnet/coreclr/issues/27134. 

The diagnostics server is a new runtime component that creates a dedicated thread and a socket/pipe for EventPipe and other various diagnostics runtime components to communicate with an external process (i.e. dotnet-trace, dotnet-dump, dotnet-counters, profiler attach, etc.). However, this cannot be turned off if a user does not want diagnostics and having a separate thread that sits idle at all times that cannot be disabled is not a desired behavior. The debugger already does this via `COMPlus_EnableDiagnostics` environment variable which is set to 1 by default, and gets turned off when it is set to 0. This change allows the same environment variable to be used for disabling the diagnostics server thread and pipe/socket creation. 

*Customer Impact*

A customer who doesn't want/need diagnostics server thread can now turn it off via the `COMPlus_EnableDiagnostics` environment variable, just like how they can turn off the debugger with the same environment variable.

*Regression?*
Yes from Core 2.2 -> 3.0 since diagnostics server was only introduced from 3.0.

*Risk*
Low. The change is very minimal.