### PR TITLE
Ensure that all of the calculations for PerfScore are done using doubles

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2298,8 +2298,9 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
 
 #if defined(DEBUG) || defined(LATE_DISASM)
     // Add code size information into the Perf Score
-    compiler->info.compPerfScore += (compiler->info.compTotalHotCodeSize * PERFSCORE_CODESIZE_COST_HOT);
-    compiler->info.compPerfScore += (compiler->info.compTotalColdCodeSize * PERFSCORE_CODESIZE_COST_COLD);
+    // All compPerfScore calculations must be performed using doubles
+    compiler->info.compPerfScore += ((double) compiler->info.compTotalHotCodeSize * (double) PERFSCORE_CODESIZE_COST_HOT);
+    compiler->info.compPerfScore += ((double) compiler->info.compTotalColdCodeSize * (double) PERFSCORE_CODESIZE_COST_COLD);
 #endif // DEBUG || LATE_DISASM
 
 #ifdef DEBUG

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2299,8 +2299,9 @@ void CodeGen::genGenerateCode(void** codePtr, ULONG* nativeSizeOfCode)
 #if defined(DEBUG) || defined(LATE_DISASM)
     // Add code size information into the Perf Score
     // All compPerfScore calculations must be performed using doubles
-    compiler->info.compPerfScore += ((double) compiler->info.compTotalHotCodeSize * (double) PERFSCORE_CODESIZE_COST_HOT);
-    compiler->info.compPerfScore += ((double) compiler->info.compTotalColdCodeSize * (double) PERFSCORE_CODESIZE_COST_COLD);
+    compiler->info.compPerfScore += ((double)compiler->info.compTotalHotCodeSize * (double)PERFSCORE_CODESIZE_COST_HOT);
+    compiler->info.compPerfScore +=
+        ((double)compiler->info.compTotalColdCodeSize * (double)PERFSCORE_CODESIZE_COST_COLD);
 #endif // DEBUG || LATE_DISASM
 
 #ifdef DEBUG

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -3414,7 +3414,8 @@ size_t emitter::emitIssue1Instr(insGroup* ig, instrDesc* id, BYTE** dp)
 
 #if defined(DEBUG) || defined(LATE_DISASM)
     float insExeCost = insEvaluateExecutionCost(id);
-    emitComp->info.compPerfScore += (ig->igWeight / BB_UNITY_WEIGHT) * insExeCost;
+    // All compPerfScore calculations must be performed using doubles
+    emitComp->info.compPerfScore += (double) (ig->igWeight / (double) BB_UNITY_WEIGHT) * insExeCost;
 #endif // defined(DEBUG) || defined(LATE_DISASM)
 
 // printf("[S=%02u]\n", emitCurStackLvl);

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -3415,7 +3415,7 @@ size_t emitter::emitIssue1Instr(insGroup* ig, instrDesc* id, BYTE** dp)
 #if defined(DEBUG) || defined(LATE_DISASM)
     float insExeCost = insEvaluateExecutionCost(id);
     // All compPerfScore calculations must be performed using doubles
-    emitComp->info.compPerfScore += (double) (ig->igWeight / (double) BB_UNITY_WEIGHT) * insExeCost;
+    emitComp->info.compPerfScore += (double)(ig->igWeight / (double)BB_UNITY_WEIGHT) * insExeCost;
 #endif // defined(DEBUG) || defined(LATE_DISASM)
 
 // printf("[S=%02u]\n", emitCurStackLvl);


### PR DESCRIPTION
Added cast to double to fix issue where were using integer divide operation an getting an integer zero.
This caused the PerfScore to be incorrectly calculated for blocks with weights that were fractional.