### PR TITLE
Tweaks to existing BulkType event

### DIFF
--- a/src/inc/eventtracebase.h
+++ b/src/inc/eventtracebase.h
@@ -46,6 +46,16 @@ enum EtwTypeFlags
     kEtwTypeFlagsFinalizable =                      0x2,
     kEtwTypeFlagsExternallyImplementedCOMObject =   0x4,
     kEtwTypeFlagsArray =                            0x8,
+    kEtwTypeFlagsArrayRankBit0 =                  0x100,
+    kEtwTypeFlagsArrayRankBit1 =                  0x200,
+    kEtwTypeFlagsArrayRankBit2 =                  0x400,
+    kEtwTypeFlagsArrayRankBit3 =                  0x800,
+    kEtwTypeFlagsArrayRankBit4 =                 0x1000,
+    kEtwTypeFlagsArrayRankBit5 =                 0x2000,
+
+    kEtwTypeFlagsArrayRankMask =                 0x3F00,
+    kEtwTypeFlagsArrayRankShift =                     8,
+    kEtwTypeFlagsArrayRankMax = kEtwTypeFlagsArrayRankMask >> kEtwTypeFlagsArrayRankShift
 };
 
 enum EtwThreadFlags

--- a/src/vm/ClrEtwAll.man
+++ b/src/vm/ClrEtwAll.man
@@ -557,6 +557,12 @@
                         <map value="0x2" message="$(string.RuntimePublisher.TypeFlags.Finalizable)"/>
                         <map value="0x4" message="$(string.RuntimePublisher.TypeFlags.ExternallyImplementedCOMObject)"/>
                         <map value="0x8" message="$(string.RuntimePublisher.TypeFlags.Array)"/>
+                        <map value="0x100" message="$(string.RuntimePublisher.TypeFlags.ArrayRankBit0)"/>
+                        <map value="0x200" message="$(string.RuntimePublisher.TypeFlags.ArrayRankBit1)"/>
+                        <map value="0x400" message="$(string.RuntimePublisher.TypeFlags.ArrayRankBit2)"/>
+                        <map value="0x800" message="$(string.RuntimePublisher.TypeFlags.ArrayRankBit3)"/>
+                        <map value="0x1000" message="$(string.RuntimePublisher.TypeFlags.ArrayRankBit4)"/>
+                        <map value="0x2000" message="$(string.RuntimePublisher.TypeFlags.ArrayRankBit5)"/>
                     </bitMap>
                     <bitMap name="GCRootFlagsMap">
                       <map value="0x1" message="$(string.RuntimePublisher.GCRootFlags.Pinning)"/>
@@ -6984,6 +6990,12 @@
                 <string id="RuntimePublisher.TypeFlags.Finalizable" value="Finalizable"/>
                 <string id="RuntimePublisher.TypeFlags.ExternallyImplementedCOMObject" value="ExternallyImplementedCOMObject"/>
                 <string id="RuntimePublisher.TypeFlags.Array" value="Array"/>
+                <string id="RuntimePublisher.TypeFlags.ArrayRankBit0" value="ArrayRankBit0"/>
+                <string id="RuntimePublisher.TypeFlags.ArrayRankBit1" value="ArrayRankBit1"/>
+                <string id="RuntimePublisher.TypeFlags.ArrayRankBit2" value="ArrayRankBit2"/>
+                <string id="RuntimePublisher.TypeFlags.ArrayRankBit3" value="ArrayRankBit3"/>
+                <string id="RuntimePublisher.TypeFlags.ArrayRankBit4" value="ArrayRankBit4"/>
+                <string id="RuntimePublisher.TypeFlags.ArrayRankBit5" value="ArrayRankBit5"/>
                 <string id="RuntimePublisher.GCRootFlags.Pinning" value="Pinning"/>
                 <string id="RuntimePublisher.GCRootFlags.WeakRef" value="WeakRef"/>
                 <string id="RuntimePublisher.GCRootFlags.Interior" value="Interior"/>


### PR DESCRIPTION
- Enable specification of exact multi-dimensional array rank
- Tolerate scenarios where the name of the type is so large that it prevents generation of the BulkType event