### PR TITLE
Disable VectorMgdMgd_ro.csproj under stress modes.

### DIFF
--- a/tests/src/JIT/Directed/VectorABI/VectorMgdMgd_ro.csproj
+++ b/tests/src/JIT/Directed/VectorABI/VectorMgdMgd_ro.csproj
@@ -6,7 +6,7 @@
     <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <JitOptimizationSensitive Condition="'$(Platform)' == 'arm64'">true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="VectorMgdMgd.cs" />

--- a/tests/src/JIT/Directed/VectorABI/VectorMgdMgd_ro.csproj
+++ b/tests/src/JIT/Directed/VectorABI/VectorMgdMgd_ro.csproj
@@ -6,6 +6,7 @@
     <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="VectorMgdMgd.cs" />


### PR DESCRIPTION
Closes #27290.

Revert when #26491 is fixed.