### PR TITLE
Fix block store local address containment on ARM

### DIFF
--- a/src/jit/lowerarmarch.cpp
+++ b/src/jit/lowerarmarch.cpp
@@ -326,6 +326,20 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
             if (!blkNode->OperIs(GT_STORE_DYN_BLK) && (size <= CPBLK_UNROLL_LIMIT))
             {
                 blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindUnroll;
+
+                if (src->OperIs(GT_IND))
+                {
+                    GenTree* srcAddr = src->AsIndir()->Addr();
+                    if (srcAddr->OperIsLocalAddr())
+                    {
+                        srcAddr->SetContained();
+                    }
+                }
+
+                if (dstAddr->OperIsLocalAddr())
+                {
+                    dstAddr->SetContained();
+                }
             }
             else
             {

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -605,7 +605,6 @@ int LinearScan::BuildBlockStore(GenTreeBlk* blkNode)
         {
             assert(src->isContained());
             srcAddrOrFill = src->AsIndir()->Addr();
-            assert(!srcAddrOrFill->isContained());
         }
 
         if (blkNode->OperIs(GT_STORE_OBJ))
@@ -632,6 +631,7 @@ int LinearScan::BuildBlockStore(GenTreeBlk* blkNode)
             // which is killed by a StoreObj (and thus needn't be reserved).
             if (srcAddrOrFill != nullptr)
             {
+                assert(!srcAddrOrFill->isContained());
                 srcRegMask = RBM_WRITE_BARRIER_SRC_BYREF;
             }
         }
@@ -655,6 +655,7 @@ int LinearScan::BuildBlockStore(GenTreeBlk* blkNode)
                     dstAddrRegMask = RBM_ARG_0;
                     if (srcAddrOrFill != nullptr)
                     {
+                        assert(!srcAddrOrFill->isContained());
                         srcRegMask = RBM_ARG_1;
                     }
                     sizeRegMask = RBM_ARG_2;


### PR DESCRIPTION
Extracted from #21711

When the source/destination address was local, genCodeForCpBlkUnroll was folding the local offset into the address mode of the generated load/store instructions as if the local address was contained. But lowering didn't actually contain the address so useless ADD instructions were still being generated.