### PR TITLE
[crossgen2] Fixes the test failure when crossgen2smoke is ran with GCStress turned on

### DIFF
--- a/src/tools/crossgen2/Common/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
+++ b/src/tools/crossgen2/Common/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
@@ -15,17 +15,8 @@ namespace ILCompiler.DependencyAnalysis
         : Internal.Runtime.ITargetBinaryWriter
 #endif
     {
-        public ObjectDataBuilder(NodeFactory factory, bool relocsOnly)
+        public ObjectDataBuilder(NodeFactory factory, bool relocsOnly) : this(factory.Target, relocsOnly)
         {
-            _target = factory.Target;
-            _data = new ArrayBuilder<byte>();
-            _relocs = new ArrayBuilder<Relocation>();
-            Alignment = 1;
-            _definedSymbols = new ArrayBuilder<ISymbolDefinitionNode>();
-#if DEBUG
-            _numReservations = 0;
-            _checkAllSymbolDependenciesMustBeMarked = !relocsOnly;
-#endif
         }
 
         public ObjectDataBuilder(TargetDetails target, bool relocsOnly)

--- a/src/tools/crossgen2/Common/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
+++ b/src/tools/crossgen2/Common/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
@@ -28,6 +28,19 @@ namespace ILCompiler.DependencyAnalysis
 #endif
         }
 
+        public ObjectDataBuilder(TargetDetails target, bool relocsOnly)
+        {
+            _target = target;
+            _data = new ArrayBuilder<byte>();
+            _relocs = new ArrayBuilder<Relocation>();
+            Alignment = 1;
+            _definedSymbols = new ArrayBuilder<ISymbolDefinitionNode>();
+#if DEBUG
+            _numReservations = 0;
+            _checkAllSymbolDependenciesMustBeMarked = !relocsOnly;
+#endif
+        }
+
         private TargetDetails _target;
         private ArrayBuilder<Relocation> _relocs;
         private ArrayBuilder<byte> _data;

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapNode.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapNode.cs
@@ -19,12 +19,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public const int GCREFMAP_LOOKUP_STRIDE = 1024;
 
         private readonly ImportSectionNode _importSection;
-        private readonly List<MethodWithGCInfo> _methods;
+        private readonly List<IMethodNode> _methods;
 
         public GCRefMapNode(ImportSectionNode importSection)
         {
             _importSection = importSection;
-            _methods = new List<MethodWithGCInfo>();
+            _methods = new List<IMethodNode>();
         }
 
         public override ObjectNodeSection Section => ObjectNodeSection.ReadOnlyDataSection;
@@ -39,7 +39,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public void AddImport(Import import)
         {
-            _methods.Add(import as IMethodNode as MethodWithGCInfo);
+            _methods.Add(import as IMethodNode);
         }
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
@@ -59,7 +59,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     definedSymbols: new ISymbolDefinitionNode[] { this });
             }
 
-            GCRefMapBuilder builder = new GCRefMapBuilder(factory, relocsOnly);
+            GCRefMapBuilder builder = new GCRefMapBuilder(factory.Target, relocsOnly);
             builder.Builder.RequireInitialAlignment(4);
             builder.Builder.AddSymbol(this);
 
@@ -84,8 +84,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     nextOffsetIndex++;
                     nextMethodIndex += GCREFMAP_LOOKUP_STRIDE;
                 }
-                MethodWithGCInfo methodNode = _methods[methodIndex];
-                if (methodNode == null || methodNode.IsEmpty)
+                IMethodNode methodNode = _methods[methodIndex];
+                if (methodNode == null || (methodNode is MethodWithGCInfo methodWithGCInfo && methodWithGCInfo.IsEmpty))
                 {
                     // Flush an empty GC ref map block to prevent
                     // the indexed records from falling out of sync with methods

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunLibraryRootProvider.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunLibraryRootProvider.cs
@@ -17,13 +17,11 @@ namespace ILCompiler
     {
         private EcmaModule _module;
         private ProfileData _profileData;
-        private TargetDetails _targetDetails;
 
-        public ReadyToRunRootProvider(EcmaModule module, ProfileDataManager profileDataManager, TargetDetails targetDetails)
+        public ReadyToRunRootProvider(EcmaModule module, ProfileDataManager profileDataManager)
         {
             _module = module;
             _profileData = profileDataManager.GetDataForModuleDesc(module);
-            _targetDetails = targetDetails;
         }
 
         public void AddCompilationRoots(IRootingServiceProvider rootProvider)
@@ -179,7 +177,7 @@ namespace ILCompiler
             // TODO: Is it possible to augment CheckTypeCanBeUsedInSignature() to accomplish the same? It is relative straightforward
             // to check if the type has indeterminate size, but is that sufficient?
             //
-            new GCRefMapBuilder(_targetDetails, false).GetCallRefMap(method);
+            new GCRefMapBuilder(_module.Context.Target, false).GetCallRefMap(method);
         }
 
         private static void CheckTypeCanBeUsedInSignature(TypeDesc type)

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunLibraryRootProvider.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunLibraryRootProvider.cs
@@ -6,7 +6,6 @@ using System;
 
 using Internal.TypeSystem.Ecma;
 using Internal.TypeSystem;
-using ILCompiler.DependencyAnalysis.ReadyToRun;
 
 namespace ILCompiler
 {
@@ -142,7 +141,7 @@ namespace ILCompiler
         /// in its signature. Unresolvable types in a method's signature prevent RyuJIT from generating
         /// even a stubbed out throwing implementation.
         /// </summary>
-        public void CheckCanGenerateMethod(MethodDesc method)
+        public static void CheckCanGenerateMethod(MethodDesc method)
         {
             MethodSignature signature = method.Signature;
 

--- a/src/tools/crossgen2/crossgen2/Program.cs
+++ b/src/tools/crossgen2/crossgen2/Program.cs
@@ -333,7 +333,7 @@ namespace ILCompiler
                         foreach (var inputFile in typeSystemContext.InputFilePaths)
                         {
                             EcmaModule module = typeSystemContext.GetModuleFromPath(inputFile.Value);
-                            compilationRoots.Add(new ReadyToRunRootProvider(module, profileDataManager));
+                            compilationRoots.Add(new ReadyToRunRootProvider(module, profileDataManager, targetDetails));
                             inputModules.Add(module);
 
                             if (!_isInputVersionBubble)

--- a/src/tools/crossgen2/crossgen2/Program.cs
+++ b/src/tools/crossgen2/crossgen2/Program.cs
@@ -333,7 +333,7 @@ namespace ILCompiler
                         foreach (var inputFile in typeSystemContext.InputFilePaths)
                         {
                             EcmaModule module = typeSystemContext.GetModuleFromPath(inputFile.Value);
-                            compilationRoots.Add(new ReadyToRunRootProvider(module, profileDataManager, targetDetails));
+                            compilationRoots.Add(new ReadyToRunRootProvider(module, profileDataManager));
                             inputModules.Add(module);
 
                             if (!_isInputVersionBubble)

--- a/tests/src/readytorun/crossgen2/crossgen2smoke.csproj
+++ b/tests/src/readytorun/crossgen2/crossgen2smoke.csproj
@@ -8,9 +8,6 @@
     <!-- Crossgen2 currently targets only x64 -->
     <DisableProjectBuild Condition="'$(Platform)' != 'x64'">true</DisableProjectBuild>
 
-    <!-- Known not to work with GCStress for now: https://github.com/dotnet/coreclr/issues/26633 -->
-    <GCStressIncompatible>true</GCStressIncompatible>
-
     <!-- Generate ILDLL so that the DLL can be the crossgenned assembly -->
     <TargetExt>.ildll</TargetExt>
 


### PR DESCRIPTION
When we emit the `GcRefMap` for methods with a signature that contains a type of indeterminate size. The `GcRefMap` generation code would crash and bring down the compiler process. This was 'fixed' by not generating `GcRefMap` for all external method calls, this does not work because this will lead to missing `GcRefMap`, and missing `GcRefMap` is the reason why `crossgen2smoke` fails under GCStress.

My fix make sure we generate `GcRefMap` for all method imports. Obviously, this alone will bring down the compiler process, therefore I added another logic at the rooting service to make sure methods with a signature that contains a type of indeterminate size is skipped from the compilation.

To validate the change, I ran `crossgen2smoke` test, this ensure the needed `GcRefMap` is generated. To validate that it doesn't bring down the process, I ran the crossgen2 compilation of `System.Text.Json.dll` through SuperIlc. The method [LocateFirstFoundByte](https://github.com/dotnet/corefx/blob/4a7075f188b5777ccb519f2af9b8a284f4383357/src/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.cs#L217) would have crashed the compiler if I didn't put the check in the rooting service, and now it doesn't.

@dotnet/crossgen-contrib 