### PR TITLE
Update Jupiter host interface method names to match official documentation

### DIFF
--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/ICustomPropertyProvider.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/WindowsRuntime/ICustomPropertyProvider.cs
@@ -117,7 +117,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
     // (such as the adapter code that addresses behavior differences between IBindableVector & List
     // as well as simplify forwarding code (except for IEnumerable)
     //
-    // 2. ICLRServices.CreateManagedReference will hand out ICCW* of a new instance of this object
+    // 2. ICLRServices.GetTrackerTarget will hand out ICCW* of a new instance of this object
     // and will hold the other object alive
     //
     //

--- a/src/vm/jupiterobject.h
+++ b/src/vm/jupiterobject.h
@@ -27,10 +27,10 @@ class ICCW;
 class DECLSPEC_UUID("29a71c6a-3c42-4416-a39d-e2825a07a773") ICLRServices : public IUnknown
 {
 public :
-    STDMETHOD(GarbageCollect)(DWORD dwFlags) = 0;
-    STDMETHOD(FinalizerThreadWait)() = 0;
-    STDMETHOD(DisconnectRCWsInCurrentApartment)() = 0;
-    STDMETHOD(CreateManagedReference)(IUnknown *pJupiterObject, ICCW **ppNewReference) = 0;
+    STDMETHOD(DisconnectUnusedReferenceSources)(DWORD dwFlags) = 0;
+    STDMETHOD(ReleaseDisconnectedReferenceSources)() = 0;
+    STDMETHOD(NotifyEndOfReferenceTrackingOnThread)() = 0;
+    STDMETHOD(GetTrackerTarget)(IUnknown *pJupiterObject, ICCW **ppNewReference) = 0;
     STDMETHOD(AddMemoryPressure)(UINT64 bytesAllocated) = 0;
     STDMETHOD(RemoveMemoryPressure)(UINT64 bytesAllocated) = 0;
 };
@@ -39,10 +39,10 @@ public :
 class DECLSPEC_UUID("3cf184b4-7ccb-4dda-8455-7e6ce99a3298") IJupiterGCManager : public IUnknown
 {
 public :
-    STDMETHOD(OnGCStarted)() = 0;
-    STDMETHOD(OnRCWWalkFinished)(BOOL bWalkFailed) = 0;
-    STDMETHOD(OnGCFinished)() = 0;
-    STDMETHOD(SetCLRServices)(/* [in] */ ICLRServices *pCLRServices) = 0;
+    STDMETHOD(ReferenceTrackingStarted)() = 0;
+    STDMETHOD(FindTrackerTargetsCompleted)(BOOL bWalkFailed) = 0;
+    STDMETHOD(ReferenceTrackingCompleted)() = 0;
+    STDMETHOD(SetReferenceTrackerHost)(/* [in] */ ICLRServices *pCLRServices) = 0;
 };
 
 // Windows.UI.Xaml.Hosting.IReferenceTrackerTarget
@@ -50,8 +50,8 @@ class DECLSPEC_UUID("64bd43f8-bfee-4ec4-b7eb-2935158dae21") ICCW : public IUnkno
 {
 
 public :
-    STDMETHOD_(ULONG, AddReferenceFromJupiter)() = 0;    
-    STDMETHOD_(ULONG, ReleaseFromJupiter)() = 0;
+    STDMETHOD_(ULONG, AddRefFromReferenceTracker)() = 0;
+    STDMETHOD_(ULONG, ReleaseFromReferenceTracker)() = 0;
     STDMETHOD(Peg)() = 0;
     STDMETHOD(Unpeg)() = 0;
 };
@@ -61,24 +61,24 @@ class DECLSPEC_UUID("04b3486c-4687-4229-8d14-505ab584dd88") IFindDependentWrappe
 {
 
 public :
-    STDMETHOD(OnFoundDependentWrapper)(/* [in] */ ICCW *pCCW) = 0;
+    STDMETHOD(FoundTrackerTarget)(/* [in] */ ICCW *pCCW) = 0;
 };
 
 // Windows.UI.Xaml.Hosting.IReferenceTracker
 class DECLSPEC_UUID("11d3b13a-180e-4789-a8be-7712882893e6") IJupiterObject : public IUnknown
 {
 public :
-    STDMETHOD(Connect)() = 0;           // Notify Jupiter that we've created a new RCW
-    STDMETHOD(Disconnect)() = 0;        // Notify Jupiter that we are about to destroy this RCW
-    STDMETHOD(FindDependentWrappers)(/* [in] */ IFindDependentWrappersCallback *pCallback) = 0;
-                                        // Find list of dependent CCWs for this RCW
-    STDMETHOD(GetJupiterGCManager)(/* [out, retval] */ IJupiterGCManager **ppJupiterGCManager) = 0;
-                                        // Retrieve IJupiterGCManager interface
-    STDMETHOD(AfterAddRef)() = 0;       // Notify Jupiter that we've done a AddRef()
-    STDMETHOD(BeforeRelease)() = 0;     // Notify Jupiter that we are about to do a Release()
-    STDMETHOD(Peg)() = 0;               // Notify Jupiter that we've returned this IJupiterObject as
-                                        // [out] parameter and this IJupiterObject object including 
-                                        // all its reachable CCWs should be pegged
+    STDMETHOD(ConnectFromTrackerSource)() = 0;     // Notify Jupiter that we've created a new RCW
+    STDMETHOD(DisconnectFromTrackerSource)() = 0;  // Notify Jupiter that we are about to destroy this RCW
+    STDMETHOD(FindTrackerTargets)(/* [in] */ IFindDependentWrappersCallback *pCallback) = 0;
+                                                // Find list of dependent CCWs for this RCW
+    STDMETHOD(GetReferenceTrackerManager)(/* [out, retval] */ IJupiterGCManager **ppJupiterGCManager) = 0;
+                                                // Retrieve IJupiterGCManager interface
+    STDMETHOD(AddRefFromTrackerSource)() = 0;   // Notify Jupiter that we've done a AddRef()
+    STDMETHOD(ReleaseFromTrackerSource)() = 0;  // Notify Jupiter that we are about to do a Release()
+    STDMETHOD(PegFromTrackerSource)() = 0;      // Notify Jupiter that we've returned this IJupiterObject as
+                                                // [out] parameter and this IJupiterObject object including
+                                                // all its reachable CCWs should be pegged
 };
 
 extern const IID IID_ICCW;

--- a/src/vm/rcwwalker.h
+++ b/src/vm/rcwwalker.h
@@ -46,7 +46,7 @@ public :
     static void OnEEShutdown();
 
     //
-    // Send out a AfterAddRef callback to notify Jupiter we've done a AddRef
+    // Send out a AddRefFromTrackerSource callback to notify Jupiter we've done a AddRef
     // We should do this *after* we made a AddRef because we should never
     // be in a state where reported refs > actual refs
     //
@@ -63,13 +63,13 @@ public :
         IJupiterObject *pJupiterObject = pRCW->GetJupiterObject();
         if (pJupiterObject)
         {
-            STRESS_LOG2(LF_INTEROP, LL_INFO100, "[RCW Walker] Calling IJupiterObject::AfterAddRef (IJupiterObject = 0x%p, RCW = 0x%p)\n", pJupiterObject, pRCW);
-            pJupiterObject->AfterAddRef();
+            STRESS_LOG2(LF_INTEROP, LL_INFO100, "[RCW Walker] Calling IJupiterObject::AddRefFromTrackerSource (IJupiterObject = 0x%p, RCW = 0x%p)\n", pJupiterObject, pRCW);
+            pJupiterObject->AddRefFromTrackerSource();
         }
     }
     
     //
-    // Send out BeforeRelease callback for every cached interface pointer
+    // Send out ReleaseFromTrackerSource callback for every cached interface pointer
     // This needs to be made before call Release because we should never be in a 
     // state that reported refs > actual refs 
     //
@@ -85,8 +85,8 @@ public :
         IJupiterObject *pJupiterObject = pRCW->GetJupiterObject();
         if (pJupiterObject)
         {
-            STRESS_LOG2(LF_INTEROP, LL_INFO100, "[RCW Walker] Calling IJupiterObject::BeforeRelease before Release (IJupiterObject = 0x%p, RCW = 0x%p)\n", pJupiterObject, pRCW);
-            pJupiterObject->BeforeRelease();
+            STRESS_LOG2(LF_INTEROP, LL_INFO100, "[RCW Walker] Calling IJupiterObject::ReleaseFromTrackerSource before Release (IJupiterObject = 0x%p, RCW = 0x%p)\n", pJupiterObject, pRCW);
+            pJupiterObject->ReleaseFromTrackerSource();
         }
     }
     


### PR DESCRIPTION
Update Jupiter host interface method names defined in .NET Core to match officially documented method names. The interface names are still different, but all function names now match.

See https://docs.microsoft.com/windows/win32/api/windows.ui.xaml.hosting.referencetracker

/cc @jkoritzinsky 