### PR TITLE
Delete unnecessary abstraction from stubbed out SecurityElement

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Security/SecurityElement.cs
+++ b/src/System.Private.CoreLib/shared/System/Security/SecurityElement.cs
@@ -8,18 +8,7 @@ using System.Text;
 
 namespace System.Security
 {
-    internal interface ISecurityElementFactory
-    {
-        SecurityElement CreateSecurityElement();
-
-        object Copy();
-
-        string GetTag();
-
-        string? Attribute(string attributeName);
-    }
-
-    public sealed class SecurityElement : ISecurityElementFactory
+    public sealed class SecurityElement
     {
         internal string _tag = null!;
         internal string? _text;
@@ -171,7 +160,6 @@ namespace System.Security
         {
             get
             {
-                ConvertSecurityElementFactories();
                 return _children;
             }
 
@@ -182,18 +170,6 @@ namespace System.Security
                     throw new ArgumentException(SR.ArgumentNull_Child);
                 }
                 _children = value;
-            }
-        }
-
-        internal void ConvertSecurityElementFactories()
-        {
-            if (_children == null)
-                return;
-
-            for (int i = 0; i < _children.Count; ++i)
-            {
-                if (_children[i] is ISecurityElementFactory iseFactory && !(_children[i] is SecurityElement))
-                    _children[i] = iseFactory.CreateSecurityElement();
             }
         }
 
@@ -301,9 +277,6 @@ namespace System.Security
                 // Maybe we can get away by only checking the number of children
                 if (_children.Count != other._children.Count)
                     return false;
-
-                ConvertSecurityElementFactories();
-                other.ConvertSecurityElementFactories();
 
                 IEnumerator lhs = _children.GetEnumerator();
                 IEnumerator rhs = other._children.GetEnumerator();
@@ -532,8 +505,6 @@ namespace System.Security
                 // Output any children.
                 if (_children != null)
                 {
-                    ConvertSecurityElementFactories();
-
                     write(obj, Environment.NewLineConst);
 
                     for (int i = 0; i < _children.Count; ++i)
@@ -630,28 +601,6 @@ namespace System.Security
                 throw new ArgumentNullException(nameof(xml));
 
             return default;
-        }
-
-        //--------------- ISecurityElementFactory implementation -----------------
-
-        SecurityElement ISecurityElementFactory.CreateSecurityElement()
-        {
-            return this;
-        }
-
-        string ISecurityElementFactory.GetTag()
-        {
-            return ((SecurityElement)this).Tag;
-        }
-
-        object ISecurityElementFactory.Copy()
-        {
-            return ((SecurityElement)this).Copy();
-        }
-
-        string? ISecurityElementFactory.Attribute(string attributeName)
-        {
-            return ((SecurityElement)this).Attribute(attributeName);
         }
     }
 }


### PR DESCRIPTION
The stubbed out SecurityElement implementation does not support extensibility that ISecurityElementFactory was designed for.