### PR TITLE
Reduce frequency of GC long running tests to twice a week. Make GC simulator tests run nightly, for now.

### DIFF
--- a/eng/pipelines/gc-longrunning.yml
+++ b/eng/pipelines/gc-longrunning.yml
@@ -3,8 +3,8 @@ trigger: none
 pr: none
 
 schedules:
-- cron: "0 11 * * *"
-  displayName: Mon through Sun at 3:00 AM (UTC-8:00)
+- cron: "0 11 * * 2,4"
+  displayName: Every Tuesday and Thursday at 3:00 AM (UTC-8:00)
   branches:
     include:
     - master

--- a/eng/pipelines/gc-simulator.yml
+++ b/eng/pipelines/gc-simulator.yml
@@ -2,6 +2,14 @@ trigger: none
 
 pr: none
 
+schedules:
+- cron: "0 11 * * *"
+  displayName: Mon through Sun at 3:00 AM (UTC-8:00)
+  branches:
+    include:
+    - master
+  always: true
+
 jobs:
 #
 # Checkout repository


### PR DESCRIPTION
Reduce frequency of GC long running tests to twice a week. Make GC simulator tests run nightly, for now.