### PR TITLE
Improve Encoding.UTF8.GetString / GetChars performance for small inputs

### DIFF
--- a/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
+++ b/src/System.Private.CoreLib/shared/System.Private.CoreLib.Shared.projitems
@@ -822,6 +822,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\UTF32Encoding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\UTF7Encoding.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\UTF8Encoding.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Text\UTF8Encoding.Sealed.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\ValueStringBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\Unicode\Utf16Utility.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Text\Unicode\Utf16Utility.Validation.cs" />

--- a/src/System.Private.CoreLib/shared/System/Text/UTF8Encoding.Sealed.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/UTF8Encoding.Sealed.cs
@@ -15,16 +15,33 @@ namespace System.Text
         /// </summary>
         internal sealed class UTF8EncodingSealed : UTF8Encoding
         {
+            /// <summary>
+            /// Maximum number of input elements we'll allow for going through the fast one-pass stackalloc code paths.
+            /// </summary>
+            private const int MaxSmallInputElementCount = 32;
+
             public UTF8EncodingSealed(bool encoderShouldEmitUTF8Identifier) : base(encoderShouldEmitUTF8Identifier) { }
 
             public override ReadOnlySpan<byte> Preamble => _emitUTF8Identifier ? PreambleSpan : default;
+
+            public override object Clone()
+            {
+                // The base implementation of Encoding.Clone calls object.MemberwiseClone and marks the new object mutable.
+                // We don't want to do this because it violates the invariants we have set for the sealed type.
+                // Instead, we'll create a new instance of the base UTF8Encoding type and mark it mutable.
+
+                return new UTF8Encoding(_emitUTF8Identifier)
+                {
+                    IsReadOnly = false
+                };
+            }
 
             public override byte[] GetBytes(string s)
             {
                 // This method is short and can be inlined, meaning that the null check below
                 // might be elided if the JIT can prove not-null at the call site.
 
-                if (s != null && s.Length <= 32)
+                if (s?.Length <= MaxSmallInputElementCount)
                 {
                     return GetBytesForSmallInput(s);
                 }
@@ -37,17 +54,17 @@ namespace System.Text
             private unsafe byte[] GetBytesForSmallInput(string s)
             {
                 Debug.Assert(s != null);
-                Debug.Assert(s.Length <= 32);
+                Debug.Assert(s.Length <= MaxSmallInputElementCount);
 
-                byte* pDestination = stackalloc byte[32 * 3]; // each char produces at most 3 bytes (2-char supplementary code points -> 4 bytes total)
+                byte* pDestination = stackalloc byte[MaxSmallInputElementCount * MaxUtf8BytesPerChar];
 
                 int sourceLength = s.Length; // hoist this to avoid having the JIT auto-insert null checks
                 int bytesWritten;
 
                 fixed (char* pSource = s)
                 {
-                    bytesWritten = GetBytesCommon(pSource, sourceLength, pDestination, 32 * 3);
-                    Debug.Assert(0 <= bytesWritten && bytesWritten <= 32 * 3);
+                    bytesWritten = GetBytesCommon(pSource, sourceLength, pDestination, MaxSmallInputElementCount * MaxUtf8BytesPerChar);
+                    Debug.Assert(0 <= bytesWritten && bytesWritten <= s.Length * MaxUtf8BytesPerChar);
                 }
 
                 return new Span<byte>(ref *pDestination, bytesWritten).ToArray(); // this overload of Span ctor doesn't validate length
@@ -58,7 +75,7 @@ namespace System.Text
                 // This method is short and can be inlined, meaning that the null check below
                 // might be elided if the JIT can prove not-null at the call site.
 
-                if (bytes != null && bytes.Length <= 32)
+                if (bytes?.Length <= MaxSmallInputElementCount)
                 {
                     return GetStringForSmallInput(bytes);
                 }
@@ -71,17 +88,17 @@ namespace System.Text
             private unsafe string GetStringForSmallInput(byte[] bytes)
             {
                 Debug.Assert(bytes != null);
-                Debug.Assert(bytes.Length <= 32);
+                Debug.Assert(bytes.Length <= MaxSmallInputElementCount);
 
-                char* pDestination = stackalloc char[32]; // each byte produces at most one char
+                char* pDestination = stackalloc char[MaxSmallInputElementCount]; // each byte produces at most one char
 
                 int sourceLength = bytes.Length; // hoist this to avoid having the JIT auto-insert null checks
                 int charsWritten;
 
                 fixed (byte* pSource = bytes)
                 {
-                    charsWritten = GetCharsCommon(pSource, sourceLength, pDestination, 32);
-                    Debug.Assert(0 <= charsWritten && charsWritten <= 32);
+                    charsWritten = GetCharsCommon(pSource, sourceLength, pDestination, MaxSmallInputElementCount);
+                    Debug.Assert(0 <= charsWritten && charsWritten <= sourceLength); // should never have more output chars than input bytes
                 }
 
                 return new string(new ReadOnlySpan<char>(ref *pDestination, charsWritten)); // this overload of ROS ctor doesn't validate length

--- a/src/System.Private.CoreLib/shared/System/Text/UTF8Encoding.Sealed.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/UTF8Encoding.Sealed.cs
@@ -1,0 +1,91 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace System.Text
+{
+    public partial class UTF8Encoding
+    {
+        /// <summary>
+        /// A special instance of <see cref="UTF8Encoding"/> that is initialized with "don't throw on invalid sequences;
+        /// perform <see cref="Rune.ReplacementChar"/> substitution instead" semantics. This type allows for devirtualization
+        /// of calls made directly off of <see cref="Encoding.UTF8"/>. See https://github.com/dotnet/coreclr/pull/9230.
+        /// </summary>
+        internal sealed class UTF8EncodingSealed : UTF8Encoding
+        {
+            public UTF8EncodingSealed(bool encoderShouldEmitUTF8Identifier) : base(encoderShouldEmitUTF8Identifier) { }
+
+            public override ReadOnlySpan<byte> Preamble => _emitUTF8Identifier ? PreambleSpan : default;
+
+            public override byte[] GetBytes(string s)
+            {
+                // This method is short and can be inlined, meaning that the null check below
+                // might be elided if the JIT can prove not-null at the call site.
+
+                if (s != null && s.Length <= 32)
+                {
+                    return GetBytesForSmallInput(s);
+                }
+                else
+                {
+                    return base.GetBytes(s!); // make the base method responsible for the null check
+                }
+            }
+
+            private unsafe byte[] GetBytesForSmallInput(string s)
+            {
+                Debug.Assert(s != null);
+                Debug.Assert(s.Length <= 32);
+
+                byte* pDestination = stackalloc byte[32 * 3]; // each char produces at most 3 bytes (2-char supplementary code points -> 4 bytes total)
+
+                int sourceLength = s.Length; // hoist this to avoid having the JIT auto-insert null checks
+                int bytesWritten;
+
+                fixed (char* pSource = s)
+                {
+                    bytesWritten = GetBytesCommon(pSource, sourceLength, pDestination, 32 * 3);
+                    Debug.Assert(0 <= bytesWritten && bytesWritten <= 32 * 3);
+                }
+
+                return new Span<byte>(ref *pDestination, bytesWritten).ToArray(); // this overload of Span ctor doesn't validate length
+            }
+
+            public override string GetString(byte[] bytes)
+            {
+                // This method is short and can be inlined, meaning that the null check below
+                // might be elided if the JIT can prove not-null at the call site.
+
+                if (bytes != null && bytes.Length <= 32)
+                {
+                    return GetStringForSmallInput(bytes);
+                }
+                else
+                {
+                    return base.GetString(bytes!); // make the base method responsible for the null check
+                }
+            }
+
+            private unsafe string GetStringForSmallInput(byte[] bytes)
+            {
+                Debug.Assert(bytes != null);
+                Debug.Assert(bytes.Length <= 32);
+
+                char* pDestination = stackalloc char[32]; // each byte produces at most one char
+
+                int sourceLength = bytes.Length; // hoist this to avoid having the JIT auto-insert null checks
+                int charsWritten;
+
+                fixed (byte* pSource = bytes)
+                {
+                    charsWritten = GetCharsCommon(pSource, sourceLength, pDestination, 32);
+                    Debug.Assert(0 <= charsWritten && charsWritten <= 32);
+                }
+
+                return new string(new ReadOnlySpan<char>(ref *pDestination, charsWritten)); // this overload of ROS ctor doesn't validate length
+            }
+        }
+    }
+}

--- a/src/System.Private.CoreLib/shared/System/Text/UTF8Encoding.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/UTF8Encoding.cs
@@ -30,7 +30,7 @@ namespace System.Text
     // used mostly to distinguish UTF-8 text from other encodings, and doesn't
     // switch the byte orderings.
 
-    public class UTF8Encoding : Encoding
+    public partial class UTF8Encoding : Encoding
     {
         /*
             bytes   bits    UTF-8 representation
@@ -47,13 +47,7 @@ namespace System.Text
 
         private const int UTF8_CODEPAGE = 65001;
 
-        // Allow for de-virtualization (see https://github.com/dotnet/coreclr/pull/9230)
-        internal sealed class UTF8EncodingSealed : UTF8Encoding
-        {
-            public UTF8EncodingSealed(bool encoderShouldEmitUTF8Identifier) : base(encoderShouldEmitUTF8Identifier) { }
 
-            public override ReadOnlySpan<byte> Preamble => _emitUTF8Identifier ? PreambleSpan : default;
-        }
 
         // Used by Encoding.UTF8 for lazy initialization
         // The initialization code will not be run until a static member of the class is referenced
@@ -379,7 +373,7 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private unsafe int GetBytesCommon(char* pChars, int charCount, byte* pBytes, int byteCount)
+        private protected unsafe int GetBytesCommon(char* pChars, int charCount, byte* pBytes, int byteCount)
         {
             // Common helper method for all non-EncoderNLS entry points to GetBytes.
             // A modification of this method should be copied in to each of the supported encodings: ASCII, UTF8, UTF16, UTF32.
@@ -571,7 +565,7 @@ namespace System.Text
         // Note:  We throw exceptions on individually encoded surrogates and other non-shortest forms.
         //        If exceptions aren't turned on, then we drop all non-shortest &individual surrogates.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private unsafe int GetCharsCommon(byte* pBytes, int byteCount, char* pChars, int charCount)
+        private protected unsafe int GetCharsCommon(byte* pBytes, int byteCount, char* pChars, int charCount)
         {
             // Common helper method for all non-DecoderNLS entry points to GetChars.
             // A modification of this method should be copied in to each of the supported encodings: ASCII, UTF8, UTF16, UTF32.

--- a/src/System.Private.CoreLib/shared/System/Text/UTF8Encoding.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/UTF8Encoding.cs
@@ -47,6 +47,14 @@ namespace System.Text
 
         private const int UTF8_CODEPAGE = 65001;
 
+        /// <summary>
+        /// Transcoding to UTF-8 bytes from UTF-16 input chars will result in a maximum 3:1 expansion.
+        /// </summary>
+        /// <remarks>
+        /// Supplementary code points are expanded to UTF-8 from UTF-16 at a 4:2 ratio,
+        /// so 3:1 is still the correct value for maximum expansion.
+        /// </remarks>
+        private const int MaxUtf8BytesPerChar = 3;
 
 
         // Used by Encoding.UTF8 for lazy initialization
@@ -57,7 +65,7 @@ namespace System.Text
 
         // Yes, the idea of emitting U+FEFF as a UTF-8 identifier has made it into
         // the standard.
-        internal readonly bool _emitUTF8Identifier = false;
+        private protected readonly bool _emitUTF8Identifier = false;
 
         private readonly bool _isThrowException = false;
 
@@ -780,8 +788,7 @@ namespace System.Text
             if (EncoderFallback.MaxCharCount > 1)
                 byteCount *= EncoderFallback.MaxCharCount;
 
-            // Max 3 bytes per char.  (4 bytes per 2 chars for surrogates)
-            byteCount *= 3;
+            byteCount *= MaxUtf8BytesPerChar;
 
             if (byteCount > 0x7fffffff)
                 throw new ArgumentOutOfRangeException(nameof(charCount), SR.ArgumentOutOfRange_GetByteCountOverflow);

--- a/src/System.Private.CoreLib/shared/System/Text/UTF8Encoding.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/UTF8Encoding.cs
@@ -65,7 +65,7 @@ namespace System.Text
 
         // Yes, the idea of emitting U+FEFF as a UTF-8 identifier has made it into
         // the standard.
-        private protected readonly bool _emitUTF8Identifier = false;
+        private readonly bool _emitUTF8Identifier = false;
 
         private readonly bool _isThrowException = false;
 
@@ -381,7 +381,7 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private protected unsafe int GetBytesCommon(char* pChars, int charCount, byte* pBytes, int byteCount)
+        private unsafe int GetBytesCommon(char* pChars, int charCount, byte* pBytes, int byteCount)
         {
             // Common helper method for all non-EncoderNLS entry points to GetBytes.
             // A modification of this method should be copied in to each of the supported encodings: ASCII, UTF8, UTF16, UTF32.
@@ -573,7 +573,7 @@ namespace System.Text
         // Note:  We throw exceptions on individually encoded surrogates and other non-shortest forms.
         //        If exceptions aren't turned on, then we drop all non-shortest &individual surrogates.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private protected unsafe int GetCharsCommon(byte* pBytes, int byteCount, char* pChars, int charCount)
+        private unsafe int GetCharsCommon(byte* pBytes, int byteCount, char* pChars, int charCount)
         {
             // Common helper method for all non-DecoderNLS entry points to GetChars.
             // A modification of this method should be copied in to each of the supported encodings: ASCII, UTF8, UTF16, UTF32.


### PR DESCRIPTION
This improves the performance of `Encoding.UTF8.GetString(byte[]) : string` and `Encoding.UTF8.GetBytes(string) : byte[]` by building on the existing JIT devirtualization logic and taking advantage of the case that most inputs to these functions are likely to be small (32 elements or fewer). For small inputs such as these, we already know that the maximum input size fits nicely into a stackalloc, so we can avoid the counting step and move straight to transcoding + the final memcpy.

|                  Method | Toolchain |                 Text |      Mean |     Error |    StdDev |    Median | Ratio | RatioSD |
|------------------------ |---------- |--------------------- |----------:|----------:|----------:|----------:|------:|--------:|
| **GetString_FromByteArray** |    **master** |                      |  **1.098 ns** | **0.0619 ns** | **0.0549 ns** |  **1.075 ns** |  **1.00** |    **0.00** |
| GetString_FromByteArray |     proto |                      |  8.682 ns | 0.2368 ns | 0.1978 ns |  8.664 ns |  7.91 |    0.48 |
|                         |           |                      |           |           |           |           |       |         |
| GetByteArray_FromString |    master |                      | 21.109 ns | 0.5399 ns | 1.4032 ns | 20.549 ns |  1.00 |    0.00 |
| GetByteArray_FromString |     proto |                      |  8.081 ns | 0.1581 ns | 0.1401 ns |  8.025 ns |  0.36 |    0.03 |
|                         |           |                      |           |           |           |           |       |         |
| **GetString_FromByteArray** |    **master** |                **Hello** | **23.182 ns** | **0.3626 ns** | **0.3028 ns** | **23.191 ns** |  **1.00** |    **0.00** |
| GetString_FromByteArray |     proto |                Hello | 18.949 ns | 0.4584 ns | 1.1997 ns | 18.436 ns |  0.88 |    0.06 |
|                         |           |                      |           |           |           |           |       |         |
| GetByteArray_FromString |    master |                Hello | 23.336 ns | 0.5520 ns | 1.0232 ns | 22.987 ns |  1.00 |    0.00 |
| GetByteArray_FromString |     proto |                Hello | 16.103 ns | 0.1553 ns | 0.1377 ns | 16.098 ns |  0.67 |    0.03 |
|                         |           |                      |           |           |           |           |       |         |
| **GetString_FromByteArray** |    **master** |         **Hello world!** | **27.745 ns** | **0.6358 ns** | **0.6803 ns** | **27.784 ns** |  **1.00** |    **0.00** |
| GetString_FromByteArray |     proto |         Hello world! | 20.178 ns | 0.2909 ns | 0.2429 ns | 20.168 ns |  0.73 |    0.02 |
|                         |           |                      |           |           |           |           |       |         |
| GetByteArray_FromString |    master |         Hello world! | 26.552 ns | 0.6135 ns | 1.4935 ns | 25.959 ns |  1.00 |    0.00 |
| GetByteArray_FromString |     proto |         Hello world! | 16.829 ns | 0.4128 ns | 0.6303 ns | 16.582 ns |  0.63 |    0.04 |
|                         |           |                      |           |           |           |           |       |         |
| **GetString_FromByteArray** |    **master** | **Lorem(...)elit. [56]** | **38.538 ns** | **0.3517 ns** | **0.3290 ns** | **38.418 ns** |  **1.00** |    **0.00** |
| GetString_FromByteArray |     proto | Lorem(...)elit. [56] | 38.339 ns | 0.4026 ns | 0.3766 ns | 38.403 ns |  0.99 |    0.01 |
|                         |           |                      |           |           |           |           |       |         |
| GetByteArray_FromString |    master | Lorem(...)elit. [56] | 34.777 ns | 0.8004 ns | 1.2695 ns | 34.059 ns |  1.00 |    0.00 |
| GetByteArray_FromString |     proto | Lorem(...)elit. [56] | 36.436 ns | 0.8080 ns | 1.3937 ns | 35.688 ns |  1.05 |    0.06 |
|                         |           |                      |           |           |           |           |       |         |
| **GetString_FromByteArray** |    **master** |             **Nǐhǎo 你好** | **44.171 ns** | **0.8742 ns** | **0.7749 ns** | **44.235 ns** |  **1.00** |    **0.00** |
| GetString_FromByteArray |     proto |             Nǐhǎo 你好 | 30.719 ns | 0.3818 ns | 0.3188 ns | 30.668 ns |  0.70 |    0.01 |
|                         |           |                      |           |           |           |           |       |         |
| GetByteArray_FromString |    master |             Nǐhǎo 你好 | 42.092 ns | 0.6221 ns | 0.4857 ns | 42.092 ns |  1.00 |    0.00 |
| GetByteArray_FromString |     proto |             Nǐhǎo 你好 | 27.424 ns | 0.2978 ns | 0.2487 ns | 27.441 ns |  0.65 |    0.01 |
|                         |           |                      |           |           |           |           |       |         |
| **GetString_FromByteArray** |    **master** |       **Γεια σου κόσμε** | **47.637 ns** | **0.5525 ns** | **0.4614 ns** | **47.535 ns** |  **1.00** |    **0.00** |
| GetString_FromByteArray |     proto |       Γεια σου κόσμε | 31.119 ns | 0.4889 ns | 0.4334 ns | 31.074 ns |  0.65 |    0.01 |
|                         |           |                      |           |           |           |           |       |         |
| GetByteArray_FromString |    master |       Γεια σου κόσμε | 45.591 ns | 0.4591 ns | 0.4295 ns | 45.518 ns |  1.00 |    0.00 |
| GetByteArray_FromString |     proto |       Γεια σου κόσμε | 30.522 ns | 0.6794 ns | 0.8592 ns | 30.236 ns |  0.67 |    0.02 |

Marked WIP because it's not fully tested and I'm trying to figure out if it would make sense to provide additional overloads beyond these two. In my own experience, the two call sites under consideration here are far and away the most commonly used methods.

These methods are overridden on the internal sealed type rather than the `UTF8Encoding` base type because that type is configurable in unexpected ways. For example, somebody may have configured the `UTF8Encoding` instance with a custom fallback mechanism, or they may have overridden a virtual method in a manner we're not anticipating. Putting this logic in the internal sealed type instead of the base type works around such potential problems.

It's also possible that we don't want to do this because it represents duplication of logic we'd rather not have. That's understandable - I'm primarily putting this out there to gauge the temperature of the response.