### PR TITLE
Simplify some if tests

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Array.cs
+++ b/src/System.Private.CoreLib/shared/System/Array.cs
@@ -657,7 +657,7 @@ namespace System
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
             }
 
-            if (startIndex < 0 || startIndex > array.Length)
+            if ((uint)startIndex > (uint)array.Length)
             {
                 ThrowHelper.ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index();
             }
@@ -746,7 +746,7 @@ namespace System
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
             }
 
-            if (startIndex < 0 || startIndex > array.Length)
+            if ((uint)startIndex > (uint)array.Length)
             {
                 ThrowHelper.ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index();
             }
@@ -836,7 +836,7 @@ namespace System
             else
             {
                 // Make sure we're not out of range
-                if (startIndex < 0 || startIndex >= array.Length)
+                if ((uint)startIndex >= (uint)array.Length)
                 {
                     ThrowHelper.ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index();
                 }
@@ -918,7 +918,7 @@ namespace System
             int lb = array.GetLowerBound(0);
             if (startIndex < lb || startIndex > array.Length + lb)
                 ThrowHelper.ThrowStartIndexArgumentOutOfRange_ArgumentOutOfRange_Index();
-            if (count < 0 || count > array.Length - startIndex + lb)
+            if ((uint)count > (uint)(array.Length - startIndex + lb))
                 ThrowHelper.ThrowCountArgumentOutOfRange_ArgumentOutOfRange_Count();
 
 #if !CORERT

--- a/src/System.Private.CoreLib/shared/System/ArraySegment.cs
+++ b/src/System.Private.CoreLib/shared/System/ArraySegment.cs
@@ -175,7 +175,7 @@ namespace System
             get
             {
                 ThrowInvalidOperationIfDefault();
-                if (index < 0 || index >= _count)
+                if ((uint)index >= (uint)_count)
                     ThrowHelper.ThrowArgumentOutOfRange_IndexException();
 
                 return _array![_offset + index];
@@ -184,7 +184,7 @@ namespace System
             set
             {
                 ThrowInvalidOperationIfDefault();
-                if (index < 0 || index >= _count)
+                if ((uint)index >= (uint)_count)
                     ThrowHelper.ThrowArgumentOutOfRange_IndexException();
 
                 _array![_offset + index] = value;
@@ -214,7 +214,7 @@ namespace System
             get
             {
                 ThrowInvalidOperationIfDefault();
-                if (index < 0 || index >= _count)
+                if ((uint)index >= (uint)_count)
                     ThrowHelper.ThrowArgumentOutOfRange_IndexException();
 
                 return _array![_offset + index];

--- a/src/System.Private.CoreLib/shared/System/BitConverter.cs
+++ b/src/System.Private.CoreLib/shared/System/BitConverter.cs
@@ -363,7 +363,7 @@ namespace System
         {
             if (value == null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
-            if (startIndex < 0 || startIndex >= value.Length && startIndex > 0)
+            if ((uint)startIndex >= (uint)value.Length && startIndex != 0)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);
             if (length < 0)
                 throw new ArgumentOutOfRangeException(nameof(length), SR.ArgumentOutOfRange_GenericPositive);

--- a/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.D.cs
+++ b/src/System.Private.CoreLib/shared/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.D.cs
@@ -374,7 +374,7 @@ namespace System.Buffers.Text
 
             // Parse the first digit separately. If invalid here, we need to return false.
             long firstDigit = source[indexOfFirstDigit] - 48; // '0'
-            if (firstDigit < 0 || firstDigit > 9)
+            if ((ulong)firstDigit > 9)
             {
                 bytesConsumed = 0;
                 value = default;
@@ -388,7 +388,7 @@ namespace System.Buffers.Text
                 for (int index = indexOfFirstDigit + 1; index < source.Length; index++)
                 {
                     long nextDigit = source[index] - 48; // '0'
-                    if (nextDigit < 0 || nextDigit > 9)
+                    if ((ulong)nextDigit > 9)
                     {
                         bytesConsumed = index;
                         value = ((long)parsedValue) * sign;
@@ -404,7 +404,7 @@ namespace System.Buffers.Text
                 for (int index = indexOfFirstDigit + 1; index < overflowLength - 1; index++)
                 {
                     long nextDigit = source[index] - 48; // '0'
-                    if (nextDigit < 0 || nextDigit > 9)
+                    if ((ulong)nextDigit > 9)
                     {
                         bytesConsumed = index;
                         value = ((long)parsedValue) * sign;
@@ -415,7 +415,7 @@ namespace System.Buffers.Text
                 for (int index = overflowLength - 1; index < source.Length; index++)
                 {
                     long nextDigit = source[index] - 48; // '0'
-                    if (nextDigit < 0 || nextDigit > 9)
+                    if ((ulong)nextDigit > 9)
                     {
                         bytesConsumed = index;
                         value = ((long)parsedValue) * sign;

--- a/src/System.Private.CoreLib/shared/System/Char.cs
+++ b/src/System.Private.CoreLib/shared/System/Char.cs
@@ -809,7 +809,7 @@ namespace System
             {
                 throw new ArgumentNullException(nameof(s));
             }
-            if (index < 0 || index >= s.Length)
+            if ((uint)index >= (uint)s.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
@@ -830,7 +830,7 @@ namespace System
             {
                 throw new ArgumentNullException(nameof(s));
             }
-            if (index < 0 || index >= s.Length)
+            if ((uint)index >= (uint)s.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
@@ -846,7 +846,7 @@ namespace System
             {
                 throw new ArgumentNullException(nameof(s));
             }
-            if (index < 0 || index >= s.Length)
+            if ((uint)index >= (uint)s.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
@@ -951,7 +951,7 @@ namespace System
                 throw new ArgumentNullException(nameof(s));
             }
 
-            if (index < 0 || index >= s.Length)
+            if ((uint)index >= (uint)s.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
             }

--- a/src/System.Private.CoreLib/shared/System/Collections/ArrayList.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/ArrayList.cs
@@ -139,12 +139,12 @@ namespace System.Collections
         {
             get
             {
-                if (index < 0 || index >= _size) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
+                if ((uint)index >= (uint)_size) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
                 return _items[index];
             }
             set
             {
-                if (index < 0 || index >= _size) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
+                if ((uint)index >= (uint)_size) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
                 _items[index] = value;
                 _version++;
             }
@@ -426,7 +426,7 @@ namespace System.Collections
         public virtual void Insert(int index, object? value)
         {
             // Note that insertions at the end are legal.
-            if (index < 0 || index > _size) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
+            if ((uint)index > (uint)_size) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
 
             if (_size == _items.Length) EnsureCapacity(_size + 1);
             if (index < _size)
@@ -447,7 +447,7 @@ namespace System.Collections
         {
             if (c == null)
                 throw new ArgumentNullException(nameof(c), SR.ArgumentNull_Collection);
-            if (index < 0 || index > _size) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
+            if ((uint)index > (uint)_size) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
 
             int count = c.Count;
             if (count > 0)
@@ -552,7 +552,7 @@ namespace System.Collections
         //
         public virtual void RemoveAt(int index)
         {
-            if (index < 0 || index >= _size) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
+            if ((uint)index >= (uint)_size) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
 
             _size--;
             if (index < _size)
@@ -635,7 +635,7 @@ namespace System.Collections
             if (c == null) throw new ArgumentNullException(nameof(c), SR.ArgumentNull_Collection);
 
             int count = c.Count;
-            if (index < 0 || index > _size - count) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
+            if ((uint)index > (uint)(_size - count)) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
 
             if (count > 0)
             {
@@ -909,7 +909,7 @@ namespace System.Collections
 
             public override int IndexOf(object? value, int startIndex, int count)
             {
-                if (startIndex < 0 || startIndex > Count) throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
+                if ((uint)startIndex > (uint)Count) throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
                 if (count < 0 || startIndex > Count - count) throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_Count);
 
                 int endIndex = startIndex + count;
@@ -939,7 +939,7 @@ namespace System.Collections
             {
                 if (c == null)
                     throw new ArgumentNullException(nameof(c), SR.ArgumentNull_Collection);
-                if (index < 0 || index > Count) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
+                if ((uint)index > (uint)Count) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
 
                 if (c.Count > 0)
                 {
@@ -977,8 +977,8 @@ namespace System.Collections
                 if (_list.Count == 0)
                     return -1;
 
-                if (startIndex < 0 || startIndex >= _list.Count) throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
-                if (count < 0 || count > startIndex + 1) throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_Count);
+                if ((uint)startIndex >= (uint)_list.Count) throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
+                if ((uint)count > (uint)(startIndex + 1)) throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_Count);
 
                 int endIndex = startIndex - count + 1;
                 if (value == null)
@@ -1054,7 +1054,7 @@ namespace System.Collections
                     throw new ArgumentNullException(nameof(c), SR.ArgumentNull_Collection);
                 }
 
-                if (index < 0 || index > _list.Count - c.Count)
+                if ((uint)index > (uint)(_list.Count - c.Count))
                 {
                     throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
                 }
@@ -2425,7 +2425,7 @@ namespace System.Collections
 
             public override int IndexOf(object? value, int startIndex, int count)
             {
-                if (startIndex < 0 || startIndex > _baseSize)
+                if ((uint)startIndex > (uint)_baseSize)
                     throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
 
                 if (count < 0 || (startIndex > _baseSize - count))
@@ -2439,7 +2439,7 @@ namespace System.Collections
 
             public override void Insert(int index, object? value)
             {
-                if (index < 0 || index > _baseSize) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
+                if ((uint)index > (uint)_baseSize) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
 
                 InternalUpdateRange();
                 _baseList.Insert(_baseIndex + index, value);
@@ -2449,7 +2449,7 @@ namespace System.Collections
 
             public override void InsertRange(int index, ICollection c)
             {
-                if (index < 0 || index > _baseSize) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
+                if ((uint)index > (uint)_baseSize) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
                 if (c == null)
                 {
                     throw new ArgumentNullException(nameof(c));
@@ -2498,7 +2498,7 @@ namespace System.Collections
 
             public override void RemoveAt(int index)
             {
-                if (index < 0 || index >= _baseSize) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
+                if ((uint)index >= (uint)_baseSize) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
 
                 InternalUpdateRange();
                 _baseList.RemoveAt(_baseIndex + index);
@@ -2539,7 +2539,7 @@ namespace System.Collections
             public override void SetRange(int index, ICollection c)
             {
                 InternalUpdateRange();
-                if (index < 0 || index >= _baseSize) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
+                if ((uint)index >= (uint)_baseSize) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
                 _baseList.SetRange(_baseIndex + index, c);
                 if (c.Count > 0)
                 {
@@ -2564,13 +2564,13 @@ namespace System.Collections
                 get
                 {
                     InternalUpdateRange();
-                    if (index < 0 || index >= _baseSize) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
+                    if ((uint)index >= (uint)_baseSize) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
                     return _baseList[_baseIndex + index];
                 }
                 set
                 {
                     InternalUpdateRange();
-                    if (index < 0 || index >= _baseSize) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
+                    if ((uint)index >= (uint)_baseSize) throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
                     _baseList[_baseIndex + index] = value;
                     InternalUpdateVersion();
                 }

--- a/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs
@@ -1321,7 +1321,7 @@ namespace System.Collections.Generic
                     ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
                 }
 
-                if (index < 0 || index > array.Length)
+                if ((uint)index > (uint)array.Length)
                 {
                     ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
                 }
@@ -1504,7 +1504,7 @@ namespace System.Collections.Generic
                     ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
                 }
 
-                if ((uint)index > array.Length)
+                if ((uint)index > (uint)array.Length)
                 {
                     ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
                 }

--- a/src/System.Private.CoreLib/shared/System/DateTime.cs
+++ b/src/System.Private.CoreLib/shared/System/DateTime.cs
@@ -254,7 +254,7 @@ namespace System
         //
         public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond)
         {
-            if (millisecond < 0 || millisecond >= MillisPerSecond)
+            if ((uint)millisecond >= MillisPerSecond)
             {
                 throw new ArgumentOutOfRangeException(nameof(millisecond), SR.Format(SR.ArgumentOutOfRange_Range, 0, MillisPerSecond - 1));
             }
@@ -277,7 +277,7 @@ namespace System
 
         public DateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, DateTimeKind kind)
         {
-            if (millisecond < 0 || millisecond >= MillisPerSecond)
+            if ((uint)millisecond >= MillisPerSecond)
             {
                 throw new ArgumentOutOfRangeException(nameof(millisecond), SR.Format(SR.ArgumentOutOfRange_Range, 0, MillisPerSecond - 1));
             }
@@ -309,7 +309,7 @@ namespace System
         {
             if (calendar == null)
                 throw new ArgumentNullException(nameof(calendar));
-            if (millisecond < 0 || millisecond >= MillisPerSecond)
+            if ((uint)millisecond >= MillisPerSecond)
             {
                 throw new ArgumentOutOfRangeException(nameof(millisecond), SR.Format(SR.ArgumentOutOfRange_Range, 0, MillisPerSecond - 1));
             }
@@ -341,7 +341,7 @@ namespace System
         {
             if (calendar == null)
                 throw new ArgumentNullException(nameof(calendar));
-            if (millisecond < 0 || millisecond >= MillisPerSecond)
+            if ((uint)millisecond >= MillisPerSecond)
             {
                 throw new ArgumentOutOfRangeException(nameof(millisecond), SR.Format(SR.ArgumentOutOfRange_Range, 0, MillisPerSecond - 1));
             }
@@ -688,7 +688,7 @@ namespace System
 
             millis += DoubleDateOffset / TicksPerMillisecond;
 
-            if (millis < 0 || millis >= MaxMillis) throw new ArgumentException(SR.Arg_OleAutDateScale);
+            if ((ulong)millis >= MaxMillis) throw new ArgumentException(SR.Arg_OleAutDateScale);
             return millis * TicksPerMillisecond;
         }
 
@@ -794,7 +794,7 @@ namespace System
 
         public static DateTime FromFileTimeUtc(long fileTime)
         {
-            if (fileTime < 0 || fileTime > MaxTicks - FileTimeOffset)
+            if ((ulong)fileTime > (MaxTicks - FileTimeOffset))
             {
                 throw new ArgumentOutOfRangeException(nameof(fileTime), SR.ArgumentOutOfRange_FileTimeInvalid);
             }
@@ -1562,11 +1562,11 @@ namespace System
             {
                 return false;
             }
-            if (hour < 0 || hour >= 24 || minute < 0 || minute >= 60 || second < 0 || second > 60)
+            if ((uint)hour >= 24 || (uint)minute >= 60 || (uint)second > 60)
             {
                 return false;
             }
-            if (millisecond < 0 || millisecond >= MillisPerSecond)
+            if ((uint)millisecond >= MillisPerSecond)
             {
                 return false;
             }

--- a/src/System.Private.CoreLib/shared/System/Globalization/Calendar.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/Calendar.cs
@@ -708,11 +708,11 @@ namespace System.Globalization
         /// </summary>
         internal static long TimeToTicks(int hour, int minute, int second, int millisecond)
         {
-            if (hour < 0 || hour >= 24 || minute < 0 || minute >= 60 || second < 0 || second >= 60)
+            if ((uint)hour >= 24 || (uint)minute >= 60 || (uint)second >= 60)
             {
                 throw new ArgumentOutOfRangeException(null, SR.ArgumentOutOfRange_BadHourMinuteSecond);
             }
-            if (millisecond < 0 || millisecond >= MillisPerSecond)
+            if ((uint)millisecond >= MillisPerSecond)
             {
                 throw new ArgumentOutOfRangeException(
                     nameof(millisecond),

--- a/src/System.Private.CoreLib/shared/System/Globalization/CharUnicodeInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CharUnicodeInfo.cs
@@ -170,7 +170,7 @@ namespace System.Globalization
             {
                 throw new ArgumentNullException(nameof(s));
             }
-            if (index < 0 || index >= s.Length)
+            if ((uint)index >= (uint)s.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
             }
@@ -189,7 +189,7 @@ namespace System.Globalization
             {
                 throw new ArgumentNullException(nameof(s));
             }
-            if (index < 0 || index >= s.Length)
+            if ((uint)index >= (uint)s.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
             }
@@ -208,7 +208,7 @@ namespace System.Globalization
             {
                 throw new ArgumentNullException(nameof(s));
             }
-            if (index < 0 || index >= s.Length)
+            if ((uint)index >= (uint)s.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_Index);
             }

--- a/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/CompareInfo.cs
@@ -906,7 +906,7 @@ namespace System.Globalization
             {
                 throw new ArgumentNullException(nameof(source));
             }
-            if (startIndex < 0 || startIndex > source.Length)
+            if ((uint)startIndex > (uint)source.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
             }
@@ -1246,7 +1246,7 @@ namespace System.Globalization
             }
 
             // Make sure we're not out of range
-            if (startIndex < 0 || startIndex > source.Length)
+            if ((uint)startIndex > (uint)source.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
             }
@@ -1305,7 +1305,7 @@ namespace System.Globalization
             }
 
             // Make sure we're not out of range
-            if (startIndex < 0 || startIndex > source.Length)
+            if ((uint)startIndex > (uint)source.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
             }

--- a/src/System.Private.CoreLib/shared/System/Globalization/DateTimeParse.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/DateTimeParse.cs
@@ -552,7 +552,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
             }
             Debug.Assert(hourOffset >= 0 && hourOffset <= 99, "hourOffset >= 0 && hourOffset <= 99");
             Debug.Assert(minuteOffset >= 0 && minuteOffset <= 99, "minuteOffset >= 0 && minuteOffset <= 99");
-            if (minuteOffset < 0 || minuteOffset >= 60)
+            if ((uint)minuteOffset >= 60)
             {
                 return false;
             }
@@ -2009,7 +2009,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
             {
                 if (timeMark == TM.AM)
                 {
-                    if (hour < 0 || hour > 12)
+                    if ((uint)hour > 12)
                     {
                         return false;
                     }
@@ -2017,7 +2017,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
                 }
                 else
                 {
-                    if (hour < 0 || hour > 23)
+                    if ((uint)hour > 23)
                     {
                         return false;
                     }
@@ -3284,7 +3284,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
                     }
                     break;
             }
-            if (minuteOffset < 0 || minuteOffset >= 60)
+            if ((uint)minuteOffset >= 60)
             {
                 return false;
             }

--- a/src/System.Private.CoreLib/shared/System/Globalization/GregorianCalendarHelper.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/GregorianCalendarHelper.cs
@@ -307,20 +307,21 @@ namespace System.Globalization
         {
             // TimeSpan.TimeToTicks is a family access function which does no error checking, so
             // we need to put some error checking out here.
-            if (hour >= 0 && hour < 24 && minute >= 0 && minute < 60 && second >= 0 && second < 60)
+            if ((uint)hour >= 24 || (uint)minute >= 60 || (uint)second >= 60)
             {
-                if (millisecond < 0 || millisecond >= MillisPerSecond)
-                {
-                    throw new ArgumentOutOfRangeException(
-                                nameof(millisecond),
-                                SR.Format(
-                                    SR.ArgumentOutOfRange_Range,
-                                    0,
-                                    MillisPerSecond - 1));
-                }
-                return InternalGlobalizationHelper.TimeToTicks(hour, minute, second) + millisecond * TicksPerMillisecond;
+                throw new ArgumentOutOfRangeException(null, SR.ArgumentOutOfRange_BadHourMinuteSecond);
             }
-            throw new ArgumentOutOfRangeException(null, SR.ArgumentOutOfRange_BadHourMinuteSecond);
+            if ((uint)millisecond >= MillisPerSecond)
+            {
+                throw new ArgumentOutOfRangeException(
+                            nameof(millisecond),
+                            SR.Format(
+                                SR.ArgumentOutOfRange_Range,
+                                0,
+                                MillisPerSecond - 1));
+            }
+
+            return InternalGlobalizationHelper.TimeToTicks(hour, minute, second) + millisecond * TicksPerMillisecond;
         }
 
         internal void CheckTicksRange(long ticks)

--- a/src/System.Private.CoreLib/shared/System/Globalization/HebrewCalendar.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/HebrewCalendar.cs
@@ -390,7 +390,7 @@ namespace System.Globalization
             // Get the offset into the LunarMonthLen array and the lunar day
             //  for January 1st.
             int index = gregorianYear - FirstGregorianTableYear;
-            if (index < 0 || index > TableSize)
+            if ((uint)index > (uint)TableSize)
             {
                 throw new ArgumentOutOfRangeException(nameof(gregorianYear));
             }

--- a/src/System.Private.CoreLib/shared/System/Globalization/IdnMapping.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/IdnMapping.cs
@@ -590,7 +590,7 @@ namespace System.Globalization
             {
                 // Find end of this segment
                 iNextDot = ascii.IndexOf('.', iAfterLastDot);
-                if (iNextDot < 0 || iNextDot > ascii.Length)
+                if ((uint)iNextDot > (uint)ascii.Length)
                     iNextDot = ascii.Length;
 
                 // Only allowed to have empty . section at end (www.microsoft.com.)
@@ -707,7 +707,7 @@ namespace System.Globalization
                         i %= (output.Length - iOutputAfterLastDot - numSurrogatePairs + 1);
 
                         // Make sure n is legal
-                        if (n < 0 || n > 0x10ffff || (n >= 0xD800 && n <= 0xDFFF))
+                        if ((uint)n > 0x10ffff || (n >= 0xD800 && n <= 0xDFFF))
                             throw new ArgumentException(SR.Argument_IdnBadPunycode, nameof(ascii));
 
                         // insert n at position i of the output:  Really tricky if we have surrogates

--- a/src/System.Private.CoreLib/shared/System/Globalization/JulianCalendar.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/JulianCalendar.cs
@@ -317,7 +317,7 @@ namespace System.Globalization
             CheckYearEraRange(year, era);
             CheckMonthRange(month);
             CheckDayRange(year, month, day);
-            if (millisecond < 0 || millisecond >= MillisPerSecond)
+            if ((uint)millisecond >= MillisPerSecond)
             {
                 throw new ArgumentOutOfRangeException(
                     nameof(millisecond),
@@ -325,7 +325,7 @@ namespace System.Globalization
                     SR.Format(SR.ArgumentOutOfRange_Range, 0, MillisPerSecond - 1));
             }
 
-            if (hour < 0 || hour >= 24 || minute < 0 || minute >= 60 || second < 0 || second >= 60)
+            if ((uint)hour >= 24 || (uint)minute >= 60 || (uint)second >= 60)
             {
                 throw new ArgumentOutOfRangeException(null, SR.ArgumentOutOfRange_BadHourMinuteSecond);
             }

--- a/src/System.Private.CoreLib/shared/System/Globalization/NumberFormatInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/NumberFormatInfo.cs
@@ -225,7 +225,7 @@ namespace System.Globalization
             get => _currencyDecimalDigits;
             set
             {
-                if (value < 0 || value > 99)
+                if ((uint)value > 99)
                 {
                     throw new ArgumentOutOfRangeException(
                         nameof(value),
@@ -397,7 +397,7 @@ namespace System.Globalization
             get => _currencyNegativePattern;
             set
             {
-                if (value < 0 || value > 15)
+                if ((uint)value > 15)
                 {
                     throw new ArgumentOutOfRangeException(
                         nameof(value),
@@ -416,7 +416,7 @@ namespace System.Globalization
             set
             {
                 // NOTENOTE: the range of value should correspond to negNumberFormats[] in vm\COMNumber.cpp.
-                if (value < 0 || value > 4)
+                if ((uint)value > 4)
                 {
                     throw new ArgumentOutOfRangeException(
                         nameof(value),
@@ -435,7 +435,7 @@ namespace System.Globalization
             set
             {
                 // NOTENOTE: the range of value should correspond to posPercentFormats[] in vm\COMNumber.cpp.
-                if (value < 0 || value > 3)
+                if ((uint)value > 3)
                 {
                     throw new ArgumentOutOfRangeException(
                         nameof(value),
@@ -454,7 +454,7 @@ namespace System.Globalization
             set
             {
                 // NOTENOTE: the range of value should correspond to posPercentFormats[] in vm\COMNumber.cpp.
-                if (value < 0 || value > 11)
+                if ((uint)value > 11)
                 {
                     throw new ArgumentOutOfRangeException(
                         nameof(value),
@@ -503,7 +503,7 @@ namespace System.Globalization
             get => _numberDecimalDigits;
             set
             {
-                if (value < 0 || value > 99)
+                if ((uint)value > 99)
                 {
                     throw new ArgumentOutOfRangeException(
                         nameof(value),
@@ -543,7 +543,7 @@ namespace System.Globalization
             get => _currencyPositivePattern;
             set
             {
-                if (value < 0 || value > 3)
+                if ((uint)value > 3)
                 {
                     throw new ArgumentOutOfRangeException(
                         nameof(value),
@@ -592,7 +592,7 @@ namespace System.Globalization
             get => _percentDecimalDigits;
             set
             {
-                if (value < 0 || value > 99)
+                if ((uint)value > 99)
                 {
                     throw new ArgumentOutOfRangeException(
                         nameof(value),

--- a/src/System.Private.CoreLib/shared/System/Globalization/StringInfo.cs
+++ b/src/System.Private.CoreLib/shared/System/Globalization/StringInfo.cs
@@ -210,7 +210,7 @@ namespace System.Globalization
             }
 
             int len = str.Length;
-            if (index < 0 || index >= len)
+            if ((uint)index >= (uint)len)
             {
                 if (index == len)
                 {
@@ -238,7 +238,7 @@ namespace System.Globalization
             }
 
             int len = str.Length;
-            if (index < 0 || index > len)
+            if ((uint)index > (uint)len)
             {
                 throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_Index);
             }

--- a/src/System.Private.CoreLib/shared/System/IO/BinaryReader.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/BinaryReader.cs
@@ -548,7 +548,7 @@ namespace System.IO
         // reasons. More about the subject in: https://github.com/dotnet/coreclr/pull/22102
         protected virtual void FillBuffer(int numBytes)
         {
-            if (numBytes < 0 || numBytes > _buffer.Length)
+            if ((uint)numBytes > (uint)_buffer.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(numBytes), SR.ArgumentOutOfRange_BinaryReaderFillBuffer);
             }

--- a/src/System.Private.CoreLib/shared/System/IO/MemoryStream.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/MemoryStream.cs
@@ -600,7 +600,7 @@ namespace System.IO
         //
         public override void SetLength(long value)
         {
-            if (value < 0 || value > int.MaxValue)
+            if ((ulong)value > int.MaxValue)
                 throw new ArgumentOutOfRangeException(nameof(value), SR.ArgumentOutOfRange_StreamLength);
 
             EnsureWriteable();

--- a/src/System.Private.CoreLib/shared/System/Numerics/Vector2_Intrinsics.cs
+++ b/src/System.Private.CoreLib/shared/System/Numerics/Vector2_Intrinsics.cs
@@ -71,7 +71,7 @@ namespace System.Numerics
                 // Match the JIT's exception type here. For perf, a NullReference is thrown instead of an ArgumentNull.
                 throw new NullReferenceException(SR.Arg_NullArgumentNullRef);
             }
-            if (index < 0 || index >= array.Length)
+            if ((uint)index >= (uint)array.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(index), SR.Format(SR.Arg_ArgumentOutOfRangeException, index));
             }

--- a/src/System.Private.CoreLib/shared/System/Numerics/Vector3_Intrinsics.cs
+++ b/src/System.Private.CoreLib/shared/System/Numerics/Vector3_Intrinsics.cs
@@ -85,7 +85,7 @@ namespace System.Numerics
                 // Match the JIT's exception type here. For perf, a NullReference is thrown instead of an ArgumentNull.
                 throw new NullReferenceException(SR.Arg_NullArgumentNullRef);
             }
-            if (index < 0 || index >= array.Length)
+            if ((uint)index >= (uint)array.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(index), SR.Format(SR.Arg_ArgumentOutOfRangeException, index));
             }

--- a/src/System.Private.CoreLib/shared/System/Numerics/Vector4_Intrinsics.cs
+++ b/src/System.Private.CoreLib/shared/System/Numerics/Vector4_Intrinsics.cs
@@ -114,7 +114,7 @@ namespace System.Numerics
                 // Match the JIT's exception type here. For perf, a NullReference is thrown instead of an ArgumentNull.
                 throw new NullReferenceException(SR.Arg_NullArgumentNullRef);
             }
-            if (index < 0 || index >= array.Length)
+            if ((uint)index >= (uint)array.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(index), SR.Format(SR.Arg_ArgumentOutOfRangeException, index));
             }

--- a/src/System.Private.CoreLib/shared/System/ParseNumbers.cs
+++ b/src/System.Private.CoreLib/shared/System/ParseNumbers.cs
@@ -48,7 +48,7 @@ namespace System
 
             int length = s.Length;
 
-            if (i < 0 || i >= length)
+            if ((uint)i >= (uint)length)
                 throw new ArgumentOutOfRangeException(SR.ArgumentOutOfRange_Index);
 
             // Get rid of the whitespace and then check that we've still got some digits to parse.
@@ -136,7 +136,7 @@ namespace System
 
             int length = s.Length;
 
-            if (i < 0 || i >= length)
+            if ((uint)i >= (uint)length)
                 throw new ArgumentOutOfRangeException(SR.ArgumentOutOfRange_Index);
 
             // Get rid of the whitespace and then check that we've still got some digits to parse.

--- a/src/System.Private.CoreLib/shared/System/Security/SecureString.cs
+++ b/src/System.Private.CoreLib/shared/System/Security/SecureString.cs
@@ -181,7 +181,7 @@ namespace System.Security
         {
             lock (_methodLock)
             {
-                if (index < 0 || index > _decryptedLength)
+                if ((uint)index > (uint)_decryptedLength)
                 {
                     throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_IndexString);
                 }
@@ -228,7 +228,7 @@ namespace System.Security
         {
             lock (_methodLock)
             {
-                if (index < 0 || index >= _decryptedLength)
+                if ((uint)index >= (uint)_decryptedLength)
                 {
                     throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_IndexString);
                 }
@@ -260,7 +260,7 @@ namespace System.Security
         {
             lock (_methodLock)
             {
-                if (index < 0 || index >= _decryptedLength)
+                if ((uint)index >= (uint)_decryptedLength)
                 {
                     throw new ArgumentOutOfRangeException(nameof(index), SR.ArgumentOutOfRange_IndexString);
                 }

--- a/src/System.Private.CoreLib/shared/System/String.Manipulation.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Manipulation.cs
@@ -533,7 +533,7 @@ namespace System
         {
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
-            if (startIndex < 0 || startIndex > this.Length)
+            if ((uint)startIndex > (uint)this.Length)
                 throw new ArgumentOutOfRangeException(nameof(startIndex));
 
             int oldLength = Length;

--- a/src/System.Private.CoreLib/shared/System/String.Searching.cs
+++ b/src/System.Private.CoreLib/shared/System/String.Searching.cs
@@ -231,12 +231,12 @@ namespace System
 
         public int IndexOf(string value, int startIndex, int count)
         {
-            if (startIndex < 0 || startIndex > this.Length)
+            if ((uint)startIndex > (uint)this.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
             }
 
-            if (count < 0 || count > this.Length - startIndex)
+            if ((uint)count > (uint)(this.Length - startIndex))
             {
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_Count);
             }
@@ -260,10 +260,10 @@ namespace System
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
 
-            if (startIndex < 0 || startIndex > this.Length)
+            if ((uint)startIndex > (uint)this.Length)
                 throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
 
-            if (count < 0 || startIndex > this.Length - count)
+            if ((uint)startIndex > (uint)(this.Length - count))
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_Count);
 
             if (comparisonType == StringComparison.Ordinal)
@@ -447,7 +447,7 @@ namespace System
                 return (value.Length == 0) ? 0 : -1;
 
             // Now after handling empty strings, make sure we're not out of range
-            if (startIndex < 0 || startIndex > this.Length)
+            if ((uint)startIndex > (uint)this.Length)
                 throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
 
             // Make sure that we allow startIndex == this.Length

--- a/src/System.Private.CoreLib/shared/System/String.cs
+++ b/src/System.Private.CoreLib/shared/System/String.cs
@@ -412,7 +412,7 @@ namespace System
         public unsafe char[] ToCharArray(int startIndex, int length)
         {
             // Range check everything.
-            if (startIndex < 0 || startIndex > Length || startIndex > Length - length)
+            if ((uint)startIndex > (uint)Length || startIndex > Length - length)
                 throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
 
             if (length <= 0)

--- a/src/System.Private.CoreLib/shared/System/Text/DecoderNLS.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/DecoderNLS.cs
@@ -109,7 +109,7 @@ namespace System.Text
                 throw new ArgumentOutOfRangeException(nameof(bytes),
                     SR.ArgumentOutOfRange_IndexCountBuffer);
 
-            if (charIndex < 0 || charIndex > chars.Length)
+            if ((uint)charIndex > (uint)chars.Length)
                 throw new ArgumentOutOfRangeException(nameof(charIndex),
                     SR.ArgumentOutOfRange_Index);
 

--- a/src/System.Private.CoreLib/shared/System/Text/EncoderNLS.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/EncoderNLS.cs
@@ -100,7 +100,7 @@ namespace System.Text
                 throw new ArgumentOutOfRangeException(nameof(chars),
                       SR.ArgumentOutOfRange_IndexCountBuffer);
 
-            if (byteIndex < 0 || byteIndex > bytes.Length)
+            if ((uint)byteIndex > (uint)bytes.Length)
                 throw new ArgumentOutOfRangeException(nameof(byteIndex),
                      SR.ArgumentOutOfRange_Index);
 

--- a/src/System.Private.CoreLib/shared/System/Text/Encoding.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/Encoding.cs
@@ -234,7 +234,7 @@ namespace System.Text
                     throw new ArgumentException(SR.Format(SR.Argument_CodepageNotSupported, codepage), nameof(codepage));
             }
 
-            if (codepage < 0 || codepage > 65535)
+            if ((uint)codepage > 65535)
             {
                 throw new ArgumentOutOfRangeException(
                     nameof(codepage), SR.Format(SR.ArgumentOutOfRange_Range, 0, 65535));

--- a/src/System.Private.CoreLib/shared/System/Text/EncodingNLS.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/EncodingNLS.cs
@@ -101,7 +101,7 @@ namespace System.Text
             if (s.Length - charIndex < charCount)
                 throw new ArgumentOutOfRangeException(nameof(s), SR.ArgumentOutOfRange_IndexCount);
 
-            if (byteIndex < 0 || byteIndex > bytes.Length)
+            if ((uint)byteIndex > (uint)bytes.Length)
                 throw new ArgumentOutOfRangeException(nameof(byteIndex), SR.ArgumentOutOfRange_Index);
 
             int byteCount = bytes.Length - byteIndex;
@@ -136,7 +136,7 @@ namespace System.Text
             if (chars.Length - charIndex < charCount)
                 throw new ArgumentOutOfRangeException(nameof(chars), SR.ArgumentOutOfRange_IndexCountBuffer);
 
-            if (byteIndex < 0 || byteIndex > bytes.Length)
+            if ((uint)byteIndex > (uint)bytes.Length)
                 throw new ArgumentOutOfRangeException(nameof(byteIndex), SR.ArgumentOutOfRange_Index);
 
             // If nothing to encode return 0, avoid fixed problem
@@ -226,7 +226,7 @@ namespace System.Text
             if (bytes.Length - byteIndex < byteCount)
                 throw new ArgumentOutOfRangeException(nameof(bytes), SR.ArgumentOutOfRange_IndexCountBuffer);
 
-            if (charIndex < 0 || charIndex > chars.Length)
+            if ((uint)charIndex > (uint)chars.Length)
                 throw new ArgumentOutOfRangeException(nameof(charIndex), SR.ArgumentOutOfRange_Index);
 
             // If no input, return 0 & avoid fixed problem

--- a/src/System.Private.CoreLib/shared/System/Text/UTF32Encoding.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/UTF32Encoding.cs
@@ -161,7 +161,7 @@ namespace System.Text
             if (s.Length - charIndex < charCount)
                 throw new ArgumentOutOfRangeException(nameof(s), SR.ArgumentOutOfRange_IndexCount);
 
-            if (byteIndex < 0 || byteIndex > bytes.Length)
+            if ((uint)byteIndex > (uint)bytes.Length)
                 throw new ArgumentOutOfRangeException(nameof(byteIndex), SR.ArgumentOutOfRange_Index);
 
             int byteCount = bytes.Length - byteIndex;
@@ -197,7 +197,7 @@ namespace System.Text
             if (chars.Length - charIndex < charCount)
                 throw new ArgumentOutOfRangeException(nameof(chars), SR.ArgumentOutOfRange_IndexCountBuffer);
 
-            if (byteIndex < 0 || byteIndex > bytes.Length)
+            if ((uint)byteIndex > (uint)bytes.Length)
                 throw new ArgumentOutOfRangeException(nameof(byteIndex), SR.ArgumentOutOfRange_Index);
 
             // If nothing to encode return 0, avoid fixed problem
@@ -293,7 +293,7 @@ namespace System.Text
             if (bytes.Length - byteIndex < byteCount)
                 throw new ArgumentOutOfRangeException(nameof(bytes), SR.ArgumentOutOfRange_IndexCountBuffer);
 
-            if (charIndex < 0 || charIndex > chars.Length)
+            if ((uint)charIndex > (uint)chars.Length)
                 throw new ArgumentOutOfRangeException(nameof(charIndex), SR.ArgumentOutOfRange_Index);
 
             // If no input, return 0 & avoid fixed problem

--- a/src/System.Private.CoreLib/shared/System/Text/UTF7Encoding.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/UTF7Encoding.cs
@@ -197,7 +197,7 @@ namespace System.Text
             if (s.Length - charIndex < charCount)
                 throw new ArgumentOutOfRangeException(nameof(s), SR.ArgumentOutOfRange_IndexCount);
 
-            if (byteIndex < 0 || byteIndex > bytes.Length)
+            if ((uint)byteIndex > (uint)bytes.Length)
                 throw new ArgumentOutOfRangeException(nameof(byteIndex), SR.ArgumentOutOfRange_Index);
 
             int byteCount = bytes.Length - byteIndex;
@@ -233,7 +233,7 @@ namespace System.Text
             if (chars.Length - charIndex < charCount)
                 throw new ArgumentOutOfRangeException(nameof(chars), SR.ArgumentOutOfRange_IndexCountBuffer);
 
-            if (byteIndex < 0 || byteIndex > bytes.Length)
+            if ((uint)byteIndex > (uint)bytes.Length)
                 throw new ArgumentOutOfRangeException(nameof(byteIndex), SR.ArgumentOutOfRange_Index);
 
             // If nothing to encode return 0, avoid fixed problem
@@ -329,7 +329,7 @@ namespace System.Text
             if (bytes.Length - byteIndex < byteCount)
                 throw new ArgumentOutOfRangeException(nameof(bytes), SR.ArgumentOutOfRange_IndexCountBuffer);
 
-            if (charIndex < 0 || charIndex > chars.Length)
+            if ((uint)charIndex > (uint)chars.Length)
                 throw new ArgumentOutOfRangeException(nameof(charIndex), SR.ArgumentOutOfRange_Index);
 
             // If no input, return 0 & avoid fixed problem

--- a/src/System.Private.CoreLib/shared/System/Text/UnicodeEncoding.cs
+++ b/src/System.Private.CoreLib/shared/System/Text/UnicodeEncoding.cs
@@ -154,7 +154,7 @@ namespace System.Text
             if (s.Length - charIndex < charCount)
                 throw new ArgumentOutOfRangeException(nameof(s), SR.ArgumentOutOfRange_IndexCount);
 
-            if (byteIndex < 0 || byteIndex > bytes.Length)
+            if ((uint)byteIndex > (uint)bytes.Length)
                 throw new ArgumentOutOfRangeException(nameof(byteIndex), SR.ArgumentOutOfRange_Index);
 
             int byteCount = bytes.Length - byteIndex;
@@ -190,7 +190,7 @@ namespace System.Text
             if (chars.Length - charIndex < charCount)
                 throw new ArgumentOutOfRangeException(nameof(chars), SR.ArgumentOutOfRange_IndexCountBuffer);
 
-            if (byteIndex < 0 || byteIndex > bytes.Length)
+            if ((uint)byteIndex > (uint)bytes.Length)
                 throw new ArgumentOutOfRangeException(nameof(byteIndex), SR.ArgumentOutOfRange_Index);
 
             // If nothing to encode return 0, avoid fixed problem
@@ -286,7 +286,7 @@ namespace System.Text
             if (bytes.Length - byteIndex < byteCount)
                 throw new ArgumentOutOfRangeException(nameof(bytes), SR.ArgumentOutOfRange_IndexCountBuffer);
 
-            if (charIndex < 0 || charIndex > chars.Length)
+            if ((uint)charIndex > (uint)chars.Length)
                 throw new ArgumentOutOfRangeException(nameof(charIndex), SR.ArgumentOutOfRange_Index);
 
             // If no input, return 0 & avoid fixed problem

--- a/src/System.Private.CoreLib/shared/System/Threading/ReaderWriterLockSlim.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/ReaderWriterLockSlim.cs
@@ -270,7 +270,7 @@ namespace System.Threading
 
                     int elapsed = Environment.TickCount - _start;
                     // elapsed may be negative if TickCount has overflowed by 2^31 milliseconds.
-                    if (elapsed < 0 || elapsed >= _total)
+                    if ((uint)elapsed >= (uint)_total)
                         return 0;
 
                     return _total - elapsed;

--- a/src/System.Private.CoreLib/shared/System/TimeZoneInfo.StringSerializer.cs
+++ b/src/System.Private.CoreLib/shared/System/TimeZoneInfo.StringSerializer.cs
@@ -192,7 +192,7 @@ namespace System
             /// </summary>
             private void SkipVersionNextDataFields(int depth /* starting depth in the nested brackets ('[', ']')*/)
             {
-                if (_currentTokenStartIndex < 0 || _currentTokenStartIndex >= _serializedText.Length)
+                if ((uint)_currentTokenStartIndex >= (uint)_serializedText.Length)
                 {
                     throw new SerializationException(SR.Serialization_InvalidData);
                 }
@@ -260,7 +260,7 @@ namespace System
                 {
                     throw new SerializationException(SR.Serialization_InvalidData);
                 }
-                if (_currentTokenStartIndex < 0 || _currentTokenStartIndex >= _serializedText.Length)
+                if ((uint)_currentTokenStartIndex >= (uint)_serializedText.Length)
                 {
                     throw new SerializationException(SR.Serialization_InvalidData);
                 }
@@ -393,7 +393,7 @@ namespace System
                 {
                     throw new SerializationException(SR.Serialization_InvalidData);
                 }
-                if (_currentTokenStartIndex < 0 || _currentTokenStartIndex >= _serializedText.Length)
+                if ((uint)_currentTokenStartIndex >= (uint)_serializedText.Length)
                 {
                     throw new SerializationException(SR.Serialization_InvalidData);
                 }
@@ -412,7 +412,7 @@ namespace System
                     return null;
                 }
 
-                if (_currentTokenStartIndex < 0 || _currentTokenStartIndex >= _serializedText.Length)
+                if ((uint)_currentTokenStartIndex >= (uint)_serializedText.Length)
                 {
                     throw new SerializationException(SR.Serialization_InvalidData);
                 }
@@ -517,7 +517,7 @@ namespace System
                     throw new SerializationException(SR.Serialization_InvalidData);
                 }
 
-                if (_currentTokenStartIndex < 0 || _currentTokenStartIndex >= _serializedText.Length)
+                if ((uint)_currentTokenStartIndex >= (uint)_serializedText.Length)
                 {
                     throw new SerializationException(SR.Serialization_InvalidData);
                 }

--- a/src/System.Private.CoreLib/src/System/Collections/ObjectModel/ReadOnlyDictionary.cs
+++ b/src/System.Private.CoreLib/src/System/Collections/ObjectModel/ReadOnlyDictionary.cs
@@ -181,7 +181,7 @@ namespace System.Collections.ObjectModel
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_NonZeroLowerBound);
             }
 
-            if (index < 0 || index > array.Length)
+            if ((uint)index > (uint)array.Length)
             {
                 ThrowHelper.ThrowIndexArgumentOutOfRange_NeedNonNegNumException();
             }

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
@@ -984,7 +984,7 @@ namespace System.Reflection.Emit
             {
                 token &= 0x00FFFFFF;
 
-                if (token < 0 || token > m_tokens.Count)
+                if ((uint)token > (uint)m_tokens.Count)
                     return null;
 
                 return m_tokens[token];

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
@@ -493,7 +493,7 @@ namespace System.Reflection.Emit
 
         public ParameterBuilder? DefineParameter(int position, ParameterAttributes attributes, string? parameterName)
         {
-            if (position < 0 || position > m_parameterTypes.Length)
+            if ((uint)position > (uint)m_parameterTypes.Length)
                 throw new ArgumentOutOfRangeException(SR.ArgumentOutOfRange_ParamSequence);
             position--; // it's 1 based. 0 is the return value
 

--- a/src/System.Private.CoreLib/src/System/Reflection/Emit/ILGenerator.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Emit/ILGenerator.cs
@@ -288,7 +288,7 @@ namespace System.Reflection.Emit
 
             int index = lbl.GetLabelValue();
 
-            if (index < 0 || index >= m_labelCount)
+            if ((uint)index >= (uint)m_labelCount)
                 throw new ArgumentException(SR.Argument_BadLabel);
 
             if (m_labelList[index] < 0)
@@ -1032,7 +1032,7 @@ namespace System.Reflection.Emit
             int labelIndex = loc.GetLabelValue();
 
             // This should never happen.
-            if (labelIndex < 0 || labelIndex >= m_labelList.Length)
+            if ((uint)labelIndex >= (uint)m_labelList.Length)
             {
                 throw new ArgumentException(SR.Argument_InvalidLabel);
             }

--- a/src/System.Private.CoreLib/src/System/Reflection/MdImport.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/MdImport.cs
@@ -118,7 +118,7 @@ namespace System.Reflection
         {
             get
             {
-                if (index < 0 || index >= m_length)
+                if ((uint)index >= (uint)m_length)
                     throw new IndexOutOfRangeException();
 
                 unsafe


### PR DESCRIPTION
Noticed a change for `Dictionary.KeyCollection` and got a bit carried away...
```
Total bytes of diff: -1150 (-0.04% of base)
    diff is an improvement.

Top file improvements by size (bytes):
    -1150 : System.Private.CoreLib.dasm (-0.04% of base)

1 total files with size differences (1 improved, 0 regressed), 0 unchanged.

Top method improvements by size (bytes):
     -93 (-3.87% of base) : System.Private.CoreLib.dasm - KeyCollection:CopyTo(ref,int):this (13 methods)
     -60 (-2.38% of base) : System.Private.CoreLib.dasm - ValueCollection:CopyTo(ref,int):this (13 methods)
     -48 (-5.61% of base) : System.Private.CoreLib.dasm - DateTime:TryCreate(int,int,int,int,int,int,int,byref):bool
     -35 (-7.58% of base) : System.Private.CoreLib.dasm - JulianCalendar:ToDateTime(int,int,int,int,int,int,int,int):struct:this
     -28 (-5.10% of base) : System.Private.CoreLib.dasm - Utf8Parser:TryParseInt64D(struct,byref,byref):bool
     -20 (-5.60% of base) : System.Private.CoreLib.dasm - Vector2:CopyTo(ref,int):this
     -17 (-2.84% of base) : System.Private.CoreLib.dasm - String:IndexOf(ref,int,int,int):int:this
     -17 (-5.94% of base) : System.Private.CoreLib.dasm - Calendar:TimeToTicks(int,int,int,int):long
     -17 (-6.37% of base) : System.Private.CoreLib.dasm - GregorianCalendarHelper:TimeToTicks(int,int,int,int):long
     -16 (-8.42% of base) : System.Private.CoreLib.dasm - Char:IsSurrogatePair(ref,int):bool
     -16 (-2.69% of base) : System.Private.CoreLib.dasm - Char:ConvertToUtf32(ref,int):int
     -16 (-4.15% of base) : System.Private.CoreLib.dasm - Vector3:CopyTo(ref,int):this
     -16 (-3.83% of base) : System.Private.CoreLib.dasm - Vector4:CopyTo(ref,int):this
     -16 (-1.48% of base) : System.Private.CoreLib.dasm - EncodingNLS:GetBytes(ref,int,int,ref,int):int:this (2 methods)
     -16 (-1.49% of base) : System.Private.CoreLib.dasm - UnicodeEncoding:GetBytes(ref,int,int,ref,int):int:this (2 methods)
     -16 (-1.49% of base) : System.Private.CoreLib.dasm - UTF32Encoding:GetBytes(ref,int,int,ref,int):int:this (2 methods)
     -16 (-1.49% of base) : System.Private.CoreLib.dasm - UTF7Encoding:GetBytes(ref,int,int,ref,int):int:this (2 methods)
     -16 (-3.83% of base) : System.Private.CoreLib.dasm - IListWrapper:LastIndexOf(ref,int,int):int:this
     -14 (-10.00% of base) : System.Private.CoreLib.dasm - Char:IsHighSurrogate(ref,int):bool
     -14 (-10.00% of base) : System.Private.CoreLib.dasm - Char:IsLowSurrogate(ref,int):bool
     -14 (-0.44% of base) : System.Private.CoreLib.dasm - IdnMapping:PunycodeDecode(ref):ref
     -11 (-1.16% of base) : System.Private.CoreLib.dasm - ParseNumbers:StringToLong(struct,int,int,byref):long
     -11 (-1.11% of base) : System.Private.CoreLib.dasm - ParseNumbers:StringToInt(struct,int,int,byref):int
     -10 (-4.37% of base) : System.Private.CoreLib.dasm - String:IndexOf(ref,int,int):int:this (2 methods)
     -10 (-1.34% of base) : System.Private.CoreLib.dasm - DateTime:.ctor(int,int,int,int,int,int,int,ref,int):this
     -10 (-0.99% of base) : System.Private.CoreLib.dasm - StringSerializer:GetNextStringValue():ref:this
      -9 (-3.41% of base) : System.Private.CoreLib.dasm - Array:FindIndex(ref,int,int,ref):int
      -9 (-0.63% of base) : System.Private.CoreLib.dasm - DateTime:.ctor(int,int,int,int,int,int,int):this (2 methods)
      -9 (-1.41% of base) : System.Private.CoreLib.dasm - DateTime:.ctor(int,int,int,int,int,int,int,ref):this
      -9 (-1.70% of base) : System.Private.CoreLib.dasm - DecoderNLS:GetChars(ref,int,int,ref,int,bool):int:this
      -9 (-1.68% of base) : System.Private.CoreLib.dasm - EncoderNLS:GetBytes(ref,int,int,ref,int,bool):int:this
      -9 (-1.60% of base) : System.Private.CoreLib.dasm - EncodingNLS:GetChars(ref,int,int,ref,int):int:this
      -9 (-1.60% of base) : System.Private.CoreLib.dasm - UnicodeEncoding:GetChars(ref,int,int,ref,int):int:this
      -9 (-1.60% of base) : System.Private.CoreLib.dasm - UTF32Encoding:GetChars(ref,int,int,ref,int):int:this
      -9 (-1.60% of base) : System.Private.CoreLib.dasm - UTF7Encoding:GetChars(ref,int,int,ref,int):int:this
      -8 (-1.42% of base) : System.Private.CoreLib.dasm - Array:IndexOf(ref,ref,int,int):int (2 methods)
      -8 (-2.42% of base) : System.Private.CoreLib.dasm - String:ToCharArray(int,int):ref:this
      -8 (-2.16% of base) : System.Private.CoreLib.dasm - String:Insert(int,ref):ref:this
      -8 (-1.34% of base) : System.Private.CoreLib.dasm - String:LastIndexOf(ref,int,int,int):int:this
      -8 (-1.72% of base) : System.Private.CoreLib.dasm - BitConverter:ToString(ref,int,int):ref
      -8 (-11.11% of base) : System.Private.CoreLib.dasm - DateTimeParse:AdjustHour(byref,int):bool
      -8 (-1.85% of base) : System.Private.CoreLib.dasm - StringSerializer:SkipVersionNextDataFields(int):this
      -8 (-0.77% of base) : System.Private.CoreLib.dasm - StringSerializer:GetNextAdjustmentRuleValue():ref:this
      -8 (-0.70% of base) : System.Private.CoreLib.dasm - StringSerializer:GetNextTransitionTimeValue():struct:this
      -8 (-1.36% of base) : System.Private.CoreLib.dasm - RuntimeModule:ResolveSignature(int):ref:this
      -8 (-1.83% of base) : System.Private.CoreLib.dasm - BinaryReader:FillBuffer(int):this
      -8 (-1.66% of base) : System.Private.CoreLib.dasm - CompareInfo:IndexOf(ref,ushort,int,int,int):int:this
      -8 (-1.21% of base) : System.Private.CoreLib.dasm - CompareInfo:LastIndexOf(ref,ushort,int,int,int):int:this
      -8 (-1.23% of base) : System.Private.CoreLib.dasm - CompareInfo:LastIndexOf(ref,ref,int,int,int):int:this
      -8 (-3.03% of base) : System.Private.CoreLib.dasm - HebrewCalendar:GetLunarMonthDay(int,ref):int
      
132 total methods with size differences (132 improved, 0 regressed), 19003 unchanged.
```

/cc @jkotas 