### PR TITLE
[Proposal] Force the inlining of StringBuilder.Append(char)

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/StringBuilder.cs
@@ -1150,6 +1150,7 @@ namespace System.Text
 
         public StringBuilder Append(bool value) => Append(value.ToString());
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public StringBuilder Append(char value)
         {
             int nextCharIndex = m_ChunkLength;


### PR DESCRIPTION
`StringBuilder.Append(char)` can benefit a lot from inlining (the same way as [List.Add](https://github.com/dotnet/coreclr/blob/111b71a65bce77e63d2463a972fe78aa042c5c0a/src/System.Private.CoreLib/shared/System/Collections/Generic/List.cs#L197) does)

It's a very frequently used method and I believe that the performance improvement is worth the size growth. 

The "before" includes https://github.com/dotnet/coreclr/pull/27340 from yesterday:

|               Method | Toolchain | length |         Mean | Ratio | Allocated |
|--------------------- |---------- |------- |-------------:|------:|----------:|
|          Append_Char |     after |    100 |     263.8 ns |  0.86 |     544 B |
|          Append_Char |    before |    100 |     308.5 ns |  1.00 |     544 B |
|                      |           |        |              |       |           |
| Append_Char_Capacity |     after |    100 |     187.7 ns |  0.68 |     272 B |
| Append_Char_Capacity |    before |    100 |     277.2 ns |  1.00 |     272 B |
|                      |           |        |              |       |           |
|          Append_Char |     after | 100000 | 176,884.8 ns |  0.84 |  209968 B |
|          Append_Char |    before | 100000 | 210,701.6 ns |  1.00 |  209968 B |
|                      |           |        |              |       |           |
| Append_Char_Capacity |     after | 100000 | 190,679.7 ns |  0.75 |  200072 B |
| Append_Char_Capacity |    before | 100000 | 253,892.5 ns |  1.00 |  200072 B |

```cs
[Benchmark]
[Arguments(100)]
[Arguments(100_000)]
public StringBuilder Append_Char(int length)
{
    StringBuilder builder = new StringBuilder();

    for (int i = 0; i < length; i++)
    {
        builder.Append('a');
    }

    return builder;
}

[Benchmark]
[Arguments(100)]
[Arguments(100_000)]
public StringBuilder Append_Char_Capacity(int length)
{
    StringBuilder builder = new StringBuilder(length);

    for (int i = 0; i < length; i++)
    {
        builder.Append('a');
    }

    return builder;
}
```