### PR TITLE
[release/3.1] Fix DecoderNLS.Convert to out the correct value for 'completed'

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Text/DecoderNLS.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/DecoderNLS.cs
@@ -207,9 +207,13 @@ namespace System.Text
             charsUsed = _encoding.GetChars(bytes, byteCount, chars, charCount, this);
             bytesUsed = _bytesUsed;
 
-            // Its completed if they've used what they wanted AND if they didn't want flush or if we are flushed
-            completed = (bytesUsed == byteCount) && (!flush || !this.HasState) &&
-                               (_fallbackBuffer == null || _fallbackBuffer.Remaining == 0);
+            // Per MSDN, "The completed output parameter indicates whether all the data in the input
+            // buffer was converted and stored in the output buffer." That means we've successfully
+            // consumed all the input _and_ there's no pending state or fallback data remaining to be output.
+
+            completed = (bytesUsed == byteCount)
+                && !this.HasState
+                && (_fallbackBuffer is null || _fallbackBuffer.Remaining == 0);
 
             // Our data thingy are now full, we can return
         }

--- a/tests/CoreFX/CoreFX.issues.rsp
+++ b/tests/CoreFX/CoreFX.issues.rsp
@@ -70,6 +70,10 @@
 # https://github.com/dotnet/coreclr/issues/22414
 -nomethod System.Numerics.Tests.ToStringTest.RunRegionSpecificStandardFormatToStringTests
 
+# Failure in System.Text.Encoding.Tests due to bug fix in DecoderNLS.Convert
+# https://github.com/dotnet/coreclr/issues/27191
+-nomethod System.Text.Tests.DecoderConvert2.PosTest6
+
 # Timeout in System.Text.RegularExpressions.Tests.RegexMatchTests.Match_ExcessPrefix
 # https://github.com/dotnet/coreclr/issues/18912
 -nomethod System.Text.RegularExpressions.Tests.RegexMatchTests.Match_ExcessPrefix


### PR DESCRIPTION
Port https://github.com/dotnet/coreclr/pull/27210 to release/3.1
Fixes https://github.com/dotnet/coreclr/issues/27191

## Description

In .NET Core 3.0 we fixed several bugs in the __System.Text__ namespace, including for how UTF-8 fallbacks sequences are calculated and the _out_ parameters from commonly-used methods like `Encoder.Convert`. (See https://github.com/dotnet/coreclr/issues/23020, for instance.) However, we missed fixing the same issue in the related method `Decoder.Convert`. That method is still producing incorrect output for some inputs.

## Customer Impact

Customers who use `Encoder.Convert` may see incorrect behavior from these APIs. Importantly, it is also blocking our ability to introduce extension methods which utilize these APIs, such as those under consideration at https://github.com/dotnet/corefx/pull/41810.

## Regression?

No. The original bug has existed since the dawn of time.

## Testing

The unit tests added as part of https://github.com/dotnet/corefx/pull/41802 should be sufficient to cover this.

## Risk

Medium. As with any behavioral changes, there exists the possibility that customers may be depending (either intentionally or unintentionally) on the incorrect outputs.