### PR TITLE
Crossgen2 CI Pipeline

### DIFF
--- a/eng/pipelines/crossgen2.yml
+++ b/eng/pipelines/crossgen2.yml
@@ -1,0 +1,44 @@
+trigger: none
+
+pr: none
+
+jobs:
+#
+# Checkout repository
+#
+- template: templates/checkout-job.yml
+
+- template: templates/platform-matrix.yml
+  parameters:
+    jobTemplate: build-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_x64
+    - OSX_x64
+    - Windows_NT_x64
+    jobParameters:
+      testGroup: innerloop
+
+- template: templates/platform-matrix.yml
+  parameters:
+    jobTemplate: build-test-job.yml
+    buildConfig: checked
+    platforms:
+    - OSX_x64
+    - Windows_NT_x64
+    jobParameters:
+      testGroup: innerloop
+
+- template: templates/platform-matrix.yml
+  parameters:
+    jobTemplate: run-test-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_x64
+    - OSX_x64
+    - Windows_NT_x64
+    jobParameters:
+      testGroup: innerloop
+      readyToRun: true
+      crossgen2: true
+      displayNameArgs: R2R_CG2

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -13,100 +13,27 @@ jobs:
 #
 - template: templates/checkout-job.yml
 
-#
-# Debug builds
-#
-- template: templates/platform-matrix.yml
-  parameters:
-    jobTemplate: build-job.yml
-    buildConfig: debug
-    platforms:
-    - Windows_NT_x64
-    - Windows_NT_x86
-    jobParameters:
-      testGroup: innerloop
-
-#
-# Checked builds
-#
 - template: templates/platform-matrix.yml
   parameters:
     jobTemplate: build-job.yml
     buildConfig: checked
     platforms:
-    - Linux_arm
-    - Linux_arm64
-    - Linux_musl_x64
     - Linux_x64
     - OSX_x64
-    - Windows_NT_arm
-    - Windows_NT_arm64
-    - Windows_NT_x64
-    - Windows_NT_x86
-    jobParameters:
-      testGroup: innerloop
-
-#
-# Release builds
-#
-- template: templates/platform-matrix.yml
-  parameters:
-    jobTemplate: build-job.yml
-    buildConfig: release
-    platforms:
-    - Linux_arm64
-    - Linux_musl_x64
-    - Linux_rhel6_x64
-    - OSX_x64
-    - Windows_NT_arm
-    - Windows_NT_arm64
     - Windows_NT_x64
     jobParameters:
       testGroup: innerloop
 
-#
-# Checked test builds
-#
 - template: templates/platform-matrix.yml
   parameters:
     jobTemplate: build-test-job.yml
     buildConfig: checked
     platforms:
-    - Linux_arm
-    - Linux_arm64
     - OSX_x64
-    - Windows_NT_arm
-    - Windows_NT_arm64
     - Windows_NT_x64
-    - Windows_NT_x86
-    helixQueueGroup: pr
     jobParameters:
       testGroup: innerloop
 
-#
-# Checked JIT test executions
-#
-- template: templates/platform-matrix.yml
-  parameters:
-    jobTemplate: run-test-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_arm
-    - Linux_arm64
-    - Linux_musl_x64
-    - Linux_x64
-    - OSX_x64
-    - Windows_NT_arm
-    - Windows_NT_arm64
-    - Windows_NT_x64
-    - Windows_NT_x86
-    helixQueueGroup: pr
-    jobParameters:
-      testGroup: innerloop
-
-#
-# Checked R2R test executions
-#
 - template: templates/platform-matrix.yml
   parameters:
     jobTemplate: run-test-job.yml
@@ -115,73 +42,8 @@ jobs:
     - Linux_x64
     - OSX_x64
     - Windows_NT_x64
-    - Windows_NT_x86
-    helixQueueGroup: pr
     jobParameters:
       testGroup: innerloop
       readyToRun: true
-      displayNameArgs: R2R
-
-#
-# CoreFX test runs against CoreCLR
-#
-- template: templates/platform-matrix.yml
-  parameters:
-    jobTemplate: run-test-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_x64
-    - Windows_NT_x64
-    helixQueueGroup: pr
-    testGroup: innerloop
-    jobParameters:
-      testGroup: innerloop
-      corefxTests: true
-      displayNameArgs: CoreFX
-
-#
-# Crossgen-comparison jobs
-#
-- template: templates/platform-matrix.yml
-  parameters:
-    jobTemplate: crossgen-comparison-job.yml
-    buildConfig: checked
-    platforms:
-    - Linux_arm
-    helixQueueGroup: pr
-
-#
-# Release test builds
-#
-- template: templates/platform-matrix.yml
-  parameters:
-    jobTemplate: build-test-job.yml
-    buildConfig: release
-    platforms:
-    - OSX_x64
-    helixQueueGroup: pr
-    jobParameters:
-      testGroup: innerloop
-
-#
-# Release test builds
-#
-- template: templates/platform-matrix.yml
-  parameters:
-    jobTemplate: run-test-job.yml
-    buildConfig: release
-    platforms:
-    - Linux_musl_x64
-    helixQueueGroup: pr
-    jobParameters:
-      testGroup: innerloop
-
-#
-# Formatting
-#
-- template: templates/platform-matrix.yml
-  parameters:
-    jobTemplate: format-job.yml
-    platforms:
-    - Linux_x64
-    - Windows_NT_x64
+      crossgen2: true
+      displayNameArgs: R2R_CG2

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -13,27 +13,100 @@ jobs:
 #
 - template: templates/checkout-job.yml
 
+#
+# Debug builds
+#
+- template: templates/platform-matrix.yml
+  parameters:
+    jobTemplate: build-job.yml
+    buildConfig: debug
+    platforms:
+    - Windows_NT_x64
+    - Windows_NT_x86
+    jobParameters:
+      testGroup: innerloop
+
+#
+# Checked builds
+#
 - template: templates/platform-matrix.yml
   parameters:
     jobTemplate: build-job.yml
     buildConfig: checked
     platforms:
+    - Linux_arm
+    - Linux_arm64
+    - Linux_musl_x64
     - Linux_x64
     - OSX_x64
+    - Windows_NT_arm
+    - Windows_NT_arm64
+    - Windows_NT_x64
+    - Windows_NT_x86
+    jobParameters:
+      testGroup: innerloop
+
+#
+# Release builds
+#
+- template: templates/platform-matrix.yml
+  parameters:
+    jobTemplate: build-job.yml
+    buildConfig: release
+    platforms:
+    - Linux_arm64
+    - Linux_musl_x64
+    - Linux_rhel6_x64
+    - OSX_x64
+    - Windows_NT_arm
+    - Windows_NT_arm64
     - Windows_NT_x64
     jobParameters:
       testGroup: innerloop
 
+#
+# Checked test builds
+#
 - template: templates/platform-matrix.yml
   parameters:
     jobTemplate: build-test-job.yml
     buildConfig: checked
     platforms:
+    - Linux_arm
+    - Linux_arm64
     - OSX_x64
+    - Windows_NT_arm
+    - Windows_NT_arm64
     - Windows_NT_x64
+    - Windows_NT_x86
+    helixQueueGroup: pr
     jobParameters:
       testGroup: innerloop
 
+#
+# Checked JIT test executions
+#
+- template: templates/platform-matrix.yml
+  parameters:
+    jobTemplate: run-test-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_arm
+    - Linux_arm64
+    - Linux_musl_x64
+    - Linux_x64
+    - OSX_x64
+    - Windows_NT_arm
+    - Windows_NT_arm64
+    - Windows_NT_x64
+    - Windows_NT_x86
+    helixQueueGroup: pr
+    jobParameters:
+      testGroup: innerloop
+
+#
+# Checked R2R test executions
+#
 - template: templates/platform-matrix.yml
   parameters:
     jobTemplate: run-test-job.yml
@@ -42,8 +115,73 @@ jobs:
     - Linux_x64
     - OSX_x64
     - Windows_NT_x64
+    - Windows_NT_x86
+    helixQueueGroup: pr
     jobParameters:
       testGroup: innerloop
       readyToRun: true
-      crossgen2: true
-      displayNameArgs: R2R_CG2
+      displayNameArgs: R2R
+
+#
+# CoreFX test runs against CoreCLR
+#
+- template: templates/platform-matrix.yml
+  parameters:
+    jobTemplate: run-test-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_x64
+    - Windows_NT_x64
+    helixQueueGroup: pr
+    testGroup: innerloop
+    jobParameters:
+      testGroup: innerloop
+      corefxTests: true
+      displayNameArgs: CoreFX
+
+#
+# Crossgen-comparison jobs
+#
+- template: templates/platform-matrix.yml
+  parameters:
+    jobTemplate: crossgen-comparison-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_arm
+    helixQueueGroup: pr
+
+#
+# Release test builds
+#
+- template: templates/platform-matrix.yml
+  parameters:
+    jobTemplate: build-test-job.yml
+    buildConfig: release
+    platforms:
+    - OSX_x64
+    helixQueueGroup: pr
+    jobParameters:
+      testGroup: innerloop
+
+#
+# Release test builds
+#
+- template: templates/platform-matrix.yml
+  parameters:
+    jobTemplate: run-test-job.yml
+    buildConfig: release
+    platforms:
+    - Linux_musl_x64
+    helixQueueGroup: pr
+    jobParameters:
+      testGroup: innerloop
+
+#
+# Formatting
+#
+- template: templates/platform-matrix.yml
+  parameters:
+    jobTemplate: format-job.yml
+    platforms:
+    - Linux_x64
+    - Windows_NT_x64

--- a/eng/pipelines/templates/run-test-job.yml
+++ b/eng/pipelines/templates/run-test-job.yml
@@ -9,6 +9,7 @@ parameters:
   testGroup: ''
   crossrootfsDir: ''
   readyToRun: false
+  crossgen2: false
   helixQueues: ''
   # If true, run the corefx tests instead of the coreclr ones
   corefxTests: false
@@ -76,6 +77,11 @@ jobs:
         value: 'crossgen'
       - name: LogNamePrefix
         value: TestRunLogs_R2R
+      - ${{ if eq(parameters.crossgen2, true) }}:
+        - name: crossgenArg
+          value: 'crossgen2'
+        - name: LogNamePrefix
+          value: TestRunLogs_R2R_CG2
 
     - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       - group: DotNet-HelixApi-Access
@@ -240,7 +246,8 @@ jobs:
           timeoutPerTestCollectionInMinutes: 300
           timeoutPerTestInMinutes: 90
 
-        runCrossGen: ${{ parameters.readyToRun }}
+        runCrossGen: ${{ and(eq(parameters.readyToRun, true), ne(parameters.crossgen2, true)) }}
+        runCrossGen2: ${{ and(eq(parameters.readyToRun, true), eq(parameters.crossgen2, true)) }}
         runInUnloadableContext: ${{ parameters.runInUnloadableContext }}
 
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:

--- a/eng/pipelines/templates/send-to-helix-step.yml
+++ b/eng/pipelines/templates/send-to-helix-step.yml
@@ -15,6 +15,7 @@ parameters:
   timeoutPerTestCollectionInMinutes: ''
   timeoutPerTestInMinutes: ''
   runCrossGen: ''
+  runCrossGen2: ''
   helixProjectArguments: ''
   runInUnloadableContext: ''
   longRunningGcTests: ''
@@ -45,6 +46,7 @@ steps:
       _HelixTargetQueues: ${{ join(',', parameters.helixQueues) }}
       _HelixType: ${{ parameters.helixType }}
       _RunCrossGen: ${{ parameters.runCrossGen }}
+      _RunCrossGen2: ${{ parameters.runCrossGen2 }}
       _RunInUnloadableContext: ${{ parameters.runInUnloadableContext }}
       _LongRunningGcTests: ${{ parameters.longRunningGcTests }}
       _GcSimulatorTests: ${{ parameters.gcSimulatorTests }}
@@ -83,6 +85,7 @@ steps:
       _HelixTargetQueues: ${{ join(',', parameters.helixQueues) }}
       _HelixType: ${{ parameters.helixType }}
       _RunCrossGen: ${{ parameters.runCrossGen }}
+      _RunCrossGen2: ${{ parameters.runCrossGen2 }}
       _RunInUnloadableContext: ${{ parameters.runInUnloadableContext }}
       _LongRunningGcTests: ${{ parameters.longRunningGcTests }}
       _GcSimulatorTests: ${{ parameters.gcSimulatorTests }}

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -76,8 +76,10 @@ if /i "%1" == "skipgeneratelayout"                      (set __SkipGenerateLayou
 if /i "%1" == "buildxunitwrappers"                      (set __BuildXunitWrappers=1&shift&goto Arg_Loop)
 if /i "%1" == "printlastresultsonly"                    (set __PrintLastResultsOnly=1&shift&goto Arg_Loop)
 if /i "%1" == "runcrossgentests"                        (set RunCrossGen=true&shift&goto Arg_Loop)
+if /i "%1" == "runcrossgen2tests"                       (set RunCrossGen2=true&shift&goto Arg_Loop)
 REM This test feature is currently intentionally undocumented
 if /i "%1" == "runlargeversionbubblecrossgentests"      (set RunCrossGen=true&set CrossgenLargeVersionBubble=true&shift&goto Arg_Loop)
+if /i "%1" == "runlargeversionbubblecrossgen2tests"     (set RunCrossGen2=true&set CrossgenLargeVersionBubble=true&shift&goto Arg_Loop)
 if /i "%1" == "link"                                    (set DoLink=true&set ILLINK=%2&shift&shift&goto Arg_Loop)
 REM tieredcompilation is on by default now, but setting this environment variable is harmless and I didn't want to break any automation that might be using it just yet
 if /i "%1" == "tieredcompilation"                       (set COMPLUS_TieredCompilation=1&shift&goto Arg_Loop)
@@ -174,6 +176,10 @@ if defined __BuildXUnitWrappers (
 
 if defined RunCrossGen (
     set __RuntestPyArgs=%__RuntestPyArgs% --run_crossgen_tests
+)
+
+if defined RunCrossGen2 (
+    set __RuntestPyArgs=%__RuntestPyArgs% --run_crossgen2_tests
 )
 
 if defined __DoCrossgen (

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -970,6 +970,11 @@ def run_tests(host_os,
         print("Setting RunCrossGen=true")
         os.environ["RunCrossGen"] = "true"
 
+    if run_crossgen2_tests:
+        print("Running tests R2R (Crossgen2)")
+        print("Setting RunCrossGen2=true")
+        os.environ["RunCrossGen2"] = "true"
+
     if large_version_bubble:
         print("Large Version Bubble enabled")
         os.environ["LargeVersionBubble"] = "true"

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -24,6 +24,7 @@ function print_usage {
     echo '  --test-env                       : Script to set environment variables for tests'
     echo '  --crossgen                       : Precompiles the framework managed assemblies'
     echo '  --runcrossgentests               : Runs the ready to run tests' 
+    echo '  --runcrossgen2tests              : Runs the ready to run tests compiled with Crossgen2' 
     echo '  --jitstress=<n>                  : Runs the tests with COMPlus_JitStress=n'
     echo '  --jitstressregs=<n>              : Runs the tests with COMPlus_JitStressRegs=n'
     echo '  --jitminopts                     : Runs the tests with COMPlus_JITMinOpts=1'
@@ -328,6 +329,9 @@ do
         --runcrossgentests)
             export RunCrossGen=1
             ;;
+        --runcrossgen2tests)
+            export RunCrossGen2=1
+            ;;
         --corefxtests)
             export RunCoreFXTests=1
             ;;
@@ -545,6 +549,10 @@ fi
 
 if [ ! -z "$RunCrossGen" ]; then
     runtestPyArguments+=("--run_crossgen_tests")
+fi
+
+if [ ! -z "$RunCrossGen2" ]; then
+    runtestPyArguments+=("--run_crossgen2_tests")
 fi
 
 if (($doCrossgen!=0)); then

--- a/tests/src/CLRTest.CrossGen.targets
+++ b/tests/src/CLRTest.CrossGen.targets
@@ -47,7 +47,7 @@ if [ ! -z ${RunCrossGen+x} ]%3B then
           mkdir IL
           cp $(MSBuildProjectName).dll IL/$(MSBuildProjectName).dll
           mv $(MSBuildProjectName).dll $(MSBuildProjectName).org
-          __Command=$_DebuggerFullPath "$CORE_ROOT/crossgen" /Platform_Assemblies_Paths $CORE_ROOT/Crossgen-ret.out%3A$PWD /in $(MSBuildProjectName).org /out $(MSBuildProjectName).dll
+          __Command=$_DebuggerFullPath "$CORE_ROOT/crossgen" /Platform_Assemblies_Paths $CORE_ROOT%3A$PWD /in $(MSBuildProjectName).org /out $(MSBuildProjectName).dll
           echo $__Command
           $__Command
           __cgExitCode=$?
@@ -108,7 +108,7 @@ if defined RunCrossGen (
             mkdir IL
             copy $(MSBuildProjectName).dll IL\$(MSBuildProjectName).dll
             ren $(MSBuildProjectName).dll $(MSBuildProjectName).org
-            set __Command=!_DebuggerFullPath! "!CORE_ROOT!\crossgen.exe" !OptionalArguments! /Platform_Assemblies_Paths !CORE_ROOT!\Crossgen-ret.out%3B%25cd%25 /in $(scriptPath)\$(MSBuildProjectName).org /out %25scriptPath%25\$(MSBuildProjectName).dll
+            set __Command=!_DebuggerFullPath! "!CORE_ROOT!\crossgen.exe" !OptionalArguments! /Platform_Assemblies_Paths !CORE_ROOT!%3B%25cd%25 /in $(scriptPath)\$(MSBuildProjectName).org /out %25scriptPath%25\$(MSBuildProjectName).dll
             echo "!__Command!"
             call !__Command!
             set CrossGenStatus=!ERRORLEVEL!

--- a/tests/src/CLRTest.CrossGen.targets
+++ b/tests/src/CLRTest.CrossGen.targets
@@ -47,12 +47,35 @@ if [ ! -z ${RunCrossGen+x} ]%3B then
           mkdir IL
           cp $(MSBuildProjectName).dll IL/$(MSBuildProjectName).dll
           mv $(MSBuildProjectName).dll $(MSBuildProjectName).org
-          echo $_DebuggerFullPath "$CORE_ROOT/crossgen" /Platform_Assemblies_Paths $CORE_ROOT%3A$PWD/IL%3A$PWD /in $(MSBuildProjectName).org /out $(MSBuildProjectName).dll
-          $_DebuggerFullPath "$CORE_ROOT/crossgen" /Platform_Assemblies_Paths $CORE_ROOT%3A$PWD/IL%3A$PWD /in $(MSBuildProjectName).org /out $(MSBuildProjectName).dll
+          __Command=$_DebuggerFullPath "$CORE_ROOT/crossgen" /Platform_Assemblies_Paths $CORE_ROOT/Crossgen-ret.out%3A$PWD /in $(MSBuildProjectName).org /out $(MSBuildProjectName).dll
+          echo $__Command
+          $__Command
           __cgExitCode=$?
           if [ $__cgExitCode -ne 0 ]
           then
             echo Crossgen failed with exitcode: $__cgExitCode
+            ReleaseLock
+            exit 1
+          fi
+        fi 
+        ReleaseLock       
+    fi        
+fi        
+# CrossGen2 Script
+if [ ! -z ${RunCrossGen2+x} ]%3B then
+    if [ ! -f $(MSBuildProjectName).org ]%3B then
+        TakeLock
+        if [ ! -f $(MSBuildProjectName).org ]%3B then
+          mkdir IL
+          cp $(MSBuildProjectName).dll IL/$(MSBuildProjectName).dll
+          mv $(MSBuildProjectName).dll $(MSBuildProjectName).org
+          __Command=$_DebuggerFullPath "$CORE_ROOT/crossgen2/crossgen2" -r:$CORE_ROOT/*.dll --targetarch=x64 -O --inputbubble -o:$(scriptPath)$(MSBuildProjectName).dll $(scriptPath)$(MSBuildProjectName).org
+          echo $__Command
+          $__Command
+          __cg2ExitCode=$?
+          if [ $__cg2ExitCode -ne 0 ]
+          then
+            echo Crossgen2 failed with exitcode: $__cg2ExitCode
             ReleaseLock
             exit 1
           fi
@@ -85,13 +108,36 @@ if defined RunCrossGen (
             mkdir IL
             copy $(MSBuildProjectName).dll IL\$(MSBuildProjectName).dll
             ren $(MSBuildProjectName).dll $(MSBuildProjectName).org
-            echo "%_DebuggerFullPath% %CORE_ROOT%\crossgen.exe" !OptionalArguments! /Platform_Assemblies_Paths %CORE_ROOT%%3B%25cd%25\IL%3B%25cd%25 /in $(MSBuildProjectName).org /out $(MSBuildProjectName).dll
-            %_DebuggerFullPath% "%CORE_ROOT%\crossgen.exe" !OptionalArguments! /Platform_Assemblies_Paths %CORE_ROOT%%3B%25cd%25\IL%3B%25cd%25 /in $(MSBuildProjectName).org /out $(MSBuildProjectName).dll
+            set __Command=!_DebuggerFullPath! "!CORE_ROOT!\crossgen.exe" !OptionalArguments! /Platform_Assemblies_Paths !CORE_ROOT!\Crossgen-ret.out%3B%25cd%25 /in $(scriptPath)\$(MSBuildProjectName).org /out %25scriptPath%25\$(MSBuildProjectName).dll
+            echo "!__Command!"
+            call !__Command!
             set CrossGenStatus=!ERRORLEVEL!
         )
         call :ReleaseLock
         IF NOT !CrossGenStatus!==0 (
             ECHO Crossgen failed with exitcode - !CrossGenStatus!
+            Exit /b 1
+        )
+    )
+) 
+REM CrossGen2 Script
+if defined RunCrossGen2 ( 
+    if defined LargeVersionBubble ( set OptionalArguments=!OptionalArguments! /largeversionbubble)
+    if not exist "$(MSBuildProjectName).org" (
+        call :TakeLock
+        set CrossGen2Status=0
+        if not exist "$(MSBuildProjectName).org" (
+            mkdir IL
+            copy $(MSBuildProjectName).dll IL\$(MSBuildProjectName).dll
+            ren $(MSBuildProjectName).dll $(MSBuildProjectName).org
+            set __Command=!_DebuggerFullPath! "!CORE_ROOT!\crossgen2\crossgen2" %21scriptPath%21$(MSBuildProjectName).org -o:%21scriptPath%21$(MSBuildProjectName).dll --targetarch:x64 -O --inputbubble -r:!CORE_ROOT!\*.dll
+            echo "!__Command!"
+            call !__Command!
+            set CrossGen2Status=!ERRORLEVEL!
+        )
+        call :ReleaseLock
+        IF NOT !CrossGen2Status!==0 (
+            ECHO Crossgen2 failed with exitcode - !CrossGen2Status!
             Exit /b 1
         )
     )

--- a/tests/src/CLRTest.CrossGen.targets
+++ b/tests/src/CLRTest.CrossGen.targets
@@ -108,7 +108,7 @@ if defined RunCrossGen (
             mkdir IL
             copy $(MSBuildProjectName).dll IL\$(MSBuildProjectName).dll
             ren $(MSBuildProjectName).dll $(MSBuildProjectName).org
-            set __Command=!_DebuggerFullPath! "!CORE_ROOT!\crossgen.exe" !OptionalArguments! /Platform_Assemblies_Paths !CORE_ROOT!%3B%25cd%25 /in $(scriptPath)\$(MSBuildProjectName).org /out %25scriptPath%25\$(MSBuildProjectName).dll
+            set __Command=!_DebuggerFullPath! "!CORE_ROOT!\crossgen.exe" !OptionalArguments! /Platform_Assemblies_Paths !CORE_ROOT!%3B%25cd%25 /in %21scriptPath%21$(MSBuildProjectName).org /out %21scriptPath%21\$(MSBuildProjectName).dll
             echo "!__Command!"
             call !__Command!
             set CrossGenStatus=!ERRORLEVEL!

--- a/tests/src/helixpublishwitharcade.proj
+++ b/tests/src/helixpublishwitharcade.proj
@@ -26,6 +26,7 @@
         HelixType=$(_HelixType);
         PublishTestResults=$(_PublishTestResults);
         RunCrossGen=$(_RunCrossGen);
+        RunCrossGen2=$(_RunCrossGen2);
         LongRunningGCTests=$(_LongRunningGCTests);
         GcSimulatorTests=$(_GcSimulatorTests);
         RunInUnloadableContext=$(_RunInUnloadableContext);
@@ -172,9 +173,11 @@
     <HelixConfiguration Condition=" '$(Scenario)' == 'normal' ">$(BuildType)</HelixConfiguration>
     <HelixConfiguration Condition=" '$(Scenario)' != 'normal' ">$(BuildType)-$(Scenario)</HelixConfiguration>
     <RunCrossGen Condition=" '$(RunCrossGen)' != 'true' ">false</RunCrossGen>
+    <RunCrossGen2 Condition=" '$(RunCrossGen2)' != 'true' ">false</RunCrossGen2>
     <LongRunningGCTests Condition=" '$(LongRunningGCTests)' != 'true' ">false</LongRunningGCTests>
     <GcSimulatorTests Condition=" '$(GcSimulatorTests)' != 'true' ">false</GcSimulatorTests>
     <TestRunNamePrefix Condition=" '$(RunCrossGen)' == 'true' ">R2R </TestRunNamePrefix>
+    <TestRunNamePrefix Condition=" '$(RunCrossGen2)' == 'true' ">R2R-CG2 </TestRunNamePrefix>
     <TestRunNamePrefix Condition=" '$(Scenario)' == 'normal' ">$(TestRunNamePrefix)$(BuildOS) $(BuildArch) $(BuildType) @ </TestRunNamePrefix>
     <TestRunNamePrefix Condition=" '$(Scenario)' != 'normal' ">$(TestRunNamePrefix)$(BuildOS) $(BuildArch) $(BuildType) $(Scenario) @ </TestRunNamePrefix>
     <TimeoutPerTestInMilliseconds Condition=" '$(TimeoutPerTestInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestInMinutes)).TotalMilliseconds)</TimeoutPerTestInMilliseconds>
@@ -192,6 +195,7 @@
     <!-- Set _NT_SYMBOL_PATH so VM _ASSERTE() asserts can find the symbol files when doing stack walks -->
     <HelixPreCommand Include="set _NT_SYMBOL_PATH=%HELIX_CORRELATION_PAYLOAD%\PDB" />
     <HelixPreCommand Include="set RunCrossGen=1" Condition=" '$(RunCrossGen)' == 'true' " />
+    <HelixPreCommand Include="set RunCrossGen2=1" Condition=" '$(RunCrossGen2)' == 'true' " />
     <HelixPreCommand Include="set RunningLongGCTests=1" Condition=" '$(LongRunningGCTests)' == 'true' " />
     <HelixPreCommand Include="set RunningGCSimulatorTests=1" Condition=" '$(GcSimulatorTests)' == 'true' " />
     <HelixPreCommand Include="set RunInUnloadableContext=1" Condition=" '$(RunInUnloadableContext)' == 'true' " />
@@ -206,6 +210,7 @@
   <ItemGroup Condition=" '$(TargetsWindows)' != 'true' ">
     <HelixPreCommand Include="export CORE_ROOT=$HELIX_CORRELATION_PAYLOAD" />
     <HelixPreCommand Include="export RunCrossGen=1" Condition=" '$(RunCrossGen)' == 'true' " />
+    <HelixPreCommand Include="export RunCrossGen2=1" Condition=" '$(RunCrossGen2)' == 'true' " />
     <HelixPreCommand Include="export RunningLongGCTests=1" Condition=" '$(LongRunningGCTests)' == 'true' " />
     <HelixPreCommand Include="export RunningGCSimulatorTests=1" Condition=" '$(GcSimulatorTests)' == 'true' " />
     <HelixPreCommand Include="export RunInUnloadableContext=1" Condition=" '$(RunInUnloadableContext)' == 'true' " />


### PR DESCRIPTION
I have refactored my Crossgen2 CI pipeline change to not use
SuperIlc for framework compilation. I intend to introduce that at a
later time to basically simplify the change and make it easier to
review and test. It's currently based on my preparatory change
"CoreCLR pipeline optimization" which also introduces the logic
to Crossgen framework assemblies as part of the run-test job.

Thanks

Tomas