### PR TITLE
Improve codegen for IsNan

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Double.cs
+++ b/src/System.Private.CoreLib/shared/System/Double.cs
@@ -90,8 +90,12 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe bool IsNaN(double d)
         {
-            long bits = BitConverter.DoubleToInt64Bits(d);
-            return (bits & 0x7FFFFFFFFFFFFFFF) > 0x7FF0000000000000;
+            // A NaN will never equal itself so this is an
+            // easy and efficient way to check for NaN.
+
+            #pragma warning disable CS1718
+            return d != d;
+            #pragma warning restore CS1718
         }
 
         /// <summary>Determines whether the specified value is negative.</summary>

--- a/src/System.Private.CoreLib/shared/System/Single.cs
+++ b/src/System.Private.CoreLib/shared/System/Single.cs
@@ -86,8 +86,12 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe bool IsNaN(float f)
         {
-            int bits = BitConverter.SingleToInt32Bits(f);
-            return (bits & 0x7FFFFFFF) > 0x7F800000;
+            // A NaN will never equal itself so this is an
+            // easy and efficient way to check for NaN.
+
+            #pragma warning disable CS1718
+            return f != f;
+            #pragma warning restore CS1718
         }
 
         /// <summary>Determines whether the specified value is negative.</summary>

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -2313,7 +2313,8 @@ void CodeGen::genCodeForJumpTrue(GenTreeOp* jtrue)
     }
 
 #if defined(_TARGET_XARCH_)
-    if ((condition.GetCode() == GenCondition::FNEU) && GenTree::Compare(relop->gtGetOp1(), relop->gtGetOp2(), true))
+    if ((condition.GetCode() == GenCondition::FNEU) &&
+        (relop->gtGetOp1()->GetRegNum() == relop->gtGetOp2()->GetRegNum()))
     {
         // For floating point, `x != x` is a common way of
         // checking for NaN. So, in the case where both

--- a/src/jit/codegenlinear.cpp
+++ b/src/jit/codegenlinear.cpp
@@ -2304,12 +2304,25 @@ void CodeGen::genCodeForJumpTrue(GenTreeOp* jtrue)
     assert(compiler->compCurBB->bbJumpKind == BBJ_COND);
     assert(jtrue->OperIs(GT_JTRUE));
 
-    GenCondition condition = GenCondition::FromRelop(jtrue->gtGetOp1());
+    GenTreeOp*   relop     = jtrue->gtGetOp1()->AsOp();
+    GenCondition condition = GenCondition::FromRelop(relop);
 
     if (condition.PreferSwap())
     {
         condition = GenCondition::Swap(condition);
     }
+
+#if defined(_TARGET_XARCH_)
+    if ((condition.GetCode() == GenCondition::FNEU) && GenTree::Compare(relop->gtGetOp1(), relop->gtGetOp2(), true))
+    {
+        // For floating point, `x != x` is a common way of
+        // checking for NaN. So, in the case where both
+        // operands are the same, we can optimize codegen
+        // to only do a single check.
+
+        condition = GenCondition(GenCondition::P);
+    }
+#endif
 
     inst_JCC(condition, compiler->compCurBB->bbJumpDest);
 }

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -6123,7 +6123,7 @@ void CodeGen::genCompareFloat(GenTree* treeNode)
     // Are we evaluating this into a register?
     if (targetReg != REG_NA)
     {
-        if ((condition.GetCode() == GenCondition::FNEU) && GenTree::Compare(op1, op2, true))
+        if ((condition.GetCode() == GenCondition::FNEU) && (op1->GetRegNum() == op2->GetRegNum()))
         {
             // For floating point, `x != x` is a common way of
             // checking for NaN. So, in the case where both

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -6123,6 +6123,16 @@ void CodeGen::genCompareFloat(GenTree* treeNode)
     // Are we evaluating this into a register?
     if (targetReg != REG_NA)
     {
+        if ((condition.GetCode() == GenCondition::FNEU) && GenTree::Compare(op1, op2, true))
+        {
+            // For floating point, `x != x` is a common way of
+            // checking for NaN. So, in the case where both
+            // operands are the same, we can optimize codegen
+            // to only do a single check.
+
+            condition = GenCondition(GenCondition::P);
+        }
+
         inst_SETCC(condition, treeNode->TypeGet(), targetReg);
         genProduceReg(tree);
     }


### PR DESCRIPTION
This resolves https://github.com/dotnet/coreclr/issues/14846 by updating `IsNaN(x)` to just do `x != x` and improving the handling of `x != x` in the JIT to only require a single branch.

```
Total bytes of diff: -16325 (-0.37% of base)
    diff is an improvement.

Top file improvements by size (bytes):
      -16325 : System.Private.CoreLib.dasm (-0.37% of base)

1 total files with size differences (1 improved, 0 regressed), 0 unchanged.

Top method improvements by size (bytes):
       -2921 (-63.47% of base) : System.Private.CoreLib.dasm - SpanHelpers:LastIndexOfAny(byref,double,double,double,int):int
       -2918 (-61.30% of base) : System.Private.CoreLib.dasm - SpanHelpers:IndexOfAny(byref,double,double,double,int):int
       -1930 (-61.45% of base) : System.Private.CoreLib.dasm - SpanHelpers:LastIndexOfAny(byref,double,double,int):int
       -1923 (-61.44% of base) : System.Private.CoreLib.dasm - SpanHelpers:IndexOfAny(byref,double,double,int):int
        -934 (-56.44% of base) : System.Private.CoreLib.dasm - SpanHelpers:LastIndexOf(byref,double,int):int

Top method improvements by size (percentage):
         -36 (-72.00% of base) : System.Private.CoreLib.dasm - Double:IsNaN(double):bool
         -80 (-65.04% of base) : System.Private.CoreLib.dasm - Double:Equals(double):bool:this
         -72 (-63.72% of base) : System.Private.CoreLib.dasm - GenericEqualityComparer`1:Equals(double,double):bool:this
       -2921 (-63.47% of base) : System.Private.CoreLib.dasm - SpanHelpers:LastIndexOfAny(byref,double,double,double,int):int
       -1930 (-61.45% of base) : System.Private.CoreLib.dasm - SpanHelpers:LastIndexOfAny(byref,double,double,int):int

57 total methods with size differences (57 improved, 0 regressed), 20447 unchanged.
```