### PR TITLE
Fix StreamReader to pass cancellation token into ReadBufferAsync

### DIFF
--- a/src/System.Private.CoreLib/shared/System/IO/StreamReader.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/StreamReader.cs
@@ -840,7 +840,7 @@ namespace System.IO
 
         private async Task<string?> ReadLineAsyncInternal()
         {
-            if (_charPos == _charLen && (await ReadBufferAsync().ConfigureAwait(false)) == 0)
+            if (_charPos == _charLen && (await ReadBufferAsync(CancellationToken.None).ConfigureAwait(false)) == 0)
             {
                 return null;
             }
@@ -876,7 +876,7 @@ namespace System.IO
 
                         _charPos = tmpCharPos = i + 1;
 
-                        if (ch == '\r' && (tmpCharPos < tmpCharLen || (await ReadBufferAsync().ConfigureAwait(false)) > 0))
+                        if (ch == '\r' && (tmpCharPos < tmpCharLen || (await ReadBufferAsync(CancellationToken.None).ConfigureAwait(false)) > 0))
                         {
                             tmpCharPos = _charPos;
                             if (_charBuffer[tmpCharPos] == '\n')
@@ -894,7 +894,7 @@ namespace System.IO
                 i = tmpCharLen - tmpCharPos;
                 sb ??= new StringBuilder(i + 80);
                 sb.Append(tmpCharBuffer, tmpCharPos, i);
-            } while (await ReadBufferAsync().ConfigureAwait(false) > 0);
+            } while (await ReadBufferAsync(CancellationToken.None).ConfigureAwait(false) > 0);
 
             return sb.ToString();
         }
@@ -928,7 +928,7 @@ namespace System.IO
                 int tmpCharPos = _charPos;
                 sb.Append(_charBuffer, tmpCharPos, _charLen - tmpCharPos);
                 _charPos = _charLen;  // We consumed these characters
-                await ReadBufferAsync().ConfigureAwait(false);
+                await ReadBufferAsync(CancellationToken.None).ConfigureAwait(false);
             } while (_charLen > 0);
 
             return sb.ToString();
@@ -961,7 +961,7 @@ namespace System.IO
             ThrowIfDisposed();
             CheckAsyncTaskInProgress();
 
-            Task<int> task = ReadAsyncInternal(new Memory<char>(buffer, index, count), default).AsTask();
+            Task<int> task = ReadAsyncInternal(new Memory<char>(buffer, index, count), CancellationToken.None).AsTask();
             _asyncReadTask = task;
 
             return task;
@@ -988,7 +988,7 @@ namespace System.IO
 
         internal override async ValueTask<int> ReadAsyncInternal(Memory<char> buffer, CancellationToken cancellationToken)
         {
-            if (_charPos == _charLen && (await ReadBufferAsync().ConfigureAwait(false)) == 0)
+            if (_charPos == _charLen && (await ReadBufferAsync(cancellationToken).ConfigureAwait(false)) == 0)
             {
                 return 0;
             }
@@ -1218,7 +1218,7 @@ namespace System.IO
             return new ValueTask<int>(t);
         }
 
-        private async ValueTask<int> ReadBufferAsync()
+        private async ValueTask<int> ReadBufferAsync(CancellationToken cancellationToken)
         {
             _charLen = 0;
             _charPos = 0;
@@ -1235,7 +1235,7 @@ namespace System.IO
                 {
                     Debug.Assert(_bytePos <= _encoding.Preamble.Length, "possible bug in _compressPreamble. Are two threads using this StreamReader at the same time?");
                     int tmpBytePos = _bytePos;
-                    int len = await tmpStream.ReadAsync(new Memory<byte>(tmpByteBuffer, tmpBytePos, tmpByteBuffer.Length - tmpBytePos)).ConfigureAwait(false);
+                    int len = await tmpStream.ReadAsync(new Memory<byte>(tmpByteBuffer, tmpBytePos, tmpByteBuffer.Length - tmpBytePos), cancellationToken).ConfigureAwait(false);
                     Debug.Assert(len >= 0, "Stream.Read returned a negative number!  This is a bug in your stream class.");
 
                     if (len == 0)
@@ -1257,7 +1257,7 @@ namespace System.IO
                 else
                 {
                     Debug.Assert(_bytePos == 0, "_bytePos can be non zero only when we are trying to _checkPreamble. Are two threads using this StreamReader at the same time?");
-                    _byteLen = await tmpStream.ReadAsync(new Memory<byte>(tmpByteBuffer)).ConfigureAwait(false);
+                    _byteLen = await tmpStream.ReadAsync(new Memory<byte>(tmpByteBuffer), cancellationToken).ConfigureAwait(false);
                     Debug.Assert(_byteLen >= 0, "Stream.Read returned a negative number!  Bug in stream class.");
 
                     if (_byteLen == 0)  // We're at EOF


### PR DESCRIPTION
ReadAsyncInternal is correctly passing its token into the two call sites where it delegates directly to the underlying stream, but in one place it calls through ReadBufferAsync, which is currently not defined to take a token.  Fix that, and pass the token through.

Contributes to https://github.com/dotnet/corefx/issues/42136
cc: @JeremyKuhne 