### PR TITLE
[WIP] Ignore GCness when attempting to reuse constants

### DIFF
--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -2643,8 +2643,7 @@ bool LinearScan::isMatchingConstant(RegRecord* physRegRecord, RefPosition* refPo
         switch (otherTreeNode->OperGet())
         {
             case GT_CNS_INT:
-                if ((refPosition->treeNode->AsIntCon()->IconValue() == otherTreeNode->AsIntCon()->IconValue()) &&
-                    (varTypeGCtype(refPosition->treeNode) == varTypeGCtype(otherTreeNode)))
+                if (refPosition->treeNode->AsIntCon()->IconValue() == otherTreeNode->AsIntCon()->IconValue())
                 {
 #ifdef _TARGET_64BIT_
                     // If the constant is negative, only reuse registers of the same type.


### PR DESCRIPTION
While attempting to minimize `GT_BLK` use (#27053) I've ran into a little CQ regression issue: INITOBJ is sometimes used to zero out both structs and  primitive/reference types and the importer uses `GT_BLK` regardless. I cannot make it use `GT_OBJ` because `ClassLayout` is meant to work with structs or with stack allocated reference types, not with actual references. And anyway it doesn't make a lot of sense to generate a block op in the case of primitive/reference types.

The problem is that converting it to `STIND.REF(LDNULL)` results in code size regressions due to LSRA restrictions on the type of reused constants - they need to have the same GCness. The block version uses a `TYP_INT` 0 while the non-block version uses `TYP_REF` 0.

However, I don't see any reason for the GCness of the constant type to matter because null references do not need to be reported to the GC. More generally, no constant needs to be reported to the GC because it cannot ever by a valid GC heap reference.

Removing the restriction also turns out to be a CQ improvement though I wasn't specifically looking for that.