### PR TITLE
[3.1] Backport fixes to ETW/EventPipe events to enable GCDumps

### DIFF
--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -4269,6 +4269,12 @@ VOID EtwCallbackCommon(
 #endif // !defined(FEATURE_PAL)
         ETW::GCLog::ForceGC(l64ClientSequenceNumber);
     }
+    // TypeSystemLog needs a notification when certain keywords are modified, so
+    // give it a hook here.
+    if (g_fEEStarted && !g_fEEShutDown && bIsPublicTraceHandle)
+    {
+        ETW::TypeSystemLog::OnKeywordsChanged();
+    }
 }
 
 // Individual callbacks for each EventPipe provider.
@@ -4487,13 +4493,6 @@ extern "C"
         }
 
         EtwCallbackCommon(providerIndex, ControlCode, Level, MatchAnyKeyword, FilterData, false);
-
-        // TypeSystemLog needs a notification when certain keywords are modified, so
-        // give it a hook here.
-        if (g_fEEStarted && !g_fEEShutDown && bIsPublicTraceHandle)
-        {
-            ETW::TypeSystemLog::OnKeywordsChanged();
-        }
 
         // A manifest based provider can be enabled to multiple event tracing sessions
         // As long as there is atleast 1 enabled session, IsEnabled will be TRUE

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -1135,6 +1135,7 @@ void BulkComLogger::FlushRcw()
 #else
     ULONG result = FireEtXplatGCBulkRCW(m_currRcw, instance, sizeof(EventRCWEntry) * m_currRcw, m_etwRcwData);
 #endif // !defined(FEATURE_PAL)
+    result |= EventPipeWriteEventGCBulkRCW(m_currRcw, instance, sizeof(EventRCWEntry) * m_currRcw, m_etwRcwData);
 
     _ASSERTE(result == ERROR_SUCCESS);
 
@@ -1224,6 +1225,7 @@ void BulkComLogger::FlushCcw()
 #else
     ULONG result = FireEtXplatGCBulkRootCCW(m_currCcw, instance, sizeof(EventCCWEntry) * m_currCcw, m_etwCcwData);
 #endif //!defined(FEATURE_PAL)
+    result |= EventPipeWriteEventGCBulkRootCCW(m_currCcw, instance, sizeof(EventCCWEntry) * m_currCcw, m_etwCcwData);
 
     _ASSERTE(result == ERROR_SUCCESS);
 
@@ -1428,6 +1430,7 @@ void BulkStaticsLogger::FireBulkStaticsEvent()
 #else
     ULONG result = FireEtXplatGCBulkRootStaticVar(m_count, appDomain, instance, m_used, m_buffer);
 #endif //!defined(FEATURE_PAL)
+    result |= EventPipeWriteEventGCBulkRootStaticVar(m_count, appDomain, instance, m_used, m_buffer);
 
     _ASSERTE(result == ERROR_SUCCESS);
 


### PR DESCRIPTION
### Description
#27237

These two commits fix two issues preventing successful GCDump creation using events sent over EventPipe. PerfView has the ability to generate GCDumps (a collections of statistics about all objects on the heap) of a running process by turning on a specific set of keywords on the `Microsoft-Windows-DotNETRuntime` provider and analyzing the data.  These are a powerful tool for triaging memory leaks and other flavors of memory issues.

ff37915 - This moves a function call to `EtwCallbackCommon` so that both ETW and EventPipe have the same behavior.  `OnKeywordsChanged` modifies some global statics for type logging to cause the type cache to be emptied when a specific keyword is not enabled.  Without clearing this type cache, type metadata events are not generated when GCs are triggered via EventPipe resulting in GCDumps that have no type information.  Moving this to `EtwCallbackCommon` ensures that the type cache is correctly flushed like it was with ETW.

2a1a6cf - This fixes 3 events that were not being sent over EventPipe previously.  Without these events, static, ccw, and rcw type metadata would not be present in GCDumps created via EventPipe.

### Customer Impact

With these changes, customers will be able to collect GCDumps on Linux, Mac, and Windows by analyzing events sent over EventPipe as they could with ETW.

### Regression

This is a discrepancy in the event parity between ETW and EventPipe (i.e., what events can be collected by what technology), but not technically a regression as this issue has existed since before 2.2.

### Risk

Low - These changes are targeted to preserve ETW behavior without modifying any other logic.

CC @tommcdon @caslan 