### PR TITLE
Re-enable crossgen2 DGML log

### DIFF
--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -60,6 +60,7 @@ namespace ILCompiler
         }
 
         public abstract void Compile(string outputFileName);
+        public abstract void WriteDependencyLog(string outputFileName);
 
         protected abstract void ComputeDependencyNodeDependencies(List<DependencyNodeCore<NodeFactory>> obj);
 
@@ -171,6 +172,7 @@ namespace ILCompiler
     public interface ICompilation
     {
         void Compile(string outputFileName);
+        void WriteDependencyLog(string outputFileName);
     }
 
     public sealed class ReadyToRunCodegenCompilation : Compilation
@@ -226,6 +228,15 @@ namespace ILCompiler
                     NodeFactory.SetMarkingComplete();
                     ReadyToRunObjectWriter.EmitObject(inputPeReader, outputFile, nodes, NodeFactory);
                 }
+            }
+        }
+
+        public override void WriteDependencyLog(string outputFileName)
+        {
+            using (FileStream dgmlOutput = new FileStream(outputFileName, FileMode.Create))
+            {
+                DgmlWriter.WriteDependencyGraphToStream(dgmlOutput, _dependencyGraph, _nodeFactory);
+                dgmlOutput.Flush();
             }
         }
 

--- a/src/tools/crossgen2/crossgen2/Program.cs
+++ b/src/tools/crossgen2/crossgen2/Program.cs
@@ -403,6 +403,9 @@ namespace ILCompiler
 
                 }
                 compilation.Compile(_outputFilePath);
+
+                if (_dgmlLogFileName != null)
+                    compilation.WriteDependencyLog(_dgmlLogFileName);
             }
 
             return 0;


### PR DESCRIPTION
The dependency graph can be dumped to disk as an XML-based DGML file. This functionality was severed when we moved over from the CoreRT repo.

cc @dotnet/crossgen-contrib 