### PR TITLE
Copy exception regions in the copy constructor

### DIFF
--- a/src/tools/crossgen2/Common/TypeSystem/IL/Stubs/ILEmitter.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/IL/Stubs/ILEmitter.cs
@@ -567,6 +567,7 @@ namespace Internal.IL.Stubs
             _tokens = methodIL._tokens;
             _method = methodIL._method;
             _debugInformation = methodIL._debugInformation;
+            _exceptionRegions = methodIL._exceptionRegions;
             _maxStack = methodIL._maxStack;
         }
 


### PR DESCRIPTION
This is used to create MethodIL for the interop stubs. I introduced this field in #27109 but forgot to make a copy here.