### PR TITLE
Check we don't marshal out parameters in SizeParamIndex test

### DIFF
--- a/tests/src/Interop/PInvoke/SizeParamIndex/PInvoke/helper.h
+++ b/tests/src/Interop/PInvoke/SizeParamIndex/PInvoke/helper.h
@@ -107,6 +107,11 @@ BOOL CheckAndChangeArrayByRef(T ** ppActual, T* Actual_Array_Size, SIZE_T Expect
 template<typename T>
 BOOL CheckAndChangeArrayByOut(T ** ppActual, T* Actual_Array_Size, SIZE_T Array_Size)
 {
+    if (*ppActual != NULL)
+    {
+        return FALSE;
+    }
+
     *ppActual = (T*)CoreClrAlloc(sizeof(T)*Array_Size);
     *Actual_Array_Size = ((T)Array_Size);
 

--- a/tests/src/Interop/PInvoke/SizeParamIndex/PInvoke/helper.h
+++ b/tests/src/Interop/PInvoke/SizeParamIndex/PInvoke/helper.h
@@ -107,8 +107,10 @@ BOOL CheckAndChangeArrayByRef(T ** ppActual, T* Actual_Array_Size, SIZE_T Expect
 template<typename T>
 BOOL CheckAndChangeArrayByOut(T ** ppActual, T* Actual_Array_Size, SIZE_T Array_Size)
 {
-    if (*ppActual != NULL)
+    if(*ppActual != NULL )
     {
+        printf("ManagedtoNative Error in Method: %s!\n",__FUNCTION__);
+        printf("Array is not NULL");
         return FALSE;
     }
 


### PR DESCRIPTION
The test passes both uninitialized (null) and initialized values to native.

We can add a check to ensure the initialized value doesn't get marshalled to native.