### PR TITLE
Disable STRESS_MIN_OPTS for ObjectStackAllocationTests.

### DIFF
--- a/tests/src/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.csproj
+++ b/tests/src/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.csproj
@@ -16,7 +16,7 @@ set COMPlus_TieredCompilation=0
 set COMPlus_ProfApi_RejitOnAttach=0
 set COMPlus_JITMinOpts=0
 set COMPlus_JitDebuggable=0
-set COMPlus_JitStressModeNamesNot=STRESS_RANDOM_INLINE
+set COMPlus_JitStressModeNamesNot=STRESS_RANDOM_INLINE,STRESS_MIN_OPTS
 set COMPlus_JitObjectStackAllocation=1
 ]]></CLRTestBatchPreCommands>
     <BashCLRTestPreCommands><![CDATA[
@@ -25,7 +25,7 @@ export COMPlus_TieredCompilation=0
 export COMPlus_ProfApi_RejitOnAttach=0
 export COMPlus_JITMinOpts=0
 export COMPlus_JitDebuggable=0
-export COMPlus_JitStressModeNamesNot=STRESS_RANDOM_INLINE
+export COMPlus_JitStressModeNamesNot=STRESS_RANDOM_INLINE,STRESS_MIN_OPTS
 export COMPlus_JitObjectStackAllocation=1
 ]]></BashCLRTestPreCommands>
   </PropertyGroup>


### PR DESCRIPTION
ObjectStackAllocationTests rely on the object stack allocation
optimization to be running. STRESS_MIN_OPTS  prevents that.