### PR TITLE
[Release/2.1] Respect profiler provided IL maps (Port #25802)

### DIFF
--- a/src/debug/daccess/dacdbiimpl.cpp
+++ b/src/debug/daccess/dacdbiimpl.cpp
@@ -1002,13 +1002,19 @@ void DacDbiInterfaceImpl::GetSequencePoints(MethodDesc *     pMethodDesc,
     if (!success)
         ThrowHR(E_FAIL);
 
-    // if there is a rejit IL map for this function, apply that in preference to load-time mapping
 #ifdef FEATURE_REJIT
     CodeVersionManager * pCodeVersionManager = pMethodDesc->GetCodeVersionManager();
+    ILCodeVersion ilVersion;
     NativeCodeVersion nativeCodeVersion = pCodeVersionManager->GetNativeCodeVersion(dac_cast<PTR_MethodDesc>(pMethodDesc), (PCODE)startAddr);
     if (!nativeCodeVersion.IsNull())
     {
-        const InstrumentedILOffsetMapping * pRejitMapping = nativeCodeVersion.GetILCodeVersion().GetInstrumentedILMap();
+        ilVersion = nativeCodeVersion.GetILCodeVersion();
+    }
+
+    // if there is a rejit IL map for this function, apply that in preference to load-time mapping
+    if (!ilVersion.IsNull() && !ilVersion.IsDefaultVersion())
+    {
+        const InstrumentedILOffsetMapping * pRejitMapping = ilVersion.GetInstrumentedILMap();
         ComposeMapping(pRejitMapping, mapCopy, &entryCount);
     }
     else


### PR DESCRIPTION
#### Description 
When a profiler modifies IL it can also provide an updated source->IL map so that the debugger (or potentially any other consumer of the source->IL map) can correctly process the updated function. There was a type introduced in 2.1 that effectively makes the runtime ignore the profiler provided maps when the debugger asks for them.
 

#### Customer Impact 
Debugging is broken for profiler modified functions, this was reported by a customer that uses the profiler APIs for a unit test framework.
 

#### Regression? 
It is a regression from desktop behavior, and preventing the customer's profiler from working with apps targeting 2.1. Profiling was not supported on core before 2.1 so it is not technically a regression on core.
 

#### Risk 
Very low risk, this code path is only used by the debugger/DAC and the fix is easy to reason about.
 