### PR TITLE
Fix resolving IBCMerge's path in build.cmd

### DIFF
--- a/src/.nuget/optdata/ibcmerge.csproj
+++ b/src/.nuget/optdata/ibcmerge.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.IBCMerge" Version="$(MicrosoftDotNetIBCMergeVersion)" GeneratePathProperty="True" />
+    <PackageReference Include="Microsoft.DotNet.IBCMerge" Version="$(MicrosoftDotNetIBCMergeVersion)" />
   </ItemGroup>
 
   <!--                                                                       -->
@@ -23,10 +23,14 @@
     <!-- Error if IbcMergePackagePathOutputFile is not set. -->
     <Error Condition="'$(IbcMergePackagePathOutputFile)'==''" Text="IbcMergePackagePathOutputFile must be passed as a property." />
 
+    <PropertyGroup>
+      <IbcMergePath>$(NuGetPackageRoot)microsoft.dotnet.ibcmerge/$(MicrosoftDOtNetIBCMergeVersion)</IbcMergePath>
+    </PropertyGroup>
+
     <!-- Cleanup old path file -->
     <Delete Files="$(IbcMergePackagePathOutputFile)" Condition="Exists('$(IbcMergePackagePathOutputFile)')" />
-    <WriteLinesToFile File="$(IbcMergePackagePathOutputFile)" Lines="$(PkgMicrosoft_DotNet_IBCMerge)" Overwrite="true"/>
-    <Message Text="MicrosoftDotNetIBCMergePath: $(PkgMicrosoft_DotNet_IBCMerge) written to: $(IbcMergePackagePathOutputFile)" Importance="High" />
+    <WriteLinesToFile File="$(IbcMergePackagePathOutputFile)" Lines="$(IbcMergePath)" Overwrite="true"/>
+    <Message Text="MicrosoftDotNetIBCMergePath: $(IbcMergePath) written to: $(IbcMergePackagePathOutputFile)" Importance="High" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Resolve IBCMerge's path via NuGetPackageRoot since we never actually restore ibcmerge.csproj directly. This will go away when we move to Arcade-driven IBCMerge.

Official build link: https://dev.azure.com/dnceng/internal/_build/results?buildId=405035&view=results
