### PR TITLE
[3.1 port] Improve the performance of Environment.WorkingSet in Windows (#26522)

### DIFF
--- a/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.GetProcessMemoryInfo.cs
+++ b/src/System.Private.CoreLib/shared/Interop/Windows/Kernel32/Interop.GetProcessMemoryInfo.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct PROCESS_MEMORY_COUNTERS
+        {
+            public uint cb;
+            public uint PageFaultCount;
+            public UIntPtr PeakWorkingSetSize;
+            public UIntPtr WorkingSetSize;
+            public UIntPtr QuotaPeakPagedPoolUsage;
+            public UIntPtr QuotaPagedPoolUsage;
+            public UIntPtr QuotaPeakNonPagedPoolUsage;
+            public UIntPtr QuotaNonPagedPoolUsage;
+            public UIntPtr PagefileUsage;
+            public UIntPtr PeakPagefileUsage;
+        }
+
+        [DllImport(Libraries.Kernel32, EntryPoint="K32GetProcessMemoryInfo")]
+        internal static extern bool GetProcessMemoryInfo(IntPtr Process, ref PROCESS_MEMORY_COUNTERS ppsmemCounters, uint cb);
+    }
+}

--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -1047,6 +1047,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.GetFullPathNameW.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.GetLongPathNameW.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.GetLogicalDrives.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.GetProcessMemoryInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.GetProcessTimes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.GetSystemDirectoryW.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop\Windows\Kernel32\Interop.GetSystemInfo.cs" />

--- a/src/System.Private.CoreLib/shared/System/Environment.Unix.cs
+++ b/src/System.Private.CoreLib/shared/System/Environment.Unix.cs
@@ -444,5 +444,24 @@ namespace System
             }
             return (int)result;
         }
+
+        public static long WorkingSet
+        {
+            get
+            {
+                Type? processType = Type.GetType("System.Diagnostics.Process, System.Diagnostics.Process, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", throwOnError: false);
+                if (processType?.GetMethod("GetCurrentProcess")?.Invoke(null, BindingFlags.DoNotWrapExceptions, null, null, null) is IDisposable currentProcess)
+                {
+                    using (currentProcess)
+                    {
+                        object? result = processType!.GetMethod("get_WorkingSet64")?.Invoke(currentProcess, BindingFlags.DoNotWrapExceptions, null, null, null);
+                        if (result is long) return (long)result;
+                    }
+                }
+
+                // Could not get the current working set.
+                return 0;
+            }
+        }
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Environment.Windows.cs
+++ b/src/System.Private.CoreLib/shared/System/Environment.Windows.cs
@@ -119,5 +119,20 @@ namespace System
                 return builder.ToString();
             }
         }
+
+        public static unsafe long WorkingSet
+        {
+            get
+            {
+                Interop.Kernel32.PROCESS_MEMORY_COUNTERS memoryCounters = default;
+                memoryCounters.cb = (uint)(sizeof(Interop.Kernel32.PROCESS_MEMORY_COUNTERS));
+
+                if (!Interop.Kernel32.GetProcessMemoryInfo(Interop.Kernel32.GetCurrentProcess(), ref memoryCounters, memoryCounters.cb))
+                {
+                    return 0;
+                }
+                return (long)memoryCounters.WorkingSetSize;
+            }
+        }
     }
 }

--- a/src/System.Private.CoreLib/shared/System/Environment.cs
+++ b/src/System.Private.CoreLib/shared/System/Environment.cs
@@ -153,30 +153,6 @@ namespace System
             }
         }
 
-        public static long WorkingSet
-        {
-            get
-            {
-                // Use reflection to access the implementation in System.Diagnostics.Process.dll.  While far from ideal,
-                // we do this to avoid duplicating the Windows, Linux, macOS, and potentially other platform-specific implementations
-                // present in Process.  If it proves important, we could look at separating that functionality out of Process into
-                // Common files which could also be included here.
-                Type? processType = Type.GetType("System.Diagnostics.Process, System.Diagnostics.Process, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", throwOnError: false);
-                IDisposable? currentProcess = processType?.GetMethod("GetCurrentProcess")?.Invoke(null, BindingFlags.DoNotWrapExceptions, null, null, null) as IDisposable;
-                if (currentProcess != null)
-                {
-                    using (currentProcess)
-                    {
-                        object? result = processType!.GetMethod("get_WorkingSet64")?.Invoke(currentProcess, BindingFlags.DoNotWrapExceptions, null, null, null);
-                        if (result is long) return (long)result;
-                    }
-                }
-
-                // Could not get the current working set.
-                return 0;
-            }
-        }
-
         private static bool ValidateAndConvertRegistryTarget(EnvironmentVariableTarget target)
         {
             Debug.Assert(target != EnvironmentVariableTarget.Process);


### PR DESCRIPTION
Description

This is a backport of #26522.

`Environment.WorkingSet` API was not made to be performant, so it was using reflection to call System.Diagnostics.Process API, which internally allocates a `ProcessInfo` object and fills up a lot of irrelevant information that gets thrown away. This changes Environment.WorkingSet API to call into the Windows API for fetching the working set directly to improve its performance on Windows. 

Customer Impact

Bing reported this API to be a blocker for adopting the runtime performance counters in their production environment. 

Regression?
No

Risk
Low. Performance tests showed an improvement of ~2000x speedup with this change. 
