### PR TITLE
Use named nested anonymous types

### DIFF
--- a/src/vm/fieldmarshaler.h
+++ b/src/vm/fieldmarshaler.h
@@ -101,7 +101,7 @@ public:
 
         if (m_isNestedType)
         {
-            image->FixupMethodTablePointer(this, &m_pNestedType);
+            image->FixupMethodTablePointer(this, &nestedTypeAndCount.m_pNestedType);
         }
     }
 #endif // defined(FEATURE_PREJIT) && !defined(DACCESS_COMPILE)
@@ -127,7 +127,7 @@ public:
         }
         CONTRACTL_END;
 
-        return m_numElements;
+        return nestedTypeAndCount.m_numElements;
     }
 
     UINT32 NativeSize() const
@@ -138,7 +138,7 @@ public:
         }
         else
         {
-            return m_nativeSize;
+            return nativeSizeAndAlignment.m_nativeSize;
         }
     }
 
@@ -150,7 +150,7 @@ public:
         }
         else
         {
-            return m_alignmentRequirement;
+            return nativeSizeAndAlignment.m_alignmentRequirement;
         }
     }
 
@@ -186,12 +186,12 @@ private:
         {
             RelativeFixupPointer<PTR_MethodTable> m_pNestedType;
             ULONG m_numElements;
-        };
+        } nestedTypeAndCount;
         struct
         {
             UINT32 m_nativeSize;
             UINT32 m_alignmentRequirement;
-        };
+        } nativeSizeAndAlignment;
     };
     UINT32 m_offset;
     NativeFieldFlags m_flags;


### PR DESCRIPTION
By naming the nested structs in anonymous union, this gcc error is fixed:

```
In file included from /home/travis/build/am11/coreclr/src/vm/ceeload.cpp:39:0:

/home/travis/build/am11/coreclr/src/vm/fieldmarshaler.h:187:51: error: member ‘RelativeFixupPointer<MethodTable*> NativeFieldDescriptor::<anonymous union>::<anonymous struct>::m_pNestedType’ with constructor not allowed in anonymous aggregate

             RelativeFixupPointer<PTR_MethodTable> m_pNestedType;

                                                   ^

In file included from /home/travis/build/am11/coreclr/src/vm/ceemain.cpp:140:0:

/home/travis/build/am11/coreclr/src/vm/fieldmarshaler.h:187:51: error: member ‘RelativeFixupPointer<MethodTable*> NativeFieldDescriptor::<anonymous union>::<anonymous struct>::m_pNestedType’ with constructor not allowed in anonymous aggregate

             RelativeFixupPointer<PTR_MethodTable> m_pNestedType;

                                                   ^
```

https://travis-ci.org/am11/coreclr/jobs/603598467#L1837
cc @jkotas, @franksinankaya
