### PR TITLE
JIT: fix def tree for CSE locals going into SSA

### DIFF
--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -2381,7 +2381,7 @@ public:
 
                     ssaVarDsc->m_vnPair        = val->gtVNPair;
                     ssaVarDsc->m_defLoc.m_blk  = blk;
-                    ssaVarDsc->m_defLoc.m_tree = asg;
+                    ssaVarDsc->m_defLoc.m_tree = asg->AsOp()->gtOp1;
                 }
 
                 /* Create a reference to the CSE temp */


### PR DESCRIPTION
When putting a new single-def CSE local into SSA, we need to set the def tree
to the LHS of the GT_ASG, not the GT_ASG.