### PR TITLE
Remove empty lines caused by empty fusion log string

### DIFF
--- a/src/System.Private.CoreLib/src/System/BadImageFormatException.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/BadImageFormatException.CoreCLR.cs
@@ -7,12 +7,11 @@ namespace System
     public partial class BadImageFormatException
     {
         // Do not delete: this is invoked from native code.
-        private BadImageFormatException(string? fileName, string? fusionLog, int hResult)
+        private BadImageFormatException(string? fileName, int hResult)
             : base(null)
         {
             HResult = hResult;
             _fileName = fileName;
-            _fusionLog = fusionLog;
             SetMessageField();
         }
     }

--- a/src/System.Private.CoreLib/src/System/IO/FileLoadException.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/IO/FileLoadException.CoreCLR.cs
@@ -10,12 +10,11 @@ namespace System.IO
     public partial class FileLoadException
     {
         // Do not delete: this is invoked from native code.
-        private FileLoadException(string? fileName, string? fusionLog, int hResult)
+        private FileLoadException(string? fileName, int hResult)
             : base(null)
         {
             HResult = hResult;
             FileName = fileName;
-            FusionLog = fusionLog;
             _message = FormatFileLoadExceptionMessage(FileName, HResult);
         }
 

--- a/src/System.Private.CoreLib/src/System/IO/FileNotFoundException.CoreCLR.cs
+++ b/src/System.Private.CoreLib/src/System/IO/FileNotFoundException.CoreCLR.cs
@@ -7,12 +7,11 @@ namespace System.IO
     public partial class FileNotFoundException
     {
         // Do not delete: this is invoked from native code.
-        private FileNotFoundException(string? fileName, string? fusionLog, int hResult)
+        private FileNotFoundException(string? fileName, int hResult)
             : base(null)
         {
             HResult = hResult;
             FileName = fileName;
-            FusionLog = fusionLog;
             SetMessageField();
         }
     }

--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -3801,7 +3801,7 @@ DomainAssembly* AppDomain::LoadDomainAssembly(AssemblySpec* pSpec,
             {
                 StackSString name;
                 pSpec->GetFileOrDisplayName(0, name);
-                pEx=new EEFileLoadException(name, pEx->GetHR(), NULL, pEx);
+                pEx=new EEFileLoadException(name, pEx->GetHR(), pEx);
                 AddExceptionToCache(pSpec, pEx);
                 PAL_CPP_THROW(Exception *, pEx);
             }

--- a/src/vm/clrex.cpp
+++ b/src/vm/clrex.cpp
@@ -1832,7 +1832,7 @@ OBJECTREF EEFileLoadException::CreateThrowable()
     gc.pNewException = AllocateObject(MscorlibBinder::GetException(m_kind));
 
     MethodDesc* pMD = MemberLoader::FindMethod(gc.pNewException->GetMethodTable(),
-                            COR_CTOR_METHOD_NAME, &gsig_IM_Str_Str_Int_RetVoid);
+                            COR_CTOR_METHOD_NAME, &gsig_IM_Str_Int_RetVoid);
 
     if (!pMD)
     {
@@ -1845,7 +1845,6 @@ OBJECTREF EEFileLoadException::CreateThrowable()
     ARG_SLOT args[] = {
         ObjToArgSlot(gc.pNewException),
         ObjToArgSlot(gc.pNewFileString),
-        NULL,
         (ARG_SLOT) m_hr
     };
 

--- a/src/vm/clrex.cpp
+++ b/src/vm/clrex.cpp
@@ -1675,10 +1675,9 @@ OBJECTREF EETypeLoadException::CreateThrowable()
 // EEFileLoadException is an EE exception subclass representing a file loading
 // error
 // ---------------------------------------------------------------------------
-EEFileLoadException::EEFileLoadException(const SString &name, HRESULT hr, void *pFusionLog, Exception *pInnerException/* = NULL*/)
+EEFileLoadException::EEFileLoadException(const SString &name, HRESULT hr, Exception *pInnerException/* = NULL*/)
   : EEException(GetFileLoadKind(hr)),
     m_name(name),
-    m_pFusionLog(pFusionLog),
     m_hr(hr)
 {
     CONTRACTL
@@ -1822,18 +1821,14 @@ OBJECTREF EEFileLoadException::CreateThrowable()
     }
     CONTRACTL_END;
 
-    // Fetch any log info from the fusion log
-    SString logText;
     struct _gc {
         OBJECTREF pNewException;
         STRINGREF pNewFileString;
-        STRINGREF pFusLogString;
     } gc;
     ZeroMemory(&gc, sizeof(gc));
     GCPROTECT_BEGIN(gc);
 
     gc.pNewFileString = StringObject::NewString(m_name);
-    gc.pFusLogString = StringObject::NewString(logText);
     gc.pNewException = AllocateObject(MscorlibBinder::GetException(m_kind));
 
     MethodDesc* pMD = MemberLoader::FindMethod(gc.pNewException->GetMethodTable(),
@@ -1850,7 +1845,7 @@ OBJECTREF EEFileLoadException::CreateThrowable()
     ARG_SLOT args[] = {
         ObjToArgSlot(gc.pNewException),
         ObjToArgSlot(gc.pNewFileString),
-        ObjToArgSlot(gc.pFusLogString),
+        NULL,
         (ARG_SLOT) m_hr
     };
 

--- a/src/vm/clrex.h
+++ b/src/vm/clrex.h
@@ -668,13 +668,11 @@ class EEFileLoadException : public EEException
     
   private:
     SString m_name;
-    void  *m_pFusionLog;
     HRESULT m_hr;       
-                        
 
   public:
 
-    EEFileLoadException(const SString &name, HRESULT hr, void *pFusionLog = NULL,  Exception *pInnerException = NULL);
+    EEFileLoadException(const SString &name, HRESULT hr, Exception *pInnerException = NULL);
     ~EEFileLoadException();
 
     // virtual overrides
@@ -698,12 +696,12 @@ class EEFileLoadException : public EEException
     virtual Exception *CloneHelper()
     {
         WRAPPER_NO_CONTRACT;
-        return new EEFileLoadException(m_name, m_hr, m_pFusionLog);
+        return new EEFileLoadException(m_name, m_hr);
     }
 
  private:
 #ifdef _DEBUG    
-    EEFileLoadException() : m_pFusionLog(NULL)
+    EEFileLoadException()
     {
         // Used only for DebugIsEECxxExceptionPointer to get the vtable pointer.
         // We need a variant which does not allocate memory.


### PR DESCRIPTION
Fusion Logs are not relevant to CoreCLR (as far as I know). Pass null, not empty string, to the FileLoadException. (It was causing extra lines in the exception output.)