### PR TITLE
Fix `costEx/Sz/level` for `GT_STORE_DYN_BLK`.

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -4482,9 +4482,6 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
         case GT_STORE_DYN_BLK:
         case GT_DYN_BLK:
         {
-            costEx = 0;
-            costSz = 0;
-
             level  = gtSetEvalOrder(tree->gtDynBlk.Addr());
             costEx = tree->gtDynBlk.Addr()->GetCostEx();
             costSz = tree->gtDynBlk.Addr()->GetCostSz();

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -4484,7 +4484,11 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
         {
             costEx = 0;
             costSz = 0;
-            level  = 0;
+
+            level  = gtSetEvalOrder(tree->gtDynBlk.Addr());
+            costEx = tree->gtDynBlk.Addr()->GetCostEx();
+            costSz = tree->gtDynBlk.Addr()->GetCostSz();
+
             if (oper == GT_STORE_DYN_BLK)
             {
                 lvl2  = gtSetEvalOrder(tree->gtDynBlk.Data());
@@ -4492,10 +4496,7 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                 costEx += tree->gtDynBlk.Data()->GetCostEx();
                 costSz += tree->gtDynBlk.Data()->GetCostSz();
             }
-            lvl2               = gtSetEvalOrder(tree->gtDynBlk.Addr());
-            level              = max(level, lvl2);
-            costEx             = tree->gtDynBlk.Addr()->GetCostEx();
-            costSz             = tree->gtDynBlk.Addr()->GetCostSz();
+
             unsigned sizeLevel = gtSetEvalOrder(tree->gtDynBlk.gtDynamicSize);
 
             // Determine whether the size node should be evaluated first.


### PR DESCRIPTION
Another issue found by PVS, we were reassigning `costEx, costSz` without using `GT_STORE_DYN_BLK` values.

There were no diffs from that change, so I tried to find how can we hit this code path. It looks like we create `GT_STORE_DYN_BLK`  only here:
https://github.com/dotnet/coreclr/blob/79319d50d45a95375f26f60341575e0284c3fa00/src/jit/rationalize.cpp#L462-L464 and that is LIR so it after possible calls to `gtSetEvalOrder`.
Is it correct or have I missed something, @CarolEidt @mikedn ?
If it is correct that probably we need to delete 
`case GT_STORE_DYN_BLK:` from `gtSetEvalOrder` so it goes to `default: Unexpected Op`.


Link #7027.