### PR TITLE
GitHub actions: add auto PR labeler for Jit changes.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,3 @@
+# Add 'area-CodeGen' to any changes within 'src/jit' folder or any subfolders
+area-CodeGen:
+  - src/jit/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Try a new GitHub feature: actions https://github.com/dotnet/coreclr/actions/new

Add a labeler as described here: https://github.com/actions/labeler/blob/master/README.md#create-workflow

I wanted to test it in my fork first but it is blocked by https://github.com/actions/labeler/issues/12

PTAL @dotnet/coreclr-infra  (for some reason I can't request a review from that team, but can mention it).

That will replace the manual script that I run from time to time to track new CodeGen PRs.