### PR TITLE
Remove UCRTVersion workaround and re-enable Windows formatting jobs.

### DIFF
--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -129,3 +129,4 @@ jobs:
     jobTemplate: format-job.yml
     platforms:
     - Linux_x64
+    - Windows_NT_x64

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -184,4 +184,4 @@ jobs:
     jobTemplate: format-job.yml
     platforms:
     - Linux_x64
-
+    - Windows_NT_x64

--- a/tests/src/Interop/Interop.settings.targets
+++ b/tests/src/Interop/Interop.settings.targets
@@ -24,12 +24,6 @@
 
     <None Include="$(VCToolsRedistDir)onecore/debug_nonredist/$(Platform)/Microsoft.VC*.DebugCRT/vcruntime*d.dll" Link="%(Filename)%(Extension)" CopyToOutputDirectory="Always" />
     <None Include="$(VCToolsRedistDir)onecore/debug_nonredist/$(Platform)/Microsoft.VC*.DebugCRT/msvcp*d.dll" Link="%(Filename)%(Extension)" CopyToOutputDirectory="Always" />
-    <None Include="$(ExtensionSdkDir)/Microsoft.UniversalCRT.Debug/$(UCRTVersion)/Redist/Debug/$(Platform)/ucrtbased.dll" CopyToOutputDirectory="Always"
-        Condition="Exists('$(ExtensionSdkDir)/Microsoft.UniversalCRT.Debug/$(UCRTVersion)/Redist/Debug/$(Platform)/ucrtbased.dll')" />
-    
-    <!-- There's a bug in VS that causes UCRTVersion env var to get set to a version that isn't actually installed on the machine. -->
-    <!-- Until that gets resolved, we need this workaround to grab the last "known" good version of ucrtbased.dll -->
-    <None Include="$(ExtensionSdkDir)/Microsoft.UniversalCRT.Debug/10.0.17763.0/Redist/Debug/$(Platform)/ucrtbased.dll" CopyToOutputDirectory="Always"
-        Condition="!Exists('$(ExtensionSdkDir)/Microsoft.UniversalCRT.Debug/$(UCRTVersion)/Redist/Debug/$(Platform)/ucrtbased.dll')" />
+    <None Include="$(ExtensionSdkDir)/Microsoft.UniversalCRT.Debug/$(UCRTVersion)/Redist/Debug/$(Platform)/ucrtbased.dll" CopyToOutputDirectory="Always" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
VS2017 VsDevCmd had a bug in setting of UCRTVersion environment variable.
That was affecting Interop tests and Windows formatting jobs.
We added a workaround for the former (#25444) and disabled Windows
formatting jobs (#25507, #25902).

The bug has been fixed in VS2019. Since we switched to VS2019 pool we
can remove the workaround and re-enable Windows formatting jobs.

Fixes #25447, #25499.