### PR TITLE
Expand BBJ_RETURN blocks with bool conditions

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4662,6 +4662,11 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags
         /* Optimize boolean conditions */
 
         optOptimizeBools();
+
+        if (info.compRetType == TYP_BOOL)
+        {
+            optMergeBoolReturns();
+        }
         EndPhase(PHASE_OPTIMIZE_BOOLS);
 
         // optOptimizeBools() might have changed the number of blocks; the dominators/reachability might be bad.

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4391,6 +4391,7 @@ public:
 
     void fgMorphStmts(BasicBlock* block, bool* lnot, bool* loadw);
     void fgMorphBlocks();
+    void fgExpandBoolReturns();
 
     bool fgMorphBlockStmt(BasicBlock* block, Statement* stmt DEBUGARG(const char* msg));
 
@@ -5738,6 +5739,10 @@ private:
 
 public:
     void optOptimizeBools();
+
+    bool isReturnBoolConst(BasicBlock* block, bool& value);
+
+    void optMergeBoolReturns();
 
 private:
     GenTree* optIsBoolCond(GenTree* condBranch, GenTree** compPtr, bool* boolPtr);


### PR DESCRIPTION
Expand `BBJ_RETURN` basic blocks with boolean conditions, let me explain it via a pic:

![image](https://user-images.githubusercontent.com/523221/66714025-ed734d00-edb9-11e9-85a2-ddb8b3d2e39b.png)

So it basically de-optimizes the control flow (optimized by Roslyn) but makes it a bit more friendly for optimizations, e.g. now both `BB1` and `BB2` jump into the same block and can be now handled by the [optOptimizeBools](https://github.com/dotnet/coreclr/blob/fd0ca99c4214538de6f821db6a38c9b6aca5ee62/src/jit/optimizer.cpp#L8851) optimizations, e.g.:
```csharp
static bool AreZero(int x, int y)
{
    return x == 0 && y == 0;
}
```
Was:
```asm
G_M22205_IG01:
G_M22205_IG02:
       test     ecx, ecx
       jne      SHORT G_M22205_IG05
G_M22205_IG03:		;; bbWeight=0.50
       test     edx, edx
       sete     al
       movzx    rax, al
G_M22205_IG04:		;; bbWeight=0.50
       ret      
G_M22205_IG05:		;; bbWeight=0.50
       xor      eax, eax
G_M22205_IG06:		;; bbWeight=0.50
       ret      
; Total bytes of code: 16
```
Now (without `optMergeBoolReturns`):
```asm
G_M22205_IG01:
G_M22205_IG02:
       or       edx, ecx
       jne      SHORT G_M22205_IG05
G_M22205_IG03:
       mov      eax, 1
G_M22205_IG04:
       ret      
G_M22205_IG05:
       xor      eax, eax
G_M22205_IG06:
       ret   
```
With `optMergeBoolReturns`:
```asm
G_M22205_IG01:
G_M22205_IG02:
       or       edx, ecx
       sete    al
       movzx    rax, al
G_M22205_IG03:
       ret      
```

So my de-optimization basically helped `optOptimizeBools` and now it's easier to go further and replace it with just `return x | y != 0` without jumps (see https://github.com/dotnet/coreclr/issues/27148). 

![image](https://user-images.githubusercontent.com/523221/66721874-ed9e3780-ee0f-11e9-829b-752206d71759.png)

The `fgExpandBoolReturns` and `optMergeBoolReturns` impl are just proof of concept so let me know please if I am moving in a wrong direction 🙂 

Jit diff:
```
Found 68 files with textual diffs.

Summary:
(Lower is better)

Total bytes of diff: -3914 (-0.01% of base)
    diff is an improvement.

Top file improvements by size (bytes):
        -549 : Microsoft.CodeAnalysis.CSharp.dasm (-0.01% of base)
        -420 : System.Private.CoreLib.dasm (-0.01% of base)
        -308 : System.Private.Xml.dasm (-0.01% of base)
        -213 : System.Linq.Parallel.dasm (-0.01% of base)
        -201 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)

68 total files with size differences (68 improved, 0 regressed), 61 unchanged.

Top method regressions by size (bytes):
           7 ( 4.05% of base) : Microsoft.CodeAnalysis.dasm - SwitchBucket:BucketOverflowUInt64Limit(ref,ref):bool
           6 ( 1.72% of base) : NuGet.Packaging.dasm - NuGet.Packaging.PackageHelper:IsPackageFile(ref,int):bool
           4 ( 1.12% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.LanguageParser:IsPossibleExpression():bool:this
           4 ( 3.15% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.DynamicTypeSymbol:Equals(ref,bool,bool):bool:this
           4 ( 1.30% of base) : System.Private.Xml.dasm - System.Xml.Xsl.IlGen.XmlILVisitor:CachesResult(ref):bool:this

Top method improvements by size (bytes):
         -41 (-6.47% of base) : NuGet.Versioning.dasm - NuGet.Versioning.FloatRange:Satisfies(ref):bool:this
         -41 (-1.97% of base) : System.Linq.Parallel.dasm - TakeOrSkipWhileQueryOperatorEnumerator`1[Vector`1,Int64][System.Numerics.Vector`1[System.Single],System.Int64]:MoveNext(byref,byref):bool:this
         -35 (-10.74% of base) : System.IO.IsolatedStorage.dasm - System.IO.IsolatedStorage.IsolatedStorageFile:ContainsUnknownFiles(ref):bool:this
         -35 (-1.78% of base) : System.Linq.Parallel.dasm - TakeOrSkipWhileQueryOperatorEnumerator`1[Double,Int64][System.Double,System.Int64]:MoveNext(byref,byref):bool:this
         -35 (-6.92% of base) : System.Private.CoreLib.dasm - System.Nullable:Equals(struct,struct):bool (6 methods)

Top method regressions by size (percentage):
           7 ( 4.05% of base) : Microsoft.CodeAnalysis.dasm - SwitchBucket:BucketOverflowUInt64Limit(ref,ref):bool
           4 ( 3.15% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.DynamicTypeSymbol:Equals(ref,bool,bool):bool:this
           6 ( 1.72% of base) : NuGet.Packaging.dasm - NuGet.Packaging.PackageHelper:IsPackageFile(ref,int):bool
           3 ( 1.69% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Stacks.CallTreeNode:get_HasChildren():bool:this
           1 ( 1.32% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - MemberLookup:ShouldLookupExtensionMethods(int,ref):bool

Top method improvements by size (percentage):
          -4 (-26.67% of base) : Microsoft.CSharp.dasm - BinOpFullSig:isLifted():bool:this
          -4 (-26.67% of base) : Microsoft.CSharp.dasm - UnaOpFullSig:isLifted():bool:this
          -4 (-26.67% of base) : System.ComponentModel.TypeConverter.dasm - FilterCacheItem:IsValid(ref):bool:this
          -4 (-26.67% of base) : System.Data.Common.dasm - System.Data.LookupNode:DependsOn(ref):bool:this
          -8 (-26.67% of base) : System.Diagnostics.TraceSource.dasm - System.Diagnostics.BooleanSwitch:get_Enabled():bool:this
```

Full diff: https://gist.github.com/EgorBo/6f84535bffe833981e550209dc1b8c56