### PR TITLE
[crossgen2] Make sure hardware intrinsic are generated for CoreLib only

### DIFF
--- a/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
+++ b/src/tools/crossgen2/Common/JitInterface/CorInfoImpl.cs
@@ -700,6 +700,12 @@ namespace Internal.JitInterface
             // Check for hardware intrinsics
             if (HardwareIntrinsicHelpers.IsHardwareIntrinsic(method))
             {
+#if READYTORUN
+                if (!isMethodDefinedInCoreLib())
+                {
+                    throw new RequiresRuntimeJitException("This function is not defined in CoreLib and it is using hardware intrinsics.");
+                }
+#endif
 #if !READYTORUN
                 // Do not report the get_IsSupported method as an intrinsic - RyuJIT would expand it to
                 // a constant depending on the code generation flags passed to it, but we would like to


### PR DESCRIPTION
To validate this change, I added this method into `tests/src/readytorun/crossgen2/Program.cs` and run the test as usual before and after the change. Because the function is not defined in CoreLib (and intentionally, the use of the hardware intrinsic is *not* protected under `IsSupported`, the code would have failfast if the running processor does not support the `lzcnt` instruction.

```C#
private static void DoNotExpandHardwareIntrinsics()
{
    uint number = 10086;
    Console.WriteLine(Lzcnt.LeadingZeroCount(number));
}
```

Before the change, the `R2RDump` of the function looks like this:

```
Void Program.DoNotExpandHardwareIntrinsics()
Handle: 0x0600004F
Rid: 79
EntryPointRuntimeFunctionId: 41
Number of RuntimeFunctions: 1

Void Program.DoNotExpandHardwareIntrinsics()
Id: 41
StartAddress: 0x00004D90
Size: 50 bytes
UnwindRVA: 0x000014FC
Version:            1
Flags:              0x03 EHANDLER UHANDLER
SizeOfProlog:       0x0005
CountOfUnwindCodes: 2
FrameRegister:      RAX
FrameOffset:        0x0
PersonalityRVA:     0x3928
UnwindCode[0]: CodeOffset 0x0005 FrameOffset 0x5205 NextOffset 0x-1 Op 48
UnwindCode[1]: CodeOffset 0x0001 FrameOffset 0x5001 NextOffset 0x-1 Op RBP(5)

GC info:
    Version:                           2
    ReturnKind:                        RT_Scalar
    ValidRangeStart:                   0x0000
    ValidRangeEnd:                     0x0000
    SecurityObjectStackSlot:           0xFFFFFFFF
    GSCookieStackSlot:                 0xFFFFFFFF
    PSPSymStackSlot:                   0xFFFFFFFF
    GenericsInstContextStackSlot:      0xFFFFFFFF
    StackBaseRegister:                 5
    SizeOfENCPreservedArea:            0xFFFFFFFF
    ReversePInvokeFrameStackSlot:      0xFFFFFFFF
    SizeOfStackOutgoingAndScratchArea: 0x0020
    NumSafePoints:                     0
    NumInterruptibleRanges:            1
    SafePointOffsets: 0
    InterruptibleRanges: 1
        Index:  0; StartOffset: 0x000F; StopOffset: 0x002C
    SlotTable:
        NumRegisters:  0
        NumStackSlots: 0
        NumUntracked:  0
        NumSlots:      0
        GcSlots:       0

Debug Info
	Bounds:
	Native Offset: 0x0, IL Offset: 0xFFFFFFFE, Source Types: StackEmpty
	Native Offset: 0xF, IL Offset: 0x0, Source Types: StackEmpty
	Native Offset: 0x10, IL Offset: 0x1, Source Types: StackEmpty
	Native Offset: 0x17, IL Offset: 0x7, Source Types: StackEmpty
	Native Offset: 0x21, IL Offset: 0xD, Source Types: SourceTypeInvalid
	Native Offset: 0x24, IL Offset: 0xD, Source Types: CallInstruction
	Native Offset: 0x2A, IL Offset: 0x12, Source Types: StackEmpty
	Native Offset: 0x2B, IL Offset: 0x13, Source Types: StackEmpty
	Native Offset: 0x2C, IL Offset: 0xFFFFFFFD, Source Types: StackEmpty

	Variable Locations:
	Variable Number: 0
	Start Offset: 0xF
	End Offset: 0x2C
	Loc Type: VLT_STK
	Base Register: RBP
	Stack Offset: -4

    4d90: 55                    push rbp
                                UWOP_PUSH_NONVOL RBP(5)
    4d91: 48 83 ec 30           sub rsp, 48
                                UWOP_ALLOC_SMALL 48
    4d95: 48 8d 6c 24 30        lea rbp, [rsp + 48]
    4d9a: 33 c0                 xor eax, eax
    4d9c: 89 45 fc              mov dword ptr [rbp - 4], eax
    4d9f: 90                    nop
    4da0: c7 45 fc 66 27 00 00  mov dword ptr [rbp - 4], 10086
    4da7: 33 c9                 xor ecx, ecx
    4da9: f3 0f bd 4d fc        lzcnt ecx, dword ptr [rbp - 4]
    4dae: 89 4d f8              mov dword ptr [rbp - 8], ecx
    4db1: 8b 4d f8              mov ecx, dword ptr [rbp - 8]
    4db4: ff 15 4e 9d 01 00     call qword ptr [0x1eb08]      // Void System.Console.WriteLine(UInt32) (METHOD_ENTRY_REF_TOKEN)
    4dba: 90                    nop
    4dbb: 90                    nop
    4dbc: 48 8d 65 00           lea rsp, [rbp]
    4dc0: 5d                    pop rbp
    4dc1: c3                    ret
```

I am not checking in the test change right now since there is no way I can validate the generated code in the current test harness.

After the change. the function is no longer compiled, the compiler will output this:
```
...
Info: Method `[crossgen2smoke]Program.DoNotExpandHardwareIntrinsics()` was not compiled because `This function is not defined in CoreLib and it is using hardware intrinsics.` requires runtime JIT
...
```

@dotnet/crossgen-contrib 