### PR TITLE
Fixes to array marshalling pregeneration

### DIFF
--- a/src/tools/crossgen2/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -174,8 +174,11 @@ namespace Internal.TypeSystem.Interop
         {
             elementMarshallerKind = MarshallerKind.Invalid;
 
+            bool isByRef = false;
             if (type.IsByRef)
             {
+                isByRef = true;
+
                 type = type.GetParameterType();
 
                 // Compat note: CLR allows ref returning blittable structs for IJW
@@ -357,6 +360,14 @@ namespace Internal.TypeSystem.Interop
             }
             else if (type.IsSzArray)
             {
+#if READYTORUN
+                // We don't want the additional test/maintenance cost of this in R2R.
+                if (isByRef)
+                    return MarshallerKind.Invalid;
+#else
+                _ = isByRef;
+#endif
+
                 if (nativeType == NativeTypeKind.Default)
                     nativeType = NativeTypeKind.Array;
 

--- a/src/tools/crossgen2/Common/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Interop/IL/Marshaller.cs
@@ -1060,8 +1060,9 @@ namespace Internal.TypeSystem.Interop
             ILEmitter emitter = _ilCodeStreams.Emitter;
             ILCodeLabel lNullArray = emitter.NewCodeLabel();
 
-            LoadNativeAddr(codeStream);
-            codeStream.Emit(ILOpcode.initobj, emitter.NewToken(NativeType));
+            codeStream.EmitLdc(0);
+            codeStream.Emit(ILOpcode.conv_u);
+            StoreNativeValue(codeStream);
 
             // Check for null array
             LoadManagedValue(codeStream);
@@ -1079,7 +1080,7 @@ namespace Internal.TypeSystem.Interop
             codeStream.Emit(ILOpcode.mul_ovf);
 
             codeStream.Emit(ILOpcode.call, emitter.NewToken(
-                                Context.GetHelperEntryPoint("InteropHelpers", "CoTaskMemAllocAndZeroMemory")));
+                InteropTypes.GetMarshal(Context).GetKnownMethod("AllocCoTaskMem", null)));
             StoreNativeValue(codeStream);
 
             codeStream.EmitLabel(lNullArray);
@@ -1160,15 +1161,25 @@ namespace Internal.TypeSystem.Interop
             ILCodeLabel lRangeCheck = emitter.NewCodeLabel();
             ILCodeLabel lLoopHeader = emitter.NewCodeLabel();
             var lNullArray = emitter.NewCodeLabel();
-            
-            // Check for null array
-            LoadManagedValue(codeStream);
-            codeStream.Emit(ILOpcode.brfalse, lNullArray);
 
+            // Check for null array
+            if (!IsManagedByRef)
+            {
+                LoadManagedValue(codeStream);
+                codeStream.Emit(ILOpcode.brfalse, lNullArray);
+            }
 
             EmitElementCount(codeStream, MarshalDirection.Reverse);
 
             codeStream.EmitStLoc(vLength);
+
+            if (IsManagedByRef)
+            {
+                codeStream.EmitLdLoc(vLength);
+                codeStream.Emit(ILOpcode.newarr, emitter.NewToken(ManagedElementType));
+                StoreManagedValue(codeStream);
+            }
+
             codeStream.Emit(ILOpcode.sizeof_, emitter.NewToken(nativeElementType));
 
             codeStream.EmitStLoc(vSizeOf);
@@ -1305,31 +1316,42 @@ namespace Internal.TypeSystem.Interop
         protected override void AllocAndTransformManagedToNative(ILCodeStream codeStream)
         {
             ILEmitter emitter = _ilCodeStreams.Emitter;
-            var arrayType = (ArrayType)ManagedType;
-            Debug.Assert(arrayType.IsSzArray);
-
-            ILLocalVariable vPinnedFirstElement = emitter.NewLocal(arrayType.ParameterType.MakeByRefType(), true);
             ILCodeLabel lNullArray = emitter.NewCodeLabel();
 
-            // Check for null array, or 0 element array.
+            MethodDesc getRawSzArrayDataMethod = InteropTypes.GetRuntimeHelpers(Context).GetKnownMethod("GetRawSzArrayData", null);
+
+            // Check for null array
             LoadManagedValue(codeStream);
             codeStream.Emit(ILOpcode.brfalse, lNullArray);
-            LoadManagedValue(codeStream);
-            codeStream.Emit(ILOpcode.ldlen);
-            codeStream.Emit(ILOpcode.conv_i4);
-            codeStream.Emit(ILOpcode.brfalse, lNullArray);
+            
+            if (IsManagedByRef)
+            {
+                base.AllocManagedToNative(codeStream);
 
-            // Array has elements.
-            LoadManagedValue(codeStream);
-            codeStream.EmitLdc(0);
-            codeStream.Emit(ILOpcode.ldelema, emitter.NewToken(arrayType.ElementType));
-            codeStream.EmitStLoc(vPinnedFirstElement);
+                LoadNativeValue(codeStream);
+                LoadManagedValue(codeStream);
+                codeStream.Emit(ILOpcode.call, emitter.NewToken(getRawSzArrayDataMethod));
+                EmitElementCount(codeStream, MarshalDirection.Forward);
+                codeStream.Emit(ILOpcode.sizeof_, emitter.NewToken(ManagedElementType));
+                codeStream.Emit(ILOpcode.mul_ovf);
+                codeStream.Emit(ILOpcode.cpblk);
 
-            // Fall through. If array didn't have elements, vPinnedFirstElement is zeroinit.
-            codeStream.EmitLabel(lNullArray);
-            codeStream.EmitLdLoc(vPinnedFirstElement);
-            codeStream.Emit(ILOpcode.conv_i);
-            StoreNativeValue(codeStream);
+                codeStream.EmitLabel(lNullArray);
+            }
+            else
+            {
+                ILLocalVariable vPinnedFirstElement = emitter.NewLocal(ManagedElementType.MakeByRefType(), true);
+
+                LoadManagedValue(codeStream);
+                codeStream.Emit(ILOpcode.call, emitter.NewToken(getRawSzArrayDataMethod));
+                codeStream.EmitStLoc(vPinnedFirstElement);
+
+                // Fall through. If array didn't have elements, vPinnedFirstElement is zeroinit.
+                codeStream.EmitLabel(lNullArray);
+                codeStream.EmitLdLoc(vPinnedFirstElement);
+                codeStream.Emit(ILOpcode.conv_i);
+                StoreNativeValue(codeStream);
+            }
         }
 
         protected override void ReInitNativeTransform(ILCodeStream codeStream)
@@ -1341,13 +1363,13 @@ namespace Internal.TypeSystem.Interop
 
         protected override void TransformNativeToManaged(ILCodeStream codeStream)
         {
-            if ((IsManagedByRef && !In) || (MarshalDirection == MarshalDirection.Reverse && MarshallerType == MarshallerType.Argument))
+            if (IsManagedByRef || (MarshalDirection == MarshalDirection.Reverse && MarshallerType == MarshallerType.Argument))
                 base.TransformNativeToManaged(codeStream);
         }
 
         protected override void EmitCleanupManaged(ILCodeStream codeStream)
         {
-            if (IsManagedByRef && !In)
+            if (IsManagedByRef)
                 base.EmitCleanupManaged(codeStream);
         }
     }

--- a/src/tools/crossgen2/Common/TypeSystem/Interop/InteropTypes.cs
+++ b/src/tools/crossgen2/Common/TypeSystem/Interop/InteropTypes.cs
@@ -45,6 +45,11 @@ namespace Internal.TypeSystem.Interop
             return context.SystemModule.GetKnownType("System.Runtime.InteropServices", "Marshal");
         }
 
+        public static MetadataType GetRuntimeHelpers(TypeSystemContext context)
+        {
+            return context.SystemModule.GetKnownType("System.Runtime.CompilerServices", "RuntimeHelpers");
+        }
+
         public static MetadataType GetStubHelpers(TypeSystemContext context)
         {
             return context.SystemModule.GetKnownType("System.StubHelpers", "StubHelpers");


### PR DESCRIPTION
* 0-length blittable arrays marshal as a pointer to the non-existent element. There are tests for this, and apparently not doing so breaks GDI+ (based on comments).
* Do not use initobj to initialize pointer field. We don't want to see a reference to the token because R2R JitInterface can't handle tokens to constructed types in generated stubs.
* Use public API to allocate the native array
* If the array is passed by-ref, we never pin the managed array. We always allocate a copy.
* If the array is returned by-ref, we allocate a new managed array.