### PR TITLE
Wrap PerfEventSource usage in IsEnabled checks

### DIFF
--- a/src/tools/crossgen2/ILCompiler.DependencyAnalysisFramework/DependencyAnalyzer.cs
+++ b/src/tools/crossgen2/ILCompiler.DependencyAnalysisFramework/DependencyAnalyzer.cs
@@ -287,7 +287,8 @@ namespace ILCompiler.DependencyAnalysisFramework
         {
             if (_marker.MarkNode(node, reason1, reason2, reason))
             {
-                PerfEventSource.Log.AddedNodeToMarkStack();
+                if (PerfEventSource.Log.IsEnabled())
+                    PerfEventSource.Log.AddedNodeToMarkStack();
 
                 // Pop the top node of the mark stack
                 if (_stackPopRandomizer == null)


### PR DESCRIPTION
After the recent start/stop event refactoring, this is the only use of PerfEventSource that is not wrapped in a IsEnabled call.

Tools like IL Linker are able to strip EventSource usage to make the app smaller and the way they do it is by replacing IsEnabled to always return false and making Write methods always throw. If we don't wrap EventSource usage in IsEnabled checks, this results in a broken app.