### PR TITLE
Enable fast-paths on Mono for Array

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Array.cs
+++ b/src/System.Private.CoreLib/shared/System/Array.cs
@@ -472,7 +472,7 @@ namespace System
                 ThrowHelper.ThrowRankException(ExceptionResource.Rank_MultiDimNotSupported);
 
             comparer ??= Comparer.Default;
-#if CORECLR
+#if !CORERT
             if (comparer == Comparer.Default)
             {
                 int retval;
@@ -921,7 +921,7 @@ namespace System
             if (count < 0 || count > array.Length - startIndex + lb)
                 ThrowHelper.ThrowCountArgumentOutOfRange_ArgumentOutOfRange_Count();
 
-#if CORECLR
+#if !CORERT
             // Try calling a quick native method to handle primitive types.
             int retVal;
             bool r = TrySZIndexOf(array, startIndex, count, value, out retVal);
@@ -1047,7 +1047,7 @@ namespace System
                 }
             }
 
-#if CORECLR
+#if !CORERT
             return EqualityComparer<T>.Default.IndexOf(array, value, startIndex, count);
 #else
             return IndexOfImpl(array, value, startIndex, count);
@@ -1104,7 +1104,7 @@ namespace System
             if (array.Rank != 1)
                 ThrowHelper.ThrowRankException(ExceptionResource.Rank_MultiDimNotSupported);
 
-#if CORECLR
+#if !CORERT
             // Try calling a quick native method to handle primitive types.
             int retVal;
             bool r = TrySZLastIndexOf(array, startIndex, count, value, out retVal);
@@ -1255,7 +1255,7 @@ namespace System
                 }
             }
 
-#if CORECLR
+#if !CORERT
             return EqualityComparer<T>.Default.LastIndexOf(array, value, startIndex, count);
 #else
             return LastIndexOfImpl(array, value, startIndex, count);
@@ -1298,7 +1298,7 @@ namespace System
             if (length <= 1)
                 return;
 
-#if CORECLR
+#if !CORERT
             bool r = TrySZReverse(array, index, length);
             if (r)
                 return;
@@ -1521,7 +1521,7 @@ namespace System
 
             if (length > 1)
             {
-#if CORECLR
+#if !CORERT
                 if (comparer == null || comparer == Comparer<T>.Default)
                 {
                     if (TrySZSort(array, null, index, index + length - 1))
@@ -1548,7 +1548,7 @@ namespace System
 
             if (length > 1)
             {
-#if CORECLR
+#if !CORERT
                 if (comparer == null || comparer == Comparer<TKey>.Default)
                 {
                     if (TrySZSort(keys, items, index, index + length - 1))

--- a/src/System.Private.CoreLib/shared/System/String.cs
+++ b/src/System.Private.CoreLib/shared/System/String.cs
@@ -33,6 +33,17 @@ namespace System
 #nullable restore
         ICloneable
     {
+        //
+        // These fields map directly onto the fields in an EE StringObject.  See object.h for the layout.
+        //
+        [NonSerialized]
+        private int _stringLength;
+
+        // For empty strings, this will be '\0' since
+        // strings are both null-terminated and length prefixed
+        [NonSerialized]
+        private char _firstChar;
+
         /*
          * CONSTRUCTORS
          *

--- a/src/System.Private.CoreLib/src/System/String.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/String.CoreCLR.cs
@@ -9,17 +9,6 @@ namespace System
 {
     public partial class String
     {
-        //
-        // These fields map directly onto the fields in an EE StringObject.  See object.h for the layout.
-        //
-        [NonSerialized]
-        private int _stringLength;
-
-        // For empty strings, this will be '\0' since
-        // strings are both null-terminated and length prefixed
-        [NonSerialized]
-        private char _firstChar;
-
         // The Empty constant holds the empty string value. It is initialized by the EE during startup.
         // It is treated as intrinsic by the JIT as so the static constructor would never run.
         // Leaving it uninitialized would confuse debuggers.


### PR DESCRIPTION
@jkotas are there any plans for moving TrySZIndexOf, TrySZReverse, etc to C#?

Also, move String fields to the shared (all three runtimes have them)