### PR TITLE
Fix GCRefMap generation in crossgen2

### DIFF
--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapNode.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapNode.cs
@@ -78,12 +78,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             int nextMethodIndex = GCREFMAP_LOOKUP_STRIDE - 1;
             for (int methodIndex = 0; methodIndex < _methods.Count; methodIndex++)
             {
-                if (methodIndex >= nextMethodIndex)
-                {
-                    builder.Builder.EmitInt(offsets[nextOffsetIndex], builder.Builder.CountBytes);
-                    nextOffsetIndex++;
-                    nextMethodIndex += GCREFMAP_LOOKUP_STRIDE;
-                }
                 IMethodNode methodNode = _methods[methodIndex];
                 if (methodNode == null || (methodNode is MethodWithGCInfo methodWithGCInfo && methodWithGCInfo.IsEmpty))
                 {
@@ -94,6 +88,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 else
                 {
                     builder.GetCallRefMap(methodNode.Method);
+                }
+                if (methodIndex >= nextMethodIndex)
+                {
+                    builder.Builder.EmitInt(offsets[nextOffsetIndex], builder.Builder.CountBytes);
+                    nextOffsetIndex++;
+                    nextMethodIndex += GCREFMAP_LOOKUP_STRIDE;
                 }
             }
             Debug.Assert(nextOffsetIndex == offsets.Length);


### PR DESCRIPTION
There was a bug in the index table - it was pointing to the last
GCRefMap in the previous stride instead of the first one in the new
stride.

I've modified R2RDump too to use the index table when loading GCRefMaps.
While it was not incorrect, the fact that it was not using the index
table has hidden this issue. Now it uses the same algorithm as the
runtime.