### PR TITLE
Extend test coverage for SafeHandle

### DIFF
--- a/tests/src/Interop/PInvoke/SafeHandles/ReliableUnmarshalTest.cs
+++ b/tests/src/Interop/PInvoke/SafeHandles/ReliableUnmarshalTest.cs
@@ -18,7 +18,7 @@ namespace SafeHandleTests
             IntPtr value = (IntPtr)123;
             TestSafeHandle h = new TestSafeHandle();
 
-            Assert.Throws<InvalidOperationException>(() => SafeHandleNative.GetHandleAndCookie(value, out h, out var cookie));
+            Assert.Throws<InvalidOperationException>(() => SafeHandleNative.GetHandleAndCookie(out _, value, out h));
 
             Assert.AreEqual(value, h.DangerousGetHandle());
 

--- a/tests/src/Interop/PInvoke/SafeHandles/ReliableUnmarshalTest.cs
+++ b/tests/src/Interop/PInvoke/SafeHandles/ReliableUnmarshalTest.cs
@@ -21,6 +21,14 @@ namespace SafeHandleTests
             Assert.Throws<InvalidOperationException>(() => SafeHandleNative.GetHandleAndCookie(value, out h, out var cookie));
 
             Assert.AreEqual(value, h.DangerousGetHandle());
+
+            // Try again, this time triggering unmarshal failure with an array.
+            value = (IntPtr)456;
+            h = new TestSafeHandle();
+
+            Assert.Throws<OverflowException>(() => SafeHandleNative.GetHandleAndArray(out _, out _, value, out h));
+
+            Assert.AreEqual(value, h.DangerousGetHandle());
         }
     }
 }

--- a/tests/src/Interop/PInvoke/SafeHandles/SafeHandleNative.cpp
+++ b/tests/src/Interop/PInvoke/SafeHandles/SafeHandleNative.cpp
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include <platformdefines.h>
+#include <xplatform.h>
 
 struct StructWithHandle
 {
@@ -66,3 +67,12 @@ extern "C" void DLL_EXPORT GetHandleAndCookie(intptr_t value, HANDLE* handle, vo
     *pCookie = (void*)4567; // the value here does not matter. It just needs to not be nullptr.
 }
 
+extern "C" void DLL_EXPORT GetHandleAndArray(/*out*/SHORT* arrSize, SHORT** ppActual, intptr_t value, HANDLE* handle)
+{
+    *arrSize = -1; // minus one is going to make this throw on unmarshal
+
+    // Still need to provide something allocated using an expected allocator so that the marshaller can unalloc
+    *ppActual = (SHORT*)CoreClrAlloc(sizeof(SHORT));
+
+    *handle = (HANDLE)value;
+}

--- a/tests/src/Interop/PInvoke/SafeHandles/SafeHandleNative.cpp
+++ b/tests/src/Interop/PInvoke/SafeHandles/SafeHandleNative.cpp
@@ -61,7 +61,7 @@ extern "C" DLL_EXPORT void STDMETHODVCALLTYPE SafeHandle_Invalid(...)
 {
 }
 
-extern "C" void DLL_EXPORT GetHandleAndCookie(intptr_t value, HANDLE* handle, void** pCookie)
+extern "C" void DLL_EXPORT GetHandleAndCookie(void** pCookie, intptr_t value, HANDLE* handle)
 {
     *handle = (HANDLE)value;
     *pCookie = (void*)4567; // the value here does not matter. It just needs to not be nullptr.

--- a/tests/src/Interop/PInvoke/SafeHandles/SafeHandleNative.cs
+++ b/tests/src/Interop/PInvoke/SafeHandles/SafeHandleNative.cs
@@ -87,7 +87,7 @@ namespace SafeHandleTests
         public static extern void StructWithSafeHandleOut(out StructWithHandle str, IntPtr expectedValue);
         
         [DllImport(nameof(SafeHandleNative))]
-        public static extern void GetHandleAndCookie(IntPtr value, out TestSafeHandle handle, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ThrowingCustomMarshaler), MarshalCookie = "")] out object cookie);
+        public static extern void GetHandleAndCookie([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ThrowingCustomMarshaler), MarshalCookie = "")] out object cookie, IntPtr value, out TestSafeHandle handle);
 
         [DllImport(nameof(SafeHandleNative))]
         public static extern void GetHandleAndArray(out short arrSize, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)] out short[] arrShort, IntPtr value, out TestSafeHandle handle);

--- a/tests/src/Interop/PInvoke/SafeHandles/SafeHandleNative.cs
+++ b/tests/src/Interop/PInvoke/SafeHandles/SafeHandleNative.cs
@@ -89,6 +89,9 @@ namespace SafeHandleTests
         [DllImport(nameof(SafeHandleNative))]
         public static extern void GetHandleAndCookie(IntPtr value, out TestSafeHandle handle, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ThrowingCustomMarshaler), MarshalCookie = "")] out object cookie);
 
+        [DllImport(nameof(SafeHandleNative))]
+        public static extern void GetHandleAndArray(out short arrSize, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)] out short[] arrShort, IntPtr value, out TestSafeHandle handle);
+
         [DllImport(nameof(SafeHandleNative), CallingConvention = CallingConvention.Cdecl)]
         public static extern void SafeHandle_Invalid([MarshalAs(UnmanagedType.Interface)] TestSafeHandle handle);
 


### PR DESCRIPTION
Trigger unmarshaling failure using an array marshaller. This is something crossgen2 will be able to pregenerate. The existing test case with CustomMarshaller will always be jitted and never pregenerated.