### PR TITLE
Fix field offset computation in crossgen2

### DIFF
--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -784,15 +784,26 @@ namespace ILCompiler
                 return;
             }
 
-            if (!_compilationGroup.ContainsTypeLayout(baseType))
+            if (_compilationGroup.ContainsType(baseType))
             {
-                LayoutInt alignment = new LayoutInt(type.Context.Target.PointerSize);
-                if (type.RequiresAlign8())
+                if (_compilationGroup.ContainsTypeLayout(baseType))
                 {
-                    alignment = new LayoutInt(8);
+                    // The type is defined in the module that's currently being compiled and the type layout doesn't depend on other modules
+                    return;
                 }
-                baseOffset = LayoutInt.AlignUp(baseOffset, alignment, type.Context.Target);
             }
+            else if (_compilationGroup.VersionsWithType(baseType))
+            {
+                // The baseType is in the current version bubble, but in a module different from the one that's currently being compiled
+                return;
+            }
+
+            LayoutInt alignment = new LayoutInt(type.Context.Target.PointerSize);
+            if (type.RequiresAlign8())
+            {
+                alignment = new LayoutInt(8);
+            }
+            baseOffset = LayoutInt.AlignUp(baseOffset, alignment, type.Context.Target);
         }
 
         public static bool IsManagedSequentialType(TypeDesc type)


### PR DESCRIPTION
The logic for determining when to align base offset was not matching the
logic that is used in the coreclr runtime. This resulted in assert
failure: `m_alignpad == 0` at runtime in 4 CoreMangLib tests.

I've actually fixed the same issue in old crossgen some time ago in #25029, so 
it was easy to figure out where the issue came from. The issue causes a memory
corruption after the end of an object, which later on results in the m_alignpad of
an object that's allocated consequently being zero.

The fix is to make the logic in `AlignBaseOffsetIfNecessary` match the one in `MethodTableBuilder::NeedsAlignedBaseOffset`.