### PR TITLE
Fix RBM_PROFILER_TAILCALL_TRASH on x86

### DIFF
--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -469,7 +469,7 @@ typedef unsigned char   regNumberSmall;
   // See vm\i386\asmhelpers.asm for more details.
   #define RBM_PROFILER_ENTER_TRASH     RBM_NONE
   #define RBM_PROFILER_LEAVE_TRASH     RBM_NONE
-  #define RBM_PROFILER_TAILCALL_TRASH  (RBM_ALLINT & ~RBM_ARG_REGS)
+  #define RBM_PROFILER_TAILCALL_TRASH  (RBM_CALLEE_TRASH & ~RBM_ARG_REGS)
 
   // What sort of reloc do we use for [disp32] address mode
   #define IMAGE_REL_BASED_DISP32   IMAGE_REL_BASED_HIGHLOW


### PR DESCRIPTION
Fix `RBM_PROFILER_TAILCALL_TRASH` that *falsely* claims that a ProfileTailcall helper can trash non-volatile registers on x86.

This was causing assertions in my another PR #26549 where I enabled JIT stress mode  to generate profiler hooks. I checked that this PR fixes those.