### PR TITLE
Fix unique ETW events for GC Type logging to also be sent to EventPipe

### DIFF
--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -1135,6 +1135,7 @@ void BulkComLogger::FlushRcw()
 #else
     ULONG result = FireEtXplatGCBulkRCW(m_currRcw, instance, sizeof(EventRCWEntry) * m_currRcw, m_etwRcwData);
 #endif // !defined(FEATURE_PAL)
+    result |= EventPipeWriteEventGCBulkRCW(m_currRcw, instance, sizeof(EventRCWEntry) * m_currRcw, m_etwRcwData);
 
     _ASSERTE(result == ERROR_SUCCESS);
 
@@ -1224,6 +1225,7 @@ void BulkComLogger::FlushCcw()
 #else
     ULONG result = FireEtXplatGCBulkRootCCW(m_currCcw, instance, sizeof(EventCCWEntry) * m_currCcw, m_etwCcwData);
 #endif //!defined(FEATURE_PAL)
+    result |= EventPipeWriteEventGCBulkRootCCW(m_currCcw, instance, sizeof(EventCCWEntry) * m_currCcw, m_etwCcwData);
 
     _ASSERTE(result == ERROR_SUCCESS);
 
@@ -1428,6 +1430,7 @@ void BulkStaticsLogger::FireBulkStaticsEvent()
 #else
     ULONG result = FireEtXplatGCBulkRootStaticVar(m_count, appDomain, instance, m_used, m_buffer);
 #endif //!defined(FEATURE_PAL)
+    result |= EventPipeWriteEventGCBulkRootStaticVar(m_count, appDomain, instance, m_used, m_buffer);
 
     _ASSERTE(result == ERROR_SUCCESS);
 


### PR DESCRIPTION
resolves #27237

There were 3 event types in the ETW GC Type Logging infrastructure that appear to be different from the rest in how they fire their events.  They don't use the generated wrapper functions and instead directly call the platform specific generated functions inside `ifdef` blocks.  As a result, it looks like they slipped through the cracks when EventPipe was added.  

There may be a more generic solution to this that will prevent this from happening again, but this is meant to be a targeted fix so that it can be paired with #26270 and ported to 3.1 in order to enable GCDump collection via EventPipe.

Without this fix, GCDumps generated by EventPipe will not contain static or COM based roots.

CC - @tommcdon 