### PR TITLE
JIT: Improve constant folding for bitwise OR

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -12508,7 +12508,7 @@ DONE_MORPHING_CHILDREN:
                 /* Fold "((x+icon1)+(y+icon2)) to ((x+y)+(icon1+icon2))" same for bitwise OR */
 
                 if (op1->OperIs(op2->OperGet()) && op1->OperIs(oper) && !gtIsActiveCSE_Candidate(op2) &&
-                    op1->AsOp()->gtOp2->gtOper == GT_CNS_INT && op2->AsOp()->gtOp2->gtOper == GT_CNS_INT)
+                    op1->AsOp()->gtGetOp2()->IsCnsIntOrI() && op2->AsOp()->gtGetOp2()->IsCnsIntOrI())
                 {
                     // Don't create a byref pointer that may point outside of the ref object.
                     // If a GC happens, the byref won't get updated. This can happen if one
@@ -12525,11 +12525,11 @@ DONE_MORPHING_CHILDREN:
                             {
                                 break;
                             }
-                            cns1->AsIntCon()->gtIconVal += cns2->AsIntCon()->gtIconVal;
+                            cns1->AsIntCon()->SetIconValue(cns1->AsIntCon()->IconValue() + cns2->AsIntCon()->IconValue());
                         }
                         else
                         {
-                            cns1->AsIntCon()->gtIconVal |= cns2->AsIntCon()->gtIconVal;
+                            cns1->AsIntCon()->SetIconValue(cns1->AsIntCon()->IconValue() | cns2->AsIntCon()->IconValue());
                         }
 #ifdef _TARGET_64BIT_
                         if (cns1->TypeGet() == TYP_INT)
@@ -12555,13 +12555,12 @@ DONE_MORPHING_CHILDREN:
 
                     if (op1->OperIs(oper) &&                                 //
                         !gtIsActiveCSE_Candidate(op1) &&                     //
-                        op1->AsOp()->gtOp2->IsCnsIntOrI() &&                 //
-                        (op1->AsOp()->gtOp2->OperGet() == op2->OperGet()) && //
-                        (op1->AsOp()->gtOp2->TypeGet() != TYP_REF) &&        // Don't fold REFs
+                        op1->AsOp()->gtGetOp2()->IsCnsIntOrI() &&                 //
+                        (op1->AsOp()->gtGetOp2()->OperGet() == op2->OperGet()) && //
+                        (op1->AsOp()->gtGetOp2()->TypeGet() != TYP_REF) &&        // Don't fold REFs
                         (op2->TypeGet() != TYP_REF))                         // Don't fold REFs
                     {
-                        cns1 = op1->AsOp()->gtOp2;
-
+                        cns1          = op1->AsOp()->gtGetOp2();
                         ssize_t icon1 = cns1->AsIntConCommon()->IconValue();
                         ssize_t icon2 = op2->AsIntConCommon()->IconValue();
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -12514,7 +12514,8 @@ DONE_MORPHING_CHILDREN:
                     // If a GC happens, the byref won't get updated. This can happen if one
                     // of the int components is negative. It also requires the address generation
                     // be in a fully-interruptible code region.
-                    if (!varTypeIsGC(op1->AsOp()->gtGetOp1()->TypeGet()) && !varTypeIsGC(op2->AsOp()->gtGetOp1()->TypeGet()))
+                    if (!varTypeIsGC(op1->AsOp()->gtGetOp1()->TypeGet()) &&
+                        !varTypeIsGC(op2->AsOp()->gtGetOp1()->TypeGet()))
                     {
                         cns1          = op1->AsOp()->gtGetOp2();
                         cns2          = op2->AsOp()->gtGetOp2();
@@ -12552,15 +12553,15 @@ DONE_MORPHING_CHILDREN:
 
                 if (op2->IsCnsIntOrI() && varTypeIsIntegralOrI(typ))
                 {
-                    /* Fold "((x+icon1)+icon2) to (x+(icon1+icon2))" same for bitwise OR*/
+                    /* Fold "((x+icon1)+icon2) to (x+(icon1+icon2))" same for bitwise OR */
                     CLANG_FORMAT_COMMENT_ANCHOR;
 
-                    if (op1->OperIs(oper) &&                                 //
-                        !gtIsActiveCSE_Candidate(op1) &&                     //
+                    if (op1->OperIs(oper) &&                                      //
+                        !gtIsActiveCSE_Candidate(op1) &&                          //
                         op1->AsOp()->gtGetOp2()->IsCnsIntOrI() &&                 //
                         (op1->AsOp()->gtGetOp2()->OperGet() == op2->OperGet()) && //
                         (op1->AsOp()->gtGetOp2()->TypeGet() != TYP_REF) &&        // Don't fold REFs
-                        (op2->TypeGet() != TYP_REF))                         // Don't fold REFs
+                        (op2->TypeGet() != TYP_REF))                              // Don't fold REFs
                     {
                         cns1          = op1->AsOp()->gtGetOp2();
                         ssize_t icon1 = cns1->AsIntConCommon()->IconValue();

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -12761,7 +12761,7 @@ DONE_MORPHING_CHILDREN:
                     goto DONE_MORPHING_CHILDREN;
                 }
             }
-            else if (fgOperIsBitwiseRotationRoot(oper))
+            if (fgOperIsBitwiseRotationRoot(oper))
             {
                 tree = fgRecognizeAndMorphBitwiseRotation(tree);
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -12514,10 +12514,12 @@ DONE_MORPHING_CHILDREN:
                     // If a GC happens, the byref won't get updated. This can happen if one
                     // of the int components is negative. It also requires the address generation
                     // be in a fully-interruptible code region.
-                    if (!varTypeIsGC(op1->AsOp()->gtOp1->TypeGet()) && !varTypeIsGC(op2->AsOp()->gtOp1->TypeGet()))
+                    if (!varTypeIsGC(op1->AsOp()->gtGetOp1()->TypeGet()) && !varTypeIsGC(op2->AsOp()->gtGetOp1()->TypeGet()))
                     {
-                        cns1 = op1->AsOp()->gtOp2;
-                        cns2 = op2->AsOp()->gtOp2;
+                        cns1          = op1->AsOp()->gtGetOp2();
+                        cns2          = op2->AsOp()->gtGetOp2();
+                        ssize_t icon1 = cns1->AsIntCon()->IconValue();
+                        ssize_t icon2 = cns2->AsIntCon()->IconValue();
 
                         if (oper == GT_ADD)
                         {
@@ -12525,11 +12527,11 @@ DONE_MORPHING_CHILDREN:
                             {
                                 break;
                             }
-                            cns1->AsIntCon()->SetIconValue(cns1->AsIntCon()->IconValue() + cns2->AsIntCon()->IconValue());
+                            cns1->AsIntCon()->SetIconValue(icon1 + icon2);
                         }
                         else
                         {
-                            cns1->AsIntCon()->SetIconValue(cns1->AsIntCon()->IconValue() | cns2->AsIntCon()->IconValue());
+                            cns1->AsIntCon()->SetIconValue(icon1 | icon2);
                         }
 #ifdef _TARGET_64BIT_
                         if (cns1->TypeGet() == TYP_INT)


### PR DESCRIPTION
This PR re-uses GT_ADD constant folding logic for GT_OR in morph.cpp.
Example:
```csharp
int Test1(int x) => x | 5 | 3; // e.g. enum flags

int Test2(int x, int y) => (x | 5) | (y | 3);
```
Was:
```asm
; Test1(int,int):int:this
       mov      eax, edx
       or       eax, 5
       or       eax, 3
       ret      
; Total bytes of code: 9


; Test2(int,int):int:this
       or       edx, 5
       mov      eax, edx
       or       eax, r8d
       or       eax, 3
       ret      
; Total bytes of code: 12
```
Now:
```asm
; Test1(int,int):int:this
       mov      eax, edx
       or       eax, 7
       ret      
; Total bytes of code: 6


; Test2(int,int):int:this
       mov      eax, edx
       or       eax, r8d
       or       eax, 7
       ret      
; Total bytes of code: 9
```

Jit-diff:
```
Found 8 files with textual diffs.

Summary:
(Lower is better)

Total bytes of diff: -148 (-0.00% of base)
    diff is an improvement.

Top file improvements by size (bytes):
         -59 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.00% of base)
         -54 : Microsoft.CodeAnalysis.CSharp.dasm (-0.00% of base)
         -16 : System.Memory.dasm (-0.00% of base)
          -7 : System.Private.Uri.dasm (-0.01% of base)
          -5 : System.Private.Xml.dasm (-0.00% of base)
          -4 : System.Net.Security.dasm (-0.00% of base)
          -3 : System.Data.Common.dasm (-0.00% of base)

7 total files with size differences (7 improved, 0 regressed), 122 unchanged.

Top method improvements by size (bytes):
         -28 (-6.81% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.SourceEventSymbol:BindEventAccessor(ref,ref):ref:this
         -14 (-0.89% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.MemberSemanticModel:GetEnclosingBinder(ref,int):ref:this
          -8 (-0.82% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - ConversionEasyOut:ClassifyPredefinedConversion(ref,ref):struct
          -7 (-1.42% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Binder:BindTypeOf(ref,ref):ref:this
          -7 (-0.30% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.SourceMethodSymbol:CreateDeclareMethod(ref,ref,ref,ref):ref
          -7 (-9.86% of base) : System.Private.Uri.dasm - BuiltInUriParser:.ctor(ref,int,int):this
          -6 (-0.16% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.OverloadResolution:GetEnumOperation(int,ref,ref,ref,ref):this
          -6 (-7.89% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.TypeofBinder:.ctor(ref,ref):this
          -6 (-2.03% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.CSharpSemanticModel:GetSpeculativeBinder(int,ref,int):ref:this
          -6 (-0.23% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.SourcePropertySymbol:Create(ref,ref,ref,ref,ref):ref
          -6 (-1.23% of base) : System.Memory.dasm - System.Buffers.Text.Base64:EncodeToUtf8InPlace(struct,int,byref):int
          -5 (-0.40% of base) : System.Memory.dasm - System.Buffers.Text.Base64:EncodeToUtf8(struct,struct,byref,byref,bool):int
          -5 (-12.20% of base) : System.Memory.dasm - System.Buffers.Text.Base64:EncodeAndPadTwo(long,byref):int
          -5 (-0.32% of base) : System.Private.Xml.dasm - System.Xml.Serialization.XmlSerializationILGen:GenerateSerializerContract(ref,ref,ref,ref,ref,ref,ref,ref):this
          -4 (-0.43% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - MemberLookup:LookupInModules(ref,ref,ref,int,int,ref,byref)

Top method improvements by size (percentage):
          -5 (-12.20% of base) : System.Memory.dasm - System.Buffers.Text.Base64:EncodeAndPadTwo(long,byref):int
          -7 (-9.86% of base) : System.Private.Uri.dasm - BuiltInUriParser:.ctor(ref,int,int):this
          -6 (-7.89% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.TypeofBinder:.ctor(ref,ref):this
          -3 (-7.69% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.WithTypeParametersBinder:CanConsiderTypeParameters(int):bool:this
          -3 (-7.69% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol:AddImpliedModifiers(int,bool,int):int
         -28 (-6.81% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.SourceEventSymbol:BindEventAccessor(ref,ref):ref:this
          -4 (-2.40% of base) : System.Net.Security.dasm - System.Net.Security.SecureChannel:GetAlertMessageFromChain(ref):int
          -6 (-2.03% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.CSharpSemanticModel:GetSpeculativeBinder(int,ref,int):ref:this
          -3 (-2.01% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.SourceMethodSymbol:GetPInvokeAttributes(ref):ushort
          -3 (-1.48% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SourceEventSymbol:MakeModifiers(struct,bool,ref,ref,byref):int:this
          -3 (-1.42% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SourcePropertySymbol:MakeModifiers(struct,bool,bool,ref,ref,byref):int:this
          -7 (-1.42% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Binder:BindTypeOf(ref,ref):ref:this
          -3 (-1.33% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE.PEMethodSymbol:IsParameterlessConstructor():bool:this
          -6 (-1.23% of base) : System.Memory.dasm - System.Buffers.Text.Base64:EncodeToUtf8InPlace(struct,int,byref):int
         -14 (-0.89% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.MemberSemanticModel:GetEnclosingBinder(ref,int):ref:this

24 total methods with size differences (24 improved, 0 regressed), 250171 unchanged.
```