### PR TITLE
Packaging for crossgen2 as a framework dependent application.

### DIFF
--- a/src/.nuget/Directory.Build.targets
+++ b/src/.nuget/Directory.Build.targets
@@ -34,6 +34,10 @@
       <NativeWithSymbolFile Include="@(ArchitectureSpecificToolFile)">
         <TargetPath>tools</TargetPath>
       </NativeWithSymbolFile>
+      <NativeWithSymbolFile Include="@(Crossgen2Files)" 
+                            Condition="'$(BuildArch)'=='x64' And ('$(__BuildOS)' == 'Windows_NT' Or '$(__BuildOS)' == 'Linux')">
+        <TargetPath>tools/crossgen2</TargetPath>
+      </NativeWithSymbolFile>
     </ItemGroup>
 
     <ItemGroup Condition="'$(HasCrossTargetComponents)'=='true'">

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -15,4 +15,34 @@
   <Import Condition="'$(_packageTargetOSGroup)' != ''"  Project="$(MSBuildThisFileDirectory)runtime.$(_packageTargetOSGroup).$(MSBuildProjectName).props" />
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
+
+
+  <PropertyGroup>
+    <!-- We're publishing crossgen2 as framework dependent application in the runtime package for now since we only have
+        two simple scenarios we want to support in the short term: win_x64 to win_x64 and linux_x64 to linux_x64 compilations.
+        Once we have more complex targets, especially cross-platform and cross-architecture, crossgen2 should move to its own
+        package, and become a self-contained package. -->
+    <Crossgen2RuntimeConfigFile>$(ArtifactsObjDir)crossgen2\crossgen2.runtimeconfig.json</Crossgen2RuntimeConfigFile>
+    <Crossgen2RuntimeConfigContents>
+{
+  "runtimeOptions": {
+    "tfm": "netcoreapp3.0",
+    "rollForward": "major",
+    "framework": {
+      "name": "Microsoft.NETCore.App",
+      "version": "3.0.0"
+    }
+  }
+}
+    </Crossgen2RuntimeConfigContents>
+  </PropertyGroup>
+  <ItemGroup>
+    <Crossgen2Files Include="$(Crossgen2RuntimeConfigFile)" />
+  </ItemGroup>
+    
+  <Target Name="WriteCrossgen2RuntimeConfig" BeforeTargets="GetSymbolPackageFiles">
+    <!-- Emit the runtime config json file that will be packaged with crossgen2 -->
+    <WriteLinesToFile File="$(Crossgen2RuntimeConfigFile)" Lines="$(Crossgen2RuntimeConfigContents)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+  </Target>
+
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Linux.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -20,5 +20,12 @@
     <CrossGenBinary Include="$(BinDir)System.Private.CoreLib.dll" />
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen" />
     <CrossArchitectureSpecificToolFile Condition="'$(HasCrossTargetComponents)' == 'true'" Include="$(BinDir)$(CrossTargetComponentFolder)\crossgen" />
+
+    <Crossgen2Files Include="$(BinDir)crossgen2\crossgen2.dll" />
+    <Crossgen2Files Include="$(BinDir)crossgen2\ILCompiler*.dll" />
+    <Crossgen2Files Include="$(BinDir)crossgen2\Microsoft.DiaSymReader.dll" />
+    <Crossgen2Files Include="$(BinDir)crossgen2\System.CommandLine.dll" />
+    <Crossgen2Files Include="$(BinDir)crossgen2\libclrjitilc.so" />
+    <Crossgen2Files Include="$(BinDir)crossgen2\libjitinterface.so" />
   </ItemGroup>
 </Project>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Windows_NT.Microsoft.NETCore.Runtime.CoreCLR.props
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/runtime.Windows_NT.Microsoft.NETCore.Runtime.CoreCLR.props
@@ -28,6 +28,13 @@
     <CrossArchitectureSpecificToolFile Include="$(BinDir)$(CrossTargetComponentFolder)\mscordaccore.dll" />
     <CrossArchitectureSpecificToolFile Include="$(BinDir)$(CrossTargetComponentFolder)\mscordbi.dll" />
 
+    <Crossgen2Files Include="$(BinDir)crossgen2\crossgen2.dll" />
+    <Crossgen2Files Include="$(BinDir)crossgen2\ILCompiler*.dll" />
+    <Crossgen2Files Include="$(BinDir)crossgen2\Microsoft.DiaSymReader.dll" />
+    <Crossgen2Files Include="$(BinDir)crossgen2\System.CommandLine.dll" />
+    <Crossgen2Files Include="$(BinDir)crossgen2\clrjitilc.dll" />
+    <Crossgen2Files Include="$(BinDir)crossgen2\jitinterface.dll" />
+
     <!-- prevent accidental inclusion in AOT projects. -->
     <File Include="$(PlaceholderFile)">
       <TargetPath>runtimes/$(PackageTargetRuntime)-aot/lib/netstandard1.0</TargetPath>

--- a/src/build.proj
+++ b/src/build.proj
@@ -10,7 +10,6 @@
     <ProjectReference Condition="'$(BuildManagedTools)' == 'true'" Include="tools/runincontext/runincontext.csproj" />
     <ProjectReference Condition="'$(BuildManagedTools)' == 'true'" Include="tools/r2rdump/R2RDump.csproj" />
     <ProjectReference Condition="'$(BuildManagedTools)' == 'true'" Include="tools/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.csproj" />
-    <ProjectReference Condition="'$(BuildManagedTools)' == 'true'" Include="tools/crossgen2/crossgen2/crossgen2.csproj" />
     <ProjectReference Include="System.Private.CoreLib\System.Private.CoreLib.csproj" />
   </ItemGroup>
 

--- a/src/tools/crossgen2/ILCompiler.DependencyAnalysisFramework/ILCompiler.DependencyAnalysisFramework.csproj
+++ b/src/tools/crossgen2/ILCompiler.DependencyAnalysisFramework/ILCompiler.DependencyAnalysisFramework.csproj
@@ -11,7 +11,6 @@
     <!-- We're binplacing these into an existing publish layout so that F5 build in VS updates
          the same bits tests expect to see in bin/crossgen2. That way we never need to wonder which
          binaries are up to date and which are stale. -->
-    <OutputPath>$(BinDir)/crossgen2</OutputPath>
     <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -12,7 +12,6 @@
     <!-- We're binplacing these into an existing publish layout so that F5 build in VS updates
          the same bits tests expect to see in bin/crossgen2. That way we never need to wonder which
          binaries are up to date and which are stale. -->
-    <OutputPath>$(BinDir)/crossgen2</OutputPath>
     <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>
   

--- a/src/tools/crossgen2/ILCompiler.TypeSystem.ReadyToRun/ILCompiler.TypeSystem.ReadyToRun.csproj
+++ b/src/tools/crossgen2/ILCompiler.TypeSystem.ReadyToRun/ILCompiler.TypeSystem.ReadyToRun.csproj
@@ -12,7 +12,6 @@
     <!-- We're binplacing these into an existing publish layout so that F5 build in VS updates
          the same bits tests expect to see in bin/crossgen2. That way we never need to wonder which
          binaries are up to date and which are stale. -->
-    <OutputPath>$(BinDir)/crossgen2</OutputPath>
     <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tools/crossgen2/crossgen2/crossgen2.csproj
+++ b/src/tools/crossgen2/crossgen2/crossgen2.csproj
@@ -11,7 +11,6 @@
     <!-- We're binplacing these into an existing publish layout so that F5 build in VS updates
          the same bits tests expect to see in bin/crossgen2. That way we never need to wonder which
          binaries are up to date and which are stale. -->
-    <OutputPath>$(BinDir)/crossgen2</OutputPath>
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>


### PR DESCRIPTION
This requires us to manually emit a runtimeconfig json for now, since the build produces a self-contained version of crossgen2.

Also includes some minor cleanups to the way we build crossgen2:
- Removed from build.proj since we explicitly build it as a self-contained application from build.cmd/build.sh
- Removed the output path property from the csproj files. We use an explicit -o argument when publishing to specify the output folder