### PR TITLE
remove double bound check from StringBuilder.Append(char)

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
@@ -1152,9 +1152,13 @@ namespace System.Text
 
         public StringBuilder Append(char value)
         {
-            if (m_ChunkLength < m_ChunkChars.Length)
+            int nextCharIndex = m_ChunkLength;
+            char[] chars = m_ChunkChars;
+
+            if ((uint)chars.Length > (uint)nextCharIndex)
             {
-                m_ChunkChars[m_ChunkLength++] = value;
+                chars[nextCharIndex] = value;
+                m_ChunkLength++;
             }
             else
             {


### PR DESCRIPTION
Idea suggested by @EgorBo in a different PR

```cs
[Benchmark]
[Arguments(100)]
[Arguments(100_000)]
public StringBuilder Append_Char(int length)
{
    StringBuilder builder = new StringBuilder();

    for (int i = 0; i < length; i++)
    {
        builder.Append('a');
    }

    return builder;
}

[Benchmark]
[Arguments(100)]
[Arguments(100_000)]
public StringBuilder Append_Char_Capacity(int length)
{
    StringBuilder builder = new StringBuilder(length);

    for (int i = 0; i < length; i++)
    {
        builder.Append('a');
    }

    return builder;
}
```

|               Method |           Toolchain | length |         Mean | Ratio |
|--------------------- |-------------------- |------- |-------------:|------:|
|          Append_Char |  \after\CoreRun.exe |    100 |     329.0 ns |  0.98 |
|          Append_Char | \before\CoreRun.exe |    100 |     335.5 ns |  1.00 |
|                      |                     |        |              |       |
| Append_Char_Capacity |  \after\CoreRun.exe |    100 |     224.5 ns |  0.89 |
| Append_Char_Capacity | \before\CoreRun.exe |    100 |     251.7 ns |  1.00 |
|                      |                     |        |              |       |
|          Append_Char |  \after\CoreRun.exe | 100000 | 235,113.5 ns |  1.00 |
|          Append_Char | \before\CoreRun.exe | 100000 | 235,569.2 ns |  1.00 |
|                      |                     |        |              |       |
| Append_Char_Capacity |  \after\CoreRun.exe | 100000 | 205,619.0 ns |  0.88 |
| Append_Char_Capacity | \before\CoreRun.exe | 100000 | 233,656.2 ns |  1.00 |

Codgen:

![obraz](https://user-images.githubusercontent.com/6011991/67228458-96185100-f439-11e9-8a6d-3e8fa4c860ca.png)


