### PR TITLE
Convert Array.IsPrimitiveTypeArray to C#

### DIFF
--- a/src/System.Private.CoreLib/src/System/Buffer.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Buffer.CoreCLR.cs
@@ -20,8 +20,7 @@ namespace System
     {
         // Returns a bool to indicate if the array is of primitive data types
         // or not.
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern bool IsPrimitiveTypeArray(Array array);
+        private static bool IsPrimitiveTypeArray(Array array) => RuntimeHelpers.IsPrimitiveTypeArray(array);
 
         // This method has a slightly different behavior on arm and other platforms.
         // On arm this method behaves like memcpy and does not handle overlapping buffers.

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -232,6 +232,11 @@ namespace System.Runtime.CompilerServices
 
             public bool IsEnum()
             {
+                if (g_pEnumClass == null) // workaround, TODO: port MscorlibBinder.GetClass
+                {
+                    g_pEnumClass = GetObjectMethodTablePointer(WFlagsHighEnum.CategoryArray);
+                }
+
                 return ParentMethodTable == g_pEnumClass;
             }
 
@@ -346,8 +351,8 @@ namespace System.Runtime.CompilerServices
             public static bool IsPrimitiveType_NoThrow(CorElementType type)
             {
                 // TODO: native code has a CorTypeInfoEntry table and this check is more efficient
-                return (type >= CorElementType.ELEMENT_TYPE_BOOLEAN && type <= CorElementType.ELEMENT_TYPE_R8) ||
-                       type == CorElementType.ELEMENT_TYPE_I || type == CorElementType.ELEMENT_TYPE_U;
+                return (type >= CorElementType.ELEMENT_TYPE_VOID && type <= CorElementType.ELEMENT_TYPE_R8) ||
+                        type == CorElementType.ELEMENT_TYPE_I || type == CorElementType.ELEMENT_TYPE_U;
             }
         }
 
@@ -357,13 +362,6 @@ namespace System.Runtime.CompilerServices
             TypeHandle elementTh = GetObjectMethodTablePointer(array)->GetArrayElementTypeHandle();
             CorElementType elementEt = elementTh.GetVerifierCorElementType();
             return CorTypeInfo.IsPrimitiveType_NoThrow(elementEt);
-        }
-
-        // Returns a bool to indicate if the array is of primitive types or not.
-        public static unsafe byte MyTest(Array array)
-        {
-            TypeHandle elementTh = GetObjectMethodTablePointer(array)->GetArrayElementTypeHandle();
-            return (byte)elementTh.GetVerifierCorElementType();
         }
 
         // Given an object reference, returns its MethodTable* as an IntPtr.


### PR DESCRIPTION
Another baby steps towards https://github.com/dotnet/coreclr/issues/18111 (along with https://github.com/dotnet/coreclr/pull/27216)

Ported line by line C++ to C# for these structs (missing some debug asserts, `#if FEATURE_PREJIT` parts and I don't know to to set `g_pEnumClass` global in order to test if a type is an enum, also I am not sure in the pointer arithmetic e.g. when I do `addr -2`).

@jkotas I was just learning CoreCLR internals, let me know if it worth continuing or feel free to take over.

But it already works for me, e.g. I can obtain a correct `CorElementType` for any Array I tried.