### PR TITLE
Fix setting WinRT assembly's fallback binder

### DIFF
--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -5029,8 +5029,7 @@ AppDomain::BindHostedPrivAssembly(
 //---------------------------------------------------------------------------------------------------------------------
 PEAssembly * AppDomain::BindAssemblySpec(
     AssemblySpec *         pSpec, 
-    BOOL                   fThrowOnFileNotFound, 
-    BOOL                   fUseHostBinderIfAvailable)
+    BOOL                   fThrowOnFileNotFound)
 {
     STATIC_CONTRACT_THROWS;
     STATIC_CONTRACT_GC_TRIGGERS;
@@ -5065,7 +5064,7 @@ PEAssembly * AppDomain::BindAssemblySpec(
                 goto EndTry2; // Goto end of try block.
 
             PTR_CLRPrivAssemblyWinRT assem = dac_cast<PTR_CLRPrivAssemblyWinRT>(pAssembly->GetHostAssembly());
-            assem->SetFallbackBinder(pSpec->GetHostBinder());
+            assem->SetFallbackBinder(pSpec->GetFallbackLoadContextBinderForRequestingAssembly());
 EndTry2:;
         }
         // The combination of this conditional catch/ the following if statement which will throw reduces the count of exceptions 

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -2097,8 +2097,7 @@ public:
     // static binding goes through this path.
     virtual PEAssembly * BindAssemblySpec(
         AssemblySpec *pSpec,
-        BOOL fThrowOnFileNotFound,
-        BOOL fUseHostBinderIfAvailable = TRUE) DAC_EMPTY_RET(NULL);
+        BOOL fThrowOnFileNotFound) DAC_EMPTY_RET(NULL);
 
     HRESULT BindAssemblySpecForHostedBinder(
         AssemblySpec *   pSpec, 

--- a/src/vm/assemblyspec.cpp
+++ b/src/vm/assemblyspec.cpp
@@ -908,14 +908,6 @@ DomainAssembly *AssemblySpec::LoadDomainAssembly(FileLoadLevel targetLevel,
 
     ETWOnStartup (LoaderCatchCall_V1, LoaderCatchCallEnd_V1);
     AppDomain* pDomain = GetAppDomain();
-    
-    ICLRPrivBinder* pBinder = GetHostBinder();
-    
-    // If no binder was explicitly set, check if parent assembly has a binder.
-    if (pBinder == nullptr)
-    {
-        pBinder = GetBindingContextFromParentAssembly(pDomain);
-    }
 
     DomainAssembly* pAssembly = nullptr;
     if (CanUseWithBindingCache())
@@ -1494,8 +1486,6 @@ BOOL AssemblySpecBindingCache::StoreAssembly(AssemblySpec *pSpec, DomainAssembly
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        // Host binder based assembly spec's cannot currently be safely inserted into caches.
-        PRECONDITION(pSpec->GetHostBinder() == nullptr);
         POSTCONDITION(UnsafeContains(this, pSpec));
         POSTCONDITION(UnsafeVerifyLookupAssembly(this, pSpec, pAssembly));
         INJECT_FAULT(COMPlusThrowOM(););
@@ -1582,8 +1572,6 @@ BOOL AssemblySpecBindingCache::StoreFile(AssemblySpec *pSpec, PEAssembly *pFile)
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        // Host binder based assembly spec's cannot currently be safely inserted into caches.
-        PRECONDITION(pSpec->GetHostBinder() == nullptr);
         POSTCONDITION((!RETVAL) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupFile(this, pSpec, pFile)));
         INJECT_FAULT(COMPlusThrowOM(););
     }
@@ -1672,8 +1660,6 @@ BOOL AssemblySpecBindingCache::StoreException(AssemblySpec *pSpec, Exception* pE
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        // Host binder based assembly spec's cannot currently be safely inserted into caches.
-        PRECONDITION(pSpec->GetHostBinder() == nullptr);
         DISABLED(POSTCONDITION(UnsafeContains(this, pSpec))); //<TODO>@todo: Getting violations here - StoreExceptions could happen anywhere so this is possibly too aggressive.</TODO>
         INJECT_FAULT(COMPlusThrowOM(););
     }

--- a/src/vm/assemblyspec.hpp
+++ b/src/vm/assemblyspec.hpp
@@ -281,19 +281,6 @@ class AssemblySpec  : public BaseAssemblySpec
         STATIC_CONTRACT_LIMITED_METHOD;
         return HasUniqueIdentity(); 
     }
-
-    inline ICLRPrivBinder *GetHostBinder() const
-    {
-        LIMITED_METHOD_CONTRACT;
-        return m_pHostBinder;
-    }
-
-    inline void SetHostBinder(ICLRPrivBinder *pHostBinder)
-    {
-        LIMITED_METHOD_CONTRACT;
-        m_pHostBinder = pHostBinder;
-    }
-
 };
 
 #define INITIAL_ASM_SPEC_HASH_SIZE 7

--- a/src/vm/baseassemblyspec.h
+++ b/src/vm/baseassemblyspec.h
@@ -29,7 +29,6 @@ protected:
     LPCWSTR                     m_wszCodeBase;         // URL to the code
     LPCSTR                      m_szWinRtTypeNamespace;
     LPCSTR                      m_szWinRtTypeClassName;
-    ICLRPrivBinder             *m_pHostBinder;
     int                         m_ownedFlags;
     ICLRPrivBinder             *m_pBindingContext;
 

--- a/src/vm/baseassemblyspec.inl
+++ b/src/vm/baseassemblyspec.inl
@@ -256,8 +256,6 @@ inline void BaseAssemblySpec::CopyFrom(const BaseAssemblySpec *pSpec)
     
     m_context = pSpec->m_context;
 
-    m_pHostBinder = pSpec->m_pHostBinder;
-
     if ((pSpec->m_ownedFlags & BAD_NAME_OWNED) != 0)
     {
         m_ownedFlags |= BAD_NAME_OWNED;

--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -317,7 +317,7 @@ HRESULT CEECompileInfo::LoadAssemblyByPath(
             // If there is a host binder then use it to bind the assembly.
             if (isWinRT)
             {
-                pAssemblyHolder = pDomain->BindAssemblySpec(&spec, TRUE, FALSE);
+                pAssemblyHolder = pDomain->BindAssemblySpec(&spec, TRUE);
             }
             else
             {
@@ -531,7 +531,7 @@ HRESULT CEECompileInfo::SetCompilationTarget(CORINFO_ASSEMBLY_HANDLE     assembl
 
         AssemblySpec mscorlib;
         mscorlib.InitializeSpec(SystemDomain::SystemFile());
-        GetAppDomain()->BindAssemblySpec(&mscorlib,TRUE,FALSE);
+        GetAppDomain()->BindAssemblySpec(&mscorlib,TRUE);
 
         if (!IsReadyToRunCompilation() && !SystemDomain::SystemFile()->HasNativeImage())
         {
@@ -7178,8 +7178,7 @@ void ReportMissingDependency(Exception * e)
 
 PEAssembly *CompilationDomain::BindAssemblySpec(
     AssemblySpec *pSpec,
-    BOOL fThrowOnFileNotFound,
-    BOOL fUseHostBinderIfAvailable)
+    BOOL fThrowOnFileNotFound)
 {
     PEAssembly *pFile = NULL;
     //
@@ -7194,8 +7193,7 @@ PEAssembly *CompilationDomain::BindAssemblySpec(
         //
         pFile = AppDomain::BindAssemblySpec(
             pSpec,
-            fThrowOnFileNotFound,
-            fUseHostBinderIfAvailable);
+            fThrowOnFileNotFound);
     }
     EX_HOOK
     {

--- a/src/vm/compile.h
+++ b/src/vm/compile.h
@@ -789,8 +789,7 @@ class CompilationDomain : public AppDomain,
 
     PEAssembly *BindAssemblySpec(
         AssemblySpec *pSpec,
-        BOOL fThrowOnFileNotFound,
-        BOOL fUseHostBinderIfAvailable = TRUE) DAC_EMPTY_RET(NULL);
+        BOOL fThrowOnFileNotFound) DAC_EMPTY_RET(NULL);
 
     BOOL CanEagerBindToZapFile(Module *targetModule, BOOL limitToHardBindList = TRUE);
 


### PR DESCRIPTION
`AssemblySpec::SetHostBinder` is no longer used. We were relying on that being set (`LoadDomainAssembly` in typeparse.cpp) to then set the fallback binder set on WinRT assembly (for use in the case of a WinRT assembly triggering the load of a non-WinRT assembly). This should now go through `AssemblySpec::GetFallbackLoadContextBinderForRequestingAssembly`

Remove unused functions and params in binding code