### PR TITLE
Consume public SuppressGCTransitionAttribute type

### DIFF
--- a/tests/src/Interop/PInvoke/Attributes/SuppressGCTransition/SuppressGCTransitionTest.cs
+++ b/tests/src/Interop/PInvoke/Attributes/SuppressGCTransition/SuppressGCTransitionTest.cs
@@ -9,8 +9,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using TestLibrary;
 
-using Console = Internal.Console;
-
 static class SuppressGCTransitionNative
 {
     [DllImport(nameof(SuppressGCTransitionNative), EntryPoint = "NextUInt")]

--- a/tests/src/Interop/PInvoke/Attributes/SuppressGCTransition/SuppressGCTransitionTest.csproj
+++ b/tests/src/Interop/PInvoke/Attributes/SuppressGCTransition/SuppressGCTransitionTest.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <ReferenceSystemPrivateCoreLib>true</ReferenceSystemPrivateCoreLib>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Interop.settings.targets))\Interop.settings.targets" />
   <ItemGroup>

--- a/tests/src/Interop/PInvoke/Attributes/SuppressGCTransition/SuppressGCTransitionUtil.il
+++ b/tests/src/Interop/PInvoke/Attributes/SuppressGCTransition/SuppressGCTransitionUtil.il
@@ -3,25 +3,25 @@
 // See the LICENSE file in the project root for more information.
 
 .assembly extern mscorlib { }
-.assembly extern System.Private.CoreLib { auto }
+.assembly extern System.Runtime { auto }
 
 .assembly SuppressGCTransitionUtil { }
 
 .class public auto ansi beforefieldinit FunctionPointer
-       extends [System.Private.CoreLib]System.Object
+       extends [System.Runtime]System.Object
 {
     .method hidebysig specialname rtspecialname 
             instance void .ctor() cil managed
     {
         ldarg.0
-        call instance void [System.Private.CoreLib]System.Object::.ctor()
+        call instance void [System.Runtime]System.Object::.ctor()
         ret
     }
 
     .method public hidebysig static int32  Call_NextUInt(native int fptr,
                                                  int32* n) cil managed
     {
-        .custom instance void [System.Private.CoreLib]System.Runtime.InteropServices.SuppressGCTransitionAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [System.Runtime]System.Runtime.InteropServices.SuppressGCTransitionAttribute::.ctor() = ( 01 00 00 00 )
         .maxstack  8
         ldarg.1
         ldarg.0


### PR DESCRIPTION
Retarget `SuppressGCTransitionAttribute` to `System.Runtime` from SPCL.

See https://github.com/dotnet/corefx/issues/40740

/cc @jkoritzinsky 