### PR TITLE
Fix #27486 - do not deadlock if we run out of memory in the completio…

### DIFF
--- a/src/System.Private.CoreLib/shared/System/IO/FileStreamCompletionSource.Win32.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/FileStreamCompletionSource.Win32.cs
@@ -187,8 +187,21 @@ namespace System.IO
                     }
                     else
                     {
-                        Exception e = Win32Marshal.GetExceptionForWin32Error(errorCode);
-                        e.SetCurrentStackTrace();
+                        Exception e = null;
+                        try
+                        {
+                            e = Win32Marshal.GetExceptionForWin32Error(errorCode);
+                            e.SetCurrentStackTrace();
+                        }
+                        catch (Exception e2)
+                        {
+                            // If we can't create a new exception, send the reason why (OutOfMemoryException unless there's
+                            // a bug) to avoid deadlock. Completion port handlers must not fail.
+                            if (ReferenceEquals(e, null))
+                            {
+                                e = e2;
+                            }
+                        }
                         TrySetException(e);
                     }
                 }


### PR DESCRIPTION
Fix #27486 - do not deadlock if we run out of memory in the completion port handling a failed asynchronous file system IO operation