### PR TITLE
Avoid mod operator when fast alternative available

### DIFF
--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -342,10 +342,10 @@ License notice for Xorshift (Wikipedia)
 https://en.wikipedia.org/wiki/Xorshift
 License: https://en.wikipedia.org/wiki/Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_3.0_Unported_License
 
-License for fastrange (https://github.com/lemire/fastrange)
+License for fastmod (https://github.com/lemire/fastmod)
 --------------------------------------
 
-   Copyright 2016 Daniel Lemire
+   Copyright 2018 Daniel Lemire
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -341,3 +341,20 @@ License notice for Xorshift (Wikipedia)
 
 https://en.wikipedia.org/wiki/Xorshift
 License: https://en.wikipedia.org/wiki/Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_3.0_Unported_License
+
+License for fastrange (https://github.com/lemire/fastrange)
+--------------------------------------
+
+   Copyright 2016 Daniel Lemire
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
@@ -454,15 +454,15 @@ namespace System.Collections.Generic
 
         private int Initialize(int capacity)
         {
-#if BIT64
-            int size = HashHelpers.GetPrime(capacity, out _fastModMultiplier);
-#else
             int size = HashHelpers.GetPrime(capacity);
-#endif
             int[] buckets = new int[size];
             Entry[] entries = new Entry[size];
-            // Assign after both allocated to guard against corruption from OOM if second fails
+
+            // Assign member varables after both arrays allocated to guard against corruption from OOM if second fails
             _freeList = -1;
+#if BIT64
+            _fastModMultiplier = HashHelpers.GetFastModMultiplier((uint)size);
+#endif
             _buckets = buckets;
             _entries = entries;
 
@@ -716,11 +716,7 @@ namespace System.Collections.Generic
 
         private void Resize()
         {
-#if BIT64
-            int size = HashHelpers.ExpandPrime(_count, out _fastModMultiplier);
-#else
             int size = HashHelpers.ExpandPrime(_count);
-#endif
             Resize(size, false);
         }
 
@@ -748,7 +744,11 @@ namespace System.Collections.Generic
                 }
             }
 
+            // Assign member varables after both arrays allocated to guard against corruption from OOM if second fails
             _buckets = new int[newSize];
+#if BIT64
+            _fastModMultiplier = HashHelpers.GetFastModMultiplier((uint)newSize);
+#endif
             for (int i = 0; i < count; i++)
             {
                 if (entries[i].next >= -1)
@@ -994,11 +994,8 @@ namespace System.Collections.Generic
             _version++;
             if (_buckets == null)
                 return Initialize(capacity);
-#if BIT64
-            int newSize = HashHelpers.GetPrime(capacity, out _fastModMultiplier);
-#else
+
             int newSize = HashHelpers.GetPrime(capacity);
-#endif
             Resize(newSize, forceNewHashCodes: false);
             return newSize;
         }
@@ -1027,11 +1024,8 @@ namespace System.Collections.Generic
         {
             if (capacity < Count)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.capacity);
-#if BIT64
-            int newSize = HashHelpers.GetPrime(capacity, out _fastModMultiplier);
-#else
+
             int newSize = HashHelpers.GetPrime(capacity);
-#endif
             Entry[]? oldEntries = _entries;
             int currentCapacity = oldEntries == null ? 0 : oldEntries.Length;
             if (newSize >= currentCapacity)

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
@@ -458,7 +458,7 @@ namespace System.Collections.Generic
             int[] buckets = new int[size];
             Entry[] entries = new Entry[size];
 
-            // Assign member varables after both arrays allocated to guard against corruption from OOM if second fails
+            // Assign member variables after both arrays allocated to guard against corruption from OOM if second fails
             _freeList = -1;
 #if BIT64
             _fastModMultiplier = HashHelpers.GetFastModMultiplier((uint)size);
@@ -741,7 +741,7 @@ namespace System.Collections.Generic
                 }
             }
 
-            // Assign member varables after both arrays allocated to guard against corruption from OOM if second fails
+            // Assign member variables after both arrays allocated to guard against corruption from OOM if second fails
             _buckets = new int[newSize];
 #if BIT64
             _fastModMultiplier = HashHelpers.GetFastModMultiplier((uint)newSize);

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
@@ -459,9 +459,12 @@ namespace System.Collections.Generic
 #else
             int size = HashHelpers.GetPrime(capacity);
 #endif
+            int[] buckets = new int[size];
+            Entry[] entries = new Entry[size];
+            // Assign after both allocated to guard against corruption from OOM if second fails
             _freeList = -1;
-            _buckets = new int[size];
-            _entries = new Entry[size];
+            _buckets = buckets;
+            _entries = entries;
 
             return size;
         }
@@ -728,7 +731,6 @@ namespace System.Collections.Generic
             Debug.Assert(_entries != null, "_entries should be non-null");
             Debug.Assert(newSize >= _entries.Length);
 
-            _buckets = new int[newSize];
             Entry[] entries = new Entry[newSize];
 
             int count = _count;
@@ -746,6 +748,7 @@ namespace System.Collections.Generic
                 }
             }
 
+            _buckets = new int[newSize];
             for (int i = 0; i < count; i++)
             {
                 if (entries[i].next >= -1)

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
@@ -1166,21 +1166,16 @@ namespace System.Collections.Generic
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private ref int GetBucket(uint hashCode)
+        {
+            int[] buckets = _buckets!;
 #if BIT64
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private ref int GetBucket(uint hashCode)
-        {
-            int[] buckets = _buckets!;
             return ref buckets[HashHelpers.FastMod(hashCode, (uint)buckets.Length, _fastModMultiplier)];
-        }
 #else
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private ref int GetBucket(uint hashCode)
-        {
-            int[] buckets = _buckets!;
             return ref buckets![hashCode % (uint)buckets.Length];
-        }
 #endif
+        }
 
         public struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>,
             IDictionaryEnumerator

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
@@ -339,7 +339,7 @@ namespace System.Collections.Generic
                 if (comparer == null)
                 {
                     uint hashCode = (uint)key.GetHashCode();
-                    int i = buckets[hashCode % (uint)buckets.Length];
+                    int i = buckets[HashHelpers.FastRange(hashCode, (uint)buckets.Length)];
                     Entry[]? entries = _entries;
                     uint collisionCount = 0;
                     if (default(TKey)! != null) // TODO-NULLABLE: default(T) == null warning (https://github.com/dotnet/roslyn/issues/34757)
@@ -407,7 +407,7 @@ namespace System.Collections.Generic
                 else
                 {
                     uint hashCode = (uint)comparer.GetHashCode(key);
-                    int i = buckets[hashCode % (uint)buckets.Length];
+                    int i = buckets[HashHelpers.FastRange(hashCode, (uint)buckets.Length)];
                     Entry[]? entries = _entries;
                     uint collisionCount = 0;
                     // Value in _buckets is 1-based; subtract 1 from i. We do it here so it fuses with the following conditional.
@@ -481,7 +481,7 @@ namespace System.Collections.Generic
             uint hashCode = (uint)((comparer == null) ? key.GetHashCode() : comparer.GetHashCode(key));
 
             uint collisionCount = 0;
-            ref int bucket = ref _buckets[hashCode % (uint)_buckets.Length];
+            ref int bucket = ref _buckets[HashHelpers.FastRange(hashCode, (uint)_buckets.Length)];
             // Value in _buckets is 1-based
             int i = bucket - 1;
 
@@ -625,7 +625,7 @@ namespace System.Collections.Generic
                 if (count == entries.Length)
                 {
                     Resize();
-                    bucket = ref _buckets[hashCode % (uint)_buckets.Length];
+                    bucket = ref _buckets[HashHelpers.FastRange(hashCode, (uint)_buckets.Length)];
                 }
                 index = count;
                 _count = count + 1;
@@ -738,7 +738,7 @@ namespace System.Collections.Generic
             {
                 if (entries[i].next >= -1)
                 {
-                    uint bucket = entries[i].hashCode % (uint)newSize;
+                    uint bucket = HashHelpers.FastRange(entries[i].hashCode, (uint)newSize);
                     // Value in _buckets is 1-based
                     entries[i].next = buckets[bucket] - 1;
                     // Value in _buckets is 1-based
@@ -767,7 +767,7 @@ namespace System.Collections.Generic
                 Debug.Assert(entries != null, "entries should be non-null");
                 uint collisionCount = 0;
                 uint hashCode = (uint)(_comparer?.GetHashCode(key) ?? key.GetHashCode());
-                uint bucket = hashCode % (uint)buckets.Length;
+                uint bucket = HashHelpers.FastRange(hashCode, (uint)buckets.Length);
                 int last = -1;
                 // Value in buckets is 1-based
                 int i = buckets[bucket] - 1;
@@ -836,7 +836,7 @@ namespace System.Collections.Generic
                 Debug.Assert(entries != null, "entries should be non-null");
                 uint collisionCount = 0;
                 uint hashCode = (uint)(_comparer?.GetHashCode(key) ?? key.GetHashCode());
-                uint bucket = hashCode % (uint)buckets.Length;
+                uint bucket = HashHelpers.FastRange(hashCode, (uint)buckets.Length);
                 int last = -1;
                 // Value in buckets is 1-based
                 int i = buckets[bucket] - 1;
@@ -1031,7 +1031,7 @@ namespace System.Collections.Generic
                 {
                     ref Entry entry = ref entries![count];
                     entry = oldEntries[i];
-                    uint bucket = hashCode % (uint)newSize;
+                    uint bucket = HashHelpers.FastRange(hashCode, (uint)newSize);
                     // Value in _buckets is 1-based
                     entry.next = buckets![bucket] - 1; // If we get here, we have entries, therefore buckets is not null.
                     // Value in _buckets is 1-based

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
@@ -715,10 +715,7 @@ namespace System.Collections.Generic
         }
 
         private void Resize()
-        {
-            int size = HashHelpers.ExpandPrime(_count);
-            Resize(size, false);
-        }
+            => Resize(HashHelpers.ExpandPrime(_count), false);
 
         private void Resize(int newSize, bool forceNewHashCodes)
         {

--- a/src/System.Private.CoreLib/shared/System/Collections/HashHelpers.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/HashHelpers.cs
@@ -58,9 +58,8 @@ namespace System.Collections
             if (min < 0)
                 throw new ArgumentException(SR.Arg_HTCapacityOverflow);
 
-            for (int i = 0; i < s_primes.Length; i++)
+            foreach (int prime in s_primes)
             {
-                int prime = s_primes[i];
                 if (prime >= min)
                     return prime;
             }
@@ -91,20 +90,6 @@ namespace System.Collections
         }
 
 #if BIT64
-        public static int GetPrime(int capacity, out ulong fastModMultiplier)
-        {
-            int prime = GetPrime(capacity);
-            fastModMultiplier = GetFastModMultiplier((uint)prime);
-            return prime;
-        }
-
-        public static int ExpandPrime(int currentPrime, out ulong fastModMultiplier)
-        {
-            int prime = ExpandPrime(currentPrime);
-            fastModMultiplier = GetFastModMultiplier((uint)prime);
-            return prime;
-        }
-
         public static ulong GetFastModMultiplier(uint divisor)
             => ulong.MaxValue / divisor + 1;
 

--- a/src/System.Private.CoreLib/shared/System/Collections/HashHelpers.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/HashHelpers.cs
@@ -4,7 +4,6 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Runtime.Intrinsics.X86;
 
 namespace System.Collections
 {
@@ -30,12 +29,14 @@ namespace System.Collections
         // h1(key) + i*h2(key), 0 <= i < size.  h2 and the size must be relatively prime.
         // We prefer the low computation costs of higher prime numbers over the increased
         // memory allocation of a fixed prime number i.e. when right sizing a HashSet.
-        public static readonly int[] primes = {
+        private static readonly int[] s_primes =
+        {
             3, 7, 11, 17, 23, 29, 37, 47, 59, 71, 89, 107, 131, 163, 197, 239, 293, 353, 431, 521, 631, 761, 919,
             1103, 1327, 1597, 1931, 2333, 2801, 3371, 4049, 4861, 5839, 7013, 8419, 10103, 12143, 14591,
             17519, 21023, 25229, 30293, 36353, 43627, 52361, 62851, 75431, 90523, 108631, 130363, 156437,
             187751, 225307, 270371, 324449, 389357, 467237, 560689, 672827, 807403, 968897, 1162687, 1395263,
-            1674319, 2009191, 2411033, 2893249, 3471899, 4166287, 4999559, 5999471, 7199369 };
+            1674319, 2009191, 2411033, 2893249, 3471899, 4166287, 4999559, 5999471, 7199369
+        };
 
         public static bool IsPrime(int candidate)
         {
@@ -57,9 +58,9 @@ namespace System.Collections
             if (min < 0)
                 throw new ArgumentException(SR.Arg_HTCapacityOverflow);
 
-            for (int i = 0; i < primes.Length; i++)
+            for (int i = 0; i < s_primes.Length; i++)
             {
-                int prime = primes[i];
+                int prime = s_primes[i];
                 if (prime >= min)
                     return prime;
             }

--- a/src/System.Private.CoreLib/shared/System/Collections/HashHelpers.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/HashHelpers.cs
@@ -108,7 +108,7 @@ namespace System.Collections
             => ulong.MaxValue / divisor + 1;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe uint FastMod(uint value, uint divisor, ulong multiplier)
+        public static uint FastMod(uint value, uint divisor, ulong multiplier)
         {
             // Using fastmod from Daniel Lemire https://lemire.me/blog/2019/02/08/faster-remainders-when-the-divisor-is-a-constant-beating-compilers-and-libdivide/
 

--- a/src/System.Private.CoreLib/shared/System/Collections/HashHelpers.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/HashHelpers.cs
@@ -89,6 +89,7 @@ namespace System.Collections
             return GetPrime(newSize);
         }
 
+#if BIT64
         public static ulong GetFastModMultiplier(uint divisor)
             => ulong.MaxValue / divisor + 1;
 
@@ -111,5 +112,6 @@ namespace System.Collections
                 return value % divisor;
             }
         }
+#endif
     }
 }


### PR DESCRIPTION
Use fastmod when 128bit multiply is available. (by @lemire https://lemire.me/blog/2019/02/08/faster-remainders-when-the-divisor-is-a-constant-beating-compilers-and-libdivide/)

Api for review dotnet/corefx#41822  to enable 128bit multiply and make it more efficient.

Other half of PR from https://github.com/dotnet/coreclr/pull/27149 (first half was https://github.com/dotnet/coreclr/pull/27195)

```
|                       Method |   Toolchain |      Mean | Ratio |
|----------------------------- |------------ |----------:|------:|
|    TryGetValue_17_Int_Object |        base |  8.427 ns |  1.00 |
|    TryGetValue_17_Int_Object |        diff |  7.070 ns |  0.84 |
|    TryGetValue_3k_Int_Object |        base |  7.611 ns |  1.00 |
|    TryGetValue_3k_Int_Object |        diff |  6.635 ns |  0.87 |
|    TryGetValue_1M_Int_Object |        base |  7.743 ns |  1.00 |
|    TryGetValue_1M_Int_Object |        diff |  6.803 ns |  0.88 |
|                              |             |           |       |
| TryGetValue_17_String_Object |        base | 16.233 ns |  1.00 |
| TryGetValue_17_String_Object |        diff | 14.775 ns |  0.91 |
| TryGetValue_3k_String_Object |        base | 22.777 ns |  1.00 |
| TryGetValue_3k_String_Object |        diff | 21.387 ns |  0.94 |
| TryGetValue_1M_String_Object |        base | 74.274 ns |  1.00 |
| TryGetValue_1M_String_Object |        diff | 72.219 ns |  0.97 |
|                              |             |           |       |
| TryGetValue_17_Object_Object |        base | 17.341 ns |  1.00 |
| TryGetValue_17_Object_Object |        diff | 17.396 ns |  1.01 |
| TryGetValue_3k_Object_Object |        base | 24.407 ns |  1.00 |
| TryGetValue_3k_Object_Object |        diff | 22.979 ns |  0.94 |
| TryGetValue_1M_Object_Object |        base | 96.327 ns |  1.00 |
| TryGetValue_1M_Object_Object |        diff | 88.482 ns |  0.92 |
```
KNucleotide
```
|        Method | Toolchain |     Mean | Ratio |
|-------------- |---------- |---------:|------:|
| KNucleotide_1 |      base | 378.8 ms |  1.00 |
| KNucleotide_1 |      diff | 352.4 ms |  0.93 |
```
/cc @jkotas @AntonLapounov @GrabYourPitchforks @AndyAyersMS @danmosemsft 