### PR TITLE
P/invoke pregeneration fixes

### DIFF
--- a/src/tools/crossgen2/Common/TypeSystem/Ecma/EcmaMethod.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Ecma/EcmaMethod.cs
@@ -454,11 +454,40 @@ namespace Internal.TypeSystem.Ecma
                 return default(PInvokeMetadata);
 
             MetadataReader metadataReader = MetadataReader;
-            MethodImport import = metadataReader.GetMethodDefinition(_handle).GetImport();
+            MethodDefinition methodDef = metadataReader.GetMethodDefinition(_handle);
+            MethodImport import = methodDef.GetImport();
             string name = metadataReader.GetString(import.Name);
 
             ModuleReference moduleRef = metadataReader.GetModuleReference(import.Module);
             string moduleName = metadataReader.GetString(moduleRef.Name);
+
+            MethodImportAttributes importAttributes = import.Attributes;
+
+            // If either BestFitMapping or ThrowOnUnmappable wasn't set on the p/invoke,
+            // look for the value in the owning type or assembly.
+            if ((importAttributes & MethodImportAttributes.BestFitMappingMask) == 0 ||
+                (importAttributes & MethodImportAttributes.ThrowOnUnmappableCharMask) == 0)
+            {
+                TypeDefinition declaringType = metadataReader.GetTypeDefinition(methodDef.GetDeclaringType());
+
+                // Start with owning type
+                MethodImportAttributes fromCA = GetImportAttributesFromBestFitMappingAttribute(declaringType.GetCustomAttributes());
+                if ((importAttributes & MethodImportAttributes.BestFitMappingMask) == 0)
+                    importAttributes |= fromCA & MethodImportAttributes.BestFitMappingMask;
+                if ((importAttributes & MethodImportAttributes.ThrowOnUnmappableCharMask) == 0)
+                    importAttributes |= fromCA & MethodImportAttributes.ThrowOnUnmappableCharMask;
+
+                // If we still don't know, check the assembly
+                if ((importAttributes & MethodImportAttributes.BestFitMappingMask) == 0 ||
+                    (importAttributes & MethodImportAttributes.ThrowOnUnmappableCharMask) == 0)
+                {
+                    fromCA = GetImportAttributesFromBestFitMappingAttribute(metadataReader.GetAssemblyDefinition().GetCustomAttributes());
+                    if ((importAttributes & MethodImportAttributes.BestFitMappingMask) == 0)
+                        importAttributes |= fromCA & MethodImportAttributes.BestFitMappingMask;
+                    if ((importAttributes & MethodImportAttributes.ThrowOnUnmappableCharMask) == 0)
+                        importAttributes |= fromCA & MethodImportAttributes.ThrowOnUnmappableCharMask;
+                }
+            }
 
             // Spot check the enums match
             Debug.Assert((int)MethodImportAttributes.CallingConventionStdCall == (int)PInvokeAttributes.CallingConventionStdCall);
@@ -466,12 +495,53 @@ namespace Internal.TypeSystem.Ecma
             Debug.Assert((int)MethodImportAttributes.CharSetUnicode == (int)PInvokeAttributes.CharSetUnicode);
             Debug.Assert((int)MethodImportAttributes.SetLastError == (int)PInvokeAttributes.SetLastError);
 
-            PInvokeAttributes attributes = (PInvokeAttributes)import.Attributes;
+            PInvokeAttributes attributes = (PInvokeAttributes)importAttributes;
 
             if ((ImplAttributes & MethodImplAttributes.PreserveSig) != 0)
                 attributes |= PInvokeAttributes.PreserveSig;
 
             return new PInvokeMetadata(moduleName, name, attributes);
+        }
+
+        private MethodImportAttributes GetImportAttributesFromBestFitMappingAttribute(CustomAttributeHandleCollection attributeHandles)
+        {
+            // Look for the [BestFitMapping(BestFitMapping: x, ThrowOnUnmappableChar = y)] attribute and
+            // translate that to MethodImportAttributes
+
+            MethodImportAttributes result = 0;
+            MetadataReader reader = MetadataReader;
+
+            CustomAttributeHandle attributeHandle = reader.GetCustomAttributeHandle(
+                attributeHandles, "System.Runtime.InteropServices", "BestFitMappingAttribute");
+            if (!attributeHandle.IsNil)
+            {
+                CustomAttribute attribute = reader.GetCustomAttribute(attributeHandle);
+                CustomAttributeValue<TypeDesc> decoded = attribute.DecodeValue(
+                    new CustomAttributeTypeProvider(_type.EcmaModule));
+                
+                if (decoded.FixedArguments.Length != 1 || !(decoded.FixedArguments[0].Value is bool))
+                    ThrowHelper.ThrowBadImageFormatException();
+                if ((bool)decoded.FixedArguments[0].Value)
+                    result |= MethodImportAttributes.BestFitMappingEnable;
+                else
+                    result |= MethodImportAttributes.BestFitMappingDisable;
+
+                foreach (CustomAttributeNamedArgument<TypeDesc> namedArg in decoded.NamedArguments)
+                {
+                    if (namedArg.Name == "ThrowOnUnmappableChar")
+                    {
+                        if (!(namedArg.Value is bool))
+                            ThrowHelper.ThrowBadImageFormatException();
+                        if ((bool)namedArg.Value)
+                            result |= MethodImportAttributes.ThrowOnUnmappableCharEnable;
+                        else
+                            result |= MethodImportAttributes.ThrowOnUnmappableCharDisable;
+                        break;
+                    }
+                }
+            }
+
+            return result;
         }
 
         public override ParameterMetadata[] GetParameterMetadata()

--- a/src/tools/crossgen2/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
@@ -295,7 +295,7 @@ namespace Internal.TypeSystem.Ecma
             Debug.Assert(_reader.RemainingBytes != 0);
 
             NativeTypeKind type = (NativeTypeKind)_reader.ReadByte();
-            NativeTypeKind arraySubType = NativeTypeKind.Invalid;
+            NativeTypeKind arraySubType = NativeTypeKind.Default;
             uint? paramNum = null, numElem = null;
 
             switch (type)

--- a/src/tools/crossgen2/Common/TypeSystem/IL/Stubs/ILEmitter.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/IL/Stubs/ILEmitter.cs
@@ -223,17 +223,23 @@ namespace Internal.IL.Stubs
         {
             switch (type.UnderlyingType.Category)
             {
-                case TypeFlags.Byte:
                 case TypeFlags.SByte:
-                case TypeFlags.Boolean:
                     Emit(ILOpcode.ldind_i1);
                     break;
-                case TypeFlags.Char:
-                case TypeFlags.UInt16:
+                case TypeFlags.Byte:
+                case TypeFlags.Boolean:
+                    Emit(ILOpcode.ldind_u1);
+                    break;
                 case TypeFlags.Int16:
                     Emit(ILOpcode.ldind_i2);
                     break;
+                case TypeFlags.Char:
+                case TypeFlags.UInt16:
+                    Emit(ILOpcode.ldind_u2);
+                    break;
                 case TypeFlags.UInt32:
+                    Emit(ILOpcode.ldind_u4);
+                    break;
                 case TypeFlags.Int32:
                     Emit(ILOpcode.ldind_i4);
                     break;

--- a/src/tools/crossgen2/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -21,7 +21,7 @@ namespace Internal.TypeSystem.Interop
                 bool isArrayElement = false)
         {
             TypeSystemContext context = type.Context;
-            NativeTypeKind nativeType = NativeTypeKind.Invalid;
+            NativeTypeKind nativeType = NativeTypeKind.Default;
             if (marshalAs != null)
             {
                 nativeType = isArrayElement ? marshalAs.ArraySubType : marshalAs.Type;
@@ -177,7 +177,7 @@ namespace Internal.TypeSystem.Interop
                 type = type.GetParameterType();
             }
             TypeSystemContext context = type.Context;
-            NativeTypeKind nativeType = NativeTypeKind.Invalid;
+            NativeTypeKind nativeType = NativeTypeKind.Default;
             bool isField = marshallerType == MarshallerType.Field;
 
             if (marshalAs != null)
@@ -201,7 +201,7 @@ namespace Internal.TypeSystem.Interop
                     case TypeFlags.Boolean:
                         switch (nativeType)
                         {
-                            case NativeTypeKind.Invalid:
+                            case NativeTypeKind.Default:
                             case NativeTypeKind.Boolean:
                                 return MarshallerKind.Bool;
 
@@ -224,7 +224,7 @@ namespace Internal.TypeSystem.Interop
                             case NativeTypeKind.U2:
                                 return MarshallerKind.UnicodeChar;
 
-                            case NativeTypeKind.Invalid:
+                            case NativeTypeKind.Default:
                                 if (isAnsi)
                                     return MarshallerKind.AnsiChar;
                                 else
@@ -235,47 +235,47 @@ namespace Internal.TypeSystem.Interop
 
                     case TypeFlags.SByte:
                     case TypeFlags.Byte:
-                        if (nativeType == NativeTypeKind.I1 || nativeType == NativeTypeKind.U1 || nativeType == NativeTypeKind.Invalid)
+                        if (nativeType == NativeTypeKind.I1 || nativeType == NativeTypeKind.U1 || nativeType == NativeTypeKind.Default)
                             return MarshallerKind.BlittableValue;
                         else
                             return MarshallerKind.Invalid;
 
                     case TypeFlags.Int16:
                     case TypeFlags.UInt16:
-                        if (nativeType == NativeTypeKind.I2 || nativeType == NativeTypeKind.U2 || nativeType == NativeTypeKind.Invalid)
+                        if (nativeType == NativeTypeKind.I2 || nativeType == NativeTypeKind.U2 || nativeType == NativeTypeKind.Default)
                             return MarshallerKind.BlittableValue;
                         else
                             return MarshallerKind.Invalid;
 
                     case TypeFlags.Int32:
                     case TypeFlags.UInt32:
-                        if (nativeType == NativeTypeKind.I4 || nativeType == NativeTypeKind.U4 || nativeType == NativeTypeKind.Invalid)
+                        if (nativeType == NativeTypeKind.I4 || nativeType == NativeTypeKind.U4 || nativeType == NativeTypeKind.Default)
                             return MarshallerKind.BlittableValue;
                         else
                             return MarshallerKind.Invalid;
 
                     case TypeFlags.Int64:
                     case TypeFlags.UInt64:
-                        if (nativeType == NativeTypeKind.I8 || nativeType == NativeTypeKind.U8 || nativeType == NativeTypeKind.Invalid)
+                        if (nativeType == NativeTypeKind.I8 || nativeType == NativeTypeKind.U8 || nativeType == NativeTypeKind.Default)
                             return MarshallerKind.BlittableValue;
                         else
                             return MarshallerKind.Invalid;
 
                     case TypeFlags.IntPtr:
                     case TypeFlags.UIntPtr:
-                        if (nativeType == NativeTypeKind.Invalid)
+                        if (nativeType == NativeTypeKind.Default)
                             return MarshallerKind.BlittableValue;
                         else
                             return MarshallerKind.Invalid;
 
                     case TypeFlags.Single:
-                        if (nativeType == NativeTypeKind.R4 || nativeType == NativeTypeKind.Invalid)
+                        if (nativeType == NativeTypeKind.R4 || nativeType == NativeTypeKind.Default)
                             return MarshallerKind.BlittableValue;
                         else
                             return MarshallerKind.Invalid;
 
                     case TypeFlags.Double:
-                        if (nativeType == NativeTypeKind.R8 || nativeType == NativeTypeKind.Invalid)
+                        if (nativeType == NativeTypeKind.R8 || nativeType == NativeTypeKind.Default)
                             return MarshallerKind.BlittableValue;
                         else
                             return MarshallerKind.Invalid;
@@ -291,7 +291,7 @@ namespace Internal.TypeSystem.Interop
 
                 if (InteropTypes.IsSystemDateTime(context, type))
                 {
-                    if (nativeType == NativeTypeKind.Invalid ||
+                    if (nativeType == NativeTypeKind.Default ||
                         nativeType == NativeTypeKind.Struct)
                         return MarshallerKind.OleDateTime;
                     else
@@ -299,7 +299,7 @@ namespace Internal.TypeSystem.Interop
                 }
                 else if (InteropTypes.IsHandleRef(context, type))
                 {
-                    if (nativeType == NativeTypeKind.Invalid)
+                    if (nativeType == NativeTypeKind.Default)
                         return MarshallerKind.HandleRef;
                     else
                         return MarshallerKind.Invalid;
@@ -307,7 +307,7 @@ namespace Internal.TypeSystem.Interop
 
                 switch (nativeType)
                 {
-                    case NativeTypeKind.Invalid:
+                    case NativeTypeKind.Default:
                     case NativeTypeKind.Struct:
                         if (InteropTypes.IsSystemDecimal(context, type))
                             return MarshallerKind.Decimal;
@@ -350,7 +350,7 @@ namespace Internal.TypeSystem.Interop
             }
             else if (type.IsSzArray)
             {
-                if (nativeType == NativeTypeKind.Invalid)
+                if (nativeType == NativeTypeKind.Default)
                     nativeType = NativeTypeKind.Array;
 
                 switch (nativeType)
@@ -405,14 +405,14 @@ namespace Internal.TypeSystem.Interop
             }
             else if (type.IsPointer || type.IsFunctionPointer)
             {
-                if (nativeType == NativeTypeKind.Invalid)
+                if (nativeType == NativeTypeKind.Default)
                     return MarshallerKind.BlittableValue;
                 else
                     return MarshallerKind.Invalid;
             }
             else if (type.IsDelegate)
             {
-                if (nativeType == NativeTypeKind.Invalid || nativeType == NativeTypeKind.Func)
+                if (nativeType == NativeTypeKind.Default || nativeType == NativeTypeKind.Func)
                     return MarshallerKind.FunctionPointer;
                 else
                     return MarshallerKind.Invalid;
@@ -445,7 +445,7 @@ namespace Internal.TypeSystem.Interop
                             return MarshallerKind.ByValUnicodeString;
                         }
 
-                    case NativeTypeKind.Invalid:
+                    case NativeTypeKind.Default:
                         if (isAnsi)
                             return MarshallerKind.AnsiString;
                         else
@@ -466,7 +466,7 @@ namespace Internal.TypeSystem.Interop
             {
                 switch (nativeType)
                 {
-                    case NativeTypeKind.Invalid:
+                    case NativeTypeKind.Default:
                         if (isAnsi)
                         {
                             return MarshallerKind.AnsiStringBuilder;
@@ -487,23 +487,23 @@ namespace Internal.TypeSystem.Interop
             }
             else if (InteropTypes.IsSafeHandle(context, type))
             {
-                if (nativeType == NativeTypeKind.Invalid)
+                if (nativeType == NativeTypeKind.Default)
                     return MarshallerKind.SafeHandle;
                 else
                     return MarshallerKind.Invalid;
             }
             else if (InteropTypes.IsCriticalHandle(context, type))
             {
-                if (nativeType == NativeTypeKind.Invalid)
+                if (nativeType == NativeTypeKind.Default)
                     return MarshallerKind.CriticalHandle;
                 else
                     return MarshallerKind.Invalid;
             }
             else if (type is MetadataType mdType && mdType.HasLayout())
             {
-                if (!isField && nativeType == NativeTypeKind.Invalid || nativeType == NativeTypeKind.LPStruct)
+                if (!isField && nativeType == NativeTypeKind.Default || nativeType == NativeTypeKind.LPStruct)
                     return MarshallerKind.LayoutClassPtr;
-                else if (isField && (nativeType == NativeTypeKind.Invalid || nativeType == NativeTypeKind.Struct))
+                else if (isField && (nativeType == NativeTypeKind.Default || nativeType == NativeTypeKind.Struct))
                     return MarshallerKind.LayoutClass;
                 else
                     return MarshallerKind.Invalid;
@@ -518,7 +518,7 @@ namespace Internal.TypeSystem.Interop
                    bool isAnsi)
         {
             TypeDesc elementType = arrayType.ElementType;
-            NativeTypeKind nativeType = NativeTypeKind.Invalid;
+            NativeTypeKind nativeType = NativeTypeKind.Default;
             TypeSystemContext context = arrayType.Context;
 
             if (marshalAs != null)
@@ -552,7 +552,7 @@ namespace Internal.TypeSystem.Interop
                             case NativeTypeKind.I1:
                             case NativeTypeKind.U1:
                                 return MarshallerKind.CBool;
-                            case NativeTypeKind.Invalid:
+                            case NativeTypeKind.Default:
                             default:
                                 return MarshallerKind.Bool;
                         }
@@ -587,7 +587,7 @@ namespace Internal.TypeSystem.Interop
                 {
                     switch (nativeType)
                     {
-                        case NativeTypeKind.Invalid:
+                        case NativeTypeKind.Default:
                         case NativeTypeKind.Struct:
                             return MarshallerKind.Decimal;
 
@@ -602,7 +602,7 @@ namespace Internal.TypeSystem.Interop
                 {
                     switch (nativeType)
                     {
-                        case NativeTypeKind.Invalid:
+                        case NativeTypeKind.Default:
                         case NativeTypeKind.Struct:
                             return MarshallerKind.BlittableValue;
 
@@ -615,7 +615,7 @@ namespace Internal.TypeSystem.Interop
                 }
                 else if (InteropTypes.IsSystemDateTime(context, elementType))
                 {
-                    if (nativeType == NativeTypeKind.Invalid ||
+                    if (nativeType == NativeTypeKind.Default ||
                         nativeType == NativeTypeKind.Struct)
                     {
                         return MarshallerKind.OleDateTime;
@@ -627,7 +627,7 @@ namespace Internal.TypeSystem.Interop
                 }
                 else if (InteropTypes.IsHandleRef(context, elementType))
                 {
-                    if (nativeType == NativeTypeKind.Invalid)
+                    if (nativeType == NativeTypeKind.Default)
                         return MarshallerKind.HandleRef;
                     else
                         return MarshallerKind.Invalid;
@@ -638,7 +638,7 @@ namespace Internal.TypeSystem.Interop
                     {
                         switch (nativeType)
                         {
-                            case NativeTypeKind.Invalid:
+                            case NativeTypeKind.Default:
                             case NativeTypeKind.Struct:
                                 return MarshallerKind.BlittableStruct;
 
@@ -655,7 +655,7 @@ namespace Internal.TypeSystem.Interop
             }
             else if (elementType.IsPointer || elementType.IsFunctionPointer)
             {
-                if (nativeType == NativeTypeKind.Invalid)
+                if (nativeType == NativeTypeKind.Default)
                     return MarshallerKind.BlittableValue;
                 else
                     return MarshallerKind.Invalid;
@@ -664,7 +664,7 @@ namespace Internal.TypeSystem.Interop
             {
                 switch (nativeType)
                 {
-                    case NativeTypeKind.Invalid:
+                    case NativeTypeKind.Default:
                         if (isAnsi)
                             return MarshallerKind.AnsiString;
                         else

--- a/src/tools/crossgen2/Common/TypeSystem/Interop/InteropTypes.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Interop/InteropTypes.cs
@@ -98,6 +98,11 @@ namespace Internal.TypeSystem.Interop
             return IsCoreNamedType(context, type, "System", "Guid");
         }
 
+        public static bool IsSystemArgIterator(TypeSystemContext context, TypeDesc type)
+        {
+            return IsCoreNamedType(context, type, "System", "ArgIterator");
+        }
+
         private static bool IsOrDerivesFromType(TypeDesc type, MetadataType targetType)
         {
             while (type != null)

--- a/src/tools/crossgen2/Common/TypeSystem/Interop/MarshalAsDescriptor.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Interop/MarshalAsDescriptor.cs
@@ -37,7 +37,7 @@ namespace Internal.TypeSystem
         LPStruct = 0x2b,    // This is not  defined in Ecma-335(II.23.4)
         CustomMarshaler = 0x2c,
         LPUTF8Str = 0x30,
-        Invalid = 0x50,      // This is the default value
+        Default = 0x50,      // This is the default value
         Variant = 0x51,
     }
 

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/IL/Stubs/PInvokeILEmitter.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/IL/Stubs/PInvokeILEmitter.cs
@@ -121,6 +121,9 @@ namespace Internal.IL.Stubs
             if (!_importMetadata.Flags.PreserveSig)
                 throw new NotSupportedException();
 
+            if (_targetMethod.HasCustomAttribute("System.Runtime.InteropServices", "LCIDConversionAttribute"))
+                throw new NotSupportedException();
+
             PInvokeILCodeStreams pInvokeILCodeStreams = new PInvokeILCodeStreams();
             ILEmitter emitter = pInvokeILCodeStreams.Emitter;
             ILCodeStream marshallingCodestream = pInvokeILCodeStreams.MarshallingCodeStream;


### PR DESCRIPTION
Today I learned about `LCIDConversionAttribute`.

This makes us pass more of the interop tests, but there's still stuff to fix. See individual commits.