### PR TITLE
Disable JIT\Directed\VectorABI\VectorMgdMgdStatic_r under JitStress modes

### DIFF
--- a/tests/src/JIT/Directed/VectorABI/VectorMgdMgdStatic_r.csproj
+++ b/tests/src/JIT/Directed/VectorABI/VectorMgdMgdStatic_r.csproj
@@ -6,6 +6,7 @@
     <DebugType />
     <Optimize />
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <JitOptimizationSensitive Condition="'$(Platform)' == 'arm64'">true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="VectorMgdMgdStatic.cs" />


### PR DESCRIPTION
Same assertion as in https://github.com/dotnet/coreclr/pull/27291
Fails in https://dev.azure.com/dnceng/public/_build/results?buildId=392704

Re-enable when #26491 is fixed

cc @dotnet/jit-contrib 