### PR TITLE
Fix slow tailcalls to VSD

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -81,6 +81,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/tailcall_v4/hijacking/*">
             <Issue>Unix does not support tailcall helper</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/tailcall/more_tailcalls/*">
+            <Issue>Unix does not support tailcall helper</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- Arm32 All OS -->
@@ -233,7 +236,10 @@
             <Issue>26105</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/tailcall_v4/hijacking/*">
-            <Issue>arm32 does not support tailcall helper</Issue>
+            <Issue>Unix arm32 does not support tailcall helper</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/tailcall/more_tailcalls/*">
+            <Issue>Unix arm32 does not support tailcall helper</Issue>
         </ExcludeList>
     </ItemGroup>
 
@@ -279,6 +285,9 @@
             <Issue>23124</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/tailcall_v4/hijacking/*">
+            <Issue>arm64 does not support tailcall helper</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/tailcall/more_tailcalls/*">
             <Issue>arm64 does not support tailcall helper</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/GitHub_26491/**/*">

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -897,12 +897,6 @@
         </ExcludeList>
     </ItemGroup>
 
-    <!-- Tests that run only on x86 Windows -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(BuildArch)' != 'x86' or '$(TargetsWindows)' != 'true')">
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/tailcall/more_tailcalls/*">
-            <Issue>x64 Windows has bugs with helper-based tailcall to VSD (#26311); rest of platforms do not support it</Issue>
-        </ExcludeList>
-    </ItemGroup>
     <!-- runtest.proj finds all the *.cmd/*.sh scripts in a test folder and creates corresponding test methods.
          Exclude these scripts to avoid creating such methods for the superpmicollect dependent test projects
          and running them separately from superpmicollect test. -->

--- a/tests/src/JIT/Directed/tailcall/more_tailcalls.ilproj
+++ b/tests/src/JIT/Directed/tailcall/more_tailcalls.ilproj
@@ -9,4 +9,14 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_JitStressModeNamesNot=STRESS_UNSAFE_BUFFER_CHECKS
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_JitStressModeNamesNot=STRESS_UNSAFE_BUFFER_CHECKS
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
This was broken in #20643 where fgCanFastTailCall was changed to call
fgInitArgInfo. fgInitArgInfo has side effects and will in some cases add
arguments to the arg list. Specifically for calls to VSD, the VSD arg is
added, however this case is treated specially for slow tailcalls and it
does not expect the arg to be here.

This targeted fix just removes this arg from the arg list.

In the future a better solution would be to refactor things so that `fgInitArgInfo` does not have side effects (rather than constructing the arg info).

cc @jashook @BruceForstall @jkotas @nguerrera 

Fixes #26311
Fixes #27275 