### PR TITLE
Avoid unintended cached var in CMake's find_program

### DIFF
--- a/configuretools.cmake
+++ b/configuretools.cmake
@@ -10,15 +10,16 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   else()
     set(LLVM_PREFIX "llvm-")
   endif()
+
   function(locate_llvm_exec exec var)
-    find_program(EXEC_LOCATION
+    find_program(EXEC_LOCATION_${exec}
      NAMES
      "${LLVM_PREFIX}${exec}${CLR_CMAKE_COMPILER_FILE_NAME_VERSION}"
      "${LLVM_PREFIX}${exec}")
-    if (EXEC_LOCATION STREQUAL "EXEC_LOCATION-NOTFOUND")
+    if (EXEC_LOCATION_${exec} STREQUAL "EXEC_LOCATION_${exec}-NOTFOUND")
       message(FATAL_ERROR "Unable to find llvm tool for: ${exec}.")
     endif()
-    set(${var} ${EXEC_LOCATION} PARENT_SCOPE)
+    set(${var} ${EXEC_LOCATION_${exec}} PARENT_SCOPE)
   endfunction()
   locate_llvm_exec(ar CMAKE_AR)
   locate_llvm_exec(link CMAKE_LINKER)
@@ -34,20 +35,20 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   endif()
 
   function(locate_gcc_exec exec var)
-    string(TOUPPER exec EXEC_UPPERCASE)
+    string(TOUPPER ${exec} EXEC_UPPERCASE)
     if(NOT "$ENV{CLR_${EXEC_UPPERCASE}}" STREQUAL "")
       set(${var} "$ENV{CLR_${EXEC_UPPERCASE}}" PARENT_SCOPE)
       return()
     endif()
 
-    find_program(EXEC_LOCATION
+    find_program(EXEC_LOCATION_${exec}
       NAMES
       "${GCC_PREFIX}${exec}${CLR_CMAKE_COMPILER_FILE_NAME_VERSION}"
       "${GCC_PREFIX}${exec}")
-    if (EXEC_LOCATION STREQUAL "EXEC_LOCATION-NOTFOUND")
+    if (EXEC_LOCATION_${exec} STREQUAL "EXEC_LOCATION_${exec}-NOTFOUND")
       message(FATAL_ERROR "Unable to find gcc tool for: ${exec}.")
     endif()
-    set(${var} ${EXEC_LOCATION} PARENT_SCOPE)
+    set(${var} ${EXEC_LOCATION_${exec}} PARENT_SCOPE)
   endfunction()
   locate_gcc_exec(ar CMAKE_AR)
   locate_gcc_exec(link CMAKE_LINKER)

--- a/src/pal/tools/find-gcc.sh
+++ b/src/pal/tools/find-gcc.sh
@@ -6,7 +6,7 @@
 if [ $# -lt 2 ]
 then
   echo "Usage..."
-  echo "gen-buildsys-gcc.sh <GccMajorVersion> <GccMinorVersion>"
+  echo "find-gcc.sh <GccMajorVersion> <GccMinorVersion>"
   echo "Specify the Gcc version to use, split into major and minor version"
   exit 1
 fi


### PR DESCRIPTION
* Use unique name of variable passed to `find program`:
  `EXEC_LOCATION` is a cached variable as per `find_program` documentation; what is not too obvious in documentation is  that even if it is wrapped in a function, the next function call will blindly skip the introspection (ignoring the fact that we have different values in the `NAMES` list). Consequently, all tools were (incorrectly) getting the value `/usr/bin/llvm-ar` in case of clang or `/usr/bin/ar` in gcc's case.
  * To debug, I used:
    ```sh
    message(FATAL_ERROR "\n>>>  AR: ${CMAKE_AR}\nLINK: ${CMAKE_LINKER}\nOBJDUMP: ${CMAKE_OBJDUMP}\nRANLIB: ${CMAKE_RANLIB}   <<<")`
    ```
    at the end of both clang and gcc case.
* Fix environment variable override knob for gcc: `exec` -> `${exec}`.
* Fix help message in find-gcc.sh.

Followup on https://github.com/dotnet/coreclr/pull/27077.

The other option is to `unset(EXEC_LOCATION CACHE)` at the start of function, which seems less intuitive.

/cc @jkoritzinsky