### PR TITLE
[crossgen2] Avoid ambiguous devirtualization

### DIFF
--- a/src/tools/crossgen2/Common/Compiler/DevirtualizationManager.cs
+++ b/src/tools/crossgen2/Common/Compiler/DevirtualizationManager.cs
@@ -74,6 +74,32 @@ namespace ILCompiler
             if (declMethod.OwningType.IsInterface)
             {
                 impl = implType.ResolveInterfaceMethodTarget(declMethod);
+
+                /**
+                 * It is possible for us to hit a scenario where a type implements
+                 * the same interface more than once due to generic instantiations.
+                 * 
+                 * In some instances of those cases, the VirtualMethodAlgorithm
+                 * does not produce identical output as CoreCLR would, leading to 
+                 * behavioral differences in compiled outputs.
+                 * 
+                 * Instead of fixing the algorithm (in which the work to fix it is 
+                 * tracked in https://github.com/dotnet/corert/issues/208), the 
+                 * following duplication detection algorithm will detect the case and
+                 * refuse to devirtualize for those scenarios.
+                 */
+                DefType[] implTypeRuntimeInterfaces = implType.RuntimeInterfaces;
+                for (int i = 0; i < implTypeRuntimeInterfaces.Length; i++)
+                {
+                    for (int j = i + 1; j < implTypeRuntimeInterfaces.Length; j++)
+                    {
+                        if (implTypeRuntimeInterfaces[i] == implTypeRuntimeInterfaces[j])
+                        {
+                            return null;
+                        }
+                    }
+                }
+
                 if (impl != null)
                 {
                     impl = implType.FindVirtualFunctionTargetMethodOnObjectType(impl);

--- a/src/tools/crossgen2/Common/Compiler/DevirtualizationManager.cs
+++ b/src/tools/crossgen2/Common/Compiler/DevirtualizationManager.cs
@@ -74,32 +74,6 @@ namespace ILCompiler
             if (declMethod.OwningType.IsInterface)
             {
                 impl = implType.ResolveInterfaceMethodTarget(declMethod);
-
-                /**
-                 * It is possible for us to hit a scenario where a type implements
-                 * the same interface more than once due to generic instantiations.
-                 * 
-                 * In some instances of those cases, the VirtualMethodAlgorithm
-                 * does not produce identical output as CoreCLR would, leading to 
-                 * behavioral differences in compiled outputs.
-                 * 
-                 * Instead of fixing the algorithm (in which the work to fix it is 
-                 * tracked in https://github.com/dotnet/corert/issues/208), the 
-                 * following duplication detection algorithm will detect the case and
-                 * refuse to devirtualize for those scenarios.
-                 */
-                DefType[] implTypeRuntimeInterfaces = implType.RuntimeInterfaces;
-                for (int i = 0; i < implTypeRuntimeInterfaces.Length; i++)
-                {
-                    for (int j = i + 1; j < implTypeRuntimeInterfaces.Length; j++)
-                    {
-                        if (implTypeRuntimeInterfaces[i] == implTypeRuntimeInterfaces[j])
-                        {
-                            return null;
-                        }
-                    }
-                }
-
                 if (impl != null)
                 {
                     impl = implType.FindVirtualFunctionTargetMethodOnObjectType(impl);


### PR DESCRIPTION
It is possible for us to hit a scenario where a type implements the same interface more than once due to generic instantiations.

In some instances of those cases, the [VirtualMethodAlgorithm ](https://github.com/dotnet/coreclr/blob/master/src/tools/crossgen2/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs)does not produce identical output as CoreCLR would, leading to behavioral differences in compiled outputs.

A canonical example for [this](https://github.com/dotnet/coreclr/blob/f1a900df6554a682b2816b64958f80055407e955/tests/src/Loader/classloader/InterfaceFolding/Ambiguous.il#L141) is interface dispatch.

Instead of fixing the algorithm (in which the work to fix it is tracked in https://github.com/dotnet/corert/issues/208), the PR introduces an early duplication detection algorithm will detect the case and refuse to devirtualize for those scenarios.

@dotnet/crossgen-contrib 