### PR TITLE
JIT: Optimize simple range checks with `uint` hack

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4721,6 +4721,9 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags
     fgSetBlockOrder();
     EndPhase(PHASE_SET_BLOCK_ORDER);
 
+    // no idea where to put it but it has to be after fgSetBlockOrder
+    myTest();
+
     // IMPORTANT, after this point, every place where tree topology changes must redo evaluation
     // order (gtSetStmtInfo) and relink nodes (fgSetStmtSeq) if required.
     CLANG_FORMAT_COMMENT_ANCHOR;

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4721,11 +4721,14 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags
     fgSetBlockOrder();
     EndPhase(PHASE_SET_BLOCK_ORDER);
 
-    // Merge simple range checks to an unsigned expression, e.g.:
-    // if (x < 10 || x > 99)           -> if ((uint)x - 10 > 89)
-    // if (x < 0 || x >= array.Length) -> if ((uint)x > (uint)array.Length)
-    optOptimizeRangeChecksWithUnsigned(false);
-    EndPhase(PHASE_OPTIMIZE_SIMPLE_RANGECHECKS);
+    if (opts.OptimizationEnabled())
+    {
+        // Merge simple range checks to an unsigned expression, e.g.:
+        // if (x < 10 || x > 99)           -> if ((uint)x - 10 > 89)
+        // if (x < 0 || x >= array.Length) -> if ((uint)x > (uint)array.Length)
+        optOptimizeRangeChecksWithUnsigned(false);
+        EndPhase(PHASE_OPTIMIZE_SIMPLE_RANGECHECKS);
+    }
 
     // IMPORTANT, after this point, every place where tree topology changes must redo evaluation
     // order (gtSetStmtInfo) and relink nodes (fgSetStmtSeq) if required.

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5715,7 +5715,11 @@ private:
     void optPerformHoistExpr(GenTree* expr, unsigned lnum);
 
 public:
-    void myTest();
+    // Merge simple range checks to an unsigned expression, e.g.:
+    // if (x < 10 || x > 99)           -> if ((uint)x - 10 > 89)
+    // if (x < 0 || x >= array.Length) -> if ((uint)x > (uint)array.Length)
+    void optOptimizeRangeChecksWithUnsigned(bool afterCse);
+
     void optOptimizeBools();
 
 private:

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5715,6 +5715,7 @@ private:
     void optPerformHoistExpr(GenTree* expr, unsigned lnum);
 
 public:
+    void myTest();
     void optOptimizeBools();
 
 private:

--- a/src/jit/compphases.h
+++ b/src/jit/compphases.h
@@ -55,6 +55,7 @@ CompPhaseNameMacro(PHASE_MARK_LOCAL_VARS,        "Mark local vars",             
 CompPhaseNameMacro(PHASE_OPTIMIZE_BOOLS,         "Optimize bools",                 "OPT-BOOL", false, -1, false)
 CompPhaseNameMacro(PHASE_FIND_OPER_ORDER,        "Find oper order",                "OPER-ORD", false, -1, false)
 CompPhaseNameMacro(PHASE_SET_BLOCK_ORDER,        "Set block order",                "BLK-ORD",  false, -1, true)
+CompPhaseNameMacro(PHASE_OPTIMIZE_SIMPLE_RANGECHECKS, "Optimize simple range checks", "SMP-RNG", false, -1, false) 
 CompPhaseNameMacro(PHASE_BUILD_SSA,              "Build SSA representation",       "SSA",      true,  -1, false)
 CompPhaseNameMacro(PHASE_BUILD_SSA_TOPOSORT,     "SSA: topological sort",          "SSA-SORT", false, PHASE_BUILD_SSA, false)
 CompPhaseNameMacro(PHASE_BUILD_SSA_DOMS,         "SSA: Doms1",                     "SSA-DOMS", false, PHASE_BUILD_SSA, false)

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -8796,12 +8796,12 @@ GenTree* Compiler::optIsBoolCond(GenTree* condBranch, GenTree** compPtr, bool* b
 }
 
 //---------------------------------------------------------------------------------------------------------------
-//  optOptimizeRangeChecksWithUnsigned: optimize simple range checks to an unsigned condition
+// optOptimizeRangeChecksWithUnsigned: optimize simple range checks with an unsigned condition
 //
 // Arguments:
 //     afterCse  -  Is CSE phase already happened?
 //
-//  Note:
+// Notes:
 //      This optimization handles two kinds of range checks:
 //      1)    if (startIndex < 0 || startIndex > array.Length)
 //                ThrowException();
@@ -8920,9 +8920,9 @@ void Compiler::optOptimizeRangeChecksWithUnsigned(bool afterCse)
             continue;
         }
 
-        ssize_t        icon1 = cnsRangeStart->IconValue();
+        ssize_t icon1          = cnsRangeStart->IconValue();
+        bool    canBeOptimized = false;
 
-        bool canBeOptimized = false;
         if (varRangeEnd->OperIs(GT_ARR_LENGTH) && condRangeEnd->OperIs(GT_LE, GT_LT))
         {
             if ((condRangeStart->OperIs(GT_LE) && icon1 == -1) || (condRangeStart->OperIs(GT_LT) && icon1 == 0))

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -8798,8 +8798,11 @@ GenTree* Compiler::optIsBoolCond(GenTree* condBranch, GenTree** compPtr, bool* b
 //---------------------------------------------------------------------------------------------------------------
 //  optOptimizeRangeChecksWithUnsigned: optimize simple range checks to an unsigned condition
 //
+// Arguments:
+//     afterCse  -  Is CSE phase already happened?
+//
 //  Note:
-//      This optimization handles two kind of range checks:
+//      This optimization handles two kinds of range checks:
 //      1)    if (startIndex < 0 || startIndex > array.Length)
 //                ThrowException();
 //
@@ -8820,8 +8823,6 @@ GenTree* Compiler::optIsBoolCond(GenTree* condBranch, GenTree** compPtr, bool* b
 //            if ((uint)startIndex - icon1 > icon2 - icon1)
 //                ThrowException();
 //
-//      This optimization should happen after CSE (or check for IsCSECandidate).
-//
 void Compiler::optOptimizeRangeChecksWithUnsigned(bool afterCse)
 {
 /*  We are looking for two conditional single-statement basic blocks
@@ -8836,8 +8837,8 @@ BB01:
 BB02:
     *  JTRUE     void  
     \--*  (GT/GE)
-       +--*  LCL_VAR (same var ^)
-       \--*  (CNS or ARR_LENGHT)   NOTE: ARR_LENGTH will be op1 + LT
+       +--*  LCL_VAR  (same var as above ^)
+       \--*  (CNS or ARR_LENGHT)   NOTE: ARR_LENGTH will be op1 + reversed op (e.g. GT -> LT)
 
 */
 

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -8950,7 +8950,7 @@ BB02:
                                 // if (startIndex - icon1 > icon2 - icon1)
                                 //     ThrowException();
                                 //
-                                ssize_t toSub              = icon1 - (b1Cond->OperIs(GT_LT) ? 0 : 1);
+                                ssize_t toSub = icon1 + (b1Cond->OperIs(GT_LT) ? 0 : 1);
 
                                 if (toSub != 0)
                                 {
@@ -8960,9 +8960,8 @@ BB02:
                                     subNode->CopyCosts(b2Cond); // not sure in this one, what costs should I set to the GT_ADD node I've just added?
                                     gtReplaceTree(nextBlock->firstStmt(), b2Cond->gtGetOp1(), subNode);
                                     gtPrepareCost(b2Cond);
-
-                                    otherOp->AsIntCon()->gtIconVal -= toSub; // icon2 - icon1
                                 }
+                                otherOp->AsIntCon()->gtIconVal -= toSub;
                                 canBeOptimized = true;
                             }
                         }

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -8950,15 +8950,19 @@ BB02:
                                 //     ThrowException();
                                 //
                                 ssize_t toSub              = icon1 - (b1Cond->OperIs(GT_LT) ? 0 : 1);
-                                GenTreeIntCon* subIconNode = gtNewIconNode(-toSub, variableB2->TypeGet());
-                                GenTree* subNode           = gtNewOperNode(GT_ADD, variableB2->TypeGet(), variableB2, subIconNode); // GT_ADD -icon1
 
-                                subNode->CopyCosts(b2Cond); // not sure in this one, what costs should I set to the GT_ADD node I've just added?
-                                gtReplaceTree(nextBlock->firstStmt(), b2Cond->gtGetOp1(), subNode);
-                                gtPrepareCost(b2Cond);
+                                if (toSub != 0)
+                                {
+                                    GenTreeIntCon* subIconNode = gtNewIconNode(-toSub, variableB2->TypeGet());
+                                    GenTree* subNode = gtNewOperNode(GT_ADD, variableB2->TypeGet(), variableB2, subIconNode); // GT_ADD -icon1
 
-                                otherOp->AsIntCon()->gtIconVal -= toSub; // icon2 - icon1
-                                canBeOptimized                  = true;
+                                    subNode->CopyCosts(b2Cond); // not sure in this one, what costs should I set to the GT_ADD node I've just added?
+                                    gtReplaceTree(nextBlock->firstStmt(), b2Cond->gtGetOp1(), subNode);
+                                    gtPrepareCost(b2Cond);
+
+                                    otherOp->AsIntCon()->gtIconVal -= toSub; // icon2 - icon1
+                                }
+                                canBeOptimized = true;
                             }
                         }
 


### PR DESCRIPTION
JIT-level optimization for checks in https://github.com/dotnet/coreclr/pull/27462.

![image](https://user-images.githubusercontent.com/523221/67635860-f8f76580-f8db-11e9-9281-7fcc3b480b9f.png)

I decided to run the optimization twice before and after CSE.
Before CSE run helps to remove bound checks but can't really optimize the constant-range case due to possible CSE candidates (if I check both conditional nodes for `IsCSECandidate` and don't run it after CSE phase I'll lose ~1000 bytes in the jit-diff).

If I remove the `weight == 0` check, the jit-diff becomes -3858 but in theory can decrease performance in some cases, e.g.:

```csharp
if (i < 10 || i > 100)
    Foo();
```
if `i < 10` is mostly true - it's better to leave this `if` as is. (Perhaps I should check the first condition for "is likely to be true" instead of zero weight for the target block)
**UPD**: It seems, C++ compilers don't really care: https://godbolt.org/z/D9YRVQ (`add` has `1` latency on most CPUs)

Current jit-diff: 
```
With `ends with exception block` condition:
Total bytes of diff: -3215 (-0.01% of base)

Without the condition:
Total bytes of diff: -3858 (-0.01% of base)
```
https://gist.github.com/EgorBo/f4a21c16e350e9ae3cd9338ef683526a
(NOTE: the diff can be a lot bigger if we remove hundreds of `uint` hacks already exist in the BCL)

Let me know if you think this opt is a good idea and I'll add tests (or feel free to close if you are ok with the managed-side fix in https://github.com/dotnet/coreclr/pull/27462).

/cc: @jkotas @mikedn @benaadams 

**UPD**: Can be implemented:
1) `return i < 10 || i > 100;` won't be optimized because it needs something like "expand BBJ_RETURN blocks to BBJ_COND" kind of de-optimization, see https://github.com/dotnet/coreclr/pull/27167
2) In theory can improve more kinds of range checks, e.g. [this one](https://github.com/dotnet/corefx/blob/cf28b7896a762f71c990a5896a160a4138d833c9/src/System.Private.Uri/src/System/Uri.cs#L5369-L5378) with bit-shifts (probably already optimized by mikedn).
3) Since the opt relies on weights, it's a +1 for `Unsafe.Assume` kind of API 🙂 
4) `if(index == 0 || index > 1)` -> `if(index >= 1)`
5) `if  (('A' <= c) && (c <= 'Z'))`