### PR TITLE
Fix debug check in `CheckAndMoveRMWLastUse`.

### DIFF
--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -1600,10 +1600,7 @@ private:
         }
         // This is probably not necessary, but keeps things consistent.
         fromTree->gtFlags &= ~GTF_VAR_DEATH;
-        if (toTree != nullptr) // Just to be conservative
-        {
-            toTree->gtFlags |= GTF_VAR_DEATH;
-        }
+        toTree->gtFlags |= GTF_VAR_DEATH;
     }
 #endif // defined(_TARGET_XARCH_)
 

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -1583,6 +1583,9 @@ private:
     bool isRMWRegOper(GenTree* tree);
     int BuildMul(GenTree* tree);
     void SetContainsAVXFlags(unsigned sizeOfSIMDVector = 0);
+#endif // defined(_TARGET_XARCH_)
+
+#if defined(_TARGET_X86_)
     // Move the last use bit, if any, from 'fromTree' to 'toTree'; 'fromTree' must be contained.
     void CheckAndMoveRMWLastUse(GenTree* fromTree, GenTree* toTree)
     {
@@ -1602,7 +1605,7 @@ private:
         fromTree->gtFlags &= ~GTF_VAR_DEATH;
         toTree->gtFlags |= GTF_VAR_DEATH;
     }
-#endif // defined(_TARGET_XARCH_)
+#endif // _TARGET_X86_
 
 #ifdef FEATURE_SIMD
     int BuildSIMD(GenTreeSIMD* tree);

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -1596,7 +1596,7 @@ private:
         }
         // If 'fromTree' was a lclVar, it must be contained and 'toTree' must match.
         if (!fromTree->isContained() || (toTree == nullptr) || !toTree->OperIs(GT_LCL_VAR) ||
-            (toTree->AsLclVarCommon()->GetLclNum() != toTree->AsLclVarCommon()->GetLclNum()))
+            (fromTree->AsLclVarCommon()->GetLclNum() != toTree->AsLclVarCommon()->GetLclNum()))
         {
             assert(!"Unmatched RMW indirections");
             return;

--- a/src/jit/lsraxarch.cpp
+++ b/src/jit/lsraxarch.cpp
@@ -2794,8 +2794,6 @@ int LinearScan::BuildIndir(GenTreeIndir* indirTree)
             // Because 'source' is contained, we haven't yet determined its special register requirements, if any.
             // As it happens, the Shift or Rotate cases are the only ones with special requirements.
             assert(source->isContained() && source->OperIsRMWMemOp());
-            GenTree*      nonMemSource = nullptr;
-            GenTreeIndir* otherIndir   = nullptr;
 
             if (source->OperIsShiftOrRotate())
             {
@@ -2810,7 +2808,8 @@ int LinearScan::BuildIndir(GenTreeIndir* indirTree)
                 // Note that BuildShiftRotate (above) will handle the byte requirement as needed,
                 // but STOREIND isn't itself an RMW op, so we have to explicitly set it for that case.
 
-                GenTree* nonMemSource = nullptr;
+                GenTree*      nonMemSource = nullptr;
+                GenTreeIndir* otherIndir   = nullptr;
 
                 if (indirTree->AsStoreInd()->IsRMWDstOp1())
                 {
@@ -2829,7 +2828,6 @@ int LinearScan::BuildIndir(GenTreeIndir* indirTree)
                 {
                     srcCandidates = RBM_BYTE_REGS;
                 }
-#endif
                 if (otherIndir != nullptr)
                 {
                     // Any lclVars in the addressing mode of this indirection are contained.
@@ -2841,6 +2839,8 @@ int LinearScan::BuildIndir(GenTreeIndir* indirTree)
                     GenTree* dstIndex = indirTree->Index();
                     CheckAndMoveRMWLastUse(index, dstIndex);
                 }
+#endif // _TARGET_X86_
+
                 srcCount += BuildBinaryUses(source->AsOp(), srcCandidates);
             }
         }


### PR DESCRIPTION
There were 2 warnings from PVS-Studio:
```
V547 Expression 'toTree != nullptr' is always true. lsra.h 1581
V501 There are identical sub-expressions 'toTree->AsLclVarCommon()->GetLclNum()' to the left and to the right of the '!=' operator. lsra.h 1574
```
so the second was a typo from https://github.com/dotnet/coreclr/pull/17431, the first was just an unnecessary check. 


Also, move the function under `_TARGET_X86_` while around.