### PR TITLE
Remove LOCK_WRITE enum value (in pal/inc/rt/objidl.h) because it conflicts with fcntl.h on Linux (#27386)

### DIFF
--- a/src/pal/inc/rt/objidl.h
+++ b/src/pal/inc/rt/objidl.h
@@ -102,13 +102,6 @@ enum tagSTREAM_SEEK
     } 	STREAM_SEEK;
 
 typedef 
-enum tagLOCKTYPE
-    {	LOCK_WRITE	= 1,
-	LOCK_EXCLUSIVE	= 2,
-	LOCK_ONLYONCE	= 4
-    } 	LOCKTYPE;
-
-typedef 
 enum tagSTATFLAG
     {	STATFLAG_DEFAULT	= 0,
 	STATFLAG_NONAME	= 1,


### PR DESCRIPTION
Remove LOCK_WRITE enum value (in pal/inc/rt/objidl.h) because it conflicts with fcntl.h on Linux

It also completely removes LOCKTYPE enum.

Fixes #27386