### PR TITLE
Clarify inner exception and aggregate exception ToString()

### DIFF
--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -2227,9 +2227,6 @@
   <data name="Exception_EndOfInnerExceptionStack" xml:space="preserve">
     <value>--- End of inner exception stack trace ---</value>
   </data>
-  <data name="Exception_EndStackTraceFromPreviousThrow" xml:space="preserve">
-    <value>--- End of stack trace from previous location ---</value>
-  </data>
   <data name="Exception_WasThrown" xml:space="preserve">
     <value>Exception of type '{0}' was thrown.</value>
   </data>

--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -812,7 +812,7 @@
     <value>The value "{0}" is not of type "{1}" and cannot be used in this generic collection.</value>
   </data>
   <data name="Argument_AbsolutePathRequired" xml:space="preserve">
-    <value>Absolute path information is required.</value>
+    <value>Path "{0}" is not an absolute path.</value>
   </data>
   <data name="Argument_AddingDuplicate" xml:space="preserve">
     <value>An item with the same key has already been added.</value>

--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -159,10 +159,6 @@
   <data name="AggregateException_DeserializationFailure" xml:space="preserve">
     <value>The serialization stream contains no inner exceptions.</value>
   </data>
-  <data name="AggregateException_InnerException" xml:space="preserve">
-    <value>(Inner Exception #{0}) </value>
-    <comment>This text is prepended to each inner exception description during aggregate exception formatting</comment>
-  </data>
   <data name="AppDomain_AppBaseNotSet" xml:space="preserve">
     <value>The ApplicationBase must be set before retrieving this property.</value>
   </data>
@@ -2223,9 +2219,6 @@
   </data>
   <data name="EventSource_VarArgsParameterMismatch" xml:space="preserve">
     <value>Event {0} was called with a different type as defined (argument "{1}"). This may cause the event to be displayed incorrectly.</value>
-  </data>
-  <data name="Exception_EndOfInnerExceptionStack" xml:space="preserve">
-    <value>--- End of inner exception stack trace ---</value>
   </data>
   <data name="Exception_WasThrown" xml:space="preserve">
     <value>Exception of type '{0}' was thrown.</value>

--- a/src/System.Private.CoreLib/shared/System/AggregateException.cs
+++ b/src/System.Private.CoreLib/shared/System/AggregateException.cs
@@ -438,16 +438,12 @@ namespace System
             StringBuilder text = new StringBuilder();
             text.Append(base.ToString());
 
-            for (int i = 0; i < m_innerExceptions.Count; i++)
+            foreach (Exception ex in m_innerExceptions)
             {
-                if (m_innerExceptions[i] == InnerException)
+                if (object.ReferenceEquals(ex, InnerException))
                     continue; // Already logged in base.ToString()
 
-                text.Append(Environment.NewLineConst + InnerExceptionPrefix);
-                text.AppendFormat(CultureInfo.InvariantCulture, SR.AggregateException_InnerException, i);
-                text.Append(m_innerExceptions[i].ToString());
-                text.Append("<---");
-                text.AppendLine();
+                text.Append(InnerExceptionToString(ex));
             }
 
             return text.ToString();

--- a/src/System.Private.CoreLib/shared/System/BadImageFormatException.cs
+++ b/src/System.Private.CoreLib/shared/System/BadImageFormatException.cs
@@ -95,11 +95,10 @@ namespace System
         {
             string s = GetType().ToString() + ": " + Message;
 
-            if (!string.IsNullOrEmpty(_fileName))
+            if (!string.IsNullOrEmpty(_fileName) && !Message.Contains(_fileName))
                 s += Environment.NewLineConst + SR.Format(SR.IO_FileName_Name, _fileName);
 
-            if (InnerException != null)
-                s += InnerExceptionPrefix + InnerException.ToString();
+            s += InnerExceptionToString(InnerException);
 
             if (StackTrace != null)
                 s += Environment.NewLineConst + StackTrace;

--- a/src/System.Private.CoreLib/shared/System/Diagnostics/StackTrace.cs
+++ b/src/System.Private.CoreLib/shared/System/Diagnostics/StackTrace.cs
@@ -321,13 +321,6 @@ namespace System.Diagnostics
                             sb.AppendFormat(CultureInfo.InvariantCulture, inFileLineNum, fileName, sf.GetFileLineNumber());
                         }
                     }
-
-                    // Skip EDI boundary for async
-                    if (sf.IsLastFrameFromForeignExceptionStackTrace && !isAsync)
-                    {
-                        sb.AppendLine();
-                        sb.Append(SR.Exception_EndStackTraceFromPreviousThrow);
-                    }
                 }
             }
 

--- a/src/System.Private.CoreLib/shared/System/Exception.cs
+++ b/src/System.Private.CoreLib/shared/System/Exception.cs
@@ -138,14 +138,14 @@ namespace System
             return s;
         }
 
-        // Returns the indented inner exception's ToString() prefixed with a newline.
+        // Returns the indented inner exception's ToString() prefixed, but not suffixed, with a newline.
         // If there is no inner exception, returns empty string.
         private protected string InnerExceptionToString(Exception? inner)
         {
             if (inner == null)
                 return "";
 
-            /* Format something like this to clearly separate from the containin exception
+            /* Format something like this to clearly separate from the containing exception
              ________________________________________________________________________________________________
             |_1.Interop+Crypto+OpenSslCryptographicException: error:25070067:DSO support routines:DSO_load:could not load the shared library
             |   at _1.Program.<>c.<Main>b__0_0() in C:\proj\30\ConsoleApp1\Program.cs:line 31
@@ -153,15 +153,15 @@ namespace System
             \________________________________________________________________________________________________
 
             */
-            const string hundredUnderscores = "________________________________________________________________________________________________" + Environment.NewLineConst;
-            string trimmedInner = inner.ToString().Trim(); // Remove any trailing newline
+            const string nl = Environment.NewLineConst;
+            string hundredUnderscores = new string('_', 100);
 
             var sb = new StringBuilder();
-            sb.Append(Environment.NewLineConst + " ").Append(hundredUnderscores);
-            sb.Append(trimmedInner);
-            sb.Replace("\r\n", "\n", Environment.NewLineConst.Length, sb.Length - Environment.NewLineConst.Length); // Normalize, after the first newline
-            sb.Replace("\n", Environment.NewLineConst + " |", Environment.NewLineConst.Length, sb.Length - Environment.NewLineConst.Length); // Indent each line, after the first
-            sb.Append(Environment.NewLineConst + " \\").Append(hundredUnderscores);
+            sb.Append(nl + " ").Append(hundredUnderscores).Append(nl);
+            sb.Append(inner.ToString().Trim()); // Remove any trailing newline
+            sb.Replace("\r\n", "\n", nl.Length, sb.Length - nl.Length); // Normalize newlines except the first
+            sb.Replace("\n", nl + " |", nl.Length, sb.Length - nl.Length); // Indent each line, after the first
+            sb.Append(nl + " \\").Append(hundredUnderscores);
 
             return sb.ToString();
         }

--- a/src/System.Private.CoreLib/shared/System/Exception.cs
+++ b/src/System.Private.CoreLib/shared/System/Exception.cs
@@ -145,11 +145,25 @@ namespace System
             if (inner == null)
                 return "";
 
-            var sb = new StringBuilder(inner.ToString());
-            sb.Replace("\r\n", "\n");
-            sb.Replace("\n", Environment.NewLineConst + "      ");
+            /* Format something like this to clearly separate from the containin exception
+             ________________________________________________________________________________________________
+            |_1.Interop+Crypto+OpenSslCryptographicException: error:25070067:DSO support routines:DSO_load:could not load the shared library
+            |   at _1.Program.<>c.<Main>b__0_0() in C:\proj\30\ConsoleApp1\Program.cs:line 31
+            |   at _1.Program.Wrap(Action cb) in C:\proj\30\ConsoleApp1\Program.cs:line 61
+            \________________________________________________________________________________________________
 
-            return Environment.NewLineConst + " ---> " + sb.ToString();
+            */
+            const string hundredUnderscores = "________________________________________________________________________________________________" + Environment.NewLineConst;
+            string trimmedInner = inner.ToString().Trim(); // Remove any trailing newline
+
+            var sb = new StringBuilder();
+            sb.Append(Environment.NewLineConst + " ").Append(hundredUnderscores);
+            sb.Append(trimmedInner);
+            sb.Replace("\r\n", "\n", Environment.NewLineConst.Length, sb.Length - Environment.NewLineConst.Length); // Normalize, after the first newline
+            sb.Replace("\n", Environment.NewLineConst + " |", Environment.NewLineConst.Length, sb.Length - Environment.NewLineConst.Length); // Indent each line, after the first
+            sb.Append(Environment.NewLineConst + " \\").Append(hundredUnderscores);
+
+            return sb.ToString();
         }
 
         protected event EventHandler<SafeSerializationEventArgs>? SerializeObjectState

--- a/src/System.Private.CoreLib/shared/System/Exception.cs
+++ b/src/System.Private.CoreLib/shared/System/Exception.cs
@@ -5,6 +5,7 @@
 using System.Collections;
 using System.Diagnostics;
 using System.Runtime.Serialization;
+using System.Text;
 
 namespace System
 {
@@ -12,8 +13,6 @@ namespace System
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public partial class Exception : ISerializable
     {
-        private protected const string InnerExceptionPrefix = " ---> ";
-
         public Exception()
         {
             _HResult = HResults.COR_E_EXCEPTION;
@@ -128,10 +127,7 @@ namespace System
                 s += ": " + message;
             }
 
-            if (_innerException != null)
-            {
-                s += Environment.NewLineConst + InnerExceptionPrefix + _innerException.ToString() + Environment.NewLineConst + "   " + SR.Exception_EndOfInnerExceptionStack;
-            }
+            s += InnerExceptionToString(InnerException);
 
             string? stackTrace = StackTrace;
             if (stackTrace != null)
@@ -140,6 +136,20 @@ namespace System
             }
 
             return s;
+        }
+
+        // Returns the indented inner exception's ToString() prefixed with a newline.
+        // If there is no inner exception, returns empty string.
+        private protected string InnerExceptionToString(Exception? inner)
+        {
+            if (inner == null)
+                return "";
+
+            var sb = new StringBuilder(inner.ToString());
+            sb.Replace("\r\n", "\n");
+            sb.Replace("\n", Environment.NewLineConst + "      ");
+
+            return Environment.NewLineConst + " ---> " + sb.ToString();
         }
 
         protected event EventHandler<SafeSerializationEventArgs>? SerializeObjectState

--- a/src/System.Private.CoreLib/shared/System/IO/FileLoadException.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileLoadException.cs
@@ -50,11 +50,10 @@ namespace System.IO
         {
             string s = GetType().ToString() + ": " + Message;
 
-            if (!string.IsNullOrEmpty(FileName))
+            if (!string.IsNullOrEmpty(FileName) && !Message.Contains(FileName))
                 s += Environment.NewLineConst + SR.Format(SR.IO_FileName_Name, FileName);
 
-            if (InnerException != null)
-                s += Environment.NewLineConst + InnerExceptionPrefix + InnerException.ToString();
+            s += InnerExceptionToString(InnerException);
 
             if (StackTrace != null)
                 s += Environment.NewLineConst + StackTrace;

--- a/src/System.Private.CoreLib/shared/System/IO/FileNotFoundException.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileNotFoundException.cs
@@ -73,11 +73,10 @@ namespace System.IO
         {
             string s = GetType().ToString() + ": " + Message;
 
-            if (!string.IsNullOrEmpty(FileName))
+            if (!string.IsNullOrEmpty(FileName) && !Message.Contains(FileName))
                 s += Environment.NewLineConst + SR.Format(SR.IO_FileName_Name, FileName);
 
-            if (InnerException != null)
-                s += Environment.NewLineConst + InnerExceptionPrefix + InnerException.ToString();
+            s += InnerExceptionToString(InnerException);
 
             if (StackTrace != null)
                 s += Environment.NewLineConst + StackTrace;

--- a/src/System.Private.CoreLib/shared/System/Reflection/Assembly.cs
+++ b/src/System.Private.CoreLib/shared/System/Reflection/Assembly.cs
@@ -227,7 +227,7 @@ namespace System.Reflection
 
             if (PathInternal.IsPartiallyQualified(path))
             {
-                throw new ArgumentException(SR.Argument_AbsolutePathRequired, nameof(path));
+                throw new ArgumentException(SR.Format(SR.Argument_AbsolutePathRequired, path), nameof(path));
             }
 
             string normalizedPath = Path.GetFullPath(path);

--- a/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/COMException.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/COMException.cs
@@ -58,11 +58,7 @@ namespace System.Runtime.InteropServices
                 s.Append(": ").Append(message);
             }
 
-            Exception? innerException = InnerException;
-            if (innerException != null)
-            {
-                s.Append(Environment.NewLineConst + InnerExceptionPrefix).Append(innerException.ToString());
-            }
+            s.Append(InnerExceptionToString(InnerException));
 
             string? stackTrace = StackTrace;
             if (stackTrace != null)

--- a/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/ExternalException.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/InteropServices/ExternalException.cs
@@ -66,11 +66,7 @@ namespace System.Runtime.InteropServices
                 s += ": " + message;
             }
 
-            Exception? innerException = InnerException;
-            if (innerException != null)
-            {
-                s += Environment.NewLineConst + InnerExceptionPrefix + innerException.ToString();
-            }
+            s += InnerExceptionToString(InnerException);
 
             if (StackTrace != null)
                 s += Environment.NewLineConst + StackTrace;

--- a/src/System.Private.CoreLib/shared/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/System.Private.CoreLib/shared/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -299,7 +299,7 @@ namespace System.Runtime.Loader
 
             if (PathInternal.IsPartiallyQualified(assemblyPath))
             {
-                throw new ArgumentException(SR.Argument_AbsolutePathRequired, nameof(assemblyPath));
+                throw new ArgumentException(SR.Format(SR.Argument_AbsolutePathRequired, assemblyPath), nameof(assemblyPath));
             }
 
             lock (_unloadLock)
@@ -319,12 +319,12 @@ namespace System.Runtime.Loader
 
             if (PathInternal.IsPartiallyQualified(nativeImagePath))
             {
-                throw new ArgumentException(SR.Argument_AbsolutePathRequired, nameof(nativeImagePath));
+                throw new ArgumentException(SR.Format(SR.Argument_AbsolutePathRequired, nativeImagePath), nameof(nativeImagePath));
             }
 
             if (assemblyPath != null && PathInternal.IsPartiallyQualified(assemblyPath))
             {
-                throw new ArgumentException(SR.Argument_AbsolutePathRequired, nameof(assemblyPath));
+                throw new ArgumentException(SR.Format(SR.Argument_AbsolutePathRequired, assemblyPath), nameof(assemblyPath));
             }
 
             lock (_unloadLock)
@@ -394,7 +394,7 @@ namespace System.Runtime.Loader
 
             if (PathInternal.IsPartiallyQualified(unmanagedDllPath))
             {
-                throw new ArgumentException(SR.Argument_AbsolutePathRequired, nameof(unmanagedDllPath));
+                throw new ArgumentException(SR.Format(SR.Argument_AbsolutePathRequired, unmanagedDllPath), nameof(unmanagedDllPath));
             }
 
             return NativeLibrary.Load(unmanagedDllPath);

--- a/src/System.Private.CoreLib/src/System/Exception.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/Exception.CoreCLR.cs
@@ -443,7 +443,6 @@ namespace System
             // when it's retrieved.
             var sb = new StringBuilder(256);
             new StackTrace(fNeedFileInfo: true).ToString(System.Diagnostics.StackTrace.TraceFormat.TrailingNewLine, sb);
-            sb.AppendLine(SR.Exception_EndStackTraceFromPreviousThrow);
             _remoteStackTraceString = sb.ToString();
         }
     }

--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -3801,7 +3801,7 @@ DomainAssembly* AppDomain::LoadDomainAssembly(AssemblySpec* pSpec,
             {
                 StackSString name;
                 pSpec->GetFileOrDisplayName(0, name);
-                pEx=new EEFileLoadException(name, pEx->GetHR(), NULL, pEx);
+                pEx=new EEFileLoadException(name, pEx->GetHR(), pEx);
                 AddExceptionToCache(pSpec, pEx);
                 PAL_CPP_THROW(Exception *, pEx);
             }

--- a/src/vm/assemblynative.cpp
+++ b/src/vm/assemblynative.cpp
@@ -250,13 +250,13 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
         
         // Need to verify that this is a valid CLR assembly. 
         if (!pILImage->CheckILFormat())
-            ThrowHR(COR_E_BADIMAGEFORMAT, BFA_BAD_IL);
+            ThrowBadFormatWorker(BFA_BAD_IL, pwzILPath);
 
         LoaderAllocator* pLoaderAllocator = NULL;
         if (SUCCEEDED(pBinderContext->GetLoaderAllocator((LPVOID*)&pLoaderAllocator)) && pLoaderAllocator->IsCollectible() && !pILImage->IsILOnly())
         {
             // Loading IJW assemblies into a collectible AssemblyLoadContext is not allowed
-            ThrowHR(COR_E_BADIMAGEFORMAT, BFA_IJW_IN_COLLECTIBLE_ALC);
+            ThrowBadFormatWorker(BFA_IJW_IN_COLLECTIBLE_ALC, pwzILPath);
         }
     }
     
@@ -270,7 +270,7 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
         {
             // ReadyToRun images are treated as IL images by the rest of the system
             if (!pNIImage->CheckILFormat())
-                ThrowHR(COR_E_BADIMAGEFORMAT);
+                ThrowBadFormatWorker(COR_E_BADIMAGEFORMAT, pwzNIPath);
 
             pILImage = pNIImage.Extract();
             pNIImage = NULL;
@@ -278,7 +278,7 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
         else
         {
             if (!pNIImage->CheckNativeFormat())
-                ThrowHR(COR_E_BADIMAGEFORMAT);
+                ThrowBadFormatWorker(COR_E_BADIMAGEFORMAT, pwzNIPath);
         }
     }
 #endif // FEATURE_PREJIT

--- a/src/vm/assemblynative.cpp
+++ b/src/vm/assemblynative.cpp
@@ -250,13 +250,13 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
         
         // Need to verify that this is a valid CLR assembly. 
         if (!pILImage->CheckILFormat())
-            ThrowBadFormatWorker(BFA_BAD_IL, pwzILPath);
+            THROW_BAD_FORMAT(BFA_BAD_IL, &*pILImage);
 
         LoaderAllocator* pLoaderAllocator = NULL;
         if (SUCCEEDED(pBinderContext->GetLoaderAllocator((LPVOID*)&pLoaderAllocator)) && pLoaderAllocator->IsCollectible() && !pILImage->IsILOnly())
         {
             // Loading IJW assemblies into a collectible AssemblyLoadContext is not allowed
-            ThrowBadFormatWorker(BFA_IJW_IN_COLLECTIBLE_ALC, pwzILPath);
+            THROW_BAD_FORMAT(BFA_IJW_IN_COLLECTIBLE_ALC, &*pILImage);
         }
     }
     
@@ -270,7 +270,7 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
         {
             // ReadyToRun images are treated as IL images by the rest of the system
             if (!pNIImage->CheckILFormat())
-                ThrowBadFormatWorker(COR_E_BADIMAGEFORMAT, pwzNIPath);
+                THROW_BAD_FORMAT(COR_E_BADIMAGEFORMAT, &*pNIImage);
 
             pILImage = pNIImage.Extract();
             pNIImage = NULL;
@@ -278,7 +278,7 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
         else
         {
             if (!pNIImage->CheckNativeFormat())
-                ThrowBadFormatWorker(COR_E_BADIMAGEFORMAT, pwzNIPath);
+                THROW_BAD_FORMAT(COR_E_BADIMAGEFORMAT, &*pNIImage);
         }
     }
 #endif // FEATURE_PREJIT

--- a/src/vm/assemblynative.cpp
+++ b/src/vm/assemblynative.cpp
@@ -250,13 +250,13 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
         
         // Need to verify that this is a valid CLR assembly. 
         if (!pILImage->CheckILFormat())
-            THROW_BAD_FORMAT(BFA_BAD_IL, &*pILImage);
+            THROW_BAD_FORMAT(BFA_BAD_IL, pILImage.GetValue());
 
         LoaderAllocator* pLoaderAllocator = NULL;
         if (SUCCEEDED(pBinderContext->GetLoaderAllocator((LPVOID*)&pLoaderAllocator)) && pLoaderAllocator->IsCollectible() && !pILImage->IsILOnly())
         {
             // Loading IJW assemblies into a collectible AssemblyLoadContext is not allowed
-            THROW_BAD_FORMAT(BFA_IJW_IN_COLLECTIBLE_ALC, &*pILImage);
+            THROW_BAD_FORMAT(BFA_IJW_IN_COLLECTIBLE_ALC, pILImage.GetValue());
         }
     }
     
@@ -270,7 +270,7 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
         {
             // ReadyToRun images are treated as IL images by the rest of the system
             if (!pNIImage->CheckILFormat())
-                THROW_BAD_FORMAT(COR_E_BADIMAGEFORMAT, &*pNIImage);
+                THROW_BAD_FORMAT(COR_E_BADIMAGEFORMAT, pNIImage.GetValue());
 
             pILImage = pNIImage.Extract();
             pNIImage = NULL;
@@ -278,7 +278,7 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
         else
         {
             if (!pNIImage->CheckNativeFormat())
-                THROW_BAD_FORMAT(COR_E_BADIMAGEFORMAT, &*pNIImage);
+                THROW_BAD_FORMAT(COR_E_BADIMAGEFORMAT, pNIImage.GetValue());
         }
     }
 #endif // FEATURE_PREJIT

--- a/src/vm/clrex.cpp
+++ b/src/vm/clrex.cpp
@@ -1675,10 +1675,9 @@ OBJECTREF EETypeLoadException::CreateThrowable()
 // EEFileLoadException is an EE exception subclass representing a file loading
 // error
 // ---------------------------------------------------------------------------
-EEFileLoadException::EEFileLoadException(const SString &name, HRESULT hr, void *pFusionLog, Exception *pInnerException/* = NULL*/)
+EEFileLoadException::EEFileLoadException(const SString &name, HRESULT hr, Exception *pInnerException/* = NULL*/)
   : EEException(GetFileLoadKind(hr)),
     m_name(name),
-    m_pFusionLog(pFusionLog),
     m_hr(hr)
 {
     CONTRACTL
@@ -1822,18 +1821,14 @@ OBJECTREF EEFileLoadException::CreateThrowable()
     }
     CONTRACTL_END;
 
-    // Fetch any log info from the fusion log
-    SString logText;
     struct _gc {
         OBJECTREF pNewException;
         STRINGREF pNewFileString;
-        STRINGREF pFusLogString;
     } gc;
     ZeroMemory(&gc, sizeof(gc));
     GCPROTECT_BEGIN(gc);
 
     gc.pNewFileString = StringObject::NewString(m_name);
-    gc.pFusLogString = StringObject::NewString(logText);
     gc.pNewException = AllocateObject(MscorlibBinder::GetException(m_kind));
 
     MethodDesc* pMD = MemberLoader::FindMethod(gc.pNewException->GetMethodTable(),
@@ -1850,7 +1845,7 @@ OBJECTREF EEFileLoadException::CreateThrowable()
     ARG_SLOT args[] = {
         ObjToArgSlot(gc.pNewException),
         ObjToArgSlot(gc.pNewFileString),
-        ObjToArgSlot(gc.pFusLogString),
+        NULL,
         (ARG_SLOT) m_hr
     };
 

--- a/src/vm/clrex.h
+++ b/src/vm/clrex.h
@@ -668,13 +668,11 @@ class EEFileLoadException : public EEException
     
   private:
     SString m_name;
-    void  *m_pFusionLog;
     HRESULT m_hr;       
-                        
 
   public:
 
-    EEFileLoadException(const SString &name, HRESULT hr, void *pFusionLog = NULL,  Exception *pInnerException = NULL);
+    EEFileLoadException(const SString &name, HRESULT hr, Exception *pInnerException = NULL);
     ~EEFileLoadException();
 
     // virtual overrides
@@ -698,12 +696,12 @@ class EEFileLoadException : public EEException
     virtual Exception *CloneHelper()
     {
         WRAPPER_NO_CONTRACT;
-        return new EEFileLoadException(m_name, m_hr, m_pFusionLog);
+        return new EEFileLoadException(m_name, m_hr);
     }
 
  private:
 #ifdef _DEBUG    
-    EEFileLoadException() : m_pFusionLog(NULL)
+    EEFileLoadException()
     {
         // Used only for DebugIsEECxxExceptionPointer to get the vtable pointer.
         // We need a variant which does not allocate memory.

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -12380,19 +12380,24 @@ VOID ThrowBadFormatWorker(UINT resID, LPCWSTR imageName DEBUGARG(__in_z const ch
 #ifndef DACCESS_COMPILE
     SString msgStr;
 
-    if ((imageName != NULL) && (imageName[0] != 0))
-    {
-        msgStr += W("[");
-        msgStr += imageName;
-        msgStr += W("] ");
-    }
-
     SString resStr;
     if (resID == 0 || !resStr.LoadResource(CCompRC::Optional, resID))
     {
-        resStr.LoadResource(CCompRC::Error, MSG_FOR_URT_HR(COR_E_BADIMAGEFORMAT));
+        resStr.LoadResource(CCompRC::Error, MSG_FOR_URT_HR(BFA_BAD_IL)); // "Bad IL format."
     }
     msgStr += resStr;
+
+    if ((imageName != NULL) && (imageName[0] != 0))
+    {
+        SString suffixResStr;
+        if (suffixResStr.LoadResource(CCompRC::Optional, COR_E_BADIMAGEFORMAT)) // "The format of the file '%1' is invalid."
+        {
+            SString suffixMsgStr;
+            suffixMsgStr.FormatMessage(FORMAT_MESSAGE_FROM_STRING, (LPCWSTR)suffixResStr, 0, 0, imageName);
+            msgStr.AppendASCII(" ");
+            msgStr += suffixMsgStr;
+        }
+    }    
 
 #ifdef _DEBUG
     if (0 != strcmp(cond, "FALSE"))


### PR DESCRIPTION
Continuation of the part of https://github.com/dotnet/coreclr/pull/25045 that was deferred from 3.0.

Using this [test program](https://gist.github.com/danmosemsft/e2263748f12a4edf81ef297dbd200c16) - the SSL case is real, albeit the stacks are not --

* [original output](https://gist.github.com/danmosemsft/421d37130f3a2ae36206fa1c8ca5b062)
* [simple indent/arrows](https://gist.github.com/danmosemsft/ae41c57a564ad5bae7699c59c3874d5f)
* [boxes](https://gist.github.com/danmosemsft/70281235ea0f07dce17245d1b3597a2f)
* [compact boxes](https://gist.github.com/danmosemsft/2ffd883ec3d553427d2fc057be8efa16)  (this PR)

It's easiest to open in separate tabs and switch between. I think the boxes make it considerably easier to match up which exception goes with which stack, and which exception is nested inside which other exception. Thoughts? Other suggestions?

Note that the non-aggregate non-nested exception case (top example) is not affected.

BTW also made some minor fixes to pretty some exceptions I noticed as I was doing this
* aae660d (one bad IL message was missing path)
* 7b57069 (non absolute path message was missing path)
* 54336a7 (2 blank lines caused by runtime passing empty string for fusion log: I assume fusion log is not relevant anymore)
* Only append the file name if it's not already in the exception message. It looks like the runtime pretty much always puts it in the message if it's available, in which case text line `File name: 'c:\some\file'` is an unnecessary line.