### PR TITLE
Improve Dictionary perfomance

### DIFF
--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -323,3 +323,20 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+License for fastrange (https://github.com/lemire/fastrange)
+--------------------------------------
+
+   Copyright 2016 Daniel Lemire
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
@@ -237,11 +237,17 @@ namespace System.Collections.Generic
         public bool ContainsValue(TValue value)
         {
             Entry[]? entries = _entries;
+            int count = _count;
+            bool result = false;
             if (value == null)
             {
-                for (int i = 0; i < _count; i++)
+                for (int i = 0; i < count; i++)
                 {
-                    if (entries![i].next >= -1 && entries[i].value == null) return true;
+                    if (entries![i].next >= -1 && entries[i].value == null)
+                    {
+                        result = true;
+                        break;
+                    }
                 }
             }
             else
@@ -249,9 +255,13 @@ namespace System.Collections.Generic
                 if (default(TValue)! != null) // TODO-NULLABLE: default(T) == null warning (https://github.com/dotnet/roslyn/issues/34757)
                 {
                     // ValueType: Devirtualize with EqualityComparer<TValue>.Default intrinsic
-                    for (int i = 0; i < _count; i++)
+                    for (int i = 0; i < count; i++)
                     {
-                        if (entries![i].next >= -1 && EqualityComparer<TValue>.Default.Equals(entries[i].value, value)) return true;
+                        if (entries![i].next >= -1 && EqualityComparer<TValue>.Default.Equals(entries[i].value, value))
+                        {
+                            result = true;
+                            break;
+                        }
                     }
                 }
                 else
@@ -260,13 +270,17 @@ namespace System.Collections.Generic
                     // https://github.com/dotnet/coreclr/issues/17273
                     // So cache in a local rather than get EqualityComparer per loop iteration
                     EqualityComparer<TValue> defaultComparer = EqualityComparer<TValue>.Default;
-                    for (int i = 0; i < _count; i++)
+                    for (int i = 0; i < count; i++)
                     {
-                        if (entries![i].next >= -1 && defaultComparer.Equals(entries[i].value, value)) return true;
+                        if (entries![i].next >= -1 && defaultComparer.Equals(entries[i].value, value))
+                        {
+                            result = true;
+                            break;
+                        }
                     }
                 }
             }
-            return false;
+            return result;
         }
 
         private void CopyTo(KeyValuePair<TKey, TValue>[] array, int index)

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
@@ -359,7 +359,7 @@ namespace System.Collections.Generic
                         Entry[]? entries = _entries;
                         int allowedCollisions = entries.Length;
 
-                        // Value in _buckets is 1-based; sutract 1 from i. We do it here so it fuses with the follwoing conditional.
+                        // Value in _buckets is 1-based; subtract 1 from i. We do it here so it fuses with the following conditional.
                         i--;
                         do
                         {
@@ -392,7 +392,7 @@ namespace System.Collections.Generic
                         EqualityComparer<TKey> defaultComparer = EqualityComparer<TKey>.Default;
                         Entry[]? entries = _entries;
                         int allowedCollisions = entries.Length;
-                        // Value in _buckets is 1-based; sutract 1 from i. We do it here so it fuses with the follwoing conditional.
+                        // Value in _buckets is 1-based; subtract 1 from i. We do it here so it fuses with the following conditional.
                         i--;
                         do
                         {
@@ -424,7 +424,7 @@ namespace System.Collections.Generic
                     int i = buckets[HashHelpers.FastRange(hashCode, (uint)buckets.Length)];
                     Entry[]? entries = _entries;
                     int allowedCollisions = entries.Length;
-                    // Value in _buckets is 1-based; sutract 1 from i. We do it here so it fuses with the follwoing conditional.
+                    // Value in _buckets is 1-based; subtract 1 from i. We do it here so it fuses with the following conditional.
                     i--;
                     do
                     {

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
@@ -352,7 +352,7 @@ namespace System.Collections.Generic
                 if (comparer == null)
                 {
                     uint hashCode = (uint)key.GetHashCode();
-                    int i = buckets[hashCode % (uint)buckets.Length];
+                    int i = buckets[HashHelpers.FastRange(hashCode, (uint)buckets.Length)];
                     if (default(TKey)! != null) // TODO-NULLABLE: default(T) == null warning (https://github.com/dotnet/roslyn/issues/34757)
                     {
                         // ValueType: Devirtualize with EqualityComparer<TValue>.Default intrinsic
@@ -421,7 +421,7 @@ namespace System.Collections.Generic
                 else
                 {
                     uint hashCode = (uint)comparer.GetHashCode(key);
-                    int i = buckets[hashCode % (uint)buckets.Length];
+                    int i = buckets[HashHelpers.FastRange(hashCode, (uint)buckets.Length)];
                     Entry[]? entries = _entries;
                     int allowedCollisions = entries.Length;
                     // Value in _buckets is 1-based; sutract 1 from i. We do it here so it fuses with the follwoing conditional.
@@ -497,7 +497,7 @@ namespace System.Collections.Generic
             uint hashCode = (uint)((comparer == null) ? key.GetHashCode() : comparer.GetHashCode(key));
 
             int allowedCollisions = entries.Length;
-            ref int bucket = ref _buckets[hashCode % (uint)_buckets.Length];
+            ref int bucket = ref _buckets[HashHelpers.FastRange(hashCode, (uint)_buckets.Length)];
             // Value in _buckets is 1-based
             int i = bucket - 1;
 
@@ -641,7 +641,7 @@ namespace System.Collections.Generic
                 if (count == entries.Length)
                 {
                     Resize();
-                    bucket = ref _buckets[hashCode % (uint)_buckets.Length];
+                    bucket = ref _buckets[HashHelpers.FastRange(hashCode, (uint)_buckets.Length)];
                 }
                 index = count;
                 _count = count + 1;
@@ -754,7 +754,7 @@ namespace System.Collections.Generic
             {
                 if (entries[i].next >= -1)
                 {
-                    uint bucket = entries[i].hashCode % (uint)newSize;
+                    uint bucket = HashHelpers.FastRange(entries[i].hashCode, (uint)newSize);
                     // Value in _buckets is 1-based
                     entries[i].next = buckets[bucket] - 1;
                     // Value in _buckets is 1-based
@@ -783,7 +783,7 @@ namespace System.Collections.Generic
                 Debug.Assert(entries != null, "entries should be non-null");
                 int allowedCollisions = entries.Length;
                 uint hashCode = (uint)(_comparer?.GetHashCode(key) ?? key.GetHashCode());
-                uint bucket = hashCode % (uint)buckets.Length;
+                uint bucket = HashHelpers.FastRange(hashCode, (uint)buckets.Length);
                 int last = -1;
                 // Value in buckets is 1-based
                 int i = buckets[bucket] - 1;
@@ -852,7 +852,7 @@ namespace System.Collections.Generic
                 Debug.Assert(entries != null, "entries should be non-null");
                 int allowedCollisions = entries.Length;
                 uint hashCode = (uint)(_comparer?.GetHashCode(key) ?? key.GetHashCode());
-                uint bucket = hashCode % (uint)buckets.Length;
+                uint bucket = HashHelpers.FastRange(hashCode, (uint)buckets.Length);
                 int last = -1;
                 // Value in buckets is 1-based
                 int i = buckets[bucket] - 1;
@@ -1035,7 +1035,7 @@ namespace System.Collections.Generic
                 {
                     ref Entry entry = ref entries![count];
                     entry = oldEntries[i];
-                    uint bucket = hashCode % (uint)newSize;
+                    uint bucket = HashHelpers.FastRange(hashCode, (uint)newSize);
                     // Value in _buckets is 1-based
                     entry.next = buckets![bucket] - 1; // If we get here, we have entries, therefore buckets is not null.
                     // Value in _buckets is 1-based

--- a/src/System.Private.CoreLib/shared/System/Collections/HashHelpers.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/HashHelpers.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers.Binary;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics.X86;
 
 namespace System.Collections
 {
@@ -85,6 +88,34 @@ namespace System.Collections
             }
 
             return GetPrime(newSize);
+        }
+
+        // Takes an index and distributes it in the range [0, range)
+        // e.g. 0 to range exclusive.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint FastRange(uint index, uint range)
+        {
+            // Sse42.IsSupported check is baked into the R2R image so while the value returned
+            // from this method will be different on both branches, it will remain stable during
+            // a process' lifetime even if it is recompiled by tiered compilation.
+            if (Sse42.IsSupported)
+            {
+                // Using fastrange from Daniel Lemire https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+                //
+                // While fastrange is "fair"; it expects an evenly distributed hashCode
+                // from [0,2^32) to produce a distibuted range. As many hashCodes in .NET
+                // are generated with the high entropy in the LSB we need to redistribute
+                // the hash; for this we use Crc32. These two together allow us to skip the
+                // more costly idiv instruction.
+
+                const uint CrcReflected = 0xEDB88320;
+                return (uint)((Sse42.Crc32(CrcReflected, index) * (ulong)range) >> 32);
+            }
+            else
+            {
+                // Fast Crc isn't supported so we will use the slower modulo.
+                return index % range;
+            }
         }
     }
 }


### PR DESCRIPTION
* Dictionary avoid second bounds check in Get methods
* Hoist collision max count check
* Avoid mod operator when fast alternative available

```
|        Method | Toolchain |      Mean | Ratio |
|-------------- |---------- |----------:|------:|
| KNucleotide_1 |      base | 368.1  ms |  1.00 |
| KNucleotide_1 |      diff | 336.9  ms |  0.92 |
| KNucleotide_9 |      base | 104.05 ms |  1.00 |
| KNucleotide_9 |      diff |  89.71 ms |  0.86 |
```

System.Collections.TryGetValueTrue_String, String
```
|     Method | Toolchain | Size |     Mean | Ratio |
|----------- |---------- |----- |---------:|------:|
| Dictionary |      base |  512 | 15.72 us |  1.00 |
| Dictionary |      diff |  512 | 12.87 us |  0.82 |
```
System.Collections.TryGetValueFalse_String, String
```
|     Method | Toolchain | Size |     Mean | Ratio |
|----------- |---------- |----- |---------:|------:|
| Dictionary |      base |  512 | 13.84 us |  1.00 |
| Dictionary |      diff |  512 | 10.61 us |  0.77 |
```
System.Collections.TryGetValueTrue_Int32, Int32
```
|     Method | Toolchain | Size |     Mean | Ratio |
|----------- |---------- |----- |---------:|------:|
| Dictionary |      base |  512 | 5.901 us |  1.00 |
| Dictionary |      diff |  512 | 3.642 us |  0.62 |
```
System.Collections.TryGetValueFalse_Int32, Int32
```
|     Method | Toolchain | Size |     Mean | Ratio |
|----------- |---------- |----- |---------:|------:|
| Dictionary |      base |  512 | 8.511 us |  1.00 |
| Dictionary |      diff |  512 | 4.194 us |  0.49 |
```
More https://github.com/dotnet/coreclr/pull/27149#issuecomment-541487864