### PR TITLE
Use aligned memory access in JIT_StackProbe

### DIFF
--- a/src/vm/amd64/JitHelpers_Fast.asm
+++ b/src/vm/amd64/JitHelpers_Fast.asm
@@ -974,15 +974,15 @@ LEAF_ENTRY JIT_StackProbe, _TEXT
         ;
         ; NOTE: this helper will probe at least one page below the one pointed by rsp.
 
-        lea     rax, [rsp - PAGE_SIZE] ; rax points to some byte on the first unprobed page
-        or      rax, (PAGE_SIZE - 1)   ; rax points to the **highest address** on the first unprobed page
+        mov     rax, rsp               ; rax points to some byte on the last probed page
+        and     rax, -PAGE_SIZE        ; rax points to the **lowest address** on the last probed page
                                        ; This is done to make the following loop end condition simpler.
 
 ProbeLoop:
-        test    dword ptr [rax], eax
-        sub     rax, PAGE_SIZE         ; rax points to the highest address of the **next page** to probe
+        sub     rax, PAGE_SIZE         ; rax points to the lowest address of the **next page** to probe
+        test    dword ptr [rax], eax   ; rax points to the lowest address on the **last probed** page
         cmp     rax, r11
-        jge     ProbeLoop              ; if (rax >= r11), then we need to probe the page pointed to by rax.
+        jg      ProbeLoop              ; If (rax > r11), then we need to probe at least one more page.
 
         ret
 

--- a/src/vm/amd64/jithelpers_fast.S
+++ b/src/vm/amd64/jithelpers_fast.S
@@ -565,15 +565,14 @@ NESTED_ENTRY JIT_StackProbe, _TEXT, NoHandler
 
     END_PROLOGUE
 
-        sub     rsp, PAGE_SIZE         // rsp points to some byte on the first unprobed page
-        or      rsp, (PAGE_SIZE - 1)   // rsp points to the **highest address** on the first unprobed page
+        and     rsp, -PAGE_SIZE        // rsp points to the **lowest address** on the last probed page
                                        // This is done to make the following loop end condition simpler.
 
 LOCAL_LABEL(ProbeLoop):
-        test    dword ptr [rsp], eax
-        sub     rsp, PAGE_SIZE         // rsp points to the highest address of the **next page** to probe
+        sub     rsp, PAGE_SIZE         // rsp points to the lowest address of the **next page** to probe
+        test    dword ptr [rsp], eax   // rsp points to the lowest address on the **last probed** page
         cmp     rsp, r11
-        jge     LOCAL_LABEL(ProbeLoop) // if (rsp >= r11), then we need to probe the page pointed to by rsp.
+        jg      LOCAL_LABEL(ProbeLoop) // if (rsp > r11), then we need to probe at least one more page.
 
         RESET_FRAME_WITH_RBP
         ret

--- a/src/vm/i386/jithelp.S
+++ b/src/vm/i386/jithelp.S
@@ -638,15 +638,14 @@ NESTED_ENTRY JIT_StackProbe, _TEXT, NoHandler
     PROLOG_BEG
     PROLOG_END
 
-    sub     esp, PAGE_SIZE         // esp points to some byte on the first unprobed page
-    or      esp, (PAGE_SIZE - 1)   // esp points to the **highest address** on the first unprobed page
+    and     esp, -PAGE_SIZE        // esp points to the **lowest address** on the last probed page
                                    // This is done to make the loop end condition simpler.
 
 LOCAL_LABEL(ProbeLoop):
-    test    [esp], eax
-    sub     esp, PAGE_SIZE         // esp points to the highest address of the **next page** to probe
+    sub     esp, PAGE_SIZE         // esp points to the lowest address of the **next page** to probe
+    test    [esp], eax             // esp points to the lowest address on the **last probed** page
     cmp     esp, eax
-    jge     LOCAL_LABEL(ProbeLoop) // if esp >= eax, then we need to probe the page pointed to by esp.
+    jg      LOCAL_LABEL(ProbeLoop) // if esp > eax, then we need to probe at least one more page.
 
     EPILOG_BEG
     mov     esp, ebp

--- a/src/vm/i386/jithelp.asm
+++ b/src/vm/i386/jithelp.asm
@@ -1480,14 +1480,13 @@ _JIT_StackProbe@0 PROC public
     push    ebp
     mov     ebp, esp
 
-    sub     esp, PAGE_SIZE       ; esp points to some byte on the first unprobed page
-    or      esp, (PAGE_SIZE - 1) ; esp points to the **highest address** on the first unprobed page
+    and     esp, -PAGE_SIZE      ; esp points to the **lowest address** on the last probed page
                                  ; This is done to make the loop end condition simpler.
 ProbeLoop:
-    test    [esp], eax
-    sub     esp, PAGE_SIZE       ; esp points to the highest address of the **next page** to probe
+    sub     esp, PAGE_SIZE       ; esp points to the lowest address of the **next page** to probe
+    test    [esp], eax           ; esp points to the lowest address on the **last probed** page
     cmp     esp, eax
-    jge     ProbeLoop            ; if esp >= eax, then we need to probe the page pointed to by esp.
+    jg      ProbeLoop            ; if esp > eax, then we need to probe at least one more page.
 
     mov     esp, ebp
     pop     ebp


### PR DESCRIPTION
As Jan suggested in https://github.com/dotnet/coreclr/pull/27184#discussion_r334700866 I reimplemented `JIT_StackProbe` so the helper uses only aligned memory access to probe the stack. It turns out that the new implementations on win-x86, linux-x86 and Linux-x64 require one instruction less.

@BruceForstall @janvorli PTAL
cc @jkotas 