### PR TITLE
Enable block init unroll on ARM32

### DIFF
--- a/src/jit/codegenarmarch.cpp
+++ b/src/jit/codegenarmarch.cpp
@@ -1933,9 +1933,6 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
 {
     assert(node->OperIs(GT_STORE_BLK));
 
-#ifndef _TARGET_ARM64_
-    NYI_ARM("genCodeForInitBlkUnroll");
-#else
     regNumber dstAddrBaseReg = genConsumeReg(node->Addr());
     unsigned  dstOffset      = 0;
 
@@ -1954,8 +1951,12 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
     }
     else
     {
+#ifdef _TARGET_ARM64_
         assert(src->IsIntegralConst(0));
         srcReg = REG_ZR;
+#else
+        unreached();
+#endif
     }
 
     if (node->IsVolatile())
@@ -1966,10 +1967,12 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
     emitter* emit = GetEmitter();
     unsigned size = node->GetLayout()->GetSize();
 
+#ifdef _TARGET_ARM64_
     for (unsigned regSize = 2 * REGSIZE_BYTES; size >= regSize; size -= regSize, dstOffset += regSize)
     {
         emit->emitIns_R_R_R_I(INS_stp, EA_8BYTE, srcReg, srcReg, dstAddrBaseReg, dstOffset);
     }
+#endif
 
     for (unsigned regSize = REGSIZE_BYTES; size > 0; size -= regSize, dstOffset += regSize)
     {
@@ -1979,26 +1982,37 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
         }
 
         instruction storeIns;
+        emitAttr    attr;
 
         switch (regSize)
         {
             case 1:
                 storeIns = INS_strb;
+#ifdef _TARGET_ARM64_
+                attr = EA_1BYTE;
+#else
+                attr = EA_4BYTE;
+#endif
                 break;
             case 2:
                 storeIns = INS_strh;
+#ifdef _TARGET_ARM64_
+                attr = EA_2BYTE;
+#else
+                attr = EA_4BYTE;
+#endif
                 break;
             case 4:
             case 8:
                 storeIns = INS_str;
+                attr     = EA_ATTR(regSize);
                 break;
             default:
                 unreached();
         }
 
-        emit->emitIns_R_R_I(storeIns, EA_ATTR(regSize), srcReg, dstAddrBaseReg, dstOffset);
+        emit->emitIns_R_R_I(storeIns, attr, srcReg, dstAddrBaseReg, dstOffset);
     }
-#endif // _TARGET_ARM64_
 }
 
 //----------------------------------------------------------------------------------

--- a/src/jit/lowerarmarch.cpp
+++ b/src/jit/lowerarmarch.cpp
@@ -246,7 +246,6 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
             blkNode->SetOper(GT_STORE_BLK);
         }
 
-#ifdef _TARGET_ARM64_
         if (!blkNode->OperIs(GT_STORE_DYN_BLK) && (size <= INITBLK_UNROLL_LIMIT) && src->OperIs(GT_CNS_INT))
         {
             blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindUnroll;
@@ -262,13 +261,19 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
 
             if (fill == 0)
             {
+#ifdef _TARGET_ARM64_
+                // On ARM64 we can just use REG_ZR instead of having to load
+                // the constant into a real register like on ARM32.
                 src->SetContained();
+#endif
             }
+#ifdef _TARGET_ARM64_
             else if (size >= REGSIZE_BYTES)
             {
                 fill *= 0x0101010101010101LL;
                 src->gtType = TYP_LONG;
             }
+#endif
             else
             {
                 fill *= 0x01010101;
@@ -277,10 +282,7 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
             src->AsIntCon()->SetIconValue(fill);
         }
         else
-#endif // _TARGET_ARM64_
         {
-            // TODO-ARM-CQ: Currently we generate a helper call for every initblk we encounter.
-            // Later on we should implement loop unrolling code sequences to improve CQ.
             blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindHelper;
         }
     }

--- a/src/jit/lowerarmarch.cpp
+++ b/src/jit/lowerarmarch.cpp
@@ -321,32 +321,29 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
 
             blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindUnroll;
         }
+        else if (blkNode->OperIs(GT_STORE_BLK) && (size <= CPBLK_UNROLL_LIMIT))
+        {
+            blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindUnroll;
+
+            if (src->OperIs(GT_IND))
+            {
+                GenTree* srcAddr = src->AsIndir()->Addr();
+                if (srcAddr->OperIsLocalAddr())
+                {
+                    srcAddr->SetContained();
+                }
+            }
+
+            if (dstAddr->OperIsLocalAddr())
+            {
+                dstAddr->SetContained();
+            }
+        }
         else
         {
             assert(blkNode->OperIs(GT_STORE_BLK, GT_STORE_DYN_BLK));
 
-            if (!blkNode->OperIs(GT_STORE_DYN_BLK) && (size <= CPBLK_UNROLL_LIMIT))
-            {
-                blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindUnroll;
-
-                if (src->OperIs(GT_IND))
-                {
-                    GenTree* srcAddr = src->AsIndir()->Addr();
-                    if (srcAddr->OperIsLocalAddr())
-                    {
-                        srcAddr->SetContained();
-                    }
-                }
-
-                if (dstAddr->OperIsLocalAddr())
-                {
-                    dstAddr->SetContained();
-                }
-            }
-            else
-            {
-                blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindHelper;
-            }
+            blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindHelper;
         }
     }
 }

--- a/src/jit/lsraarmarch.cpp
+++ b/src/jit/lsraarmarch.cpp
@@ -585,7 +585,6 @@ int LinearScan::BuildBlockStore(GenTreeBlk* blkNode)
         switch (blkNode->gtBlkOpKind)
         {
             case GenTreeBlk::BlkOpKindUnroll:
-                NYI_ARM("initblk loop unrolling is currently not implemented.");
                 break;
 
             case GenTreeBlk::BlkOpKindHelper:

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -893,7 +893,7 @@ typedef unsigned char   regNumberSmall;
   #define CPU_HAS_BYTE_REGS        0
 
   #define CPBLK_UNROLL_LIMIT       32      // Upper bound to let the code generator to loop unroll CpBlk.
-  #define INITBLK_UNROLL_LIMIT     32      // Upper bound to let the code generator to loop unroll InitBlk.
+  #define INITBLK_UNROLL_LIMIT     16      // Upper bound to let the code generator to loop unroll InitBlk.
 
   #define FEATURE_FIXED_OUT_ARGS   1       // Preallocate the outgoing arg area in the prolog
   #define FEATURE_STRUCTPROMOTE    1       // JIT Optimization to promote fields of structs into registers


### PR DESCRIPTION
Extracted from #21711

On ARM32 unroll was already done for block copy but not for block init. This was the only target that didn't unroll block init.

I've lowered the existing init unroll limit from 32 to 16, I'm not familiar with ARM perf characteristic but the limit seemed quite high, considering that the current implementation uses only 32 bit stores. Other targets have 64 and even 128 unroll limits but they also use 128 bit stores.

16 also looks like a reasonable code size trade off - with the 32 byte limit the diff ends up 5 kbytes in red but with 16 it is a 15 kbytes improvement.