### PR TITLE
Implement alive across call for CSE candidates

### DIFF
--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -443,10 +443,11 @@ struct BasicBlock : private LIR::Range
 
 #define BBF_CLONED_FINALLY_BEGIN    0x100000000 // First block of a cloned finally region
 #define BBF_CLONED_FINALLY_END      0x200000000 // Last block of a cloned finally region
+#define BBF_HAS_CALL                0x400000000 // BB contains a call
 
 // clang-format on
 
-#define BBF_DOMINATED_BY_EXCEPTIONAL_ENTRY 0x400000000 // Block is dominated by exceptional entry.
+#define BBF_DOMINATED_BY_EXCEPTIONAL_ENTRY 0x800000000 // Block is dominated by exceptional entry.
 
 // Flags that relate blocks to loop structure.
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -6115,10 +6115,24 @@ protected:
 
     static const int MIN_CSE_COST = 2;
 
-    // trait information for CSE bitsets
-    BitVecTraits* cseMaskTraits;     // one bit per CSE candidate
-    BitVecTraits* cseLivenessTraits; // two bits per CSE candidate + 1
-    EXPSET_TP     cseFull;
+    // BitVec trait information only used by the optCSE_canSwap() method, for the  CSE_defMask and CSE_useMask.
+    // This BitVec uses one bit per CSE candidate
+    BitVecTraits* cseMaskTraits; // one bit per CSE candidate
+
+    // BitVec trait information for computing CSE availability using the CSE_DataFlow algorithm.
+    // Two bits are allocated per CSE candidate to compute CSE availability
+    // plus an extra bit to handle the initial unvisited case.
+    // (See CSE_DataFlow::EndMerge for an explaination of why this is necessary)
+    //
+    // The two bits per CSE candidate have the following meanings:
+    //     11 - The CSE is available, and is also available when considering calls as killing availability.
+    //     10 - The CSE is available, but is not available when considering calls as killing availability.
+    //     00 - The CSE is not available
+    //     01 - An illegal combination
+    //
+    BitVecTraits* cseLivenessTraits;
+
+    EXPSET_TP cseCallKillsMask; // Computed once - A mask that is used to kill available CSEs at callsites
 
     /* Generic list of nodes - used by the CSE logic */
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -6115,8 +6115,9 @@ protected:
 
     static const int MIN_CSE_COST = 2;
 
-    // Keeps tracked cse indices
-    BitVecTraits* cseTraits;
+    // trait information for CSE bitsets
+    BitVecTraits* cseMaskTraits;     // one bit per CSE candidate
+    BitVecTraits* cseLivenessTraits; // two bits per CSE candidate + 1
     EXPSET_TP     cseFull;
 
     /* Generic list of nodes - used by the CSE logic */
@@ -6241,8 +6242,7 @@ protected:
     unsigned optCSECandidateCount; // Count of CSE's candidates, reset for Lexical and ValNum CSE's
     unsigned optCSEstart;          // The first local variable number that is a CSE
     unsigned optCSEcount;          // The total count of CSE's introduced.
-    unsigned optCSEweight;         // The weight of the current block when we are
-                                   // scanning for CSE expressions
+    unsigned optCSEweight;         // The weight of the current block when we are doing PerformCS
 
     bool optIsCSEcandidate(GenTree* tree);
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8191,6 +8191,8 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
             GenTree* result = gtNewLclvNode(tmpNum, lvaTable[tmpNum].lvType);
             result->gtFlags |= GTF_DONT_CSE;
 
+            compCurBB->bbFlags |= BBF_HAS_CALL; // This block has a call
+
 #ifdef DEBUG
             if (verbose)
             {
@@ -8282,6 +8284,8 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
             return fgMorphTree(optTree);
         }
     }
+
+    compCurBB->bbFlags |= BBF_HAS_CALL; // This block has a call
 
     // Make sure that return buffers containing GC pointers that aren't too large are pointers into the stack.
     GenTree* origDest = nullptr; // Will only become non-null if we do the transformation (and thus require

--- a/src/jit/utils.cpp
+++ b/src/jit/utils.cpp
@@ -633,17 +633,15 @@ void dumpILRange(const BYTE* const codeAddr, unsigned codeSize) // in bytes
  */
 const char* genES2str(BitVecTraits* traits, EXPSET_TP set)
 {
-    const int   bufSize = 17;
-    static char num1[bufSize];
-
-    static char num2[bufSize];
-
+    const int    bufSize = 65; // Supports a BitVec of up to 256 bits
+    static char  num1[bufSize];
+    static char  num2[bufSize];
     static char* nump = num1;
 
+    assert(bufSize > roundUp(BitVecTraits::GetSize(traits), (unsigned)sizeof(char)) / 8);
+
     char* temp = nump;
-
-    nump = (nump == num1) ? num2 : num1;
-
+    nump       = (nump == num1) ? num2 : num1;
     sprintf_s(temp, bufSize, "%s", BitVecOps::ToString(traits, set));
 
     return temp;
@@ -651,11 +649,9 @@ const char* genES2str(BitVecTraits* traits, EXPSET_TP set)
 
 const char* refCntWtd2str(unsigned refCntWtd)
 {
-    const int   bufSize = 17;
-    static char num1[bufSize];
-
-    static char num2[bufSize];
-
+    const int    bufSize = 17;
+    static char  num1[bufSize];
+    static char  num2[bufSize];
     static char* nump = num1;
 
     char* temp = nump;


### PR DESCRIPTION
This is a Zero-Diff change
Using the alive across call information will take place in a future change.
This information will influence how aggressively we try to replace a CSE candidate into a new CSE LclVar.
