### PR TITLE
Fix noway_assert condition in `optOptimizeBools`.

### DIFF
--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -8918,8 +8918,8 @@ void Compiler::optOptimizeBools()
                 continue;
             }
 
-            noway_assert(t1->gtOper == GT_EQ || t1->gtOper == GT_NE && t1->AsOp()->gtOp1 == c1);
-            noway_assert(t2->gtOper == GT_EQ || t2->gtOper == GT_NE && t2->AsOp()->gtOp1 == c2);
+            noway_assert(t1->OperIs(GT_EQ, GT_NE) && t1->AsOp()->gtOp1 == c1);
+            noway_assert(t2->OperIs(GT_EQ, GT_NE) && t2->AsOp()->gtOp1 == c2);
 
             // Leave out floats where the bit-representation is more complicated
             // - there are two representations for 0.


### PR DESCRIPTION
It is a noway assert that was added before 2010, so that is hard to say what was the idea here.
However, the code before and the examples after show that there is no difference between `GT_EQ` and `GT_NE` and in both cases `c(omparand)` must be the first child of the compare node `t`.

Exisiting comments that confirm that it should be ((a &&b ) || c).
```
/* t1:c1==0 t2:c2==0 ==> Branch to BX if either value is 0
/* t1:c1!=0 t2:c2!=0 ==> Branch to BX if either value is non-0
```

PVS warning: Priority of the '&&' operation is higher than that of the '||' operation.