### PR TITLE
Improve Dictionary TryGetValue size/perfomance

### DIFF
--- a/src/System.Private.CoreLib/shared/Internal/Runtime/CompilerServices/Unsafe.cs
+++ b/src/System.Private.CoreLib/shared/Internal/Runtime/CompilerServices/Unsafe.cs
@@ -387,5 +387,65 @@ namespace Internal.Runtime.CompilerServices
         {
             throw new PlatformNotSupportedException();
         }
+
+        /// <summary>
+        /// Returns a by-ref to a null reference of type <typeparamref name="T"/>.
+        /// Note this is the address of the by-ref not what the ref points to.
+        /// </summary>
+        [Intrinsic]
+        [NonVersionable]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static ref T NullRef<T>()
+        {
+#if CORECLR
+            throw new PlatformNotSupportedException();
+            // ldnull
+            // ret
+#else
+            return ref Unsafe.AsRef<T>(null);
+#endif
+        }
+
+        /// <summary>
+        /// Returns if a given by-ref of type <typeparamref name="T"/> is a null reference.
+        /// Note this is the address of the by-ref not what the ref points to.
+        /// </summary>
+        [Intrinsic]
+        [NonVersionable]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsNullRef<T>(ref T source)
+        {
+#if CORECLR
+            throw new PlatformNotSupportedException();
+            // ldarg.0
+            // ldc.i4.0
+            // conv.u
+            // ceq
+            // ret
+#else
+            return Unsafe.AsPointer(ref source) == null;
+#endif
+        }
+
+        /// <summary>
+        /// Returns if a given by-ref of type <typeparamref name="T"/> is not a null reference.
+        /// Note this is the address of the by-ref not what the ref points to.
+        /// </summary>
+        [Intrinsic]
+        [NonVersionable]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsNotNullRef<T>(ref T source)
+        {
+#if CORECLR
+            throw new PlatformNotSupportedException();
+            // ldarg.0
+            // ldc.i4.0
+            // conv.u
+            // cgt.un
+            // ret
+#else
+            return Unsafe.AsPointer(ref source) != null;
+#endif
+        }
     }
 }

--- a/src/System.Private.CoreLib/shared/Internal/Runtime/CompilerServices/Unsafe.cs
+++ b/src/System.Private.CoreLib/shared/Internal/Runtime/CompilerServices/Unsafe.cs
@@ -399,7 +399,8 @@ namespace Internal.Runtime.CompilerServices
         {
 #if CORECLR
             throw new PlatformNotSupportedException();
-            // ldnull
+            // ldc.i4.0
+            // conv.u
             // ret
 #else
             return ref Unsafe.AsRef<T>(null);
@@ -424,27 +425,6 @@ namespace Internal.Runtime.CompilerServices
             // ret
 #else
             return Unsafe.AsPointer(ref source) == null;
-#endif
-        }
-
-        /// <summary>
-        /// Returns if a given by-ref of type <typeparamref name="T"/> is not a null reference.
-        /// Note this is the address of the by-ref not what the ref points to.
-        /// </summary>
-        [Intrinsic]
-        [NonVersionable]
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool IsNotNullRef<T>(ref T source)
-        {
-#if CORECLR
-            throw new PlatformNotSupportedException();
-            // ldarg.0
-            // ldc.i4.0
-            // conv.u
-            // cgt.un
-            // ret
-#else
-            return Unsafe.AsPointer(ref source) != null;
 #endif
         }
     }

--- a/src/System.Private.CoreLib/shared/Internal/Runtime/CompilerServices/Unsafe.cs
+++ b/src/System.Private.CoreLib/shared/Internal/Runtime/CompilerServices/Unsafe.cs
@@ -395,16 +395,13 @@ namespace Internal.Runtime.CompilerServices
         [Intrinsic]
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static ref T NullRef<T>()
+        public static ref T NullRef<T>()
         {
-#if CORECLR
-            throw new PlatformNotSupportedException();
+            return ref Unsafe.AsRef<T>(null);
+
             // ldc.i4.0
             // conv.u
             // ret
-#else
-            return ref Unsafe.AsRef<T>(null);
-#endif
         }
 
         /// <summary>
@@ -417,18 +414,15 @@ namespace Internal.Runtime.CompilerServices
         [Intrinsic]
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool IsNullRef<T>(ref T source)
+        public static bool IsNullRef<T>(ref T source)
         {
-#if CORECLR
-            throw new PlatformNotSupportedException();
+            return Unsafe.AsPointer(ref source) == null;
+
             // ldarg.0
             // ldc.i4.0
             // conv.u
             // ceq
             // ret
-#else
-            return Unsafe.AsPointer(ref source) == null;
-#endif
         }
     }
 }

--- a/src/System.Private.CoreLib/shared/Internal/Runtime/CompilerServices/Unsafe.cs
+++ b/src/System.Private.CoreLib/shared/Internal/Runtime/CompilerServices/Unsafe.cs
@@ -389,8 +389,7 @@ namespace Internal.Runtime.CompilerServices
         }
 
         /// <summary>
-        /// Returns a by-ref that is a null reference to a type <typeparamref name="T"/>.
-        /// Note this is the address of the by-ref not what the ref points to.
+        /// Returns a by-ref to type <typeparamref name="T"/> that is a null reference.
         /// </summary>
         [Intrinsic]
         [NonVersionable]
@@ -406,7 +405,6 @@ namespace Internal.Runtime.CompilerServices
 
         /// <summary>
         /// Returns if a given by-ref to type <typeparamref name="T"/> is a null reference.
-        /// Note this is the address of the by-ref not what the ref points to.
         /// </summary>
         /// <remarks>
         /// This check is conceptually similar to "(void*)(&amp;source) == nullptr".

--- a/src/System.Private.CoreLib/shared/Internal/Runtime/CompilerServices/Unsafe.cs
+++ b/src/System.Private.CoreLib/shared/Internal/Runtime/CompilerServices/Unsafe.cs
@@ -389,7 +389,7 @@ namespace Internal.Runtime.CompilerServices
         }
 
         /// <summary>
-        /// Returns a by-ref to a null reference of type <typeparamref name="T"/>.
+        /// Returns a by-ref that is a null reference to a type <typeparamref name="T"/>.
         /// Note this is the address of the by-ref not what the ref points to.
         /// </summary>
         [Intrinsic]
@@ -408,9 +408,12 @@ namespace Internal.Runtime.CompilerServices
         }
 
         /// <summary>
-        /// Returns if a given by-ref of type <typeparamref name="T"/> is a null reference.
+        /// Returns if a given by-ref to type <typeparamref name="T"/> is a null reference.
         /// Note this is the address of the by-ref not what the ref points to.
         /// </summary>
+        /// <remarks>
+        /// This check is conceptually similar to "(void*)(&amp;source) == nullptr".
+        /// </remarks>
         [Intrinsic]
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
@@ -340,11 +340,11 @@ namespace System.Collections.Generic
                 {
                     uint hashCode = (uint)key.GetHashCode();
                     int i = buckets[hashCode % (uint)buckets.Length];
+                    Entry[]? entries = _entries;
+                    uint collisionCount = 0;
                     if (default(TKey)! != null) // TODO-NULLABLE: default(T) == null warning (https://github.com/dotnet/roslyn/issues/34757)
                     {
                         // ValueType: Devirtualize with EqualityComparer<TValue>.Default intrinsic
-                        Entry[]? entries = _entries;
-                        int collisionCount = 0;
 
                         // Value in _buckets is 1-based; subtract 1 from i. We do it here so it fuses with the following conditional.
                         i--;
@@ -366,7 +366,7 @@ namespace System.Collections.Generic
                             i = entry.next;
 
                             collisionCount++;
-                        } while ((uint)collisionCount <= (uint)entries.Length);
+                        } while (collisionCount <= (uint)entries.Length);
                         // The chain of entries forms a loop; which means a concurrent update has happened.
                         // Break out of the loop and throw, rather than looping forever.
                         goto ConcurrentOperation;
@@ -377,8 +377,7 @@ namespace System.Collections.Generic
                         // https://github.com/dotnet/coreclr/issues/17273
                         // So cache in a local rather than get EqualityComparer per loop iteration
                         EqualityComparer<TKey> defaultComparer = EqualityComparer<TKey>.Default;
-                        Entry[]? entries = _entries;
-                        int collisionCount = 0;
+
                         // Value in _buckets is 1-based; subtract 1 from i. We do it here so it fuses with the following conditional.
                         i--;
                         do
@@ -399,7 +398,7 @@ namespace System.Collections.Generic
                             i = entry.next;
 
                             collisionCount++;
-                        } while ((uint)collisionCount <= (uint)entries.Length);
+                        } while (collisionCount <= (uint)entries.Length);
                         // The chain of entries forms a loop; which means a concurrent update has happened.
                         // Break out of the loop and throw, rather than looping forever.
                         goto ConcurrentOperation;
@@ -410,7 +409,7 @@ namespace System.Collections.Generic
                     uint hashCode = (uint)comparer.GetHashCode(key);
                     int i = buckets[hashCode % (uint)buckets.Length];
                     Entry[]? entries = _entries;
-                    int collisionCount = 0;
+                    uint collisionCount = 0;
                     // Value in _buckets is 1-based; subtract 1 from i. We do it here so it fuses with the following conditional.
                     i--;
                     do
@@ -431,7 +430,7 @@ namespace System.Collections.Generic
                         i = entry.next;
 
                         collisionCount++;
-                    } while ((uint)collisionCount <= (uint)entries.Length);
+                    } while (collisionCount <= (uint)entries.Length);
                     // The chain of entries forms a loop; which means a concurrent update has happened.
                     // Break out of the loop and throw, rather than looping forever.
                     goto ConcurrentOperation;
@@ -481,7 +480,7 @@ namespace System.Collections.Generic
             IEqualityComparer<TKey>? comparer = _comparer;
             uint hashCode = (uint)((comparer == null) ? key.GetHashCode() : comparer.GetHashCode(key));
 
-            int collisionCount = 0;
+            uint collisionCount = 0;
             ref int bucket = ref _buckets[hashCode % (uint)_buckets.Length];
             // Value in _buckets is 1-based
             int i = bucket - 1;
@@ -520,7 +519,7 @@ namespace System.Collections.Generic
                         i = entries[i].next;
 
                         collisionCount++;
-                        if ((uint)collisionCount > (uint)entries.Length)
+                        if (collisionCount > (uint)entries.Length)
                         {
                             // The chain of entries forms a loop; which means a concurrent update has happened.
                             // Break out of the loop and throw, rather than looping forever.
@@ -563,7 +562,7 @@ namespace System.Collections.Generic
                         i = entries[i].next;
 
                         collisionCount++;
-                        if ((uint)collisionCount > (uint)entries.Length)
+                        if (collisionCount > (uint)entries.Length)
                         {
                             // The chain of entries forms a loop; which means a concurrent update has happened.
                             // Break out of the loop and throw, rather than looping forever.
@@ -603,7 +602,7 @@ namespace System.Collections.Generic
                     i = entries[i].next;
 
                     collisionCount++;
-                    if ((uint)collisionCount > (uint)entries.Length)
+                    if (collisionCount > (uint)entries.Length)
                     {
                         // The chain of entries forms a loop; which means a concurrent update has happened.
                         // Break out of the loop and throw, rather than looping forever.
@@ -766,7 +765,7 @@ namespace System.Collections.Generic
             if (buckets != null)
             {
                 Debug.Assert(entries != null, "entries should be non-null");
-                int collisionCount = 0;
+                uint collisionCount = 0;
                 uint hashCode = (uint)(_comparer?.GetHashCode(key) ?? key.GetHashCode());
                 uint bucket = hashCode % (uint)buckets.Length;
                 int last = -1;
@@ -809,7 +808,7 @@ namespace System.Collections.Generic
                     i = entry.next;
 
                     collisionCount++;
-                    if ((uint)collisionCount > (uint)entries.Length)
+                    if (collisionCount > (uint)entries.Length)
                     {
                         // The chain of entries forms a loop; which means a concurrent update has happened.
                         // Break out of the loop and throw, rather than looping forever.
@@ -835,7 +834,7 @@ namespace System.Collections.Generic
             if (buckets != null)
             {
                 Debug.Assert(entries != null, "entries should be non-null");
-                int collisionCount = 0;
+                uint collisionCount = 0;
                 uint hashCode = (uint)(_comparer?.GetHashCode(key) ?? key.GetHashCode());
                 uint bucket = hashCode % (uint)buckets.Length;
                 int last = -1;
@@ -880,7 +879,7 @@ namespace System.Collections.Generic
                     i = entry.next;
 
                     collisionCount++;
-                    if ((uint)collisionCount > (uint)entries.Length)
+                    if (collisionCount > (uint)entries.Length)
                     {
                         // The chain of entries forms a loop; which means a concurrent update has happened.
                         // Break out of the loop and throw, rather than looping forever.

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
@@ -232,7 +232,7 @@ namespace System.Collections.Generic
             }
         }
 
-        public unsafe bool ContainsKey(TKey key)
+        public bool ContainsKey(TKey key)
             => !Unsafe.IsNullRef(ref FindValue(key));
 
         public bool ContainsValue(TValue value)
@@ -891,7 +891,7 @@ namespace System.Collections.Generic
             return false;
         }
 
-        public unsafe bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
+        public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
         {
             ref TValue valRef = ref FindValue(key);
             if (!Unsafe.IsNullRef(ref valRef))

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
@@ -6,6 +6,9 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
+using System.Runtime.InteropServices;
+
+using Internal.Runtime.CompilerServices;
 
 namespace System.Collections.Generic
 {
@@ -36,14 +39,15 @@ namespace System.Collections.Generic
     [TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class Dictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue>, ISerializable, IDeserializationCallback where TKey : notnull
     {
+        [StructLayout(LayoutKind.Auto)]
         private struct Entry
         {
+            public uint hashCode;
+            public TKey key;           // Key of entry
             // 0-based index of next entry in chain: -1 means end of chain
             // also encodes whether this entry _itself_ is part of the free list by changing sign and subtracting 3,
             // so -2 means end of free list, -3 means index 0 but on free list, -4 means index 1 but on free list, etc.
             public int next;
-            public uint hashCode;
-            public TKey key;           // Key of entry
             public TValue value;         // Value of entry
         }
 
@@ -164,12 +168,15 @@ namespace System.Collections.Generic
 
         IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => _values ??= new ValueCollection(this);
 
-        public TValue this[TKey key]
+        public unsafe TValue this[TKey key]
         {
             get
             {
-                int i = FindEntry(key);
-                if (i >= 0) return _entries![i].value;
+                ref TValue value = ref FindValue(key);
+                if (Unsafe.AsPointer(ref value) != null)
+                {
+                    return value;
+                }
                 ThrowHelper.ThrowKeyNotFoundException(key);
                 return default;
             }
@@ -189,20 +196,20 @@ namespace System.Collections.Generic
         void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> keyValuePair)
             => Add(keyValuePair.Key, keyValuePair.Value);
 
-        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> keyValuePair)
+        unsafe bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> keyValuePair)
         {
-            int i = FindEntry(keyValuePair.Key);
-            if (i >= 0 && EqualityComparer<TValue>.Default.Equals(_entries![i].value, keyValuePair.Value))
+            ref TValue value = ref FindValue(keyValuePair.Key);
+            if (Unsafe.AsPointer(ref value) != null && EqualityComparer<TValue>.Default.Equals(value, keyValuePair.Value))
             {
                 return true;
             }
             return false;
         }
 
-        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> keyValuePair)
+        unsafe bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> keyValuePair)
         {
-            int i = FindEntry(keyValuePair.Key);
-            if (i >= 0 && EqualityComparer<TValue>.Default.Equals(_entries![i].value, keyValuePair.Value))
+            ref TValue value = ref FindValue(keyValuePair.Key);
+            if (Unsafe.AsPointer(ref value) != null && EqualityComparer<TValue>.Default.Equals(value, keyValuePair.Value))
             {
                 Remove(keyValuePair.Key);
                 return true;
@@ -227,8 +234,9 @@ namespace System.Collections.Generic
             }
         }
 
-        public bool ContainsKey(TKey key)
-            => FindEntry(key) >= 0;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe bool ContainsKey(TKey key)
+            => Unsafe.AsPointer(ref FindValue(key)) != null;
 
         public bool ContainsValue(TValue value)
         {
@@ -318,47 +326,53 @@ namespace System.Collections.Generic
             }
         }
 
-        private int FindEntry(TKey key)
+        private unsafe ref TValue FindValue(TKey key)
         {
             if (key == null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
             }
 
-            int i = -1;
             int[]? buckets = _buckets;
-            Entry[]? entries = _entries;
-            int collisionCount = 0;
+            ref Entry entry = ref Unsafe.AsRef<Entry>(null);
             if (buckets != null)
             {
-                Debug.Assert(entries != null, "expected entries to be != null");
+                Debug.Assert(_entries != null, "expected entries to be != null");
                 IEqualityComparer<TKey>? comparer = _comparer;
                 if (comparer == null)
                 {
                     uint hashCode = (uint)key.GetHashCode();
-                    // Value in _buckets is 1-based
-                    i = buckets[hashCode % (uint)buckets.Length] - 1;
+                    int i = buckets[hashCode % (uint)buckets.Length];
                     if (default(TKey)! != null) // TODO-NULLABLE: default(T) == null warning (https://github.com/dotnet/roslyn/issues/34757)
                     {
                         // ValueType: Devirtualize with EqualityComparer<TValue>.Default intrinsic
-                        while (true)
+                        Entry[]? entries = _entries;
+                        int collisionCount = 0;
+
+                        // Value in _buckets is 1-based; subtract 1 from i. We do it here so it fuses with the following conditional.
+                        i--;
+                        do
                         {
                             // Should be a while loop https://github.com/dotnet/coreclr/issues/15476
                             // Test in if to drop range check for following array access
-                            if ((uint)i >= (uint)entries.Length || (entries[i].hashCode == hashCode && EqualityComparer<TKey>.Default.Equals(entries[i].key, key)))
+                            if ((uint)i >= (uint)entries.Length)
                             {
-                                break;
+                                goto ReturnNotFound;
                             }
 
-                            i = entries[i].next;
-                            if (collisionCount >= entries.Length)
+                            entry = ref entries[i];
+                            if (entry.hashCode == hashCode && EqualityComparer<TKey>.Default.Equals(entry.key, key))
                             {
-                                // The chain of entries forms a loop; which means a concurrent update has happened.
-                                // Break out of the loop and throw, rather than looping forever.
-                                ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                                goto ReturnFound;
                             }
+
+                            i = entry.next;
+
                             collisionCount++;
-                        }
+                        } while ((uint)collisionCount <= (uint)entries.Length);
+                        // The chain of entries forms a loop; which means a concurrent update has happened.
+                        // Break out of the loop and throw, rather than looping forever.
+                        goto ConcurrentOperation;
                     }
                     else
                     {
@@ -366,54 +380,78 @@ namespace System.Collections.Generic
                         // https://github.com/dotnet/coreclr/issues/17273
                         // So cache in a local rather than get EqualityComparer per loop iteration
                         EqualityComparer<TKey> defaultComparer = EqualityComparer<TKey>.Default;
-                        while (true)
+                        Entry[]? entries = _entries;
+                        int collisionCount = 0;
+                        // Value in _buckets is 1-based; subtract 1 from i. We do it here so it fuses with the following conditional.
+                        i--;
+                        do
                         {
                             // Should be a while loop https://github.com/dotnet/coreclr/issues/15476
                             // Test in if to drop range check for following array access
-                            if ((uint)i >= (uint)entries.Length || (entries[i].hashCode == hashCode && defaultComparer.Equals(entries[i].key, key)))
+                            if ((uint)i >= (uint)entries.Length)
                             {
-                                break;
+                                goto ReturnNotFound;
                             }
 
-                            i = entries[i].next;
-                            if (collisionCount >= entries.Length)
+                            entry = ref entries[i];
+                            if (entry.hashCode == hashCode && defaultComparer.Equals(entry.key, key))
                             {
-                                // The chain of entries forms a loop; which means a concurrent update has happened.
-                                // Break out of the loop and throw, rather than looping forever.
-                                ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                                goto ReturnFound;
                             }
+
+                            i = entry.next;
+
                             collisionCount++;
-                        }
+                        } while ((uint)collisionCount <= (uint)entries.Length);
+                        // The chain of entries forms a loop; which means a concurrent update has happened.
+                        // Break out of the loop and throw, rather than looping forever.
+                        goto ConcurrentOperation;
                     }
                 }
                 else
                 {
                     uint hashCode = (uint)comparer.GetHashCode(key);
-                    // Value in _buckets is 1-based
-                    i = buckets[hashCode % (uint)buckets.Length] - 1;
-                    while (true)
+                    int i = buckets[hashCode % (uint)buckets.Length];
+                    Entry[]? entries = _entries;
+                    int collisionCount = 0;
+                    // Value in _buckets is 1-based; subtract 1 from i. We do it here so it fuses with the following conditional.
+                    i--;
+                    do
                     {
                         // Should be a while loop https://github.com/dotnet/coreclr/issues/15476
                         // Test in if to drop range check for following array access
-                        if ((uint)i >= (uint)entries.Length ||
-                            (entries[i].hashCode == hashCode && comparer.Equals(entries[i].key, key)))
+                        if ((uint)i >= (uint)entries.Length)
                         {
-                            break;
+                            goto ReturnNotFound;
                         }
 
-                        i = entries[i].next;
-                        if (collisionCount >= entries.Length)
+                        entry = ref entries[i];
+                        if (entry.hashCode == hashCode && comparer.Equals(entry.key, key))
                         {
-                            // The chain of entries forms a loop; which means a concurrent update has happened.
-                            // Break out of the loop and throw, rather than looping forever.
-                            ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                            goto ReturnFound;
                         }
+
+                        i = entry.next;
+
                         collisionCount++;
-                    }
+                    } while ((uint)collisionCount <= (uint)entries.Length);
+                    // The chain of entries forms a loop; which means a concurrent update has happened.
+                    // Break out of the loop and throw, rather than looping forever.
+                    goto ConcurrentOperation;
                 }
             }
 
-            return i;
+            goto ReturnNotFound;
+
+        ConcurrentOperation:
+            ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+        ReturnFound:
+            ref TValue value = ref entry.value;
+        Return:
+            return ref value;
+        ReturnNotFound:
+            value = ref Unsafe.AsRef<TValue>(null);
+            goto Return;
         }
 
         private int Initialize(int capacity)
@@ -483,13 +521,14 @@ namespace System.Collections.Generic
                         }
 
                         i = entries[i].next;
-                        if (collisionCount >= entries.Length)
+
+                        collisionCount++;
+                        if ((uint)collisionCount > (uint)entries.Length)
                         {
                             // The chain of entries forms a loop; which means a concurrent update has happened.
                             // Break out of the loop and throw, rather than looping forever.
                             ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
                         }
-                        collisionCount++;
                     }
                 }
                 else
@@ -525,13 +564,14 @@ namespace System.Collections.Generic
                         }
 
                         i = entries[i].next;
-                        if (collisionCount >= entries.Length)
+
+                        collisionCount++;
+                        if ((uint)collisionCount > (uint)entries.Length)
                         {
                             // The chain of entries forms a loop; which means a concurrent update has happened.
                             // Break out of the loop and throw, rather than looping forever.
                             ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
                         }
-                        collisionCount++;
                     }
                 }
             }
@@ -564,13 +604,14 @@ namespace System.Collections.Generic
                     }
 
                     i = entries[i].next;
-                    if (collisionCount >= entries.Length)
+
+                    collisionCount++;
+                    if ((uint)collisionCount > (uint)entries.Length)
                     {
                         // The chain of entries forms a loop; which means a concurrent update has happened.
                         // Break out of the loop and throw, rather than looping forever.
                         ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
                     }
-                    collisionCount++;
                 }
             }
 
@@ -725,10 +766,10 @@ namespace System.Collections.Generic
 
             int[]? buckets = _buckets;
             Entry[]? entries = _entries;
-            int collisionCount = 0;
             if (buckets != null)
             {
                 Debug.Assert(entries != null, "entries should be non-null");
+                int collisionCount = 0;
                 uint hashCode = (uint)(_comparer?.GetHashCode(key) ?? key.GetHashCode());
                 uint bucket = hashCode % (uint)buckets.Length;
                 int last = -1;
@@ -769,13 +810,14 @@ namespace System.Collections.Generic
 
                     last = i;
                     i = entry.next;
-                    if (collisionCount >= entries.Length)
+
+                    collisionCount++;
+                    if ((uint)collisionCount > (uint)entries.Length)
                     {
                         // The chain of entries forms a loop; which means a concurrent update has happened.
                         // Break out of the loop and throw, rather than looping forever.
                         ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
                     }
-                    collisionCount++;
                 }
             }
             return false;
@@ -793,10 +835,10 @@ namespace System.Collections.Generic
 
             int[]? buckets = _buckets;
             Entry[]? entries = _entries;
-            int collisionCount = 0;
             if (buckets != null)
             {
                 Debug.Assert(entries != null, "entries should be non-null");
+                int collisionCount = 0;
                 uint hashCode = (uint)(_comparer?.GetHashCode(key) ?? key.GetHashCode());
                 uint bucket = hashCode % (uint)buckets.Length;
                 int last = -1;
@@ -839,25 +881,26 @@ namespace System.Collections.Generic
 
                     last = i;
                     i = entry.next;
-                    if (collisionCount >= entries.Length)
+
+                    collisionCount++;
+                    if ((uint)collisionCount > (uint)entries.Length)
                     {
                         // The chain of entries forms a loop; which means a concurrent update has happened.
                         // Break out of the loop and throw, rather than looping forever.
                         ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
                     }
-                    collisionCount++;
                 }
             }
             value = default!;
             return false;
         }
 
-        public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
+        public unsafe bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
         {
-            int i = FindEntry(key);
-            if (i >= 0)
+            ref TValue valRef = ref FindValue(key);
+            if (Unsafe.AsPointer(ref valRef) != null)
             {
-                value = _entries![i].value;
+                value = valRef;
                 return true;
             }
             value = default!;
@@ -1016,16 +1059,16 @@ namespace System.Collections.Generic
 
         ICollection IDictionary.Values => (ICollection)Values;
 
-        object? IDictionary.this[object key]
+        unsafe object? IDictionary.this[object key]
         {
             get
             {
                 if (IsCompatibleKey(key))
                 {
-                    int i = FindEntry((TKey)key);
-                    if (i >= 0)
+                    ref TValue value = ref FindValue((TKey)key);
+                    if (Unsafe.AsPointer(ref value) != null)
                     {
-                        return _entries![i].value;
+                        return value;
                     }
                 }
                 return null;

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
@@ -171,7 +171,7 @@ namespace System.Collections.Generic
             get
             {
                 ref TValue value = ref FindValue(key);
-                if (Unsafe.IsNotNullRef(ref value))
+                if (!Unsafe.IsNullRef(ref value))
                 {
                     return value;
                 }
@@ -197,7 +197,7 @@ namespace System.Collections.Generic
         bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> keyValuePair)
         {
             ref TValue value = ref FindValue(keyValuePair.Key);
-            if (Unsafe.IsNotNullRef(ref value) && EqualityComparer<TValue>.Default.Equals(value, keyValuePair.Value))
+            if (!Unsafe.IsNullRef(ref value) && EqualityComparer<TValue>.Default.Equals(value, keyValuePair.Value))
             {
                 return true;
             }
@@ -207,7 +207,7 @@ namespace System.Collections.Generic
         bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> keyValuePair)
         {
             ref TValue value = ref FindValue(keyValuePair.Key);
-            if (Unsafe.IsNotNullRef(ref value) && EqualityComparer<TValue>.Default.Equals(value, keyValuePair.Value))
+            if (!Unsafe.IsNullRef(ref value) && EqualityComparer<TValue>.Default.Equals(value, keyValuePair.Value))
             {
                 Remove(keyValuePair.Key);
                 return true;
@@ -232,9 +232,8 @@ namespace System.Collections.Generic
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe bool ContainsKey(TKey key)
-            => Unsafe.IsNotNullRef(ref FindValue(key));
+            => !Unsafe.IsNullRef(ref FindValue(key));
 
         public bool ContainsValue(TValue value)
         {
@@ -324,7 +323,7 @@ namespace System.Collections.Generic
             }
         }
 
-        private unsafe ref TValue FindValue(TKey key)
+        private ref TValue FindValue(TKey key)
         {
             if (key == null)
             {
@@ -896,7 +895,7 @@ namespace System.Collections.Generic
         public unsafe bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
         {
             ref TValue valRef = ref FindValue(key);
-            if (Unsafe.IsNotNullRef(ref valRef))
+            if (!Unsafe.IsNullRef(ref valRef))
             {
                 value = valRef;
                 return true;
@@ -1064,7 +1063,7 @@ namespace System.Collections.Generic
                 if (IsCompatibleKey(key))
                 {
                     ref TValue value = ref FindValue((TKey)key);
-                    if (Unsafe.IsNotNullRef(ref value))
+                    if (!Unsafe.IsNullRef(ref value))
                     {
                         return value;
                     }

--- a/src/System.Private.CoreLib/shared/System/Collections/HashHelpers.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/HashHelpers.cs
@@ -8,7 +8,7 @@ namespace System.Collections
 {
     internal static partial class HashHelpers
     {
-        public const int HashCollisionThreshold = 100;
+        public const uint HashCollisionThreshold = 100;
 
         // This is the maximum prime smaller than Array.MaxArrayLength
         public const int MaxPrimeArrayLength = 0x7FEFFFFD;

--- a/src/System.Private.CoreLib/shared/System/Memory.cs
+++ b/src/System.Private.CoreLib/shared/System/Memory.cs
@@ -295,7 +295,7 @@ namespace System
                 // in which case that's the dangerous operation performed by the dev, and we're just following
                 // suit here to make it work as best as possible.
 
-                ref T refToReturn = ref Unsafe.AsRef<T>(null);
+                ref T refToReturn = ref Unsafe.NullRef<T>();
                 int lengthOfUnderlyingSpan = 0;
 
                 // Copy this field into a local so that it can't change out from under us mid-operation.

--- a/src/System.Private.CoreLib/shared/System/ReadOnlyMemory.cs
+++ b/src/System.Private.CoreLib/shared/System/ReadOnlyMemory.cs
@@ -217,7 +217,7 @@ namespace System
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                ref T refToReturn = ref Unsafe.AsRef<T>(null);
+                ref T refToReturn = ref Unsafe.NullRef<T>();
                 int lengthOfUnderlyingSpan = 0;
 
                 // Copy this field into a local so that it can't change out from under us mid-operation.

--- a/src/System.Private.CoreLib/shared/System/ReadOnlySpan.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/ReadOnlySpan.Fast.cs
@@ -148,10 +148,10 @@ namespace System
         /// It can be used for pinning and is required to support the use of span within a fixed statement.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public unsafe ref readonly T GetPinnableReference()
+        public ref readonly T GetPinnableReference()
         {
             // Ensure that the native code has just one forward branch that is predicted-not-taken.
-            ref T ret = ref Unsafe.AsRef<T>(null);
+            ref T ret = ref Unsafe.NullRef<T>();
             if (_length != 0) ret = ref _pointer.Value;
             return ref ret;
         }

--- a/src/System.Private.CoreLib/shared/System/Span.Fast.cs
+++ b/src/System.Private.CoreLib/shared/System/Span.Fast.cs
@@ -154,10 +154,10 @@ namespace System
         /// It can be used for pinning and is required to support the use of span within a fixed statement.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public unsafe ref T GetPinnableReference()
+        public ref T GetPinnableReference()
         {
             // Ensure that the native code has just one forward branch that is predicted-not-taken.
-            ref T ret = ref Unsafe.AsRef<T>(null);
+            ref T ret = ref Unsafe.NullRef<T>();
             if (_length != 0) ret = ref _pointer.Value;
             return ref ret;
         }

--- a/src/tools/crossgen2/Common/TypeSystem/IL/Stubs/UnsafeIntrinsics.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/IL/Stubs/UnsafeIntrinsics.cs
@@ -70,6 +70,18 @@ namespace Internal.IL.Stubs
                         (byte)ILOpcode.ldarg_1, (byte)ILOpcode.ldarg_0,
                         (byte)ILOpcode.sub,
                         (byte)ILOpcode.ret }, Array.Empty<LocalVariableDefinition>(), null);
+                case "NullRef":
+                    return new ILStubMethodIL(method, new byte[]
+                    {
+                        (byte)ILOpcode.ldc_i4_0, (byte)ILOpcode.conv_u,
+                        (byte)ILOpcode.ret }, Array.Empty<LocalVariableDefinition>(), null);
+                case "IsNullRef":
+                    return new ILStubMethodIL(method, new byte[]
+                    {
+                        (byte)ILOpcode.ldarg_0, 
+                        (byte)ILOpcode.ldc_i4_0, (byte)ILOpcode.conv_u,
+                        (byte)ILOpcode.prefix1, unchecked((byte)ILOpcode.ceq),
+                        (byte)ILOpcode.ret }, Array.Empty<LocalVariableDefinition>(), null);
             }
 
             return null;

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -7253,23 +7253,10 @@ bool getILIntrinsicImplementationForUnsafe(MethodDesc * ftn,
     }
     else if (tk == MscorlibBinder::GetMethod(METHOD__UNSAFE__BYREF_NULLREF)->GetMemberDef())
     {
-        static const BYTE ilcode[] = { CEE_LDNULL, CEE_RET };
+        static const BYTE ilcode[] = { CEE_LDC_I4_0, CEE_CONV_U, CEE_RET };
         methInfo->ILCode = const_cast<BYTE*>(ilcode);
         methInfo->ILCodeSize = sizeof(ilcode);
         methInfo->maxStack = 1;
-        methInfo->EHcount = 0;
-        methInfo->options = (CorInfoOptions)0;
-        return true;
-    }
-    else if (tk == MscorlibBinder::GetMethod(METHOD__UNSAFE__BYREF_IS_NOTNULL)->GetMemberDef())
-    {
-        // 'ldnull' opcode would produce type o, and we can't compare & against o (ECMA-335, Table III.4).
-        // However, we can compare & against native int, so we'll use that instead.
-
-        static const BYTE ilcode[] = { CEE_LDARG_0, CEE_LDC_I4_0, CEE_CONV_U, CEE_PREFIX1, (CEE_CGT_UN & 0xFF), CEE_RET };
-        methInfo->ILCode = const_cast<BYTE*>(ilcode);
-        methInfo->ILCodeSize = sizeof(ilcode);
-        methInfo->maxStack = 2;
         methInfo->EHcount = 0;
         methInfo->options = (CorInfoOptions)0;
         return true;

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -7251,6 +7251,42 @@ bool getILIntrinsicImplementationForUnsafe(MethodDesc * ftn,
         methInfo->options = (CorInfoOptions)0;
         return true;
     }
+    else if (tk == MscorlibBinder::GetMethod(METHOD__UNSAFE__BYREF_NULLREF)->GetMemberDef())
+    {
+        static const BYTE ilcode[] = { CEE_LDNULL, CEE_RET };
+        methInfo->ILCode = const_cast<BYTE*>(ilcode);
+        methInfo->ILCodeSize = sizeof(ilcode);
+        methInfo->maxStack = 1;
+        methInfo->EHcount = 0;
+        methInfo->options = (CorInfoOptions)0;
+        return true;
+    }
+    else if (tk == MscorlibBinder::GetMethod(METHOD__UNSAFE__BYREF_IS_NOTNULL)->GetMemberDef())
+    {
+        // 'ldnull' opcode would produce type o, and we can't compare & against o (ECMA-335, Table III.4).
+        // However, we can compare & against native int, so we'll use that instead.
+
+        static const BYTE ilcode[] = { CEE_LDARG_0, CEE_LDC_I4_0, CEE_CONV_U, CEE_PREFIX1, (CEE_CGT_UN & 0xFF), CEE_RET };
+        methInfo->ILCode = const_cast<BYTE*>(ilcode);
+        methInfo->ILCodeSize = sizeof(ilcode);
+        methInfo->maxStack = 2;
+        methInfo->EHcount = 0;
+        methInfo->options = (CorInfoOptions)0;
+        return true;
+    }
+    else if (tk == MscorlibBinder::GetMethod(METHOD__UNSAFE__BYREF_IS_NULL)->GetMemberDef())
+    {
+        // 'ldnull' opcode would produce type o, and we can't compare & against o (ECMA-335, Table III.4).
+        // However, we can compare & against native int, so we'll use that instead.
+
+        static const BYTE ilcode[] = { CEE_LDARG_0, CEE_LDC_I4_0, CEE_CONV_U, CEE_PREFIX1, (CEE_CEQ & 0xFF), CEE_RET };
+        methInfo->ILCode = const_cast<BYTE*>(ilcode);
+        methInfo->ILCodeSize = sizeof(ilcode);
+        methInfo->maxStack = 2;
+        methInfo->EHcount = 0;
+        methInfo->options = (CorInfoOptions)0;
+        return true;
+    }
     else if (tk == MscorlibBinder::GetMethod(METHOD__UNSAFE__BYREF_INIT_BLOCK_UNALIGNED)->GetMemberDef())
     {
         static const BYTE ilcode[] = { CEE_LDARG_0, CEE_LDARG_1, CEE_LDARG_2, CEE_PREFIX1, (CEE_UNALIGNED & 0xFF), 0x01, CEE_PREFIX1, (CEE_INITBLK & 0xFF), CEE_RET };

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -701,6 +701,9 @@ DEFINE_METHOD(JIT_HELPERS,          ENUM_COMPARE_TO,        EnumCompareTo, NoSig
 
 DEFINE_CLASS(UNSAFE,                InternalCompilerServices,       Unsafe)
 DEFINE_METHOD(UNSAFE,               AS_POINTER,             AsPointer, NoSig)
+DEFINE_METHOD(UNSAFE,               BYREF_IS_NULL,          IsNullRef, NoSig)
+DEFINE_METHOD(UNSAFE,               BYREF_IS_NOTNULL,       IsNotNullRef, NoSig)
+DEFINE_METHOD(UNSAFE,               BYREF_NULLREF,          NullRef, NoSig)
 DEFINE_METHOD(UNSAFE,               AS_REF_IN,              AsRef, GM_RefT_RetRefT)
 DEFINE_METHOD(UNSAFE,               AS_REF_POINTER,         AsRef, GM_VoidPtr_RetRefT)
 DEFINE_METHOD(UNSAFE,               SIZEOF,                 SizeOf, NoSig)

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -702,7 +702,6 @@ DEFINE_METHOD(JIT_HELPERS,          ENUM_COMPARE_TO,        EnumCompareTo, NoSig
 DEFINE_CLASS(UNSAFE,                InternalCompilerServices,       Unsafe)
 DEFINE_METHOD(UNSAFE,               AS_POINTER,             AsPointer, NoSig)
 DEFINE_METHOD(UNSAFE,               BYREF_IS_NULL,          IsNullRef, NoSig)
-DEFINE_METHOD(UNSAFE,               BYREF_IS_NOTNULL,       IsNotNullRef, NoSig)
 DEFINE_METHOD(UNSAFE,               BYREF_NULLREF,          NullRef, NoSig)
 DEFINE_METHOD(UNSAFE,               AS_REF_IN,              AsRef, GM_RefT_RetRefT)
 DEFINE_METHOD(UNSAFE,               AS_REF_POINTER,         AsRef, GM_VoidPtr_RetRefT)


### PR DESCRIPTION
From https://github.com/dotnet/coreclr/pull/27149 without the hashcode-to-bucket mapping changes

* Avoid second bounds check; by passing a `ref` rather than an index to TryGetValue/indexer get methods; so a second dip back to the backing array is not needed.
* Return null `ref` from FindValue so ContainsKey doesn't pay a struct copy cost when using same method.
* Rearrange FindValue return block to be a straighter flow for the common path of found item
* Rearrange `Entry` struct to put `hashCode` first rather than `next` as it is accessed first which should work with prefetching better.
* move `collisionCount++` before `collisionCount` test so the Jit *could* micro-fuse them (though doesn't currently https://github.com/dotnet/coreclr/issues/7566)

Size improvements
```
Total bytes of diff: -1647 (-0.05% of base)
    diff is an improvement.

Total byte diff includes -118 bytes from reconciling methods
        Base had    4 unique methods,     3935 unique bytes
        Diff had    6 unique methods,     3817 unique bytes

Top file improvements by size (bytes):
       -1647 : System.Private.CoreLib.dasm (-0.05% of base)

1 total files with size differences (1 improved, 0 regressed), 0 unchanged.
```

/cc @jkotas @AntonLapounov @GrabYourPitchforks 