### PR TITLE
Fix GCStress C issue with the fix to VS2019 optimization

### DIFF
--- a/src/vm/crossgencompile.cpp
+++ b/src/vm/crossgencompile.cpp
@@ -277,7 +277,7 @@ BOOL Object::SupportsInterface(OBJECTREF pObj, MethodTable* pInterfaceMT)
     UNREACHABLE();
 }
 
-GCFrame::GCFrame(OBJECTREF *pObjRefs, UINT numObjRefs, BOOL maybeInterior)
+GCFrame::GCFrame(Thread* pThread, OBJECTREF *pObjRefs, UINT numObjRefs, BOOL maybeInterior)
 {
 }
 
@@ -289,10 +289,6 @@ void GCFrame::GcScanRoots(promote_func *fn, ScanContext* sc)
 void HijackFrame::GcScanRoots(promote_func *fn, ScanContext* sc)
 {
     UNREACHABLE();
-}
-
-VOID GCFrame::Pop()
-{
 }
 
 void Frame::Push()

--- a/src/vm/frames.h
+++ b/src/vm/frames.h
@@ -2466,27 +2466,7 @@ private:
 //------------------------------------------------------------------------
 class GCFrame
 {
-public:
-
-
-    //--------------------------------------------------------------------
-    // This constructor pushes a new GCFrame on the GC frame chain.
-    //--------------------------------------------------------------------
-#ifndef DACCESS_COMPILE
-    GCFrame() {
-        LIMITED_METHOD_CONTRACT;
-    };
-
-    GCFrame(OBJECTREF *pObjRefs, UINT numObjRefs, BOOL maybeInterior);
-    GCFrame(Thread *pThread, OBJECTREF *pObjRefs, UINT numObjRefs, BOOL maybeInterior);
-#ifndef CROSSGEN_COMPILE
-    ~GCFrame();
-#endif // CROSSGEN_COMPILE
-
-#endif // DACCESS_COMPILE
-
     void Init(Thread *pThread, OBJECTREF *pObjRefs, UINT numObjRefs, BOOL maybeInterior);
-
     void Push(Thread *pThread);
 
     //--------------------------------------------------------------------
@@ -2494,6 +2474,21 @@ public:
     // trashes the contents of pObjRef's in _DEBUG.
     //--------------------------------------------------------------------
     VOID Pop();
+
+public:
+
+
+    //--------------------------------------------------------------------
+    // This constructor pushes a new GCFrame on the GC frame chain.
+    //--------------------------------------------------------------------
+#ifndef DACCESS_COMPILE
+    GCFrame(OBJECTREF *pObjRefs, UINT numObjRefs, BOOL maybeInterior);
+    GCFrame(Thread *pThread, OBJECTREF *pObjRefs, UINT numObjRefs, BOOL maybeInterior);
+#ifndef CROSSGEN_COMPILE
+    ~GCFrame();
+#endif // CROSSGEN_COMPILE
+
+#endif // DACCESS_COMPILE
 
     void GcScanRoots(promote_func *fn, ScanContext* sc);
 
@@ -2507,14 +2502,6 @@ public:
             }
         }
         return FALSE;
-    }
-#endif
-
-#ifndef DACCESS_COMPILE
-    void *operator new (size_t sz, void* p)
-    {
-        LIMITED_METHOD_CONTRACT;
-        return p ;
     }
 #endif
 

--- a/src/vm/frames.h
+++ b/src/vm/frames.h
@@ -2466,23 +2466,18 @@ private:
 //------------------------------------------------------------------------
 class GCFrame
 {
-    void Init(Thread *pThread, OBJECTREF *pObjRefs, UINT numObjRefs, BOOL maybeInterior);
-    void Push(Thread *pThread);
-
-    //--------------------------------------------------------------------
-    // Pops the GCFrame and cancels the GC protection. Also
-    // trashes the contents of pObjRef's in _DEBUG.
-    //--------------------------------------------------------------------
-    VOID Pop();
-
 public:
 
-
+#ifndef DACCESS_COMPILE
     //--------------------------------------------------------------------
     // This constructor pushes a new GCFrame on the GC frame chain.
     //--------------------------------------------------------------------
-#ifndef DACCESS_COMPILE
-    GCFrame(OBJECTREF *pObjRefs, UINT numObjRefs, BOOL maybeInterior);
+    GCFrame(OBJECTREF *pObjRefs, UINT numObjRefs, BOOL maybeInterior)
+        : GCFrame(GetThread(), pObjRefs, numObjRefs, maybeInterior)
+    {
+        WRAPPER_NO_CONTRACT;
+    }
+
     GCFrame(Thread *pThread, OBJECTREF *pObjRefs, UINT numObjRefs, BOOL maybeInterior);
 #ifndef CROSSGEN_COMPILE
     ~GCFrame();

--- a/src/vm/gccover.cpp
+++ b/src/vm/gccover.cpp
@@ -1769,12 +1769,8 @@ void DoGcStress (PCONTEXT regs, NativeCodeVersion nativeCodeVersion)
 #endif // !_TARGET_AMD64_ || !PLATFORM_UNIX
     }
 
-    GCFrame gcFrame;
-    if (numberOfRegs != 0)
-    {
-        _ASSERTE(sizeof(OBJECTREF) == sizeof(DWORD_PTR));
-        gcFrame.Init(pThread, (OBJECTREF*)retValRegs, numberOfRegs, TRUE);
-    }
+    _ASSERTE(sizeof(OBJECTREF) == sizeof(DWORD_PTR));
+    GCFrame gcFrame(pThread, (OBJECTREF*)retValRegs, numberOfRegs, TRUE);
 
     MethodDesc *pMD = nativeCodeVersion.GetMethodDesc();
     LOG((LF_GCROOTS, LL_EVERYTHING, "GCCOVER: Doing GC at method %s::%s offset 0x%x\n",


### PR DESCRIPTION
There is a place in the runtime that we hit during GCStress C and that
was creating uninitialized GCFrame and initializing it only
conditionally. In the GCFrame destructor, we always try to pop the
GCFrame out of the per-thread linked list and this was breaking it.

The fix is to always initialize the GCFrame. In the problematic place,
it was not being initialized / pushed on the linked list when number of
GC slots it was to protect was 0. But the logic in GCFrame works just
fine even in that case, so I've made the initialization over there
unconditional.

I've also made a couple of methods in the GCFrame private as they are
never supposed to be called from the outside, removed the default
GCFrame constructor so that noone can create uninitialized GCFrame
anymore and also removed placement new from GCFrame that doesn't seem to
have any purpose.

Close #27495