### PR TITLE
Match HasLayoutMetadata to CoreCLR

### DIFF
--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1730,20 +1730,8 @@ namespace Internal.JitInterface
                 // Sequential layout
                 return true;
             }
-            else
-            {
-                // <BUGNUM>workaround for B#104780 - VC fails to set SequentialLayout on some classes
-                // with ClassSize. Too late to fix compiler for V1.
-                //
-                // To compensate, we treat AutoLayout classes as Sequential if they
-                // meet all of the following criteria:
-                //
-                //    - ClassSize present and nonzero.
-                //    - No instance fields declared
-                //    - Base class is System.ValueType.
-                //</BUGNUM>
-                return type.BaseType.IsValueType && !type.GetFields().GetEnumerator().MoveNext();
-            }
+
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
This caught my attention because I was messing with `IsBlittableType` in a different pull request.

The condition `type.BaseType.IsValueType` is never true because one can never have a type whose base type is a valuetype.

I was trying to find out where this code is coming from so I can fix it only to realize it was silently deleted in #23015.

Cc @dotnet/crossgen-contrib 