### PR TITLE
Ignore launchSettings.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ syntax: glob
 *.userosscache
 *.sln.docstates
 *.swp
+launchSettings.json
 
 # Build results
 [Dd]ebug/


### PR DESCRIPTION
With crossgen2 now moved into this branch, debugging creates a launchSettings.json for local dev command line / working folder we should ignore.

This is controversial as a default setting for VS (https://github.com/github/gitignore/pull/2705). We are not storing required launch config in any launchSettings.json in this repo so should be fine.