### PR TITLE
Update scripts to include activity ID / related activity ID in generated native functions for firing runtime events through event pipe

### DIFF
--- a/src/scripts/genEventPipe.py
+++ b/src/scripts/genEventPipe.py
@@ -66,9 +66,10 @@ def generateMethodSignatureWrite(eventName, template, extern):
             sig_pieces.append(fnparam.name)
             sig_pieces.append(",\n")
 
-        if len(sig_pieces) > 0:
-            del sig_pieces[-1]
-
+    sig_pieces.append(lindent)
+    sig_pieces.append("LPCGUID ActivityId,\n")
+    sig_pieces.append(lindent)
+    sig_pieces.append("LPCGUID RelatedActivityId")
     sig_pieces.append(")")
     return ''.join(sig_pieces)
 
@@ -125,7 +126,7 @@ def generateClrEventPipeWriteEventsImpl(
             WriteEventImpl.append(
                 "    EventPipe::WriteEvent(*EventPipeEvent" +
                 eventName +
-                ", (BYTE*) nullptr, 0);\n")
+                ", (BYTE*) nullptr, 0, ActivityId, RelatedActivityId);\n")
 
         WriteEventImpl.append("\n    return ERROR_SUCCESS;\n}\n\n")
 
@@ -220,7 +221,7 @@ def generateWriteEventBody(template, providerName, eventName):
     }\n\n"""
 
     body = "    EventPipe::WriteEvent(*EventPipeEvent" + \
-        eventName + ", (BYTE *)buffer, (unsigned int)offset);\n"
+        eventName + ", (BYTE *)buffer, (unsigned int)offset, ActivityId, RelatedActivityId);\n"
 
     footer = """
     if (!fixedBuffer)

--- a/src/scripts/genEventing.py
+++ b/src/scripts/genEventing.py
@@ -325,13 +325,23 @@ def generateClrallEvents(eventNodes,allTemplates):
             #remove trailing commas
             if len(line) > 0:
                 del line[-1]
-            if len(fnptypeline) > 0:
-                del fnptypeline[-1]
+
+        #add activity IDs
+        fnptypeline.append(lindent)
+        fnptypeline.append("LPCGUID ActivityId = nullptr,\n")
+        fnptypeline.append(lindent)
+        fnptypeline.append("LPCGUID RelatedActivityId = nullptr")
 
         fnptype.extend(fnptypeline)
         fnptype.append("\n)\n{\n")
         fnbody.append(lindent)
-        fnbody.append("ULONG status = EventPipeWriteEvent" + eventName + "(" + ''.join(line) + ");\n")
+
+        fnbody.append("ULONG status = EventPipeWriteEvent" + eventName + "(" + ''.join(line))
+        if len(line) > 0:
+            fnbody.append(",")
+
+        fnbody.append("ActivityId,RelatedActivityId);\n")
+
         fnbody.append(lindent)
         fnbody.append("status &= FireEtXplat" + eventName + "(" + ''.join(line) + ");\n")
         fnbody.append(lindent)
@@ -437,9 +447,10 @@ def generateClrEventPipeWriteEvents(eventNodes, allTemplates, extern):
                 fnptypeline.append(fnparam.name)
                 fnptypeline.append(",\n")
 
-            #remove trailing commas
-            if len(fnptypeline) > 0:
-                del fnptypeline[-1]
+        fnptypeline.append(lindent)
+        fnptypeline.append("LPCGUID ActivityId = nullptr,\n")
+        fnptypeline.append(lindent)
+        fnptypeline.append("LPCGUID RelatedActivityId = nullptr")
 
         writeevent.extend(fnptypeline)
         writeevent.append("\n);\n")


### PR DESCRIPTION
Update scripts to include activity ID / related activity ID in generated native functions for firing runtime events through event pipe

This will allow explicitly specifying an activity ID and/or related activity ID (defaults to nullptr) when firing runtime events through event pipe. This change only updates the generated functions for event pipe, not the platform-dependent systems (ETW/LTTng) - `mc.exe` used to generate the ETW functions has an option to generate them such that they take in an activity ID, but the related activity ID is always empty in the generated code. We intend to use this for tracing binder operations.