### PR TITLE
src/pal/src/cruntime/wchar.cpp: remove redundant condition

### DIFF
--- a/src/pal/src/cruntime/wchar.cpp
+++ b/src/pal/src/cruntime/wchar.cpp
@@ -638,7 +638,7 @@ PAL_wcschr(
     {
         if (*string == c)
         {
-            LOGEXIT("wcschr returning wchar_t %p (%S)\n", string?string:W16_NULLSTRING, string?string:W16_NULLSTRING);
+            LOGEXIT("wcschr returning wchar_t %p (%S)\n", string, string);
             PERF_EXIT(wcschr);
             return (wchar_16 *) string;
         }
@@ -709,7 +709,7 @@ PAL_wcspbrk(
     {
         if (PAL_wcschr(strCharSet, *string) != NULL)
         {
-            LOGEXIT("wcspbrk returning wchar_t %p (%S)\n", string?string:W16_NULLSTRING, string?string:W16_NULLSTRING);
+            LOGEXIT("wcspbrk returning wchar_t %p (%S)\n", string, string);
             PERF_EXIT(wcspbrk);
             return (wchar_16 *) string;
         }


### PR DESCRIPTION
found by cppcheck

"while (*string)" already checks "string" against NULL

[src/pal/src/cruntime/wchar.cpp:641] -> [src/pal/src/cruntime/wchar.cpp:639]: (warning) Either the condition 'string?string:W16_NULLSTRING' is redundant or there is possible null pointer dereference: string.
[src/pal/src/cruntime/wchar.cpp:712] -> [src/pal/src/cruntime/wchar.cpp:710]: (warning) Either the condition 'string?string:W16_NULLSTRING' is redundant or there is possible null pointer dereference: string.