### PR TITLE
Implement SetThreadName in PAL for Linux.

### DIFF
--- a/src/dlls/mscordac/mscordac_unixexports.src
+++ b/src/dlls/mscordac/mscordac_unixexports.src
@@ -170,6 +170,7 @@ nativeStringResourceTable_mscorrc_debug
 #SetFilePointer
 #SetLastError
 #SetErrorMode
+#SetThreadDescription
 #Sleep
 #SleepEx
 #SwitchToThread

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -2410,6 +2410,14 @@ GetThreadTimes(
         OUT LPFILETIME lpKernelTime,
         OUT LPFILETIME lpUserTime);
 
+PALIMPORT
+HRESULT
+PALAPI
+SetThreadName(
+    IN HANDLE hThread,
+    IN PCWSTR lpThreadDescription
+);
+
 #define TLS_OUT_OF_INDEXES ((DWORD)0xFFFFFFFF)
 
 PALIMPORT

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -2413,7 +2413,7 @@ GetThreadTimes(
 PALIMPORT
 HRESULT
 PALAPI
-SetThreadName(
+SetThreadDescription(
     IN HANDLE hThread,
     IN PCWSTR lpThreadDescription
 );
@@ -5113,6 +5113,59 @@ public:
 #define _O_APPEND   0x0008
 #define _O_TEXT     0x4000
 #define _O_BINARY   0x8000
+
+/******************* HRESULT types ****************************************/
+
+#define FACILITY_WINDOWS                 8
+#define FACILITY_URT                     19
+#define FACILITY_UMI                     22
+#define FACILITY_SXS                     23
+#define FACILITY_STORAGE                 3
+#define FACILITY_SSPI                    9
+#define FACILITY_SCARD                   16
+#define FACILITY_SETUPAPI                15
+#define FACILITY_SECURITY                9
+#define FACILITY_RPC                     1
+#define FACILITY_WIN32                   7
+#define FACILITY_CONTROL                 10
+#define FACILITY_NULL                    0
+#define FACILITY_MSMQ                    14
+#define FACILITY_MEDIASERVER             13
+#define FACILITY_INTERNET                12
+#define FACILITY_ITF                     4
+#define FACILITY_DPLAY                   21
+#define FACILITY_DISPATCH                2
+#define FACILITY_COMPLUS                 17
+#define FACILITY_CERT                    11
+#define FACILITY_ACS                     20
+#define FACILITY_AAF                     18
+
+#define NO_ERROR 0L
+
+#define SEVERITY_SUCCESS    0
+#define SEVERITY_ERROR      1
+
+#define SUCCEEDED(Status) ((HRESULT)(Status) >= 0)
+#define FAILED(Status) ((HRESULT)(Status)<0)
+#define IS_ERROR(Status) ((ULONG)(Status) >> 31 == SEVERITY_ERROR) // diff from win32
+#define HRESULT_CODE(hr)    ((hr) & 0xFFFF)
+#define SCODE_CODE(sc)      ((sc) & 0xFFFF)
+#define HRESULT_FACILITY(hr)  (((hr) >> 16) & 0x1fff)
+#define SCODE_FACILITY(sc)    (((sc) >> 16) & 0x1fff)
+#define HRESULT_SEVERITY(hr)  (((hr) >> 31) & 0x1)
+#define SCODE_SEVERITY(sc)    (((sc) >> 31) & 0x1)
+
+// both macros diff from Win32
+#define MAKE_HRESULT(sev,fac,code) \
+    ((HRESULT) (((ULONG)(sev)<<31) | ((ULONG)(fac)<<16) | ((ULONG)(code))) )
+#define MAKE_SCODE(sev,fac,code) \
+    ((SCODE) (((ULONG)(sev)<<31) | ((ULONG)(fac)<<16) | ((LONG)(code))) )
+
+#define FACILITY_NT_BIT                 0x10000000
+#define HRESULT_FROM_WIN32(x) ((HRESULT)(x) <= 0 ? ((HRESULT)(x)) : ((HRESULT) (((x) & 0x0000FFFF) | (FACILITY_WIN32 << 16) | 0x80000000)))
+#define __HRESULT_FROM_WIN32(x) HRESULT_FROM_WIN32(x)
+
+#define HRESULT_FROM_NT(x)      ((HRESULT) ((x) | FACILITY_NT_BIT))
 
 #ifdef  __cplusplus
 }

--- a/src/pal/inc/rt/palrt.h
+++ b/src/pal/inc/rt/palrt.h
@@ -318,59 +318,6 @@ typedef union _ULARGE_INTEGER {
     ULONGLONG QuadPart;
 } ULARGE_INTEGER, *PULARGE_INTEGER;
 
-/******************* HRESULT types ****************************************/
-
-#define FACILITY_WINDOWS                 8
-#define FACILITY_URT                     19
-#define FACILITY_UMI                     22
-#define FACILITY_SXS                     23
-#define FACILITY_STORAGE                 3
-#define FACILITY_SSPI                    9
-#define FACILITY_SCARD                   16
-#define FACILITY_SETUPAPI                15
-#define FACILITY_SECURITY                9
-#define FACILITY_RPC                     1
-#define FACILITY_WIN32                   7
-#define FACILITY_CONTROL                 10
-#define FACILITY_NULL                    0
-#define FACILITY_MSMQ                    14
-#define FACILITY_MEDIASERVER             13
-#define FACILITY_INTERNET                12
-#define FACILITY_ITF                     4
-#define FACILITY_DPLAY                   21
-#define FACILITY_DISPATCH                2
-#define FACILITY_COMPLUS                 17
-#define FACILITY_CERT                    11
-#define FACILITY_ACS                     20
-#define FACILITY_AAF                     18
-
-#define NO_ERROR 0L
-
-#define SEVERITY_SUCCESS    0
-#define SEVERITY_ERROR      1
-
-#define SUCCEEDED(Status) ((HRESULT)(Status) >= 0)
-#define FAILED(Status) ((HRESULT)(Status)<0)
-#define IS_ERROR(Status) ((ULONG)(Status) >> 31 == SEVERITY_ERROR) // diff from win32
-#define HRESULT_CODE(hr)    ((hr) & 0xFFFF)
-#define SCODE_CODE(sc)      ((sc) & 0xFFFF)
-#define HRESULT_FACILITY(hr)  (((hr) >> 16) & 0x1fff)
-#define SCODE_FACILITY(sc)    (((sc) >> 16) & 0x1fff)
-#define HRESULT_SEVERITY(hr)  (((hr) >> 31) & 0x1)
-#define SCODE_SEVERITY(sc)    (((sc) >> 31) & 0x1)
-
-// both macros diff from Win32
-#define MAKE_HRESULT(sev,fac,code) \
-    ((HRESULT) (((ULONG)(sev)<<31) | ((ULONG)(fac)<<16) | ((ULONG)(code))) )
-#define MAKE_SCODE(sev,fac,code) \
-    ((SCODE) (((ULONG)(sev)<<31) | ((ULONG)(fac)<<16) | ((LONG)(code))) )
-
-#define FACILITY_NT_BIT                 0x10000000
-#define HRESULT_FROM_WIN32(x) ((HRESULT)(x) <= 0 ? ((HRESULT)(x)) : ((HRESULT) (((x) & 0x0000FFFF) | (FACILITY_WIN32 << 16) | 0x80000000)))
-#define __HRESULT_FROM_WIN32(x) HRESULT_FROM_WIN32(x)
-
-#define HRESULT_FROM_NT(x)      ((HRESULT) ((x) | FACILITY_NT_BIT))
-
 /******************* OLE, BSTR, VARIANT *************************/
 
 STDAPI_VIS(DLLEXPORT, LPVOID) CoTaskMemAlloc(SIZE_T cb);

--- a/src/pal/src/include/pal/thread.hpp
+++ b/src/pal/src/include/pal/thread.hpp
@@ -201,7 +201,7 @@ namespace CorUnix
 
         friend
             PAL_ERROR
-            InternalSetThreadName(
+            InternalSetThreadDescription(
                 CPalThread *,
                 HANDLE,
                 PCWSTR

--- a/src/pal/src/include/pal/thread.hpp
+++ b/src/pal/src/include/pal/thread.hpp
@@ -201,6 +201,14 @@ namespace CorUnix
 
         friend
             PAL_ERROR
+            InternalSetThreadName(
+                CPalThread *,
+                HANDLE,
+                PCWSTR
+                );
+
+        friend
+            PAL_ERROR
             CreateThreadData(
                 CPalThread **ppThread
                 );

--- a/src/pal/src/thread/thread.cpp
+++ b/src/pal/src/thread/thread.cpp
@@ -1673,7 +1673,6 @@ CorUnix::InternalSetThreadDescription(
     if (error != 0) 
     {
         palError = ERROR_INTERNAL_ERROR;
-        goto InternalSetThreadDescriptionExit;
     }
 
 InternalSetThreadDescriptionExit:

--- a/src/utilcode/winfix.cpp
+++ b/src/utilcode/winfix.cpp
@@ -292,4 +292,11 @@ HRESULT SetThreadName(HANDLE hThread, PCWSTR lpThreadDescription)
     return g_pfnSetThreadDescription(hThread, lpThreadDescription);
 }
 
+#else //!FEATURE_PAL
+
+HRESULT SetThreadName(HANDLE hThread, PCWSTR lpThreadDescription)
+{
+    return SetThreadDescription(hThread, lpThreadDescription);
+}
+
 #endif //!FEATURE_PAL

--- a/src/vm/comsynchronizable.cpp
+++ b/src/vm/comsynchronizable.cpp
@@ -1283,14 +1283,13 @@ void QCALLTYPE ThreadNative::InformThreadNameChange(QCall::ThreadHandle thread, 
     
     Thread* pThread = &(*thread);
 
-#ifndef FEATURE_PAL
     // Set on Windows 10 Creators Update and later machines the unmanaged thread name as well. That will show up in ETW traces and debuggers which is very helpful
     // if more and more threads get a meaningful name
+    // Will also show up in Linux in gdb and such.
     if (len > 0 && name != NULL && pThread->GetThreadHandle() != INVALID_HANDLE_VALUE)
     {
         SetThreadName(pThread->GetThreadHandle(), name);
     }
-#endif
 
 #ifdef PROFILING_SUPPORTED
     {

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -2071,9 +2071,9 @@ BOOL Thread::CreateNewThread(SIZE_T stackSize, LPTHREAD_START_ROUTINE start, voi
     bRet = CreateNewOSThread(stackSize, start, args);
 #ifndef FEATURE_PAL
     UndoRevert(bReverted, token);
+#endif // !FEATURE_PAL
     if (pName != NULL)
         SetThreadName(m_ThreadHandle, pName);
-#endif // !FEATURE_PAL
 
     return bRet;
 }
@@ -2130,9 +2130,8 @@ HANDLE Thread::CreateUtilityThread(Thread::StackSizeBucket stackSizeBucket, LPTH
 
     DWORD threadId;
     HANDLE hThread = CreateThread(NULL, stackSize, start, args, flags, &threadId);
-#ifndef FEATURE_PAL
+
     SetThreadName(hThread, pName);
-#endif // !FEATURE_PAL
 
 
     if (pThreadId)

--- a/src/vm/win32threadpool.cpp
+++ b/src/vm/win32threadpool.cpp
@@ -1824,9 +1824,8 @@ Thread* ThreadpoolMgr::CreateUnimpersonatedThread(LPTHREAD_START_ROUTINE lpStart
                                         lpThreadArgs,       // arguments
                                         CREATE_SUSPENDED,
                                         &threadId);
-#ifndef FEATURE_PAL
+
             SetThreadName(threadHandle, W(".NET ThreadPool Worker"));
-#endif // !FEATURE_PAL
             if (threadHandle != NULL)
                 lpThreadArgs.SuppressRelease();
         }


### PR DESCRIPTION
This means thread names will now show up in gdb, htop, etc... on Linux.

I did not implement this for any other platforms:
I did not have anything to test them with, and `pthread_setname_np`'s API varies wildly across platform. (Hell, on macOS you can't call it from any thread except the thread in question..)

I'm not very familiar with C/C++ and this is my first time contributing, so extra scrutiny would be very much appreciated.