### PR TITLE
Cast SIMD size value to unsigned explicitly

### DIFF
--- a/src/jit/hwintrinsic.cpp
+++ b/src/jit/hwintrinsic.cpp
@@ -15,7 +15,7 @@ static const HWIntrinsicInfo hwIntrinsicInfoArray[] = {
 #include "hwintrinsiclistxarch.h"
 #elif defined (_TARGET_ARM64_)
 #define HARDWARE_INTRINSIC(isa, name, ival, size, numarg, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, category, flag) \
-    {NI_##isa##_##name, #name, InstructionSet_##isa, ival, size, numarg, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, category, static_cast<HWIntrinsicFlag>(flag)},
+    {NI_##isa##_##name, #name, InstructionSet_##isa, ival, static_cast<unsigned>(size), numarg, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, category, static_cast<HWIntrinsicFlag>(flag)},
 #include "hwintrinsiclistarm64.h"
 #else
 #error Unsupported platform


### PR DESCRIPTION
In ARM64 intrinsic table, SIMD size value is -1 on [L51](https://github.com/dotnet/coreclr/blob/822cdffb88b6acbeae7d3ee1fb3fe28d90b2ba92/src/jit/hwintrinsiclistarm64.h#L51), [L53](https://github.com/dotnet/coreclr/blob/822cdffb88b6acbeae7d3ee1fb3fe28d90b2ba92/src/jit/hwintrinsiclistarm64.h#L53) and [L63](https://github.com/dotnet/coreclr/blob/822cdffb88b6acbeae7d3ee1fb3fe28d90b2ba92/src/jit/hwintrinsiclistarm64.h#L63). Type of size filed in `HWIntrinsicInfo` structure is `unsigned` and this makes gcc give the following errors:

```
/datadrive/projects/coreclr2/src/jit/hwintrinsic.cpp:24:1: error: narrowing conversion of ‘-1’ from ‘int’ to ‘unsigned int’ inside { } [-Wnarrowing]
 };
 ^
/datadrive/projects/coreclr2/src/jit/hwintrinsic.cpp:24:1: error: narrowing conversion of ‘-1’ from ‘int’ to ‘unsigned int’ inside { } [-Wnarrowing]
/datadrive/projects/coreclr2/src/jit/hwintrinsic.cpp:24:1: error: narrowing conversion of ‘-1’ from ‘int’ to ‘unsigned int’ inside { } [-Wnarrowing]
src/jit/protononjit/CMakeFiles/protononjit.dir/build.make:348: recipe for target 'src/jit/protononjit/CMakeFiles/protononjit.dir/__/hwintrinsic.cpp.o' failed
make[2]: *** [src/jit/protononjit/CMakeFiles/protononjit.dir/__/hwintrinsic.cpp.o] Error 1
CMakeFiles/Makefile2:1509: recipe for target 'src/jit/protononjit/CMakeFiles/protononjit.dir/all' failed
make[1]: *** [src/jit/protononjit/CMakeFiles/protononjit.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

gcc build is back to green: https://travis-ci.org/am11/coreclr/builds/603635391

/cc @franksinankaya, @jkotas