### PR TITLE
Remove internal binder flags

### DIFF
--- a/src/binder/assemblybinder.cpp
+++ b/src/binder/assemblybinder.cpp
@@ -490,7 +490,8 @@ namespace BINDER_SPACE
 
                 IF_FAIL_GO(BindByName(pApplicationContext,
                                       pAssemblyName,
-                                      BIND_NONE,
+                                      false, // skipFailureCaching
+                                      false, // skipVersionCompatibilityCheck
                                       excludeAppPaths,
                                       &bindResult));
             }
@@ -653,7 +654,8 @@ namespace BINDER_SPACE
     /* static */
     HRESULT AssemblyBinder::BindByName(ApplicationContext *pApplicationContext,
                                        AssemblyName       *pAssemblyName,
-                                       DWORD               dwBindFlags,
+                                       bool                skipFailureCaching,
+                                       bool                skipVersionCompatibilityCheck,
                                        bool                excludeAppPaths,
                                        BindResult         *pBindResult)
     {
@@ -668,7 +670,7 @@ namespace BINDER_SPACE
         hr = pApplicationContext->GetFailureCache()->Lookup(assemblyDisplayName);
         if (FAILED(hr))
         {
-            if ((hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)) && RerunBind(dwBindFlags))
+            if ((hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)) && skipFailureCaching)
             {
                 // Ignore pre-existing transient bind error (re-bind will succeed)
                 pApplicationContext->GetFailureCache()->Remove(assemblyDisplayName);
@@ -691,7 +693,7 @@ namespace BINDER_SPACE
 
         IF_FAIL_GO(BindLocked(pApplicationContext,
                               pAssemblyName,
-                              dwBindFlags,
+                              skipVersionCompatibilityCheck,
                               excludeAppPaths,
                               pBindResult));
 
@@ -704,7 +706,7 @@ namespace BINDER_SPACE
     Exit:
         if (FAILED(hr))
         {
-            if (RerunBind(dwBindFlags))
+            if (skipFailureCaching)
             {
                 if (hr != HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
                 {
@@ -773,7 +775,7 @@ namespace BINDER_SPACE
         {
             IF_FAIL_GO(BindLocked(pApplicationContext,
                                   pAssemblyName,
-                                  BIND_NONE,
+                                  false, // skipVersionCompatibilityCheck
                                   excludeAppPaths,
                                   &lockedBindResult));
             if (lockedBindResult.HaveResult())
@@ -803,7 +805,7 @@ namespace BINDER_SPACE
     /* static */
     HRESULT AssemblyBinder::BindLocked(ApplicationContext *pApplicationContext,
                                        AssemblyName       *pAssemblyName,
-                                       DWORD               dwBindFlags,
+                                       bool                skipVersionCompatibilityCheck,
                                        bool                excludeAppPaths,
                                        BindResult         *pBindResult)
     {
@@ -816,7 +818,7 @@ namespace BINDER_SPACE
         if (pContextEntry != NULL)
         {
 #if !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
-            if (IgnoreRefDefMatch(dwBindFlags))
+            if (skipVersionCompatibilityCheck)
             {
                 // Skip RefDef matching if we have been asked to.
             }
@@ -1531,9 +1533,12 @@ Retry:
         CRITSEC_Holder contextLock(pApplicationContext->GetCriticalSectionCookie());
         
         // Attempt uncached bind and register stream if possible
+        // We skip version compatibility check - so assemblies with same simple name will be reported
+        // as a successfull bind. Below we compare MVIDs in that case instead (which is a more precise equality check).
         hr = BindByName(pApplicationContext,
                         pAssemblyName,
-                        BIND_CACHE_RERUN_BIND | BIND_IGNORE_REFDEF_MATCH,
+                        true,  // skipFailureCaching
+                        true,  // skipVersionCompatibilityCheck
                         false, // excludeAppPaths
                         &bindResult);
         

--- a/src/binder/clrprivbindercoreclr.cpp
+++ b/src/binder/clrprivbindercoreclr.cpp
@@ -138,8 +138,6 @@ HRESULT CLRPrivBinderCoreCLR::BindUsingPEImage( /* in */ PEImage *pPEImage,
             IF_FAIL_GO(HRESULT_FROM_WIN32(ERROR_BAD_FORMAT));
         }
         
-        // Ensure we are not being asked to bind to a TPA assembly
-        //
         // Easy out for mscorlib
         if (pAssemblyName->IsMscorlib())
         {
@@ -147,8 +145,10 @@ HRESULT CLRPrivBinderCoreCLR::BindUsingPEImage( /* in */ PEImage *pPEImage,
         }
 
         {
+            // Ensure we are not being asked to bind to a TPA assembly
+            //
             SString& simpleName = pAssemblyName->GetSimpleName();
-            SimpleNameToFileNameMap * tpaMap = GetAppContext()->GetTpaList();
+            SimpleNameToFileNameMap* tpaMap = GetAppContext()->GetTpaList();
             if (tpaMap->LookupPtr(simpleName.GetUnicode()) != NULL)
             {
                 // The simple name of the assembly being requested to be bound was found in the TPA list.
@@ -159,18 +159,18 @@ HRESULT CLRPrivBinderCoreCLR::BindUsingPEImage( /* in */ PEImage *pPEImage,
                     if (pCoreCLRFoundAssembly->GetIsInGAC())
                     {
                         *ppAssembly = pCoreCLRFoundAssembly.Extract();
-                        goto Exit;                        
+                        goto Exit;
                     }
                 }
             }
+        }
             
-            hr = AssemblyBinder::BindUsingPEImage(&m_appContext, pAssemblyName, pPEImage, PeKind, pIMetaDataAssemblyImport, &pCoreCLRFoundAssembly);
-            if (hr == S_OK)
-            {
-                _ASSERTE(pCoreCLRFoundAssembly != NULL);
-                pCoreCLRFoundAssembly->SetBinder(this);
-                *ppAssembly = pCoreCLRFoundAssembly.Extract();
-            }
+        hr = AssemblyBinder::BindUsingPEImage(&m_appContext, pAssemblyName, pPEImage, PeKind, pIMetaDataAssemblyImport, &pCoreCLRFoundAssembly);
+        if (hr == S_OK)
+        {
+            _ASSERTE(pCoreCLRFoundAssembly != NULL);
+            pCoreCLRFoundAssembly->SetBinder(this);
+            *ppAssembly = pCoreCLRFoundAssembly.Extract();
         }
 Exit:;        
     }

--- a/src/binder/inc/assembly.hpp
+++ b/src/binder/inc/assembly.hpp
@@ -104,8 +104,6 @@ namespace BINDER_SPACE
 
         inline AssemblyName *GetAssemblyName(BOOL fAddRef = FALSE);
         inline BOOL GetIsInGAC();
-        inline BOOL GetIsDynamicBind();
-        inline void SetIsDynamicBind(BOOL fIsDynamicBind);
         inline BOOL GetIsByteArray();
         inline void SetIsByteArray(BOOL fIsByteArray);
         inline BOOL GetIsSharable();
@@ -121,10 +119,10 @@ namespace BINDER_SPACE
         static PEKIND GetSystemArchitecture();
         static BOOL IsValidArchitecture(PEKIND kArchitecture);
 
-		inline ICLRPrivBinder* GetBinder()
-		{
-			return m_pBinder;
-		}
+        inline ICLRPrivBinder* GetBinder()
+        {
+            return m_pBinder;
+        }
 
 #ifndef CROSSGEN_COMPILE
     protected:
@@ -134,7 +132,7 @@ namespace BINDER_SPACE
         {
             FLAG_NONE = 0x00,
             FLAG_IS_IN_GAC = 0x02,
-            FLAG_IS_DYNAMIC_BIND = 0x04,
+            //FLAG_IS_DYNAMIC_BIND = 0x04,
             FLAG_IS_BYTE_ARRAY = 0x08,
             FLAG_IS_SHARABLE = 0x10
         };

--- a/src/binder/inc/assembly.inl
+++ b/src/binder/inc/assembly.inl
@@ -100,23 +100,6 @@ void Assembly::SetIsInGAC(BOOL fIsInGAC)
     }
 }
 
-BOOL Assembly::GetIsDynamicBind()
-{
-    return ((m_dwAssemblyFlags & FLAG_IS_DYNAMIC_BIND) != 0);
-}
-
-void Assembly::SetIsDynamicBind(BOOL fIsDynamicBind)
-{
-    if (fIsDynamicBind)
-    {
-        m_dwAssemblyFlags |= FLAG_IS_DYNAMIC_BIND;
-    }
-    else
-    {
-        m_dwAssemblyFlags &= ~FLAG_IS_DYNAMIC_BIND;
-    }
-}
-
 BOOL Assembly::GetIsByteArray()
 {
     return ((m_dwAssemblyFlags & FLAG_IS_BYTE_ARRAY) != 0);

--- a/src/binder/inc/assemblybinder.hpp
+++ b/src/binder/inc/assemblybinder.hpp
@@ -81,28 +81,18 @@ namespace BINDER_SPACE
                                  
         static HRESULT TranslatePEToArchitectureType(DWORD  *pdwPAFlags, PEKIND *PeKind);
         
-    protected:
+    private:
         enum
         {
             BIND_NONE = 0x00,
-            BIND_CACHE_FAILURES = 0x01,
-            BIND_CACHE_RERUN_BIND = 0x02,
-            BIND_IGNORE_DYNAMIC_BINDS = 0x04
+            //BIND_CACHE_FAILURES = 0x01,
+            BIND_CACHE_RERUN_BIND = 0x02
+            //BIND_IGNORE_DYNAMIC_BINDS = 0x04
 #if !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
             ,
             BIND_IGNORE_REFDEF_MATCH = 0x8
 #endif // !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
         };
-
-        static BOOL IgnoreDynamicBinds(DWORD dwBindFlags)
-        {
-            return ((dwBindFlags & BIND_IGNORE_DYNAMIC_BINDS) != 0);
-        }
-
-        static BOOL CacheBindFailures(DWORD dwBindFlags)
-        {
-            return ((dwBindFlags & BIND_CACHE_FAILURES) != 0);
-        }
 
         static BOOL RerunBind(DWORD dwBindFlags)
         {

--- a/src/binder/inc/assemblybinder.hpp
+++ b/src/binder/inc/assemblybinder.hpp
@@ -82,33 +82,10 @@ namespace BINDER_SPACE
         static HRESULT TranslatePEToArchitectureType(DWORD  *pdwPAFlags, PEKIND *PeKind);
         
     private:
-        enum
-        {
-            BIND_NONE = 0x00,
-            //BIND_CACHE_FAILURES = 0x01,
-            BIND_CACHE_RERUN_BIND = 0x02
-            //BIND_IGNORE_DYNAMIC_BINDS = 0x04
-#if !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
-            ,
-            BIND_IGNORE_REFDEF_MATCH = 0x8
-#endif // !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
-        };
-
-        static BOOL RerunBind(DWORD dwBindFlags)
-        {
-            return ((dwBindFlags & BIND_CACHE_RERUN_BIND) != 0);
-        }
-        
-#if !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
-        static BOOL IgnoreRefDefMatch(DWORD dwBindFlags)
-        {
-            return ((dwBindFlags & BIND_IGNORE_REFDEF_MATCH) != 0);
-        }
-#endif // !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
-        
         static HRESULT BindByName(/* in */  ApplicationContext *pApplicationContext,
                                   /* in */  AssemblyName       *pAssemblyName,
-                                  /* in */  DWORD               dwBindFlags,
+                                  /* in */  bool                skipFailureCaching,
+                                  /* in */  bool                skipVersionCompatibilityCheck,
                                   /* in */  bool                excludeAppPaths,
                                   /* out */ BindResult         *pBindResult);
 
@@ -124,7 +101,7 @@ namespace BINDER_SPACE
 
         static HRESULT BindLocked(/* in */  ApplicationContext *pApplicationContext,
                                   /* in */  AssemblyName       *pAssemblyName,
-                                  /* in */  DWORD               dwBindFlags,
+                                  /* in */  bool                skipVersionCompatibilityCheck,
                                   /* in */  bool                excludeAppPaths,
                                   /* out */ BindResult         *pBindResult);
 

--- a/src/binder/inc/bindresult.hpp
+++ b/src/binder/inc/bindresult.hpp
@@ -29,8 +29,6 @@ namespace BINDER_SPACE
         inline IUnknown *GetAssembly(BOOL fAddRef = FALSE);
         inline Assembly *GetAsAssembly(BOOL fAddRef = FALSE);
 
-        inline BOOL GetIsDynamicBind();
-        inline void SetIsDynamicBind(BOOL fIsDynamicBind);
         inline BOOL GetIsInGAC();
         inline void SetIsInGAC(BOOL fIsInGAC);
         inline BOOL GetIsContextBound();

--- a/src/binder/inc/bindresult.inl
+++ b/src/binder/inc/bindresult.inl
@@ -61,23 +61,6 @@ Assembly *BindResult::GetAsAssembly(BOOL fAddRef /* = FALSE */)
     return static_cast<Assembly *>(GetAssembly(fAddRef));
 }
 
-BOOL BindResult::GetIsDynamicBind()
-{
-    return ((m_dwResultFlags & ContextEntry::RESULT_FLAG_IS_DYNAMIC_BIND) != 0);
-}
-
-void BindResult::SetIsDynamicBind(BOOL fIsDynamicBind)
-{
-    if (fIsDynamicBind)
-    {
-        m_dwResultFlags |= ContextEntry::RESULT_FLAG_IS_DYNAMIC_BIND;
-    }
-    else
-    {
-        m_dwResultFlags &= ~ContextEntry::RESULT_FLAG_IS_DYNAMIC_BIND;
-    }
-}
-
 BOOL BindResult::GetIsInGAC()
 {
     return ((m_dwResultFlags & ContextEntry::RESULT_FLAG_IS_IN_GAC) != 0);
@@ -150,7 +133,6 @@ void BindResult::SetResult(ContextEntry *pContextEntry, BOOL fIsContextBound /* 
 {
     _ASSERTE(pContextEntry != NULL);
 
-    SetIsDynamicBind(pContextEntry->GetIsDynamicBind());
     SetIsInGAC(pContextEntry->GetIsInGAC());
     SetIsContextBound(fIsContextBound);
     SetIsSharable(pContextEntry->GetIsSharable());
@@ -163,7 +145,6 @@ void BindResult::SetResult(Assembly *pAssembly)
 {
     _ASSERTE(pAssembly != NULL);
 
-    SetIsDynamicBind(pAssembly->GetIsDynamicBind());
     SetIsInGAC(pAssembly->GetIsInGAC());
     SetIsSharable(pAssembly->GetIsSharable());
     SAFE_RELEASE(m_pAssemblyName);

--- a/src/binder/inc/contextentry.hpp
+++ b/src/binder/inc/contextentry.hpp
@@ -26,7 +26,7 @@ namespace BINDER_SPACE
         typedef enum
         {
             RESULT_FLAG_NONE             = 0x00,
-            RESULT_FLAG_IS_DYNAMIC_BIND  = 0x01,
+            //RESULT_FLAG_IS_DYNAMIC_BIND  = 0x01,
             RESULT_FLAG_IS_IN_GAC        = 0x02,
             //RESULT_FLAG_FROM_MANIFEST    = 0x04,
             RESULT_FLAG_CONTEXT_BOUND    = 0x08,
@@ -45,23 +45,6 @@ namespace BINDER_SPACE
             SAFE_RELEASE(m_pIUnknownAssembly);
         }
         
-        BOOL GetIsDynamicBind()
-        {
-            return ((m_dwResultFlags & RESULT_FLAG_IS_DYNAMIC_BIND) != 0);
-        }
-
-        void SetIsDynamicBind(BOOL fIsDynamicBind)
-        {
-            if (fIsDynamicBind)
-            {
-                m_dwResultFlags |= RESULT_FLAG_IS_DYNAMIC_BIND;
-            }
-            else
-            {
-                m_dwResultFlags &= ~RESULT_FLAG_IS_DYNAMIC_BIND;
-            }
-        }
-
         BOOL GetIsInGAC()
         {
             return ((m_dwResultFlags & RESULT_FLAG_IS_IN_GAC) != 0);

--- a/src/binder/inc/loadcontext.inl
+++ b/src/binder/inc/loadcontext.inl
@@ -70,7 +70,6 @@ HRESULT LoadContext<dwIncludeFlags>::Register(BindResult *pBindResult)
 
     SAFE_NEW(pContextEntry, ContextEntry);
 
-    pContextEntry->SetIsDynamicBind(pBindResult->GetIsDynamicBind());
     pContextEntry->SetIsInGAC(pBindResult->GetIsInGAC());
     pContextEntry->SetIsSharable(pBindResult->GetIsSharable());
     pContextEntry->SetAssemblyName(pBindResult->GetAssemblyName(), TRUE /* fAddRef */);

--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -6620,8 +6620,6 @@ HRESULT RuntimeInvokeHostAssemblyResolver(INT_PTR pManagedAssemblyLoadContextToB
                 COMPlusThrowHR(COR_E_INVALIDOPERATION, IDS_HOST_ASSEMBLY_RESOLVER_DYNAMICALLY_EMITTED_ASSEMBLIES_UNSUPPORTED, name);
             }
                 
-            // Is the assembly already bound using a binding context that will be incompatible?
-            // An example is attempting to consume an assembly bound to WinRT binder.
             pResolvedAssembly = pLoadedPEAssembly->GetHostAssembly();
         }
             
@@ -6630,6 +6628,8 @@ HRESULT RuntimeInvokeHostAssemblyResolver(INT_PTR pManagedAssemblyLoadContextToB
             _ASSERTE(pResolvedAssembly != NULL);
 
 #ifdef FEATURE_COMINTEROP
+            // Is the assembly already bound using a binding context that will be incompatible?
+            // An example is attempting to consume an assembly bound to WinRT binder.
             if (AreSameBinderInstance(pResolvedAssembly, GetAppDomain()->GetWinRtBinder()))
             {
                 // It is invalid to return an assembly bound to an incompatible binder


### PR DESCRIPTION
Removed flags:
* Dynamic bind flags were only used for one assert - which is obviously always true (otherwise it would fail)
* Ignore dynamic bind flag was never used.
* Bind cache failures flags was on the other hand always used - so hardcode it directly
* Change the other flags to simple booleans as it makes the code easier to read (and there are now only 2 such flags). Also renamed:
  * cache rerun -> skip failure caching
  * ignore ref/def match -> skip version compatibility check

Minor additional cleanup
