### PR TITLE
Log path in a particular BIFE

### DIFF
--- a/src/vm/assemblynative.cpp
+++ b/src/vm/assemblynative.cpp
@@ -250,13 +250,13 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
         
         // Need to verify that this is a valid CLR assembly. 
         if (!pILImage->CheckILFormat())
-            ThrowHR(COR_E_BADIMAGEFORMAT, BFA_BAD_IL);
+            THROW_BAD_FORMAT(BFA_BAD_IL, &*pILImage);
 
         LoaderAllocator* pLoaderAllocator = NULL;
         if (SUCCEEDED(pBinderContext->GetLoaderAllocator((LPVOID*)&pLoaderAllocator)) && pLoaderAllocator->IsCollectible() && !pILImage->IsILOnly())
         {
             // Loading IJW assemblies into a collectible AssemblyLoadContext is not allowed
-            ThrowHR(COR_E_BADIMAGEFORMAT, BFA_IJW_IN_COLLECTIBLE_ALC);
+            THROW_BAD_FORMAT(BFA_IJW_IN_COLLECTIBLE_ALC, &*pILImage);
         }
     }
     
@@ -270,7 +270,7 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
         {
             // ReadyToRun images are treated as IL images by the rest of the system
             if (!pNIImage->CheckILFormat())
-                ThrowHR(COR_E_BADIMAGEFORMAT);
+                THROW_BAD_FORMAT(COR_E_BADIMAGEFORMAT, &*pNIImage);
 
             pILImage = pNIImage.Extract();
             pNIImage = NULL;
@@ -278,7 +278,7 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
         else
         {
             if (!pNIImage->CheckNativeFormat())
-                ThrowHR(COR_E_BADIMAGEFORMAT);
+                THROW_BAD_FORMAT(COR_E_BADIMAGEFORMAT, &*pNIImage);
         }
     }
 #endif // FEATURE_PREJIT

--- a/src/vm/assemblynative.cpp
+++ b/src/vm/assemblynative.cpp
@@ -250,13 +250,13 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
         
         // Need to verify that this is a valid CLR assembly. 
         if (!pILImage->CheckILFormat())
-            THROW_BAD_FORMAT(BFA_BAD_IL, &*pILImage);
+            THROW_BAD_FORMAT(BFA_BAD_IL, pILImage.GetValue());
 
         LoaderAllocator* pLoaderAllocator = NULL;
         if (SUCCEEDED(pBinderContext->GetLoaderAllocator((LPVOID*)&pLoaderAllocator)) && pLoaderAllocator->IsCollectible() && !pILImage->IsILOnly())
         {
             // Loading IJW assemblies into a collectible AssemblyLoadContext is not allowed
-            THROW_BAD_FORMAT(BFA_IJW_IN_COLLECTIBLE_ALC, &*pILImage);
+            THROW_BAD_FORMAT(BFA_IJW_IN_COLLECTIBLE_ALC, pILImage.GetValue());
         }
     }
     
@@ -270,7 +270,7 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
         {
             // ReadyToRun images are treated as IL images by the rest of the system
             if (!pNIImage->CheckILFormat())
-                THROW_BAD_FORMAT(COR_E_BADIMAGEFORMAT, &*pNIImage);
+                THROW_BAD_FORMAT(COR_E_BADIMAGEFORMAT, pNIImage.GetValue());
 
             pILImage = pNIImage.Extract();
             pNIImage = NULL;
@@ -278,7 +278,7 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
         else
         {
             if (!pNIImage->CheckNativeFormat())
-                THROW_BAD_FORMAT(COR_E_BADIMAGEFORMAT, &*pNIImage);
+                THROW_BAD_FORMAT(COR_E_BADIMAGEFORMAT, pNIImage.GetValue());
         }
     }
 #endif // FEATURE_PREJIT

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -12330,7 +12330,7 @@ VOID ThrowBadFormatWorker(UINT resID, LPCWSTR imageName DEBUGARG(__in_z const ch
     SString resStr;
     if (resID == 0 || !resStr.LoadResource(CCompRC::Optional, resID))
     {
-        resStr.LoadResource(CCompRC::Error, MSG_FOR_URT_HR(BFA_BAD_IL)); // "Bad IL format."
+        resStr.LoadResource(CCompRC::Error, BFA_BAD_IL); // "Bad IL format."
     }
     msgStr += resStr;
 

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -12327,19 +12327,24 @@ VOID ThrowBadFormatWorker(UINT resID, LPCWSTR imageName DEBUGARG(__in_z const ch
 #ifndef DACCESS_COMPILE
     SString msgStr;
 
-    if ((imageName != NULL) && (imageName[0] != 0))
-    {
-        msgStr += W("[");
-        msgStr += imageName;
-        msgStr += W("] ");
-    }
-
     SString resStr;
     if (resID == 0 || !resStr.LoadResource(CCompRC::Optional, resID))
     {
-        resStr.LoadResource(CCompRC::Error, MSG_FOR_URT_HR(COR_E_BADIMAGEFORMAT));
+        resStr.LoadResource(CCompRC::Error, MSG_FOR_URT_HR(BFA_BAD_IL)); // "Bad IL format."
     }
     msgStr += resStr;
+
+    if ((imageName != NULL) && (imageName[0] != 0))
+    {
+        SString suffixResStr;
+        if (suffixResStr.LoadResource(CCompRC::Optional, COR_E_BADIMAGEFORMAT)) // "The format of the file '%1' is invalid."
+        {
+            SString suffixMsgStr;
+            suffixMsgStr.FormatMessage(FORMAT_MESSAGE_FROM_STRING, (LPCWSTR)suffixResStr, 0, 0, imageName);
+            msgStr.AppendASCII(" ");
+            msgStr += suffixMsgStr;
+        }
+    }
 
 #ifdef _DEBUG
     if (0 != strcmp(cond, "FALSE"))


### PR DESCRIPTION
before
```
System.BadImageFormatException : Bad IL format.
```
after
```
System.BadImageFormatException : Bad IL format. The format of the file 'C:\WINDOWS\system32\kernelbase.dll' is invalid.
```

Note
* Just some of countless error paths for assembly load. (Over 60 instances of THROW_BAD_FORMAT alone. Some have paths some do not.)
* I can only hit the 1st path in tests. I can revert the other 3 if you like.