### PR TITLE
Fix DecoderNLS.Convert to out the correct value for 'completed'

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Text/DecoderNLS.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/DecoderNLS.cs
@@ -207,11 +207,13 @@ namespace System.Text
             charsUsed = _encoding.GetChars(bytes, byteCount, chars, charCount, this);
             bytesUsed = _bytesUsed;
 
-            // Its completed if they've used what they wanted AND if they didn't want flush or if we are flushed
-            completed = (bytesUsed == byteCount) && (!flush || !this.HasState) &&
-                               (_fallbackBuffer == null || _fallbackBuffer.Remaining == 0);
+            // Per MSDN, "The completed output parameter indicates whether all the data in the input
+            // buffer was converted and stored in the output buffer." That means we've successfully
+            // consumed all the input _and_ there's no pending state or fallback data remaining to be output.
 
-            // Our data thingy are now full, we can return
+            completed = (bytesUsed == byteCount)
+                && !this.HasState
+                && (_fallbackBuffer is null || _fallbackBuffer.Remaining == 0);
         }
 
         public bool MustFlush => _mustFlush;

--- a/src/System.Private.CoreLib/shared/System/Text/EncoderNLS.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/EncoderNLS.cs
@@ -201,8 +201,6 @@ namespace System.Text
             completed = (charsUsed == charCount)
                 && !this.HasState
                 && (_fallbackBuffer is null || _fallbackBuffer.Remaining == 0);
-
-            // Our data thingys are now full, we can return
         }
 
         public Encoding Encoding

--- a/tests/CoreFX/CoreFX.issues.rsp
+++ b/tests/CoreFX/CoreFX.issues.rsp
@@ -71,6 +71,10 @@
 # https://github.com/dotnet/coreclr/issues/22414
 -nomethod System.Numerics.Tests.ToStringTest.RunRegionSpecificStandardFormatToStringTests
 
+# Failure in System.Text.Encoding.Tests due to bug fix in DecoderNLS.Convert
+# https://github.com/dotnet/coreclr/issues/27191
+-nomethod System.Text.Tests.DecoderConvert2.PosTest6
+
 # Timeout in System.Text.RegularExpressions.Tests.RegexMatchTests.Match_ExcessPrefix
 # https://github.com/dotnet/coreclr/issues/18912
 -nomethod System.Text.RegularExpressions.Tests.RegexMatchTests.Match_ExcessPrefix


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/27191. Unit tests are in corefx and will be updated there.

I might need to suppress some test failures in coreclr as a result of this change. Will wait for CI to get the full list.