### PR TITLE
[WIP] Fix LookupPromotedStructDeathVars function.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4476,27 +4476,6 @@ public:
                            bool*            doAgain,
                            bool* pStmtInfoDirty DEBUGARG(bool* treeModf));
 
-    // For updating liveset during traversal AFTER fgComputeLife has completed
-    VARSET_VALRET_TP fgGetVarBits(GenTree* tree);
-    VARSET_VALRET_TP fgUpdateLiveSet(VARSET_VALARG_TP liveSet, GenTree* tree);
-
-    // Returns the set of live variables after endTree,
-    // assuming that liveSet is the set of live variables BEFORE tree.
-    // Requires that fgComputeLife has completed, and that tree is in the same
-    // statement as endTree, and that it comes before endTree in execution order
-
-    VARSET_VALRET_TP fgUpdateLiveSet(VARSET_VALARG_TP liveSet, GenTree* tree, GenTree* endTree)
-    {
-        VARSET_TP newLiveSet(VarSetOps::MakeCopy(this, liveSet));
-        while (tree != nullptr && tree != endTree->gtNext)
-        {
-            VarSetOps::AssignNoCopy(this, newLiveSet, fgUpdateLiveSet(newLiveSet, tree));
-            tree = tree->gtNext;
-        }
-        assert(tree == endTree->gtNext);
-        return newLiveSet;
-    }
-
     void fgInterBlockLocalVarLiveness();
 
     // The presence of a partial definition presents some difficulties for SSA: this is both a use of some SSA name

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7371,6 +7371,9 @@ public:
     bool LookupPromotedStructDeathVars(GenTree* tree, VARSET_TP** bits)
     {
         unreached();
+#ifdef _MSC_VER
+#pragma warning(disable : 4702)
+#endif
         bits = nullptr; // We are rewriting the argument value, so the address that we got
                         // is lost after that. this was added in https://github.com/dotnet/coreclr/pull/19753/files.
         bool result = false;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7370,6 +7370,7 @@ public:
 
     bool LookupPromotedStructDeathVars(GenTree* tree, VARSET_TP** bits)
     {
+        unreached();
         bits = nullptr; // We are rewriting the argument value, so the address that we got
                         // is lost after that. this was added in https://github.com/dotnet/coreclr/pull/19753/files.
         bool result = false;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7391,7 +7391,8 @@ public:
 
     bool LookupPromotedStructDeathVars(GenTree* tree, VARSET_TP** bits)
     {
-        bits        = nullptr;
+        bits = nullptr; // We are rewriting the argument value, so the address that we got
+                        // is lost after that. this was added in https://github.com/dotnet/coreclr/pull/19753/files.
         bool result = false;
 
         if (m_promotedStructDeathVars != nullptr)

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7368,12 +7368,13 @@ public:
         }
     }
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4702)
+#endif
     bool LookupPromotedStructDeathVars(GenTree* tree, VARSET_TP** bits)
     {
         unreached();
-#ifdef _MSC_VER
-#pragma warning(disable : 4702)
-#endif
         bits = nullptr; // We are rewriting the argument value, so the address that we got
                         // is lost after that. this was added in https://github.com/dotnet/coreclr/pull/19753/files.
         bool result = false;
@@ -7385,6 +7386,9 @@ public:
 
         return result;
     }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 /*
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -9841,39 +9841,6 @@ void Compiler::fgSimpleLowering()
 #endif
 }
 
-VARSET_VALRET_TP Compiler::fgGetVarBits(GenTree* tree)
-{
-    VARSET_TP varBits(VarSetOps::MakeEmpty(this));
-
-    assert(tree->gtOper == GT_LCL_VAR || tree->gtOper == GT_LCL_FLD);
-
-    unsigned int lclNum = tree->gtLclVarCommon.GetLclNum();
-    LclVarDsc*   varDsc = lvaTable + lclNum;
-    if (varDsc->lvTracked)
-    {
-        VarSetOps::AddElemD(this, varBits, varDsc->lvVarIndex);
-    }
-    // We have to check type of root tree, not Local Var descriptor because
-    // for legacy backend we promote TYP_STRUCT to TYP_INT if it is an unused or
-    // independently promoted non-argument struct local.
-    // For more details see Compiler::raAssignVars() method.
-    else if (tree->gtType == TYP_STRUCT && varDsc->lvPromoted)
-    {
-        assert(varDsc->lvType == TYP_STRUCT);
-        for (unsigned i = varDsc->lvFieldLclStart; i < varDsc->lvFieldLclStart + varDsc->lvFieldCnt; ++i)
-        {
-            noway_assert(lvaTable[i].lvIsStructField);
-            if (lvaTable[i].lvTracked)
-            {
-                unsigned varIndex = lvaTable[i].lvVarIndex;
-                noway_assert(varIndex < lvaTrackedCount);
-                VarSetOps::AddElemD(this, varBits, varIndex);
-            }
-        }
-    }
-    return varBits;
-}
-
 /*****************************************************************************
  *
  *  Find and remove any basic blocks that are useless (e.g. they have not been

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -1452,6 +1452,7 @@ VARSET_VALRET_TP Compiler::fgUpdateLiveSet(VARSET_VALARG_TP liveSet, GenTree* tr
                 VARSET_TP* deadVarBits = nullptr;
                 if (varTypeIsStruct(lclVarTree) && LookupPromotedStructDeathVars(lclVarTree, &deadVarBits))
                 {
+                    // `nullptr` dereferencing.
                     VarSetOps::DiffD(this, newLiveSet, *deadVarBits);
                 }
                 else

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -1425,61 +1425,6 @@ void Compiler::fgLiveVarAnalysis(bool updateInternalOnly)
 #endif // DEBUG
 }
 
-/*****************************************************************************
- * For updating liveset during traversal AFTER fgComputeLife has completed
- */
-
-VARSET_VALRET_TP Compiler::fgUpdateLiveSet(VARSET_VALARG_TP liveSet, GenTree* tree)
-{
-    VARSET_TP newLiveSet(VarSetOps::MakeCopy(this, liveSet));
-    assert(fgLocalVarLivenessDone == true);
-    GenTree* lclVarTree = tree; // After the tests below, "lclVarTree" will be the local variable.
-    if (tree->gtOper == GT_LCL_VAR || tree->gtOper == GT_LCL_FLD ||
-        (lclVarTree = fgIsIndirOfAddrOfLocal(tree)) != nullptr)
-    {
-        const VARSET_TP& varBits(fgGetVarBits(lclVarTree));
-
-        if (!VarSetOps::IsEmpty(this, varBits))
-        {
-            if (tree->gtFlags & GTF_VAR_DEATH)
-            {
-                // We'd like to be able to assert the following, however if we are walking
-                // through a qmark/colon tree, we may encounter multiple last-use nodes.
-                // assert (VarSetOps::IsSubset(this, varBits, newLiveSet));
-
-                // We maintain the invariant that if the lclVarTree is a promoted struct, but the
-                // the lookup fails, then all the field vars (i.e., "varBits") are dying.
-                VARSET_TP* deadVarBits = nullptr;
-                if (varTypeIsStruct(lclVarTree) && LookupPromotedStructDeathVars(lclVarTree, &deadVarBits))
-                {
-                    // `nullptr` dereferencing.
-                    VarSetOps::DiffD(this, newLiveSet, *deadVarBits);
-                }
-                else
-                {
-                    VarSetOps::DiffD(this, newLiveSet, varBits);
-                }
-            }
-            else if ((tree->gtFlags & GTF_VAR_DEF) != 0 && (tree->gtFlags & GTF_VAR_USEASG) == 0)
-            {
-                assert(tree == lclVarTree); // LDOBJ case should only be a use.
-
-                // This shouldn't be in newLiveSet, unless this is debug code, in which
-                // case we keep vars live everywhere, OR it is address-exposed, OR this block
-                // is part of a try block, in which case it may be live at the handler
-                // Could add a check that, if it's in the newLiveSet, that it's also in
-                // fgGetHandlerLiveVars(compCurBB), but seems excessive
-                //
-                assert(VarSetOps::IsEmptyIntersection(this, newLiveSet, varBits) || opts.compDbgCode ||
-                       lvaTable[tree->gtLclVarCommon.GetLclNum()].lvAddrExposed ||
-                       (compCurBB != nullptr && ehBlockHasExnFlowDsc(compCurBB)));
-                VarSetOps::UnionD(this, newLiveSet, varBits);
-            }
-        }
-    }
-    return newLiveSet;
-}
-
 //------------------------------------------------------------------------
 // Compiler::fgComputeLifeCall: compute the changes to local var liveness
 //                              due to a GT_CALL node.

--- a/src/jit/treelifeupdater.cpp
+++ b/src/jit/treelifeupdater.cpp
@@ -118,8 +118,11 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
                 VARSET_TP* deadTrackedFieldVars = nullptr;
                 hasDeadTrackedFieldVars =
                     compiler->LookupPromotedStructDeathVars(indirAddrLocal, &deadTrackedFieldVars);
+                // because `deadTrackedFieldVars` can't be changed inside `LookupPromotedStructDeathVars`
+                // it means after the call it will be `nullptr`.
                 if (hasDeadTrackedFieldVars)
                 {
+                    // so that `*deadTrackedFieldVars` will cause `nullptr` dereferencing.
                     VarSetOps::Assign(compiler, varDeltaSet, *deadTrackedFieldVars);
                 }
             }

--- a/src/jit/treelifeupdater.cpp
+++ b/src/jit/treelifeupdater.cpp
@@ -25,6 +25,10 @@ TreeLifeUpdater<ForCodeGen>::TreeLifeUpdater(Compiler* compiler)
 // Arguments:
 //    tree - the tree which affects liveness.
 //
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4702)
+#endif
 template <bool ForCodeGen>
 void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
 {
@@ -116,9 +120,6 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
             {
                 assert(!isBorn); // GTF_VAR_DEATH only set for LDOBJ last use.
                 unreached();     // Try to find a test where we use it.
-#ifdef _MSC_VER
-#pragma warning(disable : 4702)
-#endif
                 VARSET_TP* deadTrackedFieldVars = nullptr;
                 hasDeadTrackedFieldVars =
                     compiler->LookupPromotedStructDeathVars(indirAddrLocal, &deadTrackedFieldVars);
@@ -283,6 +284,9 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
         }
     }
 }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 //------------------------------------------------------------------------
 // UpdateLife: Determine whether the tree affects liveness, and update liveness sets accordingly.

--- a/src/jit/treelifeupdater.cpp
+++ b/src/jit/treelifeupdater.cpp
@@ -115,7 +115,10 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
             if (indirAddrLocal != nullptr && isDying)
             {
                 assert(!isBorn); // GTF_VAR_DEATH only set for LDOBJ last use.
-                unreached(); // Try to find a test where we use it.
+                unreached();     // Try to find a test where we use it.
+#ifdef _MSC_VER
+#pragma warning(disable : 4702)
+#endif
                 VARSET_TP* deadTrackedFieldVars = nullptr;
                 hasDeadTrackedFieldVars =
                     compiler->LookupPromotedStructDeathVars(indirAddrLocal, &deadTrackedFieldVars);

--- a/src/jit/treelifeupdater.cpp
+++ b/src/jit/treelifeupdater.cpp
@@ -115,6 +115,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree)
             if (indirAddrLocal != nullptr && isDying)
             {
                 assert(!isBorn); // GTF_VAR_DEATH only set for LDOBJ last use.
+                unreached(); // Try to find a test where we use it.
                 VARSET_TP* deadTrackedFieldVars = nullptr;
                 hasDeadTrackedFieldVars =
                     compiler->LookupPromotedStructDeathVars(indirAddrLocal, &deadTrackedFieldVars);


### PR DESCRIPTION
That started with PVS-Studio (my Friday learning day activity) warning:
`V763 Parameter 'bits' is always rewritten in function body before being used. compiler.h 7394`

I have checked that it was a real error that could end up in `nullptr` dereferencing in two places, the one was dead code, so I deleted it (the second commit).

I was not able to hit the second case locally, so let's see if ci can do that.

52b1192431: add a description of the issue, link https://github.com/dotnet/coreclr/pull/19753

b57a16409f: Delete unused functions that were referencing `LookupPromotedStructDeathVars`.

d39c9cc00b: abuse ci to find a test that could expose the issue.
update: the first check failed on `coreclr\bin\tests\Windows_NT.x64.Checked\JIT\Regression\JitBlue\GitHub_25468\GitHub_25468\GitHub_25468.dll` but it returned false so the nullptr was not dereferenced.

PTAL @CarolEidt @AndyAyersMS, cc @dotnet/jit-contrib 