### PR TITLE
Delete `fgArgInfo::ArgsComplete():hasStackArgs` local var.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -1243,7 +1243,6 @@ void fgArgInfo::EvalToTmp(fgArgTabEntry* curArgTabEntry, unsigned tmpNum, GenTre
 
 void fgArgInfo::ArgsComplete()
 {
-    bool hasStackArgs    = false;
     bool hasStructRegArg = false;
 
     for (unsigned curInx = 0; curInx < argCount; curInx++)
@@ -1254,7 +1253,7 @@ void fgArgInfo::ArgsComplete()
 
         if (curArgTabEntry->GetRegNum() == REG_STK)
         {
-            hasStackArgs = true;
+            assert(hasStackArgs == true);
 #if !FEATURE_FIXED_OUT_ARGS
             // On x86 we use push instructions to pass arguments:
             //   The non-register arguments are evaluated and pushed in order
@@ -1267,7 +1266,7 @@ void fgArgInfo::ArgsComplete()
         else if (curArgTabEntry->IsSplit())
         {
             hasStructRegArg = true;
-            hasStackArgs    = true;
+            assert(hasStackArgs == true);
         }
 #endif       // FEATURE_ARG_SPLIT
         else // we have a register argument, next we look for a struct type.


### PR DESCRIPTION
`fgArgInfo` has a field with the same name and the same function. The duplication happened because the local var was added in 2011 and the struct field was added in 2014.
https://github.com/dotnet/coreclr/blob/90e59bed1cf8c513d42fc7c660953e7d46057a4e/src/jit/compiler.h#L1757

PVS warning:  The 'hasStackArgs' local variable possesses the same name as one of the class members, which can result in a confusion. morph.cpp 1247