### PR TITLE
[release/3.1] Enable ETW/EventSource logging of task IDs for boxed state machines

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncMethodBuilder.cs
@@ -1099,7 +1099,9 @@ namespace System.Runtime.CompilerServices
         }
 
         internal static Task? TryGetContinuationTask(Action continuation) =>
-            (continuation?.Target as ContinuationWrapper)?._innerTask;
+            (continuation.Target is ContinuationWrapper wrapper) ?
+                wrapper._innerTask :           // A wrapped continuation, created by an awaiter
+                continuation.Target as Task;   // The continuation targets a task directly, such as with AsyncStateMachineBox
 
         /// <summary>
         /// Logically we pass just an Action (delegate) to a task for its action to 'ContinueWith' when it completes.


### PR DESCRIPTION
Port https://github.com/dotnet/coreclr/pull/27115 to release/3.1
Fixes https://github.com/dotnet/coreclr/issues/27076

## Description

In .NET Core 2.1 we overhauled how async state machines are implemented.  In doing so, we added code paths that enable these state machines to be passed around as their own continuations rather than forcing MoveNext delegates to be created for the same purpose.  However, we neglected to update a helper function that's used by our EventSource tracing to extract an ID from that continuation object, which means some of our events are always outputting 0 for these IDs rather than that for the actual object.

## Customer Impact

Tools that use these events to track causality may be broken.

## Regression?

Yes, from .NET Core 2.0 / .NET Framework.

## Testing

Visual Studio tools that consume these events ran their test suites, in addition to our coreclr/corefx tests.

## Risk

Low.  It's adding an additional fallback case.