### PR TITLE
[Crossgen2] Compile Multiple Assemblies per invocation

### DIFF
--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/CodeGen/ReadyToRunObjectWriter.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/CodeGen/ReadyToRunObjectWriter.cs
@@ -74,7 +74,8 @@ namespace ILCompiler.DependencyAnalysis
                 R2RPEBuilder r2rPeBuilder = new R2RPEBuilder(
                     _nodeFactory.Target,
                     _inputPeReader,
-                    GetRuntimeFunctionsTable);
+                    GetRuntimeFunctionsTable,
+                    _nodeFactory.NameMangler);
 
                 int nodeIndex = -1;
                 foreach (var depNode in _nodes)

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/CompilationModuleGroup.ReadyToRun.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/CompilationModuleGroup.ReadyToRun.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Internal.TypeSystem;
+using System.Collections.Generic;
 
 namespace ILCompiler
 {
@@ -28,5 +29,7 @@ namespace ILCompiler
         /// <param name="methodDesc">Method to check</param>
         /// <returns>True if the given method versions with the current compilation module group</returns>
         public virtual bool VersionsWithMethodBody(MethodDesc methodDesc) => ContainsMethodBody(methodDesc, unboxingStub: false);
+
+        public abstract IList<ModuleDesc> CompilationModules { get; }
     }
 }

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -19,6 +19,7 @@ namespace ILCompiler
     public sealed class ReadyToRunCodegenCompilationBuilder : CompilationBuilder
     {
         private readonly string _inputFilePath;
+        private readonly string _outputFilePath;
         private readonly EcmaModule _inputModule;
         private readonly bool _ibcTuning;
         private readonly bool _resilient;
@@ -29,10 +30,11 @@ namespace ILCompiler
         private KeyValuePair<string, string>[] _ryujitOptions = Array.Empty<KeyValuePair<string, string>>();
         private ILProvider _ilProvider = new ReadyToRunILProvider();
 
-        public ReadyToRunCodegenCompilationBuilder(CompilerTypeSystemContext context, CompilationModuleGroup group, string inputFilePath, bool ibcTuning, bool resilient)
+        public ReadyToRunCodegenCompilationBuilder(CompilerTypeSystemContext context, CompilationModuleGroup group, string inputFilePath, string outputFilePath, bool ibcTuning, bool resilient)
             : base(context, group, new CoreRTNameMangler())
         {
             _inputFilePath = inputFilePath;
+            _outputFilePath = outputFilePath;
             _ibcTuning = ibcTuning;
             _resilient = resilient;
 
@@ -165,6 +167,7 @@ namespace ILCompiler
                 new DependencyAnalysis.ReadyToRun.DevirtualizationManager(_compilationGroup),
                 jitConfig,
                 _inputFilePath,
+                _outputFilePath,
                 new ModuleDesc[] { _inputModule },
                 _resilient);
         }

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/SingleMethodCompilationModuleGroup.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/SingleMethodCompilationModuleGroup.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Internal.TypeSystem;
+using System.Collections.Generic;
 
 namespace ILCompiler
 {
@@ -12,16 +13,20 @@ namespace ILCompiler
     /// </summary>
     public class SingleMethodCompilationModuleGroup : CompilationModuleGroup
     {
+        private ModuleDesc _module;
         private MethodDesc _method;
 
-        public SingleMethodCompilationModuleGroup(MethodDesc method)
+        public SingleMethodCompilationModuleGroup(ModuleDesc module, MethodDesc method)
         {
+            _module = module;
             _method = method;
         }
 
+        public override IList<ModuleDesc> CompilationModules => new[] { _module };
+
         public override bool ContainsMethodBody(MethodDesc method, bool unboxingStub)
         {
-            return method == _method;
+            return method == _method || method == _method.GetTypicalMethodDefinition();
         }
 
         public override bool ContainsType(TypeDesc type)

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/ObjectWriter/R2RPEBuilder.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/ObjectWriter/R2RPEBuilder.cs
@@ -169,7 +169,8 @@ namespace ILCompiler.PEWriter
         public R2RPEBuilder(
             TargetDetails target,
             PEReader peReader,
-            Func<RuntimeFunctionsTableNode> getRuntimeFunctionsTable)
+            Func<RuntimeFunctionsTableNode> getRuntimeFunctionsTable,
+            NameMangler nameMangler)
             : base(PEHeaderCopier.Copy(peReader.PEHeaders, target), deterministicIdProvider: null)
         {
             _target = target;
@@ -177,7 +178,7 @@ namespace ILCompiler.PEWriter
             _getRuntimeFunctionsTable = getRuntimeFunctionsTable;
             _sectionRvaDeltas = new List<SectionRVADelta>();
 
-            _sectionBuilder = new SectionBuilder(target);
+            _sectionBuilder = new SectionBuilder(target, nameMangler);
 
             _textSectionIndex = _sectionBuilder.AddSection(TextSectionName, SectionCharacteristics.ContainsCode | SectionCharacteristics.MemExecute | SectionCharacteristics.MemRead, 512);
             _dataSectionIndex = _sectionBuilder.AddSection(DataSectionName, SectionCharacteristics.ContainsInitializedData | SectionCharacteristics.MemWrite | SectionCharacteristics.MemRead, 512);

--- a/src/tools/crossgen2/ILCompiler.ReadyToRun/ObjectWriter/SectionBuilder.cs
+++ b/src/tools/crossgen2/ILCompiler.ReadyToRun/ObjectWriter/SectionBuilder.cs
@@ -212,6 +212,11 @@ namespace ILCompiler.PEWriter
         TargetDetails _target;
 
         /// <summary>
+        /// Generate stable, unique names for various type system entities in the graph.
+        /// </summary>
+        NameMangler _nameMangler;
+
+        /// <summary>
         /// Map from symbols to their target sections and offsets.
         /// </summary>
         Dictionary<ISymbolNode, SymbolTarget> _symbolMap;
@@ -275,9 +280,10 @@ namespace ILCompiler.PEWriter
         /// <summary>
         /// Construct an empty section builder without any sections or blocks.
         /// </summary>
-        public SectionBuilder(TargetDetails target)
+        public SectionBuilder(TargetDetails target, NameMangler nameMangler)
         {
             _target = target;
+            _nameMangler = nameMangler;
             _symbolMap = new Dictionary<ISymbolNode, SymbolTarget>();
             _sections = new List<Section>();
             _exportSymbols = new List<ExportSymbol>();
@@ -388,19 +394,6 @@ namespace ILCompiler.PEWriter
             _win32ResourcesSize = resourcesSize;
         }
 
-        private CoreRTNameMangler _nameMangler;
-        
-        private NameMangler GetNameMangler()
-        {
-            if (_nameMangler == null)
-            {
-                // TODO-REFACTOR: why do we have two name manglers?
-                _nameMangler = new CoreRTNameMangler();
-                _nameMangler.CompilationUnitPrefix = "";
-            }
-            return _nameMangler;
-        }
-
         /// <summary>
         /// Add an ObjectData block to a given section.
         /// </summary>
@@ -459,7 +452,7 @@ namespace ILCompiler.PEWriter
                     if (mapFile != null)
                     {
                         Utf8StringBuilder sb = new Utf8StringBuilder();
-                        symbol.AppendMangledName(GetNameMangler(), sb);
+                        symbol.AppendMangledName(_nameMangler, sb);
                         int sectionRelativeOffset = alignedOffset + symbol.Offset;
                         mapFile.WriteLine($@"  +0x{sectionRelativeOffset:X4}: {sb.ToString()}");
                     }

--- a/src/tools/crossgen2/crossgen2/CommandLineOptions.cs
+++ b/src/tools/crossgen2/crossgen2/CommandLineOptions.cs
@@ -13,6 +13,7 @@ namespace ILCompiler
         public FileInfo[] InputFilePaths { get; set; }
         public string[] Reference { get; set; }
         public FileInfo OutputFilePath { get; set; }
+        public DirectoryInfo OutputDirectory { get; set; }
         public bool Optimize { get; set; }
         public bool OptimizeSpace { get; set; }
         public bool OptimizeTime { get; set; }
@@ -20,7 +21,7 @@ namespace ILCompiler
         public bool CompileBubbleGenerics { get; set; }
         public bool Verbose { get; set; }
 
-        public FileInfo DgmlLogFileName { get; set; }
+        public bool GenerateDgmlLog { get; set; }
         public bool GenerateFullDgmlLog { get; set; }
 
         public string TargetArch { get; set; }
@@ -43,7 +44,7 @@ namespace ILCompiler
             // For some reason, arity caps at 255 by default
             ArgumentArity arbitraryArity = new ArgumentArity(0, 100000);
 
-            return new Command("Crossgen2Compilation")
+            return new Command("Crossgen2")
             {
                 new Argument<FileInfo[]>() 
                 { 
@@ -61,6 +62,10 @@ namespace ILCompiler
                 new Option(new[] { "--outputfilepath", "--out", "-o" }, "Output file path")
                 {
                     Argument = new Argument<FileInfo>()
+                },
+                new Option(new[] { "--output-directory" ,"--od" }, "Output directory (required if compiling multiple assemblies at once)")
+                {
+                    Argument = new Argument<DirectoryInfo>()
                 },
                 new Option(new[] { "--optimize", "-O" }, "Enable optimizations") 
                 { 
@@ -84,11 +89,11 @@ namespace ILCompiler
                 { 
                     Argument = new Argument<bool>() 
                 },
-                new Option(new[] { "--dgml-log-file-name", "--dmgllog" }, "Save result of dependency analysis as DGML") 
+                new Option(new[] { "--generate-dgml-log", "--dgmllog" }, "Save result of dependency analysis as DGML adjacent to output binaries") 
                 { 
                     Argument = new Argument<FileInfo>() 
                 },
-                new Option(new[] { "--generate-full-dmgl-log", "--fulllog" }, "Save detailed log of dependency analysis") 
+                new Option(new[] { "--generate-full-dgml-log", "--fulllog" }, "Save detailed log of dependency analysis") 
                 { 
                     Argument = new Argument<bool>() 
                 },


### PR DESCRIPTION
* Multiple input files can be specified on the command line and each will be compiled with the same reference assembly set and other compilation arguments. This will allow multi-threaded compilation of assemblies with multi-threaded JIT when we set that up in the next few weeks.
* Fix broken single method compilation mode
* Simplify the `Run()` method so that it is managing fewer sets of input files and paths so they're reduced to a minimized set: a map of simple -> file names for the `TypeSystemContext`, the set of input modules used to build the set of compilation jobs, the set of referenceable modules (merge of input and references) used for IBC profile reading, compilation module groups
* Use `CompilationModuleGroup` in the compiler as the source of input modules instead of the `TypeSystemContext`. The `TypeSystemContext` is re-used for all compilations, whereas each compilation will have a `CompilationModuleGroup` and can answer that more accurately.
* Tweak the command line for DGML file output so they are generated adjacent to the map files we currently create. `--dgmllog` no longer takes a file name; it emits a file parallel to the output assembly and map file with .dgml extension.
* Refactoring - cleaned up a few places from the repo migration. Merged `MetadataManager` and `ReadyToRunTableManager`.  Removed a place we instantiated a second `NameMangler` and instead pipe through the one hanging on `NodeFactory`.

/cc @dotnet/crossgen-contrib 