### PR TITLE
[release/3.1] Fix StreamReader to pass cancellation token into ReadBufferAsync (#27464)

### DIFF
--- a/src/System.Private.CoreLib/shared/System/IO/StreamReader.cs
+++ b/src/System.Private.CoreLib/shared/System/IO/StreamReader.cs
@@ -852,7 +852,7 @@ namespace System.IO
 
         private async Task<string?> ReadLineAsyncInternal()
         {
-            if (_charPos == _charLen && (await ReadBufferAsync().ConfigureAwait(false)) == 0)
+            if (_charPos == _charLen && (await ReadBufferAsync(CancellationToken.None).ConfigureAwait(false)) == 0)
             {
                 return null;
             }
@@ -888,7 +888,7 @@ namespace System.IO
 
                         _charPos = tmpCharPos = i + 1;
 
-                        if (ch == '\r' && (tmpCharPos < tmpCharLen || (await ReadBufferAsync().ConfigureAwait(false)) > 0))
+                        if (ch == '\r' && (tmpCharPos < tmpCharLen || (await ReadBufferAsync(CancellationToken.None).ConfigureAwait(false)) > 0))
                         {
                             tmpCharPos = _charPos;
                             if (_charBuffer[tmpCharPos] == '\n')
@@ -909,7 +909,7 @@ namespace System.IO
                     sb = new StringBuilder(i + 80);
                 }
                 sb.Append(tmpCharBuffer, tmpCharPos, i);
-            } while (await ReadBufferAsync().ConfigureAwait(false) > 0);
+            } while (await ReadBufferAsync(CancellationToken.None).ConfigureAwait(false) > 0);
 
             return sb.ToString();
         }
@@ -943,7 +943,7 @@ namespace System.IO
                 int tmpCharPos = _charPos;
                 sb.Append(_charBuffer, tmpCharPos, _charLen - tmpCharPos);
                 _charPos = _charLen;  // We consumed these characters
-                await ReadBufferAsync().ConfigureAwait(false);
+                await ReadBufferAsync(CancellationToken.None).ConfigureAwait(false);
             } while (_charLen > 0);
 
             return sb.ToString();
@@ -976,7 +976,7 @@ namespace System.IO
             ThrowIfDisposed();
             CheckAsyncTaskInProgress();
 
-            Task<int> task = ReadAsyncInternal(new Memory<char>(buffer, index, count), default).AsTask();
+            Task<int> task = ReadAsyncInternal(new Memory<char>(buffer, index, count), CancellationToken.None).AsTask();
             _asyncReadTask = task;
 
             return task;
@@ -1003,7 +1003,7 @@ namespace System.IO
 
         internal override async ValueTask<int> ReadAsyncInternal(Memory<char> buffer, CancellationToken cancellationToken)
         {
-            if (_charPos == _charLen && (await ReadBufferAsync().ConfigureAwait(false)) == 0)
+            if (_charPos == _charLen && (await ReadBufferAsync(cancellationToken).ConfigureAwait(false)) == 0)
             {
                 return 0;
             }
@@ -1233,7 +1233,7 @@ namespace System.IO
             return new ValueTask<int>(t);
         }
 
-        private async ValueTask<int> ReadBufferAsync()
+        private async ValueTask<int> ReadBufferAsync(CancellationToken cancellationToken)
         {
             _charLen = 0;
             _charPos = 0;
@@ -1250,7 +1250,7 @@ namespace System.IO
                 {
                     Debug.Assert(_bytePos <= _encoding.Preamble.Length, "possible bug in _compressPreamble. Are two threads using this StreamReader at the same time?");
                     int tmpBytePos = _bytePos;
-                    int len = await tmpStream.ReadAsync(new Memory<byte>(tmpByteBuffer, tmpBytePos, tmpByteBuffer.Length - tmpBytePos)).ConfigureAwait(false);
+                    int len = await tmpStream.ReadAsync(new Memory<byte>(tmpByteBuffer, tmpBytePos, tmpByteBuffer.Length - tmpBytePos), cancellationToken).ConfigureAwait(false);
                     Debug.Assert(len >= 0, "Stream.Read returned a negative number!  This is a bug in your stream class.");
 
                     if (len == 0)
@@ -1272,7 +1272,7 @@ namespace System.IO
                 else
                 {
                     Debug.Assert(_bytePos == 0, "_bytePos can be non zero only when we are trying to _checkPreamble. Are two threads using this StreamReader at the same time?");
-                    _byteLen = await tmpStream.ReadAsync(new Memory<byte>(tmpByteBuffer)).ConfigureAwait(false);
+                    _byteLen = await tmpStream.ReadAsync(new Memory<byte>(tmpByteBuffer), cancellationToken).ConfigureAwait(false);
                     Debug.Assert(_byteLen >= 0, "Stream.Read returned a negative number!  Bug in stream class.");
 
                     if (_byteLen == 0)  // We're at EOF


### PR DESCRIPTION
Port https://github.com/dotnet/coreclr/pull/27464 to release/3.1

## Description

When StreamReader.ReadAsync is called and the reader's buffer is initially empty, it calls a helper method that in turn interacts with the underlying stream.  That helper method wasn't defined to take a CancellationToken, so ReadAsync doesn't pass along the one supplied by the caller.  That means for this first read on the underlying stream, the supplied CancellationToken is ignored.

## Customer Impact

Cancellation ends up being unreliable.

## Regression?

No.  It's been like this since the overload was added in .NET Core 2.1.

## Testing

New tests were added.  Previously tests were only validating the case where the token has cancellation requested prior to the invocation, which triggers a dedicated path that handles this correctly.

## Risk

Low.  It's just passing along a CancellationToken.

cc: @danmosemsft 