### PR TITLE
Fix -gcc flag in bash build scripts.

### DIFF
--- a/build-test.sh
+++ b/build-test.sh
@@ -522,8 +522,8 @@ build_native_projects()
             echo "Invoking \"$scriptDir/find-clang.sh\" $__ClangMajorVersion \"$__ClangMinorVersion\""
             source "$scriptDir/find-clang.sh" $__ClangMajorVersion "$__ClangMinorVersion"
         else
-            echo "Invoking \"$scriptDir/find-gcc.sh\" $__GccMajorVersion \"$__GccMinorVersion\""
-            source "$scriptDir/find-gcc.sh" $__GccMajorVersion "$__GccMinorVersion"
+            echo "Invoking \"$scriptDir/find-gcc.sh\" \"$__GccMajorVersion\" \"$__GccMinorVersion\""
+            source "$scriptDir/find-gcc.sh" "$__GccMajorVersion" "$__GccMinorVersion"
         fi
 
         if [[ -n "$__CodeCoverage" ]]; then

--- a/build.sh
+++ b/build.sh
@@ -268,8 +268,8 @@ build_native()
                 scan_build=scan-build
             fi
         else
-            echo "Invoking \"$scriptDir/find-gcc.sh\" $__GccMajorVersion \"$__GccMinorVersion\""
-            source "$scriptDir/find-gcc.sh" $__GccMajorVersion "$__GccMinorVersion"
+            echo "Invoking \"$scriptDir/find-gcc.sh\" \"$__GccMajorVersion\" \"$__GccMinorVersion\""
+            source "$scriptDir/find-gcc.sh" "$__GccMajorVersion" "$__GccMinorVersion"
         fi
         
         if [[ -n "$__CodeCoverage" ]]; then


### PR DESCRIPTION
Re-enables the -gcc flag that was broken in #27077 

cc: @franksinankaya 