### PR TITLE
Add test coverage for unsupported marshal scenarios

### DIFF
--- a/tests/src/Interop/PInvoke/Primitives/Pointer/PInvokePointerTest.cs
+++ b/tests/src/Interop/PInvoke/Primitives/Pointer/PInvokePointerTest.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using TestLibrary;
+
+unsafe class Program
+{
+    [StructLayout(LayoutKind.Sequential)]
+    struct NonBlittable
+    {
+        bool _nonBlittable;
+    }
+
+    [DllImport("Unused")]
+    private static extern void PointerToNonBlittableType(NonBlittable* pNonBlittable);
+
+    static int Main()
+    {
+        Assert.Throws<MarshalDirectiveException>(() => PointerToNonBlittableType(null));
+
+        return 100;
+    }
+}

--- a/tests/src/Interop/PInvoke/Primitives/Pointer/PInvokePointerTest.cs
+++ b/tests/src/Interop/PInvoke/Primitives/Pointer/PInvokePointerTest.cs
@@ -15,7 +15,7 @@ unsafe class Program
     }
 
     [DllImport("Unused")]
-    private static extern void PointerToNonBlittableType(NonBlittable* pNonBlittable);
+    private static extern bool PointerToNonBlittableType(NonBlittable* pNonBlittable);
 
     static int Main()
     {

--- a/tests/src/Interop/PInvoke/Primitives/Pointer/PInvokePointerTest.cs
+++ b/tests/src/Interop/PInvoke/Primitives/Pointer/PInvokePointerTest.cs
@@ -14,12 +14,14 @@ unsafe class Program
         bool _nonBlittable;
     }
 
+    // the "string unused" parameter is just so that we don't hit https://github.com/dotnet/coreclr/issues/27408 that
+    // makes this p/invoke actually work.
     [DllImport("Unused")]
-    private static extern bool PointerToNonBlittableType(NonBlittable* pNonBlittable);
+    private static extern void PointerToNonBlittableType(NonBlittable* pNonBlittable, string unused);
 
     static int Main()
     {
-        Assert.Throws<MarshalDirectiveException>(() => PointerToNonBlittableType(null));
+        Assert.Throws<MarshalDirectiveException>(() => PointerToNonBlittableType(null, null));
 
         return 100;
     }

--- a/tests/src/Interop/PInvoke/Primitives/Pointer/PInvokePointerTest.csproj
+++ b/tests/src/Interop/PInvoke/Primitives/Pointer/PInvokePointerTest.csproj
@@ -7,5 +7,5 @@
   <ItemGroup>
     <Compile Include="PInvokePointerTest.cs" />
   </ItemGroup>
-  <Import Project="../../../Interop.settings.targets" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Interop.settings.targets))\Interop.settings.targets" />
 </Project>

--- a/tests/src/Interop/PInvoke/Primitives/Pointer/PInvokePointerTest.csproj
+++ b/tests/src/Interop/PInvoke/Primitives/Pointer/PInvokePointerTest.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="PInvokePointerTest.cs" />
+  </ItemGroup>
+  <Import Project="../../../Interop.settings.targets" />
+</Project>

--- a/tests/src/Interop/PInvoke/SizeParamIndex/PInvoke/Invalid/InvalidParamIndex.cs
+++ b/tests/src/Interop/PInvoke/SizeParamIndex/PInvoke/Invalid/InvalidParamIndex.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using TestLibrary;
+
+class Program
+{
+    [DllImport("Unused")]
+    static extern void SizeParamIndexTooBig(
+        out byte arrSize, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 20)] out byte[] arrByte);
+
+    [DllImport("Unused")]
+    public static extern void SizeParamIndexWrongType(
+        out string arrSize, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)] out byte[] arrByte);
+
+    static int Main()
+    {
+        Assert.Throws<MarshalDirectiveException>(() => SizeParamIndexTooBig(out var _, out var _));
+        Assert.Throws<MarshalDirectiveException>(() => SizeParamIndexWrongType(out var _, out var _));
+
+        return 100;
+    }
+}

--- a/tests/src/Interop/PInvoke/SizeParamIndex/PInvoke/Invalid/InvalidParamIndex.csproj
+++ b/tests/src/Interop/PInvoke/SizeParamIndex/PInvoke/Invalid/InvalidParamIndex.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="InvalidParamIndex.cs" />
+  </ItemGroup>
+  <Import Project="../../../../Interop.settings.targets" />
+</Project>

--- a/tests/src/Interop/PInvoke/SizeParamIndex/PInvoke/Invalid/InvalidParamIndex.csproj
+++ b/tests/src/Interop/PInvoke/SizeParamIndex/PInvoke/Invalid/InvalidParamIndex.csproj
@@ -6,5 +6,5 @@
   <ItemGroup>
     <Compile Include="InvalidParamIndex.cs" />
   </ItemGroup>
-  <Import Project="../../../../Interop.settings.targets" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Interop.settings.targets))\Interop.settings.targets" />
 </Project>


### PR DESCRIPTION
* Pointers to non-blittable structs are not supported
* SizeParamIndex could be bogus