### PR TITLE
Use v3.0.100 of the SDK (RTM version)

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview7-012821"
+    "dotnet": "3.0.100"
   },
   "native-tools": {
     "cmake": "3.14.2",


### PR DESCRIPTION
No reason to use a preview7 version of the SDK now that we shipped.